### PR TITLE
fix(prompt-history): preserve bracketed paste paths (#458)

### DIFF
--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -12,6 +12,7 @@ import {
 import { isBrowser } from "../../shared/platform";
 import { terminalStore } from "../stores/terminal";
 import type { UnlistenFn } from "../../shared/transport";
+import { updatePromptCapture } from "./prompt-input-capture";
 import "@xterm/xterm/css/xterm.css";
 
 interface SessionTerminal {
@@ -225,18 +226,10 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       const encoder = new TextEncoder();
       void PtyAPI.write(sessionId, encoder.encode(data));
 
-      if (data === "\r") {
-        const trimmed = entry.inputBuffer.trim();
-        if (trimmed) {
-          void SessionAPI.setLastPrompt(sessionId, trimmed);
-        }
-        entry.inputBuffer = "";
-      } else if (data === "\x7f") {
-        entry.inputBuffer = entry.inputBuffer.slice(0, -1);
-      } else if (data.length === 1 && data >= " ") {
-        entry.inputBuffer += data;
-      } else if (data.length > 1 && !data.startsWith("\x1b")) {
-        entry.inputBuffer += data;
+      const capture = updatePromptCapture(entry.inputBuffer, data);
+      entry.inputBuffer = capture.buffer;
+      if (capture.submittedPrompt) {
+        void SessionAPI.setLastPrompt(sessionId, capture.submittedPrompt);
       }
     });
 

--- a/src/terminal/components/prompt-input-capture.test.ts
+++ b/src/terminal/components/prompt-input-capture.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { updatePromptCapture } from "./prompt-input-capture";
+
+function applyChunks(chunks: string[]) {
+  let buffer = "";
+  let submittedPrompt: string | null = null;
+
+  for (const chunk of chunks) {
+    const result = updatePromptCapture(buffer, chunk);
+    buffer = result.buffer;
+    submittedPrompt = result.submittedPrompt;
+  }
+
+  return { buffer, submittedPrompt };
+}
+
+describe("updatePromptCapture", () => {
+  it("preserves typed text around a bracketed-paste Windows path", () => {
+    const path = "C:\\Users\\maria\\0_mmb\\0_AC\\agentscommander_standalone_wg-1_project";
+
+    expect(applyChunks([" 1- ", `\x1b[200~${path}\x1b[201~`, " 2- ok", "\r"])).toEqual({
+      buffer: "",
+      submittedPrompt: `1- ${path} 2- ok`,
+    });
+  });
+
+  it("preserves a whole prompt pasted as one bracketed-paste chunk", () => {
+    const prompt = "1- C:\\Users\\maria\\project 2- ok";
+
+    expect(applyChunks([`\x1b[200~${prompt}\x1b[201~`, "\r"])).toEqual({
+      buffer: "",
+      submittedPrompt: prompt,
+    });
+  });
+
+  it("ignores arrow and control escape sequences", () => {
+    expect(applyChunks(["abc", "\x1b[A", "\x1b[B", "\x1b[1;5D", "\x9bC", "d", "\r"])).toEqual({
+      buffer: "",
+      submittedPrompt: "abcd",
+    });
+  });
+
+  it("keeps single-character typing, backspace, and enter behavior intact", () => {
+    expect(applyChunks(["a", "b", "c", "\x7f", "d", "\r"])).toEqual({
+      buffer: "",
+      submittedPrompt: "abd",
+    });
+  });
+});

--- a/src/terminal/components/prompt-input-capture.ts
+++ b/src/terminal/components/prompt-input-capture.ts
@@ -1,0 +1,104 @@
+export interface PromptCaptureResult {
+  buffer: string;
+  submittedPrompt: string | null;
+}
+
+const PASTE_START_7BIT = "\x1b[200~";
+const PASTE_END_7BIT = "\x1b[201~";
+const PASTE_START_8BIT = "\x9b200~";
+const PASTE_END_8BIT = "\x9b201~";
+
+function findPasteEnd(data: string, fromIndex: number) {
+  const end7 = data.indexOf(PASTE_END_7BIT, fromIndex);
+  const end8 = data.indexOf(PASTE_END_8BIT, fromIndex);
+
+  if (end7 === -1) return end8 === -1 ? null : { index: end8, marker: PASTE_END_8BIT };
+  if (end8 === -1) return { index: end7, marker: PASTE_END_7BIT };
+  return end7 < end8
+    ? { index: end7, marker: PASTE_END_7BIT }
+    : { index: end8, marker: PASTE_END_8BIT };
+}
+
+function skipControlSequence(data: string, index: number) {
+  const next = data[index + 1];
+  if (data[index] === "\x1b" && next === "[") {
+    for (let i = index + 2; i < data.length; i += 1) {
+      const code = data.charCodeAt(i);
+      if (code >= 0x40 && code <= 0x7e) {
+        return i + 1;
+      }
+    }
+    return data.length;
+  }
+
+  if (data[index] === "\x9b") {
+    for (let i = index + 1; i < data.length; i += 1) {
+      const code = data.charCodeAt(i);
+      if (code >= 0x40 && code <= 0x7e) {
+        return i + 1;
+      }
+    }
+    return data.length;
+  }
+
+  return index + 1;
+}
+
+function promptTextFromInputChunk(data: string) {
+  let text = "";
+  let index = 0;
+
+  while (index < data.length) {
+    if (data.startsWith(PASTE_START_7BIT, index) || data.startsWith(PASTE_START_8BIT, index)) {
+      const startMarker = data.startsWith(PASTE_START_7BIT, index)
+        ? PASTE_START_7BIT
+        : PASTE_START_8BIT;
+      const payloadStart = index + startMarker.length;
+      const end = findPasteEnd(data, payloadStart);
+
+      if (!end) {
+        text += data.slice(payloadStart);
+        break;
+      }
+
+      text += data.slice(payloadStart, end.index);
+      index = end.index + end.marker.length;
+      continue;
+    }
+
+    const char = data[index];
+    if (char === "\x1b" || char === "\x9b") {
+      index = skipControlSequence(data, index);
+      continue;
+    }
+
+    if (char >= " ") {
+      text += char;
+    }
+    index += 1;
+  }
+
+  return text;
+}
+
+export function updatePromptCapture(buffer: string, data: string): PromptCaptureResult {
+  if (data === "\r") {
+    const submittedPrompt = buffer.trim();
+    return {
+      buffer: "",
+      submittedPrompt: submittedPrompt || null,
+    };
+  }
+
+  if (data === "\x7f") {
+    return {
+      buffer: buffer.slice(0, -1),
+      submittedPrompt: null,
+    };
+  }
+
+  return {
+    buffer: buffer + promptTextFromInputChunk(data),
+    submittedPrompt: null,
+  };
+}


### PR DESCRIPTION
## Summary
- Preserve bracketed paste payloads in terminal prompt-history capture
- Keep PTY writes unchanged while filtering local prompt capture control sequences
- Add regression tests for Windows paths, full-prompt paste, controls, and edit/submit behavior

Closes #458