### PR TITLE
chore: clippy hygiene pass for src-tauri (#91)

### DIFF
--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -139,7 +139,7 @@ pub fn execute(args: CreateAgentArgs) -> i32 {
                     }
                 }
 
-                let parts: Vec<&str> = agent.command.trim().split_whitespace().collect();
+                let parts: Vec<&str> = agent.command.split_whitespace().collect();
                 let (shell, shell_args) = if agent.git_pull_before {
                     (
                         "cmd.exe".to_string(),

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -850,7 +850,7 @@ pub async fn discover_ac_agents(
                 wg.agents.iter().any(|agent| {
                     t.agents.iter().any(|team_ref| {
                         team_ref.rsplit('/').next()
-                            .map_or(false, |s| s == agent.name)
+                            .is_some_and(|s| s == agent.name)
                     })
                 })
             });
@@ -1236,7 +1236,7 @@ pub async fn discover_project(
                 wg.agents.iter().any(|agent| {
                     t.agents.iter().any(|team_ref| {
                         team_ref.rsplit('/').next()
-                            .map_or(false, |s| s == agent.name)
+                            .is_some_and(|s| s == agent.name)
                     })
                 })
             });

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -68,6 +68,8 @@ pub async fn open_web_remote() -> Result<(), String> {
     Ok(())
 }
 
+// Tauri command: State<> injections push us over clippy's 7-arg threshold.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn start_web_server(
     app_handle: tauri::AppHandle,

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -580,9 +580,9 @@ pub async fn create_workgroup(
         let assigned_repos: Vec<String> = team_repos
             .iter()
             .filter(|r| r.agents.iter().any(|a| agent_matches(a, agent_name)))
-            .filter_map(|r| {
+            .map(|r| {
                 let dir_name = format!("repo-{}", repo_dir_name_from_url(&r.url));
-                Some(format!("../{}", dir_name))
+                format!("../{}", dir_name)
             })
             .collect();
 
@@ -741,7 +741,7 @@ pub async fn delete_workgroup(
 
     // Safety check: detect dirty repos before deleting (skip if force)
     if !force.unwrap_or(false) {
-        let dirty_repos = check_workgroup_repos_dirty(&[wg_dir.clone()]);
+        let dirty_repos = check_workgroup_repos_dirty(std::slice::from_ref(&wg_dir));
         if !dirty_repos.is_empty() {
             let list = dirty_repos
                 .iter()
@@ -768,6 +768,8 @@ pub async fn delete_workgroup(
 }
 
 /// Update an existing team's config.json in {project_path}/.ac-new/_team_{name}/
+// Tauri command: State<> injections push us over clippy's 7-arg threshold.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn update_team(
     app: AppHandle,

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -303,6 +303,8 @@ fn should_inject_continue(
 ///   `RespawnExited` match, today driven exclusively by deferred-non-coord
 ///   `Exited(0)` records — and `restart_session` when its caller passes
 ///   `Some(false)`).
+// Shared by Tauri command + restore path; collapsing args would force a context struct.
+#[allow(clippy::too_many_arguments)]
 pub async fn create_session_inner(
     app: &AppHandle,
     session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
@@ -362,7 +364,7 @@ pub async fn create_session_inner(
     let full_cmd = format!("{} {}", shell, shell_args.join(" "));
     let cmd_basenames: Vec<String> = full_cmd
         .split_whitespace()
-        .map(|t| executable_basename(t))
+        .map(executable_basename)
         .collect();
     let is_claude = cmd_basenames.iter().any(|b| b.starts_with("claude"));
     let is_codex = cmd_basenames.iter().any(|b| b.starts_with("codex"));
@@ -505,7 +507,7 @@ pub async fn create_session_inner(
     if agent_id.is_some() {
         let app_clone = app.clone();
         let session_id = id;
-        let token = session.token.clone();
+        let token = session.token;
         let cwd_clone = cwd.clone();
         tokio::spawn(async move {
             let max_wait = std::time::Duration::from_secs(30);
@@ -610,6 +612,8 @@ pub async fn create_session_inner(
 
 /// Create a new session. Optionally override shell/args/cwd/name (for action buttons).
 /// Falls back to settings defaults when not provided.
+// Tauri command: State<> injections push us over clippy's 7-arg threshold.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn create_session(
     app: AppHandle,
@@ -814,6 +818,8 @@ fn effective_restart_skip_auto_resume(requested: Option<bool>) -> bool {
 /// `codex resume --last`, or `gemini --resume latest` injection.
 /// The restarted session is automatically activated, Telegram bridges are
 /// re-attached, and state is persisted.
+// Tauri command: State<> injections push us over clippy's 7-arg threshold.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn restart_session(
     app: AppHandle,
@@ -1128,13 +1134,13 @@ fn resolve_agent_from_shell(
     let full_cmd = format!("{} {}", shell, shell_args.join(" "));
     let cmd_basenames: Vec<String> = full_cmd
         .split_whitespace()
-        .map(|t| executable_basename(t))
+        .map(executable_basename)
         .collect();
 
     for agent in &settings.agents {
         let agent_exec = agent.command.split_whitespace().next().unwrap_or("");
         let agent_basename = executable_basename(agent_exec);
-        if !agent_basename.is_empty() && cmd_basenames.iter().any(|b| *b == agent_basename) {
+        if !agent_basename.is_empty() && cmd_basenames.contains(&agent_basename) {
             log::info!(
                 "Auto-detected agent '{}' ({}) from shell command",
                 agent.id,
@@ -1304,26 +1310,27 @@ mod tests {
     use crate::config::settings::{AgentConfig, AppSettings};
 
     fn test_settings() -> AppSettings {
-        let mut settings = AppSettings::default();
-        settings.agents = vec![
-            AgentConfig {
-                id: "claude".to_string(),
-                label: "Claude Code".to_string(),
-                command: "claude".to_string(),
-                color: "#d97706".to_string(),
-                git_pull_before: false,
-                exclude_global_claude_md: false,
-            },
-            AgentConfig {
-                id: "codex".to_string(),
-                label: "Codex".to_string(),
-                command: "codex".to_string(),
-                color: "#10b981".to_string(),
-                git_pull_before: false,
-                exclude_global_claude_md: false,
-            },
-        ];
-        settings
+        AppSettings {
+            agents: vec![
+                AgentConfig {
+                    id: "claude".to_string(),
+                    label: "Claude Code".to_string(),
+                    command: "claude".to_string(),
+                    color: "#d97706".to_string(),
+                    git_pull_before: false,
+                    exclude_global_claude_md: false,
+                },
+                AgentConfig {
+                    id: "codex".to_string(),
+                    label: "Codex".to_string(),
+                    command: "codex".to_string(),
+                    color: "#10b981".to_string(),
+                    git_pull_before: false,
+                    exclude_global_claude_md: false,
+                },
+            ],
+            ..AppSettings::default()
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -40,7 +40,7 @@ pub async fn detach_terminal(
         .expect("Failed to load app icon");
 
     WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(url.into()))
-        .title(format!("Terminal [detached]"))
+        .title("Terminal [detached]".to_string())
         .icon(icon)
         .map_err(|e| e.to_string())?
         .inner_size(900.0, 600.0)
@@ -66,7 +66,7 @@ pub async fn detach_terminal(
             .iter()
             .find(|s| {
                 let sid = Uuid::parse_str(&s.id).ok();
-                sid.map_or(false, |u| !detached_set.contains(&u))
+                sid.is_some_and(|u| !detached_set.contains(&u))
             })
             .map(|s| s.id.clone())
     }; // MutexGuard dropped here

--- a/src-tauri/src/config/agent_config.rs
+++ b/src-tauri/src/config/agent_config.rs
@@ -114,6 +114,7 @@ pub struct AgentLocalConfig {
 /// Writes to BOTH:
 ///  - `<repo_path>/config.json` (root, shared across all instances — read by discovery)
 ///  - `<repo_path>/<agent_local_dir>/config.json` (per-instance)
+///
 /// Reads existing config, upserts the coding agent entry, writes back.
 pub fn set_last_coding_agent(
     repo_path: &str,

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -19,7 +19,7 @@ pub fn ensure_session_context(agent_root: &str) -> Result<String, String> {
     let hash = simple_hash(agent_root);
     let file_path = context_dir.join(format!("ac-context-{}.md", hash));
 
-    std::fs::write(&file_path, &default_context(&canonical_root, matrix_root.as_deref()))
+    std::fs::write(&file_path, default_context(&canonical_root, matrix_root.as_deref()))
         .map_err(|e| format!("Failed to write per-agent AgentsCommanderContext.md: {}", e))?;
     log::info!(
         "Refreshed per-agent AgentsCommanderContext.md for {} → {:?}",
@@ -265,9 +265,11 @@ fn detect_git_branch(dir: &str) -> Option<String> {
 /// - `$AGENTSCOMMANDER_CONTEXT` → resolves to the global AgentsCommanderContext.md
 /// - `$REPOS_WORKSPACE_INFO` → generates workspace repo info from the "repos" field
 /// - Any other string → resolved as a path relative to `cwd`
+///
 /// After resolving context[], if `identity` is set in config.json and `<identity>/Role.md`
 /// exists on disk, it is auto-appended (unless already resolved from context[]).
 /// The global context is NOT auto-prepended — it is only included if the token is in the array.
+///
 /// Returns Ok(Some(path)) with the combined temp file, Ok(None) if no context[] field,
 /// or Err with details about missing files.
 pub fn build_replica_context(cwd: &str) -> Result<Option<String>, String> {

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -560,14 +560,13 @@ pub(crate) fn strip_auto_injected_args(shell: &str, args: &[String]) -> Vec<Stri
                 skip_next = false;
                 continue;
             }
-            if is_codex && idx == 0 && a.eq_ignore_ascii_case("resume") {
-                if args
+            if is_codex && idx == 0 && a.eq_ignore_ascii_case("resume")
+                && args
                     .get(1)
                     .is_some_and(|next| next.eq_ignore_ascii_case("--last"))
                 {
                     continue;
                 }
-            }
             if is_codex
                 && idx == 1
                 && args

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -384,20 +384,21 @@ mod tests {
     use super::{validate_agent_commands, AgentConfig, AppSettings};
 
     fn settings_with_agents(commands: &[(&str, &str)]) -> AppSettings {
-        let mut settings = AppSettings::default();
-        settings.agents = commands
-            .iter()
-            .enumerate()
-            .map(|(idx, (label, command))| AgentConfig {
-                id: format!("agent-{idx}"),
-                label: (*label).to_string(),
-                command: (*command).to_string(),
-                color: "#000000".to_string(),
-                git_pull_before: false,
-                exclude_global_claude_md: false,
-            })
-            .collect();
-        settings
+        AppSettings {
+            agents: commands
+                .iter()
+                .enumerate()
+                .map(|(idx, (label, command))| AgentConfig {
+                    id: format!("agent-{idx}"),
+                    label: (*label).to_string(),
+                    command: (*command).to_string(),
+                    color: "#000000".to_string(),
+                    git_pull_before: false,
+                    exclude_global_claude_md: false,
+                })
+                .collect(),
+            ..AppSettings::default()
+        }
     }
 
     #[test]

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -497,6 +497,133 @@ pub fn can_communicate(from: &str, to: &str, teams: &[DiscoveredTeam]) -> bool {
     false
 }
 
+/// Discover all teams from all known project paths.
+/// Scans settings.project_paths (and immediate children) for `.ac-new/_team_*/config.json`.
+pub fn discover_teams() -> Vec<DiscoveredTeam> {
+    let settings = crate::config::settings::load_settings();
+    let mut teams = Vec::new();
+
+    for repo_path in &settings.project_paths {
+        let base = Path::new(repo_path);
+        if !base.is_dir() {
+            continue;
+        }
+
+        // Check base and immediate children (same pattern as ac_discovery)
+        let mut dirs_to_check = vec![base.to_path_buf()];
+        if let Ok(entries) = std::fs::read_dir(base) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    if !name.starts_with('.') {
+                        dirs_to_check.push(p);
+                    }
+                }
+            }
+        }
+
+        for project_dir in dirs_to_check {
+            discover_teams_in_project(&project_dir, &mut teams);
+        }
+    }
+
+    log::info!(
+        "[teams] discovered {} team(s) across {} project path(s)",
+        teams.len(),
+        settings.project_paths.len()
+    );
+    teams
+}
+
+/// Discover teams in a single project directory.
+fn discover_teams_in_project(project_dir: &Path, teams: &mut Vec<DiscoveredTeam>) {
+    let ac_new = project_dir.join(".ac-new");
+    if !ac_new.is_dir() {
+        return;
+    }
+
+    let project_folder = project_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let entries = match std::fs::read_dir(&ac_new) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let team_dir = entry.path();
+        if !team_dir.is_dir() {
+            continue;
+        }
+
+        let dir_name = match team_dir.file_name().and_then(|n| n.to_str()) {
+            Some(n) if n.starts_with("_team_") => n,
+            _ => continue,
+        };
+
+        let team_name = dir_name
+            .strip_prefix("_team_")
+            .unwrap_or(dir_name)
+            .to_string();
+
+        let config_path = team_dir.join("config.json");
+        let parsed: serde_json::Value = match std::fs::read_to_string(&config_path)
+            .ok()
+            .and_then(|c| serde_json::from_str(&c).ok())
+        {
+            Some(v) => v,
+            None => continue,
+        };
+
+        // Resolve agents — build names and paths in a single pass to keep indices aligned
+        let agent_refs: Vec<String> = parsed
+            .get("agents")
+            .and_then(|a| a.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let (agent_names, agent_paths): (Vec<String>, Vec<Option<PathBuf>>) = agent_refs
+            .iter()
+            .map(|r| {
+                let name = resolve_agent_ref(&project_folder, r);
+                let path = resolve_agent_path(&ac_new, r);
+                (name, path)
+            })
+            .unzip();
+
+        // Resolve coordinator
+        let coordinator_ref = parsed
+            .get("coordinator")
+            .and_then(|c| c.as_str())
+            .map(String::from);
+
+        let coordinator_name = coordinator_ref
+            .as_ref()
+            .map(|r| resolve_agent_ref(&project_folder, r));
+
+        let coordinator_path = coordinator_ref
+            .as_ref()
+            .and_then(|r| resolve_agent_path(&ac_new, r));
+
+        teams.push(DiscoveredTeam {
+            name: team_name,
+            project: project_folder.clone(),
+            agent_names,
+            agent_paths,
+            coordinator_name,
+            coordinator_path,
+        });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -599,6 +726,9 @@ mod tests {
 
     /// Build a fake project layout on disk so `resolve_agent_target` can scan it.
     /// `projects` is a slice of `(project_name, &[(wg_name, &[agent_short])])`.
+    // The nested-slice shape is the most direct way to express the fixture; a
+    // type alias would obscure the structure at the only call sites.
+    #[allow(clippy::type_complexity)]
     fn make_project_fixture(
         projects: &[(&str, &[(&str, &[&str])])],
     ) -> (FixtureRoot, Vec<String>) {
@@ -849,138 +979,11 @@ mod tests {
     /// authority even if the local part matches. Locks in the §DR8/§G13 call.
     #[test]
     fn is_coordinator_rejects_legacy_unqualified_from() {
-        let teams = vec![dev_team("proj-a")];
+        let teams = [dev_team("proj-a")];
         // Legacy-unqualified name — local part matches the team coordinator, but
         // with no project prefix the strict rule rejects.
         assert!(!is_coordinator("wg-1-dev-team/tech-lead", &teams[0]));
         // For completeness, the fully-qualified form DOES grant authority.
         assert!(is_coordinator("proj-a:wg-1-dev-team/tech-lead", &teams[0]));
-    }
-}
-
-/// Discover all teams from all known project paths.
-/// Scans settings.project_paths (and immediate children) for `.ac-new/_team_*/config.json`.
-pub fn discover_teams() -> Vec<DiscoveredTeam> {
-    let settings = crate::config::settings::load_settings();
-    let mut teams = Vec::new();
-
-    for repo_path in &settings.project_paths {
-        let base = Path::new(repo_path);
-        if !base.is_dir() {
-            continue;
-        }
-
-        // Check base and immediate children (same pattern as ac_discovery)
-        let mut dirs_to_check = vec![base.to_path_buf()];
-        if let Ok(entries) = std::fs::read_dir(base) {
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.is_dir() {
-                    let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                    if !name.starts_with('.') {
-                        dirs_to_check.push(p);
-                    }
-                }
-            }
-        }
-
-        for project_dir in dirs_to_check {
-            discover_teams_in_project(&project_dir, &mut teams);
-        }
-    }
-
-    log::info!(
-        "[teams] discovered {} team(s) across {} project path(s)",
-        teams.len(),
-        settings.project_paths.len()
-    );
-    teams
-}
-
-/// Discover teams in a single project directory.
-fn discover_teams_in_project(project_dir: &Path, teams: &mut Vec<DiscoveredTeam>) {
-    let ac_new = project_dir.join(".ac-new");
-    if !ac_new.is_dir() {
-        return;
-    }
-
-    let project_folder = project_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown")
-        .to_string();
-
-    let entries = match std::fs::read_dir(&ac_new) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
-
-    for entry in entries.flatten() {
-        let team_dir = entry.path();
-        if !team_dir.is_dir() {
-            continue;
-        }
-
-        let dir_name = match team_dir.file_name().and_then(|n| n.to_str()) {
-            Some(n) if n.starts_with("_team_") => n,
-            _ => continue,
-        };
-
-        let team_name = dir_name
-            .strip_prefix("_team_")
-            .unwrap_or(dir_name)
-            .to_string();
-
-        let config_path = team_dir.join("config.json");
-        let parsed: serde_json::Value = match std::fs::read_to_string(&config_path)
-            .ok()
-            .and_then(|c| serde_json::from_str(&c).ok())
-        {
-            Some(v) => v,
-            None => continue,
-        };
-
-        // Resolve agents — build names and paths in a single pass to keep indices aligned
-        let agent_refs: Vec<String> = parsed
-            .get("agents")
-            .and_then(|a| a.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let (agent_names, agent_paths): (Vec<String>, Vec<Option<PathBuf>>) = agent_refs
-            .iter()
-            .map(|r| {
-                let name = resolve_agent_ref(&project_folder, r);
-                let path = resolve_agent_path(&ac_new, r);
-                (name, path)
-            })
-            .unzip();
-
-        // Resolve coordinator
-        let coordinator_ref = parsed
-            .get("coordinator")
-            .and_then(|c| c.as_str())
-            .map(String::from);
-
-        let coordinator_name = coordinator_ref
-            .as_ref()
-            .map(|r| resolve_agent_ref(&project_folder, r));
-
-        let coordinator_path = coordinator_ref
-            .as_ref()
-            .and_then(|r| resolve_agent_path(&ac_new, r));
-
-        teams.push(DiscoveredTeam {
-            name: team_name,
-            project: project_folder.clone(),
-            agent_names,
-            agent_paths,
-            coordinator_name,
-            coordinator_path,
-        });
     }
 }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -98,6 +98,12 @@ pub struct MailboxPoller {
     retry_tracker: HashMap<PathBuf, RetryState>,
 }
 
+impl Default for MailboxPoller {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MailboxPoller {
     pub fn new() -> Self {
         Self {
@@ -1396,7 +1402,7 @@ impl MailboxPoller {
         let full_cmd = format!("{} {}", shell, shell_args.join(" "));
         let basenames: Vec<String> = full_cmd
             .split_whitespace()
-            .map(|t| crate::commands::session::executable_basename(t))
+            .map(crate::commands::session::executable_basename)
             .collect();
 
         if basenames.iter().any(|b| b == "claude" || b == "aider") {

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -274,6 +274,9 @@ impl PtyManager {
         }
     }
 
+    // PTY spawn requires the full set of session knobs at once; splitting into a
+    // builder would just add ceremony for no reuse.
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         &self,
         id: Uuid,

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -13,6 +13,12 @@ pub struct SessionManager {
     next_number: Arc<RwLock<u32>>,
 }
 
+impl Default for SessionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SessionManager {
     pub fn new() -> Self {
         Self {
@@ -23,6 +29,9 @@ impl SessionManager {
         }
     }
 
+    // Session record is created with the full set of fields up front; splitting
+    // into a builder would just defer the same parameter list.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_session(
         &self,
         shell: String,

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,2 +1,4 @@
 pub mod manager;
+// Inner module shares the parent name; renaming would churn every import.
+#[allow(clippy::module_inception)]
 pub mod session;

--- a/src-tauri/src/shutdown.rs
+++ b/src-tauri/src/shutdown.rs
@@ -14,11 +14,18 @@ use tokio_util::sync::CancellationToken;
 /// - Wake-and-sleep cleanup loops (phone/mailbox.rs) — async, up to 600s timeout
 /// - Follow-up injection loops (phone/mailbox.rs) — async, up to 30s timeout
 /// - Credential injection (commands/session.rs) — one-shot async, 2s sleep
+///
 /// These run on Tauri's tokio runtime and are force-cancelled on runtime drop.
 #[derive(Clone)]
 pub struct ShutdownSignal {
     token: CancellationToken,
     flag: Arc<AtomicBool>,
+}
+
+impl Default for ShutdownSignal {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ShutdownSignal {

--- a/src-tauri/src/telegram/bridge.rs
+++ b/src-tauri/src/telegram/bridge.rs
@@ -592,6 +592,9 @@ async fn output_task(
 
 // ── Flush to Telegram ────────────────────────────────────────
 
+// Threads through the full bridge state on each flush; collapsing into a
+// struct would only move the fields, not reduce them.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn flush_buffer(
     buffer: &mut String,
     client: &reqwest::Client,

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -32,6 +32,9 @@ struct AppState {
 
 /// Start the embedded HTTP/WebSocket server.
 /// Called from Tauri's setup() — runs on the same tokio runtime.
+// Wired by a single setup() call with all shared state already in scope; an
+// args struct would just rename the same fields.
+#[allow(clippy::too_many_arguments)]
 pub fn start_server(
     bind: String,
     port: u16,


### PR DESCRIPTION
## Summary

Pre-existing `cargo clippy` warnings on `src-tauri/` swept clean. **39 → 0** lints with `-D warnings`. Zero behavior change.

## What changed

- `cargo clippy --fix --allow-dirty --allow-staged --all-targets` for mechanical lints.
- Manual cleanup for lints that don't auto-fix: `unnecessary_filter_map → map`, `cloned_ref_to_slice_refs → std::slice::from_ref`, `doc_lazy_continuation` (×7), `field_reassign_with_default` (×2 in test helpers).
- 11 `#[allow(...)]` added with inline justification:
  - `clippy::too_many_arguments` (×9): Tauri command handlers and tightly-coupled helpers where collapsing args into a context struct would just rename fields without simplification.
  - `clippy::module_inception` (×1): `session/session.rs` — refactor would churn imports project-wide.
  - `clippy::type_complexity` (×1): test fixture, test-only.

## Diff

- 18 files modified, all under `src-tauri/src/`.
- +229 / -179 lines (large delta in `config/teams.rs` is purely `items_after_test_module` reorder — same code, moved before `mod tests`).

## Verification

- `cargo clippy --all-targets -- -D warnings` → exit 0.
- `cargo check --all-targets` → exit 0.
- `cargo test --all-targets` → 122 passed, 0 failed (6 ignored, all pre-existing integration tests requiring Tauri AppHandle).
- Independent grinch review: APPROVED, zero findings.

Closes #91