### PR TITLE
fix(outbox): tolerate BOMs and harden reject path (#130)

### DIFF
--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -244,7 +244,7 @@ impl MailboxPoller {
                                 )
                             };
 
-                            let rejected = if let Ok(content) = std::fs::read_to_string(&path) {
+                            let rejected = if let Ok(content) = read_text_bom_tolerant(&path) {
                                 if let Ok(msg) = serde_json::from_str::<OutboxMessage>(&content) {
                                     self.reject_message(&path, &msg, &reason).await.is_ok()
                                 } else {
@@ -285,7 +285,7 @@ impl MailboxPoller {
         path: &Path,
         is_app_outbox: bool,
     ) -> Result<(), String> {
-        let content = std::fs::read_to_string(path)
+        let content = read_text_bom_tolerant(path)
             .map_err(|e| format!("Failed to read outbox file: {}", e))?;
 
         // `let mut msg`: §AR2-norm below mutates `msg.from` / `msg.to` in place
@@ -1796,7 +1796,7 @@ impl MailboxPoller {
         };
 
         for path in entries {
-            let content = match std::fs::read_to_string(&path) {
+            let content = match read_text_bom_tolerant(&path) {
                 Ok(c) => c,
                 Err(e) => {
                     log::warn!("[session-requests] Failed to read {:?}: {}", path, e);
@@ -1944,6 +1944,43 @@ impl MailboxPoller {
                 e
             ),
         }
+    }
+}
+
+/// Read a file as UTF-8 string, tolerant of UTF-8 / UTF-16 LE / UTF-16 BE BOMs.
+/// Logs a warning when a BOM is detected so users see which tool is writing
+/// odd encoding into outbox / session-requests (typically PowerShell on Windows).
+fn read_text_bom_tolerant(path: &Path) -> Result<String, String> {
+    let bytes = std::fs::read(path).map_err(|e| format!("Failed to read file: {}", e))?;
+
+    if bytes.starts_with(&[0xFF, 0xFE]) {
+        log::warn!(
+            "[bom] UTF-16 LE BOM detected in {:?} — decoding to UTF-8 (writer should use UTF-8 without BOM)",
+            path
+        );
+        let u16_data: Vec<u16> = bytes[2..]
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        Ok(String::from_utf16_lossy(&u16_data))
+    } else if bytes.starts_with(&[0xFE, 0xFF]) {
+        log::warn!(
+            "[bom] UTF-16 BE BOM detected in {:?} — decoding to UTF-8 (writer should use UTF-8 without BOM)",
+            path
+        );
+        let u16_data: Vec<u16> = bytes[2..]
+            .chunks_exact(2)
+            .map(|c| u16::from_be_bytes([c[0], c[1]]))
+            .collect();
+        Ok(String::from_utf16_lossy(&u16_data))
+    } else if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        log::warn!(
+            "[bom] UTF-8 BOM detected in {:?} — stripping (writer should use UTF-8 without BOM)",
+            path
+        );
+        String::from_utf8(bytes[3..].to_vec()).map_err(|e| format!("Invalid UTF-8 after BOM: {}", e))
+    } else {
+        String::from_utf8(bytes).map_err(|e| format!("Invalid UTF-8: {}", e))
     }
 }
 
@@ -2133,4 +2170,81 @@ mod tests {
     #[test]
     #[ignore = "integration: full CLI + mailbox + two-project fixture"]
     fn resolve_to_target_round_trip_integration() {}
+
+    // ── BOM-tolerant reader tests (issue #130) ──
+
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    const SAMPLE_JSON: &str = r#"{"id":"abc","kind":"ping"}"#;
+
+    fn write_temp(bytes: &[u8]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().expect("tempfile");
+        f.write_all(bytes).expect("write");
+        f.flush().expect("flush");
+        f
+    }
+
+    #[test]
+    fn bom_tolerant_reads_plain_utf8() {
+        let f = write_temp(SAMPLE_JSON.as_bytes());
+        let got = read_text_bom_tolerant(f.path()).expect("read");
+        assert_eq!(got, SAMPLE_JSON);
+        // Parses as JSON.
+        let _: serde_json::Value = serde_json::from_str(&got).expect("parse");
+    }
+
+    #[test]
+    fn bom_tolerant_strips_utf8_bom() {
+        let mut bytes = vec![0xEF, 0xBB, 0xBF];
+        bytes.extend_from_slice(SAMPLE_JSON.as_bytes());
+        let f = write_temp(&bytes);
+        let got = read_text_bom_tolerant(f.path()).expect("read");
+        assert_eq!(got, SAMPLE_JSON);
+        let _: serde_json::Value = serde_json::from_str(&got).expect("parse");
+    }
+
+    #[test]
+    fn bom_tolerant_decodes_utf16_le_bom() {
+        let mut bytes = vec![0xFF, 0xFE];
+        for u in SAMPLE_JSON.encode_utf16() {
+            bytes.extend_from_slice(&u.to_le_bytes());
+        }
+        let f = write_temp(&bytes);
+        let got = read_text_bom_tolerant(f.path()).expect("read");
+        assert_eq!(got, SAMPLE_JSON);
+        let _: serde_json::Value = serde_json::from_str(&got).expect("parse");
+    }
+
+    #[test]
+    fn bom_tolerant_decodes_utf16_be_bom() {
+        let mut bytes = vec![0xFE, 0xFF];
+        for u in SAMPLE_JSON.encode_utf16() {
+            bytes.extend_from_slice(&u.to_be_bytes());
+        }
+        let f = write_temp(&bytes);
+        let got = read_text_bom_tolerant(f.path()).expect("read");
+        assert_eq!(got, SAMPLE_JSON);
+        let _: serde_json::Value = serde_json::from_str(&got).expect("parse");
+    }
+
+    #[test]
+    fn bom_tolerant_rejects_invalid_utf8_no_bom() {
+        // Lone continuation byte 0x80 is invalid UTF-8 and not a recognized BOM.
+        let f = write_temp(&[0x80, 0x81, 0x82]);
+        let err = read_text_bom_tolerant(f.path()).expect_err("must err");
+        assert!(err.contains("Invalid UTF-8"), "unexpected error: {}", err);
+    }
+
+    #[test]
+    fn bom_tolerant_empty_file_returns_empty_string() {
+        let f = write_temp(&[]);
+        let got = read_text_bom_tolerant(f.path()).expect("empty ok");
+        assert_eq!(got, "");
+        // Serde fails with a parse error (NOT a read error) — confirms the failure
+        // surfaces at the parser, which is what the callsites wrap with their own
+        // context strings.
+        let parse_err = serde_json::from_str::<serde_json::Value>(&got).expect_err("must err");
+        assert!(parse_err.is_eof(), "expected EOF parse error, got: {}", parse_err);
+    }
 }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -244,14 +244,20 @@ impl MailboxPoller {
                                 )
                             };
 
-                            let rejected = if let Ok(content) = read_text_bom_tolerant(&path) {
-                                if let Ok(msg) = serde_json::from_str::<OutboxMessage>(&content) {
-                                    self.reject_message(&path, &msg, &reason).await.is_ok()
-                                } else {
-                                    Self::reject_raw_file(&path, &reason).is_ok()
+                            // §130-stuck-file: on read failure (e.g. non-UTF-8 non-BOM file),
+                            // fall back to `reject_raw_file` so the file is moved to `rejected/`
+                            // instead of looping forever with `attempt_count >= MAX`.
+                            let rejected = match read_text_bom_tolerant(&path) {
+                                Ok(content) => {
+                                    if let Ok(msg) =
+                                        serde_json::from_str::<OutboxMessage>(&content)
+                                    {
+                                        self.reject_message(&path, &msg, &reason).await.is_ok()
+                                    } else {
+                                        Self::reject_raw_file(&path, &reason).is_ok()
+                                    }
                                 }
-                            } else {
-                                false
+                                Err(_) => Self::reject_raw_file(&path, &reason).is_ok(),
                             };
 
                             if rejected {
@@ -2176,7 +2182,9 @@ mod tests {
     use std::io::Write;
     use tempfile::NamedTempFile;
 
-    const SAMPLE_JSON: &str = r#"{"id":"abc","kind":"ping"}"#;
+    // Includes a non-BMP codepoint (😀 U+1F600 → surrogate pair D83D DE00) so the
+    // UTF-16 LE/BE BOM tests exercise surrogate-pair decoding, not just BMP.
+    const SAMPLE_JSON: &str = r#"{"id":"abc","kind":"ping","emoji":"😀"}"#;
 
     fn write_temp(bytes: &[u8]) -> NamedTempFile {
         let mut f = NamedTempFile::new().expect("tempfile");
@@ -2246,5 +2254,50 @@ mod tests {
         // context strings.
         let parse_err = serde_json::from_str::<serde_json::Value>(&got).expect_err("must err");
         assert!(parse_err.is_eof(), "expected EOF parse error, got: {}", parse_err);
+    }
+
+    /// §130-stuck-file regression: when the reject path receives a file whose
+    /// bytes are non-UTF-8 and have no BOM (e.g. PowerShell `Set-Content
+    /// -Encoding ANSI` from a CP1252 locale), `read_text_bom_tolerant` returns
+    /// `Err` every poll cycle. Before this fix, the reject branch was guarded
+    /// by `if let Ok(content) = ...` and dropped to `else { false }` on Err —
+    /// the file stayed in the source dir at `attempt_count >= MAX`, looping
+    /// forever. The new `Err(_) => reject_raw_file(...)` arm closes that gap.
+    /// This test drives the fallback directly: an unreadable file is moved to
+    /// `rejected/` and a reason file is written, exactly as the new branch does.
+    #[test]
+    fn reject_raw_file_moves_unreadable_outbox_file_to_rejected_dir() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let outbox = tmp.path();
+        let stuck = outbox.join("stuck.json");
+        // CP1252 high-byte sequence — invalid UTF-8, no BOM.
+        std::fs::write(&stuck, [0x80, 0x81, 0x82]).expect("write stuck file");
+
+        // Precondition: this is exactly the input shape that hits the new Err arm.
+        let read_err = read_text_bom_tolerant(&stuck).expect_err("read must err");
+        assert!(
+            read_err.contains("Invalid UTF-8"),
+            "unexpected error: {}",
+            read_err
+        );
+
+        // Drive the new fallback path.
+        MailboxPoller::reject_raw_file(
+            &stuck,
+            "Undeliverable after 10 attempts. Last error: Failed to read outbox file: Invalid UTF-8",
+        )
+        .expect("reject_raw_file ok");
+
+        assert!(!stuck.exists(), "original file should be moved out of source dir");
+        let rejected_dir = outbox.join("rejected");
+        assert!(rejected_dir.is_dir(), "rejected/ should be created");
+        assert!(
+            rejected_dir.join("stuck.json").is_file(),
+            "file should be moved to rejected/stuck.json"
+        );
+        let reason_file = rejected_dir.join("stuck.reason.txt");
+        assert!(reason_file.is_file(), "reason file should be in rejected/");
+        let reason = std::fs::read_to_string(&reason_file).expect("read reason");
+        assert!(reason.contains("Undeliverable"), "reason content: {}", reason);
     }
 }


### PR DESCRIPTION
## Summary

- Outbox / session-requests parsers were rejecting JSON files with BOMs. UTF-8 BOM (`0xEF 0xBB 0xBF`) was the observed production failure (PowerShell 5.1 `-Encoding utf8` writes UTF-8 WITH BOM); UTF-16 LE/BE BOM also possible from PS defaults.
- New private helper `read_text_bom_tolerant(&Path)` reads raw bytes, detects the 3 BOMs, decodes UTF-16 via `String::from_utf16_lossy`, strips UTF-8 BOM, falls through to strict `String::from_utf8` on no-BOM. Logs `[bom]` warn on every BOM hit so the source tool's encoding is diagnosable in logs.
- Three callsites swapped in `src-tauri/src/phone/mailbox.rs`:
  - `process_message` (outbox messages) — the primary bug surface in #130.
  - `poll_session_requests` (CLI session-requests) — same pattern, same bug class.
  - `process_message` reject-path read — added on a HIGH-severity finding from `/feature-dev` and grinch's adversarial review. Fix uses `match { Ok(content) => ..., Err(_) => Self::reject_raw_file(&path, &reason).is_ok() }` so a consistently-failing read (e.g. CP1252 garbage) cannot strand a file at `attempt_count >= MAX` looping forever.
- 7 new unit tests: plain UTF-8 (regression), UTF-8 BOM, UTF-16 LE BOM (with surrogate-pair coverage via U+1F600), UTF-16 BE BOM (same), invalid UTF-8 no BOM, empty file, unreadable-file → `rejected/` move.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib` — 249 passed, 0 failed
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] WG-18 release build: `npx tauri build` succeeded, exe deployed to `agentscommander_standalone_wg-18.exe`, `--help` smoke-tested
- [ ] Manual: drop UTF-8-BOM JSON in an outbox dir → message delivers, `[bom]` warn fires once
- [ ] Manual: drop UTF-16-LE-BOM JSON in an outbox dir → message delivers
- [ ] Manual: drop non-UTF-8 garbage bytes in an outbox dir → file ends up in `rejected/` after 10 retries (no infinite loop)

## Follow-ups (not blocking)

- Same bug class exists at `mailbox.rs:1584` and `:1617` (config.json reads). Quality-of-life only since AC controls config writes; trigger requires a user editing config.json with PS5.1 `-Encoding utf8`. Separate issue worth filing.
- Test coverage gap (flagged by grinch): the unreadable-file test calls `reject_raw_file` directly and does not exercise the `match` wiring at line 260. A silent revert of `Err(_) => reject_raw_file(...)` to `Err(_) => false` would still pass all 249 tests. Mitigation requires extracting `try_dispose_unparseable` — out of scope for this PR.

Closes #130