### PR TITLE
fix(sidebar): freeze coordinator quick access order while hovered (#449)

### DIFF
--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -299,13 +299,18 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     if (cleanupZoom) cleanupZoom();
     if (cleanupGeometry) cleanupGeometry();
     if (stopTeamIdleWatcher) stopTeamIdleWatcher();
+    sessionsStore.setSidebarPointerInside(false);
     document.removeEventListener("mousedown", handleRaiseTerminal);
     document.removeEventListener("contextmenu", blockContextMenu);
   });
 
   return (
     <>
-      <div class="sidebar-layout">
+      <div
+        class="sidebar-layout"
+        onPointerEnter={() => sessionsStore.setSidebarPointerInside(true)}
+        onPointerLeave={() => sessionsStore.setSidebarPointerInside(false)}
+      >
         <Show when={!props.embedded}>
           <Titlebar />
         </Show>

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -7,7 +7,6 @@ import { isTauri } from "../../shared/platform";
 import { stripFrontmatter } from "../../shared/markdown";
 import { projectStore } from "../stores/project";
 import { sessionsStore } from "../stores/sessions";
-import { preserveVisibleOrder } from "../stores/sessions-helpers";
 import { bridgesStore } from "../stores/bridges";
 import { settingsStore } from "../../shared/stores/settings";
 import { voiceRecorder } from "../../shared/voice-recorder";
@@ -390,7 +389,7 @@ const ProjectPanel: Component = () => {
         };
 
         const hasTeams = () => proj.teams.length > 0;
-        const coordinatorItems = createMemo((previous: { replica: AcAgentReplica; wg: AcWorkgroup }[] | undefined) => {
+        const naturalCoordinatorItems = createMemo(() => {
           const result: { replica: AcAgentReplica; wg: AcWorkgroup }[] = [];
           for (const wg of proj.workgroups) {
             for (const replica of wg.agents) {
@@ -407,11 +406,23 @@ const ProjectPanel: Component = () => {
               return activityMap[session.id] ?? 0;
             };
             result.sort((a, b) => tsFor(b) - tsFor(a));
-            if (sessionsStore.sidebarPointerInside) {
-              return preserveVisibleOrder(result, previous, coordinatorItemKey);
-            }
           }
           return result;
+        });
+        const coordinatorItems = createMemo(() => {
+          const naturalItems = naturalCoordinatorItems();
+          if (!sessionsStore.coordSortByActivity) {
+            sessionsStore.recordCoordinatorVisibleOrder(proj.path, naturalItems.map(coordinatorItemKey));
+            return naturalItems;
+          }
+
+          const naturalByKey = new Map(naturalItems.map((item) => [coordinatorItemKey(item), item]));
+          const visibleKeys = sessionsStore.coordinatorVisibleOrder(proj.path, naturalItems.map(coordinatorItemKey));
+          const visibleItems = visibleKeys
+            .map((key) => naturalByKey.get(key))
+            .filter((item): item is { replica: AcAgentReplica; wg: AcWorkgroup } => item !== undefined);
+          sessionsStore.recordCoordinatorVisibleOrder(proj.path, visibleKeys);
+          return visibleItems;
         });
         const selectedCoordinatorItem = createMemo(() =>
           coordinatorItems().find((item) => replicaSession(item.wg, item.replica)?.id === sessionsStore.activeId) ?? null

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -7,6 +7,7 @@ import { isTauri } from "../../shared/platform";
 import { stripFrontmatter } from "../../shared/markdown";
 import { projectStore } from "../stores/project";
 import { sessionsStore } from "../stores/sessions";
+import { preserveVisibleOrder } from "../stores/sessions-helpers";
 import { bridgesStore } from "../stores/bridges";
 import { settingsStore } from "../../shared/stores/settings";
 import { voiceRecorder } from "../../shared/voice-recorder";
@@ -73,6 +74,10 @@ function isSessionLive(session: Session | undefined): boolean {
   if (!session) return false;
   if (typeof session.status === "object" && "exited" in session.status) return false;
   return true;
+}
+
+function coordinatorItemKey(item: { replica: AcAgentReplica; wg: AcWorkgroup }): string {
+  return `${item.wg.path}\u0000${item.replica.path}`;
 }
 
 /** Get replicas in a workgroup that have active (live) sessions */
@@ -385,7 +390,7 @@ const ProjectPanel: Component = () => {
         };
 
         const hasTeams = () => proj.teams.length > 0;
-        const coordinatorItems = createMemo(() => {
+        const coordinatorItems = createMemo((previous: { replica: AcAgentReplica; wg: AcWorkgroup }[] | undefined) => {
           const result: { replica: AcAgentReplica; wg: AcWorkgroup }[] = [];
           for (const wg of proj.workgroups) {
             for (const replica of wg.agents) {
@@ -402,6 +407,9 @@ const ProjectPanel: Component = () => {
               return activityMap[session.id] ?? 0;
             };
             result.sort((a, b) => tsFor(b) - tsFor(a));
+            if (sessionsStore.sidebarPointerInside) {
+              return preserveVisibleOrder(result, previous, coordinatorItemKey);
+            }
           }
           return result;
         });

--- a/src/sidebar/stores/sessions-helpers.test.ts
+++ b/src/sidebar/stores/sessions-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Session, SessionStatus } from "../../shared/types";
-import { isRuntimeStringStatus, upsertSessionList } from "./sessions-helpers";
+import { isRuntimeStringStatus, preserveVisibleOrder, upsertSessionList } from "./sessions-helpers";
 import { rootAgentCodingAgentAction } from "../components/root-agent-action";
 
 function mkSession(id: string, status: SessionStatus, overrides: Partial<Session> = {}): Session {
@@ -155,5 +155,34 @@ describe("upsertSessionList (#274 banner-reuse hydration)", () => {
     const next = upsertSessionList(sessions, returned);
     expect(next.find((s) => s.isRootAgent)).toBeDefined();
     expect(next[0].agentLabel).toBe("claude");
+  });
+});
+
+describe("preserveVisibleOrder", () => {
+  it("keeps previous visible positions when next order changes", () => {
+    const previous = ["coord-a", "coord-b", "coord-c"];
+    const next = ["coord-c", "coord-b", "coord-a"];
+
+    expect(preserveVisibleOrder(next, previous, (item) => item)).toEqual([
+      "coord-a",
+      "coord-b",
+      "coord-c",
+    ]);
+  });
+
+  it("removes missing items and appends newly visible items", () => {
+    const previous = ["coord-a", "coord-b", "coord-c"];
+    const next = ["coord-d", "coord-c", "coord-a"];
+
+    expect(preserveVisibleOrder(next, previous, (item) => item)).toEqual([
+      "coord-a",
+      "coord-c",
+      "coord-d",
+    ]);
+  });
+
+  it("uses the next order when there is no previous visible order", () => {
+    const next = ["coord-c", "coord-b", "coord-a"];
+    expect(preserveVisibleOrder(next, undefined, (item) => item)).toEqual(next);
   });
 });

--- a/src/sidebar/stores/sessions-helpers.test.ts
+++ b/src/sidebar/stores/sessions-helpers.test.ts
@@ -1,6 +1,9 @@
+// @vitest-environment jsdom
+
 import { describe, expect, it } from "vitest";
 import type { Session, SessionStatus } from "../../shared/types";
-import { isRuntimeStringStatus, preserveVisibleOrder, upsertSessionList } from "./sessions-helpers";
+import { isRuntimeStringStatus, preserveVisibleOrder, reconcileVisibleOrderKeys, upsertSessionList } from "./sessions-helpers";
+import { sessionsStore } from "./sessions";
 import { rootAgentCodingAgentAction } from "../components/root-agent-action";
 
 function mkSession(id: string, status: SessionStatus, overrides: Partial<Session> = {}): Session {
@@ -184,5 +187,61 @@ describe("preserveVisibleOrder", () => {
   it("uses the next order when there is no previous visible order", () => {
     const next = ["coord-c", "coord-b", "coord-a"];
     expect(preserveVisibleOrder(next, undefined, (item) => item)).toEqual(next);
+  });
+});
+
+describe("reconcileVisibleOrderKeys", () => {
+  it("keeps existing frozen keys in place while removing disappeared keys and appending new keys", () => {
+    expect(reconcileVisibleOrderKeys(["coord-d", "coord-c", "coord-a"], ["coord-a", "coord-b", "coord-c"])).toEqual([
+      "coord-a",
+      "coord-c",
+      "coord-d",
+    ]);
+  });
+});
+
+describe("sidebar coordinator hover freeze", () => {
+  it("survives recent-first recompute and releases after hover ends", () => {
+    const projectPath = "test-project-hover-recompute";
+
+    sessionsStore.setSidebarPointerInside(false);
+    sessionsStore.recordCoordinatorVisibleOrder(projectPath, ["coord-a", "coord-b", "coord-c"]);
+
+    sessionsStore.setSidebarPointerInside(true);
+    expect(sessionsStore.coordinatorVisibleOrder(projectPath, ["coord-c", "coord-a", "coord-b"])).toEqual([
+      "coord-a",
+      "coord-b",
+      "coord-c",
+    ]);
+
+    // Simulates project/workgroup object replacement recreating ProjectPanel memos.
+    expect(sessionsStore.coordinatorVisibleOrder(projectPath, ["coord-c", "coord-a", "coord-b"])).toEqual([
+      "coord-a",
+      "coord-b",
+      "coord-c",
+    ]);
+
+    sessionsStore.setSidebarPointerInside(false);
+    expect(sessionsStore.coordinatorVisibleOrder(projectPath, ["coord-c", "coord-a", "coord-b"])).toEqual([
+      "coord-c",
+      "coord-a",
+      "coord-b",
+    ]);
+  });
+
+  it("removes disappeared coordinators and appends newly visible coordinators while hovered", () => {
+    const projectPath = "test-project-hover-structural-change";
+
+    sessionsStore.setSidebarPointerInside(false);
+    sessionsStore.recordCoordinatorVisibleOrder(projectPath, ["coord-a", "coord-b", "coord-c"]);
+
+    sessionsStore.setSidebarPointerInside(true);
+    expect(sessionsStore.coordinatorVisibleOrder(projectPath, ["coord-d", "coord-c", "coord-a"])).toEqual([
+      "coord-a",
+      "coord-c",
+      "coord-d",
+    ]);
+
+    sessionsStore.setSidebarPointerInside(false);
   });
 });

--- a/src/sidebar/stores/sessions-helpers.ts
+++ b/src/sidebar/stores/sessions-helpers.ts
@@ -64,3 +64,29 @@ export function preserveVisibleOrder<T>(
 
   return ordered;
 }
+
+/**
+ * Reconcile a frozen visible key order with a freshly recomputed key set:
+ * existing keys keep their frozen positions, disappeared keys are removed, and
+ * newly visible keys append in the recomputed order.
+ */
+export function reconcileVisibleOrderKeys(nextKeys: string[], frozenKeys: string[] | undefined): string[] {
+  if (!frozenKeys || frozenKeys.length === 0) return nextKeys;
+
+  const nextKeySet = new Set(nextKeys);
+  const used = new Set<string>();
+  const ordered: string[] = [];
+
+  for (const key of frozenKeys) {
+    if (!nextKeySet.has(key)) continue;
+    ordered.push(key);
+    used.add(key);
+  }
+
+  for (const key of nextKeys) {
+    if (used.has(key)) continue;
+    ordered.push(key);
+  }
+
+  return ordered;
+}

--- a/src/sidebar/stores/sessions-helpers.ts
+++ b/src/sidebar/stores/sessions-helpers.ts
@@ -31,3 +31,36 @@ export function upsertSessionList(prev: Session[], incoming: Session): Session[]
   next[idx] = { ...prev[idx], ...incoming };
   return next;
 }
+
+/**
+ * Keep the previous visible order while allowing removals and appending new
+ * items. Used to prevent activity-driven coordinator sorting from moving rows
+ * under the pointer during Sidebar interaction.
+ */
+export function preserveVisibleOrder<T>(
+  next: T[],
+  previous: T[] | undefined,
+  keyFor: (item: T) => string,
+): T[] {
+  if (!previous || previous.length === 0) return next;
+
+  const nextByKey = new Map(next.map((item) => [keyFor(item), item]));
+  const used = new Set<string>();
+  const ordered: T[] = [];
+
+  for (const previousItem of previous) {
+    const key = keyFor(previousItem);
+    const nextItem = nextByKey.get(key);
+    if (!nextItem) continue;
+    ordered.push(nextItem);
+    used.add(key);
+  }
+
+  for (const nextItem of next) {
+    const key = keyFor(nextItem);
+    if (used.has(key)) continue;
+    ordered.push(nextItem);
+  }
+
+  return ordered;
+}

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -5,10 +5,12 @@ import type { RepoMatch, Session, SessionRepo, SessionsState, Team, TeamSessionG
 import { projectStore } from "./project";
 import { SettingsAPI } from "../../shared/ipc";
 import { settingsStore } from "../../shared/stores/settings";
-import { isRuntimeStringStatus, upsertSessionList } from "./sessions-helpers";
+import { isRuntimeStringStatus, reconcileVisibleOrderKeys, upsertSessionList } from "./sessions-helpers";
 
 const [toggleInFlight, setToggleInFlight] = createSignal(false);
 const [sidebarPointerInside, setSidebarPointerInside] = createSignal(false);
+const [lastCoordinatorVisibleOrderByProject, setLastCoordinatorVisibleOrderByProject] = createSignal<Record<string, string[]>>({});
+const [frozenCoordinatorVisibleOrderByProject, setFrozenCoordinatorVisibleOrderByProject] = createSignal<Record<string, string[]>>({});
 
 const [state, setState] = createStore<SessionsState>({
   sessions: [],
@@ -26,6 +28,11 @@ const [state, setState] = createStore<SessionsState>({
 
 function normalizePath(p: string): string {
   return p.replace(/\\/g, "/").toLowerCase().replace(/\/+$/, "");
+}
+
+function stringArraysEqual(a: string[] | undefined, b: string[]): boolean {
+  if (!a || a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
 }
 
 const allTeamPathsMemo = createMemo(() => {
@@ -412,7 +419,30 @@ export const sessionsStore = {
   },
 
   setSidebarPointerInside(value: boolean) {
+    if (value === sidebarPointerInside()) return;
+    if (value) {
+      setFrozenCoordinatorVisibleOrderByProject(lastCoordinatorVisibleOrderByProject());
+    } else {
+      setFrozenCoordinatorVisibleOrderByProject({});
+    }
     setSidebarPointerInside(value);
+  },
+
+  coordinatorVisibleOrder(projectPath: string, nextKeys: string[]): string[] {
+    if (!sidebarPointerInside()) return nextKeys;
+
+    const frozenByProject = frozenCoordinatorVisibleOrderByProject();
+    const frozenKeys = frozenByProject[projectPath] ?? lastCoordinatorVisibleOrderByProject()[projectPath] ?? nextKeys;
+    const visibleKeys = reconcileVisibleOrderKeys(nextKeys, frozenKeys);
+    if (!stringArraysEqual(frozenByProject[projectPath], visibleKeys)) {
+      setFrozenCoordinatorVisibleOrderByProject((prev) => ({ ...prev, [projectPath]: visibleKeys }));
+    }
+    return visibleKeys;
+  },
+
+  recordCoordinatorVisibleOrder(projectPath: string, visibleKeys: string[]) {
+    if (stringArraysEqual(lastCoordinatorVisibleOrderByProject()[projectPath], visibleKeys)) return;
+    setLastCoordinatorVisibleOrderByProject((prev) => ({ ...prev, [projectPath]: visibleKeys }));
   },
 
   setCoordSortByActivity(value: boolean) {

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -8,6 +8,7 @@ import { settingsStore } from "../../shared/stores/settings";
 import { isRuntimeStringStatus, upsertSessionList } from "./sessions-helpers";
 
 const [toggleInFlight, setToggleInFlight] = createSignal(false);
+const [sidebarPointerInside, setSidebarPointerInside] = createSignal(false);
 
 const [state, setState] = createStore<SessionsState>({
   sessions: [],
@@ -402,9 +403,16 @@ export const sessionsStore = {
   get toggleInFlight() {
     return toggleInFlight();
   },
+  get sidebarPointerInside() {
+    return sidebarPointerInside();
+  },
 
   setAlwaysShowSelectedWorkgroup(value: boolean) {
     setState("alwaysShowSelectedWorkgroup", value);
+  },
+
+  setSidebarPointerInside(value: boolean) {
+    setSidebarPointerInside(value);
   },
 
   setCoordSortByActivity(value: boolean) {


### PR DESCRIPTION
Closes #449

Implements a stable intermediate coordinator quick-access order while the Sidebar is hovered, so recent activity, completion events, and project/workgroup refreshes cannot visually reorder existing coordinator rows until pointer leaves.

Verified:
- npx vitest run src/sidebar/stores/sessions-helpers.test.ts
- npx tsc --noEmit
- git diff --check
- adversarial review PASS
- wg-10 build/deploy smoke test passed