### PR TITLE
chore: bump version to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Patch bump from `0.8.0` to `0.8.1`. The `0.8.0` version had been carrying 5 merged PRs without a bump:

- #103 — discovery logs and log level
- #112 — sidebar workgroups header context menu
- #114 — brief modal Enter submit
- #115 — copy-paste in embedded terminal
- #121 — RTK PreToolUse hook injection
- #122 — team idle beep on busy->all-idle transition (#110)

## Files changed

- `package.json` (top-level version)
- `src-tauri/Cargo.toml` (`[package] version`)
- `src-tauri/tauri.conf.json` (top-level version)
- `src-tauri/Cargo.lock` (auto-updated by `cargo check` — only the `agentscommander-new` package's own version field)

`cargo check` passes, no warnings.

## Test plan

- [x] All four files contain only `0.8.0` -> `0.8.1` changes (verified via `git diff`)
- [x] `cargo check` clean
- [ ] Build smoke test post-merge (shipper will run after this lands)