### PR TITLE
feat(root-agent): externalize root agent context (#444)

### DIFF
--- a/src-tauri/src/config/root_agent.rs
+++ b/src-tauri/src/config/root_agent.rs
@@ -9,6 +9,11 @@ pub const ROOT_AGENT_SESSION_NAME: &str = "Root Agent";
 pub const ROOT_AGENT_SENDER: &str = "agentscommander://root-agent";
 pub const ROOT_AGENT_SHORT_NAME: &str = "root";
 static ROOT_ROLE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+#[cfg(test)]
+static FAIL_ROOT_ROLE_WRITE_ONCE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+#[cfg(test)]
+const FAIL_ROOT_ROLE_WRITE_MARKER: &str = "FAIL_ROOT_ROLE_WRITE_ONCE";
 
 /// Returns `true` iff `target` is the canonical Root Agent reply name.
 ///
@@ -199,17 +204,9 @@ fn migrate_root_role(role_path: &Path) -> Result<(), String> {
     }
     let context_text = context_text.expect("checked above");
 
-    match std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(role_path)
-    {
-        Ok(mut file) => {
-            write_role_file(&mut file, role_path, &context_text)?;
-            return Ok(());
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
-        Err(e) => return Err(format!("Failed to create {}: {}", role_path.display(), e)),
+    match create_missing_role(role_path, &context_text)? {
+        CreateMissingRole::Created => return Ok(()),
+        CreateMissingRole::AlreadyExists => {}
     }
 
     let existing = std::fs::read_to_string(role_path)
@@ -323,11 +320,74 @@ fn atomic_write_role(role_path: &Path, content: &str) -> Result<(), String> {
     Ok(())
 }
 
+enum CreateMissingRole {
+    Created,
+    AlreadyExists,
+}
+
+fn create_missing_role(role_path: &Path, content: &str) -> Result<CreateMissingRole, String> {
+    let parent = role_path.parent().ok_or_else(|| {
+        format!(
+            "Could not resolve parent directory for {}",
+            role_path.display()
+        )
+    })?;
+    let temp_path = unique_role_temp_path(role_path);
+    let mut file = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+    {
+        Ok(file) => file,
+        Err(e) => {
+            return Err(format!(
+                "Failed to create temporary role file {}: {}",
+                temp_path.display(),
+                e
+            ))
+        }
+    };
+
+    if let Err(e) = write_role_file(&mut file, role_path, content) {
+        drop(file);
+        cleanup_temp_role(&temp_path);
+        return Err(e);
+    }
+    drop(file);
+
+    let published = match publish_missing_role_file(&temp_path, role_path) {
+        Ok(published) => published,
+        Err(e) => {
+            cleanup_temp_role(&temp_path);
+            return Err(e);
+        }
+    };
+
+    cleanup_temp_role(&temp_path);
+
+    if published {
+        sync_role_dir(parent);
+        Ok(CreateMissingRole::Created)
+    } else {
+        Ok(CreateMissingRole::AlreadyExists)
+    }
+}
+
 fn write_role_file(
     file: &mut std::fs::File,
     role_path: &Path,
     content: &str,
 ) -> Result<(), String> {
+    #[cfg(test)]
+    if content.contains(FAIL_ROOT_ROLE_WRITE_MARKER)
+        && FAIL_ROOT_ROLE_WRITE_ONCE.swap(false, Ordering::SeqCst)
+    {
+        return Err(format!(
+            "Failed to write {}: injected failure",
+            role_path.display()
+        ));
+    }
+
     file.write_all(content.as_bytes())
         .map_err(|e| format!("Failed to write {}: {}", role_path.display(), e))?;
     file.flush()
@@ -359,6 +419,31 @@ fn cleanup_temp_role(path: &Path) {
                 e
             );
         }
+    }
+}
+
+fn sync_role_dir(parent: &Path) {
+    if let Ok(dir) = std::fs::File::open(parent) {
+        if let Err(e) = dir.sync_all() {
+            log::warn!(
+                "Failed to sync root agent role directory {}: {}",
+                parent.display(),
+                e
+            );
+        }
+    }
+}
+
+fn publish_missing_role_file(temp_path: &Path, role_path: &Path) -> Result<bool, String> {
+    match std::fs::hard_link(temp_path, role_path) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Err(e) => Err(format!(
+            "Failed to publish missing role file {} from {}: {}",
+            role_path.display(),
+            temp_path.display(),
+            e
+        )),
     }
 }
 
@@ -557,6 +642,35 @@ mod tests {
         std::fs::write(&template_path, custom_template).expect("write template");
 
         ensure_root_agent_dir_at(&root).expect("ensure root");
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("Role.md")).expect("read role"),
+            custom_template
+        );
+    }
+
+    #[test]
+    fn failed_missing_role_seed_leaves_no_final_role_and_retry_creates_complete_role() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+        let template_path = temp
+            .path()
+            .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        let custom_template = format!(
+            "# Custom Root Template\n\n{FAIL_ROOT_ROLE_WRITE_MARKER}\n\nComplete seed body.\n"
+        );
+        std::fs::write(&template_path, &custom_template).expect("write template");
+
+        FAIL_ROOT_ROLE_WRITE_ONCE.store(true, Ordering::SeqCst);
+        let err = ensure_root_agent_dir_at(&root).expect_err("injected seed write must fail");
+
+        assert!(err.contains("injected failure"), "{err}");
+        assert!(
+            !root.join("Role.md").exists(),
+            "failed missing-role seed must not publish final Role.md"
+        );
+
+        ensure_root_agent_dir_at(&root).expect("retry ensure root");
 
         assert_eq!(
             std::fs::read_to_string(root.join("Role.md")).expect("read role"),

--- a/src-tauri/src/config/root_agent.rs
+++ b/src-tauri/src/config/root_agent.rs
@@ -8,6 +8,12 @@ pub const ROOT_AGENT_DIR_NAME: &str = "ac-root-agent";
 pub const ROOT_AGENT_SESSION_NAME: &str = "Root Agent";
 pub const ROOT_AGENT_SENDER: &str = "agentscommander://root-agent";
 pub const ROOT_AGENT_SHORT_NAME: &str = "root";
+const ROOT_AGENT_DEFAULT_CONTEXT: &[&str] = &[
+    "$AGENTSCOMMANDER_CONTEXT",
+    "../Context.root-agent.md",
+    "Role.md",
+];
+const ROOT_AGENT_OLD_DEFAULT_CONTEXT: &[&str] = &["$AGENTSCOMMANDER_CONTEXT", "Role.md"];
 static ROOT_ROLE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 #[cfg(test)]
 static FAIL_ROOT_ROLE_WRITE_ONCE: std::sync::atomic::AtomicBool =
@@ -110,6 +116,11 @@ Use the AgentsCommander CLI only for commands that are valid from this root-agen
     )
 });
 
+const MINIMAL_ROOT_ROLE_MD: &str = r#"# Role
+
+You are the personal Root Agent for AgentsCommander.
+"#;
+
 pub fn root_agent_dir() -> Result<String, String> {
     static ROOT_DIR: OnceLock<String> = OnceLock::new();
     if let Some(cached) = ROOT_DIR.get() {
@@ -187,24 +198,19 @@ fn migrate_root_role(role_path: &Path) -> Result<(), String> {
     let context_template_path =
         config_dir.join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
 
-    let mut context_text = read_validated_template(&context_template_path)?;
-    if context_text.is_none() {
+    if read_validated_template(&context_template_path)?.is_none() {
         crate::config::session_context::write_template_if_missing(
             &context_template_path,
             ROOT_ROLE_MD.as_str(),
         )?;
-        context_text = Some(
-            read_validated_template(&context_template_path)?.ok_or_else(|| {
-                format!(
-                    "Template missing immediately after write_template_if_missing: {}",
-                    context_template_path.display()
-                )
-            })?,
-        );
+        read_validated_template(&context_template_path)?.ok_or_else(|| {
+            format!(
+                "Template missing immediately after write_template_if_missing: {}",
+                context_template_path.display()
+            )
+        })?;
     }
-    let context_text = context_text.expect("checked above");
-
-    match create_missing_role(role_path, &context_text)? {
+    match create_missing_role(role_path, MINIMAL_ROOT_ROLE_MD)? {
         CreateMissingRole::Created => return Ok(()),
         CreateMissingRole::AlreadyExists => {}
     }
@@ -212,12 +218,11 @@ fn migrate_root_role(role_path: &Path) -> Result<(), String> {
     let existing = std::fs::read_to_string(role_path)
         .map_err(|e| format!("Failed to read {}: {}", role_path.display(), e))?;
     let existing_normalized = normalize_role_text(&existing);
-    let context_normalized = normalize_role_text(&context_text);
     let migrated = if existing_normalized == normalize_role_text(OLD_ROOT_ROLE_MD)
         || existing_normalized == normalize_role_text(&ROOT_ROLE_MD)
     {
-        if existing_normalized != context_normalized {
-            Some(context_text)
+        if existing_normalized != normalize_role_text(MINIMAL_ROOT_ROLE_MD) {
+            Some(MINIMAL_ROOT_ROLE_MD.to_string())
         } else {
             None
         }
@@ -541,14 +546,13 @@ pub(crate) fn merge_root_agent_config(config_path: &Path) -> Result<(), String> 
     obj.entry("tooling".to_string())
         .or_insert_with(|| Value::Object(Map::new()));
 
-    let has_non_empty_context = obj
-        .get("context")
-        .and_then(|v| v.as_array())
-        .is_some_and(|arr| !arr.is_empty());
-    if !has_non_empty_context {
+    let context = obj.get("context").and_then(|v| v.as_array());
+    let context_is_old_default =
+        context.is_some_and(|arr| context_array_matches(arr, ROOT_AGENT_OLD_DEFAULT_CONTEXT));
+    if context.is_none_or(|arr| arr.is_empty()) || context_is_old_default {
         obj.insert(
             "context".to_string(),
-            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT", "Role.md"]),
+            serde_json::json!(ROOT_AGENT_DEFAULT_CONTEXT),
         );
     }
 
@@ -558,6 +562,14 @@ pub(crate) fn merge_root_agent_config(config_path: &Path) -> Result<(), String> 
         .map_err(|e| format!("Failed to write {}: {}", config_path.display(), e))?;
 
     Ok(())
+}
+
+fn context_array_matches(arr: &[Value], expected: &[&str]) -> bool {
+    arr.len() == expected.len()
+        && arr
+            .iter()
+            .zip(expected)
+            .all(|(value, expected)| value.as_str() == Some(*expected))
 }
 
 pub fn read_last_coding_agent(root_dir: &str) -> Option<String> {
@@ -600,6 +612,16 @@ fn display_path(path: &Path) -> String {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn try_symlink_file(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
+    #[cfg(windows)]
+    fn try_symlink_file(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_file(target, link)
+    }
+
     #[test]
     fn ensure_root_agent_dir_at_creates_layout_role_and_config() {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -618,7 +640,11 @@ mod tests {
         assert!(template_path.is_file());
         assert_eq!(
             std::fs::read_to_string(root.join("Role.md")).expect("read role"),
-            std::fs::read_to_string(template_path).expect("read template")
+            MINIMAL_ROOT_ROLE_MD
+        );
+        assert_eq!(
+            std::fs::read_to_string(template_path).expect("read template"),
+            ROOT_ROLE_MD.as_str()
         );
         let config: Value = serde_json::from_str(
             &std::fs::read_to_string(root.join("config.json")).expect("read config"),
@@ -627,12 +653,12 @@ mod tests {
         assert_eq!(config["tooling"], serde_json::json!({}));
         assert_eq!(
             config["context"],
-            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT", "Role.md"])
+            serde_json::json!(ROOT_AGENT_DEFAULT_CONTEXT)
         );
     }
 
     #[test]
-    fn ensure_root_agent_dir_at_seeds_missing_role_from_custom_template() {
+    fn ensure_root_agent_dir_at_preserves_existing_custom_template_and_seeds_minimal_role() {
         let temp = tempfile::tempdir().expect("tempdir");
         let root = temp.path().join(ROOT_AGENT_DIR_NAME);
         let template_path = temp
@@ -645,12 +671,16 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(root.join("Role.md")).expect("read role"),
+            MINIMAL_ROOT_ROLE_MD
+        );
+        assert_eq!(
+            std::fs::read_to_string(template_path).expect("read template"),
             custom_template
         );
     }
 
     #[test]
-    fn failed_missing_role_seed_leaves_no_final_role_and_retry_creates_complete_role() {
+    fn missing_role_seed_uses_minimal_role_without_copying_custom_template() {
         let temp = tempfile::tempdir().expect("tempdir");
         let root = temp.path().join(ROOT_AGENT_DIR_NAME);
         let template_path = temp
@@ -661,19 +691,14 @@ mod tests {
         );
         std::fs::write(&template_path, &custom_template).expect("write template");
 
-        FAIL_ROOT_ROLE_WRITE_ONCE.store(true, Ordering::SeqCst);
-        let err = ensure_root_agent_dir_at(&root).expect_err("injected seed write must fail");
-
-        assert!(err.contains("injected failure"), "{err}");
-        assert!(
-            !root.join("Role.md").exists(),
-            "failed missing-role seed must not publish final Role.md"
-        );
-
-        ensure_root_agent_dir_at(&root).expect("retry ensure root");
+        ensure_root_agent_dir_at(&root).expect("ensure root");
 
         assert_eq!(
             std::fs::read_to_string(root.join("Role.md")).expect("read role"),
+            MINIMAL_ROOT_ROLE_MD
+        );
+        assert_eq!(
+            std::fs::read_to_string(template_path).expect("read template"),
             custom_template
         );
     }
@@ -700,7 +725,7 @@ mod tests {
     }
 
     #[test]
-    fn ensure_root_agent_dir_at_replaces_current_builtin_role_with_custom_template() {
+    fn ensure_root_agent_dir_at_reduces_current_builtin_role_to_minimal_role() {
         let temp = tempfile::tempdir().expect("tempdir");
         let root = temp.path().join(ROOT_AGENT_DIR_NAME);
         let template_path = temp
@@ -715,6 +740,10 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(root.join("Role.md")).expect("read role"),
+            MINIMAL_ROOT_ROLE_MD
+        );
+        assert_eq!(
+            std::fs::read_to_string(template_path).expect("read template"),
             custom_template
         );
     }
@@ -731,14 +760,14 @@ mod tests {
         let migrated = std::fs::read_to_string(root.join("Role.md")).expect("read role");
         assert_eq!(
             normalize_role_text(&migrated),
-            normalize_role_text(&ROOT_ROLE_MD)
+            normalize_role_text(MINIMAL_ROOT_ROLE_MD)
         );
-        assert!(migrated.contains("verified workgroup coordinator replicas only"));
+        assert!(!migrated.contains("verified workgroup coordinator replicas only"));
         assert!(!migrated.contains(OLD_DEFERRED_MESSAGING_PARAGRAPH));
     }
 
     #[test]
-    fn ensure_root_agent_dir_at_replaces_old_builtin_role_with_custom_template() {
+    fn ensure_root_agent_dir_at_reduces_old_builtin_role_to_minimal_role() {
         let temp = tempfile::tempdir().expect("tempdir");
         let root = temp.path().join(ROOT_AGENT_DIR_NAME);
         let template_path = temp
@@ -753,6 +782,10 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(root.join("Role.md")).expect("read role"),
+            MINIMAL_ROOT_ROLE_MD
+        );
+        assert_eq!(
+            std::fs::read_to_string(template_path).expect("read template"),
             custom_template
         );
     }
@@ -787,6 +820,25 @@ mod tests {
         std::fs::create_dir_all(&template_path).expect("create template directory");
 
         let err = ensure_root_agent_dir_at(&root).expect_err("directory template must fail");
+
+        assert!(err.contains("not a regular file"), "{err}");
+        assert!(!root.join("Role.md").exists());
+    }
+
+    #[test]
+    fn ensure_root_agent_dir_at_errors_when_root_template_is_symlink() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+        let template_path = temp
+            .path()
+            .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        let target = temp.path().join("target.md");
+        std::fs::write(&target, "linked template").expect("write target");
+        let Ok(()) = try_symlink_file(&target, &template_path) else {
+            return;
+        };
+
+        let err = ensure_root_agent_dir_at(&root).expect_err("symlink template must fail");
 
         assert!(err.contains("not a regular file"), "{err}");
         assert!(!root.join("Role.md").exists());
@@ -863,7 +915,50 @@ mod tests {
         assert_eq!(config["unknown"]["keep"], true);
         assert_eq!(
             config["context"],
-            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT", "Role.md"])
+            serde_json::json!(ROOT_AGENT_DEFAULT_CONTEXT)
+        );
+    }
+
+    #[test]
+    fn merge_root_agent_config_migrates_old_default_context() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = temp.path().join("config.json");
+        std::fs::write(
+            &config_path,
+            r#"{"tooling":{"lastCodingAgent":"codex"},"context":["$AGENTSCOMMANDER_CONTEXT","Role.md"]}"#,
+        )
+        .expect("write config");
+
+        merge_root_agent_config(&config_path).expect("merge config");
+
+        let config: Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).expect("read config"))
+                .expect("parse config");
+        assert_eq!(config["tooling"]["lastCodingAgent"], "codex");
+        assert_eq!(
+            config["context"],
+            serde_json::json!(ROOT_AGENT_DEFAULT_CONTEXT)
+        );
+    }
+
+    #[test]
+    fn merge_root_agent_config_preserves_custom_context() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = temp.path().join("config.json");
+        std::fs::write(
+            &config_path,
+            r#"{"context":["$AGENTSCOMMANDER_CONTEXT","custom.md","Role.md"]}"#,
+        )
+        .expect("write config");
+
+        merge_root_agent_config(&config_path).expect("merge config");
+
+        let config: Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).expect("read config"))
+                .expect("parse config");
+        assert_eq!(
+            config["context"],
+            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT", "custom.md", "Role.md"])
         );
     }
 
@@ -903,7 +998,7 @@ mod tests {
         assert_eq!(config["tooling"]["lastCodingAgent"], "codex");
         assert_eq!(
             config["context"],
-            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT", "Role.md"])
+            serde_json::json!(ROOT_AGENT_DEFAULT_CONTEXT)
         );
     }
 

--- a/src-tauri/src/config/root_agent.rs
+++ b/src-tauri/src/config/root_agent.rs
@@ -1,11 +1,14 @@
 use serde_json::{Map, Value};
+use std::io::Write;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, OnceLock};
 
 pub const ROOT_AGENT_DIR_NAME: &str = "ac-root-agent";
 pub const ROOT_AGENT_SESSION_NAME: &str = "Root Agent";
 pub const ROOT_AGENT_SENDER: &str = "agentscommander://root-agent";
 pub const ROOT_AGENT_SHORT_NAME: &str = "root";
+static ROOT_ROLE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Returns `true` iff `target` is the canonical Root Agent reply name.
 ///
@@ -164,16 +167,63 @@ pub(crate) fn ensure_root_agent_dir_at(root_dir: &Path) -> Result<(), String> {
 }
 
 fn migrate_root_role(role_path: &Path) -> Result<(), String> {
-    if !role_path.exists() {
-        std::fs::write(role_path, ROOT_ROLE_MD.as_bytes())
-            .map_err(|e| format!("Failed to write {}: {}", role_path.display(), e))?;
-        return Ok(());
+    let root_dir = role_path.parent().ok_or_else(|| {
+        format!(
+            "Could not resolve root agent directory from {}",
+            role_path.display()
+        )
+    })?;
+    let config_dir = root_dir.parent().ok_or_else(|| {
+        format!(
+            "Could not resolve config directory from {}",
+            role_path.display()
+        )
+    })?;
+    let context_template_path =
+        config_dir.join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+
+    let mut context_text = read_validated_template(&context_template_path)?;
+    if context_text.is_none() {
+        crate::config::session_context::write_template_if_missing(
+            &context_template_path,
+            ROOT_ROLE_MD.as_str(),
+        )?;
+        context_text = Some(
+            read_validated_template(&context_template_path)?.ok_or_else(|| {
+                format!(
+                    "Template missing immediately after write_template_if_missing: {}",
+                    context_template_path.display()
+                )
+            })?,
+        );
+    }
+    let context_text = context_text.expect("checked above");
+
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(role_path)
+    {
+        Ok(mut file) => {
+            write_role_file(&mut file, role_path, &context_text)?;
+            return Ok(());
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => return Err(format!("Failed to create {}: {}", role_path.display(), e)),
     }
 
     let existing = std::fs::read_to_string(role_path)
         .map_err(|e| format!("Failed to read {}: {}", role_path.display(), e))?;
-    let migrated = if normalize_role_text(&existing) == normalize_role_text(OLD_ROOT_ROLE_MD) {
-        Some(ROOT_ROLE_MD.to_string())
+    let existing_normalized = normalize_role_text(&existing);
+    let context_normalized = normalize_role_text(&context_text);
+    let migrated = if existing_normalized == normalize_role_text(OLD_ROOT_ROLE_MD)
+        || existing_normalized == normalize_role_text(&ROOT_ROLE_MD)
+    {
+        if existing_normalized != context_normalized {
+            Some(context_text)
+        } else {
+            None
+        }
     } else if existing.contains(OLD_DEFERRED_MESSAGING_PARAGRAPH) {
         Some(existing.replace(
             OLD_DEFERRED_MESSAGING_PARAGRAPH,
@@ -184,10 +234,195 @@ fn migrate_root_role(role_path: &Path) -> Result<(), String> {
     };
 
     if let Some(content) = migrated {
-        std::fs::write(role_path, content)
-            .map_err(|e| format!("Failed to write {}: {}", role_path.display(), e))?;
+        atomic_write_role(role_path, &content)?;
     }
 
+    Ok(())
+}
+
+fn read_validated_template(path: &Path) -> Result<Option<String>, String> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(format!(
+                "Failed to inspect root agent context template {}: {}",
+                path.display(),
+                e
+            ))
+        }
+    };
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() || !metadata.is_file() {
+        return Err(format!(
+            "Root agent context template {} exists but is not a regular file",
+            path.display()
+        ));
+    }
+    let bytes = std::fs::read(path).map_err(|e| {
+        format!(
+            "Failed to read root agent context template {}: {}",
+            path.display(),
+            e
+        )
+    })?;
+    String::from_utf8(bytes).map(Some).map_err(|e| {
+        format!(
+            "Root agent context template {} is not valid UTF-8: {}",
+            path.display(),
+            e
+        )
+    })
+}
+
+fn atomic_write_role(role_path: &Path, content: &str) -> Result<(), String> {
+    let parent = role_path.parent().ok_or_else(|| {
+        format!(
+            "Could not resolve parent directory for {}",
+            role_path.display()
+        )
+    })?;
+    let temp_path = unique_role_temp_path(role_path);
+    let mut file = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+    {
+        Ok(file) => file,
+        Err(e) => {
+            return Err(format!(
+                "Failed to create temporary role file {}: {}",
+                temp_path.display(),
+                e
+            ))
+        }
+    };
+
+    if let Err(e) = write_role_file(&mut file, role_path, content) {
+        drop(file);
+        cleanup_temp_role(&temp_path);
+        return Err(e);
+    }
+    drop(file);
+
+    if let Err(e) = replace_role_file(&temp_path, role_path) {
+        cleanup_temp_role(&temp_path);
+        return Err(e);
+    }
+
+    if let Ok(dir) = std::fs::File::open(parent) {
+        if let Err(e) = dir.sync_all() {
+            log::warn!(
+                "Failed to sync root agent role directory {}: {}",
+                parent.display(),
+                e
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn write_role_file(
+    file: &mut std::fs::File,
+    role_path: &Path,
+    content: &str,
+) -> Result<(), String> {
+    file.write_all(content.as_bytes())
+        .map_err(|e| format!("Failed to write {}: {}", role_path.display(), e))?;
+    file.flush()
+        .map_err(|e| format!("Failed to flush {}: {}", role_path.display(), e))?;
+    file.sync_all()
+        .map_err(|e| format!("Failed to sync {}: {}", role_path.display(), e))
+}
+
+fn unique_role_temp_path(role_path: &Path) -> std::path::PathBuf {
+    let parent = role_path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = role_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("Role.md");
+    let counter = ROOT_ROLE_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    parent.join(format!(
+        ".{file_name}.{}.{}.tmp",
+        std::process::id(),
+        counter
+    ))
+}
+
+fn cleanup_temp_role(path: &Path) {
+    if let Err(e) = std::fs::remove_file(path) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            log::warn!(
+                "Failed to remove temporary role file {}: {}",
+                path.display(),
+                e
+            );
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_role_file(temp_path: &Path, role_path: &Path) -> Result<(), String> {
+    std::fs::rename(temp_path, role_path).map_err(|e| {
+        format!(
+            "Failed to replace {} with {}: {}",
+            role_path.display(),
+            temp_path.display(),
+            e
+        )
+    })
+}
+
+#[cfg(windows)]
+fn replace_role_file(temp_path: &Path, role_path: &Path) -> Result<(), String> {
+    if !role_path.exists() {
+        return std::fs::rename(temp_path, role_path).map_err(|e| {
+            format!(
+                "Failed to publish {} from {}: {}",
+                role_path.display(),
+                temp_path.display(),
+                e
+            )
+        });
+    }
+
+    replace_existing_file_windows(temp_path, role_path)
+}
+
+#[cfg(windows)]
+fn replace_existing_file_windows(temp_path: &Path, role_path: &Path) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{ReplaceFileW, REPLACEFILE_WRITE_THROUGH};
+
+    let role_wide: Vec<u16> = role_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let temp_wide: Vec<u16> = temp_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let ok = unsafe {
+        ReplaceFileW(
+            role_wide.as_ptr(),
+            temp_wide.as_ptr(),
+            std::ptr::null(),
+            REPLACEFILE_WRITE_THROUGH,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if ok == 0 {
+        return Err(format!(
+            "Failed to replace {} with {}: {}",
+            role_path.display(),
+            temp_path.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
     Ok(())
 }
 
@@ -292,6 +527,14 @@ mod tests {
         }
         assert!(root.join("Role.md").is_file());
         assert!(ROOT_ROLE_MD.contains("verified workgroup coordinator replicas only"));
+        let template_path = temp
+            .path()
+            .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        assert!(template_path.is_file());
+        assert_eq!(
+            std::fs::read_to_string(root.join("Role.md")).expect("read role"),
+            std::fs::read_to_string(template_path).expect("read template")
+        );
         let config: Value = serde_json::from_str(
             &std::fs::read_to_string(root.join("config.json")).expect("read config"),
         )
@@ -304,9 +547,32 @@ mod tests {
     }
 
     #[test]
+    fn ensure_root_agent_dir_at_seeds_missing_role_from_custom_template() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+        let template_path = temp
+            .path()
+            .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        let custom_template = "# Custom Root Template\n\nUse this exact seed.\n";
+        std::fs::write(&template_path, custom_template).expect("write template");
+
+        ensure_root_agent_dir_at(&root).expect("ensure root");
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("Role.md")).expect("read role"),
+            custom_template
+        );
+    }
+
+    #[test]
     fn ensure_root_agent_dir_at_is_idempotent_and_preserves_custom_role() {
         let temp = tempfile::tempdir().expect("tempdir");
         let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+        let template_path = temp
+            .path()
+            .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        std::fs::write(&template_path, "# Custom Template\n\nTemplate body.\n")
+            .expect("write template");
         std::fs::create_dir_all(&root).expect("create root");
         std::fs::write(root.join("Role.md"), "custom role").expect("write role");
 
@@ -316,6 +582,26 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(root.join("Role.md")).expect("read role"),
             "custom role"
+        );
+    }
+
+    #[test]
+    fn ensure_root_agent_dir_at_replaces_current_builtin_role_with_custom_template() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+        let template_path = temp
+            .path()
+            .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        let custom_template = "# Custom Root Template\n\nReplace built-in text.\n";
+        std::fs::write(&template_path, custom_template).expect("write template");
+        std::fs::create_dir_all(&root).expect("create root");
+        std::fs::write(root.join("Role.md"), ROOT_ROLE_MD.as_str()).expect("write current role");
+
+        ensure_root_agent_dir_at(&root).expect("ensure root");
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("Role.md")).expect("read role"),
+            custom_template
         );
     }
 
@@ -338,6 +624,26 @@ mod tests {
     }
 
     #[test]
+    fn ensure_root_agent_dir_at_replaces_old_builtin_role_with_custom_template() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+        let template_path = temp
+            .path()
+            .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        let custom_template = "# Custom Root Template\n\nMigrate old default here.\n";
+        std::fs::write(&template_path, custom_template).expect("write template");
+        std::fs::create_dir_all(&root).expect("create root");
+        std::fs::write(root.join("Role.md"), OLD_ROOT_ROLE_MD).expect("write old role");
+
+        ensure_root_agent_dir_at(&root).expect("ensure root");
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("Role.md")).expect("read role"),
+            custom_template
+        );
+    }
+
+    #[test]
     fn ensure_root_agent_dir_at_replaces_old_deferred_paragraph_in_custom_role() {
         let temp = tempfile::tempdir().expect("tempdir");
         let root = temp.path().join(ROOT_AGENT_DIR_NAME);
@@ -355,6 +661,40 @@ mod tests {
         assert!(migrated.contains("Keep this custom tail."));
         assert!(migrated.contains(ROOT_COORDINATION_MESSAGING_PARAGRAPH));
         assert!(!migrated.contains(OLD_DEFERRED_MESSAGING_PARAGRAPH));
+    }
+
+    #[test]
+    fn ensure_root_agent_dir_at_errors_when_root_template_is_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+        let template_path = temp
+            .path()
+            .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        std::fs::create_dir_all(&template_path).expect("create template directory");
+
+        let err = ensure_root_agent_dir_at(&root).expect_err("directory template must fail");
+
+        assert!(err.contains("not a regular file"), "{err}");
+        assert!(!root.join("Role.md").exists());
+    }
+
+    #[test]
+    fn create_default_context_templates_does_not_create_root_template() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+
+        crate::config::session_context::create_default_context_templates(&workspace_dir)
+            .expect("create default templates");
+
+        assert!(workspace_dir
+            .join(crate::config::session_context::AGENT_CONTEXT_TEMPLATE_FILENAME)
+            .is_file());
+        assert!(workspace_dir
+            .join(crate::config::session_context::COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
+            .is_file());
+        assert!(!workspace_dir
+            .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME)
+            .exists());
     }
 
     #[test]

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -3477,6 +3477,9 @@ mod tests {
             .path()
             .join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
         crate::config::root_agent::ensure_root_agent_dir_at(&root).expect("ensure root agent dir");
+        let root_context_path = temp
+            .path()
+            .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
 
         let materialized =
             materialize_agent_context_file(&path_string(&root), ManagedContextTarget::Codex, false)
@@ -3487,7 +3490,24 @@ mod tests {
         assert!(content.contains("# AgentsCommander Context"));
         assert!(content.contains("You are the AgentsCommander Root Agent"));
         assert!(content.contains("verified workgroup coordinator replicas only"));
+        assert!(content.contains("You are the personal Root Agent for AgentsCommander."));
         assert!(!content.contains("Direct file-based workgroup messaging is not available"));
+
+        std::fs::write(
+            &root_context_path,
+            "# Live Root Context\n\nLIVE_ROOT_CONTEXT_BODY\n",
+        )
+        .expect("edit root context");
+
+        let materialized =
+            materialize_agent_context_file(&path_string(&root), ManagedContextTarget::Codex, false)
+                .expect("rematerialize context")
+                .expect("context path");
+        let content = std::fs::read_to_string(materialized).expect("read materialized context");
+
+        assert!(content.contains("LIVE_ROOT_CONTEXT_BODY"));
+        assert!(!content.contains("You are the AgentsCommander Root Agent"));
+        assert!(content.contains("You are the personal Root Agent for AgentsCommander."));
     }
 
     #[test]

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 pub const AGENT_CONTEXT_TEMPLATE_FILENAME: &str = "Context.agent.md";
 pub const COORDINATOR_CONTEXT_TEMPLATE_FILENAME: &str = "Context.coordinator.md";
+pub const ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME: &str = "Context.root-agent.md";
 static CONTEXT_TEMPLATE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Writes a per-agent copy of AgentsCommanderContext.md with the agent's own
@@ -802,7 +803,7 @@ pub fn create_default_context_templates(workspace_dir: &Path) -> Result<(), Stri
     Ok(())
 }
 
-fn write_template_if_missing(path: &Path, content: &str) -> Result<(), String> {
+pub(crate) fn write_template_if_missing(path: &Path, content: &str) -> Result<(), String> {
     write_template_if_missing_with(path, content, |path| {
         std::fs::OpenOptions::new()
             .write(true)


### PR DESCRIPTION
Closes #444

Summary:
- Add editable `.ac/Context.root-agent.md` for Root Agent-specific context.
- Make Root Agent context live: default root context now includes `$AGENTSCOMMANDER_CONTEXT`, `../Context.root-agent.md`, and `Role.md`.
- Preserve custom root roles/config arrays while migrating old defaults safely.
- Use atomic/no-overwrite writes for root context and Role.md seeding/migration.

Validation:
- `cargo test config::root_agent`
- `cargo test config::session_context::tests::materialize_agent_context_file_includes_root_context_and_role`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- workgroup build deployed and `--help` validated