### PR TITLE
feat(modals): Enter submits brief/description, Shift+Enter inserts newline (#108)

### DIFF
--- a/src/sidebar/components/NewEntityAgentModal.tsx
+++ b/src/sidebar/components/NewEntityAgentModal.tsx
@@ -25,17 +25,18 @@ const NewEntityAgentModal: Component<{
       await EntityAPI.createAgentMatrix(props.projectPath, name().trim(), description().trim());
       await projectStore.reloadProject(props.projectPath);
       props.onClose();
+      // intentionally do NOT clear creating() — modal unmounts; any in-flight
+      // keydown event in the close transition stays guarded.
     } catch (e: any) {
       console.error("create_agent_matrix failed:", e);
       setError(typeof e === "string" ? e : e.message || "Failed to create agent");
-    } finally {
       setCreating(false);
     }
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Escape") props.onClose();
-    if (e.key === "Enter" && !e.shiftKey && !(e.target instanceof HTMLTextAreaElement)) {
+    if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
       e.preventDefault();
       handleCreate();
     }
@@ -74,10 +75,14 @@ const NewEntityAgentModal: Component<{
               placeholder="What does this agent do? (optional, max 250 chars)"
               maxLength={250}
               rows={3}
+              aria-describedby="description-keyhint"
             />
-            <Show when={description().length > 0}>
-              <span class="entity-char-count">{description().length}/250</span>
-            </Show>
+            <div class="entity-textarea-meta">
+              <span id="description-keyhint" class="entity-textarea-hint">Enter to create · Shift+Enter for newline</span>
+              <Show when={description().length > 0}>
+                <span class="entity-char-count">{description().length}/250</span>
+              </Show>
+            </div>
           </div>
 
           <Show when={error()}>
@@ -86,7 +91,7 @@ const NewEntityAgentModal: Component<{
         </div>
 
         <div class="new-agent-footer">
-          <button class="new-agent-cancel-btn" onClick={() => props.onClose()}>Cancel</button>
+          <button type="button" class="new-agent-cancel-btn" onClick={() => props.onClose()}>Cancel</button>
           <button
             class="new-agent-create-btn"
             disabled={!canCreate() || creating()}

--- a/src/sidebar/components/NewWorkgroupModal.tsx
+++ b/src/sidebar/components/NewWorkgroupModal.tsx
@@ -29,17 +29,18 @@ const NewWorkgroupModal: Component<{
       );
       await projectStore.reloadProject(props.projectPath);
       props.onClose();
+      // intentionally do NOT clear creating() — modal unmounts; any in-flight
+      // keydown event in the close transition stays guarded.
     } catch (e: any) {
       console.error("create_workgroup failed:", e);
       setError(typeof e === "string" ? e : e.message || "Failed to create workgroup");
-    } finally {
       setCreating(false);
     }
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Escape") props.onClose();
-    if (e.key === "Enter" && !e.shiftKey && !(e.target instanceof HTMLTextAreaElement)) {
+    if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
       e.preventDefault();
       handleCreate();
     }
@@ -81,7 +82,12 @@ const NewWorkgroupModal: Component<{
               onInput={(e) => setBrief(e.currentTarget.value)}
               placeholder="Describe the task for this workgroup..."
               rows={4}
+              autofocus
+              aria-describedby="brief-keyhint"
             />
+            <div class="entity-textarea-meta">
+              <span id="brief-keyhint" class="entity-textarea-hint">Enter to create · Shift+Enter for newline</span>
+            </div>
           </div>
 
           <Show when={creating()}>
@@ -94,7 +100,7 @@ const NewWorkgroupModal: Component<{
         </div>
 
         <div class="new-agent-footer">
-          <button class="new-agent-cancel-btn" onClick={() => props.onClose()} disabled={creating()}>Cancel</button>
+          <button type="button" class="new-agent-cancel-btn" onClick={() => props.onClose()} disabled={creating()}>Cancel</button>
           <button
             class="new-agent-create-btn"
             disabled={!canCreate() || creating()}

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -4066,8 +4066,22 @@ html.light-theme[data-sidebar-style="neon-circuit"] .coord-quick-access {
 .entity-char-count {
   font-size: 9px;
   color: var(--sidebar-fg-dim);
-  text-align: right;
   opacity: 0.6;
+}
+
+.entity-textarea-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  min-height: 12px;
+}
+
+.entity-textarea-hint {
+  font-size: 9px;
+  color: var(--sidebar-fg-dim);
+  opacity: 0.6;
+  font-style: italic;
 }
 
 .entity-select {


### PR DESCRIPTION
## Summary

- Brief textarea (NewWorkgroupModal) and Description textarea (NewEntityAgentModal) now submit on **Enter** and insert a newline on **Shift+Enter** — previously Enter was inert inside textareas.
- Closed an auto-repeat race on Enter-hold: `setCreating(false)` is no longer cleared in a `finally` block; on success the modal unmounts (Portal teardown drops the signal), on failure it's cleared in `catch` after the error is set.
- First-open keyboard reachability fixed for NewWorkgroupModal: Brief textarea now `autofocus`es so Solid's delegated keydown handler receives the event without a prior click.
- Visual hint `Enter to create · Shift+Enter for newline` (U+00B7) added under both textareas, with `aria-describedby` wiring for screen readers.
- Defensive: `type="button"` on both Cancel buttons.

## Implementation pipeline

- Architect plan v2 (`_plans/108-brief-modal-enter-submit.md`) — 2 rounds, consensus from architect + dev-webpage-ui + dev-rust-grinch.
- Single bundled commit `ef2b732`: 3 files, +35/-10. `npx tsc --noEmit` clean. Multi-agent code-review (parallel reviewers) found zero HIGH severity issues.
- Build deployed locally: 22.20 MB exe, frontend embedded; manual UI verification confirmed by user.

## Test plan

- [x] Type-check: `npx tsc --noEmit` — clean.
- [x] Build: `npx tauri build` — success, 22.20 MB exe (frontend embedded).
- [x] Manual UI test — user confirmed Enter creates / Shift+Enter inserts newline in both modals.
- [ ] Auto-repeat race test (hold Enter for 1 s with empty/invalid input — should not double-submit) — covered by code change, not re-tested manually.
- [ ] Screen reader hint readout (NVDA/JAWS/VoiceOver) — not tested, ARIA wiring in place.

Closes #108