### PR TITLE
feat(sidebar): team idle beep on busy->all-idle transition (#110)

### DIFF
--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -59,6 +59,10 @@ pub struct AppSettings {
     /// Keep sidebar window always on top
     #[serde(default)]
     pub sidebar_always_on_top: bool,
+    /// When true, play a short beep when an entire team transitions from
+    /// busy→all-idle. The transition is computed in the FE from `waitingForInput`.
+    #[serde(default = "default_true")]
+    pub team_idle_beep_enabled: bool,
     /// Raise terminal window when sidebar is clicked
     #[serde(default = "default_true")]
     pub raise_terminal_on_click: bool,
@@ -208,6 +212,7 @@ impl Default for AppSettings {
             telegram_bots: vec![],
             start_only_coordinators: true,
             sidebar_always_on_top: false,
+            team_idle_beep_enabled: true,
             raise_terminal_on_click: true,
             voice_to_text_enabled: false,
             gemini_api_key: String::new(),
@@ -560,6 +565,57 @@ mod tests {
         let settings =
             settings_with_agents(&[("Codex", "codex -c instruction=\"resume later\" --search")]);
         assert!(validate_agent_commands(&settings).is_ok());
+    }
+
+    #[test]
+    fn team_idle_beep_enabled_round_trips_through_serde() {
+        let mut s = AppSettings::default();
+        assert!(s.team_idle_beep_enabled);
+        s.team_idle_beep_enabled = false;
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert!(json.contains("\"teamIdleBeepEnabled\":false"));
+        let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
+        assert!(!back.team_idle_beep_enabled);
+    }
+
+    #[test]
+    fn team_idle_beep_enabled_defaults_true_when_missing_from_json() {
+        // Old settings.json without the new field must deserialize to true (default_true).
+        let json = r#"{
+            "defaultShell": "bash",
+            "defaultShellArgs": [],
+            "agents": [],
+            "telegramBots": [],
+            "startOnlyCoordinators": true,
+            "sidebarAlwaysOnTop": false,
+            "raiseTerminalOnClick": true,
+            "voiceToTextEnabled": false,
+            "geminiApiKey": "",
+            "geminiModel": "gemini-2.5-flash",
+            "voiceAutoExecute": true,
+            "voiceAutoExecuteDelay": 15,
+            "sidebarZoom": 1.0,
+            "terminalZoom": 1.0,
+            "mainZoom": 1.0,
+            "guideZoom": 1.0,
+            "darkfactoryZoom": 1.0,
+            "sidebarGeometry": null,
+            "terminalGeometry": null,
+            "mainGeometry": null,
+            "mainSidebarWidth": 280.0,
+            "mainSidebarSide": "right",
+            "mainAlwaysOnTop": false,
+            "webServerEnabled": false,
+            "webServerPort": 7777,
+            "webServerBind": "127.0.0.1",
+            "projectPath": null,
+            "projectPaths": [],
+            "sidebarStyle": "noir-minimal",
+            "onboardingDismissed": false,
+            "coordSortByActivity": false
+        }"#;
+        let s: AppSettings = serde_json::from_str(json).expect("deserialize old json");
+        assert!(s.team_idle_beep_enabled);
     }
 
     #[test]

--- a/src/shared/sound.ts
+++ b/src/shared/sound.ts
@@ -4,6 +4,14 @@
 
 let cachedContext: AudioContext | null = null;
 
+// Coalesce window for back-to-back beep calls. When several workgroups
+// transition to idle in the same effect tick, the watcher fires
+// playTeamIdleBeep() multiple times synchronously; without coalescing,
+// the oscillators stack at the same currentTime and sum to N× peak
+// gain (loud, harsh chord instead of one soft tone).
+const COALESCE_WINDOW_S = 0.03;
+let lastBeepStartedAt = Number.NEGATIVE_INFINITY;
+
 function getAudioContext(): AudioContext | null {
   if (cachedContext) return cachedContext;
   const Ctor =
@@ -54,6 +62,9 @@ export async function playTeamIdleBeep(): Promise<void> {
   }
 
   const now = ctx.currentTime;
+  if (now - lastBeepStartedAt < COALESCE_WINDOW_S) return;
+  lastBeepStartedAt = now;
+
   scheduleTone(ctx, 660, now, 0.12);
   scheduleTone(ctx, 880, now + 0.13, 0.14);
 }

--- a/src/shared/sound.ts
+++ b/src/shared/sound.ts
@@ -1,0 +1,86 @@
+// Audio playback utilities. Synthesized via Web Audio API to avoid
+// bundling a binary asset and to render identically across the Tauri
+// webview and the browser-served WS transport.
+
+let cachedContext: AudioContext | null = null;
+
+function getAudioContext(): AudioContext | null {
+  if (cachedContext) return cachedContext;
+  const Ctor =
+    window.AudioContext ??
+    (window as unknown as { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext;
+  if (!Ctor) return null;
+  cachedContext = new Ctor();
+  return cachedContext;
+}
+
+// Chromium-based webviews (incl. Tauri) start AudioContext in "suspended"
+// until a user gesture. If the very first beep fires before the user
+// has clicked or typed inside the window, ctx.resume() rejects silently.
+// Pre-arming on the first global gesture unlocks the context so later
+// beeps play even if the user has alt-tabbed away by then.
+export function primeAudio(): void {
+  const unlock = () => {
+    const ctx = getAudioContext();
+    if (ctx && ctx.state === "suspended") {
+      ctx.resume().catch(() => {});
+    }
+  };
+  window.addEventListener("mousedown", unlock, { once: true });
+  window.addEventListener("keydown", unlock, { once: true });
+  window.addEventListener("touchstart", unlock, { once: true });
+}
+
+/**
+ * Soft two-step beep that fires when an entire team transitions from
+ * busy → all-idle. Two short tones (660 Hz then 880 Hz, ~120 ms each)
+ * with a quick attack/release envelope so it doesn't click. Total under
+ * ~280 ms — short enough not to be annoying, distinct enough to register
+ * as "team finished".
+ *
+ * Errors (no AudioContext, suspended context that can't be resumed) are
+ * swallowed — failing to beep must never break the FE.
+ */
+export async function playTeamIdleBeep(): Promise<void> {
+  const ctx = getAudioContext();
+  if (!ctx) return;
+  if (ctx.state === "suspended") {
+    try {
+      await ctx.resume();
+    } catch {
+      return;
+    }
+  }
+
+  const now = ctx.currentTime;
+  scheduleTone(ctx, 660, now, 0.12);
+  scheduleTone(ctx, 880, now + 0.13, 0.14);
+}
+
+function scheduleTone(
+  ctx: AudioContext,
+  frequency: number,
+  startTime: number,
+  duration: number,
+): void {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  osc.type = "sine";
+  osc.frequency.value = frequency;
+
+  const peakGain = 0.12;
+  const attack = 0.012;
+  const release = 0.06;
+  gain.gain.setValueAtTime(0, startTime);
+  gain.gain.linearRampToValueAtTime(peakGain, startTime + attack);
+  gain.gain.setValueAtTime(peakGain, startTime + duration - release);
+  gain.gain.linearRampToValueAtTime(0, startTime + duration);
+
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+
+  osc.start(startTime);
+  osc.stop(startTime + duration + 0.02);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -131,6 +131,7 @@ export interface AppSettings {
   startOnlyCoordinators: boolean;
   sidebarAlwaysOnTop: boolean;
   raiseTerminalOnClick: boolean;
+  teamIdleBeepEnabled: boolean;
   voiceToTextEnabled: boolean;
   geminiApiKey: string;
   geminiModel: string;

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -28,6 +28,8 @@ import { applyWindowLayout } from "../shared/window-layout";
 import { sessionsStore } from "./stores/sessions";
 import { bridgesStore } from "./stores/bridges";
 import { projectStore } from "./stores/project";
+import { startTeamIdleWatcher } from "./stores/team-idle-watcher";
+import { primeAudio } from "../shared/sound";
 import { settingsStore } from "../shared/stores/settings";
 import Titlebar from "./components/Titlebar";
 import ActionBar from "./components/ActionBar";
@@ -50,6 +52,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
   let shortcutHandler: ((e: KeyboardEvent) => void) | null = null;
   let cleanupZoom: (() => void) | null = null;
   let cleanupGeometry: (() => void) | null = null;
+  let stopTeamIdleWatcher: (() => void) | null = null;
   let raiseTerminalEnabled = true;
   let lastRaiseTime = 0;
   const blockContextMenu = (e: Event) => {
@@ -110,6 +113,15 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
 
     // Load settings into reactive store (for voice-to-text visibility etc.)
     await settingsStore.load();
+
+    // Feature #110 — start watching for team busy→all-idle transitions.
+    // Mounted after settingsStore.load() so the very first effect run
+    // already sees the user's teamIdleBeepEnabled choice; the watcher's
+    // own initialization guard separately suppresses any startup beep.
+    // primeAudio() arms the AudioContext on first user gesture so the
+    // very first beep isn't swallowed by browser autoplay policy.
+    primeAudio();
+    stopTeamIdleWatcher = startTeamIdleWatcher();
 
     // First-run: show onboarding if no coding agents configured and not previously dismissed
     if (
@@ -248,6 +260,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     if (shortcutHandler) unregisterShortcuts(shortcutHandler);
     if (cleanupZoom) cleanupZoom();
     if (cleanupGeometry) cleanupGeometry();
+    if (stopTeamIdleWatcher) stopTeamIdleWatcher();
     document.removeEventListener("mousedown", handleRaiseTerminal);
     document.removeEventListener("contextmenu", blockContextMenu);
   });

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -428,6 +428,21 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
         </Show>
       </div>
 
+      <div class="settings-section">
+        <div class="settings-section-title">Notifications</div>
+        <label class="settings-checkbox-field">
+          <input
+            type="checkbox"
+            class="settings-checkbox"
+            checked={settings.data!.teamIdleBeepEnabled}
+            onChange={(e) =>
+              updateField("teamIdleBeepEnabled", e.currentTarget.checked)
+            }
+          />
+          <span>Beep when a team finishes working (all agents idle)</span>
+        </label>
+      </div>
+
     </>
   );
 

--- a/src/sidebar/stores/team-idle-watcher.ts
+++ b/src/sidebar/stores/team-idle-watcher.ts
@@ -1,0 +1,94 @@
+// Per-workgroup busy→all-idle transition detector for Feature #110.
+// Why createRoot: the watcher is started from inside an async onMount in
+// SidebarApp; by the time we reach `await settingsStore.load()` the
+// synchronous reactive owner is gone. createRoot gives the effect its
+// own owner and an explicit dispose we can call from onCleanup.
+
+import { createEffect, createRoot } from "solid-js";
+import type { Session } from "../../shared/types";
+import { playTeamIdleBeep } from "../../shared/sound";
+import { settingsStore } from "../../shared/stores/settings";
+import { sessionsStore } from "./sessions";
+import { projectStore } from "./project";
+
+function isBusy(session: Session): boolean {
+  const status = session.status;
+  if (typeof status === "object" && status !== null && "exited" in status) {
+    return false;
+  }
+  return !session.waitingForInput;
+}
+
+// "Workgroup" is the granular unit users see in the sidebar — each
+// workgroup is a concrete instance of a team config (e.g. wg-6-dev-team)
+// with its own replica set. Sessions match replicas by name
+// `${wg.name}/${replica.name}` (the same scheme ProjectPanel uses).
+// We key the busy map by `wg.path` (filesystem path), which is unique
+// across all projects and stable across re-discovery.
+function computeBusyByWorkgroup(): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>();
+  for (const project of projectStore.projects) {
+    for (const wg of project.workgroups) {
+      const busy = new Set<string>();
+      for (const replica of wg.agents) {
+        const session = sessionsStore.findSessionByName(
+          `${wg.name}/${replica.name}`,
+        );
+        if (session && isBusy(session)) {
+          busy.add(session.id);
+        }
+      }
+      result.set(wg.path, busy);
+    }
+  }
+  return result;
+}
+
+/**
+ * Start the watcher. Returns a dispose function; call from SidebarApp's
+ * onCleanup. The first effect run snapshots state without firing — this
+ * is the "no beep at startup" rule from #110. Subsequent runs compare
+ * the busy set per workgroup against the previous snapshot and fire the
+ * beep on any non-empty → empty transition (when the setting is enabled).
+ */
+export function startTeamIdleWatcher(): () => void {
+  return createRoot((dispose) => {
+    const previousBusyByWg = new Map<string, Set<string>>();
+    let initialized = false;
+
+    createEffect(() => {
+      // Touch reactive sources so the effect re-runs on each change.
+      // computeBusyByWorkgroup reads them too, but reading here makes
+      // the dependency explicit for future maintainers.
+      void sessionsStore.sessions;
+      void projectStore.projects;
+      const enabled = settingsStore.current?.teamIdleBeepEnabled ?? true;
+
+      const currentBusyByWg = computeBusyByWorkgroup();
+
+      if (!initialized) {
+        initialized = true;
+        for (const [key, busy] of currentBusyByWg) {
+          previousBusyByWg.set(key, busy);
+        }
+        return;
+      }
+
+      if (enabled) {
+        for (const [key, currentBusy] of currentBusyByWg) {
+          const previousBusy = previousBusyByWg.get(key);
+          if (previousBusy && previousBusy.size > 0 && currentBusy.size === 0) {
+            void playTeamIdleBeep();
+          }
+        }
+      }
+
+      previousBusyByWg.clear();
+      for (const [key, busy] of currentBusyByWg) {
+        previousBusyByWg.set(key, busy);
+      }
+    });
+
+    return dispose;
+  });
+}

--- a/src/sidebar/stores/team-idle-watcher.ts
+++ b/src/sidebar/stores/team-idle-watcher.ts
@@ -1,8 +1,34 @@
 // Per-workgroup busy→all-idle transition detector for Feature #110.
-// Why createRoot: the watcher is started from inside an async onMount in
-// SidebarApp; by the time we reach `await settingsStore.load()` the
-// synchronous reactive owner is gone. createRoot gives the effect its
-// own owner and an explicit dispose we can call from onCleanup.
+//
+// **Spec deviation:** issue #110 calls for per-*team* aggregation, but
+// `sessionsStore.state.teams` is currently dead code — `setTeams()` is
+// defined but never called from anywhere in the repo. We aggregate by
+// workgroup instead, sourcing from `projectStore.projects[].workgroups[]`
+// (the live data path that ProjectPanel/TeamFilter actually use).
+// **If teams become live (someone wires up `setTeams`), revisit this
+// aggregation** — the right unit may be the team-config rather than the
+// workgroup instance.
+//
+// **Why per-session previous-busy tracking** (instead of a busy *set*
+// diff): "session destroyed", "session exited", and "session renamed"
+// all collapse to "session left the aggregation" under a set-diff
+// model, which would fire spurious beeps on user kills, exit-0
+// processes, and rename events. Tracking each session's busy flag from
+// the previous tick lets us require a *genuine* busy→idle flip on a
+// still-alive bound session before we consider beeping.
+//
+// **Why a stable sessionId→wgPath binding**: sessions match replicas
+// by name `${wg.name}/${replica.name}` at creation, but can be renamed
+// later. Resolving the binding on every effect run by name means a
+// busy session whose name changes drops out of its workgroup's
+// aggregation, which is exactly the bug above. We bind once on first
+// observation and never unbind, so rename-while-busy is harmless.
+//
+// **Why createRoot**: the watcher is started from inside an async
+// onMount in SidebarApp; by the time we reach `await
+// settingsStore.load()` the synchronous reactive owner is gone.
+// createRoot gives the effect its own owner and an explicit dispose
+// we can call from onCleanup.
 
 import { createEffect, createRoot } from "solid-js";
 import type { Session } from "../../shared/types";
@@ -11,81 +37,131 @@ import { settingsStore } from "../../shared/stores/settings";
 import { sessionsStore } from "./sessions";
 import { projectStore } from "./project";
 
-function isBusy(session: Session): boolean {
-  const status = session.status;
-  if (typeof status === "object" && status !== null && "exited" in status) {
-    return false;
-  }
-  return !session.waitingForInput;
+function isExited(status: Session["status"]): boolean {
+  return typeof status === "object" && status !== null && "exited" in status;
 }
 
-// "Workgroup" is the granular unit users see in the sidebar — each
-// workgroup is a concrete instance of a team config (e.g. wg-6-dev-team)
-// with its own replica set. Sessions match replicas by name
-// `${wg.name}/${replica.name}` (the same scheme ProjectPanel uses).
-// We key the busy map by `wg.path` (filesystem path), which is unique
-// across all projects and stable across re-discovery.
-function computeBusyByWorkgroup(): Map<string, Set<string>> {
-  const result = new Map<string, Set<string>>();
-  for (const project of projectStore.projects) {
-    for (const wg of project.workgroups) {
-      const busy = new Set<string>();
-      for (const replica of wg.agents) {
-        const session = sessionsStore.findSessionByName(
-          `${wg.name}/${replica.name}`,
-        );
-        if (session && isBusy(session)) {
-          busy.add(session.id);
-        }
-      }
-      result.set(wg.path, busy);
-    }
-  }
-  return result;
+function isBusy(session: Session): boolean {
+  if (isExited(session.status)) return false;
+  return !session.waitingForInput;
 }
 
 /**
  * Start the watcher. Returns a dispose function; call from SidebarApp's
- * onCleanup. The first effect run snapshots state without firing — this
- * is the "no beep at startup" rule from #110. Subsequent runs compare
- * the busy set per workgroup against the previous snapshot and fire the
- * beep on any non-empty → empty transition (when the setting is enabled).
+ * onCleanup.
+ *
+ * Behavior on first effect run: snapshot only, no beep (the "no beep
+ * at startup" rule). Subsequent runs fire `playTeamIdleBeep()` for any
+ * workgroup that meets ALL of:
+ *   - At least one session bound to the workgroup, alive last tick,
+ *     was busy then and is alive + idle now (genuine transition).
+ *   - All currently-bound, currently-alive sessions in the workgroup
+ *     are idle.
+ *   - The user setting `teamIdleBeepEnabled` is true.
  */
 export function startTeamIdleWatcher(): () => void {
   return createRoot((dispose) => {
-    const previousBusyByWg = new Map<string, Set<string>>();
+    // sessionId -> wg.path. Populated on first observation of each
+    // session and never overwritten — protects against rename.
+    const sessionToWg = new Map<string, string>();
+
+    // wg.path -> Map<sessionId, wasBusy>. The inner map records each
+    // bound, alive session's isBusy from the previous tick. Sessions
+    // that were not alive last tick (destroyed/exited) won't appear.
+    const previousByWg = new Map<string, Map<string, boolean>>();
+
     let initialized = false;
 
     createEffect(() => {
-      // Touch reactive sources so the effect re-runs on each change.
-      // computeBusyByWorkgroup reads them too, but reading here makes
-      // the dependency explicit for future maintainers.
-      void sessionsStore.sessions;
-      void projectStore.projects;
+      const sessions = sessionsStore.sessions;
+      const projects = projectStore.projects;
       const enabled = settingsStore.current?.teamIdleBeepEnabled ?? true;
 
-      const currentBusyByWg = computeBusyByWorkgroup();
-
-      if (!initialized) {
-        initialized = true;
-        for (const [key, busy] of currentBusyByWg) {
-          previousBusyByWg.set(key, busy);
-        }
-        return;
-      }
-
-      if (enabled) {
-        for (const [key, currentBusy] of currentBusyByWg) {
-          const previousBusy = previousBusyByWg.get(key);
-          if (previousBusy && previousBusy.size > 0 && currentBusy.size === 0) {
-            void playTeamIdleBeep();
+      // 1. Augment bindings (never unbind). Iterate workgroups and
+      //    bind any newly-discovered replica-session pairs by name.
+      for (const project of projects) {
+        for (const wg of project.workgroups) {
+          for (const replica of wg.agents) {
+            const session = sessionsStore.findSessionByName(
+              `${wg.name}/${replica.name}`,
+            );
+            if (session && !sessionToWg.has(session.id)) {
+              sessionToWg.set(session.id, wg.path);
+            }
           }
         }
       }
 
-      previousBusyByWg.clear();
-      for (const [key, busy] of currentBusyByWg) {
-        previousBusyByWg.set(key, busy);
+      // 2. Build current per-wg busy state from the alive bound
+      //    sessions only. Destroyed sessions (not in `sessions`) and
+      //    exited sessions are excluded — they don't contribute to
+      //    aggregation per spec.
+      const sessionsById = new Map<string, Session>();
+      for (const s of sessions) sessionsById.set(s.id, s);
+
+      const currentByWg = new Map<string, Map<string, boolean>>();
+      for (const [sessionId, wgPath] of sessionToWg) {
+        const session = sessionsById.get(sessionId);
+        if (!session) continue;
+        if (isExited(session.status)) continue;
+        let inner = currentByWg.get(wgPath);
+        if (!inner) {
+          inner = new Map<string, boolean>();
+          currentByWg.set(wgPath, inner);
+        }
+        inner.set(sessionId, isBusy(session));
+      }
+
+      // 3. First run is snapshot-only — see header comment.
+      if (!initialized) {
+        initialized = true;
+        for (const [wgPath, perSession] of currentByWg) {
+          previousByWg.set(wgPath, new Map(perSession));
+        }
+        return;
+      }
+
+      // 4. Detect genuine busy→idle transitions per workgroup.
+      if (enabled) {
+        for (const [wgPath, currentBusy] of currentByWg) {
+          const previousBusy = previousByWg.get(wgPath);
+          if (!previousBusy) continue;
+
+          // Genuine transition: a session that was busy last tick is
+          // still alive (still in current map) and is now idle.
+          let hadTransition = false;
+          for (const [sessionId, wasBusy] of previousBusy) {
+            if (!wasBusy) continue;
+            const isBusyNow = currentBusy.get(sessionId);
+            if (isBusyNow === false) {
+              hadTransition = true;
+              break;
+            }
+          }
+          if (!hadTransition) continue;
+
+          // All currently-alive bound sessions are idle?
+          let allIdle = currentBusy.size > 0;
+          if (allIdle) {
+            for (const isBusyNow of currentBusy.values()) {
+              if (isBusyNow) {
+                allIdle = false;
+                break;
+              }
+            }
+          }
+          if (!allIdle) continue;
+
+          void playTeamIdleBeep();
+        }
+      }
+
+      // 5. Persist current state for the next tick. Workgroups that
+      //    no longer have any alive bound sessions drop out, so a
+      //    later resurrection starts from a clean snapshot.
+      previousByWg.clear();
+      for (const [wgPath, perSession] of currentByWg) {
+        previousByWg.set(wgPath, new Map(perSession));
       }
     });
 


### PR DESCRIPTION
## Summary

- Plays a short synthesized beep (Web Audio) when an entire workgroup transitions from "≥1 agent busy" to "all agents idle".
- New toggle in Sidebar → Settings → General → Notifications, default ON.
- Trigger uses `waitingForInput` (the IdleDetector ground-truth signal), so focus-change flapping of `status` doesn't produce false beeps.

## Review history

- Round 1 grinch review found 4 substantive findings (2 MEDIUM, 2 LOW). Round 2 closed all four via a transition-event refactor (stable session->workgroup binding + per-session previous-busy flags) plus a 30 ms coalesce guard for same-tick overlapping beeps. Round 2 grinch verdict: PASS.
- 1 LOW (sessionToWg map monotonic growth) + 3 INFO items deferred to follow-up #119.

## Test plan

- [x] Toggle visible in Sidebar -> Settings -> General -> Notifications, default ON
- [x] Beep fires when last busy agent goes idle
- [x] No beep on focus changes (Active<->Running flap)
- [x] No startup beep if all agents start idle
- [x] No repeat while team stays idle
- [x] Toggle OFF stops beeps; ON resumes
- [x] Setting persists across restart
- [x] Build smoke test (--help) passes

Closes #110