### PR TITLE
fix(links): confirm external links before opening (#470)

### DIFF
--- a/src/guide/App.tsx
+++ b/src/guide/App.tsx
@@ -1,10 +1,12 @@
 import { Component, createSignal, onMount, onCleanup, Show } from "solid-js";
 import { initZoom } from "../shared/zoom";
 import { isTauri } from "../shared/platform";
+import ExternalLinkConfirm from "../shared/components/ExternalLinkConfirm";
 import HintsTab from "./components/HintsTab";
 import TutorialTab from "./components/TutorialTab";
 import iconUrl from "../assets/icon-16.png";
 import "./styles/guide.css";
+import "../shared/styles/external-link-confirm.css";
 
 type Tab = "hints" | "tutorial";
 
@@ -70,6 +72,7 @@ const GuideApp: Component = () => {
         {activeTab() === "hints" && <HintsTab />}
         {activeTab() === "tutorial" && <TutorialTab />}
       </div>
+      <ExternalLinkConfirm />
     </div>
   );
 };

--- a/src/main/App.tsx
+++ b/src/main/App.tsx
@@ -11,8 +11,10 @@ import Titlebar from "../sidebar/components/Titlebar";
 import QuitConfirmModal from "./components/QuitConfirmModal";
 import RtkBanner from "./components/RtkBanner";
 import ErrorModal from "./components/ErrorModal";
+import ExternalLinkConfirm from "../shared/components/ExternalLinkConfirm";
 import { wireHomeListeners } from "./listeners-home";
 import "./styles/main.css";
+import "../shared/styles/external-link-confirm.css";
 
 const SIDEBAR_MIN_WIDTH = 200;
 const SIDEBAR_MAX_WIDTH = 600;
@@ -253,6 +255,7 @@ const MainApp: Component = () => {
         />
       </Show>
       <ErrorModal />
+      <ExternalLinkConfirm />
     </div>
   );
 };

--- a/src/main/components/HomeView.tsx
+++ b/src/main/components/HomeView.tsx
@@ -2,7 +2,6 @@ import { Component, Show, createMemo, onMount } from "solid-js";
 import MarkdownIt from "markdown-it";
 import DOMPurify from "dompurify";
 import { homeStore } from "../stores/home";
-import { WindowAPI } from "../../shared/ipc";
 
 const md = MarkdownIt({
   html: false,
@@ -25,16 +24,6 @@ const HomeView: Component = () => {
       USE_PROFILES: { html: true },
     });
   });
-
-  const onContainerClick = (e: MouseEvent) => {
-    const target = e.target as HTMLElement;
-    const anchor = target.closest("a") as HTMLAnchorElement | null;
-    if (!anchor) return;
-    const href = anchor.getAttribute("href") ?? "";
-    if (!href) return;
-    e.preventDefault();
-    WindowAPI.openExternal(href).catch((err) => console.error("openExternal failed:", err));
-  };
 
   return (
     <div class="home-view">
@@ -62,7 +51,6 @@ const HomeView: Component = () => {
       <Show when={homeStore.content !== null}>
         <div
           class="home-markdown"
-          onClick={onContainerClick}
           // eslint-disable-next-line solid/no-innerhtml
           innerHTML={html()}
         />

--- a/src/shared/components/ExternalLinkConfirm.test.ts
+++ b/src/shared/components/ExternalLinkConfirm.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "solid-js/web";
+import ExternalLinkConfirm from "./ExternalLinkConfirm";
+import { WindowAPI } from "../ipc";
+
+vi.mock("../ipc", () => ({
+  WindowAPI: {
+    openExternal: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+const externalUrl = "https://example.com/docs";
+
+function buttonByText(text: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === text
+  );
+  if (!button) {
+    throw new Error(`Button not found: ${text}`);
+  }
+  return button as HTMLButtonElement;
+}
+
+function copyButton(): HTMLButtonElement {
+  const button = document.querySelector(
+    'button[aria-label="Copy URL"], button[aria-label="Copied URL"]'
+  );
+  if (!button) {
+    throw new Error("Copy button not found");
+  }
+  return button as HTMLButtonElement;
+}
+
+function addKeyboardActivation(button: HTMLButtonElement): void {
+  button.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      button.click();
+    }
+  });
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function openModal(): Promise<() => void> {
+  const root = document.createElement("div");
+  document.body.append(root);
+  const dispose = render(() => ExternalLinkConfirm({}), root);
+  const link = document.createElement("a");
+  link.href = externalUrl;
+  link.textContent = "external docs";
+  root.append(link);
+
+  link.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 })
+  );
+  await flushPromises();
+
+  expect(document.querySelector('[role="alertdialog"]')).not.toBeNull();
+  return dispose;
+}
+
+describe("ExternalLinkConfirm", () => {
+  beforeEach(() => {
+    vi.mocked(WindowAPI.openExternal).mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn(() => Promise.resolve()),
+      },
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("opens the pending external URL when Open anyway is activated with Enter", async () => {
+    const dispose = await openModal();
+    const openButton = buttonByText("Open anyway");
+    addKeyboardActivation(openButton);
+    openButton.focus();
+
+    openButton.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: "Enter",
+      })
+    );
+    await flushPromises();
+
+    expect(WindowAPI.openExternal).toHaveBeenCalledWith(externalUrl);
+    expect(document.querySelector('[role="alertdialog"]')).toBeNull();
+
+    dispose();
+  });
+
+  it("closes the modal when Cancel is activated with Space", async () => {
+    const dispose = await openModal();
+    const cancelButton = buttonByText("Cancel");
+    addKeyboardActivation(cancelButton);
+    cancelButton.focus();
+
+    cancelButton.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: " ",
+      })
+    );
+    await flushPromises();
+
+    expect(WindowAPI.openExternal).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alertdialog"]')).toBeNull();
+
+    dispose();
+  });
+
+  it("copies the pending external URL when Copy URL is activated with Enter", async () => {
+    const dispose = await openModal();
+    const copy = copyButton();
+    addKeyboardActivation(copy);
+    copy.focus();
+
+    copy.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: "Enter",
+      })
+    );
+    await flushPromises();
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(externalUrl);
+    expect(document.querySelector('[role="alertdialog"]')).not.toBeNull();
+
+    dispose();
+  });
+});

--- a/src/shared/components/ExternalLinkConfirm.test.ts
+++ b/src/shared/components/ExternalLinkConfirm.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "solid-js/web";
 import ExternalLinkConfirm from "./ExternalLinkConfirm";
 import { WindowAPI } from "../ipc";
+import { EXTERNAL_LINK_REQUEST_EVENT } from "../external-links";
 
 vi.mock("../ipc", () => ({
   WindowAPI: {
@@ -138,6 +139,44 @@ describe("ExternalLinkConfirm", () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(externalUrl);
     expect(document.querySelector('[role="alertdialog"]')).not.toBeNull();
 
+    dispose();
+  });
+
+  it("opens the modal from the external link request event", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(() => ExternalLinkConfirm({}), root);
+
+    document.dispatchEvent(
+      new CustomEvent(EXTERNAL_LINK_REQUEST_EVENT, {
+        detail: { url: externalUrl },
+      })
+    );
+    await flushPromises();
+
+    expect(document.querySelector('[role="alertdialog"]')).not.toBeNull();
+
+    buttonByText("Open anyway").click();
+    await flushPromises();
+
+    expect(WindowAPI.openExternal).toHaveBeenCalledWith(externalUrl);
+    dispose();
+  });
+
+  it("ignores unsupported URLs from the external link request event", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(() => ExternalLinkConfirm({}), root);
+
+    document.dispatchEvent(
+      new CustomEvent(EXTERNAL_LINK_REQUEST_EVENT, {
+        detail: { url: "mailto:support@example.com" },
+      })
+    );
+    await flushPromises();
+
+    expect(document.querySelector('[role="alertdialog"]')).toBeNull();
+    expect(WindowAPI.openExternal).not.toHaveBeenCalled();
     dispose();
   });
 });

--- a/src/shared/components/ExternalLinkConfirm.tsx
+++ b/src/shared/components/ExternalLinkConfirm.tsx
@@ -1,0 +1,170 @@
+import { Component, createSignal, onCleanup, onMount, Show } from "solid-js";
+import { Portal } from "solid-js/web";
+import { WindowAPI } from "../ipc";
+import { getConfirmableExternalUrl } from "../external-links";
+
+const ExternalLinkConfirm: Component = () => {
+  const [pendingUrl, setPendingUrl] = createSignal<string | null>(null);
+  const [copied, setCopied] = createSignal(false);
+  let cancelBtnRef: HTMLButtonElement | undefined;
+  let copyBtnRef: HTMLButtonElement | undefined;
+  let openBtnRef: HTMLButtonElement | undefined;
+  let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+  let previouslyFocused: HTMLElement | null = null;
+
+  const close = () => {
+    setPendingUrl(null);
+    setCopied(false);
+    if (copyResetTimer) {
+      clearTimeout(copyResetTimer);
+      copyResetTimer = null;
+    }
+    try { previouslyFocused?.focus(); } catch { /* best-effort */ }
+    previouslyFocused = null;
+  };
+
+  const openPendingUrl = async () => {
+    const url = pendingUrl();
+    if (!url) return;
+    try {
+      await WindowAPI.openExternal(url);
+      close();
+    } catch (err) {
+      console.error("[external-link-confirm] openExternal failed:", err);
+    }
+  };
+
+  const copyPendingUrl = async () => {
+    const url = pendingUrl();
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      if (copyResetTimer) clearTimeout(copyResetTimer);
+      copyResetTimer = setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.error("[external-link-confirm] clipboard write failed:", err);
+    }
+  };
+
+  onMount(() => {
+    const onClick = (e: MouseEvent) => {
+      if (e.defaultPrevented || e.button !== 0) {
+        return;
+      }
+      const target = e.target as HTMLElement | null;
+      const anchor = target?.closest("a") as HTMLAnchorElement | null;
+      const href = anchor?.getAttribute("href");
+      if (!href) return;
+
+      const url = getConfirmableExternalUrl(href);
+      if (!url) return;
+
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      previouslyFocused = document.activeElement as HTMLElement | null;
+      setCopied(false);
+      setPendingUrl(url);
+      queueMicrotask(() => cancelBtnRef?.focus());
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!pendingUrl()) return;
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        close();
+        return;
+      }
+      if (e.key === "Tab") {
+        e.stopImmediatePropagation();
+        const focusables = [copyBtnRef, cancelBtnRef, openBtnRef].filter(Boolean) as HTMLElement[];
+        if (focusables.length < 2) return;
+        const idx = focusables.indexOf(document.activeElement as HTMLElement);
+        if (idx === -1) {
+          e.preventDefault();
+          (e.shiftKey ? focusables[focusables.length - 1] : focusables[0]).focus();
+          return;
+        }
+        if (e.shiftKey && idx <= 0) {
+          e.preventDefault();
+          focusables[focusables.length - 1].focus();
+        } else if (!e.shiftKey && idx === focusables.length - 1) {
+          e.preventDefault();
+          focusables[0].focus();
+        }
+        return;
+      }
+      e.stopImmediatePropagation();
+    };
+
+    document.addEventListener("click", onClick, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    onCleanup(() => {
+      document.removeEventListener("click", onClick, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    });
+  });
+
+  onCleanup(() => {
+    if (copyResetTimer) clearTimeout(copyResetTimer);
+  });
+
+  return (
+    <Show when={pendingUrl()}>
+      {(url) => (
+        <Portal>
+          <div
+            class="external-link-backdrop"
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="external-link-title"
+            aria-describedby="external-link-body"
+          >
+            <div class="external-link-modal">
+              <div class="external-link-header">
+                <h2 id="external-link-title" class="external-link-title">Open external link?</h2>
+                <button
+                  ref={copyBtnRef}
+                  class="external-link-copy-btn"
+                  type="button"
+                  title={copied() ? "Copied" : "Copy URL"}
+                  aria-label={copied() ? "Copied URL" : "Copy URL"}
+                  onClick={copyPendingUrl}
+                >
+                  {copied() ? "✓" : "⧉"}
+                </button>
+              </div>
+              <p id="external-link-body" class="external-link-body">
+                This link opens outside Agents Commander.
+              </p>
+              <div class="external-link-url" title={url()}>
+                {url()}
+              </div>
+              <div class="external-link-actions">
+                <button
+                  ref={cancelBtnRef}
+                  class="external-link-btn external-link-btn-cancel"
+                  type="button"
+                  onClick={close}
+                >
+                  Cancel
+                </button>
+                <button
+                  ref={openBtnRef}
+                  class="external-link-btn external-link-btn-open"
+                  type="button"
+                  onClick={openPendingUrl}
+                >
+                  Open anyway
+                </button>
+              </div>
+            </div>
+          </div>
+        </Portal>
+      )}
+    </Show>
+  );
+};
+
+export default ExternalLinkConfirm;

--- a/src/shared/components/ExternalLinkConfirm.tsx
+++ b/src/shared/components/ExternalLinkConfirm.tsx
@@ -1,7 +1,11 @@
 import { Component, createSignal, onCleanup, onMount, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import { WindowAPI } from "../ipc";
-import { getConfirmableExternalUrl } from "../external-links";
+import {
+  EXTERNAL_LINK_REQUEST_EVENT,
+  getConfirmableExternalUrl,
+  type ExternalLinkRequestDetail,
+} from "../external-links";
 
 const ExternalLinkConfirm: Component = () => {
   const [pendingUrl, setPendingUrl] = createSignal<string | null>(null);
@@ -11,6 +15,13 @@ const ExternalLinkConfirm: Component = () => {
   let openBtnRef: HTMLButtonElement | undefined;
   let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
   let previouslyFocused: HTMLElement | null = null;
+
+  const showConfirm = (url: string) => {
+    previouslyFocused = document.activeElement as HTMLElement | null;
+    setCopied(false);
+    setPendingUrl(url);
+    queueMicrotask(() => cancelBtnRef?.focus());
+  };
 
   const close = () => {
     setPendingUrl(null);
@@ -62,10 +73,21 @@ const ExternalLinkConfirm: Component = () => {
 
       e.preventDefault();
       e.stopImmediatePropagation();
-      previouslyFocused = document.activeElement as HTMLElement | null;
-      setCopied(false);
-      setPendingUrl(url);
-      queueMicrotask(() => cancelBtnRef?.focus());
+      showConfirm(url);
+    };
+
+    const onExternalLinkRequest = (e: Event) => {
+      const detail = (e as CustomEvent<ExternalLinkRequestDetail>).detail;
+      if (!detail || typeof detail.url !== "string") {
+        return;
+      }
+
+      const url = getConfirmableExternalUrl(detail.url);
+      if (!url) {
+        return;
+      }
+
+      showConfirm(url);
     };
 
     const onKeyDown = (e: KeyboardEvent) => {
@@ -98,9 +120,11 @@ const ExternalLinkConfirm: Component = () => {
     };
 
     document.addEventListener("click", onClick, true);
+    document.addEventListener(EXTERNAL_LINK_REQUEST_EVENT, onExternalLinkRequest);
     document.addEventListener("keydown", onKeyDown, true);
     onCleanup(() => {
       document.removeEventListener("click", onClick, true);
+      document.removeEventListener(EXTERNAL_LINK_REQUEST_EVENT, onExternalLinkRequest);
       document.removeEventListener("keydown", onKeyDown, true);
     });
   });

--- a/src/shared/components/ExternalLinkConfirm.tsx
+++ b/src/shared/components/ExternalLinkConfirm.tsx
@@ -95,7 +95,6 @@ const ExternalLinkConfirm: Component = () => {
         }
         return;
       }
-      e.stopImmediatePropagation();
     };
 
     document.addEventListener("click", onClick, true);

--- a/src/shared/external-links.test.ts
+++ b/src/shared/external-links.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getConfirmableExternalUrl } from "./external-links";
+
+const appUrl = "http://tauri.localhost/index.html?window=main";
+
+describe("getConfirmableExternalUrl", () => {
+  it("returns normalized external http and https URLs", () => {
+    expect(getConfirmableExternalUrl("https://example.com/docs", appUrl)).toBe(
+      "https://example.com/docs"
+    );
+    expect(getConfirmableExternalUrl("http://example.com", appUrl)).toBe(
+      "http://example.com/"
+    );
+  });
+
+  it("does not intercept same-origin app links", () => {
+    expect(getConfirmableExternalUrl("/settings", appUrl)).toBeNull();
+    expect(
+      getConfirmableExternalUrl("http://tauri.localhost/guide", appUrl)
+    ).toBeNull();
+  });
+
+  it("does not intercept unsupported or malformed URLs", () => {
+    expect(getConfirmableExternalUrl("mailto:support@example.com", appUrl)).toBeNull();
+    expect(getConfirmableExternalUrl("javascript:alert(1)", appUrl)).toBeNull();
+    expect(getConfirmableExternalUrl("https://[", appUrl)).toBeNull();
+  });
+});

--- a/src/shared/external-links.test.ts
+++ b/src/shared/external-links.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { getConfirmableExternalUrl } from "./external-links";
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  EXTERNAL_LINK_REQUEST_EVENT,
+  getConfirmableExternalUrl,
+  requestExternalLinkConfirmation,
+} from "./external-links";
 
 const appUrl = "http://tauri.localhost/index.html?window=main";
 
@@ -24,5 +29,36 @@ describe("getConfirmableExternalUrl", () => {
     expect(getConfirmableExternalUrl("mailto:support@example.com", appUrl)).toBeNull();
     expect(getConfirmableExternalUrl("javascript:alert(1)", appUrl)).toBeNull();
     expect(getConfirmableExternalUrl("https://[", appUrl)).toBeNull();
+  });
+
+  describe("requestExternalLinkConfirmation", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("dispatches a normalized custom event for external URLs", () => {
+      const listener = vi.fn();
+      document.addEventListener(EXTERNAL_LINK_REQUEST_EVENT, listener);
+
+      expect(requestExternalLinkConfirmation("http://example.com")).toBe(true);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0][0]).toMatchObject({
+        detail: { url: "http://example.com/" },
+      });
+
+      document.removeEventListener(EXTERNAL_LINK_REQUEST_EVENT, listener);
+    });
+
+    it("does not dispatch for same-origin or unsupported URLs", () => {
+      const listener = vi.fn();
+      document.addEventListener(EXTERNAL_LINK_REQUEST_EVENT, listener);
+
+      expect(requestExternalLinkConfirmation("/settings")).toBe(false);
+      expect(requestExternalLinkConfirmation("mailto:support@example.com")).toBe(false);
+
+      expect(listener).not.toHaveBeenCalled();
+      document.removeEventListener(EXTERNAL_LINK_REQUEST_EVENT, listener);
+    });
   });
 });

--- a/src/shared/external-links.ts
+++ b/src/shared/external-links.ts
@@ -1,0 +1,23 @@
+export function getConfirmableExternalUrl(
+  href: string,
+  currentHref: string = window.location.href
+): string | null {
+  let url: URL;
+  let currentUrl: URL;
+  try {
+    currentUrl = new URL(currentHref);
+    url = new URL(href, currentUrl);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return null;
+  }
+
+  if (url.origin === currentUrl.origin) {
+    return null;
+  }
+
+  return url.href;
+}

--- a/src/shared/external-links.ts
+++ b/src/shared/external-links.ts
@@ -1,3 +1,9 @@
+export const EXTERNAL_LINK_REQUEST_EVENT = "agentscommander:external-link-request";
+
+export interface ExternalLinkRequestDetail {
+  url: string;
+}
+
 export function getConfirmableExternalUrl(
   href: string,
   currentHref: string = window.location.href
@@ -20,4 +26,18 @@ export function getConfirmableExternalUrl(
   }
 
   return url.href;
+}
+
+export function requestExternalLinkConfirmation(href: string): boolean {
+  const url = getConfirmableExternalUrl(href);
+  if (!url) {
+    return false;
+  }
+
+  document.dispatchEvent(
+    new CustomEvent<ExternalLinkRequestDetail>(EXTERNAL_LINK_REQUEST_EVENT, {
+      detail: { url },
+    })
+  );
+  return true;
 }

--- a/src/shared/styles/external-link-confirm.css
+++ b/src/shared/styles/external-link-confirm.css
@@ -1,0 +1,147 @@
+.external-link-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10002;
+}
+
+.external-link-modal {
+  width: min(520px, calc(100vw - 32px));
+  background: var(--bg-modal, #14141a);
+  color: var(--fg-primary, #e8e8e8);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.1));
+  border-radius: 6px;
+  padding: 20px 24px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  font-family: "Geist", "Outfit", "General Sans", sans-serif;
+}
+
+.external-link-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.external-link-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.external-link-copy-btn {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.15));
+  border-radius: 4px;
+  background: transparent;
+  color: var(--fg-secondary, rgba(255, 255, 255, 0.7));
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 15px;
+  line-height: 1;
+  transition: background 150ms ease-out, border-color 150ms ease-out, color 150ms ease-out;
+}
+
+.external-link-copy-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg-primary, #e8e8e8);
+}
+
+.external-link-body {
+  margin: 0 0 12px 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fg-secondary, rgba(255, 255, 255, 0.75));
+}
+
+.external-link-url {
+  max-height: 96px;
+  overflow: auto;
+  margin-bottom: 20px;
+  padding: 10px 12px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  color: var(--fg-primary, #e8e8e8);
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  word-break: break-all;
+}
+
+.external-link-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.external-link-btn {
+  padding: 6px 16px;
+  border-radius: 4px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 150ms ease-out, border-color 150ms ease-out, color 150ms ease-out;
+}
+
+.external-link-btn-cancel {
+  background: transparent;
+  color: var(--fg-secondary, rgba(255, 255, 255, 0.7));
+  border-color: var(--border-subtle, rgba(255, 255, 255, 0.15));
+}
+
+.external-link-btn-cancel:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg-primary, #e8e8e8);
+}
+
+.external-link-btn-open {
+  background: var(--btn-primary-bg, rgba(0, 212, 255, 0.2));
+  color: var(--btn-primary-fg, #00d4ff);
+  border-color: var(--btn-primary-border, rgba(0, 212, 255, 0.4));
+}
+
+.external-link-btn-open:hover {
+  background: rgba(0, 212, 255, 0.3);
+}
+
+.external-link-copy-btn:focus-visible,
+.external-link-btn:focus-visible {
+  outline: 2px solid var(--focus-ring, #00d4ff);
+  outline-offset: 2px;
+}
+
+html.light-theme .external-link-modal {
+  background: #f7f7f9;
+  color: #1a1a1e;
+  border-color: rgba(0, 0, 0, 0.1);
+}
+
+html.light-theme .external-link-body {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+html.light-theme .external-link-url {
+  background: rgba(0, 0, 0, 0.05);
+  border-color: rgba(0, 0, 0, 0.1);
+  color: #1a1a1e;
+}
+
+html.light-theme .external-link-copy-btn,
+html.light-theme .external-link-btn-cancel {
+  color: rgba(0, 0, 0, 0.65);
+  border-color: rgba(0, 0, 0, 0.15);
+}
+
+html.light-theme .external-link-copy-btn:hover,
+html.light-theme .external-link-btn-cancel:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: #1a1a1e;
+}

--- a/src/terminal/App.tsx
+++ b/src/terminal/App.tsx
@@ -23,6 +23,8 @@ import LastPrompt from "./components/LastPrompt";
 import TerminalView from "./components/TerminalView";
 import StatusBar from "./components/StatusBar";
 import HomeView from "../main/components/HomeView";
+import ExternalLinkConfirm from "../shared/components/ExternalLinkConfirm";
+import "../shared/styles/external-link-confirm.css";
 import "./styles/terminal.css";
 
 interface TerminalAppProps {
@@ -293,6 +295,9 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
           while Home is visible. Detached/locked windows never render Home. */}
       <Show when={isHomeShown()}>
         <HomeView />
+      </Show>
+      <Show when={isTauri && !props.embedded}>
+        <ExternalLinkConfirm />
       </Show>
     </div>
   );

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -12,6 +12,7 @@ import {
 import { isBrowser } from "../../shared/platform";
 import { terminalStore } from "../stores/terminal";
 import type { UnlistenFn } from "../../shared/transport";
+import { requestExternalLinkConfirmation } from "../../shared/external-links";
 import { updatePromptCapture } from "./prompt-input-capture";
 import "@xterm/xterm/css/xterm.css";
 
@@ -128,6 +129,15 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         brightWhite: "#ffffff",
       },
       allowTransparency: false,
+      linkHandler: {
+        allowNonHttpProtocols: false,
+        activate(event, text) {
+          event.preventDefault();
+          event.stopPropagation();
+          event.stopImmediatePropagation();
+          requestExternalLinkConfirmation(text);
+        },
+      },
     });
 
     const fitAddon = new FitAddon();

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -9,11 +9,11 @@ import {
   onSessionDestroyed,
   onTerminalDetached,
 } from "../../shared/ipc";
-import { isBrowser } from "../../shared/platform";
+import { isBrowser, isTauri } from "../../shared/platform";
 import { terminalStore } from "../stores/terminal";
 import type { UnlistenFn } from "../../shared/transport";
-import { requestExternalLinkConfirmation } from "../../shared/external-links";
 import { updatePromptCapture } from "./prompt-input-capture";
+import { createTerminalOptions } from "./terminal-options";
 import "@xterm/xterm/css/xterm.css";
 
 interface SessionTerminal {
@@ -99,46 +99,7 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     container.hidden = true;
     hostRef.appendChild(container);
 
-    const terminal = new Terminal({
-      fontFamily: "'Cascadia Code', 'JetBrains Mono', 'Fira Code', monospace",
-      fontSize: 14,
-      lineHeight: 1.2,
-      cursorBlink: true,
-      cursorStyle: "block",
-      scrollback: 10000,
-      theme: {
-        background: "#0a0a0f",
-        foreground: "#e8e8e8",
-        cursor: "#00d4ff",
-        selectionBackground: "rgba(0, 212, 255, 0.25)",
-        black: "#1a1a2e",
-        red: "#ff3b5c",
-        green: "#33ff99",
-        yellow: "#ffcc33",
-        blue: "#3399ff",
-        magenta: "#ff33cc",
-        cyan: "#33ccff",
-        white: "#e8e8e8",
-        brightBlack: "#4a4a5e",
-        brightRed: "#ff6699",
-        brightGreen: "#66ffbb",
-        brightYellow: "#ffdd66",
-        brightBlue: "#66bbff",
-        brightMagenta: "#ff66dd",
-        brightCyan: "#66ddff",
-        brightWhite: "#ffffff",
-      },
-      allowTransparency: false,
-      linkHandler: {
-        allowNonHttpProtocols: false,
-        activate(event, text) {
-          event.preventDefault();
-          event.stopPropagation();
-          event.stopImmediatePropagation();
-          requestExternalLinkConfirmation(text);
-        },
-      },
-    });
+    const terminal = new Terminal(createTerminalOptions(isTauri));
 
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);

--- a/src/terminal/components/terminal-options.test.ts
+++ b/src/terminal/components/terminal-options.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { EXTERNAL_LINK_REQUEST_EVENT } from "../../shared/external-links";
+import { createTerminalOptions } from "./terminal-options";
+
+describe("createTerminalOptions", () => {
+  it("omits the custom xterm link handler in browser mode", () => {
+    expect(createTerminalOptions(false).linkHandler).toBeUndefined();
+  });
+
+  it("installs a confirming xterm link handler in Tauri mode", () => {
+    const options = createTerminalOptions(true);
+    expect(options.linkHandler?.allowNonHttpProtocols).toBe(false);
+
+    const listener = vi.fn();
+    document.addEventListener(EXTERNAL_LINK_REQUEST_EVENT, listener);
+
+    const event = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+    } as unknown as MouseEvent;
+
+    options.linkHandler?.activate(event, "https://example.com/docs", {
+      start: { x: 1, y: 1 },
+      end: { x: 1, y: 1 },
+    });
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
+    expect(event.stopImmediatePropagation).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { url: "https://example.com/docs" },
+      })
+    );
+
+    document.removeEventListener(EXTERNAL_LINK_REQUEST_EVENT, listener);
+  });
+});

--- a/src/terminal/components/terminal-options.ts
+++ b/src/terminal/components/terminal-options.ts
@@ -1,0 +1,45 @@
+import type { ITerminalOptions } from "@xterm/xterm";
+import { requestExternalLinkConfirmation } from "../../shared/external-links";
+
+export const createTerminalOptions = (useExternalLinkConfirmation: boolean): ITerminalOptions => ({
+  fontFamily: "'Cascadia Code', 'JetBrains Mono', 'Fira Code', monospace",
+  fontSize: 14,
+  lineHeight: 1.2,
+  cursorBlink: true,
+  cursorStyle: "block",
+  scrollback: 10000,
+  theme: {
+    background: "#0a0a0f",
+    foreground: "#e8e8e8",
+    cursor: "#00d4ff",
+    selectionBackground: "rgba(0, 212, 255, 0.25)",
+    black: "#1a1a2e",
+    red: "#ff3b5c",
+    green: "#33ff99",
+    yellow: "#ffcc33",
+    blue: "#3399ff",
+    magenta: "#ff33cc",
+    cyan: "#33ccff",
+    white: "#e8e8e8",
+    brightBlack: "#4a4a5e",
+    brightRed: "#ff6699",
+    brightGreen: "#66ffbb",
+    brightYellow: "#ffdd66",
+    brightBlue: "#66bbff",
+    brightMagenta: "#ff66dd",
+    brightCyan: "#66ddff",
+    brightWhite: "#ffffff",
+  },
+  allowTransparency: false,
+  linkHandler: useExternalLinkConfirmation
+    ? {
+        allowNonHttpProtocols: false,
+        activate(event, text) {
+          event.preventDefault();
+          event.stopPropagation();
+          event.stopImmediatePropagation();
+          requestExternalLinkConfirmation(text);
+        },
+      }
+    : undefined,
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import solidPlugin from "vite-plugin-solid";
 
 export default defineConfig({
+  plugins: [solidPlugin({ hot: false })],
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],


### PR DESCRIPTION
## Summary
- Add a shared external-link confirmation modal for app-owned links.
- Route xterm/OSC terminal hyperlinks through the custom confirmation in Tauri windows.
- Preserve browser-mode xterm default link behavior so browser links are not swallowed.

## Validation
- npx vitest run src/shared/components/ExternalLinkConfirm.test.ts src/shared/external-links.test.ts
- npm test -- src/terminal/components/terminal-options.test.ts src/shared/external-links.test.ts src/shared/components/ExternalLinkConfirm.test.ts
- npx tsc --noEmit
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- npx tauri build
- wg-1 standalone --help smoke test

Closes #470