### PR TITLE
ci: add PR regression gates (#479)

### DIFF
--- a/.github/workflows/pr-regression-gates.yml
+++ b/.github/workflows/pr-regression-gates.yml
@@ -98,13 +98,15 @@ jobs:
             exit 0
           fi
 
+          perl -pe 's/\x1b\[[0-9;?]*[ -\/]*[@-~]//g' npm-test.log > npm-test.normalized.log
+
           # Temporary #480 guard: remove this block when the unhandled WebSocket rejection is fixed.
-          if grep -q "Unhandled Rejection" npm-test.log \
-            && grep -q "ws does not work in the browser" npm-test.log \
-            && grep -Eq "Test Files +[0-9]+ passed" npm-test.log \
-            && grep -Eq "Tests +[0-9]+ passed" npm-test.log \
-            && ! grep -Eq "(FAIL|failed)" npm-test.log \
-            && ! grep -E "^(Error|TypeError|ReferenceError|SyntaxError|RangeError|URIError|EvalError): " npm-test.log | grep -Fv "Error: ws does not work in the browser. Browser clients must use the native WebSocket object"; then
+          if grep -q "Unhandled Rejection" npm-test.normalized.log \
+            && grep -q "ws does not work in the browser" npm-test.normalized.log \
+            && grep -Eq "Test Files +[0-9]+ passed" npm-test.normalized.log \
+            && grep -Eq "Tests +[0-9]+ passed" npm-test.normalized.log \
+            && ! grep -Eq "(FAIL|failed)" npm-test.normalized.log \
+            && ! grep -E "^(Error|TypeError|ReferenceError|SyntaxError|RangeError|URIError|EvalError): " npm-test.normalized.log | grep -Fv "Error: ws does not work in the browser. Browser clients must use the native WebSocket object"; then
             echo "::warning::npm test is temporarily tolerated only for the known #480 unhandled WebSocket rejection signature. Remove this guard when #480 is fixed."
             exit 0
           fi

--- a/.github/workflows/pr-regression-gates.yml
+++ b/.github/workflows/pr-regression-gates.yml
@@ -1,0 +1,113 @@
+name: PR regression gates
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main
+      - 'release/**'
+      - 'hotfix/**'
+      - 'dependabot/**'
+      - 'revert/**'
+      - 'gh-readonly-queue/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-regression-gates-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust-regression:
+    name: rust-regression
+    # Skip branch-deletion push events while still requiring pull request validation.
+    if: github.event_name != 'push' || (github.event.deleted != true && github.event.after != '0000000000000000000000000000000000000000')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Pin npm version
+        run: npm install -g npm@11.6.2
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build frontend assets for Tauri config validation
+        run: npm run build
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: cargo check
+        working-directory: src-tauri
+        run: cargo check --all-targets
+
+      - name: cargo clippy
+        working-directory: src-tauri
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: cargo test
+        working-directory: src-tauri
+        run: cargo test --lib --bins --tests
+
+  frontend-regression:
+    name: frontend-regression
+    # Skip branch-deletion push events while still requiring pull request validation.
+    if: github.event_name != 'push' || (github.event.deleted != true && github.event.after != '0000000000000000000000000000000000000000')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Pin npm version
+        run: npm install -g npm@11.6.2
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: TypeScript type check
+        run: npm run typecheck
+
+      - name: npm test with #480 known-debt guard
+        run: |
+          set +e
+          npm test 2>&1 | tee npm-test.log
+          status=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$status" -eq 0 ]; then
+            exit 0
+          fi
+
+          # Temporary #480 guard: remove this block when the unhandled WebSocket rejection is fixed.
+          if grep -q "Unhandled Rejection" npm-test.log \
+            && grep -q "ws does not work in the browser" npm-test.log \
+            && grep -Eq "Test Files +[0-9]+ passed" npm-test.log \
+            && grep -Eq "Tests +[0-9]+ passed" npm-test.log \
+            && ! grep -Eq "(FAIL|failed)" npm-test.log \
+            && ! grep -E "^(Error|TypeError|ReferenceError|SyntaxError|RangeError|URIError|EvalError): " npm-test.log | grep -Fv "Error: ws does not work in the browser. Browser clients must use the native WebSocket object"; then
+            echo "::warning::npm test is temporarily tolerated only for the known #480 unhandled WebSocket rejection signature. Remove this guard when #480 is fixed."
+            exit 0
+          fi
+
+          echo "::error::npm test failed for a reason outside the known #480 signature."
+          exit "$status"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "version:check": "node scripts/check-version-sync.mjs",
     "prepare": "husky",
     "tauri": "tauri",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "smoke:profile-matrix": "node scripts/smoke-profile-matrix-preview.mjs",

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -601,7 +601,7 @@ impl DiscoveryBranchWatcher {
                 let refreshed: Vec<SessionRepo> = entry
                     .repos
                     .iter()
-                    .zip(branches.into_iter())
+                    .zip(branches)
                     .map(|((label, path), branch)| SessionRepo {
                         label: label.clone(),
                         source_path: path.clone(),
@@ -1103,7 +1103,7 @@ pub async fn discover_ac_agents(
                             }
                         }
                     }
-                    wg_agents.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+                    wg_agents.sort_by_key(|a| a.name.to_lowercase());
 
                     workgroups.push(AcWorkgroup {
                         name: dir_name.clone(),
@@ -1156,9 +1156,9 @@ pub async fn discover_ac_agents(
     }
 
     // Sort alphabetically
-    agents.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-    teams.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-    workgroups.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    agents.sort_by_key(|a| a.name.to_lowercase());
+    teams.sort_by_key(|a| a.name.to_lowercase());
+    workgroups.sort_by_key(|a| a.name.to_lowercase());
     drop(cfg);
 
     // Associate each workgroup with its team by matching replica membership.
@@ -1542,7 +1542,7 @@ pub async fn discover_project(
                     }
                 }
             }
-            wg_agents.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+            wg_agents.sort_by_key(|a| a.name.to_lowercase());
 
             workgroups.push(AcWorkgroup {
                 name: dir_name.clone(),
@@ -1591,9 +1591,9 @@ pub async fn discover_project(
         }
     }
 
-    agents.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-    teams.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-    workgroups.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    agents.sort_by_key(|a| a.name.to_lowercase());
+    teams.sort_by_key(|a| a.name.to_lowercase());
+    workgroups.sort_by_key(|a| a.name.to_lowercase());
 
     // Associate each workgroup with its team by matching replica membership.
     // Two-pass approach: exact match across ALL teams first, then suffix fallback.

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -1162,7 +1162,7 @@ pub async fn list_all_agents(project_paths: Vec<String>) -> Result<Vec<AgentInfo
         }
     }
 
-    agents.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    agents.sort_by_key(|a| a.name.to_lowercase());
     Ok(agents)
 }
 

--- a/src-tauri/src/commands/repos.rs
+++ b/src-tauri/src/commands/repos.rs
@@ -135,7 +135,7 @@ pub async fn search_repos(
     }
 
     // Sort alphabetically
-    results.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    results.sort_by_key(|a| a.name.to_lowercase());
 
     Ok(results)
 }

--- a/src-tauri/src/commands/role_templates.rs
+++ b/src-tauri/src/commands/role_templates.rs
@@ -730,7 +730,7 @@ fn collect_local_templates(dir: &Path) -> Vec<RoleTemplateMeta> {
     }
     // read_dir order is filesystem-arbitrary; §3.2 requires local templates
     // sorted by name (mirrors `list_all_agents`).
-    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    out.sort_by_key(|a| a.name.to_lowercase());
     out
 }
 

--- a/src-tauri/src/commands/spec_board.rs
+++ b/src-tauri/src/commands/spec_board.rs
@@ -1564,11 +1564,12 @@ mod tests {
     #[tokio::test]
     async fn path_validation_accepts_repo_specs_mermaid() {
         let tmp = TempDir::new().unwrap();
-        let repo = tmp.path().join("repo-Example");
+        let tmp_root = std::fs::canonicalize(tmp.path()).unwrap();
+        let repo = tmp_root.join("repo-Example");
         tokio::fs::create_dir_all(repo.join("specs").join("mermaids"))
             .await
             .unwrap();
-        let settings = test_settings(vec![tmp.path().to_path_buf()]);
+        let settings = test_settings(vec![tmp_root]);
         let target = repo.join("specs").join("mermaids").join("diagram.mmd");
         let validated = validate_new_or_existing_user_path(&target, &settings)
             .await
@@ -1582,9 +1583,10 @@ mod tests {
     #[tokio::test]
     async fn path_validation_preserves_missing_intermediate_dirs() {
         let tmp = TempDir::new().unwrap();
-        let repo = tmp.path().join("repo-Example");
+        let tmp_root = std::fs::canonicalize(tmp.path()).unwrap();
+        let repo = tmp_root.join("repo-Example");
         tokio::fs::create_dir_all(repo.join("specs")).await.unwrap();
-        let settings = test_settings(vec![tmp.path().to_path_buf()]);
+        let settings = test_settings(vec![tmp_root]);
         let target = repo
             .join("specs")
             .join("new-folder")

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -762,6 +762,7 @@ mod tests {
         std::fs::create_dir_all(&sibling).unwrap();
         let prev = std::env::current_dir().unwrap();
         let _guard = CwdGuard(prev);
+        let sibling = std::fs::canonicalize(&sibling).unwrap();
         std::env::set_current_dir(&sibling).unwrap();
         let mut s = AppSettings::default();
         let r = register_existing_project(&mut s, "..\\project").unwrap();

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -2342,6 +2342,20 @@ mod tests {
         path.to_string_lossy().to_string()
     }
 
+    fn canonical_display_path(path: &Path) -> String {
+        std::fs::canonicalize(path)
+            .map(|canonical| display_path(&canonical))
+            .unwrap_or_else(|_| display_path(path))
+    }
+
+    fn assert_contains_canonical_path(content: &str, path: &Path) {
+        let expected = canonical_display_path(path);
+        assert!(
+            content.contains(&expected),
+            "content should contain canonical path {expected}"
+        );
+    }
+
     struct PartialFailWriter {
         file: std::fs::File,
         bytes_written: usize,
@@ -2746,7 +2760,7 @@ mod tests {
         .expect("context path");
         let content = std::fs::read_to_string(materialized).expect("read materialized context");
 
-        assert!(content.contains(&format!("root={}", display_path(&replica_root))));
+        assert!(content.contains(&format!("root={}", canonical_display_path(&replica_root))));
         assert!(content.contains("3. **Your origin Agent Matrix"));
         assert!(content.contains("Narrow exception"));
         assert!(content.contains("Template skill."));
@@ -2772,7 +2786,7 @@ mod tests {
         let content = std::fs::read_to_string(materialized).expect("read materialized context");
 
         assert!(content.contains("LEGACY_BODY"));
-        assert!(content.contains(&display_path(&matrix_root)));
+        assert_contains_canonical_path(&content, &matrix_root);
         assert!(new_path.is_file());
         assert!(!legacy_path.exists());
         assert_eq!(
@@ -2852,7 +2866,7 @@ mod tests {
 
         assert!(content.contains("## Repos"));
         assert!(content.contains("repo-Example"));
-        assert!(content.contains(&display_path(&repo_dir)));
+        assert_contains_canonical_path(&content, &repo_dir);
         assert!(!content.contains("No repos configured"));
     }
 
@@ -2893,7 +2907,7 @@ mod tests {
         .expect("parse repaired config");
 
         assert!(content.contains("repo-Example"));
-        assert!(content.contains(&display_path(&repo_dir)));
+        assert_contains_canonical_path(&content, &repo_dir);
         assert!(!content.contains("No repos configured"));
         assert_eq!(
             repaired["context"],
@@ -2938,7 +2952,7 @@ mod tests {
         .expect("parse repaired config");
 
         assert!(content.contains("repo-Example"));
-        assert!(content.contains(&display_path(&repo_dir)));
+        assert_contains_canonical_path(&content, &repo_dir);
         assert!(!content.contains("No repos configured"));
         assert_eq!(
             repaired["context"],
@@ -3724,9 +3738,10 @@ mod tests {
         assert!(content.contains("## Skills"));
         assert!(content.contains("runtime"));
         assert!(content.contains("Runtime skill metadata."));
-        assert!(content.contains(&display_path(
-            &matrix_root.join("skills").join("runtime").join("SKILL.md")
-        )));
+        assert_contains_canonical_path(
+            &content,
+            &matrix_root.join("skills").join("runtime").join("SKILL.md"),
+        );
         assert!(!content.contains("BODY_SHOULD_NOT_RENDER"));
     }
 
@@ -3825,9 +3840,10 @@ mod tests {
         assert!(content.contains("`runtime`"));
         assert!(content.contains("Direct runtime skill metadata."));
         assert!(content.contains("When to use: Use directly from the canonical matrix."));
-        assert!(content.contains(&display_path(
-            &matrix_root.join("skills").join("runtime").join("SKILL.md")
-        )));
+        assert_contains_canonical_path(
+            &content,
+            &matrix_root.join("skills").join("runtime").join("SKILL.md"),
+        );
         assert!(!content.contains("DIRECT_BODY_SHOULD_NOT_RENDER"));
     }
 
@@ -4021,7 +4037,7 @@ mod tests {
         let content = std::fs::read_to_string(materialized).expect("read materialized context");
 
         assert!(content.contains("CUSTOM_STANDALONE_GLOBAL"));
-        assert!(content.contains(&display_path(&root)));
+        assert_contains_canonical_path(&content, &root);
         assert!(content.contains("ROOT_TEMPLATE_BODY"));
         assert!(content.contains("ROOT_ROLE_BODY"));
         assert!(!content.contains("# AgentsCommander Context"));

--- a/src-tauri/src/pty/git_watcher.rs
+++ b/src-tauri/src/pty/git_watcher.rs
@@ -121,7 +121,7 @@ impl GitWatcher {
 
             let refreshed: Vec<SessionRepo> = repos
                 .iter()
-                .zip(branches.into_iter())
+                .zip(branches)
                 .map(|(r, branch)| SessionRepo {
                     label: r.label.clone(),
                     source_path: r.source_path.clone(),

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -413,7 +413,7 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
                     }
                 }
             }
-            results.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+            results.sort_by_key(|a| a.name.to_lowercase());
             serde_json::to_value(results).map_err(|e| e.to_string())
         }
 


### PR DESCRIPTION
## Summary

Adds pull request regression gates for Rust and frontend validation.

## Changes

- Adds `.github/workflows/pr-regression-gates.yml`.
- Adds required check job names:
  - `rust-regression`
  - `frontend-regression`
- Runs Rust validation on `windows-latest` after building frontend assets required by Tauri config validation.
- Runs frontend typecheck and tests.
- Keeps a narrow temporary guard for the known #480 Vitest WebSocket rejection debt.
- Skips deleted-branch push events to avoid noisy checkout failures.

## Validation

Reported by implementation/review workflow:

- `npm run typecheck`: PASS
- `npm run build`: PASS
- `cargo check --all-targets`: PASS
- `cargo clippy --all-targets -- -D warnings`: PASS
- `cargo test --lib --bins --tests`: PASS on rerun
- `npm test`: only the known #480 failure shape
- Grinch review: PASS
- Shipper build/deploy for `agentscommander_standalone_wg-1.exe`: PASS

Closes #479.