### PR TITLE
fix(startup): restore coordinator wake state (#248)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.26",
+  "version": "0.8.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.26",
+      "version": "0.8.27",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.26",
+  "version": "0.8.27",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.26"
+version = "0.8.27"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1234,11 +1234,25 @@ fn effective_restart_skip_auto_resume(requested: Option<bool>) -> bool {
 
 /// Restart a session: destroy the existing one and recreate it with the same
 /// configuration but a fresh PTY. By default suppresses provider auto-resume
-/// (true user-intent restart — fresh conversation). Callers that are instead
-/// *waking* a previously-deferred session (e.g. a non-coordinator replica whose
-/// PTY was Exited(0) at startup due to `startOnlyCoordinators: true`) pass
-/// `skip_auto_resume = Some(false)` to allow `claude --continue`,
-/// `codex resume --last`, or `gemini --resume latest` injection.
+/// (true user-intent restart — fresh conversation).
+///
+/// Callers that are instead *waking* a previously-deferred session pass
+/// `skip_auto_resume = Some(false)`. A session is "deferred" (PTY `Exited(0)`
+/// at startup) for any of the following reasons:
+///
+///   1. `restoreCoordinatorWakeState = false` (the new-policy default per
+///      issue #248) defers every persisted session regardless of agent type.
+///   2. `restoreCoordinatorWakeState = true` defers all non-coordinator team
+///      members (these are never auto-woken on startup under the new policy).
+///   3. `restoreCoordinatorWakeState = true` defers coordinators whose PTY
+///      status was `Exited(_)` at the prior shutdown (the state-sensitive
+///      branch added by issue #248).
+///   4. The user explicitly closed the session during the prior run.
+///
+/// In all four cases, `skip_auto_resume = Some(false)` allows the next PTY
+/// spawn to inject `claude --continue`, `codex resume --last`, or
+/// `gemini --resume latest` so the prior conversation continues.
+///
 /// The restarted session is automatically activated, Telegram bridges are
 /// re-attached, and state is persisted.
 // Tauri command: State<> injections push us over clippy's 7-arg threshold.

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -7,11 +7,17 @@ use crate::session::manager::SessionManager;
 use crate::session::session::{SessionStatus, TEMP_SESSION_PREFIX};
 
 /// Minimal session data needed to restore a session on next app start.
-/// No UUID, no status - just the "recipe" to re-create it.
+/// No UUID, just the "recipe" to re-create it.
 ///
-/// The optional runtime fields (id, status, waiting_for_input, created_at) are
+/// The optional runtime fields (id, waiting_for_input, created_at) are
 /// populated during live snapshots so the CLI can read session state from the
 /// file without requiring an HTTP request. They are ignored on restore.
+///
+/// `status` is also populated during live snapshots for CLI consumption AND is
+/// now **consumed on restore** by the issue #248 startup wake policy: the
+/// restore-task closure in `lib.rs` reads `status` to decide whether a
+/// coordinator should be auto-woken (was awake at shutdown) or left dormant
+/// (was asleep at shutdown). See `should_wake_on_restore` in `lib.rs`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PersistedSession {
@@ -54,11 +60,14 @@ pub struct PersistedSession {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git_branch_prefix: Option<String>,
 
-    // ── Runtime fields (populated during live snapshots, ignored on restore) ──
+    // ── Runtime fields (populated during live snapshots; `status` consumed on
+    //    restore per issue #248, the others ignored on restore) ──
     /// Session UUID (only present in live snapshots)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    /// Current session status (only present in live snapshots)
+    /// Current session status. Populated during live snapshots; **consumed on
+    /// restore** by the issue #248 startup wake policy (see
+    /// `should_wake_on_restore` in `lib.rs`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<SessionStatus>,
     /// Whether the session is waiting for user input (only present in live snapshots)
@@ -1031,6 +1040,39 @@ mod tests {
         assert_eq!(ps.git_repos[0].source_path, "C:/repos/agentscommander");
         assert!(ps.git_branch_source.is_none());
         assert!(ps.git_branch_prefix.is_none());
+    }
+
+    /// Issue #248 — status round-trips through serialize/deserialize.
+    /// Locks the field against future "ignored on restore" misreads now that
+    /// `should_wake_on_restore` in `lib.rs` consumes it.
+    #[test]
+    fn issue_248_status_round_trips_through_persistence() {
+        use crate::session::session::SessionStatus;
+        let cases = [SessionStatus::Exited(0), SessionStatus::Running];
+        for status in cases {
+            let ps = PersistedSession {
+                name: "coord-x".into(),
+                shell: "claude".into(),
+                shell_args: vec![],
+                working_directory: "C:/proj/.ac-new/_agent_architect".into(),
+                was_active: true,
+                git_repos: vec![],
+                is_coordinator: true,
+                agent_id: Some("aid-arch".into()),
+                agent_label: Some("Architect".into()),
+                was_detached: false,
+                detached_geometry: None,
+                git_branch_source: None,
+                git_branch_prefix: None,
+                id: Some("uuid".into()),
+                status: Some(status.clone()),
+                waiting_for_input: Some(false),
+                created_at: Some("2026-05-17T00:00:00Z".into()),
+            };
+            let json = serde_json::to_string(&ps).expect("serialize");
+            let back: PersistedSession = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(back.status, Some(status));
+        }
     }
 
     /// Legacy "multi-repo" prefix → git_repos stays empty; legacy fields cleared.

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -47,10 +47,24 @@ pub struct AppSettings {
     /// Configured Telegram bots for bridge
     #[serde(default)]
     pub telegram_bots: Vec<TelegramBotConfig>,
-    /// On app start, only auto-start PTY sessions for coordinator agents.
-    /// Non-coordinator team members appear in sidebar but are not auto-started.
-    #[serde(default = "default_true")]
-    pub start_only_coordinators: bool,
+    /// When true, on app start, wake coordinators whose PTY was awake at shutdown.
+    /// Coordinators that were asleep at shutdown remain asleep. Non-coordinator
+    /// team members are never auto-woken on startup (the user must click their
+    /// replica in the sidebar to wake them). Issue #248.
+    #[serde(default)]
+    pub restore_coordinator_wake_state: bool,
+    /// Migration carrier: legacy field name from before issue #248. Read on
+    /// deserialization, then translated into `restore_coordinator_wake_state` by
+    /// `apply_issue_248_migration`. `skip_serializing_if = "Option::is_none"`
+    /// elides it on the next save once the migration has run.
+    ///
+    /// One-shot migration semantics:
+    ///   - legacy `startOnlyCoordinators: true`  → `restoreCoordinatorWakeState: true`
+    ///   - legacy `startOnlyCoordinators: false` → `restoreCoordinatorWakeState: false`
+    ///
+    /// In both cases the legacy value is dropped from disk on next save.
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "startOnlyCoordinators")]
+    pub legacy_start_only_coordinators: Option<bool>,
     /// Keep sidebar window always on top
     #[serde(default)]
     pub sidebar_always_on_top: bool,
@@ -216,7 +230,8 @@ impl Default for AppSettings {
             default_shell_args,
             agents: vec![],
             telegram_bots: vec![],
-            start_only_coordinators: true,
+            restore_coordinator_wake_state: false,
+            legacy_start_only_coordinators: None,
             sidebar_always_on_top: false,
             team_idle_beep_enabled: true,
             sounds_enabled: true,
@@ -431,12 +446,27 @@ pub fn load_settings() -> AppSettings {
         );
     }
 
-    // Auto-generate root token if missing
+    // #248 migration — translates legacy startOnlyCoordinators (if present).
+    // Track whether the legacy field was on disk so we can fire a single save
+    // at the end of the function (Grinch Z3 — without this, upgrade users
+    // with an existing root_token never persist the migration and the legacy
+    // key lingers in settings.json, spamming the migration log on every launch).
+    let issue_248_migrated = settings.legacy_start_only_coordinators.is_some();
+    apply_issue_248_migration(&mut settings);
+
+    // Auto-generate root token if missing.
+    let mut needs_save = issue_248_migrated;
     if settings.root_token.is_none() {
         settings.root_token = Some(uuid::Uuid::new_v4().to_string());
         log::info!("Generated new root token");
+        needs_save = true;
+    }
+    if needs_save {
         if let Err(e) = save_settings(&settings) {
-            log::error!("Failed to persist auto-generated root token: {}", e);
+            log::error!(
+                "Failed to persist settings (root_token gen and/or #248 migration): {}",
+                e
+            );
         }
     }
 
@@ -507,8 +537,47 @@ pub fn load_settings_for_cli() -> AppSettings {
         settings.main_always_on_top = true;
     }
 
+    // #248 migration — translate in-memory only. The CLI loader is forbidden
+    // from writing settings.json per the §463 contract (load_settings_for_cli
+    // is the read-only variant used by mutating verbs like `open-project` and
+    // `new-project`; it must not race with the GUI's settings writes). The
+    // next GUI launch finalizes the migration to disk via load_settings.
+    apply_issue_248_migration(&mut settings);
+
     // NO root_token auto-gen, NO save_settings call.
     settings
+}
+
+/// One-shot migration for issue #248: translate the legacy
+/// `startOnlyCoordinators` field into the new state-sensitive
+/// `restore_coordinator_wake_state`. Idempotent — once the legacy carrier is
+/// cleared (`.take()`), subsequent calls see `None` and do nothing.
+///
+/// Translation rules:
+///   - legacy `true`  → new `true`  (preserve "smart startup" intent under new semantics).
+///   - legacy `false` → new `false` (legacy "wake everything" mode is removed; closest
+///     equivalent under the new model is "wake nothing").
+///
+/// Conflict handling (Grinch Z4): if the user (or a third-party tool) wrote
+/// BOTH keys and the new field already differs from the legacy intent, emit a
+/// `warn!` and keep the new field's existing value — never silently overwrite
+/// a deliberate `restoreCoordinatorWakeState` with a stale legacy value.
+fn apply_issue_248_migration(settings: &mut AppSettings) {
+    if let Some(legacy) = settings.legacy_start_only_coordinators.take() {
+        if !settings.restore_coordinator_wake_state {
+            settings.restore_coordinator_wake_state = legacy;
+            log::info!(
+                "[settings-migration] #248 — translated legacy startOnlyCoordinators={} → restoreCoordinatorWakeState={}",
+                legacy, settings.restore_coordinator_wake_state
+            );
+        } else if legacy != settings.restore_coordinator_wake_state {
+            log::warn!(
+                "[settings-migration] #248 — conflicting state on disk: legacy startOnlyCoordinators={} but restoreCoordinatorWakeState={} already set; keeping the new value, dropping legacy",
+                legacy, settings.restore_coordinator_wake_state
+            );
+        }
+        // else: legacy and new agree → silent drop, no log.
+    }
 }
 
 /// Read only the `logLevel` field from `settings.json` without triggering migrations,
@@ -947,6 +1016,90 @@ mod tests {
         assert!(json.contains("\"rtkPromptDismissed\":true"));
         let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
         assert!(back.rtk_prompt_dismissed);
+    }
+
+    // ── Issue #248 — legacy startOnlyCoordinators → restoreCoordinatorWakeState ──
+    //
+    // The minimal JSON below carries the three fields without serde defaults
+    // (`defaultShell`, `defaultShellArgs`, `agents`) plus whichever issue-#248
+    // field is under test. All other AppSettings fields use their serde defaults.
+
+    #[test]
+    fn issue_248_migration_legacy_true_translates_to_new_true() {
+        let json = r#"{
+            "defaultShell": "bash",
+            "defaultShellArgs": [],
+            "agents": [],
+            "startOnlyCoordinators": true
+        }"#;
+        let mut s: AppSettings = serde_json::from_str(json).expect("deserialize");
+        // Pre-migration: legacy field is parsed, new field is at its default.
+        assert_eq!(s.legacy_start_only_coordinators, Some(true));
+        assert!(!s.restore_coordinator_wake_state);
+
+        super::apply_issue_248_migration(&mut s);
+
+        assert!(s.restore_coordinator_wake_state);
+        assert!(s.legacy_start_only_coordinators.is_none());
+
+        // Round-trip — the legacy field must NOT reappear on next save.
+        let out = serde_json::to_string(&s).expect("serialize");
+        assert!(!out.contains("startOnlyCoordinators"));
+        assert!(out.contains("\"restoreCoordinatorWakeState\":true"));
+    }
+
+    #[test]
+    fn issue_248_migration_legacy_false_translates_to_new_false() {
+        let json = r#"{
+            "defaultShell": "bash",
+            "defaultShellArgs": [],
+            "agents": [],
+            "startOnlyCoordinators": false
+        }"#;
+        let mut s: AppSettings = serde_json::from_str(json).expect("deserialize");
+        super::apply_issue_248_migration(&mut s);
+        assert!(!s.restore_coordinator_wake_state);
+        assert!(s.legacy_start_only_coordinators.is_none());
+    }
+
+    #[test]
+    fn issue_248_no_legacy_field_keeps_new_field_value() {
+        // Fresh install or post-migrated settings.json — no legacy field.
+        let json = r#"{
+            "defaultShell": "bash",
+            "defaultShellArgs": [],
+            "agents": [],
+            "restoreCoordinatorWakeState": true
+        }"#;
+        let mut s: AppSettings = serde_json::from_str(json).expect("deserialize");
+        super::apply_issue_248_migration(&mut s);
+        assert!(s.restore_coordinator_wake_state); // untouched
+        assert!(s.legacy_start_only_coordinators.is_none());
+    }
+
+    #[test]
+    fn issue_248_migration_conflict_keeps_new_value_and_drops_legacy() {
+        // Grinch Z4 — both keys present, conflicting values. The user (or a
+        // third-party tool) wrote restoreCoordinatorWakeState=true AFTER an
+        // older startOnlyCoordinators=false was already on disk. The new value
+        // wins; the legacy key is silently dropped from the next save. The
+        // helper emits a `warn!` log line for triage — not asserted here (log
+        // capture is not wired in the existing test suite), just exercised.
+        let json = r#"{
+            "defaultShell": "bash",
+            "defaultShellArgs": [],
+            "agents": [],
+            "startOnlyCoordinators": false,
+            "restoreCoordinatorWakeState": true
+        }"#;
+        let mut s: AppSettings = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(s.legacy_start_only_coordinators, Some(false));
+        assert!(s.restore_coordinator_wake_state);
+
+        super::apply_issue_248_migration(&mut s);
+
+        assert!(s.restore_coordinator_wake_state); // preserved
+        assert!(s.legacy_start_only_coordinators.is_none()); // dropped
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -103,6 +103,37 @@ impl AppOutbox {
     }
 }
 
+/// Decide whether a persisted session should be restored with a live PTY
+/// at app startup, or deferred (created as a dormant `Exited(0)` record).
+///
+/// Inputs:
+///   - `setting_on`: value of `AppSettings::restore_coordinator_wake_state`.
+///   - `is_coord`: whether the agent FQN derived from `ps.working_directory`
+///     is a coordinator of any discovered team.
+///   - `persisted_status`: `PersistedSession::status` as snapshotted at the
+///     last app shutdown. `None` means the snapshot was taken by an older
+///     binary that did not record status. Treat `None` as **awake** for
+///     forward-compat — better to wake a coord the user expected to be
+///     awake than silently leave it dormant on first launch after upgrade.
+///
+/// Returns true ⇒ restore with PTY; false ⇒ defer (dormant).
+pub(crate) fn should_wake_on_restore(
+    setting_on: bool,
+    is_coord: bool,
+    persisted_status: Option<&crate::session::session::SessionStatus>,
+) -> bool {
+    if !setting_on {
+        return false; // Setting OFF: defer everything.
+    }
+    if !is_coord {
+        return false; // Non-coord: always deferred under the new policy.
+    }
+    match persisted_status {
+        Some(crate::session::session::SessionStatus::Exited(_)) => false, // asleep at shutdown
+        Some(_) | None => true, // awake at shutdown (or unknown → fail-open)
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Same backend the CLI path now installs in `main.rs` — see `logging.rs`
@@ -620,13 +651,22 @@ pub fn run() {
                 let pty_mgr_clone = app.state::<Arc<Mutex<PtyManager>>>().inner().clone();
                 let app_handle = app.handle().clone();
 
-                // Check if we should only auto-start coordinator sessions
-                let start_only_coords = crate::config::settings::load_settings().start_only_coordinators;
-                let teams = if start_only_coords {
-                    crate::config::teams::discover_teams()
-                } else {
-                    vec![]
-                };
+                // #248 — read the new setting and always discover teams (the coord check
+                // is run for every persisted session, regardless of the setting's value).
+                let settings_snapshot = crate::config::settings::load_settings();
+                let setting_on = settings_snapshot.restore_coordinator_wake_state;
+                let teams = crate::config::teams::discover_teams();
+
+                // #248 Grinch Z10 — diagnostic: empty `teams` after a project-path rename
+                // is a real failure mode; without this line the user sees coords stay
+                // dormant with no log clue. Emits exactly once per launch.
+                log::info!(
+                    "[restore] {} teams discovered across {} project paths; setting_on={}; evaluating {} persisted sessions",
+                    teams.len(),
+                    settings_snapshot.project_paths.len(),
+                    setting_on,
+                    persisted.len()
+                );
 
                 // §224 A.2.5 — RAII guard inside the closure clears the flag
                 // on normal exit AND on panic unwind so the daemon can't get
@@ -654,6 +694,10 @@ pub fn run() {
                     let mut active_id = None;
                     let mut failed_recoverable: Vec<sessions_persistence::PersistedSession> = Vec::new();
 
+                    // #248 Grinch Z5 — count outcomes for the end-of-restore summary line.
+                    let mut n_woken: usize = 0;
+                    let mut n_deferred: usize = 0;
+
                     for ps in &persisted {
                         // Skip sessions whose CWD no longer exists (permanent failure)
                         if !std::path::Path::new(&ps.working_directory).exists() {
@@ -661,50 +705,77 @@ pub fn run() {
                             continue;
                         }
 
-                        // Defer non-coordinator team members when setting is enabled.
+                        // #248 — decide wake vs defer for this session.
                         // §DR2: use `agent_fqn_from_path` so WG replicas get project-precise
                         // team membership and coordinator checks. Strict `is_coordinator`
                         // (§AR2-strict) requires the FQN to avoid cross-project flag leaks.
-                        if start_only_coords {
-                            let agent_name = crate::config::teams::agent_fqn_from_path(&ps.working_directory);
-                            let in_team = teams.iter().any(|t| crate::config::teams::is_in_team(&agent_name, t));
-                            let is_coord = crate::config::teams::is_any_coordinator(&agent_name, &teams);
+                        let agent_name = crate::config::teams::agent_fqn_from_path(&ps.working_directory);
+                        let is_coord = crate::config::teams::is_any_coordinator(&agent_name, &teams);
+                        let wake = should_wake_on_restore(setting_on, is_coord, ps.status.as_ref());
 
-                            if in_team && !is_coord {
-                                // Create session record without PTY (dormant)
-                                let mgr = session_mgr_clone.read().await;
-                                match mgr.create_session(
-                                    ps.shell.clone(),
-                                    ps.shell_args.clone(),
-                                    ps.working_directory.clone(),
-                                    ps.agent_id.clone(),
-                                    ps.agent_label.clone(),
-                                    ps.git_repos.clone(),
-                                    false, // deferred = in_team && !is_coord, so never coordinator
-                                ).await {
-                                    Ok(session) => {
-                                        mgr.rename_session(session.id, ps.name.clone()).await.ok();
-                                        mgr.mark_exited(session.id, 0).await;
-                                        mgr.clear_active_if(session.id).await;
-                                        // Read updated session so emitted event reflects Exited status
-                                        if let Some(updated) = mgr.get_session(session.id).await {
-                                            let info = crate::session::session::SessionInfo::from(&updated);
-                                            let _ = tauri::Emitter::emit(&app_handle, "session_created", info);
-                                        }
-                                        log::info!(
-                                            "Deferred non-coordinator session '{}' (agent: {}, no PTY)",
-                                            ps.name, agent_name
-                                        );
+                        if !wake {
+                            // Defer: create a dormant Session record (no PTY, status = Exited(0)).
+                            let mgr = session_mgr_clone.read().await;
+                            match mgr.create_session(
+                                ps.shell.clone(),
+                                ps.shell_args.clone(),
+                                ps.working_directory.clone(),
+                                ps.agent_id.clone(),
+                                ps.agent_label.clone(),
+                                ps.git_repos.clone(),
+                                is_coord, // #248 — pass live is_coord so dormant coords stay coords (Z7).
+                            ).await {
+                                Ok(session) => {
+                                    mgr.rename_session(session.id, ps.name.clone()).await.ok();
+
+                                    // Grinch Z2 — preserve detach state across the defer lifecycle.
+                                    // Must be applied BEFORE mark_exited so the next snapshot_sessions
+                                    // event (whether triggered by failed_recoverable, user action, or
+                                    // shutdown) writes was_detached=true to disk. Without this, the
+                                    // first persist after defer silently drops the user's detach intent
+                                    // (manager.rs defaults was_detached to false on create_session).
+                                    if ps.was_detached {
+                                        mgr.set_was_detached(session.id, true).await;
                                     }
-                                    Err(e) => {
-                                        log::error!("Failed to create deferred session '{}': {}", ps.name, e);
-                                        failed_recoverable.push(ps.clone());
+                                    if let Some(ref geo) = ps.detached_geometry {
+                                        mgr.set_detached_geometry(session.id, geo.clone()).await;
+                                    }
+
+                                    mgr.mark_exited(session.id, 0).await;
+                                    mgr.clear_active_if(session.id).await;
+                                    // Read updated session so emitted event reflects Exited status
+                                    if let Some(updated) = mgr.get_session(session.id).await {
+                                        let info = crate::session::session::SessionInfo::from(&updated);
+                                        let _ = tauri::Emitter::emit(&app_handle, "session_created", info);
+                                    }
+                                    // Grinch Z5 — debug, not info: under the new default every
+                                    // persisted session lands here, and an info-level line per
+                                    // session creates a "mass defer" wall in startup logs that
+                                    // looks like an alarm. The end-of-loop info summary below
+                                    // carries the load-bearing signal.
+                                    log::debug!(
+                                        "Deferred session '{}' on startup (agent: {}, is_coord: {}, setting: {}, persisted_status: {:?}, was_detached: {})",
+                                        ps.name, agent_name, is_coord, setting_on, ps.status, ps.was_detached
+                                    );
+                                    n_deferred += 1;
+                                    // Preserve `was_active` for the post-loop active-switch:
+                                    // a deferred session can still be the persisted-active one.
+                                    // The post-loop branching (Fix A) ensures `set_active_only`
+                                    // is used (not `switch_session`), so the dormant status
+                                    // survives selection.
+                                    if ps.was_active {
+                                        active_id = Some(session.id.to_string());
                                     }
                                 }
-                                continue; // Skip normal restore with PTY
+                                Err(e) => {
+                                    log::error!("Failed to create deferred session '{}': {}", ps.name, e);
+                                    failed_recoverable.push(ps.clone());
+                                }
                             }
+                            continue;
                         }
 
+                        // Wake: full PTY restore via the existing create_session_inner call.
                         match commands::session::create_session_inner(
                             &app_handle,
                             &session_mgr_clone,
@@ -723,6 +794,7 @@ pub fn run() {
                                 if ps.was_active {
                                     active_id = Some(info.id.clone());
                                 }
+                                n_woken += 1;
 
                                 // Phase 3 restore: reconstruct detach state for the live session.
                                 // Deferred sessions (handled above with a `continue`) never reach
@@ -780,6 +852,15 @@ pub fn run() {
                         }
                     }
 
+                    // #248 Grinch Z5 — load-bearing summary line. Replaces the per-session
+                    // info noise demoted to debug above. Must be emitted BEFORE the post-loop
+                    // active-switch block so the restore-decision summary is grouped with
+                    // the restore log in chronological order, not interleaved with switch events.
+                    log::info!(
+                        "[restore] complete — {} woken, {} deferred (setting_on={}, total_evaluated={})",
+                        n_woken, n_deferred, setting_on, persisted.len()
+                    );
+
                     // Switch to the session that was active when the app closed. Plan §A2.2.G3
                     // filter: if the persisted-active session is now detached (respawned with
                     // `was_detached=true` above), do NOT switch main to it — main + detached
@@ -821,7 +902,33 @@ pub fn run() {
                                     );
                                 }
                             } else {
-                                let _ = mgr.switch_session(uuid).await;
+                                // #248 Fix A — preserve dormant status for the persisted-active
+                                // session. Read the candidate's current status from the live
+                                // manager (it was just set by either the defer arm or
+                                // create_session_inner upstream).
+                                let candidate_status =
+                                    mgr.get_session(uuid).await.map(|s| s.status.clone());
+                                let dormant = matches!(
+                                    candidate_status,
+                                    Some(crate::session::session::SessionStatus::Exited(_))
+                                );
+
+                                let result = if dormant {
+                                    mgr.set_active_only(uuid).await
+                                } else {
+                                    mgr.switch_session(uuid).await
+                                };
+                                if let Err(e) = result {
+                                    log::error!(
+                                        "Failed to select persisted-active session {} (dormant={}): {}",
+                                        id, dormant, e
+                                    );
+                                }
+
+                                // `session_switched` payload is unchanged — sidebar uses it for
+                                // the selection highlight; dot color is driven by `status` from
+                                // the next `list_sessions` refresh (which now correctly returns
+                                // `Exited(0)` for the dormant case thanks to set_active_only).
                                 let _ = tauri::Emitter::emit(
                                     &app_handle,
                                     "session_switched",
@@ -843,7 +950,6 @@ pub fn run() {
                             failed_recoverable.iter().map(|s| &s.name).collect::<Vec<_>>()
                         );
                     }
-                    log::info!("Session restore complete");
                 });
             }
 
@@ -999,4 +1105,39 @@ pub fn run() {
                 _ => {}
             }
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_wake_on_restore;
+    use crate::session::session::SessionStatus;
+
+    #[test]
+    fn setting_off_always_defers() {
+        assert!(!should_wake_on_restore(false, true, Some(&SessionStatus::Running)));
+        assert!(!should_wake_on_restore(false, false, None));
+    }
+
+    #[test]
+    fn non_coord_always_defers_when_on() {
+        assert!(!should_wake_on_restore(true, false, Some(&SessionStatus::Running)));
+    }
+
+    #[test]
+    fn coord_awake_at_shutdown_wakes_when_on() {
+        assert!(should_wake_on_restore(true, true, Some(&SessionStatus::Running)));
+        assert!(should_wake_on_restore(true, true, Some(&SessionStatus::Idle)));
+        assert!(should_wake_on_restore(true, true, Some(&SessionStatus::Active)));
+    }
+
+    #[test]
+    fn coord_asleep_at_shutdown_defers_when_on() {
+        assert!(!should_wake_on_restore(true, true, Some(&SessionStatus::Exited(0))));
+        assert!(!should_wake_on_restore(true, true, Some(&SessionStatus::Exited(137))));
+    }
+
+    #[test]
+    fn coord_unknown_status_fails_open_when_on() {
+        assert!(should_wake_on_restore(true, true, None));
+    }
 }

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -152,6 +152,52 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Set the active session WITHOUT mutating its status. Use when the target
+    /// session is dormant (`Exited(_)`) and we want it "selected but not running"
+    /// — e.g. the persisted-active session was deferred at startup under the
+    /// issue #248 policy. The previously-active session (if any) is demoted
+    /// Active → Running per the standard `switch_session` semantics. The newly-
+    /// active session's status is left untouched.
+    ///
+    /// Use `switch_session` for the live-selection case (status flips to
+    /// `Active`); use `set_active_only` for the dormant-selection case (status
+    /// preserved).
+    pub async fn set_active_only(&self, id: Uuid) -> Result<(), AppError> {
+        let mut sessions = self.sessions.write().await;
+        if !sessions.contains_key(&id) {
+            return Err(AppError::SessionNotFound(id.to_string()));
+        }
+
+        let mut active = self.active_session.write().await;
+
+        // Deactivate the current session — same demotion logic as switch_session.
+        if let Some(old_id) = *active {
+            if let Some(old) = sessions.get_mut(&old_id) {
+                if old.status == SessionStatus::Active {
+                    log::info!(
+                        "[session-state] {} '{}': Active → Running (deactivated for set_active_only)",
+                        &old_id.to_string()[..8],
+                        old.name
+                    );
+                    old.status = SessionStatus::Running;
+                }
+            }
+        }
+
+        // Set active WITHOUT touching the new candidate's status.
+        *active = Some(id);
+        if let Some(s) = sessions.get_mut(&id) {
+            log::info!(
+                "[session-state] {} '{}': {:?} (status preserved) → selected via set_active_only",
+                &id.to_string()[..8],
+                s.name,
+                s.status
+            );
+        }
+
+        Ok(())
+    }
+
     pub async fn rename_session(&self, id: Uuid, name: String) -> Result<(), AppError> {
         let mut sessions = self.sessions.write().await;
         let session = sessions
@@ -580,5 +626,118 @@ mod tests {
         let second_stored = mgr.get_session(second.id).await.unwrap();
         assert_eq!(first_stored.status, SessionStatus::Running);
         assert_eq!(second_stored.status, SessionStatus::Active);
+    }
+
+    // ── Issue #248 — set_active_only (Fix A) ──
+
+    #[tokio::test]
+    async fn set_active_only_preserves_dormant_status() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude".into(),
+                vec![],
+                "C:\\proj".into(),
+                None,
+                None,
+                vec![],
+                true,
+            )
+            .await
+            .unwrap();
+        // After create_session, the session is auto-activated (status = Active);
+        // call mark_exited to put it in the dormant state under test.
+        mgr.mark_exited(session.id, 0).await;
+        // clear_active_if to drop the now-stale active pointer.
+        mgr.clear_active_if(session.id).await;
+        assert_eq!(mgr.get_active().await, None);
+
+        // The behavior under test: select the dormant session without flipping
+        // its status.
+        mgr.set_active_only(session.id).await.unwrap();
+        assert_eq!(mgr.get_active().await, Some(session.id));
+        let s = mgr.get_session(session.id).await.unwrap();
+        assert!(matches!(s.status, SessionStatus::Exited(0))); // PRESERVED, not Active
+    }
+
+    #[tokio::test]
+    async fn set_active_only_demotes_previously_active() {
+        let mgr = SessionManager::new();
+        let live = mgr
+            .create_session("c".into(), vec![], "C:\\a".into(), None, None, vec![], false)
+            .await
+            .unwrap();
+        // First session auto-activates → status = Active, active_session = live.id
+        assert_eq!(mgr.get_active().await, Some(live.id));
+        let live_state = mgr.get_session(live.id).await.unwrap();
+        assert_eq!(live_state.status, SessionStatus::Active);
+
+        // Create + mark-exited a second session for the dormant-select scenario.
+        let dormant = mgr
+            .create_session("c".into(), vec![], "C:\\b".into(), None, None, vec![], false)
+            .await
+            .unwrap();
+        mgr.mark_exited(dormant.id, 0).await;
+
+        mgr.set_active_only(dormant.id).await.unwrap();
+
+        // Active pointer moved.
+        assert_eq!(mgr.get_active().await, Some(dormant.id));
+        // Previously-active demoted: Active → Running.
+        let live_after = mgr.get_session(live.id).await.unwrap();
+        assert_eq!(live_after.status, SessionStatus::Running);
+        // New active preserved as Exited.
+        let dormant_after = mgr.get_session(dormant.id).await.unwrap();
+        assert!(matches!(dormant_after.status, SessionStatus::Exited(0)));
+    }
+
+    #[tokio::test]
+    async fn set_active_only_returns_session_not_found_for_unknown_id() {
+        let mgr = SessionManager::new();
+        let bogus = uuid::Uuid::new_v4();
+        let err = mgr.set_active_only(bogus).await.unwrap_err();
+        assert!(matches!(err, AppError::SessionNotFound(_)));
+        // Active pointer untouched.
+        assert_eq!(mgr.get_active().await, None);
+    }
+
+    // ── Issue #248 / Grinch Z9 — defer + set_active_only + list_sessions chain ──
+
+    #[tokio::test]
+    async fn issue_248_defer_set_active_only_list_sessions_chain() {
+        let mgr = SessionManager::new();
+        // Simulate the defer arm of lib.rs §3.4: create a session, mark_exited,
+        // clear_active_if.
+        let session = mgr
+            .create_session(
+                "claude".into(),
+                vec![],
+                "C:\\proj\\.ac-new\\_agent_architect".into(),
+                Some("aid".into()),
+                Some("Architect".into()),
+                vec![],
+                true, // is_coordinator
+            )
+            .await
+            .unwrap();
+        mgr.mark_exited(session.id, 0).await;
+        mgr.clear_active_if(session.id).await;
+
+        // Simulate the post-loop active-switch (§3.7) with the dormant branch.
+        mgr.set_active_only(session.id).await.unwrap();
+
+        // The wire payload (what list_sessions IPC returns to the frontend).
+        let infos = mgr.list_sessions().await;
+        assert_eq!(infos.len(), 1);
+        let json = serde_json::to_value(&infos[0]).unwrap();
+
+        // The critical assertion — Round-2 Z1 blocker.
+        // Before Fix A, this would be `"status":"active"` and the FE would
+        // render the live dot, taking the wrong click path. With Fix A, status
+        // round-trips as the object form for SessionStatus::Exited.
+        assert_eq!(json["status"], serde_json::json!({ "exited": 0 }));
+
+        // Active pointer correctly reflects the selection.
+        assert_eq!(mgr.get_active().await, Some(session.id));
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.26",
+  "version": "0.8.27",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -53,9 +53,11 @@ export interface RestartSessionOptions {
   /**
    * Forwarded to the backend `restart_session` command. Omit (or pass `true`)
    * for a true user-intent restart that starts a fresh conversation. Pass
-   * `false` when waking a deferred session (PTY exited due to
-   * `startOnlyCoordinators: true`) to allow provider auto-resume
-   * (`claude --continue`, `codex resume --last`, `gemini --resume latest`).
+   * `false` when waking a deferred session — a session whose PTY is `Exited`
+   * either because it was deferred at startup (new-policy default, or the
+   * coord-was-asleep-at-shutdown branch of `restoreCoordinatorWakeState`) or
+   * because the user closed it during the prior run — to allow provider
+   * auto-resume (`claude --continue`, `codex resume --last`, `gemini --resume latest`).
    */
   skipAutoResume?: boolean;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -128,7 +128,7 @@ export interface AppSettings {
   defaultShellArgs: string[];
   agents: AgentConfig[];
   telegramBots: TelegramBotConfig[];
-  startOnlyCoordinators: boolean;
+  restoreCoordinatorWakeState: boolean;
   sidebarAlwaysOnTop: boolean;
   raiseTerminalOnClick: boolean;
   soundsEnabled: boolean;

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -101,10 +101,12 @@ const ProjectPanel: Component = () => {
     const existing = replicaSession(wg, replica);
     if (existing) {
       if (!isSessionLive(existing)) {
-        // Session exists but PTY has exited (deferred at startup by
-        // startOnlyCoordinators, or prior shutdown). Wake it with provider
-        // auto-resume so the prior conversation continues — this is NOT a
-        // user-intent "fresh conversation" restart.
+        // Session exists but PTY has exited. Possible causes:
+        //  - deferred at startup by the #248 policy (non-coord, or coord that was
+        //    asleep at shutdown, or `restoreCoordinatorWakeState=false`)
+        //  - user closed it during the prior run
+        // Wake it with provider auto-resume so the prior conversation continues —
+        // this is NOT a user-intent "fresh conversation" restart.
         try {
           await SessionAPI.restart(existing.id, { skipAutoResume: false });
           if (isTauri) {

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -336,12 +336,12 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           <input
             type="checkbox"
             class="settings-checkbox"
-            checked={settings.data!.startOnlyCoordinators}
+            checked={settings.data!.restoreCoordinatorWakeState}
             onChange={(e) =>
-              updateField("startOnlyCoordinators", e.currentTarget.checked)
+              updateField("restoreCoordinatorWakeState", e.currentTarget.checked)
             }
           />
-          <span>On start only start Coordinators</span>
+          <span>On start, wake coordinators that were awake when the app closed</span>
         </label>
         <label class="settings-checkbox-field">
           <input


### PR DESCRIPTION
## Summary
- change startup restore policy so the default is manual startup instead of waking all coordinators
- add `restoreCoordinatorWakeState` setting and migrate legacy `startOnlyCoordinators`
- preserve dormant selected sessions and deferred-session metadata so wake-on-click still works
- update Settings UI label and bump version to 0.8.27

## Verification
- cargo check
- cargo clippy
- cargo test --lib: 470 passed
- npx tsc --noEmit
- npm run test: 63 passed
- npx tauri build
- deployed/tested wg-2 executable: agentscommander_standalone_wg-2.exe

Closes #248