### PR TITLE
chore: enforce LF for .toml/.json/.rs in .gitattributes (#89)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 .husky/** text eol=lf
 *.sh      text eol=lf
+*.toml    text eol=lf
+*.json    text eol=lf
+*.rs      text eol=lf


### PR DESCRIPTION
## Summary

- Adds `*.toml`, `*.json`, `*.rs` rules with `text eol=lf` to `.gitattributes`.
- Eliminates the recurring phantom-dirty status on `src-tauri/Cargo.toml`, `src-tauri/gen/schemas/desktop-schema.json`, `src-tauri/gen/schemas/windows-schema.json` after every `tauri build` on Windows.
- No content changes anywhere else — verified via `git add --renormalize` producing no staged content for the affected files.

## Why

`core.autocrlf=true` (Git's Windows default) expects CRLF in the working tree, but Tauri build writes those three files with LF. The current `.gitattributes` only covered `.husky/**` and `*.sh`. Result: `git diff` showed no content delta, only the LF/CRLF warning, but `git status` kept marking them modified — a noisy false positive that auto-resolves silently the moment anyone runs `git add`.

The fix cancels `autocrlf` for those file types so working-tree LF matches index LF cleanly.

## Test plan

- [x] `git diff --cached` shows only the 3-line addition to `.gitattributes`.
- [x] `git add --renormalize` on the previously-dirty files stages no content (confirms byte equality with index).
- [ ] After merge, `tauri build` should leave `git status` clean — manual verification next time the branch is built.

Closes #89