### PR TITLE
feat(agents): surface Agency template install in New Agent modal (#465)

### DIFF
--- a/src-tauri/src/cli/agency_templates.rs
+++ b/src-tauri/src/cli/agency_templates.rs
@@ -15,7 +15,8 @@ use crate::commands::role_templates::{
     AGENCY_TEMPLATES_DIR,
 };
 
-const DEFAULT_REPO: &str = "https://github.com/msitarzewski/agency-agents";
+pub const DEFAULT_REPO: &str = "https://github.com/msitarzewski/agency-agents";
+pub const DEFAULT_REFERENCE: &str = "main";
 
 #[derive(Args)]
 #[command(after_help = "\
@@ -42,11 +43,21 @@ pub enum AgencyTemplatesCommand {
 pub struct AgencyTemplatesUpdateArgs {
     #[arg(long, default_value = DEFAULT_REPO)]
     pub repo: String,
-    #[arg(long = "ref", default_value = "main")]
+    #[arg(long = "ref", default_value = DEFAULT_REFERENCE)]
     pub reference: String,
     /// Compatibility no-op. agency-templates commands always print JSON.
     #[arg(long)]
     pub json: bool,
+}
+
+impl AgencyTemplatesUpdateArgs {
+    pub fn default_ui_update() -> Self {
+        Self {
+            repo: DEFAULT_REPO.into(),
+            reference: DEFAULT_REFERENCE.into(),
+            json: true,
+        }
+    }
 }
 
 #[derive(Args)]
@@ -69,16 +80,16 @@ pub struct AgencyTemplatesStatusArgs {
     pub pretty: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct UpdateResult {
-    repo: String,
+pub struct UpdateResult {
+    pub repo: String,
     #[serde(rename = "ref")]
-    reference: String,
-    commit: String,
-    template_count: usize,
-    path: String,
-    updated: bool,
+    pub reference: String,
+    pub commit: String,
+    pub template_count: usize,
+    pub path: String,
+    pub updated: bool,
 }
 
 struct CacheLock {
@@ -295,34 +306,54 @@ fn print_json<T: Serialize>(value: &T, pretty: bool) -> Result<(), String> {
     Ok(())
 }
 
-fn status(args: AgencyTemplatesStatusArgs) -> Result<(), String> {
-    let _ = args.json;
-    let config_dir = config_dir_or_err()?;
-    match CacheLock::acquire(&config_dir) {
+pub fn status_cache_at(
+    config_dir: &Path,
+) -> Result<crate::commands::role_templates::AgencyTemplatesStatus, String> {
+    match CacheLock::acquire(config_dir) {
         Ok(_lock) => {
-            if let Err(e) = recover_interrupted_publish(&config_dir) {
+            if let Err(e) = recover_interrupted_publish(config_dir) {
                 if e.starts_with("cacheInvalid") {
-                    let value = serde_json::json!({
-                        "available": false,
-                        "path": agency_templates_dir(&config_dir).to_string_lossy(),
-                        "reason": "cacheInvalid",
+                    return Ok(crate::commands::role_templates::AgencyTemplatesStatus {
+                        available: false,
+                        path: agency_templates_dir(config_dir)
+                            .to_string_lossy()
+                            .to_string(),
+                        repo: None,
+                        reference: None,
+                        commit: None,
+                        template_count: None,
+                        reason: Some("cacheInvalid".into()),
                     });
-                    return print_json(&value, args.pretty);
                 }
                 return Err(e);
             }
         }
         Err(e) if e.contains("already running") => {
-            let value = serde_json::json!({
-                "available": false,
-                "path": agency_templates_dir(&config_dir).to_string_lossy(),
-                "reason": "locked",
+            return Ok(crate::commands::role_templates::AgencyTemplatesStatus {
+                available: false,
+                path: agency_templates_dir(config_dir)
+                    .to_string_lossy()
+                    .to_string(),
+                repo: None,
+                reference: None,
+                commit: None,
+                template_count: None,
+                reason: Some("locked".into()),
             });
-            return print_json(&value, args.pretty);
         }
         Err(e) => return Err(e),
     }
-    print_json(&agency_templates_status(&config_dir), args.pretty)
+    Ok(agency_templates_status(config_dir))
+}
+
+pub fn status_cache() -> Result<crate::commands::role_templates::AgencyTemplatesStatus, String> {
+    let config_dir = config_dir_or_err()?;
+    status_cache_at(&config_dir)
+}
+
+fn status(args: AgencyTemplatesStatusArgs) -> Result<(), String> {
+    let _ = args.json;
+    print_json(&status_cache()?, args.pretty)
 }
 
 fn list(args: AgencyTemplatesListArgs) -> Result<(), String> {
@@ -343,35 +374,34 @@ fn list(args: AgencyTemplatesListArgs) -> Result<(), String> {
     print_json(&agency_template_metas_from_cache(&config_dir), args.pretty)
 }
 
-fn update(args: AgencyTemplatesUpdateArgs) -> Result<(), String> {
-    let config_dir = config_dir_or_err()?;
-    let _lock = CacheLock::acquire(&config_dir)?;
-    let _ = recover_interrupted_publish(&config_dir)?;
-    cleanup_publish_residue(&config_dir);
+pub fn update_cache_at(
+    config_dir: &Path,
+    args: AgencyTemplatesUpdateArgs,
+) -> Result<UpdateResult, String> {
+    let _lock = CacheLock::acquire(config_dir)?;
+    let _ = recover_interrupted_publish(config_dir)?;
+    cleanup_publish_residue(config_dir);
     let _ = args.json;
 
     parse_github_repo(&args.repo)?;
     let commit = resolve_commit_with_git(&args.repo, &args.reference)?;
-    let destination = agency_templates_dir(&config_dir);
-    if let Ok(current) = current_manifest_if_valid(&config_dir) {
+    let destination = agency_templates_dir(config_dir);
+    if let Ok(current) = current_manifest_if_valid(config_dir) {
         if current.repo == args.repo
             && current.reference == args.reference
             && current.commit == commit
         {
-            return print_json(
-                &UpdateResult {
-                    repo: current.repo,
-                    reference: current.reference,
-                    commit: current.commit,
-                    template_count: current.template_count,
-                    path: destination.to_string_lossy().to_string(),
-                    updated: false,
-                },
-                false,
-            );
+            return Ok(UpdateResult {
+                repo: current.repo,
+                reference: current.reference,
+                commit: current.commit,
+                template_count: current.template_count,
+                path: destination.to_string_lossy().to_string(),
+                updated: false,
+            });
         }
     }
-    let extracted = fetch_repo_with_git(&args.repo, &commit, &config_dir)?;
+    let extracted = fetch_repo_with_git(&args.repo, &commit, config_dir)?;
     let extracted = TempCacheDir::new(extracted);
     let staging = config_dir.join(format!(
         "{}.next-{}",
@@ -412,19 +442,26 @@ fn update(args: AgencyTemplatesUpdateArgs) -> Result<(), String> {
     collect_agency_templates_from_dir(staging.path())
         .map_err(|e| format!("Staged Agency cache failed validation: {}", e))?;
 
-    publish_staging(&config_dir, staging.path())?;
-    cleanup_publish_residue(&config_dir);
-    print_json(
-        &UpdateResult {
-            repo: manifest.repo,
-            reference: manifest.reference,
-            commit: manifest.commit,
-            template_count: manifest.template_count,
-            path: destination.to_string_lossy().to_string(),
-            updated: true,
-        },
-        false,
-    )
+    publish_staging(config_dir, staging.path())?;
+    cleanup_publish_residue(config_dir);
+    Ok(UpdateResult {
+        repo: manifest.repo,
+        reference: manifest.reference,
+        commit: manifest.commit,
+        template_count: manifest.template_count,
+        path: destination.to_string_lossy().to_string(),
+        updated: true,
+    })
+}
+
+pub fn update_cache(args: AgencyTemplatesUpdateArgs) -> Result<UpdateResult, String> {
+    let config_dir = config_dir_or_err()?;
+    update_cache_at(&config_dir, args)
+}
+
+fn update(args: AgencyTemplatesUpdateArgs) -> Result<(), String> {
+    let result = update_cache(args)?;
+    print_json(&result, false)
 }
 
 fn current_manifest_if_valid(config_dir: &Path) -> Result<AgencyTemplatesManifest, String> {
@@ -455,6 +492,12 @@ fn parse_github_repo(input: &str) -> Result<(), String> {
 }
 
 fn resolve_commit_with_git(repo: &str, reference: &str) -> Result<String, String> {
+    #[cfg(test)]
+    if let Ok(commit) = std::env::var("AGENTSCOMMANDER_AGENCY_TEST_COMMIT") {
+        let _ = (repo, reference);
+        return Ok(commit);
+    }
+
     let output = Command::new("git")
         .args(["ls-remote", repo, reference])
         .output()
@@ -1050,6 +1093,67 @@ mod tests {
         drop(lock);
 
         assert!(!lock_path.exists(), "lock should be removed on drop");
+    }
+
+    #[test]
+    fn status_cache_at_recovers_valid_previous_cache() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_dir = tmp.path();
+        let prev = config_dir.join(format!("{}.prev-one", AGENCY_TEMPLATES_DIR));
+        write_valid_cache(&prev);
+
+        let status = status_cache_at(config_dir).expect("status recovers previous cache");
+
+        assert!(status.available);
+        assert!(agency_templates_dir(config_dir).is_dir());
+        assert!(!prev.exists(), "previous cache should be promoted");
+        assert_eq!(status.template_count, Some(1));
+    }
+
+    #[test]
+    fn status_cache_at_reports_live_lock_as_locked() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_dir = tmp.path();
+        let lock_path = config_dir.join(format!("{}.lock", AGENCY_TEMPLATES_DIR));
+        fs::write(
+            &lock_path,
+            format!(r#"{{"pid":{},"createdUnixSecs":1}}"#, process::id()),
+        )
+        .expect("write live lock");
+
+        let status = status_cache_at(config_dir).expect("locked status should be non-fatal");
+
+        assert!(!status.available);
+        assert_eq!(status.reason.as_deref(), Some("locked"));
+        fs::remove_file(lock_path).expect("cleanup live lock");
+    }
+
+    #[test]
+    fn update_cache_at_reports_already_current_without_printed_json() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_dir = tmp.path();
+        let live = agency_templates_dir(config_dir);
+        write_valid_cache(&live);
+        let current = current_manifest_if_valid(config_dir).expect("valid manifest");
+        std::env::set_var("AGENTSCOMMANDER_AGENCY_TEST_COMMIT", &current.commit);
+
+        let result = update_cache_at(
+            config_dir,
+            AgencyTemplatesUpdateArgs {
+                repo: current.repo.clone(),
+                reference: current.reference.clone(),
+                json: true,
+            },
+        )
+        .expect("already-current update should succeed");
+
+        std::env::remove_var("AGENTSCOMMANDER_AGENCY_TEST_COMMIT");
+        assert!(!result.updated);
+        assert_eq!(result.repo, current.repo);
+        assert_eq!(result.reference, current.reference);
+        assert_eq!(result.commit, current.commit);
+        assert_eq!(result.template_count, current.template_count);
+        assert_eq!(result.path, live.to_string_lossy().to_string());
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/role_templates.rs
+++ b/src-tauri/src/commands/role_templates.rs
@@ -966,6 +966,24 @@ pub async fn list_role_templates(
     }
 }
 
+#[tauri::command]
+pub async fn get_agency_templates_status() -> Result<AgencyTemplatesStatus, String> {
+    tauri::async_runtime::spawn_blocking(crate::cli::agency_templates::status_cache)
+        .await
+        .map_err(|e| format!("Agency template status task failed: {}", e))?
+}
+
+#[tauri::command]
+pub async fn update_agency_templates() -> Result<crate::cli::agency_templates::UpdateResult, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        crate::cli::agency_templates::update_cache(
+            crate::cli::agency_templates::AgencyTemplatesUpdateArgs::default_ui_update(),
+        )
+    })
+    .await
+    .map_err(|e| format!("Agency template update task failed: {}", e))?
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1428,6 +1428,8 @@ pub fn run() {
             commands::entity_creation::delete_workgroup,
             commands::entity_creation::sync_workgroup_repos,
             commands::role_templates::list_role_templates,
+            commands::role_templates::get_agency_templates_status,
+            commands::role_templates::update_agency_templates,
         ])
         .build(tauri::generate_context!())
         .expect("error while building application")

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -271,6 +271,45 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
             Ok(json!(null))
         }
 
+        // --- Role templates ---
+        "list_role_templates" => {
+            let snapshot = state.settings.read().await.clone();
+            match crate::config::config_dir() {
+                Some(config_dir) => serde_json::to_value(
+                    crate::commands::role_templates::collect_role_templates(
+                        &snapshot,
+                        &config_dir,
+                    ),
+                )
+                .map_err(|e| e.to_string()),
+                None => {
+                    log::warn!(
+                        "[role-templates] could not resolve config dir; returning no role templates"
+                    );
+                    Ok(json!([]))
+                }
+            }
+        }
+
+        "get_agency_templates_status" => {
+            let status =
+                tauri::async_runtime::spawn_blocking(crate::cli::agency_templates::status_cache)
+                    .await
+                    .map_err(|e| format!("Agency template status task failed: {}", e))??;
+            serde_json::to_value(status).map_err(|e| e.to_string())
+        }
+
+        "update_agency_templates" => {
+            let result = tauri::async_runtime::spawn_blocking(|| {
+                crate::cli::agency_templates::update_cache(
+                    crate::cli::agency_templates::AgencyTemplatesUpdateArgs::default_ui_update(),
+                )
+            })
+            .await
+            .map_err(|e| format!("Agency template update task failed: {}", e))??;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+
         // --- Screen replay for late-joining clients ---
         "subscribe_session" => {
             let session_id = require_str(args, "sessionId")?;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -19,6 +19,8 @@ import type {
   WorkgroupTaskUpdatedEvent,
   ProjectRegistration,
   ErrorLogEntry,
+  AgencyTemplatesStatus,
+  AgencyTemplatesUpdateResult,
   RoleTemplateMeta,
   SpecBoardDocument,
   SpecBoardSnapshot,
@@ -462,6 +464,9 @@ export const ProjectAPI = {
 // Role template picker (#271)
 export const RoleTemplateAPI = {
   list: () => transport.invoke<RoleTemplateMeta[]>("list_role_templates"),
+  status: () => transport.invoke<AgencyTemplatesStatus>("get_agency_templates_status"),
+  updateAgencyTemplates: () =>
+    transport.invoke<AgencyTemplatesUpdateResult>("update_agency_templates"),
 };
 
 // Entity Creation API (agents, teams, workgroups)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -453,6 +453,25 @@ export interface RoleTemplateMeta {
   hasSkills: boolean;
 }
 
+export interface AgencyTemplatesStatus {
+  available: boolean;
+  path: string;
+  repo?: string | null;
+  ref?: string | null;
+  commit?: string | null;
+  templateCount?: number | null;
+  reason?: string | null;
+}
+
+export interface AgencyTemplatesUpdateResult {
+  repo: string;
+  ref: string;
+  commit: string;
+  templateCount: number;
+  path: string;
+  updated: boolean;
+}
+
 export interface SpecBoardDocument {
   docId: string;
   repoRoot: string;

--- a/src/sidebar/components/NewEntityAgentModal.tsx
+++ b/src/sidebar/components/NewEntityAgentModal.tsx
@@ -1,6 +1,6 @@
 import { Component, createSignal, createMemo, For, Show, onMount, onCleanup } from "solid-js";
 import { EntityAPI, RoleTemplateAPI } from "../../shared/ipc";
-import type { RoleTemplateMeta } from "../../shared/types";
+import type { AgencyTemplatesStatus, RoleTemplateMeta } from "../../shared/types";
 import {
   applyTemplatePrefill,
   filterRoleTemplates,
@@ -27,22 +27,43 @@ const NewEntityAgentModal: Component<{
   const [templates, setTemplates] = createSignal<RoleTemplateMeta[]>([]);
   const [templateQuery, setTemplateQuery] = createSignal("");
   const [selectedTemplateId, setSelectedTemplateId] = createSignal<string | null>(null);
+  const [agencyStatus, setAgencyStatus] = createSignal<AgencyTemplatesStatus | null>(null);
+  const [agencyInstalling, setAgencyInstalling] = createSignal(false);
+  const [agencyInstallError, setAgencyInstallError] = createSignal("");
   let nameRef!: HTMLInputElement;
   let listRef: HTMLDivElement | undefined;
 
-  onMount(async () => {
-    try {
-      setTemplates(await RoleTemplateAPI.list());
-    } catch (e) {
-      // Non-fatal: the picker just shows "No template". The backend logs any
-      // custom-path failure to the ErrorModal independently.
-      console.error("list_role_templates failed:", e);
+  let mounted = true;
+  onCleanup(() => {
+    mounted = false;
+  });
+
+  const reloadTemplatesAndAgencyStatus = async () => {
+    const [templatesResult, statusResult] = await Promise.allSettled([
+      RoleTemplateAPI.list(),
+      RoleTemplateAPI.status(),
+    ]);
+    if (!mounted) return;
+    if (templatesResult.status === "fulfilled") {
+      setTemplates(templatesResult.value);
+    } else {
+      console.error("list_role_templates failed:", templatesResult.reason);
     }
+    if (statusResult.status === "fulfilled") {
+      setAgencyStatus(statusResult.value);
+    } else {
+      console.error("get_agency_templates_status failed:", statusResult.reason);
+    }
+  };
+
+  onMount(async () => {
+    await reloadTemplatesAndAgencyStatus();
   });
 
   const filteredTemplates = createMemo(() =>
     filterRoleTemplates(templates(), templateQuery()),
   );
+  const shouldShowAgencyInstall = createMemo(() => agencyStatus()?.available === false);
 
   const selectTemplate = (t: RoleTemplateMeta | null) => {
     setSelectedTemplateId(t ? t.id : null);
@@ -56,6 +77,32 @@ const NewEntityAgentModal: Component<{
       setName(next.name);
       setDescription(next.description);
       setError("");
+    }
+  };
+
+  const errorMessage = (err: unknown, fallback: string) =>
+    typeof err === "string"
+      ? err
+      : err instanceof Error
+        ? err.message
+        : fallback;
+
+  const handleInstallAgencyTemplates = async (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (agencyInstalling()) return;
+    setAgencyInstalling(true);
+    setAgencyInstallError("");
+    try {
+      await RoleTemplateAPI.updateAgencyTemplates();
+      await reloadTemplatesAndAgencyStatus();
+    } catch (err: unknown) {
+      console.error("update_agency_templates failed:", err);
+      if (mounted) {
+        setAgencyInstallError(errorMessage(err, "Failed to install Agents Agency templates"));
+      }
+    } finally {
+      if (mounted) setAgencyInstalling(false);
     }
   };
 
@@ -189,6 +236,34 @@ const NewEntityAgentModal: Component<{
                 aria-label="Search role templates"
               />
             </div>
+            <Show when={shouldShowAgencyInstall()}>
+              <div class="tpl-agency-install">
+                <div class="tpl-agency-install-copy">
+                  <div class="tpl-agency-install-title">Agents Agency templates are not installed</div>
+                  <div class="tpl-agency-install-desc">
+                    Install tested specialist role templates for new agents. You can still create a blank agent.
+                  </div>
+                  <Show when={agencyInstallError()}>
+                    <div class="tpl-agency-install-error" role="status" aria-live="polite">
+                      {agencyInstallError()}
+                    </div>
+                  </Show>
+                </div>
+                <button
+                  type="button"
+                  class="tpl-agency-install-btn"
+                  disabled={agencyInstalling()}
+                  onClick={handleInstallAgencyTemplates}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") e.stopPropagation();
+                  }}
+                >
+                  <span aria-live="polite">
+                    {agencyInstalling() ? "Installing..." : "Install templates"}
+                  </span>
+                </button>
+              </div>
+            </Show>
             <div
               class="tpl-picker-list"
               ref={listRef}

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -4612,6 +4612,62 @@ html.light-theme .onboarding-card.selected {
   color: var(--sidebar-fg-dim);
 }
 
+.tpl-agency-install {
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+  padding: 8px var(--spacing-sm);
+  border: 1px solid rgba(0, 212, 255, 0.22);
+  border-radius: var(--radius-md);
+  background: rgba(0, 212, 255, 0.06);
+}
+
+.tpl-agency-install-copy {
+  flex: 1;
+  min-width: 0;
+}
+
+.tpl-agency-install-title {
+  font-size: var(--font-size-sm);
+  color: var(--sidebar-fg);
+}
+
+.tpl-agency-install-desc,
+.tpl-agency-install-error {
+  margin-top: 2px;
+  font-size: var(--font-size-xs, 11px);
+  color: var(--sidebar-fg-dim);
+  line-height: 1.35;
+}
+
+.tpl-agency-install-error {
+  color: var(--status-error, #ff5f56);
+}
+
+.tpl-agency-install-btn {
+  flex-shrink: 0;
+  margin-left: auto;
+  border: 1px solid var(--sidebar-accent);
+  border-radius: 4px;
+  background: rgba(0, 212, 255, 0.14);
+  color: var(--sidebar-fg);
+  font: inherit;
+  font-size: var(--font-size-xs, 11px);
+  padding: 5px 8px;
+  cursor: pointer;
+}
+
+.tpl-agency-install-btn:hover:not(:disabled) {
+  background: rgba(0, 212, 255, 0.22);
+}
+
+.tpl-agency-install-btn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
 .tpl-picker-list {
   margin-top: var(--spacing-xs);
   max-height: 168px;


### PR DESCRIPTION
## Summary
- show a non-blocking Agency templates install CTA in the New Agent modal when templates are missing
- wire Agency template status/list/update commands through the WebSocket dispatcher
- keep blank-agent creation available while templates are missing

## Verification
- cargo test cli::agency_templates
- cargo test cli_agency_templates
- cargo check
- cargo clippy
- npm test -- src/shared/role-templates.test.ts
- npx tsc --noEmit
- npm run build
- deployed wg-1 build validated by ac-cli-tester and manual visual testing

Closes #465