### PR TITLE
feat(root-agent): add commander lifecycle and controls (#274)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.34",
+      "version": "0.8.35",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.34"
+version = "0.8.35"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.34"
+version = "0.8.35"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -1404,7 +1404,7 @@ mod tests {
         let cmd = crate::cli::Cli::command();
         let names: Vec<&str> = cmd.get_subcommands().map(|c| c.get_name()).collect();
         assert!(
-            names.iter().any(|n| *n == "list-peers-lean"),
+            names.contains(&"list-peers-lean"),
             "list-peers-lean should be a registered subcommand; got: {:?}",
             names
         );

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -1,7 +1,6 @@
 use futures::future::join_all;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -229,28 +228,6 @@ fn strip_verbatim_prefix(p: &Path) -> PathBuf {
     s.strip_prefix(r"\\?\")
         .map(PathBuf::from)
         .unwrap_or_else(|| p.to_path_buf())
-}
-
-/// Read BRIEF.md at most 256 KiB, strip a UTF-8 BOM if present, trim, and
-/// return None on empty / read-error / file-missing. Bigger files are
-/// truncated; we do NOT attempt to stream the whole file through Tauri IPC.
-fn read_brief_capped(brief_path: &Path) -> Option<String> {
-    const MAX_BYTES: u64 = 256 * 1024;
-    let file = std::fs::File::open(brief_path).ok()?;
-    let mut buf = String::new();
-    if file.take(MAX_BYTES).read_to_string(&mut buf).is_err() {
-        return None;
-    }
-    let trimmed = buf
-        .strip_prefix('\u{FEFF}')
-        .unwrap_or(&buf)
-        .trim()
-        .to_string();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed)
-    }
 }
 
 /// Detect git branch synchronously for a given directory path.
@@ -1724,6 +1701,18 @@ pub async fn new_project(
     Ok(result)
 }
 
+type BriefFields = (Option<String>, Option<String>);
+
+fn read_brief_fields(wg_path: &Path) -> BriefFields {
+    let brief_path = wg_path.join("BRIEF.md");
+    let Ok(content) = std::fs::read_to_string(&brief_path) else {
+        return (None, None);
+    };
+    let brief = extract_brief_first_line(&content);
+    let brief_title = crate::commands::entity_creation::parse_brief_title(&content);
+    (brief, brief_title)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1833,15 +1822,4 @@ mod tests {
             Some("Body line".to_string())
         );
     }
-}
-
-type BriefFields = (Option<String>, Option<String>);
-fn read_brief_fields(wg_path: &std::path::Path) -> BriefFields {
-    let brief_path = wg_path.join("BRIEF.md");
-    let Ok(content) = std::fs::read_to_string(&brief_path) else {
-        return (None, None);
-    };
-    let brief = extract_brief_first_line(&content);
-    let brief_title = crate::commands::entity_creation::parse_brief_title(&content);
-    (brief, brief_title)
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -20,6 +20,70 @@ pub(crate) fn root_agent_session_lock() -> &'static tokio::sync::Mutex<()> {
     ROOT_AGENT_SESSION_LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExistingRootAction {
+    ReuseLive,
+    WakeDormant,
+    DiscardMissingPty,
+}
+
+fn classify_existing_root(status: &SessionStatus, has_pty: bool) -> ExistingRootAction {
+    if matches!(status, SessionStatus::Exited(_)) {
+        ExistingRootAction::WakeDormant
+    } else if has_pty {
+        ExistingRootAction::ReuseLive
+    } else {
+        ExistingRootAction::DiscardMissingPty
+    }
+}
+
+async fn rollback_pre_created_session(
+    app: &AppHandle,
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+    pty_mgr: &Arc<Mutex<PtyManager>>,
+    id: Uuid,
+    reason: &str,
+) {
+    log::warn!(
+        "[session] Rolling back pre-created session {} after setup failure: {}",
+        id,
+        reason
+    );
+
+    if let Err(e) = pty_mgr.lock().unwrap().kill(id) {
+        log::warn!(
+            "[session] Failed to clean PTY state while rolling back {}: {}",
+            id,
+            e
+        );
+    }
+
+    let mgr = session_mgr.read().await;
+    let was_active = mgr.get_active().await == Some(id);
+    match mgr.destroy_session(id).await {
+        Ok(Some(new_id)) => {
+            let _ = app.emit(
+                "session_switched",
+                serde_json::json!({ "id": new_id.to_string() }),
+            );
+        }
+        Ok(None) if was_active => {
+            let _ = app.emit(
+                "session_switched",
+                serde_json::json!({ "id": serde_json::Value::Null }),
+            );
+        }
+        Ok(None) => {}
+        Err(e) => {
+            log::warn!(
+                "[session] Failed to remove pre-created session {} after setup failure: {}",
+                id,
+                e
+            );
+        }
+    }
+}
+
 fn token_has_unclosed_quote(token: &str, quote: char) -> bool {
     token.chars().filter(|c| *c == quote).count() % 2 == 1
 }
@@ -702,9 +766,11 @@ pub async fn create_session_inner(
     }
 
     if let Some(name) = session_name {
-        mgr.rename_session(session.id, name.clone())
-            .await
-            .map_err(|e| e.to_string())?;
+        if let Err(e) = mgr.rename_session(session.id, name.clone()).await {
+            let err = e.to_string();
+            rollback_pre_created_session(app, session_mgr, pty_mgr, session.id, &err).await;
+            return Err(err);
+        }
         session.name = name;
     }
 
@@ -798,13 +864,7 @@ pub async fn create_session_inner(
                     .message(&dialog_msg)
                     .title("Context File Error")
                     .show(|_| {});
-                let mgr2 = session_mgr.read().await;
-                if let Ok(Some(new_id)) = mgr2.destroy_session(id).await {
-                    let _ = app.emit(
-                        "session_switched",
-                        serde_json::json!({ "id": new_id.to_string() }),
-                    );
-                }
+                rollback_pre_created_session(app, session_mgr, pty_mgr, id, &e).await;
                 return Err(e);
             }
         }
@@ -849,10 +909,8 @@ pub async fn create_session_inner(
         Vec::new()
     };
 
-    pty_mgr
-        .lock()
-        .unwrap()
-        .spawn(
+    let spawn_result = {
+        pty_mgr.lock().unwrap().spawn(
             id,
             &shell,
             &shell_args,
@@ -863,7 +921,12 @@ pub async fn create_session_inner(
             crate::session::profile::idle_tuning_for(agent_kind),
             app.clone(),
         )
-        .map_err(|e| e.to_string())?;
+    };
+    if let Err(e) = spawn_result {
+        let err = e.to_string();
+        rollback_pre_created_session(app, session_mgr, pty_mgr, id, &err).await;
+        return Err(err);
+    }
 
     // Auto-inject optional non-credential bootstrap text for agent sessions
     // after PTY spawn. Credentials are already present in child environment
@@ -1140,10 +1203,7 @@ pub async fn destroy_session_inner(app: &AppHandle, uuid: Uuid) -> Result<(), St
     destroy_session_inner_with_options(app, uuid, false).await
 }
 
-pub(crate) async fn force_destroy_session_inner(
-    app: &AppHandle,
-    uuid: Uuid,
-) -> Result<(), String> {
+pub(crate) async fn force_destroy_session_inner(app: &AppHandle, uuid: Uuid) -> Result<(), String> {
     destroy_session_inner_with_options(app, uuid, true).await
 }
 
@@ -1197,8 +1257,12 @@ async fn destroy_session_inner_with_options(
         mgr.set_is_root_agent(uuid, true).await;
         mgr.mark_exited(uuid, 0).await;
         mgr.clear_active_if(uuid).await;
+        let dormant_info = mgr.get_session(uuid).await.map(|s| SessionInfo::from(&s));
 
         let _ = app.emit("session_destroyed", serde_json::json!({ "id": id }));
+        if let Some(info) = dormant_info {
+            let _ = app.emit("session_created", info);
+        }
 
         let detached_label = format!("terminal-{}", id.replace('-', ""));
         if let Some(detached_win) = app.get_webview_window(&detached_label) {
@@ -1852,9 +1916,7 @@ pub(crate) async fn create_root_agent_inner(
             s.is_root_agent || crate::config::root_agent::is_root_agent_path(&s.working_directory)
         })
     };
-    let waking_existing = existing
-        .as_ref()
-        .is_some_and(|s| matches!(s.status, SessionStatus::Exited(_)));
+    let mut waking_existing = false;
 
     if let Some(existing) = existing {
         let uuid = Uuid::parse_str(&existing.id).map_err(|e| e.to_string())?;
@@ -1863,25 +1925,38 @@ pub(crate) async fn create_root_agent_inner(
             mgr.set_is_root_agent(uuid, true).await;
         }
 
-        if !matches!(existing.status, SessionStatus::Exited(_)) {
-            log::info!(
-                "[root-agent] Reusing existing live session {} at {}",
-                existing.id,
-                existing.working_directory
-            );
-            let mgr = session_mgr.read().await;
-            if let Some(updated) = mgr.get_session(uuid).await {
-                persist_current_state(&mgr).await;
-                return Ok(SessionInfo::from(&updated));
+        let has_pty = pty_mgr.lock().unwrap().has_session(uuid);
+        match classify_existing_root(&existing.status, has_pty) {
+            ExistingRootAction::ReuseLive => {
+                log::info!(
+                    "[root-agent] Reusing existing live session {} at {}",
+                    existing.id,
+                    existing.working_directory
+                );
+                let mgr = session_mgr.read().await;
+                if let Some(updated) = mgr.get_session(uuid).await {
+                    persist_current_state(&mgr).await;
+                    return Ok(SessionInfo::from(&updated));
+                }
+                return Ok(existing);
             }
-            return Ok(existing);
+            ExistingRootAction::WakeDormant => {
+                waking_existing = true;
+                log::info!(
+                    "[root-agent] Waking dormant root session {} with provider resume",
+                    existing.id
+                );
+                force_destroy_session_inner(app, uuid).await?;
+            }
+            ExistingRootAction::DiscardMissingPty => {
+                log::warn!(
+                    "[root-agent] Discarding root session {} because it has status {:?} but no PTY",
+                    existing.id,
+                    existing.status
+                );
+                force_destroy_session_inner(app, uuid).await?;
+            }
         }
-
-        log::info!(
-            "[root-agent] Waking dormant root session {} with provider resume",
-            existing.id
-        );
-        force_destroy_session_inner(app, uuid).await?;
     }
 
     let last_coding_agent = crate::config::root_agent::read_last_coding_agent(&root_agent_path);
@@ -1995,10 +2070,11 @@ pub async fn create_root_agent_session(
 #[cfg(test)]
 mod tests {
     use super::{
-        inject_codex_resume, resolve_actual_agent, resolve_root_agent_command,
-        should_inject_continue,
+        classify_existing_root, inject_codex_resume, resolve_actual_agent,
+        resolve_root_agent_command, should_inject_continue, ExistingRootAction,
     };
     use crate::config::settings::{AgentConfig, AppSettings};
+    use crate::session::session::SessionStatus;
     use std::path::PathBuf;
 
     fn test_settings() -> AppSettings {
@@ -2078,6 +2154,22 @@ mod tests {
         assert_eq!(args, vec!["-NoLogo".to_string()]);
         assert!(agent_id.is_none());
         assert!(label.is_none());
+    }
+
+    #[test]
+    fn existing_root_classifier_discards_live_record_without_pty() {
+        assert_eq!(
+            classify_existing_root(&SessionStatus::Running, false),
+            ExistingRootAction::DiscardMissingPty
+        );
+        assert_eq!(
+            classify_existing_root(&SessionStatus::Active, true),
+            ExistingRootAction::ReuseLive
+        );
+        assert_eq!(
+            classify_existing_root(&SessionStatus::Exited(0), false),
+            ExistingRootAction::WakeDormant
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use tauri::{AppHandle, Emitter, Manager, State};
 use uuid::Uuid;
 
@@ -8,10 +9,16 @@ use crate::config::sessions_persistence::persist_current_state;
 use crate::config::settings::{AppSettings, SettingsState};
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
-use crate::session::session::{SessionInfo, SessionRepo};
 use crate::session::profile::CodingAgentKind;
+use crate::session::session::{SessionInfo, SessionRepo, SessionStatus};
 use crate::telegram::manager::TelegramBridgeState;
 use crate::DetachedSessionsState;
+
+static ROOT_AGENT_SESSION_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+
+pub(crate) fn root_agent_session_lock() -> &'static tokio::sync::Mutex<()> {
+    ROOT_AGENT_SESSION_LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
 
 fn token_has_unclosed_quote(token: &str, quote: char) -> bool {
     token.chars().filter(|c| *c == quote).count() % 2 == 1
@@ -673,6 +680,7 @@ pub async fn create_session_inner(
     // every caller of create_session_inner gets the same computation.
     let teams = crate::config::teams::discover_teams();
     let is_coordinator = crate::config::teams::is_coordinator_for_cwd(&cwd, &teams);
+    let is_root_agent = crate::config::root_agent::is_root_agent_path(&cwd);
 
     let mgr = session_mgr.read().await;
     let mut session = mgr
@@ -687,6 +695,11 @@ pub async fn create_session_inner(
         )
         .await
         .map_err(|e| e.to_string())?;
+
+    if is_root_agent {
+        mgr.set_is_root_agent(session.id, true).await;
+        session.is_root_agent = true;
+    }
 
     if let Some(name) = session_name {
         mgr.rename_session(session.id, name.clone())
@@ -1124,7 +1137,31 @@ pub async fn create_session(
 /// Core session destruction logic shared by the Tauri command and the MailboxPoller.
 /// Kills PTY, detaches Telegram bridge, removes from SessionManager, persists, and emits events.
 pub async fn destroy_session_inner(app: &AppHandle, uuid: Uuid) -> Result<(), String> {
+    destroy_session_inner_with_options(app, uuid, false).await
+}
+
+pub(crate) async fn force_destroy_session_inner(
+    app: &AppHandle,
+    uuid: Uuid,
+) -> Result<(), String> {
+    destroy_session_inner_with_options(app, uuid, true).await
+}
+
+async fn destroy_session_inner_with_options(
+    app: &AppHandle,
+    uuid: Uuid,
+    force_destroy_root: bool,
+) -> Result<(), String> {
     let id = uuid.to_string();
+    let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+    let mgr = session_mgr.read().await;
+    let existing = mgr
+        .get_session(uuid)
+        .await
+        .ok_or_else(|| "Session not found".to_string())?;
+    let is_root_agent = existing.is_root_agent
+        || crate::config::root_agent::is_root_agent_path(&existing.working_directory);
+    let was_active = matches!(existing.status, SessionStatus::Active);
 
     // Remove from detached set
     {
@@ -1156,8 +1193,50 @@ pub async fn destroy_session_inner(app: &AppHandle, uuid: Uuid) -> Result<(), St
             .map_err(|e| e.to_string())?;
     }
 
-    let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
-    let mgr = session_mgr.read().await;
+    if is_root_agent && !force_destroy_root {
+        mgr.set_is_root_agent(uuid, true).await;
+        mgr.mark_exited(uuid, 0).await;
+        mgr.clear_active_if(uuid).await;
+
+        let _ = app.emit("session_destroyed", serde_json::json!({ "id": id }));
+
+        let detached_label = format!("terminal-{}", id.replace('-', ""));
+        if let Some(detached_win) = app.get_webview_window(&detached_label) {
+            let _ = detached_win.destroy();
+        }
+
+        if was_active {
+            let sessions = mgr.list_sessions().await;
+            let fallback = {
+                let detached = app.state::<DetachedSessionsState>();
+                let set = detached.lock().unwrap();
+                sessions.iter().find_map(|s| {
+                    if s.id == id || matches!(s.status, SessionStatus::Exited(_)) {
+                        return None;
+                    }
+                    Uuid::parse_str(&s.id).ok().filter(|u| !set.contains(u))
+                })
+            };
+            if let Some(fb) = fallback {
+                let _ = mgr.switch_session(fb).await;
+                let _ = app.emit(
+                    "session_switched",
+                    serde_json::json!({ "id": fb.to_string() }),
+                );
+            } else {
+                mgr.clear_active().await;
+                let _ = app.emit(
+                    "session_switched",
+                    serde_json::json!({ "id": serde_json::Value::Null }),
+                );
+            }
+        }
+
+        persist_current_state(&mgr).await;
+
+        return Ok(());
+    }
+
     let new_active = mgr.destroy_session(uuid).await.map_err(|e| e.to_string())?;
 
     // Persist after destruction
@@ -1285,7 +1364,16 @@ pub async fn restart_session(
     let uuid = Uuid::parse_str(&id).map_err(|e| e.to_string())?;
 
     // 1. Read config from existing session BEFORE destroying it
-    let (shell, shell_args, cwd, name, stored_agent_id, stored_agent_label, git_repos) = {
+    let (
+        shell,
+        shell_args,
+        cwd,
+        name,
+        stored_agent_id,
+        stored_agent_label,
+        git_repos,
+        is_root_agent,
+    ) = {
         let mgr = session_mgr.read().await;
         let session = mgr.get_session(uuid).await.ok_or("Session not found")?;
         (
@@ -1296,7 +1384,20 @@ pub async fn restart_session(
             session.agent_id.clone(),
             session.agent_label.clone(),
             session.git_repos.clone(),
+            session.is_root_agent
+                || crate::config::root_agent::is_root_agent_path(&session.working_directory),
         )
+    };
+
+    let _root_guard = if is_root_agent {
+        Some(root_agent_session_lock().lock().await)
+    } else {
+        None
+    };
+    let cwd = if is_root_agent {
+        crate::config::root_agent::ensure_root_agent_dir()?
+    } else {
+        cwd
     };
 
     // 2. Strip auto-injected args before restart so the new session starts from the saved recipe.
@@ -1314,7 +1415,11 @@ pub async fn restart_session(
     };
 
     // 3. Destroy the old session (resolves all State<> internally from app)
-    destroy_session_inner(&app, uuid).await?;
+    if is_root_agent {
+        force_destroy_session_inner(&app, uuid).await?;
+    } else {
+        destroy_session_inner(&app, uuid).await?;
+    }
 
     // 4. Create new session with same config, or switch to the selected coding agent.
     let session_info = create_session_inner(
@@ -1548,6 +1653,88 @@ fn resolve_agent_command(
     }
 }
 
+fn split_agent_command(command: &str) -> Option<(String, Vec<String>)> {
+    let parts: Vec<String> = command.split_whitespace().map(|s| s.to_string()).collect();
+    parts
+        .split_first()
+        .map(|(cmd, args)| (cmd.clone(), args.to_vec()))
+}
+
+fn resolve_root_agent_command(
+    settings: &AppSettings,
+    requested_agent_id: Option<&str>,
+    last_coding_agent: Option<&str>,
+) -> (String, Vec<String>, Option<String>, Option<String>) {
+    let resolve_configured =
+        |agent_id: &str| settings.agents.iter().find(|agent| agent.id == agent_id);
+
+    if let Some(agent_id) = requested_agent_id {
+        if let Some(agent) = resolve_configured(agent_id) {
+            if let Some((shell, shell_args)) = split_agent_command(&agent.command) {
+                return (
+                    shell,
+                    shell_args,
+                    Some(agent.id.clone()),
+                    Some(agent.label.clone()),
+                );
+            }
+            log::warn!(
+                "[root-agent] Requested coding agent '{}' has an empty command; falling back",
+                agent_id
+            );
+        } else {
+            log::warn!(
+                "[root-agent] Requested coding agent '{}' no longer exists; falling back",
+                agent_id
+            );
+        }
+    }
+
+    if let Some(agent_id) = last_coding_agent {
+        if let Some(agent) = resolve_configured(agent_id) {
+            if let Some((shell, shell_args)) = split_agent_command(&agent.command) {
+                return (
+                    shell,
+                    shell_args,
+                    Some(agent.id.clone()),
+                    Some(agent.label.clone()),
+                );
+            }
+            log::warn!(
+                "[root-agent] lastCodingAgent '{}' has an empty command; falling back",
+                agent_id
+            );
+        } else {
+            log::warn!(
+                "[root-agent] lastCodingAgent '{}' no longer exists; falling back",
+                agent_id
+            );
+        }
+    }
+
+    if let Some(agent) = settings.agents.first() {
+        if let Some((shell, shell_args)) = split_agent_command(&agent.command) {
+            return (
+                shell,
+                shell_args,
+                Some(agent.id.clone()),
+                Some(agent.label.clone()),
+            );
+        }
+        log::warn!(
+            "[root-agent] First configured coding agent '{}' has an empty command; using default shell",
+            agent.id
+        );
+    }
+
+    (
+        settings.default_shell.clone(),
+        settings.default_shell_args.clone(),
+        None,
+        None,
+    )
+}
+
 fn resolve_agent_label(agent_id: &str, settings: &AppSettings) -> Option<String> {
     settings
         .agents
@@ -1645,115 +1832,93 @@ pub async fn get_active_session(
     Ok(Some(active_id.to_string()))
 }
 
-/// Create or reuse a root agent session.
-/// Derives the root agent path from the current binary name:
-///   {exe_dir}/.{binary_name}/ac-root-agent
-/// If a session already exists at that path, switches to it instead.
-/// Uses the first configured coding agent from settings.
-/// Starts the root agent with per-child credential env when a configured coding agent is launched.
-#[tauri::command]
-pub async fn create_root_agent_session(
-    app: AppHandle,
-    session_mgr: State<'_, Arc<tokio::sync::RwLock<SessionManager>>>,
-    pty_mgr: State<'_, Arc<Mutex<PtyManager>>>,
-    tg_mgr: State<'_, TelegramBridgeState>,
-    settings: State<'_, SettingsState>,
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn create_root_agent_inner(
+    app: &AppHandle,
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+    pty_mgr: &Arc<Mutex<PtyManager>>,
+    tg_mgr: &TelegramBridgeState,
+    settings: &SettingsState,
+    requested_agent_id: Option<String>,
+    skip_auto_resume_for_new_session: bool,
 ) -> Result<SessionInfo, String> {
-    // Derive root agent path from binary name
-    let exe_path =
-        std::env::current_exe().map_err(|e| format!("Failed to get current exe path: {}", e))?;
-    let binary_name = exe_path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .ok_or("Failed to extract binary name")?
-        .to_string();
+    let _guard = root_agent_session_lock().lock().await;
+    let root_agent_path = crate::config::root_agent::ensure_root_agent_dir()?;
 
-    let exe_dir = exe_path
-        .parent()
-        .ok_or("Failed to get exe parent directory")?;
-    let root_agent_path = exe_dir
-        .join(format!(".{}", binary_name))
-        .join("ac-root-agent")
-        .to_string_lossy()
-        .to_string();
-
-    // Check if a session already exists at this path — reuse it
-    {
+    let existing = {
         let mgr = session_mgr.read().await;
         let sessions = mgr.list_sessions().await;
-        if let Some(existing) = sessions
-            .iter()
-            .find(|s| s.working_directory == root_agent_path)
+        sessions.into_iter().find(|s| {
+            s.is_root_agent || crate::config::root_agent::is_root_agent_path(&s.working_directory)
+        })
+    };
+    let waking_existing = existing
+        .as_ref()
+        .is_some_and(|s| matches!(s.status, SessionStatus::Exited(_)));
+
+    if let Some(existing) = existing {
+        let uuid = Uuid::parse_str(&existing.id).map_err(|e| e.to_string())?;
         {
-            log::info!(
-                "[root-agent] Reusing existing session {} at {}",
-                existing.id,
-                root_agent_path
-            );
-            return Ok(existing.clone());
+            let mgr = session_mgr.read().await;
+            mgr.set_is_root_agent(uuid, true).await;
         }
+
+        if !matches!(existing.status, SessionStatus::Exited(_)) {
+            log::info!(
+                "[root-agent] Reusing existing live session {} at {}",
+                existing.id,
+                existing.working_directory
+            );
+            let mgr = session_mgr.read().await;
+            if let Some(updated) = mgr.get_session(uuid).await {
+                persist_current_state(&mgr).await;
+                return Ok(SessionInfo::from(&updated));
+            }
+            return Ok(existing);
+        }
+
+        log::info!(
+            "[root-agent] Waking dormant root session {} with provider resume",
+            existing.id
+        );
+        force_destroy_session_inner(app, uuid).await?;
     }
 
-    // Create directory if it doesn't exist
-    std::fs::create_dir_all(&root_agent_path)
-        .map_err(|e| format!("Failed to create root agent directory: {}", e))?;
-
-    // Get the first configured agent from settings
-    let cfg = settings.read().await;
-    let (agent_id, shell, shell_args, agent_label) = if let Some(agent) = cfg.agents.first() {
-        let parts: Vec<String> = agent
-            .command
-            .split_whitespace()
-            .map(|s| s.to_string())
-            .collect();
-        if let Some((cmd, args)) = parts.split_first() {
-            (
-                Some(agent.id.clone()),
-                cmd.clone(),
-                args.to_vec(),
-                Some(agent.label.clone()),
-            )
-        } else {
-            (
-                None,
-                cfg.default_shell.clone(),
-                cfg.default_shell_args.clone(),
-                None,
-            )
-        }
-    } else {
-        (
-            None,
-            cfg.default_shell.clone(),
-            cfg.default_shell_args.clone(),
-            None,
+    let last_coding_agent = crate::config::root_agent::read_last_coding_agent(&root_agent_path);
+    let (shell, shell_args, agent_id, agent_label) = {
+        let cfg = settings.read().await;
+        resolve_root_agent_command(
+            &cfg,
+            requested_agent_id.as_deref(),
+            last_coding_agent.as_deref(),
         )
     };
-    drop(cfg);
 
     let info = create_session_inner(
-        &app,
-        session_mgr.inner(),
-        pty_mgr.inner(),
+        app,
+        session_mgr,
+        pty_mgr,
         shell,
         shell_args,
         root_agent_path.clone(),
-        Some("Root Agent".to_string()),
+        Some(crate::config::root_agent::ROOT_AGENT_SESSION_NAME.to_string()),
         agent_id,
         agent_label,
         false,
         Vec::new(),
-        true, // skip_auto_resume = true → fresh create, no `--continue` injection
+        if waking_existing {
+            false
+        } else {
+            skip_auto_resume_for_new_session
+        },
     )
     .await?;
 
-    // Persist after creation
     {
         let mgr = session_mgr.read().await;
         persist_current_state(&mgr).await;
     }
 
-    // Auto-attach Telegram bot if configured
     let id = Uuid::parse_str(&info.id).map_err(|e| format!("Invalid session UUID: {}", e))?;
     let config_path = std::path::Path::new(&root_agent_path)
         .join(crate::config::agent_local_dir_name())
@@ -1769,7 +1934,7 @@ pub async fn create_root_agent_session(
                     .cloned();
                 drop(cfg);
                 if let Some(bot) = bot {
-                    let pty_arc = pty_mgr.inner().clone();
+                    let pty_arc = Arc::clone(pty_mgr);
                     let reader = match crate::commands::telegram::derive_reader(
                         &info.shell,
                         &info.shell_args,
@@ -1790,7 +1955,6 @@ pub async fn create_root_agent_session(
                                     "error": err_msg,
                                 }),
                             );
-                            // Skip attach — do not silently fall back to PTY.
                             return Ok(info);
                         }
                     };
@@ -1803,14 +1967,37 @@ pub async fn create_root_agent_session(
         }
     }
 
-    // Credentials for resolved agent sessions are provided through the child process environment in PtyManager::spawn; no visible credential write occurs here.
-
     Ok(info)
+}
+
+/// Create, wake, or reuse a root agent session.
+#[tauri::command]
+pub async fn create_root_agent_session(
+    app: AppHandle,
+    session_mgr: State<'_, Arc<tokio::sync::RwLock<SessionManager>>>,
+    pty_mgr: State<'_, Arc<Mutex<PtyManager>>>,
+    tg_mgr: State<'_, TelegramBridgeState>,
+    settings: State<'_, SettingsState>,
+    agent_id: Option<String>,
+) -> Result<SessionInfo, String> {
+    create_root_agent_inner(
+        &app,
+        session_mgr.inner(),
+        pty_mgr.inner(),
+        tg_mgr.inner(),
+        settings.inner(),
+        agent_id,
+        true, // skip_auto_resume = true → fresh create, no `--continue` injection
+    )
+    .await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{inject_codex_resume, resolve_actual_agent, should_inject_continue};
+    use super::{
+        inject_codex_resume, resolve_actual_agent, resolve_root_agent_command,
+        should_inject_continue,
+    };
     use crate::config::settings::{AgentConfig, AppSettings};
     use std::path::PathBuf;
 
@@ -1836,6 +2023,61 @@ mod tests {
             ],
             ..AppSettings::default()
         }
+    }
+
+    #[test]
+    fn resolve_root_agent_command_prefers_valid_explicit_agent() {
+        let settings = test_settings();
+
+        let (shell, args, agent_id, label) =
+            resolve_root_agent_command(&settings, Some("codex"), Some("claude"));
+
+        assert_eq!(shell, "codex");
+        assert!(args.is_empty());
+        assert_eq!(agent_id.as_deref(), Some("codex"));
+        assert_eq!(label.as_deref(), Some("Codex"));
+    }
+
+    #[test]
+    fn resolve_root_agent_command_uses_last_coding_agent_when_explicit_missing() {
+        let settings = test_settings();
+
+        let (shell, _args, agent_id, label) =
+            resolve_root_agent_command(&settings, None, Some("codex"));
+
+        assert_eq!(shell, "codex");
+        assert_eq!(agent_id.as_deref(), Some("codex"));
+        assert_eq!(label.as_deref(), Some("Codex"));
+    }
+
+    #[test]
+    fn resolve_root_agent_command_falls_back_to_first_configured_agent() {
+        let settings = test_settings();
+
+        let (shell, _args, agent_id, label) =
+            resolve_root_agent_command(&settings, Some("stale"), Some("also-stale"));
+
+        assert_eq!(shell, "claude");
+        assert_eq!(agent_id.as_deref(), Some("claude"));
+        assert_eq!(label.as_deref(), Some("Claude Code"));
+    }
+
+    #[test]
+    fn resolve_root_agent_command_falls_back_to_default_shell_without_agents() {
+        let mut settings = AppSettings {
+            default_shell: "pwsh".to_string(),
+            default_shell_args: vec!["-NoLogo".to_string()],
+            ..AppSettings::default()
+        };
+        settings.agents.clear();
+
+        let (shell, args, agent_id, label) =
+            resolve_root_agent_command(&settings, Some("stale"), Some("also-stale"));
+
+        assert_eq!(shell, "pwsh");
+        assert_eq!(args, vec!["-NoLogo".to_string()]);
+        assert!(agent_id.is_none());
+        assert!(label.is_none());
     }
 
     #[test]

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -4,6 +4,7 @@ pub mod claude_settings;
 pub mod daemon_pid;
 pub mod profile;
 pub mod projects;
+pub mod root_agent;
 pub mod session_context;
 pub mod sessions_persistence;
 pub mod settings;

--- a/src-tauri/src/config/root_agent.rs
+++ b/src-tauri/src/config/root_agent.rs
@@ -1,0 +1,316 @@
+use serde_json::{Map, Value};
+use std::path::Path;
+use std::sync::OnceLock;
+
+pub const ROOT_AGENT_DIR_NAME: &str = "ac-root-agent";
+pub const ROOT_AGENT_SESSION_NAME: &str = "Root Agent";
+
+const ROOT_ROLE_MD: &str = r#"---
+name: 'agents-commander'
+description: 'Root coordinator for AgentsCommander sessions, workgroups, and agents.'
+type: agent
+---
+
+# Agents Commander
+
+You are the AgentsCommander Root Agent. You are the top-level coordinator for this AgentsCommander binary.
+
+## Responsibility
+
+Act as the top-level planning and oversight agent for sessions, workgroups, and agents available to this AgentsCommander instance. Help the user inspect available work, plan delegation, track status, and synthesize results. When direct peer messaging is unavailable, say so plainly and ask the user to route messages or wait for a future root messaging feature rather than claiming sends were performed.
+
+## State
+
+Your own canonical state lives in this `ac-root-agent` directory:
+
+- `memory/`
+- `plans/`
+- `skills/`
+- `Role.md`
+
+You are not a workgroup replica and you do not have an origin Agent Matrix. Use this directory for your own durable state.
+
+## Coordination
+
+Use the AgentsCommander CLI only for commands that are valid from this root-agent directory. Follow the write restrictions in the common context exactly.
+
+Direct file-based workgroup messaging is not available from the root-agent directory yet: `send --send` currently requires a workgroup replica root. Do not claim that you can autonomously message workgroup peers until a future root messaging feature adds explicit root-aware send instructions.
+"#;
+
+pub fn root_agent_dir() -> Result<String, String> {
+    static ROOT_DIR: OnceLock<String> = OnceLock::new();
+    if let Some(cached) = ROOT_DIR.get() {
+        return Ok(cached.clone());
+    }
+
+    let config_dir =
+        super::config_dir().ok_or_else(|| "Could not resolve app config directory".to_string())?;
+    let root_dir = display_path(&config_dir.join(ROOT_AGENT_DIR_NAME));
+    let _ = ROOT_DIR.set(root_dir.clone());
+    Ok(root_dir)
+}
+
+pub fn is_root_agent_dir_name(cwd: &str) -> bool {
+    Path::new(cwd)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.eq_ignore_ascii_case(ROOT_AGENT_DIR_NAME))
+        .unwrap_or(false)
+}
+
+pub fn is_root_agent_path(cwd: &str) -> bool {
+    let Ok(root_dir) = root_agent_dir() else {
+        return false;
+    };
+    paths_equivalent(Path::new(cwd), Path::new(&root_dir))
+}
+
+pub fn ensure_root_agent_dir() -> Result<String, String> {
+    let root_dir = root_agent_dir()?;
+    ensure_root_agent_dir_at(Path::new(&root_dir))?;
+    Ok(root_dir)
+}
+
+pub(crate) fn ensure_root_agent_dir_at(root_dir: &Path) -> Result<(), String> {
+    crate::commands::entity_creation::create_agent_matrix_layout(root_dir).map_err(
+        |(sub, e)| {
+            format!(
+                "Failed to create root agent layout entry '{}' at {}: {}",
+                sub,
+                root_dir.display(),
+                e
+            )
+        },
+    )?;
+
+    let role_path = root_dir.join("Role.md");
+    if !role_path.exists() {
+        std::fs::write(&role_path, ROOT_ROLE_MD)
+            .map_err(|e| format!("Failed to write {}: {}", role_path.display(), e))?;
+    }
+
+    merge_root_agent_config(&root_dir.join("config.json"))
+}
+
+pub(crate) fn merge_root_agent_config(config_path: &Path) -> Result<(), String> {
+    let mut root = if config_path.exists() {
+        let content = std::fs::read_to_string(config_path)
+            .map_err(|e| format!("Failed to read {}: {}", config_path.display(), e))?;
+        let parsed: Value = serde_json::from_str(&content).map_err(|e| {
+            format!(
+                "Failed to parse root agent config {}: {}",
+                config_path.display(),
+                e
+            )
+        })?;
+        if !parsed.is_object() {
+            return Err(format!(
+                "Root agent config {} must be a JSON object",
+                config_path.display()
+            ));
+        }
+        parsed
+    } else {
+        Value::Object(Map::new())
+    };
+
+    let obj = root.as_object_mut().expect("checked object above");
+    obj.entry("tooling".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+
+    let has_non_empty_context = obj
+        .get("context")
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| !arr.is_empty());
+    if !has_non_empty_context {
+        obj.insert(
+            "context".to_string(),
+            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT", "Role.md"]),
+        );
+    }
+
+    let json = serde_json::to_string_pretty(&root)
+        .map_err(|e| format!("Failed to serialize root agent config: {}", e))?;
+    std::fs::write(config_path, json)
+        .map_err(|e| format!("Failed to write {}: {}", config_path.display(), e))?;
+
+    Ok(())
+}
+
+pub fn read_last_coding_agent(root_dir: &str) -> Option<String> {
+    let config_path = Path::new(root_dir).join("config.json");
+    let contents = std::fs::read_to_string(config_path).ok()?;
+    let value: Value = serde_json::from_str(&contents).ok()?;
+    value
+        .get("tooling")
+        .and_then(|tooling| tooling.get("lastCodingAgent"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn paths_equivalent(left: &Path, right: &Path) -> bool {
+    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => normalize_for_compare(&left) == normalize_for_compare(&right),
+        _ => normalize_for_compare(left) == normalize_for_compare(right),
+    }
+}
+
+fn normalize_for_compare(path: &Path) -> String {
+    let mut s = display_path(path).replace('\\', "/");
+    while s.ends_with('/') && s.len() > 1 {
+        s.pop();
+    }
+    if cfg!(windows) {
+        s.to_ascii_lowercase()
+    } else {
+        s
+    }
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_root_agent_dir_at_creates_layout_role_and_config() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+
+        ensure_root_agent_dir_at(&root).expect("ensure root");
+
+        for sub in ["memory", "plans", "skills", "inbox", "outbox"] {
+            assert!(root.join(sub).is_dir(), "missing {}", sub);
+        }
+        assert!(root.join("Role.md").is_file());
+        let config: Value = serde_json::from_str(
+            &std::fs::read_to_string(root.join("config.json")).expect("read config"),
+        )
+        .expect("parse config");
+        assert_eq!(config["tooling"], serde_json::json!({}));
+        assert_eq!(
+            config["context"],
+            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT", "Role.md"])
+        );
+    }
+
+    #[test]
+    fn ensure_root_agent_dir_at_is_idempotent_and_preserves_role() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+        std::fs::create_dir_all(&root).expect("create root");
+        std::fs::write(root.join("Role.md"), "custom role").expect("write role");
+
+        ensure_root_agent_dir_at(&root).expect("first ensure");
+        ensure_root_agent_dir_at(&root).expect("second ensure");
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("Role.md")).expect("read role"),
+            "custom role"
+        );
+    }
+
+    #[test]
+    fn merge_root_agent_config_preserves_tooling_and_unknown_fields() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = temp.path().join("config.json");
+        std::fs::write(
+            &config_path,
+            r#"{
+  "tooling": {
+    "lastCodingAgent": "codex",
+    "codingAgents": {"codex": {"app": "Codex"}},
+    "telegramBot": "ops"
+  },
+  "unknown": {"keep": true},
+  "context": []
+}"#,
+        )
+        .expect("write config");
+
+        merge_root_agent_config(&config_path).expect("merge config");
+
+        let config: Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).expect("read config"))
+                .expect("parse config");
+        assert_eq!(config["tooling"]["lastCodingAgent"], "codex");
+        assert_eq!(config["tooling"]["telegramBot"], "ops");
+        assert_eq!(config["unknown"]["keep"], true);
+        assert_eq!(
+            config["context"],
+            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT", "Role.md"])
+        );
+    }
+
+    #[test]
+    fn malformed_config_returns_error_without_rewriting() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = temp.path().join("config.json");
+        std::fs::write(&config_path, "{not json").expect("write config");
+
+        let err = merge_root_agent_config(&config_path).expect_err("must fail");
+
+        assert!(err.contains("Failed to parse root agent config"));
+        assert_eq!(
+            std::fs::read_to_string(&config_path).expect("read config"),
+            "{not json"
+        );
+    }
+
+    #[test]
+    fn set_last_coding_agent_preserves_root_context() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+        ensure_root_agent_dir_at(&root).expect("ensure root");
+
+        crate::config::agent_config::set_last_coding_agent(
+            &root.to_string_lossy(),
+            "codex",
+            "Codex",
+            Some("session-1"),
+        )
+        .expect("set last coding agent");
+
+        let config: Value = serde_json::from_str(
+            &std::fs::read_to_string(root.join("config.json")).expect("read config"),
+        )
+        .expect("parse config");
+        assert_eq!(config["tooling"]["lastCodingAgent"], "codex");
+        assert_eq!(
+            config["context"],
+            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT", "Role.md"])
+        );
+    }
+
+    #[test]
+    fn read_last_coding_agent_reads_tooling_field_and_tolerates_bad_config() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+        std::fs::create_dir_all(&root).expect("create root");
+        std::fs::write(
+            root.join("config.json"),
+            r#"{"tooling":{"lastCodingAgent":"claude"}}"#,
+        )
+        .expect("write config");
+
+        assert_eq!(
+            read_last_coding_agent(&root.to_string_lossy()).as_deref(),
+            Some("claude")
+        );
+
+        std::fs::write(root.join("config.json"), "{not json").expect("write bad config");
+        assert!(read_last_coding_agent(&root.to_string_lossy()).is_none());
+        assert!(read_last_coding_agent(&temp.path().join("missing").to_string_lossy()).is_none());
+    }
+
+    #[test]
+    fn root_dir_name_detection_is_case_insensitive() {
+        assert!(is_root_agent_dir_name("C:/tmp/AC-ROOT-AGENT"));
+        assert!(!is_root_agent_dir_name("C:/tmp/not-root"));
+    }
+}

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -123,6 +123,14 @@ fn resolve_skill_owner_root(agent_root: &str, replica_matrix_root: Option<&str>)
             .or_else(|| Some(display_path(agent_path)));
     }
 
+    if super::root_agent::is_root_agent_dir_name(agent_root) {
+        let agent_path = Path::new(agent_root);
+        return std::fs::canonicalize(agent_path)
+            .map(|p| display_path(&p))
+            .ok()
+            .or_else(|| Some(display_path(agent_path)));
+    }
+
     None
 }
 
@@ -814,7 +822,9 @@ fn is_canonical_agent_matrix_dir(cwd: &str) -> bool {
 }
 
 fn is_agent_dir(cwd: &str) -> bool {
-    is_replica_agent_dir(cwd) || is_canonical_agent_matrix_dir(cwd)
+    is_replica_agent_dir(cwd)
+        || is_canonical_agent_matrix_dir(cwd)
+        || super::root_agent::is_root_agent_dir_name(cwd)
 }
 
 /// Build the GIT_CEILING_DIRECTORIES value for agent sessions rooted in `.ac-new`.
@@ -1111,6 +1121,18 @@ fn resolve_session_context_content(cwd: &str) -> Result<Option<String>, String> 
                 combined_path
             }
             Ok(None) => ensure_session_context(cwd)?,
+            Err(e) => return Err(e),
+        }
+    } else if super::root_agent::is_root_agent_dir_name(cwd) {
+        match build_replica_context(cwd) {
+            Ok(Some(combined_path)) => {
+                log::info!(
+                    "Using root-agent combined context for agent session: {}",
+                    combined_path
+                );
+                combined_path
+            }
+            Ok(None) => return Ok(None),
             Err(e) => return Err(e),
         }
     } else if is_canonical_agent_matrix_dir(cwd) {
@@ -2005,6 +2027,25 @@ mod tests {
             &matrix_root.join("skills").join("runtime").join("SKILL.md")
         )));
         assert!(!content.contains("DIRECT_BODY_SHOULD_NOT_RENDER"));
+    }
+
+    #[test]
+    fn materialize_agent_context_file_includes_root_context_and_role() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp
+            .path()
+            .join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
+        crate::config::root_agent::ensure_root_agent_dir_at(&root).expect("ensure root agent dir");
+
+        let materialized =
+            materialize_agent_context_file(&path_string(&root), ManagedContextTarget::Codex)
+                .expect("materialize context")
+                .expect("context path");
+        let content = std::fs::read_to_string(materialized).expect("read materialized context");
+
+        assert!(content.contains("# AgentsCommander Context"));
+        assert!(content.contains("You are the AgentsCommander Root Agent"));
+        assert!(content.contains("Direct file-based workgroup messaging is not available"));
     }
 
     #[test]

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use crate::config::settings::WindowGeometry;
 use crate::session::manager::SessionManager;
-use crate::session::session::{SessionStatus, TEMP_SESSION_PREFIX};
 use crate::session::profile::CodingAgentKind;
+use crate::session::session::{SessionStatus, TEMP_SESSION_PREFIX};
 
 /// Minimal session data needed to restore a session on next app start.
 /// No UUID, just the "recipe" to re-create it.
@@ -35,6 +35,9 @@ pub struct PersistedSession {
     /// Recomputed on restore; persisted for forward-compat only.
     #[serde(default)]
     pub is_coordinator: bool,
+    /// True for the global Root Agent session. Defaults false for old sessions.json.
+    #[serde(default)]
+    pub is_root_agent: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -91,10 +94,38 @@ fn deduplicate(sessions: Vec<PersistedSession>) -> Vec<PersistedSession> {
     let total = sessions.len();
     let mut name_index: HashMap<String, usize> = HashMap::new();
     let mut cwd_index: HashMap<String, usize> = HashMap::new();
+    let mut root_index: Option<usize> = None;
     let mut result: Vec<PersistedSession> = Vec::with_capacity(total);
 
     for session in sessions {
         let norm_cwd = session.working_directory.replace('\\', "/").to_lowercase();
+        let is_root_agent = session.is_root_agent
+            || crate::config::root_agent::is_root_agent_path(&session.working_directory);
+
+        if is_root_agent {
+            if let Some(idx) = root_index {
+                log::warn!(
+                    "[sessions] Dropping duplicate root agent session '{}' at '{}'",
+                    session.name,
+                    session.working_directory
+                );
+                if !result[idx].was_active || session.was_active {
+                    let old_cwd = result[idx]
+                        .working_directory
+                        .replace('\\', "/")
+                        .to_lowercase();
+                    name_index.remove(&result[idx].name);
+                    cwd_index.remove(&old_cwd);
+                    name_index.insert(session.name.clone(), idx);
+                    cwd_index.insert(norm_cwd, idx);
+                    result[idx] = session;
+                    result[idx].is_root_agent = true;
+                } else {
+                    result[idx].is_root_agent = true;
+                }
+                continue;
+            }
+        }
 
         // Check name-based duplicate
         if let Some(&idx) = name_index.get(&session.name) {
@@ -136,7 +167,15 @@ fn deduplicate(sessions: Vec<PersistedSession>) -> Vec<PersistedSession> {
         // New unique session
         name_index.insert(session.name.clone(), result.len());
         cwd_index.insert(norm_cwd, result.len());
+        if is_root_agent {
+            root_index = Some(result.len());
+        }
         result.push(session);
+        if is_root_agent {
+            if let Some(last) = result.last_mut() {
+                last.is_root_agent = true;
+            }
+        }
     }
 
     if result.len() < total {
@@ -346,6 +385,7 @@ pub async fn snapshot_sessions(mgr: &SessionManager) -> Vec<PersistedSession> {
             was_active: active_id.as_deref() == Some(&s.id),
             git_repos: s.git_repos.clone(),
             is_coordinator: s.is_coordinator,
+            is_root_agent: s.is_root_agent,
             agent_id: s.agent_id.clone(),
             agent_label: s.agent_label.clone(),
             // Fix A: read detach state directly from the Session (via SessionInfo). The
@@ -699,6 +739,7 @@ mod tests {
             was_active: false,
             git_repos: vec![],
             is_coordinator: false,
+            is_root_agent: false,
             agent_id: Some("aid-1".into()),
             agent_label: Some("Claude Code".into()),
             was_detached: false,
@@ -746,6 +787,7 @@ mod tests {
             was_active: false,
             git_repos: vec![],
             is_coordinator: false,
+            is_root_agent: false,
             agent_id: None,
             agent_label: None,
             was_detached: false,
@@ -765,7 +807,6 @@ mod tests {
         assert!(twice.created_at.is_none());
         assert_eq!(twice.name, "bob");
     }
-
 
     #[test]
     fn strip_auto_injected_args_removes_direct_gemini_resume_latest() {
@@ -1005,6 +1046,7 @@ mod tests {
             was_active: false,
             git_repos: vec![],
             is_coordinator: false,
+            is_root_agent: false,
             agent_id: None,
             agent_label: None,
             was_detached: false,
@@ -1054,6 +1096,7 @@ mod tests {
                 was_active: true,
                 git_repos: vec![],
                 is_coordinator: true,
+                is_root_agent: false,
                 agent_id: Some("aid-arch".into()),
                 agent_label: Some("Architect".into()),
                 was_detached: false,
@@ -1071,6 +1114,37 @@ mod tests {
         }
     }
 
+    #[test]
+    fn is_root_agent_defaults_false_for_legacy_json() {
+        let json = r#"{
+            "name": "legacy",
+            "shell": "cmd",
+            "shellArgs": [],
+            "workingDirectory": "C:/x"
+        }"#;
+
+        let back: PersistedSession = serde_json::from_str(json).expect("deserialize");
+
+        assert!(!back.is_root_agent);
+    }
+
+    #[test]
+    fn is_root_agent_round_trips_true() {
+        let ps = PersistedSession {
+            name: "Root Agent".into(),
+            shell: "codex".into(),
+            shell_args: vec![],
+            working_directory: "C:/tools/.agentscommander/ac-root-agent".into(),
+            is_root_agent: true,
+            ..Default::default()
+        };
+
+        let json = serde_json::to_value(&ps).expect("serialize");
+        assert_eq!(json["isRootAgent"], true);
+        let back: PersistedSession = serde_json::from_value(json).expect("deserialize");
+        assert!(back.is_root_agent);
+    }
+
     /// Legacy "multi-repo" prefix → git_repos stays empty; legacy fields cleared.
     #[test]
     fn legacy_migration_multi_repo_shape() {
@@ -1082,6 +1156,7 @@ mod tests {
             was_active: false,
             git_repos: vec![],
             is_coordinator: false,
+            is_root_agent: false,
             agent_id: None,
             agent_label: None,
             was_detached: false,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,6 +134,18 @@ pub(crate) fn should_wake_on_restore(
     }
 }
 
+pub(crate) fn should_wake_root_agent_on_restore(
+    persisted_status: Option<&crate::session::session::SessionStatus>,
+) -> bool {
+    match persisted_status {
+        Some(crate::session::session::SessionStatus::Exited(_)) => false,
+        Some(crate::session::session::SessionStatus::Active)
+        | Some(crate::session::session::SessionStatus::Running)
+        | Some(crate::session::session::SessionStatus::Idle)
+        | None => true,
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Same backend the CLI path now installs in `main.rs` — see `logging.rs`
@@ -458,8 +470,13 @@ pub fn run() {
                 });
             }
 
+            if let Err(e) = crate::config::root_agent::ensure_root_agent_dir() {
+                log::error!("[root-agent] Failed to provision root agent directory: {}", e);
+            }
+
             // §224 A.2.5 / G-IMPL-1 — Set restore_in_progress=TRUE BEFORE the
-            // mailbox poller starts, when persisted sessions will be restored.
+            // mailbox poller starts. The restore task now also owns the root-agent
+            // first-start path, so it must run even with no persisted sessions.
             //
             // SEQUENCE-CRITICAL: `MailboxPoller::start()` spawns a tokio worker
             // task that runs its first poll WITHOUT delay (mailbox.rs:200-204)
@@ -479,20 +496,15 @@ pub fn run() {
             // completes (or panics).
             //
             // The matching `load_sessions()` call at the original site is
-            // removed; `persisted` is reused below by `if !persisted.is_empty()`.
+            // removed; `persisted` is reused by the restore task below.
             let persisted = sessions_persistence::load_sessions();
-            if !persisted.is_empty() {
-                let restore_flag = app
-                    .state::<Arc<RestoreInProgress>>()
-                    .inner()
-                    .clone();
-                restore_flag
-                    .0
-                    .store(true, std::sync::atomic::Ordering::SeqCst);
-            }
-            // If persisted.is_empty(), the flag stays at its init value of
-            // false (lib.rs:258) — no restore task will spawn, so the race-
-            // guard wait would be pointless.
+            let restore_flag = app
+                .state::<Arc<RestoreInProgress>>()
+                .inner()
+                .clone();
+            restore_flag
+                .0
+                .store(true, std::sync::atomic::Ordering::SeqCst);
 
             // Start the mailbox poller for inter-agent message delivery
             let mailbox_poller = phone::mailbox::MailboxPoller::new();
@@ -652,10 +664,12 @@ pub fn run() {
             // §224 G-IMPL-1 — `persisted` and `restore_flag` are hoisted above
             // mailbox_poller.start() (see comment block there). `persisted` is
             // reused here; the flag is already TRUE when we enter this block.
-            if !persisted.is_empty() {
+            {
                 use tauri::Manager;
                 let session_mgr_clone = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>().inner().clone();
                 let pty_mgr_clone = app.state::<Arc<Mutex<PtyManager>>>().inner().clone();
+                let tg_mgr_clone = app.state::<TelegramBridgeState>().inner().clone();
+                let settings_state_clone = app.state::<SettingsState>().inner().clone();
                 let app_handle = app.handle().clone();
 
                 // #248 — read the new setting and always discover teams (the coord check
@@ -705,7 +719,248 @@ pub fn run() {
                     let mut n_woken: usize = 0;
                     let mut n_deferred: usize = 0;
 
+                    let root_agent_path = match crate::config::root_agent::ensure_root_agent_dir() {
+                        Ok(path) => Some(path),
+                        Err(e) => {
+                            log::error!("[root-agent] Failed to provision root agent during restore: {}", e);
+                            None
+                        }
+                    };
+                    let root_ps = persisted
+                        .iter()
+                        .find(|ps| {
+                            ps.is_root_agent
+                                || crate::config::root_agent::is_root_agent_path(
+                                    &ps.working_directory,
+                                )
+                        })
+                        .cloned();
+
+                    if let Some(root_path) = root_agent_path.clone() {
+                        match root_ps.as_ref() {
+                            None => {
+                                match commands::session::create_root_agent_inner(
+                                    &app_handle,
+                                    &session_mgr_clone,
+                                    &pty_mgr_clone,
+                                    &tg_mgr_clone,
+                                    &settings_state_clone,
+                                    None,
+                                    true,
+                                )
+                                .await
+                                {
+                                    Ok(_) => n_woken += 1,
+                                    Err(e) => log::error!(
+                                        "[root-agent] Failed to auto-create root session: {}",
+                                        e
+                                    ),
+                                }
+                            }
+                            Some(ps)
+                                if should_wake_root_agent_on_restore(ps.status.as_ref()) =>
+                            {
+                                let _root_guard =
+                                    commands::session::root_agent_session_lock().lock().await;
+                                let existing_root = {
+                                    let mgr = session_mgr_clone.read().await;
+                                    mgr.list_sessions().await.into_iter().find(|s| {
+                                        s.is_root_agent
+                                            || crate::config::root_agent::is_root_agent_path(
+                                                &s.working_directory,
+                                            )
+                                    })
+                                };
+                                let mut should_create = true;
+                                if let Some(existing) = existing_root {
+                                    if matches!(
+                                        existing.status,
+                                        crate::session::session::SessionStatus::Exited(_)
+                                    ) {
+                                        if let Ok(uuid) = uuid::Uuid::parse_str(&existing.id) {
+                                            if let Err(e) =
+                                                commands::session::force_destroy_session_inner(
+                                                    &app_handle,
+                                                    uuid,
+                                                )
+                                                .await
+                                            {
+                                                log::warn!(
+                                                    "[root-agent] Failed to force-destroy stale dormant root during restore: {}",
+                                                    e
+                                                );
+                                            }
+                                        }
+                                    } else {
+                                        if ps.was_active {
+                                            active_id = Some(existing.id.clone());
+                                        }
+                                        n_woken += 1;
+                                        should_create = false;
+                                    }
+                                }
+                                if should_create {
+                                    match commands::session::create_session_inner(
+                                        &app_handle,
+                                        &session_mgr_clone,
+                                        &pty_mgr_clone,
+                                        ps.shell.clone(),
+                                        ps.shell_args.clone(),
+                                        root_path.clone(),
+                                        Some(ps.name.clone()),
+                                        ps.agent_id.clone(),
+                                        ps.agent_label.clone(),
+                                        false,
+                                        ps.git_repos.clone(),
+                                        false,
+                                    )
+                                    .await
+                                    {
+                                        Ok(info) => {
+                                            if ps.was_active {
+                                                active_id = Some(info.id.clone());
+                                            }
+                                            n_woken += 1;
+
+                                            if ps.was_detached {
+                                                if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
+                                                    {
+                                                        let mgr = session_mgr_clone.read().await;
+                                                        mgr.set_was_detached(uuid, true).await;
+                                                        if let Some(ref geo) = ps.detached_geometry
+                                                        {
+                                                            mgr.set_detached_geometry(
+                                                                uuid,
+                                                                geo.clone(),
+                                                            )
+                                                            .await;
+                                                        }
+                                                    }
+
+                                                    let detached_state =
+                                                        app_handle.state::<DetachedSessionsState>();
+                                                    let detached_result =
+                                                        commands::window::detach_terminal_inner(
+                                                            &app_handle,
+                                                            &session_mgr_clone,
+                                                            detached_state.inner(),
+                                                            &info.id,
+                                                            ps.detached_geometry.clone(),
+                                                            true,
+                                                        )
+                                                        .await;
+                                                    if let Err(e) = detached_result {
+                                                        log::warn!(
+                                                            "[restore] detach_terminal_inner failed for root agent '{}': {} — session stays live (attached)",
+                                                            ps.name,
+                                                            e
+                                                        );
+                                                    } else {
+                                                        let mgr = session_mgr_clone.read().await;
+                                                        mgr.clear_active_if(uuid).await;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        Err(e) => {
+                                            log::error!(
+                                                "[root-agent] Failed to restore root session '{}': {}",
+                                                ps.name,
+                                                e
+                                            );
+                                            failed_recoverable.push(ps.clone());
+                                        }
+                                    }
+                                }
+                            }
+                            Some(ps) => {
+                                let _root_guard =
+                                    commands::session::root_agent_session_lock().lock().await;
+                                let existing_root = {
+                                    let mgr = session_mgr_clone.read().await;
+                                    mgr.list_sessions().await.into_iter().find(|s| {
+                                        s.is_root_agent
+                                            || crate::config::root_agent::is_root_agent_path(
+                                                &s.working_directory,
+                                            )
+                                    })
+                                };
+                                if let Some(existing) = existing_root {
+                                    if ps.was_active {
+                                        active_id = Some(existing.id.clone());
+                                    }
+                                    n_deferred += 1;
+                                } else {
+                                    let mgr = session_mgr_clone.read().await;
+                                    match mgr
+                                        .create_session(
+                                            ps.shell.clone(),
+                                            ps.shell_args.clone(),
+                                            root_path,
+                                            ps.agent_id.clone(),
+                                            ps.agent_label.clone(),
+                                            ps.git_repos.clone(),
+                                            false,
+                                        )
+                                        .await
+                                    {
+                                        Ok(session) => {
+                                            mgr.rename_session(session.id, ps.name.clone())
+                                                .await
+                                                .ok();
+                                            mgr.set_is_root_agent(session.id, true).await;
+                                            if ps.was_detached {
+                                                mgr.set_was_detached(session.id, true).await;
+                                            }
+                                            if let Some(ref geo) = ps.detached_geometry {
+                                                mgr.set_detached_geometry(session.id, geo.clone())
+                                                    .await;
+                                            }
+                                            mgr.mark_exited(session.id, 0).await;
+                                            mgr.clear_active_if(session.id).await;
+                                            if let Some(updated) =
+                                                mgr.get_session(session.id).await
+                                            {
+                                                let info =
+                                                    crate::session::session::SessionInfo::from(
+                                                        &updated,
+                                                    );
+                                                let _ = tauri::Emitter::emit(
+                                                    &app_handle,
+                                                    "session_created",
+                                                    info,
+                                                );
+                                            }
+                                            if ps.was_active {
+                                                active_id = Some(session.id.to_string());
+                                            }
+                                            n_deferred += 1;
+                                        }
+                                        Err(e) => {
+                                            log::error!(
+                                                "[root-agent] Failed to create dormant root session '{}': {}",
+                                                ps.name,
+                                                e
+                                            );
+                                            failed_recoverable.push(ps.clone());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } else if let Some(ps) = root_ps.as_ref() {
+                        failed_recoverable.push(ps.clone());
+                    }
+
                     for ps in &persisted {
+                        if ps.is_root_agent
+                            || crate::config::root_agent::is_root_agent_path(
+                                &ps.working_directory,
+                            )
+                        {
+                            continue;
+                        }
+
                         // Skip sessions whose CWD no longer exists (permanent failure)
                         if !std::path::Path::new(&ps.working_directory).exists() {
                             log::warn!("Skipping restore of '{}': CWD '{}' no longer exists", ps.name, ps.working_directory);
@@ -1117,35 +1372,87 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::should_wake_on_restore;
+    use super::{should_wake_on_restore, should_wake_root_agent_on_restore};
     use crate::session::session::SessionStatus;
 
     #[test]
     fn setting_off_always_defers() {
-        assert!(!should_wake_on_restore(false, true, Some(&SessionStatus::Running)));
+        assert!(!should_wake_on_restore(
+            false,
+            true,
+            Some(&SessionStatus::Running)
+        ));
         assert!(!should_wake_on_restore(false, false, None));
     }
 
     #[test]
     fn non_coord_always_defers_when_on() {
-        assert!(!should_wake_on_restore(true, false, Some(&SessionStatus::Running)));
+        assert!(!should_wake_on_restore(
+            true,
+            false,
+            Some(&SessionStatus::Running)
+        ));
     }
 
     #[test]
     fn coord_awake_at_shutdown_wakes_when_on() {
-        assert!(should_wake_on_restore(true, true, Some(&SessionStatus::Running)));
-        assert!(should_wake_on_restore(true, true, Some(&SessionStatus::Idle)));
-        assert!(should_wake_on_restore(true, true, Some(&SessionStatus::Active)));
+        assert!(should_wake_on_restore(
+            true,
+            true,
+            Some(&SessionStatus::Running)
+        ));
+        assert!(should_wake_on_restore(
+            true,
+            true,
+            Some(&SessionStatus::Idle)
+        ));
+        assert!(should_wake_on_restore(
+            true,
+            true,
+            Some(&SessionStatus::Active)
+        ));
     }
 
     #[test]
     fn coord_asleep_at_shutdown_defers_when_on() {
-        assert!(!should_wake_on_restore(true, true, Some(&SessionStatus::Exited(0))));
-        assert!(!should_wake_on_restore(true, true, Some(&SessionStatus::Exited(137))));
+        assert!(!should_wake_on_restore(
+            true,
+            true,
+            Some(&SessionStatus::Exited(0))
+        ));
+        assert!(!should_wake_on_restore(
+            true,
+            true,
+            Some(&SessionStatus::Exited(137))
+        ));
     }
 
     #[test]
     fn coord_unknown_status_fails_open_when_on() {
         assert!(should_wake_on_restore(true, true, None));
+    }
+
+    #[test]
+    fn root_agent_live_or_legacy_status_wakes() {
+        assert!(should_wake_root_agent_on_restore(Some(
+            &SessionStatus::Running
+        )));
+        assert!(should_wake_root_agent_on_restore(Some(
+            &SessionStatus::Idle
+        )));
+        assert!(should_wake_root_agent_on_restore(Some(
+            &SessionStatus::Active
+        )));
+        assert!(should_wake_root_agent_on_restore(None));
+    }
+
+    #[test]
+    fn root_agent_exited_status_stays_dormant() {
+        assert!(!should_wake_root_agent_on_restore(Some(
+            &SessionStatus::Exited(0)
+        )));
+        assert!(!should_wake_root_agent_on_restore(Some(
+            &SessionStatus::Exited(137)
+        )));
     }
 }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -2402,6 +2402,7 @@ mod tests {
             git_repos: vec![],
             workgroup_brief: None,
             is_coordinator: false,
+            is_root_agent: false,
             token: "t".into(),
             agent_kind: Some(crate::session::profile::CodingAgentKind::Claude),
             was_detached: false,

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -66,6 +66,7 @@ impl SessionManager {
             agent_label,
             git_repos,
             is_coordinator,
+            is_root_agent: false,
             git_repos_gen: 0,
             token: Uuid::new_v4(),
             agent_kind: None,
@@ -216,6 +217,13 @@ impl SessionManager {
             .iter()
             .filter_map(|id| sessions.get(id).map(SessionInfo::from))
             .collect()
+    }
+
+    pub async fn set_is_root_agent(&self, id: Uuid, value: bool) {
+        let mut sessions = self.sessions.write().await;
+        if let Some(session) = sessions.get_mut(&id) {
+            session.is_root_agent = value;
+        }
     }
 
     pub async fn get_active(&self) -> Option<Uuid> {

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -79,6 +79,9 @@ pub struct Session {
     /// Controls repo-badge visibility on the sidebar. Recomputed after every discovery.
     #[serde(default)]
     pub is_coordinator: bool,
+    /// Whether this is the global Root Agent / Agents Commander session.
+    #[serde(default)]
+    pub is_root_agent: bool,
     /// Monotonic generation counter for `git_repos`. Bumped on every refresh/watcher write.
     /// Used for compare-and-swap in `set_git_repos_if_gen` so an in-flight watcher poll
     /// cannot overwrite a refresh that landed during its detection window. Runtime-only;
@@ -179,6 +182,8 @@ pub struct SessionInfo {
     pub workgroup_brief: Option<String>,
     #[serde(default)]
     pub is_coordinator: bool,
+    #[serde(default)]
+    pub is_root_agent: bool,
     pub token: String,
     #[serde(default)]
     pub agent_kind: Option<CodingAgentKind>,
@@ -210,6 +215,7 @@ impl From<&Session> for SessionInfo {
             git_repos: s.git_repos.clone(),
             workgroup_brief: read_workgroup_brief_for_cwd(&s.working_directory),
             is_coordinator: s.is_coordinator,
+            is_root_agent: s.is_root_agent,
             token: s.token.to_string(),
             agent_kind: s.agent_kind,
             was_detached: s.was_detached,
@@ -239,6 +245,7 @@ mod tests {
             agent_label: None,
             git_repos: Vec::new(),
             is_coordinator: false,
+            is_root_agent: false,
             git_repos_gen: 0,
             token: Uuid::nil(),
             agent_kind: None,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -63,6 +63,10 @@ export interface RestartSessionOptions {
   skipAutoResume?: boolean;
 }
 
+export interface CreateRootAgentOptions {
+  agentId?: string;
+}
+
 export const SessionAPI = {
   create: (opts?: CreateSessionOptions) =>
     transport.invoke<Session>("create_session", {
@@ -95,8 +99,10 @@ export const SessionAPI = {
   setLastPrompt: (id: string, text: string) =>
     transport.invoke<void>("set_last_prompt", { id, text }),
 
-  createRootAgent: () =>
-    transport.invoke<Session>("create_root_agent_session"),
+  createRootAgent: (opts?: CreateRootAgentOptions) =>
+    transport.invoke<Session>("create_root_agent_session", {
+      agentId: opts?.agentId ?? null,
+    }),
 };
 
 export const PtyAPI = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -21,6 +21,7 @@ export interface Session {
   gitRepos: SessionRepo[];
   workgroupBrief: string | null;
   isCoordinator: boolean;
+  isRootAgent: boolean;
   token: string;
   agentKind: CodingAgentKind | null;
 }

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -1,6 +1,7 @@
 import { Component, createSignal, onMount, onCleanup, Show } from "solid-js";
 import { isTauri } from "../shared/platform";
 import type { UnlistenFn } from "../shared/transport";
+import type { SessionStatus } from "../shared/types";
 import {
   SessionAPI,
   SettingsAPI,
@@ -46,6 +47,10 @@ interface SidebarAppProps {
    * initializers; those are main-window concerns.
    */
   embedded?: boolean;
+}
+
+function isExitedStatus(status: SessionStatus): boolean {
+  return typeof status === "object" && status !== null && "exited" in status;
 }
 
 const SidebarApp: Component<SidebarAppProps> = (props) => {
@@ -157,7 +162,10 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       await onSessionCreated((session) => {
         sessionsStore.addSession(session);
         // New session is auto-activated if it's the first one
-        if (sessionsStore.sessions.length === 1) {
+        if (
+          sessionsStore.sessions.length === 1 &&
+          !isExitedStatus(session.status)
+        ) {
           sessionsStore.setActiveId(session.id);
         }
       })

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -325,6 +325,13 @@ const RootAgentBanner: Component = () => {
     e.stopPropagation();
     const r = rootSession();
     if (!r) return;
+    // Cancel local capture before destroy: backend marks the root dormant,
+    // which hides the in-banner cancel control and leaves MediaRecorder +
+    // mic stream running. cancel() also detaches onstop so a pending
+    // transcription doesn't write to the now-dormant session.
+    if (voiceRecorder.recordingSessionId() === r.id) {
+      voiceRecorder.cancel();
+    }
     // Root destroy is special: backend kills PTY and marks dormant rather
     // than removing the session record (see destroy_session_inner_with_options
     // in commands/session.rs). The banner stays visible and can re-wake.
@@ -440,7 +447,10 @@ const RootAgentBanner: Component = () => {
         </div>
 
         <Show when={rootSession()}>
-          <Show when={isRecording() && hasLivePty()}>
+          {/* Cancel-recording is local cleanup (MediaRecorder + mic stream),
+              not PTY-dependent — keep it visible even when the root is
+              dormant so any in-flight recording can still be torn down. */}
+          <Show when={isRecording()}>
             <button
               class="session-item-mic-cancel"
               onClick={handleCancelRecording}

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -1,40 +1,247 @@
-import { Component, createSignal } from "solid-js";
+import { Component, createMemo, createSignal, Show, onCleanup } from "solid-js";
+import { Portal } from "solid-js/web";
 import { isTauri } from "../../shared/platform";
 import { SessionAPI, WindowAPI } from "../../shared/ipc";
+import { sessionsStore } from "../stores/sessions";
+import type { Session, SessionStatus } from "../../shared/types";
+import AgentPickerModal from "./AgentPickerModal";
+
+function statusClass(status: SessionStatus): string {
+  if (typeof status === "string") return status;
+  return "exited";
+}
+
+const CONTEXT_MENU_VIEWPORT_MARGIN = 8;
 
 const RootAgentBanner: Component = () => {
-  const [creating, setCreating] = createSignal(false);
+  const [busy, setBusy] = createSignal(false);
+  const [showContextMenu, setShowContextMenu] = createSignal(false);
+  const [contextMenuPos, setContextMenuPos] = createSignal({ x: 0, y: 0 });
+  const [showAgentPicker, setShowAgentPicker] = createSignal(false);
+  let contextMenuEl: HTMLDivElement | undefined;
+
+  const rootSession = createMemo<Session | undefined>(() =>
+    sessionsStore.sessions.find((s) => s.isRootAgent)
+  );
+
+  const isActive = createMemo(() => {
+    const r = rootSession();
+    return !!r && sessionsStore.activeId === r.id;
+  });
+
+  const dotClass = createMemo(() => {
+    const r = rootSession();
+    if (!r) return "offline";
+    if (r.pendingReview) return "pending";
+    if (r.waitingForInput) return "waiting";
+    return statusClass(r.status);
+  });
+
+  const subtitle = createMemo(() => {
+    const r = rootSession();
+    if (!r) return "Root Agent";
+    if (typeof r.status !== "string") return "Exited — click to wake";
+    return "Root Agent";
+  });
+
+  const focusTerminal = async (sessionId: string) => {
+    if (!isTauri) return;
+    const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
+    const detachedLabel = `terminal-${sessionId.replace(/-/g, "")}`;
+    const detachedWin = await WebviewWindow.getByLabel(detachedLabel);
+    if (!detachedWin) {
+      await WindowAPI.ensureTerminal();
+    }
+  };
+
+  let dismissContextMenu: ((ev?: Event) => void) | null = null;
+
+  const cleanupContextMenu = () => {
+    if (dismissContextMenu) {
+      window.removeEventListener("click", dismissContextMenu);
+      window.removeEventListener("contextmenu", dismissContextMenu);
+      window.removeEventListener("keydown", dismissContextMenu as EventListener);
+      dismissContextMenu = null;
+    }
+  };
+
+  onCleanup(cleanupContextMenu);
+
+  const positionContextMenu = (x: number, y: number) => {
+    if (!contextMenuEl) return;
+    const { width, height } = contextMenuEl.getBoundingClientRect();
+    const maxX = Math.max(
+      CONTEXT_MENU_VIEWPORT_MARGIN,
+      window.innerWidth - width - CONTEXT_MENU_VIEWPORT_MARGIN
+    );
+    const maxY = Math.max(
+      CONTEXT_MENU_VIEWPORT_MARGIN,
+      window.innerHeight - height - CONTEXT_MENU_VIEWPORT_MARGIN
+    );
+    setContextMenuPos({
+      x: Math.min(Math.max(CONTEXT_MENU_VIEWPORT_MARGIN, x), maxX),
+      y: Math.min(Math.max(CONTEXT_MENU_VIEWPORT_MARGIN, y), maxY),
+    });
+  };
+
+  const handleContextMenu = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    cleanupContextMenu();
+    setContextMenuPos({ x: e.clientX, y: e.clientY });
+    setShowContextMenu(true);
+    const dismiss = (ev?: Event) => {
+      if (ev instanceof KeyboardEvent && ev.key !== "Escape") return;
+      setShowContextMenu(false);
+      cleanupContextMenu();
+    };
+    dismissContextMenu = dismiss;
+    setTimeout(() => {
+      positionContextMenu(e.clientX, e.clientY);
+      window.addEventListener("click", dismiss);
+      window.addEventListener("contextmenu", dismiss);
+      window.addEventListener("keydown", dismiss as EventListener);
+    });
+  };
 
   const handleClick = async () => {
-    if (creating()) return;
-    setCreating(true);
+    if (busy()) return;
+    setBusy(true);
     try {
-      const session = await SessionAPI.createRootAgent();
-      await SessionAPI.switch(session.id);
-      if (isTauri) {
-        await WindowAPI.ensureTerminal();
+      const r = rootSession();
+      if (!r) {
+        const session = await SessionAPI.createRootAgent();
+        await SessionAPI.switch(session.id);
+        await focusTerminal(session.id);
+      } else if (typeof r.status !== "string") {
+        const session = await SessionAPI.restart(r.id, { skipAutoResume: false });
+        await SessionAPI.switch(session.id);
+        await focusTerminal(session.id);
+      } else {
+        await SessionAPI.switch(r.id);
+        await focusTerminal(r.id);
       }
     } catch (e) {
-      console.error("[RootAgentBanner] Failed to create root agent session:", e);
+      console.error("[RootAgentBanner] click failed:", e);
     } finally {
-      setCreating(false);
+      setBusy(false);
+    }
+  };
+
+  const handleRestart = async () => {
+    setShowContextMenu(false);
+    cleanupContextMenu();
+    if (busy()) return;
+    const r = rootSession();
+    if (!r) return;
+    setBusy(true);
+    try {
+      const session = await SessionAPI.restart(r.id);
+      await SessionAPI.switch(session.id);
+      await focusTerminal(session.id);
+    } catch (e) {
+      console.error("[RootAgentBanner] restart failed:", e);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCodingAgent = () => {
+    setShowContextMenu(false);
+    cleanupContextMenu();
+    setShowAgentPicker(true);
+  };
+
+  const handleAgentSelected = async (agentId: string) => {
+    setShowAgentPicker(false);
+    if (busy()) return;
+    setBusy(true);
+    try {
+      const r = rootSession();
+      if (!r) {
+        const session = await SessionAPI.createRootAgent({ agentId });
+        await SessionAPI.switch(session.id);
+        await focusTerminal(session.id);
+      } else {
+        const session = await SessionAPI.restart(r.id, { agentId });
+        await SessionAPI.switch(session.id);
+        await focusTerminal(session.id);
+      }
+    } catch (e) {
+      console.error("[RootAgentBanner] coding-agent change failed:", e);
+    } finally {
+      setBusy(false);
     }
   };
 
   return (
-    <button class="root-agent-banner" onClick={handleClick} disabled={creating()} title="Open Root Agent session">
-      <div class="root-agent-avatar">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-          <path d="M12 2L2 7l10 5 10-5-10-5z" />
-          <path d="M2 17l10 5 10-5" />
-          <path d="M2 12l10 5 10-5" />
-        </svg>
-      </div>
-      <div class="root-agent-text">
-        <span class="root-agent-title">Agent's Commander</span>
-        <span class="root-agent-subtitle">Root Agent</span>
-      </div>
-    </button>
+    <>
+      <button
+        class="root-agent-banner"
+        classList={{ active: isActive() }}
+        onClick={handleClick}
+        onContextMenu={handleContextMenu}
+        disabled={busy()}
+        title={
+          rootSession()
+            ? "Open Root Agent session (right-click for options)"
+            : "Create Root Agent session"
+        }
+      >
+        <div class={`session-item-status ${dotClass()}`} />
+        <div class="root-agent-avatar">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <path d="M12 2L2 7l10 5 10-5-10-5z" />
+            <path d="M2 17l10 5 10-5" />
+            <path d="M2 12l10 5 10-5" />
+          </svg>
+        </div>
+        <div class="root-agent-text">
+          <span class="root-agent-title">Agent's Commander</span>
+          <span class="root-agent-subtitle">{subtitle()}</span>
+        </div>
+      </button>
+      <Show when={showAgentPicker()}>
+        <Portal>
+          <AgentPickerModal
+            sessionName={rootSession()?.name ?? "Root Agent"}
+            onSelect={(agent) => handleAgentSelected(agent.id)}
+            onClose={() => setShowAgentPicker(false)}
+          />
+        </Portal>
+      </Show>
+      <Show when={showContextMenu()}>
+        <Portal>
+          <div
+            class="session-context-menu"
+            ref={contextMenuEl}
+            style={{
+              left: `${contextMenuPos().x}px`,
+              top: `${contextMenuPos().y}px`,
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              class="session-context-option context-option-danger"
+              onClick={handleRestart}
+              disabled={!rootSession()}
+            >
+              Restart Session
+            </button>
+            <button class="session-context-option" onClick={handleCodingAgent}>
+              Coding Agent
+            </button>
+          </div>
+        </Portal>
+      </Show>
+    </>
   );
 };
 

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -112,10 +112,16 @@ const RootAgentBanner: Component = () => {
       const r = rootSession();
       if (!r) {
         const session = await SessionAPI.createRootAgent();
+        // Hydrate the store: backend may reuse an existing live root and
+        // therefore NOT emit session_created (see ReuseLive in
+        // commands/session.rs). addSession upserts, so it's safe to call
+        // even when session_created later races in.
+        sessionsStore.addSession(session);
         await SessionAPI.switch(session.id);
         await focusTerminal(session.id);
       } else if (typeof r.status !== "string") {
         const session = await SessionAPI.restart(r.id, { skipAutoResume: false });
+        sessionsStore.addSession(session);
         await SessionAPI.switch(session.id);
         await focusTerminal(session.id);
       } else {
@@ -138,6 +144,7 @@ const RootAgentBanner: Component = () => {
     setBusy(true);
     try {
       const session = await SessionAPI.restart(r.id);
+      sessionsStore.addSession(session);
       await SessionAPI.switch(session.id);
       await focusTerminal(session.id);
     } catch (e) {
@@ -165,6 +172,7 @@ const RootAgentBanner: Component = () => {
             agentId: action.agentId,
             skipAutoResume: action.skipAutoResume,
           });
+      sessionsStore.addSession(session);
       await SessionAPI.switch(session.id);
       await focusTerminal(session.id);
     } catch (e) {

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -1,9 +1,19 @@
-import { Component, createMemo, createSignal, Show, onCleanup } from "solid-js";
+import { Component, createMemo, createSignal, Show, For, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
 import { isTauri } from "../../shared/platform";
-import { SessionAPI, WindowAPI } from "../../shared/ipc";
+import {
+  SessionAPI,
+  SettingsAPI,
+  TelegramAPI,
+  WindowAPI,
+  AgentCreatorAPI,
+  emitOpenSettings,
+} from "../../shared/ipc";
 import { sessionsStore } from "../stores/sessions";
-import type { Session, SessionStatus } from "../../shared/types";
+import { bridgesStore } from "../stores/bridges";
+import { settingsStore } from "../../shared/stores/settings";
+import { voiceRecorder, formatRecordingTime } from "../../shared/voice-recorder";
+import type { Session, SessionStatus, TelegramBotConfig } from "../../shared/types";
 import AgentPickerModal from "./AgentPickerModal";
 import { rootAgentCodingAgentAction } from "./root-agent-action";
 
@@ -19,6 +29,8 @@ const RootAgentBanner: Component = () => {
   const [showContextMenu, setShowContextMenu] = createSignal(false);
   const [contextMenuPos, setContextMenuPos] = createSignal({ x: 0, y: 0 });
   const [showAgentPicker, setShowAgentPicker] = createSignal(false);
+  const [showBotMenu, setShowBotMenu] = createSignal(false);
+  const [availableBots, setAvailableBots] = createSignal<TelegramBotConfig[]>([]);
   let contextMenuEl: HTMLDivElement | undefined;
 
   const rootSession = createMemo<Session | undefined>(() =>
@@ -44,6 +56,35 @@ const RootAgentBanner: Component = () => {
     if (typeof r.status !== "string") return "Exited — click to wake";
     return "Root Agent";
   });
+
+  const bridge = () => {
+    const r = rootSession();
+    return r ? bridgesStore.getBridge(r.id) : undefined;
+  };
+  const isRecording = () => {
+    const r = rootSession();
+    return !!r && voiceRecorder.recordingSessionId() === r.id;
+  };
+  const isProcessing = () => {
+    const r = rootSession();
+    return !!r && voiceRecorder.processingSessionId() === r.id;
+  };
+  const isAutoExecuting = () => {
+    const r = rootSession();
+    return !!r && voiceRecorder.autoExecuteSessionId() === r.id;
+  };
+  const isTypingWarning = () => {
+    const r = rootSession();
+    return !!r && voiceRecorder.typingWarnSessionId() === r.id;
+  };
+  const isDetached = () => {
+    const r = rootSession();
+    return !!r && sessionsStore.isDetached(r.id);
+  };
+  const hasClaude = () =>
+    (settingsStore.current?.agents ?? []).some((a) =>
+      a.command.toLowerCase().includes("claude")
+    );
 
   const focusTerminal = async (sessionId: string) => {
     if (!isTauri) return;
@@ -182,14 +223,125 @@ const RootAgentBanner: Component = () => {
     }
   };
 
+  const handleMicClick = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (!settingsStore.voiceEnabled) {
+      emitOpenSettings("integrations").catch(console.error);
+      return;
+    }
+    const r = rootSession();
+    if (!r) return;
+    voiceRecorder.toggle(r.id);
+  };
+
+  const handleCancelRecording = (e: MouseEvent) => {
+    e.stopPropagation();
+    voiceRecorder.cancel();
+  };
+
+  const handleCancelAutoExecute = (e: MouseEvent) => {
+    e.stopPropagation();
+    voiceRecorder.cancelAutoExecute();
+  };
+
+  const handleOpenExplorer = async (e: MouseEvent) => {
+    e.stopPropagation();
+    const r = rootSession();
+    if (!r) return;
+    try {
+      await WindowAPI.openInExplorer(r.workingDirectory);
+    } catch (err) {
+      console.error("Failed to open explorer:", err);
+    }
+  };
+
+  const handleDetachToggle = async (e: MouseEvent) => {
+    e.stopPropagation();
+    const r = rootSession();
+    if (!r) return;
+    try {
+      if (isDetached()) {
+        await WindowAPI.attach(r.id);
+      } else {
+        await WindowAPI.detach(r.id);
+      }
+    } catch (err) {
+      console.error("detach/attach toggle failed:", err);
+    }
+  };
+
+  const handleContextDetachToggle = async () => {
+    setShowContextMenu(false);
+    cleanupContextMenu();
+    const r = rootSession();
+    if (!r) return;
+    try {
+      if (isDetached()) {
+        await WindowAPI.attach(r.id);
+      } else {
+        await WindowAPI.detach(r.id);
+      }
+    } catch (err) {
+      console.error("context detach/attach toggle failed:", err);
+    }
+  };
+
+  const handleTelegramClick = async (e: MouseEvent) => {
+    e.stopPropagation();
+    const r = rootSession();
+    if (!r) return;
+    const b = bridge();
+    if (b) {
+      await TelegramAPI.detach(r.id);
+    } else {
+      const settings = await SettingsAPI.get();
+      const bots = settings.telegramBots || [];
+      if (bots.length === 1) {
+        await TelegramAPI.attach(r.id, bots[0].id);
+      } else if (bots.length > 1) {
+        setAvailableBots(bots);
+        setShowBotMenu(true);
+      }
+    }
+  };
+
+  const handleBotSelect = async (botId: string) => {
+    setShowBotMenu(false);
+    const r = rootSession();
+    if (!r) return;
+    await TelegramAPI.attach(r.id, botId);
+  };
+
+  const handleClose = (e: MouseEvent) => {
+    e.stopPropagation();
+    const r = rootSession();
+    if (!r) return;
+    // Root destroy is special: backend kills PTY and marks dormant rather
+    // than removing the session record (see destroy_session_inner_with_options
+    // in commands/session.rs). The banner stays visible and can re-wake.
+    SessionAPI.destroy(r.id);
+  };
+
+  const handleExcludeClaudeMd = async (e: MouseEvent) => {
+    e.stopPropagation();
+    setShowContextMenu(false);
+    cleanupContextMenu();
+    const r = rootSession();
+    if (!r) return;
+    try {
+      await AgentCreatorAPI.writeClaudeSettingsLocal(r.workingDirectory);
+    } catch (err) {
+      console.error("Failed to write claude settings:", err);
+    }
+  };
+
   return (
     <>
-      <button
+      <div
         class="root-agent-banner"
-        classList={{ active: isActive() }}
+        classList={{ active: isActive(), disabled: busy() }}
         onClick={handleClick}
         onContextMenu={handleContextMenu}
-        disabled={busy()}
         title={
           rootSession()
             ? "Open Root Agent session (right-click for options)"
@@ -213,9 +365,128 @@ const RootAgentBanner: Component = () => {
         </div>
         <div class="root-agent-text">
           <span class="root-agent-title">Agent's Commander</span>
-          <span class="root-agent-subtitle">{subtitle()}</span>
+          <Show when={!isRecording() && !isProcessing() && !isAutoExecuting() && !isTypingWarning() && !voiceRecorder.micError()}>
+            <span class="root-agent-subtitle">{subtitle()}</span>
+          </Show>
+
+          <Show when={isRecording()}>
+            <div class="session-item-voice-indicator recording">
+              <div class="voice-dot" />
+              <div class="voice-level-bar">
+                <div
+                  class="voice-level-fill"
+                  style={{ width: `${Math.min(voiceRecorder.audioLevel() * 100 * 2.5, 100)}%` }}
+                />
+              </div>
+              <span class="voice-time">{formatRecordingTime(voiceRecorder.recordingSeconds())}</span>
+            </div>
+          </Show>
+
+          <Show when={isProcessing()}>
+            <div class="session-item-voice-indicator processing">
+              <div class="voice-spinner" />
+              <span class="voice-processing-text">Transcribing...</span>
+            </div>
+          </Show>
+
+          <Show when={isAutoExecuting()}>
+            <div class="session-item-voice-indicator auto-execute">
+              <span class="voice-countdown">{voiceRecorder.autoExecuteCountdown()}s</span>
+              <span class="voice-execute-text">Auto-execute</span>
+              <button class="voice-cancel-execute" onClick={handleCancelAutoExecute}>Cancel</button>
+            </div>
+          </Show>
+
+          <Show when={isTypingWarning()}>
+            <div class="session-item-voice-indicator warning">
+              <span class="voice-warning-text">Typed during recording</span>
+            </div>
+          </Show>
+
+          <Show when={voiceRecorder.micError() && (isRecording() || isProcessing() || rootSession())}>
+            <div class="session-item-voice-indicator error">
+              <span class="voice-error-text">{voiceRecorder.micError()}</span>
+            </div>
+          </Show>
         </div>
-      </button>
+
+        <Show when={rootSession()}>
+          <Show when={isRecording()}>
+            <button
+              class="session-item-mic-cancel"
+              onClick={handleCancelRecording}
+              title="Cancel recording"
+            >
+              &#x2715;
+            </button>
+          </Show>
+          <button
+            class={`session-item-mic ${isRecording() ? "recording" : ""} ${isProcessing() ? "processing" : ""} ${voiceRecorder.micError() ? "error" : ""} ${!settingsStore.voiceEnabled ? "disabled" : ""}`}
+            onClick={handleMicClick}
+            title={
+              !settingsStore.voiceEnabled
+                ? "Enable voice-to-text in Settings and set a Gemini API key to use this."
+                : isRecording()
+                  ? "Stop recording"
+                  : isProcessing()
+                    ? "Transcribing..."
+                    : voiceRecorder.micError()
+                      ? voiceRecorder.micError()!
+                      : "Voice to text"
+            }
+          >
+            &#x1F399;
+          </button>
+          <button
+            class="session-item-explorer"
+            onClick={handleOpenExplorer}
+            title="Open folder in explorer"
+          >
+            &#x1F4C2;
+          </button>
+          <button
+            class="session-item-detach"
+            classList={{ attached: isDetached() }}
+            onClick={handleDetachToggle}
+            title={isDetached() ? "Re-attach to main window" : "Open in new window"}
+            innerHTML={isDetached() ? "&#x2934;" : "&#x29C9;"}
+          />
+
+          <Show when={bridge()}>
+            <div
+              class="session-item-bridge-dot"
+              style={{ background: bridge()!.color }}
+              title={`Telegram: ${bridge()!.botLabel}`}
+            />
+          </Show>
+          <button
+            class={`session-item-telegram ${bridge() ? "active" : ""}`}
+            onClick={handleTelegramClick}
+            title={bridge() ? "Detach Telegram" : "Attach Telegram"}
+            style={bridge() ? { color: bridge()!.color } : {}}
+          >
+            T
+          </button>
+          <Show when={showBotMenu()}>
+            <div class="session-item-bot-menu" onClick={(e) => e.stopPropagation()}>
+              <For each={availableBots()}>
+                {(bot) => (
+                  <button
+                    class="session-item-bot-option"
+                    onClick={() => handleBotSelect(bot.id)}
+                  >
+                    <span class="settings-color-dot" style={{ background: bot.color }} />
+                    {bot.label}
+                  </button>
+                )}
+              </For>
+            </div>
+          </Show>
+          <button class="session-item-close" onClick={handleClose} title="Close session">
+            &#x2715;
+          </button>
+        </Show>
+      </div>
       <Show when={showAgentPicker()}>
         <Portal>
           <AgentPickerModal
@@ -246,6 +517,21 @@ const RootAgentBanner: Component = () => {
             <button class="session-context-option" onClick={handleCodingAgent}>
               Coding Agent
             </button>
+            <Show when={rootSession()}>
+              <div class="context-separator" />
+              <button
+                class="session-context-option"
+                onClick={handleContextDetachToggle}
+              >
+                {isDetached() ? "Re-attach to main" : "Open in new window"}
+              </button>
+              <Show when={hasClaude()}>
+                <div class="context-separator" />
+                <button class="session-context-option" onClick={handleExcludeClaudeMd}>
+                  Exclude global CLAUDE.md
+                </button>
+              </Show>
+            </Show>
           </div>
         </Portal>
       </Show>

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -5,6 +5,7 @@ import { SessionAPI, WindowAPI } from "../../shared/ipc";
 import { sessionsStore } from "../stores/sessions";
 import type { Session, SessionStatus } from "../../shared/types";
 import AgentPickerModal from "./AgentPickerModal";
+import { rootAgentCodingAgentAction } from "./root-agent-action";
 
 function statusClass(status: SessionStatus): string {
   if (typeof status === "string") return status;
@@ -157,16 +158,15 @@ const RootAgentBanner: Component = () => {
     if (busy()) return;
     setBusy(true);
     try {
-      const r = rootSession();
-      if (!r) {
-        const session = await SessionAPI.createRootAgent({ agentId });
-        await SessionAPI.switch(session.id);
-        await focusTerminal(session.id);
-      } else {
-        const session = await SessionAPI.restart(r.id, { agentId });
-        await SessionAPI.switch(session.id);
-        await focusTerminal(session.id);
-      }
+      const action = rootAgentCodingAgentAction(rootSession(), agentId);
+      const session = action.kind === "create"
+        ? await SessionAPI.createRootAgent({ agentId: action.agentId })
+        : await SessionAPI.restart(action.id, {
+            agentId: action.agentId,
+            skipAutoResume: action.skipAutoResume,
+          });
+      await SessionAPI.switch(session.id);
+      await focusTerminal(session.id);
     } catch (e) {
       console.error("[RootAgentBanner] coding-agent change failed:", e);
     } finally {

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -42,6 +42,15 @@ const RootAgentBanner: Component = () => {
     return !!r && sessionsStore.activeId === r.id;
   });
 
+  // Dormant root has status as `{ exited: number }` (not a string). Backend
+  // marks root exited/dormant instead of removing the record so the banner can
+  // re-wake — but PTY-dependent actions (mic, detach, telegram, close) must be
+  // hidden because there is no live PTY to receive input or attach to.
+  const hasLivePty = createMemo(() => {
+    const r = rootSession();
+    return !!r && typeof r.status === "string";
+  });
+
   const dotClass = createMemo(() => {
     const r = rootSession();
     if (!r) return "offline";
@@ -340,7 +349,27 @@ const RootAgentBanner: Component = () => {
       <div
         class="root-agent-banner"
         classList={{ active: isActive(), disabled: busy() }}
+        role="button"
+        tabIndex={busy() ? -1 : 0}
+        aria-disabled={busy()}
+        aria-label={
+          rootSession()
+            ? typeof rootSession()!.status === "string"
+              ? "Open Root Agent session"
+              : "Wake Root Agent session"
+            : "Create Root Agent session"
+        }
         onClick={handleClick}
+        onKeyDown={(e) => {
+          // Only intercept keys aimed at the banner itself — when focus is on
+          // a child action button, that button's native handler runs and the
+          // event still bubbles here, so we must skip to avoid double-firing.
+          if (e.currentTarget !== e.target) return;
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
         onContextMenu={handleContextMenu}
         title={
           rootSession()
@@ -411,7 +440,7 @@ const RootAgentBanner: Component = () => {
         </div>
 
         <Show when={rootSession()}>
-          <Show when={isRecording()}>
+          <Show when={isRecording() && hasLivePty()}>
             <button
               class="session-item-mic-cancel"
               onClick={handleCancelRecording}
@@ -420,23 +449,25 @@ const RootAgentBanner: Component = () => {
               &#x2715;
             </button>
           </Show>
-          <button
-            class={`session-item-mic ${isRecording() ? "recording" : ""} ${isProcessing() ? "processing" : ""} ${voiceRecorder.micError() ? "error" : ""} ${!settingsStore.voiceEnabled ? "disabled" : ""}`}
-            onClick={handleMicClick}
-            title={
-              !settingsStore.voiceEnabled
-                ? "Enable voice-to-text in Settings and set a Gemini API key to use this."
-                : isRecording()
-                  ? "Stop recording"
-                  : isProcessing()
-                    ? "Transcribing..."
-                    : voiceRecorder.micError()
-                      ? voiceRecorder.micError()!
-                      : "Voice to text"
-            }
-          >
-            &#x1F399;
-          </button>
+          <Show when={hasLivePty()}>
+            <button
+              class={`session-item-mic ${isRecording() ? "recording" : ""} ${isProcessing() ? "processing" : ""} ${voiceRecorder.micError() ? "error" : ""} ${!settingsStore.voiceEnabled ? "disabled" : ""}`}
+              onClick={handleMicClick}
+              title={
+                !settingsStore.voiceEnabled
+                  ? "Enable voice-to-text in Settings and set a Gemini API key to use this."
+                  : isRecording()
+                    ? "Stop recording"
+                    : isProcessing()
+                      ? "Transcribing..."
+                      : voiceRecorder.micError()
+                        ? voiceRecorder.micError()!
+                        : "Voice to text"
+              }
+            >
+              &#x1F399;
+            </button>
+          </Show>
           <button
             class="session-item-explorer"
             onClick={handleOpenExplorer}
@@ -444,47 +475,49 @@ const RootAgentBanner: Component = () => {
           >
             &#x1F4C2;
           </button>
-          <button
-            class="session-item-detach"
-            classList={{ attached: isDetached() }}
-            onClick={handleDetachToggle}
-            title={isDetached() ? "Re-attach to main window" : "Open in new window"}
-            innerHTML={isDetached() ? "&#x2934;" : "&#x29C9;"}
-          />
-
-          <Show when={bridge()}>
-            <div
-              class="session-item-bridge-dot"
-              style={{ background: bridge()!.color }}
-              title={`Telegram: ${bridge()!.botLabel}`}
+          <Show when={hasLivePty()}>
+            <button
+              class="session-item-detach"
+              classList={{ attached: isDetached() }}
+              onClick={handleDetachToggle}
+              title={isDetached() ? "Re-attach to main window" : "Open in new window"}
+              innerHTML={isDetached() ? "&#x2934;" : "&#x29C9;"}
             />
+
+            <Show when={bridge()}>
+              <div
+                class="session-item-bridge-dot"
+                style={{ background: bridge()!.color }}
+                title={`Telegram: ${bridge()!.botLabel}`}
+              />
+            </Show>
+            <button
+              class={`session-item-telegram ${bridge() ? "active" : ""}`}
+              onClick={handleTelegramClick}
+              title={bridge() ? "Detach Telegram" : "Attach Telegram"}
+              style={bridge() ? { color: bridge()!.color } : {}}
+            >
+              T
+            </button>
+            <Show when={showBotMenu()}>
+              <div class="session-item-bot-menu" onClick={(e) => e.stopPropagation()}>
+                <For each={availableBots()}>
+                  {(bot) => (
+                    <button
+                      class="session-item-bot-option"
+                      onClick={() => handleBotSelect(bot.id)}
+                    >
+                      <span class="settings-color-dot" style={{ background: bot.color }} />
+                      {bot.label}
+                    </button>
+                  )}
+                </For>
+              </div>
+            </Show>
+            <button class="session-item-close" onClick={handleClose} title="Close session">
+              &#x2715;
+            </button>
           </Show>
-          <button
-            class={`session-item-telegram ${bridge() ? "active" : ""}`}
-            onClick={handleTelegramClick}
-            title={bridge() ? "Detach Telegram" : "Attach Telegram"}
-            style={bridge() ? { color: bridge()!.color } : {}}
-          >
-            T
-          </button>
-          <Show when={showBotMenu()}>
-            <div class="session-item-bot-menu" onClick={(e) => e.stopPropagation()}>
-              <For each={availableBots()}>
-                {(bot) => (
-                  <button
-                    class="session-item-bot-option"
-                    onClick={() => handleBotSelect(bot.id)}
-                  >
-                    <span class="settings-color-dot" style={{ background: bot.color }} />
-                    {bot.label}
-                  </button>
-                )}
-              </For>
-            </div>
-          </Show>
-          <button class="session-item-close" onClick={handleClose} title="Close session">
-            &#x2715;
-          </button>
         </Show>
       </div>
       <Show when={showAgentPicker()}>
@@ -518,13 +551,15 @@ const RootAgentBanner: Component = () => {
               Coding Agent
             </button>
             <Show when={rootSession()}>
-              <div class="context-separator" />
-              <button
-                class="session-context-option"
-                onClick={handleContextDetachToggle}
-              >
-                {isDetached() ? "Re-attach to main" : "Open in new window"}
-              </button>
+              <Show when={hasLivePty()}>
+                <div class="context-separator" />
+                <button
+                  class="session-context-option"
+                  onClick={handleContextDetachToggle}
+                >
+                  {isDetached() ? "Re-attach to main" : "Open in new window"}
+                </button>
+              </Show>
               <Show when={hasClaude()}>
                 <div class="context-separator" />
                 <button class="session-context-option" onClick={handleExcludeClaudeMd}>

--- a/src/sidebar/components/root-agent-action.test.ts
+++ b/src/sidebar/components/root-agent-action.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { Session, SessionStatus } from "../../shared/types";
+import { rootAgentCodingAgentAction } from "./root-agent-action";
+
+function mkRoot(status: SessionStatus): Session {
+  return {
+    id: "root-id",
+    name: "Agent's Commander",
+    shell: "",
+    shellArgs: [],
+    effectiveShellArgs: null,
+    createdAt: "",
+    workingDirectory: "",
+    status,
+    waitingForInput: false,
+    pendingReview: false,
+    lastPrompt: null,
+    agentId: null,
+    agentLabel: null,
+    gitRepos: [],
+    workgroupBrief: null,
+    isCoordinator: false,
+    isRootAgent: true,
+    token: "",
+    agentKind: null,
+  };
+}
+
+describe("rootAgentCodingAgentAction", () => {
+  it("creates a new root with the chosen agent when no root exists", () => {
+    expect(rootAgentCodingAgentAction(undefined, "claude")).toEqual({
+      kind: "create",
+      agentId: "claude",
+    });
+  });
+
+  it("restarts a live root without skipAutoResume (defaults to fresh restart)", () => {
+    expect(rootAgentCodingAgentAction(mkRoot("running"), "claude")).toEqual({
+      kind: "restart",
+      id: "root-id",
+      agentId: "claude",
+    });
+  });
+
+  it("restarts an active root without skipAutoResume", () => {
+    expect(rootAgentCodingAgentAction(mkRoot("active"), "codex")).toEqual({
+      kind: "restart",
+      id: "root-id",
+      agentId: "codex",
+    });
+  });
+
+  it("restarts an idle root without skipAutoResume", () => {
+    expect(rootAgentCodingAgentAction(mkRoot("idle"), "gemini")).toEqual({
+      kind: "restart",
+      id: "root-id",
+      agentId: "gemini",
+    });
+  });
+
+  it("restarts a dormant root with skipAutoResume:false so provider resume runs", () => {
+    expect(rootAgentCodingAgentAction(mkRoot({ exited: 0 }), "claude")).toEqual({
+      kind: "restart",
+      id: "root-id",
+      agentId: "claude",
+      skipAutoResume: false,
+    });
+  });
+
+  it("restarts a dormant root that exited non-zero with skipAutoResume:false", () => {
+    expect(rootAgentCodingAgentAction(mkRoot({ exited: 1 }), "codex")).toEqual({
+      kind: "restart",
+      id: "root-id",
+      agentId: "codex",
+      skipAutoResume: false,
+    });
+  });
+});

--- a/src/sidebar/components/root-agent-action.ts
+++ b/src/sidebar/components/root-agent-action.ts
@@ -1,0 +1,23 @@
+import type { Session } from "../../shared/types";
+
+export type RootAgentAction =
+  | { kind: "create"; agentId: string }
+  | { kind: "restart"; id: string; agentId: string; skipAutoResume?: boolean };
+
+/**
+ * Decide how to apply a coding-agent selection from the Root Agent banner.
+ *
+ * Live root → fresh restart (skipAutoResume defaults true on the backend).
+ * Dormant root (status is an `{ exited }` object) → restart with
+ * skipAutoResume:false so the provider's resume flag is forwarded
+ * (`claude --continue`, `codex resume --last`, `gemini --resume latest`).
+ */
+export function rootAgentCodingAgentAction(
+  root: Session | undefined,
+  agentId: string,
+): RootAgentAction {
+  if (!root) return { kind: "create", agentId };
+  const dormant = typeof root.status !== "string";
+  if (dormant) return { kind: "restart", id: root.id, agentId, skipAutoResume: false };
+  return { kind: "restart", id: root.id, agentId };
+}

--- a/src/sidebar/stores/sessions-helpers.test.ts
+++ b/src/sidebar/stores/sessions-helpers.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import type { Session, SessionStatus } from "../../shared/types";
+import { isRuntimeStringStatus, upsertSessionList } from "./sessions-helpers";
+import { rootAgentCodingAgentAction } from "../components/root-agent-action";
+
+function mkSession(id: string, status: SessionStatus, overrides: Partial<Session> = {}): Session {
+  return {
+    id,
+    name: `session-${id}`,
+    shell: "",
+    shellArgs: [],
+    effectiveShellArgs: null,
+    createdAt: "",
+    workingDirectory: "",
+    status,
+    waitingForInput: false,
+    pendingReview: false,
+    lastPrompt: null,
+    agentId: null,
+    agentLabel: null,
+    gitRepos: [],
+    workgroupBrief: null,
+    isCoordinator: false,
+    isRootAgent: false,
+    token: "",
+    agentKind: null,
+    ...overrides,
+  };
+}
+
+describe("isRuntimeStringStatus", () => {
+  it("returns true for runtime string statuses", () => {
+    expect(isRuntimeStringStatus("active")).toBe(true);
+    expect(isRuntimeStringStatus("running")).toBe(true);
+    expect(isRuntimeStringStatus("idle")).toBe(true);
+  });
+
+  it("returns false for Exited object statuses", () => {
+    expect(isRuntimeStringStatus({ exited: 0 })).toBe(false);
+    expect(isRuntimeStringStatus({ exited: 1 })).toBe(false);
+    expect(isRuntimeStringStatus({ exited: 137 })).toBe(false);
+  });
+});
+
+/**
+ * Simulates the mutation that sessionsStore.setActiveId applies to the
+ * sessions array. Mirrors the predicates used inside sessions.ts so the
+ * Exited-preservation contract is locked down without spinning up a
+ * SolidJS root (vitest has no Solid render harness here).
+ */
+function applySetActiveIdMutation(sessions: Session[], id: string | null): Session[] {
+  return sessions.map((s) => {
+    if (s.id === id) {
+      const status: SessionStatus = isRuntimeStringStatus(s.status) ? "active" : s.status;
+      return { ...s, status, pendingReview: false };
+    }
+    if (s.status === "active") {
+      return { ...s, status: "running" as SessionStatus };
+    }
+    return s;
+  });
+}
+
+describe("setActiveId mutation (#274 dormant-root preservation)", () => {
+  it("preserves Exited object status when the dormant root is selected", () => {
+    const sessions = [mkSession("root", { exited: 0 }, { isRootAgent: true })];
+    const next = applySetActiveIdMutation(sessions, "root");
+    expect(next[0].status).toEqual({ exited: 0 });
+  });
+
+  it("preserves Exited({exited:1}) when the dormant root is selected", () => {
+    const sessions = [mkSession("root", { exited: 1 }, { isRootAgent: true })];
+    const next = applySetActiveIdMutation(sessions, "root");
+    expect(next[0].status).toEqual({ exited: 1 });
+  });
+
+  it("clears pendingReview on the newly selected session even when Exited", () => {
+    const sessions = [mkSession("root", { exited: 0 }, { isRootAgent: true, pendingReview: true })];
+    const next = applySetActiveIdMutation(sessions, "root");
+    expect(next[0].pendingReview).toBe(false);
+    expect(next[0].status).toEqual({ exited: 0 });
+  });
+
+  it("promotes a runtime-string-status selection to active", () => {
+    const sessions = [
+      mkSession("a", "idle"),
+      mkSession("b", "running"),
+    ];
+    const next = applySetActiveIdMutation(sessions, "b");
+    expect(next.find((s) => s.id === "b")!.status).toBe("active");
+  });
+
+  it("demotes the previously active session to running", () => {
+    const sessions = [
+      mkSession("a", "active"),
+      mkSession("b", "idle"),
+    ];
+    const next = applySetActiveIdMutation(sessions, "b");
+    expect(next.find((s) => s.id === "a")!.status).toBe("running");
+    expect(next.find((s) => s.id === "b")!.status).toBe("active");
+  });
+
+  it("after setActiveId on a dormant root, rootAgentCodingAgentAction still picks skipAutoResume:false", () => {
+    // Regression: setActiveId used to overwrite { exited } with "active",
+    // which made rootAgentCodingAgentAction treat the root as live and skip
+    // provider resume. Verify the Exited object survives the mutation so
+    // the wake path is preserved end-to-end.
+    const sessions = [mkSession("root-id", { exited: 0 }, { isRootAgent: true })];
+    const next = applySetActiveIdMutation(sessions, "root-id");
+    const action = rootAgentCodingAgentAction(next[0], "claude");
+    expect(action).toEqual({
+      kind: "restart",
+      id: "root-id",
+      agentId: "claude",
+      skipAutoResume: false,
+    });
+  });
+});
+
+describe("upsertSessionList (#274 banner-reuse hydration)", () => {
+  it("appends a new session when id is not present", () => {
+    const sessions = [mkSession("a", "idle")];
+    const next = upsertSessionList(sessions, mkSession("b", "running"));
+    expect(next).toHaveLength(2);
+    expect(next[1].id).toBe("b");
+  });
+
+  it("updates fields on an existing id rather than no-op", () => {
+    const sessions = [mkSession("root", { exited: 0 }, { isRootAgent: true, agentLabel: "old" })];
+    const next = upsertSessionList(
+      sessions,
+      mkSession("root", "running", { isRootAgent: true, agentLabel: "new" }),
+    );
+    expect(next).toHaveLength(1);
+    expect(next[0].status).toBe("running");
+    expect(next[0].agentLabel).toBe("new");
+  });
+
+  it("returns a new array reference on every call so SolidJS reactivity triggers", () => {
+    const sessions = [mkSession("a", "idle")];
+    const next = upsertSessionList(sessions, mkSession("a", "running"));
+    expect(next).not.toBe(sessions);
+  });
+
+  it("upsert with the returned root Session hydrates the store after createRootAgent reuse", () => {
+    // Simulates the failure scenario from grinch finding #2: backend
+    // already had the root, the initial list_sessions raced ahead of the
+    // listener registration, banner called createRootAgent() and the
+    // backend returned the existing Session WITHOUT emitting
+    // session_created. The banner now calls sessionsStore.addSession with
+    // that returned Session — upsertSessionList must replace the prior
+    // (possibly stale or missing) entry.
+    const sessions: Session[] = [];
+    const returned = mkSession("root", "running", { isRootAgent: true, agentLabel: "claude" });
+    const next = upsertSessionList(sessions, returned);
+    expect(next.find((s) => s.isRootAgent)).toBeDefined();
+    expect(next[0].agentLabel).toBe("claude");
+  });
+});

--- a/src/sidebar/stores/sessions-helpers.ts
+++ b/src/sidebar/stores/sessions-helpers.ts
@@ -1,0 +1,33 @@
+import type { Session, SessionStatus } from "../../shared/types";
+
+/**
+ * True when `status` is one of the runtime string states ("active" | "running"
+ * | "idle"). False when it is an Exited({ exited: N }) object.
+ *
+ * Used by sessionsStore.setActiveId to skip Exited sessions when promoting
+ * the selected session to "active": a dormant root must keep its
+ * { exited: N } status so RootAgentBanner's wake path
+ * (typeof status !== "string") still fires and chooses
+ * restart(..., { skipAutoResume: false }) — i.e. wake-with-provider-resume.
+ */
+export function isRuntimeStringStatus(status: SessionStatus): boolean {
+  return typeof status === "string";
+}
+
+/**
+ * Upsert `incoming` into `prev` by id. If the id is already present, merge
+ * `incoming`'s fields onto the existing entry (incoming wins). Otherwise
+ * append.
+ *
+ * Used by sessionsStore.addSession so the RootAgentBanner can hydrate the
+ * store with the Session returned from createRootAgent/restart even when the
+ * backend reuses an existing live root and therefore does NOT emit a fresh
+ * session_created event (see src-tauri/src/commands/session.rs ReuseLive).
+ */
+export function upsertSessionList(prev: Session[], incoming: Session): Session[] {
+  const idx = prev.findIndex((s) => s.id === incoming.id);
+  if (idx === -1) return [...prev, incoming];
+  const next = prev.slice();
+  next[idx] = { ...prev[idx], ...incoming };
+  return next;
+}

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -79,8 +79,11 @@ const wgReplicaMemo = createMemo(() => {
 });
 
 const filteredSessionsMemo = createMemo(() => {
+  // Root agent renders exclusively in RootAgentBanner; never list it as a generic session.
+  const nonRootSessions = state.sessions.filter((s) => !s.isRootAgent);
+
   const activeSessions = (() => {
-    if (!state.teamFilter) return state.sessions;
+    if (!state.teamFilter) return nonRootSessions;
 
     let matches: (normalizedPath: string) => boolean;
 
@@ -89,12 +92,12 @@ const filteredSessionsMemo = createMemo(() => {
       matches = (p) => !allPaths.has(p);
     } else {
       const team = state.teams.find((t) => t.id === state.teamFilter);
-      if (!team) return state.sessions;
+      if (!team) return nonRootSessions;
       const paths = new Set(team.members.map((m) => normalizePath(m.path)));
       matches = (p) => paths.has(p);
     }
 
-    return state.sessions.filter((s) => {
+    return nonRootSessions.filter((s) => {
       if (!s.workingDirectory) return state.teamFilter === NO_TEAM;
       return matches(normalizePath(s.workingDirectory));
     });

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -5,6 +5,7 @@ import type { RepoMatch, Session, SessionRepo, SessionsState, Team, TeamSessionG
 import { projectStore } from "./project";
 import { SettingsAPI } from "../../shared/ipc";
 import { settingsStore } from "../../shared/stores/settings";
+import { isRuntimeStringStatus, upsertSessionList } from "./sessions-helpers";
 
 const [toggleInFlight, setToggleInFlight] = createSignal(false);
 
@@ -283,9 +284,7 @@ export const sessionsStore = {
   },
 
   addSession(session: Session) {
-    setState("sessions", (prev) =>
-      prev.some((s) => s.id === session.id) ? prev : [...prev, session]
-    );
+    setState("sessions", (prev) => upsertSessionList(prev, session));
   },
 
   removeSession(id: string) {
@@ -296,7 +295,16 @@ export const sessionsStore = {
     const prev = state.activeId;
     console.log(`[idle-fe] setActiveId: ${id?.slice(0,8)} (prev: ${prev?.slice(0,8)})`);
     setState("activeId", id);
-    setState("sessions", (s) => s.id === id, "status", "active");
+    // Promote selected session to "active" only when its status is a runtime
+    // string. Exited({ exited: N }) is preserved so dormant roots keep the
+    // status the banner reads (typeof status !== "string") to choose
+    // restart(..., { skipAutoResume: false }).
+    setState(
+      "sessions",
+      (s) => s.id === id && isRuntimeStringStatus(s.status),
+      "status",
+      "active"
+    );
     setState("sessions", (s) => s.id === id, "pendingReview", false);
     setState(
       "sessions",

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -53,6 +53,7 @@ function makeInactiveEntry(name: string, path: string): Session {
     gitRepos: [],
     workgroupBrief: null,
     isCoordinator: false,
+    isRootAgent: false,
     token: "",
     agentKind: null,
   };

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -790,6 +790,9 @@ html, body, #root {
   text-align: left;
   font-family: var(--font-ui);
   transition: background var(--transition-fast);
+  /* Containing block for the absolutely-positioned bot picker
+     (.session-item-bot-menu uses right:0; top:100%). Mirrors .session-item. */
+  position: relative;
 }
 
 .root-agent-banner:hover {

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -510,10 +510,12 @@ html, body, #root {
 .session-item-status.offline { background: var(--status-offline); }
 /* .pending = agent finished but user hasn't focused yet (yellow) */
 .session-item .session-item-status.pending,
-.replica-item .session-item-status.pending { background: var(--status-pending); box-shadow: 0 0 6px var(--status-pending); }
+.replica-item .session-item-status.pending,
+.root-agent-banner .session-item-status.pending { background: var(--status-pending); box-shadow: 0 0 6px var(--status-pending); }
 /* .waiting must override all other status colors (active, running, idle, exited) */
 .session-item .session-item-status.waiting,
-.replica-item .session-item-status.waiting { background: var(--status-waiting); box-shadow: 0 0 6px var(--status-waiting); }
+.replica-item .session-item-status.waiting,
+.root-agent-banner .session-item-status.waiting { background: var(--status-waiting); box-shadow: 0 0 6px var(--status-waiting); }
 
 /* Inactive team member (no active session) */
 .session-item.inactive-member {
@@ -4526,3 +4528,14 @@ html.light-theme .onboarding-card.selected {
   color: var(--sidebar-fg-dim);
   text-align: center;
 }
+
+/* =============================================================================
+   Root Agent Banner — active state
+   Placed at end-of-file so source order beats per-sidebar-style background
+   overrides (which match equal specificity 0,2,0). var(--sidebar-active) is
+   defined per style, so this one rule works across all 7 sidebar styles.
+   ============================================================================= */
+.root-agent-banner.active {
+  background: var(--sidebar-active);
+}
+

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -796,9 +796,25 @@ html, body, #root {
   background: rgba(0, 212, 255, 0.08);
 }
 
-.root-agent-banner:disabled {
+.root-agent-banner:disabled,
+.root-agent-banner.disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* The text column flexes so action buttons sit on the right edge,
+   mirroring .session-item-info inside .session-item. */
+.root-agent-banner .root-agent-text {
+  flex: 1;
+}
+
+/* Mirror SessionItem's hover-reveal for action buttons. */
+.root-agent-banner:hover .session-item-mic,
+.root-agent-banner:hover .session-item-explorer,
+.root-agent-banner:hover .session-item-detach,
+.root-agent-banner:hover .session-item-telegram,
+.root-agent-banner:hover .session-item-close {
+  display: flex;
 }
 
 .root-agent-avatar {

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -4538,4 +4538,3 @@ html.light-theme .onboarding-card.selected {
 .root-agent-banner.active {
   background: var(--sidebar-active);
 }
-


### PR DESCRIPTION
## Summary

- Adds the Root Agent / Agents Commander lifecycle and default provisioning.
- Restores/wakes the root agent correctly, including coding-agent selection and restart flows.
- Adds root banner parity with normal session actions: voice, Telegram, detach/attach, explorer, close, and context menu actions.
- Bumps version to 0.8.37 after updating against main.

## Validation

- npm run version:check
- cargo check
- cargo clippy
- npx tsc --noEmit
- npx vitest run
- npx tauri build
- deployed wg-1 build smoke: --help OK

Closes #274