### PR TITLE
Fix canonical AC stale-workgroup guards (#386)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ _logbooks/
 
 # AgentsCommander workgroup replicas (always per-machine state).
 .ac/wg-*/
+.ac-new/wg-*/
 
 # Per-session agent context materialized by default_context()
 CLAUDE.md

--- a/scripts/all_agentscommander_standalone_come_to_me.ps1
+++ b/scripts/all_agentscommander_standalone_come_to_me.ps1
@@ -7,6 +7,7 @@ Assumptions:
   $env:USERPROFILE\0_repos\AgentsCommander_ac
 - Override -AcRoot if the checkout moved.
 - Workgroup folders are immediate children of the AgentsCommander_ac .ac directory and match ^wg-\d+.
+- Legacy .ac-new is used only when .ac is absent.
 - The script reads from each workgroup repo and writes only to -Destination.
 
 Destination filename convention:
@@ -16,6 +17,7 @@ Destination filename convention:
 
 [CmdletBinding()]
 param(
+    [Alias('AcNewRoot')]
     [string]$AcRoot = (Join-Path $env:USERPROFILE '0_repos\AgentsCommander_ac\.ac'),
     [string]$Destination = 'C:\Users\maria\0_mmb\0_AC',
     [switch]$Overwrite
@@ -35,11 +37,21 @@ function Resolve-AcRoot {
     }
 
     $candidate = [System.IO.Path]::GetFullPath($Path)
+    $leaf = Split-Path -Leaf $candidate
 
-    if ((Split-Path -Leaf $candidate) -ne '.ac') {
-        $nested = Join-Path $candidate '.ac'
-        if (Test-Path -LiteralPath $nested -PathType Container) {
-            return (Resolve-Path -LiteralPath $nested).ProviderPath
+    if ($leaf -ne '.ac' -and $leaf -ne '.ac-new') {
+        foreach ($workspaceName in @('.ac', '.ac-new')) {
+            $nested = Join-Path $candidate $workspaceName
+            if (Test-Path -LiteralPath $nested -PathType Container) {
+                return (Resolve-Path -LiteralPath $nested).ProviderPath
+            }
+        }
+    }
+
+    if ($leaf -eq '.ac-new') {
+        $canonicalSibling = Join-Path (Split-Path -Parent $candidate) '.ac'
+        if (Test-Path -LiteralPath $canonicalSibling -PathType Container) {
+            return (Resolve-Path -LiteralPath $canonicalSibling).ProviderPath
         }
     }
 
@@ -47,7 +59,14 @@ function Resolve-AcRoot {
         return (Resolve-Path -LiteralPath $candidate).ProviderPath
     }
 
-    throw "AgentsCommander_ac .ac directory not found: $candidate"
+    if ($leaf -eq '.ac') {
+        $legacySibling = Join-Path (Split-Path -Parent $candidate) '.ac-new'
+        if (Test-Path -LiteralPath $legacySibling -PathType Container) {
+            return (Resolve-Path -LiteralPath $legacySibling).ProviderPath
+        }
+    }
+
+    throw "AgentsCommander_ac .ac/.ac-new directory not found: $candidate"
 }
 
 function ConvertTo-SafeFileName {
@@ -84,7 +103,7 @@ $workgroups = @(
         Sort-Object Name
 )
 
-Write-Host "AgentsCommander .ac root: $acRootPath"
+Write-Host "AgentsCommander AC root: $acRootPath"
 Write-Host "Destination: $destinationPath"
 Write-Host "Overwrite conflicts: $($Overwrite.IsPresent)"
 Write-Host ''

--- a/src-tauri/src/cli/create_agent_matrix.rs
+++ b/src-tauri/src/cli/create_agent_matrix.rs
@@ -20,7 +20,7 @@ use crate::config::projects::resolve_project_reference;
 #[command(after_help = "\
 NOTES:\n  \
   --project is a registered AC project folder name from settings.projectPaths. Paths are not accepted.\n  \
-  The target project must contain .ac.\n  \
+  The target project must contain .ac or legacy .ac-new.\n  \
   --name is sanitized by the same backend as the UI into a lower-case Matrix id.\n  \
   --role-template must be an id from the same source as the New Agent picker.\n  \
   Invalid templates fail before creating the target Matrix directory.\n  \

--- a/src-tauri/src/cli/task_append_body.rs
+++ b/src-tauri/src/cli/task_append_body.rs
@@ -40,6 +40,16 @@ pub struct TaskAppendBodyArgs {
     pub text: String,
 }
 
+fn ensure_workgroup_root_is_authoritative(wg_root: &Path) -> Result<(), String> {
+    let workspace_dir = wg_root.parent().ok_or_else(|| {
+        format!(
+            "workgroup root '{}' has no parent workspace directory",
+            wg_root.display()
+        )
+    })?;
+    crate::config::workspace::ensure_authoritative_workspace_dir(workspace_dir)
+}
+
 pub fn execute(args: TaskAppendBodyArgs) -> i32 {
     let root = match args.root {
         Some(ref r) => r.clone(),
@@ -112,6 +122,10 @@ pub fn execute(args: TaskAppendBodyArgs) -> i32 {
             return 1;
         }
     };
+    if let Err(e) = ensure_workgroup_root_is_authoritative(&wg_root) {
+        eprintln!("Error: {}", e);
+        return 1;
+    }
 
     // NIT-2: include `pid={}` so an auditor can cross-reference the AC process
     // tree. `sender=` and `wg=` are both caller-derived (--root) and a forged
@@ -256,6 +270,29 @@ mod tests {
         );
         let code = execute(args);
         assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn append_body_rejects_stale_legacy_workgroup_when_canonical_exists() {
+        let fix = FixtureRoot::new("task-append-stale-legacy");
+        let project = fix.path().join("proj");
+        let canonical_wg = project.join(".ac").join("wg-1-test");
+        let legacy_wg = project.join(".ac-new").join("wg-1-test");
+        std::fs::create_dir_all(&canonical_wg).unwrap();
+        std::fs::create_dir_all(&legacy_wg).unwrap();
+
+        let err = ensure_workgroup_root_is_authoritative(&legacy_wg).unwrap_err();
+
+        assert!(err.contains("stale legacy workspace"));
+    }
+
+    #[test]
+    fn append_body_accepts_legacy_workgroup_when_canonical_absent() {
+        let fix = FixtureRoot::new("task-append-legacy-only");
+        let legacy_wg = fix.path().join("proj").join(".ac-new").join("wg-1-test");
+        std::fs::create_dir_all(&legacy_wg).unwrap();
+
+        ensure_workgroup_root_is_authoritative(&legacy_wg).expect("legacy fallback accepted");
     }
 
     // ── I16: help text documents the verb ───────────────────────────────

--- a/src-tauri/src/cli/task_set_title.rs
+++ b/src-tauri/src/cli/task_set_title.rs
@@ -39,6 +39,16 @@ pub struct TaskSetTitleArgs {
     pub title: String,
 }
 
+fn ensure_workgroup_root_is_authoritative(wg_root: &Path) -> Result<(), String> {
+    let workspace_dir = wg_root.parent().ok_or_else(|| {
+        format!(
+            "workgroup root '{}' has no parent workspace directory",
+            wg_root.display()
+        )
+    })?;
+    crate::config::workspace::ensure_authoritative_workspace_dir(workspace_dir)
+}
+
 pub fn execute(args: TaskSetTitleArgs) -> i32 {
     let root = match args.root {
         Some(ref r) => r.clone(),
@@ -108,6 +118,10 @@ pub fn execute(args: TaskSetTitleArgs) -> i32 {
             return 1;
         }
     };
+    if let Err(e) = ensure_workgroup_root_is_authoritative(&wg_root) {
+        eprintln!("Error: {}", e);
+        return 1;
+    }
 
     // Hand off to task_ops::perform.
     // NIT-2: include `pid={}` so an auditor can cross-reference the AC process
@@ -318,6 +332,29 @@ mod tests {
         );
         let code = execute(args);
         assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn set_title_rejects_stale_legacy_workgroup_when_canonical_exists() {
+        let fix = FixtureRoot::new("task-stale-legacy");
+        let project = fix.path().join("proj");
+        let canonical_wg = project.join(".ac").join("wg-1-test");
+        let legacy_wg = project.join(".ac-new").join("wg-1-test");
+        std::fs::create_dir_all(&canonical_wg).unwrap();
+        std::fs::create_dir_all(&legacy_wg).unwrap();
+
+        let err = ensure_workgroup_root_is_authoritative(&legacy_wg).unwrap_err();
+
+        assert!(err.contains("stale legacy workspace"));
+    }
+
+    #[test]
+    fn set_title_accepts_legacy_workgroup_when_canonical_absent() {
+        let fix = FixtureRoot::new("task-legacy-only");
+        let legacy_wg = fix.path().join("proj").join(".ac-new").join("wg-1-test");
+        std::fs::create_dir_all(&legacy_wg).unwrap();
+
+        ensure_workgroup_root_is_authoritative(&legacy_wg).expect("legacy fallback accepted");
     }
 
     // ── I16: help text documents the verb ───────────────────────────────

--- a/src-tauri/src/cli/workgroup.rs
+++ b/src-tauri/src/cli/workgroup.rs
@@ -100,8 +100,12 @@ pub(crate) fn resolve_cli_project(project: &str) -> Result<PathBuf, String> {
 }
 
 pub(crate) fn resolve_cli_workspace(project_path: &Path) -> Result<PathBuf, String> {
-    existing_workspace_dir(project_path)
-        .ok_or_else(|| format!("AC workspace not found in {} (.ac)", project_path.display()))
+    existing_workspace_dir(project_path).ok_or_else(|| {
+        format!(
+            "AC workspace not found in {} (.ac or legacy .ac-new)",
+            project_path.display()
+        )
+    })
 }
 
 pub(crate) fn write_refresh(project_path: &Path, changed_path: &Path, name: &str, reason: &str) {

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -543,8 +543,12 @@ fn default_agent_matrix_config() -> serde_json::Value {
 }
 
 fn selected_workspace_dir(project: &Path) -> Result<PathBuf, String> {
-    existing_workspace_dir(project)
-        .ok_or_else(|| format!(".ac directory not found in {}", project.display()))
+    existing_workspace_dir(project).ok_or_else(|| {
+        format!(
+            ".ac or legacy .ac-new directory not found in {}",
+            project.display()
+        )
+    })
 }
 
 pub(crate) fn read_team_config(

--- a/src-tauri/src/config/workspace.rs
+++ b/src-tauri/src/config/workspace.rs
@@ -1,24 +1,34 @@
 use std::path::{Path, PathBuf};
 
 pub const CANONICAL_WORKSPACE_DIR: &str = ".ac";
-pub const WORKSPACE_DIR_NAMES: [&str; 1] = [CANONICAL_WORKSPACE_DIR];
+pub const LEGACY_WORKSPACE_DIR: &str = ".ac-new";
+pub const WORKSPACE_DIR_NAMES: [&str; 2] = [CANONICAL_WORKSPACE_DIR, LEGACY_WORKSPACE_DIR];
 
 pub fn canonical_workspace_dir_label() -> &'static str {
     CANONICAL_WORKSPACE_DIR
 }
 
 pub fn workspace_dir_label() -> &'static str {
-    ".ac"
+    ".ac or legacy .ac-new"
 }
 
 pub fn workspace_dir_for_project(project: &Path) -> PathBuf {
     project.join(CANONICAL_WORKSPACE_DIR)
 }
 
+pub fn legacy_workspace_dir_for_project(project: &Path) -> PathBuf {
+    project.join(LEGACY_WORKSPACE_DIR)
+}
+
 pub fn existing_workspace_dir(project: &Path) -> Option<PathBuf> {
     let canonical = workspace_dir_for_project(project);
     if canonical.is_dir() {
         return Some(canonical);
+    }
+
+    let legacy = legacy_workspace_dir_for_project(project);
+    if legacy.is_dir() {
+        return Some(legacy);
     }
 
     None
@@ -90,8 +100,14 @@ pub fn ensure_authoritative_workspace_dir(workspace_dir: &Path) -> Result<(), St
     if same_existing_path(workspace_dir, &authoritative) {
         Ok(())
     } else {
+        let prefix = if workspace_name.eq_ignore_ascii_case(LEGACY_WORKSPACE_DIR) {
+            "stale legacy workspace"
+        } else {
+            "workspace"
+        };
         Err(format!(
-            "workspace '{}' rejected because authoritative workspace '{}' exists",
+            "{} '{}' rejected because authoritative workspace '{}' exists",
+            prefix,
             workspace_dir.display(),
             authoritative.display()
         ))

--- a/src-tauri/tests/cli_create_agent_matrix.rs
+++ b/src-tauri/tests/cli_create_agent_matrix.rs
@@ -75,9 +75,24 @@ fn settings_with_project_paths(paths: &[&Path]) -> serde_json::Value {
     })
 }
 
-fn project_with_workspace(tmp: &Path) -> PathBuf {
+fn project_with_workspace_name(tmp: &Path, workspace_name: &str) -> PathBuf {
     let project = tmp.join("ProjectAlpha");
-    std::fs::create_dir_all(project.join(".ac")).expect("create .ac");
+    std::fs::create_dir_all(project.join(workspace_name)).expect("create workspace");
+    project
+}
+
+fn project_with_workspace(tmp: &Path) -> PathBuf {
+    project_with_workspace_name(tmp, ".ac")
+}
+
+fn project_with_workspaces(tmp: &Path, canonical: bool, legacy: bool) -> PathBuf {
+    let project = tmp.join("ProjectAlpha");
+    if canonical {
+        std::fs::create_dir_all(project.join(".ac")).expect("create .ac");
+    }
+    if legacy {
+        std::fs::create_dir_all(project.join(".ac-new")).expect("create .ac-new");
+    }
     project
 }
 
@@ -107,7 +122,11 @@ fn project_refresh_request_paths(config_dir: &Path) -> Vec<PathBuf> {
     paths
 }
 
-fn assert_single_project_refresh_request(config_dir: &Path, project: &Path) -> serde_json::Value {
+fn assert_single_project_refresh_request_for_agent(
+    config_dir: &Path,
+    project: &Path,
+    agent_dir: &Path,
+) -> serde_json::Value {
     let requests = project_refresh_request_paths(config_dir);
     assert_eq!(
         requests.len(),
@@ -119,7 +138,6 @@ fn assert_single_project_refresh_request(config_dir: &Path, project: &Path) -> s
             .expect("project refresh request json");
     uuid::Uuid::parse_str(request["id"].as_str().expect("id")).expect("id should be a uuid");
     assert!(!request["timestamp"].as_str().expect("timestamp").is_empty());
-    let agent_dir = project.join(".ac").join("_agent_architect");
     assert_eq!(
         request["projectPath"].as_str().expect("projectPath"),
         std::fs::canonicalize(project)
@@ -137,6 +155,14 @@ fn assert_single_project_refresh_request(config_dir: &Path, project: &Path) -> s
     assert_eq!(request["agentName"], "ProjectAlpha/architect");
     assert_eq!(request["reason"], "createAgentMatrix");
     request
+}
+
+fn assert_single_project_refresh_request(config_dir: &Path, project: &Path) -> serde_json::Value {
+    assert_single_project_refresh_request_for_agent(
+        config_dir,
+        project,
+        &project.join(".ac").join("_agent_architect"),
+    )
 }
 
 #[test]
@@ -187,6 +213,87 @@ fn create_agent_matrix_success_prints_json_and_writes_layout() {
     for dir in ["memory", "plans", "skills", "inbox", "outbox"] {
         assert!(agent_dir.join(dir).is_dir(), "missing {}", dir);
     }
+}
+
+#[test]
+fn create_agent_matrix_uses_legacy_workspace_when_canonical_absent() {
+    let tmp = Tmp::new("cli-create-agent-matrix-legacy");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    let project = project_with_workspace_name(tmp.path(), ".ac-new");
+    write_settings(&config_dir, settings_with_project_paths(&[tmp.path()]));
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent-matrix",
+            "--project",
+            "ProjectAlpha",
+            "--name",
+            "Architect",
+            "--description",
+            "Build plans",
+        ])
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
+    let agent_dir = project.join(".ac-new").join("_agent_architect");
+    assert_eq!(
+        json["agentPath"].as_str().expect("agentPath"),
+        agent_dir.to_string_lossy().as_ref()
+    );
+    assert!(agent_dir.join("Role.md").is_file());
+    assert_single_project_refresh_request_for_agent(&config_dir, &project, &agent_dir);
+}
+
+#[test]
+fn create_agent_matrix_prefers_ac_when_both_workspaces_exist() {
+    let tmp = Tmp::new("cli-create-agent-matrix-both");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    let project = project_with_workspaces(tmp.path(), true, true);
+    write_settings(&config_dir, settings_with_project_paths(&[tmp.path()]));
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent-matrix",
+            "--project",
+            "ProjectAlpha",
+            "--name",
+            "Architect",
+            "--description",
+            "Build plans",
+        ])
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
+    let agent_dir = project.join(".ac").join("_agent_architect");
+    assert_eq!(
+        json["agentPath"].as_str().expect("agentPath"),
+        agent_dir.to_string_lossy().as_ref()
+    );
+    assert!(agent_dir.join("Role.md").is_file());
+    assert!(!project.join(".ac-new").join("_agent_architect").exists());
+    assert_single_project_refresh_request_for_agent(&config_dir, &project, &agent_dir);
 }
 
 #[test]

--- a/src-tauri/tests/cli_workgroup_team.rs
+++ b/src-tauri/tests/cli_workgroup_team.rs
@@ -53,15 +53,45 @@ fn write_settings(config_dir: &Path, project_parent: &Path) {
     .expect("write settings");
 }
 
-fn project_with_agents(tmp: &Path, agents: &[&str]) -> PathBuf {
+#[derive(Clone, Copy)]
+enum WorkspaceLayout {
+    Canonical,
+    Legacy,
+    Both,
+}
+
+fn active_workspace(project: &Path, layout: WorkspaceLayout) -> PathBuf {
+    match layout {
+        WorkspaceLayout::Canonical | WorkspaceLayout::Both => project.join(".ac"),
+        WorkspaceLayout::Legacy => project.join(".ac-new"),
+    }
+}
+
+fn project_with_agents_layout(
+    tmp: &Path,
+    agents: &[&str],
+    layout: WorkspaceLayout,
+) -> (PathBuf, PathBuf) {
     let project = tmp.join("ProjectAlpha");
-    let workspace_dir = project.join(".ac");
-    std::fs::create_dir_all(&workspace_dir).expect("create .ac");
+    if matches!(layout, WorkspaceLayout::Canonical | WorkspaceLayout::Both) {
+        std::fs::create_dir_all(project.join(".ac")).expect("create .ac");
+    }
+    if matches!(layout, WorkspaceLayout::Legacy | WorkspaceLayout::Both) {
+        std::fs::create_dir_all(project.join(".ac-new")).expect("create .ac-new");
+    }
+
+    let workspace_dir = active_workspace(&project, layout);
     for agent in agents {
         let dir = workspace_dir.join(format!("_agent_{}", agent));
         std::fs::create_dir_all(dir.join("memory")).expect("agent memory");
         std::fs::write(dir.join("Role.md"), format!("# {}\n", agent)).expect("role");
     }
+
+    (project, workspace_dir)
+}
+
+fn project_with_agents(tmp: &Path, agents: &[&str]) -> PathBuf {
+    let (project, _) = project_with_agents_layout(tmp, agents, WorkspaceLayout::Canonical);
     project
 }
 
@@ -150,6 +180,84 @@ fn workgroup_add_creates_task_messaging_replicas_and_lists() {
     assert_eq!(list[0]["team"], "dev-team");
     assert_eq!(list[0]["hasTask"], true);
     assert_eq!(list[0]["hasMessaging"], true);
+}
+
+#[test]
+fn workgroup_add_uses_legacy_workspace_when_canonical_absent() {
+    let tmp = Tmp::new("cli-workgroup-add-legacy");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let (_project, workspace) = project_with_agents_layout(
+        tmp.path(),
+        &["architect", "dev-rust"],
+        WorkspaceLayout::Legacy,
+    );
+
+    let json = run_json(
+        &bin,
+        &[
+            "workgroup",
+            "add",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--title",
+            "Build the thing",
+            "--coordinator",
+            "architect",
+            "--agent",
+            "dev-rust",
+        ],
+    );
+
+    let wg_dir = workspace.join("wg-1-dev-team");
+    assert_eq!(json["path"], wg_dir.to_string_lossy().as_ref());
+    assert!(wg_dir.join("TASK.md").is_file());
+
+    let list = run_json(&bin, &["workgroup", "list", "--project", "ProjectAlpha"]);
+    assert_eq!(list.as_array().expect("array").len(), 1);
+    assert_eq!(list[0]["path"], wg_dir.to_string_lossy().as_ref());
+}
+
+#[test]
+fn workgroup_add_and_list_prefer_ac_when_both_workspaces_exist() {
+    let tmp = Tmp::new("cli-workgroup-both-add");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let (project, workspace) =
+        project_with_agents_layout(tmp.path(), &["architect"], WorkspaceLayout::Both);
+    let legacy = project.join(".ac-new");
+    std::fs::create_dir_all(legacy.join("wg-1-stale-team")).expect("stale wg");
+
+    let json = run_json(
+        &bin,
+        &[
+            "workgroup",
+            "add",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--title",
+            "Build",
+            "--coordinator",
+            "architect",
+        ],
+    );
+
+    let wg_dir = workspace.join("wg-1-dev-team");
+    assert_eq!(json["path"], wg_dir.to_string_lossy().as_ref());
+    assert!(wg_dir.is_dir());
+    assert!(!legacy.join("wg-1-dev-team").exists());
+
+    let list = run_json(&bin, &["workgroup", "list", "--project", "ProjectAlpha"]);
+    let items = list.as_array().expect("array");
+    assert_eq!(items.len(), 1, "legacy stale workgroup must be ignored");
+    assert_eq!(items[0]["name"], "wg-1-dev-team");
+    assert_eq!(items[0]["path"], wg_dir.to_string_lossy().as_ref());
 }
 
 #[test]
@@ -388,4 +496,44 @@ fn team_add_member_creates_replica_and_peer_is_reachable() {
     );
     assert_eq!(removed["removed"], true);
     assert!(!replica.exists());
+}
+
+#[test]
+fn team_list_prefers_ac_over_stale_legacy_config() {
+    let tmp = Tmp::new("cli-team-both-list");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let (project, _workspace) =
+        project_with_agents_layout(tmp.path(), &["architect"], WorkspaceLayout::Both);
+
+    let _wg = run_json(
+        &bin,
+        &[
+            "workgroup",
+            "add",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--title",
+            "Build",
+            "--coordinator",
+            "architect",
+        ],
+    );
+
+    let legacy_team_dir = project.join(".ac-new").join("_team_dev-team");
+    std::fs::create_dir_all(&legacy_team_dir).expect("legacy team dir");
+    std::fs::write(
+        legacy_team_dir.join("config.json"),
+        r#"{"agents":["_agent_stale"],"coordinator":"_agent_stale","repos":[]}"#,
+    )
+    .expect("legacy config");
+
+    let teams = run_json(&bin, &["team", "list", "--project", "ProjectAlpha"]);
+    assert_eq!(teams.as_array().expect("teams").len(), 1);
+    assert_eq!(teams[0]["team"], "dev-team");
+    assert_eq!(teams[0]["coordinator"], "_agent_architect");
+    assert_ne!(teams[0]["coordinator"], "_agent_stale");
 }


### PR DESCRIPTION
## Summary

Closes #386.

Ports the useful pieces recovered from the local stash onto a clean branch from `origin/main`, while leaving out unrelated formatting/logging/session/UI churn.

## Changes

- Ignore canonical workgroup replicas with `.ac/wg-*/`.
- Restore shared workspace resolution that prefers canonical `.ac` and falls back to legacy `.ac-new` only when `.ac` is absent.
- Add task append/title guards so stale `.ac-new` workgroup roots are rejected when canonical `.ac` exists, while legacy-only workgroups still work.
- Update create-agent-matrix/workgroup/entity creation paths to use the shared workspace resolver.
- Update the standalone helper script to prefer `.ac`, keep `-AcNewRoot` as a legacy alias, and fall back to `.ac-new` when needed.
- Add focused regression coverage for canonical-vs-legacy workspace behavior.

## Excluded

- Did not port `src/sidebar/components/EditTeamModal.tsx`; that stash hunk conflicted with current portable team-ref UI handling and should be reviewed separately if still needed.
- Did not port unrelated formatting/import/logging/session/telegram churn from the stash.

## Validation

Dev validation:

- `rustfmt --edition 2021` on touched Rust files
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml append_body_`
- `cargo test --manifest-path src-tauri/Cargo.toml set_title_`
- `cargo test --manifest-path src-tauri/Cargo.toml --test cli_create_agent_matrix`
- `cargo test --manifest-path src-tauri/Cargo.toml --test cli_workgroup_team`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets`
- PowerShell parse check for `scripts/all_agentscommander_standalone_come_to_me.ps1`
- `git diff --check`

Grinch review:

- `GRINCH_PASS`, no findings.
- Additional checks passed: `cargo test --test cli_create_agent_matrix --test cli_workgroup_team`, `cargo test legacy_workgroup --lib`, `git diff --check origin/main...HEAD`.

Shipper validation:

- Full `npx tauri build` passed.
- Deployed only to `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-2.exe`.
- Post-deploy `--help` passed.

Known warnings were pre-existing or non-blocking: Tauri macOS bundle identifier warning, Vite large chunk/dynamic import warnings, and existing Rust dead-code/clippy warnings in untouched files.