### PR TITLE
feat(titlebar): show workgroup badge + agent@project (#152)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.1",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.1",
+      "version": "0.8.3",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",
@@ -22,7 +22,8 @@
         "husky": "^9.1.7",
         "typescript": "^5",
         "vite": "^8.0.2",
-        "vite-plugin-solid": "^2.11.11"
+        "vite-plugin-solid": "^2.11.11",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "npm": ">=11.0.0"
@@ -675,6 +676,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -976,6 +984,144 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -996,6 +1142,16 @@
       "workspaces": [
         "addons/*"
       ]
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/babel-plugin-jsx-dom-expressions": {
       "version": "0.40.5",
@@ -1115,6 +1271,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1209,6 +1375,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1217,6 +1390,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1609,6 +1802,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/merge-anything": {
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-5.1.7.tgz",
@@ -1658,6 +1861,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -1680,6 +1894,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1820,6 +2041,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/solid-js": {
       "version": "1.9.12",
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.12.tgz",
@@ -1857,6 +2085,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -1872,6 +2131,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2051,6 +2320,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2065,6 +2424,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.1",
+  "version": "0.8.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "kill-dev": "powershell.exe -ExecutionPolicy Bypass -File ./scripts/kill-dev.ps1",
     "validate-branch-name": "node scripts/validate-branch-name.mjs",
     "prepare": "husky",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
@@ -28,7 +30,8 @@
     "husky": "^9.1.7",
     "typescript": "^5",
     "vite": "^8.0.2",
-    "vite-plugin-solid": "^2.11.11"
+    "vite-plugin-solid": "^2.11.11",
+    "vitest": "^4.1.5"
   },
   "engines": {
     "npm": ">=11.0.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.1"
+version = "0.8.3"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.1"
+version = "0.8.3"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/shared/path-extractors.test.ts
+++ b/src/shared/path-extractors.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { extractProjectName, extractWorkgroupName, extractAgentName } from './path-extractors';
+
+describe('path-extractors', () => {
+  it('empty_input_returns_all_null', () => {
+    const w = '';
+    expect(extractProjectName(w)).toBeNull();
+    expect(extractWorkgroupName(w)).toBeNull();
+    expect(extractAgentName(w)).toBeNull();
+  });
+
+  it('path_without_ac_new_returns_all_null', () => {
+    const w = 'C:\\foo\\bar';
+    expect(extractProjectName(w)).toBeNull();
+    expect(extractWorkgroupName(w)).toBeNull();
+    expect(extractAgentName(w)).toBeNull();
+  });
+
+  it('ac_new_only_returns_project_only', () => {
+    const w = 'C:\\foo\\.ac-new';
+    expect(extractProjectName(w)).toBe('foo');
+    expect(extractWorkgroupName(w)).toBeNull();
+    expect(extractAgentName(w)).toBeNull();
+  });
+
+  it('agent_in_wg_returns_all_three', () => {
+    const w = 'C:\\foo\\.ac-new\\wg-19-dev-team\\__agent_tech-lead';
+    expect(extractProjectName(w)).toBe('foo');
+    expect(extractWorkgroupName(w)).toBe('WG-19-DEV-TEAM');
+    expect(extractAgentName(w)).toBe('tech-lead');
+  });
+
+  it('repo_in_wg_returns_project_and_wg_no_agent', () => {
+    const w = 'C:\\foo\\.ac-new\\wg-19-dev-team\\repo-X';
+    expect(extractProjectName(w)).toBe('foo');
+    expect(extractWorkgroupName(w)).toBe('WG-19-DEV-TEAM');
+    expect(extractAgentName(w)).toBeNull();
+  });
+
+  it('bare_underscore_agent_returns_no_agent', () => {
+    const w = 'C:\\foo\\.ac-new\\wg-1\\__agent_';
+    expect(extractProjectName(w)).toBe('foo');
+    expect(extractWorkgroupName(w)).toBe('WG-1');
+    expect(extractAgentName(w)).toBeNull();
+  });
+
+  it('nested_ac_new_uses_innermost', () => {
+    const w = 'C:\\proj\\.ac-new\\wg-1-outer\\repo-AC\\.ac-new\\wg-2-inner\\__agent_alice';
+    expect(extractProjectName(w)).toBe('repo-AC');
+    expect(extractWorkgroupName(w)).toBe('WG-2-INNER');
+    expect(extractAgentName(w)).toBe('alice');
+  });
+
+  it('unc_prefix_handled', () => {
+    const w = '\\\\?\\C:\\proj\\.ac-new\\wg-1\\__agent_x';
+    expect(extractProjectName(w)).toBe('proj');
+    expect(extractWorkgroupName(w)).toBe('WG-1');
+    expect(extractAgentName(w)).toBe('x');
+  });
+
+  it('trailing_slash_handled', () => {
+    const w = 'C:\\foo\\.ac-new\\wg-1\\__agent_x\\';
+    expect(extractProjectName(w)).toBe('foo');
+    expect(extractWorkgroupName(w)).toBe('WG-1');
+    expect(extractAgentName(w)).toBe('x');
+  });
+
+  it('lax_wg_segment_rejected_no_digits', () => {
+    const w = 'C:\\foo\\.ac-new\\wg-foo\\__agent_x';
+    expect(extractProjectName(w)).toBe('foo');
+    expect(extractWorkgroupName(w)).toBeNull();
+    expect(extractAgentName(w)).toBe('x');
+  });
+
+  it('lax_wg_segment_rejected_bare_dash', () => {
+    const w = 'C:\\foo\\.ac-new\\wg-\\__agent_x';
+    expect(extractProjectName(w)).toBe('foo');
+    expect(extractWorkgroupName(w)).toBeNull();
+    expect(extractAgentName(w)).toBe('x');
+  });
+
+  it('forward_slashes_handled', () => {
+    const w = '/foo/.ac-new/wg-1/__agent_x';
+    expect(extractProjectName(w)).toBe('foo');
+    expect(extractWorkgroupName(w)).toBe('WG-1');
+    expect(extractAgentName(w)).toBe('x');
+  });
+});

--- a/src/shared/path-extractors.ts
+++ b/src/shared/path-extractors.ts
@@ -1,0 +1,27 @@
+function pathParts(workDir: string): string[] {
+  return workDir.replace(/\\/g, '/').split('/').filter(s => s.length > 0);
+}
+
+export function extractProjectName(workDir: string): string | null {
+  const parts = pathParts(workDir);
+  const idx = parts.lastIndexOf('.ac-new');
+  return idx > 0 ? parts[idx - 1] : null;
+}
+
+export function extractWorkgroupName(workDir: string): string | null {
+  const parts = pathParts(workDir);
+  const idx = parts.lastIndexOf('.ac-new');
+  if (idx < 0 || idx + 1 >= parts.length) return null;
+  const wg = parts[idx + 1];
+  return /^wg-\d+/.test(wg) ? wg.toUpperCase() : null;
+}
+
+export function extractAgentName(workDir: string): string | null {
+  const parts = pathParts(workDir);
+  const idx = parts.lastIndexOf('.ac-new');
+  if (idx < 0 || idx + 2 >= parts.length) return null;
+  const seg = parts[idx + 2];
+  if (!seg.startsWith('__agent_')) return null;
+  const name = seg.slice('__agent_'.length);
+  return name.length > 0 ? name : null;
+}

--- a/src/sidebar/components/Titlebar.tsx
+++ b/src/sidebar/components/Titlebar.tsx
@@ -29,8 +29,10 @@ const Titlebar: Component = () => {
   const agentName = createMemo(() => extractAgentName(terminalStore.activeWorkingDirectory));
   const trailingText = createMemo(() => {
     const proj = projectName();
-    const ag = agentName() ?? terminalStore.activeSessionName;
+    const ag = agentName();
     if (proj && ag) return `${ag}@${proj}`;
+    if (ag) return ag;
+    if (proj && terminalStore.activeSessionName) return `${terminalStore.activeSessionName}@${proj}`;
     return terminalStore.activeSessionName || null;
   });
 

--- a/src/sidebar/components/Titlebar.tsx
+++ b/src/sidebar/components/Titlebar.tsx
@@ -1,11 +1,36 @@
-import { Component, Show, For, createSignal, onMount, onCleanup } from "solid-js";
+import { Component, Show, For, createSignal, createMemo, onMount, onCleanup } from "solid-js";
 import iconUrl from "../../assets/icon-16.png";
 import { SettingsAPI } from "../../shared/ipc";
 import { isTauri } from "../../shared/platform";
+import { terminalStore } from "../../terminal/stores/terminal";
 import type { MainSidebarSide } from "../../shared/types";
 
 declare const __APP_VERSION__: string;
 const APP_VERSION = __APP_VERSION__;
+
+function extractProjectName(workDir: string): string | null {
+  const parts = workDir.replace(/\\/g, '/').split('/');
+  const idx = parts.indexOf('.ac-new');
+  return idx > 0 ? parts[idx - 1] : null;
+}
+
+function extractWorkgroupName(workDir: string): string | null {
+  const parts = workDir.replace(/\\/g, '/').split('/');
+  const idx = parts.indexOf('.ac-new');
+  if (idx < 0 || idx + 1 >= parts.length) return null;
+  const wg = parts[idx + 1];
+  return wg.startsWith('wg-') ? wg.toUpperCase() : null;
+}
+
+function extractAgentName(workDir: string): string | null {
+  const parts = workDir.replace(/\\/g, '/').split('/');
+  const idx = parts.indexOf('.ac-new');
+  if (idx < 0 || idx + 2 >= parts.length) return null;
+  const seg = parts[idx + 2];
+  if (!seg.startsWith('__agent_')) return null;
+  const name = seg.slice('__agent_'.length);
+  return name.length > 0 ? name : null;
+}
 
 const SIDEBAR_WIDTH_PRESETS: Array<{ label: string; width: number }> = [
   { label: "Narrow", width: 200 },
@@ -22,6 +47,15 @@ const Titlebar: Component = () => {
   const [layoutOpen, setLayoutOpen] = createSignal(false);
   const [instanceLabel, setInstanceLabel] = createSignal("");
   const [currentSide, setCurrentSide] = createSignal<MainSidebarSide>("right");
+  const projectName = createMemo(() => extractProjectName(terminalStore.activeWorkingDirectory));
+  const wgName = createMemo(() => extractWorkgroupName(terminalStore.activeWorkingDirectory));
+  const agentName = createMemo(() => extractAgentName(terminalStore.activeWorkingDirectory));
+  const trailingText = createMemo(() => {
+    const proj = projectName();
+    const ag = agentName() ?? terminalStore.activeSessionName;
+    if (proj && ag) return `${ag}@${proj}`;
+    return terminalStore.activeSessionName || null;
+  });
 
   const handleMinimize = async () => {
     if (!isTauri) return;
@@ -105,6 +139,12 @@ const Titlebar: Component = () => {
         {instanceLabel() && (
           <span class="titlebar-stage-badge" data-tauri-drag-region>{instanceLabel()}</span>
         )}
+        <Show when={wgName()}>
+          <span class="titlebar-wg-badge" data-tauri-drag-region>{wgName()}</span>
+        </Show>
+        <Show when={trailingText()} fallback={<span>Terminal</span>}>
+          <span class="titlebar-session-name">{trailingText()}</span>
+        </Show>
       </div>
       <div class="titlebar-controls">
         <div class="layout-dropdown-wrapper">

--- a/src/sidebar/components/Titlebar.tsx
+++ b/src/sidebar/components/Titlebar.tsx
@@ -2,35 +2,12 @@ import { Component, Show, For, createSignal, createMemo, onMount, onCleanup } fr
 import iconUrl from "../../assets/icon-16.png";
 import { SettingsAPI } from "../../shared/ipc";
 import { isTauri } from "../../shared/platform";
+import { extractProjectName, extractWorkgroupName, extractAgentName } from "../../shared/path-extractors";
 import { terminalStore } from "../../terminal/stores/terminal";
 import type { MainSidebarSide } from "../../shared/types";
 
 declare const __APP_VERSION__: string;
 const APP_VERSION = __APP_VERSION__;
-
-function extractProjectName(workDir: string): string | null {
-  const parts = workDir.replace(/\\/g, '/').split('/');
-  const idx = parts.indexOf('.ac-new');
-  return idx > 0 ? parts[idx - 1] : null;
-}
-
-function extractWorkgroupName(workDir: string): string | null {
-  const parts = workDir.replace(/\\/g, '/').split('/');
-  const idx = parts.indexOf('.ac-new');
-  if (idx < 0 || idx + 1 >= parts.length) return null;
-  const wg = parts[idx + 1];
-  return wg.startsWith('wg-') ? wg.toUpperCase() : null;
-}
-
-function extractAgentName(workDir: string): string | null {
-  const parts = workDir.replace(/\\/g, '/').split('/');
-  const idx = parts.indexOf('.ac-new');
-  if (idx < 0 || idx + 2 >= parts.length) return null;
-  const seg = parts[idx + 2];
-  if (!seg.startsWith('__agent_')) return null;
-  const name = seg.slice('__agent_'.length);
-  return name.length > 0 ? name : null;
-}
 
 const SIDEBAR_WIDTH_PRESETS: Array<{ label: string; width: number }> = [
   { label: "Narrow", width: 200 },

--- a/src/sidebar/components/Titlebar.tsx
+++ b/src/sidebar/components/Titlebar.tsx
@@ -142,7 +142,7 @@ const Titlebar: Component = () => {
         <Show when={wgName()}>
           <span class="titlebar-wg-badge" data-tauri-drag-region>{wgName()}</span>
         </Show>
-        <Show when={trailingText()} fallback={<span>Terminal</span>}>
+        <Show when={trailingText()} fallback={<span class="titlebar-session-name">Terminal</span>}>
           <span class="titlebar-session-name">{trailingText()}</span>
         </Show>
       </div>

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -90,6 +90,18 @@ html, body, #root {
   vertical-align: middle;
 }
 
+.titlebar-wg-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  margin-left: 6px;
+  background: rgba(80, 200, 160, 0.15);
+  color: #5fd4a8;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
 .titlebar-controls {
   display: flex;
   gap: 0;

--- a/src/terminal/components/Titlebar.tsx
+++ b/src/terminal/components/Titlebar.tsx
@@ -20,8 +20,10 @@ const Titlebar: Component<TitlebarProps> = (props) => {
   const agentName = createMemo(() => extractAgentName(terminalStore.activeWorkingDirectory));
   const trailingText = createMemo(() => {
     const proj = projectName();
-    const ag = agentName() ?? terminalStore.activeSessionName;
+    const ag = agentName();
     if (proj && ag) return `${ag}@${proj}`;
+    if (ag) return ag;
+    if (proj && terminalStore.activeSessionName) return `${terminalStore.activeSessionName}@${proj}`;
     return terminalStore.activeSessionName || null;
   });
 

--- a/src/terminal/components/Titlebar.tsx
+++ b/src/terminal/components/Titlebar.tsx
@@ -25,7 +25,9 @@ function extractAgentName(workDir: string): string | null {
   const idx = parts.indexOf('.ac-new');
   if (idx < 0 || idx + 2 >= parts.length) return null;
   const seg = parts[idx + 2];
-  return seg.startsWith('__agent_') ? seg.slice('__agent_'.length) : null;
+  if (!seg.startsWith('__agent_')) return null;
+  const name = seg.slice('__agent_'.length);
+  return name.length > 0 ? name : null;
 }
 
 interface TitlebarProps {

--- a/src/terminal/components/Titlebar.tsx
+++ b/src/terminal/components/Titlebar.tsx
@@ -110,7 +110,7 @@ const Titlebar: Component<TitlebarProps> = (props) => {
         <Show when={wgName()}>
           <span class="titlebar-wg-badge" data-tauri-drag-region>{wgName()}</span>
         </Show>
-        <Show when={trailingText()} fallback={<span>Terminal</span>}>
+        <Show when={trailingText()} fallback={<span class="titlebar-session-name">Terminal</span>}>
           <span class="titlebar-session-name">{trailingText()}</span>
         </Show>
       </div>

--- a/src/terminal/components/Titlebar.tsx
+++ b/src/terminal/components/Titlebar.tsx
@@ -3,32 +3,9 @@ import { terminalStore } from "../stores/terminal";
 import iconUrl from "../../assets/icon-16.png";
 import { isTauri } from "../../shared/platform";
 import { WindowAPI } from "../../shared/ipc";
+import { extractProjectName, extractWorkgroupName, extractAgentName } from "../../shared/path-extractors";
 declare const __APP_VERSION__: string;
 const APP_VERSION = __APP_VERSION__;
-
-function extractProjectName(workDir: string): string | null {
-  const parts = workDir.replace(/\\/g, '/').split('/');
-  const idx = parts.indexOf('.ac-new');
-  return idx > 0 ? parts[idx - 1] : null;
-}
-
-function extractWorkgroupName(workDir: string): string | null {
-  const parts = workDir.replace(/\\/g, '/').split('/');
-  const idx = parts.indexOf('.ac-new');
-  if (idx < 0 || idx + 1 >= parts.length) return null;
-  const wg = parts[idx + 1];
-  return wg.startsWith('wg-') ? wg.toUpperCase() : null;
-}
-
-function extractAgentName(workDir: string): string | null {
-  const parts = workDir.replace(/\\/g, '/').split('/');
-  const idx = parts.indexOf('.ac-new');
-  if (idx < 0 || idx + 2 >= parts.length) return null;
-  const seg = parts[idx + 2];
-  if (!seg.startsWith('__agent_')) return null;
-  const name = seg.slice('__agent_'.length);
-  return name.length > 0 ? name : null;
-}
 
 interface TitlebarProps {
   detached?: boolean;

--- a/src/terminal/components/Titlebar.tsx
+++ b/src/terminal/components/Titlebar.tsx
@@ -12,6 +12,22 @@ function extractProjectName(workDir: string): string | null {
   return idx > 0 ? parts[idx - 1] : null;
 }
 
+function extractWorkgroupName(workDir: string): string | null {
+  const parts = workDir.replace(/\\/g, '/').split('/');
+  const idx = parts.indexOf('.ac-new');
+  if (idx < 0 || idx + 1 >= parts.length) return null;
+  const wg = parts[idx + 1];
+  return wg.startsWith('wg-') ? wg.toUpperCase() : null;
+}
+
+function extractAgentName(workDir: string): string | null {
+  const parts = workDir.replace(/\\/g, '/').split('/');
+  const idx = parts.indexOf('.ac-new');
+  if (idx < 0 || idx + 2 >= parts.length) return null;
+  const seg = parts[idx + 2];
+  return seg.startsWith('__agent_') ? seg.slice('__agent_'.length) : null;
+}
+
 interface TitlebarProps {
   detached?: boolean;
   /** Session id this detached window is locked to. Required for Re-attach button. */
@@ -21,6 +37,14 @@ interface TitlebarProps {
 const Titlebar: Component<TitlebarProps> = (props) => {
   const [instanceLabel, setInstanceLabel] = createSignal("");
   const projectName = createMemo(() => extractProjectName(terminalStore.activeWorkingDirectory));
+  const wgName = createMemo(() => extractWorkgroupName(terminalStore.activeWorkingDirectory));
+  const agentName = createMemo(() => extractAgentName(terminalStore.activeWorkingDirectory));
+  const trailingText = createMemo(() => {
+    const proj = projectName();
+    const ag = agentName() ?? terminalStore.activeSessionName;
+    if (proj && ag) return `${ag}@${proj}`;
+    return terminalStore.activeSessionName || null;
+  });
 
   onMount(async () => {
     if (isTauri) {
@@ -81,16 +105,11 @@ const Titlebar: Component<TitlebarProps> = (props) => {
         <Show when={props.detached}>
           <span class="titlebar-detached-badge">DETACHED</span>
         </Show>
-        <Show when={projectName()}>
-          <span class="titlebar-project-badge" data-tauri-drag-region>{projectName()}</span>
+        <Show when={wgName()}>
+          <span class="titlebar-wg-badge" data-tauri-drag-region>{wgName()}</span>
         </Show>
-        <Show
-          when={terminalStore.activeSessionName}
-          fallback={<span>Terminal</span>}
-        >
-          <span class="titlebar-session-name">
-            {terminalStore.activeSessionName}
-          </span>
+        <Show when={trailingText()} fallback={<span>Terminal</span>}>
+          <span class="titlebar-session-name">{trailingText()}</span>
         </Show>
       </div>
       <Show when={isTauri}>

--- a/src/terminal/styles/terminal.css
+++ b/src/terminal/styles/terminal.css
@@ -105,19 +105,6 @@ html, body, #root {
   vertical-align: middle;
 }
 
-.titlebar-project-badge {
-  display: inline-block;
-  padding: 1px 6px;
-  margin-left: 6px;
-  background: rgba(130, 80, 255, 0.15);
-  color: #b490ff;
-  border-radius: 3px;
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-}
-
 .titlebar-wg-badge {
   display: inline-block;
   padding: 1px 6px;
@@ -127,7 +114,6 @@ html, body, #root {
   border-radius: 3px;
   font-size: 10px;
   font-weight: 600;
-  text-transform: uppercase;
   letter-spacing: 0.3px;
 }
 

--- a/src/terminal/styles/terminal.css
+++ b/src/terminal/styles/terminal.css
@@ -118,6 +118,19 @@ html, body, #root {
   letter-spacing: 0.3px;
 }
 
+.titlebar-wg-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  margin-left: 6px;
+  background: rgba(80, 200, 160, 0.15);
+  color: #5fd4a8;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
 .titlebar-detached-badge {
   display: inline-block;
   padding: 1px 5px;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a workgroup badge and `<agent>@<project>` trailing text to the in-app titlebar in **both** the main window (`src/sidebar/components/Titlebar.tsx`) and detached terminal windows (`src/terminal/components/Titlebar.tsx`).
- Extracts the three path-parsing helpers to `src/shared/path-extractors.ts` with 12 unit tests under a new Vitest setup.
- Aligns the TS helpers with backend `agent_fqn_from_path` (`lastIndexOf` + empty-segment filter), so nested `.ac-new` layouts (AC dev-on-AC) are parsed correctly.
- Bumps version to **0.8.3** across `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, and `package.json`.
- Drops dead `.titlebar-project-badge` CSS rule and a redundant `text-transform: uppercase` from `.titlebar-wg-badge`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 12/12 path-extractor tests pass
- [x] `npx tauri build` produces a working .exe (deployed to `agentscommander_standalone_wg-19.exe` for testing)
- [x] Manual UI verification across the four behavior matrix rows (agent in WG, shell in WG repo, no `.ac-new`, no active session) for both main and detached windows
- [x] /feature-dev parallel reviewers — no HIGH outstanding
- [x] Adversarial review APPROVED FOR MERGE — 3 LOW notes captured below

## Follow-ups (NOT in this PR)
- LOW-A: `.titlebar-wg-badge` is duplicated in `sidebar.css` and `terminal.css`. Defensive but unnecessary — rolldown dedupes since `terminal.css` is transitively imported into the main bundle. Future drift hazard.
- LOW-B: `trailingText`'s 4-branch fallback isn't unit-tested at the component level.
- LOW-C: `src/sidebar/components/SessionItem.tsx:253` still uses `parts.indexOf('.ac-new')` — same nested-`.ac-new` mis-derivation issue that MEDIUM-1 fixed in the helpers.
- LOW-7/8/9 (pre-existing CSS patterns): badge gap+margin, brand row width discipline, light-theme contrast.

Closes #152