### PR TITLE
Add coordinator assignment context

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -716,7 +716,9 @@ pub async fn create_session_inner(
 
     // Recompute is_coordinator from the current team snapshot. One source of truth —
     // every caller of create_session_inner gets the same computation.
-    let teams = crate::config::teams::discover_teams();
+    let teams = tokio::task::spawn_blocking(crate::config::teams::discover_teams)
+        .await
+        .map_err(|e| e.to_string())?;
     let is_coordinator = crate::config::teams::is_coordinator_for_cwd(&cwd, &teams);
     let is_root_agent = crate::config::root_agent::is_root_agent_path(&cwd);
 
@@ -742,6 +744,7 @@ pub async fn create_session_inner(
     if let Some(name) = session_name {
         if let Err(e) = mgr.rename_session(session.id, name.clone()).await {
             let err = e.to_string();
+            drop(mgr);
             rollback_pre_created_session(app, session_mgr, pty_mgr, session.id, &err).await;
             return Err(err);
         }
@@ -838,6 +841,7 @@ pub async fn create_session_inner(
                     .message(&dialog_msg)
                     .title("Context File Error")
                     .show(|_| {});
+                drop(mgr);
                 rollback_pre_created_session(app, session_mgr, pty_mgr, id, &e).await;
                 return Err(e);
             }
@@ -898,6 +902,7 @@ pub async fn create_session_inner(
     };
     if let Err(e) = spawn_result {
         let err = e.to_string();
+        drop(mgr);
         rollback_pre_created_session(app, session_mgr, pty_mgr, id, &err).await;
         return Err(err);
     }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -828,7 +828,7 @@ pub async fn create_session_inner(
     }
 
     let materialized_context_path = if let Some(target) = context_target {
-        match crate::config::session_context::materialize_agent_context_file(&cwd, target) {
+        match crate::config::session_context::materialize_agent_context_file(&cwd, target, is_coordinator) {
             Ok(context) => context,
             Err(e) => {
                 log::error!("Replica context validation failed: {}", e);

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -1110,7 +1110,7 @@ pub fn build_replica_context(cwd: &str) -> Result<Option<String>, String> {
 
 /// Resolve the final session context content for an agent directory.
 /// Prefers replica config.json context[] and falls back to the per-agent default context.
-fn resolve_session_context_content(cwd: &str) -> Result<Option<String>, String> {
+fn resolve_session_context_content(cwd: &str, is_coordinator: bool) -> Result<Option<String>, String> {
     let context_path = if is_replica_agent_dir(cwd) {
         match build_replica_context(cwd) {
             Ok(Some(combined_path)) => {
@@ -1148,12 +1148,12 @@ fn resolve_session_context_content(cwd: &str) -> Result<Option<String>, String> 
         )
     })?;
 
-    let teams = crate::config::teams::discover_teams();
-    if crate::config::teams::is_coordinator_for_cwd(cwd, &teams) {
+    if is_coordinator {
         let coordinator_notice = "\n\n---\n\n# Coordinator Context\n\n\
-            You are the coordinator for your team. This is an additional assignment, not a replacement for your base role.\n\
-            You must:\n\
-            - Receive team work requests and clarify scope, outcome, constraints, and acceptance criteria.\n\
+            You are the coordinator for your team. You must:\n\
+            - Keep your base role; coordination is an additional assignment, not a replacement.\n\
+            - Receive team work requests.\n\
+            - Clarify scope, outcome, constraints, and acceptance criteria.\n\
             - Always route work to the team member best prepared for each part of the request based on role, skills, and current assignment.\n\
             - Delegate work instead of absorbing technical work when a more specialized agent is available.\n\
             - Sequence work, track progress, surface blockers, and keep ownership clear.\n\
@@ -1174,8 +1174,9 @@ fn resolve_session_context_content(cwd: &str) -> Result<Option<String>, String> 
 pub fn materialize_agent_context_file(
     cwd: &str,
     target: ManagedContextTarget,
+    is_coordinator: bool,
 ) -> Result<Option<String>, String> {
-    let content = match resolve_session_context_content(cwd)? {
+    let content = match resolve_session_context_content(cwd, is_coordinator)? {
         Some(content) => content,
         None => return Ok(None),
     };
@@ -2080,6 +2081,7 @@ mod tests {
         let materialized = materialize_agent_context_file(
             &path_string(&replica_root),
             ManagedContextTarget::Codex,
+            false,
         )
         .expect("materialize context")
         .expect("context path");
@@ -2104,7 +2106,7 @@ mod tests {
         );
 
         let materialized =
-            materialize_agent_context_file(&path_string(&matrix_root), ManagedContextTarget::Codex)
+            materialize_agent_context_file(&path_string(&matrix_root), ManagedContextTarget::Codex, false)
                 .expect("materialize context")
                 .expect("context path");
         let materialized_path = PathBuf::from(&materialized);
@@ -2134,7 +2136,7 @@ mod tests {
         crate::config::root_agent::ensure_root_agent_dir_at(&root).expect("ensure root agent dir");
 
         let materialized =
-            materialize_agent_context_file(&path_string(&root), ManagedContextTarget::Codex)
+            materialize_agent_context_file(&path_string(&root), ManagedContextTarget::Codex, false)
                 .expect("materialize context")
                 .expect("context path");
         let content = std::fs::read_to_string(materialized).expect("read materialized context");
@@ -2157,6 +2159,7 @@ mod tests {
         let materialized = materialize_agent_context_file(
             &path_string(&standalone_root),
             ManagedContextTarget::Codex,
+            false,
         )
         .expect("materialize context should not error");
 

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -1151,9 +1151,17 @@ fn resolve_session_context_content(cwd: &str) -> Result<Option<String>, String> 
     let teams = crate::config::teams::discover_teams();
     if crate::config::teams::is_coordinator_for_cwd(cwd, &teams) {
         let coordinator_notice = "\n\n---\n\n# Coordinator Context\n\n\
-            You are the coordinator for your team. You must assume responsibility for receiving team work requests, \
-            coordinating the right team members, sequencing the work, keeping scope realistic, and driving the \
-            request to resolution.\n";
+            You are the coordinator for your team. This is an additional assignment, not a replacement for your base role.\n\
+            You must:\n\
+            - Receive team work requests and clarify scope, outcome, constraints, and acceptance criteria.\n\
+            - Always route work to the team member best prepared for each part of the request based on role, skills, and current assignment.\n\
+            - Delegate work instead of absorbing technical work when a more specialized agent is available.\n\
+            - Sequence work, track progress, surface blockers, and keep ownership clear.\n\
+            - Follow up after assignment to verify the assigned agent is active and working.\n\
+            - Contact silent or inactive assigned agents up to three total attempts.\n\
+            - Require assigned agents to explicitly report completion, outcome, blockers, and verification.\n\
+            - Not infer completion solely from files/logs/artifacts when the assigned agent has not reported the outcome.\n\
+            - Give recommendations to help an agent work better without removing or overriding that agent's role/scope.\n";
         content.push_str(coordinator_notice);
     }
 

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -1141,12 +1141,22 @@ fn resolve_session_context_content(cwd: &str) -> Result<Option<String>, String> 
         return Ok(None);
     };
 
-    let content = std::fs::read_to_string(&context_path).map_err(|e| {
+    let mut content = std::fs::read_to_string(&context_path).map_err(|e| {
         format!(
             "Failed to read resolved session context {}: {}",
             context_path, e
         )
     })?;
+
+    let teams = crate::config::teams::discover_teams();
+    if crate::config::teams::is_coordinator_for_cwd(cwd, &teams) {
+        let coordinator_notice = "\n\n---\n\n# Coordinator Context\n\n\
+            You are the coordinator for your team. You must assume responsibility for receiving team work requests, \
+            coordinating the right team members, sequencing the work, keeping scope realistic, and driving the \
+            request to resolution.\n";
+        content.push_str(coordinator_notice);
+    }
+
     Ok(Some(content))
 }
 

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -1161,7 +1161,18 @@ fn resolve_session_context_content(cwd: &str, is_coordinator: bool) -> Result<Op
             - Contact silent or inactive assigned agents up to three total attempts.\n\
             - Require assigned agents to explicitly report completion, outcome, blockers, and verification.\n\
             - Not infer completion solely from files/logs/artifacts when the assigned agent has not reported the outcome.\n\
-            - Give recommendations to help an agent work better without removing or overriding that agent's role/scope.\n";
+            - Give recommendations to help an agent work better without removing or overriding that agent's role/scope.\n\n\
+            ## Sending Screenshots\n\
+            As a coordinator, you may need to send screenshots. Use the CLI subcommand:\n\
+                telegram-send-image --path <PATH> [--caption <CAPTION>] [--bot-id <ID> | --bot-label <LABEL>]\n\
+            - --path is required. --caption is optional and limited to 1024 UTF-16 units.\n\
+            - If multiple Telegram bots are configured, use --bot-id or --bot-label.\n\
+            - jpg/jpeg/png/webp up to 10 MB use sendPhoto; other formats including GIF use sendDocument up to 50 MB.\n\
+            - Symlinks/junctions are rejected.\n\n\
+            **Screenshot Capture Paths:**\n\
+            - Interactive desktop coordinator: PowerShell System.Drawing / CopyFromScreen can work. Important: cast Measure-Object results to [int] before passing dimensions to Bitmap.\n\
+            - Sandboxed harness coordinator: CopyFromScreen may return all-zero/black pixels. In that case ask the user to capture with Greenshot, use latest file from C:\\Users\\maria\\0_greenshot\\, and visually inspect the image content before sending.\n\
+            - Do not judge Greenshot screenshot relevance by filename; names can be misleading.\n";
         content.push_str(coordinator_notice);
     }
 


### PR DESCRIPTION
## Summary

- inject coordinator assignment context only for team coordinator agents
- include full coordinator responsibilities around delegation, follow-up, explicit outcome reporting, and preserving base roles
- include screenshot sending guidance for coordinators, including `telegram-send-image`, interactive capture, sandbox fallback, and Greenshot notes
- avoid async-runtime blocking/deadlock concerns by passing coordinator state into context materialization and dropping read guards before rollback paths

## Verification

- `node scripts/validate-branch-name.mjs --branch feat/311-coordinator-context`
- `cargo check`
- `cargo clippy -- -D warnings`

Closes #311