### PR TITLE
test(frontend): mock websocket in jsdom tests (#480)

### DIFF
--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -400,6 +400,7 @@ mod tests {
     use super::*;
     use crate::config::settings::AppSettings;
     use std::path::Path;
+    use std::sync::{Mutex, OnceLock};
 
     /// Auto-cleaned temp dir; mirrors `cli::task_ops::tests::FixtureRoot`.
     struct FixtureRoot(PathBuf);
@@ -728,8 +729,18 @@ mod tests {
         }
     }
 
+    static CWD_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn cwd_lock() -> std::sync::MutexGuard<'static, ()> {
+        CWD_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     #[test]
     fn absolutise_resolves_relative_path_against_cwd() {
+        let _cwd_lock = cwd_lock();
         let fix = FixtureRoot::new("proj-rel");
         std::fs::create_dir_all(fix.path().join(".ac")).unwrap();
         let prev = std::env::current_dir().unwrap();
@@ -755,6 +766,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn absolutise_collapses_dotdot_segments_on_windows() {
+        let _cwd_lock = cwd_lock();
         let fix = FixtureRoot::new("proj-dotdot");
         let project = fix.path().join("project");
         std::fs::create_dir_all(project.join(".ac")).unwrap();

--- a/src/sidebar/stores/sessions-helpers.test.ts
+++ b/src/sidebar/stores/sessions-helpers.test.ts
@@ -1,7 +1,37 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Session, SessionStatus } from "../../shared/types";
+
+vi.hoisted(() => {
+  class MockWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+
+    readonly url: string;
+    binaryType: BinaryType = "blob";
+    readyState = MockWebSocket.CLOSED;
+
+    constructor(url: string) {
+      this.url = url;
+    }
+
+    send(): void {}
+
+    close(): void {
+      this.readyState = MockWebSocket.CLOSED;
+    }
+  }
+
+  Object.defineProperty(globalThis, "WebSocket", {
+    configurable: true,
+    writable: true,
+    value: MockWebSocket,
+  });
+});
+
 import { isRuntimeStringStatus, preserveVisibleOrder, reconcileVisibleOrderKeys, upsertSessionList } from "./sessions-helpers";
 import { sessionsStore } from "./sessions";
 import { rootAgentCodingAgentAction } from "../components/root-agent-action";

--- a/src/sidebar/stores/team-idle-watcher.test.ts
+++ b/src/sidebar/stores/team-idle-watcher.test.ts
@@ -11,7 +11,37 @@
 // file-scope `createSignal` and pulls in the sibling stores, which
 // transitively touch `window.location` in `transport-ws.ts`.
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+vi.hoisted(() => {
+  class MockWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+
+    readonly url: string;
+    binaryType: BinaryType = "blob";
+    readyState = MockWebSocket.CLOSED;
+
+    constructor(url: string) {
+      this.url = url;
+    }
+
+    send(): void {}
+
+    close(): void {
+      this.readyState = MockWebSocket.CLOSED;
+    }
+  }
+
+  Object.defineProperty(globalThis, "WebSocket", {
+    configurable: true,
+    writable: true,
+    value: MockWebSocket,
+  });
+});
+
 import {
   GRACE_MS,
   shouldSuppressBeep,


### PR DESCRIPTION
## Summary

- Mock WebSocket locally in the affected jsdom sidebar helper tests.
- Prevent Vitest from opening a real ws:// connection through the transitive ipc transport import.
- Keep the mock scoped to tests that do not exercise transport behavior.

## Validation

- npm test
- npx tsc --noEmit
- grinch review PASS
- wg-1 shipper build and --help smoke PASS

Closes #480