### PR TITLE
[codex] Add regression coverage for cross-WG peer discovery

### DIFF
--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -1323,6 +1323,61 @@ mod tests {
         (temp, paths)
     }
 
+    fn make_portable_cross_wg_fixture() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-a");
+        let ac_new = project.join(".ac");
+        let team_dir = ac_new.join("_team_dev-team");
+        let local_tech_lead = ac_new.join("_agent_tech-lead");
+        let local_dev_rust = ac_new.join("_agent_dev-rust");
+        let origin = temp.path().join("origin-matrix").join(".ac-new");
+        let origin_tech_lead = origin.join("_agent_tech-lead");
+        let origin_dev_rust = origin.join("_agent_dev-rust");
+
+        for dir in [
+            &team_dir,
+            &local_tech_lead,
+            &local_dev_rust,
+            &origin_tech_lead,
+            &origin_dev_rust,
+        ] {
+            std::fs::create_dir_all(dir).unwrap();
+        }
+        std::fs::write(
+            team_dir.join("config.json"),
+            r#"{"agents":["_agent_dev-rust"],"coordinator":"_agent_tech-lead"}"#,
+        )
+        .unwrap();
+
+        let tech_lead_identity = origin_tech_lead.to_string_lossy().replace('\\', "/");
+        let dev_rust_identity = origin_dev_rust.to_string_lossy().replace('\\', "/");
+        let mut wg1_tech_lead = PathBuf::new();
+        let mut wg1_dev_rust = PathBuf::new();
+        for wg_name in ["wg-1-dev-team", "wg-2-dev-team"] {
+            let wg_dir = ac_new.join(wg_name);
+            let tech_lead_replica = wg_dir.join("__agent_tech-lead");
+            let dev_rust_replica = wg_dir.join("__agent_dev-rust");
+            std::fs::create_dir_all(&tech_lead_replica).unwrap();
+            std::fs::create_dir_all(&dev_rust_replica).unwrap();
+            std::fs::write(
+                tech_lead_replica.join("config.json"),
+                format!(r#"{{"identity":"{}"}}"#, tech_lead_identity),
+            )
+            .unwrap();
+            std::fs::write(
+                dev_rust_replica.join("config.json"),
+                format!(r#"{{"identity":"{}"}}"#, dev_rust_identity),
+            )
+            .unwrap();
+            if wg_name == "wg-1-dev-team" {
+                wg1_tech_lead = tech_lead_replica;
+                wg1_dev_rust = dev_rust_replica;
+            }
+        }
+
+        (temp, wg1_tech_lead, wg1_dev_rust)
+    }
+
     #[test]
     fn detect_wg_replica_rejects_stale_legacy_when_canonical_exists() {
         let temp = tempfile::TempDir::new().unwrap();
@@ -1383,6 +1438,38 @@ mod tests {
 
         assert!(names.contains(&"proj-a:wg-1-devs/bob"));
         assert!(!names.contains(&"proj-a:wg-1-devs/eve"));
+    }
+
+    #[test]
+    fn discover_wg_peers_for_portable_verified_coordinator_includes_cross_wg_and_root() {
+        let (_temp, wg1_tech_lead, _wg1_dev_rust) = make_portable_cross_wg_fixture();
+        let wg = detect_wg_replica(wg1_tech_lead.to_str().unwrap())
+            .unwrap()
+            .expect("portable coordinator replica");
+
+        let peers = discover_wg_peers(wg);
+        let names: Vec<&str> = peers.iter().map(|peer| peer.name.as_str()).collect();
+
+        assert!(names.contains(&"proj-a:wg-1-dev-team/dev-rust"));
+        assert!(names.contains(&"proj-a:wg-2-dev-team/tech-lead"));
+        assert!(names.contains(&crate::config::root_agent::ROOT_AGENT_SENDER));
+        assert!(!names.contains(&"proj-a:wg-2-dev-team/dev-rust"));
+    }
+
+    #[test]
+    fn discover_wg_peers_for_portable_non_coordinator_stays_wg_local_without_root() {
+        let (_temp, _wg1_tech_lead, wg1_dev_rust) = make_portable_cross_wg_fixture();
+        let wg = detect_wg_replica(wg1_dev_rust.to_str().unwrap())
+            .unwrap()
+            .expect("portable non-coordinator replica");
+
+        let peers = discover_wg_peers(wg);
+        let names: Vec<&str> = peers.iter().map(|peer| peer.name.as_str()).collect();
+
+        assert!(names.contains(&"proj-a:wg-1-dev-team/tech-lead"));
+        assert!(!names.contains(&"proj-a:wg-2-dev-team/tech-lead"));
+        assert!(!names.contains(&"proj-a:wg-2-dev-team/dev-rust"));
+        assert!(!names.contains(&crate::config::root_agent::ROOT_AGENT_SENDER));
     }
 
     #[test]

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -1181,6 +1181,64 @@ mod tests {
         (tmp, paths)
     }
 
+    fn make_portable_coordinator_fixture(
+        spoofed_coordinator_identity: bool,
+    ) -> (FixtureRoot, PathBuf, PathBuf, Vec<String>) {
+        let tmp = FixtureRoot::new("teams-portable-coord-fixture");
+        let project = tmp.path().join("proj-a");
+        let ac_new = project.join(".ac");
+        let team_dir = ac_new.join("_team_dev-team");
+        let local_tech_lead = ac_new.join("_agent_tech-lead");
+        let local_dev_rust = ac_new.join("_agent_dev-rust");
+        let origin = tmp.path().join("origin-matrix").join(".ac-new");
+        let origin_tech_lead = origin.join("_agent_tech-lead");
+        let origin_dev_rust = origin.join("_agent_dev-rust");
+        let wg_dir = ac_new.join("wg-1-dev-team");
+        let tech_lead_replica = wg_dir.join("__agent_tech-lead");
+        let dev_rust_replica = wg_dir.join("__agent_dev-rust");
+
+        for dir in [
+            &team_dir,
+            &local_tech_lead,
+            &local_dev_rust,
+            &origin_tech_lead,
+            &origin_dev_rust,
+            &tech_lead_replica,
+            &dev_rust_replica,
+        ] {
+            std::fs::create_dir_all(dir).unwrap();
+        }
+
+        std::fs::write(
+            team_dir.join("config.json"),
+            r#"{"agents":["_agent_dev-rust"],"coordinator":"_agent_tech-lead"}"#,
+        )
+        .unwrap();
+
+        let tech_lead_identity = if spoofed_coordinator_identity {
+            &origin_dev_rust
+        } else {
+            &origin_tech_lead
+        }
+        .to_string_lossy()
+        .replace('\\', "/");
+        std::fs::write(
+            tech_lead_replica.join("config.json"),
+            format!(r#"{{"identity":"{}"}}"#, tech_lead_identity),
+        )
+        .unwrap();
+
+        let dev_rust_identity = origin_dev_rust.to_string_lossy().replace('\\', "/");
+        std::fs::write(
+            dev_rust_replica.join("config.json"),
+            format!(r#"{{"identity":"{}"}}"#, dev_rust_identity),
+        )
+        .unwrap();
+
+        let paths = vec![tmp.path().to_string_lossy().to_string()];
+        (tmp, ac_new, wg_dir, paths)
+    }
+
     #[test]
     fn resolve_wg_coordinator_replica_uses_identity_not_dir_name() {
         let (tmp, _paths) = make_coordinator_fixture(false);
@@ -1204,6 +1262,26 @@ mod tests {
         let (tmp, _paths) = make_coordinator_fixture(true);
         let ac_new = tmp.path().join("proj-a").join(".ac-new");
         let wg_dir = ac_new.join("wg-1-dev-team");
+
+        assert!(resolve_wg_coordinator_replica(&ac_new, &wg_dir).is_none());
+    }
+
+    #[test]
+    fn resolve_wg_coordinator_replica_accepts_portable_ref_with_external_identity() {
+        let (_tmp, ac_new, wg_dir, _paths) = make_portable_coordinator_fixture(false);
+
+        let resolved = resolve_wg_coordinator_replica(&ac_new, &wg_dir)
+            .expect("portable coordinator ref should match declared identity agent");
+
+        assert_eq!(resolved.project, "proj-a");
+        assert_eq!(resolved.team, "dev-team");
+        assert_eq!(resolved.wg_name, "wg-1-dev-team");
+        assert_eq!(resolved.agent_name, "tech-lead");
+    }
+
+    #[test]
+    fn resolve_wg_coordinator_replica_rejects_portable_ref_with_spoofed_identity() {
+        let (_tmp, ac_new, wg_dir, _paths) = make_portable_coordinator_fixture(true);
 
         assert!(resolve_wg_coordinator_replica(&ac_new, &wg_dir).is_none());
     }
@@ -1443,6 +1521,17 @@ mod tests {
 
         let resolved = verified_wg_coordinator_target("proj-a:wg-1-dev-team/tech-lead", &paths)
             .expect("verified coordinator");
+
+        assert_eq!(resolved.agent_name, "tech-lead");
+        assert_eq!(resolved.team, "dev-team");
+    }
+
+    #[test]
+    fn verified_wg_coordinator_target_accepts_portable_ref_with_external_identity() {
+        let (_tmp, _ac_new, _wg_dir, paths) = make_portable_coordinator_fixture(false);
+
+        let resolved = verified_wg_coordinator_target("proj-a:wg-1-dev-team/tech-lead", &paths)
+            .expect("portable verified coordinator");
 
         assert_eq!(resolved.agent_name, "tech-lead");
         assert_eq!(resolved.team, "dev-team");


### PR DESCRIPTION
## Summary

Adds regression coverage for the cross-workgroup peer discovery contract from #375.

This PR is intentionally test-only. The runtime behavior is already fixed on `main` by the stale WG replica identity repair work in #380; these tests lock in the expected `list-peers` / `list-peers-lean` peer set so it does not regress.

## Coverage Added

- Verified WG coordinator sees own WG peers.
- Verified WG coordinator sees verified coordinators from other WGs in the same workspace/project.
- Verified WG coordinator sees `agentscommander://root-agent`.
- Workers from other WGs are not exposed.
- Non-coordinator WG replicas stay WG-local and do not see the Root Agent.
- Portable `_agent_*` team coordinator refs with stale/external persisted identities are covered through the repaired identity path.

## Validation

- `cargo test discover_wg_peers_for_portable --lib`
- `cargo test resolve_wg_coordinator_replica --lib`
- `cargo test verified_wg_coordinator_target --lib`
- `cargo test --lib` -> `841 passed`, `12 ignored`

Fixes/guards #375.