### PR TITLE
fix(cli): resolve CLI daemon lateral issues (#228)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.24",
+  "version": "0.8.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.24",
+      "version": "0.8.26",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.24",
+  "version": "0.8.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.24"
+version = "0.8.26"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.24"
+version = "0.8.26"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/cli/brief_append_body.rs
+++ b/src-tauri/src/cli/brief_append_body.rs
@@ -26,7 +26,8 @@ Frontmatter is never modified by this verb.\n\n\
 TEXT INPUT: --text accepts multi-line content. Newline (\\n), carriage return (\\r), \
 and tab (\\t) are permitted. NUL and other control characters are rejected.")]
 pub struct BriefAppendBodyArgs {
-    /// Session token for authentication (from AGENTSCOMMANDER_TOKEN)
+    /// Session token from AGENTSCOMMANDER_TOKEN. Shape-validated in the CLI;
+    /// per-session authorization happens at the daemon mailbox. See `--help` TOKEN VALIDATION MODEL.
     #[arg(long)]
     pub token: Option<String>,
 
@@ -124,7 +125,7 @@ pub fn execute(args: BriefAppendBodyArgs) -> i32 {
                 std::process::id(),
                 bp.display()
             );
-            println!("BRIEF.md body appended; backup: {}", bp.display());
+            crate::cli_println!("BRIEF.md body appended; backup: {}", bp.display());
             0
         }
         Ok(EditOutcome::Wrote { backup: None }) => {
@@ -134,13 +135,13 @@ pub fn execute(args: BriefAppendBodyArgs) -> i32 {
                 wg_root.display(),
                 std::process::id()
             );
-            println!("BRIEF.md created; no prior content to back up");
+            crate::cli_println!("BRIEF.md created; no prior content to back up");
             0
         }
         Ok(EditOutcome::NoOp) => {
             // append-body never produces NoOp (an append always changes the file).
             // Defensive: surface the same success line as a Wrote{None} would.
-            println!("BRIEF.md unchanged");
+            crate::cli_println!("BRIEF.md unchanged");
             0
         }
         Err(e) => {

--- a/src-tauri/src/cli/brief_set_title.rs
+++ b/src-tauri/src/cli/brief_set_title.rs
@@ -25,7 +25,8 @@ External edits between our read and our write are detected and the verb aborts.\
 TITLE INPUT: --title is a single-line string. Embedded \\n / \\r / NUL / other \
 control characters (except tab) are rejected.")]
 pub struct BriefSetTitleArgs {
-    /// Session token for authentication (from AGENTSCOMMANDER_TOKEN)
+    /// Session token from AGENTSCOMMANDER_TOKEN. Shape-validated in the CLI;
+    /// per-session authorization happens at the daemon mailbox. See `--help` TOKEN VALIDATION MODEL.
     #[arg(long)]
     pub token: Option<String>,
 
@@ -121,7 +122,7 @@ pub fn execute(args: BriefSetTitleArgs) -> i32 {
                 std::process::id(),
                 bp.display()
             );
-            println!("BRIEF.md title updated; backup: {}", bp.display());
+            crate::cli_println!("BRIEF.md title updated; backup: {}", bp.display());
             0
         }
         Ok(EditOutcome::Wrote { backup: None }) => {
@@ -131,7 +132,7 @@ pub fn execute(args: BriefSetTitleArgs) -> i32 {
                 wg_root.display(),
                 std::process::id()
             );
-            println!("BRIEF.md created; no prior content to back up");
+            crate::cli_println!("BRIEF.md created; no prior content to back up");
             0
         }
         Ok(EditOutcome::NoOp) => {
@@ -141,7 +142,7 @@ pub fn execute(args: BriefSetTitleArgs) -> i32 {
                 wg_root.display(),
                 std::process::id()
             );
-            println!("BRIEF.md unchanged (title value already matches)");
+            crate::cli_println!("BRIEF.md unchanged (title value already matches)");
             0
         }
         Err(e) => {

--- a/src-tauri/src/cli/close_session.rs
+++ b/src-tauri/src/cli/close_session.rs
@@ -17,7 +17,8 @@ If the agent doesn't exit within --timeout seconds, it falls back to force-kill.
 Use --force to skip graceful shutdown and kill immediately.\n\n\
 DISCOVERY: Use `list-peers` to get valid agent names for --target.")]
 pub struct CloseSessionArgs {
-    /// Session token for authentication (from AGENTSCOMMANDER_TOKEN)
+    /// Session token from AGENTSCOMMANDER_TOKEN. Shape-validated in the CLI;
+    /// per-session authorization happens at the daemon mailbox. See `--help` TOKEN VALIDATION MODEL.
     #[arg(long)]
     pub token: Option<String>,
 
@@ -201,7 +202,7 @@ pub fn execute(args: CloseSessionArgs) -> i32 {
         if response_path.exists() {
             match std::fs::read_to_string(&response_path) {
                 Ok(content) => {
-                    println!("{}", content);
+                    crate::cli_println!("{}", content);
                     // Parse response: exit 1 if no sessions were actually closed
                     if let Ok(resp) = serde_json::from_str::<serde_json::Value>(&content) {
                         let closed = resp
@@ -222,7 +223,7 @@ pub fn execute(args: CloseSessionArgs) -> i32 {
         }
         if resp_start.elapsed() >= resp_timeout {
             // Delivery succeeded but response timed out — sessions were likely closed
-            println!(
+            crate::cli_println!(
                 "close-session delivered but response timed out (sessions may have been closed)"
             );
             return 0;

--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -163,7 +163,7 @@ pub fn execute(args: CreateAgentArgs) -> i32 {
     };
 
     match serde_json::to_string_pretty(&result) {
-        Ok(json) => println!("{}", json),
+        Ok(json) => crate::cli_println!("{}", json),
         Err(e) => {
             eprintln!("Error: failed to serialize result: {}", e);
             return 1;

--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -39,7 +39,8 @@ NOTES:\n  \
 All agents that belong to your team(s) are listed. Agents you cannot directly\n\
 message are included with reachable=false. If you have no teams, the result is an empty array.")]
 pub struct ListPeersArgs {
-    /// Session token for authentication (from AGENTSCOMMANDER_TOKEN)
+    /// Session token from AGENTSCOMMANDER_TOKEN. Shape-validated only; this verb
+    /// reads disk state and does not authorize per-token. See `--help` TOKEN VALIDATION MODEL.
     #[arg(long)]
     pub token: Option<String>,
 
@@ -595,7 +596,7 @@ fn execute_wg_discovery(wg: WgReplicaInfo) -> i32 {
 
     match serde_json::to_string_pretty(&peers) {
         Ok(json) => {
-            println!("{}", json);
+            crate::cli_println!("{}", json);
             0
         }
         Err(e) => {
@@ -817,7 +818,7 @@ pub fn execute(args: ListPeersArgs) -> i32 {
     // Output as JSON
     match serde_json::to_string_pretty(&peers) {
         Ok(json) => {
-            println!("{}", json);
+            crate::cli_println!("{}", json);
             0
         }
         Err(e) => {

--- a/src-tauri/src/cli/list_sessions.rs
+++ b/src-tauri/src/cli/list_sessions.rs
@@ -76,6 +76,46 @@ pub fn execute(args: ListSessionsArgs) -> i32 {
         }
     }
 
+    // Issue #231: detect whether the daemon is running before trusting
+    // sessions.json. Warn on stderr if not — preserve stdout JSON and exit 0.
+    //
+    // When the caller filters by `--status exited`, the natural expectation is
+    // that the daemon may already be dead (exited sessions are the leftover
+    // state). Suppress the stale-daemon warning in that case so the consumer
+    // does not get noise on a query whose entire purpose is post-mortem
+    // inspection.
+    let suppress_stale_warning = args
+        .status
+        .as_deref()
+        .map(|s| s.eq_ignore_ascii_case("exited"))
+        .unwrap_or(false);
+    if !suppress_stale_warning {
+        match crate::config::daemon_pid::detect_daemon_state() {
+            crate::config::daemon_pid::DaemonState::Running { .. } => {}
+            crate::config::daemon_pid::DaemonState::NoPidFile => {
+                eprintln!(
+                    "[WARN] sessions.json may be stale — no AgentsCommander daemon detected \
+                     (no daemon.pid file). list-sessions reads the file directly; results may \
+                     not reflect current state."
+                );
+            }
+            crate::config::daemon_pid::DaemonState::StalePidFile { pid } => {
+                eprintln!(
+                    "[WARN] sessions.json may be stale — AgentsCommander daemon pid {} is not \
+                     running (stale daemon.pid file). list-sessions reads the file directly; \
+                     results reflect the daemon's last persisted state.",
+                    pid
+                );
+            }
+            crate::config::daemon_pid::DaemonState::MalformedPidFile => {
+                eprintln!(
+                    "[WARN] sessions.json may be stale — daemon.pid file is malformed. \
+                     list-sessions reads the file directly; results may not reflect current state."
+                );
+            }
+        }
+    }
+
     // Read sessions from the persisted file (raw, no deduplication)
     let sessions = load_sessions_raw();
 
@@ -96,7 +136,7 @@ pub fn execute(args: ListSessionsArgs) -> i32 {
 
     match serde_json::to_string_pretty(&entries) {
         Ok(json) => {
-            println!("{}", json);
+            crate::cli_println!("{}", json);
             0
         }
         Err(e) => {

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -62,11 +62,13 @@ TOKEN VALIDATION MODEL: The CLI validates token SHAPE only (root token, master t
 or any valid UUID). Per-session tokens are authoritative at the daemon mailbox boundary, \
 not in the CLI. A UUID issued by a different binary instance will pass the CLI's shape \
 check but will be REJECTED by the daemon's mailbox (write-path verbs like `send`, \
-`close-session`, `brief-set-title`, `brief-append-body`). Read-only verbs (`list-peers`, \
-`list-sessions`) REQUIRE a token but accept ANY UUID-shaped value at the CLI boundary — \
-the token value is not consulted for authorization at the CLI. These verbs read disk \
-state directly (from `--root` and the binary's per-binary config directory); authorization \
-of any specific UUID happens only at the daemon mailbox, which write-path verbs invoke.\n\n\
+`close-session`, `brief-set-title`, `brief-append-body`). Read-only verb `list-peers` \
+REQUIRES a token but accepts ANY UUID-shaped value at the CLI boundary — the token value \
+is not consulted for authorization at the CLI. It reads disk state directly (from \
+`--root` and the binary's per-binary config directory); authorization of any specific \
+UUID happens only at the daemon mailbox, which write-path verbs invoke. `list-sessions` \
+does not take a token; it reads `sessions.json` from the binary's config directory \
+directly and never contacts the daemon mailbox.\n\n\
 EXIT CODES: All subcommands return 0 on success, 1 on error.\n\n\
 AGENT NAMES: Agents are identified by their path-based name (e.g., \"repos/my-project\"). \
 Use `list-peers` to discover valid agent names before sending messages.")]

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -11,12 +11,62 @@ pub mod send;
 
 use clap::{Parser, Subcommand};
 
+/// Print to stdout with BrokenPipe tolerance. If the underlying write fails
+/// SPECIFICALLY with `io::ErrorKind::BrokenPipe` (typically because the
+/// consumer closed stdout early — `head`, captured pipe in PS without
+/// `Out-String`, etc.), exit the process cleanly with code 0 instead of
+/// panicking. ANY OTHER write error (`PermissionDenied`, `StorageFull`,
+/// `WriteZero`, `Interrupted`, `Other`, etc.) panics like `println!` does
+/// today — those are real failures and a silent exit-0 would let consumers
+/// believe an empty redirect target is a successful empty result. See #230.
+///
+/// Use this in CLI verbs anywhere we currently call `println!` for primary
+/// output (JSON results, status lines, response bodies). Continue using
+/// `eprintln!` for error / log output — stderr is rarely piped and the
+/// panic surface there is acceptable for now.
+#[macro_export]
+macro_rules! cli_println {
+    () => {{
+        use std::io::Write;
+        let stdout = std::io::stdout();
+        let mut h = stdout.lock();
+        if let Err(e) = writeln!(h) {
+            if e.kind() == std::io::ErrorKind::BrokenPipe {
+                std::process::exit(0);
+            } else {
+                panic!("failed printing to stdout: {}", e);
+            }
+        }
+    }};
+    ($($arg:tt)*) => {{
+        use std::io::Write;
+        let stdout = std::io::stdout();
+        let mut h = stdout.lock();
+        if let Err(e) = writeln!(h, $($arg)*) {
+            if e.kind() == std::io::ErrorKind::BrokenPipe {
+                std::process::exit(0);
+            } else {
+                panic!("failed printing to stdout: {}", e);
+            }
+        }
+    }};
+}
+
 #[derive(Parser)]
 #[command(about = "Agent terminal session manager with inter-agent messaging")]
 #[command(after_help = "\
 TOKEN: In agent sessions, pass AGENTSCOMMANDER_TOKEN from the environment. \
 Credentials are not delivered through visible PTY text. \
 If token validation fails, restart or respawn the sender session; live token refresh is not supported.\n\n\
+TOKEN VALIDATION MODEL: The CLI validates token SHAPE only (root token, master token, \
+or any valid UUID). Per-session tokens are authoritative at the daemon mailbox boundary, \
+not in the CLI. A UUID issued by a different binary instance will pass the CLI's shape \
+check but will be REJECTED by the daemon's mailbox (write-path verbs like `send`, \
+`close-session`, `brief-set-title`, `brief-append-body`). Read-only verbs (`list-peers`, \
+`list-sessions`) REQUIRE a token but accept ANY UUID-shaped value at the CLI boundary — \
+the token value is not consulted for authorization at the CLI. These verbs read disk \
+state directly (from `--root` and the binary's per-binary config directory); authorization \
+of any specific UUID happens only at the daemon mailbox, which write-path verbs invoke.\n\n\
 EXIT CODES: All subcommands return 0 on success, 1 on error.\n\n\
 AGENT NAMES: Agents are identified by their path-based name (e.g., \"repos/my-project\"). \
 Use `list-peers` to discover valid agent names before sending messages.")]
@@ -95,9 +145,18 @@ pub fn attach_parent_console() {
     // No-op on non-Windows
 }
 
-/// Validate CLI token: must be provided and must be either the root_token or a valid UUID.
-/// Returns `Ok((token_string, is_root))` on success, or an error message on failure.
-/// `is_root` is true when the token matches the persisted root_token in settings.
+/// CLI-side SHAPE validation for a session token. Returns `Ok((token_string, is_root))`
+/// on success, or an error message on failure. `is_root` is true when the token matches
+/// the persisted `settings.root_token` or `master-token.txt`.
+///
+/// This is NOT an authorization check. It only ensures the token exists and is parseable
+/// as a UUID (or matches the binary's root/master token). The real per-session token check
+/// happens at the daemon mailbox boundary (`phone::mailbox::process_message`), which
+/// calls `SessionManager::find_by_token` against the live in-memory session set.
+///
+/// Consequence: any valid UUID-shaped string passes this check. A UUID issued by a
+/// different binary instance will pass here but be rejected by the daemon's mailbox.
+/// Documented in `cli::Cli`'s `after_help` under TOKEN VALIDATION MODEL. See #229.
 pub fn validate_cli_token(token: &Option<String>) -> Result<(String, bool), String> {
     let token = match token {
         Some(t) if !t.is_empty() => t.clone(),
@@ -201,5 +260,20 @@ mod tests {
         assert!(!err.contains(&legacy_phrase));
         assert!(!err.to_ascii_lowercase().contains("fallback"));
         assert!(!err.to_ascii_lowercase().contains("visible"));
+    }
+
+    #[test]
+    fn cli_after_help_documents_token_validation_model() {
+        use clap::CommandFactory;
+        let cmd = Cli::command();
+        let after = cmd
+            .get_after_help()
+            .expect("Cli after_help should be present")
+            .to_string();
+        assert!(
+            after.contains("TOKEN VALIDATION MODEL"),
+            "after_help missing TOKEN VALIDATION MODEL block: {}",
+            after
+        );
     }
 }

--- a/src-tauri/src/cli/new_project.rs
+++ b/src-tauri/src/cli/new_project.rs
@@ -46,14 +46,14 @@ pub fn execute(args: NewProjectArgs) -> i32 {
         }
     }
     if result.created {
-        println!("Created AC project at {}", result.path);
+        crate::cli_println!("Created AC project at {}", result.path);
     } else {
-        println!("AC project already exists at {}", result.path);
+        crate::cli_println!("AC project already exists at {}", result.path);
     }
     if result.registered {
-        println!("Registered project: {}", result.path);
+        crate::cli_println!("Registered project: {}", result.path);
     } else {
-        println!("Project already registered: {}", result.path);
+        crate::cli_println!("Project already registered: {}", result.path);
     }
     log::info!(
         "[cli] new-project: path={} created={} registered={}",

--- a/src-tauri/src/cli/open_project.rs
+++ b/src-tauri/src/cli/open_project.rs
@@ -56,9 +56,9 @@ pub fn execute(args: OpenProjectArgs) -> i32 {
             eprintln!("Error: failed to persist settings: {}", e);
             return 1;
         }
-        println!("Registered project: {}", result.path);
+        crate::cli_println!("Registered project: {}", result.path);
     } else {
-        println!("Project already registered: {}", result.path);
+        crate::cli_println!("Project already registered: {}", result.path);
     }
     log::info!(
         "[cli] open-project: path={} registered={}",

--- a/src-tauri/src/cli/send.rs
+++ b/src-tauri/src/cli/send.rs
@@ -19,7 +19,8 @@ recipient reads the file via filesystem, bypassing PTY truncation. Sender MUST w
 invoking this command. Filename must exist in the messaging directory and match the canonical shape: \
 YYYYMMDD-HHMMSS-<wgN>-<from>-to-<wgN>-<to>-<slug>[.N].md.")]
 pub struct SendArgs {
-    /// Session token for authentication (from AGENTSCOMMANDER_TOKEN)
+    /// Session token from AGENTSCOMMANDER_TOKEN. Shape-validated in the CLI;
+    /// per-session authorization happens at the daemon mailbox. See `--help` TOKEN VALIDATION MODEL.
     #[arg(long)]
     pub token: Option<String>,
 
@@ -73,6 +74,37 @@ pub(crate) fn agent_name_from_root(root: &str) -> String {
     crate::config::teams::agent_fqn_from_path(root)
 }
 
+/// If `root` lives inside `<project_dir>/.ac-new/wg-<N>-*/__agent_*/`,
+/// return `project_dir` as a UTF-8 `String`. Returns `None` if `root` is not
+/// inside a WG-replica shape OR if the resulting `project_dir` is not valid
+/// UTF-8 (parity with `list_peers::detect_wg_replica`, which also uses
+/// `to_str()?` rather than `to_string_lossy()`).
+///
+/// Mirrors the WG-replica detection in `list_peers::detect_wg_replica` so that
+/// `send` resolves WG-peer targets against the same root-walk-up source that
+/// `list-peers` uses to emit them with `reachable: true`. See #228.
+///
+/// Keep in lockstep with `list_peers::detect_wg_replica` and
+/// `phone::mailbox::derive_project_from_outbox_path`.
+fn derive_root_project_dir(root: &str) -> Option<String> {
+    let canon = std::fs::canonicalize(root).ok()?;
+    let my_dir_name = canon.file_name()?.to_str()?;
+    if !my_dir_name.starts_with("__agent_") {
+        return None;
+    }
+    let wg_dir = canon.parent()?;
+    let wg_name = wg_dir.file_name()?.to_str()?;
+    if !wg_name.starts_with("wg-") {
+        return None;
+    }
+    let ac_new_dir = wg_dir.parent()?;
+    if ac_new_dir.file_name().and_then(|n| n.to_str()) != Some(".ac-new") {
+        return None;
+    }
+    let project_dir = ac_new_dir.parent()?;
+    Some(project_dir.to_str()?.to_string())
+}
+
 pub fn execute(args: SendArgs) -> i32 {
     let root = match args.root {
         Some(ref r) => r.clone(),
@@ -114,8 +146,28 @@ pub fn execute(args: SendArgs) -> i32 {
     // canonicalizes on receive (§AR2-norm) so direct outbox writes cannot
     // bypass the reject-on-ambiguity rule.
     let settings = crate::config::settings::load_settings();
+    // Build an in-memory project-path slice that includes the project
+    // derived from --root (if any). Mirrors list-peers's WG-replica walk-up
+    // discovery so qualified WG-peer targets that list-peers reports as
+    // reachable do not fail send with `not found in any known project`.
+    // settings.json is NOT modified. See #228 / plan _plans/228-cli-daemon-laterals.md.
+    let mut effective_project_paths = settings.project_paths.clone();
+    if let Some(root_project) = derive_root_project_dir(&root) {
+        // Canonicalize once outside the dedup closure. If canonicalization of
+        // `root_project` itself fails (rare — it just resolved milliseconds
+        // ago inside `derive_root_project_dir`), fall back to string-equality
+        // rather than a broken `None == None` match.
+        let canon_root_project = std::fs::canonicalize(&root_project).ok();
+        let already_present = effective_project_paths.iter().any(|p| match &canon_root_project {
+            Some(canon_target) => std::fs::canonicalize(p).ok().as_ref() == Some(canon_target),
+            None => p == &root_project,
+        });
+        if !already_present {
+            effective_project_paths.push(root_project);
+        }
+    }
     let resolved_to =
-        match crate::config::teams::resolve_agent_target(&args.to, &settings.project_paths) {
+        match crate::config::teams::resolve_agent_target(&args.to, &effective_project_paths) {
             Ok(fqn) => fqn,
             Err(e) => {
                 eprintln!("Error: {}", e);
@@ -305,9 +357,11 @@ pub fn execute(args: SendArgs) -> i32 {
 
     loop {
         if delivered_path.exists() {
-            println!(
+            crate::cli_println!(
                 "Delivered: {} (mode={}, to={})",
-                msg_id, mode_for_ack, to_for_ack
+                msg_id,
+                mode_for_ack,
+                to_for_ack
             );
             break;
         }
@@ -335,7 +389,7 @@ pub fn execute(args: SendArgs) -> i32 {
         let poll_interval = std::time::Duration::from_secs(2);
         let resp_start = std::time::Instant::now();
 
-        println!("Waiting for response (timeout: {}s)...", args.timeout);
+        crate::cli_println!("Waiting for response (timeout: {}s)...", args.timeout);
 
         loop {
             if resp_start.elapsed() >= timeout {
@@ -349,7 +403,7 @@ pub fn execute(args: SendArgs) -> i32 {
             if response_path.exists() {
                 match std::fs::read_to_string(&response_path) {
                     Ok(content) => {
-                        println!("{}", content);
+                        crate::cli_println!("{}", content);
                         return 0;
                     }
                     Err(e) => {
@@ -364,4 +418,51 @@ pub fn execute(args: SendArgs) -> i32 {
     }
 
     0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_root_project_dir_walks_up_wg_replica_path() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-x");
+        let agent_root = project
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        std::fs::create_dir_all(&agent_root).unwrap();
+
+        // On Windows, std::fs::canonicalize returns `\\?\C:\...` extended-length
+        // paths; compute the expected via canonicalize so the assertion holds on
+        // both Windows and Unix. Mirror pattern from list_peers.rs:972-1010
+        // (`extended_length_prefix_normalizes`).
+        let expected = std::fs::canonicalize(&project)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        let got = derive_root_project_dir(agent_root.to_str().unwrap())
+            .expect("should derive project from WG replica path");
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn derive_root_project_dir_returns_none_for_non_wg_path() {
+        let temp = tempfile::TempDir::new().unwrap();
+        // A random subdir without the WG-replica shape.
+        let random = temp.path().join("random").join("dir");
+        std::fs::create_dir_all(&random).unwrap();
+        assert!(derive_root_project_dir(random.to_str().unwrap()).is_none());
+    }
+
+    #[test]
+    fn derive_root_project_dir_returns_none_when_one_level_too_high() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let wg_dir = temp.path().join("proj-x").join(".ac-new").join("wg-1-devs");
+        std::fs::create_dir_all(&wg_dir).unwrap();
+        // Pointing at the WG dir, not the __agent_* dir → must return None.
+        assert!(derive_root_project_dir(wg_dir.to_str().unwrap()).is_none());
+    }
 }

--- a/src-tauri/src/config/daemon_pid.rs
+++ b/src-tauri/src/config/daemon_pid.rs
@@ -1,0 +1,202 @@
+//! Daemon PID file: written by the daemon at startup, removed on graceful exit.
+//! Used by CLI verbs (`list-sessions`) to detect whether `sessions.json` is
+//! authoritative or stale. See #231.
+//!
+//! Format: a single line containing the daemon's PID as a u32, no whitespace.
+
+use std::path::{Path, PathBuf};
+
+fn pid_path() -> Option<PathBuf> {
+    super::config_dir().map(|d| d.join("daemon.pid"))
+}
+
+/// Write the current process PID to `daemon.pid`. Idempotent (overwrites).
+/// Called once at daemon startup, after `config_dir` has been resolved.
+pub fn write_pid_file() {
+    if let Some(path) = pid_path() {
+        // Best-effort write. If the daemon can't write the pid file (perms?),
+        // log it but do not abort startup — the CLI just won't get its warning.
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Err(e) = std::fs::write(&path, std::process::id().to_string()) {
+            log::warn!("[daemon-pid] Failed to write pid file at {:?}: {}", path, e);
+        } else {
+            log::info!(
+                "[daemon-pid] Wrote pid {} to {:?}",
+                std::process::id(),
+                path
+            );
+        }
+    }
+}
+
+/// Remove the pid file on graceful shutdown. Best-effort.
+pub fn remove_pid_file() {
+    if let Some(path) = pid_path() {
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+/// State of the daemon as observable from the CLI side.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DaemonState {
+    /// PID file present and the PID corresponds to a live process (OR a process
+    /// we lack rights to query — see `is_pid_alive` `ACCESS_DENIED` handling
+    /// for the elevated-daemon / non-elevated-CLI case).
+    Running { pid: u32 },
+    /// PID file missing — no daemon has started, or it was force-killed and
+    /// the file was cleaned by a prior CLI invocation. (We do NOT delete the
+    /// stale pid file from the CLI — that would race a daemon coming up.)
+    NoPidFile,
+    /// PID file present but the PID does not correspond to a live process.
+    StalePidFile { pid: u32 },
+    /// PID file present but malformed (not a parseable u32).
+    MalformedPidFile,
+}
+
+/// Public entry point — resolves the pid path from `config_dir()` and
+/// delegates to `detect_daemon_state_at`. Returns `NoPidFile` if `config_dir`
+/// is unavailable (no home dir).
+pub fn detect_daemon_state() -> DaemonState {
+    match pid_path() {
+        Some(p) => detect_daemon_state_at(&p),
+        None => DaemonState::NoPidFile,
+    }
+}
+
+/// Path-parameterized inner detector. Test against this with a `tempfile::TempDir`
+/// so unit tests do NOT touch the live binary's `<config_dir>/daemon.pid`
+/// (writing to the live path would corrupt a running daemon's signal for the
+/// rest of its lifetime, race parallel test runs, and pollute the developer's
+/// home dir on machines where AC is not installed).
+pub fn detect_daemon_state_at(path: &Path) -> DaemonState {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return DaemonState::NoPidFile,
+    };
+    let pid: u32 = match contents.trim().parse() {
+        Ok(n) => n,
+        Err(_) => return DaemonState::MalformedPidFile,
+    };
+    if is_pid_alive(pid) {
+        DaemonState::Running { pid }
+    } else {
+        DaemonState::StalePidFile { pid }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn is_pid_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_ACCESS_DENIED, FALSE, STILL_ACTIVE,
+    };
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    // SAFETY: All three Win32 calls receive scalar arguments only (a raw u32
+    // PID, the BOOL constant FALSE, and feature-flag constants); no pointers
+    // into our address space are aliased, no buffers are shared across calls.
+    // The handle returned by OpenProcess is owned by this function: it is
+    // consumed by GetExitCodeProcess and then closed by CloseHandle before we
+    // return. `code` is a stack u32 written by GetExitCodeProcess; no escape.
+    // GetLastError is thread-local.
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+        if handle.is_null() {
+            // Distinguish "process does not exist" from "access denied".
+            // Elevated daemon + non-elevated CLI is a real scenario; treating
+            // ACCESS_DENIED as dead would emit a false stale warning and tempt
+            // the user toward `taskkill`. Conservative choice: assume alive
+            // when we cannot tell, so the warning is silenced.
+            return GetLastError() == ERROR_ACCESS_DENIED;
+        }
+        let mut code: u32 = 0;
+        let got_code = GetExitCodeProcess(handle, &mut code);
+        CloseHandle(handle);
+        // STILL_ACTIVE (259) means the process is running. Any other code
+        // means it has exited — treat the pid as dead even if the handle
+        // opened (could be a zombie kept alive by another handle holder).
+        got_code != 0 && code == STILL_ACTIVE as u32
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn is_pid_alive(_pid: u32) -> bool {
+    // Windows-first stub (plan D4-b). AgentsCommander is Windows-first; the
+    // daemon-pid warning is a stderr quality-of-life signal, not a
+    // correctness-critical check. Returning `true` here means the CLI never
+    // warns about a stale snapshot on Linux/macOS — acceptable until/unless
+    // we ship for those platforms. Avoids adding a `libc` direct dep
+    // (`src-tauri/Cargo.toml` does NOT currently list libc) just for platform
+    // parity. If we later need real Unix coverage, add `libc = "0.2"` under
+    // `[target.'cfg(not(target_os = "windows"))'.dependencies]` and replace
+    // this body with `unsafe { libc::kill(_pid as libc::pid_t, 0) == 0 }`.
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_process_is_alive() {
+        // On Windows, OpenProcess against our own PID succeeds and
+        // GetExitCodeProcess returns STILL_ACTIVE. On non-Windows, the stub
+        // returns true unconditionally — assertion still holds.
+        assert!(is_pid_alive(std::process::id()));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn extremely_high_pid_is_dead_on_windows() {
+        // A 32-bit max-value pid is essentially guaranteed not to be a live
+        // process. The Windows path returns false. The non-Windows stub would
+        // return true (it ignores its argument), so this assertion is
+        // Windows-only.
+        assert!(!is_pid_alive(u32::MAX));
+    }
+
+    #[test]
+    fn missing_pid_file_yields_no_pid_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("daemon.pid");
+        // Do NOT create the file.
+        assert_eq!(detect_daemon_state_at(&path), DaemonState::NoPidFile);
+    }
+
+    #[test]
+    fn malformed_pid_file_detected_against_tempdir() {
+        // This test MUST NOT write to the live binary's
+        // <config_dir>/daemon.pid (`pid_path()`). Use a TempDir and the
+        // path-parameterized `detect_daemon_state_at` instead.
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("daemon.pid");
+        std::fs::write(&path, "not-a-pid").unwrap();
+        assert_eq!(detect_daemon_state_at(&path), DaemonState::MalformedPidFile);
+    }
+
+    #[test]
+    fn living_pid_file_yields_running_against_tempdir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("daemon.pid");
+        std::fs::write(&path, std::process::id().to_string()).unwrap();
+        match detect_daemon_state_at(&path) {
+            DaemonState::Running { pid } => assert_eq!(pid, std::process::id()),
+            other => panic!("expected Running, got {:?}", other),
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn dead_pid_file_yields_stale_against_tempdir_on_windows() {
+        // Same Windows-only caveat as `extremely_high_pid_is_dead_on_windows`.
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("daemon.pid");
+        std::fs::write(&path, u32::MAX.to_string()).unwrap();
+        match detect_daemon_state_at(&path) {
+            DaemonState::StalePidFile { pid } => assert_eq!(pid, u32::MAX),
+            other => panic!("expected StalePidFile, got {:?}", other),
+        }
+    }
+}

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_config;
 pub mod agent_creation;
 pub mod claude_settings;
+pub mod daemon_pid;
 pub mod profile;
 pub mod projects;
 pub mod session_context;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,6 +143,9 @@ pub fn run() {
         let _ = std::fs::write(dir.join("app-outbox-path.txt"), app_outbox.path());
     }
 
+    // Issue #231: write daemon.pid so CLI verbs can detect a dead daemon.
+    config::daemon_pid::write_pid_file();
+
     // Create WS broadcaster (shared between Tauri commands and web server)
     let broadcaster = WsBroadcaster::new();
 
@@ -907,6 +910,10 @@ pub fn run() {
 
                     log::info!("[shutdown] Triggering background task shutdown (async, not awaited)...");
                     shutdown_for_exit.trigger();
+
+                    // Issue #231: remove daemon.pid before tearing down so a
+                    // subsequent CLI invocation sees NoPidFile (not StalePidFile).
+                    crate::config::daemon_pid::remove_pid_file();
 
                     log::info!("[shutdown] Persisting session state...");
                     let mgr_clone = session_mgr_for_exit.clone();

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -14,6 +14,50 @@ use crate::session::manager::SessionManager;
 use crate::session::session::SessionStatus;
 use crate::{AppOutbox, MasterToken};
 
+/// If `outbox_file` lives at
+/// `<project_dir>/.ac-new/wg-<N>-*/__agent_*/<local-dir>/outbox/<file>.json`,
+/// return `project_dir` as a UTF-8 `String`. Otherwise, `None`.
+///
+/// Mirrors the WG-replica walk-up in `cli::send::derive_root_project_dir` so
+/// the mailbox can resolve qualified WG-peer FQNs against the same root-walk-up
+/// source the sending CLI used (and the same source `list_peers::detect_wg_replica`
+/// uses to report siblings as `reachable: true`). In-memory only — settings.json
+/// is NOT mutated. See #228 D1-a.
+///
+/// The path layout is fixed by `MailboxPoller::poll` which constructs outbox
+/// paths as `Path::new(<all_paths-entry>).join(agent_local_dir_name()).join("outbox")`.
+/// We walk ancestors: `<file>.json` → `outbox` → `<local-dir>` → `<__agent_*>` →
+/// `<wg-*>` → `<.ac-new>` → `<project_dir>`.
+///
+/// Uses `to_str()?` (NOT `to_string_lossy()`) for parity with
+/// `list_peers::detect_wg_replica`. Keep this in lockstep with
+/// `cli::send::derive_root_project_dir`.
+fn derive_project_from_outbox_path(outbox_file: &Path) -> Option<String> {
+    let canon = std::fs::canonicalize(outbox_file).ok()?;
+    // canon = <project>/.ac-new/wg-*/__agent_*/<local-dir>/outbox/<file>.json
+    let outbox_dir = canon.parent()?; // .../outbox
+    if outbox_dir.file_name().and_then(|n| n.to_str()) != Some("outbox") {
+        return None;
+    }
+    let local_dir = outbox_dir.parent()?; // .../<local-dir>
+    let agent_dir = local_dir.parent()?; // .../__agent_*
+    let agent_name = agent_dir.file_name().and_then(|n| n.to_str())?;
+    if !agent_name.starts_with("__agent_") {
+        return None;
+    }
+    let wg_dir = agent_dir.parent()?; // .../wg-*
+    let wg_name = wg_dir.file_name().and_then(|n| n.to_str())?;
+    if !wg_name.starts_with("wg-") {
+        return None;
+    }
+    let ac_new_dir = wg_dir.parent()?; // .../.ac-new
+    if ac_new_dir.file_name().and_then(|n| n.to_str()) != Some(".ac-new") {
+        return None;
+    }
+    let project_dir = ac_new_dir.parent()?; // .../<project>
+    Some(project_dir.to_str()?.to_string())
+}
+
 /// Tracks delivery attempts for a single outbox message.
 struct RetryState {
     attempt_count: u32,
@@ -363,12 +407,32 @@ impl MailboxPoller {
         // (2) Canonicalize msg.to via the shared resolver. Empty `to` is allowed for
         // action-dispatch paths (e.g. close-session may set an empty to); skip in
         // that case. Reject-on-ambiguity semantics match the CLI (Decision 2 rule 2c).
+        //
+        // §AR2-norm D1-a augmentation: when the outbox file lives under a WG-replica
+        // layout (`<project>/.ac-new/wg-*/__agent_*/<local-dir>/outbox/<file>.json`),
+        // include the derived `<project>` in the in-memory `paths` slice so qualified
+        // WG-peer FQNs written by `cli::send` (which performs the symmetric walk-up
+        // augmentation — see #228 Step 1) resolve here too. Without this, the daemon
+        // re-rejects with `UnknownQualified` even though the CLI side succeeded.
+        // settings.json is NOT mutated. In-memory, this-message only. See #228 D1-a.
         if !msg.to.is_empty() {
-            let paths = {
+            let mut paths = {
                 let cfg = app.state::<SettingsState>();
                 let c = cfg.read().await;
                 c.project_paths.clone()
             };
+            if let Some(root_project) = derive_project_from_outbox_path(path) {
+                let canon_root_project = std::fs::canonicalize(&root_project).ok();
+                let already_present = paths.iter().any(|p| match &canon_root_project {
+                    Some(canon_target) => {
+                        std::fs::canonicalize(p).ok().as_ref() == Some(canon_target)
+                    }
+                    None => p == &root_project,
+                });
+                if !already_present {
+                    paths.push(root_project);
+                }
+            }
             match crate::config::teams::resolve_agent_target(&msg.to, &paths) {
                 Ok(fqn) => {
                     if fqn != msg.to {
@@ -1984,6 +2048,60 @@ mod tests {
     #[test]
     #[ignore = "integration: full CLI + mailbox + two-project fixture"]
     fn resolve_to_target_round_trip_integration() {}
+
+    // ── #228 D1-a — derive_project_from_outbox_path tests ──
+
+    #[test]
+    fn derive_project_from_outbox_path_walks_up_wg_replica_layout() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project_dir = temp.path().join("proj-x");
+        let outbox = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice")
+            .join(".agentscommander") // matches agent_local_dir_name() shape
+            .join("outbox");
+        std::fs::create_dir_all(&outbox).unwrap();
+        let file = outbox.join("msg-42.json");
+        std::fs::write(&file, "{}").unwrap();
+
+        let got =
+            derive_project_from_outbox_path(&file).expect("should derive project from WG layout");
+        let expected = std::fs::canonicalize(&project_dir)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn derive_project_from_outbox_path_rejects_non_wg_layout() {
+        let temp = tempfile::TempDir::new().unwrap();
+        // A path with the right tail but missing the `.ac-new` ancestor.
+        let outbox = temp
+            .path()
+            .join("random")
+            .join(".agentscommander")
+            .join("outbox");
+        std::fs::create_dir_all(&outbox).unwrap();
+        let file = outbox.join("msg.json");
+        std::fs::write(&file, "{}").unwrap();
+        assert!(derive_project_from_outbox_path(&file).is_none());
+    }
+
+    #[test]
+    fn derive_project_from_outbox_path_rejects_app_outbox_layout() {
+        // App-outbox lives at <config_dir>/app-outbox/<file>.json — no
+        // `__agent_*` / `wg-*` ancestors. Helper must return None so app-outbox
+        // messages are NOT augmented (they have their own master-token bypass).
+        let temp = tempfile::TempDir::new().unwrap();
+        let app_outbox = temp.path().join("config").join("app-outbox");
+        std::fs::create_dir_all(&app_outbox).unwrap();
+        let file = app_outbox.join("msg.json");
+        std::fs::write(&file, "{}").unwrap();
+        assert!(derive_project_from_outbox_path(&file).is_none());
+    }
 
     // ── BOM-tolerant reader tests (issue #130) ──
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.24",
+  "version": "0.8.26",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Align `send` and daemon mailbox target resolution with `list-peers` WG-replica discovery.
- Handle stdout BrokenPipe cleanly in CLI output without hiding other write errors.
- Add daemon pid-file state detection and `list-sessions` stale-daemon warnings while preserving stdout JSON.
- Clarify CLI token validation docs and bump version to 0.8.26.

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` -> 422 passed, 0 failed, 6 ignored
- `/feature-dev` review completed; one HIGH docs issue fixed in b8e5f8d
- `dev-rust-grinch` review: APPROVED
- Shipper built and deployed WG-1 exe: `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe`

Closes #228
Closes #229
Closes #230
Closes #231