### PR TITLE
feat(sidebar): show project root path tooltip (#165)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -651,6 +651,7 @@ const ProjectPanel: Component = () => {
           <div class="project-panel">
             <button
               class="project-header"
+              title={proj.path}
               onClick={() => setCollapsed((c) => !c)}
               onContextMenu={handleProjectContextMenu}
             >


### PR DESCRIPTION
Closes #165

## Summary
- Show the project root path in the sidebar project header native tooltip.
- Bump release version to 0.8.6 and sync Cargo.lock.

## Verification
- npx tsc --noEmit (only pre-existing vitest module diagnostic)
- dev-rust-grinch review PASS
- npx tauri build
- deployed and smoke-checked agentscommander_standalone_wg-21.exe --help