### PR TITLE
fix(QuitConfirmModal): handle idx === -1 focus-trap leak (#266)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.34",
+      "version": "0.8.35",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.34"
+version = "0.8.35"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.34"
+version = "0.8.35"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/main/components/QuitConfirmModal.tsx
+++ b/src/main/components/QuitConfirmModal.tsx
@@ -48,6 +48,16 @@ const QuitConfirmModal: Component<QuitConfirmModalProps> = (props) => {
         const focusables = [cancelBtnRef, quitBtnRef].filter(Boolean) as HTMLElement[];
         if (focusables.length < 2) return;
         const idx = focusables.indexOf(document.activeElement as HTMLElement);
+        // #266: activeElement can be outside the trap entirely — e.g. blurred
+        // to <body> after a click on the modal's non-focusable backdrop /
+        // header / padding. idx is -1 then; without this guard the forward
+        // branch's `idx === length - 1` is false, preventDefault is skipped,
+        // and native Tab escapes the modal to an element behind it.
+        if (idx === -1) {
+          e.preventDefault();
+          (e.shiftKey ? focusables[focusables.length - 1] : focusables[0]).focus();
+          return;
+        }
         if (e.shiftKey) {
           if (idx <= 0) {
             e.preventDefault();


### PR DESCRIPTION
## Summary

Fixes a focus-trap leak in `QuitConfirmModal.tsx`. When `document.activeElement` is outside the trap — e.g. blurred to `<body>` after a click on the modal's non-focusable backdrop / header / padding — `focusables.indexOf(...)` returns `-1`. The forward-Tab branch then tests `idx === focusables.length - 1` → false, `preventDefault()` is skipped, and native Tab moves focus to a background element. If that element is an xterm `<textarea>`, the user's keystrokes are forwarded into a background agent's PTY.

The fix adds an `idx === -1` guard that calls `preventDefault()` and pulls focus back into the trap. It mirrors the fix #264 already applied to `ErrorModal.tsx` (commit `2a6fd90`).

## Validation

- Adversarial review (dev-rust-grinch): **PASS** — all six Tab paths traced; the empty/single-element crash edge case is already guarded by the `focusables.length < 2` early return; no regression for in-trap focus.
- `npx tsc --noEmit`: clean.
- vitest: 83/83 passing.
- Version bumped 0.8.34 → 0.8.35 (5 lockstep files).
- Branch updated against `origin/main` (conflict-free).

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
