### PR TITLE
chore(release): bump version 0.8.23 -> 0.8.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.23"
+version = "0.8.24"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Bump project version from `0.8.23` to `0.8.24` across all 5 lockstep locations via `scripts/bump-version.mjs`:
  - `package.json`
  - `package-lock.json` (root + `packages[""]`)
  - `src-tauri/Cargo.toml`
  - `src-tauri/Cargo.lock` (`agentscommander-new` entry)
  - `src-tauri/tauri.conf.json`
- Unblocks the wg-2 shipper build which failed on a version collision against the already-shipped `0.8.23`.

## Verification

- `node scripts/check-version-sync.mjs` → `OK — every location at 0.8.24`
- Branch `release/0.8.24` (exempt from the `<type>/<issue>-<slug>` validator, matching the prior `release/0.8.1` bump pattern).

## Test plan

- [ ] CI version-sync check is green
- [ ] wg-2 shipper build succeeds after merge