### PR TITLE
fix(beep): suppress idle beep for focused workgroup (#254)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.28",
+      "version": "0.8.29",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.28"
+version = "0.8.29"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/sidebar/stores/team-idle-watcher.test.ts
+++ b/src/sidebar/stores/team-idle-watcher.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+//
+// Pure-helper tests for the focused-WG suppression + grace period
+// behavior introduced in #254. We exercise `shouldSuppressBeep` and
+// `updateGraceOnFocusChange` directly — no SolidJS root, no store
+// mocks, no fake timers. The wiring inside `startTeamIdleWatcher`'s
+// createEffect that calls these helpers is audited via code review
+// and the manual smoke test, not unit-mocked here.
+//
+// jsdom is required because importing this module evaluates the
+// file-scope `createSignal` and pulls in the sibling stores, which
+// transitively touch `window.location` in `transport-ws.ts`.
+
+import { describe, it, expect } from "vitest";
+import {
+  shouldSuppressBeep,
+  updateGraceOnFocusChange,
+} from "./team-idle-watcher";
+
+const GRACE_MS = 4000;
+
+describe("shouldSuppressBeep (#254)", () => {
+  it("suppresses the focused workgroup", () => {
+    expect(shouldSuppressBeep("A", "A", new Map(), 0)).toBe(true);
+  });
+
+  it("does NOT suppress non-focused workgroups with no grace entry", () => {
+    expect(shouldSuppressBeep("B", "A", new Map(), 0)).toBe(false);
+  });
+
+  it("suppresses inside an active grace window", () => {
+    const grace = new Map<string, number>([["A", 4000]]);
+    expect(shouldSuppressBeep("A", "B", grace, 2000)).toBe(true);
+  });
+
+  it("does NOT suppress once the grace window has expired", () => {
+    const grace = new Map<string, number>([["A", 4000]]);
+    expect(shouldSuppressBeep("A", "B", grace, 5000)).toBe(false);
+  });
+});
+
+describe("updateGraceOnFocusChange (#254)", () => {
+  it("fast switch A→B→A re-arms B's grace and suppresses B inside the window", () => {
+    const grace = new Map<string, number>();
+    let prev: string | null = null;
+
+    // T=0: initial focus arrives on A. previousFocusedWg was null,
+    // so no grace is armed yet.
+    prev = updateGraceOnFocusChange(prev, "A", grace, 0, GRACE_MS);
+    expect(prev).toBe("A");
+    expect(grace.size).toBe(0);
+
+    // T=0: A → B. previousFocusedWg = "A" is left behind: grace
+    // armed for A until 0 + 4000 = 4000.
+    prev = updateGraceOnFocusChange(prev, "B", grace, 0, GRACE_MS);
+    expect(prev).toBe("B");
+    expect(grace.get("A")).toBe(4000);
+
+    // T=500: B → A. previousFocusedWg = "B" leaves: grace for B
+    // until 500 + 4000 = 4500.
+    prev = updateGraceOnFocusChange(prev, "A", grace, 500, GRACE_MS);
+    expect(prev).toBe("A");
+    expect(grace.get("B")).toBe(4500);
+
+    // T=3000: B is idle, but B is non-focused and still inside its
+    // grace window (until 4500) → suppressed.
+    expect(shouldSuppressBeep("B", "A", grace, 3000)).toBe(true);
+
+    // T=5000: past B's grace → would beep.
+    expect(shouldSuppressBeep("B", "A", grace, 5000)).toBe(false);
+  });
+
+  it("alt-tab out (focus → null) arms grace for the previously focused WG", () => {
+    const grace = new Map<string, number>();
+
+    // Established focus on A.
+    const afterTabOut = updateGraceOnFocusChange(
+      "A",
+      null,
+      grace,
+      0,
+      GRACE_MS,
+    );
+
+    expect(afterTabOut).toBeNull();
+    expect(grace.get("A")).toBe(4000);
+
+    // T=2000: A becomes idle while alt-tabbed out → suppressed
+    // (grace still active).
+    expect(shouldSuppressBeep("A", null, grace, 2000)).toBe(true);
+  });
+
+  it("alt-tab back in (focus = A) restores focused-WG suppression for A", () => {
+    const grace = new Map<string, number>([["A", 4000]]);
+
+    // The previous tick left focus at null with A's grace armed.
+    // Now the window regains focus on A.
+    const afterTabIn = updateGraceOnFocusChange(
+      null,
+      "A",
+      grace,
+      6000,
+      GRACE_MS,
+    );
+
+    expect(afterTabIn).toBe("A");
+    // previousFocusedWg was null, so no grace was armed for the
+    // "left" side — and the existing A grace entry is untouched.
+    expect(grace.get("A")).toBe(4000);
+
+    // T=6000: A is focused again → suppressed by the focused-WG rule
+    // (independent of A's now-expired grace).
+    expect(shouldSuppressBeep("A", "A", grace, 6000)).toBe(true);
+  });
+
+  it("no-op when focus does not change", () => {
+    const grace = new Map<string, number>();
+    const result = updateGraceOnFocusChange("A", "A", grace, 1000, GRACE_MS);
+    expect(result).toBe("A");
+    expect(grace.size).toBe(0);
+  });
+});

--- a/src/sidebar/stores/team-idle-watcher.test.ts
+++ b/src/sidebar/stores/team-idle-watcher.test.ts
@@ -36,6 +36,14 @@ describe("shouldSuppressBeep (#254)", () => {
     const grace = new Map<string, number>([["A", 4000]]);
     expect(shouldSuppressBeep("A", "B", grace, 5000)).toBe(false);
   });
+
+  it("does NOT suppress at the exact grace boundary (now === until)", () => {
+    // The half-open window `now < until` means `now === until` is
+    // already outside grace. Locks in the boundary explicitly so a
+    // future refactor to `now <= until` would have to flip this test.
+    const grace = new Map<string, number>([["A", 4000]]);
+    expect(shouldSuppressBeep("A", "B", grace, 4000)).toBe(false);
+  });
 });
 
 describe("updateGraceOnFocusChange (#254)", () => {
@@ -116,6 +124,21 @@ describe("updateGraceOnFocusChange (#254)", () => {
     const grace = new Map<string, number>();
     const result = updateGraceOnFocusChange("A", "A", grace, 1000, GRACE_MS);
     expect(result).toBe("A");
+    expect(grace.size).toBe(0);
+  });
+
+  it("background-open: first real tick after listener resolves does not arm grace", () => {
+    // Regression guard for the bug where the snapshot tick seeded
+    // `previousFocusedWg` from a still-default-true `osFocused`,
+    // causing the first real tick (after the async listener
+    // resolved `osFocused` to false) to fire a phantom grace
+    // window for the active session's WG. The fix moves the
+    // updateGraceOnFocusChange call past the snapshot early-return,
+    // so the first real tick always sees `previousFocusedWg` of
+    // null and the resolved `focusedWg` — null→null is a no-op.
+    const grace = new Map<string, number>();
+    const result = updateGraceOnFocusChange(null, null, grace, 1000, GRACE_MS);
+    expect(result).toBeNull();
     expect(grace.size).toBe(0);
   });
 });

--- a/src/sidebar/stores/team-idle-watcher.test.ts
+++ b/src/sidebar/stores/team-idle-watcher.test.ts
@@ -13,11 +13,10 @@
 
 import { describe, it, expect } from "vitest";
 import {
+  GRACE_MS,
   shouldSuppressBeep,
   updateGraceOnFocusChange,
 } from "./team-idle-watcher";
-
-const GRACE_MS = 4000;
 
 describe("shouldSuppressBeep (#254)", () => {
   it("suppresses the focused workgroup", () => {

--- a/src/sidebar/stores/team-idle-watcher.ts
+++ b/src/sidebar/stores/team-idle-watcher.ts
@@ -165,9 +165,21 @@ export function startTeamIdleWatcher(): () => void {
 
     // Spawn the OS focus listener; capture the unlisten so we can
     // detach it in dispose. The signal stays at its default until
-    // the async listener resolves.
+    // the async listener resolves. `disposed` guards the race where
+    // the watcher is torn down before the dynamic import resolves —
+    // without it the listener would be registered into an orphan
+    // variable and leak forever.
+    let disposed = false;
     let unlistenOsFocus: (() => void) | null = null;
     void startOsFocusListener().then((unlisten) => {
+      if (disposed) {
+        try {
+          unlisten();
+        } catch {
+          // ignore — best-effort detach
+        }
+        return;
+      }
       unlistenOsFocus = unlisten;
     });
 
@@ -221,15 +233,14 @@ export function startTeamIdleWatcher(): () => void {
       const focusedWg =
         hasOsFocus && activeId ? sessionToWg.get(activeId) ?? null : null;
 
-      previousFocusedWg = updateGraceOnFocusChange(
-        previousFocusedWg,
-        focusedWg,
-        graceUntil,
-        Date.now(),
-        GRACE_MS,
-      );
-
       // 4. First run is snapshot-only — see header comment.
+      //    Crucially, we skip the focus-transition bookkeeping on
+      //    the snapshot tick: the OS-focus listener resolves
+      //    asynchronously, so the initial tick may run with the
+      //    default-true `osFocused` seed even when AC was launched
+      //    in the background. Seeding `previousFocusedWg` here
+      //    would then arm a phantom grace window on the first real
+      //    tick once `osFocused` resolves to false.
       if (!initialized) {
         initialized = true;
         for (const [wgPath, perSession] of currentByWg) {
@@ -237,6 +248,14 @@ export function startTeamIdleWatcher(): () => void {
         }
         return;
       }
+
+      previousFocusedWg = updateGraceOnFocusChange(
+        previousFocusedWg,
+        focusedWg,
+        graceUntil,
+        Date.now(),
+        GRACE_MS,
+      );
 
       // 5. Detect genuine busy→idle transitions per workgroup.
       if (enabled) {
@@ -293,6 +312,7 @@ export function startTeamIdleWatcher(): () => void {
     });
 
     return () => {
+      disposed = true;
       if (unlistenOsFocus) {
         try {
           unlistenOsFocus();

--- a/src/sidebar/stores/team-idle-watcher.ts
+++ b/src/sidebar/stores/team-idle-watcher.ts
@@ -44,7 +44,7 @@ import { settingsStore } from "../../shared/stores/settings";
 import { sessionsStore } from "./sessions";
 import { projectStore } from "./project";
 
-const GRACE_MS = 4000;
+export const GRACE_MS = 4000;
 
 // OS-level focus state for the AC sidebar window. Driven by
 // Tauri's onFocusChanged event; treated as true on mount so the

--- a/src/sidebar/stores/team-idle-watcher.ts
+++ b/src/sidebar/stores/team-idle-watcher.ts
@@ -29,13 +29,94 @@
 // settingsStore.load()` the synchronous reactive owner is gone.
 // createRoot gives the effect its own owner and an explicit dispose
 // we can call from onCleanup.
+//
+// **Focused-WG suppression (#254)**: while the user is looking at a
+// workgroup (the active session belongs to it AND the AC window holds
+// OS focus), that workgroup's beep is gated off — they can already
+// see the state change, the beep is redundant. When focus moves away
+// (tab switch or alt-tab), the just-left workgroup keeps suppressing
+// for GRACE_MS to absorb the user's typical short detour back.
 
-import { createEffect, createRoot } from "solid-js";
+import { createEffect, createRoot, createSignal } from "solid-js";
 import type { Session } from "../../shared/types";
 import { playTeamIdleBeep } from "../../shared/sound";
 import { settingsStore } from "../../shared/stores/settings";
 import { sessionsStore } from "./sessions";
 import { projectStore } from "./project";
+
+const GRACE_MS = 4000;
+
+// OS-level focus state for the AC sidebar window. Driven by
+// Tauri's onFocusChanged event; treated as true on mount so the
+// initial tick (before the listener has reported anything) treats
+// the visible WG as focused. Exposed as a signal so the watcher's
+// createEffect re-runs on focus flips even when no session has
+// changed — without this, alt-tab→idle transitions inside the
+// grace window would miss the grace setter.
+const [osFocused, setOsFocused] = createSignal(true);
+
+/**
+ * Pure decision helper: should we suppress the beep for `wgPath`
+ * given the current focus state and grace map?
+ *
+ * Suppressed when the workgroup is currently focused, OR a grace
+ * entry exists for it and `now` is still inside the window.
+ */
+export function shouldSuppressBeep(
+  wgPath: string,
+  focusedWg: string | null,
+  graceUntil: ReadonlyMap<string, number>,
+  now: number,
+): boolean {
+  if (wgPath === focusedWg) return true;
+  const until = graceUntil.get(wgPath);
+  return until !== undefined && now < until;
+}
+
+/**
+ * Pure transition helper: on a focus change, arm a grace window
+ * for the workgroup being left behind (if any) and return the new
+ * "previous focused WG" to persist for the next tick.
+ *
+ * Mutates `graceUntil` in place — callers own the map. Returns the
+ * value the caller should assign to its `previousFocusedWg`.
+ */
+export function updateGraceOnFocusChange(
+  previousFocusedWg: string | null,
+  focusedWg: string | null,
+  graceUntil: Map<string, number>,
+  now: number,
+  graceMs: number,
+): string | null {
+  if (previousFocusedWg !== focusedWg && previousFocusedWg !== null) {
+    graceUntil.set(previousFocusedWg, now + graceMs);
+  }
+  return focusedWg;
+}
+
+async function startOsFocusListener(): Promise<() => void> {
+  try {
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    const win = getCurrentWindow();
+    // Best-effort initial sync: if the window is already
+    // unfocused at mount, reflect that before any tick runs.
+    try {
+      const focused = await win.isFocused();
+      setOsFocused(focused);
+    } catch {
+      // Non-fatal — keep the default-true seed.
+    }
+    const unlisten = await win.onFocusChanged(({ payload: focused }) => {
+      setOsFocused(focused);
+    });
+    return unlisten;
+  } catch {
+    // Browser/WS transport or import failure — assume always-focused
+    // so the legacy behavior (per-WG suppression keyed only on
+    // activeId) still applies; we just can't react to OS alt-tab.
+    return () => {};
+  }
+}
 
 function isExited(status: Session["status"]): boolean {
   return typeof status === "object" && status !== null && "exited" in status;
@@ -70,12 +151,32 @@ export function startTeamIdleWatcher(): () => void {
     // that were not alive last tick (destroyed/exited) won't appear.
     const previousByWg = new Map<string, Map<string, boolean>>();
 
+    // wg.path -> epoch ms at which the grace period for that WG
+    // ends. Populated whenever effective focus moves off a WG; the
+    // entry suppresses beeps for that WG until Date.now() >= value.
+    const graceUntil = new Map<string, number>();
+
+    // The effective focused WG from the previous effect tick. Used
+    // to detect focus *transitions* so we can arm the grace window
+    // for the WG being left behind.
+    let previousFocusedWg: string | null = null;
+
     let initialized = false;
+
+    // Spawn the OS focus listener; capture the unlisten so we can
+    // detach it in dispose. The signal stays at its default until
+    // the async listener resolves.
+    let unlistenOsFocus: (() => void) | null = null;
+    void startOsFocusListener().then((unlisten) => {
+      unlistenOsFocus = unlisten;
+    });
 
     createEffect(() => {
       const sessions = sessionsStore.sessions;
       const projects = projectStore.projects;
       const enabled = settingsStore.current?.teamIdleBeepEnabled ?? true;
+      const activeId = sessionsStore.activeId;
+      const hasOsFocus = osFocused();
 
       // 1. Augment bindings (never unbind). Iterate workgroups and
       //    bind any newly-discovered replica-session pairs by name.
@@ -112,7 +213,23 @@ export function startTeamIdleWatcher(): () => void {
         inner.set(sessionId, isBusy(session));
       }
 
-      // 3. First run is snapshot-only — see header comment.
+      // 3. Resolve the effective focused workgroup for this tick.
+      //    A WG is "focused" only when AC has OS focus AND the
+      //    active session is bound to that WG. Losing either
+      //    condition (alt-tab, tab switch) collapses focusedWg to
+      //    null and arms a grace window for the WG being left.
+      const focusedWg =
+        hasOsFocus && activeId ? sessionToWg.get(activeId) ?? null : null;
+
+      previousFocusedWg = updateGraceOnFocusChange(
+        previousFocusedWg,
+        focusedWg,
+        graceUntil,
+        Date.now(),
+        GRACE_MS,
+      );
+
+      // 4. First run is snapshot-only — see header comment.
       if (!initialized) {
         initialized = true;
         for (const [wgPath, perSession] of currentByWg) {
@@ -121,8 +238,9 @@ export function startTeamIdleWatcher(): () => void {
         return;
       }
 
-      // 4. Detect genuine busy→idle transitions per workgroup.
+      // 5. Detect genuine busy→idle transitions per workgroup.
       if (enabled) {
+        const now = Date.now();
         for (const [wgPath, currentBusy] of currentByWg) {
           const previousBusy = previousByWg.get(wgPath);
           if (!previousBusy) continue;
@@ -152,11 +270,20 @@ export function startTeamIdleWatcher(): () => void {
           }
           if (!allIdle) continue;
 
+          if (shouldSuppressBeep(wgPath, focusedWg, graceUntil, now)) continue;
+
           void playTeamIdleBeep();
+        }
+
+        // Drop expired grace entries so the map stays bounded by
+        // the count of currently-tracked WGs (already finite, but
+        // tidier).
+        for (const [wgPath, until] of graceUntil) {
+          if (now >= until) graceUntil.delete(wgPath);
         }
       }
 
-      // 5. Persist current state for the next tick. Workgroups that
+      // 6. Persist current state for the next tick. Workgroups that
       //    no longer have any alive bound sessions drop out, so a
       //    later resurrection starts from a clean snapshot.
       previousByWg.clear();
@@ -165,6 +292,16 @@ export function startTeamIdleWatcher(): () => void {
       }
     });
 
-    return dispose;
+    return () => {
+      if (unlistenOsFocus) {
+        try {
+          unlistenOsFocus();
+        } catch {
+          // ignore — best-effort detach
+        }
+        unlistenOsFocus = null;
+      }
+      dispose();
+    };
   });
 }


### PR DESCRIPTION
## Summary

- Suppresses the team-idle beep for the workgroup whose session is currently `sessionsStore.activeId` while the AgentsCommander window has OS focus.
- Applies a 4-second grace period when focus leaves a workgroup (tab switch or alt-tab away from AC), preventing tail-end beeps from a WG the user just left.
- Single-file change to `src/sidebar/stores/team-idle-watcher.ts`, plus a pure-helper test file covering 10 scenarios (focused suppression, grace suppression, post-grace beep, rapid switch A->B->A, alt-tab in/out, boundary `now === until`, background-open invariant).

## Why

PTY echo from typing in the coordinator counts as activity in the Rust idle detector (`IDLE_THRESHOLD = 2500ms`). When the user paused typing in their active WG, the WG transitioned to idle and the beep fired — a phantom "something changed" alarm whose only real change was the user's own pause.

## Implementation notes

- `shouldSuppressBeep` and `updateGraceOnFocusChange` are exported as pure helpers from `team-idle-watcher.ts`. The internal `createEffect` delegates to them; tests cover them directly without SolidJS mocks.
- OS focus is tracked via Tauri's `getCurrentWindow().onFocusChanged` listener (registered via dynamic import, matching existing patterns in `App.tsx`).
- Listener pending-import race is guarded by a `disposed` flag — if the watcher disposes before the dynamic import resolves, the late-arriving `unlisten` is detached immediately.
- Background-open scenario (AC launched unfocused / restored from minimized) does not arm a phantom grace period: the snapshot tick skips `updateGraceOnFocusChange` so `previousFocusedWg` stays `null` until the OS focus listener resolves the real value.

## Test plan

- [ ] Type in a coordinator, pause to think — no beep on that WG after 2.5s.
- [ ] Other WGs continue beeping normally on busy->idle transitions.
- [ ] Switch between WGs: the one losing focus stays silent for ~4s after switch.
- [ ] Alt-tab away from AC: the focused WG stays silent for ~4s; eventually beeps after the grace expires.
- [ ] Launch AC into background (auto-start at login or restored from minimized): no phantom 4s suppression at startup.

Closes #254