### PR TITLE
feat(version): automate project version sync (#201)

### DIFF
--- a/.github/workflows/version-sync-check.yml
+++ b/.github/workflows/version-sync-check.yml
@@ -1,0 +1,55 @@
+name: Version sync check
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src-tauri/Cargo.toml'
+      - 'src-tauri/Cargo.lock'
+      - 'src-tauri/tauri.conf.json'
+      - 'scripts/bump-version.mjs'
+      - 'scripts/check-version-sync.mjs'
+      - '.github/workflows/version-sync-check.yml'
+  push:
+    branches-ignore:
+      - main
+      - 'release/**'
+      - 'hotfix/**'
+      - 'dependabot/**'
+      - 'revert/**'
+      - 'gh-readonly-queue/**'
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src-tauri/Cargo.toml'
+      - 'src-tauri/Cargo.lock'
+      - 'src-tauri/tauri.conf.json'
+      - 'scripts/bump-version.mjs'
+      - 'scripts/check-version-sync.mjs'
+      - '.github/workflows/version-sync-check.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: version-sync-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version-sync:
+    name: version-sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Pin npm version
+        run: npm install -g npm@11.6.2
+
+      - name: Verify all version locations agree
+        run: npm run version:check

--- a/README.md
+++ b/README.md
@@ -333,20 +333,23 @@ The script writes the same version to every checked location:
 The frontend titlebar reads its version from `tauri.conf.json` at build time,
 so bumping that file is enough — no source files need manual edits.
 
-After bumping, commit every file the script touched in a single commit so
-CI sees them together:
+After bumping, verify every location agrees before committing — this
+catches any future regression in the bump script locally instead of in CI:
+
+```bash
+npm run version:check
+```
+
+Then commit every file the script touched in a single commit so CI sees
+them together:
 
 ```bash
 git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
 git commit -m "chore: bump version to X.Y.Z"
 ```
 
-To verify the locations agree (run locally before pushing; CI runs the same
-check on every PR/push that touches a version-relevant file):
-
-```bash
-npm run version:check
-```
+CI runs the same `version:check` on every PR/push that touches a
+version-relevant file.
 
 ## Privacy
 

--- a/README.md
+++ b/README.md
@@ -312,12 +312,41 @@ agentscommander/
 
 ## Version
 
-Current: **0.4.8**
+The current project version lives in `package.json` and is mirrored across
+every other build artifact. Bump it with the dedicated script — never edit
+the locations by hand:
 
-Version is kept in sync across three files:
-- `src-tauri/tauri.conf.json`
-- `src-tauri/Cargo.toml`
-- `src/sidebar/components/Titlebar.tsx`
+```bash
+npm run version:bump -- patch        # 0.8.x  -> 0.8.(x+1)
+npm run version:bump -- minor        # 0.x.y  -> 0.(x+1).0
+npm run version:bump -- major        # x.y.z  -> (x+1).0.0
+npm run version:bump -- 0.9.0        # explicit X.Y.Z
+```
+
+The script writes the same version to every checked location:
+- `package.json` — `version`
+- `package-lock.json` — root `version` and `packages[""].version`
+- `src-tauri/Cargo.toml` — `[package]` version
+- `src-tauri/Cargo.lock` — `agentscommander-new` entry version
+- `src-tauri/tauri.conf.json` — `version`
+
+The frontend titlebar reads its version from `tauri.conf.json` at build time,
+so bumping that file is enough — no source files need manual edits.
+
+After bumping, commit every file the script touched in a single commit so
+CI sees them together:
+
+```bash
+git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
+git commit -m "chore: bump version to X.Y.Z"
+```
+
+To verify the locations agree (run locally before pushing; CI runs the same
+check on every PR/push that touches a version-relevant file):
+
+```bash
+npm run version:check
+```
 
 ## Privacy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.9",
+  "version": "0.8.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.9",
+      "version": "0.8.18",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.17",
+  "version": "0.8.18",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,6 +10,8 @@
     "build:stage": "cross-env BUILD_PROFILE=stage tauri build --config src-tauri/tauri.stage.conf.json",
     "kill-dev": "powershell.exe -ExecutionPolicy Bypass -File ./scripts/kill-dev.ps1",
     "validate-branch-name": "node scripts/validate-branch-name.mjs",
+    "version:bump": "node scripts/bump-version.mjs",
+    "version:check": "node scripts/check-version-sync.mjs",
     "prepare": "husky",
     "tauri": "tauri",
     "test": "vitest run",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// One-command project version bumper for issue #201.
+//
+// Updates every project version location to the same X.Y.Z so future bumps
+// can never leave package.json / package-lock.json / Cargo / Tauri metadata
+// out of sync.
+//
+// Usage:
+//   node scripts/bump-version.mjs patch       # 0.8.17 -> 0.8.18
+//   node scripts/bump-version.mjs minor       # 0.8.17 -> 0.9.0
+//   node scripts/bump-version.mjs major       # 0.8.17 -> 1.0.0
+//   node scripts/bump-version.mjs 0.9.0       # explicit X.Y.Z
+//
+// Files touched:
+//   - package.json                             "version"
+//   - package-lock.json                        root "version" + packages[""].version
+//   - src-tauri/Cargo.toml                     [package] version
+//   - src-tauri/Cargo.lock                     agentscommander-new entry version
+//   - src-tauri/tauri.conf.json                "version"
+//
+// Re-running with the same X.Y.Z target is supported and intentional: it
+// synchronizes any drifted location even when package.json is already at
+// the target.
+//
+// Exit codes:
+//   0 → success (bumped or already in sync)
+//   1 → bad usage, current version unreadable, or any target file's anchor
+//       did not match (file renamed/restructured?)
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)$/;
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT       = resolve(dirname(__filename), '..');
+
+const HELP = `Usage:
+  node scripts/bump-version.mjs <patch|minor|major|X.Y.Z>
+
+Updates every project version location:
+  - package.json
+  - package-lock.json (root + packages[""])
+  - src-tauri/Cargo.toml
+  - src-tauri/Cargo.lock (agentscommander-new entry)
+  - src-tauri/tauri.conf.json
+
+Re-running with the same X.Y.Z target re-synchronizes drifted locations.
+`;
+
+// Each entry knows the file it lives in, a human label, and the surgical
+// regex that captures the prefix before the version literal. Anchored on
+// nearby fields so we can never accidentally rewrite a dependency version.
+// Line-end tokens use \r?\n so files with either LF or CRLF endings are
+// preserved byte-for-byte outside the version literal.
+const PATCHES = [
+  {
+    file: 'package.json',
+    label: 'root version',
+    re: /(\r?\n\s*"name":\s*"agentscommander",\s*\r?\n\s*"version":\s*)"[^"]+"/,
+  },
+  {
+    file: 'package-lock.json',
+    label: 'root version',
+    re: /(\r?\n\s*"name":\s*"agentscommander",\s*\r?\n\s*"version":\s*)"[^"]+"/,
+  },
+  {
+    file: 'package-lock.json',
+    label: 'packages[""].version',
+    re: /(\r?\n\s*"":\s*\{\s*\r?\n\s*"name":\s*"agentscommander",\s*\r?\n\s*"version":\s*)"[^"]+"/,
+  },
+  {
+    file: 'src-tauri/Cargo.toml',
+    label: '[package] version',
+    re: /(\r?\n\s*name\s*=\s*"agentscommander-new"\s*\r?\nversion\s*=\s*)"[^"]+"/,
+  },
+  {
+    file: 'src-tauri/Cargo.lock',
+    label: 'agentscommander-new entry',
+    re: /(\r?\n\s*name\s*=\s*"agentscommander-new"\s*\r?\nversion\s*=\s*)"[^"]+"/,
+  },
+  {
+    file: 'src-tauri/tauri.conf.json',
+    label: 'version',
+    re: /(\r?\n\s*"productName":\s*"[^"]+",\s*\r?\n\s*"version":\s*)"[^"]+"/,
+  },
+];
+
+function die(msg) {
+  console.error(`[bump-version] ${msg}`);
+  process.exit(1);
+}
+
+function readCurrentVersion() {
+  const txt = readFileSync(join(ROOT, 'package.json'), 'utf8');
+  // Anchor on `"name": "agentscommander"` so we never accidentally read a
+  // dependency `"version"` literal that happens to appear above the project
+  // version (e.g., if package.json keys are reordered or an `overrides`
+  // block is added).
+  const m = /\r?\n\s*"name":\s*"agentscommander",\s*\r?\n\s*"version":\s*"([^"]+)"/.exec(txt);
+  if (!m) die('Cannot read current version from package.json (anchor "name": "agentscommander" not found above "version")');
+  return m[1];
+}
+
+function bump(current, kind) {
+  const m = SEMVER_RE.exec(current);
+  if (!m) die(`package.json version "${current}" is not a simple X.Y.Z`);
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  const patch = Number(m[3]);
+  switch (kind) {
+    case 'patch': return `${major}.${minor}.${patch + 1}`;
+    case 'minor': return `${major}.${minor + 1}.0`;
+    case 'major': return `${major + 1}.0.0`;
+  }
+  die(`Unknown bump kind: ${kind}`);
+}
+
+function resolveTarget(arg, current) {
+  if (arg === 'patch' || arg === 'minor' || arg === 'major') return bump(current, arg);
+  if (SEMVER_RE.test(arg)) return arg;
+  die(`Argument must be patch|minor|major or X.Y.Z (got "${arg}")`);
+}
+
+function planPatch(patch, target) {
+  const path = join(ROOT, patch.file);
+  const before = readFileSync(path, 'utf8');
+  // Anchor-not-matched is a hard fail: it means the file was renamed or
+  // restructured and our regex needs maintenance — do NOT silently skip.
+  if (!patch.re.test(before)) {
+    die(`${patch.file}: anchor for "${patch.label}" did not match — file may have been renamed or restructured. Update PATCHES regexes.`);
+  }
+  const after = before.replace(patch.re, (_match, prefix) => `${prefix}"${target}"`);
+  return { path, before, after, file: patch.file, label: patch.label };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    process.stderr.write(HELP);
+    process.exit(1);
+  }
+  if (args[0] === '-h' || args[0] === '--help') {
+    process.stdout.write(HELP);
+    process.exit(0);
+  }
+
+  const current = readCurrentVersion();
+  const target  = resolveTarget(args[0], current);
+
+  // Always run every patch — even when target equals current. That way an
+  // explicit X.Y.Z passed to repair drift will overwrite stale lock
+  // entries instead of silently skipping the writes.
+  if (target === current) {
+    console.log(`[bump-version] synchronizing at ${target}`);
+  } else {
+    console.log(`[bump-version] ${current} -> ${target}`);
+  }
+
+  // Two-phase to avoid leaving the repo half-updated if a later file fails:
+  //   phase 1 — read every file, validate every anchor, compute every new
+  //             content. If anything fails, we exit before any writeFileSync.
+  //   phase 2 — write the files whose content actually changed.
+  const plans = PATCHES.map((p) => planPatch(p, target));
+  for (const plan of plans) {
+    if (plan.after === plan.before) {
+      console.log(`[bump-version] ${plan.file} (${plan.label}) already at ${target}`);
+      continue;
+    }
+    writeFileSync(plan.path, plan.after);
+    console.log(`[bump-version] ${plan.file} (${plan.label}) -> ${target}`);
+  }
+
+  console.log(`[bump-version] OK at ${target}`);
+}
+
+main();

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -123,16 +123,27 @@ function resolveTarget(arg, current) {
   die(`Argument must be patch|minor|major or X.Y.Z (got "${arg}")`);
 }
 
-function planPatch(patch, target) {
-  const path = join(ROOT, patch.file);
+function planFile(file, patches, target) {
+  const path = join(ROOT, file);
   const before = readFileSync(path, 'utf8');
-  // Anchor-not-matched is a hard fail: it means the file was renamed or
-  // restructured and our regex needs maintenance — do NOT silently skip.
-  if (!patch.re.test(before)) {
-    die(`${patch.file}: anchor for "${patch.label}" did not match — file may have been renamed or restructured. Update PATCHES regexes.`);
+  // Apply every patch sequentially against the in-memory string so a file
+  // with multiple PATCHES entries (e.g. package-lock.json's root version +
+  // packages[""].version) lands all its rewrites in a single write. Each
+  // patch's regex is re-tested against the running buffer so we can never
+  // silently lose an entry.
+  let current = before;
+  const steps = [];
+  for (const p of patches) {
+    // Anchor-not-matched is a hard fail: it means the file was renamed or
+    // restructured and our regex needs maintenance — do NOT silently skip.
+    if (!p.re.test(current)) {
+      die(`${file}: anchor for "${p.label}" did not match — file may have been renamed or restructured. Update PATCHES regexes.`);
+    }
+    const next = current.replace(p.re, (_match, prefix) => `${prefix}"${target}"`);
+    steps.push({ label: p.label, changed: next !== current });
+    current = next;
   }
-  const after = before.replace(patch.re, (_match, prefix) => `${prefix}"${target}"`);
-  return { path, before, after, file: patch.file, label: patch.label };
+  return { path, file, before, after: current, steps };
 }
 
 function main() {
@@ -158,18 +169,39 @@ function main() {
     console.log(`[bump-version] ${current} -> ${target}`);
   }
 
+  // Group PATCHES by file so each target file is read once, mutated
+  // sequentially in memory, and written once. The previous one-plan-per-
+  // entry layout re-read the original file for every entry and then
+  // wrote each plan independently, so the second write to any file
+  // silently clobbered the first — package-lock.json lost its root
+  // version rewrite on every bump.
+  const byFile = new Map();
+  for (const p of PATCHES) {
+    const list = byFile.get(p.file) ?? [];
+    list.push(p);
+    byFile.set(p.file, list);
+  }
+
   // Two-phase to avoid leaving the repo half-updated if a later file fails:
   //   phase 1 — read every file, validate every anchor, compute every new
   //             content. If anything fails, we exit before any writeFileSync.
   //   phase 2 — write the files whose content actually changed.
-  const plans = PATCHES.map((p) => planPatch(p, target));
+  const plans = [];
+  for (const [file, patches] of byFile) {
+    plans.push(planFile(file, patches, target));
+  }
+
   for (const plan of plans) {
-    if (plan.after === plan.before) {
-      console.log(`[bump-version] ${plan.file} (${plan.label}) already at ${target}`);
-      continue;
+    if (plan.after !== plan.before) {
+      writeFileSync(plan.path, plan.after);
     }
-    writeFileSync(plan.path, plan.after);
-    console.log(`[bump-version] ${plan.file} (${plan.label}) -> ${target}`);
+    for (const step of plan.steps) {
+      if (step.changed) {
+        console.log(`[bump-version] ${plan.file} (${step.label}) -> ${target}`);
+      } else {
+        console.log(`[bump-version] ${plan.file} (${step.label}) already at ${target}`);
+      }
+    }
   }
 
   console.log(`[bump-version] OK at ${target}`);

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Verifies every project version location agrees, for issue #201.
+//
+// Reads each location bump-version.mjs writes and exits non-zero with a
+// list of mismatched files/fields when they disagree. Used locally and in
+// CI to keep the workflow trustworthy.
+//
+// Usage:
+//   node scripts/check-version-sync.mjs
+//
+// Exit codes:
+//   0 → all locations report the same version
+//   1 → one or more locations missing a version, or versions disagree
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT       = resolve(dirname(__filename), '..');
+
+function read(rel) {
+  return readFileSync(join(ROOT, rel), 'utf8');
+}
+
+function extract(label, rel, re) {
+  const txt = read(rel);
+  const m = re.exec(txt);
+  if (!m) return { label, file: rel, version: null, error: 'pattern did not match' };
+  return { label, file: rel, version: m[1], error: null };
+}
+
+const checks = [
+  extract(
+    'package.json:version',
+    'package.json',
+    /(?:\r?\n)\s*"name":\s*"agentscommander",\s*(?:\r?\n)\s*"version":\s*"([^"]+)"/,
+  ),
+  extract(
+    'package-lock.json:root.version',
+    'package-lock.json',
+    /(?:\r?\n)\s*"name":\s*"agentscommander",\s*(?:\r?\n)\s*"version":\s*"([^"]+)"/,
+  ),
+  extract(
+    'package-lock.json:packages[""].version',
+    'package-lock.json',
+    /(?:\r?\n)\s*"":\s*\{\s*(?:\r?\n)\s*"name":\s*"agentscommander",\s*(?:\r?\n)\s*"version":\s*"([^"]+)"/,
+  ),
+  extract(
+    'src-tauri/Cargo.toml:[package].version',
+    'src-tauri/Cargo.toml',
+    /(?:\r?\n)\s*name\s*=\s*"agentscommander-new"\s*(?:\r?\n)version\s*=\s*"([^"]+)"/,
+  ),
+  extract(
+    'src-tauri/Cargo.lock:agentscommander-new.version',
+    'src-tauri/Cargo.lock',
+    /(?:\r?\n)\s*name\s*=\s*"agentscommander-new"\s*(?:\r?\n)version\s*=\s*"([^"]+)"/,
+  ),
+  extract(
+    'src-tauri/tauri.conf.json:version',
+    'src-tauri/tauri.conf.json',
+    /(?:\r?\n)\s*"productName":\s*"[^"]+",\s*(?:\r?\n)\s*"version":\s*"([^"]+)"/,
+  ),
+];
+
+const broken = checks.filter(c => c.error || c.version === null);
+if (broken.length > 0) {
+  console.error('[check-version-sync] could not read version from:');
+  for (const b of broken) console.error(`  - ${b.label} (${b.file}): ${b.error || 'no match'}`);
+  console.error('Update scripts/check-version-sync.mjs anchors if a file was renamed or restructured.');
+  process.exit(1);
+}
+
+const versions = new Set(checks.map(c => c.version));
+if (versions.size === 1) {
+  const [v] = versions;
+  console.log(`[check-version-sync] OK — every location at ${v}`);
+  process.exit(0);
+}
+
+console.error('[check-version-sync] versions disagree:');
+for (const c of checks) console.error(`  - ${c.version}  ${c.label}  (${c.file})`);
+console.error('');
+console.error('Run `npm run version:bump -- patch|minor|major|X.Y.Z` to bring everything back in sync.');
+process.exit(1);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.17"
+version = "0.8.18"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.17",
+  "version": "0.8.18",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Summary
- Adds `npm run version:bump -- patch|minor|major|X.Y.Z` to update all project version locations together.
- Adds `npm run version:check` and a GitHub Actions version-sync check.
- Repairs current package-lock version drift and documents the new versioning flow.
- Fixes the package-lock multi-write bug found during review by grouping bump patches per file before writing.

Validation
- `npm run version:check` passed at 0.8.18.
- `npm install --package-lock-only --ignore-scripts` produced no package-lock drift.
- `git diff --check` passed.
- `node scripts/bump-version.mjs --help` passed; invalid argument exits 1.
- Sandbox coverage passed for patch, minor, major, explicit version, same-target drift repair, and anchor-failure no-partial-write behavior.
- Grinch re-review approved the fix for the package-lock multi-write bug.
- Shipper built and deployed `agentscommander_standalone_wg-1.exe`; `--help` smoke passed.

Closes #201