### PR TITLE
Fix ghost window flash from GitWatcher on Windows

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/pty/git_watcher.rs
+++ b/src-tauri/src/pty/git_watcher.rs
@@ -88,11 +88,17 @@ impl GitWatcher {
     }
 
     async fn detect_branch(working_dir: &str) -> Option<String> {
-        let output = tokio::process::Command::new("git")
-            .args(["rev-parse", "--abbrev-ref", "HEAD"])
-            .current_dir(working_dir)
-            .output()
-            .await;
+        #[cfg(windows)]
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+        let mut cmd = tokio::process::Command::new("git");
+        cmd.args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .current_dir(working_dir);
+
+        #[cfg(windows)]
+        cmd.creation_flags(CREATE_NO_WINDOW);
+
+        let output = cmd.output().await;
 
         match output {
             Ok(out) if out.status.success() => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "identifier": "com.agentscommander.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/sidebar/components/Titlebar.tsx
+++ b/src/sidebar/components/Titlebar.tsx
@@ -2,7 +2,7 @@ import { Component } from "solid-js";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import iconUrl from "../../assets/icon-16.png";
 
-const APP_VERSION = "0.4.4";
+const APP_VERSION = "0.4.5";
 
 const Titlebar: Component = () => {
   const appWindow = getCurrentWindow();


### PR DESCRIPTION
## Summary
- GitWatcher polls `git rev-parse --abbrev-ref HEAD` every 5s per session
- On Windows, `tokio::process::Command::new("git")` without `CREATE_NO_WINDOW` flag creates a brief visible cmd.exe window each time
- With 5 sessions = 5 ghost windows every 5 seconds
- Fix: add `.creation_flags(0x08000000)` (CREATE_NO_WINDOW) to the git command, gated behind `#[cfg(windows)]`
- Bump version to 0.4.5

## Test plan
- [ ] Run app on Windows with multiple sessions open
- [ ] Verify no ghost cmd.exe windows flash
- [ ] Verify git branch still shows correctly in sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application version to 0.4.5.

* **Bug Fixes**
  * Fixed unwanted console window appearing when the application detects git branches on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->