### PR TITLE
Fix sidebar TASK title flicker after edit + remove dead listener

### DIFF
--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -319,7 +319,10 @@ struct TaskCacheEntry {
 struct TaskUpdatedPayload {
     workgroup_path: String,
     task: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // Always serialize taskTitle, even when None, so the consumer receives an
+    // explicit signal (null) rather than `undefined`. Matches the manual-emit
+    // payload built by `commands::task::emit_task_updated`. Architect sign-off
+    // on PR #304: normalize both emitters to explicit-null.
     task_title: Option<String>,
     session_ids: Vec<String>,
 }

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -60,21 +60,38 @@ fn strip_unc(p: &Path) -> String {
     raw.strip_prefix(r"\\?\").map(str::to_string).unwrap_or(raw)
 }
 
-fn emit_task_updated(app: &AppHandle, wg_root: &Path, task: &Option<String>) {
+fn emit_task_updated(
+    app: &AppHandle,
+    wg_root: &Path,
+    task: &Option<String>,
+    task_title: &Option<String>,
+) {
     let _ = app.emit(
         "workgroup_task_updated",
         serde_json::json!({
             "workgroupRoot": strip_unc(wg_root),
             "task": task.clone(),
+            "taskTitle": task_title.clone(),
         }),
     );
 }
 
-fn read_task_at(wg_root: &Path) -> Option<String> {
-    std::fs::read_to_string(wg_root.join("TASK.md"))
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
+/// Read TASK.md once and return both the trimmed full body and the parsed
+/// YAML `title:` value. Returning both from one read avoids torn results when
+/// an external writer races us between two reads. Caller emits both fields so
+/// the sidebar can update its title without waiting for the next 15s poll.
+fn read_task_fields_at(wg_root: &Path) -> (Option<String>, Option<String>) {
+    let Ok(content) = std::fs::read_to_string(wg_root.join("TASK.md")) else {
+        return (None, None);
+    };
+    let task_title = crate::commands::entity_creation::parse_task_title(&content);
+    let trimmed = content.trim();
+    let task = if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    };
+    (task, task_title)
 }
 
 /// Read the current YAML-frontmatter `title:` value of the workgroup
@@ -131,12 +148,12 @@ pub async fn task_set_title(
         session_id,
         outcome
     );
-    let task = read_task_at(&wg_root);
+    let (task, task_title) = read_task_fields_at(&wg_root);
     let result = TaskUpdateResult {
         workgroup_root: strip_unc(&wg_root),
         task: task.clone(),
     };
-    emit_task_updated(&app, &wg_root, &task);
+    emit_task_updated(&app, &wg_root, &task, &task_title);
     Ok(result)
 }
 
@@ -158,11 +175,74 @@ pub async fn task_clean(
         session_id,
         outcome
     );
-    let task = read_task_at(&wg_root);
+    let (task, task_title) = read_task_fields_at(&wg_root);
     let result = TaskUpdateResult {
         workgroup_root: strip_unc(&wg_root),
         task: task.clone(),
     };
-    emit_task_updated(&app, &wg_root, &task);
+    emit_task_updated(&app, &wg_root, &task, &task_title);
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Covers the helper that issue #301 turns on: read_task_fields_at must
+    //! return BOTH the trimmed body and the parsed YAML title from a single
+    //! read of TASK.md, so the immediate emit on save/clean carries the title
+    //! and the sidebar does not flicker until the next 15s poll.
+    use super::read_task_fields_at;
+    use crate::cli::task_ops::{perform, TaskOp};
+
+    #[test]
+    fn read_task_fields_at_missing_file_returns_none_pair() {
+        let dir = tempfile::tempdir().unwrap();
+        let (task, title) = read_task_fields_at(dir.path());
+        assert_eq!(task, None);
+        assert_eq!(title, None);
+    }
+
+    #[test]
+    fn read_task_fields_at_empty_file_returns_none_pair() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("TASK.md"), "").unwrap();
+        let (task, title) = read_task_fields_at(dir.path());
+        assert_eq!(task, None);
+        assert_eq!(title, None);
+    }
+
+    #[test]
+    fn read_task_fields_at_parses_frontmatter_title_and_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = "---\ntitle: 'My Brief'\n---\nbody line\n";
+        std::fs::write(dir.path().join("TASK.md"), content).unwrap();
+        let (task, title) = read_task_fields_at(dir.path());
+        assert_eq!(title.as_deref(), Some("My Brief"));
+        assert_eq!(task.as_deref(), Some(content.trim()));
+    }
+
+    #[test]
+    fn set_title_via_task_ops_round_trip_returns_title() {
+        // End-to-end mirror of the task_set_title body: perform() then
+        // read_task_fields_at(). Validates that the path the Tauri command
+        // takes ends up with a non-empty taskTitle in the payload.
+        let dir = tempfile::tempdir().unwrap();
+        perform(dir.path(), TaskOp::SetTitle("Hello World".to_string()))
+            .expect("set title");
+        let (task, title) = read_task_fields_at(dir.path());
+        assert_eq!(title.as_deref(), Some("Hello World"));
+        assert!(task.is_some(), "task body should not be empty after set-title");
+    }
+
+    #[test]
+    fn clean_via_task_ops_round_trip_returns_clean_title() {
+        // After Clean, the canonical title is "Clean" (see TaskOp::Clean
+        // docs). The important thing for issue #301 is the payload carries
+        // the title at all (no None → no undefined → no spread-clobber).
+        let dir = tempfile::tempdir().unwrap();
+        perform(dir.path(), TaskOp::SetTitle("Old Title".to_string()))
+            .expect("set initial title");
+        perform(dir.path(), TaskOp::Clean).expect("clean");
+        let (_task, title) = read_task_fields_at(dir.path());
+        assert_eq!(title.as_deref(), Some("Clean"));
+    }
 }

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -221,6 +221,18 @@ mod tests {
     }
 
     #[test]
+    fn read_task_fields_at_body_only_no_frontmatter_returns_body_and_no_title() {
+        // grinch LOW (PR #304 review): coverage gap — a file with body content
+        // but no YAML frontmatter must return (Some(body), None), not (None, _).
+        let dir = tempfile::tempdir().unwrap();
+        let content = "Just a body line\nmore body\n";
+        std::fs::write(dir.path().join("TASK.md"), content).unwrap();
+        let (task, title) = read_task_fields_at(dir.path());
+        assert_eq!(title, None);
+        assert_eq!(task.as_deref(), Some(content.trim()));
+    }
+
+    #[test]
     fn set_title_via_task_ops_round_trip_returns_title() {
         // End-to-end mirror of the task_set_title body: perform() then
         // read_task_fields_at(). Validates that the path the Tauri command

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -364,20 +364,6 @@ export function onDiscoveryBranchUpdated(
   );
 }
 
-export function onAcWorkgroupTaskUpdated(
-  callback: (data: {
-    workgroupPath: string;
-    task: string | null;
-    taskTitle?: string;
-  }) => void
-): Promise<UnlistenFn> {
-  return transport.listen<{
-    workgroupPath: string;
-    task: string | null;
-    taskTitle?: string;
-  }>("ac_workgroup_task_updated", callback);
-}
-
 export function onSessionIdle(
   callback: (data: { id: string }) => void
 ): Promise<UnlistenFn> {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -260,7 +260,7 @@ export interface AcWorkgroup {
   name: string;
   path: string;
   task: string | null;
-  taskTitle?: string;
+  taskTitle?: string | null;
   agents: AcAgentReplica[];
   repoPath?: string;
   teamName?: string;
@@ -335,7 +335,7 @@ export interface WorkgroupTaskUpdatedEvent {
   workgroupPath?: string;
   task: string | null;
   sessionIds?: string[];
-  taskTitle?: string;
+  taskTitle?: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1,7 +1,7 @@
 import { Component, For, Show, createMemo, createSignal, onMount, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
 import type { AcWorkgroup, AcAgentReplica, AcTeam, Session, TelegramBotConfig, BlockerReport } from "../../shared/types";
-import { SessionAPI, WindowAPI, EntityAPI, TelegramAPI, SettingsAPI, onDiscoveryBranchUpdated, onAcWorkgroupTaskUpdated, emitOpenSettings } from "../../shared/ipc";
+import { SessionAPI, WindowAPI, EntityAPI, TelegramAPI, SettingsAPI, onDiscoveryBranchUpdated, emitOpenSettings } from "../../shared/ipc";
 import type { SessionRepoInput } from "../../shared/ipc";
 import { isTauri } from "../../shared/platform";
 import { stripFrontmatter } from "../../shared/markdown";
@@ -79,20 +79,18 @@ function getActiveReplicasForWg(wg: AcWorkgroup): AcAgentReplica[] {
 }
 
 const ProjectPanel: Component = () => {
-  // Listen for replica branch and workgroup TASK.md updates from the discovery watcher.
+  // Listen for replica branch updates from the discovery watcher. TASK.md
+  // updates are wired in sidebar/App.tsx (it owns the listener for the
+  // canonical `workgroup_task_updated` event); ProjectPanel reads the
+  // resulting state through projectStore.
   let unlistenBranch: (() => void) | null = null;
-  let unlistenWgTask: (() => void) | null = null;
   onMount(async () => {
     unlistenBranch = await onDiscoveryBranchUpdated((data) => {
       projectStore.updateReplicaBranch(data.replicaPath, data.branch);
     });
-    unlistenWgTask = await onAcWorkgroupTaskUpdated((data) => {
-      projectStore.updateWorkgroupTask(data.workgroupPath, data.task, data.taskTitle);
-    });
   });
   onCleanup(() => {
     unlistenBranch?.();
-    unlistenWgTask?.();
   });
 
   const [pendingLaunch, setPendingLaunch] = createSignal<PendingLaunch | null>(null);
@@ -477,7 +475,7 @@ const ProjectPanel: Component = () => {
           wg: AcWorkgroup,
           extraBadge?: string,
           runningPeers?: () => AcAgentReplica[],
-          taskTitle?: string
+          taskTitle?: string | null
         ) => {
           const dotClass = () => replicaDotClass(wg, replica);
           const isCoord = () => replica.isCoordinator;
@@ -573,7 +571,7 @@ const ProjectPanel: Component = () => {
               <div class={`session-item-status ${dotClass()}`} />
               <div class="replica-item-info">
                 <Show when={taskTitle}>
-                  <span class="coord-task-title" title={taskTitle}>{taskTitle}</span>
+                  <span class="coord-task-title" title={taskTitle ?? undefined}>{taskTitle}</span>
                 </Show>
                 <span class="replica-item-name">{replica.originProject ? `${replica.name}@${replica.originProject}` : replica.name}</span>
                 <div class="ac-discovery-badges">

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -148,7 +148,7 @@ export const projectStore = {
   updateWorkgroupTask(
     workgroupPath: string,
     task: string | null,
-    taskTitle: string | undefined
+    taskTitle: string | null | undefined
   ) {
 
     const normalized = normalizePath(workgroupPath);


### PR DESCRIPTION
## Summary

- **#301**: `task_set_title` / `task_clean` now include `taskTitle` in the `workgroup_task_updated` event payload. The sidebar receives the title on the immediate emit and no longer waits up to ~15 s for the discovery poll to re-emit.
- **#302**: removed the dead `onAcWorkgroupTaskUpdated` listener in `ProjectPanel` and its helper in `shared/ipc.ts`. The event name (`ac_workgroup_task_updated`) was never emitted by the backend — `App.tsx` already owns the canonical listener and updates `projectStore`.

## Why

Before this change, saving a TASK title in the terminal would:
1. Fire `workgroup_task_updated` with only `workgroupRoot` + `task`.
2. Sidebar listener calls `projectStore.updateWorkgroupTask(..., data.taskTitle)` with `taskTitle === undefined`.
3. The unconditional spread `{ ...wg, task, taskTitle }` wipes the previous title.
4. The sidebar's `<span class=\"ac-wg-task\">` blanks out until the next 15 s discovery tick re-emits the full payload.

## What changed

- `src-tauri/src/commands/task.rs` — new `read_task_fields_at` helper reads TASK.md once and returns both the trimmed body and the parsed YAML `title:`. Both `task_set_title` and `task_clean` now feed both fields into `emit_task_updated`, which serializes them as `task` + `taskTitle` (null when None, so the consumer sees an explicit signal instead of undefined).
- `src/shared/types.ts` — `WorkgroupTaskUpdatedEvent.taskTitle` and `AcWorkgroup.taskTitle` widened to `string | null` to match the new payload nullability.
- `src/sidebar/stores/project.ts` — `updateWorkgroupTask`'s `taskTitle` param widened to `string | null | undefined`.
- `src/sidebar/components/ProjectPanel.tsx` — `renderReplicaItem`'s `taskTitle` param widened; coord title span coerces `null` to `undefined` for the DOM `title` attribute.
- `src/sidebar/components/ProjectPanel.tsx` + `src/shared/ipc.ts` — dead listener + helper deleted (#302).

The two payload shapes (poll = `workgroupPath` + `sessionIds`; manual edit = `workgroupRoot` + no `sessionIds`) are kept distinct on purpose — the terminal handler at `src/terminal/App.tsx:209-230` routes off the shape difference. Unifying them is out of scope for this PR.

## Test plan

- [x] `cargo test --lib` — 752/752 passing (5 new tests in `commands::task::tests`).
- [x] `npm test` — 129/129 passing.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: open a workgroup with a TASK title, edit the title in the terminal panel, confirm the sidebar title (`ac-wg-task` span and `coord-task-title` span) updates immediately with no blank period.
- [ ] Manual: run Clean from the terminal panel, confirm the sidebar title updates to \"Clean\" (or canonical Clean state) immediately.

Fixes #301
Fixes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)