### PR TITLE
[codex] Fix stale WG replica identity trust

### DIFF
--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -560,20 +560,20 @@ fn resolve_wg_coordinator(workspace_dir: &Path, wg_dir: &Path) -> Option<String>
 
 /// Read role from a WG replica's identity matrix Role.md, falling back to CLAUDE.md.
 fn read_wg_role(replica_dir: &Path) -> String {
-    let config: serde_json::Value = match std::fs::read_to_string(replica_dir.join("config.json"))
-        .ok()
-        .and_then(|c| serde_json::from_str(&c).ok())
-    {
-        Some(v) => v,
-        None => return "WG replica agent.".to_string(),
+    let matrix_dir = match crate::config::replica_identity::read_and_repair_wg_replica_config(
+        replica_dir,
+        crate::config::replica_identity::WG_REPLICA_REQUIRED_CONTEXT,
+    ) {
+        Ok((_config, identity)) => identity.matrix_dir,
+        Err(e) => {
+            log::warn!(
+                "[list-peers] Rejected invalid WG replica identity for '{}': {}",
+                replica_dir.display(),
+                e
+            );
+            return "WG replica agent.".to_string();
+        }
     };
-
-    let identity_ref = match config.get("identity").and_then(|i| i.as_str()) {
-        Some(i) => i,
-        None => return "WG replica agent.".to_string(),
-    };
-
-    let matrix_dir = replica_dir.join(identity_ref);
     let role_path = matrix_dir.join("Role.md");
     match std::fs::read_to_string(&role_path) {
         Ok(content) => extract_role_section(&content, 3, "WG replica agent."),
@@ -1460,6 +1460,49 @@ mod tests {
             my_project: "proj-a".to_string(),
         };
         assert!(build_root_agent_synthetic_peer(&wg, &paths).is_none());
+    }
+
+    #[test]
+    fn build_root_agent_synthetic_peer_repairs_stale_same_basename_identity() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("AgentsCommander_ac");
+        let workspace = project.join(".ac");
+        let team_dir = workspace.join("_team_dev-team");
+        let matrix = workspace.join("_agent_tech-lead");
+        let wg_dir = workspace.join("wg-2-dev-team");
+        let replica = wg_dir.join("__agent_tech-lead");
+        for dir in [&team_dir, &matrix, &replica] {
+            std::fs::create_dir_all(dir).unwrap();
+        }
+        std::fs::write(
+            team_dir.join("config.json"),
+            r#"{"agents":["../_agent_tech-lead"],"coordinator":"../_agent_tech-lead"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            replica.join("config.json"),
+            r#"{"identity":"../../../../agentscommander-old/.ac-new/_agent_tech-lead"}"#,
+        )
+        .unwrap();
+
+        let wg = WgReplicaInfo {
+            my_agent_name: "tech-lead".to_string(),
+            my_wg_name: "wg-2-dev-team".to_string(),
+            my_wg_dir: wg_dir,
+            workspace_dir: workspace,
+            my_project: "AgentsCommander_ac".to_string(),
+        };
+        let paths = vec![temp.path().to_string_lossy().to_string()];
+
+        let peer = build_root_agent_synthetic_peer(&wg, &paths)
+            .expect("stale same-basename identity should repair before root verification");
+        assert_eq!(peer.name, crate::config::root_agent::ROOT_AGENT_SENDER);
+
+        let repaired: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(replica.join("config.json")).expect("read repaired config"),
+        )
+        .expect("parse repaired config");
+        assert_eq!(repaired["identity"], "../../_agent_tech-lead");
     }
 
     #[test]

--- a/src-tauri/src/cli/team.rs
+++ b/src-tauri/src/cli/team.rs
@@ -2,7 +2,8 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use crate::cli::workgroup::{
-    clone_missing_for_config, push_unique, resolve_cli_project, write_refresh,
+    clone_missing_for_config, push_unique, resolve_cli_project, resolve_cli_workspace,
+    write_refresh,
 };
 use crate::commands::entity_creation::{
     agent_ref_bare_name, create_or_update_replica_on_disk, normalize_team_config_for_project,
@@ -106,12 +107,12 @@ pub fn execute(args: TeamArgs) -> i32 {
 
 fn list(args: TeamListArgs) -> Result<(), String> {
     let project_path = resolve_cli_project(&args.project)?;
-    let ac_new = project_path.join(".ac-new");
+    let workspace_dir = resolve_cli_workspace(&project_path)?;
     let mut items = Vec::new();
     if let Some(workgroup) = args.workgroup {
         validate_existing_name(&workgroup, "Workgroup")?;
         let team = parse_team_from_workgroup_name(&workgroup)?;
-        let config = read_team_config(&ac_new, &team)?;
+        let config = read_team_config(&workspace_dir, &team)?;
         items.push(TeamListItem {
             team,
             workgroup: Some(workgroup),
@@ -119,7 +120,7 @@ fn list(args: TeamListArgs) -> Result<(), String> {
             coordinator: config.coordinator,
             repos: config.repos,
         });
-    } else if let Ok(entries) = std::fs::read_dir(&ac_new) {
+    } else if let Ok(entries) = std::fs::read_dir(&workspace_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
             if !path.is_dir() {
@@ -129,7 +130,7 @@ fn list(args: TeamListArgs) -> Result<(), String> {
             let Some(team) = name.strip_prefix("_team_") else {
                 continue;
             };
-            if let Ok(config) = read_team_config(&ac_new, team) {
+            if let Ok(config) = read_team_config(&workspace_dir, team) {
                 items.push(TeamListItem {
                     team: team.to_string(),
                     workgroup: None,
@@ -147,15 +148,17 @@ fn list(args: TeamListArgs) -> Result<(), String> {
 fn add_member(args: TeamAddMemberArgs) -> Result<(), String> {
     validate_existing_name(&args.workgroup, "Workgroup")?;
     let project_path = resolve_cli_project(&args.project)?;
-    let ac_new = project_path.join(".ac-new");
-    let wg_dir = ac_new.join(&args.workgroup);
+    let workspace_dir = resolve_cli_workspace(&project_path)?;
+    let wg_dir = workspace_dir.join(&args.workgroup);
     if !wg_dir.is_dir() {
         return Err(format!("Workgroup '{}' not found", args.workgroup));
     }
     let team = parse_team_from_workgroup_name(&args.workgroup)?;
-    let mut config =
-        normalize_team_config_for_project(&ac_new, &read_team_config(&ac_new, &team)?)?;
-    let agent_ref = resolve_agent_ref(&ac_new, &args.agent)?;
+    let mut config = normalize_team_config_for_project(
+        &workspace_dir,
+        &read_team_config(&workspace_dir, &team)?,
+    )?;
+    let agent_ref = resolve_agent_ref(&workspace_dir, &args.agent)?;
     let was_present = config.agents.contains(&agent_ref);
     push_unique(&mut config.agents, agent_ref.clone());
     if args.coordinator {
@@ -164,11 +167,10 @@ fn add_member(args: TeamAddMemberArgs) -> Result<(), String> {
     if !config.coordinator.is_empty() && !config.agents.contains(&config.coordinator) {
         return Err("Coordinator must be one of the selected agents".to_string());
     }
-    write_team_config(&ac_new, &team, &config)?;
+    write_team_config(&workspace_dir, &team, &config)?;
 
     let settings = crate::config::settings::load_settings_for_cli();
     let replica_dir = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
-        ac_new_dir: ac_new.clone(),
         wg_dir: wg_dir.clone(),
         agent_path: agent_ref.clone(),
         team_repos: config.repos.clone(),
@@ -197,15 +199,17 @@ fn add_member(args: TeamAddMemberArgs) -> Result<(), String> {
 fn remove_member(args: TeamRemoveMemberArgs) -> Result<(), String> {
     validate_existing_name(&args.workgroup, "Workgroup")?;
     let project_path = resolve_cli_project(&args.project)?;
-    let ac_new = project_path.join(".ac-new");
-    let wg_dir = ac_new.join(&args.workgroup);
+    let workspace_dir = resolve_cli_workspace(&project_path)?;
+    let wg_dir = workspace_dir.join(&args.workgroup);
     if !wg_dir.is_dir() {
         return Err(format!("Workgroup '{}' not found", args.workgroup));
     }
     let team = parse_team_from_workgroup_name(&args.workgroup)?;
-    let mut config =
-        normalize_team_config_for_project(&ac_new, &read_team_config(&ac_new, &team)?)?;
-    let agent_ref = resolve_agent_ref(&ac_new, &args.agent)?;
+    let mut config = normalize_team_config_for_project(
+        &workspace_dir,
+        &read_team_config(&workspace_dir, &team)?,
+    )?;
+    let agent_ref = resolve_agent_ref(&workspace_dir, &args.agent)?;
     if config.coordinator == agent_ref {
         return Err(
             "Cannot remove the current coordinator without choosing a replacement".to_string(),
@@ -219,7 +223,7 @@ fn remove_member(args: TeamRemoveMemberArgs) -> Result<(), String> {
     for repo in &mut config.repos {
         repo.agents.retain(|agent| agent != &agent_ref);
     }
-    write_team_config(&ac_new, &team, &config)?;
+    write_team_config(&workspace_dir, &team, &config)?;
     remove_replica_dir(&replica_dir)?;
     write_refresh(
         &project_path,

--- a/src-tauri/src/cli/team.rs
+++ b/src-tauri/src/cli/team.rs
@@ -171,6 +171,7 @@ fn add_member(args: TeamAddMemberArgs) -> Result<(), String> {
 
     let settings = crate::config::settings::load_settings_for_cli();
     let replica_dir = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
+        ac_new_dir: workspace_dir.clone(),
         wg_dir: wg_dir.clone(),
         agent_path: agent_ref.clone(),
         team_repos: config.repos.clone(),

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -8,11 +8,11 @@ use std::time::{Duration, SystemTime};
 use tauri::{AppHandle, Emitter, State};
 use uuid::Uuid;
 
+use crate::config::settings::SettingsState;
 use crate::config::workspace::{
     canonical_workspace_dir_label, existing_workspace_dir, find_workspace_segment,
     has_workspace_dir, workspace_dir_for_project,
 };
-use crate::config::settings::SettingsState;
 use crate::session::manager::SessionManager;
 use crate::session::session::SessionRepo;
 
@@ -141,6 +141,62 @@ fn extract_origin_project(identity_abs_path: &std::path::Path) -> Option<String>
     let s = identity_abs_path.to_string_lossy().replace('\\', "/");
     let parts: Vec<&str> = s.split('/').collect();
     find_workspace_segment(&parts).and_then(|i| (i > 0).then(|| parts[i - 1].to_string()))
+}
+
+struct ReplicaIdentityRead {
+    config: Option<serde_json::Value>,
+    identity: Option<crate::config::replica_identity::WgReplicaIdentity>,
+    invalid_identity: bool,
+}
+
+fn read_replica_config_with_valid_identity(replica_dir: &Path) -> ReplicaIdentityRead {
+    if !replica_dir.join("config.json").exists() {
+        return ReplicaIdentityRead {
+            config: None,
+            identity: None,
+            invalid_identity: false,
+        };
+    }
+
+    match crate::config::replica_identity::read_and_repair_wg_replica_config(
+        replica_dir,
+        crate::config::replica_identity::WG_REPLICA_REQUIRED_CONTEXT,
+    ) {
+        Ok((config, identity)) => ReplicaIdentityRead {
+            config: Some(config),
+            identity: Some(identity),
+            invalid_identity: false,
+        },
+        Err(e) => {
+            log::warn!(
+                "[ac-discovery] Rejected invalid WG replica identity for '{}': {}",
+                replica_dir.display(),
+                e
+            );
+            let config = std::fs::read_to_string(replica_dir.join("config.json"))
+                .ok()
+                .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok());
+            ReplicaIdentityRead {
+                config,
+                identity: None,
+                invalid_identity: true,
+            }
+        }
+    }
+}
+
+fn origin_project_for_replica_identity(
+    project_folder: &str,
+    identity_read: &ReplicaIdentityRead,
+) -> Option<String> {
+    if identity_read.invalid_identity {
+        return None;
+    }
+    identity_read
+        .identity
+        .as_ref()
+        .and_then(|identity| extract_origin_project(&identity.matrix_dir))
+        .or_else(|| Some(project_folder.to_string()))
 }
 
 /// Derive agent display name from its path.
@@ -659,8 +715,7 @@ impl DiscoveryBranchWatcher {
             mgr.get_sessions_working_dirs().await
         };
         for (id, cwd) in sessions {
-            if let Some(task_path) =
-                crate::session::session::find_workgroup_task_path_for_cwd(&cwd)
+            if let Some(task_path) = crate::session::session::find_workgroup_task_path_for_cwd(&cwd)
             {
                 if let Some(parent) = task_path.parent() {
                     wg_roots
@@ -968,46 +1023,28 @@ pub async fn discover_ac_agents(
                                     .unwrap_or(&wg_dir_name)
                                     .to_string();
 
-                                let replica_config = wg_path
-                                    .join("config.json")
-                                    .exists()
-                                    .then(|| {
-                                        std::fs::read_to_string(wg_path.join("config.json")).ok()
-                                    })
-                                    .flatten()
-                                    .and_then(|content| {
-                                        serde_json::from_str::<serde_json::Value>(&content).ok()
-                                    });
+                                let identity_read =
+                                    read_replica_config_with_valid_identity(&wg_path);
 
-                                let identity_path = replica_config
+                                let identity_path = identity_read
+                                    .identity
                                     .as_ref()
-                                    .and_then(|v| v.get("identity")?.as_str().map(String::from));
+                                    .map(|identity| identity.identity.clone());
 
-                                // Resolve identity to determine origin project
-                                let origin_project = identity_path.as_ref()
-                                    .and_then(|rel| {
-                                        let target = wg_path.join(rel);
-                                        std::fs::canonicalize(&target)
-                                            .inspect_err(|e| {
-                                                log::warn!(
-                                                    "[ac-discovery] identity canonicalize failed — replica='{}' target='{}' err={}",
-                                                    wg_path.display(),
-                                                    target.display(),
-                                                    e
-                                                );
-                                            })
-                                            .ok()
-                                            .and_then(|abs| extract_origin_project(&abs))
-                                    })
-                                    .or_else(|| Some(project_folder.clone()));
+                                let origin_project = origin_project_for_replica_identity(
+                                    &project_folder,
+                                    &identity_read,
+                                );
 
                                 // Resolve identity to matrix dir and read its lastCodingAgent
-                                let preferred_agent_id = identity_path.as_ref().and_then(|rel| {
-                                    read_preferred_agent_id(&wg_path.join(rel), &cfg.agents)
-                                });
+                                let preferred_agent_id =
+                                    identity_read.identity.as_ref().and_then(|identity| {
+                                        read_preferred_agent_id(&identity.matrix_dir, &cfg.agents)
+                                    });
 
                                 // Extract repos from config.json and resolve to absolute paths
-                                let repo_paths: Vec<String> = replica_config
+                                let repo_paths: Vec<String> = identity_read
+                                    .config
                                     .as_ref()
                                     .and_then(|v| v.get("repos")?.as_array().cloned())
                                     .unwrap_or_default()
@@ -1035,10 +1072,13 @@ pub async fn discover_ac_agents(
                                 // (mirrors `agent_fqn_from_path`'s `<proj>:<wg>/<agent>`
                                 // shape). Covered by
                                 // teams::tests::is_any_coordinator_requires_qualified_fqn.
-                                let is_coordinator = crate::config::teams::is_any_coordinator(
-                                    &format!("{}:{}/{}", project_folder, dir_name, replica_name),
-                                    &teams_snapshot,
-                                );
+                                let is_coordinator =
+                                    crate::config::teams::resolve_wg_coordinator_replica(
+                                        &workspace_dir,
+                                        &path,
+                                    )
+                                    .map(|resolved| resolved.agent_name == replica_name)
+                                    .unwrap_or(false);
 
                                 log::debug!(
                                     "[ac-discovery] call={} replica — project='{}' wg='{}' replica='{}' fqn='{}:{}/{}' is_coordinator={}",
@@ -1405,42 +1445,23 @@ pub async fn discover_project(
                             .unwrap_or(&wg_dir_name)
                             .to_string();
 
-                        let replica_config = wg_path
-                            .join("config.json")
-                            .exists()
-                            .then(|| std::fs::read_to_string(wg_path.join("config.json")).ok())
-                            .flatten()
-                            .and_then(|content| {
-                                serde_json::from_str::<serde_json::Value>(&content).ok()
+                        let identity_read = read_replica_config_with_valid_identity(&wg_path);
+
+                        let identity_path = identity_read
+                            .identity
+                            .as_ref()
+                            .map(|identity| identity.identity.clone());
+
+                        let origin_project =
+                            origin_project_for_replica_identity(&project_folder, &identity_read);
+
+                        let preferred_agent_id =
+                            identity_read.identity.as_ref().and_then(|identity| {
+                                read_preferred_agent_id(&identity.matrix_dir, &cfg.agents)
                             });
 
-                        let identity_path = replica_config
-                            .as_ref()
-                            .and_then(|v| v.get("identity")?.as_str().map(String::from));
-
-                        // Resolve identity to determine origin project
-                        let origin_project = identity_path.as_ref()
-                            .and_then(|rel| {
-                                let target = wg_path.join(rel);
-                                std::fs::canonicalize(&target)
-                                    .inspect_err(|e| {
-                                        log::warn!(
-                                            "[ac-discovery] identity canonicalize failed — replica='{}' target='{}' err={}",
-                                            wg_path.display(),
-                                            target.display(),
-                                            e
-                                        );
-                                    })
-                                    .ok()
-                                    .and_then(|abs| extract_origin_project(&abs))
-                            })
-                            .or_else(|| Some(project_folder.clone()));
-
-                        let preferred_agent_id = identity_path.as_ref().and_then(|rel| {
-                            read_preferred_agent_id(&wg_path.join(rel), &cfg.agents)
-                        });
-
-                        let repo_paths: Vec<String> = replica_config
+                        let repo_paths: Vec<String> = identity_read
+                            .config
                             .as_ref()
                             .and_then(|v| v.get("repos")?.as_array().cloned())
                             .unwrap_or_default()
@@ -1466,10 +1487,12 @@ pub async fn discover_project(
                         // (mirrors `agent_fqn_from_path`'s `<proj>:<wg>/<agent>`
                         // shape). Covered by
                         // teams::tests::is_any_coordinator_requires_qualified_fqn.
-                        let is_coordinator = crate::config::teams::is_any_coordinator(
-                            &format!("{}:{}/{}", project_folder, dir_name, replica_name),
-                            &teams_snapshot,
-                        );
+                        let is_coordinator = crate::config::teams::resolve_wg_coordinator_replica(
+                            &workspace_dir,
+                            &entry_path,
+                        )
+                        .map(|resolved| resolved.agent_name == replica_name)
+                        .unwrap_or(false);
 
                         log::debug!(
                             "[ac-discovery] call={} replica — project='{}' wg='{}' replica='{}' fqn='{}:{}/{}' is_coordinator={}",
@@ -1933,5 +1956,57 @@ mod tests {
         assert_eq!(note_discovery_timeout(p1), 2);
         assert_eq!(note_discovery_timeout(p2), 1);
         assert_eq!(note_discovery_timeout(p1), 3);
+    }
+
+    #[test]
+    fn invalid_replica_identity_is_not_reported_as_repaired_discovery_identity() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("AgentsCommander_ac");
+        let workspace = project.join(".ac");
+        let team_dir = workspace.join("_team_dev-team");
+        let matrix_dir = workspace.join("_agent_tech-lead");
+        let wg_dir = workspace.join("wg-2-dev-team");
+        let replica_dir = wg_dir.join("__agent_tech-lead");
+
+        for dir in [&team_dir, &matrix_dir, &replica_dir] {
+            std::fs::create_dir_all(dir).expect("create fixture dir");
+        }
+        std::fs::write(
+            team_dir.join("config.json"),
+            r#"{"agents":["../_agent_tech-lead"],"coordinator":"../_agent_tech-lead"}"#,
+        )
+        .expect("write team config");
+        std::fs::write(
+            replica_dir.join("config.json"),
+            r#"{"identity":"tech-lead"}"#,
+        )
+        .expect("write invalid replica config");
+
+        let identity_read = read_replica_config_with_valid_identity(&replica_dir);
+
+        assert!(identity_read.invalid_identity);
+        assert!(identity_read.config.is_some());
+        assert!(
+            identity_read.identity.is_none(),
+            "invalid persisted identity must not become a repaired identity path"
+        );
+        assert_eq!(
+            origin_project_for_replica_identity("AgentsCommander_ac", &identity_read),
+            None,
+            "invalid identity must not be masked as the local origin project"
+        );
+        assert!(
+            crate::config::teams::resolve_wg_coordinator_replica(&workspace, &wg_dir).is_none(),
+            "invalid identity must not grant coordinator/root authority"
+        );
+
+        let preferred_agent_id = identity_read
+            .identity
+            .as_ref()
+            .and_then(|identity| read_preferred_agent_id(&identity.matrix_dir, &[]));
+        assert!(
+            preferred_agent_id.is_none(),
+            "invalid identity must not be used to read preferred coding agent"
+        );
     }
 }

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -7,6 +7,10 @@ use tauri::{AppHandle, Emitter, State};
 
 use crate::commands::ac_discovery::DiscoveryBranchWatcher;
 use crate::config::claude_settings::ensure_claude_md_excludes;
+use crate::config::replica_identity::{
+    agent_bare_name_from_ref, expected_wg_replica_identity, normalize_wg_replica_context_entries,
+    repair_wg_replica_config_value, ROLE_MD_FILENAME, WG_REPLICA_REQUIRED_CONTEXT,
+};
 use crate::config::settings::{AppSettings, SettingsState};
 use crate::config::workspace::existing_workspace_dir;
 use crate::pty::git_watcher::{CoordinatorChangedPayload, GitWatcher};
@@ -95,7 +99,6 @@ pub(crate) struct WorkgroupDiskCreateArgs {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ReplicaDiskCreateArgs {
-    pub ac_new_dir: PathBuf,
     pub wg_dir: PathBuf,
     pub agent_path: String,
     pub team_repos: Vec<RepoAssignment>,
@@ -753,7 +756,6 @@ pub(crate) async fn create_workgroup_on_disk(
 
     for agent_path in &team_config.agents {
         create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
-            ac_new_dir: base.clone(),
             wg_dir: wg_dir.clone(),
             agent_path: agent_path.clone(),
             team_repos: team_config.repos.clone(),
@@ -777,14 +779,8 @@ pub(crate) async fn create_workgroup_on_disk(
 pub(crate) fn create_or_update_replica_on_disk(
     args: ReplicaDiskCreateArgs,
 ) -> Result<PathBuf, String> {
-    let agent_dir_name = Path::new(&args.agent_path)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or(&args.agent_path);
-    let agent_name = agent_dir_name
-        .strip_prefix("_agent_")
-        .unwrap_or(agent_dir_name);
-    validate_existing_name(agent_name, "Agent")?;
+    let agent_name = agent_bare_name_from_ref(&args.agent_path)?;
+    validate_existing_name(&agent_name, "Agent")?;
     let replica_dir = args.wg_dir.join(format!("__agent_{}", agent_name));
 
     create_agent_replica_layout(&replica_dir).map_err(|(sub, e)| match sub {
@@ -815,33 +811,23 @@ pub(crate) fn create_or_update_replica_on_disk(
     let assigned_repos: Vec<String> = args
         .team_repos
         .iter()
-        .filter(|r| r.agents.iter().any(|a| agent_matches(a, agent_name)))
+        .filter(|r| r.agents.iter().any(|a| agent_matches(a, &agent_name)))
         .map(|r| {
             let dir_name = format!("repo-{}", repo_dir_name_from_url(&r.url));
             format!("../{}", dir_name)
         })
         .collect();
 
-    let identity_rel = compute_relative_identity(&args.agent_path, &replica_dir, &args.ac_new_dir);
-    let mut context_entries: Vec<String> = vec![
-        "$AGENTSCOMMANDER_CONTEXT".to_string(),
-        "$REPOS_WORKSPACE_INFO".to_string(),
-    ];
-    let matrix_dir = if Path::new(&args.agent_path).is_absolute() {
-        Path::new(&args.agent_path).to_path_buf()
-    } else {
-        args.ac_new_dir.join(
-            args.agent_path
-                .trim_start_matches("../")
-                .trim_start_matches("./"),
-        )
-    };
-    if matrix_dir.join("Role.md").exists() {
-        context_entries.push(format!("{}/Role.md", identity_rel));
-    }
+    let identity = expected_wg_replica_identity(&replica_dir)?;
+    let context_entries = normalize_wg_replica_context_entries(
+        &[],
+        WG_REPLICA_REQUIRED_CONTEXT,
+        &identity.identity,
+        identity.matrix_dir.join(ROLE_MD_FILENAME).exists(),
+    );
 
     let replica_config = serde_json::json!({
-        "identity": identity_rel,
+        "identity": identity.identity,
         "repos": assigned_repos,
         "context": context_entries,
     });
@@ -1256,15 +1242,7 @@ pub async fn create_workgroup(
 
     // Create __agent_*/ replica dirs
     for agent_path in &team_agents {
-        let agent_dir_name = Path::new(agent_path)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(agent_path);
-
-        // Extract the clean agent name (strip _agent_ prefix)
-        let agent_name = agent_dir_name
-            .strip_prefix("_agent_")
-            .unwrap_or(agent_dir_name);
+        let agent_name = agent_bare_name_from_ref(agent_path)?;
 
         let replica_dir = wg_dir.join(format!("__agent_{}", agent_name));
 
@@ -1304,36 +1282,23 @@ pub async fn create_workgroup(
         // Determine repos assigned to this agent (match by _agent_ name)
         let assigned_repos: Vec<String> = team_repos
             .iter()
-            .filter(|r| r.agents.iter().any(|a| agent_matches(a, agent_name)))
+            .filter(|r| r.agents.iter().any(|a| agent_matches(a, &agent_name)))
             .map(|r| {
                 let dir_name = format!("repo-{}", repo_dir_name_from_url(&r.url));
                 format!("../{}", dir_name)
             })
             .collect();
 
-        // Compute relative identity path from replica to matrix
-        let identity_rel = compute_relative_identity(agent_path, &replica_dir, &base);
-
-        let mut context_entries: Vec<String> = vec![
-            "$AGENTSCOMMANDER_CONTEXT".to_string(),
-            "$REPOS_WORKSPACE_INFO".to_string(),
-        ];
-        // Resolve agent_path against the selected workspace for relative paths.
-        let matrix_dir = if Path::new(agent_path).is_absolute() {
-            Path::new(agent_path).to_path_buf()
-        } else {
-            base.join(
-                agent_path
-                    .trim_start_matches("../")
-                    .trim_start_matches("./"),
-            )
-        };
-        if matrix_dir.join("Role.md").exists() {
-            context_entries.push(format!("{}/Role.md", identity_rel));
-        }
+        let identity = expected_wg_replica_identity(&replica_dir)?;
+        let context_entries = normalize_wg_replica_context_entries(
+            &[],
+            WG_REPLICA_REQUIRED_CONTEXT,
+            &identity.identity,
+            identity.matrix_dir.join(ROLE_MD_FILENAME).exists(),
+        );
 
         let replica_config = serde_json::json!({
-            "identity": identity_rel,
+            "identity": identity.identity,
             "repos": assigned_repos,
             "context": context_entries,
         });
@@ -1727,12 +1692,28 @@ async fn sync_workgroup_repos_inner(
                 }
             };
 
+            let identity = match repair_wg_replica_config_value(
+                replica_dir,
+                &mut config,
+                WG_REPLICA_REQUIRED_CONTEXT,
+            ) {
+                Ok(identity) => identity,
+                Err(e) => {
+                    result.errors.push(SyncError {
+                        replica: dir_name.to_string(),
+                        error: e,
+                    });
+                    continue;
+                }
+            };
+
             // Update repos
             config["repos"] = serde_json::json!(assigned_repos);
 
             // Context merge: prepend required tokens to maintain consistent ordering
             // with create_workgroup() (which writes [$AC_CONTEXT, $REPOS_INFO] first).
-            // Preserve any custom entries that were added via set_replica_context_files().
+            // Preserve custom non-Role entries while replacing identity-derived Role.md
+            // entries with the repaired same-workspace identity.
             let existing_context: Vec<String> = config
                 .get("context")
                 .and_then(|v| v.as_array())
@@ -1743,26 +1724,12 @@ async fn sync_workgroup_repos_inner(
                 })
                 .unwrap_or_default();
 
-            let required = ["$AGENTSCOMMANDER_CONTEXT", "$REPOS_WORKSPACE_INFO"];
-            let mut new_context: Vec<String> = required.iter().map(|s| s.to_string()).collect();
-            for entry in &existing_context {
-                if !required.contains(&entry.as_str()) {
-                    new_context.push(entry.clone());
-                }
-            }
-
-            // Auto-inject Role.md from identity if present and not already included
-            if let Some(identity) = config.get("identity").and_then(|v| v.as_str()) {
-                let role_entry = format!("{}/Role.md", identity);
-                if !new_context.contains(&role_entry) {
-                    let role_abs = replica_dir.join(&role_entry);
-                    if role_abs.exists() {
-                        new_context.push(role_entry);
-                    }
-                }
-            }
-
-            config["context"] = serde_json::json!(new_context);
+            config["context"] = serde_json::json!(normalize_wg_replica_context_entries(
+                &existing_context,
+                &["$AGENTSCOMMANDER_CONTEXT", "$REPOS_WORKSPACE_INFO"],
+                &identity.identity,
+                identity.matrix_dir.join(ROLE_MD_FILENAME).exists(),
+            ));
 
             // Write back
             match serde_json::to_string_pretty(&config) {
@@ -2240,86 +2207,6 @@ pub(crate) fn determine_next_wg_number(ac_new_dir: &Path) -> u32 {
     (1u32..=u32::MAX).find(|n| !taken.contains(n)).unwrap_or(1)
 }
 
-/// Compute a relative path from the replica dir to the agent matrix.
-/// If the agent path is absolute, compute relative; otherwise return as-is.
-fn compute_relative_identity(agent_path: &str, replica_dir: &Path, ac_new_dir: &Path) -> String {
-    let agent = Path::new(agent_path);
-
-    // If it's already a relative path within the same workspace, make it relative to replica.
-    if agent.is_relative() {
-        // agent_path is like "../_agent_foo" or "_agent_foo"
-        // From replica inside wg-N-team/ we need to go ../../_agent_foo
-        let agent_in_ac_new = ac_new_dir.join(
-            agent_path
-                .trim_start_matches("../")
-                .trim_start_matches("./"),
-        );
-        if let Ok(rel) = pathdiff_relative(replica_dir, &agent_in_ac_new) {
-            return rel;
-        }
-        return format!(
-            "../../{}",
-            agent_path
-                .trim_start_matches("../")
-                .trim_start_matches("./")
-        );
-    }
-
-    // Absolute path — try to make relative
-    if let Ok(rel) = pathdiff_relative(replica_dir, agent) {
-        return rel;
-    }
-
-    // Fallback: return absolute
-    agent_path.to_string()
-}
-
-/// Simple relative path computation (from → to).
-/// Strips Windows UNC prefix (\\?\) from canonicalized paths to ensure consistent comparison.
-fn pathdiff_relative(from: &Path, to: &Path) -> Result<String, String> {
-    // Canonicalize and strip UNC prefix for consistent comparison on Windows
-    let strip_unc = |p: PathBuf| -> PathBuf {
-        let s = p.to_string_lossy();
-        if let Some(stripped) = s.strip_prefix(r"\\?\") {
-            PathBuf::from(stripped)
-        } else {
-            p
-        }
-    };
-
-    let from_abs = strip_unc(std::fs::canonicalize(from).unwrap_or_else(|_| from.to_path_buf()));
-    let to_abs = if to.exists() {
-        strip_unc(std::fs::canonicalize(to).unwrap_or_else(|_| to.to_path_buf()))
-    } else {
-        to.to_path_buf()
-    };
-
-    let from_components: Vec<_> = from_abs.components().collect();
-    let to_components: Vec<_> = to_abs.components().collect();
-
-    // Find common prefix length
-    let common = from_components
-        .iter()
-        .zip(to_components.iter())
-        .take_while(|(a, b)| a == b)
-        .count();
-
-    if common == 0 {
-        return Err("No common path prefix".into());
-    }
-
-    let ups = from_components.len() - common;
-    let mut result = PathBuf::new();
-    for _ in 0..ups {
-        result.push("..");
-    }
-    for comp in &to_components[common..] {
-        result.push(comp.as_os_str());
-    }
-
-    Ok(result.to_string_lossy().replace('\\', "/"))
-}
-
 /// Async git clone with CREATE_NO_WINDOW on Windows.
 async fn git_clone_async(url: &str, target: &Path) -> Result<(), String> {
     #[cfg(windows)]
@@ -2787,7 +2674,9 @@ mod tests {
         let matrix_role = matrix_dir.join("Role.md");
         std::fs::write(&matrix_role, b"# Alpha\n").expect("write matrix Role.md");
 
-        let identity = compute_relative_identity("_agent_alpha", &replica_dir, &ac_new);
+        let identity = crate::config::replica_identity::expected_wg_replica_identity(&replica_dir)
+            .expect("expected replica identity")
+            .identity;
 
         assert_eq!(
             identity, "../../_agent_alpha",
@@ -2804,6 +2693,51 @@ mod tests {
                 .expect("canonicalize matrix Role.md"),
             "replica Role.md context entry must resolve to origin matrix Role.md"
         );
+    }
+
+    #[test]
+    fn create_replica_ignores_stale_absolute_agent_ref_for_identity() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("AgentsCommander_ac");
+        let workspace = project.join(".ac");
+        let matrix_dir = workspace.join("_agent_tech-lead");
+        let wg_dir = workspace.join("wg-2-dev-team");
+        std::fs::create_dir_all(&matrix_dir).expect("create matrix");
+        std::fs::create_dir_all(&wg_dir).expect("create wg");
+        std::fs::write(matrix_dir.join("Role.md"), "# Tech Lead\n").expect("write role");
+        let stale_agent_ref = tmp
+            .path()
+            .join("agentscommander-old")
+            .join(".ac-new")
+            .join("_agent_tech-lead")
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        let replica_dir = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
+            wg_dir,
+            agent_path: stale_agent_ref,
+            team_repos: Vec::new(),
+            settings_flags: AgentMatrixSettingsFlags {
+                exclude_global_claude_md: false,
+                inject_rtk_hook: false,
+            },
+        })
+        .expect("create replica");
+
+        let config: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(replica_dir.join("config.json")).expect("read config"),
+        )
+        .expect("parse config");
+        assert_eq!(config["identity"], "../../_agent_tech-lead");
+        assert_eq!(
+            config["context"],
+            serde_json::json!([
+                "$AGENTSCOMMANDER_CONTEXT",
+                "$REPOS_WORKSPACE_INFO",
+                "../../_agent_tech-lead/Role.md"
+            ])
+        );
+        assert!(!config.to_string().contains("agentscommander-old"));
     }
 
     /// Success path: a clean WG dir with no blockers gets renamed and removed.

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -8,7 +8,7 @@ use tauri::{AppHandle, Emitter, State};
 use crate::commands::ac_discovery::DiscoveryBranchWatcher;
 use crate::config::claude_settings::ensure_claude_md_excludes;
 use crate::config::replica_identity::{
-    agent_bare_name_from_ref, expected_wg_replica_identity, normalize_wg_replica_context_entries,
+    expected_wg_replica_identity, normalize_wg_replica_context_entries,
     repair_wg_replica_config_value, ROLE_MD_FILENAME, WG_REPLICA_REQUIRED_CONTEXT,
 };
 use crate::config::settings::{AppSettings, SettingsState};
@@ -99,6 +99,7 @@ pub(crate) struct WorkgroupDiskCreateArgs {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ReplicaDiskCreateArgs {
+    pub ac_new_dir: PathBuf,
     pub wg_dir: PathBuf,
     pub agent_path: String,
     pub team_repos: Vec<RepoAssignment>,
@@ -676,16 +677,19 @@ pub(crate) fn resolve_agent_ref(ac_new_dir: &Path, raw_agent: &str) -> Result<St
     if trimmed.contains('\0') {
         return Err("Agent reference must not contain NUL".to_string());
     }
-    let path = Path::new(trimmed);
-    let dir_name = if path.components().count() > 1 || path.is_absolute() {
-        path.file_name()
-            .and_then(|n| n.to_str())
-            .ok_or_else(|| format!("Invalid agent reference '{}'", raw_agent))?
-            .to_string()
-    } else {
-        trimmed.to_string()
-    };
-    let bare = dir_name.strip_prefix("_agent_").unwrap_or(&dir_name);
+    if trimmed.contains('/') || trimmed.contains('\\') || trimmed.contains(':') {
+        return Err(format!(
+            "Invalid agent reference '{}': team configs must use portable refs like '_agent_name' or 'name', not filesystem paths",
+            raw_agent
+        ));
+    }
+    if Path::new(trimmed).is_absolute() {
+        return Err(format!(
+            "Invalid agent reference '{}': absolute paths are not allowed in team configs",
+            raw_agent
+        ));
+    }
+    let bare = trimmed.strip_prefix("_agent_").unwrap_or(trimmed);
     validate_existing_name(bare, "Agent")?;
     let canonical_ref = format!("_agent_{}", bare);
     let matrix_dir = ac_new_dir.join(&canonical_ref);
@@ -756,6 +760,7 @@ pub(crate) async fn create_workgroup_on_disk(
 
     for agent_path in &team_config.agents {
         create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
+            ac_new_dir: base.clone(),
             wg_dir: wg_dir.clone(),
             agent_path: agent_path.clone(),
             team_repos: team_config.repos.clone(),
@@ -779,7 +784,8 @@ pub(crate) async fn create_workgroup_on_disk(
 pub(crate) fn create_or_update_replica_on_disk(
     args: ReplicaDiskCreateArgs,
 ) -> Result<PathBuf, String> {
-    let agent_name = agent_bare_name_from_ref(&args.agent_path)?;
+    let agent_ref = resolve_agent_ref(&args.ac_new_dir, &args.agent_path)?;
+    let agent_name = agent_ref_bare_name(&agent_ref);
     validate_existing_name(&agent_name, "Agent")?;
     let replica_dir = args.wg_dir.join(format!("__agent_{}", agent_name));
 
@@ -1242,7 +1248,8 @@ pub async fn create_workgroup(
 
     // Create __agent_*/ replica dirs
     for agent_path in &team_agents {
-        let agent_name = agent_bare_name_from_ref(agent_path)?;
+        let agent_ref = resolve_agent_ref(&base, agent_path)?;
+        let agent_name = agent_ref_bare_name(&agent_ref);
 
         let replica_dir = wg_dir.join(format!("__agent_{}", agent_name));
 
@@ -2571,7 +2578,7 @@ mod tests {
     }
 
     #[test]
-    fn team_config_normalization_stores_project_relative_agent_refs() {
+    fn team_config_normalization_stores_portable_agent_refs() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let ac_new = tmp.path().join(".ac-new");
         let architect = ac_new.join("_agent_architect");
@@ -2581,17 +2588,14 @@ mod tests {
 
         let config = TeamConfigResult {
             agents: vec![
-                architect.to_string_lossy().to_string(),
+                "architect".to_string(),
                 "_agent_dev-rust".to_string(),
-                architect.to_string_lossy().to_string(),
+                "architect".to_string(),
             ],
-            coordinator: architect.to_string_lossy().to_string(),
+            coordinator: "_agent_architect".to_string(),
             repos: vec![RepoAssignment {
                 url: "https://example.test/repo.git".to_string(),
-                agents: vec![
-                    architect.to_string_lossy().to_string(),
-                    "_agent_dev-rust".to_string(),
-                ],
+                agents: vec!["architect".to_string(), "_agent_dev-rust".to_string()],
             }],
         };
 
@@ -2620,6 +2624,28 @@ mod tests {
             !written.contains(&tmp.path().to_string_lossy().to_string()),
             "team config must not persist absolute project paths: {}",
             written
+        );
+    }
+
+    #[test]
+    fn team_config_normalization_rejects_filesystem_agent_refs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ac_new = tmp.path().join(".ac-new");
+        let architect = ac_new.join("_agent_architect");
+        std::fs::create_dir_all(&architect).expect("architect matrix");
+        let config = TeamConfigResult {
+            agents: vec![architect.to_string_lossy().to_string()],
+            coordinator: architect.to_string_lossy().to_string(),
+            repos: Vec::new(),
+        };
+
+        let err = normalize_team_config_for_project(&ac_new, &config)
+            .expect_err("filesystem refs must be rejected");
+
+        assert!(
+            err.contains("filesystem paths"),
+            "unexpected error: {}",
+            err
         );
     }
 
@@ -2696,7 +2722,7 @@ mod tests {
     }
 
     #[test]
-    fn create_replica_ignores_stale_absolute_agent_ref_for_identity() {
+    fn create_replica_rejects_filesystem_agent_ref() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let project = tmp.path().join("AgentsCommander_ac");
         let workspace = project.join(".ac");
@@ -2713,9 +2739,44 @@ mod tests {
             .to_string_lossy()
             .replace('\\', "/");
 
-        let replica_dir = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
-            wg_dir,
+        let err = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
+            ac_new_dir: workspace,
+            wg_dir: wg_dir.clone(),
             agent_path: stale_agent_ref,
+            team_repos: Vec::new(),
+            settings_flags: AgentMatrixSettingsFlags {
+                exclude_global_claude_md: false,
+                inject_rtk_hook: false,
+            },
+        })
+        .expect_err("filesystem path refs must be rejected");
+
+        assert!(
+            err.contains("filesystem paths"),
+            "unexpected error: {}",
+            err
+        );
+        assert!(
+            !wg_dir.join("__agent_tech-lead").exists(),
+            "path refs must not create replicas"
+        );
+    }
+
+    #[test]
+    fn create_replica_writes_expected_local_identity_for_portable_ref() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("AgentsCommander_ac");
+        let workspace = project.join(".ac");
+        let matrix_dir = workspace.join("_agent_tech-lead");
+        let wg_dir = workspace.join("wg-2-dev-team");
+        std::fs::create_dir_all(&matrix_dir).expect("create matrix");
+        std::fs::create_dir_all(&wg_dir).expect("create wg");
+        std::fs::write(matrix_dir.join("Role.md"), "# Tech Lead\n").expect("write role");
+
+        let replica_dir = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
+            ac_new_dir: workspace,
+            wg_dir,
+            agent_path: "_agent_tech-lead".to_string(),
             team_repos: Vec::new(),
             settings_flags: AgentMatrixSettingsFlags {
                 exclude_global_claude_md: false,
@@ -2729,15 +2790,6 @@ mod tests {
         )
         .expect("parse config");
         assert_eq!(config["identity"], "../../_agent_tech-lead");
-        assert_eq!(
-            config["context"],
-            serde_json::json!([
-                "$AGENTSCOMMANDER_CONTEXT",
-                "$REPOS_WORKSPACE_INFO",
-                "../../_agent_tech-lead/Role.md"
-            ])
-        );
-        assert!(!config.to_string().contains("agentscommander-old"));
     }
 
     /// Success path: a clean WG dir with no blockers gets renamed and removed.

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -4,6 +4,7 @@ pub mod claude_settings;
 pub mod daemon_pid;
 pub mod profile;
 pub mod projects;
+pub mod replica_identity;
 pub mod root_agent;
 pub mod session_context;
 pub mod sessions_persistence;

--- a/src-tauri/src/config/replica_identity.rs
+++ b/src-tauri/src/config/replica_identity.rs
@@ -1,0 +1,578 @@
+use serde_json::Value;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::config::workspace::{ensure_authoritative_workspace_dir, find_workspace_ancestor};
+
+pub const ROLE_MD_FILENAME: &str = "Role.md";
+pub const WG_REPLICA_REQUIRED_CONTEXT: &[&str] =
+    &["$AGENTSCOMMANDER_CONTEXT", "$REPOS_WORKSPACE_INFO"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WgReplicaIdentity {
+    pub agent_name: String,
+    pub workspace_dir: PathBuf,
+    pub matrix_dir: PathBuf,
+    pub identity: String,
+}
+
+fn strip_unc(path: PathBuf) -> PathBuf {
+    let s = path.to_string_lossy();
+    s.strip_prefix(r"\\?\").map(PathBuf::from).unwrap_or(path)
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .to_string()
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    strip_unc(std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()))
+}
+
+fn validate_agent_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Agent name cannot be empty".to_string());
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        return Err(
+            "Invalid Agent name: only alphanumeric characters and hyphens are allowed".to_string(),
+        );
+    }
+    Ok(())
+}
+
+pub fn agent_bare_name_from_ref(raw_agent: &str) -> Result<String, String> {
+    let trimmed = raw_agent.trim();
+    if trimmed.is_empty() {
+        return Err("Agent reference cannot be empty".to_string());
+    }
+    if trimmed.contains('\0') {
+        return Err("Agent reference must not contain NUL".to_string());
+    }
+    let normalized = trimmed.replace('\\', "/");
+    let dir_name = normalized
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .next_back()
+        .ok_or_else(|| format!("Invalid agent reference '{}'", raw_agent))?;
+    let bare = dir_name
+        .strip_prefix("__agent_")
+        .or_else(|| dir_name.strip_prefix("_agent_"))
+        .unwrap_or(dir_name);
+    validate_agent_name(bare)?;
+    Ok(bare.to_string())
+}
+
+fn persisted_identity_agent_name(identity: &str) -> Result<String, String> {
+    let trimmed = identity.trim();
+    if trimmed.is_empty() {
+        return Err("WG replica identity cannot be empty".to_string());
+    }
+    if trimmed.contains('\0') {
+        return Err("WG replica identity must not contain NUL".to_string());
+    }
+
+    let normalized = trimmed.replace('\\', "/");
+    let dir_name = normalized
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .next_back()
+        .ok_or_else(|| format!("Invalid WG replica identity '{}'", identity))?;
+
+    #[cfg(windows)]
+    let bare = {
+        if !dir_name
+            .get(.."_agent_".len())
+            .map(|prefix| prefix.eq_ignore_ascii_case("_agent_"))
+            .unwrap_or(false)
+        {
+            return Err(format!(
+                "WG replica identity '{}' must end in '_agent_<name>'",
+                identity
+            ));
+        }
+        &dir_name["_agent_".len()..]
+    };
+
+    #[cfg(not(windows))]
+    let bare = dir_name.strip_prefix("_agent_").ok_or_else(|| {
+        format!(
+            "WG replica identity '{}' must end in '_agent_<name>'",
+            identity
+        )
+    })?;
+
+    validate_agent_name(bare)?;
+    Ok(bare.to_string())
+}
+
+fn persisted_identity_names_match(persisted: &str, expected: &str) -> bool {
+    if cfg!(windows) {
+        persisted.eq_ignore_ascii_case(expected)
+    } else {
+        persisted == expected
+    }
+}
+
+fn relative_path(from: &Path, to: &Path) -> Result<String, String> {
+    let from_abs = canonical_or_original(from);
+    let to_abs = canonical_or_original(to);
+
+    let from_components: Vec<_> = from_abs.components().collect();
+    let to_components: Vec<_> = to_abs.components().collect();
+    let common = from_components
+        .iter()
+        .zip(to_components.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    if common == 0 {
+        return Err(format!(
+            "cannot compute same-workspace identity between '{}' and '{}'",
+            display_path(from),
+            display_path(to)
+        ));
+    }
+
+    let mut result = PathBuf::new();
+    for _ in common..from_components.len() {
+        result.push("..");
+    }
+    for component in &to_components[common..] {
+        result.push(component.as_os_str());
+    }
+
+    Ok(result.to_string_lossy().replace('\\', "/"))
+}
+
+fn validate_local_matrix(
+    workspace_dir: &Path,
+    matrix_dir: &Path,
+    agent_name: &str,
+) -> Result<(), String> {
+    let expected_dir_name = format!("_agent_{}", agent_name);
+    let actual_dir_name = matrix_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "Agent Matrix '{}' has no valid directory name",
+                matrix_dir.display()
+            )
+        })?;
+    if actual_dir_name != expected_dir_name {
+        return Err(format!(
+            "WG replica identity target '{}' does not match expected '{}'",
+            actual_dir_name, expected_dir_name
+        ));
+    }
+
+    let metadata = std::fs::symlink_metadata(matrix_dir).map_err(|e| {
+        format!(
+            "Expected local Agent Matrix '{}' for WG replica identity, but it is not readable: {}",
+            display_path(matrix_dir),
+            e
+        )
+    })?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(format!(
+            "Expected local Agent Matrix '{}' for WG replica identity, but it is not a real directory",
+            display_path(matrix_dir)
+        ));
+    }
+
+    let workspace_abs = std::fs::canonicalize(workspace_dir)
+        .map(strip_unc)
+        .map_err(|e| {
+            format!(
+                "Failed to canonicalize AC workspace '{}': {}",
+                display_path(workspace_dir),
+                e
+            )
+        })?;
+    let matrix_abs = std::fs::canonicalize(matrix_dir)
+        .map(strip_unc)
+        .map_err(|e| {
+            format!(
+                "Failed to canonicalize Agent Matrix '{}': {}",
+                display_path(matrix_dir),
+                e
+            )
+        })?;
+    if !matrix_abs.starts_with(&workspace_abs) {
+        return Err(format!(
+            "WG replica identity target '{}' escapes authoritative workspace '{}'",
+            display_path(&matrix_abs),
+            display_path(&workspace_abs)
+        ));
+    }
+
+    Ok(())
+}
+
+/// Derive the only valid identity for a WG replica:
+/// `<project>/<workspace>/wg-N-team/__agent_NAME` -> `<project>/<workspace>/_agent_NAME`.
+pub fn expected_wg_replica_identity(replica_dir: &Path) -> Result<WgReplicaIdentity, String> {
+    let replica_dir_name = replica_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "Replica path '{}' has no valid directory name",
+                replica_dir.display()
+            )
+        })?;
+    let agent_name = replica_dir_name.strip_prefix("__agent_").ok_or_else(|| {
+        format!(
+            "WG replica directory '{}' must be named '__agent_<name>'",
+            replica_dir_name
+        )
+    })?;
+    validate_agent_name(agent_name)?;
+
+    let wg_dir = replica_dir.parent().ok_or_else(|| {
+        format!(
+            "WG replica directory '{}' has no parent workgroup",
+            display_path(replica_dir)
+        )
+    })?;
+    let wg_name = wg_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+    if !wg_name.starts_with("wg-") {
+        return Err(format!(
+            "WG replica directory '{}' is not inside a wg-* workgroup",
+            display_path(replica_dir)
+        ));
+    }
+
+    let workspace_dir = find_workspace_ancestor(replica_dir).ok_or_else(|| {
+        format!(
+            "WG replica directory '{}' is not inside an AC workspace",
+            display_path(replica_dir)
+        )
+    })?;
+    ensure_authoritative_workspace_dir(&workspace_dir)?;
+
+    let matrix_dir = workspace_dir.join(format!("_agent_{}", agent_name));
+    validate_local_matrix(&workspace_dir, &matrix_dir, agent_name)?;
+    let identity = relative_path(replica_dir, &matrix_dir)?;
+
+    Ok(WgReplicaIdentity {
+        agent_name: agent_name.to_string(),
+        workspace_dir,
+        matrix_dir,
+        identity,
+    })
+}
+
+pub fn validate_or_repair_wg_replica_identity(
+    replica_dir: &Path,
+    persisted_identity: Option<&str>,
+) -> Result<WgReplicaIdentity, String> {
+    let expected = expected_wg_replica_identity(replica_dir)?;
+    let persisted = persisted_identity.ok_or_else(|| {
+        format!(
+            "WG replica '{}' has no config.json identity; expected '{}'",
+            display_path(replica_dir),
+            expected.identity
+        )
+    })?;
+    let persisted_agent = persisted_identity_agent_name(persisted)?;
+    if !persisted_identity_names_match(&persisted_agent, &expected.agent_name) {
+        return Err(format!(
+            "WG replica '{}' identity '{}' names '_agent_{}', but the replica directory requires '_agent_{}'",
+            display_path(replica_dir),
+            persisted,
+            persisted_agent,
+            expected.agent_name
+        ));
+    }
+    Ok(expected)
+}
+
+fn is_identity_role_context_entry(entry: &str) -> bool {
+    let normalized = entry.replace('\\', "/");
+    let lower = normalized.to_ascii_lowercase();
+    lower.ends_with("/role.md")
+        && normalized
+            .split('/')
+            .any(|part| part.to_ascii_lowercase().starts_with("_agent_"))
+}
+
+pub fn normalize_wg_replica_context_entries(
+    existing_context: &[String],
+    required_prefix: &[&str],
+    identity_rel: &str,
+    role_exists: bool,
+) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut seen = HashSet::new();
+
+    for required in required_prefix {
+        if seen.insert((*required).to_string()) {
+            result.push((*required).to_string());
+        }
+    }
+
+    for entry in existing_context {
+        if required_prefix.contains(&entry.as_str()) || is_identity_role_context_entry(entry) {
+            continue;
+        }
+        if seen.insert(entry.clone()) {
+            result.push(entry.clone());
+        }
+    }
+
+    if role_exists {
+        let role_entry = format!("{}/{}", identity_rel, ROLE_MD_FILENAME);
+        if seen.insert(role_entry.clone()) {
+            result.push(role_entry);
+        }
+    }
+
+    result
+}
+
+pub fn repair_wg_replica_config_value(
+    replica_dir: &Path,
+    config: &mut Value,
+    required_context_prefix: &[&str],
+) -> Result<WgReplicaIdentity, String> {
+    let identity = validate_or_repair_wg_replica_identity(
+        replica_dir,
+        config.get("identity").and_then(|value| value.as_str()),
+    )?;
+    config["identity"] = Value::String(identity.identity.clone());
+
+    if let Some(context_array) = config.get("context").and_then(|value| value.as_array()) {
+        let existing_context: Vec<String> = context_array
+            .iter()
+            .filter_map(|value| value.as_str().map(String::from))
+            .collect();
+        let role_exists = identity.matrix_dir.join(ROLE_MD_FILENAME).exists();
+        config["context"] = serde_json::json!(normalize_wg_replica_context_entries(
+            &existing_context,
+            required_context_prefix,
+            &identity.identity,
+            role_exists,
+        ));
+    }
+
+    Ok(identity)
+}
+
+pub fn read_and_repair_wg_replica_config(
+    replica_dir: &Path,
+    required_context_prefix: &[&str],
+) -> Result<(Value, WgReplicaIdentity), String> {
+    let config_path = replica_dir.join("config.json");
+    let original = std::fs::read_to_string(&config_path)
+        .map_err(|e| format!("Failed to read {}: {}", config_path.display(), e))?;
+    let mut config: Value = serde_json::from_str(&original)
+        .map_err(|e| format!("Failed to parse {}: {}", config_path.display(), e))?;
+    let original_config = config.clone();
+    let identity =
+        repair_wg_replica_config_value(replica_dir, &mut config, required_context_prefix)?;
+    if config != original_config {
+        let repaired = serde_json::to_string_pretty(&config)
+            .map_err(|e| format!("Failed to serialize {}: {}", config_path.display(), e))?;
+        std::fs::write(&config_path, repaired)
+            .map_err(|e| format!("Failed to repair {}: {}", config_path.display(), e))?;
+    }
+    Ok((config, identity))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_replica(project_workspace_name: &str) -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp
+            .path()
+            .join("AgentsCommander_ac")
+            .join(project_workspace_name);
+        let matrix = workspace.join("_agent_tech-lead");
+        let replica = workspace.join("wg-2-dev-team").join("__agent_tech-lead");
+        std::fs::create_dir_all(&matrix).expect("create matrix");
+        std::fs::create_dir_all(&replica).expect("create replica");
+        std::fs::write(matrix.join(ROLE_MD_FILENAME), "# Tech Lead\n").expect("write Role.md");
+        temp
+    }
+
+    #[test]
+    fn expected_identity_is_same_workspace_for_canonical_ac() {
+        let temp = setup_replica(".ac");
+        let replica = temp
+            .path()
+            .join("AgentsCommander_ac")
+            .join(".ac")
+            .join("wg-2-dev-team")
+            .join("__agent_tech-lead");
+        let stale_sibling = temp
+            .path()
+            .join("agentscommander-old")
+            .join(".ac-new")
+            .join("_agent_tech-lead");
+        std::fs::create_dir_all(stale_sibling).expect("create stale sibling");
+
+        let identity = expected_wg_replica_identity(&replica).expect("identity");
+
+        assert_eq!(identity.identity, "../../_agent_tech-lead");
+        assert!(identity.matrix_dir.ends_with(
+            Path::new("AgentsCommander_ac")
+                .join(".ac")
+                .join("_agent_tech-lead")
+        ));
+    }
+
+    #[test]
+    fn read_and_repair_rewrites_stale_identity_and_role_context() {
+        let temp = setup_replica(".ac");
+        let replica = temp
+            .path()
+            .join("AgentsCommander_ac")
+            .join(".ac")
+            .join("wg-2-dev-team")
+            .join("__agent_tech-lead");
+        let stale = temp
+            .path()
+            .join("agentscommander-old")
+            .join(".ac-new")
+            .join("_agent_tech-lead")
+            .to_string_lossy()
+            .replace('\\', "/");
+        std::fs::write(
+            replica.join("config.json"),
+            serde_json::json!({
+                "identity": stale,
+                "context": [
+                    "$AGENTSCOMMANDER_CONTEXT",
+                    "../../../../agentscommander-old/.ac-new/_agent_tech-lead/Role.md",
+                    "notes.md",
+                    "../../_agent_tech-lead/Role.md"
+                ],
+                "repos": []
+            })
+            .to_string(),
+        )
+        .expect("write config");
+
+        let (config, identity) =
+            read_and_repair_wg_replica_config(&replica, WG_REPLICA_REQUIRED_CONTEXT)
+                .expect("repair config");
+
+        assert_eq!(identity.identity, "../../_agent_tech-lead");
+        assert_eq!(config["identity"], "../../_agent_tech-lead");
+        assert_eq!(
+            config["context"],
+            serde_json::json!([
+                "$AGENTSCOMMANDER_CONTEXT",
+                "$REPOS_WORKSPACE_INFO",
+                "notes.md",
+                "../../_agent_tech-lead/Role.md"
+            ])
+        );
+
+        let persisted: Value = serde_json::from_str(
+            &std::fs::read_to_string(replica.join("config.json")).expect("read config"),
+        )
+        .expect("parse config");
+        assert_eq!(persisted["identity"], "../../_agent_tech-lead");
+        assert!(!persisted.to_string().contains("agentscommander-old"));
+    }
+
+    #[test]
+    fn repair_rejects_identity_for_different_agent_basename() {
+        let temp = setup_replica(".ac");
+        let replica = temp
+            .path()
+            .join("AgentsCommander_ac")
+            .join(".ac")
+            .join("wg-2-dev-team")
+            .join("__agent_tech-lead");
+        std::fs::write(
+            replica.join("config.json"),
+            r#"{"identity":"../../../../agentscommander-old/.ac-new/_agent_architect"}"#,
+        )
+        .expect("write config");
+
+        let err = read_and_repair_wg_replica_config(&replica, WG_REPLICA_REQUIRED_CONTEXT)
+            .expect_err("mismatched identity must reject");
+
+        assert!(err.contains("_agent_architect"), "{err}");
+        assert!(err.contains("_agent_tech-lead"), "{err}");
+    }
+
+    #[test]
+    fn repair_rejects_bare_persisted_identity_component() {
+        let temp = setup_replica(".ac");
+        let replica = temp
+            .path()
+            .join("AgentsCommander_ac")
+            .join(".ac")
+            .join("wg-2-dev-team")
+            .join("__agent_tech-lead");
+        std::fs::write(replica.join("config.json"), r#"{"identity":"tech-lead"}"#)
+            .expect("write config");
+
+        let err = read_and_repair_wg_replica_config(&replica, WG_REPLICA_REQUIRED_CONTEXT)
+            .expect_err("bare identity basename must reject");
+
+        assert!(err.contains("must end in '_agent_<name>'"), "{err}");
+        let persisted: Value = serde_json::from_str(
+            &std::fs::read_to_string(replica.join("config.json")).expect("read config"),
+        )
+        .expect("parse config");
+        assert_eq!(persisted["identity"], "tech-lead");
+    }
+
+    #[test]
+    fn repair_rejects_replica_persisted_identity_component() {
+        let temp = setup_replica(".ac");
+        let replica = temp
+            .path()
+            .join("AgentsCommander_ac")
+            .join(".ac")
+            .join("wg-2-dev-team")
+            .join("__agent_tech-lead");
+        std::fs::write(
+            replica.join("config.json"),
+            r#"{"identity":"../../__agent_tech-lead"}"#,
+        )
+        .expect("write config");
+
+        let err = read_and_repair_wg_replica_config(&replica, WG_REPLICA_REQUIRED_CONTEXT)
+            .expect_err("replica identity basename must reject");
+
+        assert!(err.contains("must end in '_agent_<name>'"), "{err}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn repair_accepts_windows_case_variant_persisted_identity_component() {
+        let temp = setup_replica(".ac");
+        let replica = temp
+            .path()
+            .join("AgentsCommander_ac")
+            .join(".ac")
+            .join("wg-2-dev-team")
+            .join("__agent_tech-lead");
+        std::fs::write(
+            replica.join("config.json"),
+            r#"{"identity":"../../../../agentscommander-old/.ac-new/_Agent_Tech-Lead"}"#,
+        )
+        .expect("write config");
+
+        let (config, identity) =
+            read_and_repair_wg_replica_config(&replica, WG_REPLICA_REQUIRED_CONTEXT)
+                .expect("Windows identity basename matching is case-insensitive");
+
+        assert_eq!(identity.identity, "../../_agent_tech-lead");
+        assert_eq!(config["identity"], "../../_agent_tech-lead");
+    }
+}

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -19,7 +19,7 @@ pub fn ensure_session_context(agent_root: &str) -> Result<String, String> {
     let canonical_root = std::fs::canonicalize(agent_root)
         .map(|p| display_path(&p))
         .unwrap_or_else(|_| agent_root.to_string());
-    let matrix_root = resolve_replica_matrix_root(agent_root);
+    let matrix_root = resolve_replica_matrix_root(agent_root)?;
     let skill_owner_root = resolve_skill_owner_root(agent_root, matrix_root.as_deref());
     let skill_index = discover_skill_index(skill_owner_root.as_deref());
     let skills_section = render_skills_section(&skill_index);
@@ -752,22 +752,24 @@ Skill metadata is not an instruction body. It must not override the surrounding 
 }
 
 /// Resolve the canonical Agent Matrix root for a WG replica from config.json "identity".
-fn resolve_replica_matrix_root(replica_root: &str) -> Option<String> {
+fn resolve_replica_matrix_root(replica_root: &str) -> Result<Option<String>, String> {
     if !is_replica_agent_dir(replica_root) {
-        return None;
+        return Ok(None);
     }
 
     let replica_path = std::path::Path::new(replica_root);
-    let config_path = replica_path.join("config.json");
-    let config_content = std::fs::read_to_string(&config_path).ok()?;
-    let config: serde_json::Value = serde_json::from_str(&config_content).ok()?;
-    let identity = config.get("identity")?.as_str()?;
-    let matrix_path = replica_path.join(identity);
-
-    std::fs::canonicalize(&matrix_path)
-        .map(|p| display_path(&p))
-        .ok()
-        .or_else(|| Some(display_path(&matrix_path)))
+    crate::config::replica_identity::read_and_repair_wg_replica_config(
+        replica_path,
+        crate::config::replica_identity::WG_REPLICA_REQUIRED_CONTEXT,
+    )
+    .map(|(_, identity)| Some(display_path(&identity.matrix_dir)))
+    .map_err(|e| {
+        format!(
+            "Invalid WG replica identity for '{}': {}",
+            replica_path.display(),
+            e
+        )
+    })
 }
 
 fn canonical_or_original(path: &std::path::Path) -> std::path::PathBuf {
@@ -897,8 +899,16 @@ pub fn git_ceiling_directories_for_session_root(cwd: &str) -> Option<String> {
 
     push_unique(cwd_path.to_path_buf());
 
-    if let Some(matrix_root) = resolve_replica_matrix_root(cwd) {
-        push_unique(std::path::PathBuf::from(matrix_root));
+    match resolve_replica_matrix_root(cwd) {
+        Ok(Some(matrix_root)) => push_unique(std::path::PathBuf::from(matrix_root)),
+        Ok(None) => {}
+        Err(e) => {
+            log::warn!(
+                "[session_context] Rejected invalid WG replica identity while building Git ceiling for '{}': {}",
+                cwd,
+                e
+            );
+        }
     }
 
     if ordered.is_empty() {
@@ -1043,12 +1053,34 @@ pub fn build_replica_context(cwd: &str) -> Result<Option<String>, String> {
         return Ok(None);
     }
 
-    let config_content = std::fs::read_to_string(&config_path)
-        .map_err(|e| format!("Failed to read {}: {}", config_path.display(), e))?;
+    let (config, identity) = if is_replica_agent_dir(cwd) {
+        crate::config::replica_identity::read_and_repair_wg_replica_config(
+            cwd_path,
+            crate::config::replica_identity::WG_REPLICA_REQUIRED_CONTEXT,
+        )?
+    } else {
+        let config_content = std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("Failed to read {}: {}", config_path.display(), e))?;
+        let config: serde_json::Value = serde_json::from_str(&config_content)
+            .map_err(|e| format!("Failed to parse {}: {}", config_path.display(), e))?;
+        let identity = crate::config::replica_identity::expected_wg_replica_identity(cwd_path).ok();
+        match identity {
+            Some(identity) => (config, identity),
+            None => {
+                return build_replica_context_from_config(cwd, cwd_path, config, None);
+            }
+        }
+    };
 
-    let config: serde_json::Value = serde_json::from_str(&config_content)
-        .map_err(|e| format!("Failed to parse {}: {}", config_path.display(), e))?;
+    build_replica_context_from_config(cwd, cwd_path, config, Some(identity))
+}
 
+fn build_replica_context_from_config(
+    cwd: &str,
+    cwd_path: &Path,
+    config: serde_json::Value,
+    repaired_identity: Option<crate::config::replica_identity::WgReplicaIdentity>,
+) -> Result<Option<String>, String> {
     // No "context" field → no replica context
     let context_array = match config.get("context").and_then(|v| v.as_array()) {
         Some(arr) if !arr.is_empty() => arr,
@@ -1090,10 +1122,14 @@ pub fn build_replica_context(cwd: &str) -> Result<Option<String>, String> {
     }
 
     // Auto-inject Role.md from identity matrix if present and not already resolved.
-    let auto_role_abs = config
-        .get("identity")
-        .and_then(|v| v.as_str())
-        .map(|identity| cwd_path.join(format!("{}/{}", identity, ROLE_MD_FILENAME)));
+    let auto_role_abs = repaired_identity
+        .map(|identity| identity.matrix_dir.join(ROLE_MD_FILENAME))
+        .or_else(|| {
+            config
+                .get("identity")
+                .and_then(|v| v.as_str())
+                .map(|identity| cwd_path.join(format!("{}/{}", identity, ROLE_MD_FILENAME)))
+        });
     if let Some(role_abs) = auto_role_abs {
         let already_included = resolved_paths_include_path(&resolved_paths, &role_abs);
         if !already_included && role_abs.exists() {
@@ -2265,6 +2301,76 @@ mod tests {
             &matrix_root.join("skills").join("runtime").join("SKILL.md")
         )));
         assert!(!content.contains("BODY_SHOULD_NOT_RENDER"));
+    }
+
+    #[test]
+    fn materialize_replica_context_repairs_stale_identity_before_role_injection() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("AgentsCommander_ac");
+        let workspace = project.join(".ac");
+        let matrix_root = workspace.join("_agent_tech-lead");
+        let replica_root = workspace.join("wg-2-dev-team").join("__agent_tech-lead");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        std::fs::create_dir_all(&replica_root).expect("create replica root");
+        std::fs::write(
+            matrix_root.join(ROLE_MD_FILENAME),
+            "# Tech Lead\n\nLOCAL_MATRIX_ROLE_BODY\n",
+        )
+        .expect("write Role.md");
+        std::fs::write(
+            replica_root.join("config.json"),
+            r#"{"identity":"../../../../agentscommander-old/.ac-new/_agent_tech-lead","context":["$AGENTSCOMMANDER_CONTEXT","../../../../agentscommander-old/.ac-new/_agent_tech-lead/Role.md"]}"#,
+        )
+        .expect("write replica config");
+
+        let materialized = materialize_agent_context_file(
+            &path_string(&replica_root),
+            ManagedContextTarget::Codex,
+            false,
+        )
+        .expect("materialize context")
+        .expect("context path");
+        let content = std::fs::read_to_string(materialized).expect("read materialized context");
+
+        assert_global_context_before_one_role(&content, "LOCAL_MATRIX_ROLE_BODY");
+        assert!(!content.contains("agentscommander-old"));
+
+        let repaired: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(replica_root.join("config.json")).expect("read config"),
+        )
+        .expect("parse repaired config");
+        assert_eq!(repaired["identity"], "../../_agent_tech-lead");
+        assert_eq!(
+            repaired["context"],
+            serde_json::json!([
+                "$AGENTSCOMMANDER_CONTEXT",
+                "$REPOS_WORKSPACE_INFO",
+                "../../_agent_tech-lead/Role.md"
+            ])
+        );
+    }
+
+    #[test]
+    fn ensure_session_context_rejects_unrepairable_replica_identity() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("AgentsCommander_ac");
+        let workspace = project.join(".ac");
+        let matrix_root = workspace.join("_agent_tech-lead");
+        let replica_root = workspace.join("wg-2-dev-team").join("__agent_tech-lead");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        std::fs::create_dir_all(&replica_root).expect("create replica root");
+        std::fs::write(
+            replica_root.join("config.json"),
+            r#"{"identity":"../../../../agentscommander-old/.ac-new/_agent_architect"}"#,
+        )
+        .expect("write replica config");
+
+        let err = ensure_session_context(&path_string(&replica_root))
+            .expect_err("unrepairable identity must fail context generation");
+
+        assert!(err.contains("Invalid WG replica identity"), "{err}");
+        assert!(err.contains("_agent_architect"), "{err}");
+        assert!(err.contains("_agent_tech-lead"), "{err}");
     }
 
     #[test]

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -1,6 +1,9 @@
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
+use crate::config::replica_identity::{
+    agent_bare_name_from_ref, read_and_repair_wg_replica_config, WG_REPLICA_REQUIRED_CONTEXT,
+};
 use crate::config::workspace::{existing_workspace_dir, find_workspace_segment, has_workspace_dir};
 
 /// #280 §3.4 — record whether the missing-config one-shot INFO has already
@@ -220,6 +223,7 @@ pub struct WgCoordinatorReplica {
 /// - Lowercase (case-insensitive comparison; matches the convention used by
 ///   `cli/list_peers::norm_path`).
 /// - Trim trailing `/`.
+#[cfg(test)]
 fn normalize_path_for_compare(s: &str) -> String {
     let stripped = s.strip_prefix(r"\\?\").unwrap_or(s);
     stripped
@@ -237,6 +241,7 @@ fn normalize_path_for_compare(s: &str) -> String {
 /// Returns a forward-slash string. `..` components above the root of an
 /// absolute path are dropped; `..` components at the front of a purely
 /// relative path are preserved.
+#[cfg(test)]
 fn logical_path_resolve(path: &Path) -> String {
     use std::path::Component;
     let mut components: Vec<Component> = Vec::new();
@@ -305,6 +310,7 @@ fn logical_path_resolve(path: &Path) -> String {
 /// declared `identity` field from `config.json`, never the replica directory
 /// name (`__agent_*`). A spoofed replica that declares a different matrix
 /// path still produces a different key from the team coordinator ref.
+#[cfg(test)]
 fn identity_compare_key(path: &Path) -> String {
     let raw = match std::fs::canonicalize(path) {
         Ok(canon) => canon.to_string_lossy().into_owned(),
@@ -328,39 +334,34 @@ pub fn resolve_wg_coordinator_replica(
         .ok()
         .and_then(|raw| serde_json::from_str(&raw).ok())?;
     let coordinator_ref = team_config.get("coordinator").and_then(|c| c.as_str())?;
-    let coordinator_key = identity_compare_key(&team_dir.join(coordinator_ref));
+    let coordinator_name = agent_bare_name_from_ref(coordinator_ref).ok()?;
+    if !ac_new_dir
+        .join(format!("_agent_{}", coordinator_name))
+        .is_dir()
+    {
+        return None;
+    }
 
     for replica_entry in std::fs::read_dir(wg_dir).ok()?.flatten() {
         let replica_dir = replica_entry.path();
         if !replica_dir.is_dir() {
             continue;
         }
-        let dir_name = match replica_dir.file_name().and_then(|n| n.to_str()) {
+        let _dir_name = match replica_dir.file_name().and_then(|n| n.to_str()) {
             Some(n) if n.starts_with("__agent_") => n,
             _ => continue,
         };
-        let config: serde_json::Value =
-            match std::fs::read_to_string(replica_dir.join("config.json"))
-                .ok()
-                .and_then(|raw| serde_json::from_str(&raw).ok())
-            {
-                Some(v) => v,
-                None => continue,
-            };
-        let identity_ref = match config.get("identity").and_then(|i| i.as_str()) {
-            Some(i) => i,
-            None => continue,
+        let Ok((_config, identity)) =
+            read_and_repair_wg_replica_config(&replica_dir, WG_REPLICA_REQUIRED_CONTEXT)
+        else {
+            continue;
         };
-        let identity_key = identity_compare_key(&replica_dir.join(identity_ref));
-        if identity_key == coordinator_key {
+        if identity.agent_name == coordinator_name {
             return Some(WgCoordinatorReplica {
                 project,
                 team,
                 wg_name,
-                agent_name: dir_name
-                    .strip_prefix("__agent_")
-                    .unwrap_or(dir_name)
-                    .to_string(),
+                agent_name: identity.agent_name,
                 replica_dir,
             });
         }
@@ -1209,8 +1210,9 @@ mod tests {
 
     /// Build a fixture where both team config and replica configs reference
     /// a legacy folder name (`legacy-workspace`) that no longer exists on disk.
-    /// Mirrors the post-workspace-rename state from #299: `canonicalize()` fails
-    /// for both refs, but logical resolution should still produce equal keys.
+    /// Mirrors the post-workspace-rename state from #299/#300: persisted refs are
+    /// stale, but the same-workspace local matrices exist and are the only valid
+    /// authority targets.
     fn make_stale_coordinator_fixture(
         replica_spoofs_identity: bool,
     ) -> (FixtureRoot, PathBuf, PathBuf) {
@@ -1219,10 +1221,18 @@ mod tests {
         let ac_new = project.join(".ac-new");
         let team_dir = ac_new.join("_team_test-team");
         let wg_dir = ac_new.join("wg-1-test-team");
+        let alpha_matrix = ac_new.join("_agent_test-alpha");
+        let beta_matrix = ac_new.join("_agent_test-beta");
         let alpha_replica = wg_dir.join("__agent_test-alpha");
         let beta_replica = wg_dir.join("__agent_test-beta");
 
-        for dir in [&team_dir, &alpha_replica, &beta_replica] {
+        for dir in [
+            &team_dir,
+            &alpha_matrix,
+            &beta_matrix,
+            &alpha_replica,
+            &beta_replica,
+        ] {
             std::fs::create_dir_all(dir).unwrap();
         }
 
@@ -1277,19 +1287,24 @@ mod tests {
         (tmp, ac_new, wg_dir)
     }
 
-    /// #299: legacy stale absolute identity refs (workspace renamed; refs point
-    /// at a folder that no longer exists) must still resolve the coordinator
-    /// via logical (no-disk) path comparison.
+    /// #300: stale absolute identity refs are accepted only by repairing them
+    /// to the same-workspace local matrix with the same agent basename.
     #[test]
-    fn resolve_wg_coordinator_replica_tolerates_stale_absolute_refs() {
+    fn resolve_wg_coordinator_replica_repairs_stale_absolute_refs() {
         let (_tmp, ac_new, wg_dir) = make_stale_coordinator_fixture(false);
 
         let resolved = resolve_wg_coordinator_replica(&ac_new, &wg_dir)
-            .expect("tolerant comparison should resolve coordinator with stale refs");
+            .expect("same-workspace repair should resolve coordinator with stale refs");
 
         assert_eq!(resolved.agent_name, "test-alpha");
         assert_eq!(resolved.team, "test-team");
         assert_eq!(resolved.wg_name, "wg-1-test-team");
+        let repaired_config: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(wg_dir.join("__agent_test-alpha").join("config.json"))
+                .expect("read repaired config"),
+        )
+        .expect("parse repaired config");
+        assert_eq!(repaired_config["identity"], "../../_agent_test-alpha");
     }
 
     /// #299: even when refs are stale, spoofing must still be rejected — a
@@ -1306,20 +1321,19 @@ mod tests {
         assert!(resolve_wg_coordinator_replica(&ac_new, &wg_dir).is_none());
     }
 
-    /// #299: identity ref expressed as a relative path traversing out of the
-    /// workspace into a legacy folder (the typical post-rename shape) must
-    /// produce the same logical key as a team coordinator ref expressed as a
-    /// stale absolute path pointing at the same legacy folder.
+    /// #300: relative identity traversing out of the workspace must be repaired
+    /// to the same-workspace local matrix, not compared against the stale target.
     #[test]
-    fn resolve_wg_coordinator_replica_tolerates_stale_relative_identity() {
+    fn resolve_wg_coordinator_replica_repairs_stale_relative_identity() {
         let tmp = FixtureRoot::new("teams-stale-rel-fixture");
         let project = tmp.path().join("proj-a");
         let ac_new = project.join(".ac-new");
         let team_dir = ac_new.join("_team_test-team");
         let wg_dir = ac_new.join("wg-1-test-team");
+        let alpha_matrix = ac_new.join("_agent_test-alpha");
         let alpha_replica = wg_dir.join("__agent_test-alpha");
 
-        for dir in [&team_dir, &alpha_replica] {
+        for dir in [&team_dir, &alpha_matrix, &alpha_replica] {
             std::fs::create_dir_all(dir).unwrap();
         }
 
@@ -1349,7 +1363,7 @@ mod tests {
         .unwrap();
 
         let resolved = resolve_wg_coordinator_replica(&ac_new, &wg_dir)
-            .expect("tolerant comparison should bridge stale absolute and relative refs");
+            .expect("same-workspace repair should resolve stale relative identity");
         assert_eq!(resolved.agent_name, "test-alpha");
     }
 


### PR DESCRIPTION
## Summary

Fixes stale workgroup replica identity trust by validating and repairing local WG replica identities before they are used by session context, list-peers, root/discovery flows, or preserved during sync.

This replaces PR #379 because its original branch referenced closed issue #299 and failed the branch-name check. This branch references open issue #378.

## Root Cause

Replica identity could be computed from raw stale or cross-project refs, preserved during sync, then trusted by session context, list-peers, root, and discovery code paths.

## Fix

- Adds a shared WG replica identity validator/repair helper.
- Normalizes local same-workspace identities and applies safe repair rules.
- Rewrites and dedupes Role.md context for repaired WG replicas.
- Hardens session context, root/discovery, list-peers, and related entity creation paths against stale identity trust.
- Preserves `.ac` precedence while avoiding stale cross-project identity reuse.
- Includes the clean merge resolution from `origin/main` at `14a3398`.

## Validation

Known validation from the team:

- `cargo check -q` passed with only a pre-existing `dead_code` warning.
- `cargo test -q replica_identity --lib` passed (9 tests).
- `cargo test -q config::session_context --lib` passed (40 tests).
- `cargo test -q config::teams --lib` passed (42 tests).
- `cargo test -q cli::list_peers --lib` passed (65 tests).
- `cargo test -q commands::entity_creation --lib` passed (54 tests, then 56/57 in follow-up conflict-resolution passes).
- `cargo test -q commands::ac_discovery --lib` passed (20 tests).
- E2E patched `list-peers-lean` safe repair and unrepairable deny cases passed per ac-cli-tester.
- dev-rust-grinch final review: acceptable, no stale-identity blockers.

Conflict-resolution validation from the linked worktree:

- Scoped rustfmt check passed for `entity_creation.rs`, `workgroup.rs`, and `team.rs`.
- `cargo test -q commands::entity_creation --lib` passed (57 tests).
- `cargo test -q replica_identity --lib` passed (9 tests).
- `cargo test -q config::teams --lib` passed (42 tests).
- `cargo check -q` passed with the existing `dead_code` warning only.
- `git merge-tree --name-only HEAD origin/main` was clean from `14a3398`.

Additional shipper checks:

- PR #379 branch was updated to `14a3398` and became mergeable, but remained blocked by the closed-issue branch-name check.
- `gh issue view 378` confirmed issue #378 is open.
- The compliant branch `fix/378-wg-coordinator-stale-identity` points to the same head SHA: `14a33982e5a300fc8fcd292bd240da611d045c31`.