### PR TITLE
feat: surface ERROR-level log events via an error modal (#264)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.32",
+      "version": "0.8.33",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.33",
+      "version": "0.8.34",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.32"
+version = "0.8.33"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.32"
+version = "0.8.33"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.33"
+version = "0.8.34"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:window:allow-close",
     "core:window:allow-destroy",
     "core:window:allow-set-focus",
+    "core:window:allow-request-user-attention",
     "core:window:allow-set-title",
     "core:window:allow-minimize",
     "core:window:allow-unminimize",

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -42,6 +42,15 @@ pub async fn save_debug_logs(content: String) -> Result<(), String> {
     Ok(())
 }
 
+/// #264 — read-and-clear the buffered ERROR-level log entries for the UI error
+/// modal. The frontend calls this once on `ErrorModal` mount (to collect errors
+/// logged before the webview was listening) and again on every `error_log_event`
+/// ping. Sync (no I/O, no `.await`) — a sub-microsecond mutex take.
+#[tauri::command]
+pub fn drain_error_logs() -> Vec<crate::logging::ErrorLogEntry> {
+    crate::logging::error_sink().drain()
+}
+
 #[tauri::command]
 pub async fn get_settings(settings: State<'_, SettingsState>) -> Result<AppSettings, String> {
     let s = settings.read().await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -297,6 +297,13 @@ pub fn run() {
             // Make AppHandle available to idle detector callbacks
             let _ = app_handle_lock.set(app.handle().clone());
 
+            // #264 — spawn the background task that emits `error_log_event`
+            // pings to the UI when ERROR entries are captured. The task runs
+            // OUTSIDE the env_logger format closure (see §3.7 / B1). Entries
+            // logged before this point stay buffered; the frontend's first
+            // `drain_error_logs` call collects them.
+            crate::logging::spawn_error_emit_task(app.handle().clone());
+
             // Git branch watcher: polls git branch for each session every 5s
             let git_watcher = GitWatcher::new(session_mgr_for_git, app.handle().clone());
             git_watcher.start(shutdown_for_setup.clone());
@@ -999,6 +1006,7 @@ pub fn run() {
             commands::voice::voice_mark_recording,
             commands::voice::voice_had_typing,
             commands::config::save_debug_logs,
+            commands::config::drain_error_logs,
             commands::config::open_web_remote,
             commands::config::start_web_server,
             commands::config::stop_web_server,

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -12,8 +12,9 @@
 //! Without the guard, a second `env_logger::Builder::init()` would panic via
 //! `log::set_logger`'s "called twice" contract.
 
+use std::collections::VecDeque;
 use std::io::Write;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
 static INIT: OnceLock<()> = OnceLock::new();
 
@@ -77,6 +78,14 @@ fn init_logger_inner() {
                     record.target(),
                     record.args()
                 );
+                // #264 — tee ERROR-level entries from AgentsCommander's own
+                // targets into the process-wide sink for the UI error modal.
+                // Placed BEFORE the `?` writes below so a failing stderr/app.log
+                // write cannot skip capture (M1). MUST NOT call any log::* macro
+                // — this runs inside the logger and would recurse.
+                if should_capture(record) {
+                    error_sink().capture(ErrorLogEntry::from_record(ts.to_string(), record));
+                }
                 buf.write_all(line.as_bytes())?;
                 if let Some(ref file_mtx) = *log_file {
                     if let Ok(mut f) = file_mtx.lock() {
@@ -87,4 +96,255 @@ fn init_logger_inner() {
             }
         })
         .init();
+}
+
+// ===========================================================================
+// #264 — ERROR-level log capture for the UI error modal.
+// ===========================================================================
+
+/// One captured ERROR-level log entry, surfaced to the UI error modal (#264).
+/// Field names serialize to camelCase to match `src/shared/types.ts`.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorLogEntry {
+    /// Local wall-clock timestamp, e.g. "2026-05-21 15:56:11.123".
+    pub timestamp: String,
+    /// Level string — always "ERROR" today; kept for forward-compat + copy text.
+    pub level: String,
+    /// Log target (module path), e.g. "agentscommander_lib::commands::entity_creation".
+    pub target: String,
+    /// Full message; may contain embedded newlines (multi-line git errors etc.).
+    pub message: String,
+}
+
+impl ErrorLogEntry {
+    /// Build an entry from a log `Record` plus a preformatted timestamp.
+    /// Factored out of the format closure so it is unit-testable with a
+    /// synthetic `Record` — the closure itself cannot be invoked from a test.
+    fn from_record(timestamp: String, record: &log::Record) -> Self {
+        Self {
+            timestamp,
+            level: record.level().to_string(),
+            target: record.target().to_string(),
+            message: record.args().to_string(),
+        }
+    }
+}
+
+/// Whether a log record should be teed into the error-modal sink: ERROR level
+/// AND a target owned by one of AgentsCommander's own crates
+/// (`agentscommander_lib::…` or `agentscommander_new`). The target-prefix guard
+/// keeps third-party crates' ERROR logs (`hyper`, `reqwest`, …) out of the modal
+/// even if `RUST_LOG` is widened. Factored out of the format closure so the
+/// single most safety-critical predicate of #264 is directly unit-testable (M3).
+fn should_capture(record: &log::Record) -> bool {
+    record.level() == log::Level::Error && record.target().starts_with("agentscommander")
+}
+
+/// Buffer cap. Bounds memory if ERROR entries are produced before any frontend
+/// drains them (startup storm, or CLI mode where the sink is never drained).
+/// Oldest entries are dropped on overflow.
+const ERROR_BUFFER_CAP: usize = 200;
+
+/// Process-wide sink that tees ERROR-level log entries to the Tauri UI layer.
+///
+/// `pending` is the source of truth — every captured entry lands there.
+/// `notify` wakes the emit task (`spawn_error_emit_task`). The `env_logger`
+/// format closure calls only `capture()`, which pushes to `pending` and then
+/// `notify_one()` — both sync, log-free and panic-free. The actual
+/// `error_log_event` emit runs OUTSIDE the logger, in the emit task (see §3.7).
+/// The emitted event is a content-free *ping*: the frontend responds by calling
+/// `drain_error_logs`, which read-and-clears `pending`. Because `capture()`
+/// pushes BEFORE signalling, a drain triggered by the ping always observes the
+/// entry — race-free without sequence numbers.
+pub struct ErrorEventSink {
+    pending: Mutex<VecDeque<ErrorLogEntry>>,
+    notify: tokio::sync::Notify,
+}
+
+impl ErrorEventSink {
+    fn new() -> Self {
+        Self {
+            pending: Mutex::new(VecDeque::new()),
+            notify: tokio::sync::Notify::new(),
+        }
+    }
+
+    /// Buffer an ERROR entry and wake the emit task. Runs inside the
+    /// `env_logger` format closure, so it MUST NOT call any `log::*` macro and
+    /// MUST NOT panic. `notify_one()` is sync, non-blocking, log-free,
+    /// panic-free, and needs no tokio runtime (only the awaiting side does).
+    pub fn capture(&self, entry: ErrorLogEntry) {
+        {
+            // into_inner() recovers a poisoned lock so one panic while holding
+            // the mutex cannot permanently disable error capture.
+            let mut buf = self.pending.lock().unwrap_or_else(|e| e.into_inner());
+            if buf.len() >= ERROR_BUFFER_CAP {
+                buf.pop_front();
+            }
+            buf.push_back(entry);
+        }
+        // Wake the emit task. Coalescing is intentional: Notify holds at most
+        // one permit, so a burst of captures between wake-ups yields a single
+        // ping — the frontend's read-and-clear drain collects them all anyway.
+        self.notify.notify_one();
+    }
+
+    /// Read-and-clear all buffered entries. Each entry is returned exactly once.
+    pub fn drain(&self) -> Vec<ErrorLogEntry> {
+        let mut buf = self.pending.lock().unwrap_or_else(|e| e.into_inner());
+        Vec::from(std::mem::take(&mut *buf))
+    }
+
+    /// Await the next `capture()` signal. Used only by `spawn_error_emit_task`.
+    async fn wait_for_capture(&self) {
+        self.notify.notified().await;
+    }
+}
+
+static ERROR_SINK: OnceLock<ErrorEventSink> = OnceLock::new();
+
+/// Accessor for the process-wide error sink. Lazily initialized on first use.
+pub fn error_sink() -> &'static ErrorEventSink {
+    ERROR_SINK.get_or_init(ErrorEventSink::new)
+}
+
+/// Spawn the background task that emits the `error_log_event` ping to the UI.
+/// Called once from `lib::run()`'s `setup()` hook (§5.3.a).
+///
+/// The task waits on the sink's `Notify` and emits a content-free ping each
+/// time `capture()` signals. Running the emit HERE — outside the `env_logger`
+/// format closure — keeps the logging hot path minimal and isolates any panic
+/// inside `emit()` from the arbitrary `log::error!` call site. See §3.7.
+pub fn spawn_error_emit_task(app: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            error_sink().wait_for_capture().await;
+            // emit() is sync + thread-safe (idle-detector precedent, lib.rs:207);
+            // a failed emit is swallowed. Running outside the logger means emit()'s
+            // transitive log calls (if any) cannot re-enter the format closure.
+            let _ = tauri::Emitter::emit(&app, "error_log_event", ());
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an `ErrorLogEntry` carrying `message`; the other fields are fixed.
+    fn entry(message: &str) -> ErrorLogEntry {
+        ErrorLogEntry {
+            timestamp: "2026-05-21 12:00:00.000".to_string(),
+            level: "ERROR".to_string(),
+            target: "agentscommander_lib::test".to_string(),
+            message: message.to_string(),
+        }
+    }
+
+    /// Run `should_capture` against a synthetic record. The `Record` (and the
+    /// `format_args!` temporary it borrows) is built and consumed inside this
+    /// single expression — see §7.1's lifetime note.
+    fn captures(level: log::Level, target: &str) -> bool {
+        should_capture(
+            &log::Record::builder()
+                .level(level)
+                .target(target)
+                .args(format_args!("synthetic message"))
+                .build(),
+        )
+    }
+
+    #[test]
+    fn should_capture_applies_level_and_target_guard() {
+        // ERROR from AgentsCommander's own targets (lib + bin) → captured.
+        assert!(captures(
+            log::Level::Error,
+            "agentscommander_lib::commands::entity_creation"
+        ));
+        assert!(captures(log::Level::Error, "agentscommander_new"));
+        // ERROR from a third-party crate → not captured (target guard).
+        assert!(!captures(log::Level::Error, "hyper::client"));
+        // Below ERROR, even from our own targets → not captured (level guard).
+        assert!(!captures(log::Level::Warn, "agentscommander_lib::foo"));
+        assert!(!captures(log::Level::Info, "agentscommander_lib::foo"));
+    }
+
+    #[test]
+    fn from_record_copies_all_fields_and_keeps_newlines() {
+        let built = ErrorLogEntry::from_record(
+            "2026-05-21 12:00:00.000".to_string(),
+            &log::Record::builder()
+                .level(log::Level::Error)
+                .target("agentscommander_lib::commands::entity_creation")
+                .args(format_args!("line one\nline two"))
+                .build(),
+        );
+        assert_eq!(built.timestamp, "2026-05-21 12:00:00.000");
+        assert_eq!(built.level, "ERROR");
+        assert_eq!(
+            built.target,
+            "agentscommander_lib::commands::entity_creation"
+        );
+        // The embedded newline survives verbatim (multi-line git errors etc.).
+        assert_eq!(built.message, "line one\nline two");
+    }
+
+    /// `ErrorLogEntry` crosses the Tauri IPC boundary, so the
+    /// `#[serde(rename_all = "camelCase")]` rename is part of the contract with
+    /// `src/shared/types.ts`. The four field names are single-word today, so the
+    /// rename is a no-op — this test guards the contract against a future
+    /// field rename (mirrors `rtk_sweep_result_serializes_camel_case`).
+    #[test]
+    fn error_log_entry_serializes_camel_case() {
+        let json = serde_json::to_string(&entry("boom")).expect("serialize");
+        assert!(
+            json.contains("\"timestamp\""),
+            "missing timestamp: {}",
+            json
+        );
+        assert!(json.contains("\"level\""), "missing level: {}", json);
+        assert!(json.contains("\"target\""), "missing target: {}", json);
+        assert!(json.contains("\"message\""), "missing message: {}", json);
+    }
+
+    #[test]
+    fn sink_capture_then_drain_is_read_and_clear() {
+        let sink = ErrorEventSink::new();
+        sink.capture(entry("only"));
+        let first = sink.drain();
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].message, "only");
+        // A second drain sees nothing — drain is read-and-clear.
+        assert!(sink.drain().is_empty());
+    }
+
+    #[test]
+    fn sink_drain_preserves_fifo_order() {
+        let sink = ErrorEventSink::new();
+        sink.capture(entry("first"));
+        sink.capture(entry("second"));
+        sink.capture(entry("third"));
+        let messages: Vec<String> = sink.drain().into_iter().map(|e| e.message).collect();
+        assert_eq!(messages, ["first", "second", "third"]);
+    }
+
+    #[test]
+    fn sink_drops_oldest_entries_past_the_cap() {
+        let sink = ErrorEventSink::new();
+        let overflow = 5usize;
+        for i in 0..ERROR_BUFFER_CAP + overflow {
+            sink.capture(entry(&i.to_string()));
+        }
+        let drained = sink.drain();
+        // The buffer never grows past the cap.
+        assert_eq!(drained.len(), ERROR_BUFFER_CAP);
+        // The oldest `overflow` entries (0..5) were evicted; the surviving
+        // window starts at `overflow` and stays FIFO-ordered.
+        assert_eq!(drained[0].message, overflow.to_string());
+        assert_eq!(
+            drained[ERROR_BUFFER_CAP - 1].message,
+            (ERROR_BUFFER_CAP + overflow - 1).to_string()
+        );
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/main/App.tsx
+++ b/src/main/App.tsx
@@ -10,6 +10,7 @@ import TerminalApp from "../terminal/App";
 import Titlebar from "../sidebar/components/Titlebar";
 import QuitConfirmModal from "./components/QuitConfirmModal";
 import RtkBanner from "./components/RtkBanner";
+import ErrorModal from "./components/ErrorModal";
 import { wireHomeListeners } from "./listeners-home";
 import "./styles/main.css";
 
@@ -244,6 +245,7 @@ const MainApp: Component = () => {
           onQuit={onModalQuit}
         />
       </Show>
+      <ErrorModal />
     </div>
   );
 };

--- a/src/main/components/ErrorModal.tsx
+++ b/src/main/components/ErrorModal.tsx
@@ -1,0 +1,198 @@
+import { Component, createEffect, createMemo, createSignal, onCleanup, onMount, Show } from "solid-js";
+import { Portal } from "solid-js/web";
+import type { UnlistenFn } from "../../shared/transport";
+import type { ErrorLogEntry } from "../../shared/types";
+import { DebugAPI, onErrorLogEvent } from "../../shared/ipc";
+import { isTauri } from "../../shared/platform";
+import { errorModalStore } from "../stores/error-modal";
+
+/** Copy-to-clipboard text for one entry — header line + full message. */
+function formatEntry(e: ErrorLogEntry): string {
+  return `${e.timestamp} [${e.level}] ${e.target}\n${e.message}`;
+}
+
+const ErrorModal: Component = () => {
+  const [copied, setCopied] = createSignal(false);
+  let messageRef: HTMLDivElement | undefined;
+  let copyBtnRef: HTMLButtonElement | undefined;
+  let dismissBtnRef: HTMLButtonElement | undefined;
+  let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+  let previouslyFocused: HTMLElement | null = null;
+  let wasOpen = false;
+  const unlisteners: UnlistenFn[] = [];
+
+  // H1: a memo notifies dependents only when the entry's *identity* changes.
+  // Reading errorModalStore.current directly in an effect re-fires whenever
+  // entries() changes — including when a background error is enqueued behind an
+  // already-open modal — which would steal focus and reset "Copied!". `enqueue`
+  // only appends, so an already-shown entry keeps its object reference and the
+  // memo stays quiet; it fires only on real transitions (open, advance, close).
+  const currentEntry = createMemo(() => errorModalStore.current);
+
+  // --- Backend feed: listen for pings, drain on each + once on mount. -------
+  const drainAndEnqueue = async () => {
+    try {
+      errorModalStore.enqueue(await DebugAPI.drainErrorLogs());
+    } catch (err) {
+      console.error("[error-modal] drainErrorLogs failed:", err);
+    }
+  };
+
+  onMount(async () => {
+    if (!isTauri) return; // Web remote client: the error modal is desktop-only.
+    // Subscribe BEFORE the initial drain so a ping fired mid-mount is not lost
+    // (same ordering rule as RtkBanner). A ping racing the drain just triggers
+    // a second drain — harmless: read-and-clear returns [] when already empty.
+    unlisteners.push(await onErrorLogEvent(drainAndEnqueue));
+    await drainAndEnqueue();
+  });
+
+  // --- Keyboard: ESC dismisses, Tab traps; modal owns the keyboard. --------
+  onMount(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!errorModalStore.open) return; // closed: let keys through untouched
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        errorModalStore.dismissCurrent();
+        return;
+      }
+      if (e.key === "Tab") {
+        e.stopImmediatePropagation();
+        // H2: the scrollable message box is in the trap, in DOM order, so a
+        // keyboard-only user can Tab to it and scroll a long multi-line error.
+        const focusables = [messageRef, copyBtnRef, dismissBtnRef].filter(
+          Boolean
+        ) as HTMLElement[];
+        if (focusables.length < 2) return;
+        const idx = focusables.indexOf(document.activeElement as HTMLElement);
+        if (e.shiftKey) {
+          if (idx <= 0) { e.preventDefault(); focusables[focusables.length - 1].focus(); }
+        } else {
+          if (idx === focusables.length - 1) { e.preventDefault(); focusables[0].focus(); }
+        }
+        return;
+      }
+      // Any other key while open (incl. Enter): swallow propagation so xterm.js
+      // / global shortcuts do not react behind the modal. NOT preventDefault —
+      // native Enter/Space still activates the focused button, and arrow keys
+      // still scroll the focused message box (default action).
+      e.stopImmediatePropagation();
+    };
+    // Capture phase + stopImmediatePropagation. ErrorModal mounts before
+    // QuitConfirmModal ever does, so its capture listener is registered first
+    // and wins — while the error modal is open it fully owns the keyboard.
+    document.addEventListener("keydown", onKeyDown, true);
+    onCleanup(() => document.removeEventListener("keydown", onKeyDown, true));
+  });
+
+  onCleanup(() => {
+    unlisteners.forEach((u) => u());
+    if (copyResetTimer) clearTimeout(copyResetTimer);
+  });
+
+  // --- On closed->open while unfocused: flash the taskbar. Track focus owner.
+  createEffect(() => {
+    const open = errorModalStore.open;
+    if (open === wasOpen) return;
+    wasOpen = open;
+    if (open) {
+      previouslyFocused = document.activeElement as HTMLElement | null;
+      if (isTauri && !document.hasFocus()) {
+        void (async () => {
+          try {
+            const { getCurrentWindow, UserAttentionType } =
+              await import("@tauri-apps/api/window");
+            await getCurrentWindow().requestUserAttention(UserAttentionType.Critical);
+          } catch (err) {
+            console.error("[error-modal] requestUserAttention failed:", err);
+          }
+        })();
+      }
+    } else {
+      try { previouslyFocused?.focus(); } catch { /* best-effort */ }
+      previouslyFocused = null;
+    }
+  });
+
+  // --- On open / advance to next entry: focus Dismiss, reset Copy state. ----
+  // Tracks currentEntry() (the H1 memo) so it does NOT re-fire when a
+  // background error is enqueued behind an already-open modal.
+  createEffect(() => {
+    const cur = currentEntry();
+    setCopied(false);
+    if (cur) queueMicrotask(() => dismissBtnRef?.focus());
+  });
+
+  const onCopy = async () => {
+    const cur = currentEntry();
+    if (!cur) return;
+    try {
+      await navigator.clipboard.writeText(formatEntry(cur));
+      setCopied(true);
+      if (copyResetTimer) clearTimeout(copyResetTimer);
+      copyResetTimer = setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.error("[error-modal] clipboard write failed:", err);
+    }
+  };
+
+  return (
+    <Show when={errorModalStore.open}>
+      <Portal>
+        <div
+          class="error-modal-backdrop"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="error-modal-title"
+          aria-describedby="error-modal-message"
+        >
+          <div class="error-modal">
+            <div class="error-modal-header">
+              <h2 id="error-modal-title" class="error-modal-title">Application Error</h2>
+              <Show when={errorModalStore.total > 1}>
+                <span class="error-modal-counter">
+                  {errorModalStore.index + 1} of {errorModalStore.total}
+                </span>
+              </Show>
+            </div>
+            <div class="error-modal-meta">
+              <span class="error-modal-meta-time">{currentEntry()?.timestamp}</span>
+              <span class="error-modal-meta-target">{currentEntry()?.target}</span>
+            </div>
+            <div
+              id="error-modal-message"
+              class="error-modal-message"
+              ref={messageRef}
+              tabindex="0"
+              role="region"
+              aria-label="Error detail"
+            >
+              {currentEntry()?.message}
+            </div>
+            <div class="error-modal-actions">
+              <button
+                ref={copyBtnRef}
+                class="error-modal-btn error-modal-btn-copy"
+                type="button"
+                onClick={onCopy}
+              >
+                {copied() ? "Copied!" : "Copy"}
+              </button>
+              <button
+                ref={dismissBtnRef}
+                class="error-modal-btn error-modal-btn-dismiss"
+                type="button"
+                onClick={() => errorModalStore.dismissCurrent()}
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        </div>
+      </Portal>
+    </Show>
+  );
+};
+
+export default ErrorModal;

--- a/src/main/components/ErrorModal.tsx
+++ b/src/main/components/ErrorModal.tsx
@@ -66,6 +66,16 @@ const ErrorModal: Component = () => {
         ) as HTMLElement[];
         if (focusables.length < 2) return;
         const idx = focusables.indexOf(document.activeElement as HTMLElement);
+        // F1: activeElement can be outside the trap entirely — e.g. blurred to
+        // <body> after a click on the modal's non-focusable backdrop / header /
+        // padding. idx is -1 then; without this guard the forward branch's
+        // `idx === length - 1` is false, preventDefault is skipped, and native
+        // Tab escapes the modal to an element behind it.
+        if (idx === -1) {
+          e.preventDefault();
+          (e.shiftKey ? focusables[focusables.length - 1] : focusables[0]).focus();
+          return;
+        }
         if (e.shiftKey) {
           if (idx <= 0) { e.preventDefault(); focusables[focusables.length - 1].focus(); }
         } else {

--- a/src/main/stores/error-modal.test.ts
+++ b/src/main/stores/error-modal.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import type { ErrorLogEntry } from "../../shared/types";
+import { errorModalStore, __resetErrorModalStoreForTests } from "./error-modal";
+
+// Mirrors FRONTEND_QUEUE_CAP in error-modal.ts (module-private there). The
+// store has no IPC import, so these cases need no mocks.
+const FRONTEND_QUEUE_CAP = 200;
+
+function mkEntry(id: number): ErrorLogEntry {
+  return {
+    timestamp: "2026-05-21 12:00:00.000",
+    level: "ERROR",
+    target: "agentscommander_lib::test",
+    message: `error #${id}`,
+  };
+}
+
+function mkEntries(count: number, startId = 0): ErrorLogEntry[] {
+  return Array.from({ length: count }, (_, i) => mkEntry(startId + i));
+}
+
+describe("errorModalStore", () => {
+  beforeEach(() => {
+    __resetErrorModalStoreForTests();
+  });
+
+  it("starts closed", () => {
+    expect(errorModalStore.open).toBe(false);
+    expect(errorModalStore.current).toBeNull();
+    expect(errorModalStore.total).toBe(0);
+    expect(errorModalStore.index).toBe(0);
+  });
+
+  it("enqueue opens the modal at the first entry", () => {
+    const [a, b] = mkEntries(2);
+    errorModalStore.enqueue([a, b]);
+    expect(errorModalStore.open).toBe(true);
+    expect(errorModalStore.current).toBe(a);
+    expect(errorModalStore.index).toBe(0);
+    expect(errorModalStore.total).toBe(2);
+  });
+
+  it("dismissCurrent advances to the next entry", () => {
+    const [a, b] = mkEntries(2);
+    errorModalStore.enqueue([a, b]);
+    errorModalStore.dismissCurrent();
+    expect(errorModalStore.current).toBe(b);
+    expect(errorModalStore.index).toBe(1);
+    expect(errorModalStore.open).toBe(true);
+  });
+
+  it("dismissing the last entry closes the modal and resets index/total", () => {
+    errorModalStore.enqueue(mkEntries(2));
+    errorModalStore.dismissCurrent();
+    errorModalStore.dismissCurrent();
+    expect(errorModalStore.open).toBe(false);
+    expect(errorModalStore.current).toBeNull();
+    expect(errorModalStore.index).toBe(0);
+    expect(errorModalStore.total).toBe(0);
+  });
+
+  it("enqueue while open grows total but keeps current (reference-identical)", () => {
+    const [a, b] = mkEntries(2);
+    errorModalStore.enqueue([a, b]);
+    const before = errorModalStore.current;
+    errorModalStore.enqueue([mkEntry(99)]);
+    expect(errorModalStore.total).toBe(3);
+    expect(errorModalStore.index).toBe(0);
+    // H1 contract: the shown entry keeps its object identity, so ErrorModal's
+    // createMemo stays quiet and does not steal focus / reset "Copied!".
+    expect(errorModalStore.current).toBe(before);
+    expect(errorModalStore.current).toBe(a);
+  });
+
+  it("enqueue([]) is a no-op", () => {
+    errorModalStore.enqueue([]);
+    expect(errorModalStore.open).toBe(false);
+    expect(errorModalStore.total).toBe(0);
+    expect(errorModalStore.current).toBeNull();
+  });
+
+  it("a fresh burst after a full dismiss starts a new 1 of N", () => {
+    errorModalStore.enqueue(mkEntries(2));
+    errorModalStore.dismissCurrent();
+    errorModalStore.dismissCurrent();
+    expect(errorModalStore.open).toBe(false);
+    const burst = mkEntries(3, 100);
+    errorModalStore.enqueue(burst);
+    expect(errorModalStore.open).toBe(true);
+    expect(errorModalStore.index).toBe(0);
+    expect(errorModalStore.current).toBe(burst[0]);
+    expect(errorModalStore.total).toBe(3);
+  });
+
+  it("caps the queue at FRONTEND_QUEUE_CAP, dropping the oldest entries", () => {
+    const incoming = mkEntries(FRONTEND_QUEUE_CAP + 50);
+    errorModalStore.enqueue(incoming);
+    expect(errorModalStore.total).toBe(FRONTEND_QUEUE_CAP);
+    // Oldest 50 dropped; the queue head is now the 50th original entry.
+    expect(errorModalStore.current).toBe(incoming[50]);
+  });
+
+  it("on overflow shifts index down so current is preserved", () => {
+    errorModalStore.enqueue(mkEntries(100));
+    for (let i = 0; i < 50; i++) errorModalStore.dismissCurrent();
+    const viewing = errorModalStore.current;
+    expect(viewing).not.toBeNull();
+    // Combined 100 + 150 = 250, drop 50 oldest. The viewed entry was at
+    // index 50; index shifts down by 50 -> 0, same object reference.
+    errorModalStore.enqueue(mkEntries(150, 1000));
+    expect(errorModalStore.total).toBe(FRONTEND_QUEUE_CAP);
+    expect(errorModalStore.index).toBe(0);
+    expect(errorModalStore.current).toBe(viewing);
+  });
+
+  it("clamps index to 0 when the viewed entry is itself evicted", () => {
+    errorModalStore.enqueue(mkEntries(60));
+    for (let i = 0; i < 10; i++) errorModalStore.dismissCurrent();
+    expect(errorModalStore.index).toBe(10);
+    // Combined 60 + 300 = 360, drop 160 oldest. All 60 original entries are
+    // evicted (160 > 59), including the one being viewed -> index clamps to 0.
+    const flood = mkEntries(300, 1000);
+    errorModalStore.enqueue(flood);
+    expect(errorModalStore.total).toBe(FRONTEND_QUEUE_CAP);
+    expect(errorModalStore.index).toBe(0);
+    expect(errorModalStore.current).toBe(flood[100]);
+  });
+});

--- a/src/main/stores/error-modal.ts
+++ b/src/main/stores/error-modal.ts
@@ -1,0 +1,85 @@
+import { batch, createSignal } from "solid-js";
+import type { ErrorLogEntry } from "../../shared/types";
+
+// Queue of undismissed ERROR entries. The modal renders entries[index].
+// An empty queue means the modal is closed. The queue resets to empty once
+// the user dismisses the last entry, so each error burst gets a fresh "1 of N".
+const [entries, setEntries] = createSignal<ErrorLogEntry[]>([]);
+const [index, setIndex] = createSignal(0);
+
+// Upper bound on the frontend queue (M2). drain() is read-and-clear, so the
+// frontend ACCUMULATES entries across successive drains — the Rust-side
+// ERROR_BUFFER_CAP does NOT bound this side. Without a cap, a slow error loop
+// with the user AFK would grow `entries` without limit (and `enqueue`'s
+// array copy would be O(n²) over the run). Mirrors ERROR_BUFFER_CAP.
+const FRONTEND_QUEUE_CAP = 200;
+
+export const errorModalStore = {
+  get entries(): ErrorLogEntry[] {
+    return entries();
+  },
+  get index(): number {
+    return index();
+  },
+  get total(): number {
+    return entries().length;
+  },
+  /** The entry currently shown, or null when the modal is closed. */
+  get current(): ErrorLogEntry | null {
+    const e = entries();
+    const i = index();
+    return e.length > 0 && i < e.length ? e[i] : null;
+  },
+  /** True while the modal should be visible. */
+  get open(): boolean {
+    const e = entries();
+    return e.length > 0 && index() < e.length;
+  },
+
+  /**
+   * Append freshly-drained entries. If the modal was closed this re-opens it
+   * at the first new entry. If already open, entries are appended after the
+   * current one and the "N" in "1 of N" grows live.
+   *
+   * The queue is capped at FRONTEND_QUEUE_CAP (M2): on overflow the oldest
+   * entries are dropped and `index` is shifted down by the drop count so
+   * `current` keeps pointing at the same entry the user is viewing (clamped
+   * to 0 if that entry was itself evicted under an extreme storm). The two
+   * signal writes are `batch`ed so no effect observes a trimmed-entries /
+   * stale-index intermediate state.
+   */
+  enqueue(incoming: ErrorLogEntry[]): void {
+    if (incoming.length === 0) return;
+    const combined = [...entries(), ...incoming];
+    if (combined.length <= FRONTEND_QUEUE_CAP) {
+      setEntries(combined);
+      return;
+    }
+    const dropped = combined.length - FRONTEND_QUEUE_CAP;
+    batch(() => {
+      setEntries(combined.slice(dropped));
+      setIndex((i) => Math.max(0, i - dropped));
+    });
+  },
+
+  /**
+   * Dismiss the current entry and advance. When the last entry is dismissed
+   * the queue resets, closing the modal.
+   */
+  dismissCurrent(): void {
+    const next = index() + 1;
+    if (next >= entries().length) {
+      setEntries([]);
+      setIndex(0);
+    } else {
+      setIndex(next);
+    }
+  },
+};
+
+// Test-only reset (gated to Vite MODE === "test"). Mirrors home.ts.
+export function __resetErrorModalStoreForTests(): void {
+  if (import.meta.env.MODE !== "test") return;
+  setEntries([]);
+  setIndex(0);
+}

--- a/src/main/styles/main.css
+++ b/src/main/styles/main.css
@@ -410,3 +410,128 @@ html.light-theme .rtk-banner-btn-secondary:hover:not(:disabled) {
 
 html.light-theme .home-markdown code { background: rgba(0, 0, 0, 0.06); }
 html.light-theme .home-markdown pre { background: rgba(0, 0, 0, 0.05); }
+
+/* --- Error modal (#264) --------------------------------------------------
+ * Queued modal surfacing ERROR-level backend log events. One at a time; the
+ * "N" counter shows queue depth. z-index sits above the quit-confirm modal
+ * (10000) so a coincident error is visually dominant — and, via
+ * stopImmediatePropagation in ErrorModal's keydown handler, owns the keyboard.
+ * Variables fall back to literals so the modal renders before theme hydration.
+ */
+.error-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10001;
+}
+.error-modal {
+  background: var(--bg-modal, #14141a);
+  color: var(--fg-primary, #e8e8e8);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+  border-radius: 6px;
+  min-width: 440px;
+  max-width: 640px;
+  padding: 20px 24px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  font-family: "Geist", "Outfit", "General Sans", sans-serif;
+}
+.error-modal-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.error-modal-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 500;
+  color: #ff6b80;
+}
+.error-modal-counter {
+  flex: 0 0 auto;
+  font-size: 12px;
+  color: var(--fg-secondary, rgba(255, 255, 255, 0.6));
+}
+.error-modal-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 11px;
+  color: var(--fg-secondary, rgba(255, 255, 255, 0.55));
+  margin-bottom: 8px;
+}
+.error-modal-message {
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  border-radius: 4px;
+  padding: 10px 12px;
+  max-height: 320px;
+  overflow-y: auto;
+  margin-bottom: 20px;
+}
+.error-modal-message:focus-visible {
+  outline: 2px solid var(--focus-ring, #00d4ff);
+  outline-offset: -2px;
+}
+.error-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.error-modal-btn {
+  padding: 6px 16px;
+  border-radius: 4px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 150ms ease-out, border-color 150ms ease-out, color 150ms ease-out;
+}
+.error-modal-btn-copy {
+  background: transparent;
+  color: var(--fg-secondary, rgba(255, 255, 255, 0.7));
+  border-color: var(--border-subtle, rgba(255, 255, 255, 0.15));
+}
+.error-modal-btn-copy:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg-primary, #e8e8e8);
+}
+.error-modal-btn-dismiss {
+  background: var(--btn-primary-bg, rgba(0, 212, 255, 0.2));
+  color: var(--btn-primary-fg, #00d4ff);
+  border-color: var(--btn-primary-border, rgba(0, 212, 255, 0.4));
+}
+.error-modal-btn-dismiss:hover {
+  background: rgba(0, 212, 255, 0.3);
+}
+.error-modal-btn:focus-visible {
+  outline: 2px solid var(--focus-ring, #00d4ff);
+  outline-offset: 2px;
+}
+html.light-theme .error-modal {
+  background: #f7f7f9;
+  color: #1a1a1e;
+  border-color: rgba(0, 0, 0, 0.1);
+}
+html.light-theme .error-modal-message {
+  background: rgba(0, 0, 0, 0.05);
+  border-color: rgba(0, 0, 0, 0.1);
+}
+html.light-theme .error-modal-btn-copy {
+  color: rgba(0, 0, 0, 0.65);
+  border-color: rgba(0, 0, 0, 0.15);
+}
+html.light-theme .error-modal-btn-copy:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: #1a1a1e;
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -17,6 +17,7 @@ import type {
   BriefUpdateResult,
   WorkgroupBriefUpdatedEvent,
   ProjectRegistration,
+  ErrorLogEntry,
 } from "./types";
 
 export interface SessionRepoInput {
@@ -204,7 +205,18 @@ export const VoiceAPI = {
 export const DebugAPI = {
   saveLogs: (content: string) =>
     transport.invoke<void>("save_debug_logs", { content }),
+  /** #264 — read-and-clear the backend's buffered ERROR-level log entries. */
+  drainErrorLogs: () =>
+    transport.invoke<ErrorLogEntry[]>("drain_error_logs"),
 };
+
+// #264 — content-free ping fired when a new ERROR-level log entry is captured.
+// The listener responds by calling DebugAPI.drainErrorLogs().
+export function onErrorLogEvent(
+  callback: () => void
+): Promise<UnlistenFn> {
+  return transport.listen<unknown>("error_log_event", () => callback());
+}
 
 // Window API
 export const WindowAPI = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -349,3 +349,19 @@ export interface ProjectRegistration {
   created: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Error-log modal (#264)
+// Mirrors src-tauri/src/logging.rs::ErrorLogEntry.
+// ---------------------------------------------------------------------------
+
+export interface ErrorLogEntry {
+  /** Local timestamp string, e.g. "2026-05-21 15:56:11.123". */
+  timestamp: string;
+  /** Always "ERROR" today — kept for forward-compat and copy output. */
+  level: string;
+  /** Log target, e.g. "agentscommander_lib::commands::entity_creation". */
+  target: string;
+  /** Full message; may contain newlines (multi-line git errors etc.). */
+  message: string;
+}
+


### PR DESCRIPTION
Implements the in-app error modal for ERROR-level log events (#264).

## What

When AgentsCommander emits an `ERROR`-level `log` event, an in-app modal surfaces it to the user. Previously these errors only went to `app.log` and the user got no visible signal — e.g. a workgroup created with failed repo clones reported nothing.

## How

- **Capture** (Rust): the `env_logger` format closure pushes ERROR-level entries (target `starts_with("agentscommander")`) into a process-wide buffer. The emit is **decoupled** — a task outside the logging hook turns a `Notify` ping into a Tauri event, so no `emit()` runs inside the logger.
- **Surface** (SolidJS): a new `ErrorModal` component + store. Multiple errors queue — one modal at a time with a "1 of N" counter. The modal shows the full entry (timestamp, level, target, message, multi-line detail) with a Copy button.

## Review trail

Full path — architect plan → dev-rust + dev-webpage-ui + grinch plan enrichment → architect consolidation (`READY_FOR_IMPLEMENTATION`) → implementation → grinch adversarial review (1 Medium found & fixed, re-review PASS). 16 new tests (6 Rust + 10 vitest); `cargo test` 573 passing, `vitest` 83 passing.

## Notes

- 0 new crates, 0 new npm dependencies.
- Version bumped to `0.8.34` (main had independently moved to `0.8.33`).
- Branch is up to date with `main` (origin/main merged in).

Closes #264
