### PR TITLE
feat(session): consolidate coding-agent behavior into CodingAgentProfile (#260)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.32",
+      "version": "0.8.33",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.31",
+      "version": "0.8.32",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.32"
+version = "0.8.33"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.31"
+version = "0.8.32"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.32"
+version = "0.8.33"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -147,14 +147,21 @@ fn gemini_tokens_have_resume(tokens: &[&str], start: usize) -> bool {
 }
 
 fn inject_gemini_resume(shell: &str, shell_args: &mut Vec<String>) -> bool {
+    // #260 — resume tokens sourced from the CodingAgentProfile (single source
+    // of truth). G6: slice-pattern destructure, never index — a future
+    // <2-element slice degrades gracefully instead of panicking in release.
+    let &[resume_flag, resume_value] = CodingAgentKind::Gemini.profile().resume_tokens else {
+        debug_assert!(false, "Gemini resume_tokens must have exactly 2 elements");
+        return false;
+    };
     match executable_basename(shell).as_str() {
         "gemini" => {
             let tokens: Vec<&str> = shell_args.iter().map(|arg| arg.as_str()).collect();
             if gemini_tokens_have_resume(&tokens, 0) {
                 return false;
             }
-            shell_args.insert(0, "--resume".to_string());
-            shell_args.insert(1, "latest".to_string());
+            shell_args.insert(0, resume_flag.to_string());
+            shell_args.insert(1, resume_value.to_string());
             true
         }
         "cmd" => {
@@ -166,8 +173,8 @@ fn inject_gemini_resume(shell: &str, shell_args: &mut Vec<String>) -> bool {
                 if gemini_tokens_have_resume(&tokens, idx + 1) {
                     return false;
                 }
-                shell_args.insert(idx + 1, "--resume".to_string());
-                shell_args.insert(idx + 2, "latest".to_string());
+                shell_args.insert(idx + 1, resume_flag.to_string());
+                shell_args.insert(idx + 2, resume_value.to_string());
                 return true;
             }
 
@@ -184,8 +191,8 @@ fn inject_gemini_resume(shell: &str, shell_args: &mut Vec<String>) -> bool {
                     if gemini_tokens_have_resume(&token_refs, idx + 1) {
                         return false;
                     }
-                    tokens.insert(idx + 1, "--resume".to_string());
-                    tokens.insert(idx + 2, "latest".to_string());
+                    tokens.insert(idx + 1, resume_flag.to_string());
+                    tokens.insert(idx + 2, resume_value.to_string());
                     *arg = tokens.join(" ");
                     return true;
                 }
@@ -198,14 +205,21 @@ fn inject_gemini_resume(shell: &str, shell_args: &mut Vec<String>) -> bool {
 }
 
 fn inject_codex_resume(shell: &str, shell_args: &mut Vec<String>) -> bool {
+    // #260 — resume tokens sourced from the CodingAgentProfile (single source
+    // of truth). G6: slice-pattern destructure, never index — a future
+    // <2-element slice degrades gracefully instead of panicking in release.
+    let &[resume_subcmd, resume_flag] = CodingAgentKind::Codex.profile().resume_tokens else {
+        debug_assert!(false, "Codex resume_tokens must have exactly 2 elements");
+        return false;
+    };
     match executable_basename(shell).as_str() {
         "codex" => {
             let tokens: Vec<&str> = shell_args.iter().map(|arg| arg.as_str()).collect();
             if codex_tokens_have_resume(&tokens, 0) || codex_has_explicit_subcommand(&tokens, 0) {
                 return false;
             }
-            shell_args.insert(0, "resume".to_string());
-            shell_args.insert(1, "--last".to_string());
+            shell_args.insert(0, resume_subcmd.to_string());
+            shell_args.insert(1, resume_flag.to_string());
             true
         }
         "cmd" => {
@@ -219,8 +233,8 @@ fn inject_codex_resume(shell: &str, shell_args: &mut Vec<String>) -> bool {
                 {
                     return false;
                 }
-                shell_args.insert(idx + 1, "resume".to_string());
-                shell_args.insert(idx + 2, "--last".to_string());
+                shell_args.insert(idx + 1, resume_subcmd.to_string());
+                shell_args.insert(idx + 2, resume_flag.to_string());
                 return true;
             }
 
@@ -239,8 +253,8 @@ fn inject_codex_resume(shell: &str, shell_args: &mut Vec<String>) -> bool {
                     {
                         return false;
                     }
-                    tokens.insert(idx + 1, "resume".to_string());
-                    tokens.insert(idx + 2, "--last".to_string());
+                    tokens.insert(idx + 1, resume_subcmd.to_string());
+                    tokens.insert(idx + 2, resume_flag.to_string());
                     *arg = tokens.join(" ");
                     return true;
                 }
@@ -721,18 +735,21 @@ pub async fn create_session_inner(
         claude_project_exists,
         &full_cmd,
     ) {
+        // #260 — Claude's resume flag from the CodingAgentProfile. resume_tokens
+        // is a 1-element const for Claude, so [0] is provably in bounds.
+        let continue_flag = CodingAgentKind::Claude.profile().resume_tokens[0];
         if let Some(ref aid) = agent_id {
             if executable_basename(&shell) == "cmd" {
                 if let Some(last) = shell_args.last_mut() {
                     if executable_basename(last) == "claude"
                         || last.to_lowercase().contains("claude")
                     {
-                        *last = format!("{} --continue", last);
+                        *last = format!("{} {}", last, continue_flag);
                         log::info!("Auto-injected --continue for agent '{}' (prior conversation exists, cmd path)", aid);
                     }
                 }
             } else {
-                shell_args.push("--continue".to_string());
+                shell_args.push(continue_flag.to_string());
                 log::info!(
                     "Auto-injected --continue for agent '{}' (prior conversation exists)",
                     aid

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -9,6 +9,7 @@ use crate::config::settings::{AppSettings, SettingsState};
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
 use crate::session::session::{SessionInfo, SessionRepo};
+use crate::session::profile::CodingAgentKind;
 use crate::telegram::manager::TelegramBridgeState;
 use crate::DetachedSessionsState;
 
@@ -682,45 +683,29 @@ pub async fn create_session_inner(
 
     let id = session.id;
 
-    // Detect coding agent families so we can materialize provider-specific context files.
     let mut shell_args = shell_args;
     let full_cmd = format!("{} {}", shell, shell_args.join(" "));
-    let cmd_basenames: Vec<String> = full_cmd
-        .split_whitespace()
-        .map(executable_basename)
-        .collect();
-    // Mutually exclusive detection — precedence Claude > Codex > Gemini.
-    // Required for the `debug_assert!(mutual_exclusion)` invariant inside
-    // `derive_reader` (telegram session-reader dispatch) landing in commit 3.
-    let is_claude = cmd_basenames.iter().any(|b| b.starts_with("claude"));
-    let is_codex = !is_claude && cmd_basenames.iter().any(|b| b.starts_with("codex"));
-    let is_gemini =
-        !is_claude && !is_codex && cmd_basenames.iter().any(|b| b.starts_with("gemini"));
-    let context_target = if is_claude {
-        Some(crate::config::session_context::ManagedContextTarget::Claude)
-    } else if is_codex {
-        Some(crate::config::session_context::ManagedContextTarget::Codex)
-    } else if is_gemini {
-        Some(crate::config::session_context::ManagedContextTarget::Gemini)
-    } else {
-        None
+    // #260 — single detector (session/profile.rs). Replaces the old
+    // starts_with triple; this is the SAME call `strip_auto_injected_args`
+    // makes, so the persisted recipe and the runtime identity cannot disagree.
+    let agent_kind = CodingAgentKind::detect(&shell, &shell_args);
+    let context_target = match agent_kind {
+        Some(CodingAgentKind::Claude) => {
+            Some(crate::config::session_context::ManagedContextTarget::Claude)
+        }
+        Some(CodingAgentKind::Codex) => {
+            Some(crate::config::session_context::ManagedContextTarget::Codex)
+        }
+        Some(CodingAgentKind::Gemini) => {
+            Some(crate::config::session_context::ManagedContextTarget::Gemini)
+        }
+        None => None,
     };
 
-    // Persist agent-kind flags in the SessionManager AND the local clone.
-    // The manager update ensures get_session() returns the correct flag (for telegram_attach).
-    // The local clone update ensures SessionInfo.is_* is correct (for auto-attach sites).
-    if is_claude {
-        mgr.set_is_claude(id, true).await;
-        session.is_claude = true;
-    }
-    if is_codex {
-        mgr.set_is_codex(id, true).await;
-        session.is_codex = true;
-    }
-    if is_gemini {
-        mgr.set_is_gemini(id, true).await;
-        session.is_gemini = true;
-    }
+    // Single source of truth — store the identity on the SessionManager record
+    // AND the local clone (the latter feeds the imminent `session_created` emit).
+    mgr.set_agent_kind(id, agent_kind).await;
+    session.agent_kind = agent_kind;
 
     // Auto-inject --continue for Claude agents when AC has reason to believe a prior
     // conversation exists for this session (issue #82: `is_dir()` alone is unsound;
@@ -731,7 +716,7 @@ pub async fn create_session_inner(
         .map(|p| p.is_dir())
         .unwrap_or(false);
     if should_inject_continue(
-        is_claude,
+        agent_kind == Some(CodingAgentKind::Claude),
         skip_auto_resume,
         claude_project_exists,
         &full_cmd,
@@ -756,7 +741,7 @@ pub async fn create_session_inner(
         }
     }
 
-    if is_codex && !skip_auto_resume {
+    if agent_kind == Some(CodingAgentKind::Codex) && !skip_auto_resume {
         if let Some(ref aid) = agent_id {
             if inject_codex_resume(&shell, &mut shell_args) {
                 log::info!("Auto-injected `codex resume --last` for agent '{}'", aid);
@@ -764,7 +749,7 @@ pub async fn create_session_inner(
         }
     }
 
-    if is_gemini && !skip_auto_resume {
+    if agent_kind == Some(CodingAgentKind::Gemini) && !skip_auto_resume {
         if let Some(ref aid) = agent_id {
             if inject_gemini_resume(&shell, &mut shell_args) {
                 log::info!("Auto-injected `gemini --resume latest` for agent '{}'", aid);
@@ -798,7 +783,7 @@ pub async fn create_session_inner(
     };
 
     // Claude consumes the materialized CLAUDE.md via --append-system-prompt-file.
-    if is_claude {
+    if agent_kind == Some(CodingAgentKind::Claude) {
         if let Some(context_path) = materialized_context_path.as_ref() {
             if executable_basename(&shell) == "cmd" {
                 if let Some(last) = shell_args.last_mut() {
@@ -1086,9 +1071,7 @@ pub async fn create_session(
                         &info.shell,
                         &info.shell_args,
                         &cwd,
-                        info.is_claude,
-                        info.is_codex,
-                        info.is_gemini,
+                        info.agent_kind,
                     ) {
                         Ok(r) => r,
                         Err(reason) => {
@@ -1367,9 +1350,7 @@ pub async fn restart_session(
                         &session_info.shell,
                         &session_info.shell_args,
                         &cwd,
-                        session_info.is_claude,
-                        session_info.is_codex,
-                        session_info.is_gemini,
+                        session_info.agent_kind,
                     ) {
                         Ok(r) => r,
                         Err(reason) => {
@@ -1775,9 +1756,7 @@ pub async fn create_root_agent_session(
                         &info.shell,
                         &info.shell_args,
                         &root_agent_path,
-                        info.is_claude,
-                        info.is_codex,
-                        info.is_gemini,
+                        info.agent_kind,
                     ) {
                         Ok(r) => r,
                         Err(reason) => {

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -830,6 +830,7 @@ pub async fn create_session_inner(
             120,
             30,
             &extra_env,
+            crate::session::profile::idle_tuning_for(agent_kind),
             app.clone(),
         )
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/telegram.rs
+++ b/src-tauri/src/commands/telegram.rs
@@ -9,77 +9,69 @@ use crate::session::manager::SessionManager;
 use crate::telegram::bridge::SessionReaderKind;
 use crate::telegram::manager::TelegramBridgeState;
 use crate::telegram::types::BridgeInfo;
+use crate::session::profile::CodingAgentKind;
 
 /// Derive which session-reader pipeline to spawn for a given session.
 ///
-/// - `Ok(Some(kind))` — agent detected and resolver succeeded → caller spawns the reader.
-/// - `Ok(None)` — no agent detected (or Gemini in commit 3 — handled in commit 4)
-///   → caller falls back to PTY mode.
+/// - `Ok(Some(kind))` — agent detected and resolver succeeded → caller spawns
+///   the reader.
+/// - `Ok(None)` — `agent_kind` is `None` (plain shell) → caller falls back to
+///   PTY mode.
 /// - `Err(message)` — agent detected but resolver returned None → caller logs +
 ///   emits `telegram_bridge_error` + early-returns with its contractual success
 ///   value (or `Err` for `telegram_attach`).
 ///
-/// **Mutual exclusion (H4) is asserted in debug builds.** The detection at
-/// `commands/session.rs:692-694` is mutually exclusive (Claude > Codex > Gemini),
-/// so the assertion is invariant.
+/// #260: agent selection is `Option<CodingAgentKind>`. Mutual exclusion is now
+/// structural (an enum is one variant or none), so the pre-#260
+/// `debug_assert!(kinds_set <= 1, …)` guard was removed.
 pub(crate) fn derive_reader(
     shell: &str,
     shell_args: &[String],
     cwd: &str,
-    is_claude: bool,
-    is_codex: bool,
-    is_gemini: bool,
+    agent_kind: Option<CodingAgentKind>,
 ) -> Result<Option<SessionReaderKind>, String> {
-    let kinds_set: u8 = u8::from(is_claude) + u8::from(is_codex) + u8::from(is_gemini);
-    debug_assert!(
-        kinds_set <= 1,
-        "agent-kind flags must be mutually exclusive — fix detection at commands/session.rs:692-694 (is_claude={}, is_codex={}, is_gemini={})",
-        is_claude, is_codex, is_gemini
-    );
-
     let attach_time = chrono::Utc::now();
 
-    if is_claude {
-        return match crate::commands::session::resolve_claude_projects_dir(shell, shell_args, cwd)
-        {
-            Some(p) => Ok(Some(SessionReaderKind::Claude { project_dir: p })),
-            None => Err("Cannot resolve Claude projects dir".to_string()),
-        };
+    match agent_kind {
+        Some(CodingAgentKind::Claude) => {
+            match crate::commands::session::resolve_claude_projects_dir(shell, shell_args, cwd) {
+                Some(p) => Ok(Some(SessionReaderKind::Claude { project_dir: p })),
+                None => Err("Cannot resolve Claude projects dir".to_string()),
+            }
+        }
+        Some(CodingAgentKind::Codex) => {
+            match crate::commands::codex_resolver::resolve_codex_sessions_root(
+                shell, shell_args, cwd,
+            ) {
+                Some(root) => Ok(Some(SessionReaderKind::Codex {
+                    search_root: root,
+                    cwd: cwd.to_string(),
+                    attach_time,
+                })),
+                None => Err(
+                    "Cannot resolve Codex sessions root (~/.codex/sessions/ missing)".to_string(),
+                ),
+            }
+        }
+        Some(CodingAgentKind::Gemini) => {
+            // H1 softened contract: spawn the watcher whenever `~/.gemini/`
+            // exists; the cwd-to-slug lookup is deferred to the watcher's
+            // per-poll `lookup_chats_dir_for_cwd`. Loud abort only if Gemini
+            // was never installed on this machine.
+            match crate::commands::gemini_resolver::resolve_gemini_home(shell, shell_args, cwd) {
+                Some(home) => Ok(Some(SessionReaderKind::Gemini {
+                    gemini_home: home,
+                    cwd: cwd.to_string(),
+                    attach_time,
+                })),
+                None => Err(
+                    "Cannot resolve Gemini home (~/.gemini/ missing — Gemini never installed)"
+                        .to_string(),
+                ),
+            }
+        }
+        None => Ok(None), // No agent detected — caller falls back to PTY mode.
     }
-    if is_codex {
-        return match crate::commands::codex_resolver::resolve_codex_sessions_root(
-            shell, shell_args, cwd,
-        ) {
-            Some(root) => Ok(Some(SessionReaderKind::Codex {
-                search_root: root,
-                cwd: cwd.to_string(),
-                attach_time,
-            })),
-            None => Err(
-                "Cannot resolve Codex sessions root (~/.codex/sessions/ missing)".to_string(),
-            ),
-        };
-    }
-    if is_gemini {
-        // H1 softened contract: spawn the watcher whenever `~/.gemini/` exists;
-        // the cwd-to-slug lookup is deferred to the watcher's per-poll
-        // `lookup_chats_dir_for_cwd`. Loud abort only if Gemini was never
-        // installed on this machine.
-        return match crate::commands::gemini_resolver::resolve_gemini_home(
-            shell, shell_args, cwd,
-        ) {
-            Some(home) => Ok(Some(SessionReaderKind::Gemini {
-                gemini_home: home,
-                cwd: cwd.to_string(),
-                attach_time,
-            })),
-            None => Err(
-                "Cannot resolve Gemini home (~/.gemini/ missing — Gemini never installed)"
-                    .to_string(),
-            ),
-        };
-    }
-    Ok(None) // No agent detected — caller falls back to PTY mode.
 }
 
 #[tauri::command]
@@ -98,28 +90,19 @@ pub async fn telegram_attach(
     // (`which::which` walks `%PATH%`, opens wrapper scripts) that can take hundreds
     // of milliseconds. Holding a `tokio::sync::RwLock` read guard across that would
     // starve concurrent writers (create_session, restart_session, switch_session).
-    let (is_claude, is_codex, is_gemini, shell, shell_args, working_directory) = {
+    let (agent_kind, shell, shell_args, working_directory) = {
         let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
         let mgr = session_mgr.read().await;
         let session = mgr.get_session(uuid).await.ok_or("Session not found")?;
         (
-            session.is_claude,
-            session.is_codex,
-            session.is_gemini,
+            session.agent_kind,
             session.shell.clone(),
             session.shell_args.clone(),
             session.working_directory.clone(),
         )
     };
 
-    let reader = match derive_reader(
-        &shell,
-        &shell_args,
-        &working_directory,
-        is_claude,
-        is_codex,
-        is_gemini,
-    ) {
+    let reader = match derive_reader(&shell, &shell_args, &working_directory, agent_kind) {
         Ok(r) => r,
         Err(reason) => {
             let err_msg = format!(

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -409,9 +409,14 @@ pub(crate) fn strip_auto_injected_args(shell: &str, args: &[String]) -> Vec<Stri
     }
 
     fn strip_claude_tokens(tokens: &mut Vec<String>, start: usize) {
+        // #260 — Claude's resume flag from the CodingAgentProfile. resume_tokens
+        // is a 1-element const for Claude, so [0] is provably in bounds. The
+        // `--append-system-prompt-file` flag below is the context-file flag,
+        // NOT a resume token — intentionally kept as a literal.
+        let continue_flag = CodingAgentKind::Claude.profile().resume_tokens[0];
         let mut idx = start;
         while idx < tokens.len() {
-            if tokens[idx].eq_ignore_ascii_case("--continue") {
+            if tokens[idx].eq_ignore_ascii_case(continue_flag) {
                 tokens.remove(idx);
                 continue;
             }
@@ -428,12 +433,18 @@ pub(crate) fn strip_auto_injected_args(shell: &str, args: &[String]) -> Vec<Stri
     }
 
     fn strip_codex_tokens(tokens: &mut Vec<String>, start: usize) {
+        // #260 — resume tokens from the CodingAgentProfile. G6: slice-pattern
+        // destructure, never index; a wrong-arity slice no-ops gracefully.
+        let &[resume_subcmd, resume_flag] = CodingAgentKind::Codex.profile().resume_tokens else {
+            debug_assert!(false, "Codex resume_tokens must have exactly 2 elements");
+            return;
+        };
         if tokens
             .get(start)
-            .is_some_and(|token| token.eq_ignore_ascii_case("resume"))
+            .is_some_and(|token| token.eq_ignore_ascii_case(resume_subcmd))
             && tokens
                 .get(start + 1)
-                .is_some_and(|token| token.eq_ignore_ascii_case("--last"))
+                .is_some_and(|token| token.eq_ignore_ascii_case(resume_flag))
         {
             tokens.remove(start);
             tokens.remove(start);
@@ -441,18 +452,26 @@ pub(crate) fn strip_auto_injected_args(shell: &str, args: &[String]) -> Vec<Stri
     }
 
     fn strip_gemini_tokens(tokens: &mut Vec<String>, start: usize) {
+        // #260 — resume tokens from the CodingAgentProfile. G6: slice-pattern
+        // destructure, never index. The joined `--resume=latest` variant is
+        // derived from the same two tokens.
+        let &[resume_flag, resume_value] = CodingAgentKind::Gemini.profile().resume_tokens else {
+            debug_assert!(false, "Gemini resume_tokens must have exactly 2 elements");
+            return;
+        };
+        let joined = format!("{}={}", resume_flag, resume_value);
         if tokens
             .get(start)
-            .is_some_and(|token| token.eq_ignore_ascii_case("--resume"))
+            .is_some_and(|token| token.eq_ignore_ascii_case(resume_flag))
             && tokens
                 .get(start + 1)
-                .is_some_and(|token| token.eq_ignore_ascii_case("latest"))
+                .is_some_and(|token| token.eq_ignore_ascii_case(resume_value))
         {
             tokens.remove(start);
             tokens.remove(start);
         } else if tokens
             .get(start)
-            .is_some_and(|token| token.to_lowercase() == "--resume=latest")
+            .is_some_and(|token| token.to_lowercase() == joined)
         {
             tokens.remove(start);
         }

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use crate::config::settings::WindowGeometry;
 use crate::session::manager::SessionManager;
 use crate::session::session::{SessionStatus, TEMP_SESSION_PREFIX};
+use crate::session::profile::CodingAgentKind;
 
 /// Minimal session data needed to restore a session on next app start.
 /// No UUID, just the "recipe" to re-create it.
@@ -457,39 +458,15 @@ pub(crate) fn strip_auto_injected_args(shell: &str, args: &[String]) -> Vec<Stri
         }
     }
 
-    let is_claude = std::iter::once(shell)
-        .chain(args.iter().flat_map(|s| s.split_whitespace()))
-        .any(|t| {
-            std::path::Path::new(t)
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or(t)
-                .to_ascii_lowercase()
-                .starts_with("claude")
-        });
-    let is_codex = std::iter::once(shell)
-        .chain(args.iter().flat_map(|s| s.split_whitespace()))
-        .any(|t| {
-            std::path::Path::new(t)
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or(t)
-                .eq_ignore_ascii_case("codex")
-        });
-
-    let is_gemini = std::iter::once(shell)
-        .chain(args.iter().flat_map(|s| s.split_whitespace()))
-        .any(|t| {
-            std::path::Path::new(t)
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or(t)
-                .eq_ignore_ascii_case("gemini")
-        });
-
-    if !is_claude && !is_codex && !is_gemini {
-        return args.to_vec();
-    }
+    // #260 — consult the single detector (session/profile.rs) instead of
+    // re-deriving agent identity here. Guarantees this stripper agrees with
+    // the `agent_kind` that `create_session_inner` stamped on the session.
+    let (is_claude, is_codex, is_gemini) = match CodingAgentKind::detect(shell, args) {
+        Some(CodingAgentKind::Claude) => (true, false, false),
+        Some(CodingAgentKind::Codex) => (false, true, false),
+        Some(CodingAgentKind::Gemini) => (false, false, true),
+        None => return args.to_vec(),
+    };
 
     let is_cmd = crate::commands::session::executable_basename(shell) == "cmd";
 

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -2403,9 +2403,7 @@ mod tests {
             workgroup_brief: None,
             is_coordinator: false,
             token: "t".into(),
-            is_claude: true,
-            is_codex: false,
-            is_gemini: false,
+            agent_kind: Some(crate::session::profile::CodingAgentKind::Claude),
             was_detached: false,
             detached_geometry: None,
         }

--- a/src-tauri/src/pty/idle_detector.rs
+++ b/src-tauri/src/pty/idle_detector.rs
@@ -4,13 +4,9 @@ use std::time::{Duration, Instant};
 
 use uuid::Uuid;
 
-const IDLE_THRESHOLD: Duration = Duration::from_millis(2500);
+use crate::session::profile::IdleTuning;
+
 const CHECK_INTERVAL: Duration = Duration::from_millis(500);
-/// Grace period after a resize: PTY output during this window is prompt
-/// repaint noise, not real agent activity. Suppresses false busy→idle cycles.
-/// Must be >= IDLE_THRESHOLD to prevent resize repaint from triggering a
-/// false busy→idle transition that sets pendingReview.
-const RESIZE_GRACE: Duration = Duration::from_millis(3000);
 
 type Callback = Arc<dyn Fn(Uuid) + Send + Sync>;
 
@@ -18,8 +14,44 @@ pub struct IdleDetector {
     activity: Arc<Mutex<HashMap<Uuid, Instant>>>,
     idle_set: Arc<Mutex<HashSet<Uuid>>>,
     resize_grace: Arc<Mutex<HashMap<Uuid, Instant>>>,
+    /// Per-session idle tuning, populated by `register_session` at PTY spawn.
+    /// A session missing here falls back to `IdleTuning::DEFAULT`.
+    tuning: Arc<Mutex<HashMap<Uuid, IdleTuning>>>,
     on_idle: Callback,
     on_busy: Callback,
+}
+
+/// Pure: the sessions that should transition busy→idle on this watcher tick,
+/// paired with how long they have been silent (for logging). No locks, no
+/// callbacks — unit-testable.
+///
+/// A session is only a candidate if it is present in `activity`. #260's
+/// `register_session` seed is what guarantees presence for an otherwise-silent
+/// session whose PTY output was entirely suppressed or escape-only.
+fn sessions_crossing_idle_threshold(
+    now: Instant,
+    activity: &HashMap<Uuid, Instant>,
+    idle_set: &HashSet<Uuid>,
+    tuning: &HashMap<Uuid, IdleTuning>,
+) -> Vec<(Uuid, Duration)> {
+    activity
+        .iter()
+        .filter_map(|(&id, &last_seen)| {
+            let threshold = tuning
+                .get(&id)
+                .copied()
+                .unwrap_or(IdleTuning::DEFAULT)
+                .idle_threshold;
+            // checked_duration_since avoids a panic if a PTY thread updated
+            // last_seen between Instant::now() and the lock acquisition.
+            let elapsed = now.checked_duration_since(last_seen)?;
+            if elapsed > threshold && !idle_set.contains(&id) {
+                Some((id, elapsed))
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 impl IdleDetector {
@@ -31,9 +63,35 @@ impl IdleDetector {
             activity: Arc::new(Mutex::new(HashMap::new())),
             idle_set: Arc::new(Mutex::new(HashSet::new())),
             resize_grace: Arc::new(Mutex::new(HashMap::new())),
+            tuning: Arc::new(Mutex::new(HashMap::new())),
             on_idle: Arc::new(on_idle),
             on_busy: Arc::new(on_busy),
         })
+    }
+
+    /// Register a session with the detector at PTY spawn time. Stores the
+    /// session's idle `tuning` and — when `tuning.seed_initial_activity` is
+    /// set (#260) — seeds `activity[id] = now` so the watcher evaluates the
+    /// session from t=0 even if no un-suppressed, printable PTY chunk ever
+    /// arrives (the grinch stuck-session bug — see plan §1).
+    pub fn register_session(&self, session_id: Uuid, tuning: IdleTuning) {
+        debug_assert!(
+            tuning.resize_grace >= tuning.idle_threshold,
+            "resize_grace must be >= idle_threshold or a resize repaint can \
+             trigger a false busy→idle transition"
+        );
+        self.tuning.lock().unwrap().insert(session_id, tuning);
+        if tuning.seed_initial_activity {
+            self.activity
+                .lock()
+                .unwrap()
+                .insert(session_id, Instant::now());
+            log::info!(
+                "[idle] SEEDED activity for {} at spawn (idle_threshold={}ms)",
+                &session_id.to_string()[..8],
+                tuning.idle_threshold.as_millis()
+            );
+        }
     }
 
     /// Mark that a resize just happened for this session.
@@ -52,10 +110,19 @@ impl IdleDetector {
     /// Record PTY activity (with byte count for diagnostics).
     pub fn record_activity_with_bytes(&self, session_id: Uuid, byte_count: usize) {
         let sid = &session_id.to_string()[..8];
-        // Suppress activity caused by resize prompt repaint
+        // Per-session resize grace (#260) — copy out under a brief lock.
+        let resize_grace = self
+            .tuning
+            .lock()
+            .unwrap()
+            .get(&session_id)
+            .copied()
+            .unwrap_or(IdleTuning::DEFAULT)
+            .resize_grace;
+        // Suppress activity caused by resize prompt repaint.
         if let Some(&last_resize) = self.resize_grace.lock().unwrap().get(&session_id) {
             let elapsed = last_resize.elapsed();
-            if elapsed < RESIZE_GRACE {
+            if elapsed < resize_grace {
                 log::info!(
                     "[idle] SUPPRESSED {} ({} bytes, {}ms after resize)",
                     sid,
@@ -93,6 +160,7 @@ impl IdleDetector {
         self.activity.lock().unwrap().remove(&session_id);
         self.idle_set.lock().unwrap().remove(&session_id);
         self.resize_grace.lock().unwrap().remove(&session_id);
+        self.tuning.lock().unwrap().remove(&session_id);
     }
 
     /// Start the watcher thread that polls for idle transitions.
@@ -108,30 +176,161 @@ impl IdleDetector {
                 }
 
                 let now = Instant::now();
+                // Snapshot tuning (clone, lock released) so it is never held
+                // across the activity/idle_set critical section. Lock order:
+                // tuning → activity → idle_set (consistent everywhere).
+                let tuning = detector.tuning.lock().unwrap().clone();
                 let activity = detector.activity.lock().unwrap();
                 let mut idle_set = detector.idle_set.lock().unwrap();
 
-                for (&session_id, &last_seen) in activity.iter() {
-                    // Use checked_duration_since to avoid panic when a PTY
-                    // thread updates last_seen between Instant::now() and
-                    // the lock acquisition (last_seen > now).
-                    let elapsed = match now.checked_duration_since(last_seen) {
-                        Some(d) => d,
-                        None => continue, // last_seen is in the future — skip
-                    };
-                    if elapsed > IDLE_THRESHOLD && !idle_set.contains(&session_id) {
-                        idle_set.insert(session_id);
-                        log::info!(
-                            "[idle] IDLE {} ({}ms since last activity)",
-                            &session_id.to_string()[..8],
-                            elapsed.as_millis()
-                        );
-                        // Callback inside lock scope preserves delivery order:
-                        // on_idle always fires before any on_busy for new activity.
-                        (detector.on_idle)(session_id);
-                    }
+                let crossing =
+                    sessions_crossing_idle_threshold(now, &activity, &idle_set, &tuning);
+                for (session_id, elapsed) in crossing {
+                    idle_set.insert(session_id);
+                    log::info!(
+                        "[idle] IDLE {} ({}ms since last activity)",
+                        &session_id.to_string()[..8],
+                        elapsed.as_millis()
+                    );
+                    // Callback inside the lock scope preserves delivery order:
+                    // on_idle always fires before any on_busy for new activity.
+                    (detector.on_idle)(session_id);
                 }
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_session_seeds_activity_when_profile_opts_in() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let id = Uuid::new_v4();
+        detector.register_session(id, IdleTuning::DEFAULT); // seed = true
+        assert!(
+            detector.activity.lock().unwrap().contains_key(&id),
+            "register_session must seed activity[id] — the #260 fix"
+        );
+    }
+
+    #[test]
+    fn register_session_does_not_seed_when_opted_out() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let id = Uuid::new_v4();
+        detector.register_session(
+            id,
+            IdleTuning {
+                seed_initial_activity: false,
+                ..IdleTuning::DEFAULT
+            },
+        );
+        assert!(!detector.activity.lock().unwrap().contains_key(&id));
+        // ...but the tuning is still recorded.
+        assert!(detector.tuning.lock().unwrap().contains_key(&id));
+    }
+
+    /// Acceptance criterion #1 — the grinch stuck-session regression test.
+    /// A codex session whose entire visible output was suppressed (resize
+    /// grace) / escape-only (SKIPPED), so `record_activity_with_bytes` NEVER
+    /// ran. With the #260 seed it is still in `activity` and the watcher
+    /// transitions it busy→idle after `idle_threshold`. Revert the seed in
+    /// `register_session` and the `.expect(...)` below panics → this fails.
+    #[test]
+    fn seeded_silent_session_crosses_idle_threshold() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let id = Uuid::new_v4();
+        let tuning = IdleTuning::DEFAULT;
+        detector.register_session(id, tuning);
+
+        let seeded_at = *detector
+            .activity
+            .lock()
+            .unwrap()
+            .get(&id)
+            .expect("register_session must seed activity[id] — the #260 fix");
+
+        let activity = detector.activity.lock().unwrap().clone();
+        let idle_set: HashSet<Uuid> = HashSet::new();
+        let mut tuning_map = HashMap::new();
+        tuning_map.insert(id, tuning);
+
+        // Before the threshold: no transition.
+        let early = sessions_crossing_idle_threshold(
+            seeded_at + tuning.idle_threshold - Duration::from_millis(100),
+            &activity,
+            &idle_set,
+            &tuning_map,
+        );
+        assert!(early.is_empty(), "must not transition before idle_threshold");
+
+        // After idle_threshold of pure silence: transition fires even though
+        // record_activity_with_bytes was NEVER called for this session.
+        let crossed = sessions_crossing_idle_threshold(
+            seeded_at + tuning.idle_threshold + Duration::from_millis(100),
+            &activity,
+            &idle_set,
+            &tuning_map,
+        );
+        let ids: Vec<Uuid> = crossed.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec![id], "seeded silent session must reach idle");
+    }
+
+    /// Documents the bug mechanism: WITHOUT a seed, an all-suppressed session
+    /// is absent from `activity` and the watcher never even evaluates it —
+    /// no matter how much time passes.
+    #[test]
+    fn unseeded_session_never_transitions() {
+        let id = Uuid::new_v4();
+        let activity: HashMap<Uuid, Instant> = HashMap::new(); // never seeded
+        let idle_set: HashSet<Uuid> = HashSet::new();
+        let mut tuning_map = HashMap::new();
+        tuning_map.insert(id, IdleTuning::DEFAULT);
+
+        let crossed = sessions_crossing_idle_threshold(
+            Instant::now() + Duration::from_secs(3600),
+            &activity,
+            &idle_set,
+            &tuning_map,
+        );
+        assert!(
+            crossed.is_empty(),
+            "an un-seeded session is invisible to the watcher — the #260 bug"
+        );
+    }
+
+    /// The resize-grace suppression that contributes to the bug must not
+    /// clear the seed: output arriving inside the grace window is suppressed,
+    /// but the seeded `activity[id]` survives so the watcher can still act.
+    #[test]
+    fn resize_grace_suppression_preserves_the_seed() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let id = Uuid::new_v4();
+        detector.register_session(id, IdleTuning::DEFAULT);
+        detector.record_resize(id);
+        // "Initial output" arrives inside RESIZE_GRACE → suppressed.
+        detector.record_activity_with_bytes(id, 500);
+        assert!(
+            detector.activity.lock().unwrap().contains_key(&id),
+            "the seed must survive resize-grace suppression"
+        );
+    }
+
+    /// dev-rust R1.5 — guards the `tuning.remove` line §6.1 adds to
+    /// `remove_session`; without it a future detector-map leak is silent.
+    #[test]
+    fn remove_session_clears_tuning() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let id = Uuid::new_v4();
+        detector.register_session(id, IdleTuning::DEFAULT);
+        assert!(detector.tuning.lock().unwrap().contains_key(&id));
+        detector.remove_session(id);
+        assert!(
+            !detector.tuning.lock().unwrap().contains_key(&id),
+            "remove_session must drop the tuning entry"
+        );
+        assert!(!detector.activity.lock().unwrap().contains_key(&id));
     }
 }

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use crate::errors::AppError;
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
+use crate::session::profile::IdleTuning;
 use crate::telegram::manager::OutputSenderMap;
 
 struct PtyInstance {
@@ -287,6 +288,7 @@ impl PtyManager {
         cols: u16,
         rows: u16,
         extra_env: &[(String, String)],
+        idle_tuning: IdleTuning,
         app_handle: AppHandle,
     ) -> Result<(), AppError> {
         let pty_system = native_pty_system();
@@ -381,6 +383,11 @@ impl PtyManager {
         };
 
         self.ptys.lock().unwrap().insert(id, instance);
+
+        // #260 — register with the idle detector. Seeds activity[id] (when the
+        // profile opts in) so an all-suppressed / escape-only session is still
+        // evaluated by the watcher. Must run before the read loop starts.
+        self.idle_detector.register_session(id, idle_tuning);
 
         // Initialize vt100 screen parser for this session (for WS replay)
         {

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -743,4 +743,43 @@ mod tests {
         // Active pointer correctly reflects the selection.
         assert_eq!(mgr.get_active().await, Some(session.id));
     }
+
+    /// #260 G1 — pins `mark_idle`'s contract: the terminal mutation the
+    /// idle-detector `on_idle` callback performs. NOTE: `create_session`
+    /// auto-activates the first session (status `Active`), and `mark_idle`
+    /// only transitions `Running → Idle` — so demote via `clear_active` first.
+    /// Without that step the status assertion below would be vacuous.
+    #[tokio::test]
+    async fn mark_idle_sets_waiting_for_input_and_running_to_idle() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "codex".into(),
+                vec![],
+                "C:\\proj".into(),
+                None,
+                None,
+                vec![],
+                false,
+            )
+            .await
+            .unwrap();
+        mgr.clear_active().await; // Active → Running
+        let before = mgr.get_session(session.id).await.unwrap();
+        assert_eq!(before.status, SessionStatus::Running);
+        assert!(!before.waiting_for_input);
+
+        mgr.mark_idle(session.id).await;
+
+        let after = mgr.get_session(session.id).await.unwrap();
+        assert!(
+            after.waiting_for_input,
+            "mark_idle must set waiting_for_input = true"
+        );
+        assert_eq!(
+            after.status,
+            SessionStatus::Idle,
+            "mark_idle must transition Running → Idle"
+        );
+    }
 }

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -4,6 +4,7 @@ use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use super::session::{Session, SessionInfo, SessionRepo, SessionStatus};
+use super::profile::CodingAgentKind;
 use crate::config::settings::WindowGeometry;
 use crate::errors::AppError;
 
@@ -67,9 +68,7 @@ impl SessionManager {
             is_coordinator,
             git_repos_gen: 0,
             token: Uuid::new_v4(),
-            is_claude: false,
-            is_codex: false,
-            is_gemini: false,
+            agent_kind: None,
             was_detached: false,
             detached_geometry: None,
         };
@@ -323,24 +322,12 @@ impl SessionManager {
         }
     }
 
-    pub async fn set_is_claude(&self, id: Uuid, val: bool) {
+    /// Set the resolved coding-agent identity. Called once by
+    /// `create_session_inner` immediately after `CodingAgentKind::detect`.
+    pub async fn set_agent_kind(&self, id: Uuid, kind: Option<CodingAgentKind>) {
         let mut sessions = self.sessions.write().await;
         if let Some(s) = sessions.get_mut(&id) {
-            s.is_claude = val;
-        }
-    }
-
-    pub async fn set_is_codex(&self, id: Uuid, val: bool) {
-        let mut sessions = self.sessions.write().await;
-        if let Some(s) = sessions.get_mut(&id) {
-            s.is_codex = val;
-        }
-    }
-
-    pub async fn set_is_gemini(&self, id: Uuid, val: bool) {
-        let mut sessions = self.sessions.write().await;
-        if let Some(s) = sessions.get_mut(&id) {
-            s.is_gemini = val;
+            s.agent_kind = kind;
         }
     }
 

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -2,3 +2,4 @@ pub mod manager;
 // Inner module shares the parent name; renaming would churn every import.
 #[allow(clippy::module_inception)]
 pub mod session;
+pub mod profile;

--- a/src-tauri/src/session/profile.rs
+++ b/src-tauri/src/session/profile.rs
@@ -128,12 +128,11 @@ pub struct CodingAgentProfile {
     /// Argv tokens AC auto-injects to resume the agent's prior conversation,
     /// in argv order. The single source of truth for both injection
     /// (`create_session_inner`) and stripping (`strip_auto_injected_args`):
-    ///   - Claude → `["--continue"]`         (appended to argv)
-    ///   - Codex  → `["resume", "--last"]`   (prepended as a subcommand)
-    ///   - Gemini → `["--resume", "latest"]` (prepended; the joined
-    ///                                        `--resume=latest` form is
-    ///                                        handled by the Gemini stripper
-    ///                                        as a recognised variant)
+    /// - Claude → `["--continue"]` (appended to argv)
+    /// - Codex → `["resume", "--last"]` (prepended as a subcommand)
+    /// - Gemini → `["--resume", "latest"]` (prepended; the joined
+    ///   `--resume=latest` form is handled by the Gemini stripper as a
+    ///   recognised variant)
     pub resume_tokens: &'static [&'static str],
 }
 
@@ -266,7 +265,10 @@ mod tests {
         ] {
             assert!(kind.profile().idle.seed_initial_activity);
         }
-        assert!(IdleTuning::DEFAULT.seed_initial_activity);
+        // Routed through the non-const `idle_tuning_for` so this stays a
+        // runtime assertion (a bare `IdleTuning::DEFAULT.…` is const-folded,
+        // which clippy::assertions_on_constants rejects).
+        assert!(idle_tuning_for(None).seed_initial_activity);
     }
 
     /// dev-rust R1.5 — locks the §11 "all three profiles == DEFAULT → zero

--- a/src-tauri/src/session/profile.rs
+++ b/src-tauri/src/session/profile.rs
@@ -1,0 +1,285 @@
+//! Per-coding-agent profile — the single source of truth for behavior that
+//! varies by coding agent (Claude Code, Codex CLI, Gemini CLI).
+//!
+//! Before #260 this knowledge was scattered: three `is_claude`/`is_codex`/
+//! `is_gemini` bools on `Session`/`SessionInfo` (#258), a duplicated
+//! `starts_with` detector in `create_session_inner` and
+//! `strip_auto_injected_args`, the `derive_reader` bool triple, and
+//! hard-coded idle-detector thresholds. `CodingAgentProfile` consolidates it.
+//!
+//! Design (see _plans/260-coding-agent-profile.md §2): plain `Copy` data +
+//! `const` lookup, not a trait — the agent set is small and closed and only
+//! data varies, so a struct beats a `dyn` object (no vtables, no allocation,
+//! usable in `const` context, exhaustive `match` on `CodingAgentKind`).
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// Identity of a coding agent. `Option<CodingAgentKind>` on a session: `None`
+/// means "not a recognised coding agent" (a plain shell).
+///
+/// Mutual exclusion is **structural** — a session is exactly one kind or none.
+/// This enum is what let #260 delete the `debug_assert!` that guarded the old
+/// three-bool representation in `derive_reader`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodingAgentKind {
+    Claude,
+    Codex,
+    Gemini,
+}
+
+impl CodingAgentKind {
+    /// Detect the coding agent from a spawn command (`shell` + `args`).
+    ///
+    /// Scans the shell and every whitespace-split arg token, reduces each to
+    /// its executable basename (file stem, lowercased), and matches by
+    /// **prefix** with precedence **Claude > Codex > Gemini**. Prefix match
+    /// (not exact) is deliberate: it catches wrapper executables such as
+    /// `claude-mb`, `codex-foo`, `gemini-bar`.
+    ///
+    /// THIS IS THE detector. `create_session_inner` (which stamps
+    /// `Session::agent_kind`) and `strip_auto_injected_args` both call it, so
+    /// the persisted recipe and the runtime identity can never disagree.
+    pub fn detect(shell: &str, args: &[String]) -> Option<CodingAgentKind> {
+        // Mirror of `crate::commands::session::executable_basename`
+        // (`session.rs:1506`, identical body). Deliberately NOT shared:
+        // importing it would invert the dependency direction — the `session`
+        // domain module would depend on the `commands` (IPC) layer (§2 D2).
+        // ~6 trivial lines; do not "consolidate" into a layering violation
+        // (dev-rust R1.4 #3).
+        fn basename(token: &str) -> String {
+            std::path::Path::new(token)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or(token)
+                .to_lowercase()
+        }
+        let basenames: Vec<String> = std::iter::once(shell.to_string())
+            .chain(
+                args.iter()
+                    .flat_map(|a| a.split_whitespace().map(str::to_string)),
+            )
+            .map(|t| basename(&t))
+            .collect();
+        // Precedence claude > codex > gemini, scanning every token.
+        if basenames.iter().any(|b| b.starts_with("claude")) {
+            Some(CodingAgentKind::Claude)
+        } else if basenames.iter().any(|b| b.starts_with("codex")) {
+            Some(CodingAgentKind::Codex)
+        } else if basenames.iter().any(|b| b.starts_with("gemini")) {
+            Some(CodingAgentKind::Gemini)
+        } else {
+            None
+        }
+    }
+
+    /// Resolve the full behavior profile for this kind.
+    pub const fn profile(self) -> CodingAgentProfile {
+        match self {
+            CodingAgentKind::Claude => CLAUDE_PROFILE,
+            CodingAgentKind::Codex => CODEX_PROFILE,
+            CodingAgentKind::Gemini => GEMINI_PROFILE,
+        }
+    }
+}
+
+/// Per-session tuning for the PTY idle detector. Resolved from the session's
+/// `CodingAgentProfile` (or `DEFAULT` for a plain shell) and handed to
+/// `IdleDetector::register_session` at PTY spawn time.
+///
+/// Invariant: `resize_grace >= idle_threshold` — a resize repaint must not be
+/// able to trigger a false busy→idle transition. `register_session`
+/// `debug_assert!`s it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IdleTuning {
+    /// PTY silence after which a session is reported idle / waiting-for-input.
+    pub idle_threshold: Duration,
+    /// Grace window after a resize during which PTY output is treated as
+    /// prompt-repaint noise and does NOT reset the idle timer.
+    pub resize_grace: Duration,
+    /// #260 BUG FIX. When `true`, `IdleDetector::register_session` seeds
+    /// `activity[id] = Instant::now()` at PTY spawn. Without this seed, a
+    /// session whose entire visible output is suppressed (resize grace) or
+    /// escape-only (SKIPPED) is never inserted into the detector's `activity`
+    /// map, so the watcher thread — which only iterates `activity` — never
+    /// evaluates it and `mark_idle` never fires. See plan §1.
+    pub seed_initial_activity: bool,
+}
+
+impl IdleTuning {
+    /// Tuning for a plain shell / unrecognised agent. Also the per-field
+    /// fallback when a session id is missing from the detector's tuning map.
+    /// Values are identical to the pre-#260 `idle_detector.rs` constants.
+    pub const DEFAULT: IdleTuning = IdleTuning {
+        idle_threshold: Duration::from_millis(2500),
+        resize_grace: Duration::from_millis(3000),
+        seed_initial_activity: true,
+    };
+}
+
+/// All behavior that varies per coding agent. Plain `Copy` data (see §2 D1).
+#[derive(Debug, Clone, Copy)]
+pub struct CodingAgentProfile {
+    pub kind: CodingAgentKind,
+    /// Idle-detector tuning for sessions running this agent.
+    pub idle: IdleTuning,
+    /// Argv tokens AC auto-injects to resume the agent's prior conversation,
+    /// in argv order. The single source of truth for both injection
+    /// (`create_session_inner`) and stripping (`strip_auto_injected_args`):
+    ///   - Claude → `["--continue"]`         (appended to argv)
+    ///   - Codex  → `["resume", "--last"]`   (prepended as a subcommand)
+    ///   - Gemini → `["--resume", "latest"]` (prepended; the joined
+    ///                                        `--resume=latest` form is
+    ///                                        handled by the Gemini stripper
+    ///                                        as a recognised variant)
+    pub resume_tokens: &'static [&'static str],
+}
+
+// All three agents currently use `IdleTuning::DEFAULT` — identical to the
+// pre-#260 hard-coded constants, which GUARANTEES zero behavior change. The
+// per-profile `idle` field exists so a future agent can diverge (e.g. a
+// longer `resize_grace` for a heavier TUI) without re-plumbing the detector.
+const CLAUDE_PROFILE: CodingAgentProfile = CodingAgentProfile {
+    kind: CodingAgentKind::Claude,
+    idle: IdleTuning::DEFAULT,
+    resume_tokens: &["--continue"],
+};
+const CODEX_PROFILE: CodingAgentProfile = CodingAgentProfile {
+    kind: CodingAgentKind::Codex,
+    idle: IdleTuning::DEFAULT,
+    resume_tokens: &["resume", "--last"],
+};
+const GEMINI_PROFILE: CodingAgentProfile = CodingAgentProfile {
+    kind: CodingAgentKind::Gemini,
+    idle: IdleTuning::DEFAULT,
+    resume_tokens: &["--resume", "latest"],
+};
+
+/// Idle-detector tuning for a session, given its (optional) agent kind.
+/// `None` (plain shell / unrecognised agent) → `IdleTuning::DEFAULT`.
+pub fn idle_tuning_for(kind: Option<CodingAgentKind>) -> IdleTuning {
+    match kind {
+        Some(k) => k.profile().idle,
+        None => IdleTuning::DEFAULT,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_direct_claude_and_wrapper_basename() {
+        assert_eq!(
+            CodingAgentKind::detect("claude", &[]),
+            Some(CodingAgentKind::Claude)
+        );
+        // claude-mb wrapper — prefix match.
+        assert_eq!(
+            CodingAgentKind::detect("claude-mb", &["--effort".into(), "max".into()]),
+            Some(CodingAgentKind::Claude)
+        );
+    }
+
+    #[test]
+    fn detect_codex_and_gemini_direct() {
+        assert_eq!(
+            CodingAgentKind::detect("codex", &[]),
+            Some(CodingAgentKind::Codex)
+        );
+        assert_eq!(
+            CodingAgentKind::detect("gemini", &["-m".into(), "gpt-5".into()]),
+            Some(CodingAgentKind::Gemini)
+        );
+    }
+
+    #[test]
+    fn detect_inside_cmd_wrapper_tokenized_and_embedded() {
+        // cmd /C codex ...
+        assert_eq!(
+            CodingAgentKind::detect("cmd.exe", &["/C".into(), "codex".into()]),
+            Some(CodingAgentKind::Codex)
+        );
+        // cmd /K "git pull && gemini --resume latest"  (embedded in one arg)
+        assert_eq!(
+            CodingAgentKind::detect(
+                "cmd.exe",
+                &["/K".into(), "git pull && gemini --resume latest".into()]
+            ),
+            Some(CodingAgentKind::Gemini)
+        );
+    }
+
+    #[test]
+    fn detect_precedence_claude_wins() {
+        // A compound command mentioning both — Claude takes precedence,
+        // matching create_session_inner's pre-#260 ordering.
+        assert_eq!(
+            CodingAgentKind::detect("cmd.exe", &["/K".into(), "codex && claude".into()]),
+            Some(CodingAgentKind::Claude)
+        );
+    }
+
+    #[test]
+    fn detect_plain_shell_is_none() {
+        assert_eq!(CodingAgentKind::detect("powershell.exe", &["-NoLogo".into()]), None);
+        assert_eq!(CodingAgentKind::detect("cmd.exe", &[]), None);
+    }
+
+    #[test]
+    fn detect_strips_known_exe_extension() {
+        // `file_stem` drops the `.exe` suffix the basename match relies on
+        // (dev-rust R1.5).
+        assert_eq!(
+            CodingAgentKind::detect("claude.exe", &[]),
+            Some(CodingAgentKind::Claude)
+        );
+    }
+
+    #[test]
+    fn detect_space_in_shell_path_treats_shell_as_one_token() {
+        // #260 G3 — `detect` treats `shell` as a SINGLE token; it does NOT
+        // whitespace-split it the way pre-#260 `create_session_inner` split
+        // the joined command string. A space-containing shell path whose real
+        // executable is not an agent therefore resolves to `None` (the more
+        // correct result — the executable here is `runner.exe`).
+        assert_eq!(
+            CodingAgentKind::detect("C:\\codex tools\\runner.exe", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn idle_tuning_for_none_is_default() {
+        assert_eq!(idle_tuning_for(None), IdleTuning::DEFAULT);
+    }
+
+    #[test]
+    fn every_profile_seeds_initial_activity() {
+        // The #260 fix must be on for all agents (and the default).
+        for kind in [
+            CodingAgentKind::Claude,
+            CodingAgentKind::Codex,
+            CodingAgentKind::Gemini,
+        ] {
+            assert!(kind.profile().idle.seed_initial_activity);
+        }
+        assert!(IdleTuning::DEFAULT.seed_initial_activity);
+    }
+
+    /// dev-rust R1.5 — locks the §11 "all three profiles == DEFAULT → zero
+    /// idle-tuning regression" guarantee. A future stray per-agent retune
+    /// fails here loudly instead of silently shifting behavior.
+    #[test]
+    fn every_profile_uses_default_idle_tuning() {
+        for kind in [
+            CodingAgentKind::Claude,
+            CodingAgentKind::Codex,
+            CodingAgentKind::Gemini,
+        ] {
+            assert_eq!(kind.profile().idle, IdleTuning::DEFAULT);
+        }
+    }
+}

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use uuid::Uuid;
 
 use crate::config::settings::WindowGeometry;
+use crate::session::profile::CodingAgentKind;
 
 /// Mangle a CWD path the same way Claude Code does for its project directories.
 /// Non-alphanumeric, non-hyphen characters are replaced with '-'.
@@ -86,18 +87,13 @@ pub struct Session {
     pub git_repos_gen: u64,
     /// Unique token for CLI authentication. Agent PTY children receive it via per-child `AGENTSCOMMANDER_TOKEN` env at spawn.
     pub token: Uuid,
-    /// True if this session runs Claude Code (detected at creation time).
-    /// Used by the Telegram bridge to choose JSONL watcher vs PTY pipeline.
+    /// Resolved coding-agent identity, or `None` for a plain shell. Set once
+    /// by `create_session_inner` via `CodingAgentKind::detect`. The single
+    /// source of truth that replaced the #258 `is_claude`/`is_codex`/
+    /// `is_gemini` triple (#260). Drives idle tuning, resume-arg injection,
+    /// and Telegram reader selection.
     #[serde(default)]
-    pub is_claude: bool,
-    /// True if this session runs Codex CLI (detected at creation time).
-    /// Used by the Telegram bridge to choose the Codex JSONL watcher.
-    #[serde(default)]
-    pub is_codex: bool,
-    /// True if this session runs Gemini CLI (detected at creation time).
-    /// Used by the Telegram bridge to choose the Gemini JSONL watcher.
-    #[serde(default)]
-    pub is_gemini: bool,
+    pub agent_kind: Option<CodingAgentKind>,
     /// True while this session has a live detached window (or is marked to re-spawn
     /// one on next launch). Source of truth for persistence — `snapshot_sessions`
     /// reads this directly, NOT from `DetachedSessionsState`.
@@ -185,11 +181,7 @@ pub struct SessionInfo {
     pub is_coordinator: bool,
     pub token: String,
     #[serde(default)]
-    pub is_claude: bool,
-    #[serde(default)]
-    pub is_codex: bool,
-    #[serde(default)]
-    pub is_gemini: bool,
+    pub agent_kind: Option<CodingAgentKind>,
     #[serde(default)]
     pub was_detached: bool,
     /// Not serialized to the frontend — internal carrier for `snapshot_sessions`
@@ -219,9 +211,7 @@ impl From<&Session> for SessionInfo {
             workgroup_brief: read_workgroup_brief_for_cwd(&s.working_directory),
             is_coordinator: s.is_coordinator,
             token: s.token.to_string(),
-            is_claude: s.is_claude,
-            is_codex: s.is_codex,
-            is_gemini: s.is_gemini,
+            agent_kind: s.agent_kind,
             was_detached: s.was_detached,
             detached_geometry: s.detached_geometry.clone(),
         }
@@ -251,9 +241,7 @@ mod tests {
             is_coordinator: false,
             git_repos_gen: 0,
             token: Uuid::nil(),
-            is_claude: false,
-            is_codex: false,
-            is_gemini: false,
+            agent_kind: None,
             was_detached: false,
             detached_geometry: None,
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -22,12 +22,12 @@ export interface Session {
   workgroupBrief: string | null;
   isCoordinator: boolean;
   token: string;
-  isClaude: boolean;
-  isCodex: boolean;
-  isGemini: boolean;
+  agentKind: CodingAgentKind | null;
 }
 
 export type SessionStatus = "active" | "running" | "idle" | { exited: number };
+
+export type CodingAgentKind = "claude" | "codex" | "gemini";
 
 export interface SessionGroup {
   id: string;

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -54,6 +54,7 @@ function makeInactiveEntry(name: string, path: string): Session {
     workgroupBrief: null,
     isCoordinator: false,
     token: "",
+    agentKind: null,
   };
 }
 


### PR DESCRIPTION
## Summary

Consolidates all coding-agent-specific behavior into a single `CodingAgentProfile` abstraction (the user-chosen "refactor amplio" scope), and fixes a session-stuck bug in the idle detector.

## The bug

Codex sessions could remain marked `waiting_for_input: false` (UI shows them as not-idle / "active") indefinitely, even while the codex TUI sat idle at its `Ready` prompt. Root cause, confirmed against a live `app.log`: the session's initial visible output landed inside the `RESIZE_GRACE` window (suppressed), and afterwards codex emitted only escape-only chunks (cursor/status-bar repaints, filtered as `SKIPPED activity`). `record_activity_with_bytes` therefore never ran, the `activity` map was never populated, and the watcher thread — which iterates that map — never saw the session, so `mark_idle` never fired. The detection logic is agent-agnostic, but rich-TUI agents (codex) trigger the failure far more often than plain-text agents (Claude Code).

## Changes — 3 phases

- **Phase 1** (`27a7815`) — new `session/profile.rs`; `CodingAgentKind` enum + `CodingAgentProfile`; the 3 bools `is_claude`/`is_codex`/`is_gemini` collapse into `Session.agent_kind`; `derive_reader` consumes the enum.
- **Phase 2** (`1ada56f`) — the bug fix: per-session `IdleTuning`, idle detector **seeded at spawn** (`register_session`) so silent sessions become evaluable from t=0 and reach idle.
- **Phase 3** (`1c15a0a`) — `resume_tokens` routed through the profile; arg inject/strip consume it.

Plus `e3a8186` (clippy/tsc static-gate fixes) and `ed97aa5` (version bump to **0.8.33**). Also incorporates `origin/main` via merge `bad3cbb` (PR #262 was merged mid-flight and took 0.8.32; this branch re-bumps to 0.8.33).

## Process (full workflow)

architect plan → dev-rust + dev-rust-grinch round-1 review (converged clean, rounds 2-3 skipped) → implementation → `/feature-dev` quality review (0 HIGH) → grinch adversarial review of the implementation (`APPROVED`). `cargo test`: 565 passed / 0 failed. 17 new tests, including the regression test `seeded_silent_session_crosses_idle_threshold`.

## Smoke test (plan §9 step 5)

The plan specified a live smoke test (launch a real codex session, observe the `waiting_for_input` transition + the `[idle] SEEDED` log line). It was **deferred by user decision**: every available agent is blocked from running it (dev-rust headless, shipper by role, ac-cli-tester and tech-lead by write-zone restrictions on the binary's config dir). The wiring is instead verified by: (a) dev-rust — `cargo build` emits no `unused: idle_tuning` warning, proving `register_session` is wired; (b) grinch — traced `create_session_inner → idle_tuning_for(agent_kind) → spawn → register_session → seed` end-to-end, confirmed `spawn` has exactly one caller; (c) the unit regression test, which fails if the seed is reverted.

Closes #260