### PR TITLE
Use .ac as canonical workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You bring the coding agents. AgentsCommander coordinates them.
 
 1. **Download** the latest installer for your platform from [the releases page](https://github.com/mblua/AgentsCommander/releases/latest). Windows `.exe`, Linux `.AppImage`, and macOS `.dmg` are built on every release.
 2. **Run** the installer (or run the portable `.exe` directly; see [Portable instances](docs/features/portable-instances.md)).
-3. **Open a project**: click `New Project` in the sidebar and point it at an empty folder. AC creates an `.ac-new/` workspace there.
+3. **Open a project**: click `New Project` in the sidebar and point it at an empty folder. AC creates an `.ac/` workspace there. Existing `.ac-new/` projects still open as legacy projects.
 4. **Create a Team**: add a coordinator and one worker agent, each with a role prompt. [Teams and workgroups](docs/agents/teams-and-workgroups.md) walks through this.
 5. **Launch the coordinator**: pick Claude Code, Codex, or Gemini from the dropdown. Ask it to send the worker a hello message. The worker terminal receives a file notification and responds in real time.
 

--- a/docs/agent-matrix-conventions.md
+++ b/docs/agent-matrix-conventions.md
@@ -8,10 +8,12 @@ This document is the definitive guide for any AI agent tasked with creating or m
 
 | Concept | Prefix | Location | Purpose |
 |---|---|---|---|
-| **Agent** | `_agent_` | `.ac-new/_agent_NAME/` | A role definition — who this agent is, what it does, what it must never do |
-| **Team** | `_team_` | `.ac-new/_team_NAME/` | A grouping of agents that can message each other via `list-peers` / `send` |
-| **Workgroup** | `wg-` | `.ac-new/wg-N-TEAMNAME/` | An isolated working environment with cloned agents + cloned repo for parallel work |
-| **Workgroup Agent** | `__agent_` | `.ac-new/wg-N-TEAMNAME/__agent_NAME/` | A replica of a project-level agent inside a workgroup (double underscore) |
+| **Agent** | `_agent_` | `.ac/_agent_NAME/` | A role definition: who this agent is, what it does, what it must never do |
+| **Team** | `_team_` | `.ac/_team_NAME/` | A grouping of agents that can message each other via `list-peers` / `send` |
+| **Workgroup** | `wg-` | `.ac/wg-N-TEAMNAME/` | An isolated working environment with cloned agents + cloned repo for parallel work |
+| **Workgroup Agent** | `__agent_` | `.ac/wg-N-TEAMNAME/__agent_NAME/` | A replica of a project-level agent inside a workgroup (double underscore) |
+
+`.ac/` is the canonical workspace directory. Legacy `.ac-new/` projects use the same layout when `.ac/` is absent.
 
 **Hierarchy:** Project → Agents + Teams → Workgroups (with replicated agents + repo clones)
 
@@ -24,7 +26,7 @@ Project-level agents appear in the **AGENTS** section of the AgentsCommander sid
 ### Folder Structure
 
 ```
-.ac-new/_agent_NAME/
+.ac/_agent_NAME/
 ├── Role.md          # REQUIRED — the agent's identity, responsibilities, and rules
 ├── inbox/           # Created by AC on first use — incoming messages
 ├── outbox/          # Created by AC on first use — outgoing messages
@@ -50,7 +52,7 @@ type: agent
 
 ## Source of Truth
 
-This role is defined in Role.md of your Agent Matrix at: .ac-new/_agent_NAME/
+This role is defined in Role.md of your Agent Matrix at: .ac/_agent_NAME/
 If you are running as a replica, this file was generated from that source.
 Always use memory/ and plans/ from your Agent Matrix, and treat Role.md there as the canonical role definition. Never use external memory systems.
 
@@ -123,7 +125,7 @@ Teams define which agents can communicate with each other via `list-peers` and `
 ### Folder Structure
 
 ```
-.ac-new/_team_NAME/
+.ac/_team_NAME/
 ├── config.json      # REQUIRED — defines members, coordinator, and repos
 ├── conventions.md   # Optional — shared conventions across the team
 └── memory/          # Optional — shared team memory
@@ -134,17 +136,17 @@ Teams define which agents can communicate with each other via `list-peers` and `
 ```json
 {
   "agents": [
-    "C:\\Users\\USER\\path\\to\\project\\.ac-new\\_agent_one",
-    "C:\\Users\\USER\\path\\to\\project\\.ac-new\\_agent_two",
-    "C:\\Users\\USER\\path\\to\\project\\.ac-new\\_agent_three"
+    "C:\\Users\\USER\\path\\to\\project\\.ac\\_agent_one",
+    "C:\\Users\\USER\\path\\to\\project\\.ac\\_agent_two",
+    "C:\\Users\\USER\\path\\to\\project\\.ac\\_agent_three"
   ],
-  "coordinator": "C:\\Users\\USER\\path\\to\\project\\.ac-new\\_agent_one",
+  "coordinator": "C:\\Users\\USER\\path\\to\\project\\.ac\\_agent_one",
   "repos": [
     {
       "agents": [
-        "C:\\Users\\USER\\path\\to\\project\\.ac-new\\_agent_one",
-        "C:\\Users\\USER\\path\\to\\project\\.ac-new\\_agent_two",
-        "C:\\Users\\USER\\path\\to\\project\\.ac-new\\_agent_three"
+        "C:\\Users\\USER\\path\\to\\project\\.ac\\_agent_one",
+        "C:\\Users\\USER\\path\\to\\project\\.ac\\_agent_two",
+        "C:\\Users\\USER\\path\\to\\project\\.ac\\_agent_three"
       ],
       "url": "https://github.com/owner/repo.git"
     }
@@ -162,11 +164,11 @@ Teams define which agents can communicate with each other via `list-peers` and `
 
 ### Critical Rules for Team Config
 
-1. **Use absolute paths.** The `agents` array and `coordinator` must be absolute filesystem paths to `_agent_*` folders within the SAME project's `.ac-new/` directory.
+1. **Use absolute paths.** The `agents` array and `coordinator` must be absolute filesystem paths to `_agent_*` folders within the SAME project's `.ac/` directory.
 
 2. **Agents must exist.** Every path in the `agents` array must point to an existing `_agent_*` folder with a `Role.md`. If the folder doesn't exist, the agent won't appear.
 
-3. **Don't reference external projects.** If you're building a team for project A, the agents must be `_agent_*` folders inside project A's `.ac-new/`. Referencing agents from project B (e.g., `C:\repos\other-project\.ac-new\_agent_foo`) makes them appear as `@other-project` in the sidebar — they belong to the wrong project.
+3. **Don't reference external projects.** If you're building a team for project A, the agents must be `_agent_*` folders inside project A's `.ac/`. Referencing agents from project B (e.g., `C:\repos\other-project\.ac\_agent_foo`) makes them appear as `@other-project` in the sidebar; they belong to the wrong project.
 
 4. **The coordinator must be in the agents list.** The coordinator path must also appear in the `agents` array.
 
@@ -181,7 +183,7 @@ Workgroups are isolated working environments created when a team needs to work o
 ### Folder Structure
 
 ```
-.ac-new/wg-N-TEAMNAME/
+.ac/wg-N-TEAMNAME/
 ├── TASK.md                    # Objective, scope, and deliverables for this workgroup
 ├── __agent_NAME/               # Replica of _agent_NAME (double underscore)
 │   ├── config.json             # Points to parent agent's identity + local repo
@@ -227,13 +229,13 @@ Workgroups are isolated working environments created when a team needs to work o
 3. **Repo prefix:** Cloned repos inside workgroups use `repo-` prefix (e.g., `repo-AgentsCommander`). This is critical — the golden rule allows write access only to `repo-*` folders.
 4. **Context paths:** Use relative paths (`../../_agent_NAME/Role.md`) so the workgroup is portable.
 5. **Role.md override:** If you place a Role.md inside the `__agent_*` folder, it overrides the parent's role. To use the parent's role, reference it in `context` instead.
-6. **.gitignore:** The `.ac-new/.gitignore` MUST exclude `wg-*/` to prevent the parent repo's git operations from corrupting workgroup clones.
+6. **.gitignore:** The `.ac/.gitignore` MUST exclude `wg-*/` to prevent the parent repo's git operations from corrupting workgroup clones.
 
 ---
 
 ## 4. project-settings.json
 
-Located at `.ac-new/project-settings.json`. Defines the coding agent configurations available for the project.
+Located at `.ac/project-settings.json`. Defines the coding agent configurations available for the project.
 
 ```json
 {
@@ -263,7 +265,7 @@ Located at `.ac-new/project-settings.json`. Defines the coding agent configurati
 
 ## 5. The .gitignore
 
-**MANDATORY** at `.ac-new/.gitignore`:
+**MANDATORY** at `.ac/.gitignore`:
 
 ```
 # AgentsCommander: exclude workgroup cloned repos from parent git tracking.
@@ -279,10 +281,10 @@ This is non-negotiable. Without it, `git checkout` or `git reset` on the parent 
 
 When creating a full agent team for a new project:
 
-### Step 1 — Create `.ac-new/` structure
+### Step 1: Create `.ac/` structure
 
 ```
-.ac-new/
+.ac/
 ├── .gitignore                    # Must exclude wg-*/
 ├── project-settings.json         # Coding agent config
 ├── _agent_COORDINATOR/
@@ -311,7 +313,7 @@ type: agent
 
 ### Step 3 — Verify team config uses absolute paths to local agents
 
-All paths in `_team_*/config.json` must point to `_agent_*` folders **inside the same project's `.ac-new/`**. Never reference agents from other projects.
+All paths in `_team_*/config.json` must point to `_agent_*` folders **inside the same project's `.ac/`**. Never reference agents from other projects.
 
 ### Step 4 — Verify in AgentsCommander
 
@@ -331,7 +333,7 @@ This should return all team members. If empty, the team config is misconfigured 
 
 ### Mistake: Agents appear as `@other-project` in sidebar
 **Cause:** Team config.json references `_agent_*` folders from a different project.
-**Fix:** Create `_agent_*` folders inside THIS project's `.ac-new/` and update the team config paths.
+**Fix:** Create `_agent_*` folders inside THIS project's `.ac/` and update the team config paths.
 
 ### Mistake: `list-peers` returns empty
 **Cause:** The calling agent isn't listed in any `_team_*/config.json` `agents` array, OR the team config paths don't match the agent's actual root path.
@@ -349,15 +351,15 @@ This should return all team members. If empty, the team config is misconfigured 
 ```
 
 ### Mistake: Only creating agents in the workgroup (double underscore)
-**Cause:** Creating `__agent_*` folders inside `wg-*/` but not `_agent_*` at the `.ac-new/` level.
-**Fix:** Always create `_agent_*` (single underscore) at `.ac-new/` first. These are the canonical definitions. Workgroup agents are replicas that reference them.
+**Cause:** Creating `__agent_*` folders inside `wg-*/` but not `_agent_*` at the `.ac/` level.
+**Fix:** Always create `_agent_*` (single underscore) at `.ac/` first. These are the canonical definitions. Workgroup agents are replicas that reference them.
 
 ### Mistake: Agent folder has no Role.md
 **Cause:** Using `create-agent` CLI which creates CLAUDE.md, or creating the folder manually without the role file.
 **Fix:** Always create `Role.md` with proper frontmatter. This is the agent's identity.
 
 ### Mistake: Git operations corrupt workgroup repos
-**Cause:** Missing `.gitignore` at `.ac-new/` level that excludes `wg-*/`.
+**Cause:** Missing `.gitignore` at `.ac/` level that excludes `wg-*/`.
 **Fix:** Add `.gitignore` with `wg-*/` before creating any workgroups.
 
 ---
@@ -398,7 +400,7 @@ These are proven team compositions. Adapt to your project's domain.
 ### Create an agent programmatically
 
 ```bash
-"<BINARY>" create-agent --parent "<.ac-new path>" --name "agent-name" [--launch "Claude Code"] --root "<caller root>" --token "<token>"
+"<BINARY>" create-agent --parent "<.ac path>" --name "agent-name" [--launch "Claude Code"] --root "<caller root>" --token "<token>"
 ```
 
 This creates the folder and a basic CLAUDE.md. You'll still need to write a proper Role.md.

--- a/docs/agents/agent-skills.md
+++ b/docs/agents/agent-skills.md
@@ -23,7 +23,7 @@ such as `inbox/`, `outbox/`, and `config.json`, are omitted here.
 
 ```text
 <project>/
-+-- .ac-new/
++-- .ac/
     +-- _agent_dev-rust/
         +-- Role.md
         +-- memory/
@@ -90,7 +90,7 @@ files only when they are needed.
 ## Creating a Skill
 
 1. Open the canonical Agent Matrix directory for the agent, for example
-   `.ac-new/_agent_dev-rust/`.
+   `.ac/_agent_dev-rust/`. Legacy `.ac-new/` projects use the same layout under `.ac-new/`.
 2. Create `skills/<skill-name>/`.
 3. Add `skills/<skill-name>/SKILL.md` with YAML frontmatter.
 4. Describe when to use the skill and the exact workflow to follow.

--- a/docs/agents/creating-agents.md
+++ b/docs/agents/creating-agents.md
@@ -12,7 +12,7 @@ An agent is a directory with a role-prompt file at its root. The directory IS th
 | Codex | `AGENTS.md` (or `CLAUDE.md` fallback) |
 | Gemini | `GEMINI.md` (or `CLAUDE.md` fallback) |
 
-When the agent dir lives inside an AC project at `.ac-new/_agent_<name>/`, AC promotes it to an **agent matrix** with optional `memory/`, `plans/`, `skills/`, and a canonical `Role.md`.
+When the agent dir lives inside an AC project at `.ac/_agent_<name>/`, AC promotes it to an **agent matrix** with optional `memory/`, `plans/`, `skills/`, and a canonical `Role.md`. Legacy `.ac-new/` projects use the same layout under `.ac-new/`.
 
 ## The one rule
 
@@ -23,7 +23,7 @@ If you need two agents in the same project, give each one its own sibling direct
 ## Path 1 — through the UI (recommended)
 
 1. Open the **New Agent** modal from the sidebar (the **+ Agent** button in the project header).
-2. Pick a parent directory. For a team member, this should be inside `.ac-new/_team_<team>/` (the team will discover the new agent automatically).
+2. Pick a parent directory. For a team member, this should be inside `.ac/_team_<team>/` (the team will discover the new agent automatically).
 3. Type a name (no slashes, no NUL, lowercase kebab-case recommended).
 4. Pick a role template — see [the role-template picker](../integrations/coding-agents.md#role-template-picker).
 5. Optionally enable skills if the template ships them.
@@ -34,7 +34,7 @@ AC creates the directory, writes the chosen role into `Role.md` and `CLAUDE.md`,
 ## Path 2 — through the CLI
 
 ```bash
-agentscommander create-agent --parent "C:\repos\my-project\.ac-new" --name "dev-rust"
+agentscommander create-agent --parent "C:\repos\my-project\.ac" --name "dev-rust"
 ```
 
 Optional flags:
@@ -99,14 +99,14 @@ AC derives the agent's name from its filesystem path:
 
 | Path shape | Canonical name |
 |---|---|
-| `<project>/.ac-new/_agent_<name>/` | `<project>/<name>` |
-| `<project>/.ac-new/wg-<N>-<team>/__agent_<name>/` (replica) | `<project>:wg-<N>-<team>/<name>` |
+| `<project>/.ac/_agent_<name>/` | `<project>/<name>` |
+| `<project>/.ac/wg-<N>-<team>/__agent_<name>/` (replica) | `<project>:wg-<N>-<team>/<name>` |
 
 Use this name verbatim with `send --to`. The CLI's `list-peers-lean` always emits the canonical form.
 
 ## Updating an agent
 
-To edit a role, edit `Role.md` in the canonical agent matrix at `.ac-new/_agent_<name>/`. AC regenerates `CLAUDE.md` from it. Never edit `CLAUDE.md` directly on a workgroup replica — the next sync will overwrite your changes.
+To edit a role, edit `Role.md` in the canonical agent matrix at `.ac/_agent_<name>/`. AC regenerates `CLAUDE.md` from it. Never edit `CLAUDE.md` directly on a workgroup replica; the next sync will overwrite your changes.
 
 ## See also
 

--- a/docs/agents/teams-and-workgroups.md
+++ b/docs/agents/teams-and-workgroups.md
@@ -4,11 +4,11 @@ For developers ready to compose multiple agents around a shared goal. Teams defi
 
 ## Team
 
-A **team** is one coordinator plus one or more worker agents. The team's config lives at `.ac-new/_team_<name>/config.json` and lists members by their canonical names.
+A **team** is one coordinator plus one or more worker agents. The team's config lives at `.ac/_team_<name>/config.json` and lists members by their canonical names. Legacy `.ac-new/` projects use the same layout under `.ac-new/`.
 
 ```
 my-project/
-└── .ac-new/
+└── .ac/
     ├── _agent_tech-lead/
     ├── _agent_dev-rust/
     ├── _agent_dev-ts/
@@ -52,7 +52,7 @@ A **workgroup** is a team's active workspace for one specific task. AC spins up 
 
 ```
 my-project/
-└── .ac-new/
+└── .ac/
     └── wg-1-feature-x/
         ├── TASK.md                       # the brief
         ├── messaging/                    # inter-agent messages (see below)
@@ -107,7 +107,7 @@ Both verbs validate the caller is a coordinator of any team in the project and c
 
 From the UI, click **Activate** on the team. AC:
 
-1. Creates `.ac-new/wg-<N>-<team>/`.
+1. Creates `.ac/wg-<N>-<team>/`.
 2. Copies the team config and member references.
 3. Provisions each member's replica directory (`__agent_<name>/`, with the same double-underscore prefix for both workers and the coordinator).
 4. Generates blank `TASK.md`, `messaging/`, and per-replica session artifacts.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -30,7 +30,7 @@ You can detach a session into its own window, attach a Telegram bot to it, or ta
 
 ## Team
 
-A coordinator agent plus one or more worker agents working toward a shared goal. Teams are defined in a JSON config under `.ac-new/_team_<name>/` and discovered automatically.
+A coordinator agent plus one or more worker agents working toward a shared goal. Teams are defined in a JSON config under `.ac/_team_<name>/` and discovered automatically.
 
 The **coordinator** is the only member that can:
 - send messages to any team member (members can only send to the coordinator and to peers they share a team with),
@@ -39,19 +39,19 @@ The **coordinator** is the only member that can:
 
 ## Workgroup
 
-A workgroup is a Team **in action** on a specific task. When the coordinator decides "we are working on task X," AC creates `.ac-new/wg-<N>-<team>/` and replicates the team's agent directories into it as **replicas** (`__agent_<name>/`). The replicas are isolated working copies — every replica has its own scratch space, inbox, and outbox.
+A workgroup is a Team **in action** on a specific task. When the coordinator decides "we are working on task X," AC creates `.ac/wg-<N>-<team>/` and replicates the team's agent directories into it as **replicas** (`__agent_<name>/`). The replicas are isolated working copies — every replica has its own scratch space, inbox, and outbox.
 
 You can run multiple workgroups for the same team in parallel.
 
 ## Brief
 
-The plain-language description of the workgroup's goal. Lives at `.ac-new/wg-<N>-<team>/TASK.md` with YAML frontmatter for the title and a freeform body for context, links, and constraints.
+The plain-language description of the workgroup's goal. Lives at `.ac/wg-<N>-<team>/TASK.md` with YAML frontmatter for the title and a freeform body for context, links, and constraints.
 
 The coordinator is the only agent that should be writing to the brief directly. Workers reference it and update their own outboxes.
 
 ## Messaging
 
-Inter-agent communication is **file-based**. Every message is a markdown file at `.ac-new/wg-<N>-<team>/messaging/` with a UTC-timestamped filename:
+Inter-agent communication is **file-based**. Every message is a markdown file at `.ac/wg-<N>-<team>/messaging/` with a UTC-timestamped filename:
 
 ```
 YYYYMMDD-HHMMSS-wg<N>-<from>-to-wg<N>-<to>-<slug>.md

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -48,7 +48,7 @@ A renamed copy of `agentscommander.exe` (with an `_<suffix>` like `agentscommand
 
 ## Project (AC project)
 
-A folder containing an `.ac-new/` workspace. AC manages all agents, teams, and workgroups under that workspace.
+A folder containing an `.ac/` workspace. AC manages all agents, teams, and workgroups under that workspace. Legacy `.ac-new/` workspaces remain supported.
 
 ## PTY
 
@@ -80,7 +80,7 @@ The three tabs in the Settings modal: **General**, **Coding Agents**, **Integrat
 
 ## Team
 
-A coordinator + worker agents working toward shared goals. Defined in `.ac-new/_team_<name>/config.json`.
+A coordinator + worker agents working toward shared goals. Defined in `.ac/_team_<name>/config.json`.
 
 ## Telegram bridge
 
@@ -96,7 +96,7 @@ Push-to-talk transcription via the Google Gemini API. Dictate a prompt; AC write
 
 ## Workgroup
 
-A team's active workspace for a specific task. Lives at `.ac-new/wg-<N>-<team>/` with replicas of every team member.
+A team's active workspace for a specific task. Lives at `.ac/wg-<N>-<team>/` with replicas of every team member.
 
 ## `wg-<N>-<team>`
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,9 +26,9 @@ Run the installer, or drop the portable `.exe` into any folder and double-click.
 
 ## 2. Open or create an AC project
 
-An **AC project** is a folder with an `.ac-new/` workspace inside. AC stores agents, teams, and messaging here so the whole project is portable and version-controllable.
+An **AC project** is a folder with an `.ac/` workspace inside. AC stores agents, teams, and messaging here so the whole project is portable and version-controllable. Existing `.ac-new/` workspaces still open as a legacy fallback.
 
-In the sidebar, click **New Project** and point at any folder — empty or an existing repo. AC creates `.ac-new/` with a sensible `.gitignore` and registers the project in your sidebar.
+In the sidebar, click **New Project** and point at any folder, empty or an existing repo. AC creates `.ac/` with a sensible `.gitignore` and registers the project in your sidebar.
 
 > CLI equivalent: `agentscommander new-project /path/to/folder`
 
@@ -41,7 +41,7 @@ Open the Teams pane. A **Team** is one coordinator plus one or more worker agent
 3. Add one **worker** the same way (for example `dev-rust` with the *Rust developer* template).
 4. Mark the first agent as **coordinator**.
 
-Behind the scenes AC creates `.ac-new/wg-1-<team-name>/__agent_tech-lead/` and `__agent_dev-rust/` with `Role.md` files inside.
+Behind the scenes AC creates `.ac/wg-1-<team-name>/__agent_tech-lead/` and `__agent_dev-rust/` with `Role.md` files inside.
 
 ## 4. Write a brief and launch the coordinator
 
@@ -55,7 +55,7 @@ Ask the coordinator something like:
 
 > "Send a hello message to `<project>:wg-1-feature-x/dev-rust` and ask them to confirm the role they have."
 
-The coordinator will write a markdown file to `.ac-new/wg-1-feature-x/messaging/` and run `agentscommander send --to <peer> --send <filename> --mode wake`. In a second or two you will see the worker's session activate, read the file, and reply by writing its own message back.
+The coordinator will write a markdown file to `.ac/wg-1-feature-x/messaging/` and run `agentscommander send --to <peer> --send <filename> --mode wake`. In a second or two you will see the worker's session activate, read the file, and reply by writing its own message back.
 
 That's the loop. Every message is a file you can `cat`, `git diff`, and audit.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -227,7 +227,7 @@ Same locking + backup behaviour as `task-set-title`.
 
 ## `open-project`
 
-Register an existing AC project (folder with `.ac-new/` inside) in the GUI sidebar's project list.
+Register an existing AC project (folder with `.ac/` or legacy `.ac-new/` inside) in the GUI sidebar's project list.
 
 ```bash
 agentscommander open-project /path/to/project
@@ -239,7 +239,7 @@ agentscommander open-project /path/to/project
 
 Idempotent — re-registering the same path is a no-op (`Project already registered`).
 
-If the folder does not contain `.ac-new/` the CLI suggests `new-project` instead.
+If the folder does not contain `.ac/` or legacy `.ac-new/`, the CLI suggests `new-project` instead.
 
 **No token required** — project registration mutates the local `settings.json`, which any shell-capable process can already write to.
 
@@ -249,7 +249,7 @@ If the folder does not contain `.ac-new/` the CLI suggests `new-project` instead
 
 ## `new-project`
 
-Create an AC project at PATH (mkdir `.ac-new/` if missing) and register it.
+Create an AC project at PATH (mkdir `.ac/` if no workspace exists) and register it.
 
 ```bash
 agentscommander new-project /path/to/project
@@ -259,7 +259,7 @@ agentscommander new-project /path/to/project
 |---|---|
 | `PATH` | Absolute or relative. Folder created if it does not yet exist. |
 
-Idempotent — re-running on a folder that already has `.ac-new/` only sweeps the gitignore (appending missing patterns) and deduplicates the registration.
+Idempotent: re-running on a folder that already has `.ac/` or legacy `.ac-new/` only sweeps the selected workspace gitignore and deduplicates the registration.
 
 **No token required** — same reasoning as `open-project`.
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -40,7 +40,7 @@ When you show a command, also show what the user should expect to see — first 
 
 ## 5. Be specific about failure
 
-> ✅ "If you see `Error: ENOENT`, check that you are inside an `.ac-new/` project."
+> ✅ "If you see `Error: ENOENT`, check that you are inside an `.ac/` project. Legacy `.ac-new/` projects are also supported."
 > ❌ "If there is an error, check your setup."
 
 Name the error string. Name the directory. Name the file. Vague troubleshooting is worse than none.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -2,7 +2,7 @@
 
 For developers deciding whether AgentsCommander fits their workflow. Four worked examples — pick the one closest to your problem and adapt.
 
-Every example assumes you have the [Quickstart](quickstart.md) finished: a project with an `.ac-new/` workspace and at least one coding agent (Claude Code, Codex, or Gemini) installed.
+Every example assumes you have the [Quickstart](quickstart.md) finished: a project with an `.ac/` workspace and at least one coding agent (Claude Code, Codex, or Gemini) installed. Legacy `.ac-new/` workspaces are still supported.
 
 ## 1. Parallel feature development
 

--- a/src-tauri/src/cli/create_agent_matrix.rs
+++ b/src-tauri/src/cli/create_agent_matrix.rs
@@ -20,7 +20,7 @@ use crate::config::projects::resolve_project_reference;
 #[command(after_help = "\
 NOTES:\n  \
   --project is a registered AC project folder name from settings.projectPaths. Paths are not accepted.\n  \
-  The target project must contain .ac-new.\n  \
+  The target project must contain .ac; legacy .ac-new projects are accepted when .ac is absent.\n  \
   --name is sanitized by the same backend as the UI into a lower-case Matrix id.\n  \
   --role-template must be an id from the same source as the New Agent picker.\n  \
   Invalid templates fail before creating the target Matrix directory.\n  \

--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 
 use crate::config::agent_config::{AgentLocalConfig, CodingAgentEntry};
 use crate::config::sessions_persistence::{load_sessions_raw, PersistedSession};
-use crate::config::workspace::{existing_workspace_dir, is_workspace_dir_name};
+use crate::config::workspace::{
+    ensure_authoritative_workspace_dir, existing_workspace_dir, is_workspace_dir_name,
+    stale_legacy_workspace_error_for_path,
+};
 use crate::session::session::{SessionStatus, TEMP_SESSION_PREFIX};
 
 #[derive(Args)]
@@ -491,40 +494,60 @@ struct WgReplicaInfo {
 }
 
 /// Detect if `root` is a WG replica: path matches `*/<workspace>/wg-*/__agent_*/`.
-fn detect_wg_replica(root: &str) -> Option<WgReplicaInfo> {
+fn detect_wg_replica(root: &str) -> Result<Option<WgReplicaInfo>, String> {
     let path = PathBuf::from(root);
     let canon = match std::fs::canonicalize(&path) {
         Ok(c) => c,
-        Err(_) => return None,
+        Err(_) => return Ok(None),
     };
 
-    let my_dir_name = canon.file_name()?.to_str()?;
+    let Some(my_dir_name) = canon.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
     if !my_dir_name.starts_with("__agent_") {
-        return None;
+        return Ok(None);
     }
-    let my_agent_name = my_dir_name.strip_prefix("__agent_")?.to_string();
+    let Some(my_agent_name) = my_dir_name.strip_prefix("__agent_") else {
+        return Ok(None);
+    };
+    let my_agent_name = my_agent_name.to_string();
 
-    let wg_dir = canon.parent()?;
-    let wg_name = wg_dir.file_name()?.to_str()?;
+    let Some(wg_dir) = canon.parent() else {
+        return Ok(None);
+    };
+    let Some(wg_name) = wg_dir.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
     if !wg_name.starts_with("wg-") {
-        return None;
+        return Ok(None);
     }
 
-    let workspace_dir = wg_dir.parent()?;
-    let workspace_name = workspace_dir.file_name()?.to_str()?;
+    let Some(workspace_dir) = wg_dir.parent() else {
+        return Ok(None);
+    };
+    let Some(workspace_name) = workspace_dir.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
     if !is_workspace_dir_name(workspace_name) {
-        return None;
+        return Ok(None);
     }
+    ensure_authoritative_workspace_dir(workspace_dir)?;
 
-    let my_project = workspace_dir.parent()?.file_name()?.to_str()?.to_string();
+    let Some(my_project) = workspace_dir
+        .parent()
+        .and_then(|project| project.file_name())
+        .and_then(|name| name.to_str())
+    else {
+        return Ok(None);
+    };
 
-    Some(WgReplicaInfo {
+    Ok(Some(WgReplicaInfo {
         my_agent_name,
         my_wg_name: wg_name.to_string(),
         my_wg_dir: wg_dir.to_path_buf(),
         workspace_dir: workspace_dir.to_path_buf(),
-        my_project,
-    })
+        my_project: my_project.to_string(),
+    }))
 }
 
 /// Resolve the coordinator agent name for a WG by matching replica identity
@@ -679,7 +702,8 @@ fn discover_wg_peers(wg: WgReplicaInfo) -> Vec<PeerInfo> {
                     _ => continue,
                 };
 
-                if let Some(other_coord) = resolve_wg_coordinator(&wg.workspace_dir, &other_wg_dir) {
+                if let Some(other_coord) = resolve_wg_coordinator(&wg.workspace_dir, &other_wg_dir)
+                {
                     let coord_dir = other_wg_dir.join(format!("__agent_{}", other_coord));
                     if !coord_dir.is_dir() {
                         continue;
@@ -1020,10 +1044,7 @@ fn build_root_agent_synthetic_peer(
     // The caller is a coordinator iff `verified_wg_coordinator_target`
     // accepts its own FQN. Re-uses the same identity-cross-reference path
     // (#277 §2.3) used by the root-sender side.
-    let my_fqn = format!(
-        "{}:{}/{}",
-        wg.my_project, wg.my_wg_name, wg.my_agent_name
-    );
+    let my_fqn = format!("{}:{}/{}", wg.my_project, wg.my_wg_name, wg.my_agent_name);
     crate::config::teams::verified_wg_coordinator_target(&my_fqn, project_paths)?;
 
     let root_dir = crate::config::root_agent::root_agent_dir().ok()?;
@@ -1108,13 +1129,16 @@ fn report_unknown_peers(unknown: &[String], available: &[String]) -> i32 {
 /// Run the shared discovery — WG-replica path when `root` is a replica, the
 /// origin-agent path otherwise. Factored so `execute` and `execute_lean`
 /// share the dispatch.
-fn discover_peers(root: &str) -> Vec<PeerInfo> {
+fn discover_peers(root: &str) -> Result<Vec<PeerInfo>, String> {
+    if let Some(reason) = stale_legacy_workspace_error_for_path(Path::new(root)) {
+        return Err(reason);
+    }
     if crate::config::root_agent::is_root_agent_path(root) {
-        discover_root_coordinator_peers()
-    } else if let Some(wg) = detect_wg_replica(root) {
-        discover_wg_peers(wg)
+        Ok(discover_root_coordinator_peers())
+    } else if let Some(wg) = detect_wg_replica(root)? {
+        Ok(discover_wg_peers(wg))
     } else {
-        discover_origin_peers(root)
+        Ok(discover_origin_peers(root))
     }
 }
 
@@ -1160,7 +1184,13 @@ pub fn execute(args: ListPeersArgs) -> i32 {
         }
     };
 
-    let peers = discover_peers(&root);
+    let peers = match discover_peers(&root) {
+        Ok(peers) => peers,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
 
     // No-filter fast path: behavior is byte-for-byte unchanged from the
     // pre-filter implementation when --peer is not supplied.
@@ -1190,7 +1220,13 @@ pub fn execute_lean(args: ListPeersLeanArgs) -> i32 {
         }
     };
 
-    let peers = discover_peers(&root);
+    let peers = match discover_peers(&root) {
+        Ok(peers) => peers,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
 
     if args.peer.is_empty() {
         return serialize_lean_peers(&peers);
@@ -1285,6 +1321,68 @@ mod tests {
 
         let paths = vec![temp.path().to_string_lossy().to_string()];
         (temp, paths)
+    }
+
+    #[test]
+    fn detect_wg_replica_rejects_stale_legacy_when_canonical_exists() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-a");
+        let canonical_root = project.join(".ac").join("wg-1-devs").join("__agent_alice");
+        let stale_root = project
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        std::fs::create_dir_all(&canonical_root).unwrap();
+        std::fs::create_dir_all(&stale_root).unwrap();
+
+        let err = match detect_wg_replica(stale_root.to_str().unwrap()) {
+            Ok(_) => panic!("stale legacy workspace should be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.contains("stale legacy workspace"));
+        assert!(err.contains(".ac-new"));
+        assert!(err.contains(".ac"));
+    }
+
+    #[test]
+    fn detect_wg_replica_accepts_legacy_when_canonical_absent() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-a");
+        let legacy_root = project
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        std::fs::create_dir_all(&legacy_root).unwrap();
+
+        let wg = detect_wg_replica(legacy_root.to_str().unwrap())
+            .unwrap()
+            .expect("legacy-only workspace should be accepted");
+        assert_eq!(wg.my_project, "proj-a");
+        assert_eq!(wg.my_wg_name, "wg-1-devs");
+        assert_eq!(wg.my_agent_name, "alice");
+    }
+
+    #[test]
+    fn discover_wg_peers_uses_only_canonical_workspace_when_both_exist() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-a");
+        let canonical_wg = project.join(".ac").join("wg-1-devs");
+        let legacy_wg = project.join(".ac-new").join("wg-1-devs");
+        let canonical_root = canonical_wg.join("__agent_alice");
+        let canonical_peer = canonical_wg.join("__agent_bob");
+        let stale_peer = legacy_wg.join("__agent_eve");
+        for dir in [&canonical_root, &canonical_peer, &stale_peer] {
+            std::fs::create_dir_all(dir).unwrap();
+        }
+
+        let wg = detect_wg_replica(canonical_root.to_str().unwrap())
+            .unwrap()
+            .expect("canonical workspace should be accepted");
+        let peers = discover_wg_peers(wg);
+        let names: Vec<&str> = peers.iter().map(|peer| peer.name.as_str()).collect();
+
+        assert!(names.contains(&"proj-a:wg-1-devs/bob"));
+        assert!(!names.contains(&"proj-a:wg-1-devs/eve"));
     }
 
     #[test]

--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::config::agent_config::{AgentLocalConfig, CodingAgentEntry};
 use crate::config::sessions_persistence::{load_sessions_raw, PersistedSession};
+use crate::config::workspace::{existing_workspace_dir, is_workspace_dir_name};
 use crate::session::session::{SessionStatus, TEMP_SESSION_PREFIX};
 
 #[derive(Args)]
@@ -483,13 +484,13 @@ struct WgReplicaInfo {
     my_agent_name: String,
     my_wg_name: String,
     my_wg_dir: PathBuf,
-    ac_new_dir: PathBuf,
-    /// Project folder name (the dir containing `.ac-new/`). Forms the
+    workspace_dir: PathBuf,
+    /// Project folder name (the dir containing the AC workspace). Forms the
     /// LHS of the canonical FQN for WG replicas.
     my_project: String,
 }
 
-/// Detect if `root` is a WG replica: path matches `*/.ac-new/wg-*/__agent_*/`.
+/// Detect if `root` is a WG replica: path matches `*/<workspace>/wg-*/__agent_*/`.
 fn detect_wg_replica(root: &str) -> Option<WgReplicaInfo> {
     let path = PathBuf::from(root);
     let canon = match std::fs::canonicalize(&path) {
@@ -509,28 +510,28 @@ fn detect_wg_replica(root: &str) -> Option<WgReplicaInfo> {
         return None;
     }
 
-    let ac_new_dir = wg_dir.parent()?;
-    let ac_new_name = ac_new_dir.file_name()?.to_str()?;
-    if ac_new_name != ".ac-new" {
+    let workspace_dir = wg_dir.parent()?;
+    let workspace_name = workspace_dir.file_name()?.to_str()?;
+    if !is_workspace_dir_name(workspace_name) {
         return None;
     }
 
-    let my_project = ac_new_dir.parent()?.file_name()?.to_str()?.to_string();
+    let my_project = workspace_dir.parent()?.file_name()?.to_str()?.to_string();
 
     Some(WgReplicaInfo {
         my_agent_name,
         my_wg_name: wg_name.to_string(),
         my_wg_dir: wg_dir.to_path_buf(),
-        ac_new_dir: ac_new_dir.to_path_buf(),
+        workspace_dir: workspace_dir.to_path_buf(),
         my_project,
     })
 }
 
 /// Resolve the coordinator agent name for a WG by matching replica identity
-/// paths against the team coordinator path in `.ac-new/_team_*/config.json`.
+/// paths against the team coordinator path in the workspace `_team_*/config.json`.
 /// Only checks the team whose name matches the WG suffix (e.g. `wg-1-ac-devs` → `_team_ac-devs`).
-fn resolve_wg_coordinator(ac_new_dir: &Path, wg_dir: &Path) -> Option<String> {
-    crate::config::teams::resolve_wg_coordinator_replica(ac_new_dir, wg_dir)
+fn resolve_wg_coordinator(workspace_dir: &Path, wg_dir: &Path) -> Option<String> {
+    crate::config::teams::resolve_wg_coordinator_replica(workspace_dir, wg_dir)
         .map(|replica| replica.agent_name)
 }
 
@@ -558,7 +559,7 @@ fn read_wg_role(replica_dir: &Path) -> String {
 }
 
 /// Build a PeerInfo for a WG replica directory. Also bootstraps IPC dirs.
-/// `project` is the project folder name (dir containing `.ac-new/`) and forms
+/// `project` is the project folder name (dir containing the AC workspace) and forms
 /// the LHS of the canonical FQN.
 fn build_wg_peer(
     project: &str,
@@ -615,7 +616,7 @@ fn discover_wg_peers(wg: WgReplicaInfo) -> Vec<PeerInfo> {
     // (`can_communicate`) compare project-qualified strings.
     let my_full_name = format!("{}:{}/{}", wg.my_project, wg.my_wg_name, wg.my_agent_name);
 
-    let coordinator = resolve_wg_coordinator(&wg.ac_new_dir, &wg.my_wg_dir);
+    let coordinator = resolve_wg_coordinator(&wg.workspace_dir, &wg.my_wg_dir);
     let i_am_coordinator = coordinator.as_deref() == Some(wg.my_agent_name.as_str());
 
     if coordinator.is_none() {
@@ -664,10 +665,10 @@ fn discover_wg_peers(wg: WgReplicaInfo) -> Vec<PeerInfo> {
         ));
     }
 
-    // Coordinator also sees coordinators of OTHER WGs in the same .ac-new
+    // Coordinator also sees coordinators of other WGs in the same workspace
     // (same project, different WG — still qualified with `wg.my_project`).
     if i_am_coordinator {
-        if let Ok(entries) = std::fs::read_dir(&wg.ac_new_dir) {
+        if let Ok(entries) = std::fs::read_dir(&wg.workspace_dir) {
             for entry in entries.flatten() {
                 let other_wg_dir = entry.path();
                 if !other_wg_dir.is_dir() {
@@ -678,7 +679,7 @@ fn discover_wg_peers(wg: WgReplicaInfo) -> Vec<PeerInfo> {
                     _ => continue,
                 };
 
-                if let Some(other_coord) = resolve_wg_coordinator(&wg.ac_new_dir, &other_wg_dir) {
+                if let Some(other_coord) = resolve_wg_coordinator(&wg.workspace_dir, &other_wg_dir) {
                     let coord_dir = other_wg_dir.join(format!("__agent_{}", other_coord));
                     if !coord_dir.is_dir() {
                         continue;
@@ -714,7 +715,7 @@ fn discover_wg_peers(wg: WgReplicaInfo) -> Vec<PeerInfo> {
     let mut effective_paths = crate::config::settings::load_settings()
         .project_paths
         .clone();
-    if let Some(project_dir) = wg.ac_new_dir.parent() {
+    if let Some(project_dir) = wg.workspace_dir.parent() {
         if let Some(project_str) = project_dir.to_str() {
             let p = project_str.to_string();
             let canon_p = std::fs::canonicalize(&p).ok();
@@ -834,7 +835,7 @@ fn discover_origin_peers(root: &str) -> Vec<PeerInfo> {
     }
 
     // ── WG replica discovery ──────────────────────────────────────────────
-    // Scan project_paths for .ac-new/wg-*/__agent_* replicas
+    // Scan project_paths for workspace wg-*/__agent_* replicas
     let settings = crate::config::settings::load_settings();
     for base_path in &settings.project_paths {
         let base = Path::new(base_path);
@@ -855,16 +856,15 @@ fn discover_origin_peers(root: &str) -> Vec<PeerInfo> {
             }
         }
         for repo_dir in dirs_to_check {
-            let ac_new_dir = repo_dir.join(".ac-new");
-            if !ac_new_dir.is_dir() {
+            let Some(workspace_dir) = existing_workspace_dir(&repo_dir) else {
                 continue;
-            }
-            // Project folder name (parent of .ac-new) — LHS of the canonical FQN.
+            };
+            // Project folder name (parent of workspace) is the LHS of the canonical FQN.
             let project_folder = match repo_dir.file_name().and_then(|n| n.to_str()) {
                 Some(n) => n.to_string(),
                 None => continue,
             };
-            let wg_entries = match std::fs::read_dir(&ac_new_dir) {
+            let wg_entries = match std::fs::read_dir(&workspace_dir) {
                 Ok(e) => e,
                 Err(_) => continue,
             };
@@ -962,12 +962,11 @@ fn discover_root_coordinator_peers_from_project_paths(project_paths: &[String]) 
         }
 
         for repo_dir in dirs_to_check {
-            let ac_new_dir = repo_dir.join(".ac-new");
-            if !ac_new_dir.is_dir() {
+            let Some(workspace_dir) = existing_workspace_dir(&repo_dir) else {
                 continue;
-            }
+            };
 
-            let wg_entries = match std::fs::read_dir(&ac_new_dir) {
+            let wg_entries = match std::fs::read_dir(&workspace_dir) {
                 Ok(e) => e,
                 Err(_) => continue,
             };
@@ -982,7 +981,7 @@ fn discover_root_coordinator_peers_from_project_paths(project_paths: &[String]) 
                 }
 
                 let Some(coord) =
-                    crate::config::teams::resolve_wg_coordinator_replica(&ac_new_dir, &wg_path)
+                    crate::config::teams::resolve_wg_coordinator_replica(&workspace_dir, &wg_path)
                 else {
                     continue;
                 };
@@ -1328,7 +1327,7 @@ mod tests {
             my_agent_name: "tech-lead".to_string(),
             my_wg_name: "wg-1-dev-team".to_string(),
             my_wg_dir: PathBuf::from("ignored-for-this-test"),
-            ac_new_dir: PathBuf::from("ignored-for-this-test"),
+            workspace_dir: PathBuf::from("ignored-for-this-test"),
             my_project: "proj-a".to_string(),
         };
         let peer = build_root_agent_synthetic_peer(&wg, &paths)
@@ -1346,7 +1345,7 @@ mod tests {
             my_agent_name: "dev-rust".to_string(),
             my_wg_name: "wg-1-dev-team".to_string(),
             my_wg_dir: PathBuf::from("ignored-for-this-test"),
-            ac_new_dir: PathBuf::from("ignored-for-this-test"),
+            workspace_dir: PathBuf::from("ignored-for-this-test"),
             my_project: "proj-a".to_string(),
         };
         assert!(build_root_agent_synthetic_peer(&wg, &paths).is_none());
@@ -1359,7 +1358,7 @@ mod tests {
             my_agent_name: "tech-lead".to_string(),
             my_wg_name: "wg-1-dev-team".to_string(),
             my_wg_dir: PathBuf::from("ignored-for-this-test"),
-            ac_new_dir: PathBuf::from("ignored-for-this-test"),
+            workspace_dir: PathBuf::from("ignored-for-this-test"),
             my_project: "proj-a".to_string(),
         };
         assert!(build_root_agent_synthetic_peer(&wg, &paths).is_none());
@@ -1373,12 +1372,12 @@ mod tests {
         // with cli/send.rs::effective_project_paths).
         let (temp, _seeded_paths) = make_root_discovery_fixture(false);
         let project_dir = temp.path().join("proj-a");
-        let ac_new_dir = project_dir.join(".ac-new");
+        let workspace_dir = project_dir.join(".ac");
         let wg = WgReplicaInfo {
             my_agent_name: "tech-lead".to_string(),
             my_wg_name: "wg-1-dev-team".to_string(),
-            my_wg_dir: ac_new_dir.join("wg-1-dev-team"),
-            ac_new_dir: ac_new_dir.clone(),
+            my_wg_dir: workspace_dir.join("wg-1-dev-team"),
+            workspace_dir: workspace_dir.clone(),
             my_project: "proj-a".to_string(),
         };
 
@@ -1390,10 +1389,10 @@ mod tests {
             "without augmentation, helper must reject (otherwise this test is trivial)"
         );
 
-        // Replicate the call-site augmentation: walk up `wg.ac_new_dir.parent()`.
+        // Replicate the call-site augmentation: walk up `wg.workspace_dir.parent()`.
         let mut augmented = empty.clone();
         let project_str = wg
-            .ac_new_dir
+            .workspace_dir
             .parent()
             .and_then(|d| d.to_str())
             .expect("fixture project dir is utf-8")

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -103,9 +103,9 @@ pub enum Commands {
     TaskSetTitle(task_set_title::TaskSetTitleArgs),
     /// Append text to the body of the workgroup TASK.md (coordinator-only)
     TaskAppendBody(task_append_body::TaskAppendBodyArgs),
-    /// Register an existing AC project (.ac-new must already exist) in settings
+    /// Register an existing AC project (.ac or legacy .ac-new must already exist) in settings
     OpenProject(open_project::OpenProjectArgs),
-    /// Create an AC project (mkdir .ac-new if missing) and register it in settings
+    /// Create an AC project (mkdir .ac if no workspace exists) and register it in settings
     NewProject(new_project::NewProjectArgs),
     /// Send a local image/file to a configured Telegram bot (no GUI required)
     TelegramSendImage(telegram_send_image::TelegramSendImageArgs),

--- a/src-tauri/src/cli/new_project.rs
+++ b/src-tauri/src/cli/new_project.rs
@@ -1,5 +1,5 @@
 //! `new-project <PATH>` CLI verb — ensure an AC project structure at PATH
-//! (creating `.ac-new/` if missing) and register it in
+//! (creating `.ac/` if missing) and register it in
 //! `settings.project_paths`. Shares the registration logic with the Tauri
 //! command at `commands::ac_discovery::new_project` via the
 //! `config::projects` module.
@@ -13,12 +13,12 @@ use crate::config::settings::{load_settings_for_cli, save_settings};
 
 #[derive(Args)]
 #[command(after_help = "\
-PURPOSE: Create an AC project at PATH (mkdir-p `.ac-new/` and write its \
-`.gitignore` if missing) and register it in the GUI sidebar's project list.\n\n\
+PURPOSE: Create an AC project at PATH (mkdir-p `.ac/` and write its \
+`.gitignore` if no workspace exists) and register it in the GUI sidebar's project list.\n\n\
 PATH: Absolute or relative — relative paths are resolved against the current \
 working directory. The folder is created if it does not yet exist.\n\n\
-IDEMPOTENCY: Re-running on a folder that already has `.ac-new/` is safe — the \
-gitignore is swept (missing patterns appended), and the registration step \
+IDEMPOTENCY: Re-running on a folder that already has `.ac/` or legacy `.ac-new/` is safe; \
+the selected workspace gitignore is swept (missing patterns appended), and the registration step \
 deduplicates against any prior entry.")]
 pub struct NewProjectArgs {
     /// Path to make into an AC project (folder created if missing)
@@ -37,7 +37,7 @@ pub fn execute(args: NewProjectArgs) -> i32 {
             return 1;
         }
     };
-    // Save when we either created `.ac-new` or appended a new path entry.
+    // Save when we either created `.ac` or appended a new path entry.
     // (A pure no-op call still prints the status lines.)
     if result.created || result.registered {
         if let Err(e) = save_settings(&settings) {

--- a/src-tauri/src/cli/open_project.rs
+++ b/src-tauri/src/cli/open_project.rs
@@ -21,14 +21,14 @@ use crate::config::settings::{load_settings_for_cli, save_settings};
 #[derive(Args)]
 #[command(after_help = "\
 PURPOSE: Register an existing AC project so it appears in the GUI sidebar on \
-next launch. The folder must already contain `.ac-new/` (use `new-project` to \
+next launch. The folder must already contain `.ac/` or legacy `.ac-new/` (use `new-project` to \
 create one).\n\n\
 PATH: Absolute or relative — relative paths are resolved against the current \
 working directory. The persisted entry is the absolute form.\n\n\
 IDEMPOTENCY: Re-registering the same path is a no-op; the verb prints \
 \"Project already registered\" and exits 0.")]
 pub struct OpenProjectArgs {
-    /// Path to an existing AC project folder (must contain `.ac-new/`)
+    /// Path to an existing AC project folder (must contain `.ac/` or legacy `.ac-new/`)
     #[arg(value_name = "PATH")]
     pub path: String,
 }
@@ -43,10 +43,10 @@ pub fn execute(args: OpenProjectArgs) -> i32 {
         Err(e) => {
             eprintln!("Error: {}", e);
             // Append CLI-specific guidance when the user pointed at a folder
-            // without `.ac-new/`. The bare error string is GUI-friendly
+            // without an AC workspace. The bare error string is GUI-friendly
             // (Round-1 G8); only the CLI knows about `new-project`.
-            if matches!(e, ProjectError::AcNewMissing(_)) {
-                eprintln!("Hint: use `new-project <PATH>` to create the .ac-new structure.");
+            if matches!(e, ProjectError::WorkspaceMissing(_)) {
+                eprintln!("Hint: use `new-project <PATH>` to create the .ac structure.");
             }
             return 1;
         }

--- a/src-tauri/src/cli/send.rs
+++ b/src-tauri/src/cli/send.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 use crate::config::teams;
@@ -117,28 +117,51 @@ fn validate_root_agent_delivery_kind(
 ///
 /// Keep in lockstep with `list_peers::detect_wg_replica` and
 /// `phone::mailbox::derive_project_from_outbox_path`.
-fn derive_root_project_dir(root: &str) -> Option<String> {
-    let canon = std::fs::canonicalize(root).ok()?;
-    let my_dir_name = canon.file_name()?.to_str()?;
+fn derive_root_project_dir(root: &str) -> Result<Option<String>, String> {
+    let Some(canon) = std::fs::canonicalize(root).ok() else {
+        return Ok(None);
+    };
+    let Some(my_dir_name) = canon.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
     if !my_dir_name.starts_with("__agent_") {
-        return None;
+        return Ok(None);
     }
-    let wg_dir = canon.parent()?;
-    let wg_name = wg_dir.file_name()?.to_str()?;
+    let Some(wg_dir) = canon.parent() else {
+        return Ok(None);
+    };
+    let Some(wg_name) = wg_dir.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
     if !wg_name.starts_with("wg-") {
-        return None;
+        return Ok(None);
     }
-    let workspace_dir = wg_dir.parent()?;
+    let Some(workspace_dir) = wg_dir.parent() else {
+        return Ok(None);
+    };
     if !workspace_dir
         .file_name()
         .and_then(|n| n.to_str())
         .map(crate::config::workspace::is_workspace_dir_name)
         .unwrap_or(false)
     {
-        return None;
+        return Ok(None);
     }
-    let project_dir = workspace_dir.parent()?;
-    Some(project_dir.to_str()?.to_string())
+    crate::config::workspace::ensure_authoritative_workspace_dir(workspace_dir)?;
+    let Some(project_dir) = workspace_dir.parent() else {
+        return Ok(None);
+    };
+    Ok(project_dir.to_str().map(|path| path.to_string()))
+}
+
+fn ensure_workgroup_root_is_authoritative(wg_root: &Path) -> Result<(), String> {
+    let workspace_dir = wg_root.parent().ok_or_else(|| {
+        format!(
+            "workgroup root '{}' has no parent workspace directory",
+            wg_root.display()
+        )
+    })?;
+    crate::config::workspace::ensure_authoritative_workspace_dir(workspace_dir)
 }
 
 pub fn execute(args: SendArgs) -> i32 {
@@ -150,6 +173,14 @@ pub fn execute(args: SendArgs) -> i32 {
         }
     };
     let root_is_root_agent = crate::config::root_agent::is_root_agent_path(&root);
+    if !root_is_root_agent {
+        if let Some(reason) =
+            crate::config::workspace::stale_legacy_workspace_error_for_path(Path::new(&root))
+        {
+            eprintln!("Error: {}", reason);
+            return 1;
+        }
+    }
     if let Err(reason) =
         validate_root_agent_delivery_kind(root_is_root_agent, args.command.as_deref())
     {
@@ -196,7 +227,14 @@ pub fn execute(args: SendArgs) -> i32 {
     // reachable do not fail send with `not found in any known project`.
     // settings.json is NOT modified. See #228 / plan _plans/228-cli-daemon-laterals.md.
     let mut effective_project_paths = settings.project_paths.clone();
-    if let Some(root_project) = derive_root_project_dir(&root) {
+    let root_project = match derive_root_project_dir(&root) {
+        Ok(root_project) => root_project,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+    if let Some(root_project) = root_project {
         // Canonicalize once outside the dedup closure. If canonicalization of
         // `root_project` itself fails (rare — it just resolved milliseconds
         // ago inside `derive_root_project_dir`), fall back to string-equality
@@ -291,6 +329,10 @@ pub fn execute(args: SendArgs) -> i32 {
                     return 1;
                 }
             };
+            if let Err(e) = ensure_workgroup_root_is_authoritative(&wg_root) {
+                eprintln!("Error: {}", e);
+                return 1;
+            }
             match crate::phone::messaging::messaging_dir(&wg_root) {
                 Ok(d) => d,
                 Err(e) => {
@@ -655,8 +697,61 @@ mod tests {
             .unwrap()
             .to_string();
         let got = derive_root_project_dir(agent_root.to_str().unwrap())
+            .unwrap()
             .expect("should derive project from WG replica path");
         assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn derive_root_project_dir_rejects_stale_legacy_when_canonical_exists() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-x");
+        let canonical_root = project.join(".ac").join("wg-1-devs").join("__agent_alice");
+        let stale_root = project
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        std::fs::create_dir_all(&canonical_root).unwrap();
+        std::fs::create_dir_all(&stale_root).unwrap();
+
+        let err = derive_root_project_dir(stale_root.to_str().unwrap()).unwrap_err();
+        assert!(err.contains("stale legacy workspace"));
+    }
+
+    #[test]
+    fn derive_root_project_dir_accepts_canonical_when_both_exist() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-x");
+        let canonical_root = project.join(".ac").join("wg-1-devs").join("__agent_alice");
+        let stale_root = project
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        std::fs::create_dir_all(&canonical_root).unwrap();
+        std::fs::create_dir_all(&stale_root).unwrap();
+
+        let got = derive_root_project_dir(canonical_root.to_str().unwrap())
+            .unwrap()
+            .expect("canonical workspace should be accepted");
+        let expected = std::fs::canonicalize(&project)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn send_file_workgroup_root_rejects_stale_legacy_when_canonical_exists() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-x");
+        let canonical_wg = project.join(".ac").join("wg-1-devs");
+        let stale_wg = project.join(".ac-new").join("wg-1-devs");
+        std::fs::create_dir_all(&canonical_wg).unwrap();
+        std::fs::create_dir_all(&stale_wg).unwrap();
+
+        let err = ensure_workgroup_root_is_authoritative(&stale_wg).unwrap_err();
+        assert!(err.contains("stale legacy workspace"));
     }
 
     #[test]
@@ -665,7 +760,9 @@ mod tests {
         // A random subdir without the WG-replica shape.
         let random = temp.path().join("random").join("dir");
         std::fs::create_dir_all(&random).unwrap();
-        assert!(derive_root_project_dir(random.to_str().unwrap()).is_none());
+        assert!(derive_root_project_dir(random.to_str().unwrap())
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -674,6 +771,8 @@ mod tests {
         let wg_dir = temp.path().join("proj-x").join(".ac-new").join("wg-1-devs");
         std::fs::create_dir_all(&wg_dir).unwrap();
         // Pointing at the WG dir, not the __agent_* dir → must return None.
-        assert!(derive_root_project_dir(wg_dir.to_str().unwrap()).is_none());
+        assert!(derive_root_project_dir(wg_dir.to_str().unwrap())
+            .unwrap()
+            .is_none());
     }
 }

--- a/src-tauri/src/cli/send.rs
+++ b/src-tauri/src/cli/send.rs
@@ -105,7 +105,7 @@ fn validate_root_agent_delivery_kind(
     }
 }
 
-/// If `root` lives inside `<project_dir>/.ac-new/wg-<N>-*/__agent_*/`,
+/// If `root` lives inside `<project_dir>/<workspace>/wg-<N>-*/__agent_*/`,
 /// return `project_dir` as a UTF-8 `String`. Returns `None` if `root` is not
 /// inside a WG-replica shape OR if the resulting `project_dir` is not valid
 /// UTF-8 (parity with `list_peers::detect_wg_replica`, which also uses
@@ -128,11 +128,16 @@ fn derive_root_project_dir(root: &str) -> Option<String> {
     if !wg_name.starts_with("wg-") {
         return None;
     }
-    let ac_new_dir = wg_dir.parent()?;
-    if ac_new_dir.file_name().and_then(|n| n.to_str()) != Some(".ac-new") {
+    let workspace_dir = wg_dir.parent()?;
+    if !workspace_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(crate::config::workspace::is_workspace_dir_name)
+        .unwrap_or(false)
+    {
         return None;
     }
-    let project_dir = ac_new_dir.parent()?;
+    let project_dir = workspace_dir.parent()?;
     Some(project_dir.to_str()?.to_string())
 }
 

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -8,6 +8,10 @@ use std::time::{Duration, SystemTime};
 use tauri::{AppHandle, Emitter, State};
 use uuid::Uuid;
 
+use crate::config::workspace::{
+    canonical_workspace_dir_label, existing_workspace_dir, find_workspace_segment,
+    has_workspace_dir, workspace_dir_for_project,
+};
 use crate::config::settings::SettingsState;
 use crate::session::manager::SessionManager;
 use crate::session::session::SessionRepo;
@@ -132,21 +136,16 @@ pub struct AcDiscoveryResult {
 }
 
 /// Extract the origin project name from a resolved identity path.
-/// Looks for the folder immediately before ".ac-new" in the path.
+/// Looks for the folder immediately before the rightmost AC workspace marker.
 fn extract_origin_project(identity_abs_path: &std::path::Path) -> Option<String> {
     let s = identity_abs_path.to_string_lossy().replace('\\', "/");
     let parts: Vec<&str> = s.split('/').collect();
-    for (i, part) in parts.iter().enumerate() {
-        if *part == ".ac-new" && i > 0 {
-            return Some(parts[i - 1].to_string());
-        }
-    }
-    None
+    find_workspace_segment(&parts).and_then(|i| (i > 0).then(|| parts[i - 1].to_string()))
 }
 
 /// Derive agent display name from its path.
 /// Format: "{project_folder}/{agent_name}" where:
-/// - project_folder = directory containing .ac-new/
+/// - project_folder = directory containing the AC workspace
 /// - agent_name = folder name with "_agent_" prefix stripped
 fn agent_display_name(project_folder: &str, dir_name: &str) -> String {
     let agent_name = dir_name.strip_prefix("_agent_").unwrap_or(dir_name);
@@ -156,19 +155,17 @@ fn agent_display_name(project_folder: &str, dir_name: &str) -> String {
 /// Resolve an agent ref to a display name. Handles both relative refs
 /// (e.g. "../_agent_tech-lead") and absolute paths.
 /// For relative refs, uses project_folder as origin. For absolute paths,
-/// extracts the origin project from the folder before ".ac-new".
+/// extracts the origin project from the folder before the workspace marker.
 fn resolve_agent_ref(project_folder: &str, agent_ref: &str) -> String {
     let normalized = agent_ref.replace('\\', "/");
     let trimmed = normalized
         .trim_start_matches("../")
         .trim_start_matches("./");
     if trimmed.contains(':') || trimmed.starts_with('/') {
-        // Absolute path: extract origin project from folder before .ac-new
+        // Absolute path: extract origin project from folder before the workspace marker
         let parts: Vec<&str> = trimmed.split('/').collect();
-        let origin = parts
-            .iter()
-            .position(|p| *p == ".ac-new")
-            .and_then(|i| if i > 0 { Some(parts[i - 1]) } else { None })
+        let origin = find_workspace_segment(&parts)
+            .and_then(|i| (i > 0).then_some(parts[i - 1]))
             .unwrap_or(project_folder);
         let dir_name = parts.last().unwrap_or(&trimmed);
         agent_display_name(origin, dir_name)
@@ -331,7 +328,7 @@ struct TaskUpdatedPayload {
 pub struct DiscoveryBranchWatcher {
     app_handle: AppHandle,
     session_manager: Arc<tokio::sync::RwLock<SessionManager>>,
-    /// Keyed by the project directory that DIRECTLY CONTAINS `.ac-new/` — NOT by
+    /// Keyed by the project directory that directly contains the AC workspace, not by
     /// `settings.project_paths` entries (which may be parent dirs holding many projects).
     /// Keying by the direct parent prevents both (a) the original overwrite-across-projects
     /// bug (Grinch #1) and (b) the double-registration that occurs when `project_paths`
@@ -368,20 +365,20 @@ impl DiscoveryBranchWatcher {
     }
 
     /// Update this project's replicas in the watcher. `ac_new_parent_dir` is the directory
-    /// that directly contains `.ac-new/` — NOT a grand-parent from `settings.project_paths`.
+    /// that directly contains the AC workspace, not a grand-parent from `settings.project_paths`.
     /// See the invariant comment on the `replicas` field.
     pub fn update_replicas_for_project(&self, ac_new_parent_dir: &str, workgroups: &[AcWorkgroup]) {
         // Invariant guard: catch mistaken call-site passes (e.g. a `base_path` parent)
         // in dev builds. Release builds log a warn and return to prevent silent corruption.
-        let has_ac_new = Path::new(ac_new_parent_dir).join(".ac-new").is_dir();
+        let has_workspace = has_workspace_dir(Path::new(ac_new_parent_dir));
         debug_assert!(
-            has_ac_new,
-            "update_replicas_for_project: {} does not contain .ac-new/",
+            has_workspace,
+            "update_replicas_for_project: {} does not contain an AC workspace",
             ac_new_parent_dir
         );
-        if !has_ac_new {
+        if !has_workspace {
             log::warn!(
-                "[DiscoveryBranchWatcher] update_replicas_for_project called with {} which has no .ac-new/ — ignoring",
+                "[DiscoveryBranchWatcher] update_replicas_for_project called with {} which has no AC workspace, ignoring",
                 ac_new_parent_dir
             );
             return;
@@ -836,7 +833,7 @@ impl DiscoveryBranchWatcher {
     }
 }
 
-/// Discover AC-new agent matrices from .ac-new/ directories within configured repo paths.
+/// Discover AC agent matrices from workspace directories within configured repo paths.
 #[tauri::command]
 pub async fn discover_ac_agents(
     app: AppHandle,
@@ -855,7 +852,7 @@ pub async fn discover_ac_agents(
     let mut agents: Vec<AcAgentMatrix> = Vec::new();
     let mut teams: Vec<AcTeam> = Vec::new();
     let mut workgroups: Vec<AcWorkgroup> = Vec::new();
-    // Track the `.ac-new/`-containing dir each workgroup originated from. Keys are
+    // Track the workspace-containing dir each workgroup originated from. Keys are
     // `wg.name` values (unique within a discovery run; workgroup dir names include
     // the team name which collides only intentionally across projects). Populated as
     // we push to `workgroups` so we can later call `update_replicas_for_project` once
@@ -886,14 +883,13 @@ pub async fn discover_ac_agents(
         };
 
         for repo_dir in dirs_to_check {
-            let ac_new_dir = repo_dir.join(".ac-new");
-            if !ac_new_dir.is_dir() {
+            let Some(workspace_dir) = existing_workspace_dir(&repo_dir) else {
                 continue;
-            }
+            };
             let repo_dir_str = repo_dir.to_string_lossy().to_string();
 
             // Opportunistic: ensure gitignore exists for existing projects
-            let _ = ensure_ac_new_gitignore(&ac_new_dir);
+            let _ = ensure_workspace_gitignore(&workspace_dir);
 
             let project_folder = repo_dir
                 .file_name()
@@ -901,7 +897,7 @@ pub async fn discover_ac_agents(
                 .unwrap_or("unknown")
                 .to_string();
 
-            let entries = match std::fs::read_dir(&ac_new_dir) {
+            let entries = match std::fs::read_dir(&workspace_dir) {
                 Ok(e) => e,
                 Err(_) => continue,
             };
@@ -1165,7 +1161,7 @@ pub async fn discover_ac_agents(
         }
     }
 
-    // Update the branch watcher per-project. Each `.ac-new/`-containing dir gets its own
+    // Update the branch watcher per-project. Each workspace-containing dir gets its own
     // slot so multi-project setups don't overwrite each other (Grinch #1 + #12).
     let mut by_project: HashMap<String, Vec<AcWorkgroup>> = HashMap::new();
     for wg in &workgroups {
@@ -1214,17 +1210,16 @@ pub async fn discover_ac_agents(
     })
 }
 
-/// Check if a folder has a .ac-new/ subdirectory.
+/// Check if a folder has an AC workspace subdirectory.
 #[tauri::command]
 pub async fn check_project_path(path: String) -> Result<bool, String> {
-    let ac_new = Path::new(&path).join(".ac-new");
-    Ok(ac_new.is_dir())
+    Ok(existing_workspace_dir(Path::new(&path)).is_some())
 }
 
-/// Ensure .ac-new/.gitignore exists and contains all required exclusion patterns.
+/// Ensure the workspace .gitignore exists and contains all required exclusion patterns.
 /// Called during project creation, workgroup creation, and opportunistically during discovery.
-pub(crate) fn ensure_ac_new_gitignore(ac_new_dir: &Path) -> Result<(), String> {
-    let gitignore_path = ac_new_dir.join(".gitignore");
+pub(crate) fn ensure_workspace_gitignore(workspace_dir: &Path) -> Result<(), String> {
+    let gitignore_path = workspace_dir.join(".gitignore");
 
     // Each entry: (pattern, comment explaining why)
     let required_entries: &[(&str, &str)] = &[
@@ -1256,7 +1251,7 @@ pub(crate) fn ensure_ac_new_gitignore(ac_new_dir: &Path) -> Result<(), String> {
 
     if gitignore_path.exists() {
         let content = std::fs::read_to_string(&gitignore_path)
-            .map_err(|e| format!("Failed to read .ac-new/.gitignore: {}", e))?;
+            .map_err(|e| format!("Failed to read workspace .gitignore: {}", e))?;
 
         let mut additions = String::new();
         for (pattern, comment) in required_entries {
@@ -1271,7 +1266,7 @@ pub(crate) fn ensure_ac_new_gitignore(ac_new_dir: &Path) -> Result<(), String> {
                 &gitignore_path,
                 format!("{}{}{}", content, separator, additions),
             )
-            .map_err(|e| format!("Failed to update .ac-new/.gitignore: {}", e))?;
+            .map_err(|e| format!("Failed to update workspace .gitignore: {}", e))?;
         }
     } else {
         let mut content = String::new();
@@ -1279,19 +1274,24 @@ pub(crate) fn ensure_ac_new_gitignore(ac_new_dir: &Path) -> Result<(), String> {
             content.push_str(&format!("{}\n{}\n\n", comment, pattern));
         }
         std::fs::write(&gitignore_path, content)
-            .map_err(|e| format!("Failed to create .ac-new/.gitignore: {}", e))?;
+            .map_err(|e| format!("Failed to create workspace .gitignore: {}", e))?;
     }
 
     Ok(())
 }
 
-/// Create a .ac-new/ directory inside the given path.
+/// Create a canonical .ac/ directory inside the given path.
 #[tauri::command]
 pub async fn create_ac_project(path: String) -> Result<(), String> {
-    let ac_new = Path::new(&path).join(".ac-new");
-    std::fs::create_dir_all(&ac_new)
-        .map_err(|e| format!("Failed to create .ac-new directory: {}", e))?;
-    ensure_ac_new_gitignore(&ac_new)?;
+    let workspace_dir = workspace_dir_for_project(Path::new(&path));
+    std::fs::create_dir_all(&workspace_dir).map_err(|e| {
+        format!(
+            "Failed to create {} directory: {}",
+            canonical_workspace_dir_label(),
+            e
+        )
+    })?;
+    ensure_workspace_gitignore(&workspace_dir)?;
     Ok(())
 }
 
@@ -1313,22 +1313,21 @@ pub async fn discover_project(
 
     let cfg = settings.read().await;
 
-    let ac_new_dir = base.join(".ac-new");
-    if !ac_new_dir.is_dir() {
+    let Some(workspace_dir) = existing_workspace_dir(base) else {
         return Ok(AcDiscoveryResult {
             agents: vec![],
             teams: vec![],
             workgroups: vec![],
         });
-    }
+    };
 
     // Opportunistic: ensure gitignore protects workgroup clones
-    let _ = ensure_ac_new_gitignore(&ac_new_dir);
+    let _ = ensure_workspace_gitignore(&workspace_dir);
 
     // Discovery-wide team snapshot — see discover_ac_agents for rationale.
     // Lock-safe: discover_teams() reads settings from disk via load_settings()
     // and does NOT acquire SettingsState; the read guard above stays valid.
-    // Placed AFTER the .ac-new-missing early return so non-AC folders don't
+    // Placed AFTER the workspace-missing early return so non-AC folders don't
     // pay a wasted filesystem scan (§15 Finding F1).
     let teams_snapshot = crate::config::teams::discover_teams();
     let call_id = DISCOVERY_CALL_ID.fetch_add(1, Ordering::Relaxed);
@@ -1343,9 +1342,9 @@ pub async fn discover_project(
     let mut teams: Vec<AcTeam> = Vec::new();
     let mut workgroups: Vec<AcWorkgroup> = Vec::new();
 
-    let entries = match std::fs::read_dir(&ac_new_dir) {
+    let entries = match std::fs::read_dir(&workspace_dir) {
         Ok(e) => e,
-        Err(e) => return Err(format!("Failed to read .ac-new directory: {}", e)),
+        Err(e) => return Err(format!("Failed to read AC workspace directory: {}", e)),
     };
 
     for entry in entries.flatten() {
@@ -1714,7 +1713,7 @@ pub async fn open_project(
     Ok(result)
 }
 
-/// Ensure an AC project at `path` (creating `.ac-new/` if missing) and
+/// Ensure an AC project at `path` (creating `.ac/` if missing) and
 /// register it in `settings.project_paths`. Mirrors the ActionBar "New
 /// Project" flow at `src/sidebar/components/ActionBar.tsx:58-71`.
 #[tauri::command]
@@ -1747,40 +1746,73 @@ fn read_task_fields(wg_path: &Path) -> TaskFields {
 mod tests {
     use super::*;
 
-    #[test]
-    fn ensure_ac_new_gitignore_includes_delete_sentinels_on_create() {
+    #[tokio::test]
+    async fn check_project_path_accepts_ac() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let ac_new = tmp.path().join(".ac-new");
-        std::fs::create_dir(&ac_new).expect("create .ac-new");
+        std::fs::create_dir(tmp.path().join(".ac")).expect("create .ac");
 
-        ensure_ac_new_gitignore(&ac_new).expect("ensure .ac-new/.gitignore");
+        assert!(check_project_path(tmp.path().to_string_lossy().to_string())
+            .await
+            .expect("check path"));
+    }
+
+    #[tokio::test]
+    async fn check_project_path_accepts_legacy_ac_new() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(tmp.path().join(".ac-new")).expect("create .ac-new");
+
+        assert!(check_project_path(tmp.path().to_string_lossy().to_string())
+            .await
+            .expect("check path"));
+    }
+
+    #[tokio::test]
+    async fn create_ac_project_creates_ac_not_ac_new() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        create_ac_project(tmp.path().to_string_lossy().to_string())
+            .await
+            .expect("create project");
+
+        assert!(tmp.path().join(".ac").is_dir());
+        assert!(tmp.path().join(".ac").join(".gitignore").is_file());
+        assert!(!tmp.path().join(".ac-new").exists());
+    }
+
+    #[test]
+    fn ensure_workspace_gitignore_includes_delete_sentinels_on_create() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create .ac");
+
+        ensure_workspace_gitignore(&workspace).expect("ensure workspace .gitignore");
 
         let content =
-            std::fs::read_to_string(ac_new.join(".gitignore")).expect("read .ac-new/.gitignore");
+            std::fs::read_to_string(workspace.join(".gitignore")).expect("read .gitignore");
         assert!(
             content.lines().any(|line| line.trim() == ".deleting-*/"),
-            ".ac-new/.gitignore must ignore workgroup delete sentinel directories"
+            "workspace .gitignore must ignore workgroup delete sentinel directories"
         );
     }
 
     #[test]
-    fn ensure_ac_new_gitignore_appends_delete_sentinels_to_existing_file() {
+    fn ensure_workspace_gitignore_appends_delete_sentinels_to_existing_file() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let ac_new = tmp.path().join(".ac-new");
-        std::fs::create_dir(&ac_new).expect("create .ac-new");
-        std::fs::write(ac_new.join(".gitignore"), "wg-*/\n").expect("write .gitignore");
+        let workspace = tmp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create .ac");
+        std::fs::write(workspace.join(".gitignore"), "wg-*/\n").expect("write .gitignore");
 
-        ensure_ac_new_gitignore(&ac_new).expect("ensure .ac-new/.gitignore");
+        ensure_workspace_gitignore(&workspace).expect("ensure workspace .gitignore");
 
         let content =
-            std::fs::read_to_string(ac_new.join(".gitignore")).expect("read .ac-new/.gitignore");
+            std::fs::read_to_string(workspace.join(".gitignore")).expect("read .gitignore");
         let count = content
             .lines()
             .filter(|line| line.trim() == ".deleting-*/")
             .count();
         assert_eq!(
             count, 1,
-            ".ac-new/.gitignore should append the delete sentinel pattern exactly once"
+            "workspace .gitignore should append the delete sentinel pattern exactly once"
         );
     }
 

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -960,7 +960,7 @@ pub async fn create_workgroup(
             "$AGENTSCOMMANDER_CONTEXT".to_string(),
             "$REPOS_WORKSPACE_INFO".to_string(),
         ];
-        // Resolve agent_path against base (.ac-new) for relative paths
+        // Resolve agent_path against the selected workspace for relative paths.
         let matrix_dir = if Path::new(agent_path).is_absolute() {
             Path::new(agent_path).to_path_buf()
         } else {
@@ -1840,7 +1840,7 @@ pub(crate) fn is_file_in_use_error(e: &std::io::Error) -> bool {
     }
 }
 
-/// Scan `.ac-new/` for existing `wg-<N>-{team_name}/` dirs and return the
+/// Scan the selected workspace for existing `wg-<N>-{team_name}/` dirs and return the
 /// **lowest free positive integer** starting at 1.
 ///
 /// Issue #177: previously this returned `max(existing) + 1`, which left
@@ -1907,7 +1907,7 @@ fn determine_next_wg_number(ac_new_dir: &Path, team_name: &str) -> u32 {
 fn compute_relative_identity(agent_path: &str, replica_dir: &Path, ac_new_dir: &Path) -> String {
     let agent = Path::new(agent_path);
 
-    // If it's already a relative path within the same .ac-new/, make it relative to replica
+    // If it's already a relative path within the same workspace, make it relative to replica.
     if agent.is_relative() {
         // agent_path is like "../_agent_foo" or "_agent_foo"
         // From replica inside wg-N-team/ we need to go ../../_agent_foo
@@ -2714,7 +2714,7 @@ mod tests {
             .unwrap_or_else(|e| panic!("create_dir {}: {}", name, e));
     }
 
-    /// Empty `.ac-new/` returns slot 1 — the lowest positive integer.
+    /// Empty workspace returns slot 1, the lowest positive integer.
     #[test]
     fn determine_next_wg_number_returns_one_when_no_wg_dirs_exist() {
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -8,6 +8,7 @@ use tauri::{AppHandle, Emitter, State};
 use crate::commands::ac_discovery::DiscoveryBranchWatcher;
 use crate::config::claude_settings::ensure_claude_md_excludes;
 use crate::config::settings::{AppSettings, SettingsState};
+use crate::config::workspace::existing_workspace_dir;
 use crate::pty::git_watcher::{CoordinatorChangedPayload, GitWatcher};
 use crate::session::manager::SessionManager;
 use crate::session::session::SessionRepo;
@@ -342,7 +343,7 @@ fn build_role_content(
          {description}\n\
          {profile}\n\
          ## Source of Truth\n\n\
-         This role is defined in Role.md of your Agent Matrix at: .ac-new/_agent_{name}/\n\
+         This role is defined in Role.md of your Agent Matrix at: .ac/_agent_{name}/\n\
          If you are running as a replica, this file was generated from that source.\n\
          Always use memory/, plans/, and skills/ from your Agent Matrix, and treat Role.md \
          there as the canonical role definition. Never use external memory systems.\n\n\
@@ -404,13 +405,7 @@ pub(crate) fn create_agent_matrix_on_disk(
 ) -> Result<CreatedAgentMatrixOnDisk, String> {
     let safe_name = sanitize_name(args.name)?;
     let project = Path::new(args.project_path);
-    let base = project.join(".ac-new");
-    if !base.is_dir() {
-        return Err(format!(
-            ".ac-new directory not found in {}",
-            args.project_path
-        ));
-    }
+    let base = selected_workspace_dir(project)?;
 
     let agent_dir = base.join(format!("_agent_{}", safe_name));
     if agent_dir.exists() {
@@ -523,11 +518,20 @@ fn default_agent_matrix_config() -> serde_json::Value {
     })
 }
 
+fn selected_workspace_dir(project: &Path) -> Result<PathBuf, String> {
+    existing_workspace_dir(project).ok_or_else(|| {
+        format!(
+            ".ac directory not found in {} (legacy .ac-new also absent)",
+            project.display()
+        )
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
 
-/// Create an agent matrix directory inside {project_path}/.ac-new/_agent_{name}/
+/// Create an agent matrix directory inside {project_path}/.ac/_agent_{name}/
 ///
 /// `role_template_id` is the picker selection from `list_role_templates`; when
 /// `Some`, the resolved template's body is inserted as a `## Role Profile`
@@ -571,16 +575,13 @@ pub async fn create_agent_matrix(
 }
 
 /// Delete an agent matrix directory from a project.
-/// Removes {project_path}/.ac-new/_agent_{agent_name}/ entirely.
+/// Removes {project_path}/.ac/_agent_{agent_name}/ entirely.
 /// Checks that no team references this agent before deleting.
 #[tauri::command]
 pub async fn delete_agent_matrix(project_path: String, agent_name: String) -> Result<(), String> {
     validate_existing_name(&agent_name, "Agent")?;
 
-    let base = Path::new(&project_path).join(".ac-new");
-    if !base.is_dir() {
-        return Err(format!(".ac-new directory not found in {}", project_path));
-    }
+    let base = selected_workspace_dir(Path::new(&project_path))?;
 
     let agent_dir = base.join(format!("_agent_{}", agent_name));
     if !agent_dir.exists() {
@@ -594,7 +595,7 @@ pub async fn delete_agent_matrix(project_path: String, agent_name: String) -> Re
     let agent_dir_name = format!("_agent_{}", agent_name);
     let mut referencing_teams: Vec<String> = Vec::new();
     let entries = std::fs::read_dir(&base)
-        .map_err(|e| format!("Cannot read .ac-new directory for integrity check: {}", e))?;
+        .map_err(|e| format!("Cannot read workspace directory for integrity check: {}", e))?;
     for entry in entries {
         let entry = entry
             .map_err(|e| format!("Cannot read directory entry during integrity check: {}", e))?;
@@ -647,17 +648,16 @@ pub async fn delete_agent_matrix(project_path: String, agent_name: String) -> Re
 }
 
 /// List all agent matrices across multiple project paths.
-/// Scans {project}/.ac-new/_agent_*/ and reads Role.md frontmatter.
+/// Scans {project}/.ac/_agent_*/ and reads Role.md frontmatter.
 #[tauri::command]
 pub async fn list_all_agents(project_paths: Vec<String>) -> Result<Vec<AgentInfo>, String> {
     let mut agents: Vec<AgentInfo> = Vec::new();
 
     for project_path in &project_paths {
         let base = Path::new(project_path);
-        let ac_new = base.join(".ac-new");
-        if !ac_new.is_dir() {
+        let Some(ac_new) = existing_workspace_dir(base) else {
             continue;
-        }
+        };
 
         let project_name = base
             .file_name()
@@ -714,7 +714,7 @@ pub async fn list_all_agents(project_paths: Vec<String>) -> Result<Vec<AgentInfo
     Ok(agents)
 }
 
-/// Create a team directory inside {project_path}/.ac-new/_team_{name}/
+/// Create a team directory inside {project_path}/.ac/_team_{name}/
 #[tauri::command]
 pub async fn create_team(
     app: AppHandle,
@@ -726,10 +726,7 @@ pub async fn create_team(
     repos: Vec<RepoAssignment>,
 ) -> Result<CreatedEntityResult, String> {
     let safe_name = sanitize_name(&name)?;
-    let base = Path::new(&project_path).join(".ac-new");
-    if !base.is_dir() {
-        return Err(format!(".ac-new directory not found in {}", project_path));
-    }
+    let base = selected_workspace_dir(Path::new(&project_path))?;
 
     let team_dir = base.join(format!("_team_{}", safe_name));
     if team_dir.exists() {
@@ -802,15 +799,12 @@ pub async fn create_workgroup(
     if task_title.chars().count() > 256 {
         return Err("Task title is too long (max 256 characters)".to_string());
     }
-    let base = Path::new(&project_path).join(".ac-new");
-    if !base.is_dir() {
-        return Err(format!(".ac-new directory not found in {}", project_path));
-    }
+    let base = selected_workspace_dir(Path::new(&project_path))?;
 
     // Ensure gitignore protects workgroup clones from parent repo operations
-    if let Err(e) = crate::commands::ac_discovery::ensure_ac_new_gitignore(&base) {
+    if let Err(e) = crate::commands::ac_discovery::ensure_workspace_gitignore(&base) {
         log::warn!(
-            "[create_workgroup] Failed to ensure .ac-new/.gitignore: {}",
+            "[create_workgroup] Failed to ensure workspace .gitignore: {}",
             e
         );
     }
@@ -1023,7 +1017,7 @@ pub async fn create_workgroup(
     })
 }
 
-/// Delete a team directory from {project_path}/.ac-new/_team_{name}/
+/// Delete a team directory from {project_path}/.ac/_team_{name}/
 #[tauri::command]
 pub async fn delete_team(
     app: AppHandle,
@@ -1032,10 +1026,7 @@ pub async fn delete_team(
     team_name: String,
 ) -> Result<(), String> {
     validate_existing_name(&team_name, "Team")?;
-    let base = Path::new(&project_path).join(".ac-new");
-    if !base.is_dir() {
-        return Err(format!(".ac-new directory not found in {}", project_path));
-    }
+    let base = selected_workspace_dir(Path::new(&project_path))?;
 
     let team_dir = base.join(format!("_team_{}", team_name));
     if !team_dir.exists() {
@@ -1097,7 +1088,7 @@ pub async fn delete_team(
     Ok(())
 }
 
-/// Delete a single workgroup directory from {project_path}/.ac-new/{wg_name}/
+/// Delete a single workgroup directory from {project_path}/.ac/{wg_name}/
 /// Returns dirty repo list as an Err if any repos have uncommitted/unpushed work.
 /// Pass `force = true` to skip the dirty-repo safety check (user already confirmed).
 #[tauri::command]
@@ -1110,10 +1101,7 @@ pub async fn delete_workgroup(
 ) -> Result<(), String> {
     validate_existing_name(&workgroup_name, "Workgroup")?;
 
-    let base = Path::new(&project_path).join(".ac-new");
-    if !base.is_dir() {
-        return Err(format!(".ac-new directory not found in {}", project_path));
-    }
+    let base = selected_workspace_dir(Path::new(&project_path))?;
 
     let wg_dir = base.join(&workgroup_name);
     if !wg_dir.exists() {
@@ -1182,7 +1170,7 @@ pub async fn delete_workgroup(
     Ok(())
 }
 
-/// Update an existing team's config.json in {project_path}/.ac-new/_team_{name}/
+/// Update an existing team's config.json in {project_path}/.ac/_team_{name}/
 // Tauri command: State<> injections push us over clippy's 7-arg threshold.
 #[allow(clippy::too_many_arguments)]
 #[tauri::command]
@@ -1198,10 +1186,7 @@ pub async fn update_team(
     repos: Vec<RepoAssignment>,
 ) -> Result<(), String> {
     validate_existing_name(&team_name, "Team")?;
-    let base = Path::new(&project_path).join(".ac-new");
-    if !base.is_dir() {
-        return Err(format!(".ac-new directory not found in {}", project_path));
-    }
+    let base = selected_workspace_dir(Path::new(&project_path))?;
 
     let team_dir = base.join(format!("_team_{}", team_name));
     if !team_dir.exists() {
@@ -1526,10 +1511,7 @@ pub async fn sync_workgroup_repos(
 ) -> Result<SyncResult, String> {
     validate_existing_name(&team_name, "Team")?;
 
-    let base = Path::new(&project_path).join(".ac-new");
-    if !base.is_dir() {
-        return Err(format!(".ac-new directory not found in {}", project_path));
-    }
+    let base = selected_workspace_dir(Path::new(&project_path))?;
 
     let team_dir = base.join(format!("_team_{}", team_name));
     if !team_dir.exists() {
@@ -1605,10 +1587,7 @@ pub async fn get_team_config(
     team_name: String,
 ) -> Result<TeamConfigResult, String> {
     validate_existing_name(&team_name, "Team")?;
-    let base = Path::new(&project_path).join(".ac-new");
-    if !base.is_dir() {
-        return Err(format!(".ac-new directory not found in {}", project_path));
-    }
+    let base = selected_workspace_dir(Path::new(&project_path))?;
 
     let team_dir = base.join(format!("_team_{}", team_name));
     let config_path = team_dir.join("config.json");
@@ -2109,8 +2088,8 @@ mod tests {
     fn create_agent_matrix_on_disk_creates_full_layout_without_template() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let project = tmp.path().join("ProjectAlpha");
-        let ac_new = project.join(".ac-new");
-        std::fs::create_dir_all(&ac_new).expect("create .ac-new");
+        let workspace = project.join(".ac");
+        std::fs::create_dir_all(&workspace).expect("create .ac");
         let settings = AppSettings::default();
         let project_s = project.to_string_lossy().to_string();
 
@@ -2124,7 +2103,7 @@ mod tests {
         })
         .expect("create matrix");
 
-        let agent_dir = ac_new.join("_agent_architect");
+        let agent_dir = workspace.join("_agent_architect");
         assert_eq!(created.agent_dir, agent_dir);
         assert_eq!(created.safe_name, "architect");
         assert_eq!(created.display_name, "ProjectAlpha/architect");
@@ -2137,6 +2116,53 @@ mod tests {
                 canonical
             );
         }
+    }
+
+    #[test]
+    fn create_agent_matrix_on_disk_falls_back_to_legacy_ac_new() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("ProjectAlpha");
+        let legacy_workspace = project.join(".ac-new");
+        std::fs::create_dir_all(&legacy_workspace).expect("create .ac-new");
+        let settings = AppSettings::default();
+        let project_s = project.to_string_lossy().to_string();
+
+        let created = create_agent_matrix_on_disk(CreateAgentMatrixDiskArgs {
+            project_path: &project_s,
+            name: "Architect",
+            description: "Build plans",
+            role_template_id: None,
+            settings: &settings,
+            config_dir: None,
+        })
+        .expect("create matrix");
+
+        assert_eq!(created.agent_dir, legacy_workspace.join("_agent_architect"));
+    }
+
+    #[test]
+    fn create_agent_matrix_on_disk_prefers_ac_when_both_exist() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("ProjectAlpha");
+        let workspace = project.join(".ac");
+        let legacy_workspace = project.join(".ac-new");
+        std::fs::create_dir_all(&workspace).expect("create .ac");
+        std::fs::create_dir_all(&legacy_workspace).expect("create .ac-new");
+        let settings = AppSettings::default();
+        let project_s = project.to_string_lossy().to_string();
+
+        let created = create_agent_matrix_on_disk(CreateAgentMatrixDiskArgs {
+            project_path: &project_s,
+            name: "Architect",
+            description: "Build plans",
+            role_template_id: None,
+            settings: &settings,
+            config_dir: None,
+        })
+        .expect("create matrix");
+
+        assert_eq!(created.agent_dir, workspace.join("_agent_architect"));
+        assert!(!legacy_workspace.join("_agent_architect").exists());
     }
 
     #[test]
@@ -2846,7 +2872,7 @@ mod tests {
         let description = "Test agent description.";
         let desc_yaml = description.replace('\'', "''");
         let legacy = format!(
-            "---\nname: '{}'\ndescription: '{}'\ntype: agent\n---\n\n# {}\n\n{}\n\n## Source of Truth\n\nThis role is defined in Role.md of your Agent Matrix at: .ac-new/_agent_{}/\nIf you are running as a replica, this file was generated from that source.\nAlways use memory/, plans/, and skills/ from your Agent Matrix, and treat Role.md there as the canonical role definition. Never use external memory systems.\n\n## Agent Memory Rule\n\nIf you are running as a replica, the single source of truth for persistent knowledge is your Agent Matrix's memory/, plans/, skills/, and Role.md. Use your replica folder only for replica-local scratch, inbox/outbox, and session artifacts. NEVER use external memory systems from the coding agent (e.g., ~/.claude/projects/memory/).\n",
+            "---\nname: '{}'\ndescription: '{}'\ntype: agent\n---\n\n# {}\n\n{}\n\n## Source of Truth\n\nThis role is defined in Role.md of your Agent Matrix at: .ac/_agent_{}/\nIf you are running as a replica, this file was generated from that source.\nAlways use memory/, plans/, and skills/ from your Agent Matrix, and treat Role.md there as the canonical role definition. Never use external memory systems.\n\n## Agent Memory Rule\n\nIf you are running as a replica, the single source of truth for persistent knowledge is your Agent Matrix's memory/, plans/, skills/, and Role.md. Use your replica folder only for replica-local scratch, inbox/outbox, and session artifacts. NEVER use external memory systems from the coding agent (e.g., ~/.claude/projects/memory/).\n",
             safe_name, desc_yaml, safe_name, description, safe_name
         );
         let actual = build_role_content(safe_name, description, None);

--- a/src-tauri/src/config/claude_settings.rs
+++ b/src-tauri/src/config/claude_settings.rs
@@ -503,11 +503,11 @@ fn discriminant_label(v: &serde_json::Value) -> &'static str {
     }
 }
 
-/// Walks every `<project_root>/.ac-new/` and returns absolute paths to every
+/// Walks every `<project_root>/<workspace>/` and returns absolute paths to every
 /// `_agent_*` matrix and every `__agent_*` replica (inside `wg-*` dirs).
 ///
 /// **`project_paths` semantics.** Each entry may be either (a) a project root
-/// that directly contains `.ac-new/`, or (b) a parent dir holding many such
+/// that directly contains an AC workspace, or (b) a parent dir holding many such
 /// project roots as immediate children. We probe both shapes — base + non-
 /// hidden children — mirroring the existing pattern in
 /// `commands/ac_discovery.rs::discover_ac_agents` (~line 596) and
@@ -611,7 +611,7 @@ pub fn enumerate_managed_agent_dirs(project_paths: &[String]) -> Vec<std::path::
         }
 
         // Build the candidate list: the base itself, plus its non-hidden
-        // immediate children. Each candidate is probed for `.ac-new/`. This
+        // immediate children. Each candidate is probed for an AC workspace. This
         // matches the convention used by `commands/ac_discovery.rs` and
         // `commands/repos.rs`, where `project_paths` may be a parent dir.
         //
@@ -639,10 +639,9 @@ pub fn enumerate_managed_agent_dirs(project_paths: &[String]) -> Vec<std::path::
         }
 
         for repo_dir in candidates {
-            let ac_new = repo_dir.join(".ac-new");
-            if !ac_new.is_dir() {
+            let Some(ac_new) = crate::config::workspace::existing_workspace_dir(&repo_dir) else {
                 continue;
-            }
+            };
             scan_ac_new(&ac_new, &mut out, &mut seen);
         }
     }

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -9,6 +9,7 @@ pub mod session_context;
 pub mod sessions_persistence;
 pub mod settings;
 pub mod teams;
+pub mod workspace;
 
 use std::path::PathBuf;
 use std::sync::OnceLock;

--- a/src-tauri/src/config/profile.rs
+++ b/src-tauri/src/config/profile.rs
@@ -62,7 +62,7 @@ pub fn app_title() -> &'static str {
     TITLE.get_or_init(|| match binary_suffix() {
         Some(suffix) => format!("Agents Commander [{}]", suffix.to_uppercase()),
         None => match BUILD_PROFILE {
-            "dev" => "Agents Commander New".to_string(),
+            "dev" => "Agents Commander".to_string(),
             "stage" => "Agents Commander [STAGE]".to_string(),
             _ => "Agents Commander".to_string(),
         },
@@ -116,7 +116,7 @@ pub fn product_name() -> &'static str {
     NAME.get_or_init(|| match binary_suffix() {
         Some(suffix) => format!("Agents Commander {}", capitalize_suffix(suffix)),
         None => match BUILD_PROFILE {
-            "dev" => "Agents Commander New".to_string(),
+            "dev" => "Agents Commander".to_string(),
             "stage" => "Agents Commander Stage".to_string(),
             _ => "Agents Commander".to_string(),
         },

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use super::settings::AppSettings;
+use super::workspace::{existing_workspace_dir, has_workspace_dir, workspace_dir_for_project};
 
 /// Outcome of a register call. Callers translate this into the verb-specific
 /// stdout / IPC payload (CLI prints the lines from §2; Tauri command returns
@@ -23,7 +24,7 @@ pub struct ProjectRegistration {
     /// `true` when this call appended a new entry; `false` when the path was
     /// already present (case-insensitive, slash-normalised match).
     pub registered: bool,
-    /// `true` when this call created `.ac-new/` on disk. Always `false` for
+    /// `true` when this call created `.ac/` on disk. Always `false` for
     /// `open_project`. `true` for `new_project` only when the directory did
     /// not already exist.
     pub created: bool,
@@ -46,14 +47,14 @@ pub enum ProjectError {
     PathMissing(PathBuf),
     #[error("path is not a directory: {0}")]
     NotADirectory(PathBuf),
-    #[error("no AC project at {0} (.ac-new/ not found)")]
-    AcNewMissing(PathBuf),
+    #[error("no AC project at {0} (.ac/ or legacy .ac-new/ not found)")]
+    WorkspaceMissing(PathBuf),
     #[error("failed to resolve absolute path for '{0}': {1}")]
     CwdFailure(String, std::io::Error),
-    #[error("failed to create .ac-new directory at {0}: {1}")]
-    AcNewCreateFailed(PathBuf, std::io::Error),
-    #[error("failed to write .ac-new/.gitignore at {0}: {1}")]
-    GitignoreFailed(PathBuf, String),
+    #[error("failed to create .ac directory at {0}: {1}")]
+    WorkspaceCreateFailed(PathBuf, std::io::Error),
+    #[error("failed to write workspace .gitignore at {0}: {1}")]
+    WorkspaceGitignoreFailed(PathBuf, String),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -72,7 +73,7 @@ pub enum ProjectResolveError {
 }
 
 /// Validate an existing AC project and register it in `settings.project_paths`.
-/// Errors when the path is missing, not a directory, or has no `.ac-new/`.
+/// Errors when the path is missing, not a directory, or has no AC workspace.
 ///
 /// On success, mutates `settings.project_paths` (appends if new) and
 /// `settings.project_path` (legacy single-project field — kept in sync with
@@ -91,9 +92,8 @@ pub fn register_existing_project(
     if !abs.is_dir() {
         return Err(ProjectError::NotADirectory(abs));
     }
-    let ac_new = abs.join(".ac-new");
-    if !ac_new.is_dir() {
-        return Err(ProjectError::AcNewMissing(abs));
+    if existing_workspace_dir(&abs).is_none() {
+        return Err(ProjectError::WorkspaceMissing(abs));
     }
     let abs_str = abs.to_string_lossy().into_owned();
     let registered = upsert_project_path(settings, &abs_str);
@@ -104,11 +104,11 @@ pub fn register_existing_project(
     })
 }
 
-/// Ensure the AC project structure exists (creating `.ac-new/` and its
+/// Ensure the AC project structure exists (creating `.ac/` and its
 /// `.gitignore` when missing) and register it in `settings.project_paths`.
 ///
 /// Errors only when the path is empty, the parent does not exist, or
-/// `.ac-new/` cannot be created. A pre-existing `.ac-new/` is fine — the
+/// `.ac/` cannot be created. A pre-existing `.ac/` is fine; the
 /// gitignore sweep is opportunistic (matches `discover_project`'s behaviour
 /// at `src-tauri/src/commands/ac_discovery.rs:1308-1309`).
 pub fn register_new_project(
@@ -121,34 +121,42 @@ pub fn register_new_project(
     if abs.exists() && !abs.is_dir() {
         return Err(ProjectError::NotADirectory(abs));
     }
-    let ac_new = abs.join(".ac-new");
     // Ensure the parent (PATH itself) exists so the non-recursive
     // `create_dir` below can race-detect properly. `create_dir_all` is
     // idempotent on an already-existing dir, so this costs nothing extra
     // when PATH is already there.
-    std::fs::create_dir_all(&abs).map_err(|e| ProjectError::AcNewCreateFailed(abs.clone(), e))?;
-    // Authoritative `created` flag (Round-1 G9): use non-recursive
-    // `create_dir` so we can distinguish "we made the dir" from "another
-    // process beat us to it" via `ErrorKind::AlreadyExists`. The previous
-    // `is_dir()` check then `create_dir_all` pattern lied under that race.
-    let created = match std::fs::create_dir(&ac_new) {
-        Ok(()) => true,
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => false,
-        Err(e) => return Err(ProjectError::AcNewCreateFailed(ac_new.clone(), e)),
+    std::fs::create_dir_all(&abs)
+        .map_err(|e| ProjectError::WorkspaceCreateFailed(abs.clone(), e))?;
+
+    let (workspace_dir, created) = match existing_workspace_dir(&abs) {
+        Some(dir) => (dir, false),
+        None => {
+            let workspace_dir = workspace_dir_for_project(&abs);
+            // Authoritative `created` flag (Round-1 G9): use non-recursive
+            // `create_dir` so we can distinguish "we made the dir" from "another
+            // process beat us to it" via `ErrorKind::AlreadyExists`. The previous
+            // `is_dir()` check then `create_dir_all` pattern lied under that race.
+            let created = match std::fs::create_dir(&workspace_dir) {
+                Ok(()) => true,
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => false,
+                Err(e) => return Err(ProjectError::WorkspaceCreateFailed(workspace_dir.clone(), e)),
+            };
+            (workspace_dir, created)
+        }
     };
-    // Gitignore sweep (Round-1 G15): mandatory when we just created `.ac-new`
+    // Gitignore sweep (Round-1 G15): mandatory when we just created `.ac`
     // (a fresh AC project must ship with the protective patterns), best-effort
-    // when `.ac-new` pre-existed (a transient FS error on someone else's
+    // when `.ac` pre-existed (a transient FS error on someone else's
     // gitignore should not fail registration of a perfectly valid project).
-    match crate::commands::ac_discovery::ensure_ac_new_gitignore(&ac_new) {
+    match crate::commands::ac_discovery::ensure_workspace_gitignore(&workspace_dir) {
         Ok(()) => {}
         Err(e) if !created => {
             log::warn!(
-                "[projects] gitignore sweep failed on pre-existing .ac-new at {:?}: {} (best-effort, continuing)",
-                ac_new, e
+                "[projects] gitignore sweep failed on pre-existing AC workspace at {:?}: {} (best-effort, continuing)",
+                workspace_dir, e
             );
         }
-        Err(e) => return Err(ProjectError::GitignoreFailed(ac_new.clone(), e)),
+        Err(e) => return Err(ProjectError::WorkspaceGitignoreFailed(workspace_dir.clone(), e)),
     }
 
     let abs_str = abs.to_string_lossy().into_owned();
@@ -288,7 +296,7 @@ fn push_project_candidate(
     out: &mut Vec<ProjectResolution>,
     seen: &mut HashSet<String>,
 ) {
-    if !is_real_directory(path) || !is_real_directory(&path.join(".ac-new")) {
+    if !is_real_directory(path) || !has_workspace_dir(path) {
         return;
     }
     let Some(key) = canonical_key(path) else {
@@ -402,18 +410,18 @@ mod tests {
     }
 
     #[test]
-    fn open_rejects_path_without_ac_new() {
+    fn open_rejects_path_without_workspace() {
         let fix = FixtureRoot::new("proj-open-noacnew");
         let mut s = AppSettings::default();
         let r = register_existing_project(&mut s, fix.path().to_str().unwrap());
-        assert!(matches!(r, Err(ProjectError::AcNewMissing(_))));
+        assert!(matches!(r, Err(ProjectError::WorkspaceMissing(_))));
         assert!(s.project_paths.is_empty());
     }
 
     #[test]
-    fn open_registers_path_with_ac_new() {
+    fn open_registers_path_with_ac() {
         let fix = FixtureRoot::new("proj-open-ok");
-        std::fs::create_dir_all(fix.path().join(".ac-new")).unwrap();
+        std::fs::create_dir_all(fix.path().join(".ac")).unwrap();
         let mut s = AppSettings::default();
         let r = register_existing_project(&mut s, fix.path().to_str().unwrap()).unwrap();
         assert!(r.registered);
@@ -423,9 +431,31 @@ mod tests {
     }
 
     #[test]
+    fn open_registers_legacy_ac_new_fallback() {
+        let fix = FixtureRoot::new("proj-open-legacy-ok");
+        std::fs::create_dir_all(fix.path().join(".ac-new")).unwrap();
+        let mut s = AppSettings::default();
+        let r = register_existing_project(&mut s, fix.path().to_str().unwrap()).unwrap();
+        assert!(r.registered);
+        assert!(!r.created);
+        assert_eq!(s.project_paths.len(), 1);
+    }
+
+    #[test]
+    fn open_prefers_ac_when_both_ac_and_ac_new_exist() {
+        let fix = FixtureRoot::new("proj-open-both");
+        std::fs::create_dir_all(fix.path().join(".ac")).unwrap();
+        std::fs::create_dir_all(fix.path().join(".ac-new")).unwrap();
+        let mut s = AppSettings::default();
+        let r = register_existing_project(&mut s, fix.path().to_str().unwrap()).unwrap();
+        assert!(r.registered);
+        assert_eq!(existing_workspace_dir(fix.path()), Some(fix.path().join(".ac")));
+    }
+
+    #[test]
     fn open_is_idempotent_on_repeat_call() {
         let fix = FixtureRoot::new("proj-open-idem");
-        std::fs::create_dir_all(fix.path().join(".ac-new")).unwrap();
+        std::fs::create_dir_all(fix.path().join(".ac")).unwrap();
         let mut s = AppSettings::default();
         let _ = register_existing_project(&mut s, fix.path().to_str().unwrap()).unwrap();
         let r2 = register_existing_project(&mut s, fix.path().to_str().unwrap()).unwrap();
@@ -436,7 +466,7 @@ mod tests {
     #[test]
     fn open_dedup_is_case_insensitive_and_slash_agnostic() {
         let fix = FixtureRoot::new("proj-open-norm");
-        std::fs::create_dir_all(fix.path().join(".ac-new")).unwrap();
+        std::fs::create_dir_all(fix.path().join(".ac")).unwrap();
         let mut s = AppSettings::default();
         // Seed an entry with the exact path
         let original = fix.path().to_string_lossy().to_string();
@@ -453,21 +483,21 @@ mod tests {
     // ── register_new_project ─────────────────────────────────────────────
 
     #[test]
-    fn new_creates_ac_new_when_missing() {
+    fn new_creates_ac_when_missing() {
         let fix = FixtureRoot::new("proj-new-mkdir");
         let mut s = AppSettings::default();
         let r = register_new_project(&mut s, fix.path().to_str().unwrap()).unwrap();
         assert!(r.created);
         assert!(r.registered);
-        assert!(fix.path().join(".ac-new").is_dir());
-        assert!(fix.path().join(".ac-new").join(".gitignore").is_file());
+        assert!(fix.path().join(".ac").is_dir());
+        assert!(fix.path().join(".ac").join(".gitignore").is_file());
     }
 
     #[test]
     fn new_creates_parent_directory_when_missing() {
         // Covers the `create_dir_all(&abs)` branch in register_new_project
         // for a path whose project folder does NOT yet exist on disk. The
-        // existing `new_creates_ac_new_when_missing` test passes `fix.path()`
+        // existing `new_creates_ac_when_missing` test passes `fix.path()`
         // which `FixtureRoot::new` already created, so the parent-mkdir
         // branch was previously unexercised.
         let fix = FixtureRoot::new("proj-new-parent");
@@ -477,20 +507,32 @@ mod tests {
         assert!(r.created, "should report created=true for fresh path");
         assert!(r.registered);
         assert!(nested.is_dir(), "project root should have been created");
-        assert!(nested.join(".ac-new").is_dir());
-        assert!(nested.join(".ac-new").join(".gitignore").is_file());
+        assert!(nested.join(".ac").is_dir());
+        assert!(nested.join(".ac").join(".gitignore").is_file());
     }
 
     #[test]
-    fn new_skips_creation_when_ac_new_already_exists() {
+    fn new_skips_creation_when_ac_already_exists() {
         let fix = FixtureRoot::new("proj-new-existing");
+        std::fs::create_dir_all(fix.path().join(".ac")).unwrap();
+        let mut s = AppSettings::default();
+        let r = register_new_project(&mut s, fix.path().to_str().unwrap()).unwrap();
+        assert!(!r.created);
+        assert!(r.registered);
+        // gitignore swept opportunistically even though .ac pre-existed
+        assert!(fix.path().join(".ac").join(".gitignore").is_file());
+    }
+
+    #[test]
+    fn new_uses_legacy_ac_new_when_it_is_the_only_workspace() {
+        let fix = FixtureRoot::new("proj-new-legacy-existing");
         std::fs::create_dir_all(fix.path().join(".ac-new")).unwrap();
         let mut s = AppSettings::default();
         let r = register_new_project(&mut s, fix.path().to_str().unwrap()).unwrap();
         assert!(!r.created);
         assert!(r.registered);
-        // gitignore swept opportunistically even though .ac-new pre-existed
-        assert!(fix.path().join(".ac-new").join(".gitignore").is_file());
+        assert!(!fix.path().join(".ac").exists());
+        assert!(fix.path().join(".ac-new").is_dir());
     }
 
     #[test]
@@ -521,8 +563,8 @@ mod tests {
     fn upsert_syncs_legacy_project_path_field() {
         let fix1 = FixtureRoot::new("proj-legacy-1");
         let fix2 = FixtureRoot::new("proj-legacy-2");
-        std::fs::create_dir_all(fix1.path().join(".ac-new")).unwrap();
-        std::fs::create_dir_all(fix2.path().join(".ac-new")).unwrap();
+        std::fs::create_dir_all(fix1.path().join(".ac")).unwrap();
+        std::fs::create_dir_all(fix2.path().join(".ac")).unwrap();
         let mut s = AppSettings::default();
         let r1 = register_existing_project(&mut s, fix1.path().to_str().unwrap()).unwrap();
         assert_eq!(s.project_path.as_deref(), Some(r1.path.as_str()));
@@ -546,7 +588,7 @@ mod tests {
     #[test]
     fn absolutise_resolves_relative_path_against_cwd() {
         let fix = FixtureRoot::new("proj-rel");
-        std::fs::create_dir_all(fix.path().join(".ac-new")).unwrap();
+        std::fs::create_dir_all(fix.path().join(".ac")).unwrap();
         let prev = std::env::current_dir().unwrap();
         let _guard = CwdGuard(prev);
         std::env::set_current_dir(fix.path()).unwrap();
@@ -572,7 +614,7 @@ mod tests {
     fn absolutise_collapses_dotdot_segments_on_windows() {
         let fix = FixtureRoot::new("proj-dotdot");
         let project = fix.path().join("project");
-        std::fs::create_dir_all(project.join(".ac-new")).unwrap();
+        std::fs::create_dir_all(project.join(".ac")).unwrap();
         let sibling = fix.path().join("sibling");
         std::fs::create_dir_all(&sibling).unwrap();
         let prev = std::env::current_dir().unwrap();
@@ -592,7 +634,7 @@ mod tests {
     #[test]
     fn upsert_dedup_strips_trailing_separator() {
         let fix = FixtureRoot::new("proj-trailing");
-        std::fs::create_dir_all(fix.path().join(".ac-new")).unwrap();
+        std::fs::create_dir_all(fix.path().join(".ac")).unwrap();
         let mut s = AppSettings::default();
         let original = fix.path().to_string_lossy().to_string();
         let _ = register_existing_project(&mut s, &original).unwrap();
@@ -614,6 +656,10 @@ mod tests {
     // ── resolve_project_reference ───────────────────────────────────────
 
     fn create_ac_project(path: &Path) {
+        std::fs::create_dir_all(path.join(".ac")).unwrap();
+    }
+
+    fn create_legacy_ac_project(path: &Path) {
         std::fs::create_dir_all(path.join(".ac-new")).unwrap();
     }
 
@@ -636,6 +682,18 @@ mod tests {
         let fix = FixtureRoot::new("proj-resolve-parent");
         let project = fix.path().join("ProjectAlpha");
         create_ac_project(&project);
+        let project_paths = vec![fix.path().to_string_lossy().to_string()];
+
+        let resolved = resolve_project_reference(&project_paths, "ProjectAlpha").unwrap();
+
+        assert_eq!(resolved.path, project);
+    }
+
+    #[test]
+    fn resolve_project_reference_matches_legacy_child_project() {
+        let fix = FixtureRoot::new("proj-resolve-legacy-parent");
+        let project = fix.path().join("ProjectAlpha");
+        create_legacy_ac_project(&project);
         let project_paths = vec![fix.path().to_string_lossy().to_string()];
 
         let resolved = resolve_project_reference(&project_paths, "ProjectAlpha").unwrap();

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -774,16 +774,8 @@ fn canonical_or_original(path: &std::path::Path) -> std::path::PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-fn find_ac_new_root(path: &std::path::Path) -> Option<std::path::PathBuf> {
-    path.ancestors()
-        .find(|ancestor| {
-            ancestor
-                .file_name()
-                .and_then(|name| name.to_str())
-                .map(|name| name.eq_ignore_ascii_case(".ac-new"))
-                .unwrap_or(false)
-        })
-        .map(canonical_or_original)
+fn find_workspace_root(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    crate::config::workspace::find_workspace_ancestor(path).map(|p| canonical_or_original(&p))
 }
 
 fn write_combined_context_file(
@@ -846,11 +838,11 @@ fn has_agent_matrix_dir_name(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn path_parent_is_ac_new(path: &Path) -> bool {
+fn path_parent_is_workspace(path: &Path) -> bool {
     path.parent()
         .and_then(|parent| parent.file_name())
         .and_then(|name| name.to_str())
-        .map(|name| name.eq_ignore_ascii_case(".ac-new"))
+        .map(crate::config::workspace::is_workspace_dir_name)
         .unwrap_or(false)
 }
 
@@ -871,7 +863,7 @@ fn is_canonical_agent_matrix_dir(cwd: &str) -> bool {
     let Ok(canonical_path) = std::fs::canonicalize(path) else {
         return false;
     };
-    has_agent_matrix_dir_name(&canonical_path) && path_parent_is_ac_new(&canonical_path)
+    has_agent_matrix_dir_name(&canonical_path) && path_parent_is_workspace(&canonical_path)
 }
 
 fn is_agent_dir(cwd: &str) -> bool {
@@ -880,7 +872,7 @@ fn is_agent_dir(cwd: &str) -> bool {
         || super::root_agent::is_root_agent_dir_name(cwd)
 }
 
-/// Build the GIT_CEILING_DIRECTORIES value for agent sessions rooted in `.ac-new`.
+/// Build the GIT_CEILING_DIRECTORIES value for agent sessions rooted in an AC workspace.
 /// This blocks Git from traversing upward into the parent project repo when the
 /// current directory is an agent matrix, a WG replica, or a descendant of those roots.
 pub fn git_ceiling_directories_for_session_root(cwd: &str) -> Option<String> {
@@ -899,8 +891,8 @@ pub fn git_ceiling_directories_for_session_root(cwd: &str) -> Option<String> {
         }
     };
 
-    if let Some(ac_new_root) = find_ac_new_root(cwd_path) {
-        push_unique(ac_new_root);
+    if let Some(workspace_root) = find_workspace_root(cwd_path) {
+        push_unique(workspace_root);
     }
 
     push_unique(cwd_path.to_path_buf());
@@ -1437,9 +1429,9 @@ fn default_context(agent_root: &str, matrix_root: Option<&str>, skills_section: 
         )
     };
     let git_scope = if matrix_root.is_some() {
-        "Your replica directory and origin Agent Matrix are typically inside a parent repository's `.ac-new/` folder, which is `.gitignore`d. Do NOT run `git` commands that alter state (commit, branch, reset, etc.) from inside either location — that would affect the parent repo unintentionally. AgentsCommander blocks Git repository discovery above these `.ac-new` roots for agent sessions, but you must still switch into the appropriate `repo-*` directory before running Git operations that change repository state. `git status`, `git log`, and `git diff` are fine inside the allowed roots."
+        "Your replica directory and origin Agent Matrix are typically inside a parent repository's `.ac/` or legacy `.ac-new/` folder, which is `.gitignore`d. Do NOT run `git` commands that alter state (commit, branch, reset, etc.) from inside either location — that would affect the parent repo unintentionally. AgentsCommander blocks Git repository discovery above these AC workspace roots for agent sessions, but you must still switch into the appropriate `repo-*` directory before running Git operations that change repository state. `git status`, `git log`, and `git diff` are fine inside the allowed roots."
     } else {
-        "Your agent directory is typically inside a parent repository's `.ac-new/` folder, which is `.gitignore`d. Do NOT run `git` commands that alter state (commit, branch, reset, etc.) from inside that directory — that would affect the parent repo unintentionally. AgentsCommander blocks Git repository discovery above these `.ac-new` roots for agent sessions, but you must still switch into the appropriate `repo-*` directory before running Git operations that change repository state. `git status`, `git log`, and `git diff` are fine inside the allowed roots."
+        "Your agent directory is typically inside a parent repository's `.ac/` or legacy `.ac-new/` folder, which is `.gitignore`d. Do NOT run `git` commands that alter state (commit, branch, reset, etc.) from inside that directory — that would affect the parent repo unintentionally. AgentsCommander blocks Git repository discovery above these AC workspace roots for agent sessions, but you must still switch into the appropriate `repo-*` directory before running Git operations that change repository state. `git status`, `git log`, and `git diff` are fine inside the allowed roots."
     };
     let peer_name_format = match &messaging_mode {
         MessagingContextMode::Root(_) => "- **Root Agent sessions**: verified WG coordinator replicas only, shaped `<project>:<workgroup>/<agent>` — e.g. `agentscommander:wg-15-dev-team/tech-lead`.\n\nOrigin coordinators and non-coordinator WG replicas are not valid Root Agent targets in #277.".to_string(),

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
+use crate::config::workspace::{existing_workspace_dir, find_workspace_segment, has_workspace_dir};
+
 /// #280 §3.4 — record whether the missing-config one-shot INFO has already
 /// fired for a given `(project, team_dir)` pair this process. Returns
 /// `true` on the first call for that pair, `false` thereafter. Resets on
@@ -14,7 +16,7 @@ fn note_missing_team_config(project: &str, team_dir: &str) -> bool {
     g.insert((project.to_string(), team_dir.to_string()))
 }
 
-/// A team discovered from `_team_*/config.json` in `.ac-new/` project directories.
+/// A team discovered from `_team_*/config.json` in AC workspace directories.
 #[derive(Debug, Clone)]
 pub struct DiscoveredTeam {
     pub name: String,
@@ -62,21 +64,21 @@ pub fn split_project_prefix(name: &str) -> (Option<&str>, &str) {
 
 /// Derive the fully-qualified agent name from a CWD.
 ///
-/// - WG replica CWD `<...>/<project>/.ac-new/wg-N-team/__agent_alice[/...]`
+/// - WG replica CWD `<...>/<project>/.ac/wg-N-team/__agent_alice[/...]`
 ///   → `<project>:wg-N-team/alice`
 /// - Non-WG CWD `<...>/<project>/<agent>`
 ///   → `<project>/<agent>` (unchanged from `agent_name_from_path`)
 ///
-/// Uses `rposition` so a pathological path containing an earlier `.ac-new`
-/// segment (e.g. `C:/.ac-new/repos/proj/.ac-new/wg-1-devs/__agent_x`) anchors
+/// Uses `rposition` so a pathological path containing an earlier workspace
+/// segment (e.g. `C:/.ac/repos/proj/.ac/wg-1-devs/__agent_x`) anchors
 /// on the right-most occurrence — the identity anchor. Subdirectories inside
-/// a replica (`.ac-new/wg-1-devs/__agent_alice/some/deep`) resolve to the
+/// a replica (`.ac/wg-1-devs/__agent_alice/some/deep`) resolve to the
 /// owning replica's FQN, consistent with "alice owns her subdirs".
 pub fn agent_fqn_from_path(path: &str) -> String {
     let normalized = path.replace('\\', "/");
     let parts: Vec<&str> = normalized.split('/').filter(|s| !s.is_empty()).collect();
 
-    if let Some(ac_idx) = parts.iter().rposition(|p| *p == ".ac-new") {
+    if let Some(ac_idx) = find_workspace_segment(&parts) {
         if ac_idx > 0 && ac_idx + 2 < parts.len() {
             let project = parts[ac_idx - 1];
             let wg = parts[ac_idx + 1];
@@ -175,14 +177,14 @@ fn enumerate_project_dirs(project_paths: &[String]) -> Vec<(String, PathBuf)> {
             continue;
         }
 
-        // Include base itself if it contains `.ac-new`.
-        if base.join(".ac-new").is_dir() {
+        // Include base itself if it contains an AC workspace.
+        if has_workspace_dir(base) {
             if let Some(name) = base.file_name().and_then(|n| n.to_str()) {
                 out.push((name.to_string(), base.to_path_buf()));
             }
         }
 
-        // Plus immediate non-dot children that contain `.ac-new`.
+        // Plus immediate non-dot children that contain an AC workspace.
         if let Ok(entries) = std::fs::read_dir(base) {
             for entry in entries.flatten() {
                 let p = entry.path();
@@ -193,7 +195,7 @@ fn enumerate_project_dirs(project_paths: &[String]) -> Vec<(String, PathBuf)> {
                 if name.starts_with('.') {
                     continue;
                 }
-                if p.join(".ac-new").is_dir() {
+                if has_workspace_dir(&p) {
                     out.push((name.to_string(), p));
                 }
             }
@@ -292,7 +294,9 @@ pub fn verified_wg_coordinator_target(
         if project_name != project {
             continue;
         }
-        let ac_new_dir = project_dir.join(".ac-new");
+        let Some(ac_new_dir) = existing_workspace_dir(&project_dir) else {
+            continue;
+        };
         let wg_dir = ac_new_dir.join(wg_name);
         if !wg_dir.is_dir() {
             continue;
@@ -368,7 +372,10 @@ pub fn resolve_agent_target(
             if name != project {
                 continue;
             }
-            let candidate = dir.join(".ac-new").join(wg).join(&replica_dir);
+            let Some(workspace_dir) = existing_workspace_dir(&dir) else {
+                continue;
+            };
+            let candidate = workspace_dir.join(wg).join(&replica_dir);
             if candidate.is_dir() {
                 return Ok(target.to_string());
             }
@@ -383,7 +390,10 @@ pub fn resolve_agent_target(
         let replica_dir = format!("__agent_{}", agent);
         let mut candidates: Vec<String> = Vec::new();
         for (name, dir) in enumerate_project_dirs(project_paths) {
-            let candidate = dir.join(".ac-new").join(wg).join(&replica_dir);
+            let Some(workspace_dir) = existing_workspace_dir(&dir) else {
+                continue;
+            };
+            let candidate = workspace_dir.join(wg).join(&replica_dir);
             if candidate.is_dir() {
                 let fqn = format!("{}:{}/{}", name, wg, agent);
                 if !candidates.contains(&fqn) {
@@ -414,12 +424,10 @@ fn resolve_agent_ref(project_folder: &str, agent_ref: &str) -> String {
         .trim_start_matches("./");
 
     if trimmed.contains(':') || trimmed.starts_with('/') {
-        // Absolute path: extract origin project from folder before .ac-new
+        // Absolute path: extract origin project from folder before the workspace marker
         let parts: Vec<&str> = trimmed.split('/').collect();
-        let origin = parts
-            .iter()
-            .position(|p| *p == ".ac-new")
-            .and_then(|i| if i > 0 { Some(parts[i - 1]) } else { None })
+        let origin = find_workspace_segment(&parts)
+            .and_then(|i| (i > 0).then_some(parts[i - 1]))
             .unwrap_or(project_folder);
         let dir_name = parts.last().unwrap_or(&trimmed);
         let agent_name = dir_name
@@ -438,7 +446,7 @@ fn resolve_agent_ref(project_folder: &str, agent_ref: &str) -> String {
     }
 }
 
-/// Resolve an agent ref to an absolute path given the .ac-new directory.
+/// Resolve an agent ref to an absolute path given the workspace directory.
 fn resolve_agent_path(ac_new_dir: &Path, agent_ref: &str) -> Option<PathBuf> {
     let normalized = agent_ref.replace('\\', "/");
     let trimmed = normalized
@@ -454,13 +462,13 @@ fn resolve_agent_path(ac_new_dir: &Path, agent_ref: &str) -> Option<PathBuf> {
         return None;
     }
 
-    // Relative to .ac-new/
+    // Relative to the workspace directory.
     let candidate = ac_new_dir.join(trimmed);
     if candidate.is_dir() {
         return Some(candidate);
     }
 
-    // Try parent of .ac-new/ (project root)
+    // Try parent of the workspace directory (project root).
     if let Some(project_root) = ac_new_dir.parent() {
         let candidate = project_root.join(trimmed);
         if candidate.is_dir() {
@@ -699,7 +707,7 @@ pub fn can_communicate(from: &str, to: &str, teams: &[DiscoveredTeam]) -> bool {
 }
 
 /// Discover all teams from all known project paths.
-/// Scans settings.project_paths (and immediate children) for `.ac-new/_team_*/config.json`.
+/// Scans settings.project_paths (and immediate children) for workspace `_team_*/config.json`.
 pub fn discover_teams() -> Vec<DiscoveredTeam> {
     let settings = crate::config::settings::load_settings();
     let mut teams = Vec::new();
@@ -757,10 +765,9 @@ pub fn discover_teams() -> Vec<DiscoveredTeam> {
 
 /// Discover teams in a single project directory.
 fn discover_teams_in_project(project_dir: &Path, teams: &mut Vec<DiscoveredTeam>) {
-    let ac_new = project_dir.join(".ac-new");
-    if !ac_new.is_dir() {
+    let Some(ac_new) = existing_workspace_dir(project_dir) else {
         return;
-    }
+    };
 
     let project_folder = project_dir
         .file_name()
@@ -910,6 +917,12 @@ mod tests {
 
     #[test]
     fn agent_fqn_from_path_wg_replica() {
+        let cwd = "C:/repos/proj-a/.ac/wg-1-devs/__agent_alice";
+        assert_eq!(agent_fqn_from_path(cwd), "proj-a:wg-1-devs/alice");
+    }
+
+    #[test]
+    fn agent_fqn_from_path_legacy_wg_replica() {
         let cwd = "C:/repos/proj-a/.ac-new/wg-1-devs/__agent_alice";
         assert_eq!(agent_fqn_from_path(cwd), "proj-a:wg-1-devs/alice");
     }
@@ -924,7 +937,7 @@ mod tests {
     /// §G6 case 1: subdirectory inside a replica still resolves to the replica's FQN.
     #[test]
     fn agent_fqn_from_path_deeper_cwd_returns_replica_fqn() {
-        let cwd = "C:/repos/proj-a/.ac-new/wg-1-devs/__agent_alice/some/deep/subdir";
+        let cwd = "C:/repos/proj-a/.ac/wg-1-devs/__agent_alice/some/deep/subdir";
         assert_eq!(agent_fqn_from_path(cwd), "proj-a:wg-1-devs/alice");
     }
 

--- a/src-tauri/src/config/workspace.rs
+++ b/src-tauri/src/config/workspace.rs
@@ -1,0 +1,63 @@
+use std::path::{Path, PathBuf};
+
+pub const CANONICAL_WORKSPACE_DIR: &str = ".ac";
+pub const LEGACY_WORKSPACE_DIR: &str = ".ac-new";
+pub const WORKSPACE_DIR_NAMES: [&str; 2] = [CANONICAL_WORKSPACE_DIR, LEGACY_WORKSPACE_DIR];
+
+pub fn canonical_workspace_dir_label() -> &'static str {
+    CANONICAL_WORKSPACE_DIR
+}
+
+pub fn workspace_dir_label() -> &'static str {
+    ".ac or legacy .ac-new"
+}
+
+pub fn workspace_dir_for_project(project: &Path) -> PathBuf {
+    project.join(CANONICAL_WORKSPACE_DIR)
+}
+
+pub fn legacy_workspace_dir_for_project(project: &Path) -> PathBuf {
+    project.join(LEGACY_WORKSPACE_DIR)
+}
+
+pub fn existing_workspace_dir(project: &Path) -> Option<PathBuf> {
+    let canonical = workspace_dir_for_project(project);
+    if canonical.is_dir() {
+        return Some(canonical);
+    }
+
+    let legacy = legacy_workspace_dir_for_project(project);
+    if legacy.is_dir() {
+        return Some(legacy);
+    }
+
+    None
+}
+
+pub fn has_workspace_dir(project: &Path) -> bool {
+    existing_workspace_dir(project).is_some()
+}
+
+pub fn is_workspace_dir_name(name: &str) -> bool {
+    WORKSPACE_DIR_NAMES
+        .iter()
+        .any(|candidate| name.eq_ignore_ascii_case(candidate))
+}
+
+pub fn find_workspace_segment(parts: &[&str]) -> Option<usize> {
+    parts
+        .iter()
+        .rposition(|part| is_workspace_dir_name(part))
+}
+
+pub fn find_workspace_ancestor(path: &Path) -> Option<PathBuf> {
+    path.ancestors()
+        .find(|ancestor| {
+            ancestor
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(is_workspace_dir_name)
+                .unwrap_or(false)
+        })
+        .map(Path::to_path_buf)
+}

--- a/src-tauri/src/config/workspace.rs
+++ b/src-tauri/src/config/workspace.rs
@@ -45,9 +45,7 @@ pub fn is_workspace_dir_name(name: &str) -> bool {
 }
 
 pub fn find_workspace_segment(parts: &[&str]) -> Option<usize> {
-    parts
-        .iter()
-        .rposition(|part| is_workspace_dir_name(part))
+    parts.iter().rposition(|part| is_workspace_dir_name(part))
 }
 
 pub fn find_workspace_ancestor(path: &Path) -> Option<PathBuf> {
@@ -60,4 +58,75 @@ pub fn find_workspace_ancestor(path: &Path) -> Option<PathBuf> {
                 .unwrap_or(false)
         })
         .map(Path::to_path_buf)
+}
+
+fn same_existing_path(a: &Path, b: &Path) -> bool {
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+pub fn ensure_authoritative_workspace_dir(workspace_dir: &Path) -> Result<(), String> {
+    let workspace_name = workspace_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "workspace path '{}' has no valid directory name",
+                workspace_dir.display()
+            )
+        })?;
+    if !is_workspace_dir_name(workspace_name) {
+        return Err(format!(
+            "workspace path '{}' is not an AC workspace directory",
+            workspace_dir.display()
+        ));
+    }
+
+    let project_dir = workspace_dir.parent().ok_or_else(|| {
+        format!(
+            "workspace path '{}' has no parent project directory",
+            workspace_dir.display()
+        )
+    })?;
+    let Some(authoritative) = existing_workspace_dir(project_dir) else {
+        return Err(format!(
+            "project '{}' has no AC workspace directory",
+            project_dir.display()
+        ));
+    };
+
+    if same_existing_path(workspace_dir, &authoritative) {
+        Ok(())
+    } else {
+        Err(format!(
+            "stale legacy workspace '{}' rejected because authoritative workspace '{}' exists",
+            workspace_dir.display(),
+            authoritative.display()
+        ))
+    }
+}
+
+pub fn stale_legacy_workspace_error_for_path(path: &Path) -> Option<String> {
+    let workspace_dir = find_workspace_ancestor(path)?;
+    let workspace_name = workspace_dir.file_name().and_then(|name| name.to_str())?;
+    if !workspace_name.eq_ignore_ascii_case(LEGACY_WORKSPACE_DIR) {
+        return None;
+    }
+    let project_dir = workspace_dir.parent()?;
+    let canonical = workspace_dir_for_project(project_dir);
+    if canonical.is_dir() && !same_existing_path(&workspace_dir, &canonical) {
+        Some(format!(
+            "stale legacy workspace '{}' rejected because authoritative workspace '{}' exists",
+            workspace_dir.display(),
+            canonical.display()
+        ))
+    } else {
+        None
+    }
+}
+
+pub fn path_uses_stale_legacy_workspace(path: &Path) -> bool {
+    stale_legacy_workspace_error_for_path(path).is_some()
 }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -228,35 +228,54 @@ fn validate_root_sender_payload_with_root_dir(
 /// Uses `to_str()?` (NOT `to_string_lossy()`) for parity with
 /// `list_peers::detect_wg_replica`. Keep this in lockstep with
 /// `cli::send::derive_root_project_dir`.
-fn derive_project_from_outbox_path(outbox_file: &Path) -> Option<String> {
-    let canon = std::fs::canonicalize(outbox_file).ok()?;
+fn derive_project_from_outbox_path(outbox_file: &Path) -> Result<Option<String>, String> {
+    let Some(canon) = std::fs::canonicalize(outbox_file).ok() else {
+        return Ok(None);
+    };
     // canon = <project>/<workspace>/wg-*/__agent_*/<local-dir>/outbox/<file>.json
-    let outbox_dir = canon.parent()?; // .../outbox
+    let Some(outbox_dir) = canon.parent() else {
+        return Ok(None);
+    };
     if outbox_dir.file_name().and_then(|n| n.to_str()) != Some("outbox") {
-        return None;
+        return Ok(None);
     }
-    let local_dir = outbox_dir.parent()?; // .../<local-dir>
-    let agent_dir = local_dir.parent()?; // .../__agent_*
-    let agent_name = agent_dir.file_name().and_then(|n| n.to_str())?;
+    let Some(local_dir) = outbox_dir.parent() else {
+        return Ok(None);
+    };
+    let Some(agent_dir) = local_dir.parent() else {
+        return Ok(None);
+    };
+    let Some(agent_name) = agent_dir.file_name().and_then(|n| n.to_str()) else {
+        return Ok(None);
+    };
     if !agent_name.starts_with("__agent_") {
-        return None;
+        return Ok(None);
     }
-    let wg_dir = agent_dir.parent()?; // .../wg-*
-    let wg_name = wg_dir.file_name().and_then(|n| n.to_str())?;
+    let Some(wg_dir) = agent_dir.parent() else {
+        return Ok(None);
+    };
+    let Some(wg_name) = wg_dir.file_name().and_then(|n| n.to_str()) else {
+        return Ok(None);
+    };
     if !wg_name.starts_with("wg-") {
-        return None;
+        return Ok(None);
     }
-    let workspace_dir = wg_dir.parent()?; // .../<workspace>
+    let Some(workspace_dir) = wg_dir.parent() else {
+        return Ok(None);
+    };
     if !workspace_dir
         .file_name()
         .and_then(|n| n.to_str())
         .map(crate::config::workspace::is_workspace_dir_name)
         .unwrap_or(false)
     {
-        return None;
+        return Ok(None);
     }
-    let project_dir = workspace_dir.parent()?; // .../<project>
-    Some(project_dir.to_str()?.to_string())
+    crate::config::workspace::ensure_authoritative_workspace_dir(workspace_dir)?;
+    let Some(project_dir) = workspace_dir.parent() else {
+        return Ok(None);
+    };
+    Ok(project_dir.to_str().map(|path| path.to_string()))
 }
 
 /// Tracks delivery attempts for a single outbox message.
@@ -706,6 +725,13 @@ impl MailboxPoller {
             msg.mode
         );
 
+        let outbox_project = match derive_project_from_outbox_path(path) {
+            Ok(project) => project,
+            Err(reason) => {
+                return self.reject_message(path, &msg, &reason).await;
+            }
+        };
+
         // For repo outboxes (not app-outbox), validate that msg.from matches the outbox owner.
         // This prevents tokenless spoofing: a message in repo X's outbox must claim to be from repo X.
         //
@@ -774,16 +800,16 @@ impl MailboxPoller {
                 let c = cfg.read().await;
                 c.project_paths.clone()
             };
-            if let Some(root_project) = derive_project_from_outbox_path(path) {
-                let canon_root_project = std::fs::canonicalize(&root_project).ok();
+            if let Some(root_project) = outbox_project.as_ref() {
+                let canon_root_project = std::fs::canonicalize(root_project).ok();
                 let already_present = paths.iter().any(|p| match &canon_root_project {
                     Some(canon_target) => {
                         std::fs::canonicalize(p).ok().as_ref() == Some(canon_target)
                     }
-                    None => p == &root_project,
+                    None => p == root_project,
                 });
                 if !already_present {
-                    paths.push(root_project);
+                    paths.push(root_project.clone());
                 }
             }
             match crate::config::teams::resolve_agent_target(&msg.to, &paths) {
@@ -906,16 +932,16 @@ impl MailboxPoller {
                 let c = cfg.read().await;
                 c.project_paths.clone()
             };
-            if let Some(root_project) = derive_project_from_outbox_path(path) {
-                let canon_root_project = std::fs::canonicalize(&root_project).ok();
+            if let Some(root_project) = outbox_project.as_ref() {
+                let canon_root_project = std::fs::canonicalize(root_project).ok();
                 let already_present = paths.iter().any(|p| match &canon_root_project {
                     Some(canon_target) => {
                         std::fs::canonicalize(p).ok().as_ref() == Some(canon_target)
                     }
-                    None => p == &root_project,
+                    None => p == root_project,
                 });
                 if !already_present {
-                    paths.push(root_project);
+                    paths.push(root_project.clone());
                 }
             }
 
@@ -948,16 +974,16 @@ impl MailboxPoller {
                 let c = cfg.read().await;
                 c.project_paths.clone()
             };
-            if let Some(root_project) = derive_project_from_outbox_path(path) {
-                let canon_root_project = std::fs::canonicalize(&root_project).ok();
+            if let Some(root_project) = outbox_project.as_ref() {
+                let canon_root_project = std::fs::canonicalize(root_project).ok();
                 let already_present = paths.iter().any(|p| match &canon_root_project {
                     Some(canon_target) => {
                         std::fs::canonicalize(p).ok().as_ref() == Some(canon_target)
                     }
-                    None => p == &root_project,
+                    None => p == root_project,
                 });
                 if !already_present {
-                    paths.push(root_project);
+                    paths.push(root_project.clone());
                 }
             }
 
@@ -2319,6 +2345,9 @@ impl MailboxPoller {
         };
 
         let hits_agent = |cwd: &str| -> bool {
+            if crate::config::workspace::path_uses_stale_legacy_workspace(Path::new(cwd)) {
+                return false;
+            }
             let path_fqn = crate::config::teams::agent_fqn_from_path(cwd);
             if is_qualified {
                 path_fqn == agent_name
@@ -2410,7 +2439,9 @@ impl MailboxPoller {
                     }
 
                     for dir in dirs_to_check {
-                        let Some(workspace_dir) = crate::config::workspace::existing_workspace_dir(&dir) else {
+                        let Some(workspace_dir) =
+                            crate::config::workspace::existing_workspace_dir(&dir)
+                        else {
                             continue;
                         };
                         let candidate = workspace_dir.join(wg_name).join(&replica_dir);
@@ -3182,8 +3213,7 @@ mod tests {
         let mut root_session = pool[0].clone();
         root_session.is_root_agent = true;
         let predicate = |s: &crate::session::session::SessionInfo| {
-            s.is_root_agent
-                || crate::config::root_agent::is_root_agent_path(&s.working_directory)
+            s.is_root_agent || crate::config::root_agent::is_root_agent_path(&s.working_directory)
         };
         assert!(predicate(&root_session));
         assert_eq!(
@@ -3632,14 +3662,95 @@ mod tests {
         let file = outbox.join("msg-42.json");
         std::fs::write(&file, "{}").unwrap();
 
-        let got =
-            derive_project_from_outbox_path(&file).expect("should derive project from WG layout");
+        let got = derive_project_from_outbox_path(&file)
+            .unwrap()
+            .expect("should derive project from WG layout");
         let expected = std::fs::canonicalize(&project_dir)
             .unwrap()
             .to_str()
             .unwrap()
             .to_string();
         assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn derive_project_from_outbox_path_rejects_stale_legacy_when_canonical_exists() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project_dir = temp.path().join("proj-x");
+        let canonical_outbox = project_dir
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_alice")
+            .join(".agentscommander")
+            .join("outbox");
+        let stale_outbox = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice")
+            .join(".agentscommander")
+            .join("outbox");
+        std::fs::create_dir_all(&canonical_outbox).unwrap();
+        std::fs::create_dir_all(&stale_outbox).unwrap();
+        let file = stale_outbox.join("msg-42.json");
+        std::fs::write(&file, "{}").unwrap();
+
+        let err = derive_project_from_outbox_path(&file).unwrap_err();
+        assert!(err.contains("stale legacy workspace"));
+    }
+
+    #[test]
+    fn derive_project_from_outbox_path_accepts_canonical_when_both_exist() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project_dir = temp.path().join("proj-x");
+        let canonical_outbox = project_dir
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_alice")
+            .join(".agentscommander")
+            .join("outbox");
+        let stale_outbox = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice")
+            .join(".agentscommander")
+            .join("outbox");
+        std::fs::create_dir_all(&canonical_outbox).unwrap();
+        std::fs::create_dir_all(&stale_outbox).unwrap();
+        let file = canonical_outbox.join("msg-42.json");
+        std::fs::write(&file, "{}").unwrap();
+
+        let got = derive_project_from_outbox_path(&file)
+            .unwrap()
+            .expect("canonical outbox should derive project");
+        let expected = std::fs::canonicalize(&project_dir)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn stale_legacy_session_path_is_not_routable_when_canonical_exists() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project_dir = temp.path().join("proj-x");
+        let canonical_agent = project_dir
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        let stale_agent = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        std::fs::create_dir_all(&canonical_agent).unwrap();
+        std::fs::create_dir_all(&stale_agent).unwrap();
+
+        assert!(!crate::config::workspace::path_uses_stale_legacy_workspace(
+            &canonical_agent
+        ));
+        assert!(crate::config::workspace::path_uses_stale_legacy_workspace(
+            &stale_agent
+        ));
     }
 
     #[test]
@@ -3654,7 +3765,7 @@ mod tests {
         std::fs::create_dir_all(&outbox).unwrap();
         let file = outbox.join("msg.json");
         std::fs::write(&file, "{}").unwrap();
-        assert!(derive_project_from_outbox_path(&file).is_none());
+        assert!(derive_project_from_outbox_path(&file).unwrap().is_none());
     }
 
     #[test]
@@ -3667,7 +3778,7 @@ mod tests {
         std::fs::create_dir_all(&app_outbox).unwrap();
         let file = app_outbox.join("msg.json");
         std::fs::write(&file, "{}").unwrap();
-        assert!(derive_project_from_outbox_path(&file).is_none());
+        assert!(derive_project_from_outbox_path(&file).unwrap().is_none());
     }
 
     fn write_project_refresh_request_fixture(

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -211,7 +211,7 @@ fn validate_root_sender_payload_with_root_dir(
 }
 
 /// If `outbox_file` lives at
-/// `<project_dir>/.ac-new/wg-<N>-*/__agent_*/<local-dir>/outbox/<file>.json`,
+/// `<project_dir>/<workspace>/wg-<N>-*/__agent_*/<local-dir>/outbox/<file>.json`,
 /// return `project_dir` as a UTF-8 `String`. Otherwise, `None`.
 ///
 /// Mirrors the WG-replica walk-up in `cli::send::derive_root_project_dir` so
@@ -223,14 +223,14 @@ fn validate_root_sender_payload_with_root_dir(
 /// The path layout is fixed by `MailboxPoller::poll` which constructs outbox
 /// paths as `Path::new(<all_paths-entry>).join(agent_local_dir_name()).join("outbox")`.
 /// We walk ancestors: `<file>.json` → `outbox` → `<local-dir>` → `<__agent_*>` →
-/// `<wg-*>` → `<.ac-new>` → `<project_dir>`.
+/// `<wg-*>` → `<workspace>` → `<project_dir>`.
 ///
 /// Uses `to_str()?` (NOT `to_string_lossy()`) for parity with
 /// `list_peers::detect_wg_replica`. Keep this in lockstep with
 /// `cli::send::derive_root_project_dir`.
 fn derive_project_from_outbox_path(outbox_file: &Path) -> Option<String> {
     let canon = std::fs::canonicalize(outbox_file).ok()?;
-    // canon = <project>/.ac-new/wg-*/__agent_*/<local-dir>/outbox/<file>.json
+    // canon = <project>/<workspace>/wg-*/__agent_*/<local-dir>/outbox/<file>.json
     let outbox_dir = canon.parent()?; // .../outbox
     if outbox_dir.file_name().and_then(|n| n.to_str()) != Some("outbox") {
         return None;
@@ -246,11 +246,16 @@ fn derive_project_from_outbox_path(outbox_file: &Path) -> Option<String> {
     if !wg_name.starts_with("wg-") {
         return None;
     }
-    let ac_new_dir = wg_dir.parent()?; // .../.ac-new
-    if ac_new_dir.file_name().and_then(|n| n.to_str()) != Some(".ac-new") {
+    let workspace_dir = wg_dir.parent()?; // .../<workspace>
+    if !workspace_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(crate::config::workspace::is_workspace_dir_name)
+        .unwrap_or(false)
+    {
         return None;
     }
-    let project_dir = ac_new_dir.parent()?; // .../<project>
+    let project_dir = workspace_dir.parent()?; // .../<project>
     Some(project_dir.to_str()?.to_string())
 }
 
@@ -757,7 +762,7 @@ impl MailboxPoller {
         // that case. Reject-on-ambiguity semantics match the CLI (Decision 2 rule 2c).
         //
         // §AR2-norm D1-a augmentation: when the outbox file lives under a WG-replica
-        // layout (`<project>/.ac-new/wg-*/__agent_*/<local-dir>/outbox/<file>.json`),
+        // layout (`<project>/<workspace>/wg-*/__agent_*/<local-dir>/outbox/<file>.json`),
         // include the derived `<project>` in the in-memory `paths` slice so qualified
         // WG-peer FQNs written by `cli::send` (which performs the symmetric walk-up
         // augmentation — see #228 Step 1) resolve here too. Without this, the daemon
@@ -2360,7 +2365,7 @@ impl MailboxPoller {
             }
         }
 
-        // Loop 4: WG replica fallback. Scan `.ac-new/<wg>/__agent_<short>` under
+        // Loop 4: WG replica fallback. Scan `<workspace>/<wg>/__agent_<short>` under
         // project_paths (base + immediate non-dot children), honoring the target
         // project filter. §DR2-4 composition: push + break within a single `rp`
         // (an FQN matches at most one replica dir per project) but continue the
@@ -2405,7 +2410,10 @@ impl MailboxPoller {
                     }
 
                     for dir in dirs_to_check {
-                        let candidate = dir.join(".ac-new").join(wg_name).join(&replica_dir);
+                        let Some(workspace_dir) = crate::config::workspace::existing_workspace_dir(&dir) else {
+                            continue;
+                        };
+                        let candidate = workspace_dir.join(wg_name).join(&replica_dir);
                         if candidate.is_dir() {
                             record_match(&candidate.to_string_lossy(), &mut matches);
                             // Within a single `rp`, first hit is the unique hit —

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -426,8 +426,66 @@ pub(crate) fn filter_sessions_by_fqn<'a>(
 ) -> Vec<&'a crate::session::session::SessionInfo> {
     sessions
         .iter()
-        .filter(|s| crate::config::teams::agent_fqn_from_path(&s.working_directory) == target)
+        .filter(|s| session_cwd_matches_fqn(&s.working_directory, target))
         .collect()
+}
+
+fn routable_agent_fqn_from_path(path: &str) -> Option<String> {
+    if crate::config::workspace::path_uses_stale_legacy_workspace(Path::new(path)) {
+        None
+    } else {
+        Some(crate::config::teams::agent_fqn_from_path(path))
+    }
+}
+
+fn session_cwd_matches_fqn(cwd: &str, target: &str) -> bool {
+    routable_agent_fqn_from_path(cwd).as_deref() == Some(target)
+}
+
+fn resolve_wg_path_from_session_dirs(dirs: &[(Uuid, String)], agent_name: &str) -> Option<String> {
+    let (target_project, local) = crate::config::teams::split_project_prefix(agent_name);
+    let (wg_name, agent_short) = local.split_once('/')?;
+    if !wg_name.starts_with("wg-") {
+        return None;
+    }
+
+    let wg_marker = format!("/{}/", wg_name);
+    for (_, cwd) in dirs {
+        if routable_agent_fqn_from_path(cwd).is_none() {
+            continue;
+        }
+
+        let normalized = cwd.replace('\\', "/");
+        if let Some(wg_pos) = normalized.rfind(&wg_marker) {
+            let wg_dir = &normalized[..wg_pos + 1 + wg_name.len()];
+            let candidate = format!("{}/__agent_{}", wg_dir, agent_short);
+            if !std::path::Path::new(&candidate).is_dir() {
+                continue;
+            }
+
+            let Some(candidate_fqn) = routable_agent_fqn_from_path(&candidate) else {
+                continue;
+            };
+            if let Some(want) = target_project {
+                let (cand_project, _) = crate::config::teams::split_project_prefix(&candidate_fqn);
+                if cand_project != Some(want) {
+                    continue;
+                }
+            }
+
+            log::info!(
+                "[mailbox] wake: resolved WG agent path from sibling session: {}",
+                candidate
+            );
+            return Some(
+                std::path::PathBuf::from(&candidate)
+                    .to_string_lossy()
+                    .to_string(),
+            );
+        }
+    }
+
+    None
 }
 
 /// §224 A.2.5 — outcome of the daemon-restart race guard wait loop.
@@ -1654,12 +1712,7 @@ impl MailboxPoller {
         // (or a legacy form that genuinely matches only one project's CWD). The
         // substring/suffix fuzziness from the pre-fix code is gone — cross-project
         // leakage is impossible at this layer.
-        let mut matches: Vec<&crate::session::session::SessionInfo> = sessions
-            .iter()
-            .filter(|s| {
-                crate::config::teams::agent_fqn_from_path(&s.working_directory) == agent_name
-            })
-            .collect();
+        let mut matches = filter_sessions_by_fqn(&sessions, agent_name);
 
         if matches.is_empty() {
             log::warn!("[mailbox] No session matched for '{}'", agent_name);
@@ -1728,12 +1781,7 @@ impl MailboxPoller {
         let mgr = session_mgr.read().await;
         let sessions = mgr.list_sessions().await;
 
-        let mut matches: Vec<&crate::session::session::SessionInfo> = sessions
-            .iter()
-            .filter(|s| {
-                crate::config::teams::agent_fqn_from_path(&s.working_directory) == agent_name
-            })
-            .collect();
+        let mut matches = filter_sessions_by_fqn(&sessions, agent_name);
 
         let had_any_match = !matches.is_empty();
         if !had_any_match {
@@ -2345,10 +2393,9 @@ impl MailboxPoller {
         };
 
         let hits_agent = |cwd: &str| -> bool {
-            if crate::config::workspace::path_uses_stale_legacy_workspace(Path::new(cwd)) {
+            let Some(path_fqn) = routable_agent_fqn_from_path(cwd) else {
                 return false;
-            }
-            let path_fqn = crate::config::teams::agent_fqn_from_path(cwd);
+            };
             if is_qualified {
                 path_fqn == agent_name
             } else {
@@ -2565,47 +2612,12 @@ impl MailboxPoller {
         app: &tauri::AppHandle,
         agent_name: &str,
     ) -> Option<String> {
-        let (target_project, local) = crate::config::teams::split_project_prefix(agent_name);
-        let (wg_name, agent_short) = local.split_once('/')?;
-        if !wg_name.starts_with("wg-") {
-            return None;
-        }
-
         let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
         let mgr = session_mgr.read().await;
         let dirs = mgr.get_sessions_working_dirs().await;
         drop(mgr);
 
-        let wg_marker = format!("/{}/", wg_name);
-        for (_, cwd) in &dirs {
-            let normalized = cwd.replace('\\', "/");
-            if let Some(wg_pos) = normalized.rfind(&wg_marker) {
-                let wg_dir = &normalized[..wg_pos + 1 + wg_name.len()];
-                let candidate = format!("{}/__agent_{}", wg_dir, agent_short);
-                if std::path::Path::new(&candidate).is_dir() {
-                    // If target is qualified, enforce same project on the candidate.
-                    if let Some(want) = target_project {
-                        let candidate_fqn = crate::config::teams::agent_fqn_from_path(&candidate);
-                        let (cand_project, _) =
-                            crate::config::teams::split_project_prefix(&candidate_fqn);
-                        if cand_project != Some(want) {
-                            continue;
-                        }
-                    }
-                    log::info!(
-                        "[mailbox] wake: resolved WG agent path from sibling session: {}",
-                        candidate
-                    );
-                    return Some(
-                        std::path::PathBuf::from(&candidate)
-                            .to_string_lossy()
-                            .to_string(),
-                    );
-                }
-            }
-        }
-
-        None
+        resolve_wg_path_from_session_dirs(&dirs, agent_name)
     }
 
     /// Move an outbox message to outbox/delivered/ with token stripped.
@@ -2884,6 +2896,10 @@ mod tests {
             was_detached: false,
             detached_geometry: None,
         }
+    }
+
+    fn path_string(path: &Path) -> String {
+        path.to_string_lossy().to_string()
     }
 
     fn make_root_route_fixture(
@@ -3751,6 +3767,187 @@ mod tests {
         assert!(crate::config::workspace::path_uses_stale_legacy_workspace(
             &stale_agent
         ));
+    }
+
+    #[test]
+    fn filter_sessions_by_fqn_ignores_stale_live_target_when_canonical_exists() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project_dir = temp.path().join("proj-x");
+        let canonical_agent = project_dir
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        let stale_agent = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        std::fs::create_dir_all(&canonical_agent).unwrap();
+        std::fs::create_dir_all(&stale_agent).unwrap();
+
+        let pool = vec![make_session_info(
+            "uuid-stale",
+            "alice-stale",
+            &path_string(&stale_agent),
+            crate::session::session::SessionStatus::Idle,
+            true,
+        )];
+
+        let hits = filter_sessions_by_fqn(&pool, "proj-x:wg-1-devs/alice");
+
+        assert!(hits.is_empty(), "stale legacy live target must be ignored");
+    }
+
+    #[test]
+    fn filter_sessions_by_fqn_prefers_canonical_live_target_when_both_exist() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project_dir = temp.path().join("proj-x");
+        let canonical_agent = project_dir
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        let stale_agent = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        std::fs::create_dir_all(&canonical_agent).unwrap();
+        std::fs::create_dir_all(&stale_agent).unwrap();
+
+        let pool = vec![
+            make_session_info(
+                "uuid-stale",
+                "alice-stale",
+                &path_string(&stale_agent),
+                crate::session::session::SessionStatus::Idle,
+                true,
+            ),
+            make_session_info(
+                "uuid-canonical",
+                "alice-canonical",
+                &path_string(&canonical_agent),
+                crate::session::session::SessionStatus::Idle,
+                true,
+            ),
+        ];
+
+        let hits = filter_sessions_by_fqn(&pool, "proj-x:wg-1-devs/alice");
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id, "uuid-canonical");
+    }
+
+    #[test]
+    fn filter_sessions_by_fqn_accepts_legacy_only_live_target() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let legacy_agent = temp
+            .path()
+            .join("proj-x")
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        std::fs::create_dir_all(&legacy_agent).unwrap();
+
+        let pool = vec![make_session_info(
+            "uuid-legacy",
+            "alice-legacy",
+            &path_string(&legacy_agent),
+            crate::session::session::SessionStatus::Idle,
+            true,
+        )];
+
+        let hits = filter_sessions_by_fqn(&pool, "proj-x:wg-1-devs/alice");
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id, "uuid-legacy");
+    }
+
+    #[test]
+    fn wg_session_fallback_ignores_stale_sibling_when_canonical_exists() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project_dir = temp.path().join("proj-x");
+        let canonical_target = project_dir
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        let stale_target = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        let stale_sibling = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_bob");
+        std::fs::create_dir_all(&canonical_target).unwrap();
+        std::fs::create_dir_all(&stale_target).unwrap();
+        std::fs::create_dir_all(&stale_sibling).unwrap();
+
+        let dirs = vec![(Uuid::nil(), path_string(&stale_sibling))];
+
+        assert!(resolve_wg_path_from_session_dirs(&dirs, "proj-x:wg-1-devs/alice").is_none());
+    }
+
+    #[test]
+    fn wg_session_fallback_returns_canonical_when_stale_sibling_is_first() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project_dir = temp.path().join("proj-x");
+        let canonical_target = project_dir
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        let canonical_sibling = project_dir
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_bob");
+        let stale_target = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        let stale_sibling = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_bob");
+        std::fs::create_dir_all(&canonical_target).unwrap();
+        std::fs::create_dir_all(&canonical_sibling).unwrap();
+        std::fs::create_dir_all(&stale_target).unwrap();
+        std::fs::create_dir_all(&stale_sibling).unwrap();
+
+        let dirs = vec![
+            (Uuid::nil(), path_string(&stale_sibling)),
+            (Uuid::nil(), path_string(&canonical_sibling)),
+        ];
+
+        let got = resolve_wg_path_from_session_dirs(&dirs, "proj-x:wg-1-devs/alice")
+            .expect("canonical sibling should resolve target");
+
+        assert_eq!(
+            std::fs::canonicalize(got).unwrap(),
+            std::fs::canonicalize(canonical_target).unwrap()
+        );
+    }
+
+    #[test]
+    fn wg_session_fallback_accepts_legacy_only_sibling() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project_dir = temp.path().join("proj-x");
+        let legacy_target = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        let legacy_sibling = project_dir
+            .join(".ac-new")
+            .join("wg-1-devs")
+            .join("__agent_bob");
+        std::fs::create_dir_all(&legacy_target).unwrap();
+        std::fs::create_dir_all(&legacy_sibling).unwrap();
+
+        let dirs = vec![(Uuid::nil(), path_string(&legacy_sibling))];
+
+        let got = resolve_wg_path_from_session_dirs(&dirs, "proj-x:wg-1-devs/alice")
+            .expect("legacy-only sibling should resolve target");
+
+        assert_eq!(
+            std::fs::canonicalize(got).unwrap(),
+            std::fs::canonicalize(legacy_target).unwrap()
+        );
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
-  "productName": "Agents Commander New",
+  "productName": "Agents Commander",
   "version": "0.8.43",
   "identifier": "dev.agentscommander-new.app",
   "build": {

--- a/src/guide/components/CatalystTab.tsx
+++ b/src/guide/components/CatalystTab.tsx
@@ -18,7 +18,7 @@ const CatalystTab: Component = () => {
       <div class="guide-card">
         <div class="guide-card-title">1. Define your team</div>
         <div class="guide-card-body">
-          Go to your project's .ac-new/ directory and create a team via _team_*/config.json. Define agents, a coordinator, and repos. Teams are discovered automatically from these config files.
+          Go to your project's .ac/ directory and create a team via _team_*/config.json. Define agents, a coordinator, and repos. Teams are discovered automatically from these config files.
         </div>
       </div>
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,7 +1,12 @@
 export const NO_TEAM = "__no_team__";
 
+export const AC_WORKSPACE_DIR = ".ac";
+export const LEGACY_AC_WORKSPACE_DIR = ".ac-new";
+export const AC_WORKSPACE_DIRS = [AC_WORKSPACE_DIR, LEGACY_AC_WORKSPACE_DIR] as const;
+
 export const WINDOW_TYPE = (() => {
-  const params = new URLSearchParams(window.location.search);
+  const search = typeof window === "undefined" ? "" : window.location.search;
+  const params = new URLSearchParams(search);
   return params.get("window") || "sidebar";
 })();
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -448,7 +448,7 @@ export const ProjectAPI = {
   open: (path: string) =>
     transport.invoke<ProjectRegistration>("open_project", { path }),
   /**
-   * Ensure an AC project at `path` (mkdir `.ac-new/` if missing) and register
+   * Ensure an AC project at `path` (mkdir `.ac/` if no workspace exists) and register
    * it in settings.projectPaths. Wraps the `new_project` Tauri command added
    * in #191 — same backend logic as the CLI `new-project` verb.
    */

--- a/src/shared/path-extractors.test.ts
+++ b/src/shared/path-extractors.test.ts
@@ -14,14 +14,21 @@ describe('path-extractors', () => {
     expect(extractAgentName(w)).toBeNull();
   });
 
-  it('path_without_ac_new_returns_all_null', () => {
+  it('path_without_workspace_returns_all_null', () => {
     const w = 'C:\\foo\\bar';
     expect(extractProjectName(w)).toBeNull();
     expect(extractWorkgroupName(w)).toBeNull();
     expect(extractAgentName(w)).toBeNull();
   });
 
-  it('ac_new_only_returns_project_only', () => {
+  it('ac_only_returns_project_only', () => {
+    const w = 'C:\\foo\\.ac';
+    expect(extractProjectName(w)).toBe('foo');
+    expect(extractWorkgroupName(w)).toBeNull();
+    expect(extractAgentName(w)).toBeNull();
+  });
+
+  it('legacy_ac_new_only_returns_project_only', () => {
     const w = 'C:\\foo\\.ac-new';
     expect(extractProjectName(w)).toBe('foo');
     expect(extractWorkgroupName(w)).toBeNull();
@@ -29,6 +36,13 @@ describe('path-extractors', () => {
   });
 
   it('agent_in_wg_returns_all_three', () => {
+    const w = 'C:\\foo\\.ac\\wg-19-dev-team\\__agent_tech-lead';
+    expect(extractProjectName(w)).toBe('foo');
+    expect(extractWorkgroupName(w)).toBe('WG-19-DEV-TEAM');
+    expect(extractAgentName(w)).toBe('tech-lead');
+  });
+
+  it('legacy_agent_in_wg_returns_all_three', () => {
     const w = 'C:\\foo\\.ac-new\\wg-19-dev-team\\__agent_tech-lead';
     expect(extractProjectName(w)).toBe('foo');
     expect(extractWorkgroupName(w)).toBe('WG-19-DEV-TEAM');
@@ -49,15 +63,15 @@ describe('path-extractors', () => {
     expect(extractAgentName(w)).toBeNull();
   });
 
-  it('nested_ac_new_uses_innermost', () => {
-    const w = 'C:\\proj\\.ac-new\\wg-1-outer\\repo-AC\\.ac-new\\wg-2-inner\\__agent_alice';
+  it('nested_workspace_uses_innermost', () => {
+    const w = 'C:\\proj\\.ac-new\\wg-1-outer\\repo-AC\\.ac\\wg-2-inner\\__agent_alice';
     expect(extractProjectName(w)).toBe('repo-AC');
     expect(extractWorkgroupName(w)).toBe('WG-2-INNER');
     expect(extractAgentName(w)).toBe('alice');
   });
 
   it('unc_prefix_handled', () => {
-    const w = '\\\\?\\C:\\proj\\.ac-new\\wg-1\\__agent_x';
+    const w = '\\\\?\\C:\\proj\\.ac\\wg-1\\__agent_x';
     expect(extractProjectName(w)).toBe('proj');
     expect(extractWorkgroupName(w)).toBe('WG-1');
     expect(extractAgentName(w)).toBe('x');
@@ -85,7 +99,7 @@ describe('path-extractors', () => {
   });
 
   it('forward_slashes_handled', () => {
-    const w = '/foo/.ac-new/wg-1/__agent_x';
+    const w = '/foo/.ac/wg-1/__agent_x';
     expect(extractProjectName(w)).toBe('foo');
     expect(extractWorkgroupName(w)).toBe('WG-1');
     expect(extractAgentName(w)).toBe('x');

--- a/src/shared/path-extractors.ts
+++ b/src/shared/path-extractors.ts
@@ -1,16 +1,25 @@
+import { AC_WORKSPACE_DIR, LEGACY_AC_WORKSPACE_DIR } from './constants';
+
 function pathParts(workDir: string): string[] {
   return workDir.replace(/\\/g, '/').split('/').filter(s => s.length > 0);
 }
 
+function lastWorkspaceIndex(parts: string[]): number {
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (parts[i] === AC_WORKSPACE_DIR || parts[i] === LEGACY_AC_WORKSPACE_DIR) return i;
+  }
+  return -1;
+}
+
 export function extractProjectName(workDir: string): string | null {
   const parts = pathParts(workDir);
-  const idx = parts.lastIndexOf('.ac-new');
+  const idx = lastWorkspaceIndex(parts);
   return idx > 0 ? parts[idx - 1] : null;
 }
 
 export function extractWorkgroupName(workDir: string): string | null {
   const parts = pathParts(workDir);
-  const idx = parts.lastIndexOf('.ac-new');
+  const idx = lastWorkspaceIndex(parts);
   if (idx < 0 || idx + 1 >= parts.length) return null;
   const wg = parts[idx + 1];
   return /^wg-\d+/.test(wg) ? wg.toUpperCase() : null;
@@ -18,7 +27,7 @@ export function extractWorkgroupName(workDir: string): string | null {
 
 export function extractAgentName(workDir: string): string | null {
   const parts = pathParts(workDir);
-  const idx = parts.lastIndexOf('.ac-new');
+  const idx = lastWorkspaceIndex(parts);
   if (idx < 0 || idx + 2 >= parts.length) return null;
   const seg = parts[idx + 2];
   if (!seg.startsWith('__agent_')) return null;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -363,7 +363,7 @@ export interface ProjectRegistration {
   path: string;
   /** True when this call appended a new entry, false when already present. */
   registered: boolean;
-  /** True when this call created .ac-new/ on disk (always false for openProject). */
+  /** True when this call created .ac/ on disk (always false for openProject). */
   created: boolean;
 }
 

--- a/src/sidebar/components/ActionBar.tsx
+++ b/src/sidebar/components/ActionBar.tsx
@@ -101,7 +101,7 @@ const ActionBar: Component = () => {
       if (hasAcNew) {
         await projectStore.loadProject(picked);
       } else {
-        showToast("No AC project found in this folder (.ac-new/ not found)");
+        showToast("No AC project found in this folder (.ac/ not found; legacy .ac-new/ also supported)");
       }
     } finally {
       setIsPendingDialog(false);

--- a/src/sidebar/components/EditTeamModal.tsx
+++ b/src/sidebar/components/EditTeamModal.tsx
@@ -1,5 +1,6 @@
 import { Component, createSignal, createMemo, For, Show, onMount } from "solid-js";
 import { EntityAPI } from "../../shared/ipc";
+import { AC_WORKSPACE_DIR, LEGACY_AC_WORKSPACE_DIR } from "../../shared/constants";
 import { projectStore } from "../stores/project";
 import type { AcTeam, TeamWizardAgentEntry, TeamWizardRepoEntry, TeamWizardStep } from "../../shared/types";
 
@@ -77,7 +78,7 @@ const EditTeamModal: Component<{
       const discoveredNorm = new Set(entries.map((e) => norm(e.path)));
 
       // Synthesize entries for cross-project agents not found in discovered agents.
-      // Config stores absolute paths like C:\...\project\.ac-new\_agent_name
+      // Config stores absolute paths like C:\...\project\.ac\_agent_name
       for (const configPath of teamConfig.agents) {
         if (!discoveredNorm.has(norm(configPath))) {
           const normalized = configPath.replace(/\\/g, "/");
@@ -85,9 +86,15 @@ const EditTeamModal: Component<{
           // Extract agent name from _agent_{name} dir
           const agentDir = parts[parts.length - 1] || "";
           const agentName = agentDir.replace(/^_agent_/, "");
-          // Extract project name: parent of .ac-new
-          const acNewIdx = parts.lastIndexOf(".ac-new");
-          const projectName = acNewIdx > 0 ? parts[acNewIdx - 1] : "external";
+          // Extract project name: parent of the workspace dir.
+          let workspaceIdx = -1;
+          for (let i = parts.length - 1; i >= 0; i--) {
+            if (parts[i] === AC_WORKSPACE_DIR || parts[i] === LEGACY_AC_WORKSPACE_DIR) {
+              workspaceIdx = i;
+              break;
+            }
+          }
+          const projectName = workspaceIdx > 0 ? parts[workspaceIdx - 1] : "external";
           entries.push({ name: agentName, path: configPath, projectName });
         }
       }

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -243,11 +243,11 @@ const SessionItem: Component<{
   const isInactive = () => props.session.id.startsWith("inactive-");
 
   /** Derive short display name from workingDirectory.
-   *  .ac-new paths: "agent-name@origin-project" (e.g. "code-reviewer@phi_phibridge")
+   *  AC workspace paths: "agent-name@origin-project" (e.g. "code-reviewer@phi_phibridge")
    *  Other paths: "parentFolder/name" (last 2 segments)
    *
-   *  .ac-new parsing is delegated to extractProjectName (innermost wins via
-   *  lastIndexOf — matches the titlebar helpers, fixes nested-.ac-new bug). */
+   *  Workspace parsing is delegated to extractProjectName. The innermost
+   *  .ac or legacy .ac-new segment wins, matching the titlebar helpers. */
   const displayName = () => {
     const wd = props.session.workingDirectory;
     if (wd) {

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -46,7 +46,7 @@ export const projectStore = {
     setLoading(true);
     try {
       // #191 — backend owns the validation + dedup + persist atomically.
-      // Throws if `.ac-new/` is missing; caller (createAndLoad / pickAndCheck)
+      // Throws if `.ac/` and legacy `.ac-new/` are missing; caller (createAndLoad / pickAndCheck)
       // is responsible for creating it first via projectStore.createAndLoad
       // when that case is expected.
       const reg = await ProjectAPI.open(path);
@@ -76,7 +76,7 @@ export const projectStore = {
       // Round-1 G11 deferred: surface this to the user via toast/sidebar
       // chip in a follow-up. For now, preserve the existing swallow-and-log
       // so behaviour is no worse than today (initFromSettings silently drops
-      // a project whose .ac-new was deleted between sessions — see §6.11).
+      // a project whose workspace was deleted between sessions.
       console.error("Failed to load project:", e);
     } finally {
       loadingCount--;
@@ -96,10 +96,10 @@ export const projectStore = {
     }
   },
 
-  /** Create .ac-new in path (if missing) and register/load it. */
+  /** Create .ac in path (if no workspace exists) and register/load it. */
   async createAndLoad(path: string) {
     const reg = await ProjectAPI.new(path);
-    // After ensuring .ac-new exists + persistence is set, run discovery for UI.
+    // After ensuring a workspace exists and persistence is set, run discovery for UI.
     const result = await ProjectAPI.discover(reg.path);
     const folderName =
       reg.path.replace(/\\/g, "/").split("/").pop() ?? "unknown";
@@ -119,7 +119,7 @@ export const projectStore = {
     });
   },
 
-  /** Full open flow: pick folder, check .ac-new, auto-load if found */
+  /** Full open flow: pick folder, check workspace, auto-load if found */
   async pickAndCheck(): Promise<{ picked: string | null; hasAcNew: boolean }> {
     const picked = await AgentCreatorAPI.pickFolder();
     if (!picked) return { picked: null, hasAcNew: false };


### PR DESCRIPTION
## Summary

Refs #365.

- Make `.ac` the canonical/default AgentsCommander project workspace directory.
- Keep `.ac-new` as a legacy fallback only when `.ac` is absent.
- Prefer `.ac` when both workspaces exist and reject/ignore stale `.ac-new` roots, outboxes, and mailbox session CWDs for routing.
- Update visible Windows/Tauri product metadata to `Agents Commander` instead of `Agents Commander New`.
- Refresh docs/help/UI comments so `.ac` is shown as the default and `.ac-new` only as legacy support.
- Merge `origin/main` into the branch so the PR is mergeable against current `main` and carries version `0.8.44`.

## Validation

- `cargo test --lib stale_legacy`
- `cargo test --lib filter_sessions_by_fqn`
- `cargo test --lib wg_session_fallback`
- `cargo test --lib phone::mailbox::tests`
- `cargo test --lib cli::list_peers::tests`
- `cargo test --lib cli::send::tests`
- `cargo check`
- `cargo clippy` exited 0; current `origin/main` emits existing warnings in `sessions_persistence.rs`.
- `git diff --check` and `git diff --cached --check`
- `npm test -- path-extractors`
- Adversarial review by `dev-rust-grinch`: PASS after stale legacy routing fixes.
- Shipper rebuild: `npx tauri build` succeeded on head `7ea566b`.

## Build Artifacts

Produced by Shipper from `7ea566b`:

- `src-tauri/target/release/agentscommander-new.exe` — 27,220,992 bytes
- `src-tauri/target/release/bundle/msi/Agents Commander_0.8.44_x64_en-US.msi` — 10,027,008 bytes
- `src-tauri/target/release/bundle/nsis/Agents Commander_0.8.44_x64-setup.exe` — 6,737,568 bytes

Metadata check:

- Built exe `FileDescription`: `Agents Commander`
- Built exe `ProductName`: `Agents Commander`
- Built exe `ProductVersion`: `0.8.44`
- NSIS setup `ProductName`: `Agents Commander`

## Distribution Note

Distribution into `C:\Users\maria\0_mmb\0_AC` was not performed because explicit authorization is required for that external handoff. The previous size-gate blocker is cleared: the rebuilt exe is 14,336 bytes larger than `C:\Users\maria\0_mmb\0_AC\agentscommander_mb.exe`.