### PR TITLE
docs: update public roadmap and positioning (#351)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">Agents Commander</h1>
 
 <p align="center">
-  Run a team of AI coding agents (Claude Code, Codex, Gemini) in visible terminals, coordinating through files you can read.<br/>
-  File-based workflows, real OS processes, and no hidden orchestration state.
+  Run multiple teams of AI coding agents (Claude Code, Codex, Gemini) across separate workgroup instances.<br/>
+  Root Agent coordination, visible terminals, and file-based workflows you can inspect.
 </p>
 
 <p align="center">
@@ -31,8 +31,9 @@
 ## The 30-second pitch
 
 - **Pick the coding agent per role.** Claude Code on architecture, Codex on dev, Gemini on review, or any mix. Each runs in its own real terminal with a full PTY, not a command runner.
-- **Direct teams from the Root Agent.** The Agent Commander / Root Agent gives you one place to steer work across teams. Ask it to talk to workgroup coordinators, send work to different teams, and keep initiatives aligned across workgroups.
+- **Direct multiple workgroups from the Root Agent.** The Agent Commander / Root Agent gives you one place to steer work across teams. Ask it to talk to workgroup coordinators, send work to different teams, and keep initiatives aligned across parallel workgroups.
 - **Multi-agent Teams that coordinate through files.** Agents exchange markdown messages in a `messaging/` folder you can `cat`, `git diff`, and audit. The whole org fits in `ls`.
+- **Phone-ready updates with images.** The Telegram bridge can stream session output and send photos or screenshots captured by agents, so remote status can include the actual screen or report.
 - **Local state, no telemetry.** All state lives in plain JSON, TOML, and markdown next to the binary. Portable: copy the `.exe` to any drive and it carries its own config.
 
 You bring the coding agents. AgentsCommander coordinates them.
@@ -66,7 +67,7 @@ Most agent tools focus on in-process orchestration or one interactive session. A
 | **Parallel feature development** | Two coding agents on the same repo, each owning a different module. Coordinator routes work and merges results. |
 | **Code-review swarm** | One agent ships a PR; two others review independently. You read both reviews in their own terminals before merging. |
 | **Autonomous refactor crew** | A long-running coordinator splits a multi-file refactor across worker agents and rebases their branches as they finish. |
-| **Long-running agent with phone alerts** | Pair a session with a [Telegram bot](docs/features/telegram-bridge.md) and kick off a build from your phone. Go to bed; wake to a finished diff. |
+| **Long-running agent with phone alerts** | Pair a session with a [Telegram bot](docs/features/telegram-bridge.md), kick off a build from your phone, and receive text updates plus screenshots or image artifacts. |
 
 Full recipes: [`docs/use-cases.md`](docs/use-cases.md).
 
@@ -96,7 +97,7 @@ These are not accidents.
 - [Quickstart](docs/quickstart.md): 60-second download to first running agent
 - [Concepts](docs/concepts.md): agent, team, workgroup, coordinator, brief
 - [Teams and workgroups](docs/agents/teams-and-workgroups.md): coordinators, members, briefs, messaging
-- [Features](docs/features/): Telegram bridge, voice-to-text, portable instances, RTK integration
+- [Features](docs/features/): Telegram bridge with image and screenshot sends, voice-to-text, portable instances, RTK integration
 - [Reference](docs/reference/): full CLI, `settings.json` schema, architecture, log filtering
 - [Roadmap](ROADMAP.md) · [Changelog](CHANGELOG.md) · [Docs style guide](docs/style-guide.md)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ This file is a snapshot. The authoritative status for any item lives in its link
 - Multi-agent workgroups with file-based inter-agent messaging
 - Cross-coding-agent profiles: Claude Code · Codex · Gemini
 - Agents Agency role-template picker (vendored snapshot of [@msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents))
-- Telegram bridge (PTY-mode + JSONL reader-mode per agent)
+- Telegram bridge (PTY-mode + JSONL reader-mode per agent, plus photo/image sends for screenshots and artifacts)
 - Voice-to-text via Gemini API with auto-execute
 - Portable instances (rename the `.exe` → isolated workspace, ports, mutex, config)
 - Embedded HTTP/WebSocket server (per-instance, opt-in)
@@ -20,39 +20,41 @@ This file is a snapshot. The authoritative status for any item lives in its link
 
 ### Coding-agent integrations
 
-- **OpenCode** — first-class profile alongside Claude Code, Codex, Gemini. ([#315](https://github.com/mblua/AgentsCommander/issues/315))
-- **NVIDIA OpenShell** — sandbox-runtime integration (not a coding-agent profile; OpenShell hosts other coding agents inside a policy-driven sandbox). ([#316](https://github.com/mblua/AgentsCommander/issues/316))
+- **OpenCode** - first-class profile alongside Claude Code, Codex, Gemini. ([#315](https://github.com/mblua/AgentsCommander/issues/315))
+- **NVIDIA OpenShell** - sandbox-runtime integration (not a coding-agent profile; OpenShell hosts other coding agents inside a policy-driven sandbox). ([#316](https://github.com/mblua/AgentsCommander/issues/316))
 
 ### Per-agent configuration
 
-- **Per-agent model + effort-level selection** — pin a specific model (e.g. Opus 4.7 vs Sonnet 4.6) and a thinking-effort tier (low / medium / high / ultra) to each agent independently. Today the choice is per-session at launch time; this would persist per `_agent_<name>` in the matrix and survive across workgroups. ([#329](https://github.com/mblua/AgentsCommander/issues/329))
+- **Per-agent model + effort-level selection** - pin a specific model (e.g. Opus 4.7 vs Sonnet 4.6) and a thinking-effort tier (low / medium / high / ultra) to each agent independently. Today the choice is per-session at launch time; this would persist per `_agent_<name>` in the matrix and survive across workgroups. ([#329](https://github.com/mblua/AgentsCommander/issues/329))
 
 ### Organigram & scaling
 
-- **Build the company — multi-level coordinator hierarchies** — A workgroup today is one layer. The next step layers them: level-A coordinator talks to its level-B reports; B talks to C; A never reaches C directly. Skip-levels flow through the chain, like in any sane org. The result: a real organigram, enforced by the messaging topology instead of by convention. Cascade decisions down, roll status up, hold accountability at 5, 50, or 500 agents the same way. ([#330](https://github.com/mblua/AgentsCommander/issues/330))
+- **Build the company - multi-level coordinator hierarchies** - A workgroup today is one layer. The next step layers them: level-A coordinator talks to its level-B reports; B talks to C; A never reaches C directly. Skip-levels flow through the chain, like in any sane org. The result: a real organigram, enforced by the messaging topology instead of by convention. Cascade decisions down, roll status up, hold accountability at 5, 50, or 500 agents the same way. ([#330](https://github.com/mblua/AgentsCommander/issues/330))
+- **Coordinator auto-handoff for context management** - when a coordinator reaches a configurable context threshold, it can write a compact handoff of active continuity state and continue fresh. Forgettable or exclude-from-handoff details stay out. ([#349](https://github.com/mblua/AgentsCommander/issues/349))
+- **Telegram conversation routing between coordinators** - transfer a Telegram conversation from one coordinator/workgroup to another without manual bot or channel reconfiguration. ([#350](https://github.com/mblua/AgentsCommander/issues/350))
 
 ### CLI capabilities
 
-- **`create-workgroup` / `create-team` / `create-project`** — non-interactive equivalents of the existing `create-agent` flow for headless / script-driven setup. ([#317](https://github.com/mblua/AgentsCommander/issues/317))
+- **`create-workgroup` / `create-team` / `create-project`** - non-interactive equivalents of the existing `create-agent` flow for headless / script-driven setup. ([#317](https://github.com/mblua/AgentsCommander/issues/317))
 
 ### Execution determinism
 
-- **AC Harness** — deterministic command-execution layer that complements RTK, plus extending RTK compatibility beyond Claude to Codex, Gemini, and future agents (today only Claude's `.claude/settings.local.json` hook is wired). ([#318](https://github.com/mblua/AgentsCommander/issues/318))
+- **AC Harness** - deterministic command-execution layer that complements RTK, plus extending RTK compatibility beyond Claude to Codex, Gemini, and future agents (today only Claude's `.claude/settings.local.json` hook is wired). ([#318](https://github.com/mblua/AgentsCommander/issues/318))
 
 ### Interoperability
 
-- **Export AC agent configs** to **LangChain Deep Agents**, **OpenAI Agents SDK**, and **CrewAI** — author an agent once in AC, run it programmatically anywhere. ([#319](https://github.com/mblua/AgentsCommander/issues/319))
+- **Export AC agent configs** to **LangChain Deep Agents**, **OpenAI Agents SDK**, and **CrewAI** - author an agent once in AC, run it programmatically anywhere. ([#319](https://github.com/mblua/AgentsCommander/issues/319))
 
 ### Platform
 
-- **macOS first-class verification** — testers wanted. ([#320](https://github.com/mblua/AgentsCommander/issues/320))
+- **macOS first-class verification** - testers wanted. ([#320](https://github.com/mblua/AgentsCommander/issues/320))
 - **Web landing page** on `agentscommander.dev` or GitHub Pages from `/docs`. ([#321](https://github.com/mblua/AgentsCommander/issues/321))
 
 ## Considering
 
-- **Discord community** — defer until star count justifies it (~500 stars). ([#322](https://github.com/mblua/AgentsCommander/issues/322))
-- `docs/recipes/` — end-to-end multi-agent walkthroughs
-- **`cargo udeps` cleanup** — audit and trim unused crates (start with `futures` vs `futures-util`). ([#323](https://github.com/mblua/AgentsCommander/issues/323))
+- **Discord community** - defer until star count justifies it (~500 stars). ([#322](https://github.com/mblua/AgentsCommander/issues/322))
+- `docs/recipes/` - end-to-end multi-agent walkthroughs
+- **`cargo udeps` cleanup** - audit and trim unused crates (start with `futures` vs `futures-util`). ([#323](https://github.com/mblua/AgentsCommander/issues/323))
 
 ---
 

--- a/docs/assets/og-card.svg
+++ b/docs/assets/og-card.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
      width="1200" height="630" viewBox="0 0 1200 630">
-  <title>AgentsCommander &#8212; Open Graph card</title>
+  <title>AgentsCommander - Open Graph card</title>
   <desc>1200x630 social preview. Helmet mark on left, wordmark and tagline on right, atmospheric terminal-row hint along the bottom edge. All colors from the locked Noir palette in src/sidebar/styles/variables.css. Helmet PNG is embedded as base64 so the SVG renders identically anywhere (librsvg blocks external file refs).</desc>
 
   <defs>
@@ -48,9 +48,9 @@
         font-weight="400"
         fill="#00d4ff"
         letter-spacing="-0.2">
-    <tspan x="490" dy="0">Run a team of AI coding agents &#8212;</tspan>
-    <tspan x="490" dy="38">Claude Code, Codex, Gemini &#8212;</tspan>
-    <tspan x="490" dy="38">coordinating through files you can read.</tspan>
+    <tspan x="490" dy="0">Run multiple AI coding-agent teams</tspan>
+    <tspan x="490" dy="38">across workgroup instances</tspan>
+    <tspan x="490" dy="38">with files you can read.</tspan>
   </text>
 
   <rect x="0" y="510" width="1200" height="1" fill="#ffffff" opacity="0.05"/>

--- a/docs/features/telegram-bridge.md
+++ b/docs/features/telegram-bridge.md
@@ -10,6 +10,7 @@ Once a bot is attached to a session:
 
 - **Outbound**: PTY output is parsed by a vt100 cleaner, filtered (no spinners, box-drawing, low-alpha rows), chunked at 4000 characters, rate-limited, and sent to Telegram as plain text messages.
 - **Inbound**: Telegram messages from the bot's authorized chat are written into the session's PTY as if you typed them.
+- **Images and files**: AC can send photos/images and documents to a configured bot with `telegram-send-image`, including screenshots captured by agents during a run.
 
 The bridge is per session. You can attach different bots to different sessions, or no bot at all.
 
@@ -17,12 +18,13 @@ The bridge is per session. You can attach different bots to different sessions, 
 
 - Overnight builds. Send the agent the prompt before bed; check the chat in the morning; reply if it asks a question.
 - Long refactors. Watch periodic status updates from your phone while doing other work.
+- Visual status. Ask an agent to capture a screenshot of a report, app state, or test result and send it to Telegram.
 - Remote operations. Kick off a `gh pr review` from anywhere with a Telegram client.
 
 ## When not to use it
 
 - High-volume real-time PTY output. Telegram rate-limits and chunking add latency; bursty TUI output may be heavily filtered before it reaches the chat.
-- Sensitive content. Telegram is not end-to-end encrypted by default (only Secret Chats are). The bridge sends terminal output through Telegram's servers — see [`PRIVACY.md`](../../PRIVACY.md).
+- Sensitive content. Telegram is not end-to-end encrypted by default (only Secret Chats are). The bridge sends terminal output through Telegram's servers - see [`PRIVACY.md`](../../PRIVACY.md).
 - Untrusted networks. The bot token grants control of the bot's chats; if you commit `settings.json` by accident you must rotate.
 
 ## Coding-agent reader modes
@@ -55,7 +57,13 @@ Spinners, progress bars, and chrome are filtered out. Only "stable" output rows 
 
 Plain text. Your message is written verbatim into the session's PTY as if you typed it on the keyboard, followed by a newline. Multi-line messages are sent line by line.
 
-There is no slash-command syntax — anything you would type in the terminal works.
+There is no slash-command syntax - anything you would type in the terminal works.
+
+## Sending images and screenshots
+
+Use `agentscommander telegram-send-image` to send a photo, screenshot, or file from any shell that can access your configured bot. Images with `jpg`, `jpeg`, `png`, or `webp` extensions are sent as Telegram photos when they fit the size limit; other files are sent as documents.
+
+For the full command and setup flow, see [Telegram setup](../integrations/telegram.md#sending-photos-images-and-screenshots-from-the-cli).
 
 ## State and indicators
 
@@ -79,5 +87,5 @@ For the data-flow detail, see [`PRIVACY.md`](../../PRIVACY.md).
 
 ## See also
 
-- [Telegram setup](../integrations/telegram.md) — step-by-step
-- [`docs/troubleshooting.md#telegram-bridge`](../troubleshooting.md#telegram-bridge) — common failures
+- [Telegram setup](../integrations/telegram.md) - step-by-step
+- [`docs/troubleshooting.md#telegram-bridge`](../troubleshooting.md#telegram-bridge) - common failures

--- a/docs/home-en.md
+++ b/docs/home-en.md
@@ -1,8 +1,8 @@
 # AgentsCommander
 
-You opened AgentsCommander. Start here when you want to turn a project, a set of agent roles, and one task into a running workgroup.
+You opened AgentsCommander. Start here when you want to turn a project, a set of agent roles, and one or more tasks into coordinated workgroups.
 
-Use the Agent Commander / Root Agent when work spans more than one team. It gives you one place to talk to workgroup coordinators, ask different teams to take on tasks, and keep initiatives aligned across workgroups.
+Use the Agent Commander / Root Agent when work spans more than one team or workgroup instance. It gives you one place to talk to workgroup coordinators, ask different teams to take on tasks, and keep initiatives aligned across parallel workgroups.
 
 ## Start fast
 
@@ -10,8 +10,8 @@ Use the Agent Commander / Root Agent when work spans more than one team. It give
    Use an existing repo or create a new project folder. AgentsCommander stores the project workspace, agents, teams, and message files inside that project.
 2. Create the agents you need.
    Give each agent one clear role, such as coordinator, backend developer, reviewer, tester, or technical writer. Clear roles make delegation easier to review.
-3. Create a team or workgroup.
-   Pick one coordinator and add the worker agents that should handle the task. The coordinator plans and delegates; workers focus on their assigned parts.
+3. Create teams or workgroups.
+   Pick one coordinator per team and add the worker agents that should handle the task. Coordinators plan and delegate; workers focus on their assigned parts.
 4. Launch the coordinator.
    Open the coordinator session from the sidebar and choose the coding-agent runtime when prompted.
 5. Send the first task.

--- a/docs/integrations/telegram.md
+++ b/docs/integrations/telegram.md
@@ -11,7 +11,7 @@ In any Telegram client, talk to [@BotFather](https://t.me/BotFather):
 1. Send `/newbot`.
 2. Pick a display name (e.g. *My AC Bot*).
 3. Pick a username ending in `bot` (e.g. *my_ac_bot*).
-4. BotFather replies with a **bot token** — a string like `1234567890:ABCDEF...`.
+4. BotFather replies with a **bot token** - a string like `1234567890:ABCDEF...`.
 
 Save the token. Anyone with it can control the bot.
 
@@ -33,13 +33,13 @@ In AgentsCommander:
 1. Open **Settings → Integrations → Telegram**.
 2. Click **+ Bot**.
 3. Fill in:
-   - **Label** — a human-friendly name (e.g. *Personal bot*).
-   - **Token** — the BotFather token from step 1.
-   - **Chat ID** — the integer from step 2.
+   - **Label** - a human-friendly name (e.g. *Personal bot*).
+   - **Token** - the BotFather token from step 1.
+   - **Chat ID** - the integer from step 2.
 4. Click **Test** to fire a hello message. If your phone buzzes, you are configured.
 5. **Save**.
 
-The bot configuration is stored locally in `settings.json` under `telegramBots[]`. The token is in plaintext — protect access to your user account.
+The bot configuration is stored locally in `settings.json` under `telegramBots[]`. The token is in plaintext - protect access to your user account.
 
 ## 4. Attach to a session
 
@@ -52,9 +52,9 @@ The Telegram icon appears on the session item. From this moment:
 
 Detach with **right-click → Detach Telegram bot**.
 
-## Sending an image from the CLI
+## Sending photos, images, and screenshots from the CLI
 
-You can send a one-off image or file to a configured bot from any shell:
+You can send a one-off photo, image, screenshot, or file to a configured bot from any shell. Agents can use the same command to send screenshots they captured during a run:
 
 ```bash
 agentscommander telegram-send-image \
@@ -72,11 +72,11 @@ agentscommander telegram-send-image \
 
 Files ≤10 MB with extensions `jpg/jpeg/png/webp` use `sendPhoto`. Everything else (including GIF) falls back to `sendDocument`, capped at 50 MB.
 
-Useful for ending an overnight run with a screenshot of the test report.
+Use it to end an overnight run with a screenshot of the test report, a UI state, or another image artifact.
 
 ## Privacy
 
-The bridge sends terminal output through Telegram's servers — see [`PRIVACY.md`](../../PRIVACY.md). Telegram is not end-to-end encrypted outside Secret Chats. If you handle sensitive data, do not attach a bot to those sessions.
+The bridge sends terminal output through Telegram's servers - see [`PRIVACY.md`](../../PRIVACY.md). Telegram is not end-to-end encrypted outside Secret Chats. If you handle sensitive data, do not attach a bot to those sessions.
 
 ## Troubleshooting
 
@@ -91,6 +91,6 @@ More: [`docs/troubleshooting.md#telegram-bridge`](../troubleshooting.md#telegram
 
 ## See also
 
-- [Telegram bridge — feature page](../features/telegram-bridge.md)
-- [CLI reference — `telegram-send-image`](../reference/cli.md#telegram-send-image)
-- [Settings reference — `telegramBots`](../reference/settings.md)
+- [Telegram bridge - feature page](../features/telegram-bridge.md)
+- [CLI reference - `telegram-send-image`](../reference/cli.md#telegram-send-image)
+- [Settings reference - `telegramBots`](../reference/settings.md)


### PR DESCRIPTION
Closes #351
Closes #352

Updates public positioning around multiple teams and workgroup instances, documents Telegram image/screenshot sends, and adds roadmap links for coordinator auto-handoff (#349) and Telegram coordinator routing (#350).