### PR TITLE
docs(readme): mention Root Agent coordination (#347)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 ## The 30-second pitch
 
 - **Pick the coding agent per role.** Claude Code on architecture, Codex on dev, Gemini on review, or any mix. Each runs in its own real terminal with a full PTY, not a command runner.
+- **Direct teams from the Root Agent.** The Agent Commander / Root Agent gives you one place to steer work across teams. Ask it to talk to workgroup coordinators, send work to different teams, and keep initiatives aligned across workgroups.
 - **Multi-agent Teams that coordinate through files.** Agents exchange markdown messages in a `messaging/` folder you can `cat`, `git diff`, and audit. The whole org fits in `ls`.
 - **Local state, no telemetry.** All state lives in plain JSON, TOML, and markdown next to the binary. Portable: copy the `.exe` to any drive and it carries its own config.
 

--- a/docs/home-en.md
+++ b/docs/home-en.md
@@ -2,6 +2,8 @@
 
 You opened AgentsCommander. Start here when you want to turn a project, a set of agent roles, and one task into a running workgroup.
 
+Use the Agent Commander / Root Agent when work spans more than one team. It gives you one place to talk to workgroup coordinators, ask different teams to take on tasks, and keep initiatives aligned across workgroups.
+
 ## Start fast
 
 1. Open or create an AgentsCommander project.


### PR DESCRIPTION
Closes #347

Adds a visible Root Agent / Agent Commander mention to the public README and mirrors the guidance lightly in the in-app Home page.