### PR TITLE
feat(context): externalize AgentsCommander context (#447)

### DIFF
--- a/docs/agent-matrix-conventions.md
+++ b/docs/agent-matrix-conventions.md
@@ -21,19 +21,35 @@ This document is the definitive guide for any AI agent tasked with creating or m
 
 ## Project Context Templates
 
-AgentsCommander creates editable context templates for new projects under:
+Project `.ac` creation seeds the editable global and coordinator context templates under:
 
 ```text
 .ac/
-├── Context.agent.md
+├── Context.AgentsCommander.md
 └── Context.coordinator.md
 ```
 
-`.ac/Context.agent.md` is the base context used when AgentsCommander materializes managed context files such as `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` for matrix agents and workgroup replicas. `.ac/Context.coordinator.md` is appended only for coordinator sessions. The separator and `# Coordinator Context` heading are owned by AgentsCommander, so the coordinator file should contain only the body text.
+`.ac/Context.AgentsCommander.md` is the base context used when AgentsCommander materializes managed context files such as `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` for matrix agents and workgroup replicas. `.ac/Context.coordinator.md` is appended only for coordinator sessions. The separator and `# Coordinator Context` heading are owned by AgentsCommander, so the coordinator file should contain only the body text.
 
-Existing projects that do not have these files keep using the built-in defaults. If a template file exists and is empty, that is treated as intentional user configuration. If a template exists but cannot be read, is not UTF-8, or is not a regular file, session context generation fails with a path-specific error instead of silently discarding the customization.
+`.ac/Context.root-agent.md` is appended only for the canonical `ac-root-agent` session. It is static supplemental root prose for identity, durable root state, and high-level coordination scope. It does not receive placeholder rendering or mandatory global fallback blocks; operational write restrictions, credentials, CLI usage, inter-agent messaging, workspace repo context, skills, and runtime safety blocks belong in `.ac/Context.AgentsCommander.md`.
 
-The agent template supports these runtime tokens:
+Standalone/root AC directories and root-agent provisioning seed `Context.AgentsCommander.md`, `Context.coordinator.md`, and `Context.root-agent.md` next to `ac-root-agent`. Fresh root-agent creation seeds all three while preserving existing custom files.
+
+Existing projects with a legacy `.ac/Context.agent.md` are migrated on demand to `.ac/Context.AgentsCommander.md` when the new file does not already exist. Existing projects that do not have these files keep using the built-in defaults. If the global template file exists and is empty, AgentsCommander still injects the mandatory safety and runtime blocks listed below. If a template exists but cannot be read, is not UTF-8, or is not a regular file, session context generation fails with a path-specific error instead of silently discarding the customization.
+
+The global template must preserve these mandatory runtime tokens. If any are missing, AgentsCommander appends them during rendering so critical safety and runtime data is not dropped:
+
+| Token | Meaning |
+|---|---|
+| `{{WRITE_RESTRICTIONS}}` | Runtime write restrictions and allowed scopes |
+| `{{DELEGATED_TASK_REPORTING}}` | Required completion/blocker reporting instructions |
+| `{{SKILLS_SECTION}}` | Runtime skill index |
+| `{{WORKSPACE_REPOS}}` | Repo list rendered from the replica config `repos` field |
+| `{{CLI_CONTEXT}}` | CLI binary and help usage rules |
+| `{{SESSION_CREDENTIALS}}` | Environment-variable credential rules |
+| `{{INTER_AGENT_MESSAGING}}` | Peer discovery and file-based messaging instructions |
+
+Legacy custom templates also support these older runtime tokens:
 
 | Token | Meaning |
 |---|---|
@@ -239,7 +255,6 @@ Workgroups are isolated working environments created when a team needs to work o
 {
   "context": [
     "$AGENTSCOMMANDER_CONTEXT",
-    "$REPOS_WORKSPACE_INFO",
     "../../_agent_NAME/Role.md"
   ],
   "identity": "../../_agent_NAME",
@@ -251,7 +266,7 @@ Workgroups are isolated working environments created when a team needs to work o
 
 | Field | Description |
 |---|---|
-| `context` | Array of context sources. `$AGENTSCOMMANDER_CONTEXT` and `$REPOS_WORKSPACE_INFO` are AC-injected variables. The third entry is the path to the Role.md that defines this agent's personality. |
+| `context` | Array of context sources. `$AGENTSCOMMANDER_CONTEXT` is the AC-injected global template. The Role.md entry defines this agent's personality. `$REPOS_WORKSPACE_INFO` is deprecated; repo context is rendered through `{{WORKSPACE_REPOS}}` inside `$AGENTSCOMMANDER_CONTEXT`. |
 | `identity` | Path to the parent agent folder. This is the canonical identity — the workgroup agent is a replica of this. |
 | `repos` | Relative paths to the repo clones inside this workgroup. |
 
@@ -378,7 +393,6 @@ This should return all team members. If empty, the team config is misconfigured 
 ```json
 "context": [
   "$AGENTSCOMMANDER_CONTEXT",
-  "$REPOS_WORKSPACE_INFO",
   "../../_agent_NAME/Role.md"
 ]
 ```

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -1829,7 +1829,7 @@ mod tests {
         assert!(tmp
             .path()
             .join(".ac")
-            .join(crate::config::session_context::AGENT_CONTEXT_TEMPLATE_FILENAME)
+            .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME)
             .is_file());
         assert!(tmp
             .path()
@@ -1846,7 +1846,8 @@ mod tests {
 
         let first_result = create_ac_project_impl(&path, |workspace_dir| {
             std::fs::write(
-                workspace_dir.join(crate::config::session_context::AGENT_CONTEXT_TEMPLATE_FILENAME),
+                workspace_dir
+                    .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME),
                 crate::config::session_context::get_default_agent_template(),
             )
             .expect("write partial agent context");
@@ -1864,7 +1865,7 @@ mod tests {
         assert!(tmp
             .path()
             .join(".ac")
-            .join(crate::config::session_context::AGENT_CONTEXT_TEMPLATE_FILENAME)
+            .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME)
             .is_file());
         assert!(tmp
             .path()
@@ -1884,7 +1885,7 @@ mod tests {
             .expect("create project");
 
         assert!(!workspace
-            .join(crate::config::session_context::AGENT_CONTEXT_TEMPLATE_FILENAME)
+            .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME)
             .exists());
         assert!(!workspace
             .join(crate::config::session_context::COORDINATOR_CONTEXT_TEMPLATE_FILENAME)

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -1743,7 +1743,7 @@ async fn sync_workgroup_repos_inner(
 
             config["context"] = serde_json::json!(normalize_wg_replica_context_entries(
                 &existing_context,
-                &["$AGENTSCOMMANDER_CONTEXT", "$REPOS_WORKSPACE_INFO"],
+                &["$AGENTSCOMMANDER_CONTEXT"],
                 &identity.identity,
                 identity.matrix_dir.join(ROLE_MD_FILENAME).exists(),
             ));

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -538,7 +538,7 @@ mod tests {
         assert!(fix
             .path()
             .join(".ac")
-            .join(crate::config::session_context::AGENT_CONTEXT_TEMPLATE_FILENAME)
+            .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME)
             .is_file());
         assert!(fix
             .path()
@@ -583,7 +583,7 @@ mod tests {
         let fix = FixtureRoot::new("proj-new-template-existing");
         let workspace_dir = fix.path().join(".ac");
         std::fs::create_dir_all(&workspace_dir).unwrap();
-        let agent_template = workspace_dir.join("Context.agent.md");
+        let agent_template = workspace_dir.join("Context.AgentsCommander.md");
         let coordinator_template = workspace_dir.join("Context.coordinator.md");
         std::fs::write(&agent_template, "CUSTOM_AGENT").unwrap();
         std::fs::write(&coordinator_template, "CUSTOM_COORDINATOR").unwrap();
@@ -611,7 +611,7 @@ mod tests {
             register_new_project_impl(&mut s, fix.path().to_str().unwrap(), |workspace_dir| {
                 std::fs::write(
                     workspace_dir
-                        .join(crate::config::session_context::AGENT_CONTEXT_TEMPLATE_FILENAME),
+                        .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME),
                     crate::config::session_context::get_default_agent_template(),
                 )
                 .expect("write partial agent context");
@@ -636,7 +636,7 @@ mod tests {
         assert!(fix
             .path()
             .join(".ac")
-            .join(crate::config::session_context::AGENT_CONTEXT_TEMPLATE_FILENAME)
+            .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME)
             .is_file());
         assert!(fix
             .path()
@@ -654,7 +654,11 @@ mod tests {
         let r = register_new_project(&mut s, fix.path().to_str().unwrap()).unwrap();
 
         assert!(!r.created);
-        assert!(!fix.path().join(".ac").join("Context.agent.md").exists());
+        assert!(!fix
+            .path()
+            .join(".ac")
+            .join("Context.AgentsCommander.md")
+            .exists());
         assert!(!fix
             .path()
             .join(".ac")

--- a/src-tauri/src/config/replica_identity.rs
+++ b/src-tauri/src/config/replica_identity.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use crate::config::workspace::{ensure_authoritative_workspace_dir, find_workspace_ancestor};
 
 pub const ROLE_MD_FILENAME: &str = "Role.md";
-pub const WG_REPLICA_REQUIRED_CONTEXT: &[&str] =
-    &["$AGENTSCOMMANDER_CONTEXT", "$REPOS_WORKSPACE_INFO"];
+pub const WG_REPLICA_REQUIRED_CONTEXT: &[&str] = &["$AGENTSCOMMANDER_CONTEXT"];
+const DEPRECATED_REPOS_WORKSPACE_CONTEXT: &str = "$REPOS_WORKSPACE_INFO";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WgReplicaIdentity {
@@ -317,7 +317,10 @@ pub fn normalize_wg_replica_context_entries(
     }
 
     for entry in existing_context {
-        if required_prefix.contains(&entry.as_str()) || is_identity_role_context_entry(entry) {
+        if entry == DEPRECATED_REPOS_WORKSPACE_CONTEXT
+            || required_prefix.contains(&entry.as_str())
+            || is_identity_role_context_entry(entry)
+        {
             continue;
         }
         if seen.insert(entry.clone()) {
@@ -346,19 +349,23 @@ pub fn repair_wg_replica_config_value(
     )?;
     config["identity"] = Value::String(identity.identity.clone());
 
-    if let Some(context_array) = config.get("context").and_then(|value| value.as_array()) {
-        let existing_context: Vec<String> = context_array
-            .iter()
-            .filter_map(|value| value.as_str().map(String::from))
-            .collect();
-        let role_exists = identity.matrix_dir.join(ROLE_MD_FILENAME).exists();
-        config["context"] = serde_json::json!(normalize_wg_replica_context_entries(
-            &existing_context,
-            required_context_prefix,
-            &identity.identity,
-            role_exists,
-        ));
-    }
+    let existing_context: Vec<String> = config
+        .get("context")
+        .and_then(|value| value.as_array())
+        .map(|context_array| {
+            context_array
+                .iter()
+                .filter_map(|value| value.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    let role_exists = identity.matrix_dir.join(ROLE_MD_FILENAME).exists();
+    config["context"] = serde_json::json!(normalize_wg_replica_context_entries(
+        &existing_context,
+        required_context_prefix,
+        &identity.identity,
+        role_exists,
+    ));
 
     Ok(identity)
 }
@@ -470,7 +477,6 @@ mod tests {
             config["context"],
             serde_json::json!([
                 "$AGENTSCOMMANDER_CONTEXT",
-                "$REPOS_WORKSPACE_INFO",
                 "notes.md",
                 "../../_agent_tech-lead/Role.md"
             ])

--- a/src-tauri/src/config/root_agent.rs
+++ b/src-tauri/src/config/root_agent.rs
@@ -80,7 +80,7 @@ Use the AgentsCommander CLI only for commands that are valid from this root-agen
 Direct file-based workgroup messaging is not available from the root-agent directory yet: `send --send` currently requires a workgroup replica root. Do not claim that you can autonomously message workgroup peers until a future root messaging feature adds explicit root-aware send instructions.
 "#;
 
-static ROOT_ROLE_MD: LazyLock<String> = LazyLock::new(|| {
+static OLD_ROOT_CONTEXT_WITH_COORDINATION_MD: LazyLock<String> = LazyLock::new(|| {
     format!(
         r#"---
 name: 'agents-commander'
@@ -114,6 +114,39 @@ Use the AgentsCommander CLI only for commands that are valid from this root-agen
 {ROOT_COORDINATION_MESSAGING_PARAGRAPH}
 "#
     )
+});
+
+static ROOT_ROLE_MD: LazyLock<String> = LazyLock::new(|| {
+    r#"---
+name: 'agents-commander'
+description: 'Static supplemental root context for AgentsCommander.'
+type: agent
+---
+
+# Agents Commander
+
+You are the AgentsCommander Root Agent. You are the top-level coordinator for this AgentsCommander binary.
+
+## Responsibility
+
+Act as the top-level planning and oversight agent for sessions, workgroups, and agents available to this AgentsCommander instance. Help the user inspect available work, plan delegation, track status, and synthesize results.
+
+## State
+
+Your own durable state lives in the canonical `ac-root-agent` directory:
+
+- `memory/`
+- `plans/`
+- `skills/`
+- `Role.md`
+
+You are not a workgroup replica and you do not have an origin Agent Matrix. Use the canonical root directory for your own durable state.
+
+## Coordination
+
+Coordinate across workgroups at a high level. Delegate specialized implementation work to the appropriate team coordinators and synthesize their results for the user.
+"#
+    .to_string()
 });
 
 const MINIMAL_ROOT_ROLE_MD: &str = r#"# Role
@@ -195,21 +228,11 @@ fn migrate_root_role(role_path: &Path) -> Result<(), String> {
             role_path.display()
         )
     })?;
+    crate::config::session_context::create_default_context_templates(config_dir)?;
     let context_template_path =
         config_dir.join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
 
-    if read_validated_template(&context_template_path)?.is_none() {
-        crate::config::session_context::write_template_if_missing(
-            &context_template_path,
-            ROOT_ROLE_MD.as_str(),
-        )?;
-        read_validated_template(&context_template_path)?.ok_or_else(|| {
-            format!(
-                "Template missing immediately after write_template_if_missing: {}",
-                context_template_path.display()
-            )
-        })?;
-    }
+    migrate_root_context_template(&context_template_path)?;
     match create_missing_role(role_path, MINIMAL_ROOT_ROLE_MD)? {
         CreateMissingRole::Created => return Ok(()),
         CreateMissingRole::AlreadyExists => {}
@@ -237,6 +260,50 @@ fn migrate_root_role(role_path: &Path) -> Result<(), String> {
 
     if let Some(content) = migrated {
         atomic_write_role(role_path, &content)?;
+    }
+
+    Ok(())
+}
+
+fn migrate_root_context_template(context_template_path: &Path) -> Result<(), String> {
+    let existing = match read_validated_template(context_template_path)? {
+        Some(existing) => existing,
+        None => {
+            crate::config::session_context::write_template_if_missing(
+                context_template_path,
+                ROOT_ROLE_MD.as_str(),
+            )?;
+            return read_validated_template(context_template_path)?
+                .map(|_| ())
+                .ok_or_else(|| {
+                    format!(
+                        "Template missing immediately after write_template_if_missing: {}",
+                        context_template_path.display()
+                    )
+                });
+        }
+    };
+
+    let existing_normalized = normalize_role_text(&existing);
+    let old_generated = [
+        normalize_role_text(OLD_ROOT_ROLE_MD),
+        normalize_role_text(&OLD_ROOT_CONTEXT_WITH_COORDINATION_MD),
+    ];
+    if old_generated.contains(&existing_normalized) {
+        std::fs::write(context_template_path, ROOT_ROLE_MD.as_str()).map_err(|e| {
+            format!(
+                "Failed to migrate root agent context template {}: {}",
+                context_template_path.display(),
+                e
+            )
+        })?;
+    } else if existing.contains(ROOT_COORDINATION_MESSAGING_PARAGRAPH)
+        || existing.contains(OLD_DEFERRED_MESSAGING_PARAGRAPH)
+    {
+        log::warn!(
+            "Custom root agent context template {} appears to contain stale operational messaging prose; preserving custom content",
+            context_template_path.display()
+        );
     }
 
     Ok(())
@@ -633,11 +700,22 @@ mod tests {
             assert!(root.join(sub).is_dir(), "missing {}", sub);
         }
         assert!(root.join("Role.md").is_file());
-        assert!(ROOT_ROLE_MD.contains("verified workgroup coordinator replicas only"));
+        assert!(ROOT_ROLE_MD.contains("You are the AgentsCommander Root Agent"));
+        assert!(!ROOT_ROLE_MD.contains("verified workgroup coordinator replicas only"));
+        assert!(!ROOT_ROLE_MD.contains("list-peers-lean"));
+        assert!(!ROOT_ROLE_MD.contains("AGENTSCOMMANDER_TOKEN"));
         let template_path = temp
             .path()
             .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        let global_template_path = temp
+            .path()
+            .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        let coordinator_template_path = temp
+            .path()
+            .join(crate::config::session_context::COORDINATOR_CONTEXT_TEMPLATE_FILENAME);
         assert!(template_path.is_file());
+        assert!(global_template_path.is_file());
+        assert!(coordinator_template_path.is_file());
         assert_eq!(
             std::fs::read_to_string(root.join("Role.md")).expect("read role"),
             MINIMAL_ROOT_ROLE_MD
@@ -664,8 +742,19 @@ mod tests {
         let template_path = temp
             .path()
             .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        let global_template_path = temp
+            .path()
+            .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        let coordinator_template_path = temp
+            .path()
+            .join(crate::config::session_context::COORDINATOR_CONTEXT_TEMPLATE_FILENAME);
         let custom_template = "# Custom Root Template\n\nUse this exact seed.\n";
+        let custom_global = "# Custom Global Template\n\nKeep global.\n";
+        let custom_coordinator = "# Custom Coordinator Template\n\nKeep coordinator.\n";
         std::fs::write(&template_path, custom_template).expect("write template");
+        std::fs::write(&global_template_path, custom_global).expect("write global template");
+        std::fs::write(&coordinator_template_path, custom_coordinator)
+            .expect("write coordinator template");
 
         ensure_root_agent_dir_at(&root).expect("ensure root");
 
@@ -677,6 +766,36 @@ mod tests {
             std::fs::read_to_string(template_path).expect("read template"),
             custom_template
         );
+        assert_eq!(
+            std::fs::read_to_string(global_template_path).expect("read global template"),
+            custom_global
+        );
+        assert_eq!(
+            std::fs::read_to_string(coordinator_template_path).expect("read coordinator template"),
+            custom_coordinator
+        );
+    }
+
+    #[test]
+    fn ensure_root_agent_dir_at_migrates_old_root_template_defaults() {
+        for old_default in [
+            OLD_ROOT_ROLE_MD.to_string(),
+            OLD_ROOT_CONTEXT_WITH_COORDINATION_MD.to_string(),
+        ] {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let root = temp.path().join(ROOT_AGENT_DIR_NAME);
+            let template_path = temp
+                .path()
+                .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);
+            std::fs::write(&template_path, old_default).expect("write old template");
+
+            ensure_root_agent_dir_at(&root).expect("ensure root");
+
+            assert_eq!(
+                std::fs::read_to_string(template_path).expect("read template"),
+                ROOT_ROLE_MD.as_str()
+            );
+        }
     }
 
     #[test]
@@ -853,7 +972,7 @@ mod tests {
             .expect("create default templates");
 
         assert!(workspace_dir
-            .join(crate::config::session_context::AGENT_CONTEXT_TEMPLATE_FILENAME)
+            .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME)
             .is_file());
         assert!(workspace_dir
             .join(crate::config::session_context::COORDINATOR_CONTEXT_TEMPLATE_FILENAME)

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -4,7 +4,8 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-pub const AGENT_CONTEXT_TEMPLATE_FILENAME: &str = "Context.agent.md";
+pub const GLOBAL_CONTEXT_TEMPLATE_FILENAME: &str = "Context.AgentsCommander.md";
+const LEGACY_AGENT_CONTEXT_TEMPLATE_FILENAME: &str = "Context.agent.md";
 pub const COORDINATOR_CONTEXT_TEMPLATE_FILENAME: &str = "Context.coordinator.md";
 pub const ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME: &str = "Context.root-agent.md";
 static CONTEXT_TEMPLATE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -15,6 +16,13 @@ static CONTEXT_TEMPLATE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 /// deterministic filename based on the agent_root to prevent races between
 /// concurrent session launches.
 pub fn ensure_session_context(agent_root: &str) -> Result<String, String> {
+    ensure_session_context_with_config(agent_root, None)
+}
+
+fn ensure_session_context_with_config(
+    agent_root: &str,
+    config: Option<&serde_json::Value>,
+) -> Result<String, String> {
     let config_dir =
         super::config_dir().ok_or_else(|| "Could not resolve app config directory".to_string())?;
     let context_dir = config_dir.join("context-cache");
@@ -42,7 +50,13 @@ pub fn ensure_session_context(agent_root: &str) -> Result<String, String> {
     let hash = simple_hash(agent_root);
     let file_path = context_dir.join(format!("ac-context-{}.md", hash));
 
-    let content = resolve_agent_context(&canonical_root, matrix_root.as_deref(), &skills_section)?;
+    let content = resolve_agent_context(
+        &canonical_root,
+        matrix_root.as_deref(),
+        &skills_section,
+        Path::new(agent_root),
+        config,
+    )?;
     std::fs::write(&file_path, content)
         .map_err(|e| format!("Failed to write per-agent AgentsCommanderContext.md: {}", e))?;
     log::info!(
@@ -793,7 +807,7 @@ pub fn create_default_context_templates(workspace_dir: &Path) -> Result<(), Stri
         )
     })?;
     write_template_if_missing(
-        &workspace_dir.join(AGENT_CONTEXT_TEMPLATE_FILENAME),
+        &workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
         get_default_agent_template(),
     )?;
     write_template_if_missing(
@@ -969,11 +983,87 @@ fn read_or_create_context_template(
     let Some(context_dir) = resolve_workspace_context_dir(Path::new(agent_root)) else {
         return Ok(None);
     };
+    if filename == GLOBAL_CONTEXT_TEMPLATE_FILENAME {
+        migrate_legacy_agent_context_template(&context_dir)?;
+    }
     if let Some(content) = read_context_template(agent_root, filename)? {
         return Ok(Some(content));
     }
     write_template_if_missing(&context_dir.join(filename), default_content)?;
     read_context_template(agent_root, filename)
+}
+
+fn migrate_legacy_agent_context_template(context_dir: &Path) -> Result<(), String> {
+    migrate_legacy_agent_context_template_with(context_dir, |legacy_path, new_path| {
+        std::fs::hard_link(legacy_path, new_path)
+    })
+}
+
+fn migrate_legacy_agent_context_template_with<F>(
+    context_dir: &Path,
+    publish_no_overwrite: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&Path, &Path) -> std::io::Result<()>,
+{
+    let new_path = context_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+    match std::fs::symlink_metadata(&new_path) {
+        Ok(_) => return Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(format!(
+                "Failed to inspect context template {}: {}",
+                new_path.display(),
+                e
+            ))
+        }
+    }
+
+    let legacy_path = context_dir.join(LEGACY_AGENT_CONTEXT_TEMPLATE_FILENAME);
+    match std::fs::symlink_metadata(&legacy_path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err(format!(
+                    "Legacy context template {} exists but is not a regular file",
+                    legacy_path.display()
+                ));
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(format!(
+                "Failed to inspect legacy context template {}: {}",
+                legacy_path.display(),
+                e
+            ))
+        }
+    }
+
+    match publish_no_overwrite(&legacy_path, &new_path) {
+        Ok(()) => {
+            if let Err(e) = std::fs::remove_file(&legacy_path) {
+                log::warn!(
+                    "Migrated legacy context template {} to {}, but failed to remove legacy file: {}",
+                    legacy_path.display(),
+                    new_path.display(),
+                    e
+                );
+            }
+            log::info!(
+                "Migrated legacy context template {} to {}",
+                legacy_path.display(),
+                new_path.display()
+            );
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => Err(format!(
+            "Failed to migrate legacy context template {} to {}: {}",
+            legacy_path.display(),
+            new_path.display(),
+            e
+        )),
+    }
 }
 
 fn write_combined_context_file(
@@ -1125,35 +1215,18 @@ pub fn git_ceiling_directories_for_session_root(cwd: &str) -> Option<String> {
         })
 }
 
-/// Generate a markdown file with workspace repo information from the replica's config.
-/// Reads "repos" from `config`, resolves paths relative to `cwd_path`, detects git branches.
-/// Returns the path to the generated temp file.
-fn generate_repos_workspace_info(
+fn render_workspace_repos_string(
     cwd_path: &std::path::Path,
-    config: &serde_json::Value,
-) -> Result<std::path::PathBuf, String> {
-    let config_dir =
-        super::config_dir().ok_or_else(|| "Could not resolve app config directory".to_string())?;
-    let context_dir = config_dir.join("context-cache");
-    std::fs::create_dir_all(&context_dir)
-        .map_err(|e| format!("Failed to create context-cache dir: {}", e))?;
-
-    let hash = simple_hash(&cwd_path.to_string_lossy());
-    let file_path = context_dir.join(format!("repos-workspace-{}.md", hash));
-
+    config: Option<&serde_json::Value>,
+) -> String {
     let repos = config
-        .get("repos")
+        .and_then(|config| config.get("repos"))
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default();
 
     if repos.is_empty() {
-        std::fs::write(
-            &file_path,
-            "# Workspace Repos\n\nNo repos configured for this replica.\n",
-        )
-        .map_err(|e| format!("Failed to write repos workspace info: {}", e))?;
-        return Ok(file_path);
+        return "# Workspace Repos\n\nNo repos configured for this replica.\n".to_string();
     }
 
     let mut md = String::from(
@@ -1193,10 +1266,7 @@ fn generate_repos_workspace_info(
         ));
     }
 
-    std::fs::write(&file_path, &md)
-        .map_err(|e| format!("Failed to write repos workspace info: {}", e))?;
-
-    Ok(file_path)
+    md
 }
 
 /// Detect git branch for a given directory path.
@@ -1231,7 +1301,7 @@ fn detect_git_branch(dir: &str) -> Option<String> {
 /// Reads config.json from `cwd`, looks for `context[]` array.
 /// Entries are resolved in order:
 /// - `$AGENTSCOMMANDER_CONTEXT` → resolves to the global AgentsCommanderContext.md
-/// - `$REPOS_WORKSPACE_INFO` → generates workspace repo info from the "repos" field
+/// - `$REPOS_WORKSPACE_INFO` → deprecated; skipped because repos render inside the global context
 /// - Any other string → resolved as a path relative to `cwd`
 ///
 /// After resolving context[], if `identity` is set in config.json and `<identity>/Role.md`
@@ -1294,14 +1364,17 @@ fn build_replica_context_from_config(
         };
 
         if raw == CONTEXT_TOKEN_GLOBAL {
-            let global_path = ensure_session_context(cwd)?;
+            let global_path = ensure_session_context_with_config(cwd, Some(&config))?;
             resolved_paths.push((
                 "AgentsCommanderContext.md".to_string(),
                 std::path::PathBuf::from(&global_path),
             ));
         } else if raw == CONTEXT_TOKEN_REPOS {
-            let repos_path = generate_repos_workspace_info(cwd_path, &config)?;
-            resolved_paths.push(("Workspace Repos".to_string(), repos_path));
+            log::debug!(
+                "Skipping deprecated {} context token for {}",
+                CONTEXT_TOKEN_REPOS,
+                cwd
+            );
         } else {
             let abs = cwd_path.join(raw);
             if abs.exists() {
@@ -1364,22 +1437,26 @@ fn build_replica_context_from_config(
 
 fn build_direct_matrix_context(cwd: &str) -> Result<String, String> {
     let cwd_path = Path::new(cwd);
-    let global_context = ensure_session_context(cwd)?;
     let role_path = Path::new(cwd).join(ROLE_MD_FILENAME);
     let config_path = cwd_path.join("config.json");
+    let config = if config_path.exists() {
+        let config_content = std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("Failed to read {}: {}", config_path.display(), e))?;
+        Some(
+            serde_json::from_str::<serde_json::Value>(&config_content)
+                .map_err(|e| format!("Failed to parse {}: {}", config_path.display(), e))?,
+        )
+    } else {
+        None
+    };
+    let global_context = ensure_session_context_with_config(cwd, config.as_ref())?;
     let mut resolved_paths = vec![(
         "AgentsCommanderContext.md".to_string(),
         std::path::PathBuf::from(&global_context),
     )];
     let mut missing: Vec<String> = Vec::new();
 
-    if config_path.exists() {
-        let config_content = std::fs::read_to_string(&config_path)
-            .map_err(|e| format!("Failed to read {}: {}", config_path.display(), e))?;
-
-        let config: serde_json::Value = serde_json::from_str(&config_content)
-            .map_err(|e| format!("Failed to parse {}: {}", config_path.display(), e))?;
-
+    if let Some(config) = &config {
         if let Some(context_array) = config.get("context").and_then(|v| v.as_array()) {
             for entry in context_array {
                 let raw = match entry.as_str() {
@@ -1390,10 +1467,11 @@ fn build_direct_matrix_context(cwd: &str) -> Result<String, String> {
                 if raw == CONTEXT_TOKEN_GLOBAL {
                     continue;
                 } else if raw == CONTEXT_TOKEN_REPOS {
-                    let repos_path = generate_repos_workspace_info(cwd_path, &config)?;
-                    if !resolved_paths_include_path(&resolved_paths, &repos_path) {
-                        resolved_paths.push(("Workspace Repos".to_string(), repos_path));
-                    }
+                    log::debug!(
+                        "Skipping deprecated {} context token for {}",
+                        CONTEXT_TOKEN_REPOS,
+                        cwd
+                    );
                 } else {
                     let abs = cwd_path.join(raw);
                     if abs.exists() {
@@ -1557,112 +1635,24 @@ fn simple_hash(s: &str) -> u64 {
     hash
 }
 
-/// Generate the default agent context with a per-agent GOLDEN RULE that embeds
-/// the agent's own replica root path and, for WG replicas, the allowed Agent
-/// Matrix scope.
 pub fn get_default_agent_template() -> &'static str {
     r#"# AgentsCommander Context
 
-You are running inside an AgentsCommander session — a terminal session manager that coordinates multiple AI agents.
+You are running inside an AgentsCommander session - a terminal session manager that coordinates multiple AI agents.
 
-## GOLDEN RULE — Repository Write Restrictions
+{{WRITE_RESTRICTIONS}}
 
-**ABSOLUTE AND NON-NEGOTIABLE:** You may ONLY modify files in the entries listed below:
-
-1. **Repositories whose root folder name starts with `repo-`** (e.g. `repo-AgentsCommander`, `repo-myapp`). These are the working repos you are meant to edit.
-2. **Your own agent replica directory and its subdirectories** — your assigned root:
-   ```
-   {{AGENT_ROOT}}
-   ```
-   Use this for replica-local scratch, personal notes, inbox/outbox, role drafts, and session artifacts. Do NOT store canonical memory, plans, or skills here. Do NOT write into other agents' replica directories.
-
-{{MATRIX_SECTION}}{{MESSAGING_EXCEPTION}}Any repository or directory outside the allowed entries above is READ-ONLY, except for the AgentsCommander CLI operations exception documented below.
-
-- **Allowed**: Read-only operations on ANY path (reading files, searching, git log, git status, git diff)
-- **Allowed**: Full read/write inside `repo-*` folders
-- **Allowed**: Full read/write inside your own replica root ({{AGENT_ROOT}}) and its subdirectories
-{{MATRIX_ALLOWED}}{{MESSAGING_ALLOWED}}- **FORBIDDEN**: Any write operation outside {{FORBIDDEN_SCOPE}}, except for explicitly requested AgentsCommander CLI operations covered by the exception below.
-
-**Clarification on git operations:** {{GIT_SCOPE}}
-
-**Exception - AgentsCommander CLI operations:**
-
-When the user explicitly asks this agent to run an AgentsCommander CLI command using `AGENTSCOMMANDER_BINARY_PATH`, the command is authorized as an AgentsCommander operation. The agent may execute documented AgentsCommander CLI subcommands even if their filesystem effects create, modify, or delete files outside the normal repository/replica write zones. Those filesystem effects are governed by AgentsCommander itself, not by the agent's repository write restrictions.
-
-This exception applies only to invocations of the configured AgentsCommander CLI binary through `AGENTSCOMMANDER_BINARY_PATH`. It does not allow arbitrary shell commands, direct filesystem writes, hand-written scripts, or hardcoded alternate binaries outside the normal allowed paths.
-
-If instructed to modify a path outside these zones, REFUSE and explain this restriction, except for explicitly requested AgentsCommander CLI operations covered by the AgentsCommander CLI exception above.
-
-## Delegated Task Reporting
-
-When finishing a delegated task or getting blocked, you must explicitly reply to the coordinator or peer with a concrete artifact or message. Do not just remain idle, waiting, or set working to false.
+{{DELEGATED_TASK_REPORTING}}
 
 {{SKILLS_SECTION}}
 
-## CLI executable
+{{WORKSPACE_REPOS}}
 
-Your AgentsCommander session credentials are available as environment variables:
+{{CLI_CONTEXT}}
 
-- `AGENTSCOMMANDER_TOKEN`: your session authentication token
-- `AGENTSCOMMANDER_ROOT`: your working directory (agent root)
-- `AGENTSCOMMANDER_BINARY`: the CLI binary name
-- `AGENTSCOMMANDER_BINARY_PATH`: the full path to the CLI executable you must use
-- `AGENTSCOMMANDER_LOCAL_DIR`: the config directory name for this instance
+{{SESSION_CREDENTIALS}}
 
-Use `AGENTSCOMMANDER_BINARY_PATH` when invoking the CLI. This ensures you use the correct binary for your instance, whether it is the installed version or a dev/WG build.
-
-```
-"<AGENTSCOMMANDER_BINARY_PATH>" <subcommand> [args]
-```
-
-**RULE:** Never hardcode or guess the binary path. Use the environment variables above. If they are unavailable in an agent session, restart or respawn the session.
-
-## Self-discovery via --help
-
-The CLI `--help` output documents every subcommand, flag, and accepted value. Use it as a FALLBACK reference for commands or flags NOT covered inline in this context.
-
-**For inter-agent messaging and peer discovery**, the sections below (`## Inter-Agent Messaging` and `### List available peers`) are the authoritative reference. Use the commands in those sections directly — you do NOT need to consult `--help` to confirm their syntax.
-
-```
-"<AGENTSCOMMANDER_BINARY_PATH>" --help                  # List all subcommands
-"<AGENTSCOMMANDER_BINARY_PATH>" send --help             # Full docs for sending messages
-"<AGENTSCOMMANDER_BINARY_PATH>" list-peers-lean --help  # Full docs for discovering peers
-```
-
-**RULE:** Only run `--help` if you need a subcommand or flag not documented in the sections below, or if a documented command fails unexpectedly.
-
-## Session credentials
-
-Your session credentials are delivered only through the `AGENTSCOMMANDER_*` environment variables listed above.
-
-Live token refresh without respawn is not supported, because a parent process cannot portably mutate an already-running child process environment. If credential validation fails, restart or respawn the session so AgentsCommander can create a new child process with fresh env values.
-
-Your agent root is your current working directory.
-
-## Inter-Agent Messaging
-
-### Send a message to another agent
-
-**MANDATORY**: Before sending any message, resolve the exact agent name via `list-peers-lean`. Never guess agent names.
-
-**Peer name format** (canonical FQN, exactly what `list-peers-lean` emits in the `name` field):
-
-{{PEER_NAME_FORMAT}}
-
-**The filesystem directory name is NEVER a valid `--to` value.** Replica dirs like `__agent_shipper` and matrix dirs like `_agent_architect` are on-disk paths only — they are not peer names. The `list-peers-lean` JSON `name` field is the only authoritative source. If `list-peers-lean` returns an empty array, do NOT fall back to scanning `__agent_*` siblings on disk — that produces invalid `--to` values. Stop and report the empty result instead.
-
-{{SEND_MESSAGE_INSTRUCTIONS}}
-
-The recipient receives a short notification pointing to your file's absolute
-path and reads the content via filesystem. Do NOT use `--get-output` — it
-blocks and is only for non-interactive sessions. After sending, stay idle and
-wait for the reply.
-
-### List available peers
-
-```
-"<AGENTSCOMMANDER_BINARY_PATH>" list-peers-lean --token <AGENTSCOMMANDER_TOKEN> --root "<AGENTSCOMMANDER_ROOT>"
-```
+{{INTER_AGENT_MESSAGING}}
 "#
 }
 
@@ -1697,8 +1687,22 @@ fn render_agent_context_template(
     agent_root: &str,
     matrix_root: Option<&str>,
     skills_section: &str,
+    cwd_path: &Path,
+    config: Option<&serde_json::Value>,
 ) -> String {
     let rendered = default_context_dynamic_values(agent_root, matrix_root, skills_section);
+    let mut template = template.to_string();
+    for placeholder in MANDATORY_GLOBAL_CONTEXT_PLACEHOLDERS {
+        if !template.contains(placeholder) {
+            log::warn!(
+                "Global context template is missing mandatory placeholder {}; appending fallback block",
+                placeholder
+            );
+            template.push_str("\n\n");
+            template.push_str(placeholder);
+        }
+    }
+
     template
         .replace("{{AGENT_ROOT}}", agent_root)
         .replace("{{MATRIX_SECTION}}", &rendered.matrix_section)
@@ -1713,16 +1717,36 @@ fn render_agent_context_template(
             &rendered.send_message_instructions,
         )
         .replace("{{SKILLS_SECTION}}", skills_section)
+        .replace(
+            "{{WRITE_RESTRICTIONS}}",
+            &render_write_restrictions_block(agent_root, &rendered),
+        )
+        .replace("{{CLI_CONTEXT}}", DEFAULT_CLI_CONTEXT)
+        .replace("{{SESSION_CREDENTIALS}}", DEFAULT_SESSION_CREDENTIALS)
+        .replace(
+            "{{INTER_AGENT_MESSAGING}}",
+            &render_inter_agent_messaging_block(&rendered),
+        )
+        .replace(
+            "{{WORKSPACE_REPOS}}",
+            &render_workspace_repos_string(cwd_path, config),
+        )
+        .replace(
+            "{{DELEGATED_TASK_REPORTING}}",
+            DEFAULT_DELEGATED_TASK_REPORTING,
+        )
 }
 
 fn resolve_agent_context(
     agent_root: &str,
     matrix_root: Option<&str>,
     skills_section: &str,
+    cwd_path: &Path,
+    config: Option<&serde_json::Value>,
 ) -> Result<String, String> {
     let template = read_or_create_context_template(
         agent_root,
-        AGENT_CONTEXT_TEMPLATE_FILENAME,
+        GLOBAL_CONTEXT_TEMPLATE_FILENAME,
         get_default_agent_template(),
     )?
     .unwrap_or_else(|| default_context(agent_root, matrix_root, skills_section));
@@ -1734,9 +1758,65 @@ fn resolve_agent_context(
             agent_root,
             matrix_root,
             skills_section,
+            cwd_path,
+            config,
         ))
     }
 }
+
+const MANDATORY_GLOBAL_CONTEXT_PLACEHOLDERS: &[&str] = &[
+    "{{WRITE_RESTRICTIONS}}",
+    "{{INTER_AGENT_MESSAGING}}",
+    "{{SESSION_CREDENTIALS}}",
+    "{{CLI_CONTEXT}}",
+    "{{SKILLS_SECTION}}",
+    "{{WORKSPACE_REPOS}}",
+    "{{DELEGATED_TASK_REPORTING}}",
+];
+
+const DEFAULT_CLI_CONTEXT: &str = r#"## CLI executable
+
+Your AgentsCommander session credentials are available as environment variables:
+
+- `AGENTSCOMMANDER_TOKEN`: your session authentication token
+- `AGENTSCOMMANDER_ROOT`: your working directory (agent root)
+- `AGENTSCOMMANDER_BINARY`: the CLI binary name
+- `AGENTSCOMMANDER_BINARY_PATH`: the full path to the CLI executable you must use
+- `AGENTSCOMMANDER_LOCAL_DIR`: the config directory name for this instance
+
+Use `AGENTSCOMMANDER_BINARY_PATH` when invoking the CLI. This ensures you use the correct binary for your instance, whether it is the installed version or a dev/WG build.
+
+```
+"<AGENTSCOMMANDER_BINARY_PATH>" <subcommand> [args]
+```
+
+**RULE:** Never hardcode or guess the binary path. Use the environment variables above. If they are unavailable in an agent session, restart or respawn the session.
+
+## Self-discovery via --help
+
+The CLI `--help` output documents every subcommand, flag, and accepted value. Use it as a FALLBACK reference for commands or flags NOT covered inline in this context.
+
+**For inter-agent messaging and peer discovery**, the sections below (`## Inter-Agent Messaging` and `### List available peers`) are the authoritative reference. Use the commands in those sections directly. You do NOT need to consult `--help` to confirm their syntax.
+
+```
+"<AGENTSCOMMANDER_BINARY_PATH>" --help                  # List all subcommands
+"<AGENTSCOMMANDER_BINARY_PATH>" send --help             # Full docs for sending messages
+"<AGENTSCOMMANDER_BINARY_PATH>" list-peers-lean --help  # Full docs for discovering peers
+```
+
+**RULE:** Only run `--help` if you need a subcommand or flag not documented in the sections below, or if a documented command fails unexpectedly."#;
+
+const DEFAULT_SESSION_CREDENTIALS: &str = r#"## Session credentials
+
+Your session credentials are delivered only through the `AGENTSCOMMANDER_*` environment variables listed above.
+
+Live token refresh without respawn is not supported, because a parent process cannot portably mutate an already-running child process environment. If credential validation fails, restart or respawn the session so AgentsCommander can create a new child process with fresh env values.
+
+Your agent root is your current working directory."#;
+
+const DEFAULT_DELEGATED_TASK_REPORTING: &str = r#"## Delegated Task Reporting
+
+When finishing a delegated task or getting blocked, you must explicitly reply to the coordinator or peer with a concrete artifact or message. Do not just remain idle, waiting, or set working to false."#;
 
 struct DefaultContextDynamicValues {
     matrix_section: String,
@@ -1747,6 +1827,84 @@ struct DefaultContextDynamicValues {
     git_scope: String,
     peer_name_format: String,
     send_message_instructions: String,
+}
+
+fn render_write_restrictions_block(
+    agent_root: &str,
+    rendered: &DefaultContextDynamicValues,
+) -> String {
+    let replica_usage =
+        "   Use this for replica-local scratch, personal notes, inbox/outbox, role drafts, and session artifacts. Do NOT store canonical memory, plans, or skills here. Do NOT write into other agents' replica directories.";
+    let allowed_places = "the entries listed below";
+    format!(
+        r#"## GOLDEN RULE — Repository Write Restrictions
+
+**ABSOLUTE AND NON-NEGOTIABLE:** You may ONLY modify files in {allowed_places}:
+
+1. **Repositories whose root folder name starts with `repo-`** (e.g. `repo-AgentsCommander`, `repo-myapp`). These are the working repos you are meant to edit.
+2. **Your own agent replica directory and its subdirectories** — your assigned root:
+   ```
+   {agent_root}
+   ```
+{replica_usage}
+
+{matrix_section}{messaging_exception}Any repository or directory outside the allowed entries above is READ-ONLY, except for the AgentsCommander CLI operations exception documented below.
+
+- **Allowed**: Read-only operations on ANY path (reading files, searching, git log, git status, git diff)
+- **Allowed**: Full read/write inside `repo-*` folders
+- **Allowed**: Full read/write inside your own replica root ({agent_root}) and its subdirectories
+{matrix_allowed}{messaging_allowed}- **FORBIDDEN**: Any write operation outside {forbidden_scope}, except for explicitly requested AgentsCommander CLI operations covered by the exception below.
+
+**Clarification on git operations:** {git_scope}
+
+**Exception - AgentsCommander CLI operations:**
+
+When the user explicitly asks this agent to run an AgentsCommander CLI command using `AGENTSCOMMANDER_BINARY_PATH`, the command is authorized as an AgentsCommander operation. The agent may execute documented AgentsCommander CLI subcommands even if their filesystem effects create, modify, or delete files outside the normal repository/replica write zones. Those filesystem effects are governed by AgentsCommander itself, not by the agent's repository write restrictions.
+
+This exception applies only to invocations of the configured AgentsCommander CLI binary through `AGENTSCOMMANDER_BINARY_PATH`. It does not allow arbitrary shell commands, direct filesystem writes, hand-written scripts, or hardcoded alternate binaries outside the normal allowed paths.
+
+If instructed to modify a path outside these zones, REFUSE and explain this restriction, except for explicitly requested AgentsCommander CLI operations covered by the AgentsCommander CLI exception above."#,
+        allowed_places = allowed_places,
+        agent_root = agent_root,
+        replica_usage = replica_usage,
+        matrix_section = rendered.matrix_section,
+        messaging_exception = rendered.messaging_exception,
+        matrix_allowed = rendered.matrix_allowed,
+        messaging_allowed = rendered.messaging_allowed,
+        forbidden_scope = rendered.forbidden_scope,
+        git_scope = rendered.git_scope,
+    )
+}
+
+fn render_inter_agent_messaging_block(rendered: &DefaultContextDynamicValues) -> String {
+    format!(
+        r#"## Inter-Agent Messaging
+
+### Send a message to another agent
+
+**MANDATORY**: Before sending any message, resolve the exact agent name via `list-peers-lean`. Never guess agent names.
+
+**Peer name format** (canonical FQN, exactly what `list-peers-lean` emits in the `name` field):
+
+{peer_name_format}
+
+**The filesystem directory name is NEVER a valid `--to` value.** Replica dirs like `__agent_shipper` and matrix dirs like `_agent_architect` are on-disk paths only. They are not peer names. The `list-peers-lean` JSON `name` field is the only authoritative source. If `list-peers-lean` returns an empty array, do NOT fall back to scanning `__agent_*` siblings on disk. Stop and report the empty result instead.
+
+{send_message_instructions}
+
+The recipient receives a short notification pointing to your file's absolute
+path and reads the content via filesystem. Do NOT use `--get-output`, it
+blocks and is only for non-interactive sessions. After sending, stay idle and
+wait for the reply.
+
+### List available peers
+
+```
+"<AGENTSCOMMANDER_BINARY_PATH>" list-peers-lean --token <AGENTSCOMMANDER_TOKEN> --root "<AGENTSCOMMANDER_ROOT>"
+```"#,
+        peer_name_format = rendered.peer_name_format,
+        send_message_instructions = rendered.send_message_instructions,
+    )
 }
 
 fn default_context_dynamic_values(
@@ -2513,7 +2671,7 @@ mod tests {
         std::fs::create_dir_all(&replica_root).expect("create replica root");
         std::fs::create_dir_all(&workspace_dir).expect("create workspace dir");
         std::fs::write(
-            workspace_dir.join(AGENT_CONTEXT_TEMPLATE_FILENAME),
+            workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
             "root={{AGENT_ROOT}}\n{{MATRIX_SECTION}}\n{{MESSAGING_EXCEPTION}}\n{{SKILLS_SECTION}}",
         )
         .expect("write custom agent template");
@@ -2544,11 +2702,242 @@ mod tests {
     }
 
     #[test]
+    fn legacy_agent_template_is_migrated_to_global_template() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        let legacy_path = workspace_dir.join(LEGACY_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        let new_path = workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        std::fs::write(&legacy_path, "LEGACY_BODY {{AGENT_ROOT}}").expect("write legacy template");
+
+        let materialized = materialize_agent_context_file(
+            &path_string(&matrix_root),
+            ManagedContextTarget::Codex,
+            false,
+        )
+        .expect("materialize context")
+        .expect("context path");
+        let content = std::fs::read_to_string(materialized).expect("read materialized context");
+
+        assert!(content.contains("LEGACY_BODY"));
+        assert!(content.contains(&display_path(&matrix_root)));
+        assert!(new_path.is_file());
+        assert!(!legacy_path.exists());
+        assert_eq!(
+            std::fs::read_to_string(new_path).expect("read migrated template"),
+            "LEGACY_BODY {{AGENT_ROOT}}"
+        );
+    }
+
+    #[test]
+    fn missing_global_template_placeholders_are_force_appended() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        std::fs::write(
+            workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
+            "CUSTOM_ONLY {{WRITE_RESTRICTIONS}}",
+        )
+        .expect("write partial template");
+
+        let materialized = materialize_agent_context_file(
+            &path_string(&matrix_root),
+            ManagedContextTarget::Codex,
+            false,
+        )
+        .expect("materialize context")
+        .expect("context path");
+        let content = std::fs::read_to_string(materialized).expect("read materialized context");
+
+        assert!(content.contains("CUSTOM_ONLY"));
+        assert!(content.contains("## GOLDEN RULE"));
+        assert!(content.contains("## Delegated Task Reporting"));
+        assert!(content.contains("## Skills"));
+        assert!(content.contains("# Workspace Repos"));
+        assert!(content.contains("## CLI executable"));
+        assert!(content.contains("## Session credentials"));
+        assert!(content.contains("## Inter-Agent Messaging"));
+        for placeholder in MANDATORY_GLOBAL_CONTEXT_PLACEHOLDERS {
+            assert!(
+                !content.contains(placeholder),
+                "placeholder {placeholder} should be rendered"
+            );
+        }
+    }
+
+    #[test]
+    fn workspace_repos_placeholder_uses_repaired_replica_config() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        let replica_root = workspace_dir
+            .join("wg-19-dev-team")
+            .join("__agent_dev-rust");
+        let repo_dir = workspace_dir.join("wg-19-dev-team").join("repo-Example");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        std::fs::create_dir_all(&replica_root).expect("create replica root");
+        std::fs::create_dir_all(&repo_dir).expect("create repo dir");
+        std::fs::write(
+            workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
+            "{{WORKSPACE_REPOS}}",
+        )
+        .expect("write repos-only template");
+        std::fs::write(
+            replica_root.join("config.json"),
+            r#"{"identity":"../../_agent_dev-rust","context":["$AGENTSCOMMANDER_CONTEXT"],"repos":["../repo-Example"]}"#,
+        )
+        .expect("write replica config");
+
+        let materialized = materialize_agent_context_file(
+            &path_string(&replica_root),
+            ManagedContextTarget::Codex,
+            false,
+        )
+        .expect("materialize context")
+        .expect("context path");
+        let content = std::fs::read_to_string(materialized).expect("read materialized context");
+
+        assert!(content.contains("## Repos"));
+        assert!(content.contains("repo-Example"));
+        assert!(content.contains(&display_path(&repo_dir)));
+        assert!(!content.contains("No repos configured"));
+    }
+
+    #[test]
+    fn workspace_repos_placeholder_uses_missing_context_repaired_to_global() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        let replica_root = workspace_dir
+            .join("wg-19-dev-team")
+            .join("__agent_dev-rust");
+        let repo_dir = workspace_dir.join("wg-19-dev-team").join("repo-Example");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        std::fs::create_dir_all(&replica_root).expect("create replica root");
+        std::fs::create_dir_all(&repo_dir).expect("create repo dir");
+        std::fs::write(
+            workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
+            "{{WORKSPACE_REPOS}}",
+        )
+        .expect("write repos-only template");
+        std::fs::write(
+            replica_root.join("config.json"),
+            r#"{"identity":"../../_agent_dev-rust","repos":["../repo-Example"]}"#,
+        )
+        .expect("write replica config");
+
+        let materialized = materialize_agent_context_file(
+            &path_string(&replica_root),
+            ManagedContextTarget::Codex,
+            false,
+        )
+        .expect("materialize context")
+        .expect("context path");
+        let content = std::fs::read_to_string(materialized).expect("read materialized context");
+        let repaired: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(replica_root.join("config.json")).expect("read config"),
+        )
+        .expect("parse repaired config");
+
+        assert!(content.contains("repo-Example"));
+        assert!(content.contains(&display_path(&repo_dir)));
+        assert!(!content.contains("No repos configured"));
+        assert_eq!(
+            repaired["context"],
+            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT"])
+        );
+    }
+
+    #[test]
+    fn workspace_repos_placeholder_uses_empty_context_repaired_to_global() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        let replica_root = workspace_dir
+            .join("wg-19-dev-team")
+            .join("__agent_dev-rust");
+        let repo_dir = workspace_dir.join("wg-19-dev-team").join("repo-Example");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        std::fs::create_dir_all(&replica_root).expect("create replica root");
+        std::fs::create_dir_all(&repo_dir).expect("create repo dir");
+        std::fs::write(
+            workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
+            "{{WORKSPACE_REPOS}}",
+        )
+        .expect("write repos-only template");
+        std::fs::write(
+            replica_root.join("config.json"),
+            r#"{"identity":"../../_agent_dev-rust","context":[],"repos":["../repo-Example"]}"#,
+        )
+        .expect("write replica config");
+
+        let materialized = materialize_agent_context_file(
+            &path_string(&replica_root),
+            ManagedContextTarget::Codex,
+            false,
+        )
+        .expect("materialize context")
+        .expect("context path");
+        let content = std::fs::read_to_string(materialized).expect("read materialized context");
+        let repaired: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(replica_root.join("config.json")).expect("read config"),
+        )
+        .expect("parse repaired config");
+
+        assert!(content.contains("repo-Example"));
+        assert!(content.contains(&display_path(&repo_dir)));
+        assert!(!content.contains("No repos configured"));
+        assert_eq!(
+            repaired["context"],
+            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT"])
+        );
+    }
+
+    #[test]
+    fn deprecated_repos_context_token_is_skipped_without_generated_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        let replica_root = workspace_dir
+            .join("wg-19-dev-team")
+            .join("__agent_dev-rust");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        std::fs::create_dir_all(&replica_root).expect("create replica root");
+        std::fs::write(
+            replica_root.join("config.json"),
+            r#"{"identity":"../../_agent_dev-rust","context":["$AGENTSCOMMANDER_CONTEXT","$REPOS_WORKSPACE_INFO"]}"#,
+        )
+        .expect("write replica config");
+
+        let materialized = materialize_agent_context_file(
+            &path_string(&replica_root),
+            ManagedContextTarget::Codex,
+            false,
+        )
+        .expect("materialize context")
+        .expect("context path");
+        let content = std::fs::read_to_string(materialized).expect("read materialized context");
+        let repaired: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(replica_root.join("config.json")).expect("read config"),
+        )
+        .expect("parse repaired config");
+
+        assert!(content.contains("# Workspace Repos"));
+        assert_eq!(
+            repaired["context"],
+            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT"])
+        );
+        assert_eq!(content.matches("# Workspace Repos").count(), 1);
+    }
+
+    #[test]
     fn edited_agent_template_is_used_for_all_provider_files() {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace_dir = temp.path().join(".ac");
         let matrix_root = workspace_dir.join("_agent_dev-rust");
-        let template_path = workspace_dir.join(AGENT_CONTEXT_TEMPLATE_FILENAME);
+        let template_path = workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::write(&template_path, "CUSTOM_AGENT_BODY").expect("write custom agent template");
 
@@ -2635,7 +3024,7 @@ mod tests {
         assert!(content.contains("# Coordinator Context"));
         assert!(content.contains("You are the coordinator for your team"));
         assert_eq!(
-            std::fs::read_to_string(workspace_dir.join(AGENT_CONTEXT_TEMPLATE_FILENAME))
+            std::fs::read_to_string(workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
                 .expect("read created agent template"),
             get_default_agent_template()
         );
@@ -2655,7 +3044,7 @@ mod tests {
 
         for (filename, default_content) in [
             (
-                AGENT_CONTEXT_TEMPLATE_FILENAME,
+                GLOBAL_CONTEXT_TEMPLATE_FILENAME,
                 get_default_agent_template(),
             ),
             (
@@ -2713,7 +3102,7 @@ mod tests {
         assert!(content.contains("# Coordinator Context"));
         assert!(content.contains("You are the coordinator for your team"));
         assert_eq!(
-            std::fs::read_to_string(workspace_dir.join(AGENT_CONTEXT_TEMPLATE_FILENAME))
+            std::fs::read_to_string(workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
                 .expect("read retried agent template"),
             get_default_agent_template()
         );
@@ -2731,7 +3120,7 @@ mod tests {
         let matrix_root = workspace_dir.join("_agent_tech-lead");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
 
-        let path = workspace_dir.join(AGENT_CONTEXT_TEMPLATE_FILENAME);
+        let path = workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
         let (partial_written_tx, partial_written_rx) = mpsc::channel();
         let release_barrier = Arc::new(Barrier::new(2));
         let writer_release_barrier = Arc::clone(&release_barrier);
@@ -2764,7 +3153,7 @@ mod tests {
             "final template must not exist while temp content is partial"
         );
         assert_eq!(
-            read_context_template(&path_string(&matrix_root), AGENT_CONTEXT_TEMPLATE_FILENAME)
+            read_context_template(&path_string(&matrix_root), GLOBAL_CONTEXT_TEMPLATE_FILENAME)
                 .expect("read context template"),
             None
         );
@@ -2797,29 +3186,61 @@ mod tests {
     }
 
     #[test]
-    fn empty_agent_and_coordinator_templates_are_valid_empty_intent() {
+    fn legacy_template_migration_does_not_overwrite_concurrent_new_template() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        std::fs::create_dir_all(&workspace_dir).expect("create workspace dir");
+        let legacy_path = workspace_dir.join(LEGACY_AGENT_CONTEXT_TEMPLATE_FILENAME);
+        let new_path = workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        std::fs::write(&legacy_path, "LEGACY_TEMPLATE").expect("write legacy template");
+
+        migrate_legacy_agent_context_template_with(&workspace_dir, |legacy_path, new_path| {
+            std::fs::write(new_path, "USER_NEW_TEMPLATE")?;
+            std::fs::hard_link(legacy_path, new_path)
+        })
+        .expect("race-lost migration should succeed without overwrite");
+
+        assert_eq!(
+            std::fs::read_to_string(&new_path).expect("read new template"),
+            "USER_NEW_TEMPLATE"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&legacy_path).expect("read preserved legacy template"),
+            "LEGACY_TEMPLATE"
+        );
+    }
+
+    #[test]
+    fn empty_agent_template_falls_back_to_mandatory_blocks() {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace_dir = temp.path().join(".ac");
         let matrix_root = workspace_dir.join("_agent_tech-lead");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
-        std::fs::write(workspace_dir.join(AGENT_CONTEXT_TEMPLATE_FILENAME), "")
+        std::fs::write(workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME), "")
             .expect("write empty agent template");
         std::fs::write(
             workspace_dir.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
-            "   \n\t",
+            "COORDINATOR_ONLY",
         )
-        .expect("write empty coordinator template");
+        .expect("write coordinator template");
 
         let materialized = materialize_agent_context_file(
             &path_string(&matrix_root),
             ManagedContextTarget::Codex,
-            true,
+            false,
         )
         .expect("materialize context")
         .expect("context path");
         let content = std::fs::read_to_string(materialized).expect("read materialized context");
 
-        assert_eq!(content, "");
+        assert!(content.contains("## GOLDEN RULE"));
+        assert!(content.contains("## Delegated Task Reporting"));
+        assert!(content.contains("## Skills"));
+        assert!(content.contains("# Workspace Repos"));
+        assert!(content.contains("## CLI executable"));
+        assert!(content.contains("## Session credentials"));
+        assert!(content.contains("## Inter-Agent Messaging"));
+        assert!(!content.contains("COORDINATOR_ONLY"));
     }
 
     #[test]
@@ -2828,7 +3249,7 @@ mod tests {
         let workspace_dir = temp.path().join(".ac");
         let matrix_root = workspace_dir.join("_agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
-        std::fs::create_dir_all(workspace_dir.join(AGENT_CONTEXT_TEMPLATE_FILENAME))
+        std::fs::create_dir_all(workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
             .expect("create template directory");
 
         let err = materialize_agent_context_file(
@@ -2849,7 +3270,7 @@ mod tests {
         let matrix_root = workspace_dir.join("_agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::write(
-            workspace_dir.join(AGENT_CONTEXT_TEMPLATE_FILENAME),
+            workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
             [0xff, 0xfe],
         )
         .expect("write invalid utf8 template");
@@ -2862,7 +3283,7 @@ mod tests {
         .expect_err("invalid utf8 template must error");
 
         assert!(err.contains("not valid UTF-8"));
-        assert!(err.contains(AGENT_CONTEXT_TEMPLATE_FILENAME));
+        assert!(err.contains(GLOBAL_CONTEXT_TEMPLATE_FILENAME));
     }
 
     #[test]
@@ -3297,11 +3718,7 @@ mod tests {
         assert_eq!(repaired["identity"], "../../_agent_tech-lead");
         assert_eq!(
             repaired["context"],
-            serde_json::json!([
-                "$AGENTSCOMMANDER_CONTEXT",
-                "$REPOS_WORKSPACE_INFO",
-                "../../_agent_tech-lead/Role.md"
-            ])
+            serde_json::json!(["$AGENTSCOMMANDER_CONTEXT", "../../_agent_tech-lead/Role.md"])
         );
     }
 

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -939,7 +939,11 @@ fn cleanup_failed_context_template(path: &Path) {
 }
 
 fn resolve_workspace_context_dir(agent_root: &Path) -> Option<PathBuf> {
-    find_workspace_root(agent_root)
+    find_workspace_root(agent_root).or_else(|| {
+        super::root_agent::is_root_agent_dir_name(&agent_root.to_string_lossy())
+            .then(|| agent_root.parent().map(canonical_or_original))
+            .flatten()
+    })
 }
 
 fn read_context_template(agent_root: &str, filename: &str) -> Result<Option<String>, String> {
@@ -3906,7 +3910,12 @@ mod tests {
 
         assert!(content.contains("# AgentsCommander Context"));
         assert!(content.contains("You are the AgentsCommander Root Agent"));
-        assert!(content.contains("verified workgroup coordinator replicas only"));
+        assert!(content.contains("verified WG coordinator replicas only"));
+        assert_eq!(
+            content.matches("Root messaging is **file-based**").count(),
+            1,
+            "root operational messaging instructions should come only from the global context"
+        );
         assert!(content.contains("You are the personal Root Agent for AgentsCommander."));
         assert!(!content.contains("Direct file-based workgroup messaging is not available"));
 
@@ -3924,7 +3933,55 @@ mod tests {
 
         assert!(content.contains("LIVE_ROOT_CONTEXT_BODY"));
         assert!(!content.contains("You are the AgentsCommander Root Agent"));
+        assert_eq!(
+            content.matches("Root messaging is **file-based**").count(),
+            1,
+            "custom root context must not receive global operational fallback"
+        );
         assert!(content.contains("You are the personal Root Agent for AgentsCommander."));
+    }
+
+    #[test]
+    fn materialize_root_context_uses_standalone_sibling_global_template() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp
+            .path()
+            .join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
+        let global_template_path = temp.path().join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        std::fs::create_dir_all(&root).expect("create root");
+        std::fs::write(
+            root.join("config.json"),
+            r#"{"tooling":{},"context":["$AGENTSCOMMANDER_CONTEXT","../Context.root-agent.md","Role.md"]}"#,
+        )
+        .expect("write config");
+        std::fs::write(root.join("Role.md"), "# Root Role\n\nROOT_ROLE_BODY\n")
+            .expect("write role");
+        std::fs::write(
+            temp.path().join(ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME),
+            "# Root Context\n\nROOT_TEMPLATE_BODY\n",
+        )
+        .expect("write root context");
+        std::fs::write(
+            &global_template_path,
+            "CUSTOM_STANDALONE_GLOBAL {{AGENT_ROOT}}",
+        )
+        .expect("write global template");
+
+        let materialized =
+            materialize_agent_context_file(&path_string(&root), ManagedContextTarget::Codex, false)
+                .expect("materialize context")
+                .expect("context path");
+        let content = std::fs::read_to_string(materialized).expect("read materialized context");
+
+        assert!(content.contains("CUSTOM_STANDALONE_GLOBAL"));
+        assert!(content.contains(&display_path(&root)));
+        assert!(content.contains("ROOT_TEMPLATE_BODY"));
+        assert!(content.contains("ROOT_ROLE_BODY"));
+        assert!(!content.contains("# AgentsCommander Context"));
+        assert_eq!(
+            std::fs::read_to_string(global_template_path).expect("read global template"),
+            "CUSTOM_STANDALONE_GLOBAL {{AGENT_ROOT}}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #447

Summary:
- Externalize the global AgentsCommander context into editable Context.AgentsCommander.md templates.
- Seed global/coordinator templates for project and standalone/root AC directories while preserving custom files.
- Keep Context.root-agent.md as static root supplemental prose and migrate generated defaults safely.
- Render standalone root sessions from sibling Context.AgentsCommander.md instead of built-in-only fallback.

Validation:
- cargo test config::root_agent::tests
- cargo test config::session_context::tests::materialize
- cargo check
- cargo clippy
- npx tauri build
- wg-1 standalone smoke verified Context.AgentsCommander.md, Context.coordinator.md, Context.root-agent.md creation