### PR TITLE
feat(cli): add phase 1 harness command (#436)

### DIFF
--- a/docs/harness-roadmap.md
+++ b/docs/harness-roadmap.md
@@ -1,0 +1,42 @@
+# AgentsCommander Harness Roadmap
+
+The `agentscommander harness` command is a policy-controlled entry point for coding-agent OS command execution. Phase 1 is intentionally obedient: agents are expected to call it, but it does not prevent direct shell execution.
+
+## Phase 1: Obedient Harness
+
+Current scope:
+
+- CLI surface for argv execution and `--raw-command`.
+- Argv execution preserves argument boundaries by passing arguments directly to the child process.
+- Raw command execution explicitly uses the platform shell (`cmd.exe /C` on Windows, `sh -c` on Unix). Policy matching for raw strings is best-effort.
+- Conservative guardrails for obviously destructive commands, suspicious branch names, and nested shells.
+- JSON Lines audit log at `<config_dir>/logs/harness.log` with secret redaction and capped command text.
+
+Non-goal: Phase 1 does not provide strong sandboxing or prevent a shell-capable agent from bypassing the harness.
+
+## Phase 2: Policy Authorization
+
+Planned scope:
+
+- Stronger command classification.
+- Task and issue aware authorization.
+- Per-agent and per-workgroup policy configuration.
+- Clearer escalation paths when a command needs human approval.
+
+## Phase 3: Command Optimization
+
+Planned scope:
+
+- RTK-style command rewrites and optimization.
+- Safer alternatives for common expensive or fragile command patterns.
+- Token and output volume metrics.
+- Better policy explanations that help agents choose smaller commands.
+
+## Phase 4: Strong Enforcement
+
+Planned scope:
+
+- Executor control, PATH shims, or sandbox integration.
+- Enforcement that does not rely only on agent obedience.
+- Tamper-resistant audit flow.
+- Compatibility testing across Windows, macOS, Linux, and CI environments.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -26,6 +26,8 @@ All subcommands return:
 - `1` — error (auth, IO, routing, validation)
 - `2` — special: outcome unknown (used by `close-session` when delivery succeeded but no response landed in the poll window)
 
+Exception: `harness` returns `0` for successful `--explain` and `--dry-run`, returns `1` for deny, validation, spawn, or audit-log failures, and propagates the child process exit code when it actually executes a command.
+
 ## Discoverability
 
 ```bash
@@ -34,6 +36,32 @@ agentscommander <subcommand> --help     # full args + after-help block for one s
 ```
 
 The `--help` text is the source of truth; this page is a curated index.
+
+---
+
+## `harness`
+
+Execute a command through the Phase 1 policy harness.
+
+```bash
+agentscommander harness -- git status --short
+agentscommander harness --dry-run -- git branch risky-name
+agentscommander harness --raw-command "echo first && echo second"
+agentscommander harness --explain --raw-command "rm -rf /"
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--dry-run` | No | Evaluate policy and write the audit log without spawning the command. Exits 0 unless policy denies or logging fails. |
+| `--explain` | No | Print the policy decision without spawning the command. Exits 0 unless policy denies or logging fails. |
+| `--raw-command` | * | Literal command string executed through the platform shell (`cmd.exe /C` on Windows, `sh -c` on Unix). Policy matching is best-effort. |
+| `COMMAND...` | * | Command after `--`. Arguments are passed natively to the child process, preserving boundaries and quotes. |
+
+\* Use either `--raw-command` or a command after `--`.
+
+Audit log entries are JSON Lines at `<config_dir>/logs/harness.log`. The harness redacts token-like values before logging, caps logged command text, and treats `AGENTSCOMMANDER_ROOT` and `AGENTSCOMMANDER_TOKEN` only as unverified audit hints. Phase 1 is an obedient harness and does not prevent direct shell execution by agents.
+
+See [AgentsCommander Harness Roadmap](../harness-roadmap.md) for the phase 1 through 4 roadmap.
 
 ---
 

--- a/src-tauri/src/cli/harness.rs
+++ b/src-tauri/src/cli/harness.rs
@@ -333,7 +333,11 @@ fn is_root_target(token: &str) -> bool {
 }
 
 fn raw_command_is_chained(raw: &str) -> bool {
-    raw.contains(';') || raw.contains("&&") || raw.contains("||")
+    raw.contains(';')
+        || raw.contains("&&")
+        || raw.contains("||")
+        || raw.contains('\n')
+        || raw.contains('\r')
 }
 
 fn tokenize_raw_command_segments(raw: &str) -> Vec<Vec<String>> {
@@ -355,6 +359,7 @@ fn tokenize_raw_command_segments(raw: &str) -> Vec<Vec<String>> {
 
         match ch {
             '"' | '\'' => quote = Some(ch),
+            '\n' | '\r' => finish_raw_segment(&mut segments, &mut current, &mut token),
             ch if ch.is_whitespace() => push_raw_token(&mut current, &mut token),
             ';' | '(' | ')' => finish_raw_segment(&mut segments, &mut current, &mut token),
             '&' | '|' => {
@@ -671,7 +676,11 @@ mod tests {
 
     #[test]
     fn raw_destructive_chained_variants_are_denied() {
-        for raw in ["echo ok && rm -fr /", "echo ok; rd /q /s C:\\"] {
+        for raw in [
+            "echo ok && rm -fr /",
+            "echo ok; rd /q /s C:\\",
+            "echo ok\nrm -fr /",
+        ] {
             let input = PolicyInput {
                 raw_display: raw.to_string(),
                 argv: Vec::new(),

--- a/src-tauri/src/cli/harness.rs
+++ b/src-tauri/src/cli/harness.rs
@@ -188,37 +188,45 @@ fn evaluate_argv_policy(
     denials: &mut Vec<String>,
 ) {
     let tokens: Vec<String> = input.argv.iter().map(|s| normalize_token(s)).collect();
+    evaluate_normalized_argv_policy(&tokens, warnings, denials);
+}
+
+fn evaluate_normalized_argv_policy(
+    tokens: &[String],
+    warnings: &mut Vec<String>,
+    denials: &mut Vec<String>,
+) {
     if tokens.is_empty() {
         return;
     }
 
     warn_nested_shell(&tokens[0], warnings);
-    warn_branch_name(&tokens, warnings);
+    warn_branch_name(tokens, warnings);
 
     let cmd = tokens[0].as_str();
-    if cmd == "rm" && has_rm_recursive_force(&tokens) && tokens.iter().any(|t| is_root_target(t)) {
+    if cmd == "rm" && has_rm_recursive_force(tokens) && tokens.iter().any(|t| is_root_target(t)) {
         denials.push("denied destructive root removal".to_string());
     }
 
     if cmd == "remove-item"
-        && has_any_token(&tokens, &["-recurse", "-r"])
-        && has_any_token(&tokens, &["-force", "-fo"])
+        && has_any_token(tokens, &["-recurse", "-r"])
+        && has_any_token(tokens, &["-force", "-fo"])
         && tokens.iter().any(|t| is_root_target(t))
     {
         denials.push("denied destructive Remove-Item root removal".to_string());
     }
 
     if (cmd == "rd" || cmd == "rmdir")
-        && has_token(&tokens, "/s")
-        && has_token(&tokens, "/q")
+        && has_token(tokens, "/s")
+        && has_token(tokens, "/q")
         && tokens.iter().any(|t| is_root_target(t))
     {
         denials.push("denied destructive recursive directory removal".to_string());
     }
 
     if cmd == "del"
-        && has_token(&tokens, "/s")
-        && has_token(&tokens, "/q")
+        && has_token(tokens, "/s")
+        && has_token(tokens, "/q")
         && tokens.iter().any(|t| is_root_target(t))
     {
         denials.push("denied destructive recursive file deletion".to_string());
@@ -238,23 +246,21 @@ fn evaluate_raw_policy(input: &PolicyInput, warnings: &mut Vec<String>, denials:
         warn_branch_name(&words, warnings);
     }
 
-    let chained = raw.contains(';') || raw.contains("&&") || raw.contains("||");
-    let destructive = (raw.contains("rm -rf") && raw_contains_root_target(&raw))
-        || (raw.contains("remove-item")
-            && raw.contains("-recurse")
-            && raw.contains("-force")
-            && raw_contains_root_target(&raw))
-        || ((raw.contains("rd /s /q") || raw.contains("rmdir /s /q"))
-            && raw_contains_root_target(&raw))
-        || (raw.contains("del /s /q") && raw_contains_root_target(&raw));
+    let chained = raw_command_is_chained(&raw);
+    let before = denials.len();
+    for tokens in tokenize_raw_command_segments(&input.raw_display) {
+        let tokens: Vec<String> = tokens.iter().map(|s| normalize_token(s)).collect();
+        evaluate_normalized_argv_policy(&tokens, warnings, denials);
+    }
 
-    if destructive {
-        let reason = if chained {
-            "denied destructive command in raw shell chain"
-        } else {
-            "denied destructive raw shell command"
-        };
-        denials.push(reason.to_string());
+    if denials.len() > before {
+        for reason in denials.iter_mut().skip(before) {
+            *reason = if chained {
+                "denied destructive command in raw shell chain".to_string()
+            } else {
+                "denied destructive raw shell command".to_string()
+            };
+        }
     }
 }
 
@@ -326,14 +332,60 @@ fn is_root_target(token: &str) -> bool {
     matches!(token, "/" | "\\" | "c:\\" | "c:/" | "%systemdrive%\\")
 }
 
-fn raw_contains_root_target(raw: &str) -> bool {
-    raw.split(|c: char| c.is_whitespace() || [';', '&', '|', '(', ')'].contains(&c))
-        .any(is_root_target)
-        || raw.contains(" / ")
-        || raw.contains(" '/'")
-        || raw.contains(" \"/\"")
-        || raw.contains(" c:\\")
-        || raw.contains(" c:/")
+fn raw_command_is_chained(raw: &str) -> bool {
+    raw.contains(';') || raw.contains("&&") || raw.contains("||")
+}
+
+fn tokenize_raw_command_segments(raw: &str) -> Vec<Vec<String>> {
+    let mut segments = Vec::new();
+    let mut current = Vec::new();
+    let mut token = String::new();
+    let mut quote: Option<char> = None;
+    let mut chars = raw.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if let Some(active_quote) = quote {
+            if ch == active_quote {
+                quote = None;
+            } else {
+                token.push(ch);
+            }
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' => quote = Some(ch),
+            ch if ch.is_whitespace() => push_raw_token(&mut current, &mut token),
+            ';' | '(' | ')' => finish_raw_segment(&mut segments, &mut current, &mut token),
+            '&' | '|' => {
+                if chars.peek().is_some_and(|next| *next == ch) {
+                    chars.next();
+                }
+                finish_raw_segment(&mut segments, &mut current, &mut token);
+            }
+            _ => token.push(ch),
+        }
+    }
+
+    finish_raw_segment(&mut segments, &mut current, &mut token);
+    segments
+}
+
+fn push_raw_token(current: &mut Vec<String>, token: &mut String) {
+    if !token.is_empty() {
+        current.push(std::mem::take(token));
+    }
+}
+
+fn finish_raw_segment(
+    segments: &mut Vec<Vec<String>>,
+    current: &mut Vec<String>,
+    token: &mut String,
+) {
+    push_raw_token(current, token);
+    if !current.is_empty() {
+        segments.push(std::mem::take(current));
+    }
 }
 
 fn normalize_token(value: &str) -> String {
@@ -386,7 +438,7 @@ fn write_audit_log(
     std::fs::create_dir_all(&log_dir).map_err(|e| e.to_string())?;
     let log_path = log_dir.join("harness.log");
 
-    let redacted = redact_secrets(&input.raw_display);
+    let redacted = redacted_display(input);
     let (command, command_truncated) = cap_logged_command(&redacted);
     let (decision_name, reasons) = decision_parts(decision);
     let entry = HarnessLogEntry {
@@ -479,6 +531,43 @@ pub(crate) fn redact_secrets(command: &str) -> String {
     out.join(" ")
 }
 
+fn redact_argv(argv: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(argv.len());
+    let mut redact_next = false;
+    for token in argv {
+        let lower = token.to_ascii_lowercase();
+        if redact_next {
+            out.push("[REDACTED]".to_string());
+            redact_next = false;
+            continue;
+        }
+
+        if lower == "bearer" {
+            out.push("Bearer".to_string());
+            redact_next = true;
+        } else if is_secret_assignment(&lower) {
+            out.push(redact_assignment(token));
+            if lower.contains("bearer") {
+                redact_next = true;
+            }
+        } else if is_secret_flag(&lower) {
+            out.push(token.clone());
+            redact_next = true;
+        } else {
+            out.push(token.clone());
+        }
+    }
+    out
+}
+
+fn redacted_display(input: &PolicyInput) -> String {
+    if input.raw_shell {
+        redact_secrets(&input.raw_display)
+    } else {
+        display_argv(&redact_argv(&input.argv))
+    }
+}
+
 fn is_secret_assignment(lower: &str) -> bool {
     lower.contains("token=")
         || lower.contains("_authtoken=")
@@ -557,6 +646,42 @@ mod tests {
     }
 
     #[test]
+    fn raw_destructive_unix_flag_variants_are_denied() {
+        for raw in ["rm -fr /", "rm -r -f /"] {
+            let input = PolicyInput {
+                raw_display: raw.to_string(),
+                argv: Vec::new(),
+                raw_shell: true,
+            };
+            assert!(matches!(evaluate_policy(&input), PolicyDecision::Deny(_)));
+        }
+    }
+
+    #[test]
+    fn raw_destructive_windows_flag_variants_are_denied() {
+        for raw in ["rd /q /s C:\\", "Remove-Item -r -fo C:\\"] {
+            let input = PolicyInput {
+                raw_display: raw.to_string(),
+                argv: Vec::new(),
+                raw_shell: true,
+            };
+            assert!(matches!(evaluate_policy(&input), PolicyDecision::Deny(_)));
+        }
+    }
+
+    #[test]
+    fn raw_destructive_chained_variants_are_denied() {
+        for raw in ["echo ok && rm -fr /", "echo ok; rd /q /s C:\\"] {
+            let input = PolicyInput {
+                raw_display: raw.to_string(),
+                argv: Vec::new(),
+                raw_shell: true,
+            };
+            assert!(matches!(evaluate_policy(&input), PolicyDecision::Deny(_)));
+        }
+    }
+
+    #[test]
     fn branch_guardrail_warns_without_denying() {
         let input = PolicyInput {
             raw_display: "git checkout -b bad branch".to_string(),
@@ -599,5 +724,25 @@ mod tests {
         assert!(!redacted.contains("abc"));
         assert!(!redacted.contains("hunter2"));
         assert!(!redacted.contains("secret _authToken"));
+    }
+
+    #[test]
+    fn redacts_argv_secret_flag_value_before_display_join() {
+        let input = PolicyInput {
+            raw_display: display_argv(&[
+                "echo".to_string(),
+                "--token".to_string(),
+                "secret-leak-check".to_string(),
+            ]),
+            argv: vec![
+                "echo".to_string(),
+                "--token".to_string(),
+                "secret-leak-check".to_string(),
+            ],
+            raw_shell: false,
+        };
+        let redacted = redacted_display(&input);
+        assert!(redacted.contains("--token\u{1f}[REDACTED]"));
+        assert!(!redacted.contains("secret-leak-check"));
     }
 }

--- a/src-tauri/src/cli/harness.rs
+++ b/src-tauri/src/cli/harness.rs
@@ -1,0 +1,603 @@
+use clap::Args;
+use serde::Serialize;
+use std::collections::hash_map::DefaultHasher;
+use std::fs::OpenOptions;
+use std::hash::{Hash, Hasher};
+use std::io::Write;
+use std::process::Command;
+
+const MAX_LOGGED_COMMAND_LEN: usize = 512;
+
+#[derive(Args, Debug)]
+#[command(
+    about = "Execute commands through the AgentsCommander policy harness",
+    after_help = "PHASE 1 (Obedient Harness): This command currently routes execution through AgentsCommander and logs actions, but does not provide strong enforcement or sandboxing. Direct shell execution by agents remains possible.\nNote: --raw-command execution relies on the platform shell and policy matching is best-effort."
+)]
+pub struct HarnessArgs {
+    /// Explain the policy decision without executing the command
+    #[arg(long)]
+    pub explain: bool,
+
+    /// Evaluate policy and simulate execution without modifying state
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Command to execute, separated by -- (e.g., harness -- git push)
+    #[arg(last = true, conflicts_with = "raw_command")]
+    pub command: Vec<String>,
+
+    /// Optional literal string command for Windows ergonomics. Executed via the platform shell.
+    #[arg(long, conflicts_with = "command")]
+    pub raw_command: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PolicyDecision {
+    Allow,
+    Warn(Vec<String>),
+    Deny(Vec<String>),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PolicyInput {
+    pub raw_display: String,
+    pub argv: Vec<String>,
+    pub raw_shell: bool,
+}
+
+#[derive(Debug)]
+enum ExecutionMode {
+    Argv(Vec<String>),
+    Raw(String),
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HarnessLogEntry {
+    timestamp: String,
+    identity: String,
+    identity_note: &'static str,
+    raw_shell: bool,
+    command: String,
+    command_truncated: bool,
+    argv_count: usize,
+    command_hash: u64,
+    decision: String,
+    reasons: Vec<String>,
+    mode: String,
+    execution_result: String,
+    exit_code: Option<i32>,
+}
+
+pub fn execute(args: HarnessArgs) -> i32 {
+    let mode = match parse_mode(&args) {
+        Ok(mode) => mode,
+        Err(err) => {
+            eprintln!("Error: {}", err);
+            return 1;
+        }
+    };
+
+    let input = match &mode {
+        ExecutionMode::Argv(argv) => PolicyInput {
+            raw_display: display_argv(argv),
+            argv: argv.clone(),
+            raw_shell: false,
+        },
+        ExecutionMode::Raw(raw) => PolicyInput {
+            raw_display: raw.clone(),
+            argv: Vec::new(),
+            raw_shell: true,
+        },
+    };
+
+    let decision = evaluate_policy(&input);
+    print_decision(&decision, &input, args.explain || args.dry_run);
+
+    if let Err(err) = write_audit_log(&input, &decision, "planned", None) {
+        eprintln!("Error: failed to write harness audit log: {}", err);
+        return 1;
+    }
+
+    if matches!(decision, PolicyDecision::Deny(_)) {
+        return 1;
+    }
+
+    if args.explain || args.dry_run {
+        return 0;
+    }
+
+    let status = match run_command(&mode) {
+        Ok(status) => status,
+        Err(err) => {
+            let _ = write_audit_log(&input, &decision, "spawn_failed", Some(1));
+            eprintln!("Error: failed to execute harness command: {}", err);
+            return 1;
+        }
+    };
+
+    let code = status.code().unwrap_or(1);
+    if let Err(err) = write_audit_log(&input, &decision, "completed", Some(code)) {
+        eprintln!("Error: failed to write harness completion log: {}", err);
+        return 1;
+    }
+    code
+}
+
+fn parse_mode(args: &HarnessArgs) -> Result<ExecutionMode, String> {
+    match (&args.raw_command, args.command.is_empty()) {
+        (Some(raw), _) if raw.trim().is_empty() => Err("--raw-command cannot be empty".to_string()),
+        (Some(raw), _) => Ok(ExecutionMode::Raw(raw.clone())),
+        (None, false) => Ok(ExecutionMode::Argv(args.command.clone())),
+        (None, true) => Err("provide a command after -- or pass --raw-command".to_string()),
+    }
+}
+
+fn run_command(mode: &ExecutionMode) -> std::io::Result<std::process::ExitStatus> {
+    match mode {
+        ExecutionMode::Argv(argv) => {
+            let mut command = Command::new(&argv[0]);
+            command.args(&argv[1..]);
+            command.status()
+        }
+        ExecutionMode::Raw(raw) => {
+            let mut command = platform_shell_command(raw);
+            command.status()
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn platform_shell_command(raw: &str) -> Command {
+    let mut command = Command::new("cmd.exe");
+    command.args(["/C", raw]);
+    command
+}
+
+#[cfg(not(target_os = "windows"))]
+fn platform_shell_command(raw: &str) -> Command {
+    let mut command = Command::new("sh");
+    command.args(["-c", raw]);
+    command
+}
+
+pub(crate) fn evaluate_policy(input: &PolicyInput) -> PolicyDecision {
+    let mut warnings = Vec::new();
+    let mut denials = Vec::new();
+
+    if input.raw_shell {
+        evaluate_raw_policy(input, &mut warnings, &mut denials);
+    } else {
+        evaluate_argv_policy(input, &mut warnings, &mut denials);
+    }
+
+    if denials.is_empty() {
+        if warnings.is_empty() {
+            PolicyDecision::Allow
+        } else {
+            PolicyDecision::Warn(warnings)
+        }
+    } else {
+        PolicyDecision::Deny(denials)
+    }
+}
+
+fn evaluate_argv_policy(
+    input: &PolicyInput,
+    warnings: &mut Vec<String>,
+    denials: &mut Vec<String>,
+) {
+    let tokens: Vec<String> = input.argv.iter().map(|s| normalize_token(s)).collect();
+    if tokens.is_empty() {
+        return;
+    }
+
+    warn_nested_shell(&tokens[0], warnings);
+    warn_branch_name(&tokens, warnings);
+
+    let cmd = tokens[0].as_str();
+    if cmd == "rm" && has_rm_recursive_force(&tokens) && tokens.iter().any(|t| is_root_target(t)) {
+        denials.push("denied destructive root removal".to_string());
+    }
+
+    if cmd == "remove-item"
+        && has_any_token(&tokens, &["-recurse", "-r"])
+        && has_any_token(&tokens, &["-force", "-fo"])
+        && tokens.iter().any(|t| is_root_target(t))
+    {
+        denials.push("denied destructive Remove-Item root removal".to_string());
+    }
+
+    if (cmd == "rd" || cmd == "rmdir")
+        && has_token(&tokens, "/s")
+        && has_token(&tokens, "/q")
+        && tokens.iter().any(|t| is_root_target(t))
+    {
+        denials.push("denied destructive recursive directory removal".to_string());
+    }
+
+    if cmd == "del"
+        && has_token(&tokens, "/s")
+        && has_token(&tokens, "/q")
+        && tokens.iter().any(|t| is_root_target(t))
+    {
+        denials.push("denied destructive recursive file deletion".to_string());
+    }
+}
+
+fn evaluate_raw_policy(input: &PolicyInput, warnings: &mut Vec<String>, denials: &mut Vec<String>) {
+    let raw = normalize_token(&input.raw_display);
+    for shell in ["bash", "sh", "powershell", "pwsh", "cmd"] {
+        if contains_command_word(&raw, shell) {
+            warnings.push(format!("nested shell invocation detected: {}", shell));
+        }
+    }
+
+    if raw.contains("git checkout -b") || raw.contains("git branch") {
+        let words: Vec<String> = raw.split_whitespace().map(|s| s.to_string()).collect();
+        warn_branch_name(&words, warnings);
+    }
+
+    let chained = raw.contains(';') || raw.contains("&&") || raw.contains("||");
+    let destructive = (raw.contains("rm -rf") && raw_contains_root_target(&raw))
+        || (raw.contains("remove-item")
+            && raw.contains("-recurse")
+            && raw.contains("-force")
+            && raw_contains_root_target(&raw))
+        || ((raw.contains("rd /s /q") || raw.contains("rmdir /s /q"))
+            && raw_contains_root_target(&raw))
+        || (raw.contains("del /s /q") && raw_contains_root_target(&raw));
+
+    if destructive {
+        let reason = if chained {
+            "denied destructive command in raw shell chain"
+        } else {
+            "denied destructive raw shell command"
+        };
+        denials.push(reason.to_string());
+    }
+}
+
+fn warn_nested_shell(cmd: &str, warnings: &mut Vec<String>) {
+    if ["bash", "sh", "powershell", "pwsh", "cmd", "cmd.exe"].contains(&cmd) {
+        warnings.push(format!("nested shell invocation detected: {}", cmd));
+    }
+}
+
+fn warn_branch_name(tokens: &[String], warnings: &mut Vec<String>) {
+    let branch = if tokens.len() >= 4
+        && tokens[0] == "git"
+        && tokens[1] == "checkout"
+        && tokens[2] == "-b"
+    {
+        Some(tokens[3].as_str())
+    } else if tokens.len() >= 3 && tokens[0] == "git" && tokens[1] == "branch" {
+        Some(tokens[2].as_str())
+    } else {
+        None
+    };
+
+    if let Some(branch) = branch {
+        if !is_reasonable_branch_name(branch) {
+            warnings.push(format!("branch name may violate conventions: {}", branch));
+        }
+    }
+}
+
+fn is_reasonable_branch_name(branch: &str) -> bool {
+    let allowed_prefix = [
+        "feat/",
+        "fix/",
+        "chore/",
+        "docs/",
+        "test/",
+        "refactor/",
+        "hotfix/",
+    ]
+    .iter()
+    .any(|prefix| branch.starts_with(prefix));
+    allowed_prefix
+        && !branch.contains(' ')
+        && !branch.contains('\\')
+        && !branch.contains("..")
+        && !branch.starts_with('/')
+        && !branch.ends_with('/')
+}
+
+fn contains_command_word(raw: &str, needle: &str) -> bool {
+    raw.split(|c: char| c.is_whitespace() || [';', '&', '|', '(', ')'].contains(&c))
+        .any(|word| word == needle || word == format!("{}.exe", needle))
+}
+
+fn has_token(tokens: &[String], needle: &str) -> bool {
+    tokens.iter().any(|token| token == needle)
+}
+
+fn has_any_token(tokens: &[String], needles: &[&str]) -> bool {
+    needles.iter().any(|needle| has_token(tokens, needle))
+}
+
+fn has_rm_recursive_force(tokens: &[String]) -> bool {
+    has_any_token(tokens, &["-rf", "-fr"]) || (has_token(tokens, "-r") && has_token(tokens, "-f"))
+}
+
+fn is_root_target(token: &str) -> bool {
+    let token = token.trim_matches(|c| matches!(c, '"' | '\'' | ';' | '&' | '|' | '(' | ')'));
+    matches!(token, "/" | "\\" | "c:\\" | "c:/" | "%systemdrive%\\")
+}
+
+fn raw_contains_root_target(raw: &str) -> bool {
+    raw.split(|c: char| c.is_whitespace() || [';', '&', '|', '(', ')'].contains(&c))
+        .any(is_root_target)
+        || raw.contains(" / ")
+        || raw.contains(" '/'")
+        || raw.contains(" \"/\"")
+        || raw.contains(" c:\\")
+        || raw.contains(" c:/")
+}
+
+fn normalize_token(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_ascii_lowercase()
+}
+
+fn print_decision(decision: &PolicyDecision, input: &PolicyInput, verbose: bool) {
+    match decision {
+        PolicyDecision::Allow => println!("harness: allow"),
+        PolicyDecision::Warn(reasons) => {
+            println!("harness: warn");
+            for reason in reasons {
+                eprintln!("warning: {}", reason);
+            }
+        }
+        PolicyDecision::Deny(reasons) => {
+            eprintln!("harness: deny");
+            for reason in reasons {
+                eprintln!("denied: {}", reason);
+            }
+        }
+    }
+
+    if verbose {
+        println!(
+            "harness: {} command, policy matching {}",
+            if input.raw_shell { "raw-shell" } else { "argv" },
+            if input.raw_shell {
+                "best-effort"
+            } else {
+                "argv-preserving"
+            }
+        );
+    }
+}
+
+fn write_audit_log(
+    input: &PolicyInput,
+    decision: &PolicyDecision,
+    execution_result: &str,
+    exit_code: Option<i32>,
+) -> Result<(), String> {
+    let config_dir = crate::config::config_dir()
+        .ok_or_else(|| "could not determine config directory".to_string())?;
+    let log_dir = config_dir.join("logs");
+    std::fs::create_dir_all(&log_dir).map_err(|e| e.to_string())?;
+    let log_path = log_dir.join("harness.log");
+
+    let redacted = redact_secrets(&input.raw_display);
+    let (command, command_truncated) = cap_logged_command(&redacted);
+    let (decision_name, reasons) = decision_parts(decision);
+    let entry = HarnessLogEntry {
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        identity: derive_identity(),
+        identity_note: "unverified audit hint from process environment",
+        raw_shell: input.raw_shell,
+        command,
+        command_truncated,
+        argv_count: input.argv.len(),
+        command_hash: command_hash(&redacted),
+        decision: decision_name.to_string(),
+        reasons,
+        mode: if input.raw_shell {
+            "raw-command"
+        } else {
+            "argv"
+        }
+        .to_string(),
+        execution_result: execution_result.to_string(),
+        exit_code,
+    };
+
+    let line = serde_json::to_string(&entry).map_err(|e| e.to_string())?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|e| e.to_string())?;
+    writeln!(file, "{}", line).map_err(|e| e.to_string())
+}
+
+fn decision_parts(decision: &PolicyDecision) -> (&'static str, Vec<String>) {
+    match decision {
+        PolicyDecision::Allow => ("allow", Vec::new()),
+        PolicyDecision::Warn(reasons) => ("warn", reasons.clone()),
+        PolicyDecision::Deny(reasons) => ("deny", reasons.clone()),
+    }
+}
+
+fn derive_identity() -> String {
+    let root = std::env::var("AGENTSCOMMANDER_ROOT").unwrap_or_default();
+    if root.is_empty() {
+        return "unidentified_agent".to_string();
+    }
+
+    std::path::Path::new(&root)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.trim_start_matches("__agent_").to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unidentified_agent".to_string())
+}
+
+fn cap_logged_command(command: &str) -> (String, bool) {
+    if command.chars().count() <= MAX_LOGGED_COMMAND_LEN {
+        return (command.to_string(), false);
+    }
+    let capped: String = command.chars().take(MAX_LOGGED_COMMAND_LEN).collect();
+    (format!("{}...[truncated]", capped), true)
+}
+
+pub(crate) fn redact_secrets(command: &str) -> String {
+    let mut out = Vec::new();
+    let mut redact_next = false;
+    for token in command.split_whitespace() {
+        let lower = token.to_ascii_lowercase();
+        if redact_next {
+            out.push("[REDACTED]".to_string());
+            redact_next = false;
+            continue;
+        }
+        if lower == "bearer" {
+            out.push("Bearer".to_string());
+            redact_next = true;
+        } else if lower.starts_with("bearer ") {
+            out.push("Bearer [REDACTED]".to_string());
+        } else if is_secret_assignment(&lower) {
+            out.push(redact_assignment(token));
+            if lower.contains("bearer") {
+                redact_next = true;
+            }
+        } else if is_secret_flag(&lower) {
+            out.push(token.to_string());
+            redact_next = true;
+        } else {
+            out.push(token.to_string());
+        }
+    }
+    out.join(" ")
+}
+
+fn is_secret_assignment(lower: &str) -> bool {
+    lower.contains("token=")
+        || lower.contains("_authtoken=")
+        || lower.contains("authorization=")
+        || lower.contains("password=")
+        || lower.contains("secret=")
+        || lower.contains("api_key=")
+        || lower.contains("apikey=")
+}
+
+fn is_secret_flag(lower: &str) -> bool {
+    matches!(
+        lower,
+        "--token" | "--auth-token" | "--password" | "--secret" | "--api-key" | "-p"
+    )
+}
+
+fn redact_assignment(token: &str) -> String {
+    if let Some((key, _)) = token.split_once('=') {
+        format!("{}=[REDACTED]", key)
+    } else {
+        "[REDACTED]".to_string()
+    }
+}
+
+fn display_argv(argv: &[String]) -> String {
+    argv.join("\u{1f}")
+}
+
+fn command_hash(command: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    command.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn denies_destructive_unix_root_removal() {
+        let input = PolicyInput {
+            raw_display: display_argv(&["rm".into(), "-rf".into(), "/".into()]),
+            argv: vec!["rm".into(), "-rf".into(), "/".into()],
+            raw_shell: false,
+        };
+        assert!(matches!(evaluate_policy(&input), PolicyDecision::Deny(_)));
+    }
+
+    #[test]
+    fn denies_destructive_windows_forms() {
+        let inputs = [
+            vec!["Remove-Item", "-Recurse", "-Force", "C:\\"],
+            vec!["rd", "/s", "/q", "C:\\"],
+            vec!["del", "/s", "/q", "C:\\"],
+        ];
+        for argv in inputs {
+            let argv: Vec<String> = argv.into_iter().map(str::to_string).collect();
+            let input = PolicyInput {
+                raw_display: display_argv(&argv),
+                argv,
+                raw_shell: false,
+            };
+            assert!(matches!(evaluate_policy(&input), PolicyDecision::Deny(_)));
+        }
+    }
+
+    #[test]
+    fn raw_chain_destructive_command_is_denied() {
+        let input = PolicyInput {
+            raw_display: "echo ok && rm -rf /".to_string(),
+            argv: Vec::new(),
+            raw_shell: true,
+        };
+        assert!(matches!(evaluate_policy(&input), PolicyDecision::Deny(_)));
+    }
+
+    #[test]
+    fn branch_guardrail_warns_without_denying() {
+        let input = PolicyInput {
+            raw_display: "git checkout -b bad branch".to_string(),
+            argv: vec![
+                "git".into(),
+                "checkout".into(),
+                "-b".into(),
+                "bad branch".into(),
+            ],
+            raw_shell: false,
+        };
+        assert!(matches!(evaluate_policy(&input), PolicyDecision::Warn(_)));
+    }
+
+    #[test]
+    fn nested_shell_warns() {
+        let input = PolicyInput {
+            raw_display: "pwsh -Command echo hi".to_string(),
+            argv: vec!["pwsh".into(), "-Command".into(), "echo hi".into()],
+            raw_shell: false,
+        };
+        assert!(matches!(evaluate_policy(&input), PolicyDecision::Warn(_)));
+    }
+
+    #[test]
+    fn argv_display_preserves_argument_boundaries() {
+        let argv = vec!["echo".to_string(), "a b".to_string(), "c\"d".to_string()];
+        assert_eq!(display_argv(&argv), "echo\u{1f}a b\u{1f}c\"d");
+    }
+
+    #[test]
+    fn redacts_secret_patterns() {
+        let redacted = redact_secrets(
+            "curl -H Authorization=Bearer abc --token secret _authToken=def password=hunter2",
+        );
+        assert!(redacted.contains("Authorization=[REDACTED]"));
+        assert!(redacted.contains("--token [REDACTED]"));
+        assert!(redacted.contains("_authToken=[REDACTED]"));
+        assert!(redacted.contains("password=[REDACTED]"));
+        assert!(!redacted.contains("abc"));
+        assert!(!redacted.contains("hunter2"));
+        assert!(!redacted.contains("secret _authToken"));
+    }
+}

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod close_session;
 pub mod create_agent;
 pub mod create_agent_matrix;
+pub mod harness;
 pub mod list_peers;
 pub mod list_sessions;
 pub mod new_project;
@@ -119,6 +120,8 @@ pub enum Commands {
     Workgroup(workgroup::WorkgroupArgs),
     /// Manage team membership in an AC workgroup
     Team(team::TeamArgs),
+    /// Execute commands through the policy harness
+    Harness(harness::HarnessArgs),
 }
 
 /// Attach to parent console (or allocate a new one) ONLY if both stdout and stderr
@@ -239,6 +242,7 @@ pub fn handle_cli(cmd: Commands) -> i32 {
         Commands::TelegramSendImage(args) => telegram_send_image::execute(args),
         Commands::Workgroup(args) => workgroup::execute(args),
         Commands::Team(args) => team::execute(args),
+        Commands::Harness(args) => harness::execute(args),
     };
 
     flush_outputs();

--- a/src-tauri/tests/cli_harness.rs
+++ b/src-tauri/tests/cli_harness.rs
@@ -1,0 +1,187 @@
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+struct Tmp(PathBuf);
+
+impl Drop for Tmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+impl Tmp {
+    fn new(prefix: &str) -> Self {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        std::process::id().hash(&mut h);
+        std::thread::current().id().hash(&mut h);
+        let path = std::env::temp_dir().join(format!(
+            "ac-{}-{}-{}",
+            prefix,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+            h.finish()
+        ));
+        std::fs::create_dir_all(&path).expect("create tmp dir");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+fn copy_binary_into(tmp: &Path) -> PathBuf {
+    let src = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let dst = tmp.join(src.file_name().expect("binary file name"));
+    std::fs::copy(src, &dst).expect("copy binary");
+    dst
+}
+
+fn config_dir_for(bin: &Path) -> PathBuf {
+    let stem = bin.file_stem().unwrap().to_string_lossy().to_string();
+    bin.parent().unwrap().join(format!(".{}", stem))
+}
+
+fn run(bin: &Path, args: &[&str]) -> (Option<i32>, String, String) {
+    let out = Command::new(bin).args(args).output().expect("spawn binary");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn log_lines(bin: &Path) -> Vec<Value> {
+    let path = config_dir_for(bin).join("logs").join("harness.log");
+    let body = std::fs::read_to_string(path).expect("read harness log");
+    body.lines()
+        .map(|line| serde_json::from_str(line).expect("parse log line"))
+        .collect()
+}
+
+#[test]
+fn harness_argv_with_spaces_preserves_boundaries() {
+    let tmp = Tmp::new("harness-argv");
+    let bin = copy_binary_into(tmp.path());
+
+    #[cfg(target_os = "windows")]
+    let script = {
+        let script = tmp.path().join("check-arg.bat");
+        std::fs::write(
+            &script,
+            "@echo off\r\nif \"%~1\"==\"a b\" (exit /b 0) else (exit /b 9)\r\n",
+        )
+        .expect("write argv probe");
+        script
+    };
+
+    #[cfg(target_os = "windows")]
+    let script_arg = script.to_string_lossy().to_string();
+
+    #[cfg(target_os = "windows")]
+    let args = ["harness", "--", script_arg.as_str(), "a b"];
+
+    #[cfg(not(target_os = "windows"))]
+    let args = [
+        "harness",
+        "--",
+        "sh",
+        "-c",
+        "test \"$1\" = 'a b'",
+        "sh",
+        "a b",
+    ];
+
+    let (code, stdout, stderr) = run(&bin, &args);
+    assert_eq!(code, Some(0), "stdout: {}\nstderr: {}", stdout, stderr);
+}
+
+#[test]
+fn harness_raw_command_chains_execute_via_shell() {
+    let tmp = Tmp::new("harness-raw");
+    let bin = copy_binary_into(tmp.path());
+
+    #[cfg(target_os = "windows")]
+    let raw = "echo first && exit 0";
+    #[cfg(not(target_os = "windows"))]
+    let raw = "echo first && exit 0";
+
+    let (code, stdout, stderr) = run(&bin, &["harness", "--raw-command", raw]);
+    assert_eq!(code, Some(0), "stdout: {}\nstderr: {}", stdout, stderr);
+    assert!(stdout.contains("first"), "stdout: {}", stdout);
+}
+
+#[test]
+fn harness_secret_redaction_is_applied_in_logs() {
+    let tmp = Tmp::new("harness-redact");
+    let bin = copy_binary_into(tmp.path());
+    let secret = "super-secret-token-value";
+    let raw = format!("echo _authToken={}", secret);
+
+    let (code, stdout, stderr) = run(&bin, &["harness", "--dry-run", "--raw-command", &raw]);
+    assert_eq!(code, Some(0), "stdout: {}\nstderr: {}", stdout, stderr);
+
+    let lines = log_lines(&bin);
+    let command = lines[0]["command"].as_str().unwrap();
+    assert!(command.contains("_authToken=[REDACTED]"));
+    assert!(!command.contains(secret));
+}
+
+#[test]
+fn harness_log_uses_config_dir_logs_harness_log() {
+    let tmp = Tmp::new("harness-log-path");
+    let bin = copy_binary_into(tmp.path());
+    let cfg_dir = config_dir_for(&bin);
+
+    let (code, stdout, stderr) = run(&bin, &["harness", "--explain", "--raw-command", "echo hi"]);
+    assert_eq!(code, Some(0), "stdout: {}\nstderr: {}", stdout, stderr);
+
+    assert!(
+        cfg_dir.join("logs").join("harness.log").exists(),
+        "missing harness log under {}",
+        cfg_dir.display()
+    );
+}
+
+#[test]
+fn harness_deny_exit_code_is_one() {
+    let tmp = Tmp::new("harness-deny");
+    let bin = copy_binary_into(tmp.path());
+
+    let (code, stdout, stderr) = run(&bin, &["harness", "--raw-command", "echo ok && rm -rf /"]);
+    assert_eq!(code, Some(1), "stdout: {}\nstderr: {}", stdout, stderr);
+}
+
+#[test]
+fn harness_child_exit_code_is_propagated() {
+    let tmp = Tmp::new("harness-exit");
+    let bin = copy_binary_into(tmp.path());
+
+    #[cfg(target_os = "windows")]
+    let raw = "exit 7";
+    #[cfg(not(target_os = "windows"))]
+    let raw = "exit 7";
+
+    let (code, stdout, stderr) = run(&bin, &["harness", "--raw-command", raw]);
+    assert_eq!(code, Some(7), "stdout: {}\nstderr: {}", stdout, stderr);
+}
+
+#[test]
+fn harness_dry_run_does_not_spawn_child() {
+    let tmp = Tmp::new("harness-dry-run");
+    let bin = copy_binary_into(tmp.path());
+    let sentinel = tmp.path().join("sentinel.txt");
+
+    #[cfg(target_os = "windows")]
+    let raw = format!("echo created > \"{}\"", sentinel.display());
+    #[cfg(not(target_os = "windows"))]
+    let raw = format!("touch '{}'", sentinel.display());
+
+    let (code, stdout, stderr) = run(&bin, &["harness", "--dry-run", "--raw-command", &raw]);
+    assert_eq!(code, Some(0), "stdout: {}\nstderr: {}", stdout, stderr);
+    assert!(!sentinel.exists(), "dry-run spawned child command");
+}

--- a/src-tauri/tests/cli_harness.rs
+++ b/src-tauri/tests/cli_harness.rs
@@ -132,6 +132,24 @@ fn harness_secret_redaction_is_applied_in_logs() {
 }
 
 #[test]
+fn harness_argv_secret_redaction_is_applied_in_logs() {
+    let tmp = Tmp::new("harness-argv-redact");
+    let bin = copy_binary_into(tmp.path());
+    let secret = "secret-leak-check";
+
+    let (code, stdout, stderr) = run(
+        &bin,
+        &["harness", "--dry-run", "--", "echo", "--token", secret],
+    );
+    assert_eq!(code, Some(0), "stdout: {}\nstderr: {}", stdout, stderr);
+
+    let lines = log_lines(&bin);
+    let command = lines[0]["command"].as_str().unwrap();
+    assert!(command.contains("--token\u{1f}[REDACTED]"));
+    assert!(!command.contains(secret));
+}
+
+#[test]
 fn harness_log_uses_config_dir_logs_harness_log() {
     let tmp = Tmp::new("harness-log-path");
     let bin = copy_binary_into(tmp.path());
@@ -154,6 +172,37 @@ fn harness_deny_exit_code_is_one() {
 
     let (code, stdout, stderr) = run(&bin, &["harness", "--raw-command", "echo ok && rm -rf /"]);
     assert_eq!(code, Some(1), "stdout: {}\nstderr: {}", stdout, stderr);
+}
+
+#[test]
+fn harness_raw_destructive_flag_variants_are_denied() {
+    let tmp = Tmp::new("harness-raw-deny-variants");
+    let bin = copy_binary_into(tmp.path());
+
+    for raw in [
+        "rm -fr /",
+        "rm -r -f /",
+        "rd /q /s C:\\",
+        "echo ok && rm -fr /",
+        "Remove-Item -r -fo C:\\",
+    ] {
+        let (code, stdout, stderr) = run(&bin, &["harness", "--dry-run", "--raw-command", raw]);
+        assert_eq!(
+            code,
+            Some(1),
+            "raw: {}\nstdout: {}\nstderr: {}",
+            raw,
+            stdout,
+            stderr
+        );
+        assert!(
+            stderr.contains("harness: deny"),
+            "raw: {}\nstdout: {}\nstderr: {}",
+            raw,
+            stdout,
+            stderr
+        );
+    }
 }
 
 #[test]

--- a/src-tauri/tests/cli_harness.rs
+++ b/src-tauri/tests/cli_harness.rs
@@ -184,6 +184,7 @@ fn harness_raw_destructive_flag_variants_are_denied() {
         "rm -r -f /",
         "rd /q /s C:\\",
         "echo ok && rm -fr /",
+        "echo ok\nrm -fr /",
         "Remove-Item -r -fo C:\\",
     ] {
         let (code, stdout, stderr) = run(&bin, &["harness", "--dry-run", "--raw-command", raw]);


### PR DESCRIPTION
## Summary
- add Phase 1 agentscommander harness CLI command
- add conservative policy checks, dry-run/explain, audit logging, and redaction
- document the harness roadmap phases 1 through 4

## Verification
- cargo test cli::harness --lib
- cargo test --test cli_harness
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- npx tauri build via shipper
- deployed and smoke-tested agentscommander_standalone_wg-5.exe

Closes #436