### PR TITLE
Fix discovered repo badges for CLI-created workgroups

### DIFF
--- a/src-tauri/tests/cli_workgroup_team.rs
+++ b/src-tauri/tests/cli_workgroup_team.rs
@@ -844,6 +844,41 @@ fn workgroup_add_normalizes_include_and_exclude_repo_assignments() {
     assert!(exclude_agents
         .iter()
         .any(|agent| agent == "_agent_dev-rust"));
+
+    let replica_repos = |agent: &str| -> Vec<String> {
+        let config_path = project
+            .join(".ac")
+            .join("wg-1-dev-team")
+            .join(format!("__agent_{}", agent))
+            .join("config.json");
+        let config: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(config_path).expect("replica config"))
+                .expect("replica config json");
+        config["repos"]
+            .as_array()
+            .expect("replica repos")
+            .iter()
+            .map(|repo| repo.as_str().expect("repo string").to_string())
+            .collect()
+    };
+
+    assert_eq!(
+        replica_repos("architect"),
+        vec![
+            "../repo-all".to_string(),
+            "../repo-include".to_string(),
+            "../repo-exclude".to_string(),
+        ]
+    );
+    assert_eq!(
+        replica_repos("dev-rust"),
+        vec![
+            "../repo-all".to_string(),
+            "../repo-include".to_string(),
+            "../repo-exclude".to_string(),
+        ]
+    );
+    assert_eq!(replica_repos("qa"), vec!["../repo-all".to_string()]);
 }
 
 #[test]

--- a/src/sidebar/components/AcDiscoveryPanel.tsx
+++ b/src/sidebar/components/AcDiscoveryPanel.tsx
@@ -7,6 +7,7 @@ import AgentPickerModal from "./AgentPickerModal";
 import { sessionsStore } from "../stores/sessions";
 import { stripFrontmatter } from "../../shared/markdown";
 import { homeStore } from "../../main/stores/home";
+import { repoBadgesForReplica } from "./repo-badges";
 
 interface PendingLaunch {
   path: string;
@@ -303,15 +304,13 @@ const AcDiscoveryPanel: Component = () => {
                                   <span class="ac-discovery-badge coord">C</span>
                                 </Show>
                                 <Show when={replica.isCoordinator}>
-                                  <Show when={replica.repoPaths.length === 1 && replica.repoBranch}>
-                                    <span class="ac-discovery-badge branch">
-                                      {(() => {
-                                        const dir = replica.repoPaths[0].replace(/\\/g, "/").split("/").pop() ?? "";
-                                        const label = dir.startsWith("repo-") ? dir.slice(5) : dir;
-                                        return `${label}/${replica.repoBranch}`;
-                                      })()}
-                                    </span>
-                                  </Show>
+                                  <For each={repoBadgesForReplica(replica)}>
+                                    {(repo) => (
+                                      <span class="ac-discovery-badge branch" title={repo.sourcePath}>
+                                        {repo.label}{repo.branch ? `/${repo.branch}` : ""}
+                                      </span>
+                                    )}
+                                  </For>
                                 </Show>
                                 <span class="ac-discovery-badge team">replica</span>
                               </div>

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -20,10 +20,10 @@ import { TelegramIcon } from "./TelegramIcon";
 import { normalizeBlockerReport } from "./workgroup-delete-diagnostics";
 import {
   automationIdPart,
-  configuredReplicaRepoBadges,
   formatReplicaRepoBadgeLabel,
   repoLabelFromPath,
 } from "./replica-repo-badges";
+import { repoBadgesForReplica } from "./repo-badges";
 
 interface PendingLaunch {
   path: string;
@@ -552,12 +552,7 @@ const ProjectPanel: Component = () => {
           const dotClass = () => replicaDotClass(wg, replica);
           const isCoord = () => replica.isCoordinator;
           const session = () => replicaSession(wg, replica);
-          const repoBadges = createMemo(() => {
-            const s = session();
-            return s && s.gitRepos.length > 0
-              ? s.gitRepos
-              : configuredReplicaRepoBadges(replica, wg);
-          });
+          const repoBadges = createMemo(() => repoBadgesForReplica(replica, session()));
           const rowTestId = () =>
             `replica.row.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}`;
           const badgesTestId = () =>

--- a/src/sidebar/components/repo-badges.test.ts
+++ b/src/sidebar/components/repo-badges.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { AcAgentReplica, Session } from "../../shared/types";
+import { repoBadgesForReplica } from "./repo-badges";
+
+function mkReplica(overrides: Partial<AcAgentReplica> = {}): AcAgentReplica {
+  return {
+    name: "coordinator",
+    path: "C:/wg/__agent_coordinator",
+    repoPaths: [],
+    isCoordinator: true,
+    ...overrides,
+  };
+}
+
+function mkSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "session-id",
+    name: "wg-1-dev-team/coordinator",
+    shell: "",
+    shellArgs: [],
+    effectiveShellArgs: null,
+    createdAt: "",
+    workingDirectory: "C:/wg/__agent_coordinator",
+    status: "running",
+    waitingForInput: false,
+    pendingReview: false,
+    lastPrompt: null,
+    agentId: null,
+    agentLabel: null,
+    gitRepos: [],
+    workgroupTask: null,
+    isCoordinator: true,
+    isRootAgent: false,
+    token: "",
+    agentKind: null,
+    ...overrides,
+  };
+}
+
+describe("repoBadgesForReplica", () => {
+  it("prefers live session gitRepos", () => {
+    const replica = mkReplica({
+      repoPaths: ["C:/wg/repo-stale"],
+    });
+    const session = mkSession({
+      gitRepos: [
+        {
+          label: "live",
+          sourcePath: "C:/wg/repo-live",
+          branch: "main",
+        },
+      ],
+    });
+
+    expect(repoBadgesForReplica(replica, session)).toEqual([
+      {
+        label: "live",
+        branch: "main",
+        sourcePath: "C:/wg/repo-live",
+      },
+    ]);
+  });
+
+  it("renders repo label without branch", () => {
+    const replica = mkReplica({
+      repoPaths: ["C:/wg/repo-AgentsCommander"],
+    });
+
+    expect(repoBadgesForReplica(replica)).toEqual([
+      {
+        label: "AgentsCommander",
+        branch: null,
+        sourcePath: "C:/wg/repo-AgentsCommander",
+      },
+    ]);
+  });
+
+  it("renders single discovered repo branch when available", () => {
+    const replica = mkReplica({
+      repoPaths: ["C:/wg/repo-AgentsCommander"],
+      repoBranch: "feature/x",
+    });
+
+    expect(repoBadgesForReplica(replica)).toEqual([
+      {
+        label: "AgentsCommander",
+        branch: "feature/x",
+        sourcePath: "C:/wg/repo-AgentsCommander",
+      },
+    ]);
+  });
+
+  it("renders multiple discovered repos without branch", () => {
+    const replica = mkReplica({
+      repoPaths: ["C:/wg/repo-alpha", "C:/wg/repo-beta"],
+      repoBranch: "main",
+    });
+
+    expect(repoBadgesForReplica(replica)).toEqual([
+      {
+        label: "alpha",
+        branch: null,
+        sourcePath: "C:/wg/repo-alpha",
+      },
+      {
+        label: "beta",
+        branch: null,
+        sourcePath: "C:/wg/repo-beta",
+      },
+    ]);
+  });
+});

--- a/src/sidebar/components/repo-badges.ts
+++ b/src/sidebar/components/repo-badges.ts
@@ -1,0 +1,32 @@
+import type { AcAgentReplica, Session } from "../../shared/types";
+
+export interface RepoBadgeView {
+  label: string;
+  branch: string | null;
+  sourcePath: string;
+}
+
+function labelFromPath(path: string): string {
+  const dir = path.replace(/\\/g, "/").split("/").pop() ?? "";
+  return dir.startsWith("repo-") ? dir.slice(5) : dir;
+}
+
+export function repoBadgesForReplica(
+  replica: AcAgentReplica,
+  session?: Session | null
+): RepoBadgeView[] {
+  if (session?.gitRepos?.length) {
+    return session.gitRepos.map((repo) => ({
+      label: repo.label,
+      branch: repo.branch ?? null,
+      sourcePath: repo.sourcePath,
+    }));
+  }
+
+  const paths = replica.repoPaths ?? [];
+  return paths.map((path) => ({
+    label: labelFromPath(path),
+    branch: paths.length === 1 ? replica.repoBranch ?? null : null,
+    sourcePath: path,
+  }));
+}


### PR DESCRIPTION
Closes #495

## What changed
- Added a frontend repo badge helper that prefers live `session.gitRepos` and otherwise renders all discovered `replica.repoPaths` without requiring branch data.
- Updated `ProjectPanel` and legacy `AcDiscoveryPanel` to use the shared helper for coordinator repo badges.
- Added helper coverage for live-session precedence, branchless discovered repos, branch labels for a single discovered repo, and multi-repo discovered fallbacks.
- Added a Rust integration test proving CLI `workgroup add` writes per-replica repo metadata from team config.

## Why
The failing scenario is a newly created multi-repo workgroup visible in an already-open GUI. The old UI fallback only rendered discovered repo badges when exactly one repo and a branch were available, so multi-repo discovered coordinators could show no badges until a later live session or full app restart.

## Validation
- `npm test -- src/sidebar/components/repo-badges.test.ts src/sidebar/App.project-refresh.test.ts`
- `npm run typecheck`
- `cargo test --manifest-path src-tauri/Cargo.toml --test cli_workgroup_team workgroup_add_normalizes_include_and_exclude_repo_assignments`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `rustfmt --check src-tauri/tests/cli_workgroup_team.rs`
- Grinch implementation review passed with no required fixes.

## Acceptance retest requested
Acceptance should keep the GUI open before creating a new CLI workgroup with at least two repos assigned to the coordinator, then verify repo badges appear as soon as the workgroup appears, before restarting the app.