### PR TITLE
chore(titlebar): post-#152 cleanups (#155)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/shared/path-extractors.test.ts
+++ b/src/shared/path-extractors.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { extractProjectName, extractWorkgroupName, extractAgentName } from './path-extractors';
+import {
+  extractProjectName,
+  extractWorkgroupName,
+  extractAgentName,
+  computeTrailingText,
+} from './path-extractors';
 
 describe('path-extractors', () => {
   it('empty_input_returns_all_null', () => {
@@ -84,5 +89,47 @@ describe('path-extractors', () => {
     expect(extractProjectName(w)).toBe('foo');
     expect(extractWorkgroupName(w)).toBe('WG-1');
     expect(extractAgentName(w)).toBe('x');
+  });
+});
+
+describe('computeTrailingText', () => {
+  it('project_and_agent_returns_agent_at_project', () => {
+    const w = 'C:\\foo\\.ac-new\\wg-19-dev-team\\__agent_alice';
+    expect(computeTrailingText(w, null)).toBe('alice@foo');
+    expect(computeTrailingText(w, 'session-x')).toBe('alice@foo');
+  });
+
+  it('agent_only_returns_agent', () => {
+    const w = '\\.ac-new\\wg-1\\__agent_alice';
+    expect(extractProjectName(w)).toBeNull();
+    expect(extractAgentName(w)).toBe('alice');
+    expect(computeTrailingText(w, null)).toBe('alice');
+    expect(computeTrailingText(w, 'session-x')).toBe('alice');
+  });
+
+  it('project_and_session_no_agent_returns_session_at_project', () => {
+    const w = 'C:\\foo\\.ac-new\\wg-1\\repo-X';
+    expect(extractProjectName(w)).toBe('foo');
+    expect(extractAgentName(w)).toBeNull();
+    expect(computeTrailingText(w, 'my-session')).toBe('my-session@foo');
+  });
+
+  it('session_only_returns_session', () => {
+    const w = 'C:\\unrelated\\path';
+    expect(extractProjectName(w)).toBeNull();
+    expect(extractAgentName(w)).toBeNull();
+    expect(computeTrailingText(w, 'my-session')).toBe('my-session');
+  });
+
+  it('nothing_returns_null', () => {
+    expect(computeTrailingText('', null)).toBeNull();
+    expect(computeTrailingText('', undefined)).toBeNull();
+    expect(computeTrailingText('', '')).toBeNull();
+    expect(computeTrailingText('C:\\nothing', null)).toBeNull();
+  });
+
+  it('nested_ac_new_uses_innermost_for_trailing', () => {
+    const w = 'C:\\proj\\.ac-new\\wg-1-outer\\repo-AC\\.ac-new\\wg-2-inner\\__agent_alice';
+    expect(computeTrailingText(w, null)).toBe('alice@repo-AC');
   });
 });

--- a/src/shared/path-extractors.ts
+++ b/src/shared/path-extractors.ts
@@ -25,3 +25,17 @@ export function extractAgentName(workDir: string): string | null {
   const name = seg.slice('__agent_'.length);
   return name.length > 0 ? name : null;
 }
+
+/** Trailing label shown in titlebars: "agent@project" when both are derivable
+ *  from the path; falls back through agent-only, sessionName@project, sessionName, null. */
+export function computeTrailingText(
+  workDir: string,
+  sessionName: string | null | undefined,
+): string | null {
+  const proj = extractProjectName(workDir);
+  const ag = extractAgentName(workDir);
+  if (proj && ag) return `${ag}@${proj}`;
+  if (ag) return ag;
+  if (proj && sessionName) return `${sessionName}@${proj}`;
+  return sessionName || null;
+}

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -2,6 +2,7 @@ import { Component, createSignal, Show, For, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
 import type { Session, SessionStatus, TelegramBotConfig, RepoMatch } from "../../shared/types";
 import { SessionAPI, TelegramAPI, SettingsAPI, WindowAPI, AgentCreatorAPI, emitOpenSettings } from "../../shared/ipc";
+import { extractProjectName } from "../../shared/path-extractors";
 import { isTauri } from "../../shared/platform";
 import { bridgesStore } from "../stores/bridges";
 import { sessionsStore } from "../stores/sessions";
@@ -244,20 +245,22 @@ const SessionItem: Component<{
   /** Derive short display name from workingDirectory.
    *  .ac-new paths: "agent-name@origin-project" (e.g. "code-reviewer@phi_phibridge")
    *  Other paths: "parentFolder/name" (last 2 segments)
-   */
+   *
+   *  .ac-new parsing is delegated to extractProjectName (innermost wins via
+   *  lastIndexOf — matches the titlebar helpers, fixes nested-.ac-new bug). */
   const displayName = () => {
     const wd = props.session.workingDirectory;
     if (wd) {
-      const normalized = wd.replace(/\\/g, "/").replace(/\/+$/, "");
-      const parts = normalized.split("/");
-      const acIdx = parts.indexOf(".ac-new");
-      if (acIdx >= 1) {
-        // Use origin project from identity resolution; fall back to path-derived project
-        const projectFolder = props.originProject || parts[acIdx - 1];
-        let agentDir = parts[parts.length - 1];
-        agentDir = agentDir.replace(/^__?agent_/, "");
+      const pathProject = extractProjectName(wd);
+      if (pathProject) {
+        const projectFolder = props.originProject || pathProject;
+        const normalized = wd.replace(/\\/g, "/").replace(/\/+$/, "");
+        const parts = normalized.split("/");
+        const agentDir = parts[parts.length - 1].replace(/^__?agent_/, "");
         return `${agentDir}@${projectFolder}`;
       }
+      const normalized = wd.replace(/\\/g, "/").replace(/\/+$/, "");
+      const parts = normalized.split("/");
       if (parts.length >= 2) {
         return parts.slice(-2).join("/");
       }

--- a/src/sidebar/components/Titlebar.tsx
+++ b/src/sidebar/components/Titlebar.tsx
@@ -2,7 +2,7 @@ import { Component, Show, For, createSignal, createMemo, onMount, onCleanup } fr
 import iconUrl from "../../assets/icon-16.png";
 import { SettingsAPI } from "../../shared/ipc";
 import { isTauri } from "../../shared/platform";
-import { extractProjectName, extractWorkgroupName, extractAgentName } from "../../shared/path-extractors";
+import { extractWorkgroupName, computeTrailingText } from "../../shared/path-extractors";
 import { terminalStore } from "../../terminal/stores/terminal";
 import type { MainSidebarSide } from "../../shared/types";
 
@@ -24,17 +24,10 @@ const Titlebar: Component = () => {
   const [layoutOpen, setLayoutOpen] = createSignal(false);
   const [instanceLabel, setInstanceLabel] = createSignal("");
   const [currentSide, setCurrentSide] = createSignal<MainSidebarSide>("right");
-  const projectName = createMemo(() => extractProjectName(terminalStore.activeWorkingDirectory));
   const wgName = createMemo(() => extractWorkgroupName(terminalStore.activeWorkingDirectory));
-  const agentName = createMemo(() => extractAgentName(terminalStore.activeWorkingDirectory));
-  const trailingText = createMemo(() => {
-    const proj = projectName();
-    const ag = agentName();
-    if (proj && ag) return `${ag}@${proj}`;
-    if (ag) return ag;
-    if (proj && terminalStore.activeSessionName) return `${terminalStore.activeSessionName}@${proj}`;
-    return terminalStore.activeSessionName || null;
-  });
+  const trailingText = createMemo(() =>
+    computeTrailingText(terminalStore.activeWorkingDirectory, terminalStore.activeSessionName),
+  );
 
   const handleMinimize = async () => {
     if (!isTauri) return;

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -67,7 +67,6 @@ html, body, #root {
 .titlebar-dev-badge {
   display: inline-block;
   padding: 1px 5px;
-  margin-left: 6px;
   background: rgba(0, 180, 255, 0.15);
   color: var(--sidebar-accent);
   font-size: 8px;
@@ -80,7 +79,6 @@ html, body, #root {
 .titlebar-stage-badge {
   display: inline-block;
   padding: 1px 5px;
-  margin-left: 6px;
   background: rgba(255, 170, 0, 0.18);
   color: #ffaa00;
   font-size: 8px;
@@ -90,17 +88,8 @@ html, body, #root {
   vertical-align: middle;
 }
 
-.titlebar-wg-badge {
-  display: inline-block;
-  padding: 1px 6px;
-  margin-left: 6px;
-  background: rgba(80, 200, 160, 0.15);
-  color: #5fd4a8;
-  border-radius: 3px;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.3px;
-}
+/* .titlebar-wg-badge canonical definition lives in terminal.css.
+   Both stylesheets are bundled together, so the badge is styled in both windows. */
 
 .titlebar-controls {
   display: flex;

--- a/src/terminal/components/Titlebar.tsx
+++ b/src/terminal/components/Titlebar.tsx
@@ -3,7 +3,7 @@ import { terminalStore } from "../stores/terminal";
 import iconUrl from "../../assets/icon-16.png";
 import { isTauri } from "../../shared/platform";
 import { WindowAPI } from "../../shared/ipc";
-import { extractProjectName, extractWorkgroupName, extractAgentName } from "../../shared/path-extractors";
+import { extractWorkgroupName, computeTrailingText } from "../../shared/path-extractors";
 declare const __APP_VERSION__: string;
 const APP_VERSION = __APP_VERSION__;
 
@@ -15,17 +15,10 @@ interface TitlebarProps {
 
 const Titlebar: Component<TitlebarProps> = (props) => {
   const [instanceLabel, setInstanceLabel] = createSignal("");
-  const projectName = createMemo(() => extractProjectName(terminalStore.activeWorkingDirectory));
   const wgName = createMemo(() => extractWorkgroupName(terminalStore.activeWorkingDirectory));
-  const agentName = createMemo(() => extractAgentName(terminalStore.activeWorkingDirectory));
-  const trailingText = createMemo(() => {
-    const proj = projectName();
-    const ag = agentName();
-    if (proj && ag) return `${ag}@${proj}`;
-    if (ag) return ag;
-    if (proj && terminalStore.activeSessionName) return `${terminalStore.activeSessionName}@${proj}`;
-    return terminalStore.activeSessionName || null;
-  });
+  const trailingText = createMemo(() =>
+    computeTrailingText(terminalStore.activeWorkingDirectory, terminalStore.activeSessionName),
+  );
 
   onMount(async () => {
     if (isTauri) {

--- a/src/terminal/styles/terminal.css
+++ b/src/terminal/styles/terminal.css
@@ -65,6 +65,10 @@ html, body, #root {
   font-weight: 600;
   color: var(--statusbar-accent);
   opacity: 1;
+  max-width: 22em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .titlebar-version {
@@ -82,7 +86,6 @@ html, body, #root {
 .titlebar-dev-badge {
   display: inline-block;
   padding: 1px 5px;
-  margin-left: 6px;
   background: rgba(0, 180, 255, 0.15);
   color: #00b4ff;
   font-size: 8px;
@@ -95,7 +98,6 @@ html, body, #root {
 .titlebar-stage-badge {
   display: inline-block;
   padding: 1px 5px;
-  margin-left: 6px;
   background: rgba(255, 170, 0, 0.18);
   color: #ffaa00;
   font-size: 8px;
@@ -108,7 +110,10 @@ html, body, #root {
 .titlebar-wg-badge {
   display: inline-block;
   padding: 1px 6px;
-  margin-left: 6px;
+  max-width: 12em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   background: rgba(80, 200, 160, 0.15);
   color: #5fd4a8;
   border-radius: 3px;
@@ -120,7 +125,6 @@ html, body, #root {
 .titlebar-detached-badge {
   display: inline-block;
   padding: 1px 5px;
-  margin-right: 6px;
   background: rgba(255, 170, 0, 0.15);
   color: #ffaa00;
   font-size: 8px;
@@ -128,6 +132,28 @@ html, body, #root {
   letter-spacing: 0.5px;
   border-radius: 3px;
   vertical-align: middle;
+}
+
+/* Light-theme overrides — WCAG AA on --titlebar-bg #e8e8ec.
+   Calculated contrast ratios per WCAG 2.1 (luminance formula): */
+html.light-theme .titlebar-wg-badge {
+  /* #0a6e48 on #e8e8ec → 5.14:1 (AA) */
+  color: #0a6e48;
+  background: rgba(10, 110, 72, 0.12);
+}
+
+html.light-theme .titlebar-stage-badge,
+html.light-theme .titlebar-detached-badge {
+  /* #854700 on #e8e8ec → 5.93:1 (AAA) */
+  color: #854700;
+  background: rgba(133, 71, 0, 0.14);
+}
+
+html.light-theme .titlebar-dev-badge,
+html.light-theme .titlebar-version {
+  /* #0a4f9e on #e8e8ec → 6.56:1 (AAA) */
+  color: #0a4f9e;
+  background: rgba(10, 79, 158, 0.12);
 }
 
 .titlebar-controls {


### PR DESCRIPTION
## Summary

- Resolves the 6 LOW follow-ups deferred from PR #154 (Issue #152): duplicate-rule cleanup, `trailingText` extracted to a tested pure function, `SessionItem` switched to innermost-`.ac-new` parsing, badge spacing/sizing/contrast hardened.
- 18 unit tests passing (12 existing + 6 new for `computeTrailingText`); `tsc --noEmit` clean; `tauri build` green.
- Bumped `0.8.3 -> 0.8.4` across `tauri.conf.json` + `Cargo.toml` + `package.json` so the testing build is visually distinguishable.

## Items

- **LOW-A** — duplicate `.titlebar-wg-badge` removed from `sidebar.css`; canonical kept in `terminal.css` (cascade verified end-to-end).
- **LOW-B** — `computeTrailingText(workDir, sessionName)` extracted to `src/shared/path-extractors.ts`; both Titlebars wrap it in `createMemo`. New tests cover all 4 branches + null/undefined sessionName + nested-`.ac-new` regression.
- **LOW-C** — `SessionItem.displayName` now calls `extractProjectName` (innermost via `lastIndexOf`); zero `.ac-new` parsing remains in `SessionItem.tsx`.
- **LOW-7** — `margin-left: 6px` dropped from all 5 `.titlebar-*-badge` rules (parent `.titlebar-brand` already has `gap: 6px`); badge spacing now uniform.
- **LOW-8** — `max-width` + ellipsis on `.titlebar-wg-badge` (12em) and `.titlebar-session-name` (22em) so long names truncate cleanly on narrow windows.
- **LOW-9** — light-theme overrides for wg/stage/dev/detached/version badges, all WCAG AA verified: wg `#0a6e48` @ 5.14:1, stage/detached `#854700` @ 5.93:1, dev/version `#0a4f9e` @ 6.55:1.

## Follow-ups (not in this PR)

Grinch surfaced 4 NITs during adversarial review, all non-blocking and explicitly out-of-scope for #155. The most substantive: `SessionItem` strips `__?agent_` inline while titlebar's `extractAgentName` accepts only `__agent_`; backend (`teams.rs`) accepts both. No real session today triggers the divergence, but worth aligning the TS frontend with the backend in a separate issue.

Closes #155

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` (18 passing — 12 existing + 6 new)
- [x] `npx tauri build` produces `Agents Commander New_0.8.4_x64-setup.exe`
- [x] WG-19 exe rebuilt and deployed; `--help` smoke test green
- [ ] Manual UI verification on the deployed wg-19 build: dark + light theme, main + detached window, narrow window for LOW-8 truncation