### PR TITLE
fix(template): keep New Agent template fields in sync (#278)

### DIFF
--- a/src/shared/role-templates.test.ts
+++ b/src/shared/role-templates.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { filterRoleTemplates, slugifyTemplateName, sourceLabel } from "./role-templates";
+import {
+  applyTemplatePrefill,
+  filterRoleTemplates,
+  slugifyTemplateName,
+  sourceLabel,
+} from "./role-templates";
 import type { RoleTemplateMeta } from "./types";
 
 const meta = (over: Partial<RoleTemplateMeta>): RoleTemplateMeta => ({
@@ -126,6 +131,108 @@ describe("slugifyTemplateName", () => {
 
   it("preserves_digits", () => {
     expect(slugifyTemplateName("Agent 007")).toBe("agent-007");
+  });
+});
+
+describe("applyTemplatePrefill", () => {
+  const geographer = {
+    name: "Geographer",
+    description: "Expert in physical and human geography.",
+  };
+  const historian = {
+    name: "Historian",
+    description: "Expert in historical analysis.",
+  };
+
+  it("populates_both_fields_from_a_blank_form", () => {
+    const next = applyTemplatePrefill(geographer, {
+      name: "",
+      description: "",
+      nameDirty: false,
+      descriptionDirty: false,
+    });
+    expect(next).toEqual({
+      name: "geographer",
+      description: "Expert in physical and human geography.",
+    });
+  });
+
+  it("replaces_previous_template_values_on_second_selection_278", () => {
+    // Regression for #278: after picking Geographer, picking Historian must
+    // overwrite both fields because nothing in between marked them dirty.
+    const afterFirst = applyTemplatePrefill(geographer, {
+      name: "",
+      description: "",
+      nameDirty: false,
+      descriptionDirty: false,
+    });
+    const afterSecond = applyTemplatePrefill(historian, {
+      name: afterFirst.name,
+      description: afterFirst.description,
+      nameDirty: false,
+      descriptionDirty: false,
+    });
+    expect(afterSecond).toEqual({
+      name: "historian",
+      description: "Expert in historical analysis.",
+    });
+  });
+
+  it("preserves_user_edited_name_but_populates_description", () => {
+    const next = applyTemplatePrefill(geographer, {
+      name: "my-custom-name",
+      description: "",
+      nameDirty: true,
+      descriptionDirty: false,
+    });
+    expect(next.name).toBe("my-custom-name");
+    expect(next.description).toBe("Expert in physical and human geography.");
+  });
+
+  it("preserves_user_edited_description_but_populates_name", () => {
+    const next = applyTemplatePrefill(geographer, {
+      name: "",
+      description: "user wrote this",
+      nameDirty: false,
+      descriptionDirty: true,
+    });
+    expect(next.name).toBe("geographer");
+    expect(next.description).toBe("user wrote this");
+  });
+
+  it("preserves_both_when_both_were_user_edited", () => {
+    const next = applyTemplatePrefill(geographer, {
+      name: "my-name",
+      description: "my description",
+      nameDirty: true,
+      descriptionDirty: true,
+    });
+    expect(next).toEqual({ name: "my-name", description: "my description" });
+  });
+
+  it("clamps_template_description_to_250_chars", () => {
+    const long = { name: "Long", description: "x".repeat(400) };
+    const next = applyTemplatePrefill(long, {
+      name: "",
+      description: "",
+      nameDirty: false,
+      descriptionDirty: false,
+    });
+    expect(next.description).toHaveLength(250);
+    expect(next.name).toBe("long");
+  });
+
+  it("preserves_user_blank_field_marked_dirty", () => {
+    // If the user cleared a template-populated field on purpose, picking
+    // another template must not refill it — nameDirty is the user's signal of
+    // intent, regardless of whether the current value is empty.
+    const next = applyTemplatePrefill(historian, {
+      name: "",
+      description: "",
+      nameDirty: true,
+      descriptionDirty: true,
+    });
+    expect(next).toEqual({ name: "", description: "" });
   });
 });
 

--- a/src/shared/role-templates.ts
+++ b/src/shared/role-templates.ts
@@ -46,3 +46,33 @@ export function sourceLabel(template: Pick<RoleTemplateMeta, "source">): string 
     ? "SOURCE: https://github.com/msitarzewski/agency-agents"
     : "SOURCE: LOCAL AGENT-TEMPLATES";
 }
+
+/**
+ * Decide the next {name, description} when a template is selected. A template's
+ * defaults overwrite the current values UNLESS the user has manually edited the
+ * field (the caller flips `nameDirty`/`descriptionDirty` in its onInput
+ * handlers). Values that the previous template selection wrote stay
+ * non-dirty, so a second template click freely replaces them — fixing #278
+ * where the highlighted row moved but the form fields stuck on the first pick.
+ *
+ * The Name is slugified (display names are free text that the modal's
+ * canCreate() would reject for spaces or punctuation); the Description is
+ * clamped to 250 because the textarea's maxLength only limits typing, not
+ * programmatic writes.
+ */
+export function applyTemplatePrefill(
+  template: Pick<RoleTemplateMeta, "name" | "description">,
+  current: {
+    name: string;
+    description: string;
+    nameDirty: boolean;
+    descriptionDirty: boolean;
+  },
+): { name: string; description: string } {
+  return {
+    name: current.nameDirty ? current.name : slugifyTemplateName(template.name),
+    description: current.descriptionDirty
+      ? current.description
+      : template.description.slice(0, 250),
+  };
+}

--- a/src/sidebar/components/NewEntityAgentModal.tsx
+++ b/src/sidebar/components/NewEntityAgentModal.tsx
@@ -2,8 +2,8 @@ import { Component, createSignal, createMemo, For, Show, onMount } from "solid-j
 import { EntityAPI, RoleTemplateAPI } from "../../shared/ipc";
 import type { RoleTemplateMeta } from "../../shared/types";
 import {
+  applyTemplatePrefill,
   filterRoleTemplates,
-  slugifyTemplateName,
   sourceLabel,
 } from "../../shared/role-templates";
 import { projectStore } from "../stores/project";
@@ -16,6 +16,12 @@ const NewEntityAgentModal: Component<{
   const [description, setDescription] = createSignal("");
   const [error, setError] = createSignal("");
   const [creating, setCreating] = createSignal(false);
+
+  // #278 — distinguish user-edited fields from template-populated ones so a
+  // second template click can overwrite the first template's values without
+  // clobbering anything the user typed by hand.
+  const [nameDirty, setNameDirty] = createSignal(false);
+  const [descriptionDirty, setDescriptionDirty] = createSignal(false);
 
   // #271 — template picker state.
   const [templates, setTemplates] = createSignal<RoleTemplateMeta[]>([]);
@@ -41,11 +47,14 @@ const NewEntityAgentModal: Component<{
   const selectTemplate = (t: RoleTemplateMeta | null) => {
     setSelectedTemplateId(t ? t.id : null);
     if (t) {
-      // Prefill ONLY when the field is currently empty. Name is slugified
-      // (display names are free text that canCreate() would reject); Description
-      // is clamped to 250 (textarea maxLength only limits typing, not set()).
-      if (name().trim() === "") setName(slugifyTemplateName(t.name));
-      if (description().trim() === "") setDescription(t.description.slice(0, 250));
+      const next = applyTemplatePrefill(t, {
+        name: name(),
+        description: description(),
+        nameDirty: nameDirty(),
+        descriptionDirty: descriptionDirty(),
+      });
+      setName(next.name);
+      setDescription(next.description);
       setError("");
     }
   };
@@ -252,6 +261,7 @@ const NewEntityAgentModal: Component<{
               value={name()}
               onInput={(e) => {
                 setName(e.currentTarget.value);
+                setNameDirty(true);
                 setError("");
               }}
               placeholder="my-agent"
@@ -264,7 +274,10 @@ const NewEntityAgentModal: Component<{
             <textarea
               class="entity-textarea"
               value={description()}
-              onInput={(e) => setDescription(e.currentTarget.value)}
+              onInput={(e) => {
+                setDescription(e.currentTarget.value);
+                setDescriptionDirty(true);
+              }}
               placeholder="What does this agent do? (optional, max 250 chars)"
               maxLength={250}
               rows={3}


### PR DESCRIPTION
## Summary
- Fix New Agent template selection so subsequent template clicks keep Name/Description in sync with the selected template.
- Preserve genuinely user-edited fields using per-field dirty tracking.
- Add focused unit coverage for template prefill behavior.

## Validation
- npx tsc --noEmit
- npx vitest run src/shared/role-templates.test.ts
- npx vitest run
- dev-rust-grinch review: PASS
- wg-3 exe build/deploy succeeded

Closes #278