### PR TITLE
fix(remote-command): normalize slash command injection (#233)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.25",
+  "version": "0.8.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.25",
+      "version": "0.8.26",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.25",
+  "version": "0.8.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.25"
+version = "0.8.26"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -909,7 +909,18 @@ impl MailboxPoller {
             // against the dominant single-`\r`-eaten failure mode that
             // motivated #233.
             let cmd_text = format!("/{}", command); // NO trailing \r — the injector adds it
-            crate::pty::inject::inject_text_into_session(app, session_id, &cmd_text).await?;
+            crate::pty::inject::inject_text_into_session(app, session_id, &cmd_text)
+                .await
+                .map_err(|e| {
+                    log::error!(
+                        "[mailbox] PTY injection FAILED for command '/{}' session={} msg={}: {}",
+                        command,
+                        session_id,
+                        msg.id,
+                        e
+                    );
+                    e
+                })?;
 
             log::info!(
                 "Executed remote command '{}' on session {} (from: {})",

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -836,14 +836,30 @@ impl MailboxPoller {
     ) -> Result<(), String> {
         let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
 
-        // ── Remote command path: write /<command>\r directly, no framing ──
+        // ── Remote command path: delegate to the canonical injector ──
+        // `/clear` and `/compact` are submitted to the agent's PTY exactly the
+        // same way as a normal message body: through `inject_text_into_session`,
+        // which owns shell detection and the agent-specific double-Enter safety
+        // net (see pty/inject.rs). The injector — not this branch — appends the
+        // Enter(s); we pass just the `/command` text.
         if let Some(ref command) = msg.command {
             const ALLOWED_COMMANDS: &[&str] = &["clear", "compact"];
             if !ALLOWED_COMMANDS.contains(&command.as_str()) {
                 return Err(format!("Unsupported remote command '{}'", command));
             }
 
-            // Precondition: agent must be idle (waiting_for_input)
+            // Precondition: agent must be idle (waiting_for_input) AND the
+            // shell must be a coding-agent CLI that owns explicit-Enter
+            // handling in the canonical injector. The shell check guards
+            // against silent failure on non-agent shells (plain bash/pwsh)
+            // and on cmd-wrapped Codex sessions: under R1 the injector
+            // sends ZERO carriage returns when `needs_explicit_enter` is
+            // false, so writing `/clear` into such a shell would leave the
+            // text un-submitted and let subsequent user input concatenate
+            // with it. Reject explicitly instead — closes grinch's G1 + G3.
+            // Removing this reject requires extending `needs_explicit_enter`
+            // to recognize the rejected case as agent-aware first; see
+            // `#233-followup-cmd-wrapper`.
             {
                 let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
                 let mgr = session_mgr.read().await;
@@ -855,29 +871,45 @@ impl MailboxPoller {
                             session_id, command
                         ))
                     }
+                    Some(s) if !crate::pty::inject::needs_explicit_enter(&s.shell) => {
+                        return Err(format!(
+                            "Cannot execute remote command '/{}': session shell '{}' is not a coding-agent CLI (Claude / Codex / Gemini). cmd / pwsh wrappers around an agent are tracked separately as #233-followup-cmd-wrapper.",
+                            command, s.shell
+                        ))
+                    }
                     Some(s) if !s.waiting_for_input => {
                         return Err(format!(
                             "Cannot execute remote command '{}': agent is busy (not idle)",
                             command
                         ))
                     }
-                    _ => {} // idle — proceed
+                    _ => {} // idle agent-shell — proceed
                 }
             }
 
-            // Write /<command>\r directly to PTY stdin.
-            // Note: there is a small race window between the idle check above and
-            // this write — the agent could become busy on a separate task. This is
-            // inherent to a polling-based idle model and is acceptable for /clear
-            // and /compact which Claude Code processes even if mid-prompt.
-            let cmd_bytes = format!("/{}\r", command);
-            {
-                let mgr = pty_mgr
-                    .lock()
-                    .map_err(|e| format!("PTY lock failed: {}", e))?;
-                mgr.write(session_id, cmd_bytes.as_bytes())
-                    .map_err(|e| format!("PTY write failed for remote command: {}", e))?;
-            }
+            // Submit `/<command>` via the canonical text-block injector.
+            //
+            // TOCTOU note (round-2 correction): the gap between the idle check
+            // above and the FINAL `\r` is now ~2 s (text → 1500 ms → \r →
+            // 500 ms → \r inside `inject_text_into_session`), not microseconds
+            // as the original direct-write path. Two things can interleave
+            // inside that window:
+            //   1. User keystrokes from xterm.js — they take the path
+            //      `frontend → invoke("pty_write") → commands/pty.rs::pty_write
+            //      → PtyManager::write` (raw bytes, bypasses the injector). A
+            //      user typing between the staggered Enters concatenates with
+            //      the un-Enter'd `/<command>`.
+            //   2. The idle detector flipping `waiting_for_input` to false
+            //      based on independent PTY output, leaving the second `\r`
+            //      to land on a busy agent (harmless — at worst an extra
+            //      Enter on empty input, per pty/inject.rs:78-79).
+            // We accept this race because the standard-message path at
+            // mailbox.rs:972 already exhibits it identically and the
+            // staggered double-Enter is the empirically-tuned defense
+            // against the dominant single-`\r`-eaten failure mode that
+            // motivated #233.
+            let cmd_text = format!("/{}", command); // NO trailing \r — the injector adds it
+            crate::pty::inject::inject_text_into_session(app, session_id, &cmd_text).await?;
 
             log::info!(
                 "Executed remote command '{}' on session {} (from: {})",

--- a/src-tauri/src/pty/inject.rs
+++ b/src-tauri/src/pty/inject.rs
@@ -13,7 +13,7 @@ use crate::session::manager::SessionManager;
 /// The shell may be a bare name ("claude") or a full path
 /// ("C:\Users\...\.claude\local\claude.exe"), so we extract the filename stem
 /// before matching.
-fn needs_explicit_enter(shell: &str) -> bool {
+pub(crate) fn needs_explicit_enter(shell: &str) -> bool {
     let stem = std::path::Path::new(shell.trim())
         .file_stem()
         .and_then(|s| s.to_str())
@@ -109,4 +109,54 @@ pub async fn inject_text_into_session(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::needs_explicit_enter;
+
+    #[test]
+    fn agent_clis_require_explicit_enter() {
+        for shell in [
+            "codex",
+            "codex.exe",
+            "codex.cmd",
+            "Codex",
+            "CODEX",
+            "C:\\Users\\maria\\.codex\\codex.exe",
+            "/usr/local/bin/codex",
+            "claude",
+            "claude.exe",
+            "C:\\Users\\maria\\.claude\\local\\claude.exe",
+            "gemini",
+            "gemini.exe",
+            "  codex  ", // leading/trailing whitespace tolerated
+        ] {
+            assert!(
+                needs_explicit_enter(shell),
+                "expected true for shell={:?}",
+                shell
+            );
+        }
+    }
+
+    #[test]
+    fn plain_shells_do_not_require_explicit_enter() {
+        for shell in [
+            "bash",
+            "powershell.exe",
+            "pwsh",
+            "pwsh.exe",
+            "cmd.exe",
+            "zsh",
+            "",
+            "   ",
+        ] {
+            assert!(
+                !needs_explicit_enter(shell),
+                "expected false for shell={:?}",
+                shell
+            );
+        }
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.25",
+  "version": "0.8.26",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Route remote `/clear` and `/compact` commands through the canonical PTY text injector so Codex gets the established staggered double-Enter submit behavior.
- Reject remote command injection for non-agent shells/cmd-wrapped sessions instead of leaving `/clear` typed without submit.
- Add classifier tests for agent shells and bump version to 0.8.26.

## Validation
- `cargo check --all-targets`
- `cargo clippy --all-targets`
- `cargo test -p agentscommander-new --lib` (430 passed, 6 ignored)
- `cargo test --test cli_brief_logger`
- `cargo test --test cli_close_session` (ignored tests only)
- `cargo test --test cli_powershell_capture` (ignored tests only)
- Grinch implementation review: PASS
- Built and deployed `agentscommander_standalone_wg-2.exe`
- CLI-only validation passed; live PTY smoke was blocked because current sessions are hosted by `agentscommander_mb.exe`, not the wg-2 binary under test.

## Follow-ups
Automation gaps discovered while trying to run full E2E smoke are tracked in #239, #240, #241, #242, #243, #244, and #245.

Closes #233