### PR TITLE
refactor(terminology): clean remaining workspace wording (#439)

### DIFF
--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -487,7 +487,7 @@ struct WgReplicaInfo {
     my_wg_name: String,
     my_wg_dir: PathBuf,
     workspace_dir: PathBuf,
-    /// Project folder name (the dir containing the AC workspace). Forms the
+    /// Project folder name (the dir containing the Project AC Root). Forms the
     /// LHS of the canonical FQN for WG replicas.
     my_project: String,
 }
@@ -581,7 +581,7 @@ fn read_wg_role(replica_dir: &Path) -> String {
 }
 
 /// Build a PeerInfo for a WG replica directory. Also bootstraps IPC dirs.
-/// `project` is the project folder name (dir containing the AC workspace) and forms
+/// `project` is the project folder name (dir containing the Project AC Root) and forms
 /// the LHS of the canonical FQN.
 fn build_wg_peer(
     project: &str,
@@ -858,7 +858,7 @@ fn discover_origin_peers(root: &str) -> Vec<PeerInfo> {
     }
 
     // ── WG replica discovery ──────────────────────────────────────────────
-    // Scan project_paths for workspace wg-*/__agent_* replicas
+    // Scan project_paths for Project AC Root wg-*/__agent_* replicas
     let settings = crate::config::settings::load_settings();
     for base_path in &settings.project_paths {
         let base = Path::new(base_path);

--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -492,7 +492,7 @@ struct WgReplicaInfo {
     my_project: String,
 }
 
-/// Detect if `root` is a WG replica: path matches `*/<workspace>/wg-*/__agent_*/`.
+/// Detect if `root` is a WG replica: path matches `*/<project_ac_root>/wg-*/__agent_*/`.
 fn detect_wg_replica(root: &str) -> Result<Option<WgReplicaInfo>, String> {
     let path = PathBuf::from(root);
     let canon = match std::fs::canonicalize(&path) {
@@ -550,7 +550,7 @@ fn detect_wg_replica(root: &str) -> Result<Option<WgReplicaInfo>, String> {
 }
 
 /// Resolve the coordinator agent name for a WG by matching replica identity
-/// paths against the team coordinator path in the workspace `_team_*/config.json`.
+/// paths against the team coordinator path in Project AC Root `_team_*/config.json`.
 /// Only checks the team whose name matches the WG suffix (e.g. `wg-1-ac-devs` → `_team_ac-devs`).
 fn resolve_wg_coordinator(workspace_dir: &Path, wg_dir: &Path) -> Option<String> {
     crate::config::teams::resolve_wg_coordinator_replica(workspace_dir, wg_dir)
@@ -687,7 +687,7 @@ fn discover_wg_peers(wg: WgReplicaInfo) -> Vec<PeerInfo> {
         ));
     }
 
-    // Coordinator also sees coordinators of other WGs in the same workspace
+    // Coordinator also sees coordinators of other WGs in the same Project AC Root
     // (same project, different WG — still qualified with `wg.my_project`).
     if i_am_coordinator {
         if let Ok(entries) = std::fs::read_dir(&wg.workspace_dir) {
@@ -882,7 +882,7 @@ fn discover_origin_peers(root: &str) -> Vec<PeerInfo> {
             let Some(workspace_dir) = existing_workspace_dir(&repo_dir) else {
                 continue;
             };
-            // Project folder name (parent of workspace) is the LHS of the canonical FQN.
+            // Project folder name (parent of Project AC Root) is the LHS of the canonical FQN.
             let project_folder = match repo_dir.file_name().and_then(|n| n.to_str()) {
                 Some(n) => n.to_string(),
                 None => continue,

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -111,7 +111,7 @@ pub enum Commands {
     TaskAppendBody(task_append_body::TaskAppendBodyArgs),
     /// Register an existing AC project (.ac must already exist) in settings
     OpenProject(open_project::OpenProjectArgs),
-    /// Create an AC project (mkdir .ac if no workspace exists) and register it in settings
+    /// Create an AC project (create `.ac/` Project AC Root if missing) and register it in settings
     NewProject(new_project::NewProjectArgs),
     /// Send a local image/file to a configured Telegram bot (no GUI required)
     TelegramSendImage(telegram_send_image::TelegramSendImageArgs),

--- a/src-tauri/src/cli/send.rs
+++ b/src-tauri/src/cli/send.rs
@@ -148,7 +148,7 @@ fn wait_for_delivery_confirmation(
     }
 }
 
-/// If `root` lives inside `<project_dir>/<workspace>/wg-<N>-*/__agent_*/`,
+/// If `root` lives inside `<project_dir>/<Project AC Root>/wg-<N>-*/__agent_*/`,
 /// return `project_dir` as a UTF-8 `String`. Returns `None` if `root` is not
 /// inside a WG-replica shape OR if the resulting `project_dir` is not valid
 /// UTF-8 (parity with `list_peers::detect_wg_replica`, which also uses

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -136,7 +136,7 @@ pub struct AcDiscoveryResult {
 }
 
 /// Extract the origin project name from a resolved identity path.
-/// Looks for the folder immediately before the rightmost AC workspace marker.
+/// Looks for the folder immediately before the rightmost Project AC Root marker.
 fn extract_origin_project(identity_abs_path: &std::path::Path) -> Option<String> {
     let s = identity_abs_path.to_string_lossy().replace('\\', "/");
     let parts: Vec<&str> = s.split('/').collect();
@@ -201,7 +201,7 @@ fn origin_project_for_replica_identity(
 
 /// Derive agent display name from its path.
 /// Format: "{project_folder}/{agent_name}" where:
-/// - project_folder = directory containing the AC workspace
+/// - project_folder = directory containing the Project AC Root
 /// - agent_name = folder name with "_agent_" prefix stripped
 fn agent_display_name(project_folder: &str, dir_name: &str) -> String {
     let agent_name = dir_name.strip_prefix("_agent_").unwrap_or(dir_name);
@@ -211,14 +211,14 @@ fn agent_display_name(project_folder: &str, dir_name: &str) -> String {
 /// Resolve an agent ref to a display name. Handles both relative refs
 /// (e.g. "../_agent_tech-lead") and absolute paths.
 /// For relative refs, uses project_folder as origin. For absolute paths,
-/// extracts the origin project from the folder before the workspace marker.
+/// extracts the origin project from the folder before the Project AC Root marker.
 fn resolve_agent_ref(project_folder: &str, agent_ref: &str) -> String {
     let normalized = agent_ref.replace('\\', "/");
     let trimmed = normalized
         .trim_start_matches("../")
         .trim_start_matches("./");
     if trimmed.contains(':') || trimmed.starts_with('/') {
-        // Absolute path: extract origin project from folder before the workspace marker
+        // Absolute path: extract origin project from folder before the Project AC Root marker
         let parts: Vec<&str> = trimmed.split('/').collect();
         let origin = find_workspace_segment(&parts)
             .and_then(|i| (i > 0).then_some(parts[i - 1]))
@@ -384,7 +384,7 @@ struct TaskUpdatedPayload {
 pub struct DiscoveryBranchWatcher {
     app_handle: AppHandle,
     session_manager: Arc<tokio::sync::RwLock<SessionManager>>,
-    /// Keyed by the project directory that directly contains the AC workspace, not by
+    /// Keyed by the project directory that directly contains the Project AC Root, not by
     /// `settings.project_paths` entries (which may be parent dirs holding many projects).
     /// Keying by the direct parent prevents both (a) the original overwrite-across-projects
     /// bug (Grinch #1) and (b) the double-registration that occurs when `project_paths`
@@ -421,7 +421,7 @@ impl DiscoveryBranchWatcher {
     }
 
     /// Update this project's replicas in the watcher. `project_dir` is the directory
-    /// that directly contains the AC workspace, not a grand-parent from `settings.project_paths`.
+    /// that directly contains the Project AC Root, not a grand-parent from `settings.project_paths`.
     /// See the invariant comment on the `replicas` field.
     pub fn update_replicas_for_project(&self, project_dir: &str, workgroups: &[AcWorkgroup]) {
         // Invariant guard: catch mistaken call-site passes (e.g. a `base_path` parent)
@@ -888,7 +888,7 @@ impl DiscoveryBranchWatcher {
     }
 }
 
-/// Discover AC agent matrices from workspace directories within configured repo paths.
+/// Discover AC agent matrices from Project AC Root directories within configured repo paths.
 #[tauri::command]
 pub async fn discover_ac_agents(
     app: AppHandle,
@@ -907,7 +907,7 @@ pub async fn discover_ac_agents(
     let mut agents: Vec<AcAgentMatrix> = Vec::new();
     let mut teams: Vec<AcTeam> = Vec::new();
     let mut workgroups: Vec<AcWorkgroup> = Vec::new();
-    // Track the workspace-containing dir each workgroup originated from. Keys are
+    // Track the Project AC Root-containing dir each workgroup originated from. Keys are
     // `wg.name` values (unique within a discovery run; workgroup dir names include
     // the team name which collides only intentionally across projects). Populated as
     // we push to `workgroups` so we can later call `update_replicas_for_project` once
@@ -1201,7 +1201,7 @@ pub async fn discover_ac_agents(
         }
     }
 
-    // Update the branch watcher per-project. Each workspace-containing dir gets its own
+    // Update the branch watcher per-project. Each Project AC Root-containing dir gets its own
     // slot so multi-project setups don't overwrite each other (Grinch #1 + #12).
     let mut by_project: HashMap<String, Vec<AcWorkgroup>> = HashMap::new();
     for wg in &workgroups {
@@ -1250,13 +1250,13 @@ pub async fn discover_ac_agents(
     })
 }
 
-/// Check if a folder has an AC workspace subdirectory.
+/// Check if a folder has a Project AC Root subdirectory.
 #[tauri::command]
 pub async fn check_project_path(path: String) -> Result<bool, String> {
     Ok(existing_workspace_dir(Path::new(&path)).is_some())
 }
 
-/// Ensure the workspace .gitignore exists and contains all required exclusion patterns.
+/// Ensure the Project AC Root .gitignore exists and contains all required exclusion patterns.
 /// Called during project creation, workgroup creation, and opportunistically during discovery.
 pub(crate) fn ensure_workspace_gitignore(workspace_dir: &Path) -> Result<(), String> {
     let gitignore_path = workspace_dir.join(".gitignore");

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -2129,7 +2129,7 @@ pub(crate) fn is_file_in_use_error(e: &std::io::Error) -> bool {
     }
 }
 
-/// Scan the selected workspace for existing `wg-<N>-{team_name}/` dirs and return the
+/// Scan the selected Project AC Root for existing `wg-<N>-{team_name}/` dirs and return the
 /// **lowest free positive integer** starting at 1.
 ///
 /// Issue #177: previously this returned `max(existing) + 1`, which left

--- a/src-tauri/src/config/claude_settings.rs
+++ b/src-tauri/src/config/claude_settings.rs
@@ -507,7 +507,7 @@ fn discriminant_label(v: &serde_json::Value) -> &'static str {
 /// `_agent_*` matrix and every `__agent_*` replica (inside `wg-*` dirs).
 ///
 /// **`project_paths` semantics.** Each entry may be either (a) a project root
-/// that directly contains an AC workspace, or (b) a parent dir holding many such
+/// that directly contains a Project AC Root, or (b) a parent dir holding many such
 /// project roots as immediate children. We probe both shapes — base + non-
 /// hidden children — mirroring the existing pattern in
 /// `commands/ac_discovery.rs::discover_ac_agents` (~line 596) and
@@ -611,7 +611,7 @@ pub fn enumerate_managed_agent_dirs(project_paths: &[String]) -> Vec<std::path::
         }
 
         // Build the candidate list: the base itself, plus its non-hidden
-        // immediate children. Each candidate is probed for an AC workspace. This
+        // immediate children. Each candidate is probed for a Project AC Root. This
         // matches the convention used by `commands/ac_discovery.rs` and
         // `commands/repos.rs`, where `project_paths` may be a parent dir.
         //

--- a/src-tauri/src/config/claude_settings.rs
+++ b/src-tauri/src/config/claude_settings.rs
@@ -503,7 +503,7 @@ fn discriminant_label(v: &serde_json::Value) -> &'static str {
     }
 }
 
-/// Walks every `<project_root>/<workspace>/` and returns absolute paths to every
+/// Walks every `<project_root>/<project_ac_root>/` and returns absolute paths to every
 /// `_agent_*` matrix and every `__agent_*` replica (inside `wg-*` dirs).
 ///
 /// **`project_paths` semantics.** Each entry may be either (a) a project root
@@ -619,7 +619,7 @@ pub fn enumerate_managed_agent_dirs(project_paths: &[String]) -> Vec<std::path::
         // `push_if_new` and the `wg-*` parent re-check. Without this, a
         // symlink/junction child (e.g. `parent/Linked -> /elsewhere`) would
         // pass `p.is_dir()` (which follows links) and the sweep would write
-        // into `/elsewhere/.ac/_agent_*` outside the declared workspace.
+        // into `/elsewhere/.ac/_agent_*` outside the declared Project AC Root.
         let mut candidates: Vec<PathBuf> = vec![base.to_path_buf()];
         if let Ok(entries) = std::fs::read_dir(base) {
             for entry in entries.flatten() {
@@ -1177,7 +1177,7 @@ mod tests {
         // symlink/junction pointing OUTSIDE the parent tree to a dir that has
         // its own .ac/. The descend must NOT cross that boundary.
         // (Grinch H1' regression test — without the M7 gate at the descend
-        // step, the sweep escapes the declared workspace.)
+        // step, the sweep escapes the declared Project AC Root.)
         let dir = tempdir("t25");
         let parent = dir.join("parent");
         let real_proj = parent.join("AppA");

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -73,7 +73,7 @@ pub enum ProjectResolveError {
 }
 
 /// Validate an existing AC project and register it in `settings.project_paths`.
-/// Errors when the path is missing, not a directory, or has no AC workspace.
+/// Errors when the path is missing, not a directory, or has no Project AC Root.
 ///
 /// On success, mutates `settings.project_paths` (appends if new) and
 /// `settings.project_path` (legacy single-project field — kept in sync with

--- a/src-tauri/src/config/replica_identity.rs
+++ b/src-tauri/src/config/replica_identity.rs
@@ -211,7 +211,7 @@ fn validate_local_matrix(
 }
 
 /// Derive the only valid identity for a WG replica:
-/// `<project>/<workspace>/wg-N-team/__agent_NAME` -> `<project>/<workspace>/_agent_NAME`.
+/// `<project>/<Project AC Root>/wg-N-team/__agent_NAME` -> `<project>/<Project AC Root>/_agent_NAME`.
 pub fn expected_wg_replica_identity(replica_dir: &Path) -> Result<WgReplicaIdentity, String> {
     let replica_dir_name = replica_dir
         .file_name()

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -874,7 +874,7 @@ fn is_agent_dir(cwd: &str) -> bool {
         || super::root_agent::is_root_agent_dir_name(cwd)
 }
 
-/// Build the GIT_CEILING_DIRECTORIES value for agent sessions rooted in an AC workspace.
+/// Build the GIT_CEILING_DIRECTORIES value for agent sessions rooted in a Project AC Root.
 /// This blocks Git from traversing upward into the parent project repo when the
 /// current directory is an agent matrix, a WG replica, or a descendant of those roots.
 pub fn git_ceiling_directories_for_session_root(cwd: &str) -> Option<String> {

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -538,7 +538,7 @@ fn resolve_agent_ref(project_folder: &str, agent_ref: &str) -> String {
     }
 }
 
-/// Resolve an agent ref to an absolute path given the workspace directory.
+/// Resolve an agent ref to an absolute path given the Project AC Root directory.
 fn resolve_agent_path(workspace_dir: &Path, agent_ref: &str) -> Option<PathBuf> {
     let normalized = agent_ref.replace('\\', "/");
     let trimmed = normalized
@@ -554,13 +554,13 @@ fn resolve_agent_path(workspace_dir: &Path, agent_ref: &str) -> Option<PathBuf> 
         return None;
     }
 
-    // Relative to the workspace directory.
+    // Relative to the Project AC Root directory.
     let candidate = workspace_dir.join(trimmed);
     if candidate.is_dir() {
         return Some(candidate);
     }
 
-    // Try parent of the workspace directory (project root).
+    // Try parent of the Project AC Root directory (project root).
     if let Some(project_root) = workspace_dir.parent() {
         let candidate = project_root.join(trimmed);
         if candidate.is_dir() {
@@ -799,7 +799,7 @@ pub fn can_communicate(from: &str, to: &str, teams: &[DiscoveredTeam]) -> bool {
 }
 
 /// Discover all teams from all known project paths.
-/// Scans settings.project_paths (and immediate children) for workspace `_team_*/config.json`.
+/// Scans settings.project_paths (and immediate children) for Project AC Root `_team_*/config.json`.
 pub fn discover_teams() -> Vec<DiscoveredTeam> {
     let settings = crate::config::settings::load_settings();
     let mut teams = Vec::new();

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -19,7 +19,7 @@ fn note_missing_team_config(project: &str, team_dir: &str) -> bool {
     g.insert((project.to_string(), team_dir.to_string()))
 }
 
-/// A team discovered from `_team_*/config.json` in AC workspace directories.
+/// A team discovered from `_team_*/config.json` in Project AC Root directories.
 #[derive(Debug, Clone)]
 pub struct DiscoveredTeam {
     pub name: String,
@@ -180,14 +180,14 @@ fn enumerate_project_dirs(project_paths: &[String]) -> Vec<(String, PathBuf)> {
             continue;
         }
 
-        // Include base itself if it contains an AC workspace.
+        // Include base itself if it contains a Project AC Root.
         if has_workspace_dir(base) {
             if let Some(name) = base.file_name().and_then(|n| n.to_str()) {
                 out.push((name.to_string(), base.to_path_buf()));
             }
         }
 
-        // Plus immediate non-dot children that contain an AC workspace.
+        // Plus immediate non-dot children that contain a Project AC Root.
         if let Ok(entries) = std::fs::read_dir(base) {
             for entry in entries.flatten() {
                 let p = entry.path();
@@ -516,7 +516,7 @@ fn resolve_agent_ref(project_folder: &str, agent_ref: &str) -> String {
         .trim_start_matches("./");
 
     if trimmed.contains(':') || trimmed.starts_with('/') {
-        // Absolute path: extract origin project from folder before the workspace marker
+        // Absolute path: extract origin project from folder before the Project AC Root marker
         let parts: Vec<&str> = trimmed.split('/').collect();
         let origin = find_workspace_segment(&parts)
             .and_then(|i| (i > 0).then_some(parts[i - 1]))

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -451,7 +451,7 @@ export const ProjectAPI = {
   open: (path: string) =>
     transport.invoke<ProjectRegistration>("open_project", { path }),
   /**
-   * Ensure an AC project at `path` (mkdir `.ac/` if no workspace exists) and register
+   * Ensure an AC project at `path` (create `.ac/` Project AC Root if missing) and register
    * it in settings.projectPaths. Wraps the `new_project` Tauri command added
    * in #191 — same backend logic as the CLI `new-project` verb.
    */

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -244,10 +244,10 @@ const SessionItem: Component<{
   const isInactive = () => props.session.id.startsWith("inactive-");
 
   /** Derive short display name from workingDirectory.
-   *  AC workspace paths: "agent-name@origin-project" (e.g. "code-reviewer@phi_phibridge")
+   *  Project AC Root paths: "agent-name@origin-project" (e.g. "code-reviewer@phi_phibridge")
    *  Other paths: "parentFolder/name" (last 2 segments)
    *
-   *  Workspace parsing is delegated to extractProjectName. The innermost
+   *  Project AC Root parsing is delegated to extractProjectName. The innermost
    *  .ac segment wins, matching the titlebar helpers. */
   const displayName = () => {
     const wd = props.session.workingDirectory;

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -76,7 +76,7 @@ export const projectStore = {
       // Round-1 G11 deferred: surface this to the user via toast/sidebar
       // chip in a follow-up. For now, preserve the existing swallow-and-log
       // so behaviour is no worse than today (initFromSettings silently drops
-      // a project whose workspace was deleted between sessions.
+      // a project whose Project AC Root was deleted between sessions.
       console.error("Failed to load project:", e);
     } finally {
       loadingCount--;
@@ -96,10 +96,10 @@ export const projectStore = {
     }
   },
 
-  /** Create .ac in path (if no workspace exists) and register/load it. */
+  /** Create `.ac/` Project AC Root in path if missing and register/load it. */
   async createAndLoad(path: string) {
     const reg = await ProjectAPI.new(path);
-    // After ensuring a workspace exists and persistence is set, run discovery for UI.
+    // After ensuring Project AC Root exists and persistence is set, run discovery for UI.
     const result = await ProjectAPI.discover(reg.path);
     const folderName =
       reg.path.replace(/\\/g, "/").split("/").pop() ?? "unknown";
@@ -119,7 +119,7 @@ export const projectStore = {
     });
   },
 
-  /** Full open flow: pick folder, check workspace, auto-load if found */
+  /** Full open flow: pick folder, check Project AC Root, auto-load if found */
   async pickAndCheck(): Promise<{ picked: string | null; hasWorkspace: boolean }> {
     const picked = await AgentCreatorAPI.pickFolder();
     if (!picked) return { picked: null, hasWorkspace: false };


### PR DESCRIPTION
## Summary
- Clean up stale `workspace` wording where it referred to the `.ac` Project AC Root.
- Keep internal identifiers, compatibility names, env vars, config keys, serialization fields, CLI flags, error codes, `$REPOS_WORKSPACE_INFO`, `Workspace Repos`, and WG terms unchanged.
- Add a follow-up pass for review misses in Rust source comments.

## Verification
- `cargo check`
- `cargo clippy -- -D warnings`
- terminology/scope re-review PASS
- workgroup build/deploy PASS for `agentscommander_standalone_wg-12.exe`

Closes #439