### PR TITLE
fix: use 'Agents Commander' as display name in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: ${{ github.ref_name }}
-          releaseName: 'agentscommander ${{ github.ref_name }}'
-          releaseBody: 'See the assets below to download and install agentscommander.'
+          releaseName: 'Agents Commander ${{ github.ref_name }}'
+          releaseBody: 'See the assets below to download and install Agents Commander.'
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}


### PR DESCRIPTION
## Summary
- Changes `releaseName` and `releaseBody` in the release workflow from "agentscommander" to "Agents Commander"

## Test plan
- [ ] Next tag push should show "Agents Commander vX.Y.Z" as the release title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release metadata formatting to display "Agents Commander" instead of "agentscommander" in GitHub release name and installation instructions for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->