### PR TITLE
fix(pty): land token refresh in agent context + idle-gated detach (#81)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -546,7 +546,6 @@ pub async fn create_session_inner(
                 &app_clone,
                 session_id,
                 &cred_block,
-                true,
             )
             .await
             {

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -890,7 +890,7 @@ impl MailboxPoller {
             payload.len(),
             payload.chars().take(100).collect::<String>()
         );
-        crate::pty::inject::inject_text_into_session(app, session_id, &payload, true)
+        crate::pty::inject::inject_text_into_session(app, session_id, &payload)
             .await
             .map_err(|e| {
                 log::error!(
@@ -961,7 +961,7 @@ impl MailboxPoller {
         // Note: same TOCTOU race as the command path — agent could become busy
         // between the idle check above and this write. Acceptable for this use case.
         let payload = crate::phone::messaging::format_pty_wrap(&msg.from, &msg.body);
-        crate::pty::inject::inject_text_into_session(app, session_id, &payload, true).await
+        crate::pty::inject::inject_text_into_session(app, session_id, &payload).await
     }
 
     /// Wait for agent to become idle after `/clear`, then re-inject the
@@ -1029,7 +1029,7 @@ impl MailboxPoller {
 
         // Build + inject. Same call shape as spawn path.
         let cred_block = crate::pty::credentials::build_credentials_block(&token, &cwd);
-        crate::pty::inject::inject_text_into_session(app, session_id, &cred_block, true).await?;
+        crate::pty::inject::inject_text_into_session(app, session_id, &cred_block).await?;
 
         log::info!(
             "[mailbox] Credentials re-injected after /clear (session={})",
@@ -1871,7 +1871,7 @@ impl MailboxPoller {
                     # Updated send command:\n\
                     #   \"{exe}\" send --token {token} --root \"{root}\" --to \"<agent_name>\" --send <filename> --mode wake\n\
                     # === End Token Refresh ===\n\
-                    \r",
+                    ",
                     exe = crate::config::profile::exe_name(),
                     token = session.token,
                     root = session.working_directory,
@@ -1884,7 +1884,7 @@ impl MailboxPoller {
             // SessionManager read-lock dropped here
         };
 
-        match crate::pty::inject::inject_text_into_session(app, session_id, &notice, false).await {
+        match crate::pty::inject::inject_text_into_session(app, session_id, &notice).await {
             Ok(()) => log::info!("[mailbox] Fresh token injected into session {}", session_id),
             Err(e) => log::warn!(
                 "[mailbox] Failed to inject fresh token into session {}: {}",

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -417,7 +417,14 @@ impl MailboxPoller {
                                     "[mailbox] Stale token from '{}' — found active session {}, refreshing token",
                                     msg.from, session_id
                                 );
-                                self.inject_fresh_token(app, session_id).await;
+                                // Detach: inject_fresh_token_static blocks ~2s on the
+                                // staggered Enter writes; running it inline would stall
+                                // the poll loop. Mirrors reinject_credentials_after_clear_static
+                                // spawn pattern above (mailbox.rs:813-829).
+                                let app_clone = app.clone();
+                                tauri::async_runtime::spawn(async move {
+                                    Self::inject_fresh_token_static(&app_clone, session_id).await;
+                                });
                                 // Continue processing — sender verified by CWD match
                             } else {
                                 return self
@@ -463,7 +470,11 @@ impl MailboxPoller {
                             "[mailbox] Malformed token from '{}' — found active session {}, refreshing token",
                             msg.from, session_id
                         );
-                        self.inject_fresh_token(app, session_id).await;
+                        // Detach: see comment on the stale-token branch above.
+                        let app_clone = app.clone();
+                        tauri::async_runtime::spawn(async move {
+                            Self::inject_fresh_token_static(&app_clone, session_id).await;
+                        });
                     } else {
                         return self
                             .reject_message(
@@ -1853,9 +1864,15 @@ impl MailboxPoller {
 
     /// Inject the current valid token into a session's PTY so the agent can update its credentials.
     /// Called when we detect the agent is using a stale token.
-    async fn inject_fresh_token(&self, app: &tauri::AppHandle, session_id: Uuid) {
-        // Extract session data under the read-lock, then drop before acquiring PtyManager mutex.
-        // This follows the same lock ordering pattern as inject_into_pty / deliver_wake.
+    ///
+    /// Static — designed to run inside a detached `tauri::async_runtime::spawn`
+    /// at the call site so the ~2s staggered-Enter inject does not stall the
+    /// mailbox poll loop. Idle-gates on `waiting_for_input` before injecting so
+    /// the trailing \r writes don't submit unrelated input that landed in the
+    /// PTY between the original write and the staggered Enters.
+    async fn inject_fresh_token_static(app: &tauri::AppHandle, session_id: Uuid) {
+        // Extract session data under the read-lock, then drop before the idle-poll
+        // loop and the PTY inject. Same lock ordering as deliver_wake / inject_into_pty.
         let notice = {
             let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
             let mgr = session_mgr.read().await;
@@ -1883,6 +1900,41 @@ impl MailboxPoller {
             }
             // SessionManager read-lock dropped here
         };
+
+        // Wait for the agent to be at-prompt before injecting. Same poll/timeout
+        // values used by the other Enter-sending paths
+        // (commands/session.rs:520-541, mailbox.rs:1006-1028). On timeout, fall
+        // through and inject anyway — matches commands/session.rs:520-541 fallback.
+        let max_wait = std::time::Duration::from_secs(30);
+        let poll = std::time::Duration::from_millis(500);
+        let start = std::time::Instant::now();
+
+        loop {
+            if start.elapsed() >= max_wait {
+                log::warn!(
+                    "[mailbox] Timeout waiting for idle before fresh token inject (session={}, {}s) — injecting anyway",
+                    session_id,
+                    max_wait.as_secs()
+                );
+                break;
+            }
+            tokio::time::sleep(poll).await;
+
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let mgr = session_mgr.read().await;
+            let sessions = mgr.list_sessions().await;
+            match sessions.iter().find(|s| s.id == session_id.to_string()) {
+                Some(s) if s.waiting_for_input => break,
+                Some(_) => {} // busy — keep polling
+                None => {
+                    log::warn!(
+                        "[mailbox] Session {} gone before fresh token inject",
+                        session_id
+                    );
+                    return;
+                }
+            }
+        }
 
         match crate::pty::inject::inject_text_into_session(app, session_id, &notice).await {
             Ok(()) => log::info!("[mailbox] Fresh token injected into session {}", session_id),

--- a/src-tauri/src/pty/credentials.rs
+++ b/src-tauri/src/pty/credentials.rs
@@ -9,8 +9,8 @@ use uuid::Uuid;
 /// Build the credentials block for a session.
 ///
 /// The block is terminated by `\n` (no trailing Enter) — the caller is
-/// responsible for flagging `submit=true` to `inject_text_into_session`
-/// which adds the Enter keystrokes for agents that need them.
+/// responsible for calling `inject_text_into_session` which adds the Enter
+/// keystrokes for agents that need them.
 ///
 /// `token` is `Display`'d lowercase with dashes (standard `Uuid` format).
 /// `cwd` is the session's working directory, verbatim.

--- a/src-tauri/src/pty/inject.rs
+++ b/src-tauri/src/pty/inject.rs
@@ -24,12 +24,11 @@ fn needs_explicit_enter(shell: &str) -> bool {
 
 /// Inject a text block into a session's PTY stdin.
 ///
-/// - `submit = false` → passive injection (token refresh).
-///   Text is written as-is. No Enter is ever sent, regardless of agent type.
-/// - `submit = true` → active injection (init prompt, message delivery, Telegram input).
-///   For agents that require explicit Enter (Claude, Codex), `\r` is sent
-///   twice — at 1500 ms and 2000 ms after the text write — as a reliability
-///   measure against Enter not registering on the first attempt.
+/// For agents that require explicit Enter (Claude, Codex, Gemini), `\r` is
+/// sent twice — at 1500 ms and 2000 ms after the text write — as a reliability
+/// measure against Enter not registering on the first attempt. For plain shells
+/// (bash, powershell), no Enter is sent (the caller's text already controls
+/// submission).
 ///
 /// This is the ONLY function that should be used for text-block injection.
 /// Direct keystrokes from xterm.js (single chars, Ctrl sequences) bypass this
@@ -38,7 +37,6 @@ pub async fn inject_text_into_session(
     app: &tauri::AppHandle,
     session_id: Uuid,
     text: &str,
-    submit: bool,
 ) -> Result<(), String> {
     // Resolve shell without holding any lock across an await point
     let shell = {
@@ -49,11 +47,10 @@ pub async fn inject_text_into_session(
         result
     };
 
-    let send_enter = submit && shell.as_deref().map(needs_explicit_enter).unwrap_or(false);
+    let send_enter = shell.as_deref().map(needs_explicit_enter).unwrap_or(false);
     log::info!(
-        "[inject] session={} submit={} shell={:?} send_enter={}",
+        "[inject] session={} shell={:?} send_enter={}",
         session_id,
-        submit,
         shell,
         send_enter
     );

--- a/src-tauri/src/telegram/bridge.rs
+++ b/src-tauri/src/telegram/bridge.rs
@@ -806,7 +806,7 @@ async fn poll_task(
                                 }
                             };
 
-                            if let Err(e) = crate::pty::inject::inject_text_into_session(&app, session_id, &inject_text, true).await {
+                            if let Err(e) = crate::pty::inject::inject_text_into_session(&app, session_id, &inject_text).await {
                                 logger.log("PTY_ERR", &session_id_str, &e.to_string());
                                 log::error!("Failed to write Telegram input to PTY: {}", e);
                             }


### PR DESCRIPTION
## Summary

- **`c7ca8e3`** — Token refresh notice in `inject_fresh_token` was injected with `submit=false`, leaving the block stuck in the agent's paste buffer on Claude/Codex/Gemini sessions. Flipped to use the standard inject path (which sends the trailing 2× `\r` needed to escape paste-detection). Since `submit=false` had only one call site (the buggy one), the parameter is removed from `inject_text_into_session` entirely. Callers and doc comments updated accordingly.
- **`4094844`** — Two grinch-found follow-ups, both consequences of the submit flip: **M1** the new behavior blocks the mailbox poll loop ~2s waiting for the staggered Enter writes, fixed by wrapping in `tauri::async_runtime::spawn` (mirrors `reinject_credentials_after_clear_static`); **M2** the path lacked a `waiting_for_input` idle-gate, fixed by copying the poll-for-idle pattern other Enter-sending paths use.

## Validation

- `cargo check` clean (no new warnings)
- `cargo test` 171 passed, 0 failed
- /feature-dev manual review (3 reviewers in parallel) round 1: 0 HIGH
- grinch round 1: SHIP IT + 2 MEDIUM (M1, M2) → fixed in `4094844`
- /feature-dev manual review round 2: 0 HIGH, 1 MEDIUM accepted (`agent_id.is_some()` gate, follow-up hygiene)
- grinch round 2: SHIP IT clean (0 HIGH, 0 MEDIUM, 2 NIT non-blocking)
- **End-to-end manual verification**: triggered refresh from a Claude session via `send --token 00000000-0000-0000-0000-000000000000`. Notice landed as a new turn in Claude (not stuck in paste buffer), Claude acknowledged the new token and correctly noted the original message was already delivered (no duplicate retry).

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes (171 / 0 / 6)
- [x] Token refresh visibly lands as a turn in Claude (manual e2e)
- [x] Refresh notice does not stall the mailbox poll loop
- [x] Refresh respects idle-gate before sending Enter
- [x] No regression in other 5 `inject_text_into_session` call sites

## Follow-ups (non-blocking, can be separate issues)

- N1 — spawn-burst dedup (N redundant notices if a sender bursts N stale-token messages)
- Hygiene — add `agent_id.is_some()` gate in `inject_fresh_token_static` for parity with sibling
- Doc — clarify in `inject_fresh_token_static` why timeout-fallthrough diverges from `reinject_credentials_after_clear_static` sibling

Closes #81