### PR TITLE
fix: persist and hydrate last prompt

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1695,6 +1695,7 @@ pub async fn set_last_prompt(
     let uuid = Uuid::parse_str(&id).map_err(|e| e.to_string())?;
     let mgr = session_mgr.read().await;
     mgr.set_last_prompt(uuid, text.clone()).await;
+    crate::config::sessions_persistence::persist_current_state(&mgr).await;
     let _ = app.emit(
         "last_prompt",
         serde_json::json!({ "sessionId": id, "text": text }),

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -203,6 +203,9 @@ pub struct PersistedSession {
     #[serde(default)]
     pub was_detached: bool,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_prompt: Option<String>,
+
     /// Last-known geometry of this session's detached window. `None` for sessions
     /// that were never detached, or detached without any drag/resize yet. Auto-GC'd
     /// when the session is destroyed (field travels with the PersistedSession row).
@@ -766,6 +769,7 @@ pub async fn snapshot_sessions(mgr: &SessionManager) -> Vec<PersistedSession> {
             // `DetachedSessionsState` set is NOT consulted at persist time — the Destroyed
             // handler clears the set before `RunEvent::Exit` runs the final persist.
             was_detached: s.was_detached,
+            last_prompt: s.last_prompt.clone(),
             detached_geometry: s.detached_geometry.clone(),
             // Legacy fields are always None on new saves; skip_serializing_if elides them.
             git_branch_source: None,
@@ -1165,6 +1169,7 @@ mod tests {
     fn sanitize_failed_recoverable_drops_runtime_fields() {
         use crate::session::session::SessionStatus;
         let ps = PersistedSession {
+            last_prompt: None,
             name: "alice".into(),
             shell: "claude".into(),
             shell_args: vec!["--continue".into()],
@@ -1215,6 +1220,7 @@ mod tests {
     #[test]
     fn sanitize_failed_recoverable_is_idempotent() {
         let ps = PersistedSession {
+            last_prompt: None,
             name: "bob".into(),
             shell: "cmd".into(),
             shell_args: vec![],
@@ -1260,6 +1266,7 @@ mod tests {
     #[test]
     fn telegram_bot_id_round_trips_when_present() {
         let ps = PersistedSession {
+            last_prompt: None,
             name: "telegram-on".into(),
             shell: "codex".into(),
             shell_args: vec![],
@@ -1379,6 +1386,7 @@ mod tests {
         let project_paths = vec!["C:/projects/current".to_string()];
         let sessions = vec![
             PersistedSession {
+            last_prompt: None,
                 name: "kept-coordinator".into(),
                 working_directory: "C:/projects/current/.ac/wg-1/__agent_tech-lead".into(),
                 is_coordinator: true,
@@ -1386,6 +1394,7 @@ mod tests {
                 ..Default::default()
             },
             PersistedSession {
+            last_prompt: None,
                 name: "orphan-coordinator".into(),
                 working_directory: "C:/projects/removed/.ac/wg-1/__agent_tech-lead".into(),
                 is_coordinator: true,
@@ -1393,6 +1402,7 @@ mod tests {
                 ..Default::default()
             },
             PersistedSession {
+            last_prompt: None,
                 name: "orphan-member".into(),
                 working_directory: "C:/projects/removed/.ac/wg-1/__agent_dev-rust".into(),
                 is_coordinator: false,
@@ -1419,11 +1429,13 @@ mod tests {
 
         let sessions = vec![
             PersistedSession {
+            last_prompt: None,
                 name: "keep".into(),
                 working_directory: current_agent.to_string_lossy().to_string(),
                 ..Default::default()
             },
             PersistedSession {
+            last_prompt: None,
                 name: "drop".into(),
                 working_directory: removed_agent.to_string_lossy().to_string(),
                 ..Default::default()
@@ -1701,6 +1713,7 @@ mod tests {
     #[test]
     fn legacy_migration_single_repo_shape() {
         let mut ps = PersistedSession {
+            last_prompt: None,
             name: "sess-a".into(),
             shell: "cmd".into(),
             shell_args: vec![],
@@ -1752,6 +1765,7 @@ mod tests {
         let cases = [SessionStatus::Exited(0), SessionStatus::Running];
         for status in cases {
             let ps = PersistedSession {
+            last_prompt: None,
                 name: "coord-x".into(),
                 shell: "claude".into(),
                 shell_args: vec![],
@@ -1795,6 +1809,7 @@ mod tests {
     #[test]
     fn is_root_agent_round_trips_true() {
         let ps = PersistedSession {
+            last_prompt: None,
             name: "Root Agent".into(),
             shell: "codex".into(),
             shell_args: vec![],
@@ -1813,6 +1828,7 @@ mod tests {
     #[test]
     fn legacy_migration_multi_repo_shape() {
         let mut ps = PersistedSession {
+            last_prompt: None,
             name: "sess-multi".into(),
             shell: "cmd".into(),
             shell_args: vec![],
@@ -1920,6 +1936,7 @@ mod tests {
             let barrier = Arc::clone(&barrier);
             handles.push(thread::spawn(move || {
                 let sessions = vec![PersistedSession {
+            last_prompt: None,
                     name: format!("sess-{}", i),
                     shell: "cmd".into(),
                     shell_args: vec![],
@@ -1983,6 +2000,7 @@ mod tests {
     fn save_sessions_to_dir_round_trips_and_cleans_up_temp() {
         let tmp = tempfile::tempdir().expect("tmp");
         let sessions = vec![PersistedSession {
+            last_prompt: None,
             name: "solo".into(),
             shell: "claude".into(),
             shell_args: vec!["--print".into()],

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -849,6 +849,10 @@ pub fn run() {
                                                 ps.telegram_bot_id.as_deref(),
                                             )
                                             .await;
+                                            if let Some(ref prompt) = ps.last_prompt {
+                                                let mgr = session_mgr_clone.read().await;
+                                                mgr.set_last_prompt(uuid, prompt.clone()).await;
+                                            }
                                         }
                                         should_create = false;
                                     }
@@ -882,6 +886,13 @@ pub fn run() {
                                                     ps.telegram_bot_id.as_deref(),
                                                 )
                                                 .await;
+                                            }
+
+                                            if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
+                                                if let Some(ref prompt) = ps.last_prompt {
+                                                    let mgr = session_mgr_clone.read().await;
+                                                    mgr.set_last_prompt(uuid, prompt.clone()).await;
+                                                }
                                             }
 
                                             if ps.was_detached {
@@ -958,6 +969,9 @@ pub fn run() {
                                             ps.telegram_bot_id.as_deref(),
                                         )
                                         .await;
+                                        if let Some(ref prompt) = ps.last_prompt {
+                                            mgr.set_last_prompt(uuid, prompt.clone()).await;
+                                        }
                                     }
                                     if ps.was_active {
                                         active_id = Some(existing.id.clone());
@@ -988,6 +1002,9 @@ pub fn run() {
                                             if let Some(ref geo) = ps.detached_geometry {
                                                 mgr.set_detached_geometry(session.id, geo.clone())
                                                     .await;
+                                            }
+                                            if let Some(ref prompt) = ps.last_prompt {
+                                                mgr.set_last_prompt(session.id, prompt.clone()).await;
                                             }
                                             commands::session::preserve_deferred_telegram_intent_if_valid(
                                                 &mgr,
@@ -1083,6 +1100,9 @@ pub fn run() {
                                     if let Some(ref geo) = ps.detached_geometry {
                                         mgr.set_detached_geometry(session.id, geo.clone()).await;
                                     }
+                                    if let Some(ref prompt) = ps.last_prompt {
+                                        mgr.set_last_prompt(session.id, prompt.clone()).await;
+                                    }
                                     commands::session::preserve_deferred_telegram_intent_if_valid(
                                         &mgr,
                                         &settings_state_clone,
@@ -1153,6 +1173,13 @@ pub fn run() {
                                         ps.telegram_bot_id.as_deref(),
                                     )
                                     .await;
+                                }
+
+                                if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
+                                    if let Some(ref prompt) = ps.last_prompt {
+                                        let mgr = session_mgr_clone.read().await;
+                                        mgr.set_last_prompt(uuid, prompt.clone()).await;
+                                    }
                                 }
 
                                 // Phase 3 restore: reconstruct detach state for the live session.

--- a/src/terminal/components/LastPrompt.tsx
+++ b/src/terminal/components/LastPrompt.tsx
@@ -1,8 +1,7 @@
 import { Component, createMemo, onMount, onCleanup } from "solid-js";
 import { createStore } from "solid-js/store";
 import type { UnlistenFn } from "../../shared/transport";
-import { onLastPrompt } from "../../shared/ipc";
-import { SessionAPI } from "../../shared/ipc";
+import { onLastPrompt, onSessionCreated, onSessionSwitched, SessionAPI } from "../../shared/ipc";
 import { terminalStore } from "../stores/terminal";
 
 interface LastPromptProps {
@@ -11,7 +10,9 @@ interface LastPromptProps {
 
 const LastPrompt: Component<LastPromptProps> = (props) => {
   const [prompts, setPrompts] = createStore<Record<string, string>>({});
-  let unlisten: UnlistenFn | null = null;
+  let unlistenLastPrompt: UnlistenFn | null = null;
+  let unlistenSessionCreated: UnlistenFn | null = null;
+  let unlistenSessionSwitched: UnlistenFn | null = null;
 
   const getSessionId = () => props.sessionId ?? terminalStore.activeSessionId;
 
@@ -20,22 +21,31 @@ const LastPrompt: Component<LastPromptProps> = (props) => {
     return id ? prompts[id] ?? "" : "";
   });
 
-  onMount(async () => {
-    // Load persisted last prompts from backend
+  const loadPrompts = async () => {
     const sessions = await SessionAPI.list();
     for (const s of sessions) {
       if (s.lastPrompt) {
         setPrompts(s.id, s.lastPrompt);
       }
     }
+  };
 
-    unlisten = await onLastPrompt((data) => {
+  onMount(async () => {
+    unlistenLastPrompt = await onLastPrompt((data) => {
       setPrompts(data.sessionId, data.text);
     });
+
+    unlistenSessionCreated = await onSessionCreated(loadPrompts);
+    unlistenSessionSwitched = await onSessionSwitched(loadPrompts);
+
+    // Load persisted last prompts from backend after setting up listeners
+    await loadPrompts();
   });
 
   onCleanup(() => {
-    unlisten?.();
+    unlistenLastPrompt?.();
+    unlistenSessionCreated?.();
+    unlistenSessionSwitched?.();
   });
 
   return (


### PR DESCRIPTION
## Summary
- Restore persisted `last_prompt` for Root Agent paths.
- Hydrate the Last Prompt UI from restored sessions and refresh it on session create/switch events.
- Preserve wg-specific deploy behavior; tested in `agentscommander_standalone_wg-6.exe`.

## Validation
- `npx tsc --noEmit`
- Tauri build completed by shipper
- Deployed to `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-6.exe`
- Smoke: `agentscommander_standalone_wg-6.exe --help` exited 0
- User confirmed the wg-6 exe works