### PR TITLE
docs(home): restore Root Agent Home content (#335)

### DIFF
--- a/docs/home-en.md
+++ b/docs/home-en.md
@@ -1,0 +1,48 @@
+# Agents Commander
+
+Your command center for coordinating AI agents, distributing work, and turning an idea into parallel execution.
+
+## Quick Start
+
+### 1. Create a project
+
+Start by creating or opening an Agents Commander project. The project is where you organize agents, teams, workgroups, and repositories.
+
+### 2. Create agents
+
+Define agents with clear roles: tech lead, architect, frontend, backend, reviewer, shipper, or any specialist you need. Each agent lives in its own directory and keeps its own working context.
+
+### 3. Create teams
+
+Group agents into teams with a coordinator. Create workgroups for specific tasks, write a brief, and let each agent work in parallel with a clear responsibility.
+
+### 4. Multiply your productivity
+
+Instead of talking to a single assistant, direct a complete team: one designs, another implements, another reviews, another builds. Agents Commander helps you stay in control without losing speed.
+
+## Why Use Agents Commander
+
+Agents Commander is designed for working like a tech lead with a team of specialized agents. The app centralizes sessions, roles, teams, briefs, and communication so you can delegate real work, review results, and move forward with less context switching.
+
+The recommended workflow is simple: define the goal, assign agents, let them work in parallel, review the responses, and finish with a build ready to test.
+
+## Features
+
+- **Projects and workgroups**: organize work by project, team, and concrete task.
+- **Agents with their own roles**: each agent has its own folder, role prompt, and isolated context.
+- **Agent teams**: create teams with a coordinator, members, and associated workgroups.
+- **Parallel sessions**: run multiple agents at the same time from one interface.
+- **Real terminal**: each session runs in a full PTY, not a limited command runner.
+- **Control sidebar**: quickly open, switch, rename, detach, or close sessions.
+- **Visible brief**: keep the workgroup objective present while the work is running.
+- **Last Prompt**: quickly recover the last prompt sent to a session.
+- **Activity detection**: see which agents are still working and which are waiting for input.
+- **Detached windows**: move terminals into dedicated windows when you need more space.
+- **Agent messaging**: coordinate work through files and commands between team members.
+- **Voice to text**: dictate prompts by voice with optional transcription and auto-execution.
+- **Telegram bridge**: connect a session to Telegram for remote monitoring and control.
+- **Hints and integrated guide**: access recommendations to improve your coding-agent workflow.
+- **Global sound mute**: quickly control app sound notifications.
+- **Persistent zoom and geometry**: preserve window size, position, and scale.
+- **Portable instances**: copy and rename the executable to create isolated environments.
+- **File-based state**: configuration and communication stay in inspectable files that are easy to version.


### PR DESCRIPTION
## Summary
- Restore `docs/home-en.md`, the runtime markdown file fetched by Root Agent Home.
- Keep the emergency fix scoped to the missing Home content so existing installed builds can recover without a rebuild.
- Leave trimming, brand wording cleanup, and fallback hardening as follow-up work.

## Root Cause
`docs/home-en.md` was deleted from `main`, but `src-tauri/src/commands/config.rs` still fetches `https://raw.githubusercontent.com/mblua/AgentsCommander/main/docs/home-en.md` at runtime. Installed builds therefore showed `Could not load Home: Server returned status 404`.

## Specialist Review
- `dev-rust` restored the prior blob and verified the runtime URL still points to this file.
- `technical-writer` approved the emergency restore and recommended a later quick-start trim.
- `ux-architect` recommended keeping Home as a narrow in-app first-run surface, not a README duplicate.

## Validation
- `Test-Path docs/home-en.md` returned true.
- No banned long dash found in `docs/home-en.md`.
- Restored blob hash matches the pre-delete Home markdown blob.
- `cargo check` passed.
- `cargo clippy` passed.

Closes #335