### PR TITLE
feat(testing): add deterministic GUI test mode (#475)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,11 @@ jobs:
         run: |
           TAG="${{ github.ref_name }}"
           if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+            node scripts/copy-testable-binary.mjs
             cp src-tauri/target/release/agentscommander.exe agentscommander-windows-x86_64.exe
+            cp src-tauri/target/release/agentscommander_testeable.exe agentscommander-testeable-windows-x86_64.exe
             gh release upload "$TAG" agentscommander-windows-x86_64.exe --clobber
+            gh release upload "$TAG" agentscommander-testeable-windows-x86_64.exe --clobber
           elif [[ "${{ matrix.platform }}" == "ubuntu-22.04" ]]; then
             cp src-tauri/target/release/agentscommander agentscommander-linux-x86_64
             gh release upload "$TAG" agentscommander-linux-x86_64 --clobber

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -61,6 +61,9 @@ This creates a **draft release** with:
 
 - Auto-generated changelog (from commits since the previous tag)
 - Windows installers (signed by SignPath via the release workflow)
+- Windows raw executables:
+  - `src-tauri/target/release/agentscommander.exe`
+  - `src-tauri/target/release/agentscommander_testeable.exe`
 - Linux `.AppImage`
 - macOS `.dmg` (Apple Silicon + Intel) — unsigned today
 

--- a/docs/testing/01-project-lifecycle.md
+++ b/docs/testing/01-project-lifecycle.md
@@ -1,0 +1,279 @@
+# 01 Project Lifecycle
+
+These cases validate the first project-management surface a user touches: identifying the correct app instance, creating or opening an AC project from the UI, seeing it in the project list, and confirming that project registration persists across an app restart.
+
+Use a clearly disposable project folder for create-flow cases, for example `ac-regression-prj-YYYYMMDD-HHMMSS`. Prefer creating that folder in the tester's allowed scratch/evidence area so the app does not mutate user data. If no safe in-app cleanup exists, record the residual folder and project registration.
+
+Visual preconditions from `README.md#visual-test-environment` apply to every case in this file. PRJ-001 captures them explicitly; later cases inherit them.
+
+Current mode: use the available wg-specific app and manual or external automation placement.
+
+Future mode after #475: use `agentscommander_testeable.exe` deterministic placement and the planned safe reset before PRJ cases that require clean state. Do not assume that binary or reset command exists until #475 is implemented.
+
+## Execution Log
+
+Date: 2026-06-11
+
+Tester: ac-cli-tester
+
+App under test: `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe --app`
+
+Target window: `Agents Commander [STANDALONE_WG-1]`
+
+Evidence root: `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-1-dev-team\__agent_ac-cli-tester\evidence\testing-phase-1`
+
+Test project: `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-1-dev-team\__agent_ac-cli-tester\evidence\testing-phase-1\ac-regression-prj-20260611-020008`
+
+| Case | Result | Evidence | Notes |
+| --- | --- | --- | --- |
+| PRJ-001 | PARTIAL | `PRJ-001-window-identifiable-after-relaunch.png`, `PRJ-001-window-state-after-relaunch.json` | Target was identifiable and maximized after relaunch. Initial capture from a negative-coordinate monitor produced a bad crop; relaunch recovered capture. |
+| PRJ-002 | PASS | `PRJ-002-new-open-menu.png`, `PRJ-002-after-new-project.png`, `PRJ-002-003-settings-registration.json` | UI `New Project` flow created `.ac/` and registered the disposable project once. Native folder picker evidence was limited; UIA confirmed picker state. |
+| PRJ-003 | PARTIAL | `PRJ-002-003-settings-registration.json`, `PRJ-003-sidebar-after-scroll-restored.png` | Settings show the created project is registered once. Sidebar visual capture did not show the new entry after a geometry/sidebar anomaly. |
+| PRJ-004 | PASS | `PRJ-004-post-relaunch-window-state.json`, `PRJ-004-post-relaunch-registration.json`, `PRJ-004-post-relaunch.png` | Project registration survived normal close/relaunch. |
+| PRJ-005 | PARTIAL | `PRJ-005-open-existing-dedupe.json` | Existing-project dedupe was verified with CLI fallback because native picker automation was unstable. UI-only coverage remains pending. |
+| PRJ-006 | BLOCKED | `PRJ-003-sidebar-after-scroll-restored.png` | Basic project navigation could not be verified because the sidebar was not reliably visible/capturable after the window geometry anomaly. |
+| PRJ-007 | PARTIAL | `PRJ-007-cancel-open-flow-settings-compare.json` | UI open flow was started and canceled with Escape; settings were unchanged. Picker screenshot evidence was not captured. |
+
+Residual test data:
+
+- The disposable project folder remains at `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-1-dev-team\__agent_ac-cli-tester\evidence\testing-phase-1\ac-regression-prj-20260611-020008`.
+- The folder contains a generated `.ac/` Project AC Root.
+- The project remains registered in `C:\Users\maria\0_mmb\0_AC\.agentscommander_standalone_wg-1\settings.json`.
+- No cleanup was performed because the current app has no safe reset command for normal binaries; planned support is tracked by #475.
+
+Automation gaps observed:
+
+- Window placement is not deterministic in the current wg-specific app. The first target window was on a negative-coordinate monitor and produced a bad crop.
+- Moving/restoring the Tauri window can leave the webview/capture geometry inconsistent.
+- Native folder picker automation is unstable without deterministic placement and a resettable test app identity.
+- Sidebar verification needs either deterministic window sizing or an app-level test hook to query loaded project UI state.
+
+### PRJ-001: App launches and target wg-1 window is identifiable
+
+Purpose:
+
+Verify that the workgroup-specific app instance is running, visually identifiable, and ready for GUI validation.
+
+Preconditions:
+
+- App wg-1 is open or launchable with `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe --app`.
+- Window title `Agents Commander [STANDALONE_WG-1]` is detectable.
+- Window is maximized on the monitor designated by the user for visual validation.
+- Initial capture is saved as evidence.
+- If the window is not maximized or is on a different monitor, the case must report `BLOCKED`/`PARTIAL` or move/maximize the window if the test plan permits, leaving evidence.
+
+Steps:
+
+1. Start the app if it is not already running.
+2. Enumerate visible AgentsCommander windows and select only the one whose title is `Agents Commander [STANDALONE_WG-1]`.
+3. Record PID, HWND, executable path, window rectangle, maximized state, and capture method.
+4. Save a screenshot of the target window.
+5. Confirm the header shows the `STANDALONE_WG-1` badge and the main/sidebar UI is readable.
+
+Expected Result:
+
+The target wg-1 window is uniquely identifiable, maximized on the intended monitor, and visually readable.
+
+Evidence Required:
+
+- Window-state snapshot with PID/HWND/title/rect/maximized flag.
+- Screenshot of the target window.
+
+Pass/Fail Criteria:
+
+Pass if the correct window is detected, maximized, and the screenshot clearly shows the wg-1 UI. Partial if the app is detected but required repositioning/relaunch to become capturable. Fail if the app cannot be launched or identified.
+
+### PRJ-002: Create a new test project from UI
+
+Purpose:
+
+Verify that a user can create/register an AC project from an empty folder through the UI open-project flow.
+
+Preconditions:
+
+- Depends on PRJ-001.
+- A disposable empty folder exists for this run.
+- The folder name is unique and clearly disposable, such as `ac-regression-prj-YYYYMMDD-HHMMSS`.
+
+Steps:
+
+1. Click `New / Open` in the target window.
+2. Choose the open-project action.
+3. In the folder picker, select the disposable empty folder.
+4. When prompted that the folder does not have an AC project, confirm creation with `Yes, create project`.
+5. Wait for the sidebar to refresh.
+
+Expected Result:
+
+The app creates the Project AC Root in the selected folder, registers the project, and loads it into the sidebar without disturbing existing projects.
+
+Evidence Required:
+
+- Screenshot before opening the picker.
+- Screenshot of the create confirmation prompt when possible.
+- Screenshot after creation showing the newly loaded project.
+- Filesystem or CLI state showing that `.ac/` exists in the disposable folder.
+
+Pass/Fail Criteria:
+
+Pass if the project is created through the UI and appears in the app. Partial if creation succeeds but one transient modal could not be captured. Fail if the UI cannot create or register the project.
+
+### PRJ-003: Created project appears in project list/sidebar
+
+Purpose:
+
+Verify that the newly created project is visible in the sidebar project list.
+
+Preconditions:
+
+- Depends on PRJ-002.
+
+Steps:
+
+1. Inspect the sidebar project list.
+2. Locate the project entry matching the disposable folder name.
+3. Expand the project entry if needed.
+4. Confirm project sections such as workgroups, agents, or teams are visible.
+
+Expected Result:
+
+The newly created project appears as a project entry in the sidebar and can be expanded or inspected.
+
+Evidence Required:
+
+- Sidebar screenshot showing the disposable project entry.
+
+Pass/Fail Criteria:
+
+Pass if the project entry is visible and matches the selected folder. Fail if the project was created on disk but never appears in the sidebar.
+
+### PRJ-004: Close/reopen app and confirm project persists
+
+Purpose:
+
+Verify that project registration survives an app restart.
+
+Preconditions:
+
+- Depends on PRJ-003.
+- The app can be closed normally without terminating unrelated AgentsCommander windows.
+
+Steps:
+
+1. Capture the sidebar state with the disposable project visible.
+2. Close the target `Agents Commander [STANDALONE_WG-1]` window normally.
+3. Relaunch `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe --app`.
+4. Detect and maximize the target window again.
+5. Capture the sidebar state after relaunch.
+6. Confirm the disposable project is still listed.
+
+Expected Result:
+
+The disposable project remains registered and visible after the app closes and reopens.
+
+Evidence Required:
+
+- Pre-close screenshot.
+- Post-relaunch window-state snapshot.
+- Post-relaunch screenshot showing the project entry.
+
+Pass/Fail Criteria:
+
+Pass if the project is visible after relaunch. Partial if relaunch required geometry recovery but the project persisted. Fail if the project disappears or the app cannot reopen.
+
+### PRJ-005: Open an existing project from UI
+
+Purpose:
+
+Verify that a user can open/register an existing AC project folder from the UI.
+
+Preconditions:
+
+- Depends on PRJ-001.
+- An existing folder with a Project AC Root (`.ac/`) is available.
+- Prefer using the disposable project created in PRJ-002 after it has a `.ac/` directory.
+
+Steps:
+
+1. Click `New / Open`.
+2. Choose the open-project action.
+3. Select an existing AC project folder.
+4. Wait for the sidebar refresh.
+5. Confirm the project is present and not duplicated.
+
+Expected Result:
+
+The existing AC project loads without a create confirmation and without duplicate project entries.
+
+Evidence Required:
+
+- Screenshot after opening the existing project.
+- Optional settings/project state snapshot showing a single registration for the path.
+
+Pass/Fail Criteria:
+
+Pass if the project opens and deduplicates correctly. Fail if the project duplicates, prompts for creation despite `.ac/`, or does not load.
+
+### PRJ-006: Project selection survives basic navigation
+
+Purpose:
+
+Verify that loaded project state remains stable while the user performs simple in-app navigation.
+
+Preconditions:
+
+- Depends on PRJ-003 or PRJ-005.
+- At least one project entry is visible in the sidebar.
+
+Steps:
+
+1. Select or expand the disposable project entry.
+2. Click another safe sidebar section or project entry.
+3. Return to the disposable project entry.
+4. Confirm the project remains visible and its expanded/collapsed state is coherent.
+
+Expected Result:
+
+The project list remains stable during basic navigation and the user can return to the same project entry.
+
+Evidence Required:
+
+- Screenshot before navigation.
+- Screenshot after returning to the project entry.
+
+Pass/Fail Criteria:
+
+Pass if the project remains visible and navigable. Fail if the entry disappears, changes identity, or navigation selects the wrong project unexpectedly.
+
+### PRJ-007: Cancel create/open flow does not mutate project list
+
+Purpose:
+
+Verify that canceling an open/create flow leaves the sidebar project list unchanged.
+
+Preconditions:
+
+- Depends on PRJ-001.
+- Baseline project list has been captured.
+
+Steps:
+
+1. Capture the baseline project list.
+2. Click `New / Open`.
+3. Start the open-project flow.
+4. Cancel the folder picker or creation confirmation before accepting any folder.
+5. Capture the project list again.
+6. Compare the project list to the baseline.
+
+Expected Result:
+
+Canceling the flow does not add, remove, duplicate, or reorder projects unexpectedly.
+
+Evidence Required:
+
+- Baseline screenshot.
+- Post-cancel screenshot.
+
+Pass/Fail Criteria:
+
+Pass if the visible project list is unchanged. Partial if a native picker prevented screenshot capture but post-cancel state is unchanged. Fail if canceling mutates project registration or visible project list.

--- a/docs/testing/01-project-lifecycle.md
+++ b/docs/testing/01-project-lifecycle.md
@@ -6,9 +6,7 @@ Use a clearly disposable project folder for create-flow cases, for example `ac-r
 
 Visual preconditions from `README.md#visual-test-environment` apply to every case in this file. PRJ-001 captures them explicitly; later cases inherit them.
 
-Current mode: use the available wg-specific app and manual or external automation placement.
-
-Future mode after #475: use `agentscommander_testeable.exe` deterministic placement and the planned safe reset before PRJ cases that require clean state. Do not assume that binary or reset command exists until #475 is implemented.
+Current deterministic mode: use `agentscommander_testeable.exe` with explicit placement and `window-info` verification. Run `agentscommander_testeable.exe test-reset --confirm-testeable` before PRJ cases that require clean disposable state, and only when the testable GUI is not active.
 
 ## Execution Log
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,84 @@
+# AgentsCommander Regression Testing
+
+This directory contains repeatable, versioned regression suites for AgentsCommander. The suites are written for human-style GUI and CLI validation: each case describes the setup, action sequence, expected result, required evidence, and pass/fail criteria.
+
+The goal is to make future rounds reproducible without turning every run into one large ad hoc report. Each functional area has its own file and should be executed in order unless a case explicitly states that it is independent.
+
+## Visual Test Environment
+
+- The app under test must be the workgroup-specific build for the run. Example:
+  `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe --app`
+- The target window must be identified by title. Example:
+  `Agents Commander [STANDALONE_WG-1]`
+- If multiple AgentsCommander windows are open, never assume the active window is the target. Select the window whose title matches the workgroup under test.
+- For GUI and human-style checks, the app should be maximized on the monitor designated by the user for visual validation.
+- Before each execution, record the target HWND/PID, window rectangle, whether the window is maximized, and the capture method used.
+- In multi-monitor setups, modals and menus can appear outside the crop for the target monitor. Use virtual desktop capture, HWND capture, adjacent crop, or relative-window coordinate capture as fallback evidence.
+- Prefer coordinates relative to the detected target window. Do not hardcode absolute screen coordinates except when documenting a concrete execution.
+
+## Future Testability Support Tracked In #475
+
+Issue #475 tracks deterministic GUI test support. It is not implemented yet, so current visual tests still require manual placement or external automation to locate and maximize `Agents Commander [STANDALONE_WG-1]`.
+
+The expected future support is a dedicated testable binary, `agentscommander_testeable.exe`, that can launch with deterministic placement. When available, this suite should use an invocation equivalent to:
+
+```powershell
+agentscommander_testeable.exe --app `
+  --window-x <x> `
+  --window-y <y> `
+  --window-width <w> `
+  --window-height <h> `
+  --window-maximized
+```
+
+Even in that future mode, each case must record the real HWND, PID, and window rectangle before clicking. The suite should fail early if the actual target window does not land on the expected monitor or rectangle.
+
+Issue #475 also proposes a safe reset command. This command is planned only; do not use or document it as available until implemented. The intended contract is:
+
+- It is valid only for a binary/app identity named exactly `agentscommander_testeable.exe`.
+- It completely deletes only `.agentscommander_testeable`.
+- It completely deletes only the disposable project folder named `agentscommander_testeable`.
+- It refuses to run from `agentscommander_standalone.exe`, `agentscommander_standalone_wg-1.exe`, or other normal app binaries.
+
+Until #475 lands, tests that need clean state must create clearly disposable folders and document residual state instead of assuming a reset command exists.
+
+## Case IDs
+
+Use a three-letter functional prefix followed by a zero-padded number:
+
+- `PRJ-###`: Project lifecycle.
+- `AGT-###`: Agent lifecycle.
+- `TPL-###`: Agent templates and agency setup.
+- `TRM-###`: Terminal sessions.
+- `MSG-###`: Inter-agent messaging.
+- `WGP-###`: Workgroups and peers.
+- `SET-###`: Settings and persistence.
+- `WIN-###`: Windowing and multi-monitor behavior.
+
+Cases should become progressively more complex inside each file. If a case depends on an earlier case, state the dependency in the preconditions.
+
+## Evidence Rules
+
+Evidence should be enough for another tester to verify the observed state without rerunning the case immediately.
+
+- Store screenshots, JSON state snapshots, command logs, and notes in the executing tester's allowed evidence directory.
+- Reference evidence paths from the execution notes or final report.
+- For GUI checks, capture the target window before and after the main action.
+- For persistence checks, capture both the pre-restart and post-restart state.
+- Record any fallback used, such as HWND capture, virtual desktop capture, keyboard navigation, or relative coordinates.
+- Do not delete user data to clean up after tests. If a test creates a project and the app has no safe cleanup path, document the residual test project.
+
+## Execution Order
+
+Recommended phase order:
+
+1. `01-project-lifecycle.md`
+2. `02-agent-lifecycle.md`
+3. `03-agent-templates-agency.md`
+4. `04-terminal-sessions.md`
+5. `05-inter-agent-messaging.md`
+6. `06-workgroups-and-peers.md`
+7. `07-settings-and-persistence.md`
+8. `08-windowing-and-multimonitor.md`
+
+Within a functional file, run cases in ascending ID order unless the case says it is independent.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -6,24 +6,28 @@ The goal is to make future rounds reproducible without turning every run into on
 
 ## Visual Test Environment
 
-- The app under test must be the workgroup-specific build for the run. Example:
-  `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe --app`
-- The target window must be identified by title. Example:
-  `Agents Commander [STANDALONE_WG-1]`
+- The app under test should be `agentscommander_testeable.exe` for deterministic GUI regression runs.
+- The testable app uses a disposable config directory next to the binary: `.agentscommander_testeable`.
+- The target window title for the testable app is `Agents Commander [TESTEABLE]`.
 - If multiple AgentsCommander windows are open, never assume the active window is the target. Select the window whose title matches the workgroup under test.
-- For GUI and human-style checks, the app should be maximized on the monitor designated by the user for visual validation.
-- Before each execution, record the target HWND/PID, window rectangle, whether the window is maximized, and the capture method used.
+- For GUI and human-style checks, launch the app at the monitor rectangle designated by the user for visual validation.
+- Before each execution, record the target HWND/PID, process path, window rectangle, whether the window is maximized, and the capture method used.
 - In multi-monitor setups, modals and menus can appear outside the crop for the target monitor. Use virtual desktop capture, HWND capture, adjacent crop, or relative-window coordinate capture as fallback evidence.
 - Prefer coordinates relative to the detected target window. Do not hardcode absolute screen coordinates except when documenting a concrete execution.
 
-## Future Testability Support Tracked In #475
+## Deterministic Testable App
 
-Issue #475 tracks deterministic GUI test support. It is not implemented yet, so current visual tests still require manual placement or external automation to locate and maximize `Agents Commander [STANDALONE_WG-1]`.
+Production Windows builds create a raw testable executable alongside the normal production executable:
 
-The expected future support is a dedicated testable binary, `agentscommander_testeable.exe`, that can launch with deterministic placement. When available, this suite should use an invocation equivalent to:
+```text
+src-tauri/target/release/agentscommander.exe
+src-tauri/target/release/agentscommander_testeable.exe
+```
+
+Launch with explicit virtual-desktop placement in physical pixels:
 
 ```powershell
-agentscommander_testeable.exe --app `
+.\agentscommander_testeable.exe --app `
   --window-x <x> `
   --window-y <y> `
   --window-width <w> `
@@ -31,16 +35,48 @@ agentscommander_testeable.exe --app `
   --window-maximized
 ```
 
-Even in that future mode, each case must record the real HWND, PID, and window rectangle before clicking. The suite should fail early if the actual target window does not land on the expected monitor or rectangle.
+Example for a negative-coordinate monitor:
 
-Issue #475 also proposes a safe reset command. This command is planned only; do not use or document it as available until implemented. The intended contract is:
+```powershell
+.\agentscommander_testeable.exe --app `
+  --window-x -2891 `
+  --window-y -11 `
+  --window-width 1942 `
+  --window-height 1102 `
+  --window-maximized
+```
 
-- It is valid only for a binary/app identity named exactly `agentscommander_testeable.exe`.
-- It completely deletes only `.agentscommander_testeable`.
-- It completely deletes only the disposable project folder named `agentscommander_testeable`.
-- It refuses to run from `agentscommander_standalone.exe`, `agentscommander_standalone_wg-1.exe`, or other normal app binaries.
+The same placement can be provided through `AC_TEST_WINDOW_PLACEMENT`:
 
-Until #475 lands, tests that need clean state must create clearly disposable folders and document residual state instead of assuming a reset command exists.
+```powershell
+$env:AC_TEST_WINDOW_PLACEMENT='{"x":-2891,"y":-11,"width":1942,"height":1102,"maximized":true}'
+.\agentscommander_testeable.exe --app
+```
+
+Placement flags and `AC_TEST_WINDOW_PLACEMENT` are accepted only by `agentscommander_testeable.exe`. Normal, stage, and workgroup binaries fail closed when they receive test placement input.
+
+After launch, query the target window from a separate process:
+
+```powershell
+.\agentscommander_testeable.exe window-info
+```
+
+`window-info` returns JSON containing `processPath`, PID, HWND, rectangle, and maximized state. Tests must assert that `processPath` equals the launched `agentscommander_testeable.exe` path before clicking or capturing.
+
+## Test Reset
+
+Use the explicit reset command only from `agentscommander_testeable.exe` and only when the testable GUI is not running:
+
+```powershell
+.\agentscommander_testeable.exe test-reset --confirm-testeable
+```
+
+The command deletes only these sibling paths under the executable directory:
+
+- `.agentscommander_testeable`
+- `agentscommander_testeable`
+
+It refuses files, symlinks, junctions, mount points, Windows reparse-point directories, normal binaries, and active testable GUI instances. Refusal cases return structured JSON on stderr. Successful runs print newline-delimited JSON on stdout, with a planned-delete record followed by the final result.
 
 ## Case IDs
 
@@ -66,7 +102,7 @@ Evidence should be enough for another tester to verify the observed state withou
 - For GUI checks, capture the target window before and after the main action.
 - For persistence checks, capture both the pre-restart and post-restart state.
 - Record any fallback used, such as HWND capture, virtual desktop capture, keyboard navigation, or relative coordinates.
-- Do not delete user data to clean up after tests. If a test creates a project and the app has no safe cleanup path, document the residual test project.
+- Do not delete user data to clean up after tests. Use `test-reset --confirm-testeable` only for the disposable testable app identity. If a test creates data outside that identity, document the residual test project.
 
 ## Execution Order
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -11,6 +11,11 @@ The goal is to make future rounds reproducible without turning every run into on
 - The target window title for the testable app is `Agents Commander [TESTEABLE]`.
 - If multiple AgentsCommander windows are open, never assume the active window is the target. Select the window whose title matches the workgroup under test.
 - For GUI and human-style checks, launch the app at the monitor rectangle designated by the user for visual validation.
+- Current visual-test baseline:
+  - Logical display: `\\.\DISPLAY9`
+  - Physical rect for `window-info` / DWM: `Left=-1920 Top=0 Width=1920 Height=1080`
+  - Logical rect observed via Windows Forms: `Left=-1920 Top=0 Width=1280 Height=720`
+  - Physical and logical rectangles can differ because DPI scaling changes the coordinate space reported by different Windows APIs.
 - Before each execution, record the target HWND/PID, process path, window rectangle, whether the window is maximized, and the capture method used.
 - In multi-monitor setups, modals and menus can appear outside the crop for the target monitor. Use virtual desktop capture, HWND capture, adjacent crop, or relative-window coordinate capture as fallback evidence.
 - Prefer coordinates relative to the detected target window. Do not hardcode absolute screen coordinates except when documenting a concrete execution.
@@ -35,21 +40,21 @@ Launch with explicit virtual-desktop placement in physical pixels:
   --window-maximized
 ```
 
-Example for a negative-coordinate monitor:
+Current default visual-test example:
 
 ```powershell
 .\agentscommander_testeable.exe --app `
-  --window-x -2891 `
-  --window-y -11 `
-  --window-width 1942 `
-  --window-height 1102 `
+  --window-x -1920 `
+  --window-y 0 `
+  --window-width 1920 `
+  --window-height 1080 `
   --window-maximized
 ```
 
 The same placement can be provided through `AC_TEST_WINDOW_PLACEMENT`:
 
 ```powershell
-$env:AC_TEST_WINDOW_PLACEMENT='{"x":-2891,"y":-11,"width":1942,"height":1102,"maximized":true}'
+$env:AC_TEST_WINDOW_PLACEMENT='{"x":-1920,"y":0,"width":1920,"height":1080,"maximized":true}'
 .\agentscommander_testeable.exe --app
 ```
 
@@ -61,7 +66,9 @@ After launch, query the target window from a separate process:
 .\agentscommander_testeable.exe window-info
 ```
 
-`window-info` returns JSON containing `processPath`, PID, HWND, rectangle, and maximized state. Tests must assert that `processPath` equals the launched `agentscommander_testeable.exe` path before clicking or capturing.
+`window-info` returns JSON containing `processPath`, PID, HWND, rectangle, and maximized state. Tests must assert that `processPath` exactly equals the launched `agentscommander_testeable.exe` path before clicking or capturing. A passing visual gate should also assert that `window-info` reports approximately `left=-1920`, `top=0`, `width=1920`, `height=1080`, and `maximized:true`. If the user moves the app to a different monitor, update this baseline after measuring the new target with `window-info`.
+
+Historical reference: the old placement `--window-x -2891 --window-y -11 --window-width 1942 --window-height 1102` is obsolete and should not be used as a live visual-test baseline.
 
 ## Test Reset
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "build:prod": "cross-env BUILD_PROFILE=prod tauri build --config src-tauri/tauri.prod.conf.json",
+    "build:prod": "cross-env BUILD_PROFILE=prod tauri build --config src-tauri/tauri.prod.conf.json && node scripts/copy-testable-binary.mjs",
+    "build:testable": "node scripts/copy-testable-binary.mjs",
     "build:stage": "cross-env BUILD_PROFILE=stage tauri build --config src-tauri/tauri.stage.conf.json",
     "kill-dev": "powershell.exe -ExecutionPolicy Bypass -File ./scripts/kill-dev.ps1",
     "validate-branch-name": "node scripts/validate-branch-name.mjs",

--- a/scripts/copy-testable-binary.mjs
+++ b/scripts/copy-testable-binary.mjs
@@ -1,0 +1,28 @@
+import { copyFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const releaseDir = path.join(repoRoot, "src-tauri", "target", "release");
+const source = path.join(releaseDir, "agentscommander.exe");
+const destination = path.join(releaseDir, "agentscommander_testeable.exe");
+
+try {
+  const sourceStat = await stat(source);
+  if (!sourceStat.isFile()) {
+    console.error(`Expected production binary to be a file: ${source}`);
+    process.exit(1);
+  }
+} catch (error) {
+  console.error(`Production binary is missing: ${source}`);
+  console.error(`Run the production Tauri build before copying the testable binary.`);
+  if (error?.message) {
+    console.error(error.message);
+  }
+  process.exit(1);
+}
+
+await copyFile(source, destination);
+console.log(`Copied production binary: ${source}`);
+console.log(`Created testable binary: ${destination}`);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_RestartManager",
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Diagnostics_ToolHelp",
+    "Win32_Graphics_Dwm",
     "Win32_UI_WindowsAndMessaging",
     "Wdk_System_Threading",
 ] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_Graphics_Dwm",
+    "Win32_Graphics_Gdi",
     "Win32_UI_WindowsAndMessaging",
     "Wdk_System_Threading",
 ] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_RestartManager",
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Diagnostics_ToolHelp",
+    "Win32_UI_WindowsAndMessaging",
     "Wdk_System_Threading",
 ] }
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -85,6 +85,26 @@ pub struct Cli {
     #[arg(long)]
     pub app: bool,
 
+    /// Test-only GUI placement: virtual-desktop X coordinate in physical pixels
+    #[arg(long, allow_hyphen_values = true)]
+    pub window_x: Option<f64>,
+
+    /// Test-only GUI placement: virtual-desktop Y coordinate in physical pixels
+    #[arg(long, allow_hyphen_values = true)]
+    pub window_y: Option<f64>,
+
+    /// Test-only GUI placement: window width in physical pixels
+    #[arg(long, allow_hyphen_values = true)]
+    pub window_width: Option<f64>,
+
+    /// Test-only GUI placement: window height in physical pixels
+    #[arg(long, allow_hyphen_values = true)]
+    pub window_height: Option<f64>,
+
+    /// Test-only GUI placement: maximize after applying the requested rectangle
+    #[arg(long)]
+    pub window_maximized: bool,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }
@@ -125,6 +145,10 @@ pub enum Commands {
     Team(team::TeamArgs),
     /// Execute commands through the policy harness
     Harness(harness::HarnessArgs),
+    /// Delete only the disposable testable app state
+    TestReset(crate::testability::reset::TestResetArgs),
+    /// Inspect running AgentsCommander GUI windows for this binary identity
+    WindowInfo(crate::testability::window_info::WindowInfoArgs),
 }
 
 /// Attach to parent console (or allocate a new one) ONLY if both stdout and stderr
@@ -247,6 +271,8 @@ pub fn handle_cli(cmd: Commands) -> i32 {
         Commands::Workgroup(args) => workgroup::execute(args),
         Commands::Team(args) => team::execute(args),
         Commands::Harness(args) => harness::execute(args),
+        Commands::TestReset(args) => crate::testability::reset::execute(args),
+        Commands::WindowInfo(args) => crate::testability::window_info::execute(args),
     };
 
     flush_outputs();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -668,6 +668,56 @@ pub fn run(
                 );
             }
 
+            fn apply_test_window_placement(
+                win: &tauri::WebviewWindow,
+                geo: &crate::testability::window_placement::TestWindowPlacement,
+            ) {
+                let x = geo.x.round() as i32;
+                let y = geo.y.round() as i32;
+                let width = geo.width.round().max(1.0) as u32;
+                let height = geo.height.round().max(1.0) as u32;
+
+                #[cfg(target_os = "windows")]
+                {
+                    use windows_sys::Win32::UI::WindowsAndMessaging::{
+                        SetWindowPos, SWP_NOACTIVATE, SWP_NOZORDER, SWP_SHOWWINDOW,
+                    };
+
+                    match win.hwnd() {
+                        Ok(hwnd) => unsafe {
+                            let ok = SetWindowPos(
+                                hwnd.0 as _,
+                                std::ptr::null_mut(),
+                                x,
+                                y,
+                                width as i32,
+                                height as i32,
+                                SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW,
+                            );
+                            if ok == 0 {
+                                log::warn!("[test-window] native SetWindowPos failed");
+                            }
+                            return;
+                        },
+                        Err(e) => {
+                            log::warn!("[test-window] failed to get HWND: {}", e);
+                        }
+                    }
+                }
+
+                if let Err(e) = win.set_size(tauri::Size::Physical(tauri::PhysicalSize {
+                    width,
+                    height,
+                })) {
+                    log::warn!("[test-window] failed to set physical size: {}", e);
+                }
+                if let Err(e) = win.set_position(tauri::Position::Physical(
+                    tauri::PhysicalPosition { x, y },
+                )) {
+                    log::warn!("[test-window] failed to set physical position: {}", e);
+                }
+            }
+
             // Resolve main geometry: saved (physical) -> validate -> convert to logical -> fallback.
             // First-boot-after-upgrade users will have `main_geometry` seeded from legacy
             // `terminal_geometry` via the migration in `config::settings::load_settings`.
@@ -734,6 +784,7 @@ pub fn run(
             .build()?;
 
             if let Some(test_geo) = &test_window_placement {
+                apply_test_window_placement(&main_win, test_geo);
                 if test_geo.maximized {
                     if let Err(e) = main_win.maximize() {
                         log::warn!("[test-window] failed to maximize main window: {}", e);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -671,7 +671,7 @@ pub fn run(
             fn apply_test_window_placement(
                 win: &tauri::WebviewWindow,
                 geo: &crate::testability::window_placement::TestWindowPlacement,
-            ) {
+            ) -> bool {
                 let x = geo.x.round() as i32;
                 let y = geo.y.round() as i32;
                 let width = geo.width.round().max(1.0) as u32;
@@ -679,12 +679,82 @@ pub fn run(
 
                 #[cfg(target_os = "windows")]
                 {
+                    use windows_sys::Win32::Graphics::Gdi::{
+                        GetMonitorInfoW, MonitorFromRect, MONITORINFO,
+                        MONITOR_DEFAULTTONEAREST,
+                    };
+                    use windows_sys::Win32::Foundation::{POINT, RECT};
                     use windows_sys::Win32::UI::WindowsAndMessaging::{
-                        SetWindowPos, SWP_NOACTIVATE, SWP_NOZORDER, SWP_SHOWWINDOW,
+                        GetWindowPlacement, IsZoomed, SetWindowPlacement, SetWindowPos,
+                        ShowWindow, WINDOWPLACEMENT, SWP_NOACTIVATE, SWP_NOZORDER,
+                        SWP_SHOWWINDOW, SW_RESTORE, SW_SHOWMAXIMIZED,
                     };
 
                     match win.hwnd() {
                         Ok(hwnd) => unsafe {
+                            let requested = RECT {
+                                left: x,
+                                top: y,
+                                right: x.saturating_add(width as i32),
+                                bottom: y.saturating_add(height as i32),
+                            };
+                            let monitor = MonitorFromRect(&requested, MONITOR_DEFAULTTONEAREST);
+                            if monitor.is_null() {
+                                log::warn!(
+                                    "[test-window] MonitorFromRect returned null for requested rect ({}, {}) {}x{}",
+                                    x,
+                                    y,
+                                    width,
+                                    height
+                                );
+                            } else {
+                                let mut monitor_info = MONITORINFO {
+                                    cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+                                    rcMonitor: RECT {
+                                        left: 0,
+                                        top: 0,
+                                        right: 0,
+                                        bottom: 0,
+                                    },
+                                    rcWork: RECT {
+                                        left: 0,
+                                        top: 0,
+                                        right: 0,
+                                        bottom: 0,
+                                    },
+                                    dwFlags: 0,
+                                };
+                                if GetMonitorInfoW(monitor, &mut monitor_info) == 0 {
+                                    log::warn!(
+                                        "[test-window] GetMonitorInfoW failed for requested rect ({}, {}) {}x{}",
+                                        x,
+                                        y,
+                                        width,
+                                        height
+                                    );
+                                } else {
+                                    log::info!(
+                                        "[test-window] selected monitor rect=({}, {}) {}x{} work=({}, {}) {}x{} for requested rect ({}, {}) {}x{} maximized={}",
+                                        monitor_info.rcMonitor.left,
+                                        monitor_info.rcMonitor.top,
+                                        monitor_info.rcMonitor.right - monitor_info.rcMonitor.left,
+                                        monitor_info.rcMonitor.bottom - monitor_info.rcMonitor.top,
+                                        monitor_info.rcWork.left,
+                                        monitor_info.rcWork.top,
+                                        monitor_info.rcWork.right - monitor_info.rcWork.left,
+                                        monitor_info.rcWork.bottom - monitor_info.rcWork.top,
+                                        x,
+                                        y,
+                                        width,
+                                        height,
+                                        geo.maximized
+                                    );
+                                }
+                            }
+
+                            if IsZoomed(hwnd.0 as _) != 0 || geo.maximized {
+                                ShowWindow(hwnd.0 as _, SW_RESTORE);
+                            }
                             let ok = SetWindowPos(
                                 hwnd.0 as _,
                                 std::ptr::null_mut(),
@@ -697,7 +767,30 @@ pub fn run(
                             if ok == 0 {
                                 log::warn!("[test-window] native SetWindowPos failed");
                             }
-                            return;
+                            if geo.maximized {
+                                let mut placement = WINDOWPLACEMENT {
+                                    length: std::mem::size_of::<WINDOWPLACEMENT>() as u32,
+                                    flags: 0,
+                                    showCmd: SW_SHOWMAXIMIZED as u32,
+                                    ptMinPosition: POINT { x: -1, y: -1 },
+                                    ptMaxPosition: POINT { x: -1, y: -1 },
+                                    rcNormalPosition: requested,
+                                };
+                                if GetWindowPlacement(hwnd.0 as _, &mut placement) == 0 {
+                                    log::warn!(
+                                        "[test-window] GetWindowPlacement failed before maximize"
+                                    );
+                                }
+                                placement.length =
+                                    std::mem::size_of::<WINDOWPLACEMENT>() as u32;
+                                placement.showCmd = SW_SHOWMAXIMIZED as u32;
+                                placement.rcNormalPosition = requested;
+                                if SetWindowPlacement(hwnd.0 as _, &placement) == 0 {
+                                    log::warn!("[test-window] SetWindowPlacement maximize failed");
+                                    ShowWindow(hwnd.0 as _, SW_SHOWMAXIMIZED);
+                                }
+                            }
+                            return true;
                         },
                         Err(e) => {
                             log::warn!("[test-window] failed to get HWND: {}", e);
@@ -716,6 +809,7 @@ pub fn run(
                 )) {
                     log::warn!("[test-window] failed to set physical position: {}", e);
                 }
+                false
             }
 
             // Resolve main geometry: saved (physical) -> validate -> convert to logical -> fallback.
@@ -784,8 +878,8 @@ pub fn run(
             .build()?;
 
             if let Some(test_geo) = &test_window_placement {
-                apply_test_window_placement(&main_win, test_geo);
-                if test_geo.maximized {
+                let native_handled = apply_test_window_placement(&main_win, test_geo);
+                if test_geo.maximized && !native_handled {
                     if let Err(e) = main_win.maximize() {
                         log::warn!("[test-window] failed to maximize main window: {}", e);
                     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod pty;
 pub mod session;
 pub mod shutdown;
 pub mod telegram;
+pub mod testability;
 pub mod voice;
 pub mod web;
 
@@ -157,7 +158,9 @@ pub(crate) fn should_auto_create_root_agent_on_first_restore(
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
+pub fn run(
+    test_window_placement: Option<crate::testability::window_placement::TestWindowPlacement>,
+) {
     // Same backend the CLI path now installs in `main.rs` — see `logging.rs`
     // for the rationale. Idempotent, so a hypothetical second call (or the
     // CLI path having already run in this process) is a no-op.
@@ -640,29 +643,77 @@ pub fn run() {
                 height: default_h,
             };
 
-            // Resolve main geometry: saved (physical) → validate → convert to logical → fallback.
+            fn log_main_window_info(win: &tauri::WebviewWindow) {
+                let pid = std::process::id();
+                let pos = win.outer_position().ok();
+                let size = win.outer_size().ok();
+                let maximized = win.is_maximized().ok();
+                log::info!(
+                    "[test-window] actual pid={} position={:?} size={:?} maximized={:?}",
+                    pid,
+                    pos,
+                    size,
+                    maximized
+                );
+                println!(
+                    "{{\"event\":\"testWindowInfo\",\"pid\":{},\"position\":{},\"size\":{},\"maximized\":{}}}",
+                    pid,
+                    serde_json::to_string(&pos.map(|p| serde_json::json!({ "x": p.x, "y": p.y })))
+                        .unwrap_or_else(|_| "null".to_string()),
+                    serde_json::to_string(
+                        &size.map(|s| serde_json::json!({ "width": s.width, "height": s.height }))
+                    )
+                    .unwrap_or_else(|_| "null".to_string()),
+                    serde_json::to_string(&maximized).unwrap_or_else(|_| "null".to_string())
+                );
+            }
+
+            // Resolve main geometry: saved (physical) -> validate -> convert to logical -> fallback.
             // First-boot-after-upgrade users will have `main_geometry` seeded from legacy
             // `terminal_geometry` via the migration in `config::settings::load_settings`.
-            let main_geo = match &saved_settings.main_geometry {
-                Some(geo) if is_visible_on_monitors(geo, &monitors) => {
-                    let logical = physical_to_logical(geo, &monitors);
-                    log::info!(
-                        "[window-setup] main: saved physical ({}, {}) {}x{} → logical ({}, {}) {}x{}",
-                        geo.x, geo.y, geo.width, geo.height,
-                        logical.x, logical.y, logical.width, logical.height
-                    );
-                    logical
-                }
-                Some(geo) => {
-                    log::warn!(
-                        "[window-setup] main: saved geometry ({}, {}) {}x{} is OFF-SCREEN, falling back to centered default",
-                        geo.x, geo.y, geo.width, geo.height
-                    );
-                    default_main.clone()
-                }
-                None => {
-                    log::info!("[window-setup] main: no saved geometry, using centered default");
-                    default_main.clone()
+            let main_geo = if let Some(test_geo) = &test_window_placement {
+                let requested = config::settings::WindowGeometry {
+                    x: test_geo.x,
+                    y: test_geo.y,
+                    width: test_geo.width,
+                    height: test_geo.height,
+                };
+                let logical = physical_to_logical(&requested, &monitors);
+                log::info!(
+                    "[test-window] requested physical ({}, {}) {}x{} maximized={} -> logical ({}, {}) {}x{}",
+                    requested.x,
+                    requested.y,
+                    requested.width,
+                    requested.height,
+                    test_geo.maximized,
+                    logical.x,
+                    logical.y,
+                    logical.width,
+                    logical.height
+                );
+                logical
+            } else {
+                match &saved_settings.main_geometry {
+                    Some(geo) if is_visible_on_monitors(geo, &monitors) => {
+                        let logical = physical_to_logical(geo, &monitors);
+                        log::info!(
+                            "[window-setup] main: saved physical ({}, {}) {}x{} -> logical ({}, {}) {}x{}",
+                            geo.x, geo.y, geo.width, geo.height,
+                            logical.x, logical.y, logical.width, logical.height
+                        );
+                        logical
+                    }
+                    Some(geo) => {
+                        log::warn!(
+                            "[window-setup] main: saved geometry ({}, {}) {}x{} is off-screen, falling back to centered default",
+                            geo.x, geo.y, geo.width, geo.height
+                        );
+                        default_main.clone()
+                    }
+                    None => {
+                        log::info!("[window-setup] main: no saved geometry, using centered default");
+                        default_main.clone()
+                    }
                 }
             };
 
@@ -681,6 +732,15 @@ pub fn run() {
             .inner_size(main_geo.width, main_geo.height)
             .position(main_geo.x, main_geo.y)
             .build()?;
+
+            if let Some(test_geo) = &test_window_placement {
+                if test_geo.maximized {
+                    if let Err(e) = main_win.maximize() {
+                        log::warn!("[test-window] failed to maximize main window: {}", e);
+                    }
+                }
+                log_main_window_info(&main_win);
+            }
 
             if saved_settings.main_always_on_top {
                 let _ = main_win.set_always_on_top(true);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -50,11 +50,27 @@ fn main() {
                     }
                     None => {
                         // GUI mode (with or without --app)
+                        let placement = match agentscommander_lib::testability::window_placement::resolve_from_cli_or_env(
+                            cli.window_x,
+                            cli.window_y,
+                            cli.window_width,
+                            cli.window_height,
+                            cli.window_maximized,
+                        ) {
+                            Ok(placement) => placement,
+                            Err(e) => {
+                                agentscommander_lib::cli::attach_parent_console();
+                                eprintln!("Error: {}", e);
+                                agentscommander_lib::cli::flush_outputs();
+                                std::process::exit(1);
+                            }
+                        };
+
                         if !try_acquire_single_instance() {
-                            // Another GUI instance is already running — exit silently
+                            // Another GUI instance is already running; exit silently
                             std::process::exit(0);
                         }
-                        agentscommander_lib::run();
+                        agentscommander_lib::run(placement);
                     }
                 },
                 Err(e) => {

--- a/src-tauri/src/testability/mod.rs
+++ b/src-tauri/src/testability/mod.rs
@@ -1,0 +1,45 @@
+pub mod reset;
+pub mod window_info;
+pub mod window_placement;
+
+#[cfg(target_os = "windows")]
+pub struct ProfileMutexGuard(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(target_os = "windows")]
+impl Drop for ProfileMutexGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub fn acquire_profile_mutex_probe() -> Result<(bool, Option<ProfileMutexGuard>), String> {
+    use windows_sys::Win32::Foundation::GetLastError;
+    use windows_sys::Win32::System::Threading::CreateMutexW;
+
+    const ERROR_ALREADY_EXISTS: u32 = 183;
+
+    let mutex_name = crate::config::profile::mutex_name();
+    let name: Vec<u16> = mutex_name.encode_utf16().collect();
+    let handle = unsafe { CreateMutexW(std::ptr::null(), 0, name.as_ptr()) };
+    if handle.is_null() {
+        return Err("profile_mutex_create_failed".to_string());
+    }
+
+    let already_exists = unsafe { GetLastError() } == ERROR_ALREADY_EXISTS;
+    if already_exists {
+        unsafe {
+            let _ = windows_sys::Win32::Foundation::CloseHandle(handle);
+        }
+        Ok((true, None))
+    } else {
+        Ok((false, Some(ProfileMutexGuard(handle))))
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn acquire_profile_mutex_probe() -> Result<(bool, Option<()>), String> {
+    Ok((false, None))
+}

--- a/src-tauri/src/testability/reset.rs
+++ b/src-tauri/src/testability/reset.rs
@@ -1,0 +1,238 @@
+use clap::Args;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+use super::window_placement::TESTABLE_EXE_NAME;
+
+const TESTABLE_CONFIG_DIR: &str = ".agentscommander_testeable";
+const TESTABLE_PROJECT_DIR: &str = "agentscommander_testeable";
+
+#[derive(Debug, Args)]
+pub struct TestResetArgs {
+    #[arg(long)]
+    pub confirm_testeable: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TestResetOutput {
+    ok: bool,
+    exe_path: PathBuf,
+    deleted: Vec<PathBuf>,
+    missing: Vec<PathBuf>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TestResetPlan {
+    ok: bool,
+    exe_path: PathBuf,
+    planned_delete: Vec<PathBuf>,
+}
+
+pub fn execute(args: TestResetArgs) -> i32 {
+    match execute_inner(args) {
+        Ok(output) => {
+            print_stdout_json(&output);
+            0
+        }
+        Err(err) => {
+            eprintln!("{err}");
+            1
+        }
+    }
+}
+
+fn execute_inner(args: TestResetArgs) -> Result<TestResetOutput, String> {
+    if !args.confirm_testeable {
+        return Err(error_json(
+            "missing_confirm_testeable",
+            serde_json::json!({"required": "--confirm-testeable"}),
+        ));
+    }
+
+    let exe_path = std::env::current_exe().map_err(|e| {
+        error_json(
+            "current_exe_failed",
+            serde_json::json!({"message": e.to_string()}),
+        )
+    })?;
+    let exe_name = exe_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if exe_name != TESTABLE_EXE_NAME {
+        return Err(error_json(
+            "refusing_non_testeable_binary",
+            serde_json::json!({"exePath": exe_path, "expected": TESTABLE_EXE_NAME}),
+        ));
+    }
+
+    let exe_parent = exe_path.parent().ok_or_else(|| {
+        error_json(
+            "current_exe_has_no_parent",
+            serde_json::json!({"exePath": exe_path}),
+        )
+    })?;
+
+    let (active, _mutex_guard) =
+        crate::testability::acquire_profile_mutex_probe().map_err(|e| {
+            error_json(
+                "profile_mutex_probe_failed",
+                serde_json::json!({"message": e}),
+            )
+        })?;
+    if active {
+        return Err(error_json("testable_gui_active", serde_json::json!({})));
+    }
+
+    let candidates = candidate_paths(exe_parent);
+    for candidate in &candidates {
+        validate_candidate(exe_parent, candidate).map_err(|e| {
+            error_json(
+                e.as_str(),
+                serde_json::json!({"path": candidate, "exeParent": exe_parent}),
+            )
+        })?;
+    }
+
+    print_stdout_json(&TestResetPlan {
+        ok: true,
+        exe_path: exe_path.clone(),
+        planned_delete: candidates.clone(),
+    });
+
+    let mut deleted = Vec::new();
+    let mut missing = Vec::new();
+    for candidate in &candidates {
+        validate_candidate(exe_parent, candidate).map_err(|e| {
+            error_json(
+                e.as_str(),
+                serde_json::json!({"path": candidate, "exeParent": exe_parent}),
+            )
+        })?;
+
+        if candidate.exists() {
+            std::fs::remove_dir_all(candidate).map_err(|e| {
+                error_json(
+                    "remove_dir_all_failed",
+                    serde_json::json!({"path": candidate, "message": e.to_string()}),
+                )
+            })?;
+            deleted.push(candidate.clone());
+        } else {
+            missing.push(candidate.clone());
+        }
+    }
+
+    Ok(TestResetOutput {
+        ok: true,
+        exe_path,
+        deleted,
+        missing,
+    })
+}
+
+fn candidate_paths(exe_parent: &Path) -> Vec<PathBuf> {
+    vec![
+        exe_parent.join(TESTABLE_CONFIG_DIR),
+        exe_parent.join(TESTABLE_PROJECT_DIR),
+    ]
+}
+
+fn validate_candidate(exe_parent: &Path, candidate: &Path) -> Result<(), String> {
+    let parent_ok = candidate.parent() == Some(exe_parent);
+    if !parent_ok {
+        return Err("reset_candidate_parent_mismatch".to_string());
+    }
+
+    let file_name = candidate.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if file_name != TESTABLE_CONFIG_DIR && file_name != TESTABLE_PROJECT_DIR {
+        return Err("reset_candidate_name_not_allowed".to_string());
+    }
+
+    let metadata = match std::fs::symlink_metadata(candidate) {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(format!("reset_candidate_metadata_failed: {e}")),
+    };
+
+    if metadata.file_type().is_symlink() {
+        return Err("reset_candidate_is_symlink".to_string());
+    }
+    if !metadata.is_dir() {
+        return Err("reset_candidate_not_directory".to_string());
+    }
+    if has_windows_reparse_point(&metadata) {
+        return Err("reset_candidate_is_reparse_point".to_string());
+    }
+
+    let canonical_parent = exe_parent
+        .canonicalize()
+        .map_err(|e| format!("reset_parent_canonicalize_failed: {e}"))?;
+    let expected = canonical_parent.join(file_name);
+    let actual = candidate
+        .canonicalize()
+        .map_err(|e| format!("reset_candidate_canonicalize_failed: {e}"))?;
+    if actual != expected {
+        return Err("reset_candidate_canonical_path_mismatch".to_string());
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn has_windows_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(target_os = "windows"))]
+fn has_windows_reparse_point(_metadata: &std::fs::Metadata) -> bool {
+    false
+}
+
+fn print_stdout_json<T: Serialize>(value: &T) {
+    match serde_json::to_string(value) {
+        Ok(json) => crate::cli_println!("{json}"),
+        Err(e) => crate::cli_println!(
+            "{{\"ok\":false,\"error\":\"json_serialize_failed\",\"message\":{}}}",
+            serde_json::to_string(&e.to_string()).unwrap_or_else(|_| "\"unknown\"".to_string())
+        ),
+    }
+}
+
+fn error_json(error: &str, extra: serde_json::Value) -> String {
+    let mut value = serde_json::json!({
+        "ok": false,
+        "error": error,
+    });
+    if let (Some(dst), Some(src)) = (value.as_object_mut(), extra.as_object()) {
+        for (key, value) in src {
+            dst.insert(key.clone(), value.clone());
+        }
+    }
+    serde_json::to_string(&value)
+        .unwrap_or_else(|_| "{\"ok\":false,\"error\":\"json_serialize_failed\"}".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_candidates_are_valid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let candidate = tmp.path().join(TESTABLE_CONFIG_DIR);
+        validate_candidate(tmp.path(), &candidate).unwrap();
+    }
+
+    #[test]
+    fn file_candidate_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let candidate = tmp.path().join(TESTABLE_CONFIG_DIR);
+        std::fs::write(&candidate, "not a dir").unwrap();
+        assert_eq!(
+            validate_candidate(tmp.path(), &candidate).unwrap_err(),
+            "reset_candidate_not_directory"
+        );
+    }
+}

--- a/src-tauri/src/testability/reset.rs
+++ b/src-tauri/src/testability/reset.rs
@@ -37,6 +37,7 @@ pub fn execute(args: TestResetArgs) -> i32 {
             0
         }
         Err(err) => {
+            crate::cli_println!("{err}");
             eprintln!("{err}");
             1
         }
@@ -72,25 +73,32 @@ fn execute_inner(args: TestResetArgs) -> Result<TestResetOutput, String> {
         )
     })?;
 
-    let (active, _mutex_guard) =
-        crate::testability::acquire_profile_mutex_probe().map_err(|e| {
-            error_json(
-                "profile_mutex_probe_failed",
-                serde_json::json!({"message": e}),
-            )
-        })?;
-    if active {
-        return Err(error_json("testable_gui_active", serde_json::json!({})));
-    }
-
     let candidates = candidate_paths(exe_parent);
     for candidate in &candidates {
         validate_candidate(exe_parent, candidate).map_err(|e| {
             error_json(
                 e.as_str(),
-                serde_json::json!({"path": candidate, "exeParent": exe_parent}),
+                serde_json::json!({
+                    "path": candidate,
+                    "exeParent": exe_parent,
+                    "plannedDelete": &candidates,
+                }),
             )
         })?;
+    }
+
+    let (active, _mutex_guard) =
+        crate::testability::acquire_profile_mutex_probe().map_err(|e| {
+            error_json(
+                "profile_mutex_probe_failed",
+                serde_json::json!({"message": e, "plannedDelete": &candidates}),
+            )
+        })?;
+    if active {
+        return Err(error_json(
+            "testable_gui_active",
+            serde_json::json!({"exePath": &exe_path, "plannedDelete": &candidates}),
+        ));
     }
 
     print_stdout_json(&TestResetPlan {

--- a/src-tauri/src/testability/window_info.rs
+++ b/src-tauri/src/testability/window_info.rs
@@ -45,6 +45,7 @@ pub fn execute(_args: WindowInfoArgs) -> i32 {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct WindowInfoOutput {
+    ok: bool,
     supported: bool,
     expected_title: String,
     current_exe: String,
@@ -78,6 +79,7 @@ mod windows_impl {
     use super::{WindowInfoOutput, WindowRect, WindowSnapshot};
     use std::path::{Path, PathBuf};
     use windows_sys::Win32::Foundation::{CloseHandle, HWND, LPARAM, RECT};
+    use windows_sys::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
     use windows_sys::Win32::System::Threading::{
         OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION,
     };
@@ -107,6 +109,7 @@ mod windows_impl {
         }
 
         Ok(WindowInfoOutput {
+            ok: true,
             supported: true,
             expected_title,
             current_exe: current_exe.to_string_lossy().into_owned(),
@@ -148,15 +151,9 @@ mod windows_impl {
             return 1;
         }
 
-        let mut raw_rect = RECT {
-            left: 0,
-            top: 0,
-            right: 0,
-            bottom: 0,
-        };
-        if GetWindowRect(hwnd, &mut raw_rect) == 0 {
+        let Some(raw_rect) = physical_window_rect(hwnd) else {
             return 1;
-        }
+        };
 
         state.windows.push(WindowSnapshot {
             title,
@@ -175,6 +172,29 @@ mod windows_impl {
         });
 
         1
+    }
+
+    unsafe fn physical_window_rect(hwnd: HWND) -> Option<RECT> {
+        let mut raw_rect = RECT {
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+        };
+        let dwm_ok = DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_EXTENDED_FRAME_BOUNDS as u32,
+            &mut raw_rect as *mut RECT as *mut _,
+            std::mem::size_of::<RECT>() as u32,
+        ) == 0;
+        if dwm_ok {
+            return Some(raw_rect);
+        }
+
+        if GetWindowRect(hwnd, &mut raw_rect) == 0 {
+            return None;
+        }
+        Some(raw_rect)
     }
 
     unsafe fn window_title(hwnd: HWND) -> Option<String> {

--- a/src-tauri/src/testability/window_info.rs
+++ b/src-tauri/src/testability/window_info.rs
@@ -1,0 +1,215 @@
+use clap::Args;
+use serde::Serialize;
+
+#[derive(Debug, Args)]
+pub struct WindowInfoArgs {}
+
+#[cfg(target_os = "windows")]
+pub fn execute(_args: WindowInfoArgs) -> i32 {
+    match windows_impl::collect_window_info() {
+        Ok(output) => {
+            crate::cli_println!(
+                "{}",
+                serde_json::to_string(&output)
+                    .unwrap_or_else(|_| { "{\"supported\":true,\"windows\":[]}".to_string() })
+            );
+            0
+        }
+        Err(e) => {
+            eprintln!(
+                "{}",
+                serde_json::json!({
+                    "supported": true,
+                    "ok": false,
+                    "error": "window_info_failed",
+                    "message": e,
+                })
+            );
+            1
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn execute(_args: WindowInfoArgs) -> i32 {
+    crate::cli_println!(
+        "{}",
+        serde_json::json!({
+            "supported": false,
+            "error": "window_info_unsupported_on_platform",
+        })
+    );
+    1
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WindowInfoOutput {
+    supported: bool,
+    expected_title: String,
+    current_exe: String,
+    windows: Vec<WindowSnapshot>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WindowSnapshot {
+    title: String,
+    pid: u32,
+    process_path: String,
+    hwnd: String,
+    rect: WindowRect,
+    maximized: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WindowRect {
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+    width: i32,
+    height: i32,
+}
+
+#[cfg(target_os = "windows")]
+mod windows_impl {
+    use super::{WindowInfoOutput, WindowRect, WindowSnapshot};
+    use std::path::{Path, PathBuf};
+    use windows_sys::Win32::Foundation::{CloseHandle, HWND, LPARAM, RECT};
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetWindowRect, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
+        IsWindowVisible, IsZoomed,
+    };
+
+    pub fn collect_window_info() -> Result<WindowInfoOutput, String> {
+        let expected_title = crate::config::profile::app_title().to_string();
+        let current_exe = std::env::current_exe().map_err(|e| e.to_string())?;
+        let canonical_current = canonical_for_compare(&current_exe);
+        let mut state = EnumState {
+            expected_title: expected_title.clone(),
+            canonical_current,
+            windows: Vec::new(),
+        };
+
+        let ok = unsafe {
+            EnumWindows(
+                Some(enum_windows_proc),
+                (&mut state as *mut EnumState) as LPARAM,
+            )
+        };
+        if ok == 0 {
+            return Err("EnumWindows returned failure".to_string());
+        }
+
+        Ok(WindowInfoOutput {
+            supported: true,
+            expected_title,
+            current_exe: current_exe.to_string_lossy().into_owned(),
+            windows: state.windows,
+        })
+    }
+
+    struct EnumState {
+        expected_title: String,
+        canonical_current: PathBuf,
+        windows: Vec<WindowSnapshot>,
+    }
+
+    unsafe extern "system" fn enum_windows_proc(hwnd: HWND, lparam: LPARAM) -> i32 {
+        let state = &mut *(lparam as *mut EnumState);
+        if IsWindowVisible(hwnd) == 0 {
+            return 1;
+        }
+
+        let title = match window_title(hwnd) {
+            Some(title) => title,
+            None => return 1,
+        };
+        if title != state.expected_title {
+            return 1;
+        }
+
+        let mut pid = 0u32;
+        GetWindowThreadProcessId(hwnd, &mut pid);
+        if pid == 0 {
+            return 1;
+        }
+
+        let Some(process_path) = process_path(pid) else {
+            return 1;
+        };
+        let canonical_process = canonical_for_compare(&process_path);
+        if canonical_process != state.canonical_current {
+            return 1;
+        }
+
+        let mut raw_rect = RECT {
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+        };
+        if GetWindowRect(hwnd, &mut raw_rect) == 0 {
+            return 1;
+        }
+
+        state.windows.push(WindowSnapshot {
+            title,
+            pid,
+            process_path: process_path.to_string_lossy().into_owned(),
+            hwnd: format!("0x{:016X}", hwnd as usize),
+            rect: WindowRect {
+                left: raw_rect.left,
+                top: raw_rect.top,
+                right: raw_rect.right,
+                bottom: raw_rect.bottom,
+                width: raw_rect.right - raw_rect.left,
+                height: raw_rect.bottom - raw_rect.top,
+            },
+            maximized: IsZoomed(hwnd) != 0,
+        });
+
+        1
+    }
+
+    unsafe fn window_title(hwnd: HWND) -> Option<String> {
+        let len = GetWindowTextLengthW(hwnd);
+        if len <= 0 {
+            return None;
+        }
+        let mut buf = vec![0u16; len as usize + 1];
+        let copied = GetWindowTextW(hwnd, buf.as_mut_ptr(), buf.len() as i32);
+        if copied <= 0 {
+            return None;
+        }
+        Some(String::from_utf16_lossy(&buf[..copied as usize]))
+    }
+
+    fn process_path(pid: u32) -> Option<PathBuf> {
+        unsafe {
+            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+            if handle.is_null() {
+                return None;
+            }
+            let mut buf = vec![0u16; 32768];
+            let mut len = buf.len() as u32;
+            let ok = QueryFullProcessImageNameW(handle, 0, buf.as_mut_ptr(), &mut len);
+            let _ = CloseHandle(handle);
+            if ok == 0 || len == 0 {
+                return None;
+            }
+            Some(PathBuf::from(String::from_utf16_lossy(
+                &buf[..len as usize],
+            )))
+        }
+    }
+
+    fn canonical_for_compare(path: &Path) -> PathBuf {
+        std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    }
+}

--- a/src-tauri/src/testability/window_placement.rs
+++ b/src-tauri/src/testability/window_placement.rs
@@ -1,0 +1,253 @@
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+pub const TESTABLE_EXE_NAME: &str = "agentscommander_testeable.exe";
+pub const PLACEMENT_REQUIRES_TESTABLE: &str = "test_placement_requires_testeable_binary";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TestWindowPlacement {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    #[serde(default)]
+    pub maximized: bool,
+}
+
+pub fn resolve_from_cli_or_env(
+    x: Option<f64>,
+    y: Option<f64>,
+    width: Option<f64>,
+    height: Option<f64>,
+    maximized: bool,
+) -> Result<Option<TestWindowPlacement>, String> {
+    let exe_path =
+        std::env::current_exe().map_err(|e| format!("failed_to_resolve_current_exe: {e}"))?;
+    let env_value = std::env::var("AC_TEST_WINDOW_PLACEMENT").ok();
+    resolve_from_cli_or_env_for_exe(
+        &exe_path,
+        env_value.as_deref(),
+        x,
+        y,
+        width,
+        height,
+        maximized,
+    )
+}
+
+fn resolve_from_cli_or_env_for_exe(
+    exe_path: &Path,
+    env_value: Option<&str>,
+    x: Option<f64>,
+    y: Option<f64>,
+    width: Option<f64>,
+    height: Option<f64>,
+    maximized: bool,
+) -> Result<Option<TestWindowPlacement>, String> {
+    let cli_has_rect = x.is_some() || y.is_some() || width.is_some() || height.is_some();
+    let has_input = cli_has_rect || maximized || env_value.is_some();
+    if !has_input {
+        return Ok(None);
+    }
+
+    let exe_name = exe_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if exe_name != TESTABLE_EXE_NAME {
+        return Err(PLACEMENT_REQUIRES_TESTABLE.to_string());
+    }
+
+    if cli_has_rect || maximized {
+        let (Some(x), Some(y), Some(width), Some(height)) = (x, y, width, height) else {
+            return Err(
+                "test_window_placement_requires_x_y_width_height_when_any_cli_rect_arg_is_present"
+                    .to_string(),
+            );
+        };
+        return validate(TestWindowPlacement {
+            x,
+            y,
+            width,
+            height,
+            maximized,
+        })
+        .map(Some);
+    }
+
+    let raw = env_value.expect("env value exists when input exists");
+    let parsed: TestWindowPlacement = serde_json::from_str(raw)
+        .map_err(|e| format!("invalid_AC_TEST_WINDOW_PLACEMENT_json: {e}"))?;
+    validate(parsed).map(Some)
+}
+
+fn validate(placement: TestWindowPlacement) -> Result<TestWindowPlacement, String> {
+    for (name, value) in [
+        ("x", placement.x),
+        ("y", placement.y),
+        ("width", placement.width),
+        ("height", placement.height),
+    ] {
+        if !value.is_finite() {
+            return Err(format!("test_window_placement_{name}_must_be_finite"));
+        }
+    }
+    if placement.width <= 0.0 {
+        return Err("test_window_placement_width_must_be_positive".to_string());
+    }
+    if placement.height <= 0.0 {
+        return Err("test_window_placement_height_must_be_positive".to_string());
+    }
+    Ok(placement)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exe(name: &str) -> std::path::PathBuf {
+        std::path::PathBuf::from(format!(r"C:\tmp\{name}"))
+    }
+
+    #[test]
+    fn no_args_and_no_env_returns_none() {
+        let got = resolve_from_cli_or_env_for_exe(
+            &exe(TESTABLE_EXE_NAME),
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn partial_cli_args_error() {
+        let err = resolve_from_cli_or_env_for_exe(
+            &exe(TESTABLE_EXE_NAME),
+            None,
+            Some(1.0),
+            None,
+            Some(100.0),
+            Some(100.0),
+            false,
+        )
+        .unwrap_err();
+        assert!(err.contains("requires_x_y_width_height"));
+    }
+
+    #[test]
+    fn cli_args_override_env() {
+        let got = resolve_from_cli_or_env_for_exe(
+            &exe(TESTABLE_EXE_NAME),
+            Some(r#"{"x":9,"y":9,"width":9,"height":9,"maximized":false}"#),
+            Some(-1.0),
+            Some(-2.0),
+            Some(300.0),
+            Some(200.0),
+            true,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(got.x, -1.0);
+        assert_eq!(got.y, -2.0);
+        assert_eq!(got.width, 300.0);
+        assert_eq!(got.height, 200.0);
+        assert!(got.maximized);
+    }
+
+    #[test]
+    fn env_json_parses_negative_coordinates() {
+        let got = resolve_from_cli_or_env_for_exe(
+            &exe(TESTABLE_EXE_NAME),
+            Some(r#"{"x":-2891,"y":-11,"width":1942,"height":1102,"maximized":true}"#),
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(got.x, -2891.0);
+        assert_eq!(got.y, -11.0);
+        assert!(got.maximized);
+    }
+
+    #[test]
+    fn invalid_width_errors() {
+        let err = resolve_from_cli_or_env_for_exe(
+            &exe(TESTABLE_EXE_NAME),
+            None,
+            Some(0.0),
+            Some(0.0),
+            Some(0.0),
+            Some(100.0),
+            false,
+        )
+        .unwrap_err();
+        assert_eq!(err, "test_window_placement_width_must_be_positive");
+    }
+
+    #[test]
+    fn non_finite_cli_values_are_rejected() {
+        for (field, values) in [
+            ("x", [f64::NAN, f64::INFINITY, f64::NEG_INFINITY]),
+            ("y", [f64::NAN, f64::INFINITY, f64::NEG_INFINITY]),
+            ("width", [f64::NAN, f64::INFINITY, f64::NEG_INFINITY]),
+            ("height", [f64::NAN, f64::INFINITY, f64::NEG_INFINITY]),
+        ] {
+            for value in values {
+                let (x, y, width, height) = match field {
+                    "x" => (value, 0.0, 100.0, 100.0),
+                    "y" => (0.0, value, 100.0, 100.0),
+                    "width" => (0.0, 0.0, value, 100.0),
+                    "height" => (0.0, 0.0, 100.0, value),
+                    _ => unreachable!(),
+                };
+                let err = resolve_from_cli_or_env_for_exe(
+                    &exe(TESTABLE_EXE_NAME),
+                    None,
+                    Some(x),
+                    Some(y),
+                    Some(width),
+                    Some(height),
+                    false,
+                )
+                .unwrap_err();
+                assert_eq!(err, format!("test_window_placement_{field}_must_be_finite"));
+            }
+        }
+    }
+
+    #[test]
+    fn malformed_env_on_testable_errors() {
+        let err = resolve_from_cli_or_env_for_exe(
+            &exe(TESTABLE_EXE_NAME),
+            Some("not-json"),
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert!(err.contains("invalid_AC_TEST_WINDOW_PLACEMENT_json"));
+    }
+
+    #[test]
+    fn malformed_env_on_non_testable_fails_closed() {
+        let err = resolve_from_cli_or_env_for_exe(
+            &exe("agentscommander.exe"),
+            Some("not-json"),
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert_eq!(err, PLACEMENT_REQUIRES_TESTABLE);
+    }
+}

--- a/src-tauri/tests/cli_test_reset.rs
+++ b/src-tauri/tests/cli_test_reset.rs
@@ -1,0 +1,217 @@
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+struct Tmp(PathBuf);
+
+impl Drop for Tmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+impl Tmp {
+    fn new(prefix: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "ac-{}-{}-{}",
+            prefix,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&path).expect("create tmp dir");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+fn copy_binary_as(tmp: &Path, name: &str) -> PathBuf {
+    let src = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let dst = tmp.join(name);
+    std::fs::copy(src, &dst).expect("copy binary");
+    dst
+}
+
+fn run(bin: &Path, args: &[&str]) -> (Option<i32>, String, String) {
+    let out = Command::new(bin).args(args).output().expect("spawn binary");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn last_stdout_json(stdout: &str) -> Value {
+    let line = stdout
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .expect("stdout json line");
+    serde_json::from_str(line).expect("parse stdout json")
+}
+
+fn stderr_json(stderr: &str) -> Value {
+    let line = stderr
+        .lines()
+        .rev()
+        .find(|line| line.trim_start().starts_with('{'))
+        .expect("stderr json line");
+    serde_json::from_str(line).expect("parse stderr json")
+}
+
+#[test]
+fn missing_confirm_refuses() {
+    let tmp = Tmp::new("reset-confirm");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    let (code, stdout, stderr) = run(&bin, &["test-reset"]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stderr_json(&stderr)["error"], "missing_confirm_testeable");
+}
+
+#[test]
+fn non_testable_binary_refuses() {
+    let tmp = Tmp::new("reset-non-testable");
+    let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
+    let (code, stdout, stderr) = run(&bin, &["test-reset", "--confirm-testeable"]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(
+        stderr_json(&stderr)["error"],
+        "refusing_non_testeable_binary"
+    );
+}
+
+#[test]
+fn deletes_only_allowed_testable_directories() {
+    let tmp = Tmp::new("reset-delete");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    let config_dir = tmp.path().join(".agentscommander_testeable");
+    let project_dir = tmp.path().join("agentscommander_testeable");
+    let keep_dir = tmp.path().join(".agentscommander_other");
+    std::fs::create_dir_all(config_dir.join("nested")).unwrap();
+    std::fs::create_dir_all(project_dir.join("nested")).unwrap();
+    std::fs::create_dir_all(&keep_dir).unwrap();
+
+    let (code, stdout, stderr) = run(&bin, &["test-reset", "--confirm-testeable"]);
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    let final_json = last_stdout_json(&stdout);
+    assert_eq!(final_json["ok"], true);
+    assert!(!config_dir.exists(), "config dir should be deleted");
+    assert!(!project_dir.exists(), "project dir should be deleted");
+    assert!(keep_dir.exists(), "unrelated dir should remain");
+}
+
+#[test]
+fn file_target_refuses_and_deletes_nothing() {
+    let tmp = Tmp::new("reset-file");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    let config_path = tmp.path().join(".agentscommander_testeable");
+    let project_dir = tmp.path().join("agentscommander_testeable");
+    std::fs::write(&config_path, "not a dir").unwrap();
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let (code, stdout, stderr) = run(&bin, &["test-reset", "--confirm-testeable"]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(
+        stderr_json(&stderr)["error"],
+        "reset_candidate_not_directory"
+    );
+    assert!(config_path.exists(), "file target should remain");
+    assert!(
+        project_dir.exists(),
+        "other candidate should not be deleted after refusal"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_target_refuses_and_deletes_nothing() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = Tmp::new("reset-symlink");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    let real = tmp.path().join("real-dir");
+    let link = tmp.path().join(".agentscommander_testeable");
+    let project_dir = tmp.path().join("agentscommander_testeable");
+    std::fs::create_dir_all(&real).unwrap();
+    symlink(&real, &link).unwrap();
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let (code, stdout, stderr) = run(&bin, &["test-reset", "--confirm-testeable"]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stderr_json(&stderr)["error"], "reset_candidate_is_symlink");
+    assert!(link.exists(), "symlink should remain");
+    assert!(real.exists(), "symlink target should remain");
+    assert!(
+        project_dir.exists(),
+        "other candidate should not be deleted after refusal"
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn held_testable_mutex_refuses_and_deletes_nothing() {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::CreateMutexW;
+
+    let tmp = Tmp::new("reset-active-mutex");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    let config_dir = tmp.path().join(".agentscommander_testeable");
+    std::fs::create_dir_all(&config_dir).unwrap();
+
+    let mutex_name: Vec<u16> = "Local\\AgentsCommander_SingleInstance_Testeable\0"
+        .encode_utf16()
+        .collect();
+    let handle = unsafe { CreateMutexW(std::ptr::null(), 0, mutex_name.as_ptr()) };
+    assert!(!handle.is_null(), "failed to create mutex");
+
+    let (code, stdout, stderr) = run(&bin, &["test-reset", "--confirm-testeable"]);
+    unsafe {
+        let _ = CloseHandle(handle);
+    }
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stderr_json(&stderr)["error"], "testable_gui_active");
+    assert!(config_dir.exists(), "active GUI refusal should not delete");
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+#[ignore = "Manual smoke: requires Windows junction creation support in the test runner"]
+fn junction_target_refuses_and_deletes_nothing() {
+    let tmp = Tmp::new("reset-junction");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    let real = tmp.path().join("real-dir");
+    let junction = tmp.path().join(".agentscommander_testeable");
+    let project_dir = tmp.path().join("agentscommander_testeable");
+    std::fs::create_dir_all(&real).unwrap();
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let status = Command::new("cmd")
+        .args([
+            "/C",
+            "mklink",
+            "/J",
+            junction.to_str().unwrap(),
+            real.to_str().unwrap(),
+        ])
+        .status()
+        .expect("create junction");
+    assert!(status.success(), "mklink /J failed");
+
+    let (code, stdout, stderr) = run(&bin, &["test-reset", "--confirm-testeable"]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(
+        stderr_json(&stderr)["error"],
+        "reset_candidate_is_reparse_point"
+    );
+    assert!(junction.exists(), "junction should remain");
+    assert!(real.exists(), "junction target should remain");
+    assert!(
+        project_dir.exists(),
+        "other candidate should not be deleted after refusal"
+    );
+}

--- a/src-tauri/tests/cli_test_reset.rs
+++ b/src-tauri/tests/cli_test_reset.rs
@@ -1,6 +1,9 @@
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Mutex, MutexGuard};
+
+static TESTABLE_RESET_IDENTITY_LOCK: Mutex<()> = Mutex::new(());
 
 struct Tmp(PathBuf);
 
@@ -37,6 +40,12 @@ fn copy_binary_as(tmp: &Path, name: &str) -> PathBuf {
     dst
 }
 
+fn testable_reset_identity_lock() -> MutexGuard<'static, ()> {
+    TESTABLE_RESET_IDENTITY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 fn run(bin: &Path, args: &[&str]) -> (Option<i32>, String, String) {
     let out = Command::new(bin).args(args).output().expect("spawn binary");
     (
@@ -66,6 +75,7 @@ fn stderr_json(stderr: &str) -> Value {
 
 #[test]
 fn missing_confirm_refuses() {
+    let _guard = testable_reset_identity_lock();
     let tmp = Tmp::new("reset-confirm");
     let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
     let (code, stdout, stderr) = run(&bin, &["test-reset"]);
@@ -87,6 +97,7 @@ fn non_testable_binary_refuses() {
 
 #[test]
 fn deletes_only_allowed_testable_directories() {
+    let _guard = testable_reset_identity_lock();
     let tmp = Tmp::new("reset-delete");
     let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
     let config_dir = tmp.path().join(".agentscommander_testeable");
@@ -107,6 +118,7 @@ fn deletes_only_allowed_testable_directories() {
 
 #[test]
 fn file_target_refuses_and_deletes_nothing() {
+    let _guard = testable_reset_identity_lock();
     let tmp = Tmp::new("reset-file");
     let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
     let config_path = tmp.path().join(".agentscommander_testeable");
@@ -132,6 +144,7 @@ fn file_target_refuses_and_deletes_nothing() {
 fn symlink_target_refuses_and_deletes_nothing() {
     use std::os::unix::fs::symlink;
 
+    let _guard = testable_reset_identity_lock();
     let tmp = Tmp::new("reset-symlink");
     let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
     let real = tmp.path().join("real-dir");
@@ -158,6 +171,7 @@ fn held_testable_mutex_refuses_and_deletes_nothing() {
     use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::System::Threading::CreateMutexW;
 
+    let _guard = testable_reset_identity_lock();
     let tmp = Tmp::new("reset-active-mutex");
     let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
     let config_dir = tmp.path().join(".agentscommander_testeable");
@@ -182,6 +196,7 @@ fn held_testable_mutex_refuses_and_deletes_nothing() {
 #[test]
 #[ignore = "Manual smoke: requires Windows junction creation support in the test runner"]
 fn junction_target_refuses_and_deletes_nothing() {
+    let _guard = testable_reset_identity_lock();
     let tmp = Tmp::new("reset-junction");
     let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
     let real = tmp.path().join("real-dir");

--- a/src-tauri/tests/cli_window_placement.rs
+++ b/src-tauri/tests/cli_window_placement.rs
@@ -1,0 +1,140 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+struct Tmp(PathBuf);
+
+impl Drop for Tmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+impl Tmp {
+    fn new(prefix: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "ac-{}-{}-{}",
+            prefix,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&path).expect("create tmp dir");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+fn copy_binary_as(tmp: &Path, name: &str) -> PathBuf {
+    let src = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let dst = tmp.join(name);
+    std::fs::copy(src, &dst).expect("copy binary");
+    dst
+}
+
+fn run(bin: &Path, args: &[&str]) -> (Option<i32>, String, String) {
+    let out = Command::new(bin).args(args).output().expect("spawn binary");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn run_with_env(bin: &Path, env_value: &str) -> (Option<i32>, String, String) {
+    let out = Command::new(bin)
+        .env("AC_TEST_WINDOW_PLACEMENT", env_value)
+        .output()
+        .expect("spawn binary");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn normal_binary_refuses_cli_placement_input() {
+    let tmp = Tmp::new("placement-prod-cli");
+    let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "--app",
+            "--window-x",
+            "-1",
+            "--window-y",
+            "0",
+            "--window-width",
+            "100",
+            "--window-height",
+            "100",
+        ],
+    );
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(stderr.contains("test_placement_requires_testeable_binary"));
+}
+
+#[test]
+fn workgroup_binary_refuses_cli_placement_input() {
+    let tmp = Tmp::new("placement-wg-cli");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_wg1-dev-team.exe");
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "--app",
+            "--window-x",
+            "-1",
+            "--window-y",
+            "0",
+            "--window-width",
+            "100",
+            "--window-height",
+            "100",
+        ],
+    );
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(stderr.contains("test_placement_requires_testeable_binary"));
+}
+
+#[test]
+fn normal_binary_refuses_env_placement_input_before_parsing() {
+    let tmp = Tmp::new("placement-prod-env");
+    let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
+    let (code, stdout, stderr) = run_with_env(&bin, "not-json");
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(stderr.contains("test_placement_requires_testeable_binary"));
+    assert!(!stderr.contains("invalid_AC_TEST_WINDOW_PLACEMENT_json"));
+}
+
+#[test]
+fn workgroup_binary_refuses_env_placement_input_before_parsing() {
+    let tmp = Tmp::new("placement-wg-env");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_wg1-dev-team.exe");
+    let (code, stdout, stderr) = run_with_env(&bin, "not-json");
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(stderr.contains("test_placement_requires_testeable_binary"));
+    assert!(!stderr.contains("invalid_AC_TEST_WINDOW_PLACEMENT_json"));
+}
+
+#[test]
+fn testable_binary_reports_malformed_env() {
+    let tmp = Tmp::new("placement-testable-env");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    let (code, stdout, stderr) = run_with_env(&bin, "not-json");
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(stderr.contains("invalid_AC_TEST_WINDOW_PLACEMENT_json"));
+}
+
+#[test]
+fn window_maximized_alone_counts_as_testable_only_input() {
+    let tmp = Tmp::new("placement-maximized");
+    let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
+    let (code, stdout, stderr) = run(&bin, &["--app", "--window-maximized"]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(stderr.contains("test_placement_requires_testeable_binary"));
+}


### PR DESCRIPTION
## Summary
- add deterministic GUI test support gated to exact `agentscommander_testeable.exe`
- add test-only window placement flags/env handling with non-testable fail-closed behavior
- add `window-info` for Windows GUI test discovery with process-path filtering
- add guarded `test-reset --confirm-testeable` for `.agentscommander_testeable` and disposable `agentscommander_testeable` project state
- make `npm run build:prod` generate `agentscommander_testeable.exe`
- add Windows release workflow testable raw artifact support
- add `docs/testing/` regression suite foundation and release docs

## Verification
- cargo check
- cargo clippy --all-targets -- -D warnings
- cargo test --test cli_test_reset
- cargo test --test cli_window_placement
- cargo test window_placement
- npm run build:prod
- grinch re-review PASS after reset-test serialization fix
- shipper build/deploy PASS for wg-1, including testable exe smoke checks
- ac-cli-tester TESTABLE release gate PASS on DISPLAY9 baseline, PRJ-001..PRJ-007 PASS
- wg-1 final deploy PASS after TESTABLE gate

Closes #475