### PR TITLE
fix(ui): persist theme mode preference (#289)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.40",
+  "version": "0.8.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.40",
+      "version": "0.8.41",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.40",
+  "version": "0.8.41",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.40"
+version = "0.8.41"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.40"
+version = "0.8.41"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -238,6 +238,25 @@ pub async fn set_sounds_enabled(
     Ok(())
 }
 
+/// Narrow setter — flips ONLY `theme_light`. Same lock-held-through-save
+/// pattern as `set_sounds_enabled` (issue #289). Lets the UI persist the
+/// user's light/dark mode choice without going through `update_settings`,
+/// which could clobber unrelated fields from a stale snapshot. The
+/// `update_settings` caveat documented on `set_inject_rtk_hook` applies here
+/// too.
+#[tauri::command]
+pub async fn set_theme_light(
+    settings: State<'_, SettingsState>,
+    value: bool,
+) -> Result<(), String> {
+    let mut s = settings.write().await;
+    s.theme_light = value;
+    let snapshot = s.clone();
+    save_settings(&snapshot)?;
+    drop(s); // explicit; lock released AFTER the disk write completes
+    Ok(())
+}
+
 /// Sweep every AC-managed agent directory and apply
 /// `ensure_rtk_pretool_hook(dir, enabled)`. Best-effort per directory:
 /// per-dir failures are logged + appended to `errors` and the sweep

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -189,6 +189,11 @@ pub struct AppSettings {
     /// `<config_dir>/`. Absolute ⇒ used as-is.
     #[serde(default)]
     pub agent_templates_path: Option<String>,
+    /// When true, the app uses the light theme; when false, the dark theme.
+    /// Defaults to `true` so existing settings files without the field stay on
+    /// the legacy light-mode behavior. Issue #289.
+    #[serde(default = "default_true")]
+    pub theme_light: bool,
 }
 
 fn default_true() -> bool {
@@ -272,6 +277,7 @@ impl Default for AppSettings {
             rtk_prompt_dismissed: false,
             auto_generate_brief_title: true,
             agent_templates_path: None,
+            theme_light: true,
         }
     }
 }
@@ -824,6 +830,76 @@ mod tests {
         assert!(s.sounds_enabled);
         // Existing per-feature toggle is honored as-is.
         assert!(!s.team_idle_beep_enabled);
+    }
+
+    #[test]
+    fn theme_light_round_trips_through_serde() {
+        let mut s = AppSettings::default();
+        assert!(s.theme_light);
+        s.theme_light = false;
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert!(json.contains("\"themeLight\":false"));
+        let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
+        assert!(!back.theme_light);
+    }
+
+    #[test]
+    fn theme_light_defaults_true_when_missing_from_json() {
+        // Old settings.json without the new field must deserialize with
+        // theme_light = true so existing users stay on the legacy light-mode
+        // behavior until they explicitly switch to dark.
+        let json = r#"{
+            "defaultShell": "bash",
+            "defaultShellArgs": [],
+            "agents": [],
+            "telegramBots": [],
+            "startOnlyCoordinators": true,
+            "sidebarAlwaysOnTop": false,
+            "raiseTerminalOnClick": true,
+            "voiceToTextEnabled": false,
+            "geminiApiKey": "",
+            "geminiModel": "gemini-2.5-flash",
+            "voiceAutoExecute": true,
+            "voiceAutoExecuteDelay": 15,
+            "sidebarZoom": 1.0,
+            "terminalZoom": 1.0,
+            "mainZoom": 1.0,
+            "guideZoom": 1.0,
+            "darkfactoryZoom": 1.0,
+            "sidebarGeometry": null,
+            "terminalGeometry": null,
+            "mainGeometry": null,
+            "mainSidebarWidth": 280.0,
+            "mainSidebarSide": "right",
+            "mainAlwaysOnTop": false,
+            "webServerEnabled": false,
+            "webServerPort": 7777,
+            "webServerBind": "127.0.0.1",
+            "projectPath": null,
+            "projectPaths": [],
+            "sidebarStyle": "noir-minimal",
+            "onboardingDismissed": false,
+            "coordSortByActivity": false
+        }"#;
+        let s: AppSettings = serde_json::from_str(json).expect("deserialize old json");
+        assert!(s.theme_light);
+    }
+
+    #[test]
+    fn theme_light_explicit_false_survives_round_trip() {
+        // Once a user explicitly disables light mode, the value must survive
+        // serialize/deserialize without reverting to the `default_true` default.
+        let json = r#"{
+            "defaultShell": "bash",
+            "defaultShellArgs": [],
+            "agents": [],
+            "themeLight": false
+        }"#;
+        let s: AppSettings = serde_json::from_str(json).expect("deserialize");
+        assert!(!s.theme_light);
+        let out = serde_json::to_string(&s).expect("serialize");
+        let back: AppSettings = serde_json::from_str(&out).expect("re-deserialize");
+        assert!(!back.theme_light);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1240,6 +1240,7 @@ pub fn run() {
             commands::config::set_inject_rtk_hook,
             commands::config::set_rtk_prompt_dismissed,
             commands::config::set_sounds_enabled,
+            commands::config::set_theme_light,
             commands::config::sweep_rtk_hook,
             commands::config::get_rtk_startup_status,
             commands::repos::search_repos,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander New",
-  "version": "0.8.40",
+  "version": "0.8.41",
   "identifier": "dev.agentscommander-new.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/main/App.tsx
+++ b/src/main/App.tsx
@@ -145,6 +145,10 @@ const MainApp: Component = () => {
   };
 
   onMount(async () => {
+    // #289 — optimistic light-mode first paint (legacy default); the
+    // SettingsAPI.get() block below overrides to dark for users who chose it.
+    // The embedded SidebarApp + TerminalApp each run their own corrective
+    // step on the same documentElement — idempotent overlap is fine.
     document.documentElement.classList.add("light-theme");
 
     // Main window owns zoom + geometry persistence. Embedded Sidebar+Terminal
@@ -155,6 +159,9 @@ const MainApp: Component = () => {
     // Load splitter width + always-on-top from settings.
     try {
       const settings = await SettingsAPI.get();
+      if (!settings.themeLight) {
+        document.documentElement.classList.remove("light-theme");
+      }
       const saved = settings.mainSidebarWidth ?? DEFAULT_SIDEBAR_WIDTH;
       setSidebarWidth(clampSidebarWidth(saved, window.innerWidth));
       setSidebarSide(settings.mainSidebarSide === "left" ? "left" : DEFAULT_SIDEBAR_SIDE);

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -151,6 +151,8 @@ export const SettingsAPI = {
     transport.invoke<void>("set_rtk_prompt_dismissed", { value }),
   setSoundsEnabled: (value: boolean) =>
     transport.invoke<void>("set_sounds_enabled", { value }),
+  setThemeLight: (value: boolean) =>
+    transport.invoke<void>("set_theme_light", { value }),
   sweepRtkHook: (enabled: boolean) =>
     transport.invoke<RtkSweepResult>("sweep_rtk_hook", { enabled }),
   getRtkStartupStatus: () =>

--- a/src/shared/stores/settings.ts
+++ b/src/shared/stores/settings.ts
@@ -26,6 +26,8 @@ export const settingsStore = {
   },
 
   refresh() {
-    void settingsStore.load();
+    settingsStore.load().catch((err) => {
+      console.error("settingsStore.refresh() failed:", err);
+    });
   },
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -164,6 +164,7 @@ export interface AppSettings {
   rtkPromptDismissed: boolean;
   autoGenerateBriefTitle: boolean;
   agentTemplatesPath: string | null;
+  themeLight: boolean;
 }
 
 // Team grouping for sidebar

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -86,7 +86,15 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
   };
 
   onMount(async () => {
-    document.documentElement.classList.add("light-theme");
+    // #289 — optimistically paint in light mode (the historic default and the
+    // AppSettings default) to keep first paint flash-free for the common case.
+    // The persisted-preference check after SettingsAPI.get() below overrides
+    // back to dark for users who chose it last session. Guarded with
+    // !props.embedded because MainApp owns the documentElement classList when
+    // this is mounted inside the unified layout — same pattern as zoom/geometry.
+    if (!props.embedded) {
+      document.documentElement.classList.add("light-theme");
+    }
     shortcutHandler = registerShortcuts();
     if (!props.embedded) {
       cleanupZoom = await initZoom("sidebar");
@@ -95,6 +103,9 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
 
     // Apply window settings
     const appSettings = await SettingsAPI.get();
+    if (!props.embedded && !appSettings.themeLight) {
+      document.documentElement.classList.remove("light-theme");
+    }
     raiseTerminalEnabled = appSettings.raiseTerminalOnClick;
     sessionsStore.setCoordSortByActivity(appSettings.coordSortByActivity ?? false);
     // Apply sidebar style from settings (remap removed themes to default)

--- a/src/sidebar/components/ActionBar.tsx
+++ b/src/sidebar/components/ActionBar.tsx
@@ -18,8 +18,23 @@ const ActionBar: Component = () => {
   const [pendingSection, setPendingSection] = createSignal<string | undefined>(undefined, { equals: false });
   const [confirmPath, setConfirmPath] = createSignal<string | null>(null);
   const [toastMsg, setToastMsg] = createSignal<string | null>(null);
-  const [isLight, setIsLight] = createSignal(true);
   const [isPendingDialog, setIsPendingDialog] = createSignal(false);
+  // #289 — local synchronous mirror of the persisted theme. Drives the button
+  // glyph directly so rapid double-clicks each see the freshly-toggled value
+  // (a getter that reads settingsStore.current?.themeLight would see the
+  // pre-write value until fire-and-forget refresh() resolves, so clicks 2+ in
+  // a quick burst would all flip from the same stale state). createEffect
+  // syncs in when the store loads or changes externally (SettingsModal, the
+  // peer window's theme_changed event, etc.). Default true mirrors
+  // AppSettings::default for the brief window before load() resolves on mount.
+  const [localThemeLight, setLocalThemeLight] = createSignal(
+    settingsStore.current?.themeLight ?? true,
+  );
+  createEffect(() => {
+    const t = settingsStore.current?.themeLight;
+    if (t !== undefined) setLocalThemeLight(t);
+  });
+  const isLight = (): boolean => localThemeLight();
   let dropdownRef: HTMLDivElement | undefined;
 
   // Click-away to close dropdown
@@ -124,6 +139,36 @@ const ActionBar: Component = () => {
     }
   };
 
+  // #289 — flip the DOM class optimistically (snappy UI), persist, and roll
+  // back both DOM and toast on failure. Mirrors handleToggleMute: the user
+  // intent in clicking is to *see* the new theme immediately, so the visual
+  // swap precedes the IPC roundtrip. emitThemeChanged keeps the other window
+  // in sync; on rollback we re-emit the previous value so it follows back.
+  const applyThemeClass = (light: boolean) => {
+    if (light) {
+      document.documentElement.classList.add("light-theme");
+    } else {
+      document.documentElement.classList.remove("light-theme");
+    }
+  };
+  const handleToggleTheme = async () => {
+    const previousValue = isLight();
+    const newValue = !previousValue;
+    setLocalThemeLight(newValue);
+    applyThemeClass(newValue);
+    emitThemeChanged(newValue).catch(console.error);
+    try {
+      await SettingsAPI.setThemeLight(newValue);
+      settingsStore.refresh();
+    } catch (err) {
+      setLocalThemeLight(previousValue);
+      applyThemeClass(previousValue);
+      emitThemeChanged(previousValue).catch(console.error);
+      const msg = err instanceof Error ? err.message : String(err);
+      showToast(`Failed to switch to ${newValue ? "light" : "dark"} theme: ${msg}`);
+    }
+  };
+
   return (
     <>
       <div class="action-bar">
@@ -188,16 +233,8 @@ const ActionBar: Component = () => {
           </button>
           <button
             class="toolbar-gear-btn"
-            onClick={() => {
-              const next = !isLight();
-              setIsLight(next);
-              if (next) {
-                document.documentElement.classList.add("light-theme");
-              } else {
-                document.documentElement.classList.remove("light-theme");
-              }
-              emitThemeChanged(next).catch(console.error);
-            }}
+            disabled={!settingsStore.current}
+            onClick={handleToggleTheme}
             title="Toggle theme"
           >
             {isLight() ? "\u2600\uFE0F" : "\uD83C\uDF19"}

--- a/src/terminal/App.tsx
+++ b/src/terminal/App.tsx
@@ -80,7 +80,14 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
   };
 
   onMount(async () => {
-    document.documentElement.classList.add("light-theme");
+    // #289 — optimistic light-mode first paint (legacy default); the
+    // settingsStore.load() corrective step below restores dark for users
+    // who persisted that preference. Guarded with !props.embedded because
+    // MainApp owns the documentElement classList when this is mounted inside
+    // the unified layout — same pattern as zoom/geometry/onThemeChanged below.
+    if (!props.embedded) {
+      document.documentElement.classList.add("light-theme");
+    }
     shortcutHandler = registerShortcuts();
 
     // Register destroy listener FIRST to catch any destroy event fired
@@ -135,7 +142,13 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
         cleanupGeometry = await initWindowGeometry("terminal");
       }
     }
-    settingsStore.load();
+    await settingsStore.load();
+    // #289 — restore persisted theme. Awaited above (vs. fire-and-forget)
+    // so themeLight is known before the corrective remove runs. Embedded
+    // children skip per the convention above.
+    if (!props.embedded && !settingsStore.current?.themeLight) {
+      document.documentElement.classList.remove("light-theme");
+    }
     await loadActiveSession();
 
     if (!props.lockedSessionId) {


### PR DESCRIPTION
## Summary
- persist the dark/light theme preference in app settings
- restore the saved theme on startup across main, sidebar, and terminal windows
- bump version to 0.8.41 for the new build

## Validation
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test --manifest-path src-tauri/Cargo.toml --lib --bins --tests
- npx tsc --noEmit
- npx vitest run
- dev-rust-grinch re-review passed
- wg-2 exe build deployed and --help validated

Closes #289