### PR TITLE
fix: task_ops returns content to prevent out-of-order emits

### DIFF
--- a/src-tauri/src/cli/task_append_body.rs
+++ b/src-tauri/src/cli/task_append_body.rs
@@ -117,7 +117,7 @@ pub fn execute(args: TaskAppendBodyArgs) -> i32 {
     // tree. `sender=` and `wg=` are both caller-derived (--root) and a forged
     // --root produces a forged-but-consistent line; pid disambiguates.
     match task_ops::perform(&wg_root, TaskOp::AppendBody(args.text.clone())) {
-        Ok(EditOutcome::Wrote { backup: Some(bp) }) => {
+        Ok(EditOutcome::Wrote { backup: Some(bp), .. }) => {
             log::info!(
                 "[task] append-body: sender={} wg={} pid={} backup={}",
                 sender,
@@ -128,7 +128,7 @@ pub fn execute(args: TaskAppendBodyArgs) -> i32 {
             crate::cli_println!("TASK.md body appended; backup: {}", bp.display());
             0
         }
-        Ok(EditOutcome::Wrote { backup: None }) => {
+        Ok(EditOutcome::Wrote { backup: None, .. }) => {
             log::info!(
                 "[task] append-body: sender={} wg={} pid={} backup=<no prior file>",
                 sender,
@@ -138,7 +138,7 @@ pub fn execute(args: TaskAppendBodyArgs) -> i32 {
             crate::cli_println!("TASK.md created; no prior content to back up");
             0
         }
-        Ok(EditOutcome::NoOp) => {
+        Ok(EditOutcome::NoOp { .. }) => {
             // append-body never produces NoOp (an append always changes the file).
             // Defensive: surface the same success line as a Wrote{None} would.
             crate::cli_println!("TASK.md unchanged");

--- a/src-tauri/src/cli/task_ops.rs
+++ b/src-tauri/src/cli/task_ops.rs
@@ -51,9 +51,16 @@ pub enum TaskOp {
 #[derive(Debug, Clone)]
 pub enum EditOutcome {
     /// File was written. `backup` is `None` when the file did not exist before.
-    Wrote { backup: Option<PathBuf> },
+    Wrote {
+        backup: Option<PathBuf>,
+        content: String,
+        title: Option<String>,
+    },
     /// Set-title found the existing value already matched; no write performed.
-    NoOp,
+    NoOp {
+        content: String,
+        title: Option<String>,
+    },
 }
 
 /// Errors emitted by [`perform`]. `Display` impls match the §3 error matrix
@@ -474,7 +481,10 @@ where
         TaskOp::AppendBody(_) => false,
     };
     if is_noop {
-        return Ok(EditOutcome::NoOp);
+        return Ok(EditOutcome::NoOp {
+            content: existing.clone(),
+            title: title_value_of(&parsed),
+        });
     }
 
     // ── 5b. Render to bytes for the upcoming write ────────────────────────
@@ -592,6 +602,8 @@ where
 
     Ok(EditOutcome::Wrote {
         backup: backup_path,
+        content: new_content.clone(),
+        title: title_value_of(&new_parsed),
     })
 }
 
@@ -761,7 +773,7 @@ mod tests {
         let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
         let r = perform_inner(&wg, TaskOp::SetTitle("X".into()), now).unwrap();
         match r {
-            EditOutcome::NoOp => {}
+            EditOutcome::NoOp { .. } => {}
             other => panic!("expected NoOp, got {:?}", other),
         }
     }
@@ -897,7 +909,7 @@ mod tests {
         let now = || fixed_now_at(2026, 1, 1, 12, 34, 56);
         let r = perform_inner(&wg, TaskOp::SetTitle("X".into()), now).unwrap();
         let bp = match r {
-            EditOutcome::Wrote { backup: Some(bp) } => bp,
+            EditOutcome::Wrote { backup: Some(bp), .. } => bp,
             other => panic!("expected Wrote with backup, got {:?}", other),
         };
         let name = bp.file_name().unwrap().to_string_lossy().into_owned();
@@ -1222,7 +1234,7 @@ mod tests {
         let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
         let r = perform_inner(&wg, TaskOp::Clean, now).unwrap();
         match r {
-            EditOutcome::NoOp => {}
+            EditOutcome::NoOp { .. } => {}
             other => panic!("expected NoOp, got {:?}", other),
         }
         // No backup file created.
@@ -1249,7 +1261,7 @@ mod tests {
         let now = || fixed_now_at(2026, 5, 7, 12, 0, 0);
         let r = perform_inner(&wg, TaskOp::Clean, now).unwrap();
         let backup_path = match &r {
-            EditOutcome::Wrote { backup: Some(bp) } => bp.clone(),
+            EditOutcome::Wrote { backup: Some(bp), .. } => bp.clone(),
             other => panic!("expected Wrote with backup, got {:?}", other),
         };
         // HIGH-2 assertion: backup bytes must equal the pre-clean file.
@@ -1274,7 +1286,7 @@ mod tests {
         std::fs::create_dir_all(&wg).unwrap();
         let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
         let r = perform_inner(&wg, TaskOp::Clean, now).unwrap();
-        assert!(matches!(r, EditOutcome::Wrote { backup: None }));
+        assert!(matches!(r, EditOutcome::Wrote { backup: None, .. }));
         assert_eq!(
             std::fs::read_to_string(wg.join("TASK.md")).unwrap(),
             "---\ntitle: 'Clean'\n---\nReady to start a new topic\n"
@@ -1285,5 +1297,57 @@ mod tests {
             .filter(|e| e.file_name().to_string_lossy().ends_with(".bak.md"))
             .count();
         assert_eq!(bak_count, 0);
+    }
+
+    #[test]
+    fn concurrent_writes_return_correct_post_edit_content() {
+        for _iter in 0..10 {
+            let fix = FixtureRoot::new("task-u42");
+            let wg = fix.path().join("wg-1");
+            std::fs::create_dir_all(&wg).unwrap();
+            let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
+            
+            // First call sets up the file
+            perform_inner(&wg, TaskOp::SetTitle("Initial".into()), now).unwrap();
+            
+            let barrier = Arc::new(Barrier::new(2));
+            let wg_clone1 = wg.clone();
+            let wg_clone2 = wg.clone();
+            let b1 = barrier.clone();
+            let b2 = barrier.clone();
+
+            let h1 = thread::spawn(move || {
+                b1.wait();
+                perform(&wg_clone1, TaskOp::AppendBody("first append".into()))
+            });
+            let h2 = thread::spawn(move || {
+                b2.wait();
+                perform(&wg_clone2, TaskOp::AppendBody("second append".into()))
+            });
+            
+            let r1 = h1.join().unwrap();
+            let r2 = h2.join().unwrap();
+            
+            let content1 = match r1 {
+                Ok(EditOutcome::Wrote { content, .. }) => content,
+                Err(TaskOpError::LockTimeout) => continue,
+                other => panic!("h1 unexpected outcome: {:?}", other),
+            };
+            let content2 = match r2 {
+                Ok(EditOutcome::Wrote { content, .. }) => content,
+                Err(TaskOpError::LockTimeout) => continue,
+                other => panic!("h2 unexpected outcome: {:?}", other),
+            };
+            
+            let final_disk_content = std::fs::read_to_string(wg.join("TASK.md")).unwrap();
+            
+            if final_disk_content.ends_with("first append\n") {
+                assert_eq!(content1, final_disk_content);
+            } else if final_disk_content.ends_with("second append\n") {
+                assert_eq!(content2, final_disk_content);
+            } else {
+                panic!("unexpected final disk content");
+            }
+        }
     }
 }

--- a/src-tauri/src/cli/task_set_title.rs
+++ b/src-tauri/src/cli/task_set_title.rs
@@ -114,7 +114,7 @@ pub fn execute(args: TaskSetTitleArgs) -> i32 {
     // tree. `sender=` and `wg=` are both caller-derived (--root) and a forged
     // --root produces a forged-but-consistent line; pid disambiguates.
     match task_ops::perform(&wg_root, TaskOp::SetTitle(args.title.clone())) {
-        Ok(EditOutcome::Wrote { backup: Some(bp) }) => {
+        Ok(EditOutcome::Wrote { backup: Some(bp), .. }) => {
             log::info!(
                 "[task] set-title: sender={} wg={} pid={} backup={}",
                 sender,
@@ -125,7 +125,7 @@ pub fn execute(args: TaskSetTitleArgs) -> i32 {
             crate::cli_println!("TASK.md title updated; backup: {}", bp.display());
             0
         }
-        Ok(EditOutcome::Wrote { backup: None }) => {
+        Ok(EditOutcome::Wrote { backup: None, .. }) => {
             log::info!(
                 "[task] set-title: sender={} wg={} pid={} backup=<no prior file>",
                 sender,
@@ -135,7 +135,7 @@ pub fn execute(args: TaskSetTitleArgs) -> i32 {
             crate::cli_println!("TASK.md created; no prior content to back up");
             0
         }
-        Ok(EditOutcome::NoOp) => {
+        Ok(EditOutcome::NoOp { .. }) => {
             log::info!(
                 "[task] set-title (no-op): sender={} wg={} pid={} (title value already matches)",
                 sender,

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -80,6 +80,7 @@ fn emit_task_updated(
 /// YAML `title:` value. Returning both from one read avoids torn results when
 /// an external writer races us between two reads. Caller emits both fields so
 /// the sidebar can update its title without waiting for the next 15s poll.
+#[allow(dead_code)]
 fn read_task_fields_at(wg_root: &Path) -> (Option<String>, Option<String>) {
     let Ok(content) = std::fs::read_to_string(wg_root.join("TASK.md")) else {
         return (None, None);
@@ -148,7 +149,13 @@ pub async fn task_set_title(
         session_id,
         outcome
     );
-    let (task, task_title) = read_task_fields_at(&wg_root);
+    
+    let (content, task_title) = match &outcome {
+        task_ops::EditOutcome::Wrote { content, title, .. } => (content.clone(), title.clone()),
+        task_ops::EditOutcome::NoOp { content, title } => (content.clone(), title.clone()),
+    };
+    let trimmed = content.trim();
+    let task = if trimmed.is_empty() { None } else { Some(trimmed.to_string()) };
     let result = TaskUpdateResult {
         workgroup_root: strip_unc(&wg_root),
         task: task.clone(),
@@ -175,7 +182,13 @@ pub async fn task_clean(
         session_id,
         outcome
     );
-    let (task, task_title) = read_task_fields_at(&wg_root);
+    
+    let (content, task_title) = match &outcome {
+        task_ops::EditOutcome::Wrote { content, title, .. } => (content.clone(), title.clone()),
+        task_ops::EditOutcome::NoOp { content, title } => (content.clone(), title.clone()),
+    };
+    let trimmed = content.trim();
+    let task = if trimmed.is_empty() { None } else { Some(trimmed.to_string()) };
     let result = TaskUpdateResult {
         workgroup_root: strip_unc(&wg_root),
         task: task.clone(),


### PR DESCRIPTION
Fixes #308