### PR TITLE
chore(ci): bump GitHub Actions to v5 + Node 22 (#79)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -59,9 +59,9 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/validate-branch-name.yml
+++ b/.github/workflows/validate-branch-name.yml
@@ -26,14 +26,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history for grandfather ancestor check)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Validate branch name and issue state
         env:


### PR DESCRIPTION
## Summary

Silences the Node 20 deprecation warning emitted on every workflow run (observed on [run 24866638700](https://github.com/mblua/AgentsCommander/actions/runs/24866638700)).

- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- `node-version: 20` → `22`

v5 is the first release of both actions with Node 24 runtime support. Node 22 is the current LTS.

## Test plan

- [x] `validate-branch-name` CI run on this branch is green and no longer emits the Node 20 deprecation warning.
- [ ] Next release build will use `actions/checkout@v5` + Node 22.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)