### PR TITLE
cli: add create-agent-matrix with role-template support

### DIFF
--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -81,12 +81,17 @@ pub(crate) fn build_session_request(
     cwd: String,
     session_name: String,
     agent: &crate::config::settings::AgentConfig,
-) -> SessionRequest {
-    let parts: Vec<&str> = agent.command.split_whitespace().collect();
+) -> Result<SessionRequest, String> {
+    let command = agent.command.trim();
+    if command.is_empty() {
+        return Err(format!("launch agent '{}' has an empty command", agent.id));
+    }
+
+    let parts: Vec<&str> = command.split_whitespace().collect();
     let (shell, shell_args) = if agent.git_pull_before {
         (
             "cmd.exe".to_string(),
-            vec!["/K".to_string(), format!("git pull && {}", agent.command)],
+            vec!["/K".to_string(), format!("git pull && {}", command)],
         )
     } else {
         (
@@ -100,7 +105,7 @@ pub(crate) fn build_session_request(
         )
     };
 
-    SessionRequest {
+    Ok(SessionRequest {
         id: uuid::Uuid::new_v4().to_string(),
         cwd,
         session_name,
@@ -108,7 +113,7 @@ pub(crate) fn build_session_request(
         shell,
         shell_args,
         timestamp: chrono::Utc::now().to_rfc3339(),
-    }
+    })
 }
 
 pub fn execute(args: CreateAgentArgs) -> i32 {
@@ -149,17 +154,20 @@ pub fn execute(args: CreateAgentArgs) -> i32 {
                     eprintln!("Warning: failed to apply rtk hook: {}", e);
                 }
 
-                let request = build_session_request(
+                match build_session_request(
                     agent_path_str.clone(),
                     created.display_name.clone(),
                     agent,
-                );
-
-                match write_session_request(&request) {
-                    Ok(()) => {
-                        launched = true;
-                        launch_agent_id = Some(agent.id.clone());
-                    }
+                ) {
+                    Ok(request) => match write_session_request(&request) {
+                        Ok(()) => {
+                            launched = true;
+                            launch_agent_id = Some(agent.id.clone());
+                        }
+                        Err(e) => {
+                            eprintln!("Warning: agent created but failed to request launch: {}", e);
+                        }
+                    },
                     Err(e) => {
                         eprintln!("Warning: agent created but failed to request launch: {}", e);
                     }
@@ -267,7 +275,8 @@ mod tests {
             "C:/repo/.ac-new/_agent_architect".to_string(),
             "repo/architect".to_string(),
             &launch_agent,
-        );
+        )
+        .expect("request");
 
         assert_eq!(request.cwd, "C:/repo/.ac-new/_agent_architect");
         assert_eq!(request.session_name, "repo/architect");
@@ -280,6 +289,22 @@ mod tests {
                 "git pull && codex --ask-for-approval never".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn build_session_request_rejects_blank_and_whitespace_commands() {
+        for command in ["", "   \t  "] {
+            let launch_agent = agent("codex", "Codex", command);
+            let err = build_session_request(
+                "C:/repo/.ac-new/_agent_architect".to_string(),
+                "repo/architect".to_string(),
+                &launch_agent,
+            )
+            .expect_err("blank command");
+
+            assert!(err.contains("empty command"));
+            assert!(err.contains("codex"));
+        }
     }
 
     #[test]

--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -68,6 +68,11 @@ pub(crate) fn find_launch_agent<'a>(
     settings: &'a crate::config::settings::AppSettings,
     requested: &str,
 ) -> Option<&'a crate::config::settings::AgentConfig> {
+    let requested = requested.trim();
+    if requested.is_empty() {
+        return None;
+    }
+
     let requested_lower = requested.to_lowercase();
     settings.agents.iter().find(|a| {
         a.id.eq_ignore_ascii_case(requested)
@@ -264,6 +269,22 @@ mod tests {
             find_launch_agent(&settings, "powershell").map(|a| a.id.as_str()),
             Some("pwsh")
         );
+        assert_eq!(
+            find_launch_agent(&settings, "  CODEX  ").map(|a| a.id.as_str()),
+            Some("codex")
+        );
+    }
+
+    #[test]
+    fn find_launch_agent_rejects_empty_and_whitespace_requests() {
+        let mut settings = AppSettings::default();
+        settings.agents = vec![
+            agent("codex", "OpenAI Codex", "codex"),
+            agent("claude", "Claude Desktop", "claude"),
+        ];
+
+        assert!(find_launch_agent(&settings, "").is_none());
+        assert!(find_launch_agent(&settings, "   \t  ").is_none());
     }
 
     #[test]

--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -64,6 +64,53 @@ pub struct SessionRequest {
     pub timestamp: String,
 }
 
+pub(crate) fn find_launch_agent<'a>(
+    settings: &'a crate::config::settings::AppSettings,
+    requested: &str,
+) -> Option<&'a crate::config::settings::AgentConfig> {
+    let requested_lower = requested.to_lowercase();
+    settings.agents.iter().find(|a| {
+        a.id.eq_ignore_ascii_case(requested)
+            || a.label.eq_ignore_ascii_case(requested)
+            || a.label.to_lowercase().contains(&requested_lower)
+            || a.command.to_lowercase().starts_with(&requested_lower)
+    })
+}
+
+pub(crate) fn build_session_request(
+    cwd: String,
+    session_name: String,
+    agent: &crate::config::settings::AgentConfig,
+) -> SessionRequest {
+    let parts: Vec<&str> = agent.command.split_whitespace().collect();
+    let (shell, shell_args) = if agent.git_pull_before {
+        (
+            "cmd.exe".to_string(),
+            vec!["/K".to_string(), format!("git pull && {}", agent.command)],
+        )
+    } else {
+        (
+            parts.first().copied().unwrap_or_default().to_string(),
+            parts
+                .get(1..)
+                .unwrap_or(&[])
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        )
+    };
+
+    SessionRequest {
+        id: uuid::Uuid::new_v4().to_string(),
+        cwd,
+        session_name,
+        agent_id: agent.id.clone(),
+        shell,
+        shell_args,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    }
+}
+
 pub fn execute(args: CreateAgentArgs) -> i32 {
     let created = match agent_creation::create_agent_folder_on_disk(&args.parent, &args.name) {
         Ok(created) => created,
@@ -81,15 +128,7 @@ pub fn execute(args: CreateAgentArgs) -> i32 {
     if let Some(ref agent_id) = args.launch {
         let settings = config::settings::load_settings();
 
-        let agent_id_lower = agent_id.to_lowercase();
-        let agent_config = settings.agents.iter().find(|a| {
-            a.id.eq_ignore_ascii_case(agent_id)
-                || a.label.eq_ignore_ascii_case(agent_id)
-                || a.label.to_lowercase().contains(&agent_id_lower)
-                || a.command.to_lowercase().starts_with(&agent_id_lower)
-        });
-
-        match agent_config {
+        match find_launch_agent(&settings, agent_id) {
             Some(agent) => {
                 // Auto-generate .claude/settings.local.json if the agent has the flag
                 if agent.exclude_global_claude_md {
@@ -110,28 +149,11 @@ pub fn execute(args: CreateAgentArgs) -> i32 {
                     eprintln!("Warning: failed to apply rtk hook: {}", e);
                 }
 
-                let parts: Vec<&str> = agent.command.split_whitespace().collect();
-                let (shell, shell_args) = if agent.git_pull_before {
-                    (
-                        "cmd.exe".to_string(),
-                        vec!["/K".to_string(), format!("git pull && {}", agent.command)],
-                    )
-                } else {
-                    (
-                        parts[0].to_string(),
-                        parts[1..].iter().map(|s| s.to_string()).collect(),
-                    )
-                };
-
-                let request = SessionRequest {
-                    id: uuid::Uuid::new_v4().to_string(),
-                    cwd: agent_path_str.clone(),
-                    session_name: created.display_name.clone(),
-                    agent_id: agent.id.clone(),
-                    shell,
-                    shell_args,
-                    timestamp: chrono::Utc::now().to_rfc3339(),
-                };
+                let request = build_session_request(
+                    agent_path_str.clone(),
+                    created.display_name.clone(),
+                    agent,
+                );
 
                 match write_session_request(&request) {
                     Ok(()) => {
@@ -174,7 +196,7 @@ pub fn execute(args: CreateAgentArgs) -> i32 {
 }
 
 /// Write a session request file to ~/.agentscommander/session-requests/.
-fn write_session_request(request: &SessionRequest) -> Result<(), String> {
+pub(crate) fn write_session_request(request: &SessionRequest) -> Result<(), String> {
     let config_dir = config::config_dir().ok_or("Cannot determine config directory")?;
 
     let requests_dir = config_dir.join("session-requests");
@@ -187,4 +209,103 @@ fn write_session_request(request: &SessionRequest) -> Result<(), String> {
     std::fs::write(&path, json).map_err(|e| format!("Failed to write session request: {}", e))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::{AgentConfig, AppSettings};
+
+    fn agent(id: &str, label: &str, command: &str) -> AgentConfig {
+        AgentConfig {
+            id: id.to_string(),
+            label: label.to_string(),
+            command: command.to_string(),
+            color: "#000000".to_string(),
+            git_pull_before: false,
+            exclude_global_claude_md: false,
+        }
+    }
+
+    #[test]
+    fn find_launch_agent_matches_id_label_substring_and_command_prefix() {
+        let mut settings = AppSettings::default();
+        settings.agents = vec![
+            agent("codex", "OpenAI Codex", "codex"),
+            agent(
+                "claude",
+                "Claude Desktop",
+                "claude --dangerously-skip-permissions",
+            ),
+            agent("pwsh", "PowerShell", "powershell.exe -NoLogo"),
+        ];
+
+        assert_eq!(
+            find_launch_agent(&settings, "CODEX").map(|a| a.id.as_str()),
+            Some("codex")
+        );
+        assert_eq!(
+            find_launch_agent(&settings, "Claude Desktop").map(|a| a.id.as_str()),
+            Some("claude")
+        );
+        assert_eq!(
+            find_launch_agent(&settings, "desktop").map(|a| a.id.as_str()),
+            Some("claude")
+        );
+        assert_eq!(
+            find_launch_agent(&settings, "powershell").map(|a| a.id.as_str()),
+            Some("pwsh")
+        );
+    }
+
+    #[test]
+    fn build_session_request_wraps_git_pull_before_with_cmd_on_windows_shape() {
+        let mut launch_agent = agent("codex", "Codex", "codex --ask-for-approval never");
+        launch_agent.git_pull_before = true;
+
+        let request = build_session_request(
+            "C:/repo/.ac-new/_agent_architect".to_string(),
+            "repo/architect".to_string(),
+            &launch_agent,
+        );
+
+        assert_eq!(request.cwd, "C:/repo/.ac-new/_agent_architect");
+        assert_eq!(request.session_name, "repo/architect");
+        assert_eq!(request.agent_id, "codex");
+        assert_eq!(request.shell, "cmd.exe");
+        assert_eq!(
+            request.shell_args,
+            vec![
+                "/K".to_string(),
+                "git pull && codex --ask-for-approval never".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn write_session_request_is_still_json_camel_case() {
+        let request = SessionRequest {
+            id: format!("test-{}", uuid::Uuid::new_v4().simple()),
+            cwd: "C:/repo/.ac-new/_agent_architect".to_string(),
+            session_name: "repo/architect".to_string(),
+            agent_id: "codex".to_string(),
+            shell: "codex".to_string(),
+            shell_args: vec!["--ask-for-approval".to_string(), "never".to_string()],
+            timestamp: "2026-05-28T00:00:00Z".to_string(),
+        };
+
+        write_session_request(&request).expect("write request");
+
+        let path = crate::config::config_dir()
+            .expect("config dir")
+            .join("session-requests")
+            .join(format!("{}.json", request.id));
+        let json = std::fs::read_to_string(&path).expect("read request");
+        let _ = std::fs::remove_file(&path);
+
+        assert!(json.contains("\"sessionName\""));
+        assert!(json.contains("\"agentId\""));
+        assert!(!json.contains("session_name"));
+        assert!(!json.contains("agent_id"));
+    }
 }

--- a/src-tauri/src/cli/create_agent_matrix.rs
+++ b/src-tauri/src/cli/create_agent_matrix.rs
@@ -7,7 +7,7 @@
 //! the running GUI through the session-request mailbox.
 
 use clap::Args;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::cli::create_agent;
 use crate::commands::entity_creation::{
@@ -63,6 +63,17 @@ struct CreateAgentMatrixResult {
     launch_agent: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectRefreshRequest {
+    pub id: String,
+    pub project_path: String,
+    pub agent_path: String,
+    pub agent_name: String,
+    pub reason: String,
+    pub timestamp: String,
+}
+
 pub fn execute(args: CreateAgentMatrixArgs) -> i32 {
     let settings = crate::config::settings::load_settings_for_cli();
     let config_dir = crate::config::config_dir();
@@ -89,6 +100,30 @@ pub fn execute(args: CreateAgentMatrixArgs) -> i32 {
 
     let agent_path = created.agent_dir.to_string_lossy().to_string();
     let role_path = created.role_path.to_string_lossy().to_string();
+
+    let project_path_for_refresh = std::fs::canonicalize(&args.project)
+        .unwrap_or_else(|_| std::path::PathBuf::from(&args.project))
+        .to_string_lossy()
+        .to_string();
+    let agent_path_for_refresh = std::fs::canonicalize(&created.agent_dir)
+        .unwrap_or_else(|_| created.agent_dir.clone())
+        .to_string_lossy()
+        .to_string();
+    let refresh_request = ProjectRefreshRequest {
+        id: uuid::Uuid::new_v4().to_string(),
+        project_path: project_path_for_refresh,
+        agent_path: agent_path_for_refresh,
+        agent_name: created.display_name.clone(),
+        reason: "createAgentMatrix".to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    };
+    if let Err(e) = write_project_refresh_request(&refresh_request) {
+        eprintln!(
+            "Warning: agent matrix created but failed to request sidebar refresh: {}",
+            e
+        );
+    }
+
     let mut launched = false;
     let mut launch_agent_id: Option<String> = None;
 
@@ -148,4 +183,26 @@ pub fn execute(args: CreateAgentMatrixArgs) -> i32 {
     }
 
     0
+}
+
+fn write_project_refresh_request(request: &ProjectRefreshRequest) -> Result<(), String> {
+    let config_dir =
+        crate::config::config_dir().ok_or("Cannot determine config directory".to_string())?;
+    let requests_dir = config_dir.join("project-refresh-requests");
+    std::fs::create_dir_all(&requests_dir)
+        .map_err(|e| format!("Failed to create project-refresh-requests dir: {}", e))?;
+
+    let final_path = requests_dir.join(format!("{}.json", request.id));
+    let tmp_path = requests_dir.join(format!("{}.json.tmp", request.id));
+    let json = serde_json::to_string_pretty(request)
+        .map_err(|e| format!("Failed to serialize project refresh request: {}", e))?;
+
+    std::fs::write(&tmp_path, json)
+        .map_err(|e| format!("Failed to write project refresh request: {}", e))?;
+    std::fs::rename(&tmp_path, &final_path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        format!("Failed to finalize project refresh request: {}", e)
+    })?;
+
+    Ok(())
 }

--- a/src-tauri/src/cli/create_agent_matrix.rs
+++ b/src-tauri/src/cli/create_agent_matrix.rs
@@ -1,0 +1,144 @@
+//! CLI entrypoint for creating Agent Matrices.
+//!
+//! This command runs out of process, so it reads the persisted settings snapshot
+//! with `load_settings_for_cli()` and cannot share the GUI's in-memory
+//! `SettingsState` or RTK sweep lock. That matches the existing CLI mutation
+//! model: local disk creation is immediate, while launch requests are handed to
+//! the running GUI through the session-request mailbox.
+
+use clap::Args;
+use serde::Serialize;
+
+use crate::cli::create_agent;
+use crate::commands::entity_creation::{
+    apply_agent_matrix_settings_files, create_agent_matrix_on_disk, AgentMatrixSettingsFlags,
+    CreateAgentMatrixDiskArgs,
+};
+
+#[derive(Args)]
+#[command(after_help = "\
+NOTES:\n  \
+  .ac-new must already exist under --project.\n  \
+  --name is sanitized by the same backend as the UI into a lower-case Matrix id.\n  \
+  --role-template must be an id from the same source as the New Agent picker.\n  \
+  Invalid templates fail before creating the target Matrix directory.\n  \
+  Output is JSON with agentPath, agentName, rolePath, launched, launchAgent.")]
+pub struct CreateAgentMatrixArgs {
+    /// AC project directory that already contains .ac-new
+    #[arg(long, value_name = "PATH")]
+    pub project: String,
+
+    /// Agent Matrix display/input name, sanitized into the _agent_<id> folder
+    #[arg(long)]
+    pub name: String,
+
+    /// Description written into Role.md frontmatter and body
+    #[arg(long)]
+    pub description: String,
+
+    /// Optional role template id, for example agency:dev-rust or local:my-template
+    #[arg(long = "role-template", value_name = "TEMPLATE_ID")]
+    pub role_template: Option<String>,
+
+    /// Coding agent to launch after creation
+    #[arg(long)]
+    pub launch: Option<String>,
+
+    /// Agent root directory of the caller, accepted for parity with create-agent
+    #[arg(long)]
+    pub root: Option<String>,
+
+    /// Session token, accepted for parity with create-agent
+    #[arg(long)]
+    pub token: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateAgentMatrixResult {
+    agent_path: String,
+    agent_name: String,
+    role_path: String,
+    launched: bool,
+    launch_agent: Option<String>,
+}
+
+pub fn execute(args: CreateAgentMatrixArgs) -> i32 {
+    let settings = crate::config::settings::load_settings_for_cli();
+    let config_dir = crate::config::config_dir();
+
+    let created = match create_agent_matrix_on_disk(CreateAgentMatrixDiskArgs {
+        project_path: &args.project,
+        name: &args.name,
+        description: &args.description,
+        role_template_id: args.role_template.as_deref(),
+        settings: &settings,
+        config_dir: config_dir.as_deref(),
+    }) {
+        Ok(created) => created,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+
+    let flags = AgentMatrixSettingsFlags::from_settings(&settings);
+    for warning in apply_agent_matrix_settings_files(&created.agent_dir, flags) {
+        eprintln!("Warning: {}", warning);
+    }
+
+    let agent_path = created.agent_dir.to_string_lossy().to_string();
+    let role_path = created.role_path.to_string_lossy().to_string();
+    let mut launched = false;
+    let mut launch_agent_id: Option<String> = None;
+
+    if let Some(ref requested) = args.launch {
+        match create_agent::find_launch_agent(&settings, requested) {
+            Some(agent) => {
+                let request = create_agent::build_session_request(
+                    agent_path.clone(),
+                    created.display_name.clone(),
+                    agent,
+                );
+                match create_agent::write_session_request(&request) {
+                    Ok(()) => {
+                        launched = true;
+                        launch_agent_id = Some(agent.id.clone());
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: agent matrix created but failed to request launch: {}",
+                            e
+                        );
+                    }
+                }
+            }
+            None => {
+                let available: Vec<&str> = settings.agents.iter().map(|a| a.id.as_str()).collect();
+                eprintln!(
+                    "Warning: agent '{}' not found in settings. Available: {}. Matrix created but not launched.",
+                    requested,
+                    available.join(", ")
+                );
+            }
+        }
+    }
+
+    let result = CreateAgentMatrixResult {
+        agent_path,
+        agent_name: created.display_name,
+        role_path,
+        launched,
+        launch_agent: launch_agent_id,
+    };
+
+    match serde_json::to_string_pretty(&result) {
+        Ok(json) => crate::cli_println!("{}", json),
+        Err(e) => {
+            eprintln!("Error: failed to serialize result: {}", e);
+            return 1;
+        }
+    }
+
+    0
+}

--- a/src-tauri/src/cli/create_agent_matrix.rs
+++ b/src-tauri/src/cli/create_agent_matrix.rs
@@ -95,16 +95,23 @@ pub fn execute(args: CreateAgentMatrixArgs) -> i32 {
     if let Some(ref requested) = args.launch {
         match create_agent::find_launch_agent(&settings, requested) {
             Some(agent) => {
-                let request = create_agent::build_session_request(
+                match create_agent::build_session_request(
                     agent_path.clone(),
                     created.display_name.clone(),
                     agent,
-                );
-                match create_agent::write_session_request(&request) {
-                    Ok(()) => {
-                        launched = true;
-                        launch_agent_id = Some(agent.id.clone());
-                    }
+                ) {
+                    Ok(request) => match create_agent::write_session_request(&request) {
+                        Ok(()) => {
+                            launched = true;
+                            launch_agent_id = Some(agent.id.clone());
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "Warning: agent matrix created but failed to request launch: {}",
+                                e
+                            );
+                        }
+                    },
                     Err(e) => {
                         eprintln!(
                             "Warning: agent matrix created but failed to request launch: {}",

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod task_ops;
 pub mod task_set_title;
 pub mod close_session;
 pub mod create_agent;
+pub mod create_agent_matrix;
 pub mod list_peers;
 pub mod list_sessions;
 pub mod new_project;
@@ -94,6 +95,8 @@ pub enum Commands {
     ListSessions(list_sessions::ListSessionsArgs),
     /// Create a new agent: folder + CLAUDE.md, optionally launch it
     CreateAgent(create_agent::CreateAgentArgs),
+    /// Create a full Agent Matrix in an AC project, optionally from a role template
+    CreateAgentMatrix(create_agent_matrix::CreateAgentMatrixArgs),
     /// Close all sessions for a target agent (coordinator authorization required)
     CloseSession(close_session::CloseSessionArgs),
     /// Set the title field in the workgroup TASK.md frontmatter (coordinator-only)
@@ -216,6 +219,7 @@ pub fn handle_cli(cmd: Commands) -> i32 {
         Commands::ListPeersLean(args) => list_peers::execute_lean(args),
         Commands::ListSessions(args) => list_sessions::execute(args),
         Commands::CreateAgent(args) => create_agent::execute(args),
+        Commands::CreateAgentMatrix(args) => create_agent_matrix::execute(args),
         Commands::CloseSession(args) => close_session::execute(args),
         Commands::TaskSetTitle(args) => task_set_title::execute(args),
         Commands::TaskAppendBody(args) => task_append_body::execute(args),

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -95,6 +95,13 @@ pub struct SyncResult {
 pub(crate) const AGENT_MATRIX_DIRS: &[&str] = &["memory", "plans", "skills", "inbox", "outbox"];
 pub(crate) const AGENT_REPLICA_DIRS: &[&str] = &["inbox", "outbox"];
 
+fn create_agent_matrix_subdirs(agent_dir: &Path) -> Result<(), (&'static str, std::io::Error)> {
+    for &sub in AGENT_MATRIX_DIRS {
+        std::fs::create_dir_all(agent_dir.join(sub)).map_err(|e| (sub, e))?;
+    }
+    Ok(())
+}
+
 /// Create the full Agent Matrix layout, including the root directory.
 ///
 /// The returned tag is `"agent_dir"` for root failures or the failing subdir
@@ -103,10 +110,19 @@ pub(crate) fn create_agent_matrix_layout(
     agent_dir: &Path,
 ) -> Result<(), (&'static str, std::io::Error)> {
     std::fs::create_dir_all(agent_dir).map_err(|e| ("agent_dir", e))?;
-    for &sub in AGENT_MATRIX_DIRS {
-        std::fs::create_dir_all(agent_dir.join(sub)).map_err(|e| (sub, e))?;
-    }
-    Ok(())
+    create_agent_matrix_subdirs(agent_dir)
+}
+
+/// Create a new Agent Matrix layout after atomically claiming the root.
+///
+/// Unlike `create_agent_matrix_layout`, this fails if the root already exists.
+/// Use it for user-facing creation paths so concurrent creates cannot overwrite
+/// each other's Role.md or config.json.
+pub(crate) fn create_new_agent_matrix_layout(
+    agent_dir: &Path,
+) -> Result<(), (&'static str, std::io::Error)> {
+    std::fs::create_dir(agent_dir).map_err(|e| ("agent_dir", e))?;
+    create_agent_matrix_subdirs(agent_dir)
 }
 
 /// Create the full workgroup replica layout, including the root directory.
@@ -422,8 +438,11 @@ pub(crate) fn create_agent_matrix_on_disk(
             None => None,
         };
 
-    create_agent_matrix_layout(&agent_dir).map_err(|(sub, e)| match sub {
-        "agent_dir" => format!("Failed to create agent directory: {}", e),
+    create_new_agent_matrix_layout(&agent_dir).map_err(|(sub, e)| match (sub, e.kind()) {
+        ("agent_dir", std::io::ErrorKind::AlreadyExists) => {
+            format!("Agent '{}' already exists", safe_name)
+        }
+        ("agent_dir", _) => format!("Failed to create agent directory: {}", e),
         _ => format!("Failed to create {} directory: {}", sub, e),
     })?;
 
@@ -2135,6 +2154,40 @@ mod tests {
         assert!(
             !ac_new.join("_agent_architect").exists(),
             "invalid template must not create the target matrix directory"
+        );
+    }
+
+    #[test]
+    fn create_agent_matrix_on_disk_existing_root_fails_without_overwrite() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("ProjectAlpha");
+        let ac_new = project.join(".ac-new");
+        let agent_dir = ac_new.join("_agent_architect");
+        std::fs::create_dir_all(&agent_dir).expect("create existing matrix root");
+        std::fs::write(agent_dir.join("Role.md"), "keep role").expect("write existing role");
+        std::fs::write(agent_dir.join("config.json"), "keep config")
+            .expect("write existing config");
+        let settings = AppSettings::default();
+        let project_s = project.to_string_lossy().to_string();
+
+        let err = create_agent_matrix_on_disk(CreateAgentMatrixDiskArgs {
+            project_path: &project_s,
+            name: "Architect",
+            description: "Build plans",
+            role_template_id: None,
+            settings: &settings,
+            config_dir: None,
+        })
+        .expect_err("existing root");
+
+        assert_eq!(err, "Agent 'architect' already exists");
+        assert_eq!(
+            std::fs::read_to_string(agent_dir.join("Role.md")).expect("read existing role"),
+            "keep role"
+        );
+        assert_eq!(
+            std::fs::read_to_string(agent_dir.join("config.json")).expect("read existing config"),
+            "keep config"
         );
     }
 

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -7,7 +7,7 @@ use tauri::{AppHandle, Emitter, State};
 
 use crate::commands::ac_discovery::DiscoveryBranchWatcher;
 use crate::config::claude_settings::ensure_claude_md_excludes;
-use crate::config::settings::SettingsState;
+use crate::config::settings::{AppSettings, SettingsState};
 use crate::pty::git_watcher::{CoordinatorChangedPayload, GitWatcher};
 use crate::session::manager::SessionManager;
 use crate::session::session::SessionRepo;
@@ -342,6 +342,158 @@ fn build_role_content(
     )
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AgentMatrixSettingsFlags {
+    pub exclude_global_claude_md: bool,
+    pub inject_rtk_hook: bool,
+}
+
+impl AgentMatrixSettingsFlags {
+    pub(crate) fn from_settings(settings: &AppSettings) -> Self {
+        Self {
+            exclude_global_claude_md: settings.agents.iter().any(|a| a.exclude_global_claude_md),
+            inject_rtk_hook: settings.inject_rtk_hook,
+        }
+    }
+}
+
+pub(crate) struct CreateAgentMatrixDiskArgs<'a> {
+    pub project_path: &'a str,
+    pub name: &'a str,
+    pub description: &'a str,
+    pub role_template_id: Option<&'a str>,
+    pub settings: &'a AppSettings,
+    pub config_dir: Option<&'a Path>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CreatedAgentMatrixOnDisk {
+    pub agent_dir: PathBuf,
+    pub display_name: String,
+    pub safe_name: String,
+    pub role_path: PathBuf,
+}
+
+fn agent_matrix_display_name(project_path: &Path, safe_name: &str) -> String {
+    let project_folder = project_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| project_path.to_string_lossy().to_string());
+    format!("{}/{}", project_folder, safe_name)
+}
+
+pub(crate) fn create_agent_matrix_on_disk(
+    args: CreateAgentMatrixDiskArgs<'_>,
+) -> Result<CreatedAgentMatrixOnDisk, String> {
+    let safe_name = sanitize_name(args.name)?;
+    let project = Path::new(args.project_path);
+    let base = project.join(".ac-new");
+    if !base.is_dir() {
+        return Err(format!(
+            ".ac-new directory not found in {}",
+            args.project_path
+        ));
+    }
+
+    let agent_dir = base.join(format!("_agent_{}", safe_name));
+    if agent_dir.exists() {
+        return Err(format!("Agent '{}' already exists", safe_name));
+    }
+
+    // Resolve the picked template before any target disk mutation so unknown or
+    // unreadable template ids cannot leave a half-built matrix behind.
+    let resolved_template: Option<crate::commands::role_templates::ResolvedRoleTemplate> =
+        match args
+            .role_template_id
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Some(id) => {
+                let config_dir = args
+                    .config_dir
+                    .ok_or_else(|| "Could not determine config directory".to_string())?;
+                Some(crate::commands::role_templates::resolve_role_template(
+                    id,
+                    args.settings,
+                    config_dir,
+                )?)
+            }
+            None => None,
+        };
+
+    create_agent_matrix_layout(&agent_dir).map_err(|(sub, e)| match sub {
+        "agent_dir" => format!("Failed to create agent directory: {}", e),
+        _ => format!("Failed to create {} directory: {}", sub, e),
+    })?;
+
+    let role_content = build_role_content(&safe_name, args.description, resolved_template.as_ref());
+    let role_path = agent_dir.join("Role.md");
+    std::fs::write(&role_path, &role_content)
+        .map_err(|e| format!("Failed to write Role.md: {}", e))?;
+
+    if let Some(ref t) = resolved_template {
+        if let Some(ref src) = t.skills_src {
+            let dst = agent_dir.join("skills");
+            let failures = crate::commands::role_templates::copy_dir_recursive(src, &dst);
+            if !failures.is_empty() {
+                log::error!(
+                    "[entity_creation] some files from template '{}' skills/ could not be \
+                     copied into {} ({} failure(s)): {}",
+                    t.id,
+                    dst.display(),
+                    failures.len(),
+                    failures.join("; ")
+                );
+            }
+        }
+    }
+
+    std::fs::write(agent_dir.join("config.json"), "{\n  \"tooling\": {}\n}\n")
+        .map_err(|e| format!("Failed to write config.json: {}", e))?;
+
+    let display_name = agent_matrix_display_name(project, &safe_name);
+    Ok(CreatedAgentMatrixOnDisk {
+        agent_dir,
+        display_name,
+        safe_name,
+        role_path,
+    })
+}
+
+pub(crate) fn apply_agent_matrix_settings_files(
+    agent_dir: &Path,
+    flags: AgentMatrixSettingsFlags,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    if flags.exclude_global_claude_md {
+        if let Err(e) = ensure_claude_md_excludes(agent_dir) {
+            let warning = format!(
+                "Failed to write .claude/settings.local.json for {}: {}",
+                agent_dir.display(),
+                e
+            );
+            log::warn!("[entity_creation] {}", warning);
+            warnings.push(warning);
+        }
+    }
+
+    if let Err(e) =
+        crate::config::claude_settings::ensure_rtk_pretool_hook(agent_dir, flags.inject_rtk_hook)
+    {
+        let warning = format!(
+            "Failed to apply rtk hook for matrix {}: {}",
+            agent_dir.display(),
+            e
+        );
+        log::warn!("[entity_creation] {}", warning);
+        warnings.push(warning);
+    }
+
+    warnings
+}
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
@@ -362,119 +514,29 @@ pub async fn create_agent_matrix(
     description: String,
     role_template_id: Option<String>,
 ) -> Result<CreatedEntityResult, String> {
-    let safe_name = sanitize_name(&name)?;
-    let base = Path::new(&project_path).join(".ac-new");
-    if !base.is_dir() {
-        return Err(format!(".ac-new directory not found in {}", project_path));
-    }
+    let settings_snapshot = settings.read().await.clone();
+    let flags = AgentMatrixSettingsFlags::from_settings(&settings_snapshot);
+    let config_dir = crate::config::config_dir();
 
-    let agent_dir = base.join(format!("_agent_{}", safe_name));
-    if agent_dir.exists() {
-        return Err(format!("Agent '{}' already exists", safe_name));
-    }
-
-    // #271 — resolve the picked template BEFORE any disk mutation so an unknown
-    // / unreadable id fails fast and no half-built matrix is left on disk. If
-    // the user picked a template but the config dir is unresolvable, hard-error
-    // (plan §4.2.2) rather than silently producing a no-template agent — that
-    // would be a contract violation. Distinct from `list_role_templates`, where
-    // a missing config dir can degrade to "agency-only" since no selection has
-    // been made yet.
-    let resolved_template: Option<crate::commands::role_templates::ResolvedRoleTemplate> =
-        match role_template_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-        {
-            Some(id) => {
-                let settings_snapshot = settings.read().await.clone();
-                let config_dir = crate::config::config_dir()
-                    .ok_or_else(|| "Could not determine config directory".to_string())?;
-                Some(crate::commands::role_templates::resolve_role_template(
-                    id,
-                    &settings_snapshot,
-                    &config_dir,
-                )?)
-            }
-            None => None,
-        };
-
-    // Create directory structure. The helper owns both root and subdir creation.
-    create_agent_matrix_layout(&agent_dir).map_err(|(sub, e)| match sub {
-        "agent_dir" => format!("Failed to create agent directory: {}", e),
-        _ => format!("Failed to create {} directory: {}", sub, e),
+    let created = create_agent_matrix_on_disk(CreateAgentMatrixDiskArgs {
+        project_path: &project_path,
+        name: &name,
+        description: &description,
+        role_template_id: role_template_id.as_deref(),
+        settings: &settings_snapshot,
+        config_dir: config_dir.as_deref(),
     })?;
 
-    // Role.md with YAML frontmatter (single-quoted values for safe YAML).
-    let role_content = build_role_content(&safe_name, &description, resolved_template.as_ref());
-
-    std::fs::write(agent_dir.join("Role.md"), &role_content)
-        .map_err(|e| format!("Failed to write Role.md: {}", e))?;
-
-    // #271 — best-effort copy of the template's skills/ AFTER the layout exists.
-    // Failures here are non-fatal: the matrix is still usable, the user can
-    // re-add skills manually, and partial-copy state is just files inside an
-    // otherwise valid matrix directory. Surfaced via log::error! → ErrorModal.
-    if let Some(ref t) = resolved_template {
-        if let Some(ref src) = t.skills_src {
-            let dst = agent_dir.join("skills");
-            let failures = crate::commands::role_templates::copy_dir_recursive(src, &dst);
-            if !failures.is_empty() {
-                log::error!(
-                    "[entity_creation] some files from template '{}' skills/ could not be \
-                     copied into {} ({} failure(s)): {}",
-                    t.id,
-                    dst.display(),
-                    failures.len(),
-                    failures.join("; ")
-                );
-            }
-        }
-    }
-
-    // config.json
-    std::fs::write(agent_dir.join("config.json"), "{\n  \"tooling\": {}\n}\n")
-        .map_err(|e| format!("Failed to write config.json: {}", e))?;
-
-    // Issue #84 — auto-generate .claude/settings.local.json if any configured
-    // coding agent has `exclude_global_claude_md`. Inert for Codex/Gemini.
-    // Reads from in-memory SettingsState (kept in sync by `update_settings` in
-    // commands/config.rs:32-44). Avoids the disk-read race that load_settings()
-    // would have against a concurrent save_settings() (see plan §13.2).
-    //
-    // Issue #120 — also gate the rtk hook on `inject_rtk_hook` (read from the
-    // same snapshot). Acquires `RtkSweepLockState` around the helper sequence
-    // so concurrent sweeps cannot interleave a read-modify-write on the file.
-    let (exclude_claude_md, inject_rtk_hook) = {
-        let s = settings.read().await;
-        (
-            s.agents.iter().any(|a| a.exclude_global_claude_md),
-            s.inject_rtk_hook,
-        )
-    };
     {
         let _guard = sweep_lock.lock().await;
-        if exclude_claude_md {
-            if let Err(e) = ensure_claude_md_excludes(&agent_dir) {
-                log::warn!(
-                    "[entity_creation] Failed to write .claude/settings.local.json for {}: {}",
-                    agent_dir.display(),
-                    e
-                );
-            }
-        }
-        if let Err(e) =
-            crate::config::claude_settings::ensure_rtk_pretool_hook(&agent_dir, inject_rtk_hook)
-        {
-            log::warn!(
-                "[entity_creation] Failed to apply rtk hook for matrix {}: {}",
-                agent_dir.display(),
-                e
-            );
-        }
+        let _warnings = apply_agent_matrix_settings_files(&created.agent_dir, flags);
     }
 
-    let result_path = agent_dir.to_string_lossy().to_string();
+    let result_path = created.agent_dir.to_string_lossy().to_string();
+    log::debug!(
+        "[entity_creation] Created agent matrix safe name: {}",
+        created.safe_name
+    );
     log::info!("[entity_creation] Created agent matrix: {}", result_path);
     Ok(CreatedEntityResult { path: result_path })
 }
@@ -2012,6 +2074,163 @@ mod tests {
             sentinel.is_file(),
             "second call must not wipe pre-existing files in memory/"
         );
+    }
+
+    #[test]
+    fn create_agent_matrix_on_disk_creates_full_layout_without_template() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("ProjectAlpha");
+        let ac_new = project.join(".ac-new");
+        std::fs::create_dir_all(&ac_new).expect("create .ac-new");
+        let settings = AppSettings::default();
+        let project_s = project.to_string_lossy().to_string();
+
+        let created = create_agent_matrix_on_disk(CreateAgentMatrixDiskArgs {
+            project_path: &project_s,
+            name: "Architect",
+            description: "Build plans",
+            role_template_id: None,
+            settings: &settings,
+            config_dir: None,
+        })
+        .expect("create matrix");
+
+        let agent_dir = ac_new.join("_agent_architect");
+        assert_eq!(created.agent_dir, agent_dir);
+        assert_eq!(created.safe_name, "architect");
+        assert_eq!(created.display_name, "ProjectAlpha/architect");
+        assert!(agent_dir.join("Role.md").is_file());
+        assert!(agent_dir.join("config.json").is_file());
+        for canonical in AGENT_MATRIX_DIRS {
+            assert!(
+                agent_dir.join(canonical).is_dir(),
+                "missing canonical dir {}",
+                canonical
+            );
+        }
+    }
+
+    #[test]
+    fn create_agent_matrix_on_disk_resolves_template_before_mutation() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("ProjectAlpha");
+        let ac_new = project.join(".ac-new");
+        let config_dir = tmp.path().join("config");
+        std::fs::create_dir_all(&ac_new).expect("create .ac-new");
+        std::fs::create_dir_all(&config_dir).expect("create config");
+        let settings = AppSettings::default();
+        let project_s = project.to_string_lossy().to_string();
+
+        let err = create_agent_matrix_on_disk(CreateAgentMatrixDiskArgs {
+            project_path: &project_s,
+            name: "Architect",
+            description: "Build plans",
+            role_template_id: Some("agency:not-real"),
+            settings: &settings,
+            config_dir: Some(&config_dir),
+        })
+        .expect_err("invalid template");
+
+        assert!(err.contains("Unknown built-in role template"));
+        assert!(
+            !ac_new.join("_agent_architect").exists(),
+            "invalid template must not create the target matrix directory"
+        );
+    }
+
+    #[test]
+    fn create_agent_matrix_on_disk_applies_local_template_and_skills() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("ProjectAlpha");
+        let ac_new = project.join(".ac-new");
+        let config_dir = tmp.path().join("config");
+        let template_dir = config_dir.join("agent-templates").join("my-template");
+        std::fs::create_dir_all(&ac_new).expect("create .ac-new");
+        std::fs::create_dir_all(template_dir.join("skills").join("example"))
+            .expect("create template skill dir");
+        std::fs::write(
+            template_dir.join("Role.md"),
+            "---\nname: My Template\n---\n\n# Template Body\n\nUse this profile.\n",
+        )
+        .expect("write template role");
+        std::fs::write(
+            template_dir.join("skills").join("example").join("SKILL.md"),
+            "# Skill\n",
+        )
+        .expect("write template skill");
+        let settings = AppSettings::default();
+        let project_s = project.to_string_lossy().to_string();
+
+        let created = create_agent_matrix_on_disk(CreateAgentMatrixDiskArgs {
+            project_path: &project_s,
+            name: "Architect",
+            description: "Build plans",
+            role_template_id: Some("local:my-template"),
+            settings: &settings,
+            config_dir: Some(&config_dir),
+        })
+        .expect("create matrix from template");
+
+        let role = std::fs::read_to_string(created.role_path).expect("read Role.md");
+        assert!(role.contains("## Role Profile"));
+        assert!(role.contains("# Template Body"));
+        assert!(role.contains("Use this profile."));
+        assert!(created
+            .agent_dir
+            .join("skills")
+            .join("example")
+            .join("SKILL.md")
+            .is_file());
+    }
+
+    #[test]
+    fn agent_matrix_settings_flags_match_ui_contract() {
+        let mut settings = AppSettings::default();
+        settings.inject_rtk_hook = true;
+        settings.agents = vec![
+            crate::config::settings::AgentConfig {
+                id: "codex".to_string(),
+                label: "Codex".to_string(),
+                command: "codex".to_string(),
+                color: "#000000".to_string(),
+                git_pull_before: false,
+                exclude_global_claude_md: false,
+            },
+            crate::config::settings::AgentConfig {
+                id: "claude".to_string(),
+                label: "Claude".to_string(),
+                command: "claude".to_string(),
+                color: "#ffffff".to_string(),
+                git_pull_before: false,
+                exclude_global_claude_md: true,
+            },
+        ];
+
+        let flags = AgentMatrixSettingsFlags::from_settings(&settings);
+
+        assert!(flags.exclude_global_claude_md);
+        assert!(flags.inject_rtk_hook);
+    }
+
+    #[test]
+    fn apply_agent_matrix_settings_files_writes_expected_settings() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent_dir = tmp.path().join("_agent_architect");
+        std::fs::create_dir_all(&agent_dir).expect("create agent dir");
+
+        let warnings = apply_agent_matrix_settings_files(
+            &agent_dir,
+            AgentMatrixSettingsFlags {
+                exclude_global_claude_md: true,
+                inject_rtk_hook: true,
+            },
+        );
+
+        assert!(warnings.is_empty(), "unexpected warnings: {:?}", warnings);
+        let settings_path = agent_dir.join(".claude").join("settings.local.json");
+        let json = std::fs::read_to_string(settings_path).expect("read settings.local.json");
+        assert!(json.contains("claudeMdExcludes"));
+        assert!(json.contains("PreToolUse"));
     }
 
     #[test]

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -1345,16 +1345,22 @@ You are running inside an AgentsCommander session — a terminal session manager
 {replica_usage}
 
 {matrix_section}{messaging_exception}
-Any repository or directory outside the allowed entries above is READ-ONLY.
+Any repository or directory outside the allowed entries above is READ-ONLY, except for the AgentsCommander CLI operations exception documented below.
 
 - **Allowed**: Read-only operations on ANY path (reading files, searching, git log, git status, git diff)
 - **Allowed**: Full read/write inside `repo-*` folders
 - **Allowed**: Full read/write inside your own replica root ({agent_root}) and its subdirectories
-{matrix_allowed}{messaging_allowed}- **FORBIDDEN**: Any write operation outside {forbidden_scope}
+{matrix_allowed}{messaging_allowed}- **FORBIDDEN**: Any write operation outside {forbidden_scope}, except for explicitly requested AgentsCommander CLI operations covered by the exception below.
 
 **Clarification on git operations:** {git_scope}
 
-If instructed to modify a path outside these zones, REFUSE and explain this restriction. There are NO exceptions beyond those listed above.
+**Exception - AgentsCommander CLI operations:**
+
+When the user explicitly asks this agent to run an AgentsCommander CLI command using `AGENTSCOMMANDER_BINARY_PATH`, the command is authorized as an AgentsCommander operation. The agent may execute documented AgentsCommander CLI subcommands even if their filesystem effects create, modify, or delete files outside the normal repository/replica write zones. Those filesystem effects are governed by AgentsCommander itself, not by the agent's repository write restrictions.
+
+This exception applies only to invocations of the configured AgentsCommander CLI binary through `AGENTSCOMMANDER_BINARY_PATH`. It does not allow arbitrary shell commands, direct filesystem writes, hand-written scripts, or hardcoded alternate binaries outside the normal allowed paths.
+
+If instructed to modify a path outside these zones, REFUSE and explain this restriction, except for explicitly requested AgentsCommander CLI operations covered by the AgentsCommander CLI exception above.
 
 {skills_section}
 
@@ -1525,6 +1531,31 @@ mod tests {
     }
 
     #[test]
+    fn default_context_documents_agentscommander_cli_exception() {
+        let out = default_context(
+            "C:/fake/wg-7-dev-team/__agent_architect",
+            Some("C:/fake/_agent_architect"),
+            &no_skill_section(),
+        );
+
+        assert!(out.contains("**Exception - AgentsCommander CLI operations:**"));
+        assert!(out.contains(
+            "explicitly asks this agent to run an AgentsCommander CLI command using `AGENTSCOMMANDER_BINARY_PATH`"
+        ));
+        assert!(out.contains(
+            "filesystem effects create, modify, or delete files outside the normal repository/replica write zones"
+        ));
+        assert!(out.contains("Those filesystem effects are governed by AgentsCommander itself"));
+        assert!(out.contains(
+            "does not allow arbitrary shell commands, direct filesystem writes, hand-written scripts, or hardcoded alternate binaries"
+        ));
+        assert!(out.contains(
+            "REFUSE and explain this restriction, except for explicitly requested AgentsCommander CLI operations"
+        ));
+        assert!(!out.contains("There are NO exceptions beyond those listed above"));
+    }
+
+    #[test]
     fn default_context_without_matrix_root_marks_skill_discovery_unavailable() {
         let skills = render_skills_section(&discover_skill_index(None));
         let out = default_context("C:/tmp/fake-agent", None, &skills);
@@ -1634,7 +1665,7 @@ mod tests {
             .find("Narrow exception")
             .expect("messaging exception must be present");
         let summary_pos = out
-            .find("Any repository or directory outside the allowed entries above is READ-ONLY.")
+            .find("Any repository or directory outside the allowed entries above is READ-ONLY, except")
             .expect("summary line must be present");
         let forbidden_pos = out
             .find("- **FORBIDDEN**")

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+use serde::Serialize;
 use tauri::Manager;
 use uuid::Uuid;
 
@@ -28,6 +29,103 @@ fn sender_name_for_session_cwd_with_root_flag(
 fn sender_name_for_session_cwd(working_directory: &str) -> String {
     let is_root_agent = crate::config::root_agent::is_root_agent_path(working_directory);
     sender_name_for_session_cwd_with_root_flag(working_directory, is_root_agent)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProjectRefreshEventPayload {
+    id: String,
+    project_path: String,
+    agent_path: String,
+    agent_name: String,
+    reason: String,
+}
+
+#[derive(Debug, Default)]
+struct ProjectRefreshPollBatch {
+    payloads: Vec<ProjectRefreshEventPayload>,
+    processed_paths: Vec<PathBuf>,
+}
+
+fn canonical_project_refresh_path(path: &str) -> String {
+    std::fs::canonicalize(path)
+        .unwrap_or_else(|_| PathBuf::from(path))
+        .to_string_lossy()
+        .to_string()
+}
+
+fn collect_project_refresh_requests(requests_dir: &Path) -> ProjectRefreshPollBatch {
+    if !requests_dir.is_dir() {
+        return ProjectRefreshPollBatch::default();
+    }
+
+    let mut entries: Vec<PathBuf> = match std::fs::read_dir(requests_dir) {
+        Ok(rd) => rd
+            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .collect(),
+        Err(e) => {
+            log::warn!(
+                "[project-refresh-requests] Failed to read {:?}: {}",
+                requests_dir,
+                e
+            );
+            return ProjectRefreshPollBatch::default();
+        }
+    };
+    entries.sort();
+
+    let mut batch = ProjectRefreshPollBatch::default();
+    let mut seen_projects = BTreeSet::new();
+
+    for path in entries {
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+
+        let content = match read_text_bom_tolerant(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!(
+                    "[project-refresh-requests] Failed to read {:?}: {}",
+                    path,
+                    e
+                );
+                continue;
+            }
+        };
+
+        let mut request: crate::cli::create_agent_matrix::ProjectRefreshRequest =
+            match serde_json::from_str(&content) {
+                Ok(r) => r,
+                Err(e) => {
+                    log::warn!(
+                        "[project-refresh-requests] Failed to parse {:?}: {}",
+                        path,
+                        e
+                    );
+                    let _ = std::fs::remove_file(&path);
+                    continue;
+                }
+            };
+
+        let canonical_project_path = canonical_project_refresh_path(&request.project_path);
+        request.project_path = canonical_project_path.clone();
+        batch.processed_paths.push(path);
+
+        if !seen_projects.insert(canonical_project_path) {
+            continue;
+        }
+
+        batch.payloads.push(ProjectRefreshEventPayload {
+            id: request.id,
+            project_path: request.project_path,
+            agent_path: request.agent_path,
+            agent_name: request.agent_name,
+            reason: request.reason,
+        });
+    }
+
+    batch
 }
 
 fn validate_root_sender_route(
@@ -567,6 +665,9 @@ impl MailboxPoller {
 
         // Prune tracker entries for files that no longer exist
         self.retry_tracker.retain(|path, _| path.exists());
+
+        // Poll project-refresh-requests directory from create-agent-matrix CLI.
+        self.poll_project_refresh_requests(app).await;
 
         // Poll session-requests directory (from create-agent CLI)
         self.poll_session_requests(app).await;
@@ -2555,6 +2656,29 @@ impl MailboxPoller {
         Ok(())
     }
 
+    /// Poll ~/.agentscommander/project-refresh-requests/ for sidebar refresh requests.
+    async fn poll_project_refresh_requests(&self, app: &tauri::AppHandle) {
+        let config_dir = match crate::config::config_dir() {
+            Some(d) => d,
+            None => return,
+        };
+        let requests_dir = config_dir.join("project-refresh-requests");
+        let batch = collect_project_refresh_requests(&requests_dir);
+
+        for payload in &batch.payloads {
+            log::info!(
+                "[project-refresh-requests] Emitting refresh: project='{}' agent='{}'",
+                payload.project_path,
+                payload.agent_name
+            );
+            let _ = tauri::Emitter::emit(app, "ac_project_refresh_requested", payload);
+        }
+
+        for path in batch.processed_paths {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+
     /// Poll ~/.agentscommander/session-requests/ for launch requests from the CLI.
     async fn poll_session_requests(&self, app: &tauri::AppHandle) {
         let config_dir = match crate::config::config_dir() {
@@ -3536,6 +3660,99 @@ mod tests {
         let file = app_outbox.join("msg.json");
         std::fs::write(&file, "{}").unwrap();
         assert!(derive_project_from_outbox_path(&file).is_none());
+    }
+
+    fn write_project_refresh_request_fixture(
+        path: &Path,
+        id: &str,
+        project_path: &Path,
+        agent_name: &str,
+    ) {
+        let request = crate::cli::create_agent_matrix::ProjectRefreshRequest {
+            id: id.to_string(),
+            project_path: project_path.to_string_lossy().to_string(),
+            agent_path: project_path
+                .join(".ac-new")
+                .join("_agent_architect")
+                .to_string_lossy()
+                .to_string(),
+            agent_name: agent_name.to_string(),
+            reason: "createAgentMatrix".to_string(),
+            timestamp: "2026-05-28T20:00:00Z".to_string(),
+        };
+        std::fs::write(path, serde_json::to_string_pretty(&request).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn project_refresh_request_reader_skips_tmp_files() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let requests_dir = temp.path().join("project-refresh-requests");
+        std::fs::create_dir_all(&requests_dir).unwrap();
+        let project = temp.path().join("ProjectAlpha");
+        std::fs::create_dir_all(&project).unwrap();
+        let tmp_file = requests_dir.join("request.json.tmp");
+        write_project_refresh_request_fixture(
+            &tmp_file,
+            "request-tmp",
+            &project,
+            "ProjectAlpha/architect",
+        );
+
+        let batch = collect_project_refresh_requests(&requests_dir);
+
+        assert!(batch.payloads.is_empty());
+        assert!(batch.processed_paths.is_empty());
+        assert!(
+            tmp_file.is_file(),
+            "tmp file should be left for a future poll"
+        );
+    }
+
+    #[test]
+    fn project_refresh_request_reader_deletes_malformed_json() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let requests_dir = temp.path().join("project-refresh-requests");
+        std::fs::create_dir_all(&requests_dir).unwrap();
+        let bad_file = requests_dir.join("bad.json");
+        std::fs::write(&bad_file, "{not json").unwrap();
+
+        let batch = collect_project_refresh_requests(&requests_dir);
+
+        assert!(batch.payloads.is_empty());
+        assert!(batch.processed_paths.is_empty());
+        assert!(!bad_file.exists(), "malformed request should be deleted");
+    }
+
+    #[test]
+    fn project_refresh_request_reader_coalesces_same_project() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let requests_dir = temp.path().join("project-refresh-requests");
+        std::fs::create_dir_all(&requests_dir).unwrap();
+        let project = temp.path().join("ProjectAlpha");
+        std::fs::create_dir_all(project.join(".ac-new").join("_agent_architect")).unwrap();
+        write_project_refresh_request_fixture(
+            &requests_dir.join("a.json"),
+            "request-a",
+            &project,
+            "ProjectAlpha/architect",
+        );
+        write_project_refresh_request_fixture(
+            &requests_dir.join("b.json"),
+            "request-b",
+            &project,
+            "ProjectAlpha/planner",
+        );
+
+        let batch = collect_project_refresh_requests(&requests_dir);
+
+        assert_eq!(batch.payloads.len(), 1);
+        assert_eq!(batch.processed_paths.len(), 2);
+        let expected_project = std::fs::canonicalize(&project)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(batch.payloads[0].project_path, expected_project);
+        assert_eq!(batch.payloads[0].id, "request-a");
     }
 
     // ── Issue #223 deliver_wake integration placeholders ──

--- a/src-tauri/tests/cli_create_agent_matrix.rs
+++ b/src-tauri/tests/cli_create_agent_matrix.rs
@@ -89,6 +89,52 @@ fn session_request_paths(config_dir: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
+fn project_refresh_request_paths(config_dir: &Path) -> Vec<PathBuf> {
+    let requests_dir = config_dir.join("project-refresh-requests");
+    if !requests_dir.exists() {
+        return Vec::new();
+    }
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(&requests_dir)
+        .expect("read project-refresh-requests")
+        .map(|entry| entry.expect("entry").path())
+        .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("json"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn assert_single_project_refresh_request(config_dir: &Path, project: &Path) -> serde_json::Value {
+    let requests = project_refresh_request_paths(config_dir);
+    assert_eq!(
+        requests.len(),
+        1,
+        "expected exactly one project refresh request"
+    );
+    let request: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&requests[0]).expect("read request"))
+            .expect("project refresh request json");
+    uuid::Uuid::parse_str(request["id"].as_str().expect("id")).expect("id should be a uuid");
+    assert!(!request["timestamp"].as_str().expect("timestamp").is_empty());
+    let agent_dir = project.join(".ac-new").join("_agent_architect");
+    assert_eq!(
+        request["projectPath"].as_str().expect("projectPath"),
+        std::fs::canonicalize(project)
+            .expect("canonical project")
+            .to_string_lossy()
+            .as_ref()
+    );
+    assert_eq!(
+        request["agentPath"].as_str().expect("agentPath"),
+        std::fs::canonicalize(agent_dir)
+            .expect("canonical agent dir")
+            .to_string_lossy()
+            .as_ref()
+    );
+    assert_eq!(request["agentName"], "ProjectAlpha/architect");
+    assert_eq!(request["reason"], "createAgentMatrix");
+    request
+}
+
 #[test]
 fn create_agent_matrix_success_prints_json_and_writes_layout() {
     let tmp = Tmp::new("cli-create-agent-matrix-success");
@@ -138,6 +184,39 @@ fn create_agent_matrix_success_prints_json_and_writes_layout() {
     for dir in ["memory", "plans", "skills", "inbox", "outbox"] {
         assert!(agent_dir.join(dir).is_dir(), "missing {}", dir);
     }
+}
+
+#[test]
+fn create_agent_matrix_success_writes_project_refresh_request() {
+    let tmp = Tmp::new("cli-create-agent-matrix-success-refresh");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, minimal_settings());
+    let project = project_with_ac_new(tmp.path());
+    let project_s = project.to_string_lossy().to_string();
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent-matrix",
+            "--project",
+            &project_s,
+            "--name",
+            "Architect",
+            "--description",
+            "Build plans",
+        ])
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert_single_project_refresh_request(&config_dir, &project);
 }
 
 #[test]
@@ -230,6 +309,10 @@ fn create_agent_matrix_invalid_template_exits_1_without_target_dir() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("Unknown built-in role template"));
     assert!(!project.join(".ac-new").join("_agent_architect").exists());
+    assert!(
+        project_refresh_request_paths(&config_dir).is_empty(),
+        "invalid template must not write a project refresh request"
+    );
 }
 
 #[test]
@@ -348,6 +431,8 @@ fn create_agent_matrix_launch_writes_session_request() {
     );
     assert_eq!(request["sessionName"], "ProjectAlpha/architect");
     assert_eq!(request["agentId"], "codex");
+
+    assert_single_project_refresh_request(&config_dir, &project);
 }
 
 #[test]

--- a/src-tauri/tests/cli_create_agent_matrix.rs
+++ b/src-tauri/tests/cli_create_agent_matrix.rs
@@ -1,0 +1,288 @@
+//! Integration tests for the `create-agent-matrix` CLI verb.
+//!
+//! Each test copies the binary under test into a temp directory so
+//! `config_dir()` resolves to an isolated sibling config directory.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+struct Tmp(PathBuf);
+
+impl Drop for Tmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+impl Tmp {
+    fn new(prefix: &str) -> Self {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        std::process::id().hash(&mut h);
+        std::thread::current().id().hash(&mut h);
+        let path = std::env::temp_dir().join(format!(
+            "ac-{}-{}-{}",
+            prefix,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+            h.finish()
+        ));
+        std::fs::create_dir_all(&path).expect("create tmp dir");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+fn copy_binary_into(tmp: &Path) -> PathBuf {
+    let src = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let dst = tmp.join(src.file_name().expect("binary file name"));
+    std::fs::copy(src, &dst).expect("copy binary");
+    dst
+}
+
+fn config_dir_for_bin(bin: &Path) -> PathBuf {
+    let stem = bin
+        .file_stem()
+        .expect("bin stem")
+        .to_string_lossy()
+        .to_string();
+    bin.parent().expect("bin parent").join(format!(".{}", stem))
+}
+
+fn write_settings(config_dir: &Path, settings: serde_json::Value) {
+    std::fs::create_dir_all(config_dir).expect("create config dir");
+    std::fs::write(
+        config_dir.join("settings.json"),
+        serde_json::to_string_pretty(&settings).expect("settings json"),
+    )
+    .expect("write settings.json");
+}
+
+fn minimal_settings() -> serde_json::Value {
+    serde_json::json!({
+        "defaultShell": "powershell.exe",
+        "defaultShellArgs": [],
+        "agents": [],
+    })
+}
+
+fn project_with_ac_new(tmp: &Path) -> PathBuf {
+    let project = tmp.join("ProjectAlpha");
+    std::fs::create_dir_all(project.join(".ac-new")).expect("create .ac-new");
+    project
+}
+
+#[test]
+fn create_agent_matrix_success_prints_json_and_writes_layout() {
+    let tmp = Tmp::new("cli-create-agent-matrix-success");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, minimal_settings());
+    let project = project_with_ac_new(tmp.path());
+    let project_s = project.to_string_lossy().to_string();
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent-matrix",
+            "--project",
+            &project_s,
+            "--name",
+            "Architect",
+            "--description",
+            "Build plans",
+        ])
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
+    let agent_dir = project.join(".ac-new").join("_agent_architect");
+    assert_eq!(
+        json["agentPath"].as_str().expect("agentPath"),
+        agent_dir.to_string_lossy().as_ref()
+    );
+    assert_eq!(json["agentName"], "ProjectAlpha/architect");
+    assert_eq!(
+        json["rolePath"].as_str().expect("rolePath"),
+        agent_dir.join("Role.md").to_string_lossy().as_ref()
+    );
+    assert_eq!(json["launched"], false);
+    assert!(json["launchAgent"].is_null());
+    assert!(agent_dir.join("Role.md").is_file());
+    assert!(agent_dir.join("config.json").is_file());
+    for dir in ["memory", "plans", "skills", "inbox", "outbox"] {
+        assert!(agent_dir.join(dir).is_dir(), "missing {}", dir);
+    }
+}
+
+#[test]
+fn create_agent_matrix_invalid_template_exits_1_without_target_dir() {
+    let tmp = Tmp::new("cli-create-agent-matrix-invalid-template");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, minimal_settings());
+    let project = project_with_ac_new(tmp.path());
+    let project_s = project.to_string_lossy().to_string();
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent-matrix",
+            "--project",
+            &project_s,
+            "--name",
+            "Architect",
+            "--description",
+            "Build plans",
+            "--role-template",
+            "agency:not-real",
+        ])
+        .output()
+        .expect("spawn binary");
+
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("Unknown built-in role template"));
+    assert!(!project.join(".ac-new").join("_agent_architect").exists());
+}
+
+#[test]
+fn create_agent_matrix_honors_settings_flags() {
+    let tmp = Tmp::new("cli-create-agent-matrix-settings");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(
+        &config_dir,
+        serde_json::json!({
+            "defaultShell": "powershell.exe",
+            "defaultShellArgs": [],
+            "agents": [{
+                "id": "claude",
+                "label": "Claude",
+                "command": "claude",
+                "color": "#ffffff",
+                "excludeGlobalClaudeMd": true
+            }],
+            "injectRtkHook": true
+        }),
+    );
+    let project = project_with_ac_new(tmp.path());
+    let project_s = project.to_string_lossy().to_string();
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent-matrix",
+            "--project",
+            &project_s,
+            "--name",
+            "Architect",
+            "--description",
+            "Build plans",
+        ])
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let settings_path = project
+        .join(".ac-new")
+        .join("_agent_architect")
+        .join(".claude")
+        .join("settings.local.json");
+    let settings = std::fs::read_to_string(settings_path).expect("read settings.local.json");
+    assert!(settings.contains("claudeMdExcludes"));
+    assert!(settings.contains("PreToolUse"));
+}
+
+#[test]
+fn create_agent_matrix_launch_writes_session_request() {
+    let tmp = Tmp::new("cli-create-agent-matrix-launch");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(
+        &config_dir,
+        serde_json::json!({
+            "defaultShell": "powershell.exe",
+            "defaultShellArgs": [],
+            "agents": [{
+                "id": "codex",
+                "label": "Codex",
+                "command": "codex --ask-for-approval never",
+                "color": "#000000"
+            }]
+        }),
+    );
+    let project = project_with_ac_new(tmp.path());
+    let project_s = project.to_string_lossy().to_string();
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent-matrix",
+            "--project",
+            &project_s,
+            "--name",
+            "Architect",
+            "--description",
+            "Build plans",
+            "--launch",
+            "codex",
+        ])
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
+    assert_eq!(json["launched"], true);
+    assert_eq!(json["launchAgent"], "codex");
+
+    let requests_dir = config_dir.join("session-requests");
+    let requests: Vec<PathBuf> = std::fs::read_dir(&requests_dir)
+        .expect("read session-requests")
+        .map(|entry| entry.expect("entry").path())
+        .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("json"))
+        .collect();
+    assert_eq!(requests.len(), 1, "expected exactly one session request");
+
+    let request: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&requests[0]).expect("read request"))
+            .expect("request json");
+    let agent_dir = project.join(".ac-new").join("_agent_architect");
+    assert_eq!(
+        request["cwd"].as_str().expect("cwd"),
+        agent_dir.to_string_lossy().as_ref()
+    );
+    assert_eq!(request["sessionName"], "ProjectAlpha/architect");
+    assert_eq!(request["agentId"], "codex");
+}

--- a/src-tauri/tests/cli_create_agent_matrix.rs
+++ b/src-tauri/tests/cli_create_agent_matrix.rs
@@ -77,6 +77,18 @@ fn project_with_ac_new(tmp: &Path) -> PathBuf {
     project
 }
 
+fn session_request_paths(config_dir: &Path) -> Vec<PathBuf> {
+    let requests_dir = config_dir.join("session-requests");
+    if !requests_dir.exists() {
+        return Vec::new();
+    }
+    std::fs::read_dir(&requests_dir)
+        .expect("read session-requests")
+        .map(|entry| entry.expect("entry").path())
+        .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("json"))
+        .collect()
+}
+
 #[test]
 fn create_agent_matrix_success_prints_json_and_writes_layout() {
     let tmp = Tmp::new("cli-create-agent-matrix-success");
@@ -126,6 +138,62 @@ fn create_agent_matrix_success_prints_json_and_writes_layout() {
     for dir in ["memory", "plans", "skills", "inbox", "outbox"] {
         assert!(agent_dir.join(dir).is_dir(), "missing {}", dir);
     }
+}
+
+#[test]
+fn create_agent_matrix_local_template_writes_role_and_skills() {
+    let tmp = Tmp::new("cli-create-agent-matrix-local-template");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, minimal_settings());
+    let template_dir = config_dir.join("agent-templates").join("planner");
+    std::fs::create_dir_all(template_dir.join("skills").join("demo"))
+        .expect("create local template skills");
+    std::fs::write(
+        template_dir.join("Role.md"),
+        "---\nname: Planner\n---\n\n# Planner Template\n\nPlan carefully.\n",
+    )
+    .expect("write local template role");
+    std::fs::write(
+        template_dir.join("skills").join("demo").join("SKILL.md"),
+        "# Demo Skill\n",
+    )
+    .expect("write local template skill");
+    let project = project_with_ac_new(tmp.path());
+    let project_s = project.to_string_lossy().to_string();
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent-matrix",
+            "--project",
+            &project_s,
+            "--name",
+            "Architect",
+            "--description",
+            "Build plans",
+            "--role-template",
+            "local:planner",
+        ])
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let agent_dir = project.join(".ac-new").join("_agent_architect");
+    let role = std::fs::read_to_string(agent_dir.join("Role.md")).expect("read Role.md");
+    assert!(role.contains("## Role Profile"));
+    assert!(role.contains("# Planner Template"));
+    assert!(agent_dir
+        .join("skills")
+        .join("demo")
+        .join("SKILL.md")
+        .is_file());
 }
 
 #[test]
@@ -267,12 +335,7 @@ fn create_agent_matrix_launch_writes_session_request() {
     assert_eq!(json["launched"], true);
     assert_eq!(json["launchAgent"], "codex");
 
-    let requests_dir = config_dir.join("session-requests");
-    let requests: Vec<PathBuf> = std::fs::read_dir(&requests_dir)
-        .expect("read session-requests")
-        .map(|entry| entry.expect("entry").path())
-        .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("json"))
-        .collect();
+    let requests = session_request_paths(&config_dir);
     assert_eq!(requests.len(), 1, "expected exactly one session request");
 
     let request: serde_json::Value =
@@ -285,4 +348,113 @@ fn create_agent_matrix_launch_writes_session_request() {
     );
     assert_eq!(request["sessionName"], "ProjectAlpha/architect");
     assert_eq!(request["agentId"], "codex");
+}
+
+#[test]
+fn create_agent_matrix_whitespace_launch_command_warns_without_request() {
+    let tmp = Tmp::new("cli-create-agent-matrix-blank-launch");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(
+        &config_dir,
+        serde_json::json!({
+            "defaultShell": "powershell.exe",
+            "defaultShellArgs": [],
+            "agents": [{
+                "id": "codex",
+                "label": "Codex",
+                "command": "   \t  ",
+                "color": "#000000"
+            }]
+        }),
+    );
+    let project = project_with_ac_new(tmp.path());
+    let project_s = project.to_string_lossy().to_string();
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent-matrix",
+            "--project",
+            &project_s,
+            "--name",
+            "Architect",
+            "--description",
+            "Build plans",
+            "--launch",
+            "codex",
+        ])
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
+    assert_eq!(json["launched"], false);
+    assert!(json["launchAgent"].is_null());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("empty command"));
+    assert!(
+        session_request_paths(&config_dir).is_empty(),
+        "blank command must not write a launch request"
+    );
+}
+
+#[test]
+fn create_agent_blank_launch_command_warns_without_request() {
+    let tmp = Tmp::new("cli-create-agent-blank-launch");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(
+        &config_dir,
+        serde_json::json!({
+            "defaultShell": "powershell.exe",
+            "defaultShellArgs": [],
+            "agents": [{
+                "id": "codex",
+                "label": "Codex",
+                "command": "",
+                "color": "#000000"
+            }]
+        }),
+    );
+    let parent = tmp.path().join("Agents");
+    std::fs::create_dir_all(&parent).expect("create parent");
+    let parent_s = parent.to_string_lossy().to_string();
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent",
+            "--parent",
+            &parent_s,
+            "--name",
+            "Bot",
+            "--launch",
+            "codex",
+        ])
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
+    assert_eq!(json["launched"], false);
+    assert!(json["launchAgent"].is_null());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("empty command"));
+    assert!(
+        session_request_paths(&config_dir).is_empty(),
+        "blank command must not write a launch request"
+    );
 }

--- a/src-tauri/tests/cli_create_agent_matrix.rs
+++ b/src-tauri/tests/cli_create_agent_matrix.rs
@@ -406,6 +406,61 @@ fn create_agent_matrix_whitespace_launch_command_warns_without_request() {
 }
 
 #[test]
+fn create_agent_matrix_empty_launch_request_warns_without_request() {
+    let tmp = Tmp::new("cli-create-agent-matrix-empty-launch-request");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(
+        &config_dir,
+        serde_json::json!({
+            "defaultShell": "powershell.exe",
+            "defaultShellArgs": [],
+            "agents": [{
+                "id": "codex",
+                "label": "Codex",
+                "command": "codex --ask-for-approval never",
+                "color": "#000000"
+            }]
+        }),
+    );
+    let project = project_with_ac_new(tmp.path());
+    let project_s = project.to_string_lossy().to_string();
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent-matrix",
+            "--project",
+            &project_s,
+            "--name",
+            "Architect",
+            "--description",
+            "Build plans",
+            "--launch",
+            "",
+        ])
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
+    assert_eq!(json["launched"], false);
+    assert!(json["launchAgent"].is_null());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("not found in settings"));
+    assert!(
+        session_request_paths(&config_dir).is_empty(),
+        "empty launch request must not write a launch request"
+    );
+}
+
+#[test]
 fn create_agent_blank_launch_command_warns_without_request() {
     let tmp = Tmp::new("cli-create-agent-blank-launch");
     let bin = copy_binary_into(tmp.path());

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -12,6 +12,7 @@ import type {
   PhoneMessage,
   AgentInfo,
   AcDiscoveryResult,
+  AcProjectRefreshRequestedPayload,
   TeamConfigResult,
   WindowGeometry,
   TaskUpdateResult,
@@ -376,6 +377,15 @@ export function onAcWorkgroupTaskUpdated(
     task: string | null;
     taskTitle?: string;
   }>("ac_workgroup_task_updated", callback);
+}
+
+export function onAcProjectRefreshRequested(
+  callback: (data: AcProjectRefreshRequestedPayload) => void
+): Promise<UnlistenFn> {
+  return transport.listen<AcProjectRefreshRequestedPayload>(
+    "ac_project_refresh_requested",
+    callback
+  );
 }
 
 export function onSessionIdle(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -272,6 +272,14 @@ export interface AcDiscoveryResult {
   workgroups: AcWorkgroup[];
 }
 
+export interface AcProjectRefreshRequestedPayload {
+  id: string;
+  projectPath: string;
+  agentPath?: string;
+  agentName?: string;
+  reason: "createAgentMatrix";
+}
+
 // Team wizard shared types (used by NewTeamModal and EditTeamModal)
 
 export interface TeamWizardAgentEntry {

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -22,6 +22,7 @@ import {
   onTerminalDetached,
   onTerminalAttached,
   onWorkgroupTaskUpdated,
+  onAcProjectRefreshRequested,
 } from "../shared/ipc";
 import { taskFirstLine } from "../shared/markdown";
 import { registerShortcuts, unregisterShortcuts } from "../shared/shortcuts";
@@ -148,6 +149,12 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     ) {
       setShowOnboarding(true);
     }
+
+    unlisteners.push(
+      await onAcProjectRefreshRequested((data) => {
+        void projectStore.reloadProjectIfLoaded(data.projectPath);
+      })
+    );
 
     // Load saved project if any
     await projectStore.initFromSettings(

--- a/src/sidebar/stores/project-refresh.test.ts
+++ b/src/sidebar/stores/project-refresh.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  findLoadedProjectPathForRefresh,
+  normalizeProjectPathForCompare,
+} from "./project-refresh";
+
+describe("project refresh path matching", () => {
+  it("normalizes slashes case and trailing separators", () => {
+    expect(normalizeProjectPathForCompare("C:\\Users\\Maria\\Project\\")).toBe(
+      "c:/users/maria/project"
+    );
+    expect(normalizeProjectPathForCompare("C:/Users/Maria/Project///")).toBe(
+      "c:/users/maria/project"
+    );
+  });
+
+  it("returns the loaded path for an equivalent incoming path", () => {
+    const loadedPath = "C:\\Users\\Maria\\Project";
+
+    expect(
+      findLoadedProjectPathForRefresh(
+        [{ path: loadedPath }],
+        "c:/users/maria/project/"
+      )
+    ).toBe(loadedPath);
+  });
+
+  it("returns null for an unknown project path", () => {
+    expect(
+      findLoadedProjectPathForRefresh(
+        [{ path: "C:\\Users\\Maria\\Project" }],
+        "C:\\Users\\Maria\\Other"
+      )
+    ).toBeNull();
+  });
+});

--- a/src/sidebar/stores/project-refresh.ts
+++ b/src/sidebar/stores/project-refresh.ts
@@ -1,0 +1,15 @@
+export function normalizeProjectPathForCompare(path: string): string {
+  return path.replace(/\\/g, "/").toLowerCase().replace(/\/+$/, "");
+}
+
+export function findLoadedProjectPathForRefresh(
+  projects: readonly { readonly path: string }[],
+  incomingPath: string
+): string | null {
+  const normalizedIncoming = normalizeProjectPathForCompare(incomingPath);
+  const match = projects.find(
+    (project) =>
+      normalizeProjectPathForCompare(project.path) === normalizedIncoming
+  );
+  return match?.path ?? null;
+}

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -1,6 +1,10 @@
 import { createSignal } from "solid-js";
 import type { AcWorkgroup, AcAgentMatrix, AcTeam } from "../../shared/types";
 import { ProjectAPI, SettingsAPI, AgentCreatorAPI } from "../../shared/ipc";
+import {
+  findLoadedProjectPathForRefresh,
+  normalizeProjectPathForCompare,
+} from "./project-refresh";
 
 export interface ProjectState {
   path: string;
@@ -15,7 +19,7 @@ const [loading, setLoading] = createSignal(false);
 let loadingCount = 0;
 
 function normalizePath(p: string): string {
-  return p.replace(/\\/g, "/").toLowerCase().replace(/\/+$/, "");
+  return normalizeProjectPathForCompare(p);
 }
 
 export const projectStore = {
@@ -180,6 +184,14 @@ export const projectStore = {
     } catch (e) {
       console.error("Failed to reload project:", e);
     }
+  },
+
+  /** Re-discover a project only when it is already loaded in the sidebar. */
+  async reloadProjectIfLoaded(path: string): Promise<boolean> {
+    const loadedPath = findLoadedProjectPathForRefresh(projects(), path);
+    if (!loadedPath) return false;
+    await projectStore.reloadProject(loadedPath);
+    return true;
   },
 
   /** Remove a project from the list by path */


### PR DESCRIPTION
## Summary

Closes #309.

Adds a `create-agent-matrix` CLI verb that creates the same full Agent Matrix layout as the UI flow, including `Role.md`, canonical Matrix directories, `config.json`, role-template resolution, best-effort template `skills/` copy, settings-file updates, and optional launch request support.

The implementation refactors the existing UI Matrix creation path into shared backend helpers instead of duplicating layout/template behavior. It also hardens CLI automation cases found during review:

- atomically claims the target Matrix root to avoid concurrent overwrite races
- rejects blank configured launch commands without failing creation
- rejects empty or whitespace `--launch` selectors before fuzzy matching
- updates generated agent context so explicit `AGENTSCOMMANDER_BINARY_PATH` operations are allowed even when AgentsCommander itself writes outside normal repo/replica zones, while direct shell writes and scripts remain forbidden
- writes a project refresh request after successful `create-agent-matrix`, consumed by the mailbox poller as local Tauri event `ac_project_refresh_requested`
- refreshes already-loaded sidebar projects from that event so newly created agents appear without a full app reload

Teams, workgroups, membership wiring, replica creation, and remote WebSocket refresh parity remain out of scope for #309 and are still tracked by #241 or future work.

## Validation

- `cargo check`
- `cargo clippy`
- `cargo test create_agent_matrix_on_disk`
- `cargo test build_session_request`
- `cargo test --test cli_create_agent_matrix` (9 passed)
- `cargo test project_refresh_request`
- `cargo test agent_matrix_settings_flags`
- `cargo test apply_agent_matrix_settings_files`
- `cargo test find_launch_agent`
- `cargo test default_context --lib` (13 passed)
- `cargo test agentscommander_cli_exception`
- `cargo test --lib --bins --tests -- --test-threads=1` (764 passed, 12 ignored, integration test binaries passed)
- `cargo build --manifest-path .\src-tauri\Cargo.toml --locked --offline`
- `npx tsc --noEmit`
- `npm test -- project-refresh`
- `npm test` (11 files / 132 tests)
- `npx tauri build`

External CLI validation covered success path, invalid template no-mutation/no-refresh-request, local template application and skills copy, settings flags, valid launch request creation, invalid/empty/whitespace launch selectors, configured launch agents with empty commands, generated `AGENTS.md` CLI-operation exception, and refresh request JSON/schema behavior.

Adversarial review approved the backend/frontend refresh contract with no findings. Full visible branch-GUI sidebar refresh was not directly observed in the tester environment because the live app binary was not the branch build; coverage comes from mailbox event tests plus frontend listener/store tests.

## Notes

- Existing Codex replicas need to be respawned after this change is deployed before they load the updated generated `AGENTS.md` policy.
- A default `cargo test` reaches the known local Windows doctest blocker: `rustdoc.exe` is not applicable to the `stable-x86_64-pc-windows-msvc` toolchain.
- A default parallel non-doctest run exposed an existing global-current-dir test race; the affected test passes isolated and the serial non-doctest suite passes.
- The deployed standalone wg-1 binary must be rebuilt from `d08da41` or newer to include both `create-agent-matrix` and sidebar refresh support.