### PR TITLE
chore(ci): extend prefixes, sync lockfile, add drift check (#117)

### DIFF
--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -11,6 +11,8 @@ on:
       - 'release/**'
       - 'hotfix/**'
       - 'dependabot/**'
+      - 'revert/**'
+      - 'gh-readonly-queue/**'
     paths:
       - 'package.json'
       - 'package-lock.json'
@@ -33,6 +35,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          cache: 'npm'
 
       - name: Regenerate lockfile in-place
         run: npm install --package-lock-only --ignore-scripts

--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -1,0 +1,45 @@
+name: Lockfile drift check
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    branches-ignore:
+      - main
+      - 'release/**'
+      - 'hotfix/**'
+      - 'dependabot/**'
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lockfile-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lockfile-drift:
+    name: lockfile-drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Regenerate lockfile in-place
+        run: npm install --package-lock-only --ignore-scripts
+
+      - name: Fail if lockfile is out of sync
+        run: |
+          if ! git diff --exit-code -- package-lock.json; then
+            echo "::error::package-lock.json is out of sync with package.json. Run 'npm install --package-lock-only' locally and commit the result."
+            exit 1
+          fi

--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -37,6 +37,9 @@ jobs:
           node-version: 22
           cache: 'npm'
 
+      - name: Pin npm version
+        run: npm install -g npm@11.6.2
+
       - name: Regenerate lockfile in-place
         run: npm install --package-lock-only --ignore-scripts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ All new branches **must** follow this pattern and reference an **open GitHub Iss
 | `ci/` | CI / workflow changes |
 | `style/` | Formatting-only tweaks |
 
+### Local dev requirements
+
+- `npm` ≥ 11.0.0 (enforced via `package.json` `engines`). Older versions may produce a stale lockfile that fails the `lockfile-drift` CI check.
+
 **Valid**:
 - `feature/63-branch-name-enforcement`
 - `fix/42-pty-resize-on-windows`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,23 @@ All new branches **must** follow this pattern and reference an **open GitHub Iss
 
 | Field | Rules |
 |---|---|
-| `<type>` | One of `feature`, `fix`, `bug` |
+| `<type>` | See **Branch type prefixes** table below |
 | `<issue-number>` | An open issue in this repo (no leading zeros, e.g. `63` not `063`) |
 | `<slug>` | Lowercase kebab-case, `[a-z0-9]+(-[a-z0-9]+)*`, at most 50 characters |
+
+### Branch type prefixes
+
+| Prefix | Use for |
+|---|---|
+| `feat/` (alias `feature/`) | New functionality |
+| `fix/` | Bug fixes |
+| `bug/` | Investigation / repro of a defect |
+| `chore/` | Tooling, deps, non-functional |
+| `docs/` | Documentation only |
+| `refactor/` | Internal restructuring, no behaviour change |
+| `test/` | Test-only changes |
+| `ci/` | CI / workflow changes |
+| `style/` | Formatting-only tweaks |
 
 **Valid**:
 - `feature/63-branch-name-enforcement`
@@ -20,7 +34,7 @@ All new branches **must** follow this pattern and reference an **open GitHub Iss
 - `bug/101-missing-idle-callback`
 
 **Invalid**:
-- `feat/63-foo` — `feat` is not a recognized type
+- `wip/63-foo` — `wip` is not a recognized type (see Branch type prefixes table)
 - `feature/63_branch_name` — underscores not allowed
 - `feature/63-Branch-Name` — uppercase not allowed
 - `feature/63--doubledash` — consecutive dashes not allowed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
         "typescript": "^5",
         "vite": "^8.0.2",
         "vite-plugin-solid": "^2.11.11"
+      },
+      "engines": {
+        "npm": ">=11.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "typescript": "^5",
     "vite": "^8.0.2",
     "vite-plugin-solid": "^2.11.11"
+  },
+  "engines": {
+    "npm": ">=11.0.0"
   }
 }

--- a/scripts/validate-branch-name.mjs
+++ b/scripts/validate-branch-name.mjs
@@ -12,7 +12,7 @@
 
 import { execFileSync } from 'node:child_process';
 
-const PATTERN          = /^(feature|fix|bug)\/([1-9][0-9]*)-([a-z0-9]+(?:-[a-z0-9]+)*)$/;
+const PATTERN          = /^(bug|chore|ci|docs|feat|feature|fix|refactor|style|test)\/([1-9][0-9]*)-([a-z0-9]+(?:-[a-z0-9]+)*)$/;
 const MAX_SLUG         = 50;
 const TARGET_REPO      = 'mblua/AgentsCommander';
 const CUTOFF_SHA_PATH  = '.github/branch-name-enforcement.cutoff.sha';
@@ -86,7 +86,7 @@ function validateFormat(branch) {
     die(
       `Branch "${branch}" does not match the naming convention.\n` +
       `  Expected: <type>/<issue-number>-<slug>\n` +
-      `    <type>   ∈ { feature | fix | bug }\n` +
+      `    <type>   ∈ { bug | chore | ci | docs | feat | feature | fix | refactor | style | test }\n` +
       `    <issue>  = open GitHub issue number (no leading zeros)\n` +
       `    <slug>   = lowercase-kebab-case, [a-z0-9]+(-[a-z0-9]+)*, ≤ ${MAX_SLUG} chars\n` +
       `  Example:  feature/63-branch-name-enforcement`


### PR DESCRIPTION
## Summary
Three small chores bundled into one PR:

1. **Extend `validate-branch-name.mjs` accepted prefixes** — the regex now accepts `feat|feature|fix|bug|chore|docs|refactor|test|ci|style` (was just `feature|fix|bug`). All prefixes still require the existing `<issue#>-<slug>` format. Updates the validator's user-facing error message to match. Updates `CONTRIBUTING.md` with a canonical Branch type prefixes table + counter-example fix (`feat/63-foo` was wrongly listed as invalid; replaced with `wip/63-foo`).
2. **Sync `package-lock.json`** — the lockfile in `main` had `version: 0.7.1` while `package.json` declared `0.8.0`. Aligned to stop the recurring 2-line diff from every `npm install`.
3. **Add lockfile drift CI check** — `.github/workflows/lockfile-check.yml` runs `npm install --package-lock-only --ignore-scripts` on PRs and feature-branch pushes that touch `package.json` / `package-lock.json`, and fails if the result differs from the committed lockfile. Pins `npm@11.6.2` in the runner to match local determinism (avoids `peer:true` flag drift between npm versions). Adds `engines.npm: >=11.0.0` to `package.json` to enforce the floor for future contributors. Documents the requirement in CONTRIBUTING.md.

## Implementation notes
- Validator regex change is alphabetically ordered: `(bug|chore|ci|docs|feat|feature|fix|refactor|style|test)`.
- Error message in `scripts/validate-branch-name.mjs:89` updated in the same commit (single fact stated twice; splitting would create an intermediate commit with regex/message divergence).
- `lockfile-check.yml` uses paths filter (`package.json` + `package-lock.json` only), `branches-ignore` parity with `validate-branch-name.yml` (`main`, `release/**`, `hotfix/**`, `dependabot/**`, `revert/**`, `gh-readonly-queue/**`), `cache: 'npm'` for runtime, and concurrency group with `cancel-in-progress`.
- `--ignore-scripts` is safe: only lifecycle script in `package.json` is `prepare: husky` which doesn't affect lockfile content.

## Test plan
- [x] Validator regex accepts all 10 new prefixes with `<issue#>-<slug>`.
- [x] Backwards compat: existing `feature/...` branches still validate.
- [x] CI workflow self-tested green on commit `975cf8b` (12s).
- [x] CONTRIBUTING.md prefix list and counter-example match the validator regex.
- [x] `npm install --package-lock-only --ignore-scripts` is idempotent locally with `npm@11.6.2`.

## Follow-ups
- After merge, manually add `lockfile-drift` as a required status check on the `main` branch ruleset (so PRs with drift can't merge).
- Track the 3 preexisting `npm audit` vulnerabilities (1 moderate + 2 high) — separate issue to be opened.

Closes #117