### PR TITLE
docs: make npm the primary install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/mblua/AgentsCommander/releases/latest"><b>⬇ Download (latest release)</b></a>
-  &nbsp;·&nbsp;
   <a href="#installation"><b>npm install</b></a>
+  &nbsp;·&nbsp;
+  <a href="https://github.com/mblua/AgentsCommander/releases/latest"><b>Download desktop installer</b></a>
   &nbsp;·&nbsp;
   <a href="#60-second-quickstart"><b>▶ 60-second quickstart</b></a>
   &nbsp;·&nbsp;
@@ -47,6 +47,8 @@ agentscommander new-project /path/to/project
 
 The npm package is `@mblua/agentscommander`. The installed command is still `agentscommander`.
 
+Prefer a desktop installer or a manual download? Get the signed Windows installer, Linux AppImage, macOS dmg, or portable assets from [GitHub Releases](https://github.com/mblua/AgentsCommander/releases/latest).
+
 ## The 30-second pitch
 
 - **Pick the coding agent per role.** Claude Code on architecture, Codex on dev, Gemini on review, or any mix. Each runs in its own real terminal with a full PTY, not a command runner.
@@ -67,11 +69,22 @@ You bring the coding agents. AgentsCommander coordinates them.
 
 ## 60-second quickstart
 
-1. **Download** the latest installer for your platform from [the releases page](https://github.com/mblua/AgentsCommander/releases/latest). Windows `.exe`, Linux `.AppImage`, and macOS `.dmg` are built on every release.
-2. **Run** the installer (or run the portable `.exe` directly; see [Portable instances](docs/features/portable-instances.md)).
-3. **Open a project**: click `New Project` in the sidebar and point it at an empty folder. AC creates an `.ac/` workspace there.
-4. **Create a Team**: add a coordinator and one worker agent, each with a role prompt. [Teams and workgroups](docs/agents/teams-and-workgroups.md) walks through this.
-5. **Launch the coordinator**: pick Claude Code, Codex, or Gemini from the dropdown. Ask it to send the worker a hello message. The worker terminal receives a file notification and responds in real time.
+1. **Install** AgentsCommander from npm:
+
+   ```bash
+   npm install -g @mblua/agentscommander
+   ```
+
+   Then start it:
+
+   ```bash
+   agentscommander
+   ```
+
+   Prefer a desktop installer or portable binary? Use [GitHub Releases](https://github.com/mblua/AgentsCommander/releases/latest).
+2. **Open a project**: click `New Project` in the sidebar and point it at an empty folder. AC creates an `.ac/` workspace there.
+3. **Create a Team**: add a coordinator and one worker agent, each with a role prompt. [Teams and workgroups](docs/agents/teams-and-workgroups.md) walks through this.
+4. **Launch the coordinator**: pick Claude Code, Codex, or Gemini from the dropdown. Ask it to send the worker a hello message. The worker terminal receives a file notification and responds in real time.
 
 Full walkthrough: [`docs/quickstart.md`](docs/quickstart.md).
 
@@ -113,7 +126,7 @@ These are not accidents.
 
 ## Documentation
 
-- [Quickstart](docs/quickstart.md): 60-second download to first running agent
+- [Quickstart](docs/quickstart.md): 60-second install to first running agent
 - [Concepts](docs/concepts.md): agent, team, workgroup, coordinator, brief
 - [Teams and workgroups](docs/agents/teams-and-workgroups.md): coordinators, members, briefs, messaging
 - [Features](docs/features/): Telegram bridge with image and screenshot sends, voice-to-text, portable instances, RTK integration

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -47,7 +47,7 @@ AutoGen (and the community fork AG2) is Microsoft's multi-agent conversational f
 CrewAI defines role-based agent teams with hierarchical processes — in Python.
 
 **Where AC wins**:
-- Ships as a desktop app with a portable installer. You can demo it in 60 seconds.
+- Installs from npm, with desktop and portable installers still available from GitHub Releases. You can demo it in 60 seconds.
 - No `pip install`, no config-by-code, no rewriting your tools as CrewAI primitives.
 
 **Where CrewAI wins**:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,14 +7,29 @@ By the end of this guide you will have AgentsCommander installed, an AC project 
 ## Prerequisites
 
 - One of [Claude Code](https://docs.claude.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), or [Gemini CLI](https://github.com/google-gemini/gemini-cli) installed and authenticated on your machine. You can install more than one — AC will let you pick per agent.
+- Node.js 18+ and npm if you install AgentsCommander from npm.
 - Git installed.
 - A repo you want the agents to work on (it can be empty).
 
-You do **not** need Node.js or Rust to run AgentsCommander. Those are only needed if you want to build from source — see [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+You do **not** need Rust to run AgentsCommander. Rust is only needed if you want to build from source — see [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
-## 1. Download and install
+## 1. Install AgentsCommander
 
-Download the latest installer for your platform from [the releases page](https://github.com/mblua/AgentsCommander/releases/latest):
+The fastest install path is npm:
+
+```bash
+npm install -g @mblua/agentscommander
+```
+
+Start AgentsCommander:
+
+```bash
+agentscommander
+```
+
+The npm package is `@mblua/agentscommander`. The installed command is still `agentscommander`.
+
+If you prefer a desktop installer or manual download, get the latest asset for your platform from [GitHub Releases](https://github.com/mblua/AgentsCommander/releases/latest):
 
 | Platform | Asset |
 |---|---|

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,32 @@
+# AgentsCommander
+
+Install and run AgentsCommander from npm.
+
+AgentsCommander coordinates AI coding agents like Claude Code, Codex, and Gemini in real terminal sessions. Agents work in local folders and exchange markdown messages you can inspect, diff, and audit.
+
+## Install
+
+```bash
+npm install -g @mblua/agentscommander
+```
+
+## Run
+
+```bash
+agentscommander
+```
+
+The npm package is `@mblua/agentscommander`. The installed CLI command is `agentscommander`.
+
+## Desktop and Manual Installers
+
+If you prefer a desktop installer, portable binary, or direct release asset, use GitHub Releases:
+
+https://github.com/mblua/AgentsCommander/releases/latest
+
+## Requirements
+
+- Node.js 18+
+- One supported coding-agent CLI installed separately: Claude Code, Codex, or Gemini
+
+AgentsCommander does not install coding-agent CLIs for you.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mblua/agentscommander",
   "version": "0.8.50",
-  "description": "AgentsCommander terminal session manager",
+  "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"
   },
@@ -15,6 +15,17 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "homepage": "https://github.com/mblua/AgentsCommander#readme",
+  "bugs": {
+    "url": "https://github.com/mblua/AgentsCommander/issues"
+  },
+  "keywords": [
+    "agentscommander",
+    "ai-agents",
+    "coding-agents",
+    "tauri",
+    "terminal"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/mblua/AgentsCommander.git"


### PR DESCRIPTION
Updates the public documentation now that AgentsCommander is available through npm.\n\n- Make npm the primary install path in README and quickstart docs\n- Keep GitHub Releases as the desktop/manual installer path\n- Clarify that the npm package is @mblua/agentscommander and the installed command remains agentscommander\n- Add npm package README content for future package-page publishing\n\nRelated to #406