### PR TITLE
docs(role): warn PowerShell agents not to prefix AC CLI with rtk (#136)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/rtk.md
+++ b/plugins/rtk.md
@@ -6,7 +6,8 @@ RTK is a CLI proxy installed on this machine that compresses command outputs to 
 
 - **Repo:** https://github.com/rtk-ai/rtk
 - RTK only compresses output from Bash tool calls, not native Claude Code tools (Read, Grep, Glob)
-- If RTK has a dedicated filter for a command, it compresses the output. If not, it passes through unchanged. This means RTK is always safe to use.
+- If RTK has a dedicated filter for a command, it compresses the output. If not, it passes through unchanged. RTK is safe to apply to commands that run through a bash/zsh shell.
+- **PowerShell + AC CLI caveat:** RTK is bash-oriented. Do **NOT** prefix `rtk` to AgentsCommander CLI invocations made from a PowerShell session — PowerShell parses `rtk & '<BinaryPath>' ...` as `AmpersandNotAllowed` and aborts before the command runs. On PowerShell, invoke the AC CLI directly: `& '<BinaryPath>' <subcommand> <args>`. This carve-out applies only to commands that PowerShell would already execute via the `&` call operator (notably any quoted-path call, including the AC CLI). Bash-tool commands inside Claude Code are unaffected.
 
 ## Setup (two parts, both required)
 
@@ -67,7 +68,7 @@ Add to the project's `CLAUDE.md` as a fallback in case the hook is not present:
 
 `rtk` is a CLI proxy installed on this machine that compresses command outputs to reduce tokens.
 
-**Rule:** ALWAYS prefix Bash commands with `rtk`. If RTK has a filter for that command, it compresses the output. If not, it passes through unchanged. It is always safe to use.
+**Rule:** ALWAYS prefix Bash commands with `rtk`. If RTK has a filter for that command, it compresses the output. If not, it passes through unchanged. Safe for Bash/zsh shells. **Do NOT** apply this to AgentsCommander CLI calls under PowerShell — `rtk & '<BinaryPath>' ...` triggers PowerShell's `AmpersandNotAllowed` parser error. On PowerShell, invoke the AC CLI directly: `& '<BinaryPath>' <subcommand> [args]`.
 
 In command chains with &&, prefix each command:
 rtk git add . && rtk git commit -m "msg" && rtk git push

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -544,7 +544,26 @@ Your Session Credentials include a `BinaryPath` field — **always use that path
 "<YOUR_BINARY_PATH>" <subcommand> [args]
 ```
 
+> **PowerShell users:** the bare quoted-path form above is **not** directly executable in PowerShell — see `### PowerShell invocation` below for the correct call shape. The same caveat applies to **every** other quoted-path snippet in this document (the `--help` examples under `## Self-discovery via --help`, and the `send` / `list-peers` examples under `## Inter-Agent Messaging`).
+
 **RULE:** Never hardcode or guess the binary path. Always read `BinaryPath` from your `# === Session Credentials ===` block and use that exact path.
+
+### PowerShell invocation
+
+PowerShell is the default shell for AgentsCommander sessions on Windows. On PowerShell, a quoted path is a string expression, not a command — to actually invoke the binary you must use the **`&` call operator**:
+
+```powershell
+& '<YOUR_BINARY_PATH>' <subcommand> [args]
+```
+
+This rule applies to **every** quoted-path AC CLI snippet shown elsewhere in this document — including the `--help`, `send`, and `list-peers` examples below. The bare `"<YOUR_BINARY_PATH>" <subcommand>` form fails on PowerShell with `Unexpected token '<subcommand>' in expression or statement` (parser error, before the command runs). The bare-quoted form is kept as the shell-agnostic abstract example; PowerShell sessions must apply `&` themselves.
+
+Do **NOT** prefix AC CLI calls with `rtk` (or any other shell wrapper) on PowerShell. `rtk` is a bash-oriented command-rewrite tool; on PowerShell its rewritten form clashes with PowerShell's `&` call operator and the parser fails with `AmpersandNotAllowed` **before** the command runs:
+
+- BAD:  `rtk & '<YOUR_BINARY_PATH>' list-peers ...`  (PowerShell parser error: AmpersandNotAllowed)
+- GOOD: `& '<YOUR_BINARY_PATH>' list-peers ...`
+
+This applies to **every** AC CLI subcommand (`send`, `list-peers`, `create-agent`, `--help`, etc.). If you see `AmpersandNotAllowed` from PowerShell, drop the `rtk` prefix and any other wrapper — invoke the binary directly with `&`.
 
 ## Self-discovery via --help
 
@@ -639,5 +658,36 @@ mod tests {
         assert!(out.contains("filename ONLY"));
         assert!(out.contains("BAD:"));
         assert!(out.contains("GOOD:"));
+    }
+
+    #[test]
+    fn default_context_warns_about_rtk_prefix_on_powershell() {
+        // Cover BOTH variants: replica-only (None) and replica-with-matrix (Some).
+        // A future refactor that splits rendering by branch must keep the warning in both.
+        for out in [
+            default_context("C:/tmp/fake-agent", None),
+            default_context("C:/tmp/fake-agent", Some("C:/tmp/fake-matrix")),
+        ] {
+            assert!(
+                out.contains("### PowerShell invocation"),
+                "missing PowerShell invocation subsection in rendered agent context"
+            );
+            assert!(
+                out.contains("> **PowerShell users:**"),
+                "missing reader-order lead-in after the bare-quoted CLI snippet"
+            );
+            assert!(
+                out.contains("& '<YOUR_BINARY_PATH>'"),
+                "missing PowerShell call-operator example in rendered agent context"
+            );
+            assert!(
+                out.contains("Do **NOT** prefix AC CLI calls with `rtk`"),
+                "missing explicit rtk-prefix warning in rendered agent context"
+            );
+            assert!(
+                out.contains("AmpersandNotAllowed"),
+                "missing AmpersandNotAllowed parser-error name in rendered agent context"
+            );
+        }
     }
 }

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -552,7 +552,7 @@ Your Session Credentials include a `BinaryPath` field — **always use that path
 
 PowerShell is the default shell for AgentsCommander sessions on Windows. On PowerShell, a quoted path is a string expression, not a command — to actually invoke the binary you must use the **`&` call operator**:
 
-```powershell
+```
 & '<YOUR_BINARY_PATH>' <subcommand> [args]
 ```
 
@@ -664,29 +664,39 @@ mod tests {
     fn default_context_warns_about_rtk_prefix_on_powershell() {
         // Cover BOTH variants: replica-only (None) and replica-with-matrix (Some).
         // A future refactor that splits rendering by branch must keep the warning in both.
-        for out in [
-            default_context("C:/tmp/fake-agent", None),
-            default_context("C:/tmp/fake-agent", Some("C:/tmp/fake-matrix")),
-        ] {
+        // Each case carries a `branch_marker` that only appears in its branch's
+        // rendered output, so each iteration actually proves the right branch ran
+        // (otherwise the loop would be theatrical — the warning text is identical
+        // across branches and would pass even if both calls routed to the same path).
+        let cases: [(Option<&str>, &str); 2] = [
+            (None, "two places"),
+            (Some("C:/tmp/fake-matrix"), "C:/tmp/fake-matrix"),
+        ];
+        for (matrix_root, branch_marker) in cases {
+            let out = default_context("C:/tmp/fake-agent", matrix_root);
+            assert!(
+                out.contains(branch_marker),
+                "fixture broken: rendered output for matrix_root={matrix_root:?} did not contain branch marker {branch_marker:?}"
+            );
             assert!(
                 out.contains("### PowerShell invocation"),
-                "missing PowerShell invocation subsection in rendered agent context"
+                "missing PowerShell invocation subsection for matrix_root={matrix_root:?}"
             );
             assert!(
                 out.contains("> **PowerShell users:**"),
-                "missing reader-order lead-in after the bare-quoted CLI snippet"
+                "missing reader-order lead-in for matrix_root={matrix_root:?}"
             );
             assert!(
                 out.contains("& '<YOUR_BINARY_PATH>'"),
-                "missing PowerShell call-operator example in rendered agent context"
+                "missing PowerShell call-operator example for matrix_root={matrix_root:?}"
             );
             assert!(
                 out.contains("Do **NOT** prefix AC CLI calls with `rtk`"),
-                "missing explicit rtk-prefix warning in rendered agent context"
+                "missing explicit rtk-prefix warning for matrix_root={matrix_root:?}"
             );
             assert!(
                 out.contains("AmpersandNotAllowed"),
-                "missing AmpersandNotAllowed parser-error name in rendered agent context"
+                "missing AmpersandNotAllowed parser-error name for matrix_root={matrix_root:?}"
             );
         }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/guide/components/HintsTab.tsx
+++ b/src/guide/components/HintsTab.tsx
@@ -41,7 +41,7 @@ const sections: HintSection[] = [
       },
       {
         title: "RTK — Token Optimizer",
-        body: "CLI proxy that compresses command outputs to reduce token consumption. Prefix any command with rtk and it transparently compresses verbose outputs (git, cargo, npm, etc.) while passing through unchanged when no filter applies. Always safe to use.",
+        body: "Bash-oriented CLI proxy that compresses command outputs to reduce token consumption. Prefix Bash commands with rtk and it transparently compresses verbose outputs (git, cargo, npm, etc.). Caveat: do NOT prefix rtk on AgentsCommander CLI invocations from PowerShell — its rewritten form collides with PowerShell's & call operator and trips AmpersandNotAllowed before the command runs. On PowerShell, invoke the AC CLI directly via & '<BinaryPath>'.",
         link: {
           label: "rtk-ai.app",
           url: "https://www.rtk-ai.app/",


### PR DESCRIPTION
## Summary
- Adds generated agent-context guidance for PowerShell AC CLI invocation via `& '<YOUR_BINARY_PATH>' ...`.
- Warns agents not to prefix AC CLI calls with `rtk` on PowerShell because it triggers `AmpersandNotAllowed`.
- Narrows RTK plugin docs, the copy-paste RTK template, and the in-app RTK hint to include the PowerShell/AC CLI caveat.
- Bumps version to 0.8.1 for the wg-11 test build.

## Verification
- `npx tsc --noEmit` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml --lib config::session_context::tests` passed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --tests -- -D warnings` still fails only on pre-existing unrelated `src/config/settings.rs:39` `derivable_impls` lint.
- Built and deployed wg-11 test exe: `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-11.exe`.

Closes #136