### PR TITLE
Remove .ac-new legacy workspace support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ _logbooks/
 .deleting-*
 
 # AgentsCommander workgroup replicas (always per-machine state).
-.ac-new/wg-*/
+.ac/wg-*/
 
 # Per-session agent context materialized by default_context()
 CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Public-push release: repo cleanup, documentation rewrite scaffolding, and factua
 ### Changed
 
 - Documentation: `ROLE_AC_BUILDER.md` moved to `docs/agent-matrix-conventions.md`.
-- `.gitignore`: added `_logbooks/`; replaced the hand-listed `.ac-new/wg-{1,2,3}-ac-devs/` entries with the single glob `.ac-new/wg-*/`.
+- `.gitignore`: added `_logbooks/`; replaced hand-listed workgroup entries with a single workspace workgroup glob.
 - README factual fixes:
   - Supported coding agents corrected to **Claude Code · Codex · Gemini** (was: Claude Code · Codex · OpenCode — OpenCode is not yet supported; tracked in [#315](https://github.com/mblua/AgentsCommander/issues/315)).
   - Window-model description updated to reflect the unified main window (the old "Sidebar and Terminal are independent windows" description was pre-unification).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You bring the coding agents. AgentsCommander coordinates them.
 
 1. **Download** the latest installer for your platform from [the releases page](https://github.com/mblua/AgentsCommander/releases/latest). Windows `.exe`, Linux `.AppImage`, and macOS `.dmg` are built on every release.
 2. **Run** the installer (or run the portable `.exe` directly; see [Portable instances](docs/features/portable-instances.md)).
-3. **Open a project**: click `New Project` in the sidebar and point it at an empty folder. AC creates an `.ac/` workspace there. Existing `.ac-new/` projects still open as legacy projects.
+3. **Open a project**: click `New Project` in the sidebar and point it at an empty folder. AC creates an `.ac/` workspace there.
 4. **Create a Team**: add a coordinator and one worker agent, each with a role prompt. [Teams and workgroups](docs/agents/teams-and-workgroups.md) walks through this.
 5. **Launch the coordinator**: pick Claude Code, Codex, or Gemini from the dropdown. Ask it to send the worker a hello message. The worker terminal receives a file notification and responds in real time.
 

--- a/docs/agent-matrix-conventions.md
+++ b/docs/agent-matrix-conventions.md
@@ -13,7 +13,7 @@ This document is the definitive guide for any AI agent tasked with creating or m
 | **Workgroup** | `wg-` | `.ac/wg-N-TEAMNAME/` | An isolated working environment with cloned agents + cloned repo for parallel work |
 | **Workgroup Agent** | `__agent_` | `.ac/wg-N-TEAMNAME/__agent_NAME/` | A replica of a project-level agent inside a workgroup (double underscore) |
 
-`.ac/` is the canonical workspace directory. Legacy `.ac-new/` projects use the same layout when `.ac/` is absent.
+`.ac/` is the only supported workspace directory.
 
 **Hierarchy:** Project → Agents + Teams → Workgroups (with replicated agents + repo clones)
 

--- a/docs/agents/agent-skills.md
+++ b/docs/agents/agent-skills.md
@@ -90,7 +90,7 @@ files only when they are needed.
 ## Creating a Skill
 
 1. Open the canonical Agent Matrix directory for the agent, for example
-   `.ac/_agent_dev-rust/`. Legacy `.ac-new/` projects use the same layout under `.ac-new/`.
+   `.ac/_agent_dev-rust/`.
 2. Create `skills/<skill-name>/`.
 3. Add `skills/<skill-name>/SKILL.md` with YAML frontmatter.
 4. Describe when to use the skill and the exact workflow to follow.

--- a/docs/agents/creating-agents.md
+++ b/docs/agents/creating-agents.md
@@ -12,7 +12,7 @@ An agent is a directory with a role-prompt file at its root. The directory IS th
 | Codex | `AGENTS.md` (or `CLAUDE.md` fallback) |
 | Gemini | `GEMINI.md` (or `CLAUDE.md` fallback) |
 
-When the agent dir lives inside an AC project at `.ac/_agent_<name>/`, AC promotes it to an **agent matrix** with optional `memory/`, `plans/`, `skills/`, and a canonical `Role.md`. Legacy `.ac-new/` projects use the same layout under `.ac-new/`.
+When the agent dir lives inside an AC project at `.ac/_agent_<name>/`, AC promotes it to an **agent matrix** with optional `memory/`, `plans/`, `skills/`, and a canonical `Role.md`.
 
 ## The one rule
 

--- a/docs/agents/teams-and-workgroups.md
+++ b/docs/agents/teams-and-workgroups.md
@@ -4,7 +4,7 @@ For developers ready to compose multiple agents around a shared goal. Teams defi
 
 ## Team
 
-A **team** is one coordinator plus one or more worker agents. The team's config lives at `.ac/_team_<name>/config.json` and lists members by their canonical names. Legacy `.ac-new/` projects use the same layout under `.ac-new/`.
+A **team** is one coordinator plus one or more worker agents. The team's config lives at `.ac/_team_<name>/config.json` and lists members by their canonical names.
 
 ```
 my-project/

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -48,7 +48,7 @@ A renamed copy of `agentscommander.exe` (with an `_<suffix>` like `agentscommand
 
 ## Project (AC project)
 
-A folder containing an `.ac/` workspace. AC manages all agents, teams, and workgroups under that workspace. Legacy `.ac-new/` workspaces remain supported.
+A folder containing an `.ac/` workspace. AC manages all agents, teams, and workgroups under that workspace.
 
 ## PTY
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,7 @@ Run the installer, or drop the portable `.exe` into any folder and double-click.
 
 ## 2. Open or create an AC project
 
-An **AC project** is a folder with an `.ac/` workspace inside. AC stores agents, teams, and messaging here so the whole project is portable and version-controllable. Existing `.ac-new/` workspaces still open as a legacy fallback.
+An **AC project** is a folder with an `.ac/` workspace inside. AC stores agents, teams, and messaging here so the whole project is portable and version-controllable.
 
 In the sidebar, click **New Project** and point at any folder, empty or an existing repo. AC creates `.ac/` with a sensible `.gitignore` and registers the project in your sidebar.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -353,7 +353,7 @@ Same locking + backup behaviour as `task-set-title`.
 
 ## `open-project`
 
-Register an existing AC project (folder with `.ac/` or legacy `.ac-new/` inside) in the GUI sidebar's project list.
+Register an existing AC project (folder with `.ac/` inside) in the GUI sidebar's project list.
 
 ```bash
 agentscommander open-project /path/to/project
@@ -365,7 +365,7 @@ agentscommander open-project /path/to/project
 
 Idempotent — re-registering the same path is a no-op (`Project already registered`).
 
-If the folder does not contain `.ac/` or legacy `.ac-new/`, the CLI suggests `new-project` instead.
+If the folder does not contain `.ac/`, the CLI suggests `new-project` instead.
 
 **No token required** — project registration mutates the local `settings.json`, which any shell-capable process can already write to.
 
@@ -385,7 +385,7 @@ agentscommander new-project /path/to/project
 |---|---|
 | `PATH` | Absolute or relative. Folder created if it does not yet exist. |
 
-Idempotent: re-running on a folder that already has `.ac/` or legacy `.ac-new/` only sweeps the selected workspace gitignore and deduplicates the registration.
+Idempotent: re-running on a folder that already has `.ac/` only sweeps the workspace gitignore and deduplicates the registration.
 
 **No token required** — same reasoning as `open-project`.
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -40,7 +40,7 @@ When you show a command, also show what the user should expect to see — first 
 
 ## 5. Be specific about failure
 
-> ✅ "If you see `Error: ENOENT`, check that you are inside an `.ac/` project. Legacy `.ac-new/` projects are also supported."
+> ✅ "If you see `Error: ENOENT`, check that you are inside an `.ac/` project."
 > ❌ "If there is an error, check your setup."
 
 Name the error string. Name the directory. Name the file. Vague troubleshooting is worse than none.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -2,7 +2,7 @@
 
 For developers deciding whether AgentsCommander fits their workflow. Four worked examples — pick the one closest to your problem and adapt.
 
-Every example assumes you have the [Quickstart](quickstart.md) finished: a project with an `.ac/` workspace and at least one coding agent (Claude Code, Codex, or Gemini) installed. Legacy `.ac-new/` workspaces are still supported.
+Every example assumes you have the [Quickstart](quickstart.md) finished: a project with an `.ac/` workspace and at least one coding agent (Claude Code, Codex, or Gemini) installed.
 
 ## 1. Parallel feature development
 

--- a/scripts/all_agentscommander_standalone_come_to_me.ps1
+++ b/scripts/all_agentscommander_standalone_come_to_me.ps1
@@ -5,8 +5,8 @@ all_agentscommander_standalone_come_to_me.ps1
 Assumptions:
 - By default, AgentsCommander_ac is checked out at:
   $env:USERPROFILE\0_repos\AgentsCommander_ac
-- Override -AcNewRoot if the checkout moved.
-- Workgroup folders are immediate children of the AgentsCommander_ac .ac-new directory and match ^wg-\d+.
+- Override -AcRoot if the checkout moved.
+- Workgroup folders are immediate children of the AgentsCommander_ac .ac directory and match ^wg-\d+.
 - The script reads from each workgroup repo and writes only to -Destination.
 
 Destination filename convention:
@@ -16,7 +16,7 @@ Destination filename convention:
 
 [CmdletBinding()]
 param(
-    [string]$AcNewRoot = (Join-Path $env:USERPROFILE '0_repos\AgentsCommander_ac\.ac-new'),
+    [string]$AcRoot = (Join-Path $env:USERPROFILE '0_repos\AgentsCommander_ac\.ac'),
     [string]$Destination = 'C:\Users\maria\0_mmb\0_AC',
     [switch]$Overwrite
 )
@@ -24,20 +24,20 @@ param(
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = 'Stop'
 
-function Resolve-AcNewRoot {
+function Resolve-AcRoot {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Path
     )
 
     if ([string]::IsNullOrWhiteSpace($Path)) {
-        throw 'AcNewRoot cannot be empty.'
+        throw 'AcRoot cannot be empty.'
     }
 
     $candidate = [System.IO.Path]::GetFullPath($Path)
 
-    if ((Split-Path -Leaf $candidate) -ne '.ac-new') {
-        $nested = Join-Path $candidate '.ac-new'
+    if ((Split-Path -Leaf $candidate) -ne '.ac') {
+        $nested = Join-Path $candidate '.ac'
         if (Test-Path -LiteralPath $nested -PathType Container) {
             return (Resolve-Path -LiteralPath $nested).ProviderPath
         }
@@ -47,7 +47,7 @@ function Resolve-AcNewRoot {
         return (Resolve-Path -LiteralPath $candidate).ProviderPath
     }
 
-    throw "AgentsCommander_ac .ac-new directory not found: $candidate"
+    throw "AgentsCommander_ac .ac directory not found: $candidate"
 }
 
 function ConvertTo-SafeFileName {
@@ -60,7 +60,7 @@ function ConvertTo-SafeFileName {
     return ($Name -replace $invalidPattern, '_')
 }
 
-$acNewRootPath = Resolve-AcNewRoot -Path $AcNewRoot
+$acRootPath = Resolve-AcRoot -Path $AcRoot
 $destinationPath = [System.IO.Path]::GetFullPath($Destination)
 
 if (-not (Test-Path -LiteralPath $destinationPath -PathType Container)) {
@@ -79,12 +79,12 @@ $stats = @{
 
 $patterns = @('agentscommander*.exe', 'agentscommander.*.exe')
 $workgroups = @(
-    Get-ChildItem -LiteralPath $acNewRootPath -Directory -ErrorAction Stop |
+    Get-ChildItem -LiteralPath $acRootPath -Directory -ErrorAction Stop |
         Where-Object { $_.Name -match '^wg-\d+' } |
         Sort-Object Name
 )
 
-Write-Host "AgentsCommander .ac-new root: $acNewRootPath"
+Write-Host "AgentsCommander .ac root: $acRootPath"
 Write-Host "Destination: $destinationPath"
 Write-Host "Overwrite conflicts: $($Overwrite.IsPresent)"
 Write-Host ''

--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -216,13 +216,13 @@ mod tests {
         launch_agent.git_pull_before = true;
 
         let request = build_session_request(
-            "C:/repo/.ac-new/_agent_architect".to_string(),
+            "C:/repo/.ac/_agent_architect".to_string(),
             "repo/architect".to_string(),
             &launch_agent,
         )
         .expect("request");
 
-        assert_eq!(request.cwd, "C:/repo/.ac-new/_agent_architect");
+        assert_eq!(request.cwd, "C:/repo/.ac/_agent_architect");
         assert_eq!(request.session_name, "repo/architect");
         assert_eq!(request.agent_id, "codex");
         assert_eq!(request.shell, "cmd.exe");
@@ -240,7 +240,7 @@ mod tests {
         for command in ["", "   \t  "] {
             let launch_agent = agent("codex", "Codex", command);
             let err = build_session_request(
-                "C:/repo/.ac-new/_agent_architect".to_string(),
+                "C:/repo/.ac/_agent_architect".to_string(),
                 "repo/architect".to_string(),
                 &launch_agent,
             )
@@ -255,7 +255,7 @@ mod tests {
     fn write_session_request_is_still_json_camel_case() {
         let request = SessionRequest {
             id: format!("test-{}", uuid::Uuid::new_v4().simple()),
-            cwd: "C:/repo/.ac-new/_agent_architect".to_string(),
+            cwd: "C:/repo/.ac/_agent_architect".to_string(),
             session_name: "repo/architect".to_string(),
             agent_id: "codex".to_string(),
             shell: "codex".to_string(),

--- a/src-tauri/src/cli/create_agent_matrix.rs
+++ b/src-tauri/src/cli/create_agent_matrix.rs
@@ -20,7 +20,7 @@ use crate::config::projects::resolve_project_reference;
 #[command(after_help = "\
 NOTES:\n  \
   --project is a registered AC project folder name from settings.projectPaths. Paths are not accepted.\n  \
-  The target project must contain .ac; legacy .ac-new projects are accepted when .ac is absent.\n  \
+  The target project must contain .ac.\n  \
   --name is sanitized by the same backend as the UI into a lower-case Matrix id.\n  \
   --role-template must be an id from the same source as the New Agent picker.\n  \
   Invalid templates fail before creating the target Matrix directory.\n  \

--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -7,7 +7,6 @@ use crate::config::agent_config::{AgentLocalConfig, CodingAgentEntry};
 use crate::config::sessions_persistence::{load_sessions_raw, PersistedSession};
 use crate::config::workspace::{
     ensure_authoritative_workspace_dir, existing_workspace_dir, is_workspace_dir_name,
-    stale_legacy_workspace_error_for_path,
 };
 use crate::session::session::{SessionStatus, TEMP_SESSION_PREFIX};
 
@@ -1130,9 +1129,6 @@ fn report_unknown_peers(unknown: &[String], available: &[String]) -> i32 {
 /// origin-agent path otherwise. Factored so `execute` and `execute_lean`
 /// share the dispatch.
 fn discover_peers(root: &str) -> Result<Vec<PeerInfo>, String> {
-    if let Some(reason) = stale_legacy_workspace_error_for_path(Path::new(root)) {
-        return Err(reason);
-    }
     if crate::config::root_agent::is_root_agent_path(root) {
         Ok(discover_root_coordinator_peers())
     } else if let Some(wg) = detect_wg_replica(root)? {
@@ -1280,11 +1276,11 @@ mod tests {
     ) -> (tempfile::TempDir, Vec<String>) {
         let temp = tempfile::TempDir::new().unwrap();
         let project = temp.path().join("proj-a");
-        let ac_new = project.join(".ac-new");
-        let team_dir = ac_new.join("_team_dev-team");
-        let origin_tech_lead = ac_new.join("_agent_tech-lead");
-        let origin_dev_rust = ac_new.join("_agent_dev-rust");
-        let wg_dir = ac_new.join("wg-1-dev-team");
+        let workspace_dir = project.join(".ac");
+        let team_dir = workspace_dir.join("_team_dev-team");
+        let origin_tech_lead = workspace_dir.join("_agent_tech-lead");
+        let origin_dev_rust = workspace_dir.join("_agent_dev-rust");
+        let wg_dir = workspace_dir.join("wg-1-dev-team");
         let tech_lead_replica = wg_dir.join("__agent_tech-lead");
         let dev_rust_replica = wg_dir.join("__agent_dev-rust");
 
@@ -1326,11 +1322,11 @@ mod tests {
     fn make_portable_cross_wg_fixture() -> (tempfile::TempDir, PathBuf, PathBuf) {
         let temp = tempfile::TempDir::new().unwrap();
         let project = temp.path().join("proj-a");
-        let ac_new = project.join(".ac");
-        let team_dir = ac_new.join("_team_dev-team");
-        let local_tech_lead = ac_new.join("_agent_tech-lead");
-        let local_dev_rust = ac_new.join("_agent_dev-rust");
-        let origin = temp.path().join("origin-matrix").join(".ac-new");
+        let workspace_dir = project.join(".ac");
+        let team_dir = workspace_dir.join("_team_dev-team");
+        let local_tech_lead = workspace_dir.join("_agent_tech-lead");
+        let local_dev_rust = workspace_dir.join("_agent_dev-rust");
+        let origin = temp.path().join("origin-matrix").join(".ac");
         let origin_tech_lead = origin.join("_agent_tech-lead");
         let origin_dev_rust = origin.join("_agent_dev-rust");
 
@@ -1354,7 +1350,7 @@ mod tests {
         let mut wg1_tech_lead = PathBuf::new();
         let mut wg1_dev_rust = PathBuf::new();
         for wg_name in ["wg-1-dev-team", "wg-2-dev-team"] {
-            let wg_dir = ac_new.join(wg_name);
+            let wg_dir = workspace_dir.join(wg_name);
             let tech_lead_replica = wg_dir.join("__agent_tech-lead");
             let dev_rust_replica = wg_dir.join("__agent_dev-rust");
             std::fs::create_dir_all(&tech_lead_replica).unwrap();
@@ -1379,65 +1375,38 @@ mod tests {
     }
 
     #[test]
-    fn detect_wg_replica_rejects_stale_legacy_when_canonical_exists() {
+    fn detect_wg_replica_accepts_ac_workspace() {
         let temp = tempfile::TempDir::new().unwrap();
         let project = temp.path().join("proj-a");
-        let canonical_root = project.join(".ac").join("wg-1-devs").join("__agent_alice");
-        let stale_root = project
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        std::fs::create_dir_all(&canonical_root).unwrap();
-        std::fs::create_dir_all(&stale_root).unwrap();
+        let root = project.join(".ac").join("wg-1-devs").join("__agent_alice");
+        std::fs::create_dir_all(&root).unwrap();
 
-        let err = match detect_wg_replica(stale_root.to_str().unwrap()) {
-            Ok(_) => panic!("stale legacy workspace should be rejected"),
-            Err(err) => err,
-        };
-        assert!(err.contains("stale legacy workspace"));
-        assert!(err.contains(".ac-new"));
-        assert!(err.contains(".ac"));
-    }
-
-    #[test]
-    fn detect_wg_replica_accepts_legacy_when_canonical_absent() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let project = temp.path().join("proj-a");
-        let legacy_root = project
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        std::fs::create_dir_all(&legacy_root).unwrap();
-
-        let wg = detect_wg_replica(legacy_root.to_str().unwrap())
+        let wg = detect_wg_replica(root.to_str().unwrap())
             .unwrap()
-            .expect("legacy-only workspace should be accepted");
+            .expect(".ac workspace should be accepted");
         assert_eq!(wg.my_project, "proj-a");
         assert_eq!(wg.my_wg_name, "wg-1-devs");
         assert_eq!(wg.my_agent_name, "alice");
     }
 
     #[test]
-    fn discover_wg_peers_uses_only_canonical_workspace_when_both_exist() {
+    fn discover_wg_peers_lists_ac_workspace_peers() {
         let temp = tempfile::TempDir::new().unwrap();
         let project = temp.path().join("proj-a");
-        let canonical_wg = project.join(".ac").join("wg-1-devs");
-        let legacy_wg = project.join(".ac-new").join("wg-1-devs");
-        let canonical_root = canonical_wg.join("__agent_alice");
-        let canonical_peer = canonical_wg.join("__agent_bob");
-        let stale_peer = legacy_wg.join("__agent_eve");
-        for dir in [&canonical_root, &canonical_peer, &stale_peer] {
+        let wg_dir = project.join(".ac").join("wg-1-devs");
+        let root = wg_dir.join("__agent_alice");
+        let peer = wg_dir.join("__agent_bob");
+        for dir in [&root, &peer] {
             std::fs::create_dir_all(dir).unwrap();
         }
 
-        let wg = detect_wg_replica(canonical_root.to_str().unwrap())
+        let wg = detect_wg_replica(root.to_str().unwrap())
             .unwrap()
-            .expect("canonical workspace should be accepted");
+            .expect(".ac workspace should be accepted");
         let peers = discover_wg_peers(wg);
         let names: Vec<&str> = peers.iter().map(|peer| peer.name.as_str()).collect();
 
         assert!(names.contains(&"proj-a:wg-1-devs/bob"));
-        assert!(!names.contains(&"proj-a:wg-1-devs/eve"));
     }
 
     #[test]
@@ -1568,7 +1537,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             replica.join("config.json"),
-            r#"{"identity":"../../../../agentscommander-old/.ac-new/_agent_tech-lead"}"#,
+            r#"{"identity":"../../../../agentscommander-old/.ac/_agent_tech-lead"}"#,
         )
         .unwrap();
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -106,7 +106,7 @@ pub enum Commands {
     TaskSetTitle(task_set_title::TaskSetTitleArgs),
     /// Append text to the body of the workgroup TASK.md (coordinator-only)
     TaskAppendBody(task_append_body::TaskAppendBodyArgs),
-    /// Register an existing AC project (.ac or legacy .ac-new must already exist) in settings
+    /// Register an existing AC project (.ac must already exist) in settings
     OpenProject(open_project::OpenProjectArgs),
     /// Create an AC project (mkdir .ac if no workspace exists) and register it in settings
     NewProject(new_project::NewProjectArgs),

--- a/src-tauri/src/cli/new_project.rs
+++ b/src-tauri/src/cli/new_project.rs
@@ -17,7 +17,7 @@ PURPOSE: Create an AC project at PATH (mkdir-p `.ac/` and write its \
 `.gitignore` if no workspace exists) and register it in the GUI sidebar's project list.\n\n\
 PATH: Absolute or relative — relative paths are resolved against the current \
 working directory. The folder is created if it does not yet exist.\n\n\
-IDEMPOTENCY: Re-running on a folder that already has `.ac/` or legacy `.ac-new/` is safe; \
+IDEMPOTENCY: Re-running on a folder that already has `.ac/` is safe; \
 the selected workspace gitignore is swept (missing patterns appended), and the registration step \
 deduplicates against any prior entry.")]
 pub struct NewProjectArgs {

--- a/src-tauri/src/cli/open_project.rs
+++ b/src-tauri/src/cli/open_project.rs
@@ -21,14 +21,14 @@ use crate::config::settings::{load_settings_for_cli, save_settings};
 #[derive(Args)]
 #[command(after_help = "\
 PURPOSE: Register an existing AC project so it appears in the GUI sidebar on \
-next launch. The folder must already contain `.ac/` or legacy `.ac-new/` (use `new-project` to \
+next launch. The folder must already contain `.ac/` (use `new-project` to \
 create one).\n\n\
 PATH: Absolute or relative — relative paths are resolved against the current \
 working directory. The persisted entry is the absolute form.\n\n\
 IDEMPOTENCY: Re-registering the same path is a no-op; the verb prints \
 \"Project already registered\" and exits 0.")]
 pub struct OpenProjectArgs {
-    /// Path to an existing AC project folder (must contain `.ac/` or legacy `.ac-new/`)
+    /// Path to an existing AC project folder (must contain `.ac/`)
     #[arg(value_name = "PATH")]
     pub path: String,
 }
@@ -118,8 +118,8 @@ mod tests {
     }
 
     #[test]
-    fn open_project_returns_1_when_no_ac_new() {
-        let fix = FixtureRoot::new("cli-open-noacnew");
+    fn open_project_returns_1_when_no_ac() {
+        let fix = FixtureRoot::new("cli-open-noac");
         let code = execute(OpenProjectArgs {
             path: fix.path().to_string_lossy().into(),
         });

--- a/src-tauri/src/cli/send.rs
+++ b/src-tauri/src/cli/send.rs
@@ -173,14 +173,6 @@ pub fn execute(args: SendArgs) -> i32 {
         }
     };
     let root_is_root_agent = crate::config::root_agent::is_root_agent_path(&root);
-    if !root_is_root_agent {
-        if let Some(reason) =
-            crate::config::workspace::stale_legacy_workspace_error_for_path(Path::new(&root))
-        {
-            eprintln!("Error: {}", reason);
-            return 1;
-        }
-    }
     if let Err(reason) =
         validate_root_agent_delivery_kind(root_is_root_agent, args.command.as_deref())
     {
@@ -551,11 +543,11 @@ mod tests {
     fn make_verified_coordinator_fixture() -> (tempfile::TempDir, Vec<String>) {
         let temp = tempfile::TempDir::new().unwrap();
         let project = temp.path().join("proj-a");
-        let ac_new = project.join(".ac-new");
-        let team_dir = ac_new.join("_team_dev-team");
-        let origin_tech_lead = ac_new.join("_agent_tech-lead");
-        let origin_dev_rust = ac_new.join("_agent_dev-rust");
-        let wg_dir = ac_new.join("wg-1-dev-team");
+        let workspace_dir = project.join(".ac");
+        let team_dir = workspace_dir.join("_team_dev-team");
+        let origin_tech_lead = workspace_dir.join("_agent_tech-lead");
+        let origin_dev_rust = workspace_dir.join("_agent_dev-rust");
+        let wg_dir = workspace_dir.join("wg-1-dev-team");
         let tech_lead_replica = wg_dir.join("__agent_tech-lead");
         let dev_rust_replica = wg_dir.join("__agent_dev-rust");
 
@@ -681,10 +673,7 @@ mod tests {
     fn derive_root_project_dir_walks_up_wg_replica_path() {
         let temp = tempfile::TempDir::new().unwrap();
         let project = temp.path().join("proj-x");
-        let agent_root = project
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice");
+        let agent_root = project.join(".ac").join("wg-1-devs").join("__agent_alice");
         std::fs::create_dir_all(&agent_root).unwrap();
 
         // On Windows, std::fs::canonicalize returns `\\?\C:\...` extended-length
@@ -703,55 +692,21 @@ mod tests {
     }
 
     #[test]
-    fn derive_root_project_dir_rejects_stale_legacy_when_canonical_exists() {
+    fn derive_root_project_dir_accepts_ac_workspace() {
         let temp = tempfile::TempDir::new().unwrap();
         let project = temp.path().join("proj-x");
-        let canonical_root = project.join(".ac").join("wg-1-devs").join("__agent_alice");
-        let stale_root = project
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        std::fs::create_dir_all(&canonical_root).unwrap();
-        std::fs::create_dir_all(&stale_root).unwrap();
+        let root = project.join(".ac").join("wg-1-devs").join("__agent_alice");
+        std::fs::create_dir_all(&root).unwrap();
 
-        let err = derive_root_project_dir(stale_root.to_str().unwrap()).unwrap_err();
-        assert!(err.contains("stale legacy workspace"));
-    }
-
-    #[test]
-    fn derive_root_project_dir_accepts_canonical_when_both_exist() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let project = temp.path().join("proj-x");
-        let canonical_root = project.join(".ac").join("wg-1-devs").join("__agent_alice");
-        let stale_root = project
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        std::fs::create_dir_all(&canonical_root).unwrap();
-        std::fs::create_dir_all(&stale_root).unwrap();
-
-        let got = derive_root_project_dir(canonical_root.to_str().unwrap())
+        let got = derive_root_project_dir(root.to_str().unwrap())
             .unwrap()
-            .expect("canonical workspace should be accepted");
+            .expect(".ac workspace should be accepted");
         let expected = std::fs::canonicalize(&project)
             .unwrap()
             .to_str()
             .unwrap()
             .to_string();
         assert_eq!(got, expected);
-    }
-
-    #[test]
-    fn send_file_workgroup_root_rejects_stale_legacy_when_canonical_exists() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let project = temp.path().join("proj-x");
-        let canonical_wg = project.join(".ac").join("wg-1-devs");
-        let stale_wg = project.join(".ac-new").join("wg-1-devs");
-        std::fs::create_dir_all(&canonical_wg).unwrap();
-        std::fs::create_dir_all(&stale_wg).unwrap();
-
-        let err = ensure_workgroup_root_is_authoritative(&stale_wg).unwrap_err();
-        assert!(err.contains("stale legacy workspace"));
     }
 
     #[test]
@@ -768,7 +723,7 @@ mod tests {
     #[test]
     fn derive_root_project_dir_returns_none_when_one_level_too_high() {
         let temp = tempfile::TempDir::new().unwrap();
-        let wg_dir = temp.path().join("proj-x").join(".ac-new").join("wg-1-devs");
+        let wg_dir = temp.path().join("proj-x").join(".ac").join("wg-1-devs");
         std::fs::create_dir_all(&wg_dir).unwrap();
         // Pointing at the WG dir, not the __agent_* dir → must return None.
         assert!(derive_root_project_dir(wg_dir.to_str().unwrap())

--- a/src-tauri/src/cli/task_append_body.rs
+++ b/src-tauri/src/cli/task_append_body.rs
@@ -11,8 +11,8 @@
 use clap::Args;
 use std::path::Path;
 
-use super::task_ops::{self, TaskOp, EditOutcome};
 use super::send::agent_name_from_root;
+use super::task_ops::{self, EditOutcome, TaskOp};
 
 #[derive(Args)]
 #[command(after_help = "\
@@ -117,7 +117,9 @@ pub fn execute(args: TaskAppendBodyArgs) -> i32 {
     // tree. `sender=` and `wg=` are both caller-derived (--root) and a forged
     // --root produces a forged-but-consistent line; pid disambiguates.
     match task_ops::perform(&wg_root, TaskOp::AppendBody(args.text.clone())) {
-        Ok(EditOutcome::Wrote { backup: Some(bp), .. }) => {
+        Ok(EditOutcome::Wrote {
+            backup: Some(bp), ..
+        }) => {
             log::info!(
                 "[task] append-body: sender={} wg={} pid={} backup={}",
                 sender,
@@ -188,7 +190,7 @@ mod tests {
     fn make_wg_fixture(tmp: &Path) -> PathBuf {
         let agent_root = tmp
             .join("proj")
-            .join(".ac-new")
+            .join(".ac")
             .join("wg-1-test")
             .join("__agent_alice");
         std::fs::create_dir_all(&agent_root).unwrap();

--- a/src-tauri/src/cli/task_set_title.rs
+++ b/src-tauri/src/cli/task_set_title.rs
@@ -11,8 +11,8 @@
 use clap::Args;
 use std::path::Path;
 
-use super::task_ops::{self, TaskOp, EditOutcome};
 use super::send::agent_name_from_root;
+use super::task_ops::{self, EditOutcome, TaskOp};
 
 #[derive(Args)]
 #[command(after_help = "\
@@ -114,7 +114,9 @@ pub fn execute(args: TaskSetTitleArgs) -> i32 {
     // tree. `sender=` and `wg=` are both caller-derived (--root) and a forged
     // --root produces a forged-but-consistent line; pid disambiguates.
     match task_ops::perform(&wg_root, TaskOp::SetTitle(args.title.clone())) {
-        Ok(EditOutcome::Wrote { backup: Some(bp), .. }) => {
+        Ok(EditOutcome::Wrote {
+            backup: Some(bp), ..
+        }) => {
             log::info!(
                 "[task] set-title: sender={} wg={} pid={} backup={}",
                 sender,
@@ -192,7 +194,7 @@ mod tests {
     fn make_wg_fixture(tmp: &Path) -> PathBuf {
         let agent_root = tmp
             .join("proj")
-            .join(".ac-new")
+            .join(".ac")
             .join("wg-1-test")
             .join("__agent_alice");
         std::fs::create_dir_all(&agent_root).unwrap();
@@ -305,7 +307,7 @@ mod tests {
     fn set_title_rejects_when_root_is_workgroup_root_directly() {
         let fix = FixtureRoot::new("task-i18");
         let _agent_root = make_wg_fixture(fix.path());
-        let wg_root = fix.path().join("proj").join(".ac-new").join("wg-1-test");
+        let wg_root = fix.path().join("proj").join(".ac").join("wg-1-test");
         // Coordinator running directly from the WG dir (no __agent_*) — the
         // is_any_coordinator gate fails closed (sender is not a coordinator).
         let token = uuid::Uuid::new_v4().to_string();

--- a/src-tauri/src/cli/team.rs
+++ b/src-tauri/src/cli/team.rs
@@ -171,7 +171,7 @@ fn add_member(args: TeamAddMemberArgs) -> Result<(), String> {
 
     let settings = crate::config::settings::load_settings_for_cli();
     let replica_dir = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
-        ac_new_dir: workspace_dir.clone(),
+        workspace_dir: workspace_dir.clone(),
         wg_dir: wg_dir.clone(),
         agent_path: agent_ref.clone(),
         team_repos: config.repos.clone(),

--- a/src-tauri/src/cli/workgroup.rs
+++ b/src-tauri/src/cli/workgroup.rs
@@ -100,12 +100,8 @@ pub(crate) fn resolve_cli_project(project: &str) -> Result<PathBuf, String> {
 }
 
 pub(crate) fn resolve_cli_workspace(project_path: &Path) -> Result<PathBuf, String> {
-    existing_workspace_dir(project_path).ok_or_else(|| {
-        format!(
-            "AC workspace not found in {} (.ac or legacy .ac-new)",
-            project_path.display()
-        )
-    })
+    existing_workspace_dir(project_path)
+        .ok_or_else(|| format!("AC workspace not found in {} (.ac)", project_path.display()))
 }
 
 pub(crate) fn write_refresh(project_path: &Path, changed_path: &Path, name: &str, reason: &str) {
@@ -231,7 +227,7 @@ fn remove(args: WorkgroupRemoveArgs) -> Result<(), String> {
 }
 
 pub(crate) fn build_final_team_config(
-    ac_new: &Path,
+    workspace_dir: &Path,
     team_name: &str,
     coordinator: &str,
     agents: &[String],
@@ -239,17 +235,17 @@ pub(crate) fn build_final_team_config(
     repo_agents: &[String],
     repo_exclude_agents: &[String],
 ) -> Result<TeamConfigResult, String> {
-    let existing = read_team_config(ac_new, team_name).ok();
+    let existing = read_team_config(workspace_dir, team_name).ok();
     let mut roster = Vec::new();
     if let Some(config) = existing.as_ref() {
         for agent in &config.agents {
-            push_unique(&mut roster, resolve_agent_ref(ac_new, agent)?);
+            push_unique(&mut roster, resolve_agent_ref(workspace_dir, agent)?);
         }
     }
     for agent in agents {
-        push_unique(&mut roster, resolve_agent_ref(ac_new, agent)?);
+        push_unique(&mut roster, resolve_agent_ref(workspace_dir, agent)?);
     }
-    let coordinator = resolve_agent_ref(ac_new, coordinator)?;
+    let coordinator = resolve_agent_ref(workspace_dir, coordinator)?;
     push_unique(&mut roster, coordinator.clone());
     if roster.is_empty() {
         return Err("At least one team agent is required".to_string());
@@ -258,7 +254,13 @@ pub(crate) fn build_final_team_config(
         if repos.is_empty() && repo_agents.is_empty() && repo_exclude_agents.is_empty() {
             existing.map(|config| config.repos).unwrap_or_default()
         } else {
-            build_repo_assignments(ac_new, &roster, repos, repo_agents, repo_exclude_agents)?
+            build_repo_assignments(
+                workspace_dir,
+                &roster,
+                repos,
+                repo_agents,
+                repo_exclude_agents,
+            )?
         };
     Ok(TeamConfigResult {
         agents: roster,
@@ -268,7 +270,7 @@ pub(crate) fn build_final_team_config(
 }
 
 fn build_repo_assignments(
-    ac_new: &Path,
+    workspace_dir: &Path,
     roster: &[String],
     repos: &[String],
     repo_agents: &[String],
@@ -308,9 +310,9 @@ fn build_repo_assignments(
     let mut out = Vec::new();
     for url in order {
         let agents = if let Some(list) = include.get(&url) {
-            resolve_assignment_agents(ac_new, roster, list)?
+            resolve_assignment_agents(workspace_dir, roster, list)?
         } else if let Some(list) = exclude.get(&url) {
-            let excluded = resolve_assignment_agents(ac_new, roster, list)?;
+            let excluded = resolve_assignment_agents(workspace_dir, roster, list)?;
             roster
                 .iter()
                 .filter(|agent| !excluded.contains(agent))
@@ -355,13 +357,13 @@ fn parse_assignment_specs(
 }
 
 fn resolve_assignment_agents(
-    ac_new: &Path,
+    workspace_dir: &Path,
     roster: &[String],
     agents: &[String],
 ) -> Result<Vec<String>, String> {
     let mut out = Vec::new();
     for agent in agents {
-        let resolved = resolve_agent_ref(ac_new, agent)?;
+        let resolved = resolve_agent_ref(workspace_dir, agent)?;
         if !roster.contains(&resolved) {
             return Err(format!(
                 "Repo assignment references agent '{}' which is not in the final team roster",

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -420,22 +420,22 @@ impl DiscoveryBranchWatcher {
         })
     }
 
-    /// Update this project's replicas in the watcher. `ac_new_parent_dir` is the directory
+    /// Update this project's replicas in the watcher. `project_dir` is the directory
     /// that directly contains the AC workspace, not a grand-parent from `settings.project_paths`.
     /// See the invariant comment on the `replicas` field.
-    pub fn update_replicas_for_project(&self, ac_new_parent_dir: &str, workgroups: &[AcWorkgroup]) {
+    pub fn update_replicas_for_project(&self, project_dir: &str, workgroups: &[AcWorkgroup]) {
         // Invariant guard: catch mistaken call-site passes (e.g. a `base_path` parent)
         // in dev builds. Release builds log a warn and return to prevent silent corruption.
-        let has_workspace = has_workspace_dir(Path::new(ac_new_parent_dir));
+        let has_workspace = has_workspace_dir(Path::new(project_dir));
         debug_assert!(
             has_workspace,
             "update_replicas_for_project: {} does not contain an AC workspace",
-            ac_new_parent_dir
+            project_dir
         );
         if !has_workspace {
             log::warn!(
                 "[DiscoveryBranchWatcher] update_replicas_for_project called with {} which has no AC workspace, ignoring",
-                ac_new_parent_dir
+                project_dir
             );
             return;
         }
@@ -445,13 +445,13 @@ impl DiscoveryBranchWatcher {
         // converge to one map slot per project. Without this, the same project can
         // end up with two entries (e.g. from `discover_ac_agents` reading `read_dir`
         // output vs `discover_project` receiving a user-typed path) and emit doubled.
-        let canonical_key = std::fs::canonicalize(ac_new_parent_dir)
+        let canonical_key = std::fs::canonicalize(project_dir)
             .ok()
             .map(|p| {
                 let s = p.to_string_lossy();
                 s.strip_prefix(r"\\?\").unwrap_or(&s).to_string()
             })
-            .unwrap_or_else(|| ac_new_parent_dir.to_string());
+            .unwrap_or_else(|| project_dir.to_string());
 
         // Invariant: git_repos order = replica.repo_paths order (which follows config.json `repos`).
         // Never sort or dedupe here.
@@ -1780,17 +1780,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn check_project_path_accepts_legacy_ac_new() {
+    async fn check_project_path_rejects_non_ac_workspace() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        std::fs::create_dir(tmp.path().join(".ac-new")).expect("create .ac-new");
+        std::fs::create_dir(tmp.path().join(".workspace")).expect("create non-AC workspace");
 
-        assert!(check_project_path(tmp.path().to_string_lossy().to_string())
-            .await
-            .expect("check path"));
+        assert!(
+            !check_project_path(tmp.path().to_string_lossy().to_string())
+                .await
+                .expect("check path")
+        );
     }
 
     #[tokio::test]
-    async fn create_ac_project_creates_ac_not_ac_new() {
+    async fn create_ac_project_creates_ac() {
         let tmp = tempfile::tempdir().expect("tempdir");
 
         create_ac_project(tmp.path().to_string_lossy().to_string())
@@ -1799,7 +1801,6 @@ mod tests {
 
         assert!(tmp.path().join(".ac").is_dir());
         assert!(tmp.path().join(".ac").join(".gitignore").is_file());
-        assert!(!tmp.path().join(".ac-new").exists());
     }
 
     #[test]

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -99,7 +99,7 @@ pub(crate) struct WorkgroupDiskCreateArgs {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ReplicaDiskCreateArgs {
-    pub ac_new_dir: PathBuf,
+    pub workspace_dir: PathBuf,
     pub wg_dir: PathBuf,
     pub agent_path: String,
     pub team_repos: Vec<RepoAssignment>,
@@ -543,20 +543,16 @@ fn default_agent_matrix_config() -> serde_json::Value {
 }
 
 fn selected_workspace_dir(project: &Path) -> Result<PathBuf, String> {
-    existing_workspace_dir(project).ok_or_else(|| {
-        format!(
-            ".ac directory not found in {} (legacy .ac-new also absent)",
-            project.display()
-        )
-    })
+    existing_workspace_dir(project)
+        .ok_or_else(|| format!(".ac directory not found in {}", project.display()))
 }
 
 pub(crate) fn read_team_config(
-    ac_new_dir: &Path,
+    workspace_dir: &Path,
     team_name: &str,
 ) -> Result<TeamConfigResult, String> {
     validate_existing_name(team_name, "Team")?;
-    let team_dir = ac_new_dir.join(format!("_team_{}", team_name));
+    let team_dir = workspace_dir.join(format!("_team_{}", team_name));
     let config_path = team_dir.join("config.json");
     if !config_path.exists() {
         return Err(format!("Team '{}' config not found", team_name));
@@ -565,16 +561,16 @@ pub(crate) fn read_team_config(
         .map_err(|e| format!("Failed to read config.json: {}", e))?;
     let config: TeamConfigResult = serde_json::from_str(&content)
         .map_err(|e| format!("Failed to parse config.json: {}", e))?;
-    normalize_team_config_for_project(ac_new_dir, &config)
+    normalize_team_config_for_project(workspace_dir, &config)
 }
 
 pub(crate) fn write_team_config(
-    ac_new_dir: &Path,
+    workspace_dir: &Path,
     team_name: &str,
     config: &TeamConfigResult,
 ) -> Result<PathBuf, String> {
     validate_existing_name(team_name, "Team")?;
-    let team_dir = ac_new_dir.join(format!("_team_{}", team_name));
+    let team_dir = workspace_dir.join(format!("_team_{}", team_name));
     std::fs::create_dir_all(&team_dir)
         .map_err(|e| format!("Failed to create team directory: {}", e))?;
     std::fs::create_dir_all(team_dir.join("memory"))
@@ -584,7 +580,7 @@ pub(crate) fn write_team_config(
         std::fs::write(&conventions, "")
             .map_err(|e| format!("Failed to write conventions.md: {}", e))?;
     }
-    let config = normalize_team_config_for_project(ac_new_dir, config)?;
+    let config = normalize_team_config_for_project(workspace_dir, config)?;
     let config_str = serde_json::to_string_pretty(&config)
         .map_err(|e| format!("Failed to serialize config.json: {}", e))?;
     std::fs::write(team_dir.join("config.json"), config_str)
@@ -593,14 +589,14 @@ pub(crate) fn write_team_config(
 }
 
 pub(crate) fn normalize_team_config_for_project(
-    ac_new_dir: &Path,
+    workspace_dir: &Path,
     config: &TeamConfigResult,
 ) -> Result<TeamConfigResult, String> {
-    let agents = normalize_team_agent_refs(ac_new_dir, &config.agents)?;
+    let agents = normalize_team_agent_refs(workspace_dir, &config.agents)?;
     let coordinator = if config.coordinator.trim().is_empty() {
         String::new()
     } else {
-        resolve_agent_ref(ac_new_dir, &config.coordinator)?
+        resolve_agent_ref(workspace_dir, &config.coordinator)?
     };
     if !coordinator.is_empty() && !agents.contains(&coordinator) {
         return Err("Coordinator must be one of the selected agents".to_string());
@@ -609,7 +605,7 @@ pub(crate) fn normalize_team_config_for_project(
     for repo in &config.repos {
         repos.push(RepoAssignment {
             url: repo.url.clone(),
-            agents: normalize_team_agent_refs(ac_new_dir, &repo.agents)?,
+            agents: normalize_team_agent_refs(workspace_dir, &repo.agents)?,
         });
     }
     Ok(TeamConfigResult {
@@ -619,10 +615,10 @@ pub(crate) fn normalize_team_config_for_project(
     })
 }
 
-fn normalize_team_agent_refs(ac_new_dir: &Path, refs: &[String]) -> Result<Vec<String>, String> {
+fn normalize_team_agent_refs(workspace_dir: &Path, refs: &[String]) -> Result<Vec<String>, String> {
     let mut normalized = Vec::new();
     for agent in refs {
-        let resolved = resolve_agent_ref(ac_new_dir, agent)?;
+        let resolved = resolve_agent_ref(workspace_dir, agent)?;
         if !normalized.contains(&resolved) {
             normalized.push(resolved);
         }
@@ -630,9 +626,9 @@ fn normalize_team_agent_refs(ac_new_dir: &Path, refs: &[String]) -> Result<Vec<S
     Ok(normalized)
 }
 
-pub(crate) fn list_workgroup_dirs(ac_new_dir: &Path) -> Vec<PathBuf> {
+pub(crate) fn list_workgroup_dirs(workspace_dir: &Path) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(ac_new_dir) {
+    if let Ok(entries) = std::fs::read_dir(workspace_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
             if !path.is_dir() {
@@ -671,7 +667,7 @@ pub(crate) fn parse_team_from_workgroup_name(workgroup_name: &str) -> Result<Str
     Ok(team.to_string())
 }
 
-pub(crate) fn resolve_agent_ref(ac_new_dir: &Path, raw_agent: &str) -> Result<String, String> {
+pub(crate) fn resolve_agent_ref(workspace_dir: &Path, raw_agent: &str) -> Result<String, String> {
     let trimmed = raw_agent.trim();
     if trimmed.is_empty() {
         return Err("Agent reference cannot be empty".to_string());
@@ -694,7 +690,7 @@ pub(crate) fn resolve_agent_ref(ac_new_dir: &Path, raw_agent: &str) -> Result<St
     let bare = trimmed.strip_prefix("_agent_").unwrap_or(trimmed);
     validate_existing_name(bare, "Agent")?;
     let canonical_ref = format!("_agent_{}", bare);
-    let matrix_dir = ac_new_dir.join(&canonical_ref);
+    let matrix_dir = workspace_dir.join(&canonical_ref);
     if !matrix_dir.is_dir() {
         return Err(format!("Agent '{}' not found", bare));
     }
@@ -762,7 +758,7 @@ pub(crate) async fn create_workgroup_on_disk(
 
     for agent_path in &team_config.agents {
         create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
-            ac_new_dir: base.clone(),
+            workspace_dir: base.clone(),
             wg_dir: wg_dir.clone(),
             agent_path: agent_path.clone(),
             team_repos: team_config.repos.clone(),
@@ -786,7 +782,7 @@ pub(crate) async fn create_workgroup_on_disk(
 pub(crate) fn create_or_update_replica_on_disk(
     args: ReplicaDiskCreateArgs,
 ) -> Result<PathBuf, String> {
-    let agent_ref = resolve_agent_ref(&args.ac_new_dir, &args.agent_path)?;
+    let agent_ref = resolve_agent_ref(&args.workspace_dir, &args.agent_path)?;
     let agent_name = agent_ref_bare_name(&agent_ref);
     validate_existing_name(&agent_name, "Agent")?;
     let replica_dir = args.wg_dir.join(format!("__agent_{}", agent_name));
@@ -1030,7 +1026,7 @@ pub async fn list_all_agents(project_paths: Vec<String>) -> Result<Vec<AgentInfo
 
     for project_path in &project_paths {
         let base = Path::new(project_path);
-        let Some(ac_new) = existing_workspace_dir(base) else {
+        let Some(workspace_dir) = existing_workspace_dir(base) else {
             continue;
         };
 
@@ -1040,7 +1036,7 @@ pub async fn list_all_agents(project_paths: Vec<String>) -> Result<Vec<AgentInfo
             .unwrap_or("unknown")
             .to_string();
 
-        let entries = match std::fs::read_dir(&ac_new) {
+        let entries = match std::fs::read_dir(&workspace_dir) {
             Ok(e) => e,
             Err(_) => continue,
         };
@@ -2099,7 +2095,7 @@ pub(crate) fn is_file_in_use_error(e: &std::io::Error) -> bool {
 /// up in `taken` but is never tested by `find` and so cannot displace
 /// slot 1.
 ///
-/// Read-error degradation: if `std::fs::read_dir(ac_new_dir)` fails
+/// Read-error degradation: if `std::fs::read_dir(workspace_dir)` fails
 /// (permission denied, transient I/O, broken junction, path-too-long
 /// on Windows), the function returns `1` as a graceful fallback. The
 /// post-allocate `wg_dir.exists()` guard in `create_workgroup` will
@@ -2107,10 +2103,10 @@ pub(crate) fn is_file_in_use_error(e: &std::io::Error) -> bool {
 /// `wg-1-{team}` is in fact present; otherwise the slot-1 creation
 /// succeeds with stale state. Surfacing the read error is tracked
 /// separately and is out of scope for #177.
-pub(crate) fn determine_next_wg_number(ac_new_dir: &Path) -> u32 {
+pub(crate) fn determine_next_wg_number(workspace_dir: &Path) -> u32 {
     let mut taken: HashSet<u32> = HashSet::new();
 
-    if let Ok(entries) = std::fs::read_dir(ac_new_dir) {
+    if let Ok(entries) = std::fs::read_dir(workspace_dir) {
         for entry in entries.flatten() {
             if !entry.path().is_dir() {
                 continue;
@@ -2275,15 +2271,15 @@ mod tests {
     }
 
     #[test]
-    fn create_agent_matrix_on_disk_falls_back_to_legacy_ac_new() {
+    fn create_agent_matrix_on_disk_rejects_non_ac_workspace() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let project = tmp.path().join("ProjectAlpha");
-        let legacy_workspace = project.join(".ac-new");
-        std::fs::create_dir_all(&legacy_workspace).expect("create .ac-new");
+        let invalid_workspace = project.join(".workspace");
+        std::fs::create_dir_all(&invalid_workspace).expect("create invalid workspace");
         let settings = AppSettings::default();
         let project_s = project.to_string_lossy().to_string();
 
-        let created = create_agent_matrix_on_disk(CreateAgentMatrixDiskArgs {
+        let err = create_agent_matrix_on_disk(CreateAgentMatrixDiskArgs {
             project_path: &project_s,
             name: "Architect",
             description: "Build plans",
@@ -2291,19 +2287,18 @@ mod tests {
             settings: &settings,
             config_dir: None,
         })
-        .expect("create matrix");
+        .unwrap_err();
 
-        assert_eq!(created.agent_dir, legacy_workspace.join("_agent_architect"));
+        assert!(err.contains(".ac directory not found"));
+        assert!(!invalid_workspace.join("_agent_architect").exists());
     }
 
     #[test]
-    fn create_agent_matrix_on_disk_prefers_ac_when_both_exist() {
+    fn create_agent_matrix_on_disk_uses_ac_workspace() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let project = tmp.path().join("ProjectAlpha");
         let workspace = project.join(".ac");
-        let legacy_workspace = project.join(".ac-new");
         std::fs::create_dir_all(&workspace).expect("create .ac");
-        std::fs::create_dir_all(&legacy_workspace).expect("create .ac-new");
         let settings = AppSettings::default();
         let project_s = project.to_string_lossy().to_string();
 
@@ -2318,16 +2313,15 @@ mod tests {
         .expect("create matrix");
 
         assert_eq!(created.agent_dir, workspace.join("_agent_architect"));
-        assert!(!legacy_workspace.join("_agent_architect").exists());
     }
 
     #[test]
     fn create_agent_matrix_on_disk_resolves_template_before_mutation() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let project = tmp.path().join("ProjectAlpha");
-        let ac_new = project.join(".ac-new");
+        let workspace_dir = project.join(".ac");
         let config_dir = tmp.path().join("config");
-        std::fs::create_dir_all(&ac_new).expect("create .ac-new");
+        std::fs::create_dir_all(&workspace_dir).expect("create .ac");
         std::fs::create_dir_all(&config_dir).expect("create config");
         let settings = AppSettings::default();
         let project_s = project.to_string_lossy().to_string();
@@ -2344,7 +2338,7 @@ mod tests {
 
         assert!(err.contains("Unknown built-in role template"));
         assert!(
-            !ac_new.join("_agent_architect").exists(),
+            !workspace_dir.join("_agent_architect").exists(),
             "invalid template must not create the target matrix directory"
         );
     }
@@ -2353,8 +2347,8 @@ mod tests {
     fn create_agent_matrix_on_disk_existing_root_fails_without_overwrite() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let project = tmp.path().join("ProjectAlpha");
-        let ac_new = project.join(".ac-new");
-        let agent_dir = ac_new.join("_agent_architect");
+        let workspace_dir = project.join(".ac");
+        let agent_dir = workspace_dir.join("_agent_architect");
         std::fs::create_dir_all(&agent_dir).expect("create existing matrix root");
         std::fs::write(agent_dir.join("Role.md"), "keep role").expect("write existing role");
         std::fs::write(agent_dir.join("config.json"), "keep config")
@@ -2387,10 +2381,10 @@ mod tests {
     fn create_agent_matrix_on_disk_applies_local_template_and_skills() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let project = tmp.path().join("ProjectAlpha");
-        let ac_new = project.join(".ac-new");
+        let workspace_dir = project.join(".ac");
         let config_dir = tmp.path().join("config");
         let template_dir = config_dir.join("agent-templates").join("my-template");
-        std::fs::create_dir_all(&ac_new).expect("create .ac-new");
+        std::fs::create_dir_all(&workspace_dir).expect("create .ac");
         std::fs::create_dir_all(template_dir.join("skills").join("example"))
             .expect("create template skill dir");
         std::fs::write(
@@ -2504,9 +2498,9 @@ mod tests {
     #[test]
     fn team_config_normalization_stores_portable_agent_refs() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let ac_new = tmp.path().join(".ac-new");
-        let architect = ac_new.join("_agent_architect");
-        let dev_rust = ac_new.join("_agent_dev-rust");
+        let workspace_dir = tmp.path().join(".ac");
+        let architect = workspace_dir.join("_agent_architect");
+        let dev_rust = workspace_dir.join("_agent_dev-rust");
         std::fs::create_dir_all(&architect).expect("architect matrix");
         std::fs::create_dir_all(&dev_rust).expect("dev-rust matrix");
 
@@ -2524,7 +2518,7 @@ mod tests {
         };
 
         let normalized =
-            normalize_team_config_for_project(&ac_new, &config).expect("normalize config");
+            normalize_team_config_for_project(&workspace_dir, &config).expect("normalize config");
         assert_eq!(
             normalized.agents,
             vec![
@@ -2541,9 +2535,10 @@ mod tests {
             ]
         );
 
-        write_team_config(&ac_new, "dev-team", &config).expect("write config");
-        let written = std::fs::read_to_string(ac_new.join("_team_dev-team").join("config.json"))
-            .expect("read config");
+        write_team_config(&workspace_dir, "dev-team", &config).expect("write config");
+        let written =
+            std::fs::read_to_string(workspace_dir.join("_team_dev-team").join("config.json"))
+                .expect("read config");
         assert!(
             !written.contains(&tmp.path().to_string_lossy().to_string()),
             "team config must not persist absolute project paths: {}",
@@ -2554,18 +2549,18 @@ mod tests {
     #[test]
     fn team_config_normalization_rejects_filesystem_paths() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let ac_new = tmp.path().join(".ac-new");
-        std::fs::create_dir_all(ac_new.join("_agent_architect")).expect("architect matrix");
+        let workspace_dir = tmp.path().join(".ac");
+        std::fs::create_dir_all(workspace_dir.join("_agent_architect")).expect("architect matrix");
 
         let absolute_config = TeamConfigResult {
-            agents: vec![ac_new
+            agents: vec![workspace_dir
                 .join("_agent_architect")
                 .to_string_lossy()
                 .to_string()],
             coordinator: "_agent_architect".to_string(),
             repos: Vec::new(),
         };
-        let err = normalize_team_config_for_project(&ac_new, &absolute_config)
+        let err = normalize_team_config_for_project(&workspace_dir, &absolute_config)
             .expect_err("absolute path refs must be rejected");
         assert!(
             err.contains("filesystem paths"),
@@ -2574,11 +2569,11 @@ mod tests {
         );
 
         let windows_config = TeamConfigResult {
-            agents: vec![r"C:\Users\maria\project\.ac-new\_agent_architect".to_string()],
+            agents: vec![r"C:\Users\maria\project\.ac\_agent_architect".to_string()],
             coordinator: "_agent_architect".to_string(),
             repos: Vec::new(),
         };
-        let err = normalize_team_config_for_project(&ac_new, &windows_config)
+        let err = normalize_team_config_for_project(&workspace_dir, &windows_config)
             .expect_err("windows path refs must be rejected");
         assert!(
             err.contains("filesystem paths"),
@@ -2590,14 +2585,14 @@ mod tests {
     #[test]
     fn replica_creation_rejects_filesystem_agent_paths() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let ac_new = tmp.path().join(".ac-new");
-        let wg_dir = ac_new.join("wg-1-dev-team");
-        let matrix_dir = ac_new.join("_agent_architect");
+        let workspace_dir = tmp.path().join(".ac");
+        let wg_dir = workspace_dir.join("wg-1-dev-team");
+        let matrix_dir = workspace_dir.join("_agent_architect");
         std::fs::create_dir_all(&matrix_dir).expect("architect matrix");
         std::fs::create_dir_all(&wg_dir).expect("workgroup");
 
         let err = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
-            ac_new_dir: ac_new.clone(),
+            workspace_dir: workspace_dir.clone(),
             wg_dir: wg_dir.clone(),
             agent_path: matrix_dir.to_string_lossy().to_string(),
             team_repos: Vec::new(),
@@ -2663,9 +2658,9 @@ mod tests {
     #[test]
     fn replica_identity_resolves_to_origin_matrix_role_md() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let ac_new = tmp.path().join(".ac-new");
-        let matrix_dir = ac_new.join("_agent_alpha");
-        let replica_dir = ac_new.join("wg-1-team").join("__agent_alpha");
+        let workspace_dir = tmp.path().join(".ac");
+        let matrix_dir = workspace_dir.join("_agent_alpha");
+        let replica_dir = workspace_dir.join("wg-1-team").join("__agent_alpha");
         std::fs::create_dir_all(&matrix_dir).expect("create matrix_dir");
         std::fs::create_dir_all(&replica_dir).expect("create replica_dir");
 
@@ -2678,7 +2673,7 @@ mod tests {
 
         assert_eq!(
             identity, "../../_agent_alpha",
-            "expected identity to traverse wg-1-team -> .ac-new -> _agent_alpha"
+            "expected identity to traverse wg-1-team -> .ac -> _agent_alpha"
         );
 
         let resolved = replica_dir.join(&identity).join("Role.md");
@@ -2706,13 +2701,13 @@ mod tests {
         let stale_agent_ref = tmp
             .path()
             .join("agentscommander-old")
-            .join(".ac-new")
+            .join(".ac")
             .join("_agent_tech-lead")
             .to_string_lossy()
             .replace('\\', "/");
 
         let err = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
-            ac_new_dir: workspace,
+            workspace_dir: workspace,
             wg_dir: wg_dir.clone(),
             agent_path: stale_agent_ref,
             team_repos: Vec::new(),
@@ -2746,7 +2741,7 @@ mod tests {
         std::fs::write(matrix_dir.join("Role.md"), "# Tech Lead\n").expect("write role");
 
         let replica_dir = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
-            ac_new_dir: workspace,
+            workspace_dir: workspace,
             wg_dir,
             agent_path: "_agent_tech-lead".to_string(),
             team_repos: Vec::new(),

--- a/src-tauri/src/config/claude_settings.rs
+++ b/src-tauri/src/config/claude_settings.rs
@@ -548,14 +548,14 @@ pub fn enumerate_managed_agent_dirs(project_paths: &[String]) -> Vec<std::path::
         }
     };
 
-    let scan_ac_new =
-        |ac_new: &std::path::Path, out: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>| {
-            let entries = match std::fs::read_dir(ac_new) {
+    let scan_workspace =
+        |workspace_dir: &std::path::Path, out: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>| {
+            let entries = match std::fs::read_dir(workspace_dir) {
                 Ok(e) => e,
                 Err(e) => {
                     log::warn!(
                         "[rtk-sweep] Cannot read {} for replica enumeration: {}",
-                        ac_new.display(),
+                        workspace_dir.display(),
                         e
                     );
                     return;
@@ -619,7 +619,7 @@ pub fn enumerate_managed_agent_dirs(project_paths: &[String]) -> Vec<std::path::
         // `push_if_new` and the `wg-*` parent re-check. Without this, a
         // symlink/junction child (e.g. `parent/Linked -> /elsewhere`) would
         // pass `p.is_dir()` (which follows links) and the sweep would write
-        // into `/elsewhere/.ac-new/_agent_*` outside the declared workspace.
+        // into `/elsewhere/.ac/_agent_*` outside the declared workspace.
         let mut candidates: Vec<PathBuf> = vec![base.to_path_buf()];
         if let Ok(entries) = std::fs::read_dir(base) {
             for entry in entries.flatten() {
@@ -639,10 +639,11 @@ pub fn enumerate_managed_agent_dirs(project_paths: &[String]) -> Vec<std::path::
         }
 
         for repo_dir in candidates {
-            let Some(ac_new) = crate::config::workspace::existing_workspace_dir(&repo_dir) else {
+            let Some(workspace_dir) = crate::config::workspace::existing_workspace_dir(&repo_dir)
+            else {
                 continue;
             };
-            scan_ac_new(&ac_new, &mut out, &mut seen);
+            scan_workspace(&workspace_dir, &mut out, &mut seen);
         }
     }
     out
@@ -876,13 +877,13 @@ mod tests {
     fn t12_enumerate_filters_team_repo_nondir() {
         let dir = tempdir("t12");
         let project = dir.join("proj");
-        let ac_new = project.join(".ac-new");
-        std::fs::create_dir_all(ac_new.join("_agent_one")).unwrap();
-        std::fs::create_dir_all(ac_new.join("wg-1-team").join("__agent_two")).unwrap();
-        std::fs::create_dir_all(ac_new.join("wg-1-team").join("__agent_three")).unwrap();
-        std::fs::create_dir_all(ac_new.join("wg-1-team").join("repo-x")).unwrap();
-        std::fs::create_dir_all(ac_new.join("_team_team")).unwrap();
-        std::fs::write(ac_new.join("readme.txt"), "hello").unwrap();
+        let workspace_dir = project.join(".ac");
+        std::fs::create_dir_all(workspace_dir.join("_agent_one")).unwrap();
+        std::fs::create_dir_all(workspace_dir.join("wg-1-team").join("__agent_two")).unwrap();
+        std::fs::create_dir_all(workspace_dir.join("wg-1-team").join("__agent_three")).unwrap();
+        std::fs::create_dir_all(workspace_dir.join("wg-1-team").join("repo-x")).unwrap();
+        std::fs::create_dir_all(workspace_dir.join("_team_team")).unwrap();
+        std::fs::write(workspace_dir.join("readme.txt"), "hello").unwrap();
 
         let project_paths = vec![project.to_string_lossy().to_string()];
         let result = enumerate_managed_agent_dirs(&project_paths);
@@ -990,8 +991,8 @@ mod tests {
     fn t19_enumerate_skips_symlinks_and_junctions() {
         let dir = tempdir("t19");
         let project = dir.join("proj");
-        let ac_new = project.join(".ac-new");
-        let wg = ac_new.join("wg-1-team");
+        let workspace_dir = project.join(".ac");
+        let wg = workspace_dir.join("wg-1-team");
         std::fs::create_dir_all(&wg).unwrap();
         let real_target = dir.join("outside-target");
         std::fs::create_dir_all(&real_target).unwrap();
@@ -1051,7 +1052,7 @@ mod tests {
     fn t20_enumerate_dedupes_by_canonical_path() {
         let dir = tempdir("t20");
         let project = dir.join("proj");
-        std::fs::create_dir_all(project.join(".ac-new").join("_agent_one")).unwrap();
+        std::fs::create_dir_all(project.join(".ac").join("_agent_one")).unwrap();
         let s = project.to_string_lossy().to_string();
         let project_paths = vec![s.clone(), s];
         let result = enumerate_managed_agent_dirs(&project_paths);
@@ -1105,7 +1106,7 @@ mod tests {
 
     #[test]
     fn t23_enumerate_descends_one_level_for_parent_project_paths() {
-        // project_paths may be either a project root (containing .ac-new/)
+        // project_paths may be either a project root (containing .ac/)
         // or a parent dir holding many such roots. Mirrors the convention in
         // commands/ac_discovery.rs::discover_ac_agents — without descending
         // one level, sweeps silently no-op for the parent-dir shape.
@@ -1113,14 +1114,8 @@ mod tests {
         let parent = dir.join("parent");
         let proj_a = parent.join("AppA");
         let proj_b = parent.join("AppB");
-        std::fs::create_dir_all(proj_a.join(".ac-new").join("_agent_alpha")).unwrap();
-        std::fs::create_dir_all(
-            proj_b
-                .join(".ac-new")
-                .join("wg-1-team")
-                .join("__agent_beta"),
-        )
-        .unwrap();
+        std::fs::create_dir_all(proj_a.join(".ac").join("_agent_alpha")).unwrap();
+        std::fs::create_dir_all(proj_b.join(".ac").join("wg-1-team").join("__agent_beta")).unwrap();
         // A hidden child should be skipped (matching ac_discovery convention).
         std::fs::create_dir_all(parent.join(".hidden")).unwrap();
 
@@ -1180,17 +1175,17 @@ mod tests {
     fn t25_enumerate_descend_skips_symlinked_child() {
         // project_paths = parent dir; one of parent's non-hidden children is a
         // symlink/junction pointing OUTSIDE the parent tree to a dir that has
-        // its own .ac-new/. The descend must NOT cross that boundary.
+        // its own .ac/. The descend must NOT cross that boundary.
         // (Grinch H1' regression test — without the M7 gate at the descend
         // step, the sweep escapes the declared workspace.)
         let dir = tempdir("t25");
         let parent = dir.join("parent");
         let real_proj = parent.join("AppA");
-        std::fs::create_dir_all(real_proj.join(".ac-new").join("_agent_real")).unwrap();
+        std::fs::create_dir_all(real_proj.join(".ac").join("_agent_real")).unwrap();
 
-        // Create the would-be-leaked target outside `parent`, with its own .ac-new.
+        // Create the would-be-leaked target outside `parent`, with its own .ac.
         let outside = dir.join("outside");
-        std::fs::create_dir_all(outside.join(".ac-new").join("_agent_outside")).unwrap();
+        std::fs::create_dir_all(outside.join(".ac").join("_agent_outside")).unwrap();
 
         // Symlink/junction parent/Linked -> outside.
         let link = parent.join("Linked");

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -47,7 +47,7 @@ pub enum ProjectError {
     PathMissing(PathBuf),
     #[error("path is not a directory: {0}")]
     NotADirectory(PathBuf),
-    #[error("no AC project at {0} (.ac/ or legacy .ac-new/ not found)")]
+    #[error("no AC project at {0} (.ac/ not found)")]
     WorkspaceMissing(PathBuf),
     #[error("failed to resolve absolute path for '{0}': {1}")]
     CwdFailure(String, std::io::Error),
@@ -139,7 +139,12 @@ pub fn register_new_project(
             let created = match std::fs::create_dir(&workspace_dir) {
                 Ok(()) => true,
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => false,
-                Err(e) => return Err(ProjectError::WorkspaceCreateFailed(workspace_dir.clone(), e)),
+                Err(e) => {
+                    return Err(ProjectError::WorkspaceCreateFailed(
+                        workspace_dir.clone(),
+                        e,
+                    ))
+                }
             };
             (workspace_dir, created)
         }
@@ -156,7 +161,12 @@ pub fn register_new_project(
                 workspace_dir, e
             );
         }
-        Err(e) => return Err(ProjectError::WorkspaceGitignoreFailed(workspace_dir.clone(), e)),
+        Err(e) => {
+            return Err(ProjectError::WorkspaceGitignoreFailed(
+                workspace_dir.clone(),
+                e,
+            ))
+        }
     }
 
     let abs_str = abs.to_string_lossy().into_owned();
@@ -411,7 +421,7 @@ mod tests {
 
     #[test]
     fn open_rejects_path_without_workspace() {
-        let fix = FixtureRoot::new("proj-open-noacnew");
+        let fix = FixtureRoot::new("proj-open-no-workspace");
         let mut s = AppSettings::default();
         let r = register_existing_project(&mut s, fix.path().to_str().unwrap());
         assert!(matches!(r, Err(ProjectError::WorkspaceMissing(_))));
@@ -431,25 +441,26 @@ mod tests {
     }
 
     #[test]
-    fn open_registers_legacy_ac_new_fallback() {
-        let fix = FixtureRoot::new("proj-open-legacy-ok");
-        std::fs::create_dir_all(fix.path().join(".ac-new")).unwrap();
+    fn open_rejects_non_ac_workspace() {
+        let fix = FixtureRoot::new("proj-open-invalid-workspace");
+        std::fs::create_dir_all(fix.path().join(".workspace")).unwrap();
         let mut s = AppSettings::default();
-        let r = register_existing_project(&mut s, fix.path().to_str().unwrap()).unwrap();
-        assert!(r.registered);
-        assert!(!r.created);
-        assert_eq!(s.project_paths.len(), 1);
+        let r = register_existing_project(&mut s, fix.path().to_str().unwrap());
+        assert!(matches!(r, Err(ProjectError::WorkspaceMissing(_))));
+        assert!(s.project_paths.is_empty());
     }
 
     #[test]
-    fn open_prefers_ac_when_both_ac_and_ac_new_exist() {
+    fn open_registers_path_when_ac_exists() {
         let fix = FixtureRoot::new("proj-open-both");
         std::fs::create_dir_all(fix.path().join(".ac")).unwrap();
-        std::fs::create_dir_all(fix.path().join(".ac-new")).unwrap();
         let mut s = AppSettings::default();
         let r = register_existing_project(&mut s, fix.path().to_str().unwrap()).unwrap();
         assert!(r.registered);
-        assert_eq!(existing_workspace_dir(fix.path()), Some(fix.path().join(".ac")));
+        assert_eq!(
+            existing_workspace_dir(fix.path()),
+            Some(fix.path().join(".ac"))
+        );
     }
 
     #[test]
@@ -524,15 +535,14 @@ mod tests {
     }
 
     #[test]
-    fn new_uses_legacy_ac_new_when_it_is_the_only_workspace() {
-        let fix = FixtureRoot::new("proj-new-legacy-existing");
-        std::fs::create_dir_all(fix.path().join(".ac-new")).unwrap();
+    fn new_skips_creation_when_ac_already_exists_via_workspace_lookup() {
+        let fix = FixtureRoot::new("proj-new-existing-lookup");
+        std::fs::create_dir_all(fix.path().join(".ac")).unwrap();
         let mut s = AppSettings::default();
         let r = register_new_project(&mut s, fix.path().to_str().unwrap()).unwrap();
         assert!(!r.created);
         assert!(r.registered);
-        assert!(!fix.path().join(".ac").exists());
-        assert!(fix.path().join(".ac-new").is_dir());
+        assert!(fix.path().join(".ac").is_dir());
     }
 
     #[test]
@@ -659,10 +669,6 @@ mod tests {
         std::fs::create_dir_all(path.join(".ac")).unwrap();
     }
 
-    fn create_legacy_ac_project(path: &Path) {
-        std::fs::create_dir_all(path.join(".ac-new")).unwrap();
-    }
-
     #[test]
     fn resolve_project_reference_matches_registered_folder_name() {
         let fix = FixtureRoot::new("proj-resolve-name");
@@ -690,15 +696,15 @@ mod tests {
     }
 
     #[test]
-    fn resolve_project_reference_matches_legacy_child_project() {
-        let fix = FixtureRoot::new("proj-resolve-legacy-parent");
+    fn resolve_project_reference_rejects_non_ac_child_project() {
+        let fix = FixtureRoot::new("proj-resolve-invalid-workspace");
         let project = fix.path().join("ProjectAlpha");
-        create_legacy_ac_project(&project);
+        std::fs::create_dir_all(project.join(".workspace")).unwrap();
         let project_paths = vec![fix.path().to_string_lossy().to_string()];
 
-        let resolved = resolve_project_reference(&project_paths, "ProjectAlpha").unwrap();
+        let err = resolve_project_reference(&project_paths, "ProjectAlpha").unwrap_err();
 
-        assert_eq!(resolved.path, project);
+        assert!(matches!(err, ProjectResolveError::NotFound(_)));
     }
 
     #[test]
@@ -768,7 +774,7 @@ mod tests {
     fn project_registration_serializes_camel_case() {
         // Today's fields are already lowercase single-words, so no rename
         // happens. This test locks the invariant: a future field like
-        // `ac_new_dir` must serialize to `acNewDir`. If the
+        // `workspace_dir` must serialize to `workspaceDir`. If the
         // `#[serde(rename_all = "camelCase")]` attribute is ever dropped,
         // this test catches it before the FE silently breaks.
         let r = ProjectRegistration {
@@ -790,7 +796,7 @@ mod tests {
         );
         // No snake_case relics from any current field name.
         assert!(
-            !json.contains("ac_new"),
+            !json.contains("workspace_dir"),
             "snake_case field name leaked: {}",
             json
         );

--- a/src-tauri/src/config/replica_identity.rs
+++ b/src-tauri/src/config/replica_identity.rs
@@ -416,7 +416,7 @@ mod tests {
         let stale_sibling = temp
             .path()
             .join("agentscommander-old")
-            .join(".ac-new")
+            .join(".ac")
             .join("_agent_tech-lead");
         std::fs::create_dir_all(stale_sibling).expect("create stale sibling");
 
@@ -442,7 +442,7 @@ mod tests {
         let stale = temp
             .path()
             .join("agentscommander-old")
-            .join(".ac-new")
+            .join(".ac")
             .join("_agent_tech-lead")
             .to_string_lossy()
             .replace('\\', "/");
@@ -452,7 +452,7 @@ mod tests {
                 "identity": stale,
                 "context": [
                     "$AGENTSCOMMANDER_CONTEXT",
-                    "../../../../agentscommander-old/.ac-new/_agent_tech-lead/Role.md",
+                    "../../../../agentscommander-old/.ac/_agent_tech-lead/Role.md",
                     "notes.md",
                     "../../_agent_tech-lead/Role.md"
                 ],
@@ -497,7 +497,7 @@ mod tests {
             .join("__agent_tech-lead");
         std::fs::write(
             replica.join("config.json"),
-            r#"{"identity":"../../../../agentscommander-old/.ac-new/_agent_architect"}"#,
+            r#"{"identity":"../../../../agentscommander-old/.ac/_agent_architect"}"#,
         )
         .expect("write config");
 
@@ -564,7 +564,7 @@ mod tests {
             .join("__agent_tech-lead");
         std::fs::write(
             replica.join("config.json"),
-            r#"{"identity":"../../../../agentscommander-old/.ac-new/_Agent_Tech-Lead"}"#,
+            r#"{"identity":"../../../../agentscommander-old/.ac/_Agent_Tech-Lead"}"#,
         )
         .expect("write config");
 

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -1465,9 +1465,9 @@ fn default_context(agent_root: &str, matrix_root: Option<&str>, skills_section: 
         )
     };
     let git_scope = if matrix_root.is_some() {
-        "Your replica directory and origin Agent Matrix are typically inside a parent repository's `.ac/` or legacy `.ac-new/` folder, which is `.gitignore`d. Do NOT run `git` commands that alter state (commit, branch, reset, etc.) from inside either location — that would affect the parent repo unintentionally. AgentsCommander blocks Git repository discovery above these AC workspace roots for agent sessions, but you must still switch into the appropriate `repo-*` directory before running Git operations that change repository state. `git status`, `git log`, and `git diff` are fine inside the allowed roots."
+        "Your replica directory and origin Agent Matrix are typically inside a parent repository's `.ac/` folder, which is `.gitignore`d. Do NOT run `git` commands that alter state (commit, branch, reset, etc.) from inside either location, because that would affect the parent repo unintentionally. AgentsCommander blocks Git repository discovery above these AC workspace roots for agent sessions, but you must still switch into the appropriate `repo-*` directory before running Git operations that change repository state. `git status`, `git log`, and `git diff` are fine inside the allowed roots."
     } else {
-        "Your agent directory is typically inside a parent repository's `.ac/` or legacy `.ac-new/` folder, which is `.gitignore`d. Do NOT run `git` commands that alter state (commit, branch, reset, etc.) from inside that directory — that would affect the parent repo unintentionally. AgentsCommander blocks Git repository discovery above these AC workspace roots for agent sessions, but you must still switch into the appropriate `repo-*` directory before running Git operations that change repository state. `git status`, `git log`, and `git diff` are fine inside the allowed roots."
+        "Your agent directory is typically inside a parent repository's `.ac/` folder, which is `.gitignore`d. Do NOT run `git` commands that alter state (commit, branch, reset, etc.) from inside that directory, because that would affect the parent repo unintentionally. AgentsCommander blocks Git repository discovery above these AC workspace roots for agent sessions, but you must still switch into the appropriate `repo-*` directory before running Git operations that change repository state. `git status`, `git log`, and `git diff` are fine inside the allowed roots."
     };
     let peer_name_format = match &messaging_mode {
         MessagingContextMode::Root(_) => "- **Root Agent sessions**: verified WG coordinator replicas only, shaped `<project>:<workgroup>/<agent>` — e.g. `agentscommander:wg-15-dev-team/tech-lead`.\n\nOrigin coordinators and non-coordinator WG replicas are not valid Root Agent targets in #277.".to_string(),
@@ -1928,7 +1928,7 @@ mod tests {
     #[test]
     fn resolve_skill_owner_root_supports_origin_matrix_sessions() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let matrix_root = temp.path().join(".ac-new").join("_agent_dev-rust");
+        let matrix_root = temp.path().join(".ac").join("_agent_dev-rust");
         write_skill(
             &matrix_root,
             "example",
@@ -2271,9 +2271,11 @@ mod tests {
     #[test]
     fn materialize_agent_context_file_includes_skills_for_replica_context() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let ac_new = temp.path().join(".ac-new");
-        let matrix_root = ac_new.join("_agent_dev-rust");
-        let replica_root = ac_new.join("wg-19-dev-team").join("__agent_dev-rust");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        let replica_root = workspace_dir
+            .join("wg-19-dev-team")
+            .join("__agent_dev-rust");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
         write_skill(
             &matrix_root,
@@ -2319,7 +2321,7 @@ mod tests {
         .expect("write Role.md");
         std::fs::write(
             replica_root.join("config.json"),
-            r#"{"identity":"../../../../agentscommander-old/.ac-new/_agent_tech-lead","context":["$AGENTSCOMMANDER_CONTEXT","../../../../agentscommander-old/.ac-new/_agent_tech-lead/Role.md"]}"#,
+            r#"{"identity":"../../../../agentscommander-old/.ac/_agent_tech-lead","context":["$AGENTSCOMMANDER_CONTEXT","../../../../agentscommander-old/.ac/_agent_tech-lead/Role.md"]}"#,
         )
         .expect("write replica config");
 
@@ -2361,7 +2363,7 @@ mod tests {
         std::fs::create_dir_all(&replica_root).expect("create replica root");
         std::fs::write(
             replica_root.join("config.json"),
-            r#"{"identity":"../../../../agentscommander-old/.ac-new/_agent_architect"}"#,
+            r#"{"identity":"../../../../agentscommander-old/.ac/_agent_architect"}"#,
         )
         .expect("write replica config");
 
@@ -2376,7 +2378,7 @@ mod tests {
     #[test]
     fn materialize_agent_context_file_includes_skills_for_direct_matrix_context() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let matrix_root = temp.path().join(".ac-new").join("_agent_dev-rust");
+        let matrix_root = temp.path().join(".ac").join("_agent_dev-rust");
         write_skill(
             &matrix_root,
             "runtime",
@@ -2411,7 +2413,7 @@ mod tests {
     #[test]
     fn materialize_agent_context_file_includes_local_role_for_direct_matrix_context() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let matrix_root = temp.path().join(".ac-new").join("_agent_dev-rust");
+        let matrix_root = temp.path().join(".ac").join("_agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::write(
             matrix_root.join(ROLE_MD_FILENAME),
@@ -2434,7 +2436,7 @@ mod tests {
     #[test]
     fn materialize_direct_matrix_default_config_includes_global_and_one_role() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let matrix_root = temp.path().join(".ac-new").join("_agent_dev-rust");
+        let matrix_root = temp.path().join(".ac").join("_agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::write(
             matrix_root.join("config.json"),
@@ -2462,7 +2464,7 @@ mod tests {
     #[test]
     fn materialize_direct_matrix_role_only_config_prepends_global_context() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let matrix_root = temp.path().join(".ac-new").join("_agent_dev-rust");
+        let matrix_root = temp.path().join(".ac").join("_agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::write(
             matrix_root.join("config.json"),
@@ -2490,7 +2492,7 @@ mod tests {
     #[test]
     fn materialize_direct_matrix_null_context_keeps_global_context_and_role() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let matrix_root = temp.path().join(".ac-new").join("_agent_dev-rust");
+        let matrix_root = temp.path().join(".ac").join("_agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::write(
             matrix_root.join("config.json"),

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -1167,7 +1167,7 @@ mod tests {
             name: "alice".into(),
             shell: "claude".into(),
             shell_args: vec!["--continue".into()],
-            working_directory: r"C:\proj\.ac-new\wg-1-devs\__agent_alice".into(),
+            working_directory: r"C:\proj\.ac\wg-1-devs\__agent_alice".into(),
             was_active: false,
             git_repos: vec![],
             is_coordinator: false,
@@ -1379,21 +1379,21 @@ mod tests {
         let sessions = vec![
             PersistedSession {
                 name: "kept-coordinator".into(),
-                working_directory: "C:/projects/current/.ac-new/wg-1/__agent_tech-lead".into(),
+                working_directory: "C:/projects/current/.ac/wg-1/__agent_tech-lead".into(),
                 is_coordinator: true,
                 status: Some(SessionStatus::Running),
                 ..Default::default()
             },
             PersistedSession {
                 name: "orphan-coordinator".into(),
-                working_directory: "C:/projects/removed/.ac-new/wg-1/__agent_tech-lead".into(),
+                working_directory: "C:/projects/removed/.ac/wg-1/__agent_tech-lead".into(),
                 is_coordinator: true,
                 status: Some(SessionStatus::Running),
                 ..Default::default()
             },
             PersistedSession {
                 name: "orphan-member".into(),
-                working_directory: "C:/projects/removed/.ac-new/wg-1/__agent_dev-rust".into(),
+                working_directory: "C:/projects/removed/.ac/wg-1/__agent_dev-rust".into(),
                 is_coordinator: false,
                 status: Some(SessionStatus::Exited(0)),
                 ..Default::default()
@@ -1411,8 +1411,8 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let current = temp.path().join("current");
         let removed = temp.path().join("removed");
-        let current_agent = current.join(".ac-new").join("wg-1").join("__agent_keep");
-        let removed_agent = removed.join(".ac-new").join("wg-1").join("__agent_old");
+        let current_agent = current.join(".ac").join("wg-1").join("__agent_keep");
+        let removed_agent = removed.join(".ac").join("wg-1").join("__agent_old");
         std::fs::create_dir_all(&current_agent).expect("create current agent");
         std::fs::create_dir_all(&removed_agent).expect("create removed agent");
 
@@ -1449,11 +1449,11 @@ mod tests {
         let project_paths = vec!["C:/repo/foo".to_string()];
 
         assert!(working_directory_under_any_project_path(
-            "C:/repo/foo/.ac-new/wg-1/__agent_a",
+            "C:/repo/foo/.ac/wg-1/__agent_a",
             &project_paths
         ));
         assert!(!working_directory_under_any_project_path(
-            "C:/repo/foobar/.ac-new/wg-1/__agent_a",
+            "C:/repo/foobar/.ac/wg-1/__agent_a",
             &project_paths
         ));
     }
@@ -1464,7 +1464,7 @@ mod tests {
         let project_paths = vec![r"C:\Users\Maria\Project".to_string()];
 
         assert!(working_directory_under_any_project_path(
-            r"c:\users\maria\project\.ac-new\wg-1\__agent_a",
+            r"c:\users\maria\project\.ac\wg-1\__agent_a",
             &project_paths
         ));
     }
@@ -1754,7 +1754,7 @@ mod tests {
                 name: "coord-x".into(),
                 shell: "claude".into(),
                 shell_args: vec![],
-                working_directory: "C:/proj/.ac-new/_agent_architect".into(),
+                working_directory: "C:/proj/.ac/_agent_architect".into(),
                 was_active: true,
                 git_repos: vec![],
                 is_coordinator: true,

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -320,22 +320,22 @@ fn identity_compare_key(path: &Path) -> String {
 }
 
 pub fn resolve_wg_coordinator_replica(
-    ac_new_dir: &Path,
+    workspace_dir: &Path,
     wg_dir: &Path,
 ) -> Option<WgCoordinatorReplica> {
-    let project = ac_new_dir.parent()?.file_name()?.to_str()?.to_string();
+    let project = workspace_dir.parent()?.file_name()?.to_str()?.to_string();
     let wg_name = wg_dir.file_name()?.to_str()?.to_string();
     let team = wg_name
         .strip_prefix("wg-")
         .and_then(|s| s.split_once('-').map(|(_, rest)| rest.to_string()))?;
 
-    let team_dir = ac_new_dir.join(format!("_team_{}", team));
+    let team_dir = workspace_dir.join(format!("_team_{}", team));
     let team_config: serde_json::Value = std::fs::read_to_string(team_dir.join("config.json"))
         .ok()
         .and_then(|raw| serde_json::from_str(&raw).ok())?;
     let coordinator_ref = team_config.get("coordinator").and_then(|c| c.as_str())?;
     let coordinator_name = agent_bare_name_from_ref(coordinator_ref).ok()?;
-    if !ac_new_dir
+    if !workspace_dir
         .join(format!("_agent_{}", coordinator_name))
         .is_dir()
     {
@@ -386,14 +386,14 @@ pub fn verified_wg_coordinator_target(
         if project_name != project {
             continue;
         }
-        let Some(ac_new_dir) = existing_workspace_dir(&project_dir) else {
+        let Some(workspace_dir) = existing_workspace_dir(&project_dir) else {
             continue;
         };
-        let wg_dir = ac_new_dir.join(wg_name);
+        let wg_dir = workspace_dir.join(wg_name);
         if !wg_dir.is_dir() {
             continue;
         }
-        if let Some(resolved) = resolve_wg_coordinator_replica(&ac_new_dir, &wg_dir) {
+        if let Some(resolved) = resolve_wg_coordinator_replica(&workspace_dir, &wg_dir) {
             if resolved.agent_name == agent_name {
                 return Some(resolved);
             }
@@ -539,7 +539,7 @@ fn resolve_agent_ref(project_folder: &str, agent_ref: &str) -> String {
 }
 
 /// Resolve an agent ref to an absolute path given the workspace directory.
-fn resolve_agent_path(ac_new_dir: &Path, agent_ref: &str) -> Option<PathBuf> {
+fn resolve_agent_path(workspace_dir: &Path, agent_ref: &str) -> Option<PathBuf> {
     let normalized = agent_ref.replace('\\', "/");
     let trimmed = normalized
         .trim_start_matches("../")
@@ -555,13 +555,13 @@ fn resolve_agent_path(ac_new_dir: &Path, agent_ref: &str) -> Option<PathBuf> {
     }
 
     // Relative to the workspace directory.
-    let candidate = ac_new_dir.join(trimmed);
+    let candidate = workspace_dir.join(trimmed);
     if candidate.is_dir() {
         return Some(candidate);
     }
 
     // Try parent of the workspace directory (project root).
-    if let Some(project_root) = ac_new_dir.parent() {
+    if let Some(project_root) = workspace_dir.parent() {
         let candidate = project_root.join(trimmed);
         if candidate.is_dir() {
             return Some(candidate);
@@ -857,7 +857,7 @@ pub fn discover_teams() -> Vec<DiscoveredTeam> {
 
 /// Discover teams in a single project directory.
 fn discover_teams_in_project(project_dir: &Path, teams: &mut Vec<DiscoveredTeam>) {
-    let Some(ac_new) = existing_workspace_dir(project_dir) else {
+    let Some(workspace_dir) = existing_workspace_dir(project_dir) else {
         return;
     };
 
@@ -867,7 +867,7 @@ fn discover_teams_in_project(project_dir: &Path, teams: &mut Vec<DiscoveredTeam>
         .unwrap_or("unknown")
         .to_string();
 
-    let entries = match std::fs::read_dir(&ac_new) {
+    let entries = match std::fs::read_dir(&workspace_dir) {
         Ok(e) => e,
         Err(_) => return,
     };
@@ -962,7 +962,7 @@ fn discover_teams_in_project(project_dir: &Path, teams: &mut Vec<DiscoveredTeam>
             .iter()
             .map(|r| {
                 let name = resolve_agent_ref(&project_folder, r);
-                let path = resolve_agent_path(&ac_new, r);
+                let path = resolve_agent_path(&workspace_dir, r);
                 (name, path)
             })
             .unzip();
@@ -979,7 +979,7 @@ fn discover_teams_in_project(project_dir: &Path, teams: &mut Vec<DiscoveredTeam>
 
         let coordinator_path = coordinator_ref
             .as_ref()
-            .and_then(|r| resolve_agent_path(&ac_new, r));
+            .and_then(|r| resolve_agent_path(&workspace_dir, r));
 
         teams.push(DiscoveredTeam {
             name: team_name,
@@ -1014,8 +1014,8 @@ mod tests {
     }
 
     #[test]
-    fn agent_fqn_from_path_legacy_wg_replica() {
-        let cwd = "C:/repos/proj-a/.ac-new/wg-1-devs/__agent_alice";
+    fn agent_fqn_from_path_wg_replica_windows_style() {
+        let cwd = "C:/repos/proj-a/.ac/wg-1-devs/__agent_alice";
         assert_eq!(agent_fqn_from_path(cwd), "proj-a:wg-1-devs/alice");
     }
 
@@ -1036,14 +1036,14 @@ mod tests {
     /// §G6 case 3: Windows UNC `\\?\` prefix must still resolve correctly.
     #[test]
     fn agent_fqn_from_path_handles_unc_prefix() {
-        let cwd = r"\\?\C:\repos\proj-a\.ac-new\wg-1-devs\__agent_alice";
+        let cwd = r"\\?\C:\repos\proj-a\.ac\wg-1-devs\__agent_alice";
         assert_eq!(agent_fqn_from_path(cwd), "proj-a:wg-1-devs/alice");
     }
 
-    /// §G6 case 2: parent path containing `.ac-new` anchors on the right-most one (rposition).
+    /// §G6 case 2: parent path containing `.ac` anchors on the right-most one (rposition).
     #[test]
-    fn agent_fqn_from_path_pathological_ac_new_prefix() {
-        let cwd = "C:/.ac-new/repos/proj-a/.ac-new/wg-1-devs/__agent_alice";
+    fn agent_fqn_from_path_parent_ac_prefix() {
+        let cwd = "C:/.ac/repos/proj-a/.ac/wg-1-devs/__agent_alice";
         assert_eq!(agent_fqn_from_path(cwd), "proj-a:wg-1-devs/alice");
     }
 
@@ -1120,10 +1120,10 @@ mod tests {
         for (proj_name, wgs) in projects {
             let proj_dir = tmp.path().join(proj_name);
             std::fs::create_dir_all(&proj_dir).unwrap();
-            let ac_new = proj_dir.join(".ac-new");
-            std::fs::create_dir_all(&ac_new).unwrap();
+            let workspace_dir = proj_dir.join(".ac");
+            std::fs::create_dir_all(&workspace_dir).unwrap();
             for (wg_name, agents) in *wgs {
-                let wg_dir = ac_new.join(wg_name);
+                let wg_dir = workspace_dir.join(wg_name);
                 std::fs::create_dir_all(&wg_dir).unwrap();
                 for agent in *agents {
                     let replica = wg_dir.join(format!("__agent_{}", agent));
@@ -1138,11 +1138,11 @@ mod tests {
     fn make_coordinator_fixture(spoofed_coordinator_identity: bool) -> (FixtureRoot, Vec<String>) {
         let tmp = FixtureRoot::new("teams-coord-fixture");
         let project = tmp.path().join("proj-a");
-        let ac_new = project.join(".ac-new");
-        let team_dir = ac_new.join("_team_dev-team");
-        let origin_tech_lead = ac_new.join("_agent_tech-lead");
-        let origin_dev_rust = ac_new.join("_agent_dev-rust");
-        let wg_dir = ac_new.join("wg-1-dev-team");
+        let workspace_dir = project.join(".ac");
+        let team_dir = workspace_dir.join("_team_dev-team");
+        let origin_tech_lead = workspace_dir.join("_agent_tech-lead");
+        let origin_dev_rust = workspace_dir.join("_agent_dev-rust");
+        let wg_dir = workspace_dir.join("wg-1-dev-team");
         let tech_lead_replica = wg_dir.join("__agent_tech-lead");
         let dev_rust_replica = wg_dir.join("__agent_dev-rust");
 
@@ -1186,14 +1186,14 @@ mod tests {
     ) -> (FixtureRoot, PathBuf, PathBuf, Vec<String>) {
         let tmp = FixtureRoot::new("teams-portable-coord-fixture");
         let project = tmp.path().join("proj-a");
-        let ac_new = project.join(".ac");
-        let team_dir = ac_new.join("_team_dev-team");
-        let local_tech_lead = ac_new.join("_agent_tech-lead");
-        let local_dev_rust = ac_new.join("_agent_dev-rust");
-        let origin = tmp.path().join("origin-matrix").join(".ac-new");
+        let workspace_dir = project.join(".ac");
+        let team_dir = workspace_dir.join("_team_dev-team");
+        let local_tech_lead = workspace_dir.join("_agent_tech-lead");
+        let local_dev_rust = workspace_dir.join("_agent_dev-rust");
+        let origin = tmp.path().join("origin-matrix").join(".ac");
         let origin_tech_lead = origin.join("_agent_tech-lead");
         let origin_dev_rust = origin.join("_agent_dev-rust");
-        let wg_dir = ac_new.join("wg-1-dev-team");
+        let wg_dir = workspace_dir.join("wg-1-dev-team");
         let tech_lead_replica = wg_dir.join("__agent_tech-lead");
         let dev_rust_replica = wg_dir.join("__agent_dev-rust");
 
@@ -1236,16 +1236,17 @@ mod tests {
         .unwrap();
 
         let paths = vec![tmp.path().to_string_lossy().to_string()];
-        (tmp, ac_new, wg_dir, paths)
+        (tmp, workspace_dir, wg_dir, paths)
     }
 
     #[test]
     fn resolve_wg_coordinator_replica_uses_identity_not_dir_name() {
         let (tmp, _paths) = make_coordinator_fixture(false);
-        let ac_new = tmp.path().join("proj-a").join(".ac-new");
-        let wg_dir = ac_new.join("wg-1-dev-team");
+        let workspace_dir = tmp.path().join("proj-a").join(".ac");
+        let wg_dir = workspace_dir.join("wg-1-dev-team");
 
-        let resolved = resolve_wg_coordinator_replica(&ac_new, &wg_dir).expect("coordinator");
+        let resolved =
+            resolve_wg_coordinator_replica(&workspace_dir, &wg_dir).expect("coordinator");
 
         assert_eq!(resolved.project, "proj-a");
         assert_eq!(resolved.team, "dev-team");
@@ -1260,17 +1261,17 @@ mod tests {
     #[test]
     fn resolve_wg_coordinator_replica_rejects_spoofed_name() {
         let (tmp, _paths) = make_coordinator_fixture(true);
-        let ac_new = tmp.path().join("proj-a").join(".ac-new");
-        let wg_dir = ac_new.join("wg-1-dev-team");
+        let workspace_dir = tmp.path().join("proj-a").join(".ac");
+        let wg_dir = workspace_dir.join("wg-1-dev-team");
 
-        assert!(resolve_wg_coordinator_replica(&ac_new, &wg_dir).is_none());
+        assert!(resolve_wg_coordinator_replica(&workspace_dir, &wg_dir).is_none());
     }
 
     #[test]
     fn resolve_wg_coordinator_replica_accepts_portable_ref_with_external_identity() {
-        let (_tmp, ac_new, wg_dir, _paths) = make_portable_coordinator_fixture(false);
+        let (_tmp, workspace_dir, wg_dir, _paths) = make_portable_coordinator_fixture(false);
 
-        let resolved = resolve_wg_coordinator_replica(&ac_new, &wg_dir)
+        let resolved = resolve_wg_coordinator_replica(&workspace_dir, &wg_dir)
             .expect("portable coordinator ref should match declared identity agent");
 
         assert_eq!(resolved.project, "proj-a");
@@ -1281,14 +1282,14 @@ mod tests {
 
     #[test]
     fn resolve_wg_coordinator_replica_rejects_portable_ref_with_spoofed_identity() {
-        let (_tmp, ac_new, wg_dir, _paths) = make_portable_coordinator_fixture(true);
+        let (_tmp, workspace_dir, wg_dir, _paths) = make_portable_coordinator_fixture(true);
 
-        assert!(resolve_wg_coordinator_replica(&ac_new, &wg_dir).is_none());
+        assert!(resolve_wg_coordinator_replica(&workspace_dir, &wg_dir).is_none());
     }
 
     /// Build a fixture where both team config and replica configs reference
-    /// a legacy folder name (`legacy-workspace`) that no longer exists on disk.
-    /// Mirrors the post-workspace-rename state from #299/#300: persisted refs are
+    /// a renamed folder (`renamed-workspace`) that no longer exists on disk.
+    /// Mirrors the post-workspace-rename state from #299: persisted refs are
     /// stale, but the same-workspace local matrices exist and are the only valid
     /// authority targets.
     fn make_stale_coordinator_fixture(
@@ -1296,11 +1297,11 @@ mod tests {
     ) -> (FixtureRoot, PathBuf, PathBuf) {
         let tmp = FixtureRoot::new("teams-stale-coord-fixture");
         let project = tmp.path().join("proj-a");
-        let ac_new = project.join(".ac-new");
-        let team_dir = ac_new.join("_team_test-team");
-        let wg_dir = ac_new.join("wg-1-test-team");
-        let alpha_matrix = ac_new.join("_agent_test-alpha");
-        let beta_matrix = ac_new.join("_agent_test-beta");
+        let workspace_dir = project.join(".ac");
+        let team_dir = workspace_dir.join("_team_test-team");
+        let wg_dir = workspace_dir.join("wg-1-test-team");
+        let alpha_matrix = workspace_dir.join("_agent_test-alpha");
+        let beta_matrix = workspace_dir.join("_agent_test-beta");
         let alpha_replica = wg_dir.join("__agent_test-alpha");
         let beta_replica = wg_dir.join("__agent_test-beta");
 
@@ -1314,11 +1315,11 @@ mod tests {
             std::fs::create_dir_all(dir).unwrap();
         }
 
-        // Stale absolute path (the `legacy-workspace` folder is never created).
+        // Stale absolute path (the `renamed-workspace` folder is never created).
         let stale_coord = tmp
             .path()
-            .join("legacy-workspace")
-            .join(".ac-new")
+            .join("renamed-workspace")
+            .join(".ac")
             .join("_agent_test-alpha");
         let stale_coord_str = stale_coord.to_string_lossy().replace('\\', "/");
 
@@ -1333,8 +1334,8 @@ mod tests {
         // points to a DIFFERENT stale matrix (the test-beta slot) — must reject.
         let alpha_identity = if replica_spoofs_identity {
             tmp.path()
-                .join("legacy-workspace")
-                .join(".ac-new")
+                .join("renamed-workspace")
+                .join(".ac")
                 .join("_agent_test-beta")
                 .to_string_lossy()
                 .replace('\\', "/")
@@ -1351,8 +1352,8 @@ mod tests {
         // Not the coordinator — must not match.
         let beta_identity = tmp
             .path()
-            .join("legacy-workspace")
-            .join(".ac-new")
+            .join("renamed-workspace")
+            .join(".ac")
             .join("_agent_test-beta")
             .to_string_lossy()
             .replace('\\', "/");
@@ -1362,16 +1363,16 @@ mod tests {
         )
         .unwrap();
 
-        (tmp, ac_new, wg_dir)
+        (tmp, workspace_dir, wg_dir)
     }
 
-    /// #300: stale absolute identity refs are accepted only by repairing them
+    /// Stale absolute identity refs are accepted only by repairing them
     /// to the same-workspace local matrix with the same agent basename.
     #[test]
     fn resolve_wg_coordinator_replica_repairs_stale_absolute_refs() {
-        let (_tmp, ac_new, wg_dir) = make_stale_coordinator_fixture(false);
+        let (_tmp, workspace_dir, wg_dir) = make_stale_coordinator_fixture(false);
 
-        let resolved = resolve_wg_coordinator_replica(&ac_new, &wg_dir)
+        let resolved = resolve_wg_coordinator_replica(&workspace_dir, &wg_dir)
             .expect("same-workspace repair should resolve coordinator with stale refs");
 
         assert_eq!(resolved.agent_name, "test-alpha");
@@ -1390,25 +1391,25 @@ mod tests {
     /// (e.g. `_agent_test-beta`) must not be accepted as coordinator.
     #[test]
     fn resolve_wg_coordinator_replica_rejects_spoofed_stale_identity() {
-        let (_tmp, ac_new, wg_dir) = make_stale_coordinator_fixture(true);
+        let (_tmp, workspace_dir, wg_dir) = make_stale_coordinator_fixture(true);
 
         // The test-alpha replica has been spoofed to claim the test-beta matrix.
         // The test-beta replica claims the test-beta matrix too. Neither matches
         // the team's coordinator ref (`_agent_test-alpha`), so no coordinator
         // is resolved.
-        assert!(resolve_wg_coordinator_replica(&ac_new, &wg_dir).is_none());
+        assert!(resolve_wg_coordinator_replica(&workspace_dir, &wg_dir).is_none());
     }
 
-    /// #300: relative identity traversing out of the workspace must be repaired
+    /// Relative identity traversing out of the workspace must be repaired
     /// to the same-workspace local matrix, not compared against the stale target.
     #[test]
     fn resolve_wg_coordinator_replica_repairs_stale_relative_identity() {
         let tmp = FixtureRoot::new("teams-stale-rel-fixture");
         let project = tmp.path().join("proj-a");
-        let ac_new = project.join(".ac-new");
-        let team_dir = ac_new.join("_team_test-team");
-        let wg_dir = ac_new.join("wg-1-test-team");
-        let alpha_matrix = ac_new.join("_agent_test-alpha");
+        let workspace_dir = project.join(".ac");
+        let team_dir = workspace_dir.join("_team_test-team");
+        let wg_dir = workspace_dir.join("wg-1-test-team");
+        let alpha_matrix = workspace_dir.join("_agent_test-alpha");
         let alpha_replica = wg_dir.join("__agent_test-alpha");
 
         for dir in [&team_dir, &alpha_matrix, &alpha_replica] {
@@ -1416,11 +1417,11 @@ mod tests {
         }
 
         // Team config: stale absolute coordinator path
-        // → tmp/legacy-workspace/.ac-new/_agent_test-alpha
+        // -> tmp/renamed-workspace/.ac/_agent_test-alpha
         let stale_abs = tmp
             .path()
-            .join("legacy-workspace")
-            .join(".ac-new")
+            .join("renamed-workspace")
+            .join(".ac")
             .join("_agent_test-alpha");
         let stale_abs_str = stale_abs.to_string_lossy().replace('\\', "/");
         std::fs::write(
@@ -1430,17 +1431,17 @@ mod tests {
         .unwrap();
 
         // Replica identity: relative path that traverses out to the same
-        // legacy folder. From `<tmp>/proj-a/.ac-new/wg-1-test-team/__agent_test-alpha`,
-        // `../../../../legacy-workspace/.ac-new/_agent_test-alpha` resolves to
-        // `<tmp>/legacy-workspace/.ac-new/_agent_test-alpha` — the same logical
+        // legacy folder. From `<tmp>/proj-a/.ac/wg-1-test-team/__agent_test-alpha`,
+        // `../../../../renamed-workspace/.ac/_agent_test-alpha` resolves to
+        // `<tmp>/renamed-workspace/.ac/_agent_test-alpha` — the same logical
         // target as the team coordinator ref.
         std::fs::write(
             alpha_replica.join("config.json"),
-            r#"{"identity":"../../../../legacy-workspace/.ac-new/_agent_test-alpha"}"#,
+            r#"{"identity":"../../../../renamed-workspace/.ac/_agent_test-alpha"}"#,
         )
         .unwrap();
 
-        let resolved = resolve_wg_coordinator_replica(&ac_new, &wg_dir)
+        let resolved = resolve_wg_coordinator_replica(&workspace_dir, &wg_dir)
             .expect("same-workspace repair should resolve stale relative identity");
         assert_eq!(resolved.agent_name, "test-alpha");
     }
@@ -1478,8 +1479,8 @@ mod tests {
     fn identity_compare_key_equal_for_stale_paths_pointing_to_same_target() {
         // Two refs expressed differently but logically pointing at the same
         // non-existent legacy location should produce equal keys.
-        let a = Path::new("/some/where/legacy/.ac-new/_agent_test-alpha");
-        let b = Path::new("/some/where/proj/.ac-new/wg-1-test-team/__agent_test-alpha/../../../../legacy/.ac-new/_agent_test-alpha");
+        let a = Path::new("/some/where/legacy/.ac/_agent_test-alpha");
+        let b = Path::new("/some/where/proj/.ac/wg-1-test-team/__agent_test-alpha/../../../../legacy/.ac/_agent_test-alpha");
         assert_eq!(identity_compare_key(a), identity_compare_key(b));
     }
 
@@ -1487,8 +1488,8 @@ mod tests {
     fn identity_compare_key_differs_for_different_matrix_names() {
         // Stale refs to different matrix dirs must produce different keys —
         // protects spoofing when both refs are stale.
-        let a = Path::new("/some/where/legacy/.ac-new/_agent_test-alpha");
-        let b = Path::new("/some/where/legacy/.ac-new/_agent_test-beta");
+        let a = Path::new("/some/where/legacy/.ac/_agent_test-alpha");
+        let b = Path::new("/some/where/legacy/.ac/_agent_test-beta");
         assert_ne!(identity_compare_key(a), identity_compare_key(b));
     }
 
@@ -1496,8 +1497,8 @@ mod tests {
     fn identity_compare_key_case_insensitive() {
         // Comparison is case-insensitive (Windows convention; matches
         // cli/list_peers::norm_path).
-        let a = Path::new("/Some/Where/.ac-new/_Agent_Test-Alpha");
-        let b = Path::new("/some/where/.ac-new/_agent_test-alpha");
+        let a = Path::new("/Some/Where/.ac/_Agent_Test-Alpha");
+        let b = Path::new("/some/where/.ac/_agent_test-alpha");
         assert_eq!(identity_compare_key(a), identity_compare_key(b));
     }
 
@@ -1528,7 +1529,7 @@ mod tests {
 
     #[test]
     fn verified_wg_coordinator_target_accepts_portable_ref_with_external_identity() {
-        let (_tmp, _ac_new, _wg_dir, paths) = make_portable_coordinator_fixture(false);
+        let (_tmp, _workspace, _wg_dir, paths) = make_portable_coordinator_fixture(false);
 
         let resolved = verified_wg_coordinator_target("proj-a:wg-1-dev-team/tech-lead", &paths)
             .expect("portable verified coordinator");
@@ -1606,12 +1607,12 @@ mod tests {
     #[test]
     fn resolve_agent_target_two_level_scan() {
         let tmp = FixtureRoot::new("teams-two-level");
-        // Lay out: tmp/ contains proj-a/ and proj-b/, each with a .ac-new/ + colliding replica.
+        // Lay out: tmp/ contains proj-a/ and proj-b/, each with a .ac/ + colliding replica.
         for proj in ["proj-a", "proj-b"] {
             let replica = tmp
                 .path()
                 .join(proj)
-                .join(".ac-new")
+                .join(".ac")
                 .join("wg-1-devs")
                 .join("__agent_alice");
             std::fs::create_dir_all(&replica).unwrap();
@@ -1700,15 +1701,15 @@ mod tests {
         }];
 
         // Coordinator replica (any WG of the same team) resolves true.
-        let coord_cwd = "C:/repos/foo/.ac-new/wg-4-dev-team/__agent_tech-lead";
+        let coord_cwd = "C:/repos/foo/.ac/wg-4-dev-team/__agent_tech-lead";
         assert!(is_coordinator_for_cwd(coord_cwd, &teams));
 
         // Non-coordinator member of the team → false.
-        let member_cwd = "C:/repos/foo/.ac-new/wg-4-dev-team/__agent_dev-rust";
+        let member_cwd = "C:/repos/foo/.ac/wg-4-dev-team/__agent_dev-rust";
         assert!(!is_coordinator_for_cwd(member_cwd, &teams));
 
         // Unrelated agent outside any team → false.
-        let other_cwd = "C:/repos/foo/.ac-new/wg-9-other-team/__agent_dev-rust";
+        let other_cwd = "C:/repos/foo/.ac/wg-9-other-team/__agent_dev-rust";
         assert!(!is_coordinator_for_cwd(other_cwd, &teams));
     }
 
@@ -1716,7 +1717,7 @@ mod tests {
     #[test]
     fn is_coordinator_for_cwd_empty_teams() {
         let teams: Vec<DiscoveredTeam> = vec![];
-        let cwd = "C:/repos/foo/.ac-new/wg-1-dev-team/__agent_tech-lead";
+        let cwd = "C:/repos/foo/.ac/wg-1-dev-team/__agent_tech-lead";
         assert!(!is_coordinator_for_cwd(cwd, &teams));
     }
 
@@ -1772,9 +1773,9 @@ mod tests {
     fn is_coordinator_for_cwd_project_qualified() {
         let teams = vec![dev_team("proj-a"), dev_team("proj-b")];
         // tech-lead of proj-a's dev-team.
-        let coord_a_cwd = "C:/repos/proj-a/.ac-new/wg-1-dev-team/__agent_tech-lead";
+        let coord_a_cwd = "C:/repos/proj-a/.ac/wg-1-dev-team/__agent_tech-lead";
         // tech-lead of proj-b's dev-team.
-        let coord_b_cwd = "C:/repos/proj-b/.ac-new/wg-1-dev-team/__agent_tech-lead";
+        let coord_b_cwd = "C:/repos/proj-b/.ac/wg-1-dev-team/__agent_tech-lead";
         assert!(is_coordinator_for_cwd(coord_a_cwd, &teams));
         assert!(is_coordinator_for_cwd(coord_b_cwd, &teams));
     }

--- a/src-tauri/src/config/workspace.rs
+++ b/src-tauri/src/config/workspace.rs
@@ -1,34 +1,24 @@
 use std::path::{Path, PathBuf};
 
 pub const CANONICAL_WORKSPACE_DIR: &str = ".ac";
-pub const LEGACY_WORKSPACE_DIR: &str = ".ac-new";
-pub const WORKSPACE_DIR_NAMES: [&str; 2] = [CANONICAL_WORKSPACE_DIR, LEGACY_WORKSPACE_DIR];
+pub const WORKSPACE_DIR_NAMES: [&str; 1] = [CANONICAL_WORKSPACE_DIR];
 
 pub fn canonical_workspace_dir_label() -> &'static str {
     CANONICAL_WORKSPACE_DIR
 }
 
 pub fn workspace_dir_label() -> &'static str {
-    ".ac or legacy .ac-new"
+    ".ac"
 }
 
 pub fn workspace_dir_for_project(project: &Path) -> PathBuf {
     project.join(CANONICAL_WORKSPACE_DIR)
 }
 
-pub fn legacy_workspace_dir_for_project(project: &Path) -> PathBuf {
-    project.join(LEGACY_WORKSPACE_DIR)
-}
-
 pub fn existing_workspace_dir(project: &Path) -> Option<PathBuf> {
     let canonical = workspace_dir_for_project(project);
     if canonical.is_dir() {
         return Some(canonical);
-    }
-
-    let legacy = legacy_workspace_dir_for_project(project);
-    if legacy.is_dir() {
-        return Some(legacy);
     }
 
     None
@@ -101,32 +91,9 @@ pub fn ensure_authoritative_workspace_dir(workspace_dir: &Path) -> Result<(), St
         Ok(())
     } else {
         Err(format!(
-            "stale legacy workspace '{}' rejected because authoritative workspace '{}' exists",
+            "workspace '{}' rejected because authoritative workspace '{}' exists",
             workspace_dir.display(),
             authoritative.display()
         ))
     }
-}
-
-pub fn stale_legacy_workspace_error_for_path(path: &Path) -> Option<String> {
-    let workspace_dir = find_workspace_ancestor(path)?;
-    let workspace_name = workspace_dir.file_name().and_then(|name| name.to_str())?;
-    if !workspace_name.eq_ignore_ascii_case(LEGACY_WORKSPACE_DIR) {
-        return None;
-    }
-    let project_dir = workspace_dir.parent()?;
-    let canonical = workspace_dir_for_project(project_dir);
-    if canonical.is_dir() && !same_existing_path(&workspace_dir, &canonical) {
-        Some(format!(
-            "stale legacy workspace '{}' rejected because authoritative workspace '{}' exists",
-            workspace_dir.display(),
-            canonical.display()
-        ))
-    } else {
-        None
-    }
-}
-
-pub fn path_uses_stale_legacy_workspace(path: &Path) -> bool {
-    stale_legacy_workspace_error_for_path(path).is_some()
 }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -430,16 +430,8 @@ pub(crate) fn filter_sessions_by_fqn<'a>(
         .collect()
 }
 
-fn routable_agent_fqn_from_path(path: &str) -> Option<String> {
-    if crate::config::workspace::path_uses_stale_legacy_workspace(Path::new(path)) {
-        None
-    } else {
-        Some(crate::config::teams::agent_fqn_from_path(path))
-    }
-}
-
 fn session_cwd_matches_fqn(cwd: &str, target: &str) -> bool {
-    routable_agent_fqn_from_path(cwd).as_deref() == Some(target)
+    crate::config::teams::agent_fqn_from_path(cwd) == target
 }
 
 fn resolve_wg_path_from_session_dirs(dirs: &[(Uuid, String)], agent_name: &str) -> Option<String> {
@@ -451,10 +443,6 @@ fn resolve_wg_path_from_session_dirs(dirs: &[(Uuid, String)], agent_name: &str) 
 
     let wg_marker = format!("/{}/", wg_name);
     for (_, cwd) in dirs {
-        if routable_agent_fqn_from_path(cwd).is_none() {
-            continue;
-        }
-
         let normalized = cwd.replace('\\', "/");
         if let Some(wg_pos) = normalized.rfind(&wg_marker) {
             let wg_dir = &normalized[..wg_pos + 1 + wg_name.len()];
@@ -463,9 +451,7 @@ fn resolve_wg_path_from_session_dirs(dirs: &[(Uuid, String)], agent_name: &str) 
                 continue;
             }
 
-            let Some(candidate_fqn) = routable_agent_fqn_from_path(&candidate) else {
-                continue;
-            };
+            let candidate_fqn = crate::config::teams::agent_fqn_from_path(&candidate);
             if let Some(want) = target_project {
                 let (cand_project, _) = crate::config::teams::split_project_prefix(&candidate_fqn);
                 if cand_project != Some(want) {
@@ -2393,9 +2379,7 @@ impl MailboxPoller {
         };
 
         let hits_agent = |cwd: &str| -> bool {
-            let Some(path_fqn) = routable_agent_fqn_from_path(cwd) else {
-                return false;
-            };
+            let path_fqn = crate::config::teams::agent_fqn_from_path(cwd);
             if is_qualified {
                 path_fqn == agent_name
             } else {
@@ -2907,11 +2891,11 @@ mod tests {
     ) -> (tempfile::TempDir, Vec<String>) {
         let temp = tempfile::TempDir::new().unwrap();
         let project = temp.path().join("proj-a");
-        let ac_new = project.join(".ac-new");
-        let team_dir = ac_new.join("_team_dev-team");
-        let origin_tech_lead = ac_new.join("_agent_tech-lead");
-        let origin_dev_rust = ac_new.join("_agent_dev-rust");
-        let wg_dir = ac_new.join("wg-1-dev-team");
+        let workspace_dir = project.join(".ac");
+        let team_dir = workspace_dir.join("_team_dev-team");
+        let origin_tech_lead = workspace_dir.join("_agent_tech-lead");
+        let origin_dev_rust = workspace_dir.join("_agent_dev-rust");
+        let wg_dir = workspace_dir.join("wg-1-dev-team");
         let tech_lead_replica = wg_dir.join("__agent_tech-lead");
         let dev_rust_replica = wg_dir.join("__agent_dev-rust");
 
@@ -2980,7 +2964,7 @@ mod tests {
         );
         assert_eq!(
             sender_name_for_session_cwd_with_root_flag(
-                "C:/tmp/proj-a/.ac-new/wg-1-dev-team/__agent_tech-lead",
+                "C:/tmp/proj-a/.ac/wg-1-dev-team/__agent_tech-lead",
                 false
             ),
             "proj-a:wg-1-dev-team/tech-lead"
@@ -3248,7 +3232,7 @@ mod tests {
         let s = make_session_info(
             "uuid-1",
             "alice",
-            r"C:\proj\.ac-new\wg-1-devs\__agent_alice",
+            r"C:\proj\.ac\wg-1-devs\__agent_alice",
             crate::session::session::SessionStatus::Idle,
             true,
         );
@@ -3267,7 +3251,7 @@ mod tests {
         let s = make_session_info(
             "uuid-1",
             "bob",
-            r"C:\proj\.ac-new\wg-1-devs\__agent_bob",
+            r"C:\proj\.ac\wg-1-devs\__agent_bob",
             crate::session::session::SessionStatus::Active,
             false,
         );
@@ -3284,7 +3268,7 @@ mod tests {
         let mut active = make_session_info(
             "uuid-a",
             "alice-active",
-            r"C:\proj\.ac-new\wg-1-devs\__agent_alice",
+            r"C:\proj\.ac\wg-1-devs\__agent_alice",
             crate::session::session::SessionStatus::Active,
             false,
         );
@@ -3292,14 +3276,14 @@ mod tests {
         let idle = make_session_info(
             "uuid-b",
             "alice-idle",
-            r"C:\proj\.ac-new\wg-1-devs\__agent_alice",
+            r"C:\proj\.ac\wg-1-devs\__agent_alice",
             crate::session::session::SessionStatus::Idle,
             true,
         );
         let exited = make_session_info(
             "uuid-c",
             "alice-exited",
-            r"C:\proj\.ac-new\wg-1-devs\__agent_alice",
+            r"C:\proj\.ac\wg-1-devs\__agent_alice",
             crate::session::session::SessionStatus::Exited(0),
             false,
         );
@@ -3669,7 +3653,7 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let project_dir = temp.path().join("proj-x");
         let outbox = project_dir
-            .join(".ac-new")
+            .join(".ac")
             .join("wg-1-devs")
             .join("__agent_alice")
             .join(".agentscommander") // matches agent_local_dir_name() shape
@@ -3690,54 +3674,22 @@ mod tests {
     }
 
     #[test]
-    fn derive_project_from_outbox_path_rejects_stale_legacy_when_canonical_exists() {
+    fn derive_project_from_outbox_path_accepts_ac_outbox() {
         let temp = tempfile::TempDir::new().unwrap();
         let project_dir = temp.path().join("proj-x");
-        let canonical_outbox = project_dir
+        let outbox = project_dir
             .join(".ac")
             .join("wg-1-devs")
             .join("__agent_alice")
             .join(".agentscommander")
             .join("outbox");
-        let stale_outbox = project_dir
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice")
-            .join(".agentscommander")
-            .join("outbox");
-        std::fs::create_dir_all(&canonical_outbox).unwrap();
-        std::fs::create_dir_all(&stale_outbox).unwrap();
-        let file = stale_outbox.join("msg-42.json");
-        std::fs::write(&file, "{}").unwrap();
-
-        let err = derive_project_from_outbox_path(&file).unwrap_err();
-        assert!(err.contains("stale legacy workspace"));
-    }
-
-    #[test]
-    fn derive_project_from_outbox_path_accepts_canonical_when_both_exist() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let project_dir = temp.path().join("proj-x");
-        let canonical_outbox = project_dir
-            .join(".ac")
-            .join("wg-1-devs")
-            .join("__agent_alice")
-            .join(".agentscommander")
-            .join("outbox");
-        let stale_outbox = project_dir
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice")
-            .join(".agentscommander")
-            .join("outbox");
-        std::fs::create_dir_all(&canonical_outbox).unwrap();
-        std::fs::create_dir_all(&stale_outbox).unwrap();
-        let file = canonical_outbox.join("msg-42.json");
+        std::fs::create_dir_all(&outbox).unwrap();
+        let file = outbox.join("msg-42.json");
         std::fs::write(&file, "{}").unwrap();
 
         let got = derive_project_from_outbox_path(&file)
             .unwrap()
-            .expect("canonical outbox should derive project");
+            .expect(".ac outbox should derive project");
         let expected = std::fs::canonicalize(&project_dir)
             .unwrap()
             .to_str()
@@ -3747,109 +3699,20 @@ mod tests {
     }
 
     #[test]
-    fn stale_legacy_session_path_is_not_routable_when_canonical_exists() {
+    fn filter_sessions_by_fqn_accepts_ac_live_target() {
         let temp = tempfile::TempDir::new().unwrap();
-        let project_dir = temp.path().join("proj-x");
-        let canonical_agent = project_dir
-            .join(".ac")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        let stale_agent = project_dir
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        std::fs::create_dir_all(&canonical_agent).unwrap();
-        std::fs::create_dir_all(&stale_agent).unwrap();
-
-        assert!(!crate::config::workspace::path_uses_stale_legacy_workspace(
-            &canonical_agent
-        ));
-        assert!(crate::config::workspace::path_uses_stale_legacy_workspace(
-            &stale_agent
-        ));
-    }
-
-    #[test]
-    fn filter_sessions_by_fqn_ignores_stale_live_target_when_canonical_exists() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let project_dir = temp.path().join("proj-x");
-        let canonical_agent = project_dir
-            .join(".ac")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        let stale_agent = project_dir
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        std::fs::create_dir_all(&canonical_agent).unwrap();
-        std::fs::create_dir_all(&stale_agent).unwrap();
-
-        let pool = vec![make_session_info(
-            "uuid-stale",
-            "alice-stale",
-            &path_string(&stale_agent),
-            crate::session::session::SessionStatus::Idle,
-            true,
-        )];
-
-        let hits = filter_sessions_by_fqn(&pool, "proj-x:wg-1-devs/alice");
-
-        assert!(hits.is_empty(), "stale legacy live target must be ignored");
-    }
-
-    #[test]
-    fn filter_sessions_by_fqn_prefers_canonical_live_target_when_both_exist() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let project_dir = temp.path().join("proj-x");
-        let canonical_agent = project_dir
-            .join(".ac")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        let stale_agent = project_dir
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        std::fs::create_dir_all(&canonical_agent).unwrap();
-        std::fs::create_dir_all(&stale_agent).unwrap();
-
-        let pool = vec![
-            make_session_info(
-                "uuid-stale",
-                "alice-stale",
-                &path_string(&stale_agent),
-                crate::session::session::SessionStatus::Idle,
-                true,
-            ),
-            make_session_info(
-                "uuid-canonical",
-                "alice-canonical",
-                &path_string(&canonical_agent),
-                crate::session::session::SessionStatus::Idle,
-                true,
-            ),
-        ];
-
-        let hits = filter_sessions_by_fqn(&pool, "proj-x:wg-1-devs/alice");
-
-        assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].id, "uuid-canonical");
-    }
-
-    #[test]
-    fn filter_sessions_by_fqn_accepts_legacy_only_live_target() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let legacy_agent = temp
+        let agent = temp
             .path()
             .join("proj-x")
-            .join(".ac-new")
+            .join(".ac")
             .join("wg-1-devs")
             .join("__agent_alice");
-        std::fs::create_dir_all(&legacy_agent).unwrap();
+        std::fs::create_dir_all(&agent).unwrap();
 
         let pool = vec![make_session_info(
-            "uuid-legacy",
-            "alice-legacy",
-            &path_string(&legacy_agent),
+            "uuid-ac",
+            "alice-ac",
+            &path_string(&agent),
             crate::session::session::SessionStatus::Idle,
             true,
         )];
@@ -3857,103 +3720,54 @@ mod tests {
         let hits = filter_sessions_by_fqn(&pool, "proj-x:wg-1-devs/alice");
 
         assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].id, "uuid-legacy");
+        assert_eq!(hits[0].id, "uuid-ac");
     }
 
     #[test]
-    fn wg_session_fallback_ignores_stale_sibling_when_canonical_exists() {
+    fn wg_session_fallback_returns_none_without_target_agent() {
         let temp = tempfile::TempDir::new().unwrap();
         let project_dir = temp.path().join("proj-x");
-        let canonical_target = project_dir
+        let sibling = project_dir
             .join(".ac")
             .join("wg-1-devs")
-            .join("__agent_alice");
-        let stale_target = project_dir
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        let stale_sibling = project_dir
-            .join(".ac-new")
-            .join("wg-1-devs")
             .join("__agent_bob");
-        std::fs::create_dir_all(&canonical_target).unwrap();
-        std::fs::create_dir_all(&stale_target).unwrap();
-        std::fs::create_dir_all(&stale_sibling).unwrap();
+        std::fs::create_dir_all(&sibling).unwrap();
 
-        let dirs = vec![(Uuid::nil(), path_string(&stale_sibling))];
+        let dirs = vec![(Uuid::nil(), path_string(&sibling))];
 
         assert!(resolve_wg_path_from_session_dirs(&dirs, "proj-x:wg-1-devs/alice").is_none());
     }
 
     #[test]
-    fn wg_session_fallback_returns_canonical_when_stale_sibling_is_first() {
+    fn wg_session_fallback_returns_ac_target_from_sibling() {
         let temp = tempfile::TempDir::new().unwrap();
         let project_dir = temp.path().join("proj-x");
-        let canonical_target = project_dir
+        let target = project_dir
             .join(".ac")
             .join("wg-1-devs")
             .join("__agent_alice");
-        let canonical_sibling = project_dir
+        let sibling = project_dir
             .join(".ac")
             .join("wg-1-devs")
             .join("__agent_bob");
-        let stale_target = project_dir
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        let stale_sibling = project_dir
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_bob");
-        std::fs::create_dir_all(&canonical_target).unwrap();
-        std::fs::create_dir_all(&canonical_sibling).unwrap();
-        std::fs::create_dir_all(&stale_target).unwrap();
-        std::fs::create_dir_all(&stale_sibling).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::create_dir_all(&sibling).unwrap();
 
-        let dirs = vec![
-            (Uuid::nil(), path_string(&stale_sibling)),
-            (Uuid::nil(), path_string(&canonical_sibling)),
-        ];
+        let dirs = vec![(Uuid::nil(), path_string(&sibling))];
 
         let got = resolve_wg_path_from_session_dirs(&dirs, "proj-x:wg-1-devs/alice")
-            .expect("canonical sibling should resolve target");
+            .expect(".ac sibling should resolve target");
 
         assert_eq!(
             std::fs::canonicalize(got).unwrap(),
-            std::fs::canonicalize(canonical_target).unwrap()
-        );
-    }
-
-    #[test]
-    fn wg_session_fallback_accepts_legacy_only_sibling() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let project_dir = temp.path().join("proj-x");
-        let legacy_target = project_dir
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_alice");
-        let legacy_sibling = project_dir
-            .join(".ac-new")
-            .join("wg-1-devs")
-            .join("__agent_bob");
-        std::fs::create_dir_all(&legacy_target).unwrap();
-        std::fs::create_dir_all(&legacy_sibling).unwrap();
-
-        let dirs = vec![(Uuid::nil(), path_string(&legacy_sibling))];
-
-        let got = resolve_wg_path_from_session_dirs(&dirs, "proj-x:wg-1-devs/alice")
-            .expect("legacy-only sibling should resolve target");
-
-        assert_eq!(
-            std::fs::canonicalize(got).unwrap(),
-            std::fs::canonicalize(legacy_target).unwrap()
+            std::fs::canonicalize(target).unwrap()
         );
     }
 
     #[test]
     fn derive_project_from_outbox_path_rejects_non_wg_layout() {
         let temp = tempfile::TempDir::new().unwrap();
-        // A path with the right tail but missing the `.ac-new` ancestor.
+        // A path with the right tail but missing the `.ac` ancestor.
         let outbox = temp
             .path()
             .join("random")
@@ -3988,7 +3802,7 @@ mod tests {
             id: id.to_string(),
             project_path: project_path.to_string_lossy().to_string(),
             agent_path: project_path
-                .join(".ac-new")
+                .join(".ac")
                 .join("_agent_architect")
                 .to_string_lossy()
                 .to_string(),
@@ -4045,7 +3859,7 @@ mod tests {
         let requests_dir = temp.path().join("project-refresh-requests");
         std::fs::create_dir_all(&requests_dir).unwrap();
         let project = temp.path().join("ProjectAlpha");
-        std::fs::create_dir_all(project.join(".ac-new").join("_agent_architect")).unwrap();
+        std::fs::create_dir_all(project.join(".ac").join("_agent_architect")).unwrap();
         write_project_refresh_request_fixture(
             &requests_dir.join("a.json"),
             "request-a",

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -785,7 +785,7 @@ mod tests {
             .create_session(
                 "claude".into(),
                 vec![],
-                "C:\\proj\\.ac-new\\_agent_architect".into(),
+                "C:\\proj\\.ac\\_agent_architect".into(),
                 Some("aid".into()),
                 Some("Architect".into()),
                 vec![],

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -318,23 +318,19 @@ mod tests {
 
     #[test]
     fn find_workgroup_task_path_returns_path_when_cwd_is_workgroup_root() {
-        let p = find_workgroup_task_path_for_cwd(r"C:\proj\.ac-new\wg-3-team");
+        let p = find_workgroup_task_path_for_cwd(r"C:\proj\.ac\wg-3-team");
         assert_eq!(
             p,
-            Some(std::path::PathBuf::from(
-                r"C:\proj\.ac-new\wg-3-team\TASK.md"
-            ))
+            Some(std::path::PathBuf::from(r"C:\proj\.ac\wg-3-team\TASK.md"))
         );
     }
 
     #[test]
     fn find_workgroup_task_path_walks_up_from_replica_dir() {
-        let p = find_workgroup_task_path_for_cwd(r"C:\proj\.ac-new\wg-3-team\__agent_dev-rust");
+        let p = find_workgroup_task_path_for_cwd(r"C:\proj\.ac\wg-3-team\__agent_dev-rust");
         assert_eq!(
             p,
-            Some(std::path::PathBuf::from(
-                r"C:\proj\.ac-new\wg-3-team\TASK.md"
-            ))
+            Some(std::path::PathBuf::from(r"C:\proj\.ac\wg-3-team\TASK.md"))
         );
     }
 
@@ -349,7 +345,7 @@ mod tests {
         // §9.4 strips the prefix downstream when embedding into the prompt.
         // This test documents that the walk-up still finds the wg-* ancestor
         // even when the input carries the prefix.
-        let p = find_workgroup_task_path_for_cwd(r"\\?\C:\proj\.ac-new\wg-3-team");
+        let p = find_workgroup_task_path_for_cwd(r"\\?\C:\proj\.ac\wg-3-team");
         assert!(p.is_some());
         let p = p.unwrap().to_string_lossy().to_string();
         assert!(p.ends_with(r"\wg-3-team\TASK.md"));

--- a/src-tauri/tests/cli_close_session.rs
+++ b/src-tauri/tests/cli_close_session.rs
@@ -119,7 +119,7 @@ fn build_fixture(tmp: &Path, agent: &str) -> Fixture {
     std::fs::write(cfg_dir.join("master-token.txt"), &master).expect("write master token");
 
     // settings.json with projectPaths pointing at <tmp> so enumerate_project_dirs
-    // discovers `<tmp>/proj` (an immediate child containing `.ac-new`).
+    // discovers `<tmp>/proj` (an immediate child containing `.ac`).
     // Required fields (no serde default): defaultShell, defaultShellArgs, agents.
     let settings = serde_json::json!({
         "defaultShell": "powershell.exe",
@@ -135,7 +135,7 @@ fn build_fixture(tmp: &Path, agent: &str) -> Fixture {
 
     let agent_root = tmp
         .join("proj")
-        .join(".ac-new")
+        .join(".ac")
         .join("wg-1-test")
         .join(format!("__agent_{}", agent));
     std::fs::create_dir_all(&agent_root).expect("create agent dir");
@@ -169,8 +169,7 @@ fn simulate_daemon_response(
         if let Ok(rd) = std::fs::read_dir(outbox_dir) {
             let found = rd.flatten().find_map(|entry| {
                 let p = entry.path();
-                (p.is_file() && p.extension().and_then(|s| s.to_str()) == Some("json"))
-                    .then_some(p)
+                (p.is_file() && p.extension().and_then(|s| s.to_str()) == Some("json")).then_some(p)
             });
             if let Some(p) = found {
                 break p;
@@ -214,12 +213,7 @@ fn run_close_session_with_simulator(
     session_ids: &[&str],
     target: &str,
 ) -> (Option<i32>, String, String) {
-    let stem = fix
-        .bin
-        .file_stem()
-        .unwrap()
-        .to_string_lossy()
-        .to_string();
+    let stem = fix.bin.file_stem().unwrap().to_string_lossy().to_string();
     let ac_dir = fix.agent_root.join(format!(".{}", stem));
     let outbox_dir = ac_dir.join("outbox");
     let responses_dir = ac_dir.join("responses");
@@ -297,8 +291,7 @@ fn close_session_no_match_exits_zero_with_prose() {
     let fix = build_fixture(tmp.path(), "bob-not-running");
     let target = "proj:wg-1-test/bob-not-running";
 
-    let (code, stdout, stderr) =
-        run_close_session_with_simulator(&fix, "no_match", 0, &[], target);
+    let (code, stdout, stderr) = run_close_session_with_simulator(&fix, "no_match", 0, &[], target);
 
     assert_eq!(
         code,
@@ -420,12 +413,7 @@ fn close_session_response_via_outbox_relative_path_only() {
     let fix = build_fixture(tmp.path(), "frank-rel-only");
     let target = "proj:wg-1-test/frank-rel-only";
 
-    let stem = fix
-        .bin
-        .file_stem()
-        .unwrap()
-        .to_string_lossy()
-        .to_string();
+    let stem = fix.bin.file_stem().unwrap().to_string_lossy().to_string();
     let responses_dir = fix.agent_root.join(format!(".{}", stem)).join("responses");
 
     let (code, stdout, _stderr) =

--- a/src-tauri/tests/cli_create_agent_matrix.rs
+++ b/src-tauri/tests/cli_create_agent_matrix.rs
@@ -75,9 +75,9 @@ fn settings_with_project_paths(paths: &[&Path]) -> serde_json::Value {
     })
 }
 
-fn project_with_ac_new(tmp: &Path) -> PathBuf {
+fn project_with_workspace(tmp: &Path) -> PathBuf {
     let project = tmp.join("ProjectAlpha");
-    std::fs::create_dir_all(project.join(".ac-new")).expect("create .ac-new");
+    std::fs::create_dir_all(project.join(".ac")).expect("create .ac");
     project
 }
 
@@ -119,7 +119,7 @@ fn assert_single_project_refresh_request(config_dir: &Path, project: &Path) -> s
             .expect("project refresh request json");
     uuid::Uuid::parse_str(request["id"].as_str().expect("id")).expect("id should be a uuid");
     assert!(!request["timestamp"].as_str().expect("timestamp").is_empty());
-    let agent_dir = project.join(".ac-new").join("_agent_architect");
+    let agent_dir = project.join(".ac").join("_agent_architect");
     assert_eq!(
         request["projectPath"].as_str().expect("projectPath"),
         std::fs::canonicalize(project)
@@ -144,7 +144,7 @@ fn create_agent_matrix_success_prints_json_and_writes_layout() {
     let tmp = Tmp::new("cli-create-agent-matrix-success");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
     write_settings(&config_dir, settings_with_project_paths(&[tmp.path()]));
 
     let out = Command::new(&bin)
@@ -170,7 +170,7 @@ fn create_agent_matrix_success_prints_json_and_writes_layout() {
 
     let json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
-    let agent_dir = project.join(".ac-new").join("_agent_architect");
+    let agent_dir = project.join(".ac").join("_agent_architect");
     assert_eq!(
         json["agentPath"].as_str().expect("agentPath"),
         agent_dir.to_string_lossy().as_ref()
@@ -203,7 +203,7 @@ fn create_agent_matrix_resolves_project_name_from_settings_for_unrelated_root() 
             "projectPaths": [tmp.path().to_string_lossy().to_string()]
         }),
     );
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
     let root = tmp.path().join("root-agent");
     std::fs::create_dir_all(&root).expect("root dir");
     let root_s = root.to_string_lossy().to_string();
@@ -235,7 +235,7 @@ fn create_agent_matrix_resolves_project_name_from_settings_for_unrelated_root() 
 
     let json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
-    let agent_dir = project.join(".ac-new").join("_agent_architect");
+    let agent_dir = project.join(".ac").join("_agent_architect");
     assert_eq!(
         json["agentPath"].as_str().expect("agentPath"),
         agent_dir.to_string_lossy().as_ref()
@@ -254,8 +254,8 @@ fn create_agent_matrix_rejects_ambiguous_project_name_without_writing() {
     let parent_b = tmp.path().join("b");
     let project_a = parent_a.join("ProjectAlpha");
     let project_b = parent_b.join("ProjectAlpha");
-    std::fs::create_dir_all(project_a.join(".ac-new")).expect("project a");
-    std::fs::create_dir_all(project_b.join(".ac-new")).expect("project b");
+    std::fs::create_dir_all(project_a.join(".ac")).expect("project a");
+    std::fs::create_dir_all(project_b.join(".ac")).expect("project b");
     write_settings(
         &config_dir,
         serde_json::json!({
@@ -291,8 +291,8 @@ fn create_agent_matrix_rejects_ambiguous_project_name_without_writing() {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("ambiguous"));
-    assert!(!project_a.join(".ac-new").join("_agent_architect").exists());
-    assert!(!project_b.join(".ac-new").join("_agent_architect").exists());
+    assert!(!project_a.join(".ac").join("_agent_architect").exists());
+    assert!(!project_b.join(".ac").join("_agent_architect").exists());
     assert!(project_refresh_request_paths(&config_dir).is_empty());
 }
 
@@ -310,7 +310,7 @@ fn create_agent_project_mode_requires_description() {
             "projectPaths": [tmp.path().to_string_lossy().to_string()]
         }),
     );
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
 
     let out = Command::new(&bin)
         .args([
@@ -330,7 +330,7 @@ fn create_agent_project_mode_requires_description() {
         String::from_utf8_lossy(&out.stderr)
     );
     assert!(String::from_utf8_lossy(&out.stderr).contains("required"));
-    assert!(!project.join(".ac-new").join("_agent_architect").exists());
+    assert!(!project.join(".ac").join("_agent_architect").exists());
 }
 
 #[test]
@@ -370,7 +370,7 @@ fn create_agent_rejects_project_path_input_without_writing() {
     let tmp = Tmp::new("cli-create-agent-reject-project-path");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
     write_settings(&config_dir, settings_with_project_paths(&[tmp.path()]));
     let project_path = project.to_string_lossy().to_string();
 
@@ -395,7 +395,7 @@ fn create_agent_rejects_project_path_input_without_writing() {
         String::from_utf8_lossy(&out.stderr)
     );
     assert!(String::from_utf8_lossy(&out.stderr).contains("was not found"));
-    assert!(!project.join(".ac-new").join("_agent_architect").exists());
+    assert!(!project.join(".ac").join("_agent_architect").exists());
     assert!(project_refresh_request_paths(&config_dir).is_empty());
 }
 
@@ -404,7 +404,7 @@ fn create_agent_matrix_rejects_project_path_input_without_writing() {
     let tmp = Tmp::new("cli-create-agent-matrix-reject-project-path");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
     write_settings(&config_dir, settings_with_project_paths(&[tmp.path()]));
     let project_path = project.to_string_lossy().to_string();
 
@@ -429,7 +429,7 @@ fn create_agent_matrix_rejects_project_path_input_without_writing() {
         String::from_utf8_lossy(&out.stderr)
     );
     assert!(String::from_utf8_lossy(&out.stderr).contains("was not found"));
-    assert!(!project.join(".ac-new").join("_agent_architect").exists());
+    assert!(!project.join(".ac").join("_agent_architect").exists());
     assert!(project_refresh_request_paths(&config_dir).is_empty());
 }
 
@@ -438,7 +438,7 @@ fn create_agent_matrix_success_writes_project_refresh_request() {
     let tmp = Tmp::new("cli-create-agent-matrix-success-refresh");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
     write_settings(&config_dir, settings_with_project_paths(&[tmp.path()]));
 
     let out = Command::new(&bin)
@@ -472,10 +472,10 @@ fn create_agent_matrix_project_name_resolves_from_settings_not_cwd() {
     let config_dir = config_dir_for_bin(&bin);
     let registered_parent = tmp.path().join("registered");
     let registered_project = registered_parent.join("ProjectAlpha");
-    std::fs::create_dir_all(registered_project.join(".ac-new")).expect("registered project");
+    std::fs::create_dir_all(registered_project.join(".ac")).expect("registered project");
     let caller_cwd = tmp.path().join("caller-cwd");
     let cwd_project = caller_cwd.join("ProjectAlpha");
-    std::fs::create_dir_all(cwd_project.join(".ac-new")).expect("cwd project");
+    std::fs::create_dir_all(cwd_project.join(".ac")).expect("cwd project");
     write_settings(
         &config_dir,
         serde_json::json!({
@@ -510,8 +510,8 @@ fn create_agent_matrix_project_name_resolves_from_settings_not_cwd() {
 
     let json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
-    let registered_agent_dir = registered_project.join(".ac-new").join("_agent_architect");
-    let cwd_agent_dir = cwd_project.join(".ac-new").join("_agent_architect");
+    let registered_agent_dir = registered_project.join(".ac").join("_agent_architect");
+    let cwd_agent_dir = cwd_project.join(".ac").join("_agent_architect");
     assert_eq!(
         json["agentPath"].as_str().expect("agentPath"),
         registered_agent_dir.to_string_lossy().as_ref()
@@ -529,7 +529,7 @@ fn create_agent_project_mode_delegates_to_matrix_creation() {
     let tmp = Tmp::new("cli-create-agent-project-mode");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
     write_settings(
         &config_dir,
         serde_json::json!({
@@ -563,7 +563,7 @@ fn create_agent_project_mode_delegates_to_matrix_creation() {
 
     let json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
-    let agent_dir = project.join(".ac-new").join("_agent_architect");
+    let agent_dir = project.join(".ac").join("_agent_architect");
     assert_eq!(
         json["agentPath"].as_str().expect("agentPath"),
         agent_dir.to_string_lossy().as_ref()
@@ -584,7 +584,7 @@ fn create_agent_matrix_local_template_writes_role_and_skills() {
     let tmp = Tmp::new("cli-create-agent-matrix-local-template");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
     write_settings(&config_dir, settings_with_project_paths(&[tmp.path()]));
     let template_dir = config_dir.join("agent-templates").join("planner");
     std::fs::create_dir_all(template_dir.join("skills").join("demo"))
@@ -623,7 +623,7 @@ fn create_agent_matrix_local_template_writes_role_and_skills() {
         String::from_utf8_lossy(&out.stderr)
     );
 
-    let agent_dir = project.join(".ac-new").join("_agent_architect");
+    let agent_dir = project.join(".ac").join("_agent_architect");
     let role = std::fs::read_to_string(agent_dir.join("Role.md")).expect("read Role.md");
     assert!(role.contains("## Role Profile"));
     assert!(role.contains("# Planner Template"));
@@ -639,7 +639,7 @@ fn create_agent_matrix_invalid_template_exits_1_without_target_dir() {
     let tmp = Tmp::new("cli-create-agent-matrix-invalid-template");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
     write_settings(&config_dir, settings_with_project_paths(&[tmp.path()]));
 
     let out = Command::new(&bin)
@@ -666,7 +666,7 @@ fn create_agent_matrix_invalid_template_exits_1_without_target_dir() {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("Unknown built-in role template"));
-    assert!(!project.join(".ac-new").join("_agent_architect").exists());
+    assert!(!project.join(".ac").join("_agent_architect").exists());
     assert!(
         project_refresh_request_paths(&config_dir).is_empty(),
         "invalid template must not write a project refresh request"
@@ -678,7 +678,7 @@ fn create_agent_matrix_honors_settings_flags() {
     let tmp = Tmp::new("cli-create-agent-matrix-settings");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
     write_settings(
         &config_dir,
         serde_json::json!({
@@ -718,7 +718,7 @@ fn create_agent_matrix_honors_settings_flags() {
     );
 
     let settings_path = project
-        .join(".ac-new")
+        .join(".ac")
         .join("_agent_architect")
         .join(".claude")
         .join("settings.local.json");
@@ -732,7 +732,7 @@ fn create_agent_matrix_launch_writes_session_request() {
     let tmp = Tmp::new("cli-create-agent-matrix-launch");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
     write_settings(
         &config_dir,
         serde_json::json!({
@@ -782,7 +782,7 @@ fn create_agent_matrix_launch_writes_session_request() {
     let request: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&requests[0]).expect("read request"))
             .expect("request json");
-    let agent_dir = project.join(".ac-new").join("_agent_architect");
+    let agent_dir = project.join(".ac").join("_agent_architect");
     assert_eq!(
         request["cwd"].as_str().expect("cwd"),
         agent_dir.to_string_lossy().as_ref()
@@ -798,7 +798,7 @@ fn create_agent_matrix_whitespace_launch_command_warns_without_request() {
     let tmp = Tmp::new("cli-create-agent-matrix-blank-launch");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let _project = project_with_ac_new(tmp.path());
+    let _project = project_with_workspace(tmp.path());
     write_settings(
         &config_dir,
         serde_json::json!({
@@ -853,7 +853,7 @@ fn create_agent_matrix_empty_launch_request_warns_without_request() {
     let tmp = Tmp::new("cli-create-agent-matrix-empty-launch-request");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let _project = project_with_ac_new(tmp.path());
+    let _project = project_with_workspace(tmp.path());
     write_settings(
         &config_dir,
         serde_json::json!({
@@ -908,7 +908,7 @@ fn create_agent_project_mode_blank_launch_command_warns_without_request() {
     let tmp = Tmp::new("cli-create-agent-project-blank-launch");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let project = project_with_ac_new(tmp.path());
+    let project = project_with_workspace(tmp.path());
     write_settings(
         &config_dir,
         serde_json::json!({
@@ -953,7 +953,7 @@ fn create_agent_project_mode_blank_launch_command_warns_without_request() {
     assert!(json["launchAgent"].is_null());
     assert_eq!(json["agentName"], "ProjectAlpha/architect");
     assert!(String::from_utf8_lossy(&out.stderr).contains("empty command"));
-    assert!(project.join(".ac-new").join("_agent_architect").is_dir());
+    assert!(project.join(".ac").join("_agent_architect").is_dir());
     assert!(
         session_request_paths(&config_dir).is_empty(),
         "blank command must not write a launch request"

--- a/src-tauri/tests/cli_task_logger.rs
+++ b/src-tauri/tests/cli_task_logger.rs
@@ -64,7 +64,7 @@ fn copy_binary_into(tmp: &Path) -> PathBuf {
 fn make_wg_fixture(tmp: &Path) -> PathBuf {
     let agent_root = tmp
         .join("proj")
-        .join(".ac-new")
+        .join(".ac")
         .join("wg-1-test")
         .join("__agent_alice");
     std::fs::create_dir_all(&agent_root).expect("create agent root");

--- a/src-tauri/tests/cli_workgroup_team.rs
+++ b/src-tauri/tests/cli_workgroup_team.rs
@@ -55,10 +55,10 @@ fn write_settings(config_dir: &Path, project_parent: &Path) {
 
 fn project_with_agents(tmp: &Path, agents: &[&str]) -> PathBuf {
     let project = tmp.join("ProjectAlpha");
-    let ac_new = project.join(".ac-new");
-    std::fs::create_dir_all(&ac_new).expect("create .ac-new");
+    let workspace_dir = project.join(".ac");
+    std::fs::create_dir_all(&workspace_dir).expect("create .ac");
     for agent in agents {
-        let dir = ac_new.join(format!("_agent_{}", agent));
+        let dir = workspace_dir.join(format!("_agent_{}", agent));
         std::fs::create_dir_all(dir.join("memory")).expect("agent memory");
         std::fs::write(dir.join("Role.md"), format!("# {}\n", agent)).expect("role");
     }
@@ -119,7 +119,7 @@ fn workgroup_add_creates_task_messaging_replicas_and_lists() {
         ],
     );
 
-    let wg_dir = project.join(".ac-new").join("wg-1-dev-team");
+    let wg_dir = project.join(".ac").join("wg-1-dev-team");
     assert_eq!(json["path"], wg_dir.to_string_lossy().as_ref());
     assert!(wg_dir.join("TASK.md").is_file());
     assert!(wg_dir.join("messaging").is_dir());
@@ -132,7 +132,7 @@ fn workgroup_add_creates_task_messaging_replicas_and_lists() {
         .join("config.json")
         .is_file());
     let team_config_path = project
-        .join(".ac-new")
+        .join(".ac")
         .join("_team_dev-team")
         .join("config.json");
     let team_config: serde_json::Value =
@@ -159,7 +159,7 @@ fn workgroup_add_uses_global_lowest_free_number() {
     let config_dir = config_dir_for_bin(&bin);
     write_settings(&config_dir, tmp.path());
     let project = project_with_agents(tmp.path(), &["architect"]);
-    std::fs::create_dir_all(project.join(".ac-new").join("wg-1-dev-team")).expect("wg1");
+    std::fs::create_dir_all(project.join(".ac").join("wg-1-dev-team")).expect("wg1");
 
     let json = run_json(
         &bin,
@@ -206,7 +206,7 @@ fn workgroup_remove_deletes_and_reuses_number() {
             "architect",
         ],
     );
-    let wg_dir = project.join(".ac-new").join("wg-1-dev-team");
+    let wg_dir = project.join(".ac").join("wg-1-dev-team");
     assert_eq!(created["path"], wg_dir.to_string_lossy().as_ref());
     assert!(wg_dir.is_dir());
 
@@ -280,7 +280,7 @@ fn workgroup_add_normalizes_include_and_exclude_repo_assignments() {
     );
 
     let config_path = project
-        .join(".ac-new")
+        .join(".ac")
         .join("_team_dev-team")
         .join("config.json");
     let config: serde_json::Value =
@@ -341,14 +341,14 @@ fn team_add_member_creates_replica_and_peer_is_reachable() {
         ],
     );
     let replica = project
-        .join(".ac-new")
+        .join(".ac")
         .join("wg-1-dev-team")
         .join("__agent_dev-rust");
     assert_eq!(added["added"], true);
     assert!(replica.join("config.json").is_file());
 
     let sender_root = project
-        .join(".ac-new")
+        .join(".ac")
         .join("wg-1-dev-team")
         .join("__agent_architect");
     let out = Command::new(&bin)

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,8 +1,7 @@
 export const NO_TEAM = "__no_team__";
 
 export const AC_WORKSPACE_DIR = ".ac";
-export const LEGACY_AC_WORKSPACE_DIR = ".ac-new";
-export const AC_WORKSPACE_DIRS = [AC_WORKSPACE_DIR, LEGACY_AC_WORKSPACE_DIR] as const;
+export const AC_WORKSPACE_DIRS = [AC_WORKSPACE_DIR] as const;
 
 export const WINDOW_TYPE = (() => {
   const search = typeof window === "undefined" ? "" : window.location.search;

--- a/src/shared/path-extractors.test.ts
+++ b/src/shared/path-extractors.test.ts
@@ -28,13 +28,6 @@ describe('path-extractors', () => {
     expect(extractAgentName(w)).toBeNull();
   });
 
-  it('legacy_ac_new_only_returns_project_only', () => {
-    const w = 'C:\\foo\\.ac-new';
-    expect(extractProjectName(w)).toBe('foo');
-    expect(extractWorkgroupName(w)).toBeNull();
-    expect(extractAgentName(w)).toBeNull();
-  });
-
   it('agent_in_wg_returns_all_three', () => {
     const w = 'C:\\foo\\.ac\\wg-19-dev-team\\__agent_tech-lead';
     expect(extractProjectName(w)).toBe('foo');
@@ -42,29 +35,22 @@ describe('path-extractors', () => {
     expect(extractAgentName(w)).toBe('tech-lead');
   });
 
-  it('legacy_agent_in_wg_returns_all_three', () => {
-    const w = 'C:\\foo\\.ac-new\\wg-19-dev-team\\__agent_tech-lead';
-    expect(extractProjectName(w)).toBe('foo');
-    expect(extractWorkgroupName(w)).toBe('WG-19-DEV-TEAM');
-    expect(extractAgentName(w)).toBe('tech-lead');
-  });
-
   it('repo_in_wg_returns_project_and_wg_no_agent', () => {
-    const w = 'C:\\foo\\.ac-new\\wg-19-dev-team\\repo-X';
+    const w = 'C:\\foo\\.ac\\wg-19-dev-team\\repo-X';
     expect(extractProjectName(w)).toBe('foo');
     expect(extractWorkgroupName(w)).toBe('WG-19-DEV-TEAM');
     expect(extractAgentName(w)).toBeNull();
   });
 
   it('bare_underscore_agent_returns_no_agent', () => {
-    const w = 'C:\\foo\\.ac-new\\wg-1\\__agent_';
+    const w = 'C:\\foo\\.ac\\wg-1\\__agent_';
     expect(extractProjectName(w)).toBe('foo');
     expect(extractWorkgroupName(w)).toBe('WG-1');
     expect(extractAgentName(w)).toBeNull();
   });
 
   it('nested_workspace_uses_innermost', () => {
-    const w = 'C:\\proj\\.ac-new\\wg-1-outer\\repo-AC\\.ac\\wg-2-inner\\__agent_alice';
+    const w = 'C:\\proj\\.ac\\wg-1-outer\\repo-AC\\.ac\\wg-2-inner\\__agent_alice';
     expect(extractProjectName(w)).toBe('repo-AC');
     expect(extractWorkgroupName(w)).toBe('WG-2-INNER');
     expect(extractAgentName(w)).toBe('alice');
@@ -78,21 +64,21 @@ describe('path-extractors', () => {
   });
 
   it('trailing_slash_handled', () => {
-    const w = 'C:\\foo\\.ac-new\\wg-1\\__agent_x\\';
+    const w = 'C:\\foo\\.ac\\wg-1\\__agent_x\\';
     expect(extractProjectName(w)).toBe('foo');
     expect(extractWorkgroupName(w)).toBe('WG-1');
     expect(extractAgentName(w)).toBe('x');
   });
 
   it('lax_wg_segment_rejected_no_digits', () => {
-    const w = 'C:\\foo\\.ac-new\\wg-foo\\__agent_x';
+    const w = 'C:\\foo\\.ac\\wg-foo\\__agent_x';
     expect(extractProjectName(w)).toBe('foo');
     expect(extractWorkgroupName(w)).toBeNull();
     expect(extractAgentName(w)).toBe('x');
   });
 
   it('lax_wg_segment_rejected_bare_dash', () => {
-    const w = 'C:\\foo\\.ac-new\\wg-\\__agent_x';
+    const w = 'C:\\foo\\.ac\\wg-\\__agent_x';
     expect(extractProjectName(w)).toBe('foo');
     expect(extractWorkgroupName(w)).toBeNull();
     expect(extractAgentName(w)).toBe('x');
@@ -108,13 +94,13 @@ describe('path-extractors', () => {
 
 describe('computeTrailingText', () => {
   it('project_and_agent_returns_agent_at_project', () => {
-    const w = 'C:\\foo\\.ac-new\\wg-19-dev-team\\__agent_alice';
+    const w = 'C:\\foo\\.ac\\wg-19-dev-team\\__agent_alice';
     expect(computeTrailingText(w, null)).toBe('alice@foo');
     expect(computeTrailingText(w, 'session-x')).toBe('alice@foo');
   });
 
   it('agent_only_returns_agent', () => {
-    const w = '\\.ac-new\\wg-1\\__agent_alice';
+    const w = '\\.ac\\wg-1\\__agent_alice';
     expect(extractProjectName(w)).toBeNull();
     expect(extractAgentName(w)).toBe('alice');
     expect(computeTrailingText(w, null)).toBe('alice');
@@ -122,7 +108,7 @@ describe('computeTrailingText', () => {
   });
 
   it('project_and_session_no_agent_returns_session_at_project', () => {
-    const w = 'C:\\foo\\.ac-new\\wg-1\\repo-X';
+    const w = 'C:\\foo\\.ac\\wg-1\\repo-X';
     expect(extractProjectName(w)).toBe('foo');
     expect(extractAgentName(w)).toBeNull();
     expect(computeTrailingText(w, 'my-session')).toBe('my-session@foo');
@@ -142,8 +128,8 @@ describe('computeTrailingText', () => {
     expect(computeTrailingText('C:\\nothing', null)).toBeNull();
   });
 
-  it('nested_ac_new_uses_innermost_for_trailing', () => {
-    const w = 'C:\\proj\\.ac-new\\wg-1-outer\\repo-AC\\.ac-new\\wg-2-inner\\__agent_alice';
+  it('nested_workspace_uses_innermost_for_trailing', () => {
+    const w = 'C:\\proj\\.ac\\wg-1-outer\\repo-AC\\.ac\\wg-2-inner\\__agent_alice';
     expect(computeTrailingText(w, null)).toBe('alice@repo-AC');
   });
 });

--- a/src/shared/path-extractors.ts
+++ b/src/shared/path-extractors.ts
@@ -1,4 +1,4 @@
-import { AC_WORKSPACE_DIR, LEGACY_AC_WORKSPACE_DIR } from './constants';
+import { AC_WORKSPACE_DIR } from './constants';
 
 function pathParts(workDir: string): string[] {
   return workDir.replace(/\\/g, '/').split('/').filter(s => s.length > 0);
@@ -6,7 +6,7 @@ function pathParts(workDir: string): string[] {
 
 function lastWorkspaceIndex(parts: string[]): number {
   for (let i = parts.length - 1; i >= 0; i--) {
-    if (parts[i] === AC_WORKSPACE_DIR || parts[i] === LEGACY_AC_WORKSPACE_DIR) return i;
+    if (parts[i] === AC_WORKSPACE_DIR) return i;
   }
   return -1;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -230,7 +230,7 @@ export interface AgentInfo {
   isCoordinatorOf: string[];
 }
 
-// AC-new discovery types
+// AC discovery types
 
 export interface AcAgentMatrix {
   name: string;

--- a/src/sidebar/components/ActionBar.tsx
+++ b/src/sidebar/components/ActionBar.tsx
@@ -75,9 +75,9 @@ const ActionBar: Component = () => {
     setShowDropdown(false);
     setIsPendingDialog(true);
     try {
-      const { picked, hasAcNew } = await projectStore.pickAndCheck();
+      const { picked, hasWorkspace } = await projectStore.pickAndCheck();
       if (!picked) return;
-      if (!hasAcNew) {
+      if (!hasWorkspace) {
         await projectStore.createAndLoad(picked);
       }
     } finally {
@@ -97,11 +97,11 @@ const ActionBar: Component = () => {
     try {
       const picked = await open({ directory: true, title: "Select AC Project Folder" });
       if (!picked) return;
-      const hasAcNew = await ProjectAPI.checkPath(picked);
-      if (hasAcNew) {
+      const hasWorkspace = await ProjectAPI.checkPath(picked);
+      if (hasWorkspace) {
         await projectStore.loadProject(picked);
       } else {
-        showToast("No AC project found in this folder (.ac/ not found; legacy .ac-new/ also supported)");
+        showToast("No AC project found in this folder (.ac/ not found)");
       }
     } finally {
       setIsPendingDialog(false);

--- a/src/sidebar/components/EditTeamModal.tsx
+++ b/src/sidebar/components/EditTeamModal.tsx
@@ -1,6 +1,6 @@
 import { Component, createSignal, createMemo, For, Show, onMount } from "solid-js";
 import { EntityAPI } from "../../shared/ipc";
-import { LEGACY_AC_WORKSPACE_DIR } from "../../shared/constants";
+import { AC_WORKSPACE_DIR } from "../../shared/constants";
 import { projectStore } from "../stores/project";
 import type { AcTeam, TeamWizardAgentEntry, TeamWizardRepoEntry, TeamWizardStep } from "../../shared/types";
 
@@ -86,7 +86,7 @@ const EditTeamModal: Component<{
         if (!discoveredRefs.has(agentRef)) {
           const agentName = agentRef.replace(/^_agent_/, "");
           const fallbackPath =
-            `${props.projectPath.replace(/[\\/]+$/, "")}/${LEGACY_AC_WORKSPACE_DIR}/${agentRef}`;
+            `${props.projectPath.replace(/[\\/]+$/, "")}/${AC_WORKSPACE_DIR}/${agentRef}`;
           entries.push({
             name: agentName,
             path: fallbackPath,

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -247,7 +247,7 @@ const SessionItem: Component<{
    *  Other paths: "parentFolder/name" (last 2 segments)
    *
    *  Workspace parsing is delegated to extractProjectName. The innermost
-   *  .ac or legacy .ac-new segment wins, matching the titlebar helpers. */
+   *  .ac segment wins, matching the titlebar helpers. */
   const displayName = () => {
     const wd = props.session.workingDirectory;
     if (wd) {

--- a/src/sidebar/components/Toolbar.tsx
+++ b/src/sidebar/components/Toolbar.tsx
@@ -9,9 +9,9 @@ const Toolbar: Component = () => {
   const [confirmPath, setConfirmPath] = createSignal<string | null>(null);
 
   const handleOpenProject = async () => {
-    const { picked, hasAcNew } = await projectStore.pickAndCheck();
+    const { picked, hasWorkspace } = await projectStore.pickAndCheck();
     if (!picked) return;
-    if (!hasAcNew) {
+    if (!hasWorkspace) {
       setConfirmPath(picked);
     }
   };

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -46,7 +46,7 @@ export const projectStore = {
     setLoading(true);
     try {
       // #191 — backend owns the validation + dedup + persist atomically.
-      // Throws if `.ac/` and legacy `.ac-new/` are missing; caller (createAndLoad / pickAndCheck)
+      // Throws if `.ac/` is missing; caller (createAndLoad / pickAndCheck)
       // is responsible for creating it first via projectStore.createAndLoad
       // when that case is expected.
       const reg = await ProjectAPI.open(path);
@@ -120,15 +120,15 @@ export const projectStore = {
   },
 
   /** Full open flow: pick folder, check workspace, auto-load if found */
-  async pickAndCheck(): Promise<{ picked: string | null; hasAcNew: boolean }> {
+  async pickAndCheck(): Promise<{ picked: string | null; hasWorkspace: boolean }> {
     const picked = await AgentCreatorAPI.pickFolder();
-    if (!picked) return { picked: null, hasAcNew: false };
+    if (!picked) return { picked: null, hasWorkspace: false };
 
-    const hasAcNew = await ProjectAPI.checkPath(picked);
-    if (hasAcNew) {
+    const hasWorkspace = await ProjectAPI.checkPath(picked);
+    if (hasWorkspace) {
       await projectStore.loadProject(picked);
     }
-    return { picked, hasAcNew };
+    return { picked, hasWorkspace };
   },
 
   /** Update a replica's branch from the discovery branch watcher */


### PR DESCRIPTION
## Summary
- Make `.ac` the only recognized workspace directory across Rust workspace helpers, project open/create/discovery, team/workgroup, messaging/mailbox, session context, replica identity, and persistence paths.
- Remove the legacy `.ac-new` fallback semantics and stale legacy helper/test behavior instead of tolerating them as compatibility paths.
- Update frontend path extraction/sidebar labels, distribution script defaults, `.gitignore`, README, docs, and generated guidance references to use `.ac` only.

Closes #382.

## Issue 300
Issue #300 is now superseded and closed as `not_planned`. Its original fallback criterion conflicts with this initiative, so the PR follows the new rule: no `.ac-new` fallback, docs, generated fixtures, or legacy runtime acceptance.

## Verification
- `rg -n -i --hidden -g '!node_modules/**' -g '!target/**' -g '!dist/**' -g '!build/**' -g '!coverage/**' -g '!*.lock' -g '!.git/**' "\.ac-new|ac-new|ac_new|AcNew|legacy_ac_new|#300"` returns no matches.
- `npm run build` passed.
- `npm run test -- --run src/shared/path-extractors.test.ts` passed, 18 tests.
- `cargo test --lib --tests` passed; library tests reported 833 passed, 12 ignored, and targeted integration tests passed.
- `git diff --check` passed.

Note: plain `cargo test` ran unit/integration tests successfully but failed at doctests because this Windows toolchain reports `rustdoc.exe` is not applicable to `stable-x86_64-pc-windows-msvc`. Dev-rust also reported `cargo check`, `cargo clippy --all-targets`, `cargo test --lib`, and targeted CLI tests passing for the backend scope.