### PR TITLE
fix(npm): scope package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ npm install -g agentscommander
 
 The npm package downloads the matching executable for your platform from the GitHub release.
 
+If npm rejects the unscoped package name in your registry/account, install the scoped package instead:
+
+```bash
+npm install -g @mblua/agentscommander
+```
+
 ## The 30-second pitch
 
 - **Pick the coding agent per role.** Claude Code on architecture, Codex on dev, Gemini on review, or any mix. Each runs in its own real terminal with a full PTY, not a command runner.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentscommander",
+  "name": "@mblua/agentscommander",
   "version": "0.8.50",
   "description": "AgentsCommander terminal session manager",
   "bin": {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -70,7 +70,7 @@ const PATCHES = [
   {
     file: 'npm/package.json',
     label: 'npm wrapper version',
-    re: /(\r?\n\s*"name":\s*"agentscommander",\s*\r?\n\s*"version":\s*)"[^"]+"/,
+    re: /(\r?\n\s*"name":\s*"@mblua\/agentscommander",\s*\r?\n\s*"version":\s*)"[^"]+"/,
   },
   {
     file: 'package-lock.json',

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -39,7 +39,7 @@ const checks = [
   extract(
     'npm/package.json:version',
     'npm/package.json',
-    /(?:\r?\n)\s*"name":\s*"agentscommander",\s*(?:\r?\n)\s*"version":\s*"([^"]+)"/,
+    /(?:\r?\n)\s*"name":\s*"@mblua\/agentscommander",\s*(?:\r?\n)\s*"version":\s*"([^"]+)"/,
   ),
   extract(
     'npm/install.js:VERSION',


### PR DESCRIPTION
Scopes the npm package as `@mblua/agentscommander` after npm rejected the unscoped `agentscommander` name as too similar to an existing package.

The CLI binary remains `agentscommander`.

Validation:
- npm run version:check
- node --check npm/install.js
- node --check npm/run.js
- npm pack --dry-run from npm/

Refs #406