### PR TITLE
docs(hints): add workflow practice guidance (#472)

### DIFF
--- a/docs/agents/teams-and-workgroups.md
+++ b/docs/agents/teams-and-workgroups.md
@@ -64,6 +64,10 @@ my-project/
 
 The integer `<N>` is the lowest free positive number across the project, not per team. Deleted numbers are reused, so multiple teams still share one workgroup number sequence.
 
+### Why replicas?
+
+Workgroup replicas give each team a separate operating space instead of sharing a plain disposable git worktree. A replica includes its own repository copy, agent directories, messaging area, filesystem write boundaries, and workgroup-specific executable. This costs more disk space and setup time than a basic worktree, but it gives AgentsCommander stronger isolation for parallel teams, safer delegation boundaries, and cleaner test or build state per workgroup.
+
 ### Replicas vs the matrix
 
 | | Canonical matrix (`_agent_<name>`) | Workgroup replica (`__agent_<name>`) |

--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.8.50"; // Must match package.json
+const VERSION = "0.8.51"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.8.50",
+  "version": "0.8.51",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.50",
+  "version": "0.8.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.50",
+      "version": "0.8.51",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.50",
+  "version": "0.8.51",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.50"
+version = "0.8.51"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.50"
+version = "0.8.51"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.8.50",
+  "version": "0.8.51",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {

--- a/src/guide/components/HintsTab.tsx
+++ b/src/guide/components/HintsTab.tsx
@@ -25,7 +25,7 @@ const sections: HintSection[] = [
       },
       {
         title: "claude-hud",
-        body: "A statusline HUD for Claude Code that displays real-time context in your terminal — model, token usage, active tools, and session state at a glance. Essential for monitoring long-running agent sessions.",
+        body: "A statusline HUD for Claude Code that displays real-time context in your terminal - model, token usage, active tools, and session state at a glance. Essential for monitoring long-running agent sessions.",     
         link: {
           label: "GitHub repo",
           url: "https://github.com/jarrodwatts/claude-hud",
@@ -33,14 +33,14 @@ const sections: HintSection[] = [
       },
       {
         title: "feature-dev plugin",
-        body: "Official Claude plugin for guided feature development. It analyzes your codebase, designs architectures, and writes implementation plans before writing code — resulting in higher quality features that follow your project's conventions.",
+        body: "Official Claude plugin for guided feature development. It analyzes your codebase, designs architectures, and writes implementation plans before writing code - resulting in higher quality features that follow your project's conventions.",
         link: {
           label: "Install plugin",
           url: "https://claude.com/plugins/feature-dev",
         },
       },
       {
-        title: "RTK — Token Optimizer",
+        title: "RTK - Token Optimizer",
         body: "CLI proxy that compresses command outputs to reduce token consumption. Prefix any command with rtk and it transparently compresses verbose outputs (git, cargo, npm, etc.) while passing through unchanged when no filter applies. Always safe to use.",
         link: {
           label: "rtk-ai.app",
@@ -69,6 +69,47 @@ const sections: HintSection[] = [
   {
     agent: "OpenCode",
     hints: [],
+  },
+  {
+    agent: "Crucial Practices",
+    hints: [
+      {
+        title: "Isolation and sandboxes",
+        body: "For tasks that may touch local state, isolate the work before you delegate it. Disposable git worktrees, containers, and VMs are useful options. AgentsCommander workgroup replicas are stronger but heavier: each workgroup gets its own repo copy, agent session directories, messaging area, write zones, and executable, which keeps team context and test builds separated.",
+      },
+      {
+        title: "Specification first",
+        body: "Write the desired behavior, constraints, acceptance checks, and non-goals before implementation. A clear spec gives agents a stable target and makes review less subjective.",
+      },
+      {
+        title: "Break work into small tasks",
+        body: "Split large goals into reviewable steps with one clear outcome each. Smaller tasks reduce context drift and make it easier to recover when an agent chooses the wrong path.",
+      },
+      {
+        title: "Use lighter agents when no filesystem is needed",
+        body: "If a task only needs reasoning, drafting, classification, or summarization, use a model session without coding-agent filesystem instructions. It keeps prompts smaller and saves tokens.",
+      },
+      {
+        title: "Polish context before starting",
+        body: "Give agents concise, current context: the exact repo, branch, goal, constraints, files to inspect, and definition of done. Remove stale notes and irrelevant history.",
+      },
+      {
+        title: "Evaluate the workflow",
+        body: "Keep notes on what worked, what failed, where agents got stuck, and which prompts produced reliable results. Treat agent workflows as systems that need measurement.",
+      },
+      {
+        title: "Prefer red/green development",
+        body: "When behavior matters, ask for a failing test first, then the smallest change that makes it pass. This gives the agent a concrete feedback loop and gives reviewers evidence.",
+      },
+      {
+        title: "Keep CI/CD authoritative",
+        body: "Use CI to run formatting, linting, tests, security checks, and packaging. Agents should not be the final source of truth for whether a change is ready.",
+      },
+      {
+        title: "Automate deterministic work",
+        body: "If a step can be handled by a script, generator, formatter, linter, or validation command, make it deterministic. Save agent attention for judgment, debugging, and tradeoffs.",
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
## Summary
- Add crucial workflow practice guidance to the Hints page
- Document workgroup replicas as a stronger but heavier isolation model
- Bump version to 0.8.51 for release

## Validation
- npm run version:check
- npm test
- wg-4 Tauri build and --help verification completed before release handoff

Closes #472