### PR TITLE
feat(telegram): session-reading for Codex and Gemini (#258)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.30",
+      "version": "0.8.31",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.30"
+version = "0.8.31"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/commands/codex_resolver.rs
+++ b/src-tauri/src/commands/codex_resolver.rs
@@ -1,0 +1,126 @@
+// Codex CLI session-file path resolver.
+//
+// Codex stores rollouts under `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`.
+// The filename is UUID-keyed, so the actual file must be discovered per-poll
+// inside the watcher by reading each candidate's `session_meta.cwd` and
+// matching against AC's canonicalized cwd.
+
+use std::path::{Path, PathBuf};
+
+/// Returns the `~/.codex/sessions/` root if it exists.
+///
+/// Returns `None` if `~/.codex/sessions/` does not exist (Codex never run on
+/// this machine) or `dirs::home_dir()` is unavailable.
+///
+/// The `_shell` / `_shell_args` params are unused today but kept for symmetry
+/// with `resolve_claude_projects_dir` (`commands/session.rs:277`) and to allow
+/// a future env-var override (e.g. `CODEX_HOME`) without an attach-site
+/// refactor.
+pub(crate) fn resolve_codex_sessions_root(
+    shell: &str,
+    args: &[String],
+    cwd: &str,
+) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    resolve_codex_sessions_root_at(&home, shell, args, cwd)
+}
+
+pub(crate) fn resolve_codex_sessions_root_at(
+    home: &Path,
+    _shell: &str,
+    _args: &[String],
+    _cwd: &str,
+) -> Option<PathBuf> {
+    let root = home.join(".codex").join("sessions");
+    if root.is_dir() {
+        Some(root)
+    } else {
+        None
+    }
+}
+
+/// Canonicalize a path-string for cwd comparison against Codex's
+/// `session_meta.cwd` field.
+///
+/// On Windows: lowercase + normalize `/` → `\` + strip the `\\?\` extended-
+/// length prefix that `std::fs::canonicalize` sometimes returns.
+/// On Unix: lowercase only.
+///
+/// **Must be applied to BOTH sides** inside `find_session_file` (H6): AC's
+/// `expected_cwd` AND the file's `session_meta.cwd`. Tests cover both the
+/// forward-slash-AC-input vs backslash-Codex-input case and the canonical
+/// prefix-stripped case.
+pub(crate) fn canonicalize_cwd_for_codex(cwd: &str) -> String {
+    #[cfg(windows)]
+    {
+        let stripped = cwd.strip_prefix(r"\\?\").unwrap_or(cwd);
+        stripped.replace('/', "\\").to_lowercase()
+    }
+    #[cfg(not(windows))]
+    {
+        cwd.to_lowercase()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_when_sessions_root_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions = tmp.path().join(".codex").join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        let resolved = resolve_codex_sessions_root_at(tmp.path(), "codex", &[], "");
+        assert_eq!(resolved.as_deref(), Some(sessions.as_path()));
+    }
+
+    #[test]
+    fn returns_none_when_sessions_root_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No `.codex/sessions/` created.
+        let resolved = resolve_codex_sessions_root_at(tmp.path(), "codex", &[], "");
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn resolve_codex_sessions_root_uses_home_dir_join_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let expected = tmp.path().join(".codex").join("sessions");
+        std::fs::create_dir_all(&expected).unwrap();
+        let resolved = resolve_codex_sessions_root_at(tmp.path(), "codex", &[], "");
+        assert_eq!(resolved.unwrap(), expected);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn canonicalize_cwd_for_codex_lowercases_and_normalizes() {
+        assert_eq!(
+            canonicalize_cwd_for_codex("C:/Users/Foo"),
+            "c:\\users\\foo"
+        );
+        assert_eq!(
+            canonicalize_cwd_for_codex(r"C:\Users\Foo"),
+            "c:\\users\\foo"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn canonicalize_cwd_for_codex_strips_extended_prefix() {
+        assert_eq!(
+            canonicalize_cwd_for_codex(r"\\?\C:\Users\Foo"),
+            "c:\\users\\foo"
+        );
+        assert_eq!(
+            canonicalize_cwd_for_codex(r"\\?\C:/Users/Foo"),
+            "c:\\users\\foo"
+        );
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn canonicalize_cwd_for_codex_lowercases_only_on_unix() {
+        assert_eq!(canonicalize_cwd_for_codex("/Home/Foo"), "/home/foo");
+    }
+}

--- a/src-tauri/src/commands/gemini_resolver.rs
+++ b/src-tauri/src/commands/gemini_resolver.rs
@@ -1,0 +1,179 @@
+// Gemini CLI session-file path resolver.
+//
+// Gemini stores sessions under `~/.gemini/tmp/<slug>/chats/session-*.jsonl`,
+// where `<slug>` is keyed off the cwd via `~/.gemini/projects.json`. Under
+// the softened H1 contract, the resolver only checks that `~/.gemini/`
+// exists; the cwd-to-slug lookup is deferred to the watcher's per-poll
+// `lookup_chats_dir_for_cwd` because Gemini's startup race may not yet
+// have written the `projects.json` entry for a freshly-launched cwd.
+
+use std::path::{Path, PathBuf};
+
+/// Returns `Some(~/.gemini)` if that directory exists. Returns `None` only
+/// when Gemini has never been installed on this machine.
+///
+/// The cwd-to-slug lookup is deferred to `lookup_chats_dir_for_cwd` below
+/// (H1 softened contract — see plan §4.3).
+pub(crate) fn resolve_gemini_home(
+    shell: &str,
+    args: &[String],
+    cwd: &str,
+) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    resolve_gemini_home_at(&home, shell, args, cwd)
+}
+
+pub(crate) fn resolve_gemini_home_at(
+    home: &Path,
+    _shell: &str,
+    _args: &[String],
+    _cwd: &str,
+) -> Option<PathBuf> {
+    let gemini = home.join(".gemini");
+    if gemini.is_dir() {
+        Some(gemini)
+    } else {
+        None
+    }
+}
+
+/// Per-poll cwd-to-chats-dir lookup. Returns the chats dir if `projects.json`
+/// contains a mapping for the canonicalized `cwd`, or `None` if the mapping is
+/// not yet present (the caller polls again next tick) or `projects.json` is
+/// missing/malformed.
+pub(crate) fn lookup_chats_dir_for_cwd(gemini_home: &Path, cwd: &str) -> Option<PathBuf> {
+    let projects_path = gemini_home.join("projects.json");
+    let contents = std::fs::read_to_string(&projects_path).ok()?;
+    let projects: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    let map = projects.get("projects")?.as_object()?;
+    let normalized = canonicalize_cwd_for_gemini(cwd);
+    let slug = map.get(&normalized)?.as_str()?;
+    Some(gemini_home.join("tmp").join(slug).join("chats"))
+}
+
+/// Canonicalize a path-string for cwd comparison against `projects.json` keys.
+/// On Windows: strip `\\?\` prefix + normalize `/` -> `\` + lowercase. On Unix:
+/// lowercase only.
+#[cfg(windows)]
+pub(crate) fn canonicalize_cwd_for_gemini(cwd: &str) -> String {
+    let stripped = cwd.strip_prefix(r"\\?\").unwrap_or(cwd);
+    stripped.replace('/', "\\").to_lowercase()
+}
+
+#[cfg(not(windows))]
+pub(crate) fn canonicalize_cwd_for_gemini(cwd: &str) -> String {
+    cwd.to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn resolve_gemini_home_returns_some_if_dir_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemini = tmp.path().join(".gemini");
+        fs::create_dir_all(&gemini).unwrap();
+        let resolved = resolve_gemini_home_at(tmp.path(), "gemini", &[], "");
+        assert_eq!(resolved.as_deref(), Some(gemini.as_path()));
+    }
+
+    #[test]
+    fn resolve_gemini_home_returns_none_if_dir_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let resolved = resolve_gemini_home_at(tmp.path(), "gemini", &[], "");
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn lookup_chats_dir_for_cwd_resolves_from_projects_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemini = tmp.path().join(".gemini");
+        fs::create_dir_all(&gemini).unwrap();
+        let projects = serde_json::json!({
+            "projects": {
+                "c:\\foo": "myslug",
+            }
+        });
+        fs::write(gemini.join("projects.json"), projects.to_string()).unwrap();
+
+        let chats = lookup_chats_dir_for_cwd(&gemini, "c:\\foo");
+        let expected = gemini.join("tmp").join("myslug").join("chats");
+        assert_eq!(chats, Some(expected));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn lookup_chats_dir_for_cwd_canonicalization_is_lowercase_on_windows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemini = tmp.path().join(".gemini");
+        fs::create_dir_all(&gemini).unwrap();
+        let projects = serde_json::json!({
+            "projects": {
+                "c:\\users\\foo": "slug-foo",
+            }
+        });
+        fs::write(gemini.join("projects.json"), projects.to_string()).unwrap();
+
+        let chats = lookup_chats_dir_for_cwd(&gemini, r"C:\Users\Foo");
+        assert!(chats.is_some());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn lookup_chats_dir_for_cwd_with_forward_slashes_canonicalizes_to_backslash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemini = tmp.path().join(".gemini");
+        fs::create_dir_all(&gemini).unwrap();
+        let projects = serde_json::json!({
+            "projects": {
+                "c:\\users\\foo": "slug-foo",
+            }
+        });
+        fs::write(gemini.join("projects.json"), projects.to_string()).unwrap();
+
+        let chats = lookup_chats_dir_for_cwd(&gemini, "C:/Users/Foo");
+        assert!(chats.is_some());
+    }
+
+    #[test]
+    fn lookup_chats_dir_for_cwd_returns_none_when_cwd_not_in_projects_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemini = tmp.path().join(".gemini");
+        fs::create_dir_all(&gemini).unwrap();
+        let projects = serde_json::json!({"projects": {}});
+        fs::write(gemini.join("projects.json"), projects.to_string()).unwrap();
+
+        let chats = lookup_chats_dir_for_cwd(&gemini, "c:\\users\\foo");
+        assert!(chats.is_none());
+    }
+
+    #[test]
+    fn lookup_chats_dir_for_cwd_returns_none_when_projects_json_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemini = tmp.path().join(".gemini");
+        fs::create_dir_all(&gemini).unwrap();
+        // No projects.json file written.
+
+        let chats = lookup_chats_dir_for_cwd(&gemini, "c:\\users\\foo");
+        assert!(chats.is_none());
+    }
+
+    #[test]
+    fn lookup_chats_dir_for_cwd_returns_none_when_projects_json_malformed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemini = tmp.path().join(".gemini");
+        fs::create_dir_all(&gemini).unwrap();
+        fs::write(gemini.join("projects.json"), "not json").unwrap();
+
+        let chats = lookup_chats_dir_for_cwd(&gemini, "c:\\users\\foo");
+        assert!(chats.is_none());
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn canonicalize_cwd_for_gemini_lowercases_only_on_unix() {
+        assert_eq!(canonicalize_cwd_for_gemini("/Home/Foo"), "/home/foo");
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod ac_discovery;
 pub mod agent_creator;
 pub mod brief;
 pub mod codex_resolver;
+pub mod gemini_resolver;
 pub mod config;
 pub mod entity_creation;
 pub mod phone;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod ac_discovery;
 pub mod agent_creator;
 pub mod brief;
+pub mod codex_resolver;
 pub mod config;
 pub mod entity_creation;
 pub mod phone;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1082,33 +1082,34 @@ pub async fn create_session(
 
                 if let Some(bot) = bot {
                     let pty_arc = pty_mgr.inner().clone();
-                    let jsonl_project_dir = if info.is_claude {
-                        match resolve_claude_projects_dir(&info.shell, &info.shell_args, &cwd) {
-                            Some(p) => Some(p),
-                            None => {
-                                let err_msg = format!(
-                                    "Telegram bridge: cannot resolve Claude projects dir for session {} (shell={:?}). Bridge inactive.",
-                                    id, info.shell
-                                );
-                                log::error!("{}", err_msg);
-                                let _ = app.emit(
-                                    "telegram_bridge_error",
-                                    serde_json::json!({
-                                        "sessionId": info.id,
-                                        "error": err_msg,
-                                    }),
-                                );
-                                // Skip attach — do not silently fall back to PTY for Claude.
-                                return Ok(info);
-                            }
+                    let reader = match crate::commands::telegram::derive_reader(
+                        &info.shell,
+                        &info.shell_args,
+                        &cwd,
+                        info.is_claude,
+                        info.is_codex,
+                        info.is_gemini,
+                    ) {
+                        Ok(r) => r,
+                        Err(reason) => {
+                            let err_msg = format!(
+                                "Telegram bridge: {} for session {} (shell={:?}). Bridge inactive.",
+                                reason, id, info.shell
+                            );
+                            log::error!("{}", err_msg);
+                            let _ = app.emit(
+                                "telegram_bridge_error",
+                                serde_json::json!({
+                                    "sessionId": info.id,
+                                    "error": err_msg,
+                                }),
+                            );
+                            // Skip attach — do not silently fall back to PTY.
+                            return Ok(info);
                         }
-                    } else {
-                        None
                     };
                     let mut tg = tg_mgr.lock().await;
-                    if let Ok(bridge_info) =
-                        tg.attach(id, &bot, pty_arc, app.clone(), jsonl_project_dir)
-                    {
+                    if let Ok(bridge_info) = tg.attach(id, &bot, pty_arc, app.clone(), reader) {
                         let _ = app.emit("telegram_bridge_attached", bridge_info);
                     }
                 }
@@ -1362,42 +1363,40 @@ pub async fn restart_session(
 
                 if let Some(bot) = bot {
                     let pty_arc = pty_mgr.inner().clone();
-                    let jsonl_project_dir = if session_info.is_claude {
-                        match resolve_claude_projects_dir(
-                            &session_info.shell,
-                            &session_info.shell_args,
-                            &cwd,
-                        ) {
-                            Some(p) => Some(p),
-                            None => {
-                                let err_msg = format!(
-                                    "Telegram bridge: cannot resolve Claude projects dir for session {} (shell={:?}). Bridge inactive.",
-                                    new_uuid, session_info.shell
-                                );
-                                log::error!("{}", err_msg);
-                                let _ = app.emit(
-                                    "telegram_bridge_error",
-                                    serde_json::json!({
-                                        "sessionId": session_info.id,
-                                        "error": err_msg,
-                                    }),
-                                );
-                                // Skip attach — do not silently fall back to PTY for Claude.
-                                // Persist + return the new session info so restart still succeeds
-                                // semantically (the user explicitly restarted; only the bridge fails).
-                                {
-                                    let mgr = session_mgr.read().await;
-                                    persist_current_state(&mgr).await;
-                                }
-                                return Ok(session_info);
+                    let reader = match crate::commands::telegram::derive_reader(
+                        &session_info.shell,
+                        &session_info.shell_args,
+                        &cwd,
+                        session_info.is_claude,
+                        session_info.is_codex,
+                        session_info.is_gemini,
+                    ) {
+                        Ok(r) => r,
+                        Err(reason) => {
+                            let err_msg = format!(
+                                "Telegram bridge: {} for session {} (shell={:?}). Bridge inactive.",
+                                reason, new_uuid, session_info.shell
+                            );
+                            log::error!("{}", err_msg);
+                            let _ = app.emit(
+                                "telegram_bridge_error",
+                                serde_json::json!({
+                                    "sessionId": session_info.id,
+                                    "error": err_msg,
+                                }),
+                            );
+                            // Skip attach — do not silently fall back to PTY.
+                            // Persist + return the new session info so restart still succeeds
+                            // semantically (the user explicitly restarted; only the bridge fails).
+                            {
+                                let mgr = session_mgr.read().await;
+                                persist_current_state(&mgr).await;
                             }
+                            return Ok(session_info);
                         }
-                    } else {
-                        None
                     };
                     let mut tg = tg_mgr.lock().await;
-                    if let Ok(bridge_info) =
-                        tg.attach(new_uuid, &bot, pty_arc, app.clone(), jsonl_project_dir)
+                    if let Ok(bridge_info) = tg.attach(new_uuid, &bot, pty_arc, app.clone(), reader)
                     {
                         let _ = app.emit("telegram_bridge_attached", bridge_info);
                     }
@@ -1772,37 +1771,34 @@ pub async fn create_root_agent_session(
                 drop(cfg);
                 if let Some(bot) = bot {
                     let pty_arc = pty_mgr.inner().clone();
-                    let jsonl_project_dir = if info.is_claude {
-                        match resolve_claude_projects_dir(
-                            &info.shell,
-                            &info.shell_args,
-                            &root_agent_path,
-                        ) {
-                            Some(p) => Some(p),
-                            None => {
-                                let err_msg = format!(
-                                    "Telegram bridge: cannot resolve Claude projects dir for session {} (shell={:?}). Bridge inactive.",
-                                    id, info.shell
-                                );
-                                log::error!("{}", err_msg);
-                                let _ = app.emit(
-                                    "telegram_bridge_error",
-                                    serde_json::json!({
-                                        "sessionId": info.id,
-                                        "error": err_msg,
-                                    }),
-                                );
-                                // Skip attach — do not silently fall back to PTY for Claude.
-                                return Ok(info);
-                            }
+                    let reader = match crate::commands::telegram::derive_reader(
+                        &info.shell,
+                        &info.shell_args,
+                        &root_agent_path,
+                        info.is_claude,
+                        info.is_codex,
+                        info.is_gemini,
+                    ) {
+                        Ok(r) => r,
+                        Err(reason) => {
+                            let err_msg = format!(
+                                "Telegram bridge: {} for session {} (shell={:?}). Bridge inactive.",
+                                reason, id, info.shell
+                            );
+                            log::error!("{}", err_msg);
+                            let _ = app.emit(
+                                "telegram_bridge_error",
+                                serde_json::json!({
+                                    "sessionId": info.id,
+                                    "error": err_msg,
+                                }),
+                            );
+                            // Skip attach — do not silently fall back to PTY.
+                            return Ok(info);
                         }
-                    } else {
-                        None
                     };
                     let mut tg = tg_mgr.lock().await;
-                    if let Ok(bridge_info) =
-                        tg.attach(id, &bot, pty_arc, app.clone(), jsonl_project_dir)
-                    {
+                    if let Ok(bridge_info) = tg.attach(id, &bot, pty_arc, app.clone(), reader) {
                         let _ = app.emit("telegram_bridge_attached", bridge_info);
                     }
                 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -689,9 +689,13 @@ pub async fn create_session_inner(
         .split_whitespace()
         .map(executable_basename)
         .collect();
+    // Mutually exclusive detection — precedence Claude > Codex > Gemini.
+    // Required for the `debug_assert!(mutual_exclusion)` invariant inside
+    // `derive_reader` (telegram session-reader dispatch) landing in commit 3.
     let is_claude = cmd_basenames.iter().any(|b| b.starts_with("claude"));
-    let is_codex = cmd_basenames.iter().any(|b| b.starts_with("codex"));
-    let is_gemini = cmd_basenames.iter().any(|b| b.starts_with("gemini"));
+    let is_codex = !is_claude && cmd_basenames.iter().any(|b| b.starts_with("codex"));
+    let is_gemini =
+        !is_claude && !is_codex && cmd_basenames.iter().any(|b| b.starts_with("gemini"));
     let context_target = if is_claude {
         Some(crate::config::session_context::ManagedContextTarget::Claude)
     } else if is_codex {
@@ -702,12 +706,20 @@ pub async fn create_session_inner(
         None
     };
 
-    // Persist is_claude flag in the SessionManager AND the local clone.
+    // Persist agent-kind flags in the SessionManager AND the local clone.
     // The manager update ensures get_session() returns the correct flag (for telegram_attach).
-    // The local clone update ensures SessionInfo.is_claude is correct (for auto-attach sites).
+    // The local clone update ensures SessionInfo.is_* is correct (for auto-attach sites).
     if is_claude {
         mgr.set_is_claude(id, true).await;
         session.is_claude = true;
+    }
+    if is_codex {
+        mgr.set_is_codex(id, true).await;
+        session.is_codex = true;
+    }
+    if is_gemini {
+        mgr.set_is_gemini(id, true).await;
+        session.is_gemini = true;
     }
 
     // Auto-inject --continue for Claude agents when AC has reason to believe a prior

--- a/src-tauri/src/commands/telegram.rs
+++ b/src-tauri/src/commands/telegram.rs
@@ -61,9 +61,23 @@ pub(crate) fn derive_reader(
         };
     }
     if is_gemini {
-        // Gemini reader lands in commit 4 (#258). Until then, Gemini sessions
-        // fall back to PTY mode just like undetected agents.
-        return Ok(None);
+        // H1 softened contract: spawn the watcher whenever `~/.gemini/` exists;
+        // the cwd-to-slug lookup is deferred to the watcher's per-poll
+        // `lookup_chats_dir_for_cwd`. Loud abort only if Gemini was never
+        // installed on this machine.
+        return match crate::commands::gemini_resolver::resolve_gemini_home(
+            shell, shell_args, cwd,
+        ) {
+            Some(home) => Ok(Some(SessionReaderKind::Gemini {
+                gemini_home: home,
+                cwd: cwd.to_string(),
+                attach_time,
+            })),
+            None => Err(
+                "Cannot resolve Gemini home (~/.gemini/ missing — Gemini never installed)"
+                    .to_string(),
+            ),
+        };
     }
     Ok(None) // No agent detected — caller falls back to PTY mode.
 }

--- a/src-tauri/src/commands/telegram.rs
+++ b/src-tauri/src/commands/telegram.rs
@@ -6,8 +6,67 @@ use uuid::Uuid;
 use crate::config::settings::SettingsState;
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
+use crate::telegram::bridge::SessionReaderKind;
 use crate::telegram::manager::TelegramBridgeState;
 use crate::telegram::types::BridgeInfo;
+
+/// Derive which session-reader pipeline to spawn for a given session.
+///
+/// - `Ok(Some(kind))` — agent detected and resolver succeeded → caller spawns the reader.
+/// - `Ok(None)` — no agent detected (or Gemini in commit 3 — handled in commit 4)
+///   → caller falls back to PTY mode.
+/// - `Err(message)` — agent detected but resolver returned None → caller logs +
+///   emits `telegram_bridge_error` + early-returns with its contractual success
+///   value (or `Err` for `telegram_attach`).
+///
+/// **Mutual exclusion (H4) is asserted in debug builds.** The detection at
+/// `commands/session.rs:692-694` is mutually exclusive (Claude > Codex > Gemini),
+/// so the assertion is invariant.
+pub(crate) fn derive_reader(
+    shell: &str,
+    shell_args: &[String],
+    cwd: &str,
+    is_claude: bool,
+    is_codex: bool,
+    is_gemini: bool,
+) -> Result<Option<SessionReaderKind>, String> {
+    let kinds_set: u8 = u8::from(is_claude) + u8::from(is_codex) + u8::from(is_gemini);
+    debug_assert!(
+        kinds_set <= 1,
+        "agent-kind flags must be mutually exclusive — fix detection at commands/session.rs:692-694 (is_claude={}, is_codex={}, is_gemini={})",
+        is_claude, is_codex, is_gemini
+    );
+
+    let attach_time = chrono::Utc::now();
+
+    if is_claude {
+        return match crate::commands::session::resolve_claude_projects_dir(shell, shell_args, cwd)
+        {
+            Some(p) => Ok(Some(SessionReaderKind::Claude { project_dir: p })),
+            None => Err("Cannot resolve Claude projects dir".to_string()),
+        };
+    }
+    if is_codex {
+        return match crate::commands::codex_resolver::resolve_codex_sessions_root(
+            shell, shell_args, cwd,
+        ) {
+            Some(root) => Ok(Some(SessionReaderKind::Codex {
+                search_root: root,
+                cwd: cwd.to_string(),
+                attach_time,
+            })),
+            None => Err(
+                "Cannot resolve Codex sessions root (~/.codex/sessions/ missing)".to_string(),
+            ),
+        };
+    }
+    if is_gemini {
+        // Gemini reader lands in commit 4 (#258). Until then, Gemini sessions
+        // fall back to PTY mode just like undetected agents.
+        return Ok(None);
+    }
+    Ok(None) // No agent detected — caller falls back to PTY mode.
+}
 
 #[tauri::command]
 pub async fn telegram_attach(
@@ -20,55 +79,49 @@ pub async fn telegram_attach(
 ) -> Result<BridgeInfo, String> {
     let uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
 
-    // For Claude sessions we pre-resolve the JSONL `projects/<mangled-cwd>` directory
-    // so wrapper-driven `CLAUDE_CONFIG_DIR` overrides (e.g. `claude-mb`) are honored.
-    // If is_claude is true but the resolver returns None, fail loud: emit
-    // telegram_bridge_error and abort — silent fallback to PTY for Claude is exactly
-    // the noisy mode we are trying to retire.
-    //
     // Extract the fields the resolver needs and drop the SessionManager read guard
-    // BEFORE invoking the resolver — the resolver does blocking filesystem I/O
+    // BEFORE invoking `derive_reader` — the resolver does blocking filesystem I/O
     // (`which::which` walks `%PATH%`, opens wrapper scripts) that can take hundreds
     // of milliseconds. Holding a `tokio::sync::RwLock` read guard across that would
     // starve concurrent writers (create_session, restart_session, switch_session).
-    let (is_claude, shell, shell_args, working_directory) = {
+    let (is_claude, is_codex, is_gemini, shell, shell_args, working_directory) = {
         let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
         let mgr = session_mgr.read().await;
         let session = mgr.get_session(uuid).await.ok_or("Session not found")?;
         (
             session.is_claude,
+            session.is_codex,
+            session.is_gemini,
             session.shell.clone(),
             session.shell_args.clone(),
             session.working_directory.clone(),
         )
-        // Guard dropped at end of this block, before the resolver call below.
     };
 
-    let jsonl_project_dir = if is_claude {
-        match crate::commands::session::resolve_claude_projects_dir(
-            &shell,
-            &shell_args,
-            &working_directory,
-        ) {
-            Some(p) => Some(p),
-            None => {
-                let err_msg = format!(
-                    "Telegram bridge: cannot resolve Claude projects dir for session {} (shell={:?}). Bridge inactive.",
-                    uuid, shell
-                );
-                log::error!("{}", err_msg);
-                let _ = app.emit(
-                    "telegram_bridge_error",
-                    serde_json::json!({
-                        "sessionId": session_id,
-                        "error": err_msg,
-                    }),
-                );
-                return Err(err_msg);
-            }
+    let reader = match derive_reader(
+        &shell,
+        &shell_args,
+        &working_directory,
+        is_claude,
+        is_codex,
+        is_gemini,
+    ) {
+        Ok(r) => r,
+        Err(reason) => {
+            let err_msg = format!(
+                "Telegram bridge: {} for session {} (shell={:?}). Bridge inactive.",
+                reason, uuid, shell
+            );
+            log::error!("{}", err_msg);
+            let _ = app.emit(
+                "telegram_bridge_error",
+                serde_json::json!({
+                    "sessionId": session_id,
+                    "error": err_msg,
+                }),
+            );
+            return Err(err_msg);
         }
-    } else {
-        None
     };
 
     let cfg = settings.read().await;
@@ -83,7 +136,7 @@ pub async fn telegram_attach(
     let pty_arc = pty_mgr.inner().clone();
     let mut tg = tg_mgr.lock().await;
     let info = tg
-        .attach(uuid, &bot, pty_arc, app.clone(), jsonl_project_dir)
+        .attach(uuid, &bot, pty_arc, app.clone(), reader)
         .map_err(|e| e.to_string())?;
 
     let _ = app.emit("telegram_bridge_attached", info.clone());

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -2404,6 +2404,8 @@ mod tests {
             is_coordinator: false,
             token: "t".into(),
             is_claude: true,
+            is_codex: false,
+            is_gemini: false,
             was_detached: false,
             detached_geometry: None,
         }

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -68,6 +68,8 @@ impl SessionManager {
             git_repos_gen: 0,
             token: Uuid::new_v4(),
             is_claude: false,
+            is_codex: false,
+            is_gemini: false,
             was_detached: false,
             detached_geometry: None,
         };
@@ -325,6 +327,20 @@ impl SessionManager {
         let mut sessions = self.sessions.write().await;
         if let Some(s) = sessions.get_mut(&id) {
             s.is_claude = val;
+        }
+    }
+
+    pub async fn set_is_codex(&self, id: Uuid, val: bool) {
+        let mut sessions = self.sessions.write().await;
+        if let Some(s) = sessions.get_mut(&id) {
+            s.is_codex = val;
+        }
+    }
+
+    pub async fn set_is_gemini(&self, id: Uuid, val: bool) {
+        let mut sessions = self.sessions.write().await;
+        if let Some(s) = sessions.get_mut(&id) {
+            s.is_gemini = val;
         }
     }
 

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -90,6 +90,14 @@ pub struct Session {
     /// Used by the Telegram bridge to choose JSONL watcher vs PTY pipeline.
     #[serde(default)]
     pub is_claude: bool,
+    /// True if this session runs Codex CLI (detected at creation time).
+    /// Used by the Telegram bridge to choose the Codex JSONL watcher.
+    #[serde(default)]
+    pub is_codex: bool,
+    /// True if this session runs Gemini CLI (detected at creation time).
+    /// Used by the Telegram bridge to choose the Gemini JSONL watcher.
+    #[serde(default)]
+    pub is_gemini: bool,
     /// True while this session has a live detached window (or is marked to re-spawn
     /// one on next launch). Source of truth for persistence — `snapshot_sessions`
     /// reads this directly, NOT from `DetachedSessionsState`.
@@ -179,6 +187,10 @@ pub struct SessionInfo {
     #[serde(default)]
     pub is_claude: bool,
     #[serde(default)]
+    pub is_codex: bool,
+    #[serde(default)]
+    pub is_gemini: bool,
+    #[serde(default)]
     pub was_detached: bool,
     /// Not serialized to the frontend — internal carrier for `snapshot_sessions`
     /// so persistence can read the last-known detached-window geometry without a
@@ -208,6 +220,8 @@ impl From<&Session> for SessionInfo {
             is_coordinator: s.is_coordinator,
             token: s.token.to_string(),
             is_claude: s.is_claude,
+            is_codex: s.is_codex,
+            is_gemini: s.is_gemini,
             was_detached: s.was_detached,
             detached_geometry: s.detached_geometry.clone(),
         }
@@ -238,6 +252,8 @@ mod tests {
             git_repos_gen: 0,
             token: Uuid::nil(),
             is_claude: false,
+            is_codex: false,
+            is_gemini: false,
             was_detached: false,
             detached_geometry: None,
         }

--- a/src-tauri/src/telegram/bridge.rs
+++ b/src-tauri/src/telegram/bridge.rs
@@ -427,7 +427,6 @@ pub enum SessionReaderKind {
     /// Watch Gemini CLI's append-only `session-*.jsonl` under
     /// `~/.gemini/tmp/<slug>/chats/`. The slug is resolved lazily by the
     /// watcher on each poll via `lookup_chats_dir_for_cwd` until it succeeds.
-    #[allow(dead_code)] // constructed in commit 4
     Gemini {
         gemini_home: PathBuf,
         cwd: String,
@@ -484,11 +483,22 @@ pub fn spawn_bridge(
                 app_handle.clone(),
             );
         }
-        Some(SessionReaderKind::Gemini { .. }) => {
-            // Gemini watcher lands in commit 4 (#258). `derive_reader` does not
-            // produce this variant yet, so this arm is currently unreachable.
+        Some(SessionReaderKind::Gemini {
+            gemini_home,
+            cwd,
+            attach_time,
+        }) => {
             drop(rx);
-            unreachable!("Gemini SessionReaderKind constructed without gemini_watcher being wired (commit 4 of #258 lifts this)");
+            super::gemini_watcher::spawn_watch_task(
+                gemini_home,
+                cwd,
+                attach_time,
+                bot_token.clone(),
+                chat_id,
+                session_id_str.clone(),
+                cancel.clone(),
+                app_handle.clone(),
+            );
         }
         None => {
             // PTY mode: existing 6-phase pipeline

--- a/src-tauri/src/telegram/bridge.rs
+++ b/src-tauri/src/telegram/bridge.rs
@@ -411,6 +411,30 @@ fn is_thinking_line(s: &str) -> bool {
 
 // ── Bridge spawn ─────────────────────────────────────────────
 
+/// Which session-reader pipeline to spawn for this bridge. `None` (the bridge
+/// signature) falls back to the PTY 6-phase pipeline (legacy noisy mode).
+#[derive(Debug, Clone)]
+pub enum SessionReaderKind {
+    /// Watch Claude Code's append-only JSONL session log at the resolved projects dir.
+    Claude { project_dir: PathBuf },
+    /// Watch Codex CLI's append-only `rollout-*.jsonl` under `~/.codex/sessions/`,
+    /// filtering candidates by `session_meta.cwd` match.
+    Codex {
+        search_root: PathBuf,
+        cwd: String,
+        attach_time: chrono::DateTime<chrono::Utc>,
+    },
+    /// Watch Gemini CLI's append-only `session-*.jsonl` under
+    /// `~/.gemini/tmp/<slug>/chats/`. The slug is resolved lazily by the
+    /// watcher on each poll via `lookup_chats_dir_for_cwd` until it succeeds.
+    #[allow(dead_code)] // constructed in commit 4
+    Gemini {
+        gemini_home: PathBuf,
+        cwd: String,
+        attach_time: chrono::DateTime<chrono::Utc>,
+    },
+}
+
 pub struct BridgeHandle {
     pub info: BridgeInfo,
     pub cancel: CancellationToken,
@@ -424,34 +448,59 @@ pub fn spawn_bridge(
     info: BridgeInfo,
     pty_mgr: Arc<Mutex<PtyManager>>,
     app_handle: tauri::AppHandle,
-    jsonl_project_dir: Option<PathBuf>,
+    reader: Option<SessionReaderKind>,
 ) -> BridgeHandle {
     let cancel = CancellationToken::new();
     let (tx, rx) = mpsc::channel::<Vec<u8>>(256);
 
     let session_id_str = session_id.to_string();
 
-    if let Some(project_dir) = jsonl_project_dir {
-        // JSONL mode: watch Claude Code session log instead of PTY pipeline
-        drop(rx); // not needed — no PTY bytes feed
-        super::claude_watcher::spawn_watch_task(
-            project_dir,
-            bot_token.clone(),
-            chat_id,
-            session_id_str.clone(),
-            cancel.clone(),
-            app_handle.clone(),
-        );
-    } else {
-        // PTY mode: existing 6-phase pipeline
-        tokio::spawn(output_task(
-            rx,
-            bot_token.clone(),
-            chat_id,
-            session_id_str.clone(),
-            cancel.clone(),
-            app_handle.clone(),
-        ));
+    match reader {
+        Some(SessionReaderKind::Claude { project_dir }) => {
+            drop(rx); // not needed — no PTY bytes feed
+            super::claude_watcher::spawn_watch_task(
+                project_dir,
+                bot_token.clone(),
+                chat_id,
+                session_id_str.clone(),
+                cancel.clone(),
+                app_handle.clone(),
+            );
+        }
+        Some(SessionReaderKind::Codex {
+            search_root,
+            cwd,
+            attach_time,
+        }) => {
+            drop(rx);
+            super::codex_watcher::spawn_watch_task(
+                search_root,
+                cwd,
+                attach_time,
+                bot_token.clone(),
+                chat_id,
+                session_id_str.clone(),
+                cancel.clone(),
+                app_handle.clone(),
+            );
+        }
+        Some(SessionReaderKind::Gemini { .. }) => {
+            // Gemini watcher lands in commit 4 (#258). `derive_reader` does not
+            // produce this variant yet, so this arm is currently unreachable.
+            drop(rx);
+            unreachable!("Gemini SessionReaderKind constructed without gemini_watcher being wired (commit 4 of #258 lifts this)");
+        }
+        None => {
+            // PTY mode: existing 6-phase pipeline
+            tokio::spawn(output_task(
+                rx,
+                bot_token.clone(),
+                chat_id,
+                session_id_str.clone(),
+                cancel.clone(),
+                app_handle.clone(),
+            ));
+        }
     }
 
     // Poll task: Telegram getUpdates -> write to PTY stdin (runs in BOTH modes)

--- a/src-tauri/src/telegram/bridge.rs
+++ b/src-tauri/src/telegram/bridge.rs
@@ -434,7 +434,7 @@ pub fn spawn_bridge(
     if let Some(project_dir) = jsonl_project_dir {
         // JSONL mode: watch Claude Code session log instead of PTY pipeline
         drop(rx); // not needed — no PTY bytes feed
-        super::jsonl_watcher::spawn_watch_task(
+        super::claude_watcher::spawn_watch_task(
             project_dir,
             bot_token.clone(),
             chat_id,

--- a/src-tauri/src/telegram/claude_watcher.rs
+++ b/src-tauri/src/telegram/claude_watcher.rs
@@ -1,9 +1,11 @@
-// JSONL file watcher for Claude Code sessions.
-// Polls Claude Code's structured session log files for new assistant messages
-// and sends them to Telegram, bypassing the PTY-based pipeline entirely.
+// Claude Code JSONL session-file watcher.
+// Polls Claude Code's append-only structured session log for new assistant
+// messages and sends them to Telegram, bypassing the PTY-based pipeline.
+//
+// Shared scaffold (find_latest_jsonl, read_new_lines, polling/rotation
+// constants) lives in `jsonl_kernel.rs` — see commit 1 for the extraction.
 
-use std::io::{Read as IoRead, Seek, SeekFrom};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::SystemTime;
 
 use tauri::Emitter;
@@ -11,11 +13,11 @@ use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 use crate::telegram::bridge::{flush_buffer, BridgeLogger, DiagLogger};
+use crate::telegram::jsonl_kernel::{
+    find_latest_jsonl, read_new_lines, POLL_INTERVAL_MS, ROTATION_STALE_SECS,
+};
 
-const POLL_INTERVAL_MS: u64 = 500;
 const FLUSH_DELAY_MS: u64 = 500;
-/// Duration a tracked file must be stale before switching to a newer one (file rotation guard)
-const ROTATION_STALE_SECS: u64 = 3;
 
 /// Spawn a JSONL file watcher task that polls for new assistant messages
 /// and sends them to Telegram via the shared buffer/send pipeline.
@@ -43,34 +45,6 @@ pub fn spawn_watch_task(
         .await;
         log::info!("[JSONL_EXIT] Watcher task ended for session {}", session_id);
     })
-}
-
-/// Find the most recently modified .jsonl file in the project directory.
-fn find_latest_jsonl(project_dir: &Path) -> Option<PathBuf> {
-    let entries = std::fs::read_dir(project_dir).ok()?;
-    let mut best: Option<(PathBuf, SystemTime)> = None;
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-            continue;
-        }
-        if let Ok(meta) = entry.metadata() {
-            if let Ok(modified) = meta.modified() {
-                match &best {
-                    Some((_, best_time)) if modified > *best_time => {
-                        best = Some((path, modified));
-                    }
-                    None => {
-                        best = Some((path, modified));
-                    }
-                    _ => {}
-                }
-            }
-        }
-    }
-
-    best.map(|(p, _)| p)
 }
 
 /// Parse a single JSONL line and extract assistant text content.
@@ -118,69 +92,6 @@ fn extract_assistant_text(line: &str) -> Option<String> {
         }
         _ => None,
     }
-}
-
-/// Read new bytes from a file starting at the given byte offset.
-/// Returns parsed complete lines and updates the offset by actual bytes read.
-/// Partial lines are accumulated in `remainder` for the next poll.
-fn read_new_lines(
-    path: &Path,
-    offset: &mut u64,
-    remainder: &mut String,
-) -> std::io::Result<Vec<String>> {
-    let mut file = std::fs::File::open(path)?;
-    // Use metadata on the open handle (avoids TOCTOU with path-based metadata)
-    let file_len = file.metadata()?.len();
-
-    // G3: File truncation/shrink detection — reset to beginning
-    if file_len < *offset {
-        log::warn!(
-            "[JSONL_TRUNCATE] File shrank ({} < {}), resetting offset",
-            file_len,
-            *offset
-        );
-        *offset = 0;
-        remainder.clear();
-    }
-
-    if file_len <= *offset {
-        return Ok(vec![]);
-    }
-
-    file.seek(SeekFrom::Start(*offset))?;
-    let mut buf = String::new();
-    file.read_to_string(&mut buf)?;
-
-    // G2: Track offset by actual bytes read, not reported file length
-    *offset += buf.len() as u64;
-
-    // Prepend any partial line from previous read
-    if !remainder.is_empty() {
-        let mut combined = std::mem::take(remainder);
-        combined.push_str(&buf);
-        buf = combined;
-    }
-
-    let mut lines = Vec::new();
-    let mut last_newline = 0;
-
-    for (i, ch) in buf.char_indices() {
-        if ch == '\n' {
-            let line = &buf[last_newline..i];
-            let trimmed = line.trim();
-            if !trimmed.is_empty() {
-                lines.push(trimmed.to_string());
-            }
-            last_newline = i + 1;
-        }
-    }
-
-    // Keep unterminated tail in remainder for next poll
-    if last_newline < buf.len() {
-        *remainder = buf[last_newline..].to_string();
-    }
-
-    Ok(lines)
 }
 
 async fn watch_loop(

--- a/src-tauri/src/telegram/claude_watcher.rs
+++ b/src-tauri/src/telegram/claude_watcher.rs
@@ -8,13 +8,15 @@
 use std::path::PathBuf;
 use std::time::SystemTime;
 
+use chrono::{DateTime, Utc};
 use tauri::Emitter;
 use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 use crate::telegram::bridge::{flush_buffer, BridgeLogger, DiagLogger};
 use crate::telegram::jsonl_kernel::{
-    find_latest_jsonl, read_new_lines, POLL_INTERVAL_MS, ROTATION_STALE_SECS,
+    find_latest_jsonl, read_new_lines, read_preamble_for_race, POLL_INTERVAL_MS,
+    ROTATION_STALE_SECS,
 };
 
 const FLUSH_DELAY_MS: u64 = 500;
@@ -45,6 +47,16 @@ pub fn spawn_watch_task(
         .await;
         log::info!("[JSONL_EXIT] Watcher task ended for session {}", session_id);
     })
+}
+
+/// Extractor for `read_preamble_for_race`: pairs each emitted body with the
+/// line's `timestamp` field so the kernel can apply its grace-window filter.
+fn claude_preamble_extractor(line: &str) -> Option<(DateTime<Utc>, String)> {
+    let body = extract_assistant_text(line)?;
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    let ts_str = v.get("timestamp")?.as_str()?;
+    let ts = DateTime::parse_from_rfc3339(ts_str).ok()?.with_timezone(&Utc);
+    Some((ts, body))
 }
 
 /// Parse a single JSONL line and extract assistant text content.
@@ -113,6 +125,7 @@ async fn watch_loop(
     let mut last_buffer_add = Instant::now();
     let flush_delay = Duration::from_millis(FLUSH_DELAY_MS);
 
+    let attach_time: DateTime<Utc> = Utc::now();
     let mut current_file: Option<PathBuf> = None;
     let mut current_file_mtime: Option<SystemTime> = None;
     let mut file_offset: u64 = 0;
@@ -161,13 +174,32 @@ async fn watch_loop(
 
                     if should_switch {
                         if current_file.is_none() {
-                            // First attach: skip existing content (seek to end)
-                            file_offset = latest.as_ref()
-                                .and_then(|p| std::fs::metadata(p).ok())
-                                .map(|m| m.len())
-                                .unwrap_or(0);
-                            logger.log("JSONL_FILE", &session_id,
-                                &format!("initial file, skipping to offset {}", file_offset));
+                            // First attach (§J preamble scan): emit recent
+                            // lines from the file's tail, then set offset = file_len.
+                            if let Some(ref p) = latest {
+                                match read_preamble_for_race(p, attach_time, claude_preamble_extractor) {
+                                    Ok((bodies, file_len)) => {
+                                        for text in bodies {
+                                            logger.log("JSONL_PREAMBLE", &session_id, &text);
+                                            buffer.push_str(&text);
+                                            buffer.push('\n');
+                                            last_buffer_add = Instant::now();
+                                        }
+                                        file_offset = file_len;
+                                        logger.log("JSONL_FILE", &session_id,
+                                            &format!("initial file, preamble scan done, offset={}", file_offset));
+                                    }
+                                    Err(e) => {
+                                        logger.log("JSONL_ERR", &session_id,
+                                            &format!("preamble scan failed: {}", e));
+                                        file_offset = std::fs::metadata(p).ok()
+                                            .map(|m| m.len())
+                                            .unwrap_or(0);
+                                    }
+                                }
+                            } else {
+                                file_offset = 0;
+                            }
                         } else {
                             // File rotation (new Claude session): read from start
                             file_offset = 0;

--- a/src-tauri/src/telegram/claude_watcher.rs
+++ b/src-tauri/src/telegram/claude_watcher.rs
@@ -51,12 +51,14 @@ pub fn spawn_watch_task(
 
 /// Extractor for `read_preamble_for_race`: pairs each emitted body with the
 /// line's `timestamp` field so the kernel can apply its grace-window filter.
-fn claude_preamble_extractor(line: &str) -> Option<(DateTime<Utc>, String)> {
+/// Claude does not dedupe by id (idempotent assistant turns are absent in the
+/// JSONL format), so the id slot is always `None`.
+fn claude_preamble_extractor(line: &str) -> Option<(DateTime<Utc>, Option<String>, String)> {
     let body = extract_assistant_text(line)?;
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
     let ts_str = v.get("timestamp")?.as_str()?;
     let ts = DateTime::parse_from_rfc3339(ts_str).ok()?.with_timezone(&Utc);
-    Some((ts, body))
+    Some((ts, None, body))
 }
 
 /// Parse a single JSONL line and extract assistant text content.
@@ -178,7 +180,7 @@ async fn watch_loop(
                             // lines from the file's tail, then set offset = file_len.
                             if let Some(ref p) = latest {
                                 match read_preamble_for_race(p, attach_time, claude_preamble_extractor) {
-                                    Ok((bodies, file_len)) => {
+                                    Ok((bodies, _ids, file_len)) => {
                                         for text in bodies {
                                             logger.log("JSONL_PREAMBLE", &session_id, &text);
                                             buffer.push_str(&text);

--- a/src-tauri/src/telegram/codex_watcher.rs
+++ b/src-tauri/src/telegram/codex_watcher.rs
@@ -63,13 +63,14 @@ pub fn spawn_watch_task(
 
 /// Extractor for `read_preamble_for_race`: pairs each emitted body with the
 /// line's top-level `timestamp` field so the kernel can apply its grace-window
-/// filter.
-fn codex_preamble_extractor(line: &str) -> Option<(DateTime<Utc>, String)> {
+/// filter. Codex agent_message events have no stable per-line id we need for
+/// dedup, so the id slot is always `None`.
+fn codex_preamble_extractor(line: &str) -> Option<(DateTime<Utc>, Option<String>, String)> {
     let body = extract_agent_message(line)?;
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
     let ts_str = v.get("timestamp")?.as_str()?;
     let ts = DateTime::parse_from_rfc3339(ts_str).ok()?.with_timezone(&Utc);
-    Some((ts, body))
+    Some((ts, None, body))
 }
 
 /// Parse a single Codex rollout JSONL line and extract the `agent_message`
@@ -266,7 +267,7 @@ async fn watch_loop(
                             line_remainder.clear();
                             if first_bind {
                                 match read_preamble_for_race(&found, attach_time, codex_preamble_extractor) {
-                                    Ok((bodies, file_len)) => {
+                                    Ok((bodies, _ids, file_len)) => {
                                         for text in bodies {
                                             logger.log("CODEX_PREAMBLE", &session_id, &text);
                                             buffer.push_str(&text);

--- a/src-tauri/src/telegram/codex_watcher.rs
+++ b/src-tauri/src/telegram/codex_watcher.rs
@@ -116,8 +116,14 @@ fn read_first_line(path: &Path) -> Option<String> {
 /// `rollout-*.jsonl` whose mtime is recent enough, parse its first
 /// `session_meta` line, and return the path whose `payload.cwd` (after
 /// canonicalization) equals the canonicalized `expected_cwd`, preferring the
-/// candidate with the newest `payload.timestamp` (which is when codex started
-/// or last appended to the session).
+/// candidate with the newest **file mtime**.
+///
+/// **mtime, not `payload.timestamp`**: `session_meta.payload.timestamp` is the
+/// session CREATION time and is NEVER updated on resume. M6 empirical (Codex
+/// 0.130.0) shows `codex resume --last` appends to the original file from the
+/// resumed session's creation day — so a 4-day-old file's `payload.timestamp`
+/// is 4 days old even when it was just appended to. mtime tracks the
+/// most-recently-written file, which is the live one Codex is appending to.
 ///
 /// Returns `None` if no candidate matches; the watcher polls again next tick.
 fn find_session_file(
@@ -129,7 +135,7 @@ fn find_session_file(
     let mtime_cutoff = attach_time - chrono::Duration::seconds(FILE_MTIME_GRACE_SECS);
     let mtime_cutoff_st: SystemTime = mtime_cutoff.into();
 
-    let mut best: Option<(PathBuf, DateTime<Utc>)> = None;
+    let mut best: Option<(PathBuf, SystemTime)> = None;
 
     for offset in 0..=DAY_WALK_DEPTH {
         let day = attach_time.date_naive() - chrono::Duration::days(offset);
@@ -154,11 +160,13 @@ fn find_session_file(
                 Ok(m) => m,
                 Err(_) => continue,
             };
+            let mtime = match meta.modified() {
+                Ok(m) => m,
+                Err(_) => continue, // can't compare without mtime
+            };
             // Skip files modified more than 5 min before attach (stale).
-            if let Ok(mtime) = meta.modified() {
-                if mtime < mtime_cutoff_st {
-                    continue;
-                }
+            if mtime < mtime_cutoff_st {
+                continue;
             }
             let first = match read_first_line(&path) {
                 Some(l) => l,
@@ -179,17 +187,9 @@ fn find_session_file(
             if canonicalize_cwd_for_codex(candidate_cwd) != normalized_expected {
                 continue;
             }
-            let ts_str = match payload.get("timestamp").and_then(|t| t.as_str()) {
-                Some(t) => t,
-                None => continue,
-            };
-            let ts = match DateTime::parse_from_rfc3339(ts_str) {
-                Ok(t) => t.with_timezone(&Utc),
-                Err(_) => continue,
-            };
             match &best {
-                Some((_, best_ts)) if ts > *best_ts => best = Some((path, ts)),
-                None => best = Some((path, ts)),
+                Some((_, best_mtime)) if mtime > *best_mtime => best = Some((path, mtime)),
+                None => best = Some((path, mtime)),
                 _ => {}
             }
         }
@@ -222,6 +222,7 @@ async fn watch_loop(
 
     let mut current_file: Option<PathBuf> = None;
     let mut current_file_mtime: Option<SystemTime> = None;
+    let mut last_mtime_advance: Instant = Instant::now();
     let mut file_offset: u64 = 0;
     let mut line_remainder = String::new();
     let mut search_warned = false;
@@ -243,18 +244,15 @@ async fn watch_loop(
         tokio::select! {
             _ = cancel.cancelled() => break,
             _ = poll_interval.tick() => {
-                // M5: only re-scan when we don't have a current file or the
-                // tracked file has gone stale (no mtime advance for ROTATION_STALE_SECS)
-                // or has been unlinked.
-                let need_rescan = match (&current_file, &current_file_mtime) {
-                    (None, _) => true,
-                    (Some(p), _) if !p.exists() => true,
-                    (Some(_), Some(mtime)) => {
-                        mtime.elapsed()
-                            .map(|d| d.as_secs() >= ROTATION_STALE_SECS)
-                            .unwrap_or(false)
-                    }
-                    _ => false,
+                // M5: re-scan only when we don't have a current file, the tracked
+                // file has been unlinked, or the file's mtime has not advanced
+                // for ROTATION_STALE_SECS wall-clock seconds (i.e. it might have
+                // been rotated out from under us). `last_mtime_advance` is
+                // updated below when we observe the file's current mtime grow.
+                let need_rescan = match &current_file {
+                    None => true,
+                    Some(p) if !p.exists() => true,
+                    Some(_) => last_mtime_advance.elapsed().as_secs() >= ROTATION_STALE_SECS,
                 };
 
                 if need_rescan {
@@ -293,9 +291,13 @@ async fn watch_loop(
                             }
                             current_file = Some(found);
                         }
-                        current_file_mtime = current_file.as_ref()
+                        let new_mtime = current_file.as_ref()
                             .and_then(|p| std::fs::metadata(p).ok())
                             .and_then(|m| m.modified().ok());
+                        if new_mtime != current_file_mtime {
+                            last_mtime_advance = Instant::now();
+                        }
+                        current_file_mtime = new_mtime;
                     } else if !search_warned {
                         logger.log("CODEX_WAIT", &session_id,
                             "no rollout matching cwd found yet");
@@ -314,8 +316,12 @@ async fn watch_loop(
                                     last_buffer_add = Instant::now();
                                 }
                             }
-                            current_file_mtime = std::fs::metadata(path).ok()
+                            let new_mtime = std::fs::metadata(path).ok()
                                 .and_then(|m| m.modified().ok());
+                            if new_mtime != current_file_mtime {
+                                last_mtime_advance = Instant::now();
+                            }
+                            current_file_mtime = new_mtime;
                         }
                         Err(e) => {
                             logger.log("CODEX_ERR", &session_id, &e.to_string());
@@ -502,31 +508,76 @@ mod tests {
     }
 
     #[test]
-    fn find_session_file_picks_newest_timestamp_when_multiple_match() {
+    fn find_session_file_picks_newest_mtime_when_multiple_match() {
+        // M6: tiebreaker is file mtime, not payload.timestamp — see
+        // find_session_file doc comment for why.
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         let now = Utc::now();
         let today = day_dir(root, now.date_naive());
 
         let cwd = r"C:\Users\foo\bar";
-        let ts_old = (now - chrono::Duration::seconds(60)).to_rfc3339();
-        let ts_new = (now - chrono::Duration::seconds(10)).to_rfc3339();
-
+        // Both files reference the same cwd; payload.timestamp values are not
+        // used for tie-breaking. Sleep 150 ms between writes so the two
+        // candidates have definitely-distinct mtimes on Windows NTFS.
+        let ts = now.to_rfc3339();
         let _old = write_rollout(
             &today,
             "rollout-old.jsonl",
             &cwd.replace('\\', "\\\\"),
-            &ts_old,
+            &ts,
         );
+        std::thread::sleep(std::time::Duration::from_millis(150));
         let expected_new = write_rollout(
             &today,
             "rollout-new.jsonl",
             &cwd.replace('\\', "\\\\"),
-            &ts_new,
+            &ts,
         );
 
         let found = find_session_file(root, "c:\\users\\foo\\bar", now);
         assert_eq!(found, Some(expected_new));
+    }
+
+    #[test]
+    fn find_session_file_picks_resumed_file_even_with_old_payload_timestamp() {
+        // M6 use case: codex exec resume --last appends to a 4-day-old file.
+        // The candidate has payload.timestamp = 4 days ago but mtime = now.
+        // Another (older session, abandoned) candidate exists with both
+        // payload.timestamp and mtime "today (earlier)".
+        // The mtime tiebreaker should pick the resumed file (current mtime),
+        // NOT the abandoned same-day file.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let now = Utc::now();
+        let cwd = r"C:\Users\foo\bar";
+
+        // Abandoned same-day session — its payload.timestamp is "today" but
+        // it was last touched a couple of minutes ago.
+        let today = day_dir(root, now.date_naive());
+        let abandoned_today = write_rollout(
+            &today,
+            "rollout-abandoned.jsonl",
+            &cwd.replace('\\', "\\\\"),
+            &(now - chrono::Duration::minutes(2)).to_rfc3339(),
+        );
+        std::thread::sleep(std::time::Duration::from_millis(150));
+
+        // Resumed file lives 4 days back — its payload.timestamp is 4 days ago
+        // but its mtime is "now" (we just wrote it = the resume just appended).
+        let four_days_ago = now - chrono::Duration::days(4);
+        let dir4 = day_dir(root, four_days_ago.date_naive());
+        let resumed = write_rollout(
+            &dir4,
+            "rollout-resumed-4d.jsonl",
+            &cwd.replace('\\', "\\\\"),
+            &four_days_ago.to_rfc3339(),
+        );
+
+        let found = find_session_file(root, "c:\\users\\foo\\bar", now);
+        assert_eq!(found, Some(resumed));
+        // The abandoned file should NOT have been chosen.
+        assert_ne!(found, Some(abandoned_today));
     }
 
     #[test]

--- a/src-tauri/src/telegram/codex_watcher.rs
+++ b/src-tauri/src/telegram/codex_watcher.rs
@@ -1,0 +1,602 @@
+// Codex CLI session-file watcher.
+//
+// Polls `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` files for `event_msg`
+// records with `payload.type == "agent_message"` and sends the assistant prose
+// to Telegram. Uses Kernel A (offset-based append-only JSONL) from
+// `jsonl_kernel.rs` once `find_session_file` selects the right rollout.
+
+use std::io::Read as IoRead;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use chrono::{DateTime, Utc};
+use tauri::Emitter;
+use tokio::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+
+use crate::commands::codex_resolver::canonicalize_cwd_for_codex;
+use crate::telegram::bridge::{flush_buffer, BridgeLogger, DiagLogger};
+use crate::telegram::jsonl_kernel::{read_new_lines, POLL_INTERVAL_MS, ROTATION_STALE_SECS};
+
+/// Buffer thresholds tuned for Codex's commentary cadence.
+/// `event_msg + agent_message` events average 200-400 B and arrive 3-8 per
+/// turn within 800-2500 ms. Coalesce a whole turn into one Telegram message.
+const FLUSH_DELAY_MS: u64 = 1500;
+const FLUSH_BYTES: usize = 3000;
+
+/// Grace window for the M6 day-walk: files older than this aren't considered.
+const FILE_MTIME_GRACE_SECS: i64 = 5 * 60;
+
+/// M6 empirical (Codex 0.130.0): `codex resume --last` APPENDS to the prior
+/// rollout file. The walk therefore covers today + last 7 UTC days to catch
+/// resumes from week-old sessions. See plan §15 §A for the empirical record.
+const DAY_WALK_DEPTH: i64 = 7;
+
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_watch_task(
+    search_root: PathBuf,
+    expected_cwd: String,
+    attach_time: DateTime<Utc>,
+    bot_token: String,
+    chat_id: i64,
+    session_id: String,
+    cancel: CancellationToken,
+    app: tauri::AppHandle,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        watch_loop(
+            search_root,
+            expected_cwd,
+            attach_time,
+            bot_token,
+            chat_id,
+            session_id.clone(),
+            cancel,
+            app.clone(),
+        )
+        .await;
+        log::info!("[CODEX_EXIT] Watcher task ended for session {}", session_id);
+    })
+}
+
+/// Parse a single Codex rollout JSONL line and extract the `agent_message`
+/// body, if any. Returns `None` for any other event/payload type, or for
+/// empty/whitespace-only messages.
+fn extract_agent_message(line: &str) -> Option<String> {
+    // Fast-path: skip lines that can't be agent_message events. Codex rollouts
+    // contain many tool_call / response_item lines per assistant turn.
+    if !line.contains("\"type\":\"event_msg\"") && !line.contains("\"type\": \"event_msg\"") {
+        return None;
+    }
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    if v.get("type")?.as_str()? != "event_msg" {
+        return None;
+    }
+    let payload = v.get("payload")?;
+    if payload.get("type")?.as_str()? != "agent_message" {
+        return None;
+    }
+    let msg = payload.get("message")?.as_str()?;
+    let trimmed = msg.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Open `path`, read up to 64 KiB from the start, return the first complete
+/// JSON line. Used by `find_session_file` to inspect each candidate's
+/// `session_meta` header without slurping the full rollout (a 2 MB file would
+/// be ~30 ms of blocking I/O per candidate otherwise).
+fn read_first_line(path: &Path) -> Option<String> {
+    let mut f = std::fs::File::open(path).ok()?;
+    let mut buf = vec![0u8; 64 * 1024];
+    let n = f.read(&mut buf).ok()?;
+    let bytes = &buf[..n];
+    let end = bytes.iter().position(|&b| b == b'\n').unwrap_or(bytes.len());
+    let line = String::from_utf8_lossy(&bytes[..end]).into_owned();
+    Some(line)
+}
+
+/// Walk today + last 7 UTC days of `search_root`, open each candidate
+/// `rollout-*.jsonl` whose mtime is recent enough, parse its first
+/// `session_meta` line, and return the path whose `payload.cwd` (after
+/// canonicalization) equals the canonicalized `expected_cwd`, preferring the
+/// candidate with the newest `payload.timestamp` (which is when codex started
+/// or last appended to the session).
+///
+/// Returns `None` if no candidate matches; the watcher polls again next tick.
+fn find_session_file(
+    search_root: &Path,
+    expected_cwd: &str,
+    attach_time: DateTime<Utc>,
+) -> Option<PathBuf> {
+    let normalized_expected = canonicalize_cwd_for_codex(expected_cwd);
+    let mtime_cutoff = attach_time - chrono::Duration::seconds(FILE_MTIME_GRACE_SECS);
+    let mtime_cutoff_st: SystemTime = mtime_cutoff.into();
+
+    let mut best: Option<(PathBuf, DateTime<Utc>)> = None;
+
+    for offset in 0..=DAY_WALK_DEPTH {
+        let day = attach_time.date_naive() - chrono::Duration::days(offset);
+        let dir = search_root
+            .join(format!("{:04}", day.format("%Y")))
+            .join(format!("{:02}", day.format("%m")))
+            .join(format!("{:02}", day.format("%d")));
+        let read = match std::fs::read_dir(&dir) {
+            Ok(r) => r,
+            Err(_) => continue, // partition missing — normal for days with no codex usage
+        };
+        for entry in read.flatten() {
+            let path = entry.path();
+            let fname = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n,
+                None => continue,
+            };
+            if !fname.starts_with("rollout-") || !fname.ends_with(".jsonl") {
+                continue;
+            }
+            let meta = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            // Skip files modified more than 5 min before attach (stale).
+            if let Ok(mtime) = meta.modified() {
+                if mtime < mtime_cutoff_st {
+                    continue;
+                }
+            }
+            let first = match read_first_line(&path) {
+                Some(l) => l,
+                None => continue,
+            };
+            let v: serde_json::Value = match serde_json::from_str(&first) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let payload = match v.get("payload") {
+                Some(p) => p,
+                None => continue,
+            };
+            let candidate_cwd = match payload.get("cwd").and_then(|c| c.as_str()) {
+                Some(c) => c,
+                None => continue,
+            };
+            if canonicalize_cwd_for_codex(candidate_cwd) != normalized_expected {
+                continue;
+            }
+            let ts_str = match payload.get("timestamp").and_then(|t| t.as_str()) {
+                Some(t) => t,
+                None => continue,
+            };
+            let ts = match DateTime::parse_from_rfc3339(ts_str) {
+                Ok(t) => t.with_timezone(&Utc),
+                Err(_) => continue,
+            };
+            match &best {
+                Some((_, best_ts)) if ts > *best_ts => best = Some((path, ts)),
+                None => best = Some((path, ts)),
+                _ => {}
+            }
+        }
+    }
+
+    best.map(|(p, _)| p)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn watch_loop(
+    search_root: PathBuf,
+    expected_cwd: String,
+    attach_time: DateTime<Utc>,
+    token: String,
+    chat_id: i64,
+    session_id: String,
+    cancel: CancellationToken,
+    app: tauri::AppHandle,
+) {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap_or_default();
+
+    let mut logger = BridgeLogger::new(&session_id);
+    let mut diag = DiagLogger::new();
+    let mut buffer = String::new();
+    let mut last_buffer_add = Instant::now();
+    let flush_delay = Duration::from_millis(FLUSH_DELAY_MS);
+
+    let mut current_file: Option<PathBuf> = None;
+    let mut current_file_mtime: Option<SystemTime> = None;
+    let mut file_offset: u64 = 0;
+    let mut line_remainder = String::new();
+    let mut search_warned = false;
+
+    logger.log(
+        "CODEX_INIT",
+        &session_id,
+        &format!(
+            "search_root={} expected_cwd={}",
+            search_root.display(),
+            expected_cwd
+        ),
+    );
+
+    let mut poll_interval = tokio::time::interval(Duration::from_millis(POLL_INTERVAL_MS));
+    poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            _ = poll_interval.tick() => {
+                // M5: only re-scan when we don't have a current file or the
+                // tracked file has gone stale (no mtime advance for ROTATION_STALE_SECS)
+                // or has been unlinked.
+                let need_rescan = match (&current_file, &current_file_mtime) {
+                    (None, _) => true,
+                    (Some(p), _) if !p.exists() => true,
+                    (Some(_), Some(mtime)) => {
+                        mtime.elapsed()
+                            .map(|d| d.as_secs() >= ROTATION_STALE_SECS)
+                            .unwrap_or(false)
+                    }
+                    _ => false,
+                };
+
+                if need_rescan {
+                    if let Some(found) = find_session_file(&search_root, &expected_cwd, attach_time) {
+                        if Some(&found) != current_file.as_ref() {
+                            // First bind OR rotation. Initialize offset to current
+                            // file_len so we don't replay existing content (§J
+                            // preamble scan will land in commit 5 and supersede this).
+                            file_offset = std::fs::metadata(&found).ok().map(|m| m.len()).unwrap_or(0);
+                            line_remainder.clear();
+                            logger.log("CODEX_FILE", &session_id,
+                                &format!("bound to {} at offset {}", found.display(), file_offset));
+                            current_file = Some(found);
+                        }
+                        current_file_mtime = current_file.as_ref()
+                            .and_then(|p| std::fs::metadata(p).ok())
+                            .and_then(|m| m.modified().ok());
+                    } else if !search_warned {
+                        logger.log("CODEX_WAIT", &session_id,
+                            "no rollout matching cwd found yet");
+                        search_warned = true;
+                    }
+                }
+
+                if let Some(ref path) = current_file {
+                    match read_new_lines(path, &mut file_offset, &mut line_remainder) {
+                        Ok(new_lines) => {
+                            for line in new_lines {
+                                if let Some(text) = extract_agent_message(&line) {
+                                    logger.log("CODEX_EXTRACT", &session_id, &text);
+                                    buffer.push_str(&text);
+                                    buffer.push('\n');
+                                    last_buffer_add = Instant::now();
+                                }
+                            }
+                            current_file_mtime = std::fs::metadata(path).ok()
+                                .and_then(|m| m.modified().ok());
+                        }
+                        Err(e) => {
+                            logger.log("CODEX_ERR", &session_id, &e.to_string());
+                            log::error!("[CODEX_ERR] Read error for session {}: {}", session_id, e);
+                            let _ = app.emit(
+                                "telegram_bridge_error",
+                                serde_json::json!({
+                                    "sessionId": session_id,
+                                    "error": format!("Codex JSONL read error: {}", e),
+                                }),
+                            );
+                        }
+                    }
+                }
+
+                if !buffer.is_empty() {
+                    let elapsed = last_buffer_add.elapsed();
+                    if elapsed >= flush_delay || buffer.len() > FLUSH_BYTES {
+                        flush_buffer(
+                            &mut buffer, &client, &token, chat_id,
+                            &session_id, &app, &mut logger, &mut diag,
+                            true,
+                        ).await;
+                    }
+                }
+            }
+        }
+    }
+
+    // Final poll + flush after cancel.
+    if let Some(ref path) = current_file {
+        if let Ok(new_lines) = read_new_lines(path, &mut file_offset, &mut line_remainder) {
+            for line in new_lines {
+                if let Some(text) = extract_agent_message(&line) {
+                    buffer.push_str(&text);
+                    buffer.push('\n');
+                }
+            }
+        }
+    }
+    if !buffer.is_empty() {
+        flush_buffer(
+            &mut buffer, &client, &token, chat_id,
+            &session_id, &app, &mut logger, &mut diag, true,
+        ).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    const SESSION_META_TEMPLATE: &str =
+        r#"{"timestamp":"{ts}","type":"session_meta","payload":{"id":"{id}","cwd":"{cwd}","timestamp":"{ts}"}}"#;
+
+    fn write_rollout(dir: &Path, name: &str, cwd: &str, ts: &str) -> PathBuf {
+        fs::create_dir_all(dir).unwrap();
+        let path = dir.join(name);
+        let line = SESSION_META_TEMPLATE
+            .replace("{ts}", ts)
+            .replace("{cwd}", cwd)
+            .replace("{id}", "test-uuid");
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "{}", line).unwrap();
+        path
+    }
+
+    // ── extract_agent_message ─────────────────────────────────────────────
+
+    #[test]
+    fn extract_agent_message_from_real_event() {
+        let line = r#"{"timestamp":"2026-05-19T05:00:00Z","type":"event_msg","payload":{"type":"agent_message","message":"  Hello from Codex.  ","phase":"commentary"}}"#;
+        assert_eq!(extract_agent_message(line), Some("Hello from Codex.".into()));
+    }
+
+    #[test]
+    fn extract_agent_message_skips_non_event_msg_types() {
+        for kind in ["session_meta", "turn_context", "task_started", "response_item", "token_count"] {
+            let line = format!(r#"{{"type":"{}","payload":{{}}}}"#, kind);
+            assert_eq!(extract_agent_message(&line), None, "kind={}", kind);
+        }
+    }
+
+    #[test]
+    fn extract_agent_message_skips_other_payload_types() {
+        for ptype in [
+            "reasoning",
+            "function_call",
+            "function_call_output",
+            "input_text",
+            "output_text",
+        ] {
+            let line = format!(
+                r#"{{"type":"event_msg","payload":{{"type":"{}","message":"x"}}}}"#,
+                ptype
+            );
+            assert_eq!(extract_agent_message(&line), None, "ptype={}", ptype);
+        }
+    }
+
+    #[test]
+    fn extract_agent_message_skips_empty_or_whitespace() {
+        for msg in ["", "   ", "\n", "\t  \t"] {
+            let line = format!(
+                r#"{{"type":"event_msg","payload":{{"type":"agent_message","message":"{}"}}}}"#,
+                msg.replace('\t', "\\t").replace('\n', "\\n")
+            );
+            assert_eq!(extract_agent_message(&line), None, "msg={:?}", msg);
+        }
+    }
+
+    #[test]
+    fn extract_agent_message_fast_path_rejects_unrelated_lines() {
+        // Line shouldn't even contain `"type":"event_msg"` substring.
+        assert_eq!(extract_agent_message(r#"{"type":"response_item"}"#), None);
+        assert_eq!(extract_agent_message("not json at all"), None);
+    }
+
+    #[test]
+    fn extract_agent_message_handles_phase_variants() {
+        let commentary = r#"{"type":"event_msg","payload":{"type":"agent_message","message":"a","phase":"commentary"}}"#;
+        let final_ = r#"{"type":"event_msg","payload":{"type":"agent_message","message":"b","phase":"final"}}"#;
+        assert_eq!(extract_agent_message(commentary), Some("a".into()));
+        assert_eq!(extract_agent_message(final_), Some("b".into()));
+    }
+
+    // ── find_session_file ─────────────────────────────────────────────────
+
+    fn day_dir(root: &Path, day: chrono::NaiveDate) -> PathBuf {
+        root.join(format!("{:04}", day.format("%Y")))
+            .join(format!("{:02}", day.format("%m")))
+            .join(format!("{:02}", day.format("%d")))
+    }
+
+    #[test]
+    fn find_session_file_matches_by_cwd_canonicalization() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let now = Utc::now();
+        let today = day_dir(root, now.date_naive());
+
+        let cwd_a = r"C:\Users\foo\bar";
+        let cwd_b = r"C:\Users\foo\baz";
+
+        let expected_a = write_rollout(
+            &today,
+            "rollout-a.jsonl",
+            &cwd_a.replace('\\', "\\\\"),
+            &now.to_rfc3339(),
+        );
+        let _b = write_rollout(
+            &today,
+            "rollout-b.jsonl",
+            &cwd_b.replace('\\', "\\\\"),
+            &now.to_rfc3339(),
+        );
+
+        let found = find_session_file(root, "c:\\users\\foo\\bar", now);
+        assert_eq!(found, Some(expected_a));
+    }
+
+    #[test]
+    fn find_session_file_matches_forward_slash_ac_input_against_backslash_codex_input() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let now = Utc::now();
+        let today = day_dir(root, now.date_naive());
+
+        // Codex writes backslashes in cwd; AC passes forward slashes.
+        let codex_cwd = r"C:\Users\foo\bar";
+        let ac_cwd = "C:/Users/foo/bar";
+
+        let expected = write_rollout(
+            &today,
+            "rollout-fwd.jsonl",
+            &codex_cwd.replace('\\', "\\\\"),
+            &now.to_rfc3339(),
+        );
+
+        let found = find_session_file(root, ac_cwd, now);
+        assert_eq!(found, Some(expected));
+    }
+
+    #[test]
+    fn find_session_file_picks_newest_timestamp_when_multiple_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let now = Utc::now();
+        let today = day_dir(root, now.date_naive());
+
+        let cwd = r"C:\Users\foo\bar";
+        let ts_old = (now - chrono::Duration::seconds(60)).to_rfc3339();
+        let ts_new = (now - chrono::Duration::seconds(10)).to_rfc3339();
+
+        let _old = write_rollout(
+            &today,
+            "rollout-old.jsonl",
+            &cwd.replace('\\', "\\\\"),
+            &ts_old,
+        );
+        let expected_new = write_rollout(
+            &today,
+            "rollout-new.jsonl",
+            &cwd.replace('\\', "\\\\"),
+            &ts_new,
+        );
+
+        let found = find_session_file(root, "c:\\users\\foo\\bar", now);
+        assert_eq!(found, Some(expected_new));
+    }
+
+    #[test]
+    fn find_session_file_accepts_fresh_mtime_files() {
+        // A file created "now" must NOT be skipped by the mtime grace window.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let now = Utc::now();
+        let today = day_dir(root, now.date_naive());
+
+        let cwd = r"C:\Users\foo\bar";
+        let expected = write_rollout(
+            &today,
+            "rollout-fresh.jsonl",
+            &cwd.replace('\\', "\\\\"),
+            &now.to_rfc3339(),
+        );
+        let found = find_session_file(root, "c:\\users\\foo\\bar", now);
+        assert_eq!(found, Some(expected));
+    }
+
+    #[test]
+    fn find_session_file_skips_files_without_rollout_prefix() {
+        // Files whose name doesn't match `rollout-*.jsonl` must be ignored
+        // (defensive against stray files in the partition).
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let now = Utc::now();
+        let today = day_dir(root, now.date_naive());
+
+        let cwd = r"C:\Users\foo\bar";
+        // No `rollout-` prefix.
+        let _stray = write_rollout(
+            &today,
+            "session.jsonl",
+            &cwd.replace('\\', "\\\\"),
+            &now.to_rfc3339(),
+        );
+        let found = find_session_file(root, "c:\\users\\foo\\bar", now);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn find_session_file_returns_none_when_no_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let now = Utc::now();
+        let today = day_dir(root, now.date_naive());
+
+        let other = r"C:\Other\Path";
+        let _file = write_rollout(
+            &today,
+            "rollout.jsonl",
+            &other.replace('\\', "\\\\"),
+            &now.to_rfc3339(),
+        );
+
+        let found = find_session_file(root, "c:\\users\\foo\\bar", now);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn find_session_file_handles_missing_date_partition() {
+        // Empty root — no partitions at all. Function returns None without panic.
+        let tmp = tempfile::tempdir().unwrap();
+        let now = Utc::now();
+        let found = find_session_file(tmp.path(), "c:\\users\\foo\\bar", now);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn find_session_file_skips_unparseable_first_line() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let now = Utc::now();
+        let today = day_dir(root, now.date_naive());
+        fs::create_dir_all(&today).unwrap();
+
+        let bad = today.join("rollout-bad.jsonl");
+        let mut f = fs::File::create(&bad).unwrap();
+        writeln!(f, "{{ this is not valid JSON").unwrap();
+
+        let found = find_session_file(root, "c:\\users\\foo\\bar", now);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn find_session_file_walks_past_seven_days() {
+        // M6: the day-walk covers today + last 7 UTC days. A file 4 days
+        // ago should be found.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let now = Utc::now();
+        let four_days_ago = now - chrono::Duration::days(4);
+        let dir = day_dir(root, four_days_ago.date_naive());
+
+        let cwd = r"C:\Users\foo\bar";
+        // The mtime of the freshly-written file will be now (well within the
+        // 5 min mtime grace), simulating an APPEND on a resumed session.
+        let expected = write_rollout(
+            &dir,
+            "rollout-old-session.jsonl",
+            &cwd.replace('\\', "\\\\"),
+            &four_days_ago.to_rfc3339(),
+        );
+
+        let found = find_session_file(root, "c:\\users\\foo\\bar", now);
+        assert_eq!(found, Some(expected));
+    }
+}

--- a/src-tauri/src/telegram/codex_watcher.rs
+++ b/src-tauri/src/telegram/codex_watcher.rs
@@ -16,7 +16,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::commands::codex_resolver::canonicalize_cwd_for_codex;
 use crate::telegram::bridge::{flush_buffer, BridgeLogger, DiagLogger};
-use crate::telegram::jsonl_kernel::{read_new_lines, POLL_INTERVAL_MS, ROTATION_STALE_SECS};
+use crate::telegram::jsonl_kernel::{
+    read_new_lines, read_preamble_for_race, POLL_INTERVAL_MS, ROTATION_STALE_SECS,
+};
 
 /// Buffer thresholds tuned for Codex's commentary cadence.
 /// `event_msg + agent_message` events average 200-400 B and arrive 3-8 per
@@ -57,6 +59,17 @@ pub fn spawn_watch_task(
         .await;
         log::info!("[CODEX_EXIT] Watcher task ended for session {}", session_id);
     })
+}
+
+/// Extractor for `read_preamble_for_race`: pairs each emitted body with the
+/// line's top-level `timestamp` field so the kernel can apply its grace-window
+/// filter.
+fn codex_preamble_extractor(line: &str) -> Option<(DateTime<Utc>, String)> {
+    let body = extract_agent_message(line)?;
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    let ts_str = v.get("timestamp")?.as_str()?;
+    let ts = DateTime::parse_from_rfc3339(ts_str).ok()?.with_timezone(&Utc);
+    Some((ts, body))
 }
 
 /// Parse a single Codex rollout JSONL line and extract the `agent_message`
@@ -247,13 +260,37 @@ async fn watch_loop(
                 if need_rescan {
                     if let Some(found) = find_session_file(&search_root, &expected_cwd, attach_time) {
                         if Some(&found) != current_file.as_ref() {
-                            // First bind OR rotation. Initialize offset to current
-                            // file_len so we don't replay existing content (§J
-                            // preamble scan will land in commit 5 and supersede this).
-                            file_offset = std::fs::metadata(&found).ok().map(|m| m.len()).unwrap_or(0);
+                            // First bind OR rotation. On first bind, run the §J
+                            // preamble scan to emit any agent_message from the file's
+                            // tail with timestamp >= attach_time - 5s. Then set
+                            // offset = file_len.
+                            let first_bind = current_file.is_none();
                             line_remainder.clear();
-                            logger.log("CODEX_FILE", &session_id,
-                                &format!("bound to {} at offset {}", found.display(), file_offset));
+                            if first_bind {
+                                match read_preamble_for_race(&found, attach_time, codex_preamble_extractor) {
+                                    Ok((bodies, file_len)) => {
+                                        for text in bodies {
+                                            logger.log("CODEX_PREAMBLE", &session_id, &text);
+                                            buffer.push_str(&text);
+                                            buffer.push('\n');
+                                            last_buffer_add = Instant::now();
+                                        }
+                                        file_offset = file_len;
+                                        logger.log("CODEX_FILE", &session_id,
+                                            &format!("bound to {}, preamble done, offset={}", found.display(), file_offset));
+                                    }
+                                    Err(e) => {
+                                        logger.log("CODEX_ERR", &session_id,
+                                            &format!("preamble scan failed: {}", e));
+                                        file_offset = std::fs::metadata(&found).ok().map(|m| m.len()).unwrap_or(0);
+                                    }
+                                }
+                            } else {
+                                // Rotation. Re-anchor at the new file's current EOF.
+                                file_offset = std::fs::metadata(&found).ok().map(|m| m.len()).unwrap_or(0);
+                                logger.log("CODEX_ROTATE", &session_id,
+                                    &format!("rotated to {}, offset={}", found.display(), file_offset));
+                            }
                             current_file = Some(found);
                         }
                         current_file_mtime = current_file.as_ref()

--- a/src-tauri/src/telegram/gemini_watcher.rs
+++ b/src-tauri/src/telegram/gemini_watcher.rs
@@ -133,12 +133,17 @@ fn seed_emitted_ids_from_preamble(
                 Ok(v) => v,
                 Err(_) => continue,
             };
+            // Match gemini_preamble_extractor exactly: a line is "emitted" by
+            // the kernel iff it has a parseable timestamp >= cutoff. A line
+            // without a timestamp is dropped by the extractor, so we MUST NOT
+            // pre-mark its id as emitted here — doing so would suppress the
+            // same id when it (re)appears in future polls with a valid stamp.
             let ts_ok = v
                 .get("timestamp")
                 .and_then(|t| t.as_str())
                 .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
                 .map(|t| t.with_timezone(&Utc) >= cutoff)
-                .unwrap_or(true); // unknown timestamp → treat as recent
+                .unwrap_or(false);
             if ts_ok {
                 emitted_ids.insert(id);
             }
@@ -223,6 +228,7 @@ async fn watch_loop(
     let mut chats_dir: Option<PathBuf> = None;
     let mut current_file: Option<PathBuf> = None;
     let mut current_file_mtime: Option<SystemTime> = None;
+    let mut last_mtime_advance: Instant = Instant::now();
     let mut file_offset: u64 = 0;
     let mut line_remainder = String::new();
     let mut emitted_ids: HashSet<String> = HashSet::new();
@@ -308,15 +314,14 @@ async fn watch_loop(
                 }
 
                 // Step 4: Kernel A discovery — pick newest session-*.jsonl by mtime.
-                let need_rescan = match (&current_file, &current_file_mtime) {
-                    (None, _) => true,
-                    (Some(p), _) if !p.exists() => true,
-                    (Some(_), Some(mtime)) => {
-                        mtime.elapsed()
-                            .map(|d| d.as_secs() >= ROTATION_STALE_SECS)
-                            .unwrap_or(false)
-                    }
-                    _ => false,
+                // M5: rescan only when we don't have a current file, the file
+                // was unlinked, or its mtime has not advanced for
+                // ROTATION_STALE_SECS wall-clock seconds. `last_mtime_advance`
+                // is updated below whenever we observe the file's mtime grow.
+                let need_rescan = match &current_file {
+                    None => true,
+                    Some(p) if !p.exists() => true,
+                    Some(_) => last_mtime_advance.elapsed().as_secs() >= ROTATION_STALE_SECS,
                 };
 
                 if need_rescan {
@@ -363,9 +368,13 @@ async fn watch_loop(
                             }
                             current_file = Some(found);
                         }
-                        current_file_mtime = current_file.as_ref()
+                        let new_mtime = current_file.as_ref()
                             .and_then(|p| std::fs::metadata(p).ok())
                             .and_then(|m| m.modified().ok());
+                        if new_mtime != current_file_mtime {
+                            last_mtime_advance = Instant::now();
+                        }
+                        current_file_mtime = new_mtime;
                     }
                 }
 
@@ -382,8 +391,12 @@ async fn watch_loop(
                                     }
                                 }
                             }
-                            current_file_mtime = std::fs::metadata(path).ok()
+                            let new_mtime = std::fs::metadata(path).ok()
                                 .and_then(|m| m.modified().ok());
+                            if new_mtime != current_file_mtime {
+                                last_mtime_advance = Instant::now();
+                            }
+                            current_file_mtime = new_mtime;
                         }
                         Err(e) => {
                             logger.log("GEMINI_ERR", &session_id, &e.to_string());

--- a/src-tauri/src/telegram/gemini_watcher.rs
+++ b/src-tauri/src/telegram/gemini_watcher.rs
@@ -502,7 +502,9 @@ mod tests {
 
         let a = chats.join("session-2026-05-01T00-00-aaaaaaaa.jsonl");
         fs::write(&a, b"{}").unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        // Windows NTFS mtime resolution can be as coarse as 100 ms; sleep
+        // long enough that the two files definitely have distinct mtimes.
+        std::thread::sleep(std::time::Duration::from_millis(150));
         let b = chats.join("session-2026-05-02T00-00-bbbbbbbb.jsonl");
         fs::write(&b, b"{}").unwrap();
 

--- a/src-tauri/src/telegram/gemini_watcher.rs
+++ b/src-tauri/src/telegram/gemini_watcher.rs
@@ -1,0 +1,551 @@
+// Gemini CLI session-file watcher.
+//
+// P1 pivot: Telegram bridging targets new Gemini sessions only — the legacy
+// `.json` (full-rewrite) format is out-of-scope; users on
+// `@google/gemini-cli < 0.42.0` see a one-time `telegram_bridge_warning`.
+// New Gemini sessions write append-only `session-*.jsonl` via `appendFileSync`
+// (verified against `@google/gemini-cli@0.42.0` bundle line 248711), so this
+// watcher reuses Kernel A (offset-based) just like Claude and Codex.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use chrono::{DateTime, Utc};
+use tauri::Emitter;
+use tokio::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+
+use crate::commands::gemini_resolver::lookup_chats_dir_for_cwd;
+use crate::telegram::bridge::{flush_buffer, BridgeLogger, DiagLogger};
+use crate::telegram::jsonl_kernel::{read_new_lines, POLL_INTERVAL_MS, ROTATION_STALE_SECS};
+
+/// Buffer thresholds tuned for Gemini's whole-turn-at-once cadence.
+const FLUSH_DELAY_MS: u64 = 250;
+const FLUSH_BYTES: usize = 1000;
+
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_watch_task(
+    gemini_home: PathBuf,
+    cwd: String,
+    attach_time: DateTime<Utc>,
+    bot_token: String,
+    chat_id: i64,
+    session_id: String,
+    cancel: CancellationToken,
+    app: tauri::AppHandle,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        watch_loop(
+            gemini_home,
+            cwd,
+            attach_time,
+            bot_token,
+            chat_id,
+            session_id.clone(),
+            cancel,
+            app.clone(),
+        )
+        .await;
+        log::info!(
+            "[GEMINI_EXIT] Watcher task ended for session {}",
+            session_id
+        );
+    })
+}
+
+/// Parse a Gemini `.jsonl` line and extract `(id, content)` for `type:"gemini"`
+/// records with non-empty string content. Returns `None` for any other record
+/// kind (session header, `$set`, `$rewindTo`, `type:"user"`, `type:"info"`,
+/// etc.) and for empty/whitespace-only content (in-progress turns that have
+/// only `thoughts[]` so far).
+fn extract_gemini_message(line: &str) -> Option<(String, String)> {
+    // Fast-path: skip lines that can't be a "gemini" type record.
+    if !line.contains("\"type\":\"gemini\"") && !line.contains("\"type\": \"gemini\"") {
+        return None;
+    }
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    if v.get("type")?.as_str()? != "gemini" {
+        return None;
+    }
+    let id = v.get("id")?.as_str()?.to_string();
+    let content = v.get("content")?.as_str()?.trim();
+    if content.is_empty() {
+        return None;
+    }
+    Some((id, content.to_string()))
+}
+
+/// Non-recursive scan of `chats_dir`: returns the newest file whose name
+/// starts with `session-` and ends with `.jsonl`. Subagent files live at
+/// `chats/<parentId>/<sessionId>.jsonl` (different naming and a different
+/// depth), so they're excluded by both the prefix filter and the
+/// non-recursive walk.
+fn find_newest_session_jsonl(chats_dir: &Path) -> Option<PathBuf> {
+    let read = std::fs::read_dir(chats_dir).ok()?;
+    let mut best: Option<(PathBuf, SystemTime)> = None;
+    for entry in read.flatten() {
+        let path = entry.path();
+        let fname = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if !fname.starts_with("session-") || !fname.ends_with(".jsonl") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(mtime) = meta.modified() {
+                match &best {
+                    Some((_, best_t)) if mtime > *best_t => best = Some((path, mtime)),
+                    None => best = Some((path, mtime)),
+                    _ => {}
+                }
+            }
+        }
+    }
+    best.map(|(p, _)| p)
+}
+
+/// Returns true if `chats_dir` contains any file matching the given extension.
+fn dir_has_extension(chats_dir: &Path, ext_without_dot: &str) -> bool {
+    let Ok(read) = std::fs::read_dir(chats_dir) else {
+        return false;
+    };
+    for entry in read.flatten() {
+        let path = entry.path();
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if !name.starts_with("session-") {
+            continue;
+        }
+        let extension = path.extension().and_then(|e| e.to_str());
+        if extension == Some(ext_without_dot) {
+            return true;
+        }
+    }
+    false
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn watch_loop(
+    gemini_home: PathBuf,
+    cwd: String,
+    _attach_time: DateTime<Utc>,
+    token: String,
+    chat_id: i64,
+    session_id: String,
+    cancel: CancellationToken,
+    app: tauri::AppHandle,
+) {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap_or_default();
+
+    let mut logger = BridgeLogger::new(&session_id);
+    let mut diag = DiagLogger::new();
+    let mut buffer = String::new();
+    let mut last_buffer_add = Instant::now();
+    let flush_delay = Duration::from_millis(FLUSH_DELAY_MS);
+
+    let mut chats_dir: Option<PathBuf> = None;
+    let mut current_file: Option<PathBuf> = None;
+    let mut current_file_mtime: Option<SystemTime> = None;
+    let mut file_offset: u64 = 0;
+    let mut line_remainder = String::new();
+    let mut emitted_ids: HashSet<String> = HashSet::new();
+    let mut chats_dir_warned = false;
+    let mut chats_empty_warned = false;
+    let mut legacy_json_warned = false;
+
+    logger.log(
+        "GEMINI_INIT",
+        &session_id,
+        &format!("gemini_home={} cwd={}", gemini_home.display(), cwd),
+    );
+
+    let mut poll_interval = tokio::time::interval(Duration::from_millis(POLL_INTERVAL_MS));
+    poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            _ = poll_interval.tick() => {
+                // Step 1 (H1): resolve chats_dir lazily until projects.json has the cwd.
+                if chats_dir.is_none() {
+                    match lookup_chats_dir_for_cwd(&gemini_home, &cwd) {
+                        Some(cd) => {
+                            logger.log("GEMINI_DIR", &session_id,
+                                &format!("resolved chats_dir={}", cd.display()));
+                            chats_dir = Some(cd);
+                        }
+                        None => {
+                            if !chats_dir_warned {
+                                logger.log("GEMINI_WAIT_PROJECTS", &session_id,
+                                    "cwd not yet in projects.json");
+                                let _ = app.emit(
+                                    "telegram_bridge_warning",
+                                    serde_json::json!({
+                                        "sessionId": session_id,
+                                        "warning": "Gemini has not yet recorded this working directory. Telegram will start delivering messages once Gemini finishes its startup phase and writes projects.json.",
+                                    }),
+                                );
+                                chats_dir_warned = true;
+                            }
+                            continue;
+                        }
+                    }
+                }
+                let chats_dir_ref = chats_dir.as_ref().expect("chats_dir bound above");
+
+                // Step 2: chats_dir resolved but the directory may not exist on disk yet.
+                if !chats_dir_ref.is_dir() {
+                    if !chats_empty_warned {
+                        logger.log("GEMINI_WAIT_CHATS", &session_id,
+                            "chats dir does not exist yet");
+                        let _ = app.emit(
+                            "telegram_bridge_warning",
+                            serde_json::json!({
+                                "sessionId": session_id,
+                                "warning": "Gemini's chats directory does not exist yet. Telegram will start delivering messages once Gemini writes its first session file.",
+                            }),
+                        );
+                        chats_empty_warned = true;
+                    }
+                    continue;
+                }
+
+                // Step 3 (H3): warn once if only legacy .json files are present.
+                let has_jsonl = dir_has_extension(chats_dir_ref, "jsonl");
+                let has_json = dir_has_extension(chats_dir_ref, "json");
+                if !has_jsonl && has_json && !legacy_json_warned {
+                    logger.log("GEMINI_LEGACY_JSON", &session_id,
+                        ".json only, no .jsonl (upgrade gemini-cli)");
+                    let _ = app.emit(
+                        "telegram_bridge_warning",
+                        serde_json::json!({
+                            "sessionId": session_id,
+                            "warning": "Gemini is writing the legacy .json session format. Upgrade @google/gemini-cli to >= 0.42.0 for Telegram bridging support.",
+                        }),
+                    );
+                    legacy_json_warned = true;
+                    continue;
+                }
+                if !has_jsonl {
+                    continue;
+                }
+
+                // Step 4: Kernel A discovery — pick newest session-*.jsonl by mtime.
+                let need_rescan = match (&current_file, &current_file_mtime) {
+                    (None, _) => true,
+                    (Some(p), _) if !p.exists() => true,
+                    (Some(_), Some(mtime)) => {
+                        mtime.elapsed()
+                            .map(|d| d.as_secs() >= ROTATION_STALE_SECS)
+                            .unwrap_or(false)
+                    }
+                    _ => false,
+                };
+
+                if need_rescan {
+                    if let Some(found) = find_newest_session_jsonl(chats_dir_ref) {
+                        if Some(&found) != current_file.as_ref() {
+                            // Bind to the newest file. On rotation (mid-session /new),
+                            // clear emitted_ids so the new file's ids don't collide.
+                            file_offset = std::fs::metadata(&found).ok().map(|m| m.len()).unwrap_or(0);
+                            line_remainder.clear();
+                            if current_file.is_some() {
+                                emitted_ids.clear();
+                                logger.log("GEMINI_ROTATE", &session_id,
+                                    &format!("rotated to {}", found.display()));
+                            } else {
+                                logger.log("GEMINI_FILE", &session_id,
+                                    &format!("bound to {} at offset {}", found.display(), file_offset));
+                            }
+                            current_file = Some(found);
+                        }
+                        current_file_mtime = current_file.as_ref()
+                            .and_then(|p| std::fs::metadata(p).ok())
+                            .and_then(|m| m.modified().ok());
+                    }
+                }
+
+                if let Some(ref path) = current_file {
+                    match read_new_lines(path, &mut file_offset, &mut line_remainder) {
+                        Ok(new_lines) => {
+                            for line in new_lines {
+                                if let Some((id, content)) = extract_gemini_message(&line) {
+                                    if emitted_ids.insert(id) {
+                                        logger.log("GEMINI_EXTRACT", &session_id, &content);
+                                        buffer.push_str(&content);
+                                        buffer.push('\n');
+                                        last_buffer_add = Instant::now();
+                                    }
+                                }
+                            }
+                            current_file_mtime = std::fs::metadata(path).ok()
+                                .and_then(|m| m.modified().ok());
+                        }
+                        Err(e) => {
+                            logger.log("GEMINI_ERR", &session_id, &e.to_string());
+                            log::error!("[GEMINI_ERR] Read error for session {}: {}", session_id, e);
+                            let _ = app.emit(
+                                "telegram_bridge_error",
+                                serde_json::json!({
+                                    "sessionId": session_id,
+                                    "error": format!("Gemini JSONL read error: {}", e),
+                                }),
+                            );
+                        }
+                    }
+                }
+
+                if !buffer.is_empty() {
+                    let elapsed = last_buffer_add.elapsed();
+                    if elapsed >= flush_delay || buffer.len() > FLUSH_BYTES {
+                        flush_buffer(
+                            &mut buffer, &client, &token, chat_id,
+                            &session_id, &app, &mut logger, &mut diag,
+                            true,
+                        ).await;
+                    }
+                }
+            }
+        }
+    }
+
+    // Final poll + flush after cancel.
+    if let Some(ref path) = current_file {
+        if let Ok(new_lines) = read_new_lines(path, &mut file_offset, &mut line_remainder) {
+            for line in new_lines {
+                if let Some((id, content)) = extract_gemini_message(&line) {
+                    if emitted_ids.insert(id) {
+                        buffer.push_str(&content);
+                        buffer.push('\n');
+                    }
+                }
+            }
+        }
+    }
+    if !buffer.is_empty() {
+        flush_buffer(
+            &mut buffer, &client, &token, chat_id,
+            &session_id, &app, &mut logger, &mut diag, true,
+        ).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    // ── extract_gemini_message ────────────────────────────────────────────
+
+    #[test]
+    fn extract_gemini_message_returns_id_and_content() {
+        let line = r#"{"type":"gemini","id":"abc","content":"Hello","thoughts":[]}"#;
+        assert_eq!(
+            extract_gemini_message(line),
+            Some(("abc".into(), "Hello".into()))
+        );
+    }
+
+    #[test]
+    fn extract_gemini_message_skips_empty_content() {
+        let line = r#"{"type":"gemini","id":"abc","content":"","thoughts":[]}"#;
+        assert_eq!(extract_gemini_message(line), None);
+    }
+
+    #[test]
+    fn extract_gemini_message_skips_whitespace_only_content() {
+        let line = r#"{"type":"gemini","id":"abc","content":"   ","thoughts":[]}"#;
+        assert_eq!(extract_gemini_message(line), None);
+    }
+
+    #[test]
+    fn extract_gemini_message_skips_user_records() {
+        let line = r#"{"type":"user","id":"u1","content":[{"text":"hi"}]}"#;
+        assert_eq!(extract_gemini_message(line), None);
+    }
+
+    #[test]
+    fn extract_gemini_message_skips_set_record() {
+        let line = r#"{"$set":{"updatedAt":"2026-05-19T00:00:00Z"}}"#;
+        assert_eq!(extract_gemini_message(line), None);
+    }
+
+    #[test]
+    fn extract_gemini_message_skips_rewind_record() {
+        let line = r#"{"$rewindTo":"abc","timestamp":"2026-05-19T00:00:00Z"}"#;
+        assert_eq!(extract_gemini_message(line), None);
+    }
+
+    #[test]
+    fn extract_gemini_message_skips_session_header() {
+        let line = r#"{"sessionId":"abc","projectHash":"deadbeef","startTime":"2026-05-19T00:00:00Z","kind":"main"}"#;
+        assert_eq!(extract_gemini_message(line), None);
+    }
+
+    #[test]
+    fn extract_gemini_message_skips_info_record() {
+        let line = r#"{"type":"info","content":"some info"}"#;
+        assert_eq!(extract_gemini_message(line), None);
+    }
+
+    // ── find_newest_session_jsonl ─────────────────────────────────────────
+
+    #[test]
+    fn find_newest_session_jsonl_picks_latest_mtime() {
+        let tmp = tempfile::tempdir().unwrap();
+        let chats = tmp.path();
+
+        let a = chats.join("session-2026-05-01T00-00-aaaaaaaa.jsonl");
+        fs::write(&a, b"{}").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let b = chats.join("session-2026-05-02T00-00-bbbbbbbb.jsonl");
+        fs::write(&b, b"{}").unwrap();
+
+        let found = find_newest_session_jsonl(chats);
+        assert_eq!(found, Some(b));
+    }
+
+    #[test]
+    fn find_newest_session_jsonl_skips_subagent_files() {
+        // Subagent files live one level deeper under <parentId>/<sessionId>.jsonl.
+        // The non-recursive scan must not descend.
+        let tmp = tempfile::tempdir().unwrap();
+        let chats = tmp.path();
+
+        let main = chats.join("session-2026-05-02T00-00-main.jsonl");
+        fs::write(&main, b"{}").unwrap();
+
+        let subdir = chats.join("parent-uuid");
+        fs::create_dir_all(&subdir).unwrap();
+        let sub = subdir.join("sub-uuid.jsonl");
+        fs::write(&sub, b"{}").unwrap();
+
+        let found = find_newest_session_jsonl(chats);
+        assert_eq!(found, Some(main));
+    }
+
+    #[test]
+    fn find_newest_session_jsonl_skips_non_session_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let chats = tmp.path();
+        fs::write(chats.join("not-a-session.jsonl"), b"{}").unwrap();
+        fs::write(chats.join("session-2026-05-02T00-00-x.json"), b"{}").unwrap(); // .json not .jsonl
+        let found = find_newest_session_jsonl(chats);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn find_newest_session_jsonl_returns_none_when_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let found = find_newest_session_jsonl(tmp.path());
+        assert!(found.is_none());
+    }
+
+    // ── dir_has_extension ─────────────────────────────────────────────────
+
+    #[test]
+    fn dir_has_extension_distinguishes_json_and_jsonl() {
+        let tmp = tempfile::tempdir().unwrap();
+        let chats = tmp.path();
+        fs::write(chats.join("session-old.json"), b"{}").unwrap();
+        assert!(dir_has_extension(chats, "json"));
+        assert!(!dir_has_extension(chats, "jsonl"));
+
+        fs::write(chats.join("session-new.jsonl"), b"{}").unwrap();
+        assert!(dir_has_extension(chats, "jsonl"));
+    }
+
+    #[test]
+    fn dir_has_extension_ignores_non_session_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let chats = tmp.path();
+        // A `.jsonl` file but NOT a session file shouldn't count.
+        fs::write(chats.join("something.jsonl"), b"{}").unwrap();
+        assert!(!dir_has_extension(chats, "jsonl"));
+    }
+
+    // ── dedup behavior (integration-ish via direct buffer/HashSet) ────────
+
+    #[test]
+    fn dedup_set_emits_each_id_once_across_reappends() {
+        let mut emitted: HashSet<String> = HashSet::new();
+        let mut out: Vec<String> = Vec::new();
+
+        // First emit: non-empty content, new id.
+        let l1 = r#"{"type":"gemini","id":"a","content":"first"}"#;
+        if let Some((id, c)) = extract_gemini_message(l1) {
+            if emitted.insert(id) {
+                out.push(c);
+            }
+        }
+        // Re-append with same id, same content — skip.
+        if let Some((id, c)) = extract_gemini_message(l1) {
+            if emitted.insert(id) {
+                out.push(c);
+            }
+        }
+        // In-progress empty-content pattern — never emits anyway.
+        let l2 = r#"{"type":"gemini","id":"b","content":"","thoughts":[]}"#;
+        if let Some((id, c)) = extract_gemini_message(l2) {
+            if emitted.insert(id) {
+                out.push(c);
+            }
+        }
+        // Non-empty content for new id — emits once.
+        let l3 = r#"{"type":"gemini","id":"c","content":"new"}"#;
+        if let Some((id, c)) = extract_gemini_message(l3) {
+            if emitted.insert(id) {
+                out.push(c);
+            }
+        }
+
+        assert_eq!(out, vec!["first".to_string(), "new".to_string()]);
+    }
+
+    // ── multi-line file integration via read_new_lines + extractor ────────
+
+    #[test]
+    fn extracts_only_non_empty_gemini_messages_from_real_fixture() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session-2026-05-19T00-00-fixture.jsonl");
+        let mut f = fs::File::create(&path).unwrap();
+        // Session header (no `type`).
+        writeln!(f, r#"{{"sessionId":"abc","projectHash":"x","startTime":"2026-05-19T00:00:00Z","kind":"main"}}"#).unwrap();
+        // user message.
+        writeln!(f, r#"{{"id":"u1","timestamp":"2026-05-19T00:00:01Z","type":"user","content":[{{"text":"hi"}}]}}"#).unwrap();
+        // $set metadata record.
+        writeln!(f, r#"{{"$set":{{"lastUpdated":"2026-05-19T00:00:02Z"}}}}"#).unwrap();
+        // gemini in-progress (empty content, thoughts only).
+        writeln!(f, r#"{{"id":"g1","timestamp":"2026-05-19T00:00:03Z","type":"gemini","content":"","thoughts":[{{"subject":"x"}}]}}"#).unwrap();
+        // gemini final.
+        writeln!(f, r#"{{"id":"g1","timestamp":"2026-05-19T00:00:04Z","type":"gemini","content":"Hello world"}}"#).unwrap();
+        // gemini re-appended (same id) — must be deduped.
+        writeln!(f, r#"{{"id":"g1","timestamp":"2026-05-19T00:00:05Z","type":"gemini","content":"Hello world"}}"#).unwrap();
+        // $rewindTo record.
+        writeln!(f, r#"{{"$rewindTo":"g1","timestamp":"2026-05-19T00:00:06Z"}}"#).unwrap();
+        drop(f);
+
+        let mut offset: u64 = 0;
+        let mut remainder = String::new();
+        let lines = read_new_lines(&path, &mut offset, &mut remainder).unwrap();
+
+        let mut emitted: HashSet<String> = HashSet::new();
+        let mut out: Vec<String> = Vec::new();
+        for line in lines {
+            if let Some((id, c)) = extract_gemini_message(&line) {
+                if emitted.insert(id) {
+                    out.push(c);
+                }
+            }
+        }
+        assert_eq!(out, vec!["Hello world".to_string()]);
+    }
+}

--- a/src-tauri/src/telegram/gemini_watcher.rs
+++ b/src-tauri/src/telegram/gemini_watcher.rs
@@ -18,7 +18,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::commands::gemini_resolver::lookup_chats_dir_for_cwd;
 use crate::telegram::bridge::{flush_buffer, BridgeLogger, DiagLogger};
-use crate::telegram::jsonl_kernel::{read_new_lines, POLL_INTERVAL_MS, ROTATION_STALE_SECS};
+use crate::telegram::jsonl_kernel::{
+    read_new_lines, read_preamble_for_race, POLL_INTERVAL_MS, ROTATION_STALE_SECS,
+};
 
 /// Buffer thresholds tuned for Gemini's whole-turn-at-once cadence.
 const FLUSH_DELAY_MS: u64 = 250;
@@ -54,6 +56,18 @@ pub fn spawn_watch_task(
     })
 }
 
+/// Extractor for `read_preamble_for_race`: pairs each emitted body with the
+/// line's `timestamp` field so the kernel can apply its grace-window filter.
+/// The kernel sees only the BODY; dedup against `emitted_ids` happens at the
+/// call site post-preamble.
+fn gemini_preamble_extractor(line: &str) -> Option<(DateTime<Utc>, String)> {
+    let (_id, body) = extract_gemini_message(line)?;
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    let ts_str = v.get("timestamp")?.as_str()?;
+    let ts = DateTime::parse_from_rfc3339(ts_str).ok()?.with_timezone(&Utc);
+    Some((ts, body))
+}
+
 /// Parse a Gemini `.jsonl` line and extract `(id, content)` for `type:"gemini"`
 /// records with non-empty string content. Returns `None` for any other record
 /// kind (session header, `$set`, `$rewindTo`, `type:"user"`, `type:"info"`,
@@ -74,6 +88,62 @@ fn extract_gemini_message(line: &str) -> Option<(String, String)> {
         return None;
     }
     Some((id, content.to_string()))
+}
+
+/// Walk the same preamble window the §J scan reads, parse every
+/// `type:"gemini"` line's `id`, and insert into `emitted_ids` so subsequent
+/// `read_new_lines` calls treat already-emitted ids as duplicates. Errors are
+/// swallowed (the watcher still polls forward; worst case a duplicate emit).
+fn seed_emitted_ids_from_preamble(
+    path: &Path,
+    attach_time: DateTime<Utc>,
+    emitted_ids: &mut HashSet<String>,
+) {
+    use crate::telegram::jsonl_kernel::{PREAMBLE_MAX_BYTES, RACE_GRACE_SECS};
+    use std::io::{Read as IoRead, Seek, SeekFrom};
+
+    let Ok(len) = std::fs::metadata(path).map(|m| m.len()) else {
+        return;
+    };
+    let start = len.saturating_sub(PREAMBLE_MAX_BYTES);
+    let mut f = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+    if f.seek(SeekFrom::Start(start)).is_err() {
+        return;
+    }
+    let mut buf: Vec<u8> = Vec::with_capacity((len - start) as usize);
+    if f.read_to_end(&mut buf).is_err() {
+        return;
+    }
+    let bytes: &[u8] = if start == 0 {
+        &buf
+    } else {
+        match buf.iter().position(|&b| b == b'\n') {
+            Some(i) => &buf[i + 1..],
+            None => return,
+        }
+    };
+    let text = String::from_utf8_lossy(bytes);
+    let cutoff = attach_time - chrono::Duration::seconds(RACE_GRACE_SECS);
+    for line in text.lines() {
+        if let Some((id, _content)) = extract_gemini_message(line) {
+            let v: serde_json::Value = match serde_json::from_str(line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let ts_ok = v
+                .get("timestamp")
+                .and_then(|t| t.as_str())
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|t| t.with_timezone(&Utc) >= cutoff)
+                .unwrap_or(true); // unknown timestamp → treat as recent
+            if ts_ok {
+                emitted_ids.insert(id);
+            }
+        }
+    }
 }
 
 /// Non-recursive scan of `chats_dir`: returns the newest file whose name
@@ -132,7 +202,7 @@ fn dir_has_extension(chats_dir: &Path, ext_without_dot: &str) -> bool {
 async fn watch_loop(
     gemini_home: PathBuf,
     cwd: String,
-    _attach_time: DateTime<Utc>,
+    attach_time: DateTime<Utc>,
     token: String,
     chat_id: i64,
     session_id: String,
@@ -252,17 +322,44 @@ async fn watch_loop(
                 if need_rescan {
                     if let Some(found) = find_newest_session_jsonl(chats_dir_ref) {
                         if Some(&found) != current_file.as_ref() {
-                            // Bind to the newest file. On rotation (mid-session /new),
-                            // clear emitted_ids so the new file's ids don't collide.
-                            file_offset = std::fs::metadata(&found).ok().map(|m| m.len()).unwrap_or(0);
+                            let first_bind = current_file.is_none();
                             line_remainder.clear();
-                            if current_file.is_some() {
+                            if first_bind {
+                                // §J preamble scan on first bind. Re-emit recent
+                                // assistant lines from the file's tail (timestamp
+                                // >= attach_time - 5s). Dedup against emitted_ids:
+                                // each id is tracked here so subsequent reads
+                                // don't re-emit.
+                                match read_preamble_for_race(&found, attach_time, gemini_preamble_extractor) {
+                                    Ok((bodies, file_len)) => {
+                                        // The preamble extractor surfaced bodies WITHOUT ids,
+                                        // so we can't dedup THIS pass against future appends with
+                                        // the same id. To keep correctness, re-parse the preamble
+                                        // window's lines to grab ids and seed emitted_ids.
+                                        seed_emitted_ids_from_preamble(&found, attach_time, &mut emitted_ids);
+                                        for text in bodies {
+                                            logger.log("GEMINI_PREAMBLE", &session_id, &text);
+                                            buffer.push_str(&text);
+                                            buffer.push('\n');
+                                            last_buffer_add = Instant::now();
+                                        }
+                                        file_offset = file_len;
+                                        logger.log("GEMINI_FILE", &session_id,
+                                            &format!("bound to {}, preamble done, offset={}",
+                                                found.display(), file_offset));
+                                    }
+                                    Err(e) => {
+                                        logger.log("GEMINI_ERR", &session_id,
+                                            &format!("preamble scan failed: {}", e));
+                                        file_offset = std::fs::metadata(&found).ok().map(|m| m.len()).unwrap_or(0);
+                                    }
+                                }
+                            } else {
+                                // Rotation (mid-session /new). Clear dedup and re-anchor at EOF.
                                 emitted_ids.clear();
+                                file_offset = std::fs::metadata(&found).ok().map(|m| m.len()).unwrap_or(0);
                                 logger.log("GEMINI_ROTATE", &session_id,
                                     &format!("rotated to {}", found.display()));
-                            } else {
-                                logger.log("GEMINI_FILE", &session_id,
-                                    &format!("bound to {} at offset {}", found.display(), file_offset));
                             }
                             current_file = Some(found);
                         }

--- a/src-tauri/src/telegram/gemini_watcher.rs
+++ b/src-tauri/src/telegram/gemini_watcher.rs
@@ -56,16 +56,18 @@ pub fn spawn_watch_task(
     })
 }
 
-/// Extractor for `read_preamble_for_race`: pairs each emitted body with the
-/// line's `timestamp` field so the kernel can apply its grace-window filter.
-/// The kernel sees only the BODY; dedup against `emitted_ids` happens at the
-/// call site post-preamble.
-fn gemini_preamble_extractor(line: &str) -> Option<(DateTime<Utc>, String)> {
-    let (_id, body) = extract_gemini_message(line)?;
+/// Extractor for `read_preamble_for_race`: returns
+/// `(timestamp, Some(id), body)` for each `type:"gemini"` line. The kernel
+/// returns the surfaced ids alongside the bodies in a single read, which the
+/// watcher uses to seed `emitted_ids` directly — closing the M1 TOCTOU where
+/// a separate seeder pass re-read the file and could mark a line's id as
+/// emitted whose body landed BETWEEN the two reads (silent permanent drop).
+fn gemini_preamble_extractor(line: &str) -> Option<(DateTime<Utc>, Option<String>, String)> {
+    let (id, body) = extract_gemini_message(line)?;
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
     let ts_str = v.get("timestamp")?.as_str()?;
     let ts = DateTime::parse_from_rfc3339(ts_str).ok()?.with_timezone(&Utc);
-    Some((ts, body))
+    Some((ts, Some(id), body))
 }
 
 /// Parse a Gemini `.jsonl` line and extract `(id, content)` for `type:"gemini"`
@@ -88,67 +90,6 @@ fn extract_gemini_message(line: &str) -> Option<(String, String)> {
         return None;
     }
     Some((id, content.to_string()))
-}
-
-/// Walk the same preamble window the §J scan reads, parse every
-/// `type:"gemini"` line's `id`, and insert into `emitted_ids` so subsequent
-/// `read_new_lines` calls treat already-emitted ids as duplicates. Errors are
-/// swallowed (the watcher still polls forward; worst case a duplicate emit).
-fn seed_emitted_ids_from_preamble(
-    path: &Path,
-    attach_time: DateTime<Utc>,
-    emitted_ids: &mut HashSet<String>,
-) {
-    use crate::telegram::jsonl_kernel::{PREAMBLE_MAX_BYTES, RACE_GRACE_SECS};
-    use std::io::{Read as IoRead, Seek, SeekFrom};
-
-    let Ok(len) = std::fs::metadata(path).map(|m| m.len()) else {
-        return;
-    };
-    let start = len.saturating_sub(PREAMBLE_MAX_BYTES);
-    let mut f = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return,
-    };
-    if f.seek(SeekFrom::Start(start)).is_err() {
-        return;
-    }
-    let mut buf: Vec<u8> = Vec::with_capacity((len - start) as usize);
-    if f.read_to_end(&mut buf).is_err() {
-        return;
-    }
-    let bytes: &[u8] = if start == 0 {
-        &buf
-    } else {
-        match buf.iter().position(|&b| b == b'\n') {
-            Some(i) => &buf[i + 1..],
-            None => return,
-        }
-    };
-    let text = String::from_utf8_lossy(bytes);
-    let cutoff = attach_time - chrono::Duration::seconds(RACE_GRACE_SECS);
-    for line in text.lines() {
-        if let Some((id, _content)) = extract_gemini_message(line) {
-            let v: serde_json::Value = match serde_json::from_str(line) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            // Match gemini_preamble_extractor exactly: a line is "emitted" by
-            // the kernel iff it has a parseable timestamp >= cutoff. A line
-            // without a timestamp is dropped by the extractor, so we MUST NOT
-            // pre-mark its id as emitted here — doing so would suppress the
-            // same id when it (re)appears in future polls with a valid stamp.
-            let ts_ok = v
-                .get("timestamp")
-                .and_then(|t| t.as_str())
-                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                .map(|t| t.with_timezone(&Utc) >= cutoff)
-                .unwrap_or(false);
-            if ts_ok {
-                emitted_ids.insert(id);
-            }
-        }
-    }
 }
 
 /// Non-recursive scan of `chats_dir`: returns the newest file whose name
@@ -332,16 +273,16 @@ async fn watch_loop(
                             if first_bind {
                                 // §J preamble scan on first bind. Re-emit recent
                                 // assistant lines from the file's tail (timestamp
-                                // >= attach_time - 5s). Dedup against emitted_ids:
-                                // each id is tracked here so subsequent reads
-                                // don't re-emit.
+                                // >= attach_time - 5s). The kernel returns
+                                // (bodies, ids, file_len) from a SINGLE read, so
+                                // seeding emitted_ids from `ids` (no second read)
+                                // is race-free: an id can't be marked emitted
+                                // unless its body was surfaced in this same pass.
                                 match read_preamble_for_race(&found, attach_time, gemini_preamble_extractor) {
-                                    Ok((bodies, file_len)) => {
-                                        // The preamble extractor surfaced bodies WITHOUT ids,
-                                        // so we can't dedup THIS pass against future appends with
-                                        // the same id. To keep correctness, re-parse the preamble
-                                        // window's lines to grab ids and seed emitted_ids.
-                                        seed_emitted_ids_from_preamble(&found, attach_time, &mut emitted_ids);
+                                    Ok((bodies, ids, file_len)) => {
+                                        for id in ids.into_iter().flatten() {
+                                            emitted_ids.insert(id);
+                                        }
                                         for text in bodies {
                                             logger.log("GEMINI_PREAMBLE", &session_id, &text);
                                             buffer.push_str(&text);
@@ -659,5 +600,101 @@ mod tests {
             }
         }
         assert_eq!(out, vec!["Hello world".to_string()]);
+    }
+
+    // ── M1 TOCTOU regression ──────────────────────────────────────────────
+
+    #[test]
+    fn gemini_first_attach_does_not_silently_drop_concurrent_append() {
+        // M1 regression test. Old code had a TOCTOU on first attach:
+        //   1. read_preamble_for_race read the file → surfaced bodies for X, Y.
+        //   2. line Z appended to file.
+        //   3. seed_emitted_ids_from_preamble re-read the file → marked X, Y,
+        //      AND Z as already-emitted (Z's body was never surfaced).
+        //   4. next read_new_lines saw Z → dedup said "emitted" → silent drop.
+        //
+        // Fix: the kernel returns (bodies, ids, file_len) from a SINGLE read,
+        // so seeding emitted_ids from `ids` (no second file read) means an id
+        // can only be marked emitted if its body was surfaced in the same pass.
+        //
+        // This test exercises the fixed flow: scan + seed, simulate an append
+        // happening AFTER the kernel returned (i.e. what the old double-read
+        // would have racily incorporated into the seeder), then verify the
+        // appended line surfaces via the next read_new_lines.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session-2026-05-19T00-00-race.jsonl");
+        let now = Utc::now();
+        let fresh = now - chrono::Duration::seconds(1);
+
+        // Initial state: 2 fresh gemini lines.
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"id":"a","timestamp":"{}","type":"gemini","content":"first"}}"#,
+            fresh.to_rfc3339()
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"id":"b","timestamp":"{}","type":"gemini","content":"second"}}"#,
+            fresh.to_rfc3339()
+        )
+        .unwrap();
+        drop(f);
+
+        // Single-read preamble scan: surfaces bodies AND ids in one pass.
+        let (bodies, ids, file_len) =
+            read_preamble_for_race(&path, now, gemini_preamble_extractor).unwrap();
+        assert_eq!(
+            bodies.len(),
+            ids.len(),
+            "kernel must return parallel bodies/ids arrays"
+        );
+        assert_eq!(bodies, vec!["first".to_string(), "second".to_string()]);
+
+        // Seed emitted_ids ONLY from kernel's returned ids — no second file read.
+        let mut emitted_ids: HashSet<String> = HashSet::new();
+        for id in ids.into_iter().flatten() {
+            emitted_ids.insert(id);
+        }
+        assert!(emitted_ids.contains("a"));
+        assert!(emitted_ids.contains("b"));
+
+        // Race: a third line lands AFTER the kernel returned. In the old
+        // double-read this would have happened BETWEEN the two reads and the
+        // seeder would have pre-marked "c" as emitted — silently dropping its
+        // body on the next poll. With the single-read fix, "c" is invisible
+        // to the seed step and must surface here.
+        let mut f = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"id":"c","timestamp":"{}","type":"gemini","content":"third"}}"#,
+            fresh.to_rfc3339()
+        )
+        .unwrap();
+        drop(f);
+
+        assert!(
+            !emitted_ids.contains("c"),
+            "M1 regression: id 'c' must NOT be pre-seeded after a single-read scan"
+        );
+
+        // Next poll picks up the new line cleanly.
+        let mut file_offset = file_len;
+        let mut line_remainder = String::new();
+        let new_lines = read_new_lines(&path, &mut file_offset, &mut line_remainder).unwrap();
+        let mut surfaced: Vec<String> = Vec::new();
+        for line in new_lines {
+            if let Some((id, c)) = extract_gemini_message(&line) {
+                if emitted_ids.insert(id) {
+                    surfaced.push(c);
+                }
+            }
+        }
+        assert_eq!(
+            surfaced,
+            vec!["third".to_string()],
+            "concurrently-appended line must surface, not be silently dropped"
+        );
     }
 }

--- a/src-tauri/src/telegram/jsonl_kernel.rs
+++ b/src-tauri/src/telegram/jsonl_kernel.rs
@@ -1,0 +1,108 @@
+// Shared scaffold for append-only JSONL session-file readers.
+// Hosts the primitives reused by claude_watcher, codex_watcher, and
+// gemini_watcher: directory scan, offset-based incremental read,
+// truncation detection, and rotation-flicker constants.
+
+use std::io::{Read as IoRead, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+pub(crate) const POLL_INTERVAL_MS: u64 = 500;
+/// Duration a tracked file must be stale before switching to a newer one (file rotation guard)
+pub(crate) const ROTATION_STALE_SECS: u64 = 3;
+
+/// Find the most recently modified .jsonl file in a directory (non-recursive).
+/// Used by the Claude watcher; Codex and Gemini have their own per-poll discovery.
+pub(crate) fn find_latest_jsonl(project_dir: &Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(project_dir).ok()?;
+    let mut best: Option<(PathBuf, SystemTime)> = None;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(modified) = meta.modified() {
+                match &best {
+                    Some((_, best_time)) if modified > *best_time => {
+                        best = Some((path, modified));
+                    }
+                    None => {
+                        best = Some((path, modified));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    best.map(|(p, _)| p)
+}
+
+/// Read new bytes from a file starting at the given byte offset.
+/// Returns parsed complete lines and updates the offset by actual bytes read.
+/// Partial lines are accumulated in `remainder` for the next poll.
+///
+/// On shrink (truncation), resets `offset = 0` and clears `remainder` so the
+/// next read starts from the beginning. The H2 reset-to-EOF semantics land in
+/// commit 5 (preamble scan + truncation-skip fix).
+pub(crate) fn read_new_lines(
+    path: &Path,
+    offset: &mut u64,
+    remainder: &mut String,
+) -> std::io::Result<Vec<String>> {
+    let mut file = std::fs::File::open(path)?;
+    // Use metadata on the open handle (avoids TOCTOU with path-based metadata)
+    let file_len = file.metadata()?.len();
+
+    // G3: File truncation/shrink detection — reset to beginning
+    if file_len < *offset {
+        log::warn!(
+            "[JSONL_TRUNCATE] File shrank ({} < {}), resetting offset",
+            file_len,
+            *offset
+        );
+        *offset = 0;
+        remainder.clear();
+    }
+
+    if file_len <= *offset {
+        return Ok(vec![]);
+    }
+
+    file.seek(SeekFrom::Start(*offset))?;
+    let mut buf = String::new();
+    file.read_to_string(&mut buf)?;
+
+    // G2: Track offset by actual bytes read, not reported file length
+    *offset += buf.len() as u64;
+
+    // Prepend any partial line from previous read
+    if !remainder.is_empty() {
+        let mut combined = std::mem::take(remainder);
+        combined.push_str(&buf);
+        buf = combined;
+    }
+
+    let mut lines = Vec::new();
+    let mut last_newline = 0;
+
+    for (i, ch) in buf.char_indices() {
+        if ch == '\n' {
+            let line = &buf[last_newline..i];
+            let trimmed = line.trim();
+            if !trimmed.is_empty() {
+                lines.push(trimmed.to_string());
+            }
+            last_newline = i + 1;
+        }
+    }
+
+    // Keep unterminated tail in remainder for next poll
+    if last_newline < buf.len() {
+        *remainder = buf[last_newline..].to_string();
+    }
+
+    Ok(lines)
+}

--- a/src-tauri/src/telegram/jsonl_kernel.rs
+++ b/src-tauri/src/telegram/jsonl_kernel.rs
@@ -1,15 +1,29 @@
 // Shared scaffold for append-only JSONL session-file readers.
 // Hosts the primitives reused by claude_watcher, codex_watcher, and
 // gemini_watcher: directory scan, offset-based incremental read,
-// truncation detection, and rotation-flicker constants.
+// truncation detection, rotation-flicker constants, and the §J first-attach
+// preamble scan.
 
 use std::io::{Read as IoRead, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+use chrono::{DateTime, Utc};
+
 pub(crate) const POLL_INTERVAL_MS: u64 = 500;
 /// Duration a tracked file must be stale before switching to a newer one (file rotation guard)
 pub(crate) const ROTATION_STALE_SECS: u64 = 3;
+
+/// Window size for the §J first-attach preamble scan. 64 KiB comfortably holds
+/// a recent assistant turn for all three backends: Claude assistant lines are
+/// 1-4 KiB, Codex `event_msg` lines are 200-800 B (worst-observed turn ≈47 KiB),
+/// Gemini turns are usually one large line.
+pub(crate) const PREAMBLE_MAX_BYTES: u64 = 64 * 1024;
+
+/// Grace window for the §J timestamp filter. Lines with embedded timestamp
+/// ≥ attach_time - RACE_GRACE_SECS are emitted (strict lower bound — future
+/// timestamps from the live agent are always emitted).
+pub(crate) const RACE_GRACE_SECS: i64 = 5;
 
 /// Find the most recently modified .jsonl file in a directory (non-recursive).
 /// Used by the Claude watcher; Codex and Gemini have their own per-poll discovery.
@@ -44,9 +58,12 @@ pub(crate) fn find_latest_jsonl(project_dir: &Path) -> Option<PathBuf> {
 /// Returns parsed complete lines and updates the offset by actual bytes read.
 /// Partial lines are accumulated in `remainder` for the next poll.
 ///
-/// On shrink (truncation), resets `offset = 0` and clears `remainder` so the
-/// next read starts from the beginning. The H2 reset-to-EOF semantics land in
-/// commit 5 (preamble scan + truncation-skip fix).
+/// **H2 truncation reset (commit 5):** on file shrink, set `offset = file_len`
+/// (silent skip to current EOF, NO replay) and clear `remainder`. This
+/// supersedes the previous reset-to-0 behavior which replayed the full file
+/// to Telegram after operational truncates (logrotate, manual `truncate`,
+/// replacing snapshot, partial-write race). The §J preamble scan is
+/// first-attach-only and does NOT re-apply on truncation.
 pub(crate) fn read_new_lines(
     path: &Path,
     offset: &mut u64,
@@ -56,15 +73,16 @@ pub(crate) fn read_new_lines(
     // Use metadata on the open handle (avoids TOCTOU with path-based metadata)
     let file_len = file.metadata()?.len();
 
-    // G3: File truncation/shrink detection — reset to beginning
+    // H2: File truncation/shrink — silent skip to current EOF, no replay.
     if file_len < *offset {
         log::warn!(
-            "[JSONL_TRUNCATE] File shrank ({} < {}), resetting offset",
-            file_len,
-            *offset
+            "[JSONL_TRUNCATE] File shrunk from {} to {}, skipping past replay",
+            *offset,
+            file_len
         );
-        *offset = 0;
+        *offset = file_len;
         remainder.clear();
+        return Ok(vec![]);
     }
 
     if file_len <= *offset {
@@ -105,4 +123,372 @@ pub(crate) fn read_new_lines(
     }
 
     Ok(lines)
+}
+
+/// §J first-message-race fix. Instead of skipping to EOF on first attach,
+/// read the last `PREAMBLE_MAX_BYTES` of the file and emit only lines whose
+/// embedded timestamp is ≥ `attach_time - RACE_GRACE_SECS` (strict lower
+/// bound). Then set `offset = file_len` so the watch loop continues from
+/// the current EOF.
+///
+/// **Byte-safe at the seek point (M1):** reading from `len - 64 KiB` may land
+/// mid-UTF-8 codepoint, so we (1) read raw bytes, (2) drop everything before
+/// the first `\n` unless the window starts at offset 0, (3) only then convert
+/// to UTF-8 lossily.
+///
+/// `extractor` is the per-backend "given a line, return its `(timestamp, body)`
+/// if it's an emission candidate, else None". The kernel does NOT attempt to
+/// understand the line shape; that's the caller's responsibility.
+///
+/// Returns `(bodies, file_len)`. Callers should set `offset = file_len` so the
+/// subsequent `read_new_lines` polls start from current EOF.
+pub(crate) fn read_preamble_for_race(
+    path: &Path,
+    attach_time: DateTime<Utc>,
+    extractor: impl Fn(&str) -> Option<(DateTime<Utc>, String)>,
+) -> std::io::Result<(Vec<String>, u64)> {
+    let len = std::fs::metadata(path)?.len();
+    let start = len.saturating_sub(PREAMBLE_MAX_BYTES);
+    let mut f = std::fs::File::open(path)?;
+    f.seek(SeekFrom::Start(start))?;
+    let mut buf: Vec<u8> = Vec::with_capacity((len - start) as usize);
+    f.read_to_end(&mut buf)?;
+
+    // Drop everything before the first `\n` UNLESS we read from offset 0.
+    // The seek point at `len - 64 KiB` almost certainly lands mid-line.
+    let bytes: &[u8] = if start == 0 {
+        &buf
+    } else {
+        match buf.iter().position(|&b| b == b'\n') {
+            Some(i) => &buf[i + 1..],
+            None => return Ok((vec![], len)), // single huge line, can't reason about it
+        }
+    };
+    let text = String::from_utf8_lossy(bytes);
+
+    let cutoff = attach_time - chrono::Duration::seconds(RACE_GRACE_SECS);
+    let mut out = Vec::new();
+    for line in text.lines() {
+        if let Some((ts, body)) = extractor(line) {
+            if ts >= cutoff {
+                out.push(body);
+            }
+        }
+    }
+    Ok((out, len))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    // ── H2 truncation tests ───────────────────────────────────────────────
+
+    #[test]
+    fn truncation_does_not_replay_old_lines() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+
+        // Write 5 lines, advance offset to file_len.
+        let mut f = fs::File::create(&path).unwrap();
+        for i in 0..5 {
+            writeln!(f, r#"{{"id":"{}","content":"line{}"}}"#, i, i).unwrap();
+        }
+        f.sync_all().unwrap();
+        drop(f);
+        let file_len = fs::metadata(&path).unwrap().len();
+        let mut offset = file_len;
+        let mut remainder = String::new();
+
+        // No new content — read returns empty.
+        let lines = read_new_lines(&path, &mut offset, &mut remainder).unwrap();
+        assert!(lines.is_empty());
+        assert_eq!(offset, file_len);
+
+        // Truncate to 1 line.
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+        writeln!(f, r#"{{"id":"x","content":"only"}}"#).unwrap();
+        f.sync_all().unwrap();
+        drop(f);
+        let new_len = fs::metadata(&path).unwrap().len();
+        assert!(new_len < file_len, "truncation must shrink the file");
+
+        // read_new_lines must NOT replay the truncated content. It sets
+        // offset = new_len and returns an empty Vec.
+        let lines = read_new_lines(&path, &mut offset, &mut remainder).unwrap();
+        assert!(lines.is_empty(), "truncation must not replay");
+        assert_eq!(offset, new_len, "offset must be re-anchored to new EOF");
+    }
+
+    #[test]
+    fn truncation_followed_by_new_lines_emits_only_new() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+
+        // Initial state: 5 lines + offset at EOF.
+        let mut f = fs::File::create(&path).unwrap();
+        for i in 0..5 {
+            writeln!(f, r#"{{"id":"{}","content":"line{}"}}"#, i, i).unwrap();
+        }
+        drop(f);
+        let mut offset = fs::metadata(&path).unwrap().len();
+        let mut remainder = String::new();
+
+        // Truncate to nothing.
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+        // Append 1 new line.
+        writeln!(f, r#"{{"id":"new","content":"after-truncate"}}"#).unwrap();
+        drop(f);
+
+        // First poll detects shrink, re-anchors, emits nothing.
+        let lines = read_new_lines(&path, &mut offset, &mut remainder).unwrap();
+        assert!(lines.is_empty());
+
+        // The truncated file already has 1 line; offset should be at file_len
+        // matching that 1 line. So a follow-up append is what we want to test.
+        // Append one more line.
+        let mut f = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        writeln!(f, r#"{{"id":"newer","content":"after-append"}}"#).unwrap();
+        drop(f);
+
+        let lines = read_new_lines(&path, &mut offset, &mut remainder).unwrap();
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("after-append"));
+    }
+
+    // ── §J preamble scan tests ────────────────────────────────────────────
+
+    /// Extractor for tests: reads `timestamp` field as RFC3339, `content` as the body.
+    fn test_extractor(line: &str) -> Option<(DateTime<Utc>, String)> {
+        let v: serde_json::Value = serde_json::from_str(line).ok()?;
+        let ts_str = v.get("timestamp")?.as_str()?;
+        let ts = DateTime::parse_from_rfc3339(ts_str).ok()?.with_timezone(&Utc);
+        let body = v.get("content")?.as_str()?.to_string();
+        Some((ts, body))
+    }
+
+    #[test]
+    fn preamble_scan_emits_messages_inside_grace_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        let now = Utc::now();
+        let old1 = now - chrono::Duration::seconds(20);
+        let old2 = now - chrono::Duration::seconds(15);
+        let fresh = now - chrono::Duration::seconds(1);
+
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"{}","content":"old1"}}"#,
+            old1.to_rfc3339()
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"{}","content":"old2"}}"#,
+            old2.to_rfc3339()
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"{}","content":"fresh"}}"#,
+            fresh.to_rfc3339()
+        )
+        .unwrap();
+        drop(f);
+
+        let (bodies, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        assert_eq!(bodies, vec!["fresh".to_string()]);
+        assert_eq!(file_len, fs::metadata(&path).unwrap().len());
+    }
+
+    #[test]
+    fn preamble_scan_emits_nothing_when_all_lines_old() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        let now = Utc::now();
+        let old = now - chrono::Duration::seconds(30);
+
+        let mut f = fs::File::create(&path).unwrap();
+        for i in 0..3 {
+            writeln!(
+                f,
+                r#"{{"timestamp":"{}","content":"old{}"}}"#,
+                old.to_rfc3339(),
+                i
+            )
+            .unwrap();
+        }
+        drop(f);
+
+        let (bodies, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        assert!(bodies.is_empty());
+        assert_eq!(file_len, fs::metadata(&path).unwrap().len());
+    }
+
+    #[test]
+    fn preamble_scan_emits_future_timestamps() {
+        // Future timestamps relative to attach_time are emitted (lower-bound
+        // filter only).
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        let now = Utc::now();
+        let future = now + chrono::Duration::seconds(60);
+
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"{}","content":"future"}}"#,
+            future.to_rfc3339()
+        )
+        .unwrap();
+        drop(f);
+
+        let (bodies, _file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        assert_eq!(bodies, vec!["future".to_string()]);
+    }
+
+    #[test]
+    fn preamble_scan_caps_at_64_kib() {
+        // File > 64 KiB. Only the last 64 KiB's lines should be examined.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        let now = Utc::now();
+        let fresh = now - chrono::Duration::seconds(1);
+
+        let mut f = fs::File::create(&path).unwrap();
+        // Pad with junk to exceed 64 KiB (each line ~100 B; need ~700 lines).
+        // Each "junk" line will not parse via test_extractor (missing
+        // `timestamp` field) so we don't need to be precise about content.
+        let padding_line = "x".repeat(200);
+        for _ in 0..700 {
+            writeln!(f, "{}", padding_line).unwrap();
+        }
+        // One fresh line at the end.
+        writeln!(
+            f,
+            r#"{{"timestamp":"{}","content":"tail"}}"#,
+            fresh.to_rfc3339()
+        )
+        .unwrap();
+        drop(f);
+
+        let file_size = fs::metadata(&path).unwrap().len();
+        assert!(file_size > PREAMBLE_MAX_BYTES);
+
+        let (bodies, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        assert_eq!(bodies, vec!["tail".to_string()]);
+        assert_eq!(file_len, file_size);
+    }
+
+    #[test]
+    fn preamble_scan_handles_partial_first_line_in_window() {
+        // First line in the 64 KiB window is mid-JSON → that line is skipped
+        // (drop bytes before first `\n`).
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        let now = Utc::now();
+        let fresh = now - chrono::Duration::seconds(1);
+
+        // Write a HUGE first line that gets cut by the 64 KiB window.
+        let mut f = fs::File::create(&path).unwrap();
+        let huge = "z".repeat((PREAMBLE_MAX_BYTES as usize) + 500);
+        writeln!(f, "{}", huge).unwrap();
+        // Then a real line.
+        writeln!(
+            f,
+            r#"{{"timestamp":"{}","content":"after-huge"}}"#,
+            fresh.to_rfc3339()
+        )
+        .unwrap();
+        drop(f);
+
+        let (bodies, _file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        // The huge first line's tail (z's) won't parse; only "after-huge" is emitted.
+        assert_eq!(bodies, vec!["after-huge".to_string()]);
+    }
+
+    #[test]
+    fn preamble_scan_byte_safe_on_utf8_split_at_seek_point() {
+        // Seek lands mid-multi-byte-UTF-8 character. Skip-to-first-\n drops
+        // the partial codepoint; lossy UTF-8 conversion never errors.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        let now = Utc::now();
+        let fresh = now - chrono::Duration::seconds(1);
+
+        // Build a file where the byte at PREAMBLE_MAX_BYTES (from the end)
+        // is in the middle of a 3-byte UTF-8 codepoint (em dash U+2014 is
+        // 0xE2 0x80 0x94 in UTF-8).
+        let mut f = fs::File::create(&path).unwrap();
+        // Padding to push the start of the window into the middle of a codepoint:
+        // Write 64 KB + some bytes of padding lines, then sprinkle in em-dashes
+        // that span the seek point.
+        for _ in 0..600 {
+            // ~120 bytes per line including em dash
+            writeln!(f, "padding em-dash \u{2014} text").unwrap();
+        }
+        // Emit one tail line that should be emitted.
+        writeln!(
+            f,
+            r#"{{"timestamp":"{}","content":"tail-line"}}"#,
+            fresh.to_rfc3339()
+        )
+        .unwrap();
+        drop(f);
+
+        // Just verify the call returns Ok (no panic) and includes "tail-line".
+        let (bodies, _) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        assert!(bodies.contains(&"tail-line".to_string()));
+    }
+
+    #[test]
+    fn preamble_scan_with_single_huge_line_partial_at_start_emits_empty() {
+        // File contains one 80 KB line — preamble window has no `\n` → empty Vec.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        let now = Utc::now();
+
+        let mut f = fs::File::create(&path).unwrap();
+        // Single line, no trailing \n, ~80 KB.
+        let huge = "z".repeat(80 * 1024);
+        f.write_all(huge.as_bytes()).unwrap();
+        drop(f);
+
+        let (bodies, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        assert!(bodies.is_empty());
+        assert_eq!(file_len, fs::metadata(&path).unwrap().len());
+    }
+
+    #[test]
+    fn preamble_scan_small_file_starts_from_offset_zero() {
+        // File < 64 KiB → start == 0 path is exercised; we keep the first
+        // (complete) line.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("session.jsonl");
+        let now = Utc::now();
+        let fresh = now - chrono::Duration::seconds(1);
+
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"{}","content":"only"}}"#,
+            fresh.to_rfc3339()
+        )
+        .unwrap();
+        drop(f);
+
+        let (bodies, _file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        assert_eq!(bodies, vec!["only".to_string()]);
+    }
 }

--- a/src-tauri/src/telegram/jsonl_kernel.rs
+++ b/src-tauri/src/telegram/jsonl_kernel.rs
@@ -147,12 +147,18 @@ pub(crate) fn read_preamble_for_race(
     attach_time: DateTime<Utc>,
     extractor: impl Fn(&str) -> Option<(DateTime<Utc>, String)>,
 ) -> std::io::Result<(Vec<String>, u64)> {
-    let len = std::fs::metadata(path)?.len();
-    let start = len.saturating_sub(PREAMBLE_MAX_BYTES);
+    let initial_len = std::fs::metadata(path)?.len();
+    let start = initial_len.saturating_sub(PREAMBLE_MAX_BYTES);
     let mut f = std::fs::File::open(path)?;
     f.seek(SeekFrom::Start(start))?;
-    let mut buf: Vec<u8> = Vec::with_capacity((len - start) as usize);
+    let mut buf: Vec<u8> = Vec::with_capacity((initial_len - start) as usize);
     f.read_to_end(&mut buf)?;
+    // Return the offset that matches what we ACTUALLY read (start + bytes read),
+    // not the stale path-level metadata `initial_len`. Concurrent writers can
+    // grow the file between the metadata call and the read; using the stale
+    // value would leave a gap that `read_new_lines` then re-reads, causing
+    // duplicate sends to Telegram.
+    let new_offset = start + buf.len() as u64;
 
     // Drop everything before the first `\n` UNLESS we read from offset 0.
     // The seek point at `len - 64 KiB` almost certainly lands mid-line.
@@ -161,7 +167,7 @@ pub(crate) fn read_preamble_for_race(
     } else {
         match buf.iter().position(|&b| b == b'\n') {
             Some(i) => &buf[i + 1..],
-            None => return Ok((vec![], len)), // single huge line, can't reason about it
+            None => return Ok((vec![], new_offset)), // single huge line, can't reason about it
         }
     };
     let text = String::from_utf8_lossy(bytes);
@@ -175,7 +181,7 @@ pub(crate) fn read_preamble_for_race(
             }
         }
     }
-    Ok((out, len))
+    Ok((out, new_offset))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/telegram/jsonl_kernel.rs
+++ b/src-tauri/src/telegram/jsonl_kernel.rs
@@ -136,17 +136,23 @@ pub(crate) fn read_new_lines(
 /// the first `\n` unless the window starts at offset 0, (3) only then convert
 /// to UTF-8 lossily.
 ///
-/// `extractor` is the per-backend "given a line, return its `(timestamp, body)`
-/// if it's an emission candidate, else None". The kernel does NOT attempt to
-/// understand the line shape; that's the caller's responsibility.
+/// `extractor` is the per-backend "given a line, return its
+/// `(timestamp, optional_id, body)` if it's an emission candidate, else None".
+/// The `id` slot lets backends that dedupe by id (Gemini) seed their dedup set
+/// directly from this single read — eliminating the M1 TOCTOU where a parallel
+/// `seed_emitted_ids_from_preamble` pass re-read the file and could mark an
+/// id as emitted whose body was appended between the two reads. Backends that
+/// don't dedupe (Claude, Codex) pass `None` for the id slot.
 ///
-/// Returns `(bodies, file_len)`. Callers should set `offset = file_len` so the
-/// subsequent `read_new_lines` polls start from current EOF.
+/// Returns `(bodies, ids, file_len)` where `bodies` and `ids` are parallel
+/// arrays: `ids[i]` is the optional id of `bodies[i]`. Callers should set
+/// `offset = file_len` so the subsequent `read_new_lines` polls start from
+/// current EOF.
 pub(crate) fn read_preamble_for_race(
     path: &Path,
     attach_time: DateTime<Utc>,
-    extractor: impl Fn(&str) -> Option<(DateTime<Utc>, String)>,
-) -> std::io::Result<(Vec<String>, u64)> {
+    extractor: impl Fn(&str) -> Option<(DateTime<Utc>, Option<String>, String)>,
+) -> std::io::Result<(Vec<String>, Vec<Option<String>>, u64)> {
     let initial_len = std::fs::metadata(path)?.len();
     let start = initial_len.saturating_sub(PREAMBLE_MAX_BYTES);
     let mut f = std::fs::File::open(path)?;
@@ -167,21 +173,23 @@ pub(crate) fn read_preamble_for_race(
     } else {
         match buf.iter().position(|&b| b == b'\n') {
             Some(i) => &buf[i + 1..],
-            None => return Ok((vec![], new_offset)), // single huge line, can't reason about it
+            None => return Ok((vec![], vec![], new_offset)), // single huge line, can't reason about it
         }
     };
     let text = String::from_utf8_lossy(bytes);
 
     let cutoff = attach_time - chrono::Duration::seconds(RACE_GRACE_SECS);
-    let mut out = Vec::new();
+    let mut bodies = Vec::new();
+    let mut ids = Vec::new();
     for line in text.lines() {
-        if let Some((ts, body)) = extractor(line) {
+        if let Some((ts, id, body)) = extractor(line) {
             if ts >= cutoff {
-                out.push(body);
+                bodies.push(body);
+                ids.push(id);
             }
         }
     }
-    Ok((out, new_offset))
+    Ok((bodies, ids, new_offset))
 }
 
 #[cfg(test)]
@@ -275,12 +283,14 @@ mod tests {
     // ── §J preamble scan tests ────────────────────────────────────────────
 
     /// Extractor for tests: reads `timestamp` field as RFC3339, `content` as the body.
-    fn test_extractor(line: &str) -> Option<(DateTime<Utc>, String)> {
+    /// `id` slot is unused (None) — backends that dedupe by id are covered in
+    /// gemini_watcher tests.
+    fn test_extractor(line: &str) -> Option<(DateTime<Utc>, Option<String>, String)> {
         let v: serde_json::Value = serde_json::from_str(line).ok()?;
         let ts_str = v.get("timestamp")?.as_str()?;
         let ts = DateTime::parse_from_rfc3339(ts_str).ok()?.with_timezone(&Utc);
         let body = v.get("content")?.as_str()?.to_string();
-        Some((ts, body))
+        Some((ts, None, body))
     }
 
     #[test]
@@ -313,8 +323,9 @@ mod tests {
         .unwrap();
         drop(f);
 
-        let (bodies, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        let (bodies, ids, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
         assert_eq!(bodies, vec!["fresh".to_string()]);
+        assert_eq!(ids.len(), bodies.len(), "ids parallel to bodies");
         assert_eq!(file_len, fs::metadata(&path).unwrap().len());
     }
 
@@ -337,8 +348,9 @@ mod tests {
         }
         drop(f);
 
-        let (bodies, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        let (bodies, ids, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
         assert!(bodies.is_empty());
+        assert!(ids.is_empty());
         assert_eq!(file_len, fs::metadata(&path).unwrap().len());
     }
 
@@ -360,7 +372,7 @@ mod tests {
         .unwrap();
         drop(f);
 
-        let (bodies, _file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        let (bodies, _ids, _file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
         assert_eq!(bodies, vec!["future".to_string()]);
     }
 
@@ -392,7 +404,7 @@ mod tests {
         let file_size = fs::metadata(&path).unwrap().len();
         assert!(file_size > PREAMBLE_MAX_BYTES);
 
-        let (bodies, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        let (bodies, _ids, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
         assert_eq!(bodies, vec!["tail".to_string()]);
         assert_eq!(file_len, file_size);
     }
@@ -419,7 +431,7 @@ mod tests {
         .unwrap();
         drop(f);
 
-        let (bodies, _file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        let (bodies, _ids, _file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
         // The huge first line's tail (z's) won't parse; only "after-huge" is emitted.
         assert_eq!(bodies, vec!["after-huge".to_string()]);
     }
@@ -454,7 +466,7 @@ mod tests {
         drop(f);
 
         // Just verify the call returns Ok (no panic) and includes "tail-line".
-        let (bodies, _) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        let (bodies, _ids, _) = read_preamble_for_race(&path, now, test_extractor).unwrap();
         assert!(bodies.contains(&"tail-line".to_string()));
     }
 
@@ -471,8 +483,9 @@ mod tests {
         f.write_all(huge.as_bytes()).unwrap();
         drop(f);
 
-        let (bodies, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        let (bodies, ids, file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
         assert!(bodies.is_empty());
+        assert!(ids.is_empty());
         assert_eq!(file_len, fs::metadata(&path).unwrap().len());
     }
 
@@ -494,7 +507,8 @@ mod tests {
         .unwrap();
         drop(f);
 
-        let (bodies, _file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
+        let (bodies, ids, _file_len) = read_preamble_for_race(&path, now, test_extractor).unwrap();
         assert_eq!(bodies, vec!["only".to_string()]);
+        assert_eq!(ids, vec![None]);
     }
 }

--- a/src-tauri/src/telegram/manager.rs
+++ b/src-tauri/src/telegram/manager.rs
@@ -1,12 +1,11 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use uuid::Uuid;
 
 use crate::errors::AppError;
 use crate::pty::manager::PtyManager;
-use crate::telegram::bridge::{self, BridgeHandle};
+use crate::telegram::bridge::{self, BridgeHandle, SessionReaderKind};
 use crate::telegram::types::{BridgeInfo, BridgeStatus, TelegramBotConfig};
 
 /// Shared map of session_id → mpsc sender. The PTY read loop checks this
@@ -37,7 +36,7 @@ impl TelegramBridgeManager {
         bot: &TelegramBotConfig,
         pty_mgr: Arc<Mutex<PtyManager>>,
         app_handle: tauri::AppHandle,
-        jsonl_project_dir: Option<PathBuf>,
+        reader: Option<SessionReaderKind>,
     ) -> Result<BridgeInfo, AppError> {
         // Exclusivity: one bot can only be attached to one session
         if let Some(existing) = self.bot_assignments.get(&bot.id) {
@@ -63,7 +62,7 @@ impl TelegramBridgeManager {
             color: bot.color.clone(),
         };
 
-        let is_jsonl_mode = jsonl_project_dir.is_some();
+        let is_reader_mode = reader.is_some();
 
         let handle = bridge::spawn_bridge(
             bot.token.clone(),
@@ -72,12 +71,12 @@ impl TelegramBridgeManager {
             info.clone(),
             pty_mgr,
             app_handle,
-            jsonl_project_dir,
+            reader,
         );
 
         // Only register output sender for PTY mode.
-        // In JSONL mode, the watcher reads directly from file — no PTY byte feed needed.
-        if !is_jsonl_mode {
+        // In reader mode, the watcher reads directly from file — no PTY byte feed needed.
+        if !is_reader_mode {
             if let Ok(mut senders) = self.output_senders.lock() {
                 senders.insert(session_id, handle.output_sender.clone());
             }

--- a/src-tauri/src/telegram/mod.rs
+++ b/src-tauri/src/telegram/mod.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod bridge;
 pub mod claude_watcher;
 pub mod codex_watcher;
+pub mod gemini_watcher;
 pub mod jsonl_kernel;
 pub mod manager;
 pub mod types;

--- a/src-tauri/src/telegram/mod.rs
+++ b/src-tauri/src/telegram/mod.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod bridge;
-pub mod jsonl_watcher;
+pub mod claude_watcher;
+pub mod jsonl_kernel;
 pub mod manager;
 pub mod types;

--- a/src-tauri/src/telegram/mod.rs
+++ b/src-tauri/src/telegram/mod.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod bridge;
 pub mod claude_watcher;
+pub mod codex_watcher;
 pub mod jsonl_kernel;
 pub mod manager;
 pub mod types;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -22,6 +22,9 @@ export interface Session {
   workgroupBrief: string | null;
   isCoordinator: boolean;
   token: string;
+  isClaude: boolean;
+  isCodex: boolean;
+  isGemini: boolean;
 }
 
 export type SessionStatus = "active" | "running" | "idle" | { exited: number };


### PR DESCRIPTION
## Summary

Extends the Telegram session-reading pipeline (previously Claude Code only) to **Codex CLI** and **Gemini CLI**. Telegram now receives clean assistant prose from Codex/Gemini sessions by reading their session files directly, instead of capturing dirty PTY output.

## What's included

- New `jsonl_kernel` shared scaffold extracted from the Claude watcher; `jsonl_watcher.rs` renamed to `claude_watcher.rs` (git mv, blame preserved).
- Codex watcher + resolver: reads `~/.codex/sessions/Y/M/D/rollout-*.jsonl`, locates the session file by matching `session_meta.cwd`, walks today + last 7 UTC days (verified that Codex `resume --last` appends to the prior file).
- Gemini watcher + resolver: reads `~/.gemini/tmp/<slug>/chats/session-*.jsonl` (the current `.jsonl` format used by Gemini CLI 0.42.0+), maps cwd to slug via `~/.gemini/projects.json`.
- `is_codex` / `is_gemini` persisted on `Session`, with mutually-exclusive detection at the launch-command parse site.
- `SessionReaderKind` dispatch wired through `spawn_bridge` and all auto-attach call sites; `derive_reader` returns a plain `Result` so each call site emits its own error.
- First-message race fix + truncation-skip-past-replay, applied uniformly across all three backends via the shared kernel.
- Gemini first-attach TOCTOU fix: single-read preamble that returns bodies and ids together — no double read, no silent message loss.
- New `telegram_bridge_warning` event for Gemini fallback cases (cwd not yet in projects.json, empty chats dir, legacy `.json`-only chats dir).
- Version bump 0.8.30 to 0.8.31 (5-file lockstep).

## Workflow

Full pipeline: architect plan, dev-rust + grinch consensus (1 round), implementation (8 commits), `/feature-dev` parallel code review (4 HIGH/MEDIUM findings fixed), grinch adversarial implementation review, M1 TOCTOU fix, grinch re-review (approved), shipper build.

## Testing

- 549 lib + integration tests pass (547 baseline + 2 new: `truncation_does_not_replay_old_lines`, `gemini_first_attach_does_not_silently_drop_concurrent_append`).
- `cargo check` / `cargo clippy --lib` clean (one pre-existing unrelated dead-code warning).
- Manually verified by the user: Codex and Gemini sessions deliver clean output to Telegram.

## Known follow-ups (not blocking)

- Codex day-walk has a silent cliff for sessions resumed after more than 7 days (grinch L5).
- Watcher-task panic invisibility — pre-existing, now spread across 3 backends (grinch L6).

Closes #258
