### PR TITLE
fix(send): structured 'Delivered: <id>' ack on success (#135)

### DIFF
--- a/src-tauri/src/cli/send.rs
+++ b/src-tauri/src/cli/send.rs
@@ -231,6 +231,9 @@ pub fn execute(args: SendArgs) -> i32 {
         None
     };
 
+    let mode_for_ack = args.mode.clone();
+    let to_for_ack = resolved_to.clone();
+
     let message = OutboxMessage {
         id: msg_id.clone(),
         token: args.token,
@@ -302,7 +305,10 @@ pub fn execute(args: SendArgs) -> i32 {
 
     loop {
         if delivered_path.exists() {
-            println!("Message delivered: {}", msg_id);
+            println!(
+                "Delivered: {} (mode={}, to={})",
+                msg_id, mode_for_ack, to_for_ack
+            );
             break;
         }
         if rejected_reason_path.exists() {


### PR DESCRIPTION
## Summary

- Replace `Message delivered: <id>` with structured `Delivered: <id> (mode=X, to=Y)` on successful send so callers can distinguish "delivered" from "no-op" and grep a single line that includes `id`, `mode`, and the recipient FQN.
- Pre-clone `args.mode` and `resolved_to` before the move into `OutboxMessage` so both values stay available for the post-confirmation `println!`.
- Single file change: `src-tauri/src/cli/send.rs` (+7/-1).

## Out of scope (per intake decision)

- `--json` flag — issue marks it as optional; deferred until a caller actually needs machine-readable output.
- "Queued" branch from the issue spec — mode `queue` is already removed (line 97 validates only `wake`); the polling loop only resolves to `delivered/` or `rejected/`, so no "Queued" path is reachable.

## Test plan

- [ ] `send --send <file>` emits `Delivered: <id> (mode=wake, to=<peer-fqn>)` on success
- [ ] `send --command clear` / `send --command compact` emit the same format (same loop)
- [ ] Failure paths (rejected, timeout, validation) still emit error to stderr and exit non-zero
- [ ] Stdout flush under non-interactive PowerShell — covered globally by #129 in `cli/mod.rs:140` (`flush_outputs()`); confirmed during review that no per-call-site flush is needed

## Review trail

- `dev-rust-grinch` adversarial review: PASS, 0 bugs found (verified global flush, scanned tests/docs for stale string assertions, checked move semantics, edge cases).
- `shipper` build: `npx tauri build` clean, frontend embedded (binary +206KB vs reference), no new warnings.
- Local rebase onto `origin/main` (#118 PTY/credentials fix): clean, 0 conflicts, fast-forward mergeable.

Closes #135
