### PR TITLE
fix(root-agent): avoid shell fallback before agent setup (#391)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.44",
+  "version": "0.8.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.44",
+      "version": "0.8.46",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.44",
+  "version": "0.8.46",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.44"
+version = "0.8.46"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.44"
+version = "0.8.46"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1754,8 +1754,6 @@ fn normalize_agent_command_for_source(
         })
 }
 
-type ResolvedRootAgentCommand = (String, Vec<String>, Option<String>, Option<String>);
-
 pub(crate) fn resolve_root_agent_command(
     settings: &AppSettings,
     requested_agent_id: Option<&str>,

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1968,6 +1968,8 @@ pub(crate) async fn create_root_agent_inner(
     };
     let mut waking_existing = false;
     let mut restored_telegram_bot_id: Option<String> = None;
+    let last_coding_agent = crate::config::root_agent::read_last_coding_agent(&root_agent_path);
+    let mut resolved_root_agent_command: Option<ResolvedRootAgentCommand> = None;
 
     if let Some(existing) = existing {
         let uuid = Uuid::parse_str(&existing.id).map_err(|e| e.to_string())?;
@@ -1992,6 +1994,14 @@ pub(crate) async fn create_root_agent_inner(
                 return Ok(existing);
             }
             ExistingRootAction::WakeDormant => {
+                resolved_root_agent_command = Some({
+                    let cfg = settings.read().await;
+                    resolve_root_agent_command(
+                        &cfg,
+                        requested_agent_id.as_deref(),
+                        last_coding_agent.as_deref(),
+                    )?
+                });
                 waking_existing = true;
                 restored_telegram_bot_id = existing.telegram_bot_id.clone();
                 log::info!(
@@ -2001,6 +2011,14 @@ pub(crate) async fn create_root_agent_inner(
                 force_destroy_session_inner(app, uuid).await?;
             }
             ExistingRootAction::DiscardMissingPty => {
+                resolved_root_agent_command = Some({
+                    let cfg = settings.read().await;
+                    resolve_root_agent_command(
+                        &cfg,
+                        requested_agent_id.as_deref(),
+                        last_coding_agent.as_deref(),
+                    )?
+                });
                 log::warn!(
                     "[root-agent] Discarding root session {} because it has status {:?} but no PTY",
                     existing.id,
@@ -2011,15 +2029,17 @@ pub(crate) async fn create_root_agent_inner(
         }
     }
 
-    let last_coding_agent = crate::config::root_agent::read_last_coding_agent(&root_agent_path);
-    let (shell, shell_args, agent_id, agent_label) = {
-        let cfg = settings.read().await;
-        resolve_root_agent_command(
-            &cfg,
-            requested_agent_id.as_deref(),
-            last_coding_agent.as_deref(),
-        )?
-    };
+    let (shell, shell_args, agent_id, agent_label) =
+        if let Some(resolved) = resolved_root_agent_command {
+            resolved
+        } else {
+            let cfg = settings.read().await;
+            resolve_root_agent_command(
+                &cfg,
+                requested_agent_id.as_deref(),
+                last_coding_agent.as_deref(),
+            )?
+        };
 
     let info = create_session_inner(
         app,
@@ -2086,6 +2106,7 @@ mod tests {
         ExistingRootAction,
     };
     use crate::config::settings::{AgentConfig, AppSettings};
+    use crate::session::manager::SessionManager;
     use crate::session::session::SessionStatus;
     use std::path::PathBuf;
 
@@ -2249,6 +2270,49 @@ mod tests {
             classify_existing_root(&SessionStatus::Exited(0), false),
             ExistingRootAction::WakeDormant
         );
+    }
+
+    #[tokio::test]
+    async fn dormant_root_command_resolution_failure_preserves_existing_session() {
+        let session_mgr = SessionManager::new();
+        let settings = AppSettings {
+            agents: Vec::new(),
+            ..AppSettings::default()
+        };
+
+        let dormant = {
+            let session = session_mgr
+                .create_session(
+                    "codex".to_string(),
+                    Vec::new(),
+                    "C:\\test\\ac-root-agent".to_string(),
+                    Some("codex".to_string()),
+                    Some("Codex".to_string()),
+                    Vec::new(),
+                    false,
+                )
+                .await
+                .expect("failed to create dormant root session");
+            session_mgr.set_is_root_agent(session.id, true).await;
+            session_mgr.mark_exited(session.id, 0).await;
+            session
+        };
+
+        assert_eq!(
+            classify_existing_root(&SessionStatus::Exited(0), false),
+            ExistingRootAction::WakeDormant
+        );
+
+        let err = resolve_root_agent_command(&settings, Some("stale"), Some("also-stale"))
+            .expect_err("replacement command should fail before destroying dormant root");
+
+        assert!(err.contains("No resolvable coding agent"));
+        let preserved = session_mgr.get_session(dormant.id).await;
+        assert!(matches!(
+            preserved.as_ref().map(|s| &s.status),
+            Some(SessionStatus::Exited(0))
+        ));
+        assert!(preserved.is_some_and(|s| s.is_root_agent));
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1754,7 +1754,9 @@ fn normalize_agent_command_for_source(
         })
 }
 
-fn resolve_root_agent_command(
+type ResolvedRootAgentCommand = (String, Vec<String>, Option<String>, Option<String>);
+
+pub(crate) fn resolve_root_agent_command(
     settings: &AppSettings,
     requested_agent_id: Option<&str>,
     last_coding_agent: Option<&str>,
@@ -1809,12 +1811,7 @@ fn resolve_root_agent_command(
         ));
     }
 
-    Ok((
-        settings.default_shell.clone(),
-        settings.default_shell_args.clone(),
-        None,
-        None,
-    ))
+    Err("No resolvable coding agent is configured for the Root Agent. Configure a coding agent before launching the Root Agent.".to_string())
 }
 
 fn resolve_agent_label(agent_id: &str, settings: &AppSettings) -> Option<String> {
@@ -2154,7 +2151,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_root_agent_command_falls_back_to_default_shell_without_agents() {
+    fn resolve_root_agent_command_rejects_default_shell_without_agents() {
         let mut settings = AppSettings {
             default_shell: "pwsh".to_string(),
             default_shell_args: vec!["-NoLogo".to_string()],
@@ -2162,13 +2159,10 @@ mod tests {
         };
         settings.agents.clear();
 
-        let (shell, args, agent_id, label) =
-            resolve_root_agent_command(&settings, Some("stale"), Some("also-stale")).unwrap();
+        let err =
+            resolve_root_agent_command(&settings, Some("stale"), Some("also-stale")).unwrap_err();
 
-        assert_eq!(shell, "pwsh");
-        assert_eq!(args, vec!["-NoLogo".to_string()]);
-        assert!(agent_id.is_none());
-        assert!(label.is_none());
+        assert!(err.contains("No resolvable coding agent"));
     }
 
     #[test]

--- a/src-tauri/src/config/replica_identity.rs
+++ b/src-tauri/src/config/replica_identity.rs
@@ -54,8 +54,7 @@ pub fn agent_bare_name_from_ref(raw_agent: &str) -> Result<String, String> {
     let normalized = trimmed.replace('\\', "/");
     let dir_name = normalized
         .split('/')
-        .filter(|part| !part.is_empty())
-        .next_back()
+        .rfind(|part| !part.is_empty())
         .ok_or_else(|| format!("Invalid agent reference '{}'", raw_agent))?;
     let bare = dir_name
         .strip_prefix("__agent_")
@@ -77,8 +76,7 @@ fn persisted_identity_agent_name(identity: &str) -> Result<String, String> {
     let normalized = trimmed.replace('\\', "/");
     let dir_name = normalized
         .split('/')
-        .filter(|part| !part.is_empty())
-        .next_back()
+        .rfind(|part| !part.is_empty())
         .ok_or_else(|| format!("Invalid WG replica identity '{}'", identity))?;
 
     #[cfg(windows)]

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -443,7 +443,7 @@ pub fn load_sessions_raw() -> Vec<PersistedSession> {
     if !path.exists() {
         return vec![];
     }
-    match std::fs::read_to_string(&path) {
+    match std::fs::read_to_string(path) {
         Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
         Err(_) => vec![],
     }
@@ -472,7 +472,7 @@ fn load_sessions_from_path(path: &Path) -> Vec<PersistedSession> {
         return vec![];
     }
 
-    match std::fs::read_to_string(&path) {
+    match std::fs::read_to_string(path) {
         Ok(contents) => match serde_json::from_str::<Vec<PersistedSession>>(&contents) {
             Ok(sessions) => {
                 // Safety net: filter out [temp] sessions that should never survive a restart
@@ -1119,13 +1119,6 @@ pub async fn persist_current_state_result(mgr: &SessionManager) -> Result<(), St
     persist_current_state_to_dir_for_project_paths_result(mgr, &dir, Some(&project_paths)).await
 }
 
-async fn persist_current_state_to_dir_result(
-    mgr: &SessionManager,
-    dir: &Path,
-) -> Result<(), String> {
-    persist_current_state_to_dir_for_project_paths_result(mgr, dir, None).await
-}
-
 async fn persist_current_state_to_dir_for_project_paths_result(
     mgr: &SessionManager,
     dir: &Path,
@@ -1138,6 +1131,14 @@ async fn persist_current_state_to_dir_for_project_paths_result(
         None => snapshot,
     };
     save_sessions_to_dir(dir, &snapshot)
+}
+
+#[cfg(test)]
+async fn persist_current_state_to_dir_result(
+    mgr: &SessionManager,
+    dir: &Path,
+) -> Result<(), String> {
+    persist_current_state_to_dir_for_project_paths_result(mgr, dir, None).await
 }
 
 pub async fn persist_current_state(mgr: &SessionManager) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -146,6 +146,13 @@ pub(crate) fn should_wake_root_agent_on_restore(
     }
 }
 
+pub(crate) fn should_auto_create_root_agent_on_first_restore(
+    settings: &crate::config::settings::AppSettings,
+    last_coding_agent: Option<&str>,
+) -> bool {
+    commands::session::resolve_root_agent_command(settings, None, last_coding_agent).is_ok()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Same backend the CLI path now installs in `main.rs` — see `logging.rs`
@@ -745,22 +752,38 @@ pub fn run() {
                     if let Some(root_path) = root_agent_path.clone() {
                         match root_ps.as_ref() {
                             None => {
-                                match commands::session::create_root_agent_inner(
-                                    &app_handle,
-                                    &session_mgr_clone,
-                                    &pty_mgr_clone,
-                                    &tg_mgr_clone,
-                                    &settings_state_clone,
-                                    None,
-                                    true,
-                                )
-                                .await
-                                {
-                                    Ok(_) => n_woken += 1,
-                                    Err(e) => log::error!(
-                                        "[root-agent] Failed to auto-create root session: {}",
-                                        e
-                                    ),
+                                let last_coding_agent =
+                                    crate::config::root_agent::read_last_coding_agent(&root_path);
+                                let should_auto_create = {
+                                    let cfg = settings_state_clone.read().await;
+                                    should_auto_create_root_agent_on_first_restore(
+                                        &cfg,
+                                        last_coding_agent.as_deref(),
+                                    )
+                                };
+
+                                if should_auto_create {
+                                    match commands::session::create_root_agent_inner(
+                                        &app_handle,
+                                        &session_mgr_clone,
+                                        &pty_mgr_clone,
+                                        &tg_mgr_clone,
+                                        &settings_state_clone,
+                                        None,
+                                        true,
+                                    )
+                                    .await
+                                    {
+                                        Ok(_) => n_woken += 1,
+                                        Err(e) => log::error!(
+                                            "[root-agent] Failed to auto-create root session: {}",
+                                            e
+                                        ),
+                                    }
+                                } else {
+                                    log::info!(
+                                        "[root-agent] Skipping startup auto-create: no resolvable coding agent is configured"
+                                    );
                                 }
                             }
                             Some(ps)
@@ -1432,8 +1455,26 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::{should_wake_on_restore, should_wake_root_agent_on_restore};
+    use super::{
+        should_auto_create_root_agent_on_first_restore, should_wake_on_restore,
+        should_wake_root_agent_on_restore,
+    };
+    use crate::config::settings::{AgentConfig, AppSettings};
     use crate::session::session::SessionStatus;
+
+    fn settings_with_agent() -> AppSettings {
+        AppSettings {
+            agents: vec![AgentConfig {
+                id: "codex".to_string(),
+                label: "Codex".to_string(),
+                command: "codex".to_string(),
+                color: "#10b981".to_string(),
+                git_pull_before: false,
+                exclude_global_claude_md: false,
+            }],
+            ..AppSettings::default()
+        }
+    }
 
     #[test]
     fn setting_off_always_defers() {
@@ -1514,5 +1555,33 @@ mod tests {
         assert!(!should_wake_root_agent_on_restore(Some(
             &SessionStatus::Exited(137)
         )));
+    }
+
+    #[test]
+    fn first_restore_does_not_auto_create_root_agent_without_agents() {
+        let settings = AppSettings::default();
+
+        assert!(!should_auto_create_root_agent_on_first_restore(
+            &settings, None
+        ));
+    }
+
+    #[test]
+    fn first_restore_auto_creates_root_agent_with_configured_agent() {
+        let settings = settings_with_agent();
+
+        assert!(should_auto_create_root_agent_on_first_restore(
+            &settings, None
+        ));
+    }
+
+    #[test]
+    fn first_restore_auto_creates_root_agent_with_valid_last_coding_agent() {
+        let settings = settings_with_agent();
+
+        assert!(should_auto_create_root_agent_on_first_restore(
+            &settings,
+            Some("codex")
+        ));
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.8.44",
+  "version": "0.8.46",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {


### PR DESCRIPTION
## Summary
- Prevent first startup from auto-spawning Root Agent as a default shell when no Coding Agent is resolvable.
- Preserve dormant Root Agent session state when launch command resolution fails.
- Update release metadata to 0.8.46 after rebasing onto latest origin/main.

## Validation
- npm ci
- npm run build
- cargo test root_agent --lib
- cargo check
- cargo clippy --all-targets -- -D warnings
- npm test
- Built and deployed wg-2 executable for validation; user confirmed it worked.

Closes #391