### PR TITLE
fix(agent-matrix): pin canonical state directories (#209)

### DIFF
--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -85,6 +85,44 @@ pub struct SyncResult {
 // Helpers
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Agent Matrix / replica directory contract (issue #209)
+// ---------------------------------------------------------------------------
+//
+// Agent Matrices own canonical state (`memory/`, `plans/`, `skills/`) plus
+// mailboxes. Workgroup replicas own only mailboxes; their config points back
+// to the origin matrix for canonical state.
+pub(crate) const AGENT_MATRIX_DIRS: &[&str] = &["memory", "plans", "skills", "inbox", "outbox"];
+pub(crate) const AGENT_REPLICA_DIRS: &[&str] = &["inbox", "outbox"];
+
+/// Create the full Agent Matrix layout, including the root directory.
+///
+/// The returned tag is `"agent_dir"` for root failures or the failing subdir
+/// name for child directory failures, so callers can preserve diagnostics.
+pub(crate) fn create_agent_matrix_layout(
+    agent_dir: &Path,
+) -> Result<(), (&'static str, std::io::Error)> {
+    std::fs::create_dir_all(agent_dir).map_err(|e| ("agent_dir", e))?;
+    for &sub in AGENT_MATRIX_DIRS {
+        std::fs::create_dir_all(agent_dir.join(sub)).map_err(|e| (sub, e))?;
+    }
+    Ok(())
+}
+
+/// Create the full workgroup replica layout, including the root directory.
+///
+/// Canonical state is intentionally absent here; replicas reference the origin
+/// Agent Matrix through `config.json`.
+pub(crate) fn create_agent_replica_layout(
+    replica_dir: &Path,
+) -> Result<(), (&'static str, std::io::Error)> {
+    std::fs::create_dir_all(replica_dir).map_err(|e| ("replica_dir", e))?;
+    for &sub in AGENT_REPLICA_DIRS {
+        std::fs::create_dir_all(replica_dir.join(sub)).map_err(|e| (sub, e))?;
+    }
+    Ok(())
+}
+
 /// Sanitize a user-provided name into a safe directory component:
 /// lowercase, only a-z 0-9 and hyphens, no leading/trailing hyphens.
 fn sanitize_name(raw: &str) -> Result<String, String> {
@@ -279,19 +317,16 @@ pub async fn create_agent_matrix(
         return Err(format!("Agent '{}' already exists", safe_name));
     }
 
-    // Create directory structure
-    std::fs::create_dir_all(&agent_dir)
-        .map_err(|e| format!("Failed to create agent directory: {}", e))?;
-
-    for sub in &["memory", "plans", "skills", "inbox", "outbox"] {
-        std::fs::create_dir_all(agent_dir.join(sub))
-            .map_err(|e| format!("Failed to create {} directory: {}", sub, e))?;
-    }
+    // Create directory structure. The helper owns both root and subdir creation.
+    create_agent_matrix_layout(&agent_dir).map_err(|(sub, e)| match sub {
+        "agent_dir" => format!("Failed to create agent directory: {}", e),
+        _ => format!("Failed to create {} directory: {}", sub, e),
+    })?;
 
     // Role.md with YAML frontmatter (single-quoted values for safe YAML)
     let desc_yaml = description.replace('\'', "''");
     let role_content = format!(
-        "---\nname: '{}'\ndescription: '{}'\ntype: agent\n---\n\n# {}\n\n{}\n\n## Source of Truth\n\nThis role is defined in Role.md of your Agent Matrix at: .ac-new/_agent_{}/\nIf you are running as a replica, this file was generated from that source.\nAlways use memory/ and plans/ from your Agent Matrix, and treat Role.md there as the canonical role definition. Never use external memory systems.\n\n## Agent Memory Rule\n\nIf you are running as a replica, the single source of truth for persistent knowledge is your Agent Matrix's memory/, plans/, and Role.md. Use your replica folder only for replica-local scratch, inbox/outbox, and session artifacts. NEVER use external memory systems from the coding agent (e.g., ~/.claude/projects/memory/).\n",
+        "---\nname: '{}'\ndescription: '{}'\ntype: agent\n---\n\n# {}\n\n{}\n\n## Source of Truth\n\nThis role is defined in Role.md of your Agent Matrix at: .ac-new/_agent_{}/\nIf you are running as a replica, this file was generated from that source.\nAlways use memory/, plans/, and skills/ from your Agent Matrix, and treat Role.md there as the canonical role definition. Never use external memory systems.\n\n## Agent Memory Rule\n\nIf you are running as a replica, the single source of truth for persistent knowledge is your Agent Matrix's memory/, plans/, skills/, and Role.md. Use your replica folder only for replica-local scratch, inbox/outbox, and session artifacts. NEVER use external memory systems from the coding agent (e.g., ~/.claude/projects/memory/).\n",
         safe_name, desc_yaml, safe_name, description, safe_name
     );
 
@@ -329,10 +364,9 @@ pub async fn create_agent_matrix(
                 );
             }
         }
-        if let Err(e) = crate::config::claude_settings::ensure_rtk_pretool_hook(
-            &agent_dir,
-            inject_rtk_hook,
-        ) {
+        if let Err(e) =
+            crate::config::claude_settings::ensure_rtk_pretool_hook(&agent_dir, inject_rtk_hook)
+        {
             log::warn!(
                 "[entity_creation] Failed to apply rtk hook for matrix {}: {}",
                 agent_dir.display(),
@@ -679,14 +713,12 @@ pub async fn create_workgroup(
             .unwrap_or(agent_dir_name);
 
         let replica_dir = wg_dir.join(format!("__agent_{}", agent_name));
-        std::fs::create_dir_all(&replica_dir)
-            .map_err(|e| format!("Failed to create replica dir for {}: {}", agent_name, e))?;
 
-        // inbox/ and outbox/
-        for sub in &["inbox", "outbox"] {
-            std::fs::create_dir_all(replica_dir.join(sub))
-                .map_err(|e| format!("Failed to create {} for {}: {}", sub, agent_name, e))?;
-        }
+        // Per-replica layout. Canonical state stays in the origin matrix.
+        create_agent_replica_layout(&replica_dir).map_err(|(sub, e)| match sub {
+            "replica_dir" => format!("Failed to create replica dir for {}: {}", agent_name, e),
+            _ => format!("Failed to create {} for {}: {}", sub, agent_name, e),
+        })?;
 
         // Issue #84 / #120 — write .claude/settings.local.json if any agent has
         // the flag, and apply the rtk hook based on the global toggle. Per-replica
@@ -1670,9 +1702,7 @@ fn determine_next_wg_number(ac_new_dir: &Path, team_name: &str) -> u32 {
                 // suffix checks but produces a slice with start > end,
                 // which would panic with `&str[..]`. `.get(..)` returns
                 // `None` instead, so such entries are silently ignored.
-                if let Some(middle) =
-                    name_str.get(3..name_str.len() - suffix.len())
-                {
+                if let Some(middle) = name_str.get(3..name_str.len() - suffix.len()) {
                     if let Ok(n) = middle.parse::<u32>() {
                         taken.insert(n);
                     }
@@ -1686,9 +1716,7 @@ fn determine_next_wg_number(ac_new_dir: &Path, team_name: &str) -> u32 {
     // the first miss so the actual cost is O(taken.len() + 1) in practice.
     // A `0` may end up in `taken` (from a stray `wg-0-{team}`) but is never
     // tested here — the search starts at 1, so slot 1 is always reachable.
-    (1u32..=u32::MAX)
-        .find(|n| !taken.contains(n))
-        .unwrap_or(1)
+    (1u32..=u32::MAX).find(|n| !taken.contains(n)).unwrap_or(1)
 }
 
 /// Compute a relative path from the replica dir to the agent matrix.
@@ -1825,11 +1853,133 @@ async fn git_clone_async(url: &str, target: &Path) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    //! Tests for the preflight-rename `delete_workgroup` helper added in
-    //! the #113 follow-up dispatch, plus the #107 helper
-    //! `parse_brief_title`.
+    //! Tests for Agent Matrix/replica layout invariants, the preflight-rename
+    //! `delete_workgroup` helper added in the #113 follow-up dispatch, plus
+    //! the #107 helper `parse_brief_title`.
 
     use super::*;
+
+    #[test]
+    fn create_agent_matrix_layout_creates_root_and_canonical_subdirs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent_dir = tmp.path().join("_agent_test");
+
+        assert!(!agent_dir.exists(), "agent_dir must not exist before call");
+
+        create_agent_matrix_layout(&agent_dir).expect("create_agent_matrix_layout");
+
+        assert!(
+            agent_dir.is_dir(),
+            "helper must create the matrix root itself"
+        );
+        for canonical in &["memory", "plans", "skills"] {
+            assert!(
+                agent_dir.join(canonical).is_dir(),
+                "expected canonical state dir {}/",
+                canonical
+            );
+        }
+        assert!(agent_dir.join("inbox").is_dir(), "expected inbox/");
+        assert!(agent_dir.join("outbox").is_dir(), "expected outbox/");
+    }
+
+    #[test]
+    fn create_agent_matrix_layout_is_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent_dir = tmp.path().join("_agent_test");
+
+        create_agent_matrix_layout(&agent_dir).expect("first call");
+        let sentinel = agent_dir.join("memory").join("sentinel.md");
+        std::fs::write(&sentinel, b"x").expect("write sentinel");
+
+        create_agent_matrix_layout(&agent_dir).expect("second call");
+        assert!(
+            sentinel.is_file(),
+            "second call must not wipe pre-existing files in memory/"
+        );
+    }
+
+    #[test]
+    fn agent_matrix_dirs_contains_memory_plans_skills() {
+        let names: std::collections::HashSet<&str> = AGENT_MATRIX_DIRS.iter().copied().collect();
+        for required in &["memory", "plans", "skills"] {
+            assert!(
+                names.contains(required),
+                "AGENT_MATRIX_DIRS must contain {} (issue #209)",
+                required
+            );
+        }
+    }
+
+    #[test]
+    fn create_agent_replica_layout_creates_only_inbox_outbox() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let replica_dir = tmp.path().join("__agent_test");
+
+        assert!(
+            !replica_dir.exists(),
+            "replica_dir must not exist before call"
+        );
+
+        create_agent_replica_layout(&replica_dir).expect("create_agent_replica_layout");
+
+        assert!(
+            replica_dir.is_dir(),
+            "helper must create the replica root itself"
+        );
+        assert!(replica_dir.join("inbox").is_dir(), "expected inbox/");
+        assert!(replica_dir.join("outbox").is_dir(), "expected outbox/");
+        for canonical in &["memory", "plans", "skills"] {
+            assert!(
+                !replica_dir.join(canonical).exists(),
+                "replica MUST NOT have {}/; origin matrix is canonical",
+                canonical
+            );
+        }
+    }
+
+    #[test]
+    fn agent_matrix_and_replica_dir_sets_are_disjoint_on_canonical_state() {
+        let canonical: std::collections::HashSet<&str> =
+            ["memory", "plans", "skills"].into_iter().collect();
+        let replica: std::collections::HashSet<&str> = AGENT_REPLICA_DIRS.iter().copied().collect();
+        assert!(
+            canonical.is_disjoint(&replica),
+            "AGENT_REPLICA_DIRS must not include canonical state names; overlap: {:?}",
+            canonical.intersection(&replica).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn replica_identity_resolves_to_origin_matrix_role_md() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ac_new = tmp.path().join(".ac-new");
+        let matrix_dir = ac_new.join("_agent_alpha");
+        let replica_dir = ac_new.join("wg-1-team").join("__agent_alpha");
+        std::fs::create_dir_all(&matrix_dir).expect("create matrix_dir");
+        std::fs::create_dir_all(&replica_dir).expect("create replica_dir");
+
+        let matrix_role = matrix_dir.join("Role.md");
+        std::fs::write(&matrix_role, b"# Alpha\n").expect("write matrix Role.md");
+
+        let identity = compute_relative_identity("_agent_alpha", &replica_dir, &ac_new);
+
+        assert_eq!(
+            identity, "../../_agent_alpha",
+            "expected identity to traverse wg-1-team -> .ac-new -> _agent_alpha"
+        );
+
+        let resolved = replica_dir.join(&identity).join("Role.md");
+        assert_eq!(
+            resolved
+                .canonicalize()
+                .expect("canonicalize resolved Role.md"),
+            matrix_role
+                .canonicalize()
+                .expect("canonicalize matrix Role.md"),
+            "replica Role.md context entry must resolve to origin matrix Role.md"
+        );
+    }
 
     /// Success path: a clean WG dir with no blockers gets renamed and removed.
     /// The original path must not exist after the call, and there must be no
@@ -1855,11 +2005,7 @@ mod tests {
         let orphans: Vec<_> = std::fs::read_dir(parent)
             .expect("read tempdir")
             .flatten()
-            .filter(|e| {
-                e.file_name()
-                    .to_string_lossy()
-                    .starts_with(".deleting-")
-            })
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".deleting-"))
             .collect();
         assert!(
             orphans.is_empty(),
@@ -1918,7 +2064,10 @@ mod tests {
         match &outcome {
             WgDeleteOutcome::Blocked(_) => {
                 assert!(wg_dir.is_dir(), "wg_dir must remain after blocked rename");
-                assert!(inside.is_file(), "inner file must remain after blocked rename");
+                assert!(
+                    inside.is_file(),
+                    "inner file must remain after blocked rename"
+                );
             }
             WgDeleteOutcome::Deleted => {
                 panic!(
@@ -2217,8 +2366,7 @@ mod tests {
     #[test]
     fn determine_next_wg_number_ignores_files_named_like_workgroups() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        std::fs::write(tmp.path().join("wg-1-dev-team"), b"not a dir")
-            .expect("write file");
+        std::fs::write(tmp.path().join("wg-1-dev-team"), b"not a dir").expect("write file");
         assert_eq!(determine_next_wg_number(tmp.path(), "dev-team"), 1);
     }
 
@@ -2276,5 +2424,4 @@ mod tests {
         // For team `dev-team`: only `wg-1-dev-team` counts. Next free is 2.
         assert_eq!(determine_next_wg_number(tmp.path(), "dev-team"), 2);
     }
-
 }

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -478,7 +478,7 @@ fn simple_hash(s: &str) -> u64 {
 fn default_context(agent_root: &str, matrix_root: Option<&str>) -> String {
     let allowed_places = "the entries listed below";
     let replica_usage =
-        "   Use this for replica-local scratch, personal notes, inbox/outbox, role drafts, and session artifacts. Do NOT store canonical memory or plans here. Do NOT write into other agents' replica directories.";
+        "   Use this for replica-local scratch, personal notes, inbox/outbox, role drafts, and session artifacts. Do NOT store canonical memory, plans, or skills here. Do NOT write into other agents' replica directories.";
     let matrix_section = match matrix_root {
         Some(matrix_root) => format!(
             "3. **Your origin Agent Matrix, but only for the canonical agent state listed below:**\n   ```\n   {matrix_root}\n   ```\n   Allowed there:\n   - `memory/`\n   - `plans/`\n   - `skills/`\n   - `Role.md`\n\n",
@@ -493,14 +493,13 @@ fn default_context(agent_root: &str, matrix_root: Option<&str>) -> String {
         ),
         None => String::new(),
     };
-    let messaging_dir_display = crate::phone::messaging::workgroup_root(
-        std::path::Path::new(agent_root),
-    )
-    .ok()
-    .map(|wg| {
-        let dir = wg.join(crate::phone::messaging::MESSAGING_DIR_NAME);
-        display_path(&dir)
-    });
+    let messaging_dir_display =
+        crate::phone::messaging::workgroup_root(std::path::Path::new(agent_root))
+            .ok()
+            .map(|wg| {
+                let dir = wg.join(crate::phone::messaging::MESSAGING_DIR_NAME);
+                display_path(&dir)
+            });
     let messaging_exception = match &messaging_dir_display {
         Some(path) => format!(
             "**Narrow exception — workgroup messaging directory:**\n\n\
@@ -706,6 +705,11 @@ mod tests {
         assert!(
             out.contains("`memory/`, `plans/`, `skills/`, and `Role.md`"),
             "expected consolidated Allowed line to list `skills/` between `plans/` and `Role.md`, got:\n{}",
+            out
+        );
+        assert!(
+            out.contains("Do NOT store canonical memory, plans, or skills here."),
+            "expected replica usage warning to include skills, got:\n{}",
             out
         );
     }


### PR DESCRIPTION
## Summary
- Centralize Agent Matrix and workgroup replica directory layout creation behind named helpers.
- Pin canonical Agent Matrix state directories (`memory/`, `plans/`, `skills/`) with focused tests.
- Keep workgroup replicas limited to local operational dirs while preserving origin Agent Matrix identity references.
- Align generated context/Role wording so `skills/` is listed with `memory/` and `plans/`.

## Validation
- `cargo test --lib` PASS: 303 passed, 0 failed, 6 ignored.
- `cargo check` PASS, with unrelated existing dead_code warnings in `src-tauri/src/commands/ac_discovery.rs`.
- `cargo clippy` PASS, same unrelated warnings.
- Grinch review PASS with no findings.
- Shipper build PASS after `npm ci`; deploy blocked by size gate because the new exe is 185,344 bytes smaller than `agentscommander_mb.exe`.

Closes #209