### PR TITLE
fix(readme): document scoped npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,20 @@
 
 ## Installation
 
-Install AgentsCommander globally via npm:
-
-```bash
-npm install -g agentscommander
-```
-
-The npm package downloads the matching executable for your platform from the GitHub release.
-
-If npm rejects the unscoped package name in your registry/account, install the scoped package instead:
+### Install from npm
 
 ```bash
 npm install -g @mblua/agentscommander
 ```
+
+Then run the CLI:
+
+```bash
+agentscommander --help
+agentscommander new-project /path/to/project
+```
+
+The npm package is `@mblua/agentscommander`. The installed command is still `agentscommander`.
 
 ## The 30-second pitch
 


### PR DESCRIPTION
Superseded by a replacement branch/PR referencing open issue #432, because branch validation rejects branches tied to closed issue #406.

Original purpose: update README npm install guidance to use `@mblua/agentscommander` and keep `agentscommander` only as the installed CLI command.