### PR TITLE
feat(rtk): make startup prompt opt-in (#426)

### DIFF
--- a/docs/features/rtk-integration.md
+++ b/docs/features/rtk-integration.md
@@ -28,16 +28,18 @@ Claude Code's Bash tool emits the full command output back into the model's cont
 
 ## What AC does automatically
 
-On every AC startup AC probes `PATH` for the `rtk` binary and runs one of these branches (`src-tauri/src/lib.rs:382-473`):
+On every AC startup AC probes `PATH` for the `rtk` binary and maps the result, with three persisted settings flags, to a mode via `compute_rtk_startup_mode` (`src-tauri/src/config/settings.rs`); the setup task in `src-tauri/src/lib.rs` then runs one of these branches:
 
-| `rtk` on PATH? | `injectRtkHook` setting | `rtkPromptDismissed` | Behavior |
-|---|---|---|---|
-| Yes | `false` | `false` | Emits `rtk_startup_status mode=prompt-enable` — the sidebar banner offers to enable injection. |
-| Yes | `true` | any | Mode `active`. Sweeps every managed agent dir and (re)writes the `.claude/settings.local.json` inside each managed agent directory with the RTK `PreToolUse` hook. |
-| No | `true` | any | Mode `auto-disabled`. Persists `injectRtkHook=false`, then sweeps to remove any stale hooks. |
-| No | `false` | any | Mode `silent`. No-op. |
+| `rtk` on PATH? | `injectRtkHook` | `rtkPromptDismissed` | `informWhenRtkInstalled` | Behavior |
+|---|---|---|---|---|
+| Yes | `false` | `false` | `true` | Emits `rtk_startup_status mode=prompt-enable`. The sidebar banner offers to enable injection. |
+| Yes | `false` | `false` | `false` | Mode `silent`. The banner is suppressed because the opt-in is off (the default). |
+| Yes | `false` | `true` | any | Mode `silent`. A dismissed banner stays suppressed regardless of the opt-in. |
+| Yes | `true` | any | any | Mode `active`. Sweeps every managed agent dir and (re)writes the `.claude/settings.local.json` inside each managed agent directory with the RTK `PreToolUse` hook. |
+| No | `true` | any | any | Mode `auto-disabled`. Persists `injectRtkHook=false`, then sweeps to remove any stale hooks. |
+| No | `false` | any | any | Mode `silent`. No-op. |
 
-The sweep loop is idempotent and serialized under an internal lock so concurrent settings updates cannot race against it.
+`informWhenRtkInstalled` defaults to `false`, so the banner is opt-in: enable it under **Settings → General → RTK**. The sweep loop is idempotent and serialized under an internal lock so concurrent settings updates cannot race against it.
 
 ## What gets written
 
@@ -70,7 +72,9 @@ AC does not bundle RTK; you install it yourself once:
 
 1. Follow the RTK installation instructions at [https://github.com/rtk-ai/rtk](https://github.com/rtk-ai/rtk).
 2. Verify it is on PATH: `rtk --version`.
-3. Restart AC. The sidebar banner appears offering to enable the hook injection. Click **Enable**.
+3. Enable the integration one of two ways:
+   - Turn on **Settings → General → RTK → Inject RTK hook into agent replicas** directly, or
+   - Turn on **Settings → General → RTK → Show the startup banner when RTK is installed but not enabled**, restart AC, and click **Enable** on the banner that appears.
 
 From that point on, AC injects the hook into every managed agent directory at startup. New agents you create through the UI inherit the hook automatically.
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -152,7 +152,8 @@ See [Telegram bridge setup](../integrations/telegram.md).
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `injectRtkHook` | bool | `false` | Inject the RTK `PreToolUse` hook into every managed agent's `.claude/settings.local.json` at startup. |
-| `rtkPromptDismissed` | bool | `false` | Suppress the "RTK detected — enable hook injection?" banner for the lifetime of this settings file. |
+| `informWhenRtkInstalled` | bool | `false` | Opt-in gate for the startup "RTK detected, enable hook injection?" banner. Off by default, so the banner never appears unless you enable it. The banner also requires `injectRtkHook=false` and `rtkPromptDismissed=false`. Evaluated at startup; a change applies on the next launch. |
+| `rtkPromptDismissed` | bool | `false` | Suppress the "RTK detected, enable hook injection?" banner for the lifetime of this settings file. |
 
 See [RTK integration](../features/rtk-integration.md).
 

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -253,6 +253,13 @@ pub struct AppSettings {
     /// ask again]` button on the banner. See issue #120.
     #[serde(default)]
     pub rtk_prompt_dismissed: bool,
+    /// When true, AC may surface the startup banner offering to enable
+    /// `inject_rtk_hook`, subject to the other gates: `rtk` on PATH,
+    /// `inject_rtk_hook == false`, and `rtk_prompt_dismissed == false`.
+    /// Defaults to `false` so the banner is opt-in and never appears unless the
+    /// user enables it in Settings → General → RTK. See issue #426.
+    #[serde(default)]
+    pub inform_when_rtk_installed: bool,
     /// When true, on Coordinator session spawn AC injects a prompt asking the
     /// agent to add a YAML frontmatter `title:` line to its workgroup
     /// `TASK.md` (only if the brief is non-empty and has no `title:` yet).
@@ -376,10 +383,48 @@ impl Default for AppSettings {
             log_level: None,
             inject_rtk_hook: false,
             rtk_prompt_dismissed: false,
+            inform_when_rtk_installed: false,
             auto_generate_task_title: true,
             agent_templates_path: None,
             theme_light: true,
         }
+    }
+}
+
+/// Pure decision for the boot-time RTK banner/sweep mode (issue #120 §18,
+/// extended by issue #426). Maps the three persisted settings flags plus the
+/// runtime `rtk`-on-PATH probe to one of the four `RtkStartupMode` strings the
+/// frontend understands. Side-effect-free so the full truth table is unit
+/// testable without booting Tauri, spawning the setup task, probing PATH, or
+/// touching disk.
+///
+/// `inform_when_rtk_installed` is the issue #426 opt-in gate: the
+/// `prompt-enable` banner only appears when the user has explicitly turned it
+/// on. `rtk_prompt_dismissed` is retained as a secondary suppression gate (the
+/// banner's `[Don't ask again]` button) and still wins when set.
+pub fn compute_rtk_startup_mode(
+    rtk_present: bool,
+    inject_enabled: bool,
+    prompt_dismissed: bool,
+    inform_when_rtk_installed: bool,
+) -> &'static str {
+    match (
+        rtk_present,
+        inject_enabled,
+        prompt_dismissed,
+        inform_when_rtk_installed,
+    ) {
+        // Opt-in banner: rtk present, not yet injected, not dismissed, and the
+        // user asked to be informed. All four must hold (issue #426).
+        (true, false, false, true) => "prompt-enable",
+        // Already enabled: recover/refresh the hook. `inform` and `dismissed`
+        // are irrelevant once injection is on.
+        (true, true, _, _) => "active",
+        // Enabled but the binary vanished from PATH: auto-disable and clean up.
+        (false, true, _, _) => "auto-disabled",
+        // Everything else (inform=false, or dismissed=true, or rtk absent and
+        // not injected) is a no-op.
+        _ => "silent",
     }
 }
 
@@ -1281,6 +1326,88 @@ mod tests {
         assert!(json.contains("\"rtkPromptDismissed\":true"));
         let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
         assert!(back.rtk_prompt_dismissed);
+    }
+
+    #[test]
+    fn inform_when_rtk_installed_round_trips_through_serde() {
+        let mut s = AppSettings::default();
+        assert!(!s.inform_when_rtk_installed);
+        s.inform_when_rtk_installed = true;
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert!(json.contains("\"informWhenRtkInstalled\":true"));
+        let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.inform_when_rtk_installed);
+    }
+
+    #[test]
+    fn inform_when_rtk_installed_defaults_false_when_missing_from_json() {
+        // Old settings.json without the #426 field must deserialize to false so
+        // the startup banner stays opt-in (never appears after an upgrade).
+        let json = r#"{
+            "defaultShell": "bash",
+            "defaultShellArgs": [],
+            "agents": []
+        }"#;
+        let s: AppSettings = serde_json::from_str(json).expect("deserialize old json");
+        assert!(!s.inform_when_rtk_installed);
+    }
+
+    #[test]
+    fn compute_rtk_startup_mode_prompt_enable_requires_all_gates() {
+        // Opt-in banner: only when rtk present, injection off, not dismissed,
+        // AND the user opted in (#426).
+        assert_eq!(
+            super::compute_rtk_startup_mode(true, false, false, true),
+            "prompt-enable"
+        );
+    }
+
+    #[test]
+    fn compute_rtk_startup_mode_silent_when_inform_off() {
+        // Core #426 regression guard: rtk present, not injected, not dismissed,
+        // but inform=false => no banner (silent). This is the new default.
+        assert_eq!(
+            super::compute_rtk_startup_mode(true, false, false, false),
+            "silent"
+        );
+    }
+
+    #[test]
+    fn compute_rtk_startup_mode_dismissed_suppresses_even_when_inform_on() {
+        // rtk_prompt_dismissed remains a secondary gate (#426): a dismissed
+        // prompt stays suppressed even if inform was later enabled.
+        assert_eq!(
+            super::compute_rtk_startup_mode(true, false, true, true),
+            "silent"
+        );
+    }
+
+    #[test]
+    fn compute_rtk_startup_mode_active_when_injected_regardless_of_inform() {
+        assert_eq!(
+            super::compute_rtk_startup_mode(true, true, false, false),
+            "active"
+        );
+        assert_eq!(
+            super::compute_rtk_startup_mode(true, true, true, true),
+            "active"
+        );
+    }
+
+    #[test]
+    fn compute_rtk_startup_mode_auto_disabled_when_missing_but_injected() {
+        assert_eq!(
+            super::compute_rtk_startup_mode(false, true, false, false),
+            "auto-disabled"
+        );
+    }
+
+    #[test]
+    fn compute_rtk_startup_mode_silent_when_missing_and_not_injected() {
+        assert_eq!(
+            super::compute_rtk_startup_mode(false, false, false, true),
+            "silent"
+        );
     }
 
     // ── Issue #248 — legacy startOnlyCoordinators → restoreCoordinatorWakeState ──

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -376,16 +376,21 @@ pub fn run() {
                 }
             }
 
-            // Issue #120 — RTK startup detection. Probes PATH for `rtk`, then:
-            //   - rtk found AND inject_rtk_hook=false AND rtk_prompt_dismissed=false
-            //       → emit "rtk_startup_status" with mode="prompt-enable"
-            //   - rtk found AND inject_rtk_hook=true
-            //       → emit mode="active" + active-recovery ON-sweep (idempotent)
-            //   - rtk missing AND inject_rtk_hook=true
-            //       → persist inject_rtk_hook=false (write lock held through save —
-            //         grinch H4 + N1); sweep with enabled=false (RtkSweepLock held —
-            //         grinch M8); emit mode="auto-disabled".
-            //   - otherwise: emit mode="silent" (frontend treats as no-op).
+            // Issue #120 / #426 — RTK startup detection. Probes PATH for `rtk`,
+            // then maps (rtk_present, inject_rtk_hook, rtk_prompt_dismissed,
+            // inform_when_rtk_installed) to a mode via
+            // `crate::config::settings::compute_rtk_startup_mode`:
+            //   - prompt-enable: rtk found AND inject_rtk_hook=false AND
+            //       rtk_prompt_dismissed=false AND inform_when_rtk_installed=true.
+            //       The banner is opt-in (issue #426): default-false inform means
+            //       no banner unless the user enabled it in Settings.
+            //   - active: rtk found AND inject_rtk_hook=true. Emits mode="active"
+            //       plus an active-recovery ON-sweep (idempotent).
+            //   - auto-disabled: rtk missing AND inject_rtk_hook=true. Persists
+            //       inject_rtk_hook=false (write lock held through save: grinch
+            //       H4 + N1); sweeps with enabled=false (RtkSweepLock held: grinch
+            //       M8); emits mode="auto-disabled".
+            //   - silent: everything else (frontend treats as no-op).
             // Detached so the rest of setup is not blocked by disk I/O.
             {
                 let app_handle_for_rtk = app.handle().clone();
@@ -401,17 +406,21 @@ pub fn run() {
                     let settings_state = app_handle_for_rtk
                         .state::<crate::config::settings::SettingsState>();
 
-                    let (inject_enabled, prompt_dismissed) = {
+                    let (inject_enabled, prompt_dismissed, inform_when_installed) = {
                         let s = settings_state.read().await;
-                        (s.inject_rtk_hook, s.rtk_prompt_dismissed)
+                        (
+                            s.inject_rtk_hook,
+                            s.rtk_prompt_dismissed,
+                            s.inform_when_rtk_installed,
+                        )
                     };
 
-                    let mode: &'static str = match (rtk_present, inject_enabled, prompt_dismissed) {
-                        (true, false, false) => "prompt-enable",
-                        (true, true, _) => "active",
-                        (false, true, _) => "auto-disabled",
-                        _ => "silent",
-                    };
+                    let mode: &'static str = crate::config::settings::compute_rtk_startup_mode(
+                        rtk_present,
+                        inject_enabled,
+                        prompt_dismissed,
+                        inform_when_installed,
+                    );
 
                     // §18 — cache the boot decision BEFORE running side effects
                     // so a late-mounting banner sees the SAME mode the listener
@@ -471,11 +480,12 @@ pub fn run() {
                     );
 
                     log::info!(
-                        "[rtk-startup] mode={} rtkPresent={} injectEnabled={} promptDismissed={}",
+                        "[rtk-startup] mode={} rtkPresent={} injectEnabled={} promptDismissed={} informWhenInstalled={}",
                         mode,
                         rtk_present,
                         inject_enabled,
-                        prompt_dismissed
+                        prompt_dismissed,
+                        inform_when_installed
                     );
                 });
             }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -180,6 +180,7 @@ export interface AppSettings {
   coordSortByActivity: boolean;
   injectRtkHook: boolean;
   rtkPromptDismissed: boolean;
+  informWhenRtkInstalled: boolean;
   autoGenerateTaskTitle: boolean;
   agentTemplatesPath: string | null;
   themeLight: boolean;

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -379,6 +379,23 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           />
           <span>Inject RTK hook into agent replicas</span>
         </label>
+        <label class="settings-checkbox-field">
+          <input
+            type="checkbox"
+            class="settings-checkbox"
+            checked={settings.data!.informWhenRtkInstalled}
+            disabled={saving()}
+            onChange={(e) =>
+              updateField("informWhenRtkInstalled", e.currentTarget.checked)
+            }
+          />
+          <span>Show the startup banner when RTK is installed but not enabled</span>
+        </label>
+        <div class="settings-hint">
+          Off by default. When on, AC offers to enable RTK injection via a sidebar
+          banner at startup. This banner setting is read once at launch, so changes
+          to it take effect the next time AC starts.
+        </div>
       </div>
 
       <div class="settings-section">


### PR DESCRIPTION
## Summary
- Add informWhenRtkInstalled setting with default false
- Gate the RTK installed startup banner on that opt-in setting
- Add Settings UI, TS contract, docs, and Rust tests

## Verification
- cargo check --all-targets
- cargo clippy --all-targets
- cargo test --lib rtk
- npx tsc --noEmit
- vitest run
- dev-rust-grinch REVIEW_PASS

Closes #426