### PR TITLE
fix(telegram): JSONL watcher resolves Claude config dir (#218)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.21",
+  "version": "0.8.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.21",
+      "version": "0.8.23",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.21"
+version = "0.8.22"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.22"
+version = "0.8.23"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.21"
+version = "0.8.22"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1069,13 +1069,33 @@ pub async fn create_session(
 
                 if let Some(bot) = bot {
                     let pty_arc = pty_mgr.inner().clone();
-                    let jsonl_cwd = if info.is_claude {
-                        Some(cwd.clone())
+                    let jsonl_project_dir = if info.is_claude {
+                        match resolve_claude_projects_dir(&info.shell, &info.shell_args, &cwd) {
+                            Some(p) => Some(p),
+                            None => {
+                                let err_msg = format!(
+                                    "Telegram bridge: cannot resolve Claude projects dir for session {} (shell={:?}). Bridge inactive.",
+                                    id, info.shell
+                                );
+                                log::error!("{}", err_msg);
+                                let _ = app.emit(
+                                    "telegram_bridge_error",
+                                    serde_json::json!({
+                                        "sessionId": info.id,
+                                        "error": err_msg,
+                                    }),
+                                );
+                                // Skip attach — do not silently fall back to PTY for Claude.
+                                return Ok(info);
+                            }
+                        }
                     } else {
                         None
                     };
                     let mut tg = tg_mgr.lock().await;
-                    if let Ok(bridge_info) = tg.attach(id, &bot, pty_arc, app.clone(), jsonl_cwd) {
+                    if let Ok(bridge_info) =
+                        tg.attach(id, &bot, pty_arc, app.clone(), jsonl_project_dir)
+                    {
                         let _ = app.emit("telegram_bridge_attached", bridge_info);
                     }
                 }
@@ -1315,14 +1335,42 @@ pub async fn restart_session(
 
                 if let Some(bot) = bot {
                     let pty_arc = pty_mgr.inner().clone();
-                    let jsonl_cwd = if session_info.is_claude {
-                        Some(cwd.clone())
+                    let jsonl_project_dir = if session_info.is_claude {
+                        match resolve_claude_projects_dir(
+                            &session_info.shell,
+                            &session_info.shell_args,
+                            &cwd,
+                        ) {
+                            Some(p) => Some(p),
+                            None => {
+                                let err_msg = format!(
+                                    "Telegram bridge: cannot resolve Claude projects dir for session {} (shell={:?}). Bridge inactive.",
+                                    new_uuid, session_info.shell
+                                );
+                                log::error!("{}", err_msg);
+                                let _ = app.emit(
+                                    "telegram_bridge_error",
+                                    serde_json::json!({
+                                        "sessionId": session_info.id,
+                                        "error": err_msg,
+                                    }),
+                                );
+                                // Skip attach — do not silently fall back to PTY for Claude.
+                                // Persist + return the new session info so restart still succeeds
+                                // semantically (the user explicitly restarted; only the bridge fails).
+                                {
+                                    let mgr = session_mgr.read().await;
+                                    persist_current_state(&mgr).await;
+                                }
+                                return Ok(session_info);
+                            }
+                        }
                     } else {
                         None
                     };
                     let mut tg = tg_mgr.lock().await;
                     if let Ok(bridge_info) =
-                        tg.attach(new_uuid, &bot, pty_arc, app.clone(), jsonl_cwd)
+                        tg.attach(new_uuid, &bot, pty_arc, app.clone(), jsonl_project_dir)
                     {
                         let _ = app.emit("telegram_bridge_attached", bridge_info);
                     }
@@ -1697,13 +1745,37 @@ pub async fn create_root_agent_session(
                 drop(cfg);
                 if let Some(bot) = bot {
                     let pty_arc = pty_mgr.inner().clone();
-                    let jsonl_cwd = if info.is_claude {
-                        Some(root_agent_path.clone())
+                    let jsonl_project_dir = if info.is_claude {
+                        match resolve_claude_projects_dir(
+                            &info.shell,
+                            &info.shell_args,
+                            &root_agent_path,
+                        ) {
+                            Some(p) => Some(p),
+                            None => {
+                                let err_msg = format!(
+                                    "Telegram bridge: cannot resolve Claude projects dir for session {} (shell={:?}). Bridge inactive.",
+                                    id, info.shell
+                                );
+                                log::error!("{}", err_msg);
+                                let _ = app.emit(
+                                    "telegram_bridge_error",
+                                    serde_json::json!({
+                                        "sessionId": info.id,
+                                        "error": err_msg,
+                                    }),
+                                );
+                                // Skip attach — do not silently fall back to PTY for Claude.
+                                return Ok(info);
+                            }
+                        }
                     } else {
                         None
                     };
                     let mut tg = tg_mgr.lock().await;
-                    if let Ok(bridge_info) = tg.attach(id, &bot, pty_arc, app.clone(), jsonl_cwd) {
+                    if let Ok(bridge_info) =
+                        tg.attach(id, &bot, pty_arc, app.clone(), jsonl_project_dir)
+                    {
                         let _ = app.emit("telegram_bridge_attached", bridge_info);
                     }
                 }

--- a/src-tauri/src/commands/telegram.rs
+++ b/src-tauri/src/commands/telegram.rs
@@ -20,16 +20,55 @@ pub async fn telegram_attach(
 ) -> Result<BridgeInfo, String> {
     let uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
 
-    // Look up session to check is_claude flag for JSONL watcher mode
-    let jsonl_cwd = {
+    // For Claude sessions we pre-resolve the JSONL `projects/<mangled-cwd>` directory
+    // so wrapper-driven `CLAUDE_CONFIG_DIR` overrides (e.g. `claude-mb`) are honored.
+    // If is_claude is true but the resolver returns None, fail loud: emit
+    // telegram_bridge_error and abort — silent fallback to PTY for Claude is exactly
+    // the noisy mode we are trying to retire.
+    //
+    // Extract the fields the resolver needs and drop the SessionManager read guard
+    // BEFORE invoking the resolver — the resolver does blocking filesystem I/O
+    // (`which::which` walks `%PATH%`, opens wrapper scripts) that can take hundreds
+    // of milliseconds. Holding a `tokio::sync::RwLock` read guard across that would
+    // starve concurrent writers (create_session, restart_session, switch_session).
+    let (is_claude, shell, shell_args, working_directory) = {
         let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
         let mgr = session_mgr.read().await;
         let session = mgr.get_session(uuid).await.ok_or("Session not found")?;
-        if session.is_claude {
-            Some(session.working_directory.clone())
-        } else {
-            None
+        (
+            session.is_claude,
+            session.shell.clone(),
+            session.shell_args.clone(),
+            session.working_directory.clone(),
+        )
+        // Guard dropped at end of this block, before the resolver call below.
+    };
+
+    let jsonl_project_dir = if is_claude {
+        match crate::commands::session::resolve_claude_projects_dir(
+            &shell,
+            &shell_args,
+            &working_directory,
+        ) {
+            Some(p) => Some(p),
+            None => {
+                let err_msg = format!(
+                    "Telegram bridge: cannot resolve Claude projects dir for session {} (shell={:?}). Bridge inactive.",
+                    uuid, shell
+                );
+                log::error!("{}", err_msg);
+                let _ = app.emit(
+                    "telegram_bridge_error",
+                    serde_json::json!({
+                        "sessionId": session_id,
+                        "error": err_msg,
+                    }),
+                );
+                return Err(err_msg);
+            }
         }
+    } else {
+        None
     };
 
     let cfg = settings.read().await;
@@ -44,7 +83,7 @@ pub async fn telegram_attach(
     let pty_arc = pty_mgr.inner().clone();
     let mut tg = tg_mgr.lock().await;
     let info = tg
-        .attach(uuid, &bot, pty_arc, app.clone(), jsonl_cwd)
+        .attach(uuid, &bot, pty_arc, app.clone(), jsonl_project_dir)
         .map_err(|e| e.to_string())?;
 
     let _ = app.emit("telegram_bridge_attached", info.clone());

--- a/src-tauri/src/telegram/bridge.rs
+++ b/src-tauri/src/telegram/bridge.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::io::Write as IoWrite;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use tauri::{Emitter, Manager};
@@ -423,18 +424,18 @@ pub fn spawn_bridge(
     info: BridgeInfo,
     pty_mgr: Arc<Mutex<PtyManager>>,
     app_handle: tauri::AppHandle,
-    jsonl_cwd: Option<String>,
+    jsonl_project_dir: Option<PathBuf>,
 ) -> BridgeHandle {
     let cancel = CancellationToken::new();
     let (tx, rx) = mpsc::channel::<Vec<u8>>(256);
 
     let session_id_str = session_id.to_string();
 
-    if let Some(cwd) = jsonl_cwd {
+    if let Some(project_dir) = jsonl_project_dir {
         // JSONL mode: watch Claude Code session log instead of PTY pipeline
         drop(rx); // not needed — no PTY bytes feed
         super::jsonl_watcher::spawn_watch_task(
-            cwd,
+            project_dir,
             bot_token.clone(),
             chat_id,
             session_id_str.clone(),

--- a/src-tauri/src/telegram/jsonl_watcher.rs
+++ b/src-tauri/src/telegram/jsonl_watcher.rs
@@ -10,7 +10,6 @@ use tauri::Emitter;
 use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
-use crate::session::session::mangle_cwd_for_claude;
 use crate::telegram::bridge::{flush_buffer, BridgeLogger, DiagLogger};
 
 const POLL_INTERVAL_MS: u64 = 500;
@@ -20,8 +19,12 @@ const ROTATION_STALE_SECS: u64 = 3;
 
 /// Spawn a JSONL file watcher task that polls for new assistant messages
 /// and sends them to Telegram via the shared buffer/send pipeline.
+///
+/// `project_dir` must be the already-resolved Claude `projects/<mangled-cwd>`
+/// directory (callers resolve via `commands::session::resolve_claude_projects_dir`
+/// so wrapper-driven `CLAUDE_CONFIG_DIR` overrides like `claude-mb` are honored).
 pub fn spawn_watch_task(
-    cwd: String,
+    project_dir: PathBuf,
     bot_token: String,
     chat_id: i64,
     session_id: String,
@@ -30,7 +33,7 @@ pub fn spawn_watch_task(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         watch_loop(
-            cwd,
+            project_dir,
             bot_token,
             chat_id,
             session_id.clone(),
@@ -181,26 +184,13 @@ fn read_new_lines(
 }
 
 async fn watch_loop(
-    cwd: String,
+    project_dir: PathBuf,
     token: String,
     chat_id: i64,
     session_id: String,
     cancel: CancellationToken,
     app: tauri::AppHandle,
 ) {
-    let project_dir = match dirs::home_dir() {
-        Some(home) => home
-            .join(".claude")
-            .join("projects")
-            .join(mangle_cwd_for_claude(&cwd)),
-        None => {
-            log::error!("[JSONL_ERR] Cannot resolve home directory — JSONL watcher dormant");
-            // Stay alive but dormant until cancelled
-            cancel.cancelled().await;
-            return;
-        }
-    };
-
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()

--- a/src-tauri/src/telegram/manager.rs
+++ b/src-tauri/src/telegram/manager.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use uuid::Uuid;
@@ -36,7 +37,7 @@ impl TelegramBridgeManager {
         bot: &TelegramBotConfig,
         pty_mgr: Arc<Mutex<PtyManager>>,
         app_handle: tauri::AppHandle,
-        jsonl_cwd: Option<String>,
+        jsonl_project_dir: Option<PathBuf>,
     ) -> Result<BridgeInfo, AppError> {
         // Exclusivity: one bot can only be attached to one session
         if let Some(existing) = self.bot_assignments.get(&bot.id) {
@@ -62,6 +63,8 @@ impl TelegramBridgeManager {
             color: bot.color.clone(),
         };
 
+        let is_jsonl_mode = jsonl_project_dir.is_some();
+
         let handle = bridge::spawn_bridge(
             bot.token.clone(),
             bot.chat_id,
@@ -69,12 +72,12 @@ impl TelegramBridgeManager {
             info.clone(),
             pty_mgr,
             app_handle,
-            jsonl_cwd.clone(),
+            jsonl_project_dir,
         );
 
         // Only register output sender for PTY mode.
         // In JSONL mode, the watcher reads directly from file — no PTY byte feed needed.
-        if jsonl_cwd.is_none() {
+        if !is_jsonl_mode {
             if let Ok(mut senders) = self.output_senders.lock() {
                 senders.insert(session_id, handle.output_sender.clone());
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Telegram outbound bridge's JSONL watcher used to hardcode `~/.claude/projects/...`, which broke users running `claude-mb` (or any Claude variant with `CLAUDE_CONFIG_DIR` overridden). The watcher polled a non-existent directory and silently idled forever, leaving Telegram outbound effectively dead.
- Wires the existing `resolve_claude_projects_dir()` helper through `attach` → `spawn_bridge` → `spawn_watch_task` (signature change: `Option<String>` cwd → `Option<PathBuf>` resolved projects dir). Resolver runs once at attach time, outside any tokio lock.
- Fail-loud on resolver miss: when `is_claude` is true and the resolver returns `None`, the bridge emits `telegram_bridge_error`, logs an actionable message, and does NOT register. No PTY fallback for Claude sessions — silent degradation to noisy PTY output was the failure mode we wanted to eliminate.
- Version bumped to `0.8.23` (vs the parallel `0.8.22` build of #213 that already shipped to the WG-2 exe earlier today).

## Test plan

- [x] `cargo check` / `cargo clippy --all-targets` / `cargo fmt --check` clean for touched code.
- [x] `/feature-dev` parallel-reviewer pass — caught a self-introduced `tokio::sync::RwLock` read guard held across blocking filesystem I/O in `telegram_attach`; fixed in the same commit by extracting needed fields and dropping the guard before resolver call. Re-reviewed clean.
- [x] Adversarial review (dev-rust-grinch) verdict: CLEAN. Line-by-line verification of all 4 attach call sites, persist symmetry in `restart_session`, type-change consumer trace, version bump cross-file, resolver-None reachability, concurrent attach safety.
- [x] `agentscommander_standalone_wg-2.exe` built and deployed at `0.8.23`. `FileVersion`/`ProductVersion` confirmed.

## Out of scope (tracked separately)

- Codex (`~/.codex/sessions/`) and Gemini (`~/.gemini/tmp/...`) transcript watchers.
- UI surfacing of `telegram_bridge_error` (currently console-only — pre-existing, also affects PTY-path errors).
- Resolver tokenization edge case with whitespace in shell-args paths (pre-existing).
- `BridgeHandle.output_sender` paired with dropped receiver in JSONL mode (pre-existing, harmless).
- Repo-wide `cargo fmt` drift (86 hunks unrelated to this fix).

Closes #218