### PR TITLE
fix(cli): preserve stdio in non-interactive PowerShell (#129)

### DIFF
--- a/scripts/smoke-cli-powershell.ps1
+++ b/scripts/smoke-cli-powershell.ps1
@@ -1,0 +1,172 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$BinaryPath,
+    [string]$Token = "00000000-0000-0000-0000-000000000000",
+    [string]$Root = (New-Item -ItemType Directory -Force -Path (Join-Path $env:TEMP "ac-smoke-$([guid]::NewGuid().ToString('N'))")).FullName
+)
+
+$ErrorActionPreference = "Continue"
+$failed = 0
+
+# Bug-reproducing harness: spawn a fresh `powershell.exe -NonInteractive -NoProfile`
+# and run the AC exe via `&` direct call (no pipeline operators in the inner command).
+# This is the exact shape from verify-prod-binary.ps1 and R2.6's Rust test, and it is
+# the ONLY shape that reproduces issue #129's failure mode.
+#
+# Note on exit codes: PS-NonInteractive bare `&` does NOT propagate $LASTEXITCODE for
+# GUI-subsystem children (PE Subsystem=2 — empirically verified in Round 3, R3.G.3).
+# The outer process always sees ExitCode=0 regardless of the AC binary's true exit
+# code. This is the same bare-`&`-vs-pipeline asymmetry underlying issue #129 itself,
+# and it cannot be worked around in this harness shape (the harness shape is mandatory
+# to reproduce the bug). Tests 1-3 therefore drop exit-code assertions and rely on
+# stdout/stderr presence — those are the bug-relevant signals (Round 4, Option 1).
+function Invoke-PSNonInteractiveDirect {
+    param(
+        [Parameter(Mandatory=$true)] [string]$Exe,
+        [Parameter(Mandatory=$true)] [string[]]$ExeArgs
+    )
+    $escapedExe = $Exe -replace "'", "''"
+    $quotedArgs = ($ExeArgs | ForEach-Object {
+        "'" + ($_ -replace "'", "''") + "'"
+    }) -join ' '
+    $inner = "& '$escapedExe' $quotedArgs"
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = 'powershell.exe'
+    $psi.Arguments = "-NonInteractive -NoProfile -Command `"$inner`""
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
+    $stderrTask = $proc.StandardError.ReadToEndAsync()
+    $proc.WaitForExit()
+
+    [pscustomobject]@{
+        Stdout = if ($null -eq $stdoutTask.Result) { '' } else { $stdoutTask.Result }
+        Stderr = if ($null -eq $stderrTask.Result) { '' } else { $stderrTask.Result }
+    }
+}
+
+function Assert-True([string]$Name, [bool]$Cond, [string]$Detail) {
+    if ($Cond) {
+        Write-Host "PASS: $Name" -ForegroundColor Green
+    } else {
+        Write-Host "FAIL: $Name -- $Detail" -ForegroundColor Red
+        $script:failed++
+    }
+}
+
+# Test 1: list-peers -- stdout has JSON, stderr is empty (post-fix contract).
+# Failure mode on unfixed binary (per R2.1 / R3.2): AC binary inherits valid PIPE
+# stdout from PS-NonInteractive's `&` direct call; the unfixed `attach_parent_console`
+# unconditionally calls AttachConsole, which rebinds STD_OUTPUT_HANDLE to PS's hidden
+# console buffer (PIPE -> CHAR); PS-NonInteractive does not surface that buffer to
+# its captured stdout pipe; captured stdout is empty. Test 1's "stdout non-empty"
+# assertion fails. Empirically confirmed in verify-prod-binary.ps1 Test 1.
+$r1 = Invoke-PSNonInteractiveDirect -Exe $BinaryPath -ExeArgs @('list-peers', '--token', $Token, '--root', $Root)
+Assert-True "list-peers stdout non-empty" (-not [string]::IsNullOrWhiteSpace($r1.Stdout)) "stdout was empty (issue #129 not fixed)"
+Assert-True "list-peers stderr empty" ([string]::IsNullOrWhiteSpace($r1.Stderr)) "stderr leaked content: $($r1.Stderr)"
+# NEW-4 fix: layered guard mirroring Test 4's NEW-2 fix. Empty/whitespace stdout is
+# already covered by the prior `stdout non-empty` assertion; only attempt parse when
+# stdout has content, and explicitly fail on `$null -eq $parsed` to avoid the silent
+# false-PASS that `'' | ConvertFrom-Json -ErrorAction Stop` would otherwise produce.
+if (-not [string]::IsNullOrWhiteSpace($r1.Stdout)) {
+    try {
+        $parsed = $r1.Stdout | ConvertFrom-Json -ErrorAction Stop
+        if ($null -eq $parsed) {
+            Write-Host "FAIL: list-peers ConvertFrom-Json returned null on non-empty stdout" -ForegroundColor Red
+            $failed++
+        } else {
+            Write-Host "PASS: list-peers stdout parses as JSON" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host "FAIL: list-peers stdout not valid JSON: $($r1.Stdout)" -ForegroundColor Red
+        $failed++
+    }
+}
+# else: empty case is already counted as a fail by the prior `stdout non-empty` assertion above
+
+# Test 2: send --help -- stdout has clap-rendered help text.
+# Failure mode on unfixed binary: identical to Test 1 — clap writes the help text
+# to stdout; AttachConsole rebinds the inherited PIPE stdout to PS's hidden console
+# buffer; captured stdout is empty. Test 2's "stdout non-empty" assertion fails.
+# Empirically confirmed in verify-prod-binary.ps1 Test 1 (same `send --help` invocation).
+$r2 = Invoke-PSNonInteractiveDirect -Exe $BinaryPath -ExeArgs @('send', '--help')
+Assert-True "send --help stdout non-empty" (-not [string]::IsNullOrWhiteSpace($r2.Stdout)) "stdout was empty (issue #129 not fixed for --help path)"
+Assert-True "send --help mentions --to flag" ($r2.Stdout -match '--to') "stdout missing expected flag mention"
+
+# Test 3: send unknown flag -- stderr has clap usage error.
+# Failure mode on unfixed binary: clap writes the parse-error/usage text to stderr.
+# The AC binary's STD_ERROR_HANDLE is also inherited as a valid PIPE; the unfixed
+# `attach_parent_console` rebinds it to PS's hidden console buffer the same way as
+# stdout; captured stderr is empty. Test 3's "stderr non-empty" assertion fails.
+# Per R3.G.3 / R3.G.5 (Round 3 grinch verification, integrated in Round 4),
+# exit-code propagation is not usable in this harness: PS-NonInteractive bare `&`
+# does NOT update $LASTEXITCODE for GUI-subsystem children, so any `exit non-zero`
+# assertion would fail even on a correctly fixed binary. `stderr non-empty` is the
+# sole — and bug-relevant — signal for this test.
+$r3 = Invoke-PSNonInteractiveDirect -Exe $BinaryPath -ExeArgs @('send', '--bogus-flag-xyz')
+Assert-True "send unknown flag stderr non-empty" (-not [string]::IsNullOrWhiteSpace($r3.Stderr)) "stderr was empty (issue #129 not fixed for clap-error path)"
+
+# Test 4 (G3 regression check): `2>&1 | ConvertFrom-Json` on list-peers must still work.
+# This test deliberately uses a DIFFERENT inner command shape — pipeline mode with
+# `2>&1 | Out-String`. Pipeline mode bypasses issue #129 (R2.1 confirmed: pipeline
+# operators give the child a PIPE stdout via STARTUPINFO redirection, no NULL → no
+# AttachConsole rebind). So Test 4 PASSES on both fixed and unfixed binary as long
+# as stderr is empty (which it is post-Step-A). Test 4 FAILS only if a future change
+# reintroduces dual-write to stderr — the merged stream would then contain non-JSON
+# stderr content, breaking ConvertFrom-Json. That is the regression Test 4 guards.
+#
+# NEW-2 fix: replace the broken `-replace [char]39, [char]39 + [char]39` (which is a
+# PS parser error -- three args to -replace -- that with $ErrorActionPreference="Continue"
+# silently produced an empty inner command) with string-literal `-replace "'", "''"`
+# (Option B from R2.G.5). Also tighten the assertion: fail on empty merged output
+# regardless of ConvertFrom-Json's silent null-on-empty-input behavior.
+# NEW-5 fix (Round 4): escape and single-quote-wrap $Token consistently with
+# $BinaryPath / $Root. Default Token is a UUID and therefore safe, but a custom
+# -Token containing single quotes would otherwise break the inner command.
+$escapedBin = $BinaryPath -replace "'", "''"
+$escapedRoot = $Root -replace "'", "''"
+$escapedToken = $Token -replace "'", "''"
+$inner = "& '$escapedBin' list-peers --token '$escapedToken' --root '$escapedRoot' 2>&1 | Out-String"
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = 'powershell.exe'
+$psi.Arguments = "-NonInteractive -NoProfile -Command `"$inner`""
+$psi.UseShellExecute = $false
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.CreateNoWindow = $true
+$proc = [System.Diagnostics.Process]::Start($psi)
+$mergedTask = $proc.StandardOutput.ReadToEndAsync()
+$null = $proc.StandardError.ReadToEndAsync()
+$proc.WaitForExit()
+$mergedOut = if ($null -eq $mergedTask.Result) { '' } else { $mergedTask.Result }
+
+if ([string]::IsNullOrWhiteSpace($mergedOut)) {
+    Write-Host "FAIL: Test 4 merged output is empty (inner command may have failed or produced no output)" -ForegroundColor Red
+    $failed++
+} else {
+    try {
+        $parsed = $mergedOut | ConvertFrom-Json -ErrorAction Stop
+        if ($null -eq $parsed) {
+            Write-Host "FAIL: Test 4 ConvertFrom-Json returned null on non-empty merged output" -ForegroundColor Red
+            $failed++
+        } else {
+            Write-Host "PASS: 2>&1 | ConvertFrom-Json continues to work (no dual-write regression)" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host "FAIL: 2>&1 | ConvertFrom-Json broken -- merged stream is not valid JSON: $mergedOut" -ForegroundColor Red
+        $failed++
+    }
+}
+
+if ($failed -gt 0) {
+    Write-Host "`n$failed check(s) failed" -ForegroundColor Red
+    exit 1
+}
+Write-Host "`nAll checks passed" -ForegroundColor Green
+exit 0

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ tauri-plugin-dialog = "2.6.0"
 which = "7"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_System_Console", "Win32_Foundation", "Win32_System_Threading"] }
+windows-sys = { version = "0.59", features = ["Win32_System_Console", "Win32_Foundation", "Win32_System_Threading", "Win32_Storage_FileSystem"] }
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -37,13 +37,41 @@ pub enum Commands {
     CloseSession(close_session::CloseSessionArgs),
 }
 
-/// Attach to parent console on Windows release builds so CLI output is visible.
+/// Attach to parent console (or allocate a new one) ONLY if both stdout and stderr
+/// have invalid/missing handles. When stdio is already valid (inherited pipes,
+/// inherited console handles, or file redirects from the parent), `AttachConsole`
+/// would REBIND the std handles to a fresh console buffer — breaking those
+/// inherited channels. That rebinding is the root cause of issue #129: PS
+/// -NonInteractive `&` direct calls inherit pipe handles to the GUI-subsystem
+/// child, and AttachConsole's rebind sends subsequent writes to a console buffer
+/// that PS does not surface, dropping all output.
+///
+/// The condition uses `GetFileType` on the std handles. `FILE_TYPE_UNKNOWN`
+/// (returned for null/invalid handles) is the only case where attaching is
+/// useful (the user double-clicked the GUI exe in explorer.exe, etc.). For PIPE,
+/// CHAR, DISK, REMOTE — the inherited handle is already routable, leave it alone.
 #[cfg(target_os = "windows")]
+#[allow(clippy::collapsible_if)]
 pub fn attach_parent_console() {
-    use windows_sys::Win32::System::Console::{AllocConsole, AttachConsole, ATTACH_PARENT_PROCESS};
+    use windows_sys::Win32::Storage::FileSystem::{GetFileType, FILE_TYPE_UNKNOWN};
+    use windows_sys::Win32::System::Console::{
+        AllocConsole, AttachConsole, GetStdHandle, ATTACH_PARENT_PROCESS,
+        STD_ERROR_HANDLE, STD_OUTPUT_HANDLE,
+    };
+
     unsafe {
-        if AttachConsole(ATTACH_PARENT_PROCESS) == 0 {
-            AllocConsole();
+        let out = GetStdHandle(STD_OUTPUT_HANDLE);
+        let err = GetStdHandle(STD_ERROR_HANDLE);
+
+        // GetFileType returns FILE_TYPE_UNKNOWN for null/invalid handles. Short-
+        // circuit the null check first so GetFileType is never called on null.
+        let out_invalid = out.is_null() || GetFileType(out) == FILE_TYPE_UNKNOWN;
+        let err_invalid = err.is_null() || GetFileType(err) == FILE_TYPE_UNKNOWN;
+
+        if out_invalid && err_invalid {
+            if AttachConsole(ATTACH_PARENT_PROCESS) == 0 {
+                AllocConsole();
+            }
         }
     }
 }
@@ -101,11 +129,27 @@ pub fn validate_cli_token(token: &Option<String>) -> Result<(String, bool), Stri
 pub fn handle_cli(cmd: Commands) -> i32 {
     attach_parent_console();
 
-    match cmd {
+    let code = match cmd {
         Commands::Send(args) => send::execute(args),
         Commands::ListPeers(args) => list_peers::execute(args),
         Commands::ListSessions(args) => list_sessions::execute(args),
         Commands::CreateAgent(args) => create_agent::execute(args),
         Commands::CloseSession(args) => close_session::execute(args),
-    }
+    };
+
+    flush_outputs();
+    code
+}
+
+/// Flush stdout and stderr. Called before any `std::process::exit` to ensure
+/// that pending writes are committed before the process is torn down.
+///
+/// `std::process::exit` skips destructors, so the default flush-on-drop
+/// behavior of `Stdout`/`Stderr` does not run. This helper forces an
+/// explicit flush. Errors are silenced — there is nothing meaningful to do
+/// with a flush failure at process exit.
+pub fn flush_outputs() {
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+    let _ = std::io::stderr().flush();
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -35,6 +35,7 @@ fn main() {
                 Err(e) => {
                     agentscommander_lib::cli::attach_parent_console();
                     let _ = e.print();
+                    agentscommander_lib::cli::flush_outputs();
                     std::process::exit(1);
                 }
             }
@@ -43,6 +44,7 @@ fn main() {
             // --help, --version, or invalid args: print and exit
             agentscommander_lib::cli::attach_parent_console();
             let _ = e.print();
+            agentscommander_lib::cli::flush_outputs();
             std::process::exit(if e.use_stderr() { 1 } else { 0 });
         }
     }

--- a/src-tauri/tests/cli_powershell_capture.rs
+++ b/src-tauri/tests/cli_powershell_capture.rs
@@ -1,0 +1,162 @@
+#![cfg(target_os = "windows")]
+//! Integration test for issue #129. Reproduces the PS-NonInteractive `&` direct-
+//! call failure mode and asserts that the fix (conditional AttachConsole) lets
+//! stdout flow through the inherited pipe.
+//!
+//! IMPORTANT: marked #[ignore] because the bug only reproduces in release mode
+//! (`windows_subsystem = "windows"` is gated on `not(debug_assertions)`). To run:
+//!     cargo test --release --test cli_powershell_capture -- --ignored
+
+use std::process::{Command, Stdio};
+
+const BIN: &str = env!("CARGO_BIN_EXE_agentscommander-new");
+
+fn ps_command(shell: &str, args: &str) -> Option<Command> {
+    if Command::new(shell)
+        .arg("-Help")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_err()
+    {
+        return None;
+    }
+    let mut c = Command::new(shell);
+    c.args([
+        "-NonInteractive",
+        "-NoProfile",
+        "-Command",
+        &format!("& '{}' {}", BIN.replace('\'', "''"), args),
+    ]);
+    c.stdout(Stdio::piped());
+    c.stderr(Stdio::piped());
+    Some(c)
+}
+
+fn run_ps(shell: &str, args: &str) -> Option<(i32, String, String)> {
+    let mut cmd = ps_command(shell, args)?;
+    let out = cmd.spawn().ok()?.wait_with_output().ok()?;
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    Some((code, stdout, stderr))
+}
+
+#[allow(clippy::assertions_on_constants)] // Plan R2.6 step 3: intentional runtime guard.
+fn debug_guard() {
+    assert!(
+        !cfg!(debug_assertions),
+        "This test only validates issue #129 in release mode. \
+         Run with `cargo test --release --test cli_powershell_capture -- --ignored`."
+    );
+}
+
+// Exit-code assertions are intentionally absent on all four tests (R5.4 — applies
+// R4.1's NEW-3 logic symmetrically to R2.6). PS-NonInteractive bare `&` does not
+// propagate the AC binary's $LASTEXITCODE for GUI-subsystem children (PE
+// Subsystem=2); the outer powershell.exe always exits 0 regardless. The bug-
+// relevant signals are stdout/stderr presence — those alone distinguish fixed
+// from unfixed binaries.
+
+#[test]
+#[ignore = "Requires release build (windows_subsystem=\"windows\"); run with --release --ignored"]
+fn list_peers_outputs_valid_json_under_powershell_noninteractive() {
+    debug_guard();
+
+    let tmp = std::env::temp_dir().join(format!(
+        "ac-test-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4().simple()
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let safe_root = tmp.to_string_lossy().replace('\'', "''");
+    let token = "00000000-0000-0000-0000-000000000000";
+
+    let (_code, stdout, stderr) = run_ps(
+        "powershell.exe",
+        &format!("list-peers --token {} --root '{}'", token, safe_root),
+    )
+    .expect("powershell.exe must be available on Windows CI/dev");
+
+    assert!(
+        !stdout.trim().is_empty(),
+        "stdout should contain the JSON payload (post-fix). stderr=[{}]",
+        stderr
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout should parse as JSON");
+    assert!(parsed.is_array(), "expected JSON array");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+#[ignore = "Requires release build; run with --release --ignored"]
+fn send_help_outputs_under_powershell_noninteractive() {
+    debug_guard();
+
+    let (_code, stdout, stderr) =
+        run_ps("powershell.exe", "send --help").expect("powershell.exe must be available");
+
+    assert!(
+        !stdout.trim().is_empty(),
+        "stdout should contain help text. stderr=[{}]",
+        stderr
+    );
+    assert!(
+        stdout.contains("--to") || stdout.contains("DELIVERY MODES"),
+        "help text missing expected content; got: {}",
+        stdout
+    );
+}
+
+#[test]
+#[ignore = "Requires release build; run with --release --ignored"]
+fn send_unknown_flag_emits_stderr_under_powershell_noninteractive() {
+    debug_guard();
+
+    let (_code, _stdout, stderr) = run_ps("powershell.exe", "send --bogus-flag-xyz")
+        .expect("powershell.exe must be available");
+    assert!(
+        !stderr.trim().is_empty(),
+        "stderr must contain a usage error"
+    );
+}
+
+// G8: parallel pwsh.exe tests. Skip if pwsh not installed.
+#[test]
+#[ignore = "Requires release build + pwsh.exe; run with --release --ignored"]
+fn list_peers_outputs_valid_json_under_pwsh_noninteractive() {
+    debug_guard();
+
+    let tmp = std::env::temp_dir().join(format!(
+        "ac-test-pwsh-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4().simple()
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let safe_root = tmp.to_string_lossy().replace('\'', "''");
+    let token = "00000000-0000-0000-0000-000000000000";
+
+    let result = run_ps(
+        "pwsh.exe",
+        &format!("list-peers --token {} --root '{}'", token, safe_root),
+    );
+    let (_code, stdout, _stderr) = match result {
+        Some(t) => t,
+        None => {
+            eprintln!("skip: pwsh.exe not available");
+            let _ = std::fs::remove_dir_all(&tmp);
+            return;
+        }
+    };
+
+    assert!(
+        !stdout.trim().is_empty(),
+        "stdout should contain the JSON payload"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(parsed.is_array());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}


### PR DESCRIPTION
## Summary

Fixes silent stdout/stderr drop when `agentscommander_mb.exe` is invoked from non-interactive PowerShell hosts (Codex tool harness, Claude Code's PS tool, automated scripts via `& '<exe>' <subcmd>`). Parent saw `exit 0`, empty stdout, empty stderr — even for static `--help`.

**Root cause**: unconditional `AttachConsole(ATTACH_PARENT_PROCESS)` rebinds inherited PIPE handles for `STD_OUTPUT_HANDLE`/`STD_ERROR_HANDLE` to a hidden console buffer that PS-NonInteractive does not surface. Both streams were dropped equally — not just stdout.

**Fix**: gate `AttachConsole`/`AllocConsole` on `GetFileType == FILE_TYPE_UNKNOWN` for BOTH stdout AND stderr. When the parent passes valid handles (PIPE/CHAR/DISK/REMOTE), they remain bound and output flows through.

Empirically verified via a release-mode `windows_subsystem=\"windows\"` probe binary spawned through the same harness shape Codex uses.

## Test plan

- [x] Rust integration test (`cargo test --release --test cli_powershell_capture -- --ignored`) — 4/4 PASS (pwsh.exe path skip-OK on hosts without pwsh 7).
- [x] PowerShell smoke script (`scripts/smoke-cli-powershell.ps1`) — 7/7 PASS against fixed binary; 4/7 FAIL against unfixed prod 0.8.1 (regression-guard signals: bug-relevant assertions correctly fail).
- [x] Manual user-confirmed test on deployed `agentscommander_standalone.exe` — works as expected.
- [x] Adversarial review: 14 probes (smart-attach correctness, idempotency, INVALID_HANDLE_VALUE, file-redirect, scope creep, etc.) — all clean.

## Notes

- No new external crate deps (added `Win32_Storage_FileSystem` to existing `windows-sys` feature set for `GetFileType`/`FILE_TYPE_UNKNOWN`).
- `flush_outputs()` helper kept as belt-and-suspenders against `std::process::exit` skipping destructors.
- Smoke script omits exit-code assertions because PS-NonInteractive bare `&` does not propagate `\$LASTEXITCODE` from GUI-subsystem children (same bare-`&`-vs-pipeline asymmetry as the bug itself); kept stdout/stderr non-empty + JSON parse + `--to` flag mention as the bug-relevant signals.

Closes #129
Closes #126