### PR TITLE
feat(telegram): send images to Telegram (#282)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.37",
+  "version": "0.8.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.37",
+      "version": "0.8.38",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.38",
+  "version": "0.8.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.38",
+      "version": "0.8.39",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.37",
+  "version": "0.8.38",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.38",
+  "version": "0.8.39",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3700,6 +3700,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.38"
+version = "0.8.39"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.37"
+version = "0.8.38"
 edition = "2021"
 
 [dependencies]
@@ -18,7 +18,7 @@ env_logger = "0.11"
 clap = { version = "4", features = ["derive"] }
 thiserror = "2"
 dirs = "6"
-reqwest = { version = "0.12", features = ["json", "blocking"] }
+reqwest = { version = "0.12", features = ["json", "blocking", "multipart"] }
 base64 = "0.22"
 tokio-util = "0.7"
 vt100 = "0.15"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.38"
+version = "0.8.39"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod list_sessions;
 pub mod new_project;
 pub mod open_project;
 pub mod send;
+pub mod telegram_send_image;
 
 use clap::{Parser, Subcommand};
 
@@ -103,6 +104,8 @@ pub enum Commands {
     OpenProject(open_project::OpenProjectArgs),
     /// Create an AC project (mkdir .ac-new if missing) and register it in settings
     NewProject(new_project::NewProjectArgs),
+    /// Send a local image/file to a configured Telegram bot (no GUI required)
+    TelegramSendImage(telegram_send_image::TelegramSendImageArgs),
 }
 
 /// Attach to parent console (or allocate a new one) ONLY if both stdout and stderr
@@ -218,6 +221,7 @@ pub fn handle_cli(cmd: Commands) -> i32 {
         Commands::BriefAppendBody(args) => brief_append_body::execute(args),
         Commands::OpenProject(args) => open_project::execute(args),
         Commands::NewProject(args) => new_project::execute(args),
+        Commands::TelegramSendImage(args) => telegram_send_image::execute(args),
     };
 
     flush_outputs();

--- a/src-tauri/src/cli/telegram_send_image.rs
+++ b/src-tauri/src/cli/telegram_send_image.rs
@@ -1,0 +1,266 @@
+//! `telegram-send-image` CLI verb — sends a local image (or generic file) to
+//! a configured Telegram bot from an external terminal, bypassing the Tauri
+//! frontend. Issue #282.
+//!
+//! Reuses `commands::telegram::perform_send_image` so size/extension/symlink
+//! validation and multipart-upload logic live in exactly one place.
+//!
+//! No `--token` requirement: the verb reads `settings.json` and posts to the
+//! Telegram Bot API directly. Outbound HTTP from a process the user already
+//! controls does not cross AC's per-session authorization boundary.
+
+use clap::Args;
+
+use crate::config::settings::load_settings_for_cli;
+use crate::telegram::types::TelegramBotConfig;
+
+#[derive(Args)]
+#[command(after_help = "\
+PURPOSE: Send a local image or file to a configured Telegram bot from the \
+terminal. Files <=10 MB with extension jpg/jpeg/png/webp use sendPhoto; \
+everything else (including GIF) falls back to sendDocument, capped at \
+50 MB.\n\n\
+BOT SELECTION:\n  \
+  --bot-id <id>         Pick a bot by its persisted id (from settings.json).\n  \
+  --bot-label <label>   Pick a bot by its human label (exact match).\n  \
+  If exactly one bot is configured, both flags may be omitted.\n  \
+  If multiple bots are configured and neither flag is provided, the verb \
+errors with the list of available bots.\n\n\
+CAPTION: Trimmed and clamped to Telegram's 1024 UTF-16-code-unit limit. \
+Empty/whitespace-only captions are dropped.\n\n\
+SYMLINKS: Symlinks and (on Windows) reparse points / junctions are rejected.")]
+pub struct TelegramSendImageArgs {
+    /// Absolute or relative path to the file to send (required)
+    #[arg(long)]
+    pub path: String,
+
+    /// Optional caption to attach to the image / document
+    #[arg(long)]
+    pub caption: Option<String>,
+
+    /// Bot id (from settings.json telegramBots[*].id). Mutually exclusive with --bot-label
+    #[arg(long, conflicts_with = "bot_label")]
+    pub bot_id: Option<String>,
+
+    /// Bot label (exact match against telegramBots[*].label). Mutually exclusive with --bot-id
+    #[arg(long)]
+    pub bot_label: Option<String>,
+}
+
+/// Pick a bot from `bots` using the CLI selector flags.
+///
+/// Selection rules:
+///   - `--bot-id` → match by `id`; error if none found.
+///   - `--bot-label` → match by `label`; error if none found or multiple match.
+///   - Neither → if exactly one bot is configured, use it; otherwise error
+///     listing every available bot so the user knows which selector to pass.
+fn resolve_bot<'a>(
+    bots: &'a [TelegramBotConfig],
+    bot_id: Option<&str>,
+    bot_label: Option<&str>,
+) -> Result<&'a TelegramBotConfig, String> {
+    if bots.is_empty() {
+        return Err("No Telegram bots are configured. Add one in the AgentsCommander GUI under Settings/Telegram first.".to_string());
+    }
+
+    if let Some(id) = bot_id {
+        return bots.iter().find(|b| b.id == id).ok_or_else(|| {
+            format!(
+                "No Telegram bot with id '{}'. Available bots: {}",
+                id,
+                format_bot_list(bots)
+            )
+        });
+    }
+
+    if let Some(label) = bot_label {
+        let matches: Vec<&TelegramBotConfig> = bots.iter().filter(|b| b.label == label).collect();
+        return match matches.len() {
+            0 => Err(format!(
+                "No Telegram bot with label '{}'. Available bots: {}",
+                label,
+                format_bot_list(bots)
+            )),
+            1 => Ok(matches[0]),
+            _ => Err(format!(
+                "Multiple Telegram bots share label '{}'; disambiguate with --bot-id. Candidates: {}",
+                label,
+                format_bot_list(&matches.into_iter().cloned().collect::<Vec<_>>())
+            )),
+        };
+    }
+
+    if bots.len() == 1 {
+        Ok(&bots[0])
+    } else {
+        Err(format!(
+            "Multiple Telegram bots are configured; pass --bot-id <id> or --bot-label <label>. Available bots: {}",
+            format_bot_list(bots)
+        ))
+    }
+}
+
+fn format_bot_list(bots: &[TelegramBotConfig]) -> String {
+    bots.iter()
+        .map(|b| format!("{} (id={})", b.label, b.id))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+pub fn execute(args: TelegramSendImageArgs) -> i32 {
+    if args.path.trim().is_empty() {
+        eprintln!("Error: --path must not be empty");
+        return 1;
+    }
+
+    let settings = load_settings_for_cli();
+    let bot = match resolve_bot(
+        &settings.telegram_bots,
+        args.bot_id.as_deref(),
+        args.bot_label.as_deref(),
+    ) {
+        Ok(b) => b.clone(),
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("Error: failed to build tokio runtime: {}", e);
+            return 1;
+        }
+    };
+
+    let result = rt.block_on(crate::commands::telegram::perform_send_image(
+        &bot,
+        &args.path,
+        args.caption.as_deref(),
+    ));
+
+    match result {
+        Ok(()) => {
+            crate::cli_println!("Sent: bot={} path={}", bot.id, args.path);
+            log::info!(
+                "[cli] telegram-send-image: bot={} path={} caption_present={}",
+                bot.id,
+                args.path,
+                args.caption.is_some()
+            );
+            0
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bot(id: &str, label: &str) -> TelegramBotConfig {
+        TelegramBotConfig {
+            id: id.to_string(),
+            label: label.to_string(),
+            token: "test-token".to_string(),
+            chat_id: 0,
+            color: "#000000".to_string(),
+        }
+    }
+
+    #[test]
+    fn resolve_bot_errors_when_no_bots_configured() {
+        let err = resolve_bot(&[], None, None).unwrap_err();
+        assert!(err.contains("No Telegram bots are configured"));
+    }
+
+    #[test]
+    fn resolve_bot_picks_single_bot_when_no_selector() {
+        let bots = vec![bot("only-id", "OnlyBot")];
+        let got = resolve_bot(&bots, None, None).unwrap();
+        assert_eq!(got.id, "only-id");
+    }
+
+    #[test]
+    fn resolve_bot_requires_selector_when_multiple_bots() {
+        let bots = vec![bot("a", "Alpha"), bot("b", "Beta")];
+        let err = resolve_bot(&bots, None, None).unwrap_err();
+        assert!(err.contains("--bot-id"));
+        assert!(err.contains("--bot-label"));
+        assert!(err.contains("Alpha"));
+        assert!(err.contains("Beta"));
+    }
+
+    #[test]
+    fn resolve_bot_matches_by_id() {
+        let bots = vec![bot("a", "Alpha"), bot("b", "Beta")];
+        let got = resolve_bot(&bots, Some("b"), None).unwrap();
+        assert_eq!(got.label, "Beta");
+    }
+
+    #[test]
+    fn resolve_bot_unknown_id_lists_available() {
+        let bots = vec![bot("a", "Alpha"), bot("b", "Beta")];
+        let err = resolve_bot(&bots, Some("zzz"), None).unwrap_err();
+        assert!(err.contains("'zzz'"));
+        assert!(err.contains("Alpha"));
+        assert!(err.contains("Beta"));
+    }
+
+    #[test]
+    fn resolve_bot_matches_by_label() {
+        let bots = vec![bot("a", "Alpha"), bot("b", "Beta")];
+        let got = resolve_bot(&bots, None, Some("Beta")).unwrap();
+        assert_eq!(got.id, "b");
+    }
+
+    #[test]
+    fn resolve_bot_label_ambiguous_lists_candidates() {
+        let bots = vec![bot("a", "Same"), bot("b", "Same"), bot("c", "Other")];
+        let err = resolve_bot(&bots, None, Some("Same")).unwrap_err();
+        assert!(err.contains("Multiple"));
+        assert!(err.contains("--bot-id"));
+        // Both ambiguous candidates listed
+        assert!(err.contains("id=a"));
+        assert!(err.contains("id=b"));
+    }
+
+    #[test]
+    fn resolve_bot_unknown_label_lists_available() {
+        let bots = vec![bot("a", "Alpha"), bot("b", "Beta")];
+        let err = resolve_bot(&bots, None, Some("Gamma")).unwrap_err();
+        assert!(err.contains("'Gamma'"));
+        assert!(err.contains("Alpha"));
+        assert!(err.contains("Beta"));
+    }
+
+    #[test]
+    fn execute_errors_on_empty_path() {
+        let args = TelegramSendImageArgs {
+            path: "   ".to_string(),
+            caption: None,
+            bot_id: None,
+            bot_label: None,
+        };
+        let code = execute(args);
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn help_text_documents_telegram_send_image() {
+        use clap::CommandFactory;
+        let help = crate::cli::Cli::command().render_help().to_string();
+        assert!(
+            help.contains("telegram-send-image"),
+            "help missing verb: {}",
+            help
+        );
+    }
+}

--- a/src-tauri/src/cli/telegram_send_image.rs
+++ b/src-tauri/src/cli/telegram_send_image.rs
@@ -85,7 +85,7 @@ fn resolve_bot<'a>(
             _ => Err(format!(
                 "Multiple Telegram bots share label '{}'; disambiguate with --bot-id. Candidates: {}",
                 label,
-                format_bot_list(&matches.into_iter().cloned().collect::<Vec<_>>())
+                format_bot_list(matches.iter().copied())
             )),
         };
     }
@@ -100,8 +100,8 @@ fn resolve_bot<'a>(
     }
 }
 
-fn format_bot_list(bots: &[TelegramBotConfig]) -> String {
-    bots.iter()
+fn format_bot_list<'a>(bots: impl IntoIterator<Item = &'a TelegramBotConfig>) -> String {
+    bots.into_iter()
         .map(|b| format!("{} (id={})", b.label, b.id))
         .collect::<Vec<_>>()
         .join(", ")
@@ -126,6 +126,13 @@ pub fn execute(args: TelegramSendImageArgs) -> i32 {
         }
     };
 
+    // INVARIANT: `perform_send_image` must use only the async `reqwest::Client`
+    // and `tokio::fs`; never `reqwest::blocking::*`. A blocking-reqwest call
+    // from inside `block_on` would try to spin a nested runtime on this same
+    // thread and panic with "Cannot start a runtime from within a runtime".
+    // `new_current_thread` is the right choice for a one-shot CLI verb (cheap,
+    // single-shot, no thread-pool overhead) but only as long as the helper
+    // stays fully async.
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -145,13 +152,13 @@ pub fn execute(args: TelegramSendImageArgs) -> i32 {
 
     match result {
         Ok(()) => {
-            crate::cli_println!("Sent: bot={} path={}", bot.id, args.path);
             log::info!(
                 "[cli] telegram-send-image: bot={} path={} caption_present={}",
                 bot.id,
                 args.path,
                 args.caption.is_some()
             );
+            crate::cli_println!("Sent: bot={} path={}", bot.id, args.path);
             0
         }
         Err(e) => {
@@ -241,6 +248,11 @@ mod tests {
         assert!(err.contains("Beta"));
     }
 
+    // Only covers the pre-settings empty-path early-exit (line 111 short-circuits
+    // before `load_settings_for_cli`). Do NOT extend with a non-empty path: a
+    // real path here would invoke `load_settings_for_cli()` and hit the
+    // developer's actual `settings.json` on disk. Path-validation belongs in
+    // tests of `perform_send_image` directly.
     #[test]
     fn execute_errors_on_empty_path() {
         let args = TelegramSendImageArgs {

--- a/src-tauri/src/commands/telegram.rs
+++ b/src-tauri/src/commands/telegram.rs
@@ -1,6 +1,8 @@
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::io::AsyncReadExt;
 use uuid::Uuid;
 
 use crate::config::settings::SettingsState;
@@ -203,4 +205,238 @@ pub async fn telegram_send_test(token: String) -> Result<i64, String> {
         .map_err(|e| e.to_string())?;
 
     Ok(chat_id)
+}
+
+/// Telegram `sendPhoto` upper bound. Files at or below this size with a
+/// supported image extension take the inline-photo path; anything larger
+/// falls back to `sendDocument`.
+const SEND_PHOTO_MAX_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Hard cap for `telegram_send_image`. Telegram Bot API allows
+/// `sendDocument` up to 50 MB without the local-bot-API server.
+const SEND_DOCUMENT_MAX_BYTES: u64 = 50 * 1024 * 1024;
+
+/// Telegram caption hard cap. The Bot API counts UTF-16 code units, not
+/// Rust chars or UTF-8 bytes; non-BMP chars (emoji) encode to 2 units, so a
+/// char-count truncation can produce up to 2x the limit and the server
+/// returns `Bad Request: caption is too long`.
+const CAPTION_MAX_UTF16_UNITS: usize = 1024;
+
+/// Extensions Telegram renders inline via `sendPhoto`. GIF is intentionally
+/// excluded because `sendPhoto` strips animation.
+const PHOTO_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp"];
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Endpoint {
+    Photo,
+    Document,
+}
+
+/// Deterministic endpoint selection. Photo path requires BOTH size <= 10 MB
+/// AND a known photo extension; everything else routes to document.
+/// `ext` must already be lowercased by the caller.
+pub(crate) fn choose_endpoint(size: u64, ext: &str) -> Endpoint {
+    if size <= SEND_PHOTO_MAX_BYTES && PHOTO_EXTENSIONS.contains(&ext) {
+        Endpoint::Photo
+    } else {
+        Endpoint::Document
+    }
+}
+
+/// Map a (lowercased) file extension to the explicit `Content-Type` we pass
+/// to Telegram. Unknown extensions fall back to `application/octet-stream`.
+pub(crate) fn extension_to_mime(ext: &str) -> &'static str {
+    match ext {
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "webp" => "image/webp",
+        "gif" => "image/gif",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Trim leading/trailing whitespace, then truncate to Telegram's 1024
+/// UTF-16-code-unit cap. If the cut lands inside a surrogate pair, drop the
+/// dangling high surrogate so `String::from_utf16_lossy` does not emit
+/// `U+FFFD`.
+pub(crate) fn truncate_caption(input: &str) -> String {
+    let t = input.trim();
+    let units: Vec<u16> = t.encode_utf16().collect();
+    if units.len() <= CAPTION_MAX_UTF16_UNITS {
+        return t.to_string();
+    }
+    let mut cut = units;
+    cut.truncate(CAPTION_MAX_UTF16_UNITS);
+    if matches!(cut.last(), Some(&u) if (0xD800..=0xDBFF).contains(&u)) {
+        cut.pop();
+    }
+    String::from_utf16_lossy(&cut)
+}
+
+/// Send a local image (or generic file) through a configured Telegram bot.
+///
+/// v1 contract:
+///   - `path` must point to an existing regular file; symlinks are rejected.
+///   - Files <= 10 MB with extension in `PHOTO_EXTENSIONS` use `sendPhoto`.
+///   - Everything else uses `sendDocument`, up to a 50 MB hard cap enforced
+///     both at the metadata check and at the read/allocation boundary.
+///   - `caption` is trimmed and clamped to `CAPTION_MAX_UTF16_UNITS` UTF-16
+///     code units (Telegram's true unit). Empty captions are dropped.
+#[tauri::command]
+pub async fn telegram_send_image(
+    settings: State<'_, SettingsState>,
+    bot_id: String,
+    path: String,
+    caption: Option<String>,
+) -> Result<(), String> {
+    let cfg = settings.read().await;
+    let bot = cfg
+        .telegram_bots
+        .iter()
+        .find(|b| b.id == bot_id)
+        .ok_or_else(|| format!("Bot not found: {}", bot_id))?
+        .clone();
+    drop(cfg);
+
+    let p = Path::new(&path);
+    let lmeta = tokio::fs::symlink_metadata(p)
+        .await
+        .map_err(|e| format!("stat failed: {}", e))?;
+    if lmeta.file_type().is_symlink() {
+        return Err(format!("Symlinks are not supported in v1: {}", path));
+    }
+    if !lmeta.is_file() {
+        return Err(format!("Not a regular file: {}", path));
+    }
+    let size = lmeta.len();
+    if size == 0 {
+        return Err(format!("File is empty: {}", path));
+    }
+    if size > SEND_DOCUMENT_MAX_BYTES {
+        return Err(format!(
+            "File exceeds Telegram 50 MB limit ({} bytes): {}",
+            size, path
+        ));
+    }
+
+    let f = tokio::fs::File::open(p)
+        .await
+        .map_err(|e| format!("open failed: {}", e))?;
+    let mut bytes: Vec<u8> = Vec::with_capacity(size as usize);
+    f.take(SEND_DOCUMENT_MAX_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .await
+        .map_err(|e| format!("read failed: {}", e))?;
+    if bytes.len() as u64 > SEND_DOCUMENT_MAX_BYTES {
+        return Err(format!("File grew past 50 MB during read: {}", path));
+    }
+
+    let filename = match p.file_name().and_then(|s| s.to_str()) {
+        Some(name) => name.to_string(),
+        None => {
+            log::warn!(
+                "telegram_send_image: non-UTF8 filename for {}, sending as 'image'",
+                path
+            );
+            "image".to_string()
+        }
+    };
+
+    let caption_trimmed: Option<String> = caption.as_deref().map(truncate_caption);
+    let caption_ref: Option<&str> = caption_trimmed.as_deref().filter(|s| !s.is_empty());
+
+    let ext = p
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    let endpoint = choose_endpoint(size, &ext);
+    let mime = extension_to_mime(&ext);
+
+    log::info!(
+        "telegram_send_image: bot={} path={} size={} ext={} endpoint={:?} mime={}",
+        bot_id, path, size, ext, endpoint, mime
+    );
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let result = match endpoint {
+        Endpoint::Photo => crate::telegram::api::send_photo(
+            &client,
+            &bot.token,
+            bot.chat_id,
+            bytes,
+            &filename,
+            mime,
+            caption_ref,
+        )
+        .await
+        .map_err(|e| e.to_string()),
+        Endpoint::Document => crate::telegram::api::send_document(
+            &client,
+            &bot.token,
+            bot.chat_id,
+            bytes,
+            &filename,
+            mime,
+            caption_ref,
+        )
+        .await
+        .map_err(|e| e.to_string()),
+    };
+
+    if let Err(ref e) = result {
+        log::error!("telegram_send_image failed: {}", e);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_photo_under_limit() {
+        assert_eq!(choose_endpoint(9 * 1024 * 1024, "png"), Endpoint::Photo);
+    }
+
+    #[test]
+    fn endpoint_document_size_kickout() {
+        assert_eq!(
+            choose_endpoint(11 * 1024 * 1024, "png"),
+            Endpoint::Document
+        );
+    }
+
+    #[test]
+    fn endpoint_document_extension_kickout() {
+        assert_eq!(
+            choose_endpoint(5 * 1024 * 1024, "gif"),
+            Endpoint::Document
+        );
+    }
+
+    #[test]
+    fn truncate_caption_ascii() {
+        let s = "a".repeat(2048);
+        let out = truncate_caption(&s);
+        assert_eq!(out.encode_utf16().count(), 1024);
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn truncate_caption_emoji_surrogate() {
+        let s: String = "\u{1F600}".repeat(600);
+        assert_eq!(s.encode_utf16().count(), 1200);
+        let out = truncate_caption(&s);
+        let units = out.encode_utf16().count();
+        assert!(units <= 1024, "expected <= 1024 UTF-16 units, got {}", units);
+        assert!(
+            !out.contains('\u{FFFD}'),
+            "truncate_caption emitted U+FFFD: dangling surrogate not dropped"
+        );
+    }
 }

--- a/src-tauri/src/commands/telegram.rs
+++ b/src-tauri/src/commands/telegram.rs
@@ -10,7 +10,7 @@ use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
 use crate::telegram::bridge::SessionReaderKind;
 use crate::telegram::manager::TelegramBridgeState;
-use crate::telegram::types::BridgeInfo;
+use crate::telegram::types::{BridgeInfo, TelegramBotConfig};
 use crate::session::profile::CodingAgentKind;
 
 /// Derive which session-reader pipeline to spawn for a given session.
@@ -303,23 +303,16 @@ fn truncate_caption(input: &str) -> String {
 ///     both at the metadata check and at the read/allocation boundary.
 ///   - `caption` is trimmed and clamped to `CAPTION_MAX_UTF16_UNITS` UTF-16
 ///     code units (Telegram's true unit). Empty captions are dropped.
-#[tauri::command]
-pub async fn telegram_send_image(
-    settings: State<'_, SettingsState>,
-    bot_id: String,
-    path: String,
-    caption: Option<String>,
+///
+/// Pure helper — does NOT depend on `tauri::State`. Shared by the Tauri
+/// command `telegram_send_image` and the `telegram-send-image` CLI verb so
+/// validation/multipart logic lives in exactly one place.
+pub(crate) async fn perform_send_image(
+    bot: &TelegramBotConfig,
+    path: &str,
+    caption: Option<&str>,
 ) -> Result<(), String> {
-    let cfg = settings.read().await;
-    let bot = cfg
-        .telegram_bots
-        .iter()
-        .find(|b| b.id == bot_id)
-        .ok_or_else(|| format!("Bot not found: {}", bot_id))?
-        .clone();
-    drop(cfg);
-
-    let p = Path::new(&path);
+    let p = Path::new(path);
     let lmeta = tokio::fs::symlink_metadata(p)
         .await
         .map_err(|e| format!("stat failed: {}", e))?;
@@ -366,7 +359,7 @@ pub async fn telegram_send_image(
         }
     };
 
-    let caption_trimmed: Option<String> = caption.as_deref().map(truncate_caption);
+    let caption_trimmed: Option<String> = caption.map(truncate_caption);
     let caption_ref: Option<&str> = caption_trimmed.as_deref().filter(|s| !s.is_empty());
 
     let ext = p
@@ -379,7 +372,7 @@ pub async fn telegram_send_image(
 
     log::info!(
         "telegram_send_image: bot={} path={} size={} ext={} endpoint={:?} mime={}",
-        bot_id, path, size, ext, endpoint, mime
+        bot.id, path, size, ext, endpoint, mime
     );
 
     let client = reqwest::Client::builder()
@@ -416,6 +409,25 @@ pub async fn telegram_send_image(
         log::error!("telegram_send_image failed: {}", e);
     }
     result
+}
+
+#[tauri::command]
+pub async fn telegram_send_image(
+    settings: State<'_, SettingsState>,
+    bot_id: String,
+    path: String,
+    caption: Option<String>,
+) -> Result<(), String> {
+    let cfg = settings.read().await;
+    let bot = cfg
+        .telegram_bots
+        .iter()
+        .find(|b| b.id == bot_id)
+        .ok_or_else(|| format!("Bot not found: {}", bot_id))?
+        .clone();
+    drop(cfg);
+
+    perform_send_image(&bot, &path, caption.as_deref()).await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/telegram.rs
+++ b/src-tauri/src/commands/telegram.rs
@@ -227,7 +227,7 @@ const CAPTION_MAX_UTF16_UNITS: usize = 1024;
 const PHOTO_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp"];
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) enum Endpoint {
+enum Endpoint {
     Photo,
     Document,
 }
@@ -235,7 +235,7 @@ pub(crate) enum Endpoint {
 /// Deterministic endpoint selection. Photo path requires BOTH size <= 10 MB
 /// AND a known photo extension; everything else routes to document.
 /// `ext` must already be lowercased by the caller.
-pub(crate) fn choose_endpoint(size: u64, ext: &str) -> Endpoint {
+fn choose_endpoint(size: u64, ext: &str) -> Endpoint {
     if size <= SEND_PHOTO_MAX_BYTES && PHOTO_EXTENSIONS.contains(&ext) {
         Endpoint::Photo
     } else {
@@ -245,7 +245,7 @@ pub(crate) fn choose_endpoint(size: u64, ext: &str) -> Endpoint {
 
 /// Map a (lowercased) file extension to the explicit `Content-Type` we pass
 /// to Telegram. Unknown extensions fall back to `application/octet-stream`.
-pub(crate) fn extension_to_mime(ext: &str) -> &'static str {
+fn extension_to_mime(ext: &str) -> &'static str {
     match ext {
         "jpg" | "jpeg" => "image/jpeg",
         "png" => "image/png",
@@ -255,11 +255,31 @@ pub(crate) fn extension_to_mime(ext: &str) -> &'static str {
     }
 }
 
+/// True if `meta` describes a symlink or — on Windows — ANY reparse point
+/// (junction, mount point, …). Mirrors the helper in `commands/role_templates.rs`;
+/// keep both in sync. `FileType::is_symlink()` does not flag Windows junctions
+/// or file-typed reparse points, so the raw `FILE_ATTRIBUTE_REPARSE_POINT`
+/// (0x400) bit is checked as well.
+fn is_link_or_reparse(meta: &std::fs::Metadata) -> bool {
+    if meta.file_type().is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return true;
+        }
+    }
+    false
+}
+
 /// Trim leading/trailing whitespace, then truncate to Telegram's 1024
 /// UTF-16-code-unit cap. If the cut lands inside a surrogate pair, drop the
 /// dangling high surrogate so `String::from_utf16_lossy` does not emit
 /// `U+FFFD`.
-pub(crate) fn truncate_caption(input: &str) -> String {
+fn truncate_caption(input: &str) -> String {
     let t = input.trim();
     let units: Vec<u16> = t.encode_utf16().collect();
     if units.len() <= CAPTION_MAX_UTF16_UNITS {
@@ -276,7 +296,8 @@ pub(crate) fn truncate_caption(input: &str) -> String {
 /// Send a local image (or generic file) through a configured Telegram bot.
 ///
 /// v1 contract:
-///   - `path` must point to an existing regular file; symlinks are rejected.
+///   - `path` must point to an existing regular file; symlinks and (on Windows)
+///     reparse points / junctions are rejected.
 ///   - Files <= 10 MB with extension in `PHOTO_EXTENSIONS` use `sendPhoto`.
 ///   - Everything else uses `sendDocument`, up to a 50 MB hard cap enforced
 ///     both at the metadata check and at the read/allocation boundary.
@@ -302,8 +323,11 @@ pub async fn telegram_send_image(
     let lmeta = tokio::fs::symlink_metadata(p)
         .await
         .map_err(|e| format!("stat failed: {}", e))?;
-    if lmeta.file_type().is_symlink() {
-        return Err(format!("Symlinks are not supported in v1: {}", path));
+    if is_link_or_reparse(&lmeta) {
+        return Err(format!(
+            "Symlinks and reparse points are not supported in v1: {}",
+            path
+        ));
     }
     if !lmeta.is_file() {
         return Err(format!("Not a regular file: {}", path));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1248,6 +1248,7 @@ pub fn run() {
             commands::telegram::telegram_list_bridges,
             commands::telegram::telegram_get_bridge,
             commands::telegram::telegram_send_test,
+            commands::telegram::telegram_send_image,
             commands::window::detach_terminal,
             commands::window::attach_terminal,
             commands::window::list_detached_sessions,

--- a/src-tauri/src/telegram/api.rs
+++ b/src-tauri/src/telegram/api.rs
@@ -201,3 +201,104 @@ pub async fn download_file(
         .map(|b| b.to_vec())
         .map_err(|e| AppError::Telegram(e.to_string()))
 }
+
+/// Telegram `sendPhoto`. Used for static images <= 10 MB whose extension
+/// indicates a format Telegram renders inline (`jpg`/`jpeg`/`png`/`webp`).
+/// Caller is responsible for size + extension gating and for supplying the
+/// matching `mime` string; this primitive is dumb on purpose so callers can
+/// swap to `send_document` for the fallback path without redoing validation.
+pub async fn send_photo(
+    client: &reqwest::Client,
+    token: &str,
+    chat_id: i64,
+    bytes: Vec<u8>,
+    filename: &str,
+    mime: &str,
+    caption: Option<&str>,
+) -> Result<(), AppError> {
+    let url = format!("https://api.telegram.org/bot{}/sendPhoto", token);
+
+    let part = reqwest::multipart::Part::bytes(bytes)
+        .file_name(filename.to_string())
+        .mime_str(mime)
+        .map_err(|e| AppError::Telegram(e.to_string()))?;
+
+    let mut form = reqwest::multipart::Form::new()
+        .text("chat_id", chat_id.to_string())
+        .part("photo", part);
+
+    if let Some(c) = caption {
+        form = form.text("caption", c.to_string());
+    }
+
+    let resp = client
+        .post(&url)
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| AppError::Telegram(e.to_string()))?;
+
+    let body: TelegramResponse<serde_json::Value> = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Telegram(e.to_string()))?;
+
+    if !body.ok {
+        return Err(AppError::Telegram(
+            body.description
+                .unwrap_or_else(|| "sendPhoto failed".to_string()),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Telegram `sendDocument`. Used as the fallback for files that exceed the
+/// 10 MB `sendPhoto` limit or carry an extension Telegram will not render
+/// as a photo. Hard upper bound (50 MB) is enforced by the caller; this
+/// primitive will happily forward whatever the caller passes.
+pub async fn send_document(
+    client: &reqwest::Client,
+    token: &str,
+    chat_id: i64,
+    bytes: Vec<u8>,
+    filename: &str,
+    mime: &str,
+    caption: Option<&str>,
+) -> Result<(), AppError> {
+    let url = format!("https://api.telegram.org/bot{}/sendDocument", token);
+
+    let part = reqwest::multipart::Part::bytes(bytes)
+        .file_name(filename.to_string())
+        .mime_str(mime)
+        .map_err(|e| AppError::Telegram(e.to_string()))?;
+
+    let mut form = reqwest::multipart::Form::new()
+        .text("chat_id", chat_id.to_string())
+        .part("document", part);
+
+    if let Some(c) = caption {
+        form = form.text("caption", c.to_string());
+    }
+
+    let resp = client
+        .post(&url)
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| AppError::Telegram(e.to_string()))?;
+
+    let body: TelegramResponse<serde_json::Value> = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Telegram(e.to_string()))?;
+
+    if !body.ok {
+        return Err(AppError::Telegram(
+            body.description
+                .unwrap_or_else(|| "sendDocument failed".to_string()),
+        ));
+    }
+
+    Ok(())
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.38",
+  "version": "0.8.39",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.37",
+  "version": "0.8.38",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -303,6 +303,11 @@ export const TelegramAPI = {
 
   sendTest: (token: string) =>
     transport.invoke<number>("telegram_send_test", { token }),
+
+  // #282 — send an existing local file to the bot's configured chat.
+  // ≤ 10 MB jpg/jpeg/png/webp ⇒ sendPhoto; otherwise sendDocument up to 50 MB.
+  sendImage: (botId: string, path: string, caption?: string) =>
+    transport.invoke<void>("telegram_send_image", { botId, path, caption }),
 };
 
 export function onPtyResized(


### PR DESCRIPTION
## Summary
- Add Telegram image/file sending through the Tauri command and frontend IPC wrapper.
- Add terminal CLI verb: telegram-send-image with --path, --caption, --bot-id, and --bot-label.
- Reuse the shared Telegram multipart send logic with file validation, size caps, caption clamping, and symlink/reparse rejection.

## Verification
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test --lib --bins --tests
- grinch implementation review passed
- wg-3 runtime smoke test sent a PNG successfully via telegram-send-image

Closes #282