### PR TITLE
Add dedicated team create CLI flow

### DIFF
--- a/docs/agents/teams-and-workgroups.md
+++ b/docs/agents/teams-and-workgroups.md
@@ -30,7 +30,7 @@ my-project/
 }
 ```
 
-You create teams from the **Teams** UI in the sidebar, or from the CLI when creating a workgroup. Pick a coordinator (must already exist as an agent), pick one or more members, save.
+You create teams from the **Teams** UI in the sidebar, or from the CLI with `team create`. Pick a coordinator (must already exist as an agent), pick one or more members, save.
 
 ### Coordinator authority
 
@@ -116,27 +116,36 @@ From the UI, click **Activate** on the team. From the CLI, use `workgroup add`. 
 When activated from the UI, AC also launches the coordinator's session. The CLI creates the workgroup and requests a sidebar refresh; launch sessions separately as needed.
 
 ```bash
-agentscommander workgroup add \
+agentscommander team create \
   --project MyProject \
   --team "Feature X" \
-  --title "Add OAuth2 login flow" \
   --coordinator tech-lead \
   --agent dev-rust \
   --agent dev-ts
-```
 
-Repository access can be assigned at creation:
-
-```bash
 agentscommander workgroup add \
   --project MyProject \
   --team "Feature X" \
-  --title "Add OAuth2 login flow" \
+  --title "Add OAuth2 login flow"
+```
+
+Repository access can be assigned when the team is created:
+
+```bash
+agentscommander team create \
+  --project MyProject \
+  --team "Feature X" \
   --coordinator tech-lead \
   --agent dev-rust \
+  --agent dev-ts \
   --repo https://github.com/org/app.git \
   --repo-agents https://github.com/org/admin.git=tech-lead,dev-rust \
   --repo-exclude-agents https://github.com/org/docs.git=dev-ts
+
+agentscommander workgroup add \
+  --project MyProject \
+  --team "Feature X" \
+  --title "Add OAuth2 login flow"
 ```
 
 Plain `--repo` assigns the repo to the final team roster. `--repo-agents` includes only the named agents for that repo. `--repo-exclude-agents` assigns the repo to the final team roster minus the named agents. The include and exclude forms are mutually exclusive per repo URL.

--- a/docs/agents/teams-and-workgroups.md
+++ b/docs/agents/teams-and-workgroups.md
@@ -4,7 +4,7 @@ For developers ready to compose multiple agents around a shared goal. Teams defi
 
 ## Team
 
-A **team** is one coordinator plus one or more worker agents. The team's config lives at `.ac/_team_<name>/config.json` and lists members by their canonical names.
+A **team** is one coordinator plus one or more worker agents. The coordinator and every member must already exist as agent matrices before you create the team. The team's config lives at `.ac/_team_<name>/config.json` and lists members by their canonical names.
 
 ```
 my-project/
@@ -30,7 +30,7 @@ my-project/
 }
 ```
 
-You create teams from the **Teams** UI in the sidebar, or from the CLI with `team create`. Pick a coordinator (must already exist as an agent), pick one or more members, save.
+You create teams from the **Teams** UI in the sidebar, or from the CLI with `team create`. Pick an existing coordinator agent, pick one or more existing member agents, optionally define repo access, then save. Workgroups are created later when you activate the team for a task.
 
 ### Coordinator authority
 
@@ -129,7 +129,7 @@ agentscommander workgroup add \
   --title "Add OAuth2 login flow"
 ```
 
-Repository access can be assigned when the team is created:
+Repository access is a team-level definition. Set it during team creation or editing; `workgroup add` only activates an existing team and uses the repo access already defined on that team.
 
 ```bash
 agentscommander team create \
@@ -173,7 +173,7 @@ agentscommander team add-member \
   --agent qa
 ```
 
-This updates the team config and creates `wg-1-feature-x/__agent_qa/` immediately. Use `--coordinator` to make the added agent the coordinator.
+This updates the team config used by `wg-1-feature-x` and creates `wg-1-feature-x/__agent_qa/` immediately. Use `--coordinator` to make the added agent the coordinator.
 
 Remove a non-coordinator member with:
 
@@ -185,6 +185,8 @@ agentscommander team remove-member \
 ```
 
 Removal refuses live sessions under that member's replica.
+
+Membership edits are scoped to the selected workgroup. Other existing workgroups for the same team are not updated globally, so update or recreate those workgroups separately when they need the same roster change.
 
 ## Recovery
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,18 +49,18 @@ In the sidebar, click **New Project** and point at any folder, empty or an exist
 
 ## 3. Create your first Team
 
-Open the Teams pane. A **Team** is one coordinator plus one or more worker agents working toward a shared goal.
+Open the Teams pane. A **Team** is one coordinator plus one or more worker agents working toward a shared goal. The agents are created first, then the team definition links those existing agents together.
 
 1. Click **+ Team** and give it a name (for example `feature-x`).
 2. Add the **coordinator** — give the agent a directory name (for example `tech-lead`), pick a role template from the [Agents Agency picker](integrations/coding-agents.md#role-template-picker), and finish.
 3. Add one **worker** the same way (for example `dev-rust` with the *Rust developer* template).
 4. Mark the first agent as **coordinator**.
 
-Behind the scenes AC creates `.ac/wg-1-<team-name>/__agent_tech-lead/` and `__agent_dev-rust/` with `Role.md` files inside.
+Behind the scenes AC creates agent matrices under `.ac/_agent_tech-lead/` and `.ac/_agent_dev-rust/`, then saves the team definition under `.ac/_team_<team-name>/`.
 
 ## 4. Write a brief and launch the coordinator
 
-Open the team's `TASK.md` and write what you want the team to do. One paragraph is enough; the coordinator will expand it.
+Activate the team for a task and give the workgroup a title. AC creates `.ac/wg-1-<team-name>/`, including `TASK.md`, `messaging/`, and each `__agent_<name>/` replica. Open the new `TASK.md` and write what you want the team to do. One paragraph is enough; the coordinator will expand it.
 
 Click the coordinator's session in the sidebar. AC opens a real terminal and prompts you to pick a coding agent (Claude Code, Codex, or Gemini). Pick one. AC launches the agent in the coordinator's directory with the role and brief already loaded.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -186,7 +186,7 @@ Output is JSON. Each item includes `name`, `team`, `path`, `hasMessaging`, `hasT
 
 ## `team create`
 
-Create a team configuration in a registered project.
+Create a team configuration in a registered project from existing agent matrices. Create the coordinator and member agents first, then create the team, then activate it with `workgroup add`.
 
 ```bash
 agentscommander team create \
@@ -207,10 +207,10 @@ agentscommander workgroup add \
 | `--project` | Yes | Registered project name. |
 | `--team` | Yes | Team name. Sanitized for `_team_<name>`. |
 | `--coordinator` | Yes | Existing agent matrix name or `_agent_<name>` reference. Automatically included in the roster. |
-| `--agent` | No | Worker/member agent. Repeat for multiple agents. |
-| `--repo` | No | Repo URL assigned to the full final roster. Repeat for multiple repos. |
-| `--repo-agents` | No | `URL=agent-a,agent-b`; assigns only listed agents to that repo. |
-| `--repo-exclude-agents` | No | `URL=agent-a,agent-b`; assigns the full final roster except listed agents. |
+| `--agent` | No | Existing agent matrix name or `_agent_<name>` reference. Repeat for multiple members. |
+| `--repo` | No | Repo URL assigned to the full final roster when workgroups are created. Repeat for multiple repos. |
+| `--repo-agents` | No | `URL=agent-a,agent-b`; defines repo access for only the listed team agents when workgroups are created. |
+| `--repo-exclude-agents` | No | `URL=agent-a,agent-b`; defines repo access for the final team roster except listed agents when workgroups are created. |
 
 Output is JSON:
 
@@ -247,9 +247,7 @@ agentscommander workgroup add \
 
 Workgroup numbers are allocated globally per project as the lowest free positive integer, across all teams. Deleted numbers are reused. There is no `--name` override.
 
-`workgroup add` activates an existing team and refuses to update existing team configuration. Create or change the team with `team create` and `team add-member` first.
-
-Deprecated compatibility flags are still accepted only when the target team is missing: `--coordinator`, `--agent`, `--repo`, `--repo-agents`, and `--repo-exclude-agents`. New scripts should not use them. When the team already exists, passing any of those flags fails before disk writes.
+`workgroup add` activates an existing team and refuses to update existing team configuration. Create the agents first, define the team with `team create`, then activate the workgroup with project, team, and title.
 
 Output is JSON `{ path, cloneErrors }`. Clone failures are reported in `cloneErrors` and do not roll back workgroup creation.
 
@@ -309,7 +307,7 @@ agentscommander team add-member \
 | `--agent` | Yes | Existing agent matrix name or `_agent_<name>` reference. |
 | `--coordinator` | No | Make the added agent the coordinator. |
 
-The command writes the team config, creates `wg-.../__agent_<name>/`, applies replica settings, and clones missing assigned repos into the workgroup. Output is JSON.
+The command writes the team config used by the selected workgroup, creates `wg-.../__agent_<name>/`, applies replica settings, and clones missing assigned repos into that workgroup. Other existing workgroups for the same team are not updated globally; update or recreate them separately when they need the same roster change. Output is JSON.
 
 ---
 
@@ -330,7 +328,7 @@ agentscommander team remove-member \
 | `--workgroup` | Yes | Existing workgroup name. |
 | `--agent` | Yes | Existing agent matrix name or `_agent_<name>` reference. |
 
-The command refuses to remove the current coordinator and refuses live sessions under the target replica. It also removes the agent from repo assignments in the team config.
+The command refuses to remove the current coordinator and refuses live sessions under the target replica. It also removes the agent from repo assignments in the team config used by the selected workgroup. Other existing workgroups for the same team are not updated globally; update or recreate them separately when they need the same roster change.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -184,18 +184,59 @@ Output is JSON. Each item includes `name`, `team`, `path`, `hasMessaging`, `hasT
 
 ---
 
+## `team create`
+
+Create a team configuration in a registered project.
+
+```bash
+agentscommander team create \
+  --project MyProject \
+  --team "Dev Team" \
+  --coordinator architect \
+  --agent dev-rust \
+  --agent dev-ts
+
+agentscommander workgroup add \
+  --project MyProject \
+  --team "Dev Team" \
+  --title "Add OAuth2 login flow"
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--project` | Yes | Registered project name. |
+| `--team` | Yes | Team name. Sanitized for `_team_<name>`. |
+| `--coordinator` | Yes | Existing agent matrix name or `_agent_<name>` reference. Automatically included in the roster. |
+| `--agent` | No | Worker/member agent. Repeat for multiple agents. |
+| `--repo` | No | Repo URL assigned to the full final roster. Repeat for multiple repos. |
+| `--repo-agents` | No | `URL=agent-a,agent-b`; assigns only listed agents to that repo. |
+| `--repo-exclude-agents` | No | `URL=agent-a,agent-b`; assigns the full final roster except listed agents. |
+
+Output is JSON:
+
+```json
+{
+  "team": "dev-team",
+  "path": "C:\\...\\.ac\\_team_dev-team",
+  "agents": ["_agent_architect", "_agent_dev-rust", "_agent_dev-ts"],
+  "coordinator": "_agent_architect",
+  "repos": []
+}
+```
+
+Repo include and exclude forms are mutually exclusive for the same URL. `team create` refuses to overwrite an existing `_team_<name>` directory, even when it has no `config.json`.
+
+---
+
 ## `workgroup add`
 
-Create an auto-numbered workgroup for a team.
+Create an auto-numbered workgroup for an existing team.
 
 ```bash
 agentscommander workgroup add \
   --project MyProject \
   --team "Dev Team" \
-  --title "Add OAuth2 login flow" \
-  --coordinator architect \
-  --agent dev-rust \
-  --agent dev-ts
+  --title "Add OAuth2 login flow"
 ```
 
 | Flag | Required | Description |
@@ -203,15 +244,14 @@ agentscommander workgroup add \
 | `--project` | Yes | Registered project name. |
 | `--team` | Yes | Team name. Sanitized for `_team_<name>` and `wg-<N>-<name>`. |
 | `--title` | Yes | Initial `TASK.md` title. |
-| `--coordinator` | Yes | Existing agent to make coordinator. |
-| `--agent` | No | Team member to add before provisioning. Repeat for multiple agents. |
-| `--repo` | No | Repo URL assigned to the full final roster. Repeat for multiple repos. |
-| `--repo-agents` | No | `URL=agent-a,agent-b`; assigns only listed agents to that repo. |
-| `--repo-exclude-agents` | No | `URL=agent-a,agent-b`; assigns the full final roster except listed agents. |
 
 Workgroup numbers are allocated globally per project as the lowest free positive integer, across all teams. Deleted numbers are reused. There is no `--name` override.
 
-Repo include and exclude forms are mutually exclusive for the same URL. Output is JSON `{ path, cloneErrors }`. Clone failures are reported in `cloneErrors` and do not roll back workgroup creation.
+`workgroup add` activates an existing team and refuses to update existing team configuration. Create or change the team with `team create` and `team add-member` first.
+
+Deprecated compatibility flags are still accepted only when the target team is missing: `--coordinator`, `--agent`, `--repo`, `--repo-agents`, and `--repo-exclude-agents`. New scripts should not use them. When the team already exists, passing any of those flags fails before disk writes.
+
+Output is JSON `{ path, cloneErrors }`. Clone failures are reported in `cloneErrors` and do not roll back workgroup creation.
 
 ---
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -121,7 +121,7 @@ pub enum Commands {
     TelegramSendImage(telegram_send_image::TelegramSendImageArgs),
     /// Manage workgroups in an AC project
     Workgroup(workgroup::WorkgroupArgs),
-    /// Manage team membership in an AC workgroup
+    /// Manage teams and scoped workgroup membership
     Team(team::TeamArgs),
     /// Execute commands through the policy harness
     Harness(harness::HarnessArgs),

--- a/src-tauri/src/cli/team.rs
+++ b/src-tauri/src/cli/team.rs
@@ -2,14 +2,14 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use crate::cli::workgroup::{
-    clone_missing_for_config, push_unique, resolve_cli_project, resolve_cli_workspace,
-    write_refresh,
+    build_new_team_config, clone_missing_for_config, push_unique, resolve_cli_project,
+    resolve_cli_workspace, write_refresh,
 };
 use crate::commands::entity_creation::{
-    agent_ref_bare_name, create_or_update_replica_on_disk, normalize_team_config_for_project,
-    parse_team_from_workgroup_name, read_team_config, remove_replica_dir, resolve_agent_ref,
-    validate_existing_name, write_team_config, AgentMatrixSettingsFlags, ReplicaDiskCreateArgs,
-    RepoAssignment,
+    agent_ref_bare_name, create_new_team_config_on_disk, create_or_update_replica_on_disk,
+    normalize_team_config_for_project, parse_team_from_workgroup_name, read_team_config,
+    remove_replica_dir, resolve_agent_ref, sanitize_name, validate_existing_name,
+    write_team_config, AgentMatrixSettingsFlags, ReplicaDiskCreateArgs, RepoAssignment,
 };
 
 #[derive(Args)]
@@ -20,6 +20,8 @@ pub struct TeamArgs {
 
 #[derive(Subcommand)]
 enum TeamCommand {
+    /// Create a team configuration
+    Create(TeamCreateArgs),
     /// List team configuration
     List(TeamListArgs),
     /// Add an agent to one workgroup and team config
@@ -34,6 +36,24 @@ struct TeamListArgs {
     project: String,
     #[arg(long)]
     workgroup: Option<String>,
+}
+
+#[derive(Args)]
+struct TeamCreateArgs {
+    #[arg(long)]
+    project: String,
+    #[arg(long)]
+    team: String,
+    #[arg(long)]
+    coordinator: String,
+    #[arg(long = "agent")]
+    agents: Vec<String>,
+    #[arg(long = "repo")]
+    repos: Vec<String>,
+    #[arg(long = "repo-agents")]
+    repo_agents: Vec<String>,
+    #[arg(long = "repo-exclude-agents")]
+    repo_exclude_agents: Vec<String>,
 }
 
 #[derive(Args)]
@@ -70,6 +90,16 @@ struct TeamListItem {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct TeamCreateResult {
+    team: String,
+    path: String,
+    agents: Vec<String>,
+    coordinator: String,
+    repos: Vec<RepoAssignment>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct AddMemberResult {
     team: String,
     workgroup: String,
@@ -92,6 +122,7 @@ struct RemoveMemberResult {
 
 pub fn execute(args: TeamArgs) -> i32 {
     let result = match args.command {
+        TeamCommand::Create(args) => create(args),
         TeamCommand::List(args) => list(args),
         TeamCommand::AddMember(args) => add_member(args),
         TeamCommand::RemoveMember(args) => remove_member(args),
@@ -103,6 +134,29 @@ pub fn execute(args: TeamArgs) -> i32 {
             1
         }
     }
+}
+
+fn create(args: TeamCreateArgs) -> Result<(), String> {
+    let project_path = resolve_cli_project(&args.project)?;
+    let workspace_dir = resolve_cli_workspace(&project_path)?;
+    let safe_team = sanitize_name(&args.team)?;
+    let config = build_new_team_config(
+        &workspace_dir,
+        &args.coordinator,
+        &args.agents,
+        &args.repos,
+        &args.repo_agents,
+        &args.repo_exclude_agents,
+    )?;
+    let team_dir = create_new_team_config_on_disk(&workspace_dir, &safe_team, &config)?;
+    write_refresh(&project_path, &team_dir, &safe_team, "teamCreated");
+    print_json(&TeamCreateResult {
+        team: safe_team,
+        path: team_dir.to_string_lossy().to_string(),
+        agents: config.agents,
+        coordinator: config.coordinator,
+        repos: config.repos,
+    })
 }
 
 fn list(args: TeamListArgs) -> Result<(), String> {

--- a/src-tauri/src/cli/team.rs
+++ b/src-tauri/src/cli/team.rs
@@ -20,7 +20,7 @@ pub struct TeamArgs {
 
 #[derive(Subcommand)]
 enum TeamCommand {
-    /// Create a team configuration
+    /// Create a team configuration from existing agents
     Create(TeamCreateArgs),
     /// List team configuration
     List(TeamListArgs),
@@ -44,15 +44,30 @@ struct TeamCreateArgs {
     project: String,
     #[arg(long)]
     team: String,
-    #[arg(long)]
+    #[arg(
+        long,
+        help = "Existing agent matrix name or _agent_<name> reference. Automatically included in the roster"
+    )]
     coordinator: String,
-    #[arg(long = "agent")]
+    #[arg(
+        long = "agent",
+        help = "Existing agent matrix name or _agent_<name> reference. Repeat for multiple members"
+    )]
     agents: Vec<String>,
-    #[arg(long = "repo")]
+    #[arg(
+        long = "repo",
+        help = "Define a repo available to the team when workgroups are created. Repeat for multiple repos"
+    )]
     repos: Vec<String>,
-    #[arg(long = "repo-agents")]
+    #[arg(
+        long = "repo-agents",
+        help = "Define team repo access for workgroup creation as URL=agent-a,agent-b"
+    )]
     repo_agents: Vec<String>,
-    #[arg(long = "repo-exclude-agents")]
+    #[arg(
+        long = "repo-exclude-agents",
+        help = "Define team repo access for workgroup creation as URL=excluded-agent-a,excluded-agent-b"
+    )]
     repo_exclude_agents: Vec<String>,
 }
 

--- a/src-tauri/src/cli/workgroup.rs
+++ b/src-tauri/src/cli/workgroup.rs
@@ -44,27 +44,15 @@ struct WorkgroupAddArgs {
     team: String,
     #[arg(long)]
     title: String,
-    #[arg(long, help = "Deprecated on workgroup add; use team create first")]
+    #[arg(long, hide = true)]
     coordinator: Option<String>,
-    #[arg(
-        long = "agent",
-        help = "Deprecated on workgroup add; use team create first"
-    )]
+    #[arg(long = "agent", hide = true)]
     agents: Vec<String>,
-    #[arg(
-        long = "repo",
-        help = "Deprecated on workgroup add; use team create first"
-    )]
+    #[arg(long = "repo", hide = true)]
     repos: Vec<String>,
-    #[arg(
-        long = "repo-agents",
-        help = "Deprecated on workgroup add; use team create first"
-    )]
+    #[arg(long = "repo-agents", hide = true)]
     repo_agents: Vec<String>,
-    #[arg(
-        long = "repo-exclude-agents",
-        help = "Deprecated on workgroup add; use team create first"
-    )]
+    #[arg(long = "repo-exclude-agents", hide = true)]
     repo_exclude_agents: Vec<String>,
 }
 
@@ -202,11 +190,10 @@ fn add(args: WorkgroupAddArgs) -> Result<(), String> {
         None
     } else if has_legacy_team_flags {
         let coordinator = args.coordinator.as_deref().ok_or_else(|| {
-            "--coordinator is required when using deprecated team-definition flags on workgroup add"
-                .to_string()
+            "--coordinator is required when supplying team details on workgroup add".to_string()
         })?;
         eprintln!(
-            "Warning: using deprecated `workgroup add` team-definition flags. Use `team create` first, then `workgroup add` without --coordinator/--agent/--repo flags."
+            "Warning: created missing team configuration from supplied workgroup details. Prefer creating the team before activating a workgroup."
         );
         Some(build_new_team_config(
             &workspace_dir,

--- a/src-tauri/src/cli/workgroup.rs
+++ b/src-tauri/src/cli/workgroup.rs
@@ -44,15 +44,27 @@ struct WorkgroupAddArgs {
     team: String,
     #[arg(long)]
     title: String,
-    #[arg(long)]
-    coordinator: String,
-    #[arg(long = "agent")]
+    #[arg(long, help = "Deprecated on workgroup add; use team create first")]
+    coordinator: Option<String>,
+    #[arg(
+        long = "agent",
+        help = "Deprecated on workgroup add; use team create first"
+    )]
     agents: Vec<String>,
-    #[arg(long = "repo")]
+    #[arg(
+        long = "repo",
+        help = "Deprecated on workgroup add; use team create first"
+    )]
     repos: Vec<String>,
-    #[arg(long = "repo-agents")]
+    #[arg(
+        long = "repo-agents",
+        help = "Deprecated on workgroup add; use team create first"
+    )]
     repo_agents: Vec<String>,
-    #[arg(long = "repo-exclude-agents")]
+    #[arg(
+        long = "repo-exclude-agents",
+        help = "Deprecated on workgroup add; use team create first"
+    )]
     repo_exclude_agents: Vec<String>,
 }
 
@@ -100,8 +112,12 @@ pub(crate) fn resolve_cli_project(project: &str) -> Result<PathBuf, String> {
 }
 
 pub(crate) fn resolve_cli_workspace(project_path: &Path) -> Result<PathBuf, String> {
-    existing_workspace_dir(project_path)
-        .ok_or_else(|| format!("Project AC Root not found in {} (.ac)", project_path.display()))
+    existing_workspace_dir(project_path).ok_or_else(|| {
+        format!(
+            "Project AC Root not found in {} (.ac)",
+            project_path.display()
+        )
+    })
 }
 
 pub(crate) fn write_refresh(project_path: &Path, changed_path: &Path, name: &str, reason: &str) {
@@ -167,25 +183,64 @@ fn add(args: WorkgroupAddArgs) -> Result<(), String> {
     let project_path = resolve_cli_project(&args.project)?;
     let workspace_dir = resolve_cli_workspace(&project_path)?;
     let safe_team = sanitize_name(&args.team)?;
-    let final_config = build_final_team_config(
-        &workspace_dir,
-        &safe_team,
-        &args.coordinator,
-        &args.agents,
-        &args.repos,
-        &args.repo_agents,
-        &args.repo_exclude_agents,
-    )?;
+    let has_legacy_team_flags = args.coordinator.is_some()
+        || !args.agents.is_empty()
+        || !args.repos.is_empty()
+        || !args.repo_agents.is_empty()
+        || !args.repo_exclude_agents.is_empty();
+    let team_dir = workspace_dir.join(format!("_team_{}", safe_team));
+    let config_path = team_dir.join("config.json");
+    let team_config_exists = team_dir.exists() || config_path.exists();
+    let provisioning_config = if team_config_exists {
+        read_team_config(&workspace_dir, &safe_team)?;
+        if has_legacy_team_flags {
+            return Err(format!(
+                "Team '{}' already exists. `workgroup add` no longer updates team configuration. Use `team create` before `workgroup add`, or `team add-member` for membership changes.",
+                safe_team
+            ));
+        }
+        None
+    } else if has_legacy_team_flags {
+        let coordinator = args.coordinator.as_deref().ok_or_else(|| {
+            "--coordinator is required when using deprecated team-definition flags on workgroup add"
+                .to_string()
+        })?;
+        eprintln!(
+            "Warning: using deprecated `workgroup add` team-definition flags. Use `team create` first, then `workgroup add` without --coordinator/--agent/--repo flags."
+        );
+        Some(build_new_team_config(
+            &workspace_dir,
+            coordinator,
+            &args.agents,
+            &args.repos,
+            &args.repo_agents,
+            &args.repo_exclude_agents,
+        )?)
+    } else {
+        return Err(format!(
+            "Team '{}' config not found. Create it first with `team create`.",
+            safe_team
+        ));
+    };
     let settings = crate::config::settings::load_settings_for_cli();
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|e| format!("Failed to create async runtime: {}", e))?;
+    let (coordinator, agents, repos) = if let Some(config) = provisioning_config {
+        (
+            Some(config.coordinator.clone()),
+            config.agents.clone(),
+            config.repos.clone(),
+        )
+    } else {
+        (None, Vec::new(), Vec::new())
+    };
     let result = runtime.block_on(create_workgroup_on_disk(WorkgroupDiskCreateArgs {
         project_path: project_path.clone(),
         team_name: safe_team,
         task_title: args.title,
-        coordinator: Some(final_config.coordinator.clone()),
-        agents: final_config.agents.clone(),
-        repos: final_config.repos.clone(),
+        coordinator,
+        agents,
+        repos,
         settings_flags: AgentMatrixSettingsFlags::from_settings(&settings),
     }))?;
     let changed_path = PathBuf::from(&result.path);
@@ -246,42 +301,26 @@ fn remove(args: WorkgroupRemoveArgs) -> Result<(), String> {
     }
 }
 
-pub(crate) fn build_final_team_config(
+pub(crate) fn build_new_team_config(
     workspace_dir: &Path,
-    team_name: &str,
     coordinator: &str,
     agents: &[String],
     repos: &[String],
     repo_agents: &[String],
     repo_exclude_agents: &[String],
 ) -> Result<TeamConfigResult, String> {
-    let existing = read_team_config(workspace_dir, team_name).ok();
-    let mut roster = Vec::new();
-    if let Some(config) = existing.as_ref() {
-        for agent in &config.agents {
-            push_unique(&mut roster, resolve_agent_ref(workspace_dir, agent)?);
-        }
-    }
+    let coordinator = resolve_agent_ref(workspace_dir, coordinator)?;
+    let mut roster = vec![coordinator.clone()];
     for agent in agents {
         push_unique(&mut roster, resolve_agent_ref(workspace_dir, agent)?);
     }
-    let coordinator = resolve_agent_ref(workspace_dir, coordinator)?;
-    push_unique(&mut roster, coordinator.clone());
-    if roster.is_empty() {
-        return Err("At least one team agent is required".to_string());
-    }
-    let repo_config =
-        if repos.is_empty() && repo_agents.is_empty() && repo_exclude_agents.is_empty() {
-            existing.map(|config| config.repos).unwrap_or_default()
-        } else {
-            build_repo_assignments(
-                workspace_dir,
-                &roster,
-                repos,
-                repo_agents,
-                repo_exclude_agents,
-            )?
-        };
+    let repo_config = build_repo_assignments(
+        workspace_dir,
+        &roster,
+        repos,
+        repo_agents,
+        repo_exclude_agents,
+    )?;
     Ok(TeamConfigResult {
         agents: roster,
         coordinator,

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -91,6 +91,8 @@ pub(crate) struct WorkgroupDiskCreateArgs {
     pub project_path: PathBuf,
     pub team_name: String,
     pub task_title: String,
+    // Legacy provisioning path. Ordinary callers should pass None and empty
+    // vectors so workgroup creation activates an existing team config.
     pub coordinator: Option<String>,
     pub agents: Vec<String>,
     pub repos: Vec<RepoAssignment>,
@@ -640,6 +642,29 @@ pub(crate) fn write_team_config(
     Ok(team_dir)
 }
 
+pub(crate) fn create_new_team_config_on_disk(
+    workspace_dir: &Path,
+    team_name: &str,
+    config: &TeamConfigResult,
+) -> Result<PathBuf, String> {
+    validate_existing_name(team_name, "Team")?;
+    let team_dir = workspace_dir.join(format!("_team_{}", team_name));
+    std::fs::create_dir(&team_dir).map_err(|e| match e.kind() {
+        std::io::ErrorKind::AlreadyExists => format!("Team '{}' already exists", team_name),
+        _ => format!("Failed to create team directory: {}", e),
+    })?;
+    std::fs::create_dir(team_dir.join("memory"))
+        .map_err(|e| format!("Failed to create memory directory: {}", e))?;
+    std::fs::write(team_dir.join("conventions.md"), "")
+        .map_err(|e| format!("Failed to write conventions.md: {}", e))?;
+    let config = normalize_team_config_for_project(workspace_dir, config)?;
+    let config_str = serde_json::to_string_pretty(&config)
+        .map_err(|e| format!("Failed to serialize config.json: {}", e))?;
+    std::fs::write(team_dir.join("config.json"), config_str)
+        .map_err(|e| format!("Failed to write config.json: {}", e))?;
+    Ok(team_dir)
+}
+
 pub(crate) fn normalize_team_config_for_project(
     workspace_dir: &Path,
     config: &TeamConfigResult,
@@ -1017,8 +1042,12 @@ pub async fn delete_agent_matrix(project_path: String, agent_name: String) -> Re
     // the final path component after replacing backslashes.
     let agent_dir_name = format!("_agent_{}", agent_name);
     let mut referencing_teams: Vec<String> = Vec::new();
-    let entries = std::fs::read_dir(&base)
-        .map_err(|e| format!("Cannot read Project AC Root directory for integrity check: {}", e))?;
+    let entries = std::fs::read_dir(&base).map_err(|e| {
+        format!(
+            "Cannot read Project AC Root directory for integrity check: {}",
+            e
+        )
+    })?;
     for entry in entries {
         let entry = entry
             .map_err(|e| format!("Cannot read directory entry during integrity check: {}", e))?;
@@ -1151,11 +1180,6 @@ pub async fn create_team(
     let safe_name = sanitize_name(&name)?;
     let base = selected_workspace_dir(Path::new(&project_path))?;
 
-    let team_dir = base.join(format!("_team_{}", safe_name));
-    if team_dir.exists() {
-        return Err(format!("Team '{}' already exists", safe_name));
-    }
-
     let config = normalize_team_config_for_project(
         &base,
         &TeamConfigResult {
@@ -1164,7 +1188,7 @@ pub async fn create_team(
             repos,
         },
     )?;
-    write_team_config(&base, &safe_name, &config)?;
+    let team_dir = create_new_team_config_on_disk(&base, &safe_name, &config)?;
 
     let result_path = team_dir.to_string_lossy().to_string();
     log::info!("[entity_creation] Created team: {}", result_path);

--- a/src-tauri/src/config/root_agent.rs
+++ b/src-tauri/src/config/root_agent.rs
@@ -154,7 +154,7 @@ When asked to set up a new team for automation, use this order:
 2. Create the team with `team create`, choosing one coordinator and the worker agents.
 3. Activate a task workspace with `workgroup add` using only `--project`, `--team`, and `--title`.
 
-Do not use `workgroup add --coordinator` to create or update a team. That legacy path exists only for compatibility.
+Agents must exist before team creation. Team creation defines membership and repo access; workgroup activation uses the existing team definition.
 
 ## Agency Agents Roles
 
@@ -731,7 +731,8 @@ mod tests {
         assert!(ROOT_ROLE_MD.contains("Do not invent Agency template IDs"));
         assert!(ROOT_ROLE_MD.contains("team create"));
         assert!(ROOT_ROLE_MD.contains("workgroup add"));
-        assert!(ROOT_ROLE_MD.contains("Do not use `workgroup add --coordinator`"));
+        assert!(ROOT_ROLE_MD.contains("Agents must exist before team creation"));
+        assert!(!ROOT_ROLE_MD.contains("workgroup add --coordinator"));
         let template_path = temp
             .path()
             .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);

--- a/src-tauri/src/config/root_agent.rs
+++ b/src-tauri/src/config/root_agent.rs
@@ -146,6 +146,16 @@ You are not a workgroup replica and you do not have an origin Agent Matrix. Use 
 
 Coordinate across workgroups at a high level. Delegate specialized implementation work to the appropriate team coordinators and synthesize their results for the user.
 
+## Team and workgroup setup
+
+When asked to set up a new team for automation, use this order:
+
+1. Create any missing agents with `create-agent-matrix`.
+2. Create the team with `team create`, choosing one coordinator and the worker agents.
+3. Activate a task workspace with `workgroup add` using only `--project`, `--team`, and `--title`.
+
+Do not use `workgroup add --coordinator` to create or update a team. That legacy path exists only for compatibility.
+
 ## Agency Agents Roles
 
 You may offer to download tested role templates from Agency Agents when the user wants a new specialist role. Ask before downloading or updating. If the user accepts, use the AgentsCommander CLI from `AGENTSCOMMANDER_BINARY_PATH`:
@@ -719,6 +729,9 @@ mod tests {
         assert!(ROOT_ROLE_MD.contains("agency-templates update"));
         assert!(ROOT_ROLE_MD.contains("agency-templates list"));
         assert!(ROOT_ROLE_MD.contains("Do not invent Agency template IDs"));
+        assert!(ROOT_ROLE_MD.contains("team create"));
+        assert!(ROOT_ROLE_MD.contains("workgroup add"));
+        assert!(ROOT_ROLE_MD.contains("Do not use `workgroup add --coordinator`"));
         let template_path = temp
             .path()
             .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME);

--- a/src-tauri/tests/cli_workgroup_team.rs
+++ b/src-tauri/tests/cli_workgroup_team.rs
@@ -166,6 +166,47 @@ fn run_fail(bin: &Path, args: &[&str]) -> String {
     String::from_utf8_lossy(&out.stderr).to_string()
 }
 
+fn run_stdout(bin: &Path, args: &[&str]) -> String {
+    let out = Command::new(bin).args(args).output().expect("spawn");
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+#[test]
+fn team_help_describes_existing_agents_and_workgroup_scoped_membership() {
+    let tmp = Tmp::new("cli-team-help");
+    let bin = copy_binary_into(tmp.path());
+
+    let team_help = run_stdout(&bin, &["team", "--help"]);
+    assert!(team_help.contains("Manage teams and scoped workgroup membership"));
+
+    let create_help = run_stdout(&bin, &["team", "create", "--help"]);
+    assert!(create_help.contains("Create a team configuration from existing agents"));
+    assert!(create_help.contains("Existing agent matrix name or _agent_<name> reference"));
+    assert!(create_help.contains("Define a repo available to the team when workgroups are created"));
+}
+
+#[test]
+fn workgroup_add_help_hides_team_definition_flags() {
+    let tmp = Tmp::new("cli-workgroup-help");
+    let bin = copy_binary_into(tmp.path());
+
+    let help = run_stdout(&bin, &["workgroup", "add", "--help"]);
+    assert!(help.contains("--project"));
+    assert!(help.contains("--team"));
+    assert!(help.contains("--title"));
+    assert!(!help.contains("--coordinator"));
+    assert!(!help.contains("--agent"));
+    assert!(!help.contains("--repo"));
+    assert!(!help.to_ascii_lowercase().contains("deprecated"));
+}
+
 #[test]
 fn workgroup_add_creates_task_messaging_replicas_and_lists() {
     let tmp = Tmp::new("cli-workgroup-add");
@@ -781,7 +822,9 @@ fn workgroup_add_legacy_missing_team_still_bootstraps_with_warning() {
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
-    assert!(String::from_utf8_lossy(&out.stderr).contains("deprecated"));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("created missing team configuration"));
+    assert!(!stderr.to_ascii_lowercase().contains("deprecated"));
     assert!(project
         .join(".ac")
         .join("_team_dev-team")

--- a/src-tauri/tests/cli_workgroup_team.rs
+++ b/src-tauri/tests/cli_workgroup_team.rs
@@ -155,6 +155,17 @@ fn run_json_machine(bin: &Path, args: &[&str]) -> serde_json::Value {
     serde_json::from_slice(&out.stdout).expect("stdout json")
 }
 
+fn run_fail(bin: &Path, args: &[&str]) -> String {
+    let out = Command::new(bin).args(args).output().expect("spawn");
+    assert!(
+        !out.status.success(),
+        "expected failure\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
 #[test]
 fn workgroup_add_creates_task_messaging_replicas_and_lists() {
     let tmp = Tmp::new("cli-workgroup-add");
@@ -162,6 +173,33 @@ fn workgroup_add_creates_task_messaging_replicas_and_lists() {
     let config_dir = config_dir_for_bin(&bin);
     write_settings(&config_dir, tmp.path());
     let project = project_with_agents(tmp.path(), &["architect", "dev-rust"]);
+
+    let created_team = run_json(
+        &bin,
+        &[
+            "team",
+            "create",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--coordinator",
+            "architect",
+            "--agent",
+            "dev-rust",
+        ],
+    );
+    assert_eq!(created_team["team"], "dev-team");
+    assert_eq!(
+        created_team["agents"],
+        serde_json::json!(["_agent_architect", "_agent_dev-rust"])
+    );
+
+    let team_config_path = project
+        .join(".ac")
+        .join("_team_dev-team")
+        .join("config.json");
+    let team_config_before = std::fs::read(&team_config_path).expect("team config before");
 
     let json = run_json(
         &bin,
@@ -174,10 +212,6 @@ fn workgroup_add_creates_task_messaging_replicas_and_lists() {
             "Dev Team",
             "--title",
             "Build the thing",
-            "--coordinator",
-            "architect",
-            "--agent",
-            "dev-rust",
         ],
     );
 
@@ -193,16 +227,16 @@ fn workgroup_add_creates_task_messaging_replicas_and_lists() {
         .join("__agent_dev-rust")
         .join("config.json")
         .is_file());
-    let team_config_path = project
-        .join(".ac")
-        .join("_team_dev-team")
-        .join("config.json");
+    assert_eq!(
+        std::fs::read(&team_config_path).expect("team config after"),
+        team_config_before
+    );
     let team_config: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(team_config_path).expect("config"))
             .expect("team config json");
     assert_eq!(
         team_config["agents"],
-        serde_json::json!(["_agent_dev-rust", "_agent_architect"])
+        serde_json::json!(["_agent_architect", "_agent_dev-rust"])
     );
     assert_eq!(team_config["coordinator"], "_agent_architect");
 
@@ -214,9 +248,16 @@ fn workgroup_add_creates_task_messaging_replicas_and_lists() {
     assert_eq!(list[0]["hasMessaging"], true);
 
     let requests = read_project_refresh_requests(&config_dir);
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 2);
     assert_refresh_request(
-        &requests[0],
+        find_refresh_request(&requests, "teamCreated"),
+        &project,
+        ".ac/_team_dev-team",
+        "dev-team",
+        "teamCreated",
+    );
+    assert_refresh_request(
+        find_refresh_request(&requests, "workgroupCreated"),
         &project,
         ".ac/wg-1-dev-team",
         "wg-1-dev-team",
@@ -233,6 +274,19 @@ fn workgroup_add_uses_global_lowest_free_number() {
     let project = project_with_agents(tmp.path(), &["architect"]);
     std::fs::create_dir_all(project.join(".ac").join("wg-1-dev-team")).expect("wg1");
 
+    let _team = run_json(
+        &bin,
+        &[
+            "team",
+            "create",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "QA Team",
+            "--coordinator",
+            "architect",
+        ],
+    );
     let json = run_json(
         &bin,
         &[
@@ -244,8 +298,6 @@ fn workgroup_add_uses_global_lowest_free_number() {
             "QA Team",
             "--title",
             "Test it",
-            "--coordinator",
-            "architect",
         ],
     );
 
@@ -334,17 +386,15 @@ fn workgroup_add_normalizes_include_and_exclude_repo_assignments() {
     write_settings(&config_dir, tmp.path());
     let project = project_with_agents(tmp.path(), &["architect", "dev-rust", "qa"]);
 
-    let _json = run_json(
+    let _team = run_json(
         &bin,
         &[
-            "workgroup",
-            "add",
+            "team",
+            "create",
             "--project",
             "ProjectAlpha",
             "--team",
             "Dev Team",
-            "--title",
-            "Build",
             "--coordinator",
             "architect",
             "--agent",
@@ -357,6 +407,19 @@ fn workgroup_add_normalizes_include_and_exclude_repo_assignments() {
             "https://example.test/include.git=architect,dev-rust",
             "--repo-exclude-agents",
             "https://example.test/exclude.git=qa",
+        ],
+    );
+    let _json = run_json(
+        &bin,
+        &[
+            "workgroup",
+            "add",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--title",
+            "Build",
         ],
     );
 
@@ -392,6 +455,19 @@ fn team_add_member_creates_replica_and_peer_is_reachable() {
     write_settings(&config_dir, tmp.path());
     let project = project_with_agents(tmp.path(), &["architect", "dev-rust"]);
 
+    let _team = run_json(
+        &bin,
+        &[
+            "team",
+            "create",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--coordinator",
+            "architect",
+        ],
+    );
     let _wg = run_json(
         &bin,
         &[
@@ -403,8 +479,6 @@ fn team_add_member_creates_replica_and_peer_is_reachable() {
             "Dev Team",
             "--title",
             "Build",
-            "--coordinator",
-            "architect",
         ],
     );
 
@@ -454,7 +528,7 @@ fn team_add_member_creates_replica_and_peer_is_reachable() {
     });
     assert!(found, "added peer should be reachable: {}", peers);
     let requests = read_project_refresh_requests(&config_dir);
-    assert_eq!(requests.len(), 2);
+    assert_eq!(requests.len(), 3);
     assert_refresh_request(
         find_refresh_request(&requests, "teamMembershipChanged"),
         &project,
@@ -479,7 +553,7 @@ fn team_add_member_creates_replica_and_peer_is_reachable() {
     assert_eq!(removed["removed"], true);
     assert!(!replica.exists());
     let requests = read_project_refresh_requests(&config_dir);
-    assert_eq!(requests.len(), 3);
+    assert_eq!(requests.len(), 4);
     assert_refresh_request(
         find_refresh_request(&requests, "teamMembershipRemoved"),
         &project,
@@ -487,4 +561,255 @@ fn team_add_member_creates_replica_and_peer_is_reachable() {
         "wg-1-dev-team/dev-rust",
         "teamMembershipRemoved",
     );
+}
+
+#[test]
+fn team_create_refuses_existing_team() {
+    let tmp = Tmp::new("cli-team-create-existing");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let _project = project_with_agents(tmp.path(), &["architect"]);
+
+    let _team = run_json(
+        &bin,
+        &[
+            "team",
+            "create",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--coordinator",
+            "architect",
+        ],
+    );
+    let stderr = run_fail(
+        &bin,
+        &[
+            "team",
+            "create",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--coordinator",
+            "architect",
+        ],
+    );
+    assert!(stderr.contains("Team 'dev-team' already exists"));
+}
+
+#[test]
+fn team_create_refuses_preexisting_empty_team_dir() {
+    let tmp = Tmp::new("cli-team-create-empty-dir");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let project = project_with_agents(tmp.path(), &["architect"]);
+    std::fs::create_dir_all(project.join(".ac").join("_team_dev-team")).expect("team dir");
+
+    let stderr = run_fail(
+        &bin,
+        &[
+            "team",
+            "create",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--coordinator",
+            "architect",
+        ],
+    );
+    assert!(stderr.contains("Team 'dev-team' already exists"));
+}
+
+#[test]
+fn team_create_outputs_coordinator_first_roster() {
+    let tmp = Tmp::new("cli-team-create-roster");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let project = project_with_agents(tmp.path(), &["architect", "dev-rust", "qa"]);
+
+    let json = run_json(
+        &bin,
+        &[
+            "team",
+            "create",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--coordinator",
+            "architect",
+            "--agent",
+            "dev-rust",
+            "--agent",
+            "architect",
+            "--agent",
+            "qa",
+        ],
+    );
+    let expected = serde_json::json!(["_agent_architect", "_agent_dev-rust", "_agent_qa"]);
+    assert_eq!(json["agents"], expected);
+
+    let config_path = project
+        .join(".ac")
+        .join("_team_dev-team")
+        .join("config.json");
+    let config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(config_path).expect("config"))
+            .expect("config json");
+    assert_eq!(config["agents"], expected);
+}
+
+#[test]
+fn workgroup_add_existing_team_refuses_legacy_flags_without_rewrite() {
+    let tmp = Tmp::new("cli-wg-existing-refuses-legacy");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let project = project_with_agents(tmp.path(), &["architect", "dev-rust"]);
+
+    let _team = run_json(
+        &bin,
+        &[
+            "team",
+            "create",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--coordinator",
+            "architect",
+            "--agent",
+            "dev-rust",
+        ],
+    );
+    let config_path = project
+        .join(".ac")
+        .join("_team_dev-team")
+        .join("config.json");
+    let before = std::fs::read(&config_path).expect("before");
+    let stderr = run_fail(
+        &bin,
+        &[
+            "workgroup",
+            "add",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--title",
+            "Second",
+            "--coordinator",
+            "dev-rust",
+        ],
+    );
+    assert!(stderr.contains("workgroup add` no longer updates team configuration"));
+    assert_eq!(std::fs::read(&config_path).expect("after"), before);
+    let config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(config_path).expect("config"))
+            .expect("config json");
+    assert_eq!(config["coordinator"], "_agent_architect");
+}
+
+#[test]
+fn workgroup_add_existing_invalid_team_config_errors_without_rewrite() {
+    let tmp = Tmp::new("cli-wg-invalid-team");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let project = project_with_agents(tmp.path(), &["architect", "dev-rust"]);
+    let team_dir = project.join(".ac").join("_team_dev-team");
+    std::fs::create_dir_all(&team_dir).expect("team dir");
+    let config_path = team_dir.join("config.json");
+    let original = b"{ not json".to_vec();
+    std::fs::write(&config_path, &original).expect("write invalid config");
+
+    let stderr = run_fail(
+        &bin,
+        &[
+            "workgroup",
+            "add",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--title",
+            "Second",
+            "--coordinator",
+            "architect",
+            "--agent",
+            "dev-rust",
+        ],
+    );
+    assert!(stderr.contains("Failed to parse config.json"));
+    assert_eq!(std::fs::read(&config_path).expect("after"), original);
+}
+
+#[test]
+fn workgroup_add_legacy_missing_team_still_bootstraps_with_warning() {
+    let tmp = Tmp::new("cli-wg-legacy-bootstrap");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let project = project_with_agents(tmp.path(), &["architect", "dev-rust"]);
+
+    let out = Command::new(&bin)
+        .args([
+            "workgroup",
+            "add",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--title",
+            "Build",
+            "--coordinator",
+            "architect",
+            "--agent",
+            "dev-rust",
+        ])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(String::from_utf8_lossy(&out.stderr).contains("deprecated"));
+    assert!(project
+        .join(".ac")
+        .join("_team_dev-team")
+        .join("config.json")
+        .is_file());
+}
+
+#[test]
+fn workgroup_add_missing_team_without_legacy_flags_errors() {
+    let tmp = Tmp::new("cli-wg-missing-team");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let _project = project_with_agents(tmp.path(), &["architect"]);
+
+    let stderr = run_fail(
+        &bin,
+        &[
+            "workgroup",
+            "add",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Missing Team",
+            "--title",
+            "Build",
+        ],
+    );
+    assert!(stderr.contains("Team 'missing-team' config not found"));
+    assert!(stderr.contains("Create it first with `team create`"));
 }


### PR DESCRIPTION
## Summary

- Add a dedicated `team create` CLI flow that defines teams from existing agents before workgroup activation.
- Make `workgroup add` activate existing teams with `--project`, `--team`, and `--title`, without teaching the old one-step team-definition path in public help/docs.
- Clarify docs, CLI help, quickstart, and Root Agent guidance around agent creation order, team-level repos, and scoped workgroup membership edits.

Closes #464

## Validation

- `cargo test --test cli_workgroup_team`
- `cargo test root_agent`
- `cargo test --lib session_context`
- `cargo check`
- `cargo clippy`
- Grinch review passed with no findings.
- Shipper built and deployed `agentscommander_standalone_wg-1.exe` from commit `e924617`; `--help` exited 0.