### PR TITLE
feat(npm): add install distribution package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,3 +87,48 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}
+
+      - name: Upload raw binaries and npm assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG="${{ github.ref_name }}"
+          if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+            cp src-tauri/target/release/agentscommander.exe agentscommander-windows-x86_64.exe
+            gh release upload "$TAG" agentscommander-windows-x86_64.exe --clobber
+          elif [[ "${{ matrix.platform }}" == "ubuntu-22.04" ]]; then
+            cp src-tauri/target/release/agentscommander agentscommander-linux-x86_64
+            gh release upload "$TAG" agentscommander-linux-x86_64 --clobber
+          elif [[ "${{ matrix.args }}" == *aarch64* ]]; then
+            cp src-tauri/target/aarch64-apple-darwin/release/agentscommander agentscommander-mac-aarch64
+            gh release upload "$TAG" agentscommander-mac-aarch64 --clobber
+            APP_TAR=$(find src-tauri/target/aarch64-apple-darwin/release/bundle/macos -name "*.app.tar.gz" | head -n 1)
+            cp "$APP_TAR" agentscommander-mac-aarch64.app.tar.gz
+            gh release upload "$TAG" agentscommander-mac-aarch64.app.tar.gz --clobber
+          elif [[ "${{ matrix.args }}" == *x86_64* ]]; then
+            cp src-tauri/target/x86_64-apple-darwin/release/agentscommander agentscommander-mac-x86_64
+            gh release upload "$TAG" agentscommander-mac-x86_64 --clobber
+            APP_TAR=$(find src-tauri/target/x86_64-apple-darwin/release/bundle/macos -name "*.app.tar.gz" | head -n 1)
+            cp "$APP_TAR" agentscommander-mac-x86_64.app.tar.gz
+            gh release upload "$TAG" agentscommander-mac-x86_64.app.tar.gz --clobber
+          fi
+
+  checksums:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+      - name: Generate and upload checksums
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          mkdir -p release-assets
+          cd release-assets
+          gh release download "$TAG"
+          sha256sum * > ../SHASUMS256.txt
+          cd ..
+          gh release upload "$TAG" SHASUMS256.txt --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ _logbooks/
 CLAUDE.md
 GEMINI.md
 AGENTS.md
+
+# npm wrapper downloaded binaries
+npm/bin/

--- a/README.md
+++ b/README.md
@@ -21,12 +21,24 @@
 <p align="center">
   <a href="https://github.com/mblua/AgentsCommander/releases/latest"><b>⬇ Download (latest release)</b></a>
   &nbsp;·&nbsp;
+  <a href="#installation"><b>npm install</b></a>
+  &nbsp;·&nbsp;
   <a href="#60-second-quickstart"><b>▶ 60-second quickstart</b></a>
   &nbsp;·&nbsp;
   <a href="docs/quickstart.md"><b>Quickstart</b></a>
 </p>
 
 ---
+
+## Installation
+
+Install AgentsCommander globally via npm:
+
+```bash
+npm install -g agentscommander
+```
+
+The npm package downloads the matching executable for your platform from the GitHub release.
 
 ## The 30-second pitch
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,153 @@
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const crypto = require('crypto');
+const os = require('os');
+const { execSync } = require('child_process');
+
+const VERSION = "0.8.50"; // Must match package.json
+const OWNER = 'mblua';
+const REPO = 'AgentsCommander';
+
+const platform = os.platform();
+const arch = os.arch();
+
+// Map Node platform/arch to our release asset names
+let assetName = '';
+if (platform === 'darwin') {
+  assetName = `agentscommander-mac-${arch === 'arm64' ? 'aarch64' : 'x86_64'}.app.tar.gz`;
+} else if (platform === 'win32') {
+  assetName = `agentscommander-windows-${arch === 'arm64' ? 'aarch64' : 'x86_64'}.exe`;
+} else if (platform === 'linux') {
+  assetName = `agentscommander-linux-${arch === 'arm64' ? 'aarch64' : 'x86_64'}`;
+} else {
+  console.error(`Unsupported platform: ${platform}`);
+  process.exit(1);
+}
+
+const binDir = path.join(__dirname, 'bin');
+if (!fs.existsSync(binDir)) {
+  fs.mkdirSync(binDir, { recursive: true });
+}
+
+const targetPath = path.join(binDir, assetName);
+const tmpPath = targetPath + '.tmp';
+const shasumUrl = `https://github.com/${OWNER}/${REPO}/releases/download/v${VERSION}/SHASUMS256.txt`;
+const assetUrl = `https://github.com/${OWNER}/${REPO}/releases/download/v${VERSION}/${assetName}`;
+
+function fetchUrl(url, redirectCount = 0) {
+  return new Promise((resolve, reject) => {
+    if (redirectCount > 5) {
+      return reject(new Error('Too many redirects'));
+    }
+    https.get(url, (res) => {
+      if (res.statusCode === 301 || res.statusCode === 302) {
+        res.resume();
+        return fetchUrl(res.headers.location, redirectCount + 1).then(resolve).catch(reject);
+      }
+      if (res.statusCode !== 200) {
+        return reject(new Error(`Failed to fetch ${url}: HTTP ${res.statusCode}`));
+      }
+      resolve(res);
+    }).on('error', reject);
+  });
+}
+
+function downloadFile(url, dest) {
+  return new Promise((resolve, reject) => {
+    fetchUrl(url).then(res => {
+      const file = fs.createWriteStream(dest);
+      
+      const handleError = (err) => {
+        file.close(() => {
+          if (fs.existsSync(dest)) fs.unlinkSync(dest);
+          reject(err);
+        });
+      };
+
+      res.on('error', handleError);
+      file.on('error', handleError);
+
+      res.pipe(file);
+      file.on('finish', () => {
+        file.close(() => {
+          resolve();
+        });
+      });
+    }).catch(reject);
+  });
+}
+
+async function verifyChecksum(filePath, fileName, expectedShasums) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256');
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', data => hash.update(data));
+    stream.on('end', () => {
+      const fileHash = hash.digest('hex');
+      const expectedLines = expectedShasums.split('\n');
+      const expectedLine = expectedLines.find(line => line.includes(fileName));
+      if (!expectedLine) {
+        return reject(new Error(`Checksum for ${fileName} not found in SHASUMS256.txt`));
+      }
+      const expectedHash = expectedLine.split(/\s+/)[0];
+      if (fileHash !== expectedHash) {
+        return reject(new Error(`Checksum mismatch for ${fileName}. Expected: ${expectedHash}, Actual: ${fileHash}`));
+      }
+      resolve();
+    });
+    stream.on('error', reject);
+  });
+}
+
+async function main() {
+  const shasumTmpPath = path.join(binDir, 'SHASUMS256.txt.tmp');
+  try {
+    console.log(`Downloading SHASUMS256.txt from ${shasumUrl}`);
+    // moved to top
+    await downloadFile(shasumUrl, shasumTmpPath);
+    const expectedShasums = fs.readFileSync(shasumTmpPath, 'utf8');
+
+    console.log(`Downloading ${assetName} from ${assetUrl}`);
+    await downloadFile(assetUrl, tmpPath);
+
+    console.log(`Verifying checksum for ${assetName}`);
+    await verifyChecksum(tmpPath, assetName, expectedShasums);
+    console.log('Checksum verified.');
+
+    if (platform === 'darwin') {
+      console.log('Extracting macOS bundle...');
+      const extractTmpDir = path.join(binDir, 'tmp-extract');
+      if (fs.existsSync(extractTmpDir)) fs.rmSync(extractTmpDir, { recursive: true, force: true });
+      fs.mkdirSync(extractTmpDir, { recursive: true });
+      try {
+        execSync(`tar -xzf "${tmpPath}" -C "${extractTmpDir}"`);
+        const extractedFiles = fs.readdirSync(extractTmpDir);
+        for (const file of extractedFiles) {
+          const dest = path.join(binDir, file);
+          if (fs.existsSync(dest)) fs.rmSync(dest, { recursive: true, force: true });
+          fs.renameSync(path.join(extractTmpDir, file), dest);
+        }
+      } finally {
+        if (fs.existsSync(extractTmpDir)) fs.rmSync(extractTmpDir, { recursive: true, force: true });
+      }
+      fs.unlinkSync(tmpPath);
+    } else {
+      const finalBinPath = path.join(binDir, platform === 'win32' ? 'agentscommander.exe' : 'agentscommander');
+      if (platform !== 'win32') {
+        fs.chmodSync(tmpPath, 0o755);
+      }
+      fs.renameSync(tmpPath, finalBinPath);
+    }
+    
+    fs.unlinkSync(shasumTmpPath);
+    console.log('Installation completed successfully.');
+  } catch (err) {
+    console.error('Installation failed:', err.message);
+    if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
+    if (typeof shasumTmpPath !== 'undefined' && fs.existsSync(shasumTmpPath)) fs.unlinkSync(shasumTmpPath);
+    process.exit(1);
+  }
+}
+
+main();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "agentscommander",
+  "version": "0.8.50",
+  "description": "AgentsCommander terminal session manager",
+  "bin": {
+    "agentscommander": "run.js"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "files": [
+    "run.js",
+    "install.js"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mblua/AgentsCommander.git"
+  }
+}

--- a/npm/run.js
+++ b/npm/run.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+const binName = os.platform() === 'win32' ? 'agentscommander.exe' : 'agentscommander';
+const binPath = path.join(__dirname, 'bin', binName);
+
+if (!fs.existsSync(binPath)) {
+  console.error(`Error: Cannot find AgentsCommander executable at ${binPath}`);
+  console.error('Please ensure the package was installed correctly.');
+  process.exit(1);
+}
+
+const child = spawn(binPath, process.argv.slice(2), {
+  stdio: 'inherit',
+  windowsHide: true
+});
+
+child.on('error', (err) => {
+  console.error('Failed to start AgentsCommander:', err.message);
+  process.exit(1);
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    try {
+      process.kill(process.pid, signal);
+    } catch (e) {
+      process.exit(1);
+    }
+  } else {
+    process.exit(code !== null ? code : 1);
+  }
+});
+
+const signals = ['SIGINT', 'SIGTERM', 'SIGQUIT'];
+signals.forEach(sig => {
+  process.on(sig, () => {
+    if (child && !child.killed) {
+      child.kill(sig);
+    }
+  });
+});

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -58,8 +58,18 @@ Re-running with the same X.Y.Z target re-synchronizes drifted locations.
 // compatibility. Production bundle identity comes from Tauri config.
 const PATCHES = [
   {
+    file: 'npm/install.js',
+    label: 'install.js constant',
+    re: /(\r?\nconst VERSION\s*=\s*)['"][^'"]+['"]/,
+  },
+  {
     file: 'package.json',
     label: 'root version',
+    re: /(\r?\n\s*"name":\s*"agentscommander",\s*\r?\n\s*"version":\s*)"[^"]+"/,
+  },
+  {
+    file: 'npm/package.json',
+    label: 'npm wrapper version',
     re: /(\r?\n\s*"name":\s*"agentscommander",\s*\r?\n\s*"version":\s*)"[^"]+"/,
   },
   {

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -37,6 +37,16 @@ const checks = [
     /(?:\r?\n)\s*"name":\s*"agentscommander",\s*(?:\r?\n)\s*"version":\s*"([^"]+)"/,
   ),
   extract(
+    'npm/package.json:version',
+    'npm/package.json',
+    /(?:\r?\n)\s*"name":\s*"agentscommander",\s*(?:\r?\n)\s*"version":\s*"([^"]+)"/,
+  ),
+  extract(
+    'npm/install.js:VERSION',
+    'npm/install.js',
+    /(?:\r?\n)const VERSION\s*=\s*["']([^"']+)["']/,
+  ),
+  extract(
     'package-lock.json:root.version',
     'package-lock.json',
     /(?:\r?\n)\s*"name":\s*"agentscommander",\s*(?:\r?\n)\s*"version":\s*"([^"]+)"/,


### PR DESCRIPTION
Adds the npm wrapper package and release assets needed for npm-based installation.

Includes:
- npm package wrapper under npm/
- release workflow raw binary uploads and SHASUMS256.txt
- version bump/check coverage for npm wrapper files
- README npm install instructions

Validation:
- npm run version:check
- node --check npm/install.js
- node --check npm/run.js
- npm pack --dry-run from npm/

Refs #406