### PR TITLE
[codex] Reject filesystem paths in team agent refs

### DIFF
--- a/linux-setup/README.md
+++ b/linux-setup/README.md
@@ -1,0 +1,33 @@
+# Linux Setup
+
+This folder contains the Ubuntu dependencies needed to build and test
+AgentsCommander locally on Linux.
+
+## Ubuntu
+
+Run:
+
+```bash
+./linux-setup/install-ubuntu-deps.sh
+```
+
+Then verify:
+
+```bash
+./linux-setup/verify-ubuntu-deps.sh
+```
+
+## What This Installs
+
+- C/C++ build toolchain for Rust native crates.
+- `pkg-config`, used by Rust `*-sys` crates to discover system libraries.
+- OpenSSL development headers.
+- Wayland, GLib, GTK, WebKitGTK, AppIndicator, and SVG development packages
+  used by Tauri/Wry on Linux.
+
+## Notes
+
+Ubuntu package names can vary across releases. This script targets modern
+Ubuntu releases where Tauri uses WebKitGTK 4.1. If `libwebkit2gtk-4.1-dev` is
+not available on a given machine, try the distro-provided WebKitGTK development
+package for that Ubuntu version.

--- a/linux-setup/install-ubuntu-deps.sh
+++ b/linux-setup/install-ubuntu-deps.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "This installer is intended for Ubuntu/Debian systems with apt-get." >&2
+  exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  pkg-config \
+  libssl-dev \
+  libwayland-dev \
+  libglib2.0-dev \
+  libgtk-3-dev \
+  libwebkit2gtk-4.1-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev
+
+echo "Ubuntu native build dependencies installed."

--- a/linux-setup/verify-ubuntu-deps.sh
+++ b/linux-setup/verify-ubuntu-deps.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=0
+
+require_cmd() {
+  local cmd="$1"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    echo "ok: command $cmd"
+  else
+    echo "missing: command $cmd" >&2
+    missing=1
+  fi
+}
+
+require_pkg() {
+  local pkg="$1"
+  if pkg-config --exists "$pkg"; then
+    echo "ok: pkg-config $pkg"
+  else
+    echo "missing: pkg-config $pkg" >&2
+    missing=1
+  fi
+}
+
+require_cmd cc
+require_cmd pkg-config
+require_cmd cargo
+require_cmd rustc
+require_cmd node
+require_cmd npm
+
+require_pkg openssl
+require_pkg wayland-client
+require_pkg glib-2.0
+require_pkg gtk+-3.0
+require_pkg webkit2gtk-4.1
+require_pkg ayatana-appindicator3-0.1
+require_pkg librsvg-2.0
+
+if [[ "$missing" -ne 0 ]]; then
+  echo "One or more Linux build dependencies are missing." >&2
+  exit 1
+fi
+
+echo "All checked Linux build dependencies are available."

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -559,7 +559,9 @@ pub(crate) fn read_team_config(
     }
     let content = std::fs::read_to_string(&config_path)
         .map_err(|e| format!("Failed to read config.json: {}", e))?;
-    serde_json::from_str(&content).map_err(|e| format!("Failed to parse config.json: {}", e))
+    let config: TeamConfigResult = serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse config.json: {}", e))?;
+    normalize_team_config_for_project(ac_new_dir, &config)
 }
 
 pub(crate) fn write_team_config(
@@ -673,16 +675,19 @@ pub(crate) fn resolve_agent_ref(ac_new_dir: &Path, raw_agent: &str) -> Result<St
     if trimmed.contains('\0') {
         return Err("Agent reference must not contain NUL".to_string());
     }
-    let path = Path::new(trimmed);
-    let dir_name = if path.components().count() > 1 || path.is_absolute() {
-        path.file_name()
-            .and_then(|n| n.to_str())
-            .ok_or_else(|| format!("Invalid agent reference '{}'", raw_agent))?
-            .to_string()
-    } else {
-        trimmed.to_string()
-    };
-    let bare = dir_name.strip_prefix("_agent_").unwrap_or(&dir_name);
+    if trimmed.contains('/') || trimmed.contains('\\') || trimmed.contains(':') {
+        return Err(format!(
+            "Invalid agent reference '{}': team configs must use portable refs like '_agent_name' or 'name', not filesystem paths",
+            raw_agent
+        ));
+    }
+    if Path::new(trimmed).is_absolute() {
+        return Err(format!(
+            "Invalid agent reference '{}': absolute paths are not allowed in team configs",
+            raw_agent
+        ));
+    }
+    let bare = trimmed.strip_prefix("_agent_").unwrap_or(trimmed);
     validate_existing_name(bare, "Agent")?;
     let canonical_ref = format!("_agent_{}", bare);
     let matrix_dir = ac_new_dir.join(&canonical_ref);
@@ -777,10 +782,11 @@ pub(crate) async fn create_workgroup_on_disk(
 pub(crate) fn create_or_update_replica_on_disk(
     args: ReplicaDiskCreateArgs,
 ) -> Result<PathBuf, String> {
-    let agent_dir_name = Path::new(&args.agent_path)
+    let agent_ref = resolve_agent_ref(&args.ac_new_dir, &args.agent_path)?;
+    let agent_dir_name = Path::new(&agent_ref)
         .file_name()
         .and_then(|n| n.to_str())
-        .unwrap_or(&args.agent_path);
+        .unwrap_or(&agent_ref);
     let agent_name = agent_dir_name
         .strip_prefix("_agent_")
         .unwrap_or(agent_dir_name);
@@ -822,20 +828,12 @@ pub(crate) fn create_or_update_replica_on_disk(
         })
         .collect();
 
-    let identity_rel = compute_relative_identity(&args.agent_path, &replica_dir, &args.ac_new_dir);
+    let identity_rel = compute_relative_identity(&agent_ref, &replica_dir, &args.ac_new_dir);
     let mut context_entries: Vec<String> = vec![
         "$AGENTSCOMMANDER_CONTEXT".to_string(),
         "$REPOS_WORKSPACE_INFO".to_string(),
     ];
-    let matrix_dir = if Path::new(&args.agent_path).is_absolute() {
-        Path::new(&args.agent_path).to_path_buf()
-    } else {
-        args.ac_new_dir.join(
-            args.agent_path
-                .trim_start_matches("../")
-                .trim_start_matches("./"),
-        )
-    };
+    let matrix_dir = args.ac_new_dir.join(&agent_ref);
     if matrix_dir.join("Role.md").exists() {
         context_entries.push(format!("{}/Role.md", identity_rel));
     }
@@ -1167,17 +1165,7 @@ pub async fn create_workgroup(
         );
     }
 
-    // Read team config
-    let team_dir = base.join(format!("_team_{}", safe_team));
-    let team_config_path = team_dir.join("config.json");
-    if !team_config_path.exists() {
-        return Err(format!("Team '{}' not found (no config.json)", safe_team));
-    }
-
-    let team_config_str = std::fs::read_to_string(&team_config_path)
-        .map_err(|e| format!("Failed to read team config: {}", e))?;
-    let team_config: serde_json::Value = serde_json::from_str(&team_config_str)
-        .map_err(|e| format!("Failed to parse team config: {}", e))?;
+    let team_config = read_team_config(&base, &safe_team)?;
 
     // Determine next WG number
     let wg_number = determine_next_wg_number(&base);
@@ -1197,38 +1185,8 @@ pub async fn create_workgroup(
     std::fs::write(wg_dir.join("TASK.md"), &task_content)
         .map_err(|e| format!("Failed to write TASK.md: {}", e))?;
 
-    // Parse team agents and repos
-    let team_agents: Vec<String> = team_config
-        .get("agents")
-        .and_then(|a| a.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let team_repos: Vec<RepoAssignment> = team_config
-        .get("repos")
-        .and_then(|r| r.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| {
-                    let url = v.get("url")?.as_str()?.to_string();
-                    let agents = v
-                        .get("agents")
-                        .and_then(|a| a.as_array())
-                        .map(|a| {
-                            a.iter()
-                                .filter_map(|x| x.as_str().map(String::from))
-                                .collect()
-                        })
-                        .unwrap_or_default();
-                    Some(RepoAssignment { url, agents })
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+    let team_agents = team_config.agents;
+    let team_repos = team_config.repos;
 
     // Collect unique repo URLs and their directory names
     let mut unique_repos: Vec<(String, String)> = Vec::new(); // (url, dir_name)
@@ -1861,33 +1819,7 @@ pub async fn sync_workgroup_repos(
         return Err(format!("Team '{}' not found", team_name));
     }
 
-    // Read team config and parse repo assignments
-    let config_content = std::fs::read_to_string(team_dir.join("config.json"))
-        .map_err(|e| format!("Failed to read team config: {}", e))?;
-    let config: serde_json::Value = serde_json::from_str(&config_content)
-        .map_err(|e| format!("Failed to parse team config: {}", e))?;
-
-    let repos: Vec<RepoAssignment> = config
-        .get("repos")
-        .and_then(|r| r.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| {
-                    let url = v.get("url")?.as_str()?.to_string();
-                    let agents = v
-                        .get("agents")
-                        .and_then(|a| a.as_array())
-                        .map(|a| {
-                            a.iter()
-                                .filter_map(|x| x.as_str().map(String::from))
-                                .collect()
-                        })
-                        .unwrap_or_default();
-                    Some(RepoAssignment { url, agents })
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+    let repos = read_team_config(&base, &team_name)?.repos;
 
     sync_workgroup_repos_inner(
         &base,
@@ -1931,19 +1863,7 @@ pub async fn get_team_config(
 ) -> Result<TeamConfigResult, String> {
     validate_existing_name(&team_name, "Team")?;
     let base = selected_workspace_dir(Path::new(&project_path))?;
-
-    let team_dir = base.join(format!("_team_{}", team_name));
-    let config_path = team_dir.join("config.json");
-    if !config_path.exists() {
-        return Err(format!("Team '{}' config not found", team_name));
-    }
-
-    let content = std::fs::read_to_string(&config_path)
-        .map_err(|e| format!("Failed to read config.json: {}", e))?;
-    let result: TeamConfigResult = serde_json::from_str(&content)
-        .map_err(|e| format!("Failed to parse config.json: {}", e))?;
-
-    Ok(result)
+    read_team_config(&base, &team_name)
 }
 
 // ---------------------------------------------------------------------------
@@ -2684,7 +2604,7 @@ mod tests {
     }
 
     #[test]
-    fn team_config_normalization_stores_project_relative_agent_refs() {
+    fn team_config_normalization_stores_portable_agent_refs() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let ac_new = tmp.path().join(".ac-new");
         let architect = ac_new.join("_agent_architect");
@@ -2694,15 +2614,15 @@ mod tests {
 
         let config = TeamConfigResult {
             agents: vec![
-                architect.to_string_lossy().to_string(),
+                "_agent_architect".to_string(),
                 "_agent_dev-rust".to_string(),
-                architect.to_string_lossy().to_string(),
+                "_agent_architect".to_string(),
             ],
-            coordinator: architect.to_string_lossy().to_string(),
+            coordinator: "_agent_architect".to_string(),
             repos: vec![RepoAssignment {
                 url: "https://example.test/repo.git".to_string(),
                 agents: vec![
-                    architect.to_string_lossy().to_string(),
+                    "_agent_architect".to_string(),
                     "_agent_dev-rust".to_string(),
                 ],
             }],
@@ -2733,6 +2653,76 @@ mod tests {
             !written.contains(&tmp.path().to_string_lossy().to_string()),
             "team config must not persist absolute project paths: {}",
             written
+        );
+    }
+
+    #[test]
+    fn team_config_normalization_rejects_filesystem_paths() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ac_new = tmp.path().join(".ac-new");
+        std::fs::create_dir_all(ac_new.join("_agent_architect")).expect("architect matrix");
+
+        let absolute_config = TeamConfigResult {
+            agents: vec![ac_new
+                .join("_agent_architect")
+                .to_string_lossy()
+                .to_string()],
+            coordinator: "_agent_architect".to_string(),
+            repos: Vec::new(),
+        };
+        let err = normalize_team_config_for_project(&ac_new, &absolute_config)
+            .expect_err("absolute path refs must be rejected");
+        assert!(
+            err.contains("filesystem paths"),
+            "unexpected error: {}",
+            err
+        );
+
+        let windows_config = TeamConfigResult {
+            agents: vec![r"C:\Users\maria\project\.ac-new\_agent_architect".to_string()],
+            coordinator: "_agent_architect".to_string(),
+            repos: Vec::new(),
+        };
+        let err = normalize_team_config_for_project(&ac_new, &windows_config)
+            .expect_err("windows path refs must be rejected");
+        assert!(
+            err.contains("filesystem paths"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn replica_creation_rejects_filesystem_agent_paths() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ac_new = tmp.path().join(".ac-new");
+        let wg_dir = ac_new.join("wg-1-dev-team");
+        let matrix_dir = ac_new.join("_agent_architect");
+        std::fs::create_dir_all(&matrix_dir).expect("architect matrix");
+        std::fs::create_dir_all(&wg_dir).expect("workgroup");
+
+        let err = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
+            ac_new_dir: ac_new.clone(),
+            wg_dir: wg_dir.clone(),
+            agent_path: matrix_dir.to_string_lossy().to_string(),
+            team_repos: Vec::new(),
+            settings_flags: AgentMatrixSettingsFlags {
+                exclude_global_claude_md: false,
+                inject_rtk_hook: false,
+            },
+        })
+        .expect_err("absolute path refs must be rejected");
+
+        assert!(
+            err.contains("filesystem paths"),
+            "unexpected error: {}",
+            err
+        );
+        assert!(
+            !wg_dir
+                .join(format!("__agent_{}", matrix_dir.to_string_lossy()))
+                .exists(),
+            "replica creation must not create path-derived agent directories"
         );
     }
 

--- a/src/sidebar/components/EditTeamModal.tsx
+++ b/src/sidebar/components/EditTeamModal.tsx
@@ -1,6 +1,6 @@
 import { Component, createSignal, createMemo, For, Show, onMount } from "solid-js";
 import { EntityAPI } from "../../shared/ipc";
-import { AC_WORKSPACE_DIR, LEGACY_AC_WORKSPACE_DIR } from "../../shared/constants";
+import { LEGACY_AC_WORKSPACE_DIR } from "../../shared/constants";
 import { projectStore } from "../stores/project";
 import type { AcTeam, TeamWizardAgentEntry, TeamWizardRepoEntry, TeamWizardStep } from "../../shared/types";
 
@@ -26,24 +26,6 @@ const EditTeamModal: Component<{
     const idx = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
     return idx >= 0 ? p.slice(idx + 1) : p;
   });
-
-  const currentProjectRoot = createMemo(() =>
-    props.projectPath.replace(/[\\/]+$/, "").replace(/\\/g, "/")
-  );
-
-  const norm = (p: string) => p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
-
-  const resolveConfigAgentPath = (agentRef: string) => {
-    const normalized = agentRef.replace(/\\/g, "/");
-    if (/^[A-Za-z]:\//.test(normalized) || normalized.startsWith("/")) {
-      return normalized;
-    }
-    const trimmed = normalized.replace(/^\.\/+/, "").replace(/^(\.\.\/)+/, "");
-    if (trimmed.startsWith(`${AC_WORKSPACE_DIR}/`) || trimmed.startsWith(`${LEGACY_AC_WORKSPACE_DIR}/`)) {
-      return `${currentProjectRoot()}/${trimmed}`;
-    }
-    return `${currentProjectRoot()}/${AC_WORKSPACE_DIR}/${trimmed}`;
-  };
 
   const agentsByProject = createMemo(() => {
     const filter = agentFilter().toLowerCase();
@@ -72,6 +54,11 @@ const EditTeamModal: Component<{
     allAgents().filter((a) => selectedAgents().has(a.path))
   );
 
+  const portableAgentRef = (path: string) => {
+    const last = path.replace(/\\/g, "/").split("/").filter(Boolean).pop() ?? path;
+    return last.startsWith("_agent_") ? last : `_agent_${last}`;
+  };
+
   const canNext2 = createMemo(() =>
     selectedAgents().size > 0 && coordinator() !== ""
   );
@@ -91,44 +78,33 @@ const EditTeamModal: Component<{
         projectName: a.projectName,
       }));
 
-      const discoveredNorm = new Set(entries.map((e) => norm(e.path)));
+      const discoveredRefs = new Set(entries.map((e) => portableAgentRef(e.path)));
 
-      // Synthesize entries for cross-project agents not found in discovered agents.
-      // Team config is stored relative to the AC workspace for portability; older configs
-      // may still contain absolute paths. Resolve before comparing with discovery.
+      // Synthesize entries for portable refs not found in discovered agents.
       for (const configPath of teamConfig.agents) {
-        const resolvedPath = resolveConfigAgentPath(configPath);
-        if (!discoveredNorm.has(norm(resolvedPath))) {
-          const normalized = resolvedPath.replace(/\\/g, "/");
-          const parts = normalized.split("/");
-          // Extract agent name from _agent_{name} dir
-          const agentDir = parts[parts.length - 1] || "";
-          const agentName = agentDir.replace(/^_agent_/, "");
-          // Extract project name: parent of the workspace dir.
-          let workspaceIdx = -1;
-          for (let i = parts.length - 1; i >= 0; i--) {
-            if (parts[i] === AC_WORKSPACE_DIR || parts[i] === LEGACY_AC_WORKSPACE_DIR) {
-              workspaceIdx = i;
-              break;
-            }
-          }
-          const projectName = workspaceIdx > 0 ? parts[workspaceIdx - 1] : "external";
-          entries.push({ name: agentName, path: resolvedPath, projectName });
+        const agentRef = portableAgentRef(configPath);
+        if (!discoveredRefs.has(agentRef)) {
+          const agentName = agentRef.replace(/^_agent_/, "");
+          const fallbackPath =
+            `${props.projectPath.replace(/[\\/]+$/, "")}/${LEGACY_AC_WORKSPACE_DIR}/${agentRef}`;
+          entries.push({
+            name: agentName,
+            path: fallbackPath,
+            projectName: currentProjectName(),
+          });
         }
       }
 
       setAllAgents(entries);
-      const entryPathByNorm = new Map(entries.map((e) => [norm(e.path), e.path]));
+      const entryPathByRef = new Map(entries.map((e) => [portableAgentRef(e.path), e.path]));
       const configPathForUi = (agentRef: string) =>
-        entryPathByNorm.get(norm(resolveConfigAgentPath(agentRef))) ?? agentRef;
+        entryPathByRef.get(portableAgentRef(agentRef)) ?? agentRef;
 
       // Pre-select agents matching config paths
-      const configAgentNorm = new Set(
-        teamConfig.agents.map((p) => norm(resolveConfigAgentPath(p)))
-      );
+      const configAgentRefs = new Set(teamConfig.agents.map(portableAgentRef));
       const matched = new Set<string>();
       for (const entry of entries) {
-        if (configAgentNorm.has(norm(entry.path))) {
+        if (configAgentRefs.has(portableAgentRef(entry.path))) {
           matched.add(entry.path);
         }
       }
@@ -136,8 +112,8 @@ const EditTeamModal: Component<{
 
       // Pre-select coordinator
       if (teamConfig.coordinator) {
-        const coordNorm = norm(resolveConfigAgentPath(teamConfig.coordinator));
-        const coordEntry = entries.find((e) => norm(e.path) === coordNorm);
+        const coordRef = portableAgentRef(teamConfig.coordinator);
+        const coordEntry = entries.find((e) => portableAgentRef(e.path) === coordRef);
         if (coordEntry) {
           setCoordinator(coordEntry.path);
         }
@@ -224,13 +200,13 @@ const EditTeamModal: Component<{
     try {
       const repoData = repos().map((r) => ({
         url: r.url,
-        agents: Array.from(r.agents),
+        agents: Array.from(r.agents).map(portableAgentRef),
       }));
       await EntityAPI.updateTeam(
         props.projectPath,
         props.team.name,
-        Array.from(selectedAgents()),
-        coordinator(),
+        Array.from(selectedAgents()).map(portableAgentRef),
+        portableAgentRef(coordinator()),
         repoData
       );
       await projectStore.reloadProject(props.projectPath);

--- a/src/sidebar/components/NewTeamModal.tsx
+++ b/src/sidebar/components/NewTeamModal.tsx
@@ -69,6 +69,11 @@ const NewTeamModal: Component<{
     allAgents().filter((a) => selectedAgents().has(a.path))
   );
 
+  const portableAgentRef = (path: string) => {
+    const last = path.replace(/\\/g, "/").split("/").filter(Boolean).pop() ?? path;
+    return last.startsWith("_agent_") ? last : `_agent_${last}`;
+  };
+
   const canNext1 = createMemo(() => {
     const n = teamName().trim();
     return n.length > 0 && !n.includes("/") && !n.includes("\\") && !n.includes(" ");
@@ -160,13 +165,13 @@ const NewTeamModal: Component<{
     try {
       const repoData = repos().map((r) => ({
         url: r.url,
-        agents: Array.from(r.agents),
+        agents: Array.from(r.agents).map(portableAgentRef),
       }));
       await EntityAPI.createTeam(
         props.projectPath,
         teamName().trim(),
-        Array.from(selectedAgents()),
-        coordinator(),
+        Array.from(selectedAgents()).map(portableAgentRef),
+        portableAgentRef(coordinator()),
         repoData
       );
       await projectStore.reloadProject(props.projectPath);


### PR DESCRIPTION
## Summary

Fixes #372.

This changes team configuration to use portable agent references only (`_agent_name` / `name`) and rejects filesystem paths in team agent fields. The UI now sends portable refs when creating or editing teams, and backend team config reads normalize through the same strict contract before workgroup creation, repo sync, or config reads proceed.

It also adds a Linux setup folder with Ubuntu dependency install and verification scripts for local native builds.

## Root Cause

Team configs could persist absolute Windows paths such as `C:\Users\...\.ac-new\_agent_tech-lead`. On Linux those values are treated as literal path text, which polluted workgroup replica directory names and visible agent identity.

## Impact

- Rejects absolute or path-like agent refs (`/`, `\`, `:`) in team configs.
- Prevents new workgroup replica directories from being derived from Windows paths.
- Makes new/edit team flows store portable refs instead of host-specific absolute paths.
- Existing legacy configs with filesystem paths now fail fast instead of being silently migrated.

## Validation

Passed:

- `cargo test team_config_normalization --lib`
- `cargo test replica_creation_rejects --lib`
- `npm run test -- --run src/shared/path-extractors.test.ts src/sidebar/stores/project-refresh.test.ts`
- `npm run build`
- `npm run build:prod`
- `npm run build:stage`
- `git diff --check -- src-tauri/src/commands/entity_creation.rs src/sidebar/components/NewTeamModal.tsx src/sidebar/components/EditTeamModal.tsx linux-setup`
- `rustfmt --edition 2021 --check src-tauri/src/commands/entity_creation.rs`
- `./linux-setup/verify-ubuntu-deps.sh`

Known residual test state:

- `cargo test --lib` has 9 unrelated Linux failures in existing Windows/path-specific tests; the targeted Rust tests for this fix pass.