### PR TITLE
fix(#272): handle idx === -1 focus-trap leak in BriefCleanConfirmModal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.35",
+      "version": "0.8.36",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.35"
+version = "0.8.36"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/terminal/components/BriefCleanConfirmModal.tsx
+++ b/src/terminal/components/BriefCleanConfirmModal.tsx
@@ -35,6 +35,17 @@ const BriefCleanConfirmModal: Component<BriefCleanConfirmModalProps> = (props) =
         const focusables = [cancelBtnRef, confirmBtnRef].filter(Boolean) as HTMLElement[];
         if (focusables.length < 2) return;
         const idx = focusables.indexOf(document.activeElement as HTMLElement);
+        // #272: activeElement can be outside the trap entirely — e.g. blurred
+        // to <body> after a click on the modal's non-focusable backdrop /
+        // header / padding. idx is -1 then; without this guard the forward
+        // branch's `idx === length - 1` is false, preventDefault is skipped,
+        // and native Tab escapes the modal — here, into the live xterm PTY
+        // <textarea> rendered directly behind it.
+        if (idx === -1) {
+          e.preventDefault();
+          (e.shiftKey ? focusables[focusables.length - 1] : focusables[0]).focus();
+          return;
+        }
         if (e.shiftKey) {
           if (idx <= 0) {
             e.preventDefault();


### PR DESCRIPTION
## Summary

Fixes a focus-trap leak in `BriefCleanConfirmModal.tsx`. When `document.activeElement` is not one of the modal's focusable elements — e.g. blurred to `<body>` after a click on the modal's non-focusable backdrop / header / padding — `focusables.indexOf(activeElement)` returns `-1`. The forward-Tab branch (`idx === focusables.length - 1`) then evaluates false, `preventDefault()` is skipped, and native Tab moves focus **out** of the modal into the live xterm `<textarea>` PTY input rendered behind it.

The fix adds an `idx === -1` guard that calls `preventDefault()` and re-seeds focus inside the trap. It is character-identical to the focus-trap fixes already shipped for `ErrorModal` (#264) and `QuitConfirmModal` (#266).

## Changes

- `src/terminal/components/BriefCleanConfirmModal.tsx` — `idx === -1` guard. Purely additive: 11 insertions, 0 deletions; no existing line modified.
- Version bump `0.8.35 → 0.8.36` across the 5 lockstep files (`package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`).

## Verification

- `/feature-dev` review — no HIGH findings.
- Adversarial review (grinch) — verdict **CLEAN**: guard correct in both Tab directions, regression-free (additive diff), version bump complete and surgical (the coincidental third-party `encoding_rs` 0.8.35 correctly left untouched).
- Build — `npx tauri build` from the WG-2 replica, exit 0; deployed `agentscommander_standalone_wg-2.exe` reports v0.8.36.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
