### PR TITLE
[codex] Clarify team and workgroup context terminology

### DIFF
--- a/docs/agent-matrix-conventions.md
+++ b/docs/agent-matrix-conventions.md
@@ -15,6 +15,8 @@ This document is the definitive guide for any AI agent tasked with creating or m
 
 `.ac/` is the only supported Project AC Root directory.
 
+The team is the logical capability and organization: it defines who can work together, who coordinates, and which repos are available. The workgroup is an operational runtime replica instance of a team for a specific task: it contains replica agents and `repo-*` working repositories.
+
 **Hierarchy:** Project → Agents + Teams → Workgroups (with replicated agents + repo clones)
 
 ---

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -1644,6 +1644,11 @@ pub fn get_default_agent_template() -> &'static str {
 
 You are running inside an AgentsCommander session - a terminal session manager that coordinates multiple AI agents.
 
+## Core Concepts
+
+- **Team**: the logical capability and organization. It defines who can work together, who coordinates, and which repos are available.
+- **Workgroup**: an operational runtime replica instance of a team for a specific task. It contains replica agents and `repo-*` working repositories.
+
 {{WRITE_RESTRICTIONS}}
 
 {{DELEGATED_TASK_REPORTING}}
@@ -3085,6 +3090,11 @@ mod tests {
         let content = std::fs::read_to_string(materialized).expect("read materialized context");
 
         assert!(content.contains("# AgentsCommander Context"));
+        assert!(content.contains("## Core Concepts"));
+        assert!(content.contains("**Team**: the logical capability and organization"));
+        assert!(content.contains(
+            "**Workgroup**: an operational runtime replica instance of a team for a specific task"
+        ));
         assert!(content.contains("When finishing a delegated task or getting blocked"));
         assert!(content.contains("# Coordinator Context"));
         assert!(content.contains("You are the coordinator for your team"));


### PR DESCRIPTION
## Summary

- Add a `## Core Concepts` section to the built-in global agent context template.
- Define Team as the logical capability/organization and Workgroup as the operational runtime replica instance for a task.
- Mirror the distinction in `docs/agent-matrix-conventions.md`.
- Extend the focused session context materialization test to assert the new wording appears in generated provider context.

Closes #492.

## Validation

- `cargo test missing_templates_are_created_and_used_during_regeneration` from `src-tauri`: PASS
- `cargo test config::session_context::tests` from `src-tauri`: PASS, 60 tests
- `cargo check` from `src-tauri`: PASS
- `cargo clippy --all-targets -- -D warnings` from `src-tauri`: PASS
- `git diff --check`: PASS
- `npx tauri build`: PASS
- Deployed and smoke-tested `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-6.exe --help`: PASS

## Notes

Existing custom `.ac/Context.AgentsCommander.md` templates are intentionally preserved. They will receive this wording only if regenerated from missing defaults or edited manually.