### PR TITLE
fix(sidebar): render workgroup briefTitle instead of "---" (#256)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.29",
+  "version": "0.8.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.29",
+      "version": "0.8.30",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.29",
+  "version": "0.8.30",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.29"
+version = "0.8.30"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -1816,10 +1816,7 @@ fn read_brief_fields(wg_path: &std::path::Path) -> BriefFields {
     let Ok(content) = std::fs::read_to_string(&brief_path) else {
         return (None, None);
     };
-    let brief = content
-        .lines()
-        .next()
-        .map(|l| l.trim_start_matches("# ").to_string());
+    let brief = extract_brief_first_line(&content);
     let brief_title = crate::commands::entity_creation::parse_brief_title(&content);
     (brief, brief_title)
 }

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -194,9 +194,17 @@ fn extract_brief_first_line(content: &str) -> Option<String> {
 
     let mut lines = content.lines().peekable();
 
-    // YAML frontmatter: opener `---` on the first line, drain through closer.
+    // Drain leading blank lines first so a stray "\n\n" before the frontmatter
+    // opener doesn't bypass detection and leak the literal `---` into the sidebar.
+    let mut first_non_empty = lines.peek().map(|l| l.trim());
+    while first_non_empty == Some("") {
+        lines.next();
+        first_non_empty = lines.peek().map(|l| l.trim());
+    }
+
+    // YAML frontmatter: opener `---` on the first non-empty line, drain through closer.
     // If the closer is missing, the for-loop drains the rest and `find` returns None.
-    if lines.peek().map(|l| l.trim()) == Some("---") {
+    if first_non_empty == Some("---") {
         lines.next();
         for line in lines.by_ref() {
             if line.trim() == "---" {
@@ -1806,6 +1814,23 @@ mod tests {
         assert_eq!(
             extract_brief_first_line(content),
             Some("Real Title".to_string())
+        );
+    }
+
+    #[test]
+    fn brief_leading_blanks_before_frontmatter() {
+        // Regression: leading blank lines before `---` used to bypass the
+        // frontmatter check and leak the literal `---` into the sidebar.
+        let content = "\n\n---\ntitle: x\n---\n# Body";
+        assert_eq!(extract_brief_first_line(content), Some("Body".to_string()));
+    }
+
+    #[test]
+    fn brief_leading_blanks_no_frontmatter() {
+        let content = "\n\n# Body line";
+        assert_eq!(
+            extract_brief_first_line(content),
+            Some("Body line".to_string())
         );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.29",
+  "version": "0.8.30",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/sidebar/components/AcDiscoveryPanel.tsx
+++ b/src/sidebar/components/AcDiscoveryPanel.tsx
@@ -283,8 +283,8 @@ const AcDiscoveryPanel: Component = () => {
                   <div class="ac-wg-group">
                     <div class="ac-wg-header" title={wg.path}>
                       <span class="ac-wg-name">{wg.name}</span>
-                      <Show when={stripFrontmatter(wg.brief ?? "").trim()}>
-                        {(brief) => <span class="ac-wg-brief">{brief()}</span>}
+                      <Show when={wg.briefTitle?.trim() || stripFrontmatter(wg.brief ?? "").trim()}>
+                        {(text) => <span class="ac-wg-brief">{text()}</span>}
                       </Show>
                     </div>
                     <For each={wg.agents}>

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -860,8 +860,8 @@ const ProjectPanel: Component = () => {
                                     </span>
                                     <div class="ac-wg-header-text">
                                       <span class="ac-wg-name">{wg.name}</span>
-                                      <Show when={stripFrontmatter(wg.brief ?? "").trim()}>
-                                        {(brief) => <span class="ac-wg-brief">{brief()}</span>}
+                                      <Show when={wg.briefTitle?.trim() || stripFrontmatter(wg.brief ?? "").trim()}>
+                                        {(text) => <span class="ac-wg-brief">{text()}</span>}
                                       </Show>
                                     </div>
                                   </div>


### PR DESCRIPTION
## Summary

- Backend (`src-tauri/src/commands/ac_discovery.rs`): `read_brief_fields` now uses the existing `extract_brief_first_line` helper (from #161) so `wg.brief` is no longer the literal `---` for BRIEFs with YAML frontmatter. Also hardened `extract_brief_first_line` to drain leading blank lines before checking the frontmatter opener (regression caught in adversarial review).
- Frontend (`src/sidebar/components/ProjectPanel.tsx`, `src/sidebar/components/AcDiscoveryPanel.tsx`): the sidebar now prefers `wg.briefTitle` (the title parsed from frontmatter) over `wg.brief` (first body line), with a graceful fallback for legacy BRIEFs without frontmatter.
- Version bump 0.8.29 → 0.8.30 (lockstep across `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, `package.json`, `package-lock.json`).

## Tests

- 13/13 `commands::ac_discovery::tests` pass (11 original + 2 new: `brief_leading_blanks_before_frontmatter`, `brief_leading_blanks_no_frontmatter`).
- `cargo check`, `cargo clippy --lib`: clean (one pre-existing dead-code warning, not from this PR).
- `npx tsc --noEmit`: clean.
- `npx tauri build`: 1m23s, deployed to `agentscommander_standalone_wg-1.exe` for manual verification.

## Review process

- dev-webpage-ui investigated root cause (two layers) and proposed both fixes.
- dev-rust implemented Fix A.
- dev-webpage-ui implemented Fix B.
- dev-rust-grinch FAILED first review by catching a regression: the helper returned `Some("---")` when BRIEF.md started with blank lines before the frontmatter (real case: editors that insert leading newlines, merge conflicts).
- dev-rust fixed the regression + added two unit tests covering the exact repro.
- dev-rust-grinch APPROVED on re-review after probing 6 attack vectors (Unicode whitespace, CRLF, BOM + leading blanks, only-blanks input, unclosed frontmatter, heading-after-blanks).

Closes #256