### PR TITLE
[codex] Use production release identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
       matrix:
         include:
           - platform: windows-latest
-            args: ''
+            args: '--config src-tauri/tauri.prod.conf.json'
           - platform: ubuntu-22.04
-            args: ''
+            args: '--config src-tauri/tauri.prod.conf.json'
           - platform: macos-latest
-            args: '--target aarch64-apple-darwin'
+            args: '--config src-tauri/tauri.prod.conf.json --target aarch64-apple-darwin'
           - platform: macos-latest
-            args: '--target x86_64-apple-darwin'
+            args: '--config src-tauri/tauri.prod.conf.json --target x86_64-apple-darwin'
 
     runs-on: ${{ matrix.platform }}
 

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -25,7 +25,7 @@ You can verify the digital signature of any `.exe` or `.msi` file:
 
 **PowerShell**:
 ```powershell
-Get-AuthenticodeSignature "Agents Commander_x64-setup.exe"
+Get-AuthenticodeSignature "Agents Commander_X.Y.Z_x64-setup.exe"
 ```
 
 ## Privacy

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,7 +20,7 @@ Download the latest installer for your platform from [the releases page](https:/
 |---|---|
 | Windows 10 1809+ | `Agents Commander_X.Y.Z_x64-setup.exe` (signed) or the portable `agentscommander.exe` |
 | Linux | `agentscommander_*_amd64.AppImage` |
-| macOS | `AgentsCommander_*.dmg` (Apple Silicon + Intel) |
+| macOS | `Agents Commander_*.dmg` (Apple Silicon + Intel) |
 
 Run the installer, or drop the portable `.exe` into any folder and double-click. On first launch AC creates its config directory next to the binary (e.g. `.agentscommander/` on Windows). See [Portable instances](features/portable-instances.md) for the rules.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ Download the latest installer for your platform from [the releases page](https:/
 
 | Platform | Asset |
 |---|---|
-| Windows 10 1809+ | `AgentsCommander_*_x64-setup.exe` (signed) or the portable `agentscommander.exe` |
+| Windows 10 1809+ | `Agents Commander_X.Y.Z_x64-setup.exe` (signed) or the portable `agentscommander.exe` |
 | Linux | `agentscommander_*_amd64.AppImage` |
 | macOS | `AgentsCommander_*.dmg` (Apple Silicon + Intel) |
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -22,7 +22,7 @@ The script writes the same version to every checked location:
 | `package.json` | `version` |
 | `package-lock.json` | root `version` and `packages[""].version` |
 | `src-tauri/Cargo.toml` | `[package]` version |
-| `src-tauri/Cargo.lock` | `agentscommander` entry version |
+| `src-tauri/Cargo.lock` | internal Cargo crate entry (`agentscommander-new`) version |
 | `src-tauri/tauri.conf.json` | `version` |
 
 The frontend titlebar reads its version from `tauri.conf.json` at build time, so bumping that one file is enough to update what users see — no source files need manual edits.
@@ -65,6 +65,8 @@ This creates a **draft release** with:
 - macOS `.dmg` (Apple Silicon + Intel) — unsigned today
 
 The workflow file is `.github/workflows/release.yml`.
+Every release matrix row passes `--config src-tauri/tauri.prod.conf.json`;
+the macOS rows add their `--target` after the production config.
 
 ## 5. Verify and publish
 
@@ -73,7 +75,7 @@ The release shows up under [Releases](https://github.com/mblua/AgentsCommander/r
 - **Asset count.** Every platform produced an installer. Re-run the failing job if one is missing.
 - **Windows signature.** Right-click the installer → Properties → Digital Signatures → SignPath Foundation. Or:
   ```powershell
-  Get-AuthenticodeSignature "AgentsCommander_X.Y.Z_x64-setup.exe"
+  Get-AuthenticodeSignature "Agents.Commander_X.Y.Z_x64-setup.exe"
   ```
 - **Changelog.** Add curated highlights at the top (the auto-generated list goes underneath). Use the previous release as a tone reference.
 - **Tag matches the bump.** If you tagged `v0.8.42` but the binary reports `0.8.41`, abort and re-bump.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -75,7 +75,7 @@ The release shows up under [Releases](https://github.com/mblua/AgentsCommander/r
 - **Asset count.** Every platform produced an installer. Re-run the failing job if one is missing.
 - **Windows signature.** Right-click the installer → Properties → Digital Signatures → SignPath Foundation. Or:
   ```powershell
-  Get-AuthenticodeSignature "Agents.Commander_X.Y.Z_x64-setup.exe"
+  Get-AuthenticodeSignature "Agents Commander_X.Y.Z_x64-setup.exe"
   ```
 - **Changelog.** Add curated highlights at the top (the auto-generated list goes underneath). Use the previous release as a tone reference.
 - **Tag matches the bump.** If you tagged `v0.8.42` but the binary reports `0.8.41`, abort and re-bump.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@ For developers hitting an error. Skim the headings for the symptom that matches 
 The Windows release is signed by SignPath, but a freshly-released asset may not have reputation yet. Click **More info → Run anyway**. To verify the signature first:
 
 ```powershell
-Get-AuthenticodeSignature "AgentsCommander_0.8.43_x64-setup.exe"
+Get-AuthenticodeSignature "Agents Commander_X.Y.Z_x64-setup.exe"
 ```
 
 `Status` should read `Valid`. See [`CODE_SIGNING_POLICY.md`](../CODE_SIGNING_POLICY.md).

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -15,7 +15,7 @@
 //   - package.json                             "version"
 //   - package-lock.json                        root "version" + packages[""].version
 //   - src-tauri/Cargo.toml                     [package] version
-//   - src-tauri/Cargo.lock                     agentscommander-new entry version
+//   - src-tauri/Cargo.lock                     internal Cargo crate entry version
 //   - src-tauri/tauri.conf.json                "version"
 //
 // Re-running with the same X.Y.Z target is supported and intentional: it
@@ -43,7 +43,7 @@ Updates every project version location:
   - package.json
   - package-lock.json (root + packages[""])
   - src-tauri/Cargo.toml
-  - src-tauri/Cargo.lock (agentscommander-new entry)
+  - src-tauri/Cargo.lock (internal Cargo crate entry)
   - src-tauri/tauri.conf.json
 
 Re-running with the same X.Y.Z target re-synchronizes drifted locations.
@@ -54,6 +54,8 @@ Re-running with the same X.Y.Z target re-synchronizes drifted locations.
 // nearby fields so we can never accidentally rewrite a dependency version.
 // Line-end tokens use \r?\n so files with either LF or CRLF endings are
 // preserved byte-for-byte outside the version literal.
+// The Rust crate is still named agentscommander-new for Cargo/test binary
+// compatibility. Production bundle identity comes from Tauri config.
 const PATCHES = [
   {
     file: 'package.json',
@@ -77,7 +79,7 @@ const PATCHES = [
   },
   {
     file: 'src-tauri/Cargo.lock',
-    label: 'agentscommander-new entry',
+    label: 'internal Cargo crate entry',
     re: /(\r?\n\s*name\s*=\s*"agentscommander-new"\s*\r?\nversion\s*=\s*)"[^"]+"/,
   },
   {

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -52,7 +52,7 @@ const checks = [
     /(?:\r?\n)\s*name\s*=\s*"agentscommander-new"\s*(?:\r?\n)version\s*=\s*"([^"]+)"/,
   ),
   extract(
-    'src-tauri/Cargo.lock:agentscommander-new.version',
+    'src-tauri/Cargo.lock:internal-crate.version',
     'src-tauri/Cargo.lock',
     /(?:\r?\n)\s*name\s*=\s*"agentscommander-new"\s*(?:\r?\n)version\s*=\s*"([^"]+)"/,
   ),

--- a/src-tauri/src/config/profile.rs
+++ b/src-tauri/src/config/profile.rs
@@ -40,7 +40,8 @@ fn capitalize_suffix(suffix: &str) -> String {
 
 /// Config directory name under $HOME.
 /// Only "dev" (via suffix or BUILD_PROFILE) gets a separate dir.
-/// Everyone else shares `.agentscommander-new`.
+/// Everyone else shares the legacy `.agentscommander-new` data directory for
+/// settings compatibility. This is internal storage, not release identity.
 pub fn config_dir_name() -> &'static str {
     static NAME: OnceLock<String> = OnceLock::new();
     NAME.get_or_init(|| {
@@ -101,6 +102,8 @@ pub fn exe_name() -> &'static str {
             .ok()
             .and_then(|p| p.file_name().map(|f| f.to_string_lossy().to_string()))
             .unwrap_or_else(|| match BUILD_PROFILE {
+                // Internal dev fallback for direct cargo runs. Tauri production
+                // bundles set mainBinaryName to `agentscommander`.
                 "dev" => "agentscommander-new.exe".to_string(),
                 "stage" => "agentscommander-stage.exe".to_string(),
                 _ => "agentscommander.exe".to_string(),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
   "version": "0.8.44",
-  "identifier": "dev.agentscommander-new.app",
+  "identifier": "dev.agentscommander.app",
+  "mainBinaryName": "agentscommander",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",

--- a/src-tauri/tauri.prod.conf.json
+++ b/src-tauri/tauri.prod.conf.json
@@ -1,5 +1,5 @@
 {
   "productName": "Agents Commander",
-  "identifier": "com.agentscommander.app",
+  "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander"
 }


### PR DESCRIPTION
## Summary
- force release builds to use `src-tauri/tauri.prod.conf.json` on Windows, Linux, and both macOS targets
- set production Tauri identity to `Agents Commander`, `dev.agentscommander.app`, and `agentscommander`
- align release/download docs with the final `Agents Commander` artifact naming and remove legacy `New` public references

## Verification
- `node scripts/check-version-sync.mjs`
- `npm run build`
- `cargo check`
- targeted legacy-name and artifact-name `rg` checks
- Shipper validation: `npx tauri build --debug --bundles nsis --config src-tauri/tauri.prod.conf.json --ci`
- adversarial review final PASS

Fixes #385