### PR TITLE
fix(sidebar): refresh projects after CLI registration (#459)

### DIFF
--- a/src-tauri/src/cli/create_agent_matrix.rs
+++ b/src-tauri/src/cli/create_agent_matrix.rs
@@ -70,8 +70,10 @@ struct CreateAgentMatrixResult {
 pub struct ProjectRefreshRequest {
     pub id: String,
     pub project_path: String,
-    pub agent_path: String,
-    pub agent_name: String,
+    #[serde(alias = "agentPath")]
+    pub changed_path: Option<String>,
+    #[serde(alias = "agentName")]
+    pub changed_name: Option<String>,
     pub reason: String,
     pub timestamp: String,
 }
@@ -138,8 +140,8 @@ pub(crate) fn execute_matrix_project_create(
     let refresh_request = ProjectRefreshRequest {
         id: uuid::Uuid::new_v4().to_string(),
         project_path: project_path_for_refresh,
-        agent_path: agent_path_for_refresh,
-        agent_name: created.display_name.clone(),
+        changed_path: Some(agent_path_for_refresh),
+        changed_name: Some(created.display_name.clone()),
         reason: "createAgentMatrix".to_string(),
         timestamp: chrono::Utc::now().to_rfc3339(),
     };
@@ -229,6 +231,12 @@ pub(crate) fn write_project_refresh_request(request: &ProjectRefreshRequest) -> 
         let _ = std::fs::remove_file(&tmp_path);
         format!("Failed to finalize project refresh request: {}", e)
     })?;
+    log::info!(
+        "[project-refresh-requests] Wrote request: dir='{}' project='{}' reason='{}'",
+        requests_dir.display(),
+        request.project_path,
+        request.reason
+    );
 
     Ok(())
 }

--- a/src-tauri/src/cli/new_project.rs
+++ b/src-tauri/src/cli/new_project.rs
@@ -7,7 +7,9 @@
 //! Same GUI concurrency caveat as `open-project` — see that file.
 
 use clap::Args;
+use std::path::PathBuf;
 
+use crate::cli::workgroup::write_project_registration_refresh;
 use crate::config::projects::register_new_project;
 use crate::config::settings::{load_settings_for_cli, save_settings};
 
@@ -44,6 +46,7 @@ pub fn execute(args: NewProjectArgs) -> i32 {
             eprintln!("Error: failed to persist settings: {}", e);
             return 1;
         }
+        write_project_registration_refresh(&PathBuf::from(&result.path), "projectRegistered");
     }
     if result.created {
         crate::cli_println!("Created AC project at {}", result.path);

--- a/src-tauri/src/cli/open_project.rs
+++ b/src-tauri/src/cli/open_project.rs
@@ -14,7 +14,9 @@
 //! in the plan §6 — a watcher/reload story is a follow-up issue.
 
 use clap::Args;
+use std::path::PathBuf;
 
+use crate::cli::workgroup::write_project_registration_refresh;
 use crate::config::projects::{register_existing_project, ProjectError};
 use crate::config::settings::{load_settings_for_cli, save_settings};
 
@@ -56,6 +58,7 @@ pub fn execute(args: OpenProjectArgs) -> i32 {
             eprintln!("Error: failed to persist settings: {}", e);
             return 1;
         }
+        write_project_registration_refresh(&PathBuf::from(&result.path), "projectRegistered");
         crate::cli_println!("Registered project: {}", result.path);
     } else {
         crate::cli_println!("Project already registered: {}", result.path);

--- a/src-tauri/src/cli/workgroup.rs
+++ b/src-tauri/src/cli/workgroup.rs
@@ -105,11 +105,31 @@ pub(crate) fn resolve_cli_workspace(project_path: &Path) -> Result<PathBuf, Stri
 }
 
 pub(crate) fn write_refresh(project_path: &Path, changed_path: &Path, name: &str, reason: &str) {
+    let canonical_project_path =
+        std::fs::canonicalize(project_path).unwrap_or_else(|_| project_path.to_path_buf());
+    let canonical_changed_path =
+        std::fs::canonicalize(changed_path).unwrap_or_else(|_| changed_path.to_path_buf());
     let request = ProjectRefreshRequest {
         id: uuid::Uuid::new_v4().to_string(),
-        project_path: project_path.to_string_lossy().to_string(),
-        agent_path: changed_path.to_string_lossy().to_string(),
-        agent_name: name.to_string(),
+        project_path: canonical_project_path.to_string_lossy().to_string(),
+        changed_path: Some(canonical_changed_path.to_string_lossy().to_string()),
+        changed_name: Some(name.to_string()),
+        reason: reason.to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    };
+    if let Err(e) = write_project_refresh_request(&request) {
+        eprintln!("Warning: failed to request project refresh: {}", e);
+    }
+}
+
+pub(crate) fn write_project_registration_refresh(project_path: &Path, reason: &str) {
+    let canonical_project_path =
+        std::fs::canonicalize(project_path).unwrap_or_else(|_| project_path.to_path_buf());
+    let request = ProjectRefreshRequest {
+        id: uuid::Uuid::new_v4().to_string(),
+        project_path: canonical_project_path.to_string_lossy().to_string(),
+        changed_path: None,
+        changed_name: None,
         reason: reason.to_string(),
         timestamp: chrono::Utc::now().to_rfc3339(),
     };

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -36,8 +36,8 @@ fn sender_name_for_session_cwd(working_directory: &str) -> String {
 struct ProjectRefreshEventPayload {
     id: String,
     project_path: String,
-    agent_path: String,
-    agent_name: String,
+    changed_path: Option<String>,
+    changed_name: Option<String>,
     reason: String,
 }
 
@@ -52,6 +52,14 @@ fn canonical_project_refresh_path(path: &str) -> String {
         .unwrap_or_else(|_| PathBuf::from(path))
         .to_string_lossy()
         .to_string()
+}
+
+fn project_refresh_priority(reason: &str) -> u8 {
+    if reason == "projectRegistered" {
+        0
+    } else {
+        1
+    }
 }
 
 fn collect_project_refresh_requests(requests_dir: &Path) -> ProjectRefreshPollBatch {
@@ -75,7 +83,8 @@ fn collect_project_refresh_requests(requests_dir: &Path) -> ProjectRefreshPollBa
     entries.sort();
 
     let mut batch = ProjectRefreshPollBatch::default();
-    let mut seen_projects = BTreeSet::new();
+    let mut selected_by_project: HashMap<String, (u8, ProjectRefreshEventPayload)> = HashMap::new();
+    let mut project_order: Vec<String> = Vec::new();
 
     for path in entries {
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
@@ -112,17 +121,31 @@ fn collect_project_refresh_requests(requests_dir: &Path) -> ProjectRefreshPollBa
         request.project_path = canonical_project_path.clone();
         batch.processed_paths.push(path);
 
-        if !seen_projects.insert(canonical_project_path) {
-            continue;
-        }
-
-        batch.payloads.push(ProjectRefreshEventPayload {
+        let priority = project_refresh_priority(&request.reason);
+        let payload = ProjectRefreshEventPayload {
             id: request.id,
             project_path: request.project_path,
-            agent_path: request.agent_path,
-            agent_name: request.agent_name,
+            changed_path: request.changed_path,
+            changed_name: request.changed_name,
             reason: request.reason,
-        });
+        };
+
+        match selected_by_project.get(&canonical_project_path) {
+            Some((existing_priority, _)) if *existing_priority <= priority => {}
+            Some(_) => {
+                selected_by_project.insert(canonical_project_path, (priority, payload));
+            }
+            None => {
+                project_order.push(canonical_project_path.clone());
+                selected_by_project.insert(canonical_project_path, (priority, payload));
+            }
+        }
+    }
+
+    for project_path in project_order {
+        if let Some((_, payload)) = selected_by_project.remove(&project_path) {
+            batch.payloads.push(payload);
+        }
     }
 
     batch
@@ -2770,9 +2793,10 @@ impl MailboxPoller {
 
         for payload in &batch.payloads {
             log::info!(
-                "[project-refresh-requests] Emitting refresh: project='{}' agent='{}'",
+                "[project-refresh-requests] Emitting refresh: dir='{}' project='{}' reason='{}'",
+                requests_dir.display(),
                 payload.project_path,
-                payload.agent_name
+                payload.reason
             );
             let _ = tauri::Emitter::emit(app, "ac_project_refresh_requested", payload);
         }
@@ -4000,18 +4024,21 @@ mod tests {
         path: &Path,
         id: &str,
         project_path: &Path,
-        agent_name: &str,
+        changed_name: Option<&str>,
+        reason: &str,
     ) {
         let request = crate::cli::create_agent_matrix::ProjectRefreshRequest {
             id: id.to_string(),
             project_path: project_path.to_string_lossy().to_string(),
-            agent_path: project_path
-                .join(".ac")
-                .join("_agent_architect")
-                .to_string_lossy()
-                .to_string(),
-            agent_name: agent_name.to_string(),
-            reason: "createAgentMatrix".to_string(),
+            changed_path: changed_name.map(|_| {
+                project_path
+                    .join(".ac")
+                    .join("_agent_architect")
+                    .to_string_lossy()
+                    .to_string()
+            }),
+            changed_name: changed_name.map(str::to_string),
+            reason: reason.to_string(),
             timestamp: "2026-05-28T20:00:00Z".to_string(),
         };
         std::fs::write(path, serde_json::to_string_pretty(&request).unwrap()).unwrap();
@@ -4029,7 +4056,8 @@ mod tests {
             &tmp_file,
             "request-tmp",
             &project,
-            "ProjectAlpha/architect",
+            Some("ProjectAlpha/architect"),
+            "createAgentMatrix",
         );
 
         let batch = collect_project_refresh_requests(&requests_dir);
@@ -4068,13 +4096,15 @@ mod tests {
             &requests_dir.join("a.json"),
             "request-a",
             &project,
-            "ProjectAlpha/architect",
+            Some("ProjectAlpha/architect"),
+            "createAgentMatrix",
         );
         write_project_refresh_request_fixture(
             &requests_dir.join("b.json"),
             "request-b",
             &project,
-            "ProjectAlpha/planner",
+            Some("ProjectAlpha/planner"),
+            "workgroupCreated",
         );
 
         let batch = collect_project_refresh_requests(&requests_dir);
@@ -4087,6 +4117,99 @@ mod tests {
             .to_string();
         assert_eq!(batch.payloads[0].project_path, expected_project);
         assert_eq!(batch.payloads[0].id, "request-a");
+    }
+
+    #[test]
+    fn project_refresh_request_reader_preserves_registration_payload() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let requests_dir = temp.path().join("project-refresh-requests");
+        std::fs::create_dir_all(&requests_dir).unwrap();
+        let project = temp.path().join("ProjectAlpha");
+        std::fs::create_dir_all(project.join(".ac")).unwrap();
+        write_project_refresh_request_fixture(
+            &requests_dir.join("registration.json"),
+            "request-registration",
+            &project,
+            None,
+            "projectRegistered",
+        );
+
+        let batch = collect_project_refresh_requests(&requests_dir);
+
+        assert_eq!(batch.payloads.len(), 1);
+        let payload = &batch.payloads[0];
+        assert_eq!(payload.id, "request-registration");
+        assert_eq!(payload.reason, "projectRegistered");
+        assert_eq!(payload.changed_path, None);
+        assert_eq!(payload.changed_name, None);
+    }
+
+    #[test]
+    fn project_refresh_request_reader_accepts_legacy_agent_fields() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let requests_dir = temp.path().join("project-refresh-requests");
+        std::fs::create_dir_all(&requests_dir).unwrap();
+        let project = temp.path().join("ProjectAlpha");
+        let agent_path = project.join(".ac").join("_agent_architect");
+        std::fs::create_dir_all(&agent_path).unwrap();
+        let request = serde_json::json!({
+            "id": "legacy-request",
+            "projectPath": project.to_string_lossy(),
+            "agentPath": agent_path.to_string_lossy(),
+            "agentName": "ProjectAlpha/architect",
+            "reason": "createAgentMatrix",
+            "timestamp": "2026-05-28T20:00:00Z"
+        });
+        std::fs::write(
+            requests_dir.join("legacy.json"),
+            serde_json::to_string_pretty(&request).unwrap(),
+        )
+        .unwrap();
+
+        let batch = collect_project_refresh_requests(&requests_dir);
+
+        assert_eq!(batch.payloads.len(), 1);
+        let expected_agent_path = agent_path.to_string_lossy().to_string();
+        assert_eq!(
+            batch.payloads[0].changed_path.as_deref(),
+            Some(expected_agent_path.as_str())
+        );
+        assert_eq!(
+            batch.payloads[0].changed_name.as_deref(),
+            Some("ProjectAlpha/architect")
+        );
+    }
+
+    #[test]
+    fn project_refresh_request_reader_prioritizes_registration_for_same_project() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let requests_dir = temp.path().join("project-refresh-requests");
+        std::fs::create_dir_all(&requests_dir).unwrap();
+        let project = temp.path().join("ProjectAlpha");
+        std::fs::create_dir_all(project.join(".ac").join("_agent_architect")).unwrap();
+        write_project_refresh_request_fixture(
+            &requests_dir.join("a-mutation.json"),
+            "request-mutation",
+            &project,
+            Some("ProjectAlpha/architect"),
+            "createAgentMatrix",
+        );
+        write_project_refresh_request_fixture(
+            &requests_dir.join("z-registration.json"),
+            "request-registration",
+            &project,
+            None,
+            "projectRegistered",
+        );
+
+        let batch = collect_project_refresh_requests(&requests_dir);
+
+        assert_eq!(batch.payloads.len(), 1);
+        assert_eq!(batch.processed_paths.len(), 2);
+        assert_eq!(batch.payloads[0].id, "request-registration");
+        assert_eq!(batch.payloads[0].reason, "projectRegistered");
+        assert_eq!(batch.payloads[0].changed_path, None);
+        assert_eq!(batch.payloads[0].changed_name, None);
     }
 
     // ── Issue #223 deliver_wake integration placeholders ──

--- a/src-tauri/tests/cli_create_agent_matrix.rs
+++ b/src-tauri/tests/cli_create_agent_matrix.rs
@@ -154,13 +154,13 @@ fn assert_single_project_refresh_request(config_dir: &Path, project: &Path) -> s
             .as_ref()
     );
     assert_eq!(
-        request["agentPath"].as_str().expect("agentPath"),
+        request["changedPath"].as_str().expect("changedPath"),
         std::fs::canonicalize(agent_dir)
             .expect("canonical agent dir")
             .to_string_lossy()
             .as_ref()
     );
-    assert_eq!(request["agentName"], "ProjectAlpha/architect");
+    assert_eq!(request["changedName"], "ProjectAlpha/architect");
     assert_eq!(request["reason"], "createAgentMatrix");
     request
 }

--- a/src-tauri/tests/cli_project_registration.rs
+++ b/src-tauri/tests/cli_project_registration.rs
@@ -1,0 +1,207 @@
+//! Integration tests for project registration CLI refresh requests.
+//!
+//! Each test copies the binary under test into a temp directory so
+//! `config_dir()` resolves to an isolated sibling config directory.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+struct Tmp(PathBuf);
+
+impl Drop for Tmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+impl Tmp {
+    fn new(prefix: &str) -> Self {
+        let path =
+            std::env::temp_dir().join(format!("ac-{}-{}", prefix, uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&path).expect("create tmp dir");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+fn copy_binary_into(tmp: &Path) -> PathBuf {
+    let src = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let dst = tmp.join(src.file_name().expect("binary file name"));
+    std::fs::copy(src, &dst).expect("copy binary");
+    dst
+}
+
+fn config_dir_for_bin(bin: &Path) -> PathBuf {
+    let stem = bin
+        .file_stem()
+        .expect("bin stem")
+        .to_string_lossy()
+        .to_string();
+    bin.parent().expect("bin parent").join(format!(".{}", stem))
+}
+
+fn write_settings(config_dir: &Path, project_paths: &[&Path]) {
+    std::fs::create_dir_all(config_dir).expect("create config dir");
+    let settings = serde_json::json!({
+        "defaultShell": "powershell.exe",
+        "defaultShellArgs": [],
+        "agents": [],
+        "projectPaths": project_paths
+            .iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect::<Vec<_>>()
+    });
+    std::fs::write(
+        config_dir.join("settings.json"),
+        serde_json::to_string_pretty(&settings).expect("settings json"),
+    )
+    .expect("write settings");
+}
+
+fn project_refresh_request_paths(config_dir: &Path) -> Vec<PathBuf> {
+    let requests_dir = config_dir.join("project-refresh-requests");
+    if !requests_dir.exists() {
+        return Vec::new();
+    }
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(&requests_dir)
+        .expect("read project-refresh-requests")
+        .map(|entry| entry.expect("entry").path())
+        .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("json"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn clear_project_refresh_requests(config_dir: &Path) {
+    let requests_dir = config_dir.join("project-refresh-requests");
+    if requests_dir.exists() {
+        std::fs::remove_dir_all(requests_dir).expect("clear requests");
+    }
+}
+
+fn read_single_project_refresh_request(config_dir: &Path) -> serde_json::Value {
+    let requests = project_refresh_request_paths(config_dir);
+    assert_eq!(requests.len(), 1, "expected one project refresh request");
+    serde_json::from_str(&std::fs::read_to_string(&requests[0]).expect("read request"))
+        .expect("request json")
+}
+
+fn assert_registration_request(request: &serde_json::Value, project: &Path) {
+    uuid::Uuid::parse_str(request["id"].as_str().expect("id")).expect("request id");
+    assert!(!request["timestamp"].as_str().expect("timestamp").is_empty());
+    assert_eq!(
+        request["projectPath"].as_str().expect("projectPath"),
+        std::fs::canonicalize(project)
+            .expect("canonical project")
+            .to_string_lossy()
+            .as_ref()
+    );
+    assert!(request
+        .get("changedPath")
+        .is_none_or(|value| value.is_null()));
+    assert!(request
+        .get("changedName")
+        .is_none_or(|value| value.is_null()));
+    assert_eq!(request["reason"], "projectRegistered");
+}
+
+fn run_success(bin: &Path, args: &[&str]) {
+    let out = Command::new(bin).args(args).output().expect("spawn");
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn run_failure(bin: &Path, args: &[&str]) {
+    let out = Command::new(bin).args(args).output().expect("spawn");
+    assert!(
+        !out.status.success(),
+        "expected failure\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn new_project_writes_project_registered_refresh() {
+    let tmp = Tmp::new("cli-new-project-refresh");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, &[]);
+    let project = tmp.path().join("ProjectAlpha");
+    let project_arg = project.to_string_lossy().to_string();
+
+    run_success(&bin, &["new-project", &project_arg]);
+
+    assert!(project.join(".ac").is_dir());
+    let request = read_single_project_refresh_request(&config_dir);
+    assert_registration_request(&request, &project);
+}
+
+#[test]
+fn open_project_writes_project_registered_refresh_for_new_registration() {
+    let tmp = Tmp::new("cli-open-project-refresh");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, &[]);
+    let project = tmp.path().join("ProjectAlpha");
+    std::fs::create_dir_all(project.join(".ac")).expect("create project");
+    let project_arg = project.to_string_lossy().to_string();
+
+    run_success(&bin, &["open-project", &project_arg]);
+
+    let request = read_single_project_refresh_request(&config_dir);
+    assert_registration_request(&request, &project);
+}
+
+#[test]
+fn open_project_noop_does_not_write_refresh() {
+    let tmp = Tmp::new("cli-open-project-noop-refresh");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    let project = tmp.path().join("ProjectAlpha");
+    std::fs::create_dir_all(project.join(".ac")).expect("create project");
+    write_settings(&config_dir, &[&project]);
+    let project_arg = project.to_string_lossy().to_string();
+
+    run_success(&bin, &["open-project", &project_arg]);
+
+    assert!(project_refresh_request_paths(&config_dir).is_empty());
+}
+
+#[test]
+fn new_project_noop_does_not_write_refresh() {
+    let tmp = Tmp::new("cli-new-project-noop-refresh");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, &[]);
+    let project = tmp.path().join("ProjectAlpha");
+    let project_arg = project.to_string_lossy().to_string();
+    run_success(&bin, &["new-project", &project_arg]);
+    clear_project_refresh_requests(&config_dir);
+
+    run_success(&bin, &["new-project", &project_arg]);
+
+    assert!(project_refresh_request_paths(&config_dir).is_empty());
+}
+
+#[test]
+fn open_project_invalid_path_does_not_write_refresh() {
+    let tmp = Tmp::new("cli-open-project-invalid-refresh");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, &[]);
+    let missing = tmp.path().join("MissingProject");
+    let missing_arg = missing.to_string_lossy().to_string();
+
+    run_failure(&bin, &["open-project", &missing_arg]);
+
+    assert!(project_refresh_request_paths(&config_dir).is_empty());
+}

--- a/src-tauri/tests/cli_workgroup_team.rs
+++ b/src-tauri/tests/cli_workgroup_team.rs
@@ -53,6 +53,68 @@ fn write_settings(config_dir: &Path, project_parent: &Path) {
     .expect("write settings");
 }
 
+fn project_refresh_request_paths(config_dir: &Path) -> Vec<PathBuf> {
+    let requests_dir = config_dir.join("project-refresh-requests");
+    if !requests_dir.exists() {
+        return Vec::new();
+    }
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(&requests_dir)
+        .expect("read project-refresh-requests")
+        .map(|entry| entry.expect("entry").path())
+        .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("json"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn read_project_refresh_requests(config_dir: &Path) -> Vec<serde_json::Value> {
+    project_refresh_request_paths(config_dir)
+        .iter()
+        .map(|path| {
+            serde_json::from_str(&std::fs::read_to_string(path).expect("read request"))
+                .expect("request json")
+        })
+        .collect()
+}
+
+fn assert_refresh_request(
+    request: &serde_json::Value,
+    project: &Path,
+    changed_path_suffix: &str,
+    changed_name: &str,
+    reason: &str,
+) {
+    assert_eq!(
+        request["projectPath"].as_str().expect("projectPath"),
+        std::fs::canonicalize(project)
+            .expect("canonical project")
+            .to_string_lossy()
+            .as_ref()
+    );
+    assert!(
+        request["changedPath"]
+            .as_str()
+            .expect("changedPath")
+            .replace('\\', "/")
+            .ends_with(changed_path_suffix),
+        "changedPath {:?} should end with {}",
+        request["changedPath"],
+        changed_path_suffix
+    );
+    assert_eq!(request["changedName"], changed_name);
+    assert_eq!(request["reason"], reason);
+}
+
+fn find_refresh_request<'a>(
+    requests: &'a [serde_json::Value],
+    reason: &str,
+) -> &'a serde_json::Value {
+    requests
+        .iter()
+        .find(|request| request["reason"] == reason)
+        .unwrap_or_else(|| panic!("missing refresh request reason {}", reason))
+}
+
 fn project_with_agents(tmp: &Path, agents: &[&str]) -> PathBuf {
     let project = tmp.join("ProjectAlpha");
     let workspace_dir = project.join(".ac");
@@ -150,6 +212,16 @@ fn workgroup_add_creates_task_messaging_replicas_and_lists() {
     assert_eq!(list[0]["team"], "dev-team");
     assert_eq!(list[0]["hasTask"], true);
     assert_eq!(list[0]["hasMessaging"], true);
+
+    let requests = read_project_refresh_requests(&config_dir);
+    assert_eq!(requests.len(), 1);
+    assert_refresh_request(
+        &requests[0],
+        &project,
+        ".ac/wg-1-dev-team",
+        "wg-1-dev-team",
+        "workgroupCreated",
+    );
 }
 
 #[test]
@@ -223,6 +295,15 @@ fn workgroup_remove_deletes_and_reuses_number() {
     );
     assert_eq!(removed["removed"], true);
     assert!(!wg_dir.exists());
+    let requests = read_project_refresh_requests(&config_dir);
+    assert_eq!(requests.len(), 2);
+    assert_refresh_request(
+        find_refresh_request(&requests, "workgroupRemoved"),
+        &project,
+        ".ac/wg-1-dev-team",
+        "wg-1-dev-team",
+        "workgroupRemoved",
+    );
 
     let recreated = run_json(
         &bin,
@@ -372,6 +453,15 @@ fn team_add_member_creates_replica_and_peer_is_reachable() {
         peer["name"] == "ProjectAlpha:wg-1-dev-team/dev-rust" && peer["reachable"] == true
     });
     assert!(found, "added peer should be reachable: {}", peers);
+    let requests = read_project_refresh_requests(&config_dir);
+    assert_eq!(requests.len(), 2);
+    assert_refresh_request(
+        find_refresh_request(&requests, "teamMembershipChanged"),
+        &project,
+        ".ac/wg-1-dev-team/__agent_dev-rust",
+        "wg-1-dev-team/dev-rust",
+        "teamMembershipChanged",
+    );
 
     let removed = run_json(
         &bin,
@@ -388,4 +478,13 @@ fn team_add_member_creates_replica_and_peer_is_reachable() {
     );
     assert_eq!(removed["removed"], true);
     assert!(!replica.exists());
+    let requests = read_project_refresh_requests(&config_dir);
+    assert_eq!(requests.len(), 3);
+    assert_refresh_request(
+        find_refresh_request(&requests, "teamMembershipRemoved"),
+        &project,
+        ".ac/wg-1-dev-team/__agent_dev-rust",
+        "wg-1-dev-team/dev-rust",
+        "teamMembershipRemoved",
+    );
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -294,12 +294,21 @@ export interface AcDiscoveryResult {
   workgroups: AcWorkgroup[];
 }
 
+export type AcProjectRefreshReason =
+  | "projectRegistered"
+  | "createAgentMatrix"
+  | "workgroupCreated"
+  | "workgroupRemoved"
+  | "teamMembershipChanged"
+  | "teamMembershipRemoved"
+  | string;
+
 export interface AcProjectRefreshRequestedPayload {
   id: string;
   projectPath: string;
-  agentPath?: string;
-  agentName?: string;
-  reason: "createAgentMatrix";
+  changedPath?: string | null;
+  changedName?: string | null;
+  reason: AcProjectRefreshReason;
 }
 
 // Team wizard shared types (used by NewTeamModal and EditTeamModal)

--- a/src/sidebar/App.project-refresh.test.ts
+++ b/src/sidebar/App.project-refresh.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AcProjectRefreshReason } from "../shared/types";
+
+vi.mock("./stores/project", () => ({
+  projectStore: {
+    loadProject: vi.fn(),
+    reloadProjectIfLoaded: vi.fn(),
+  },
+}));
+
+import { handleProjectRefreshRequested } from "./project-refresh-handler";
+
+function refreshPayload(reason: AcProjectRefreshReason) {
+  return {
+    id: "request-1",
+    projectPath: "C:\\Users\\Maria\\Project",
+    changedPath: null,
+    changedName: null,
+    reason,
+  };
+}
+
+describe("handleProjectRefreshRequested", () => {
+  it("loads registered projects", () => {
+    const store = {
+      loadProject: vi.fn(),
+      reloadProjectIfLoaded: vi.fn(),
+    };
+
+    handleProjectRefreshRequested(refreshPayload("projectRegistered"), store);
+
+    expect(store.loadProject).toHaveBeenCalledWith("C:\\Users\\Maria\\Project");
+    expect(store.reloadProjectIfLoaded).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "createAgentMatrix",
+    "workgroupCreated",
+    "workgroupRemoved",
+    "teamMembershipChanged",
+    "teamMembershipRemoved",
+    "futureReason",
+  ] as const)("reloads loaded projects for %s", (reason) => {
+    const store = {
+      loadProject: vi.fn(),
+      reloadProjectIfLoaded: vi.fn(),
+    };
+
+    handleProjectRefreshRequested(refreshPayload(reason), store);
+
+    expect(store.reloadProjectIfLoaded).toHaveBeenCalledWith("C:\\Users\\Maria\\Project");
+    expect(store.loadProject).not.toHaveBeenCalled();
+  });
+});

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -40,6 +40,7 @@ import ActionBar from "./components/ActionBar";
 import RootAgentBanner from "./components/RootAgentBanner";
 import ProjectPanel from "./components/ProjectPanel";
 import OnboardingModal from "./components/OnboardingModal";
+import { handleProjectRefreshRequested } from "./project-refresh-handler";
 import "./styles/sidebar.css";
 
 interface SidebarAppProps {
@@ -96,6 +97,12 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     if (!props.embedded) {
       document.documentElement.classList.add("light-theme");
     }
+    unlisteners.push(
+      await onAcProjectRefreshRequested((data) => {
+        handleProjectRefreshRequested(data);
+      })
+    );
+
     shortcutHandler = registerShortcuts();
     if (!props.embedded) {
       cleanupZoom = await initZoom("sidebar");
@@ -150,12 +157,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     ) {
       setShowOnboarding(true);
     }
-
-    unlisteners.push(
-      await onAcProjectRefreshRequested((data) => {
-        void projectStore.reloadProjectIfLoaded(data.projectPath);
-      })
-    );
 
     // Load saved project if any
     await projectStore.initFromSettings(
@@ -328,3 +329,4 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
 };
 
 export default SidebarApp;
+export { handleProjectRefreshRequested };

--- a/src/sidebar/components/SettingsModal.test.ts
+++ b/src/sidebar/components/SettingsModal.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { AppSettings } from "../../shared/types";
+import { mergeSettingsForSavePreservingProjects } from "./settings-save";
+
+function settings(overrides: Partial<AppSettings>): AppSettings {
+  return {
+    defaultShell: "pwsh",
+    defaultShellArgs: [],
+    sidebarAlwaysOnTop: false,
+    sidebarStyle: "noir-minimal",
+    themeLight: true,
+    telegramNetworkPollErrorLogging: {
+      firstFailureLevel: "warn",
+      transientRepeatLevel: "debug",
+      sustainedLevel: "warn",
+      sustainedAfterSeconds: 60,
+      sustainedRepeatSeconds: 300,
+      recoveryLevel: "info",
+    },
+    raiseTerminalOnClick: true,
+    coordSortByActivity: false,
+    alwaysShowSelectedWorkgroup: true,
+    restoreCoordinatorWakeState: true,
+    soundsEnabled: true,
+    teamIdleBeepEnabled: true,
+    injectRtkHook: false,
+    informWhenRtkInstalled: true,
+    webServerEnabled: false,
+    webServerPort: 8765,
+    webServerBind: "127.0.0.1",
+    voiceToTextEnabled: false,
+    voiceAutoExecute: false,
+    voiceAutoExecuteDelay: 15,
+    geminiApiKey: "",
+    geminiModel: "gemini-2.5-flash",
+    sidebarZoom: 1,
+    terminalZoom: 1,
+    guideZoom: 1,
+    mainZoom: 1,
+    sidebarGeometry: null,
+    terminalGeometry: null,
+    mainGeometry: null,
+    mainSidebarWidth: 360,
+    mainSidebarSide: "right",
+    mainAlwaysOnTop: false,
+    agents: [],
+    telegramBots: [],
+    onboardingDismissed: false,
+    projectPaths: [],
+    projectPath: null,
+    rtkPromptDismissed: false,
+    autoGenerateTaskTitle: true,
+    agentTemplatesPath: null,
+    specBoardEnabled: false,
+    ...overrides,
+  };
+}
+
+describe("mergeSettingsForSavePreservingProjects", () => {
+  it("preserves fresh project registration fields from disk", () => {
+    const draft = settings({
+      soundsEnabled: false,
+      projectPaths: ["C:\\Stale"],
+      projectPath: "C:\\Stale",
+    });
+    const fresh = settings({
+      soundsEnabled: true,
+      projectPaths: ["C:\\Fresh", "D:\\Other"],
+      projectPath: "C:\\Fresh",
+    });
+
+    expect(mergeSettingsForSavePreservingProjects(draft, fresh)).toMatchObject({
+      soundsEnabled: false,
+      projectPaths: ["C:\\Fresh", "D:\\Other"],
+      projectPath: "C:\\Fresh",
+    });
+  });
+});

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -11,6 +11,7 @@ import { settingsStore } from "../../shared/stores/settings";
 import { setSoundsEnabled } from "../../shared/sound";
 import { sessionsStore } from "../stores/sessions";
 import { AGENT_PRESET_MAP, newAgentId } from "../../shared/agent-presets";
+import { mergeSettingsForSavePreservingProjects } from "./settings-save";
 
 const GEMINI_MODELS = [
   { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash (recommended)" },
@@ -232,22 +233,27 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     }
     setSaveError("");
     setSaving(true);
-    await SettingsAPI.update(settings.data);
+    const nextSettings = mergeSettingsForSavePreservingProjects(
+      settings.data,
+      await SettingsAPI.get()
+    );
+    await SettingsAPI.update(nextSettings);
+    setSettings("data", nextSettings);
     // #158 — push soundsEnabled into sound.ts synchronously so the gate
     // updates before the settingsStore.refresh() roundtrip below resolves.
     // Without this, a beep emitted between this point and the next load()
     // would see the stale gate value.
-    setSoundsEnabled(settings.data.soundsEnabled ?? true);
+    setSoundsEnabled(nextSettings.soundsEnabled ?? true);
     if (isTauri) {
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
-      await getCurrentWindow().setAlwaysOnTop(settings.data.sidebarAlwaysOnTop);
+      await getCurrentWindow().setAlwaysOnTop(nextSettings.sidebarAlwaysOnTop);
     }
     // RTK sweep — only when the toggle value changed during this modal session.
     // Fired AFTER update_settings persists, so a sweep failure cannot leave
     // the persisted setting in disagreement with the on-disk replica state
     // worse than the pre-save baseline.
     const initial = initialInjectRtk();
-    const next = settings.data.injectRtkHook;
+    const next = nextSettings.injectRtkHook;
     if (initial !== null && initial !== next) {
       setRtkSweepInFlight(true);
       try {

--- a/src/sidebar/components/settings-save.ts
+++ b/src/sidebar/components/settings-save.ts
@@ -1,0 +1,12 @@
+import type { AppSettings } from "../../shared/types";
+
+export function mergeSettingsForSavePreservingProjects(
+  draft: AppSettings,
+  fresh: AppSettings
+): AppSettings {
+  return {
+    ...draft,
+    projectPaths: fresh.projectPaths ?? [],
+    projectPath: fresh.projectPath ?? null,
+  };
+}

--- a/src/sidebar/project-refresh-handler.ts
+++ b/src/sidebar/project-refresh-handler.ts
@@ -1,0 +1,13 @@
+import type { AcProjectRefreshRequestedPayload } from "../shared/types";
+import { projectStore } from "./stores/project";
+
+export function handleProjectRefreshRequested(
+  data: AcProjectRefreshRequestedPayload,
+  store: Pick<typeof projectStore, "loadProject" | "reloadProjectIfLoaded"> = projectStore
+) {
+  if (data.reason === "projectRegistered") {
+    void store.loadProject(data.projectPath);
+    return;
+  }
+  void store.reloadProjectIfLoaded(data.projectPath);
+}

--- a/src/sidebar/stores/project.test.ts
+++ b/src/sidebar/stores/project.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const m = vi.hoisted(() => ({
+  open: vi.fn(),
+  discover: vi.fn(),
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+}));
+
+vi.mock("../../shared/ipc", () => ({
+  ProjectAPI: {
+    open: m.open,
+    discover: m.discover,
+  },
+  SettingsAPI: {
+    get: m.getSettings,
+    update: m.updateSettings,
+  },
+  AgentCreatorAPI: {
+    pickFolder: vi.fn(),
+  },
+}));
+
+import { projectStore } from "./project";
+
+describe("projectStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectStore.clear();
+    m.open.mockResolvedValue({ path: "C:\\Users\\Maria\\Project" });
+    m.discover.mockResolvedValue({ workgroups: [], agents: [], teams: [] });
+  });
+
+  afterEach(() => {
+    projectStore.clear();
+  });
+
+  it("shares concurrent loadProject calls for equivalent paths", async () => {
+    await Promise.all([
+      projectStore.loadProject("C:\\Users\\Maria\\Project\\"),
+      projectStore.loadProject("c:/users/maria/project"),
+      projectStore.loadProject("\\\\?\\C:\\Users\\Maria\\Project"),
+    ]);
+
+    expect(m.open).toHaveBeenCalledTimes(1);
+    expect(m.discover).toHaveBeenCalledTimes(1);
+    expect(projectStore.projects).toHaveLength(1);
+    expect(projectStore.projects[0].path).toBe("C:\\Users\\Maria\\Project");
+  });
+});

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -16,6 +16,8 @@ export interface ProjectState {
 
 const [projects, setProjects] = createSignal<ProjectState[]>([]);
 const [loading, setLoading] = createSignal(false);
+const inFlightLoads = new Map<string, Promise<void>>();
+const inFlightReloads = new Map<string, Promise<void>>();
 let loadingCount = 0;
 
 function normalizePath(p: string): string {
@@ -41,47 +43,54 @@ export const projectStore = {
   async loadProject(path: string) {
     const normalized = normalizePath(path);
     if (projects().some((p) => normalizePath(p.path) === normalized)) return;
+    const existing = inFlightLoads.get(normalized);
+    if (existing) return existing;
 
-    loadingCount++;
-    setLoading(true);
-    try {
-      // #191 — backend owns the validation + dedup + persist atomically.
-      // Throws if `.ac/` is missing; caller (createAndLoad / pickAndCheck)
-      // is responsible for creating it first via projectStore.createAndLoad
-      // when that case is expected.
-      const reg = await ProjectAPI.open(path);
-      const result = await ProjectAPI.discover(reg.path);
-      const folderName =
-        reg.path.replace(/\\/g, "/").split("/").pop() ?? "unknown";
-      // Round-1 G2: re-check against the BACKEND-absolutised reg.path
-      // (which may differ from the input `path` in case/slashes/`..`),
-      // mirroring the inner dedup pattern in createAndLoad. Closes the
-      // double-render race when two concurrent calls pass differently-
-      // shaped strings that resolve to the same registered entry.
-      const normalizedReg = normalizePath(reg.path);
-      setProjects((prev) => {
-        if (prev.some((p) => normalizePath(p.path) === normalizedReg)) return prev;
-        return [
-          ...prev,
-          {
-            path: reg.path,
-            folderName,
-            workgroups: result.workgroups,
-            agents: result.agents,
-            teams: result.teams,
-          },
-        ];
-      });
-    } catch (e) {
-      // Round-1 G11 deferred: surface this to the user via toast/sidebar
-      // chip in a follow-up. For now, preserve the existing swallow-and-log
-      // so behaviour is no worse than today (initFromSettings silently drops
-      // a project whose Project AC Root was deleted between sessions.
-      console.error("Failed to load project:", e);
-    } finally {
-      loadingCount--;
-      if (loadingCount === 0) setLoading(false);
-    }
+    const promise = (async () => {
+      loadingCount++;
+      setLoading(true);
+      try {
+        // #191 — backend owns the validation + dedup + persist atomically.
+        // Throws if `.ac/` is missing; caller (createAndLoad / pickAndCheck)
+        // is responsible for creating it first via projectStore.createAndLoad
+        // when that case is expected.
+        const reg = await ProjectAPI.open(path);
+        const result = await ProjectAPI.discover(reg.path);
+        const folderName =
+          reg.path.replace(/\\/g, "/").split("/").pop() ?? "unknown";
+        // Round-1 G2: re-check against the BACKEND-absolutised reg.path
+        // (which may differ from the input `path` in case/slashes/`..`),
+        // mirroring the inner dedup pattern in createAndLoad. Closes the
+        // double-render race when two concurrent calls pass differently-
+        // shaped strings that resolve to the same registered entry.
+        const normalizedReg = normalizePath(reg.path);
+        setProjects((prev) => {
+          if (prev.some((p) => normalizePath(p.path) === normalizedReg)) return prev;
+          return [
+            ...prev,
+            {
+              path: reg.path,
+              folderName,
+              workgroups: result.workgroups,
+              agents: result.agents,
+              teams: result.teams,
+            },
+          ];
+        });
+      } catch (e) {
+        // Round-1 G11 deferred: surface this to the user via toast/sidebar
+        // chip in a follow-up. For now, preserve the existing swallow-and-log
+        // so behaviour is no worse than today (initFromSettings silently drops
+        // a project whose Project AC Root was deleted between sessions.
+        console.error("Failed to load project:", e);
+      } finally {
+        loadingCount--;
+        if (loadingCount === 0) setLoading(false);
+        inFlightLoads.delete(normalized);
+      }
+    })();
+    inFlightLoads.set(normalized, promise);
+    return promise;
   },
 
   /** Initialize from saved settings (call on mount) */
@@ -172,18 +181,27 @@ export const projectStore = {
   /** Re-discover a single project and update its data in place */
   async reloadProject(path: string) {
     const normalized = normalizePath(path);
-    try {
-      const result = await ProjectAPI.discover(path);
-      setProjects((prev) =>
-        prev.map((p) =>
-          normalizePath(p.path) === normalized
-            ? { ...p, workgroups: result.workgroups, agents: result.agents, teams: result.teams }
-            : p
-        )
-      );
-    } catch (e) {
-      console.error("Failed to reload project:", e);
-    }
+    const existing = inFlightReloads.get(normalized);
+    if (existing) return existing;
+
+    const promise = (async () => {
+      try {
+        const result = await ProjectAPI.discover(path);
+        setProjects((prev) =>
+          prev.map((p) =>
+            normalizePath(p.path) === normalized
+              ? { ...p, workgroups: result.workgroups, agents: result.agents, teams: result.teams }
+              : p
+          )
+        );
+      } catch (e) {
+        console.error("Failed to reload project:", e);
+      } finally {
+        inFlightReloads.delete(normalized);
+      }
+    })();
+    inFlightReloads.set(normalized, promise);
+    return promise;
   },
 
   /** Re-discover a project only when it is already loaded in the sidebar. */
@@ -203,6 +221,10 @@ export const projectStore = {
 
   clear() {
     setProjects([]);
+    loadingCount = 0;
+    setLoading(false);
+    inFlightLoads.clear();
+    inFlightReloads.clear();
   },
 };
 


### PR DESCRIPTION
## Summary
- emit project refresh requests when CLI project registration succeeds
- prioritize projectRegistered mailbox events so Sidebar loads newly registered projects
- update Sidebar refresh handling, duplicate guards, and SettingsModal stale-save preservation

## Verification
- cargo test --test cli_create_agent_matrix --test cli_workgroup_team --test cli_project_registration
- cargo test project_refresh_request
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- npm test -- project-refresh App.project-refresh project SettingsModal
- npm test
- npx tsc --noEmit
- npx tauri build
- deployed wg-1 executable and verified --help

Closes #459