### PR TITLE
feat(settings): add global app sound mute toggle (#158)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.3",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.3",
+      "version": "0.8.5",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -204,6 +204,25 @@ pub async fn set_rtk_prompt_dismissed(
     Ok(())
 }
 
+/// Narrow setter — flips ONLY `sounds_enabled`. Same lock-held-through-save
+/// pattern as `set_inject_rtk_hook` (issue #158). Replaces the toolbar's
+/// previous full-object `update_settings(next)` call, which could clobber
+/// unrelated fields from a stale `settingsStore.current` snapshot.
+/// The `update_settings` caveat documented on `set_inject_rtk_hook` applies
+/// here too.
+#[tauri::command]
+pub async fn set_sounds_enabled(
+    settings: State<'_, SettingsState>,
+    value: bool,
+) -> Result<(), String> {
+    let mut s = settings.write().await;
+    s.sounds_enabled = value;
+    let snapshot = s.clone();
+    save_settings(&snapshot)?;
+    drop(s); // explicit; lock released AFTER the disk write completes
+    Ok(())
+}
+
 /// Sweep every AC-managed agent directory and apply
 /// `ensure_rtk_pretool_hook(dir, enabled)`. Best-effort per directory:
 /// per-dir failures are logged + appended to `errors` and the sweep

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -58,6 +58,11 @@ pub struct AppSettings {
     /// busy→all-idle. The transition is computed in the FE from `waitingForInput`.
     #[serde(default = "default_true")]
     pub team_idle_beep_enabled: bool,
+    /// Master switch for all app-emitted sounds. When false, every current and
+    /// future app-generated playback path must stay silent. Per-feature toggles
+    /// (e.g. `team_idle_beep_enabled`) act as additional gates underneath this one.
+    #[serde(default = "default_true")]
+    pub sounds_enabled: bool,
     /// Raise terminal window when sidebar is clicked
     #[serde(default = "default_true")]
     pub raise_terminal_on_click: bool,
@@ -214,6 +219,7 @@ impl Default for AppSettings {
             start_only_coordinators: true,
             sidebar_always_on_top: false,
             team_idle_beep_enabled: true,
+            sounds_enabled: true,
             raise_terminal_on_click: true,
             voice_to_text_enabled: false,
             gemini_api_key: String::new(),
@@ -618,6 +624,62 @@ mod tests {
         }"#;
         let s: AppSettings = serde_json::from_str(json).expect("deserialize old json");
         assert!(s.team_idle_beep_enabled);
+    }
+
+    #[test]
+    fn sounds_enabled_round_trips_through_serde() {
+        let mut s = AppSettings::default();
+        assert!(s.sounds_enabled);
+        s.sounds_enabled = false;
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert!(json.contains("\"soundsEnabled\":false"));
+        let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
+        assert!(!back.sounds_enabled);
+    }
+
+    #[test]
+    fn sounds_enabled_defaults_true_when_missing_from_json() {
+        // Old settings.json with only team_idle_beep_enabled (and no soundsEnabled
+        // field) must deserialize with sounds_enabled = true so existing users
+        // remain audible until they explicitly mute.
+        let json = r#"{
+            "defaultShell": "bash",
+            "defaultShellArgs": [],
+            "agents": [],
+            "telegramBots": [],
+            "startOnlyCoordinators": true,
+            "sidebarAlwaysOnTop": false,
+            "raiseTerminalOnClick": true,
+            "teamIdleBeepEnabled": false,
+            "voiceToTextEnabled": false,
+            "geminiApiKey": "",
+            "geminiModel": "gemini-2.5-flash",
+            "voiceAutoExecute": true,
+            "voiceAutoExecuteDelay": 15,
+            "sidebarZoom": 1.0,
+            "terminalZoom": 1.0,
+            "mainZoom": 1.0,
+            "guideZoom": 1.0,
+            "darkfactoryZoom": 1.0,
+            "sidebarGeometry": null,
+            "terminalGeometry": null,
+            "mainGeometry": null,
+            "mainSidebarWidth": 280.0,
+            "mainSidebarSide": "right",
+            "mainAlwaysOnTop": false,
+            "webServerEnabled": false,
+            "webServerPort": 7777,
+            "webServerBind": "127.0.0.1",
+            "projectPath": null,
+            "projectPaths": [],
+            "sidebarStyle": "noir-minimal",
+            "onboardingDismissed": false,
+            "coordSortByActivity": false
+        }"#;
+        let s: AppSettings = serde_json::from_str(json).expect("deserialize old json");
+        assert!(s.sounds_enabled);
+        // Existing per-feature toggle is honored as-is.
+        assert!(!s.team_idle_beep_enabled);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -792,6 +792,7 @@ pub fn run() {
             commands::config::update_settings,
             commands::config::set_inject_rtk_hook,
             commands::config::set_rtk_prompt_dismissed,
+            commands::config::set_sounds_enabled,
             commands::config::sweep_rtk_hook,
             commands::config::get_rtk_startup_status,
             commands::repos::search_repos,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -136,6 +136,8 @@ export const SettingsAPI = {
     transport.invoke<void>("set_inject_rtk_hook", { value }),
   setRtkPromptDismissed: (value: boolean) =>
     transport.invoke<void>("set_rtk_prompt_dismissed", { value }),
+  setSoundsEnabled: (value: boolean) =>
+    transport.invoke<void>("set_sounds_enabled", { value }),
   sweepRtkHook: (enabled: boolean) =>
     transport.invoke<RtkSweepResult>("sweep_rtk_hook", { enabled }),
   getRtkStartupStatus: () =>

--- a/src/shared/sound.ts
+++ b/src/shared/sound.ts
@@ -4,6 +4,18 @@
 
 let cachedContext: AudioContext | null = null;
 
+// Global app-sound master switch (#158). Single source of truth that every
+// playback function in this module checks at entry. Decoupled from any
+// settings store so this module stays leaf-level (no circular imports);
+// settings code pushes the value via setSoundsEnabled on load/refresh and
+// on toolbar mute toggle. Default true matches the Rust-side default and
+// keeps users audible if the FE settings load fails.
+let soundsEnabled = true;
+
+export function setSoundsEnabled(enabled: boolean): void {
+  soundsEnabled = enabled;
+}
+
 // Coalesce window for back-to-back beep calls. When several workgroups
 // transition to idle in the same effect tick, the watcher fires
 // playTeamIdleBeep() multiple times synchronously; without coalescing,
@@ -51,6 +63,7 @@ export function primeAudio(): void {
  * swallowed — failing to beep must never break the FE.
  */
 export async function playTeamIdleBeep(): Promise<void> {
+  if (!soundsEnabled) return;
   const ctx = getAudioContext();
   if (!ctx) return;
   if (ctx.state === "suspended") {

--- a/src/shared/stores/settings.ts
+++ b/src/shared/stores/settings.ts
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js";
 import type { AppSettings } from "../types";
 import { SettingsAPI } from "../ipc";
+import { setSoundsEnabled } from "../sound";
 
 const [settings, setSettings] = createSignal<AppSettings | null>(null);
 
@@ -17,6 +18,11 @@ export const settingsStore = {
   async load() {
     const s = await SettingsAPI.get();
     setSettings(s);
+    // Push the global mute state into sound.ts so every play* call sees the
+    // current value (#158). Default true is intentional — old settings.json
+    // files predate `soundsEnabled` and must remain audible until the user
+    // explicitly mutes.
+    setSoundsEnabled(s.soundsEnabled ?? true);
   },
 
   refresh() {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -131,6 +131,7 @@ export interface AppSettings {
   startOnlyCoordinators: boolean;
   sidebarAlwaysOnTop: boolean;
   raiseTerminalOnClick: boolean;
+  soundsEnabled: boolean;
   teamIdleBeepEnabled: boolean;
   voiceToTextEnabled: boolean;
   geminiApiKey: string;

--- a/src/sidebar/components/ActionBar.tsx
+++ b/src/sidebar/components/ActionBar.tsx
@@ -5,6 +5,7 @@ import { sessionsStore } from "../stores/sessions";
 import type { UnlistenFn } from "../../shared/transport";
 import { ProjectAPI, GuideAPI, SettingsAPI, emitThemeChanged, onOpenSettings } from "../../shared/ipc";
 import { settingsStore } from "../../shared/stores/settings";
+import { setSoundsEnabled } from "../../shared/sound";
 import type { AppSettings } from "../../shared/types";
 import SettingsModal from "./SettingsModal";
 
@@ -100,19 +101,30 @@ const ActionBar: Component = () => {
     }
   };
 
-  // #158 — global app-sound mute. Reads/persists `soundsEnabled` on
-  // AppSettings; back-compat default is true so users with old settings.json
-  // files (no `soundsEnabled` field) stay audible. The full-settings update
-  // pattern matches SettingsModal's Save path. settingsStore.refresh()
-  // propagates the new value to sound.ts via setSoundsEnabled.
+  // #158 — global app-sound mute. Default true so old settings.json files
+  // (no `soundsEnabled` field) stay audible. setSoundsEnabled is pushed
+  // synchronously BEFORE the persist roundtrip so a beep that fires between
+  // the click and the IPC reply (e.g. team-idle-watcher transitioning during
+  // file IO) sees the new gate value — the user's intent in clicking mute is
+  // exactly to suppress imminent beeps. On persist failure we rollback the
+  // gate and toast.
   const isSoundsEnabled = (): boolean =>
     settingsStore.current?.soundsEnabled ?? true;
   const handleToggleMute = async () => {
     const current = settingsStore.current;
     if (!current) return;
-    const next: AppSettings = { ...current, soundsEnabled: !isSoundsEnabled() };
-    await SettingsAPI.update(next);
-    settingsStore.refresh();
+    const previousValue = isSoundsEnabled();
+    const newValue = !previousValue;
+    setSoundsEnabled(newValue);
+    const next: AppSettings = { ...current, soundsEnabled: newValue };
+    try {
+      await SettingsAPI.update(next);
+      settingsStore.refresh();
+    } catch (err) {
+      setSoundsEnabled(previousValue);
+      const msg = err instanceof Error ? err.message : String(err);
+      showToast(`Failed to ${newValue ? "unmute" : "mute"} sounds: ${msg}`);
+    }
   };
 
   return (

--- a/src/sidebar/components/ActionBar.tsx
+++ b/src/sidebar/components/ActionBar.tsx
@@ -6,7 +6,6 @@ import type { UnlistenFn } from "../../shared/transport";
 import { ProjectAPI, GuideAPI, SettingsAPI, emitThemeChanged, onOpenSettings } from "../../shared/ipc";
 import { settingsStore } from "../../shared/stores/settings";
 import { setSoundsEnabled } from "../../shared/sound";
-import type { AppSettings } from "../../shared/types";
 import SettingsModal from "./SettingsModal";
 
 const ActionBar: Component = () => {
@@ -111,14 +110,11 @@ const ActionBar: Component = () => {
   const isSoundsEnabled = (): boolean =>
     settingsStore.current?.soundsEnabled ?? true;
   const handleToggleMute = async () => {
-    const current = settingsStore.current;
-    if (!current) return;
     const previousValue = isSoundsEnabled();
     const newValue = !previousValue;
     setSoundsEnabled(newValue);
-    const next: AppSettings = { ...current, soundsEnabled: newValue };
     try {
-      await SettingsAPI.update(next);
+      await SettingsAPI.setSoundsEnabled(newValue);
       settingsStore.refresh();
     } catch (err) {
       setSoundsEnabled(previousValue);

--- a/src/sidebar/components/ActionBar.tsx
+++ b/src/sidebar/components/ActionBar.tsx
@@ -3,7 +3,9 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { projectStore } from "../stores/project";
 import { sessionsStore } from "../stores/sessions";
 import type { UnlistenFn } from "../../shared/transport";
-import { ProjectAPI, GuideAPI, emitThemeChanged, onOpenSettings } from "../../shared/ipc";
+import { ProjectAPI, GuideAPI, SettingsAPI, emitThemeChanged, onOpenSettings } from "../../shared/ipc";
+import { settingsStore } from "../../shared/stores/settings";
+import type { AppSettings } from "../../shared/types";
 import SettingsModal from "./SettingsModal";
 
 const ActionBar: Component = () => {
@@ -98,6 +100,21 @@ const ActionBar: Component = () => {
     }
   };
 
+  // #158 — global app-sound mute. Reads/persists `soundsEnabled` on
+  // AppSettings; back-compat default is true so users with old settings.json
+  // files (no `soundsEnabled` field) stay audible. The full-settings update
+  // pattern matches SettingsModal's Save path. settingsStore.refresh()
+  // propagates the new value to sound.ts via setSoundsEnabled.
+  const isSoundsEnabled = (): boolean =>
+    settingsStore.current?.soundsEnabled ?? true;
+  const handleToggleMute = async () => {
+    const current = settingsStore.current;
+    if (!current) return;
+    const next: AppSettings = { ...current, soundsEnabled: !isSoundsEnabled() };
+    await SettingsAPI.update(next);
+    settingsStore.refresh();
+  };
+
   return (
     <>
       <div class="action-bar">
@@ -131,6 +148,15 @@ const ActionBar: Component = () => {
             title={sessionsStore.coordSortByActivity ? "Show recent coordinators first" : "Show coordinators in default order"}
           >
             &#x1F525;
+          </button>
+          <button
+            class={`toolbar-gear-btn sounds-mute-btn ${isSoundsEnabled() ? "" : "active"}`}
+            disabled={!settingsStore.current}
+            onClick={handleToggleMute}
+            title={isSoundsEnabled() ? "Mute all app sounds" : "Unmute app sounds"}
+            aria-label={isSoundsEnabled() ? "Mute all app sounds" : "Unmute app sounds"}
+          >
+            {isSoundsEnabled() ? "🔊" : "🔇"}
           </button>
           <button
             class={`toolbar-gear-btn show-categories-btn ${sessionsStore.showCategories ? "active" : ""}`}

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -445,7 +445,19 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           <input
             type="checkbox"
             class="settings-checkbox"
+            checked={settings.data!.soundsEnabled}
+            onChange={(e) =>
+              updateField("soundsEnabled", e.currentTarget.checked)
+            }
+          />
+          <span>Enable app sounds (master switch)</span>
+        </label>
+        <label class="settings-checkbox-field">
+          <input
+            type="checkbox"
+            class="settings-checkbox"
             checked={settings.data!.teamIdleBeepEnabled}
+            disabled={!settings.data!.soundsEnabled}
             onChange={(e) =>
               updateField("teamIdleBeepEnabled", e.currentTarget.checked)
             }

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -8,6 +8,7 @@ import type {
 } from "../../shared/types";
 import { SettingsAPI, TelegramAPI, ReposAPI } from "../../shared/ipc";
 import { settingsStore } from "../../shared/stores/settings";
+import { setSoundsEnabled } from "../../shared/sound";
 import { sessionsStore } from "../stores/sessions";
 import { AGENT_PRESET_MAP, newAgentId } from "../../shared/agent-presets";
 
@@ -232,6 +233,11 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     setSaveError("");
     setSaving(true);
     await SettingsAPI.update(settings.data);
+    // #158 — push soundsEnabled into sound.ts synchronously so the gate
+    // updates before the settingsStore.refresh() roundtrip below resolves.
+    // Without this, a beep emitted between this point and the next load()
+    // would see the stale gate value.
+    setSoundsEnabled(settings.data.soundsEnabled ?? true);
     if (isTauri) {
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
       await getCurrentWindow().setAlwaysOnTop(settings.data.sidebarAlwaysOnTop);


### PR DESCRIPTION
## Summary
- Add a global app-sound master switch (`soundsEnabled` / `sounds_enabled`) that defaults to enabled for backward compatibility.
- Add a speaker/mute button next to the flame button and a master switch in Settings > Notifications.
- Gate the existing team-idle beep through the global sound gate without affecting voice recording input analysis.
- Add a narrow `set_sounds_enabled` Tauri command so the toolbar toggle does not use stale full-settings updates.
- Bump app version to 0.8.3.

## Verification
- `npm run validate-branch-name`
- `npx tsc --noEmit`
- `cargo test --lib config::settings::tests`
- `cargo clippy --lib --no-deps -- -D warnings`
- `npx tauri build`
- Shipper deployed wg-18 build to `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-18.exe`

Closes #158