### PR TITLE
fix(messaging): normalize wake agent commands (#374)

### DIFF
--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -81,27 +81,27 @@ pub(crate) fn build_session_request(
     session_name: String,
     agent: &crate::config::settings::AgentConfig,
 ) -> Result<SessionRequest, String> {
-    let command = agent.command.trim();
+    let command = agent
+        .command
+        .trim_matches(|c: char| c.is_ascii_whitespace());
     if command.is_empty() {
         return Err(format!("launch agent '{}' has an empty command", agent.id));
     }
 
-    let parts: Vec<&str> = command.split_whitespace().collect();
     let (shell, shell_args) = if agent.git_pull_before {
         (
             "cmd.exe".to_string(),
             vec!["/K".to_string(), format!("git pull && {}", command)],
         )
     } else {
-        (
-            parts.first().copied().unwrap_or_default().to_string(),
-            parts
-                .get(1..)
-                .unwrap_or(&[])
-                .iter()
-                .map(|s| s.to_string())
-                .collect(),
-        )
+        let normalized = crate::config::agent_command::normalize_legacy_agent_command(command)
+            .map_err(|e| {
+                format!(
+                    "launch agent '{}' has an invalid command: {}. command={:?}",
+                    agent.id, e, agent.command
+                )
+            })?;
+        (normalized.shell, normalized.shell_args)
     };
 
     Ok(SessionRequest {
@@ -165,16 +165,18 @@ mod tests {
 
     #[test]
     fn find_launch_agent_matches_id_label_substring_and_command_prefix() {
-        let mut settings = AppSettings::default();
-        settings.agents = vec![
-            agent("codex", "OpenAI Codex", "codex"),
-            agent(
-                "claude",
-                "Claude Desktop",
-                "claude --dangerously-skip-permissions",
-            ),
-            agent("pwsh", "PowerShell", "powershell.exe -NoLogo"),
-        ];
+        let settings = AppSettings {
+            agents: vec![
+                agent("codex", "OpenAI Codex", "codex"),
+                agent(
+                    "claude",
+                    "Claude Desktop",
+                    "claude --dangerously-skip-permissions",
+                ),
+                agent("pwsh", "PowerShell", "powershell.exe -NoLogo"),
+            ],
+            ..AppSettings::default()
+        };
 
         assert_eq!(
             find_launch_agent(&settings, "CODEX").map(|a| a.id.as_str()),
@@ -200,11 +202,13 @@ mod tests {
 
     #[test]
     fn find_launch_agent_rejects_empty_and_whitespace_requests() {
-        let mut settings = AppSettings::default();
-        settings.agents = vec![
-            agent("codex", "OpenAI Codex", "codex"),
-            agent("claude", "Claude Desktop", "claude"),
-        ];
+        let settings = AppSettings {
+            agents: vec![
+                agent("codex", "OpenAI Codex", "codex"),
+                agent("claude", "Claude Desktop", "claude"),
+            ],
+            ..AppSettings::default()
+        };
 
         assert!(find_launch_agent(&settings, "").is_none());
         assert!(find_launch_agent(&settings, "   \t  ").is_none());
@@ -233,6 +237,52 @@ mod tests {
                 "git pull && codex --ask-for-approval never".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn build_session_request_preserves_agent_args_from_command() {
+        let launch_agent = agent("codex-yolo", "Codex Yolo", "codex --yolo");
+        let request = build_session_request(
+            "C:/repo/.ac/_agent_architect".to_string(),
+            "repo/architect".to_string(),
+            &launch_agent,
+        )
+        .unwrap();
+
+        assert_eq!(request.shell, "codex");
+        assert_eq!(request.shell_args, vec!["--yolo"]);
+    }
+
+    #[test]
+    fn build_session_request_supports_quoted_executable_path() {
+        let launch_agent = agent(
+            "codex-local",
+            "Codex Local",
+            "\"C:\\Program Files\\Codex\\codex.exe\" --yolo",
+        );
+        let request = build_session_request(
+            "C:/repo/.ac/_agent_architect".to_string(),
+            "repo/architect".to_string(),
+            &launch_agent,
+        )
+        .unwrap();
+
+        assert_eq!(request.shell, "C:\\Program Files\\Codex\\codex.exe");
+        assert_eq!(request.shell_args, vec!["--yolo"]);
+    }
+
+    #[test]
+    fn build_session_request_rejects_invalid_quoted_command() {
+        let launch_agent = agent("codex", "Codex", "codex \"unterminated");
+        let err = build_session_request(
+            "C:/repo/.ac/_agent_architect".to_string(),
+            "repo/architect".to_string(),
+            &launch_agent,
+        )
+        .unwrap_err();
+
+        assert!(err.contains("codex"));
+        assert!(err.contains("unclosed double quote"));
     }
 
     #[test]

--- a/src-tauri/src/cli/send.rs
+++ b/src-tauri/src/cli/send.rs
@@ -51,7 +51,7 @@ pub struct SendArgs {
     #[arg(long)]
     pub command: Option<String>,
 
-    /// Agent CLI to use when `wake` spawns a new persistent session for
+    /// Configured agent id to use when `wake` spawns a new persistent session for
     /// the destination. `auto` picks the session's saved `lastCodingAgent`.
     #[arg(long, default_value = "auto")]
     pub agent: String,

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1077,7 +1077,7 @@ pub async fn create_session(
 
     // If agentId provided and shell not explicitly set, use that agent's command
     let (shell, shell_args, agent_label) = match (&shell, &agent_id) {
-        (None, Some(aid)) => resolve_agent_command(aid, &cfg),
+        (None, Some(aid)) => resolve_agent_command(aid, &cfg)?,
         _ => {
             let s = shell.unwrap_or_else(|| cfg.default_shell.clone());
             let sa = shell_args.unwrap_or_else(|| cfg.default_shell_args.clone());
@@ -1553,7 +1553,7 @@ pub async fn restart_session(
     let requested_agent_id = agent_id;
     let (shell, shell_args, agent_label) = if let Some(ref aid) = requested_agent_id {
         let cfg = settings.read().await;
-        let resolved = resolve_agent_command(aid, &cfg);
+        let resolved = resolve_agent_command(aid, &cfg)?;
         drop(cfg);
         resolved
     } else {
@@ -1711,10 +1711,12 @@ pub(crate) fn executable_basename(s: &str) -> String {
         .to_lowercase()
 }
 
+type ResolvedRootAgentCommand = (String, Vec<String>, Option<String>, Option<String>);
+
 fn resolve_agent_command(
     agent_id: &str,
     settings: &AppSettings,
-) -> (String, Vec<String>, Option<String>) {
+) -> Result<(String, Vec<String>, Option<String>), String> {
     if let Some(agent) = settings.agents.iter().find(|a| a.id == agent_id) {
         log::info!(
             "[session] Agent resolved: id={:?}, label={:?}, command={:?}",
@@ -1722,62 +1724,54 @@ fn resolve_agent_command(
             agent.label,
             agent.command
         );
-        let parts: Vec<String> = agent
-            .command
-            .split_whitespace()
-            .map(|s| s.to_string())
-            .collect();
-        if let Some((cmd, args)) = parts.split_first() {
-            (cmd.clone(), args.to_vec(), Some(agent.label.clone()))
-        } else {
-            (
-                settings.default_shell.clone(),
-                settings.default_shell_args.clone(),
-                Some(agent.label.clone()),
-            )
-        }
+        let source = format!("selected agent '{}'", agent_id);
+        let (shell, shell_args) = normalize_agent_command_for_source(agent, &source)?;
+        Ok((shell, shell_args, Some(agent.label.clone())))
     } else {
         log::warn!(
             "[session] Agent NOT found for aid={:?}. Falling back to default shell.",
             agent_id
         );
-        (
+        Ok((
             settings.default_shell.clone(),
             settings.default_shell_args.clone(),
             None,
-        )
+        ))
     }
 }
 
-fn split_agent_command(command: &str) -> Option<(String, Vec<String>)> {
-    let parts: Vec<String> = command.split_whitespace().map(|s| s.to_string()).collect();
-    parts
-        .split_first()
-        .map(|(cmd, args)| (cmd.clone(), args.to_vec()))
+fn normalize_agent_command_for_source(
+    agent: &crate::config::settings::AgentConfig,
+    source: &str,
+) -> Result<(String, Vec<String>), String> {
+    crate::config::agent_command::normalize_legacy_agent_command(&agent.command)
+        .map(|cmd| (cmd.shell, cmd.shell_args))
+        .map_err(|e| {
+            format!(
+                "Invalid agent command from {} (agent id '{}', label '{}'): {}. command={:?}",
+                source, agent.id, agent.label, e, agent.command
+            )
+        })
 }
 
 fn resolve_root_agent_command(
     settings: &AppSettings,
     requested_agent_id: Option<&str>,
     last_coding_agent: Option<&str>,
-) -> (String, Vec<String>, Option<String>, Option<String>) {
+) -> Result<ResolvedRootAgentCommand, String> {
     let resolve_configured =
         |agent_id: &str| settings.agents.iter().find(|agent| agent.id == agent_id);
 
     if let Some(agent_id) = requested_agent_id {
         if let Some(agent) = resolve_configured(agent_id) {
-            if let Some((shell, shell_args)) = split_agent_command(&agent.command) {
-                return (
-                    shell,
-                    shell_args,
-                    Some(agent.id.clone()),
-                    Some(agent.label.clone()),
-                );
-            }
-            log::warn!(
-                "[root-agent] Requested coding agent '{}' has an empty command; falling back",
-                agent_id
-            );
+            let source = format!("requested root agent '{}'", agent_id);
+            let (shell, shell_args) = normalize_agent_command_for_source(agent, &source)?;
+            return Ok((
+                shell,
+                shell_args,
+                Some(agent.id.clone()),
+                Some(agent.label.clone()),
+            ));
         } else {
             log::warn!(
                 "[root-agent] Requested coding agent '{}' no longer exists; falling back",
@@ -1788,18 +1782,14 @@ fn resolve_root_agent_command(
 
     if let Some(agent_id) = last_coding_agent {
         if let Some(agent) = resolve_configured(agent_id) {
-            if let Some((shell, shell_args)) = split_agent_command(&agent.command) {
-                return (
-                    shell,
-                    shell_args,
-                    Some(agent.id.clone()),
-                    Some(agent.label.clone()),
-                );
-            }
-            log::warn!(
-                "[root-agent] lastCodingAgent '{}' has an empty command; falling back",
-                agent_id
-            );
+            let source = format!("root lastCodingAgent '{}'", agent_id);
+            let (shell, shell_args) = normalize_agent_command_for_source(agent, &source)?;
+            return Ok((
+                shell,
+                shell_args,
+                Some(agent.id.clone()),
+                Some(agent.label.clone()),
+            ));
         } else {
             log::warn!(
                 "[root-agent] lastCodingAgent '{}' no longer exists; falling back",
@@ -1809,26 +1799,22 @@ fn resolve_root_agent_command(
     }
 
     if let Some(agent) = settings.agents.first() {
-        if let Some((shell, shell_args)) = split_agent_command(&agent.command) {
-            return (
-                shell,
-                shell_args,
-                Some(agent.id.clone()),
-                Some(agent.label.clone()),
-            );
-        }
-        log::warn!(
-            "[root-agent] First configured coding agent '{}' has an empty command; using default shell",
-            agent.id
-        );
+        let source = format!("first configured root agent '{}'", agent.id);
+        let (shell, shell_args) = normalize_agent_command_for_source(agent, &source)?;
+        return Ok((
+            shell,
+            shell_args,
+            Some(agent.id.clone()),
+            Some(agent.label.clone()),
+        ));
     }
 
-    (
+    Ok((
         settings.default_shell.clone(),
         settings.default_shell_args.clone(),
         None,
         None,
-    )
+    ))
 }
 
 fn resolve_agent_label(agent_id: &str, settings: &AppSettings) -> Option<String> {
@@ -1846,6 +1832,31 @@ fn resolve_actual_agent(
     requested_agent_label: Option<&str>,
     settings: &AppSettings,
 ) -> (Option<String>, Option<String>) {
+    if let Some(agent_id) = requested_agent_id {
+        if let Some(agent) = settings.agents.iter().find(|a| a.id == agent_id) {
+            match crate::config::agent_command::normalize_legacy_agent_command(&agent.command) {
+                Ok(normalized)
+                    if normalized.shell == shell && normalized.shell_args == shell_args =>
+                {
+                    return (
+                        Some(agent.id.clone()),
+                        requested_agent_label
+                            .map(ToString::to_string)
+                            .or_else(|| Some(agent.label.clone())),
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::debug!(
+                        "[session] Requested agent_id='{}' command did not normalize during metadata resolution: {}",
+                        agent_id,
+                        e
+                    );
+                }
+            }
+        }
+    }
+
     let detected = resolve_agent_from_shell(shell, shell_args, settings);
 
     if let Some(agent_id) = requested_agent_id {
@@ -1886,16 +1897,26 @@ fn resolve_agent_from_shell(
     shell_args: &[String],
     settings: &AppSettings,
 ) -> (Option<String>, Option<String>) {
-    // Collect all tokens from shell + args, extract basenames for comparison
-    let full_cmd = format!("{} {}", shell, shell_args.join(" "));
-    let cmd_basenames: Vec<String> = full_cmd
-        .split_whitespace()
-        .map(executable_basename)
-        .collect();
+    // Compare against already-normalized launch tokens without re-splitting shell.
+    let mut cmd_basenames: Vec<String> = Vec::with_capacity(shell_args.len() + 1);
+    cmd_basenames.push(executable_basename(shell));
+    cmd_basenames.extend(shell_args.iter().map(|arg| executable_basename(arg)));
 
     for agent in &settings.agents {
-        let agent_exec = agent.command.split_whitespace().next().unwrap_or("");
-        let agent_basename = executable_basename(agent_exec);
+        let normalized = match crate::config::agent_command::normalize_legacy_agent_command(
+            &agent.command,
+        ) {
+            Ok(cmd) => cmd,
+            Err(e) => {
+                log::debug!(
+                    "[session] Skipping agent '{}' during shell auto-detection because its command is invalid: {}",
+                    agent.id,
+                    e
+                );
+                continue;
+            }
+        };
+        let agent_basename = executable_basename(&normalized.shell);
         if !agent_basename.is_empty() && cmd_basenames.contains(&agent_basename) {
             log::info!(
                 "Auto-detected agent '{}' ({}) from shell command",
@@ -2000,7 +2021,7 @@ pub(crate) async fn create_root_agent_inner(
             &cfg,
             requested_agent_id.as_deref(),
             last_coding_agent.as_deref(),
-        )
+        )?
     };
 
     let info = create_session_inner(
@@ -2063,8 +2084,9 @@ pub async fn create_root_agent_session(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_existing_root, inject_codex_resume, resolve_actual_agent,
-        resolve_root_agent_command, should_inject_continue, ExistingRootAction,
+        classify_existing_root, inject_codex_resume, resolve_actual_agent, resolve_agent_command,
+        resolve_agent_from_shell, resolve_root_agent_command, should_inject_continue,
+        ExistingRootAction,
     };
     use crate::config::settings::{AgentConfig, AppSettings};
     use crate::session::session::SessionStatus;
@@ -2099,7 +2121,7 @@ mod tests {
         let settings = test_settings();
 
         let (shell, args, agent_id, label) =
-            resolve_root_agent_command(&settings, Some("codex"), Some("claude"));
+            resolve_root_agent_command(&settings, Some("codex"), Some("claude")).unwrap();
 
         assert_eq!(shell, "codex");
         assert!(args.is_empty());
@@ -2112,7 +2134,7 @@ mod tests {
         let settings = test_settings();
 
         let (shell, _args, agent_id, label) =
-            resolve_root_agent_command(&settings, None, Some("codex"));
+            resolve_root_agent_command(&settings, None, Some("codex")).unwrap();
 
         assert_eq!(shell, "codex");
         assert_eq!(agent_id.as_deref(), Some("codex"));
@@ -2124,7 +2146,7 @@ mod tests {
         let settings = test_settings();
 
         let (shell, _args, agent_id, label) =
-            resolve_root_agent_command(&settings, Some("stale"), Some("also-stale"));
+            resolve_root_agent_command(&settings, Some("stale"), Some("also-stale")).unwrap();
 
         assert_eq!(shell, "claude");
         assert_eq!(agent_id.as_deref(), Some("claude"));
@@ -2141,12 +2163,82 @@ mod tests {
         settings.agents.clear();
 
         let (shell, args, agent_id, label) =
-            resolve_root_agent_command(&settings, Some("stale"), Some("also-stale"));
+            resolve_root_agent_command(&settings, Some("stale"), Some("also-stale")).unwrap();
 
         assert_eq!(shell, "pwsh");
         assert_eq!(args, vec!["-NoLogo".to_string()]);
         assert!(agent_id.is_none());
         assert!(label.is_none());
+    }
+
+    #[test]
+    fn resolve_agent_command_preserves_args() {
+        let mut settings = test_settings();
+        settings
+            .agents
+            .iter_mut()
+            .find(|agent| agent.id == "codex")
+            .unwrap()
+            .command = "codex --yolo".to_string();
+
+        let (shell, args, label) = resolve_agent_command("codex", &settings).unwrap();
+
+        assert_eq!(shell, "codex");
+        assert_eq!(args, vec!["--yolo".to_string()]);
+        assert_eq!(label.as_deref(), Some("Codex"));
+    }
+
+    #[test]
+    fn resolve_agent_command_rejects_invalid_selected_command() {
+        let mut settings = test_settings();
+        settings
+            .agents
+            .iter_mut()
+            .find(|agent| agent.id == "codex")
+            .unwrap()
+            .command = "codex \"unterminated".to_string();
+
+        let err = resolve_agent_command("codex", &settings).unwrap_err();
+
+        assert!(err.contains("selected agent 'codex'"));
+        assert!(err.contains("agent id 'codex'"));
+        assert!(err.contains("unclosed double quote"));
+    }
+
+    #[test]
+    fn resolve_root_agent_command_preserves_args() {
+        let mut settings = test_settings();
+        settings
+            .agents
+            .iter_mut()
+            .find(|agent| agent.id == "codex")
+            .unwrap()
+            .command = "codex --yolo".to_string();
+
+        let (shell, args, agent_id, label) =
+            resolve_root_agent_command(&settings, Some("codex"), None).unwrap();
+
+        assert_eq!(shell, "codex");
+        assert_eq!(args, vec!["--yolo".to_string()]);
+        assert_eq!(agent_id.as_deref(), Some("codex"));
+        assert_eq!(label.as_deref(), Some("Codex"));
+    }
+
+    #[test]
+    fn resolve_root_agent_command_rejects_invalid_last_coding_agent_command() {
+        let mut settings = test_settings();
+        settings
+            .agents
+            .iter_mut()
+            .find(|agent| agent.id == "codex")
+            .unwrap()
+            .command = "codex \"unterminated".to_string();
+
+        let err = resolve_root_agent_command(&settings, None, Some("codex")).unwrap_err();
+
+        assert!(err.contains("root lastCodingAgent 'codex'"));
+        assert!(err.contains("agent id 'codex'"));
+        assert!(err.contains("unclosed double quote"));
     }
 
     #[test]
@@ -2394,6 +2486,35 @@ mod tests {
     }
 
     #[test]
+    fn resolve_actual_agent_keeps_requested_agent_when_normalized_command_matches() {
+        let mut settings = test_settings();
+        settings.agents.push(AgentConfig {
+            id: "codex-yolo".to_string(),
+            label: "Codex Yolo".to_string(),
+            command: "codex --yolo".to_string(),
+            color: "#10b981".to_string(),
+            git_pull_before: false,
+            exclude_global_claude_md: false,
+        });
+
+        let resolved = resolve_actual_agent(
+            "codex",
+            &["--yolo".to_string()],
+            Some("codex-yolo"),
+            Some("Codex Yolo"),
+            &settings,
+        );
+
+        assert_eq!(
+            resolved,
+            (
+                Some("codex-yolo".to_string()),
+                Some("Codex Yolo".to_string())
+            )
+        );
+    }
+
+    #[test]
     fn resolve_actual_agent_falls_back_to_detected_label_when_validated_match_has_no_stored_label()
     {
         let settings = test_settings();
@@ -2437,6 +2558,23 @@ mod tests {
             resolved,
             (Some("claude".to_string()), Some("Claude Code".to_string()))
         );
+    }
+
+    #[test]
+    fn resolve_agent_from_shell_skips_invalid_configured_command() {
+        let mut settings = test_settings();
+        settings.agents = vec![AgentConfig {
+            id: "broken-codex".to_string(),
+            label: "Broken Codex".to_string(),
+            command: "codex \"unterminated".to_string(),
+            color: "#10b981".to_string(),
+            git_pull_before: false,
+            exclude_global_claude_md: false,
+        }];
+
+        let resolved = resolve_agent_from_shell("codex", &[], &settings);
+
+        assert_eq!(resolved, (None, None));
     }
 
     #[test]

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -1,0 +1,113 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedAgentCommand {
+    pub shell: String,
+    pub shell_args: Vec<String>,
+}
+
+pub fn normalize_legacy_agent_command(command: &str) -> Result<NormalizedAgentCommand, String> {
+    let input = command.trim_matches(|c: char| c.is_ascii_whitespace());
+    if input.is_empty() {
+        return Err("agent command is empty".to_string());
+    }
+
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut token_started = false;
+
+    for ch in input.chars() {
+        match (quote, ch) {
+            (Some(q), c) if c == q => {
+                quote = None;
+                token_started = true;
+            }
+            (Some(_), c) => {
+                current.push(c);
+                token_started = true;
+            }
+            (None, '\'' | '"') => {
+                quote = Some(ch);
+                token_started = true;
+            }
+            (None, c) if c.is_ascii_whitespace() => {
+                if token_started {
+                    tokens.push(std::mem::take(&mut current));
+                    token_started = false;
+                }
+            }
+            (None, c) => {
+                current.push(c);
+                token_started = true;
+            }
+        }
+    }
+
+    if let Some(q) = quote {
+        return Err(format!(
+            "unclosed {} quote",
+            if q == '"' { "double" } else { "single" }
+        ));
+    }
+
+    if token_started {
+        tokens.push(current);
+    }
+
+    let Some((shell, args)) = tokens.split_first() else {
+        return Err("agent command is empty".to_string());
+    };
+    if shell.is_empty() {
+        return Err("agent executable is empty".to_string());
+    }
+
+    Ok(NormalizedAgentCommand {
+        shell: shell.clone(),
+        shell_args: args.to_vec(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_legacy_agent_command;
+
+    #[test]
+    fn normalizes_plain_command_with_args() {
+        let got = normalize_legacy_agent_command("codex --yolo").unwrap();
+        assert_eq!(got.shell, "codex");
+        assert_eq!(got.shell_args, vec!["--yolo"]);
+    }
+
+    #[test]
+    fn preserves_quoted_arg_with_spaces() {
+        let got = normalize_legacy_agent_command("codex --model \"gpt 5\"").unwrap();
+        assert_eq!(got.shell, "codex");
+        assert_eq!(got.shell_args, vec!["--model", "gpt 5"]);
+    }
+
+    #[test]
+    fn supports_quoted_windows_executable_path() {
+        let got = normalize_legacy_agent_command("\"C:\\Program Files\\Codex\\codex.exe\" --yolo")
+            .unwrap();
+        assert_eq!(got.shell, "C:\\Program Files\\Codex\\codex.exe");
+        assert_eq!(got.shell_args, vec!["--yolo"]);
+    }
+
+    #[test]
+    fn preserves_empty_quoted_arg() {
+        let got = normalize_legacy_agent_command("codex --config \"\" --flag").unwrap();
+        assert_eq!(got.shell, "codex");
+        assert_eq!(got.shell_args, vec!["--config", "", "--flag"]);
+    }
+
+    #[test]
+    fn rejects_unclosed_quote() {
+        let err = normalize_legacy_agent_command("codex \"unterminated").unwrap_err();
+        assert!(err.contains("unclosed double quote"));
+    }
+
+    #[test]
+    fn rejects_empty_quoted_executable() {
+        let err = normalize_legacy_agent_command("\"\" --flag").unwrap_err();
+        assert!(err.contains("agent executable is empty"));
+    }
+}

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_command;
 pub mod agent_config;
 pub mod agent_creation;
 pub mod claude_settings;

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -7,7 +7,7 @@ use tauri::Manager;
 use uuid::Uuid;
 
 use crate::config::agent_config::AgentLocalConfig;
-use crate::config::settings::SettingsState;
+use crate::config::settings::{AgentConfig, SettingsState};
 use crate::config::teams;
 use crate::phone::types::OutboxMessage;
 use crate::pty::manager::PtyManager;
@@ -126,6 +126,92 @@ fn collect_project_refresh_requests(requests_dir: &Path) -> ProjectRefreshPollBa
     }
 
     batch
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedWakeAgentCommand {
+    shell: String,
+    shell_args: Vec<String>,
+    agent_id: Option<String>,
+    agent_label: Option<String>,
+    source: String,
+    raw_command: String,
+}
+
+fn normalize_agent_for_wake(
+    agent: &AgentConfig,
+    source: String,
+) -> Result<ResolvedWakeAgentCommand, String> {
+    let normalized = crate::config::agent_command::normalize_legacy_agent_command(&agent.command)
+        .map_err(|e| {
+            format!(
+                "Invalid agent command from {} (agent id '{}', label '{}'): {}. command={:?}",
+                source, agent.id, agent.label, e, agent.command
+            )
+        })?;
+
+    Ok(ResolvedWakeAgentCommand {
+        shell: normalized.shell,
+        shell_args: normalized.shell_args,
+        agent_id: Some(agent.id.clone()),
+        agent_label: Some(agent.label.clone()),
+        source,
+        raw_command: agent.command.clone(),
+    })
+}
+
+fn resolve_wake_agent_command_from_sources(
+    agents: &[AgentConfig],
+    preferred_agent: &str,
+    destination_last_agent: Option<&str>,
+    destination_config_path: Option<&Path>,
+    sender_agent: Option<&str>,
+) -> Result<Option<ResolvedWakeAgentCommand>, String> {
+    if preferred_agent != "auto" {
+        if let Some(agent) = agents.iter().find(|a| a.id == preferred_agent) {
+            return normalize_agent_for_wake(
+                agent,
+                format!("preferredAgent '{}'", preferred_agent),
+            )
+            .map(Some);
+        }
+        log::warn!(
+            "[mailbox] wake: preferredAgent '{}' did not match a configured agent id; falling back to auto resolution",
+            preferred_agent
+        );
+    }
+
+    if let Some(agent_id) = destination_last_agent {
+        if let Some(agent) = agents.iter().find(|a| a.id == agent_id) {
+            let source = match destination_config_path {
+                Some(path) => format!("lastCodingAgent '{}' from {}", agent_id, path.display()),
+                None => format!("lastCodingAgent '{}'", agent_id),
+            };
+            return normalize_agent_for_wake(agent, source).map(Some);
+        }
+        log::debug!(
+            "[mailbox] wake: lastCodingAgent '{}' did not match a configured agent id; falling back",
+            agent_id
+        );
+    }
+
+    if let Some(agent_id) = sender_agent {
+        if let Some(agent) = agents.iter().find(|a| a.id == agent_id) {
+            return normalize_agent_for_wake(agent, format!("senderAgent '{}'", agent_id))
+                .map(Some);
+        }
+        log::debug!(
+            "[mailbox] wake: senderAgent '{}' did not match a configured agent id; falling back",
+            agent_id
+        );
+    }
+
+    agents
+        .first()
+        .map(|agent| {
+            normalize_agent_for_wake(agent, format!("first configured agent '{}'", agent.id))
+        })
+        .transpose()
 }
 
 fn validate_root_sender_route(
@@ -1299,9 +1385,12 @@ impl MailboxPoller {
             };
         }
 
-        let agent_command = self.resolve_agent_command(app, msg).await;
-        let (shell, shell_args) = agent_command.ok_or_else(|| {
-            format!("No agent command resolved for '{}' — cannot spawn session. Configure lastCodingAgent or agents in settings.", msg.to)
+        let resolved_command = self.resolve_agent_command(app, msg).await?;
+        let resolved_command = resolved_command.ok_or_else(|| {
+            format!(
+                "No agent command resolved for '{}'; preferredAgent={:?}. Configure lastCodingAgent or agents in settings.",
+                msg.to, msg.preferred_agent
+            )
         })?;
 
         let dest_path = self.resolve_repo_path(&msg.to, app).await;
@@ -1320,9 +1409,6 @@ impl MailboxPoller {
             }
         };
 
-        // Resolve agent_id and label from lastCodingAgent config
-        let (agent_id, agent_label) = self.resolve_agent_id_and_label(app, &cwd).await;
-
         // §AR2-session-name: strip optional `<project>:` prefix from the display
         // name so the sidebar label stays short (e.g. "wg-1-devs/tech-lead" not
         // "proj-a:wg-1-devs/tech-lead"). The canonical FQN stays recoverable via
@@ -1335,22 +1421,41 @@ impl MailboxPoller {
         let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
         let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
 
+        let spawn_source = resolved_command.source.clone();
+        let spawn_shell = resolved_command.shell.clone();
+        let spawn_args = resolved_command.shell_args.clone();
+        let spawn_raw = resolved_command.raw_command.clone();
+
+        log::info!(
+            "[mailbox] wake: spawning '{}' from {}: raw_command={:?}, shell={:?}, args={:?}",
+            msg.to,
+            spawn_source,
+            spawn_raw,
+            spawn_shell,
+            spawn_args
+        );
+
         let info = crate::commands::session::create_session_inner(
             app,
             session_mgr.inner(),
             pty_mgr.inner(),
-            shell,
-            shell_args,
+            resolved_command.shell,
+            resolved_command.shell_args,
             cwd,
             Some(session_name), // readable name, no [temp] prefix
-            agent_id,           // links to agent config
-            agent_label,        // human-readable label
+            resolved_command.agent_id, // links to agent config
+            resolved_command.agent_label, // human-readable label
             false,              // skip_tooling_save = false → persist lastCodingAgent
             Vec::new(),         // git_repos
             wake_spawn_skip_auto_resume(spawn_with_resume), // see deliver_wake top
         )
         .await
-        .map_err(|e| format!("Failed to spawn session for '{}': {}", msg.to, e))?;
+        .map_err(|e| {
+            format!(
+                "Failed to spawn session for '{}': command from {} resolved raw_command={:?}, shell={:?}, args={:?}: {}",
+                msg.to, spawn_source, spawn_raw, spawn_shell, spawn_args, e
+            )
+        })?;
 
         let session_id =
             Uuid::parse_str(&info.id).map_err(|e| format!("Failed to parse session id: {}", e))?;
@@ -2516,73 +2621,36 @@ impl MailboxPoller {
         &self,
         app: &tauri::AppHandle,
         msg: &OutboxMessage,
-    ) -> Option<(String, Vec<String>)> {
-        let settings = app.state::<SettingsState>();
-        let cfg = settings.read().await;
+    ) -> Result<Option<ResolvedWakeAgentCommand>, String> {
+        let agents = {
+            let settings = app.state::<SettingsState>();
+            let cfg = settings.read().await;
+            cfg.agents.clone()
+        };
 
-        // If specific agent requested
-        if msg.preferred_agent != "auto" {
-            if let Some(agent) = cfg.agents.iter().find(|a| a.id == msg.preferred_agent) {
-                return Some((agent.command.clone(), vec![]));
-            }
-        }
+        let mut destination_last_agent: Option<String> = None;
+        let mut destination_config_path: Option<PathBuf> = None;
 
-        // Try lastCodingAgent from destination's config.json
         if let Some(dest_path) = self.resolve_repo_path(&msg.to, app).await {
             let config_path = Path::new(&dest_path)
                 .join(crate::config::agent_local_dir_name())
                 .join("config.json");
+            destination_config_path = Some(config_path.clone());
+
             if let Ok(content) = std::fs::read_to_string(&config_path) {
                 if let Ok(local_config) = serde_json::from_str::<AgentLocalConfig>(&content) {
-                    if let Some(last_agent) = local_config.tooling.last_coding_agent.as_deref() {
-                        if let Some(agent) = cfg.agents.iter().find(|a| a.id == last_agent) {
-                            return Some((agent.command.clone(), vec![]));
-                        }
-                    }
+                    destination_last_agent = local_config.tooling.last_coding_agent;
                 }
             }
         }
 
-        // Fallback: use sender's agent if known
-        if let Some(ref sender_agent) = msg.sender_agent {
-            if let Some(agent) = cfg.agents.iter().find(|a| a.id == *sender_agent) {
-                return Some((agent.command.clone(), vec![]));
-            }
-        }
-
-        // Last resort: use first configured agent
-        cfg.agents.first().map(|a| (a.command.clone(), vec![]))
-    }
-
-    /// Resolve agent_id and agent_label for a destination agent.
-    /// Reads lastCodingAgent from the dest's config.json, then looks up the label in settings.
-    async fn resolve_agent_id_and_label(
-        &self,
-        app: &tauri::AppHandle,
-        cwd: &str,
-    ) -> (Option<String>, Option<String>) {
-        let config_path = std::path::Path::new(cwd)
-            .join(crate::config::agent_local_dir_name())
-            .join("config.json");
-
-        let last_agent_id = std::fs::read_to_string(&config_path)
-            .ok()
-            .and_then(|content| serde_json::from_str::<AgentLocalConfig>(&content).ok())
-            .and_then(|cfg| cfg.tooling.last_coding_agent);
-
-        let Some(ref agent_id) = last_agent_id else {
-            return (None, None);
-        };
-
-        let settings = app.state::<SettingsState>();
-        let cfg = settings.read().await;
-        let label = cfg
-            .agents
-            .iter()
-            .find(|a| a.id == *agent_id)
-            .map(|a| a.label.clone());
-
-        (last_agent_id, label)
+        resolve_wake_agent_command_from_sources(
+            &agents,
+            &msg.preferred_agent,
+            destination_last_agent.as_deref(),
+            destination_config_path.as_deref(),
+            msg.sender_agent.as_deref(),
+        )
     }
 
     /// Fallback path resolution for WG agents: find a sibling session in the same WG,
@@ -2954,6 +3022,142 @@ mod tests {
             force: None,
             timeout_secs: None,
         }
+    }
+
+    fn wake_agent(id: &str, label: &str, command: &str) -> AgentConfig {
+        AgentConfig {
+            id: id.into(),
+            label: label.into(),
+            command: command.into(),
+            color: "#10b981".into(),
+            git_pull_before: false,
+            exclude_global_claude_md: false,
+        }
+    }
+
+    fn wake_agents() -> Vec<AgentConfig> {
+        vec![
+            wake_agent("codex", "Codex", "codex --yolo"),
+            wake_agent("claude", "Claude", "claude"),
+        ]
+    }
+
+    #[test]
+    fn wake_agent_command_normalizes_preferred_agent_command() {
+        let agents = wake_agents();
+
+        let resolved =
+            resolve_wake_agent_command_from_sources(&agents, "codex", Some("claude"), None, None)
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(resolved.shell, "codex");
+        assert_eq!(resolved.shell_args, vec!["--yolo"]);
+        assert_eq!(resolved.agent_id.as_deref(), Some("codex"));
+        assert!(resolved.source.contains("preferredAgent 'codex'"));
+    }
+
+    #[test]
+    fn wake_agent_command_stale_preferred_agent_falls_back_to_last_coding_agent() {
+        let agents = wake_agents();
+        let config_path = Path::new("C:/repo/.agentscommander/config.json");
+
+        let resolved = resolve_wake_agent_command_from_sources(
+            &agents,
+            "missing",
+            Some("codex"),
+            Some(config_path),
+            Some("claude"),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(resolved.shell, "codex");
+        assert_eq!(resolved.shell_args, vec!["--yolo"]);
+        assert!(resolved.source.contains("lastCodingAgent 'codex'"));
+    }
+
+    #[test]
+    fn wake_agent_command_normalizes_last_coding_agent_command() {
+        let agents = wake_agents();
+
+        let resolved =
+            resolve_wake_agent_command_from_sources(&agents, "auto", Some("codex"), None, None)
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(resolved.shell, "codex");
+        assert_eq!(resolved.shell_args, vec!["--yolo"]);
+        assert!(resolved.source.contains("lastCodingAgent"));
+    }
+
+    #[test]
+    fn wake_agent_command_uses_sender_agent_after_missing_last_coding_agent() {
+        let agents = wake_agents();
+
+        let resolved = resolve_wake_agent_command_from_sources(
+            &agents,
+            "auto",
+            Some("missing"),
+            None,
+            Some("claude"),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(resolved.shell, "claude");
+        assert!(resolved.shell_args.is_empty());
+        assert_eq!(resolved.agent_id.as_deref(), Some("claude"));
+        assert!(resolved.source.contains("senderAgent 'claude'"));
+    }
+
+    #[test]
+    fn wake_agent_command_uses_first_configured_agent_as_last_resort() {
+        let agents = wake_agents();
+
+        let resolved = resolve_wake_agent_command_from_sources(
+            &agents,
+            "auto",
+            Some("missing"),
+            None,
+            Some("also-missing"),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(resolved.shell, "codex");
+        assert_eq!(resolved.shell_args, vec!["--yolo"]);
+        assert_eq!(resolved.agent_id.as_deref(), Some("codex"));
+        assert!(resolved.source.contains("first configured agent 'codex'"));
+    }
+
+    #[test]
+    fn wake_agent_command_rejects_invalid_quoted_command_with_source() {
+        let agents = vec![wake_agent("codex", "Codex", "codex \"unterminated")];
+
+        let err = resolve_wake_agent_command_from_sources(&agents, "codex", None, None, None)
+            .unwrap_err();
+
+        assert!(err.contains("preferredAgent 'codex'"));
+        assert!(err.contains("agent id 'codex'"));
+        assert!(err.contains("label 'Codex'"));
+        assert!(err.contains("command=\"codex \\\"unterminated\""));
+        assert!(err.contains("unclosed double quote"));
+    }
+
+    #[test]
+    fn wake_agent_command_selected_agent_preserves_args() {
+        let agents = wake_agents();
+
+        let resolved =
+            resolve_wake_agent_command_from_sources(&agents, "codex", None, None, Some("claude"))
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(resolved.shell, "codex");
+        assert_eq!(resolved.shell_args, vec!["--yolo"]);
+        assert_eq!(resolved.agent_id.as_deref(), Some("codex"));
+        assert_eq!(resolved.agent_label.as_deref(), Some("Codex"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Normalize legacy configured agent commands into executable plus args before wake/session spawning.
- Share command parsing across session/root-agent/CLI/wake paths, including quoted executable paths and empty quoted args.
- Preserve existing `send --agent` semantics as a configured agent id selector.
- Add source-aware errors for invalid configured commands and wake selection diagnostics.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml agent_command`
- `cargo test --manifest-path src-tauri/Cargo.toml build_session_request`
- `cargo test --manifest-path src-tauri/Cargo.toml resolve_root_agent_command`
- `cargo test --manifest-path src-tauri/Cargo.toml resolve_actual_agent`
- `cargo test --manifest-path src-tauri/Cargo.toml resolve_agent_from_shell`
- `cargo test --manifest-path src-tauri/Cargo.toml wake_agent_command`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets`
- `git diff --check`
- Shipper built/deployed `agentscommander_standalone_wg-6.exe` and verified `--help`.

Closes #374

Related: #384