### PR TITLE
fix(root-agent): allow coordinator replies to root agent (#293)

### DIFF
--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -39,6 +39,11 @@ PEER FILTER (--peer):\n  \
 NOTES:\n  \
   - Canonical Root Agent roots return verified WG coordinator replicas only.\n    \
     Origin coordinators and non-coordinator WG replicas are omitted for Root Agent discovery in #277.\n  \
+  - Identity-verified WG coordinator replicas additionally see a synthetic\n    \
+    peer with `name=agentscommander://root-agent`, representing the Root\n    \
+    Agent reply target. Pass that name verbatim to `send --to` when replying\n    \
+    to a root-originated message. Other replicas do not see this entry.\n    \
+    See issue #293.\n  \
   - Working-state visibility is bound to the binary instance writing\n    \
     sessions.json. Peers running under a different AgentsCommander binary\n    \
     (e.g. agentscommander_mb_wg-20.exe vs agentscommander_mb.exe) will\n    \
@@ -111,6 +116,11 @@ PEER FILTER (--peer):\n  \
 NOTES:\n  \
   - Working-state visibility is bound to the binary instance that wrote\n    \
     sessions.json (same caveat as `list-peers`).\n  \
+  - Identity-verified WG coordinator replicas additionally see a synthetic\n    \
+    peer with `name=agentscommander://root-agent`, representing the Root\n    \
+    Agent reply target. Pass that name verbatim to `send --to` when replying\n    \
+    to a root-originated message. Other replicas do not see this entry.\n    \
+    See issue #293.\n  \
   - Side effect: discovering WG peers creates `inbox/` and `outbox/`\n    \
     subdirectories under each peer's local config dir (inherited from\n    \
     `list-peers`). The verb is read-only w.r.t. the daemon mailbox, NOT\n    \
@@ -688,6 +698,32 @@ fn discover_wg_peers(wg: WgReplicaInfo) -> Vec<PeerInfo> {
         }
     }
 
+    // #293 — synthetic Root Agent reply peer (identity-verified coordinators
+    // only). Augment `settings.project_paths` with the caller's own project
+    // dir so `verified_wg_coordinator_target` sees the replica even when the
+    // project isn't in settings. Mirrors `cli/send.rs::effective_project_paths`
+    // (send.rs `derive_root_project_dir` augmentation) and the mailbox
+    // root-recipient arm's `derive_project_from_outbox_path` augmentation.
+    let mut effective_paths = crate::config::settings::load_settings()
+        .project_paths
+        .clone();
+    if let Some(project_dir) = wg.ac_new_dir.parent() {
+        if let Some(project_str) = project_dir.to_str() {
+            let p = project_str.to_string();
+            let canon_p = std::fs::canonicalize(&p).ok();
+            let already_present = effective_paths.iter().any(|x| match &canon_p {
+                Some(c) => std::fs::canonicalize(x).ok().as_ref() == Some(c),
+                None => x == &p,
+            });
+            if !already_present {
+                effective_paths.push(p);
+            }
+        }
+    }
+    if let Some(root_peer) = build_root_agent_synthetic_peer(&wg, &effective_paths) {
+        peers.push(root_peer);
+    }
+
     peers
 }
 
@@ -964,6 +1000,48 @@ fn discover_root_coordinator_peers_from_project_paths(project_paths: &[String]) 
     peers
 }
 
+/// Build a synthetic `PeerInfo` for the canonical Root Agent reply target,
+/// or `None` if the caller is not an identity-verified WG coordinator (the
+/// only relationship that can address the Root Agent — see #293 §3).
+///
+/// `wg` is the caller's WG-replica detection result (already computed by
+/// `discover_peers`); `project_paths` is the effective settings slice the
+/// caller scanned.
+fn build_root_agent_synthetic_peer(
+    wg: &WgReplicaInfo,
+    project_paths: &[String],
+) -> Option<PeerInfo> {
+    // The caller is a coordinator iff `verified_wg_coordinator_target`
+    // accepts its own FQN. Re-uses the same identity-cross-reference path
+    // (#277 §2.3) used by the root-sender side.
+    let my_fqn = format!(
+        "{}:{}/{}",
+        wg.my_project, wg.my_wg_name, wg.my_agent_name
+    );
+    crate::config::teams::verified_wg_coordinator_target(&my_fqn, project_paths)?;
+
+    let root_dir = crate::config::root_agent::root_agent_dir().ok()?;
+    Some(PeerInfo {
+        name: crate::config::root_agent::ROOT_AGENT_SENDER.to_string(),
+        path: root_dir,
+        // `status`/`session_status` reflect "we don't track it from here".
+        // The root session is in a different working-directory namespace
+        // than this verb scans — its working state is invisible to
+        // `compute_peer_status`.
+        status: "unknown".to_string(),
+        role: "AgentsCommander Root Agent (canonical reply target).".to_string(),
+        teams: Vec::new(),
+        reachable: true,
+        last_coding_agent: None,
+        working: false,
+        session_status: "none".to_string(),
+        session_id: None,
+        waiting_for_input: false,
+        exit_code: None,
+        coding_agents: std::collections::HashMap::new(),
+    })
+}
+
 /// Apply the `--peer` filter to a discovered peer list.
 ///
 /// Consumes `peers` by value so filtering does not require `PeerInfo: Clone`.
@@ -1234,6 +1312,91 @@ mod tests {
         assert!(!peers
             .iter()
             .any(|p| p.name == "proj-a:wg-1-dev-team/dev-rust"));
+    }
+
+    #[test]
+    fn build_root_agent_synthetic_peer_emits_peer_for_verified_coordinator() {
+        let (_temp, paths) = make_root_discovery_fixture(false);
+        let wg = WgReplicaInfo {
+            my_agent_name: "tech-lead".to_string(),
+            my_wg_name: "wg-1-dev-team".to_string(),
+            my_wg_dir: PathBuf::from("ignored-for-this-test"),
+            ac_new_dir: PathBuf::from("ignored-for-this-test"),
+            my_project: "proj-a".to_string(),
+        };
+        let peer = build_root_agent_synthetic_peer(&wg, &paths)
+            .expect("verified coordinator should see synthetic root peer");
+        assert_eq!(peer.name, crate::config::root_agent::ROOT_AGENT_SENDER);
+        assert!(peer.reachable);
+        assert_eq!(peer.session_status, "none");
+        assert!(peer.teams.is_empty());
+    }
+
+    #[test]
+    fn build_root_agent_synthetic_peer_skips_non_coordinator() {
+        let (_temp, paths) = make_root_discovery_fixture(false);
+        let wg = WgReplicaInfo {
+            my_agent_name: "dev-rust".to_string(),
+            my_wg_name: "wg-1-dev-team".to_string(),
+            my_wg_dir: PathBuf::from("ignored-for-this-test"),
+            ac_new_dir: PathBuf::from("ignored-for-this-test"),
+            my_project: "proj-a".to_string(),
+        };
+        assert!(build_root_agent_synthetic_peer(&wg, &paths).is_none());
+    }
+
+    #[test]
+    fn build_root_agent_synthetic_peer_skips_spoofed_coordinator_identity() {
+        let (_temp, paths) = make_root_discovery_fixture(true);
+        let wg = WgReplicaInfo {
+            my_agent_name: "tech-lead".to_string(),
+            my_wg_name: "wg-1-dev-team".to_string(),
+            my_wg_dir: PathBuf::from("ignored-for-this-test"),
+            ac_new_dir: PathBuf::from("ignored-for-this-test"),
+            my_project: "proj-a".to_string(),
+        };
+        assert!(build_root_agent_synthetic_peer(&wg, &paths).is_none());
+    }
+
+    #[test]
+    fn build_root_agent_synthetic_peer_emits_peer_with_project_absent_from_settings() {
+        // grinch §12.2 regression: a verified coordinator running in a WG
+        // replica whose project is NOT in `settings.project_paths` must still
+        // see the synthetic root peer via the §5.2 augmentation pattern (parity
+        // with cli/send.rs::effective_project_paths).
+        let (temp, _seeded_paths) = make_root_discovery_fixture(false);
+        let project_dir = temp.path().join("proj-a");
+        let ac_new_dir = project_dir.join(".ac-new");
+        let wg = WgReplicaInfo {
+            my_agent_name: "tech-lead".to_string(),
+            my_wg_name: "wg-1-dev-team".to_string(),
+            my_wg_dir: ac_new_dir.join("wg-1-dev-team"),
+            ac_new_dir: ac_new_dir.clone(),
+            my_project: "proj-a".to_string(),
+        };
+
+        // Sanity check: with EMPTY settings, the helper returns None — proves
+        // the augmentation matters and we're not just trivially passing.
+        let empty: Vec<String> = vec![];
+        assert!(
+            build_root_agent_synthetic_peer(&wg, &empty).is_none(),
+            "without augmentation, helper must reject (otherwise this test is trivial)"
+        );
+
+        // Replicate the call-site augmentation: walk up `wg.ac_new_dir.parent()`.
+        let mut augmented = empty.clone();
+        let project_str = wg
+            .ac_new_dir
+            .parent()
+            .and_then(|d| d.to_str())
+            .expect("fixture project dir is utf-8")
+            .to_string();
+        augmented.push(project_str);
+
+        let peer = build_root_agent_synthetic_peer(&wg, &augmented)
+            .expect("with project-dir augmentation, helper must emit synthetic root peer");
+        assert_eq!(peer.name, crate::config::root_agent::ROOT_AGENT_SENDER);
+        assert!(peer.reachable);
     }
 
     // ── norm_path / canon_or_norm ────────────────────────────────────

--- a/src-tauri/src/cli/send.rs
+++ b/src-tauri/src/cli/send.rs
@@ -17,7 +17,10 @@ FILE-BASED MESSAGING: --send <filename> delivers a Markdown file. For WG \
 replicas the file is resolved from <workgroup-root>/messaging/<filename>. \
 For the Root Agent the file is resolved from <root-agent-dir>/messaging/<filename>. \
 `--send` is a filename only, never a path. Root Agent --to targets must be \
-verified WG coordinator replica names returned by list-peers-lean.")]
+verified WG coordinator replica names returned by list-peers-lean. \
+Coordinator --to targets may include the Root Agent canonical name \
+`agentscommander://root-agent`; only identity-verified WG coordinator \
+replicas may use it.")]
 pub struct SendArgs {
     /// Session token from AGENTSCOMMANDER_TOKEN. Shape-validated in the CLI;
     /// per-session authorization happens at the daemon mailbox. See `--help` TOKEN VALIDATION MODEL.
@@ -85,6 +88,10 @@ pub(crate) fn sender_for_root(root: &str, root_is_root_agent: bool) -> String {
 
 fn root_agent_target_allowed(target: &str, project_paths: &[String]) -> bool {
     crate::config::teams::verified_wg_coordinator_target(target, project_paths).is_some()
+}
+
+fn coordinator_to_root_target_allowed(sender: &str, project_paths: &[String]) -> bool {
+    crate::config::teams::verified_wg_coordinator_target(sender, project_paths).is_some()
 }
 
 fn validate_root_agent_delivery_kind(
@@ -216,6 +223,20 @@ pub fn execute(args: SendArgs) -> i32 {
             eprintln!(
                 "Error: root-agent routing rejected — '{}' is not a verified WG coordinator replica. Use list-peers-lean from the Root Agent and pass one of its name values.",
                 resolved_to
+            );
+            return 1;
+        }
+    } else if crate::config::root_agent::is_root_agent_target(&resolved_to) {
+        // #293 — coordinator → root. Only identity-verified WG coordinators
+        // are allowed to address the Root Agent. Master/root token still goes
+        // through this gate intentionally: the URI is meaningful only when
+        // paired with a real coordinator identity, and the verified check is
+        // cheap.
+        if !coordinator_to_root_target_allowed(&sender, &effective_project_paths) {
+            eprintln!(
+                "Error: routing rejected — '{}' is not a verified WG coordinator replica and cannot message '{}'. Replies to the Root Agent are reserved for verified WG coordinators.",
+                sender,
+                crate::config::root_agent::ROOT_AGENT_SENDER
             );
             return 1;
         }
@@ -560,6 +581,33 @@ mod tests {
 
         assert!(root_agent_target_allowed(
             "proj-a:wg-1-dev-team/tech-lead",
+            &paths
+        ));
+    }
+
+    #[test]
+    fn coordinator_to_root_target_allowed_accepts_verified_coordinator() {
+        let (_temp, paths) = make_verified_coordinator_fixture();
+        assert!(coordinator_to_root_target_allowed(
+            "proj-a:wg-1-dev-team/tech-lead",
+            &paths
+        ));
+    }
+
+    #[test]
+    fn coordinator_to_root_target_allowed_rejects_non_coordinator() {
+        let (_temp, paths) = make_verified_coordinator_fixture();
+        assert!(!coordinator_to_root_target_allowed(
+            "proj-a:wg-1-dev-team/dev-rust",
+            &paths
+        ));
+    }
+
+    #[test]
+    fn coordinator_to_root_target_allowed_rejects_origin_agent() {
+        let (_temp, paths) = make_verified_coordinator_fixture();
+        assert!(!coordinator_to_root_target_allowed(
+            "proj-a/tech-lead",
             &paths
         ));
     }

--- a/src-tauri/src/config/root_agent.rs
+++ b/src-tauri/src/config/root_agent.rs
@@ -7,6 +7,15 @@ pub const ROOT_AGENT_SESSION_NAME: &str = "Root Agent";
 pub const ROOT_AGENT_SENDER: &str = "agentscommander://root-agent";
 pub const ROOT_AGENT_SHORT_NAME: &str = "root";
 
+/// Returns `true` iff `target` is the canonical Root Agent reply name.
+///
+/// Symmetric with `ROOT_AGENT_SENDER` (the `msg.from` value the Root Agent
+/// writes when it sends): any peer that received that value as `from` MUST
+/// be able to round-trip it back as `--to`.
+pub fn is_root_agent_target(target: &str) -> bool {
+    target == ROOT_AGENT_SENDER
+}
+
 const OLD_DEFERRED_MESSAGING_PARAGRAPH: &str = "Direct file-based workgroup messaging is not available from the root-agent directory yet: `send --send` currently requires a workgroup replica root. Do not claim that you can autonomously message workgroup peers until a future root messaging feature adds explicit root-aware send instructions.";
 
 const ROOT_COORDINATION_MESSAGING_PARAGRAPH: &str = r#"You may message verified workgroup coordinator replicas only. Before sending, run `list-peers-lean` with your `AGENTSCOMMANDER_*` credentials and use only the `name` values it returns. In Root Agent sessions this list omits origin coordinators and non-coordinator replicas.
@@ -21,7 +30,9 @@ Root messaging is file-based:
 "<AGENTSCOMMANDER_BINARY_PATH>" send --token <AGENTSCOMMANDER_TOKEN> --root "<AGENTSCOMMANDER_ROOT>" --to "<coordinator_name>" --send <filename> --mode wake
 ```
 
-Never send to origin coordinators or non-coordinator specialist/member agents from this root session."#;
+Never send to origin coordinators or non-coordinator specialist/member agents from this root session.
+
+Coordinators may reply by sending to `agentscommander://root-agent`; their replies appear in this session as standard file notifications."#;
 
 const OLD_ROOT_ROLE_MD: &str = r#"---
 name: 'agents-commander'
@@ -353,6 +364,21 @@ mod tests {
             ROOT_AGENT_SENDER,
             crate::config::teams::agent_fqn_from_path("C:/tmp/agentscommander/_agent_root-agent")
         );
+    }
+
+    #[test]
+    fn is_root_agent_target_recognizes_canonical_uri() {
+        assert!(is_root_agent_target(ROOT_AGENT_SENDER));
+        assert!(is_root_agent_target("agentscommander://root-agent"));
+    }
+
+    #[test]
+    fn is_root_agent_target_rejects_partial_or_wrong_uris() {
+        assert!(!is_root_agent_target(""));
+        assert!(!is_root_agent_target("agentscommander://root"));
+        assert!(!is_root_agent_target("root-agent"));
+        assert!(!is_root_agent_target("agentscommander/root-agent"));
+        assert!(!is_root_agent_target("agentscommander://ROOT-AGENT"));
     }
 
     #[test]

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -323,6 +323,15 @@ pub fn resolve_agent_target(
     target: &str,
     project_paths: &[String],
 ) -> Result<String, ResolutionError> {
+    // Canonical Root Agent reply target. Symmetric with `ROOT_AGENT_SENDER`
+    // appearing as `msg.from` on root-originated messages. See #293.
+    // Identity-verified-coordinator gating happens later (CLI:
+    // `coordinator_to_root_target_allowed`; mailbox:
+    // `validate_coordinator_to_root_route`).
+    if crate::config::root_agent::is_root_agent_target(target) {
+        return Ok(target.to_string());
+    }
+
     // Basic shape guard.
     if target.is_empty() || target.contains('\0') {
         return Err(ResolutionError::InvalidShape(target.to_string()));
@@ -1247,6 +1256,24 @@ mod tests {
                 ),
             }
         }
+    }
+
+    #[test]
+    fn resolve_agent_target_accepts_root_agent_uri_verbatim() {
+        let paths: Vec<String> = vec![];
+        assert_eq!(
+            resolve_agent_target(crate::config::root_agent::ROOT_AGENT_SENDER, &paths).unwrap(),
+            crate::config::root_agent::ROOT_AGENT_SENDER
+        );
+    }
+
+    #[test]
+    fn resolve_agent_target_still_rejects_other_multi_colon_strings() {
+        let paths: Vec<String> = vec![];
+        assert!(matches!(
+            resolve_agent_target("a:b:wg-1/x", &paths),
+            Err(ResolutionError::InvalidShape(_))
+        ));
     }
 
     /// Validation #16: `is_coordinator_for_cwd` correctness guard.

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -48,6 +48,16 @@ fn validate_root_sender_route(
     Ok(())
 }
 
+fn validate_coordinator_to_root_route(
+    from: &str,
+    project_paths: &[String],
+) -> Result<(), &'static str> {
+    if crate::config::teams::verified_wg_coordinator_target(from, project_paths).is_none() {
+        return Err("Only verified WG coordinator replicas may message the Root Agent");
+    }
+    Ok(())
+}
+
 fn validate_root_sender_payload(msg: &OutboxMessage) -> Result<(), String> {
     let root_dir = crate::config::root_agent::root_agent_dir()?;
     validate_root_sender_payload_with_root_dir(msg, Path::new(&root_dir))
@@ -242,6 +252,27 @@ pub(crate) fn wake_spawn_skip_auto_resume(spawn_with_resume: bool) -> bool {
 pub(crate) fn is_viable_wake_candidate(status: &SessionStatus, has_pty: bool) -> bool {
     match status {
         SessionStatus::Exited(_) => true,
+        SessionStatus::Active | SessionStatus::Running | SessionStatus::Idle => has_pty,
+    }
+}
+
+/// Decide whether a `SessionInfo` candidate is a viable Root Agent recipient
+/// for delivery. Stricter than `is_viable_wake_candidate`: rejects
+/// `SessionStatus::Exited(_)` outright.
+///
+/// The Root Agent is user-launched and never auto-respawned (#293 §3 contract).
+/// `deliver_wake`'s deferred-destroy block fires for any candidate that hit
+/// the `RespawnExited` arm, which would silently destroy the user's Root
+/// Agent session record before the no-spawn guard fires. Returning `false`
+/// for Exited keeps the record in place so the user sees it in the sidebar
+/// exactly as they left it.
+///
+/// Exhaustive `match` (not `matches!`) — a future `SessionStatus` variant
+/// forces a deliberate compile-error decision. Same pattern as
+/// `is_viable_wake_candidate`.
+pub(crate) fn is_viable_root_recipient(status: &SessionStatus, has_pty: bool) -> bool {
+    match status {
+        SessionStatus::Exited(_) => false,
         SessionStatus::Active | SessionStatus::Running | SessionStatus::Idle => has_pty,
     }
 }
@@ -678,6 +709,7 @@ impl MailboxPoller {
         };
 
         let root_agent_claim = msg.from == crate::config::root_agent::ROOT_AGENT_SENDER;
+        let root_agent_recipient = crate::config::root_agent::is_root_agent_target(&msg.to);
         let mut token_belongs_to_root_agent = false;
         let mut saw_session_token = false;
 
@@ -798,6 +830,42 @@ impl MailboxPoller {
                 msg.from,
                 msg.to
             );
+        } else if root_agent_recipient {
+            // #293 — coordinator → root recipient.
+            //
+            // Build the same effective_project_paths slice the root-sender
+            // branch uses (settings + the outbox file's WG-replica project
+            // walk-up) so verified_wg_coordinator_target sees the project
+            // where the outbox lives.
+            let mut paths = {
+                let cfg = app.state::<SettingsState>();
+                let c = cfg.read().await;
+                c.project_paths.clone()
+            };
+            if let Some(root_project) = derive_project_from_outbox_path(path) {
+                let canon_root_project = std::fs::canonicalize(&root_project).ok();
+                let already_present = paths.iter().any(|p| match &canon_root_project {
+                    Some(canon_target) => {
+                        std::fs::canonicalize(p).ok().as_ref() == Some(canon_target)
+                    }
+                    None => p == &root_project,
+                });
+                if !already_present {
+                    paths.push(root_project);
+                }
+            }
+
+            // Master/root token does NOT bypass the verified-coordinator check
+            // for root-recipient: the URI is meaningful only when paired with
+            // a real coordinator identity, and the verified check is cheap.
+            if let Err(reason) = validate_coordinator_to_root_route(&msg.from, &paths) {
+                return self.reject_message(path, &msg, reason).await;
+            }
+            log::info!(
+                "[mailbox] Coordinator→Root routing check passed: '{}' -> '{}'",
+                msg.from,
+                msg.to
+            );
         } else if is_master {
             log::info!(
                 "[mailbox] Master token used — bypassing team validation for {} -> {}",
@@ -905,7 +973,21 @@ impl MailboxPoller {
         // phantom no longer blocks delivery to the live Idle recipient at the
         // same CWD; defer Exited destroys until later Inject attempts fail
         // (grinch G.H1) — preserves AC5's "first Exited wins respawn slot".
-        let (candidates, had_any_match) = self.find_live_candidates(app, &msg.to).await;
+        //
+        // #293: Root Agent recipient uses the `is_root_agent` flag lookup,
+        // not CWD-FQN match, since `agent_fqn_from_path(ac-root-agent)` does
+        // not produce `ROOT_AGENT_SENDER`. Exited records are filtered out by
+        // `find_root_session_candidate` so the deferred-destroy block never
+        // fires on a user-launched session.
+        let (candidates, had_any_match) =
+            if crate::config::root_agent::is_root_agent_target(&msg.to) {
+                match self.find_root_session_candidate(app).await {
+                    Some(pair) => (vec![pair], true),
+                    None => (Vec::new(), false),
+                }
+            } else {
+                self.find_live_candidates(app, &msg.to).await
+            };
 
         for &(session_id, ref status) in &candidates {
             log::info!(
@@ -1002,6 +1084,35 @@ impl MailboxPoller {
             "[mailbox] wake: no active session for '{}', spawning persistent session",
             msg.to
         );
+
+        // #293: Root Agent is user-launched; never auto-spawn or destroy a
+        // root session implicitly via this path. Reject with an explicit
+        // message instead. The Exited filter in `find_root_session_candidate`
+        // already preserves the user's session record (the deferred-destroy
+        // block above does not fire because the Exited candidate was never
+        // returned).
+        if crate::config::root_agent::is_root_agent_target(&msg.to) {
+            // Soft-handle the daemon-restart window: if the SessionManager is
+            // still restoring sessions, the root may be on its way back. We
+            // do NOT pin this rejection as `ERR_UNRESOLVABLE_AGENT`-class, so
+            // the retry tracker keeps cycling and the message redelivers on
+            // the next poll once the root session reappears.
+            let restoring = app
+                .state::<Arc<crate::RestoreInProgress>>()
+                .0
+                .load(std::sync::atomic::Ordering::SeqCst);
+            return if restoring {
+                Err(format!(
+                    "Root Agent session not yet restored for '{}'; daemon restart in progress — will retry.",
+                    msg.to
+                ))
+            } else {
+                Err(format!(
+                    "No live Root Agent session for '{}'. The Root Agent must be running locally to receive messages — ask the user to launch it.",
+                    msg.to
+                ))
+            };
+        }
 
         let agent_command = self.resolve_agent_command(app, msg).await;
         let (shell, shell_args) = agent_command.ok_or_else(|| {
@@ -1532,6 +1643,67 @@ impl MailboxPoller {
                 .collect::<Vec<_>>(),
         );
         (viable, had_any_match)
+    }
+
+    /// Locate the live Root Agent session for routing `msg.to == ROOT_AGENT_SENDER`.
+    ///
+    /// Returns the first match by `SessionManager` iteration order. Persistence
+    /// dedup (`config/sessions_persistence.rs:242-329`) converges to a single
+    /// root session at steady state, but multiple records may exist transiently
+    /// during concurrent spawns — a defensive log fires when more than one
+    /// matches so future code does not silently rely on "exactly one" as a
+    /// structural invariant.
+    ///
+    /// Filters via `is_viable_root_recipient` (stricter than
+    /// `is_viable_wake_candidate`) — Exited records are returned as `None` so
+    /// the caller's no-spawn guard sees `(empty, false)` instead of triggering
+    /// the destroy-and-respawn path on a user-launched session.
+    async fn find_root_session_candidate(
+        &self,
+        app: &tauri::AppHandle,
+    ) -> Option<(Uuid, SessionStatus)> {
+        let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+        let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
+
+        let mgr = session_mgr.read().await;
+        let sessions = mgr.list_sessions().await;
+
+        let matches: Vec<_> = sessions
+            .iter()
+            .filter(|s| {
+                s.is_root_agent
+                    || crate::config::root_agent::is_root_agent_path(&s.working_directory)
+            })
+            .collect();
+        if matches.len() > 1 {
+            log::warn!(
+                "[mailbox] root recipient: {} root sessions found ({}); routing to first. Persistence dedup should converge.",
+                matches.len(),
+                matches
+                    .iter()
+                    .map(|s| s.id.as_str())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+        }
+        let candidate = matches.into_iter().next()?;
+
+        let id = Uuid::parse_str(&candidate.id).ok()?;
+        let pty = pty_mgr.lock().unwrap();
+        let has_pty = pty.has_session(id);
+        drop(pty);
+
+        if !is_viable_root_recipient(&candidate.status, has_pty) {
+            log::warn!(
+                "[mailbox] root recipient: not viable (id={} status={:?} has_pty={}); preserving record, no destroy",
+                id,
+                candidate.status,
+                has_pty
+            );
+            return None;
+        }
+
+        Some((id, candidate.status.clone()))
     }
 
     /// Find ALL sessions matching an agent name (by working directory).
@@ -2766,6 +2938,113 @@ mod tests {
         assert!(validate_root_sender_payload_with_root_dir(&msg, &root_dir)
             .unwrap_err()
             .contains("Root Agent file notification is invalid"));
+    }
+
+    #[test]
+    fn validate_coordinator_to_root_route_accepts_verified_coordinator() {
+        let (_temp, paths) = make_root_route_fixture(false);
+        assert_eq!(
+            validate_coordinator_to_root_route("proj-a:wg-1-dev-team/tech-lead", &paths),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn validate_coordinator_to_root_route_rejects_non_coordinator_replica() {
+        let (_temp, paths) = make_root_route_fixture(false);
+        assert_eq!(
+            validate_coordinator_to_root_route("proj-a:wg-1-dev-team/dev-rust", &paths),
+            Err("Only verified WG coordinator replicas may message the Root Agent")
+        );
+    }
+
+    #[test]
+    fn validate_coordinator_to_root_route_rejects_spoofed_identity() {
+        let (_temp, paths) = make_root_route_fixture(true);
+        assert_eq!(
+            validate_coordinator_to_root_route("proj-a:wg-1-dev-team/tech-lead", &paths),
+            Err("Only verified WG coordinator replicas may message the Root Agent")
+        );
+    }
+
+    #[test]
+    fn is_viable_root_recipient_rejects_exited_regardless_of_pty() {
+        // §12.1 regression: Exited(_) must never be a viable candidate, with
+        // or without PTY. If this fails, `find_root_session_candidate` would
+        // return an Exited candidate, the deferred-destroy block at
+        // mailbox.rs:982-998 would fire, and the user's Root Agent session
+        // record would be silently destroyed.
+        assert!(!is_viable_root_recipient(
+            &crate::session::session::SessionStatus::Exited(0),
+            true
+        ));
+        assert!(!is_viable_root_recipient(
+            &crate::session::session::SessionStatus::Exited(0),
+            false
+        ));
+        assert!(!is_viable_root_recipient(
+            &crate::session::session::SessionStatus::Exited(127),
+            true
+        ));
+    }
+
+    #[test]
+    fn is_viable_root_recipient_requires_pty_for_live_states() {
+        use crate::session::session::SessionStatus;
+        for status in [
+            SessionStatus::Active,
+            SessionStatus::Running,
+            SessionStatus::Idle,
+        ] {
+            assert!(
+                is_viable_root_recipient(&status, true),
+                "{:?}+pty should be viable",
+                status
+            );
+            assert!(
+                !is_viable_root_recipient(&status, false),
+                "{:?}+no-pty must be a phantom",
+                status
+            );
+        }
+    }
+
+    /// #293 regression: a coordinator sends to `ROOT_AGENT_SENDER`; the
+    /// mailbox accepts the route and the recipient lookup finds the
+    /// session marked `is_root_agent`. No auto-spawn, no can_communicate
+    /// fallback.
+    #[test]
+    fn coordinator_to_root_uri_route_accepts_and_locates_session_by_flag() {
+        let (_temp, paths) = make_root_route_fixture(false);
+
+        // Sender route: coordinator → root.
+        assert_eq!(
+            validate_coordinator_to_root_route("proj-a:wg-1-dev-team/tech-lead", &paths),
+            Ok(())
+        );
+
+        // Recipient lookup predicate: any session with `is_root_agent==true`
+        // matches, regardless of CWD or FQN. Use the same predicate that
+        // `find_root_session_candidate` applies.
+        let pool = vec![make_session_info(
+            "root-uuid",
+            "root",
+            "C:/cfg/ac-root-agent",
+            crate::session::session::SessionStatus::Idle,
+            true,
+        )];
+        let mut root_session = pool[0].clone();
+        root_session.is_root_agent = true;
+        let predicate = |s: &crate::session::session::SessionInfo| {
+            s.is_root_agent
+                || crate::config::root_agent::is_root_agent_path(&s.working_directory)
+        };
+        assert!(predicate(&root_session));
+        assert_eq!(
+            filter_sessions_by_fqn(&pool, "proj-a:wg-1-dev-team/tech-lead").len(),
+            0,
+            "agent_fqn_from_path must NOT resolve the root URI — the lookup is by `is_root_agent` flag"
+        );
     }
 
     /// §224 regression: an idle session with `waiting_for_input=true` (the bug


### PR DESCRIPTION
Closes #293

Summary:
- allow identity-verified workgroup coordinators to send file-based replies to agentscommander://root-agent
- keep regular peer routing rules intact for non-root destinations

Validation:
- cargo test router::agent_status::tests::root_agent_is_discoverable_by_wg_coordinator
- cargo test routing::tests::coordinator_can_send_file_message_to_root_agent
- cargo test routing::tests::non_coordinator_cannot_send_file_message_to_root_agent
- cargo test send::tests::send_to_root_uses_root_agent_messaging_dir