### PR TITLE
Add test debt guard for ignored and placeholder tests

### DIFF
--- a/.github/workflows/pr-regression-gates.yml
+++ b/.github/workflows/pr-regression-gates.yml
@@ -19,6 +19,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test-debt:
+    name: test-debt
+    # Skip branch-deletion push events while still requiring pull request validation.
+    if: github.event_name != 'push' || (github.event.deleted != true && github.event.after != '0000000000000000000000000000000000000000')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Pin npm version
+        run: npm install -g npm@11.6.2
+
+      - name: Check ignored and placeholder test debt
+        run: npm run test:debt
+
   rust-regression:
     name: rust-regression
     # Skip branch-deletion push events while still requiring pull request validation.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "tauri": "tauri",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:debt": "node scripts/check-test-debt.mjs",
+    "test:debt:self": "node scripts/check-test-debt.mjs --self-test",
     "test:watch": "vitest",
     "smoke:profile-matrix": "node scripts/smoke-profile-matrix-preview.mjs",
     "smoke:current-app": "node scripts/smoke-current-app-mockup.mjs"

--- a/scripts/check-test-debt.mjs
+++ b/scripts/check-test-debt.mjs
@@ -146,6 +146,18 @@ function findMatchingBrace(masked, openIndex) {
   return -1;
 }
 
+function findMatchingParen(masked, openIndex) {
+  let depth = 0;
+  for (let i = openIndex; i < masked.length; i += 1) {
+    if (masked[i] === '(') depth += 1;
+    if (masked[i] === ')') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
 function discoverFiles(root) {
   const files = [];
   const roots = [
@@ -212,8 +224,12 @@ function hasExecutableRustBody(originalBody, strippedBody) {
   if (/^(todo!\s*\(\s*\)|unimplemented!\s*\(\s*\)|panic!\s*\(\s*["'`]TODO[\s\S]*["'`]\s*\))\s*;?$/.test(compact)) {
     return false;
   }
-  if (/[A-Za-z_][A-Za-z0-9_]*\s*[!(.]/.test(withoutComments)) return true;
-  if (/[?=]|assert/.test(withoutComments)) return true;
+  if (/\b(?:assert|assert_eq|assert_ne|debug_assert|debug_assert_eq|debug_assert_ne)!\s*\(/.test(withoutComments)) return true;
+  if (/\?/.test(withoutComments)) return true;
+  if (/\.(?:unwrap|expect)\s*\(/.test(withoutComments)) return true;
+  if (/(^|[^A-Za-z0-9_])(?:[A-Za-z_][A-Za-z0-9_]*::)*[A-Za-z_][A-Za-z0-9_]*!\s*[\(\[]/.test(withoutComments)) return true;
+  if (/(^|[^A-Za-z0-9_])(?:[A-Za-z_][A-Za-z0-9_]*::)*[A-Za-z_][A-Za-z0-9_]*\s*\(/.test(withoutComments)) return true;
+  if (/\.[A-Za-z_][A-Za-z0-9_]*\s*\(/.test(withoutComments)) return true;
   return false;
 }
 
@@ -265,7 +281,7 @@ function scanRustFile(root, filePath) {
     const line = lineOf(source, match.index);
     const hasIgnore = /#\s*\[\s*ignore(?:\s|\]|=)/.test(attrs);
     const originalBody = source.slice(bodyOpen + 1, bodyClose);
-    const strippedBody = maskedComments.slice(bodyOpen + 1, bodyClose);
+    const strippedBody = maskCommentsAndStrings(originalBody, { singleQuote: false });
     const executable = hasExecutableRustBody(originalBody, strippedBody);
 
     if (hasIgnore) {
@@ -314,29 +330,85 @@ function suiteAt(ranges, index) {
     .map((range) => range.name);
 }
 
-function addFrontendSkippedFindings(source, rel, ranges, findings) {
-  const patterns = [
-    /\b(describe|it|test)(?:\s*\.\s*(?:only|concurrent))*\s*\.\s*(skip|todo)\s*\(\s*(['"`])([^'"`]+)\3/g,
-    /\b(describe|it|test)(?:\s*\.\s*(?:only|concurrent))*\s*\.\s*(skip|todo)\s*\.\s*each\s*\([\s\S]*?\)\s*\(\s*(['"`])([^'"`]+)\3/g,
-    /\b(describe|it|test)\s*\.\s*each\s*\([\s\S]*?\)\s*\.\s*(skip|todo)\s*\(\s*(['"`])([^'"`]+)\3/g,
-    /\b(it|test)\s*\.\s*concurrent\s*\.\s*(skip|todo)\s*\(\s*(['"`])([^'"`]+)\3/g,
-  ];
+function skipWhitespace(source, index) {
+  let i = index;
+  while (i < source.length && /\s/.test(source[i])) i += 1;
+  return i;
+}
 
-  for (const re of patterns) {
-    let match;
-    while ((match = re.exec(source)) !== null) {
-      const kind = match[1];
-      const name = match[4];
-      const suite = kind === 'describe' ? suiteAt(ranges, match.index) : suiteAt(ranges, match.index);
-      const id = frontendId(rel, suite, name);
-      if (!findings.some((item) => item.category === 'skipped-frontend-test' && item.id === id)) {
-        findings.push({
-          category: 'skipped-frontend-test',
-          id,
-          file: rel,
-          line: lineOf(source, match.index),
-        });
-      }
+function readStringLiteral(source, index) {
+  let i = skipWhitespace(source, index);
+  const quote = source[i];
+  if (quote !== '"' && quote !== '\'' && quote !== '`') return null;
+  i += 1;
+  let value = '';
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '\\') {
+      if (i + 1 < source.length) value += source[i + 1];
+      i += 2;
+      continue;
+    }
+    if (ch === quote) {
+      return { value, end: i + 1 };
+    }
+    value += ch;
+    i += 1;
+  }
+  return null;
+}
+
+function addFrontendFinding(findings, category, source, rel, ranges, matchIndex, nameStart) {
+  const literal = readStringLiteral(source, nameStart);
+  if (!literal) return null;
+  const finding = {
+    category,
+    id: frontendId(rel, suiteAt(ranges, matchIndex), literal.value),
+    file: rel,
+    line: lineOf(source, matchIndex),
+  };
+  if (!findings.some((item) => item.category === finding.category && item.id === finding.id)) {
+    findings.push(finding);
+  }
+  return { finding, literal };
+}
+
+function addFrontendSkippedFindings(source, rel, ranges, findings) {
+  const masked = maskCommentsAndStrings(source);
+
+  let direct;
+  const directRe = /\b(describe|it|test)(?:\s*\.\s*(?:only|concurrent))*\s*\.\s*(?:skip|todo)\s*\(/g;
+  while ((direct = directRe.exec(masked)) !== null) {
+    addFrontendFinding(findings, 'skipped-frontend-test', source, rel, ranges, direct.index, directRe.lastIndex);
+  }
+
+  let skipEach;
+  const skipEachRe = /\b(describe|it|test)(?:\s*\.\s*(?:only|concurrent))*\s*\.\s*(?:skip|todo)\s*\.\s*each\s*\(/g;
+  while ((skipEach = skipEachRe.exec(masked)) !== null) {
+    const eachClose = findMatchingParen(masked, skipEachRe.lastIndex - 1);
+    if (eachClose === -1) continue;
+    const nameOpen = masked.indexOf('(', eachClose + 1);
+    if (nameOpen !== -1) {
+      addFrontendFinding(findings, 'skipped-frontend-test', source, rel, ranges, skipEach.index, nameOpen + 1);
+    }
+  }
+
+  let eachSkip;
+  const eachSkipRe = /\b(describe|it|test)(?:\s*\.\s*(?:only|concurrent))*\s*\.\s*each\s*\(/g;
+  while ((eachSkip = eachSkipRe.exec(masked)) !== null) {
+    const eachClose = findMatchingParen(masked, eachSkipRe.lastIndex - 1);
+    if (eachClose === -1) continue;
+    const suffix = masked.slice(eachClose + 1).match(/^\s*\.\s*(?:skip|todo)\s*\(/);
+    if (suffix) {
+      addFrontendFinding(
+        findings,
+        'skipped-frontend-test',
+        source,
+        rel,
+        ranges,
+        eachSkip.index,
+        eachClose + 1 + suffix[0].length,
+      );
     }
   }
 }
@@ -365,18 +437,44 @@ function isFrontendPlaceholder(body) {
 
 function addFrontendPlaceholderFindings(source, rel, ranges, findings, warnings) {
   const masked = maskCommentsAndStrings(source);
-  const re = /\b(it|test)(?:\s*\.\s*(?:only|concurrent))*\s*\(\s*(['"`])([^'"`]+)\2\s*,/g;
+  const directRe = /\b(it|test)(?:\s*\.\s*(?:only|concurrent))*\s*\(/g;
   let match;
-  while ((match = re.exec(source)) !== null) {
-    const name = match[3];
-    const body = callbackBody(source, masked, re.lastIndex);
+  while ((match = directRe.exec(masked)) !== null) {
+    const added = addFrontendFinding([], 'placeholder-frontend-test', source, rel, ranges, match.index, directRe.lastIndex);
+    if (!added) continue;
+    const comma = masked.indexOf(',', added.literal.end);
+    if (comma === -1) continue;
+    const body = callbackBody(source, masked, comma + 1);
     if (!body) {
       continue;
     }
     if (isFrontendPlaceholder(body.body)) {
       findings.push({
         category: 'placeholder-frontend-test',
-        id: frontendId(rel, suiteAt(ranges, match.index), name),
+        id: added.finding.id,
+        file: rel,
+        line: lineOf(source, match.index),
+      });
+    }
+  }
+
+  const eachRe = /\b(it|test)(?:\s*\.\s*(?:only|concurrent))*\s*\.\s*each\s*\(/g;
+  while ((match = eachRe.exec(masked)) !== null) {
+    const eachClose = findMatchingParen(masked, eachRe.lastIndex - 1);
+    if (eachClose === -1) continue;
+    if (/^\s*\.\s*(?:skip|todo)\s*\(/.test(masked.slice(eachClose + 1))) continue;
+    const nameOpen = masked.indexOf('(', eachClose + 1);
+    if (nameOpen === -1) continue;
+    const added = addFrontendFinding([], 'placeholder-frontend-test', source, rel, ranges, match.index, nameOpen + 1);
+    if (!added) continue;
+    const comma = masked.indexOf(',', added.literal.end);
+    if (comma === -1) continue;
+    const body = callbackBody(source, masked, comma + 1);
+    if (!body) continue;
+    if (isFrontendPlaceholder(body.body)) {
+      findings.push({
+        category: 'placeholder-frontend-test',
+        id: added.finding.id,
         file: rel,
         line: lineOf(source, match.index),
       });
@@ -574,6 +672,12 @@ fn comment_only_case() {
 }
 
 #[test]
+fn assignment_only_placeholder() {
+    let value = 1;
+    let _copy = value;
+}
+
+#[test]
 #[ignore = "manual placeholder"]
 fn ignored_empty_case() {}
 `);
@@ -587,9 +691,11 @@ describe("frontend debt", () => {
   test.each([[1]]).skip("each skip", () => {});
   describe.skip.each([[1]])("describe skip each", () => {});
   it("empty", () => {});
+  test.each([[1]])("empty parameterized %s", () => {});
   test("tautology", () => {
     expect(true).toBe(true);
   });
+  // Example only: it.skip("not real debt", () => {});
 });
 `);
     writeFile(path.join(root, 'src-tauri/tests/comment_false_positive.rs'), `
@@ -604,8 +710,11 @@ fn real_test() {
     assertSelf(result.findings.some((f) => f.category === 'ignored-rust-test' && f.id.endsWith('ignored.rs::ignored_case')), 'ignored Rust finding missing');
     assertSelf(result.findings.some((f) => f.category === 'placeholder-rust-test' && f.id.endsWith('ignored.rs::empty_case')), 'empty Rust finding missing');
     assertSelf(result.findings.some((f) => f.category === 'placeholder-rust-test' && f.id.endsWith('ignored.rs::comment_only_case')), 'comment-only Rust finding missing');
+    assertSelf(result.findings.some((f) => f.category === 'placeholder-rust-test' && f.id.endsWith('ignored.rs::assignment_only_placeholder')), 'assignment-only Rust finding missing');
     assertSelf(result.findings.some((f) => f.category === 'skipped-frontend-test' && f.id.includes('skip each')), 'skip.each finding missing');
     assertSelf(result.findings.some((f) => f.category === 'skipped-frontend-test' && f.id.includes('each skip')), 'each(...).skip finding missing');
+    assertSelf(result.findings.some((f) => f.category === 'placeholder-frontend-test' && f.id.includes('empty parameterized')), 'parameterized frontend placeholder missing');
+    assertSelf(!result.findings.some((f) => f.category === 'skipped-frontend-test' && f.id.includes('not real debt')), 'commented frontend skip false positive detected');
     assertSelf(!result.findings.some((f) => f.id.endsWith('comment_false_positive.rs::real_test') && f.category === 'ignored-rust-test'), 'comment false positive detected');
 
     const entries = result.findings.map((finding) => ({

--- a/scripts/check-test-debt.mjs
+++ b/scripts/check-test-debt.mjs
@@ -1,0 +1,680 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const CATEGORIES = new Set([
+  'ignored-rust-test',
+  'placeholder-rust-test',
+  'skipped-frontend-test',
+  'placeholder-frontend-test',
+]);
+
+const EXCLUDED_DIRS = new Set([
+  '.ac',
+  '.git',
+  '_logbooks',
+  '_plans',
+  'dist',
+  'node_modules',
+  'target',
+]);
+
+function normalizePath(filePath) {
+  return filePath.replaceAll(path.sep, '/');
+}
+
+function relPath(root, filePath) {
+  return normalizePath(path.relative(root, filePath));
+}
+
+function lineOf(source, index) {
+  let line = 1;
+  for (let i = 0; i < index && i < source.length; i += 1) {
+    if (source.charCodeAt(i) === 10) line += 1;
+  }
+  return line;
+}
+
+function blankPreserveNewlines(text) {
+  return text.replace(/[^\n\r]/g, ' ');
+}
+
+function maskComments(source) {
+  let out = '';
+  for (let i = 0; i < source.length;) {
+    if (source.startsWith('//', i)) {
+      const end = source.indexOf('\n', i);
+      if (end === -1) {
+        out += blankPreserveNewlines(source.slice(i));
+        break;
+      }
+      out += blankPreserveNewlines(source.slice(i, end)) + '\n';
+      i = end + 1;
+      continue;
+    }
+    if (source.startsWith('/*', i)) {
+      const end = source.indexOf('*/', i + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      out += blankPreserveNewlines(source.slice(i, stop));
+      i = stop;
+      continue;
+    }
+    out += source[i];
+    i += 1;
+  }
+  return out;
+}
+
+function maskCommentsAndStrings(source, options = {}) {
+  const singleQuote = options.singleQuote ?? true;
+  const noComments = maskComments(source);
+  let out = '';
+  for (let i = 0; i < noComments.length;) {
+    const ch = noComments[i];
+    if ((ch === 'r' || (ch === 'b' && noComments[i + 1] === 'r')) && /[br#"]/.test(noComments[i + 1] ?? '')) {
+      const start = ch === 'b' ? i + 2 : i + 1;
+      let j = start;
+      while (noComments[j] === '#') j += 1;
+      if (noComments[j] === '"') {
+        const hashes = noComments.slice(start, j);
+        const terminator = `"${hashes}`;
+        const contentStart = j + 1;
+        const end = noComments.indexOf(terminator, contentStart);
+        const stop = end === -1 ? noComments.length : end + terminator.length;
+        out += noComments.slice(i, contentStart).replace(/[^\n\r]/g, ' ');
+        out += blankPreserveNewlines(noComments.slice(contentStart, stop));
+        i = stop;
+        continue;
+      }
+    }
+    if (ch === 'b' && noComments[i + 1] === '"') {
+      out += '  ';
+      i += 2;
+      while (i < noComments.length) {
+        const c = noComments[i];
+        if (c === '\\') {
+          out += ' ';
+          if (i + 1 < noComments.length) {
+            out += noComments[i + 1] === '\n' ? '\n' : ' ';
+          }
+          i += 2;
+          continue;
+        }
+        out += c === '\n' || c === '\r' ? c : ' ';
+        i += 1;
+        if (c === '"') break;
+      }
+      continue;
+    }
+    if (ch === '"' || (singleQuote && ch === '\'') || ch === '`') {
+      const quote = ch;
+      out += ch;
+      i += 1;
+      while (i < noComments.length) {
+        const c = noComments[i];
+        if (c === '\\') {
+          out += ' ';
+          if (i + 1 < noComments.length) {
+            out += noComments[i + 1] === '\n' ? '\n' : ' ';
+          }
+          i += 2;
+          continue;
+        }
+        out += c === '\n' || c === '\r' ? c : ' ';
+        i += 1;
+        if (c === quote) break;
+      }
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+function findMatchingBrace(masked, openIndex) {
+  let depth = 0;
+  for (let i = openIndex; i < masked.length; i += 1) {
+    if (masked[i] === '{') depth += 1;
+    if (masked[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function discoverFiles(root) {
+  const files = [];
+  const roots = [
+    path.join(root, 'src-tauri', 'src'),
+    path.join(root, 'src-tauri', 'tests'),
+    path.join(root, 'src'),
+  ];
+
+  function walk(dir) {
+    if (!fs.existsSync(dir)) return;
+    const base = path.basename(dir);
+    if (EXCLUDED_DIRS.has(base)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile()) {
+        const rel = relPath(root, full);
+        if (
+          (rel.startsWith('src-tauri/src/') && rel.endsWith('.rs')) ||
+          (rel.startsWith('src-tauri/tests/') && rel.endsWith('.rs')) ||
+          (rel.startsWith('src/') && (rel.endsWith('.test.ts') || rel.endsWith('.test.tsx')))
+        ) {
+          files.push(full);
+        }
+      }
+    }
+  }
+
+  for (const scanRoot of roots) walk(scanRoot);
+  files.sort((a, b) => relPath(root, a).localeCompare(relPath(root, b)));
+  return files;
+}
+
+function moduleRanges(masked) {
+  const ranges = [];
+  const modRe = /\bmod\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{/g;
+  let match;
+  while ((match = modRe.exec(masked)) !== null) {
+    const open = masked.indexOf('{', match.index);
+    const close = findMatchingBrace(masked, open);
+    if (close !== -1) {
+      ranges.push({ name: match[1], start: open, end: close });
+    }
+  }
+  return ranges;
+}
+
+function rustTestId(rel, modules, fnName) {
+  const parts = [rel];
+  if (!rel.startsWith('src-tauri/tests/')) {
+    parts.push(...modules);
+  } else if (modules.length > 0) {
+    parts.push(...modules);
+  }
+  parts.push(fnName);
+  return `rust:${parts.join('::')}`;
+}
+
+function hasExecutableRustBody(originalBody, strippedBody) {
+  const withoutComments = strippedBody.trim().replace(/;/g, '').trim();
+  if (withoutComments.length === 0) return false;
+  const compact = maskComments(originalBody).trim();
+  if (/^(todo!\s*\(\s*\)|unimplemented!\s*\(\s*\)|panic!\s*\(\s*["'`]TODO[\s\S]*["'`]\s*\))\s*;?$/.test(compact)) {
+    return false;
+  }
+  if (/[A-Za-z_][A-Za-z0-9_]*\s*[!(.]/.test(withoutComments)) return true;
+  if (/[?=]|assert/.test(withoutComments)) return true;
+  return false;
+}
+
+function scanRustFile(root, filePath) {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const rel = relPath(root, filePath);
+  const maskedComments = maskComments(source);
+  const masked = maskCommentsAndStrings(source, { singleQuote: false });
+  const modules = moduleRanges(masked);
+  const findings = [];
+  const warnings = [];
+  const fnRe = /((?:\s*#\s*\[[^\]]*\]\s*)*)\s*(?:pub(?:\s*\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:<[^>{}]*>)?\s*\(/g;
+  let match;
+
+  while ((match = fnRe.exec(masked)) !== null) {
+    const attrs = match[1] || '';
+    if (!/#\s*\[\s*test\b/.test(attrs)) continue;
+    const fnName = match[2];
+    const fnStart = match.index + match[0].lastIndexOf('fn ');
+    const bodyOpen = masked.indexOf('{', fnRe.lastIndex);
+    if (bodyOpen === -1) {
+      warnings.push({
+        category: 'parse-warning',
+        id: `parse:${rel}::${fnName}`,
+        file: rel,
+        line: lineOf(source, match.index),
+        message: 'Rust test body open brace not found',
+      });
+      continue;
+    }
+    let bodyClose = findMatchingBrace(masked, bodyOpen);
+    let usedFallbackClose = false;
+    if (bodyClose === -1) {
+      const nextTest = maskedComments.slice(bodyOpen + 1).search(/#\s*\[\s*test\b/);
+      if (nextTest !== -1) {
+        bodyClose = bodyOpen + 1 + nextTest;
+        usedFallbackClose = true;
+      } else {
+        bodyClose = source.length;
+        usedFallbackClose = true;
+      }
+    }
+
+    const modulePath = modules
+      .filter((mod) => mod.start < fnStart && fnStart < mod.end)
+      .sort((a, b) => a.start - b.start)
+      .map((mod) => mod.name);
+    const id = rustTestId(rel, modulePath, fnName);
+    const line = lineOf(source, match.index);
+    const hasIgnore = /#\s*\[\s*ignore(?:\s|\]|=)/.test(attrs);
+    const originalBody = source.slice(bodyOpen + 1, bodyClose);
+    const strippedBody = maskedComments.slice(bodyOpen + 1, bodyClose);
+    const executable = hasExecutableRustBody(originalBody, strippedBody);
+
+    if (hasIgnore) {
+      findings.push({ category: 'ignored-rust-test', id, file: rel, line });
+    }
+    if (!executable) {
+      if (usedFallbackClose) {
+        warnings.push({
+          category: 'parse-warning',
+          id: `parse:${rel}::${fnName}`,
+          file: rel,
+          line,
+          message: 'Rust test body close brace not found for a possible placeholder',
+        });
+      }
+      findings.push({ category: 'placeholder-rust-test', id, file: rel, line });
+    }
+  }
+
+  return { findings, warnings };
+}
+
+function describeRanges(source) {
+  const masked = maskCommentsAndStrings(source);
+  const ranges = [];
+  const re = /\bdescribe(?:\s*\.\s*(?:only|skip|concurrent|each))*\s*\(\s*(['"`])([^'"`]+)\1[\s\S]*?\{/g;
+  let match;
+  while ((match = re.exec(source)) !== null) {
+    const open = masked.indexOf('{', match.index);
+    if (open === -1) continue;
+    const close = findMatchingBrace(masked, open);
+    if (close !== -1) ranges.push({ name: match[2], start: open, end: close });
+  }
+  return ranges;
+}
+
+function frontendId(rel, suite, name) {
+  const parts = [rel, ...suite, name].filter(Boolean);
+  return `frontend:${parts.join('::')}`;
+}
+
+function suiteAt(ranges, index) {
+  return ranges
+    .filter((range) => range.start < index && index < range.end)
+    .sort((a, b) => a.start - b.start)
+    .map((range) => range.name);
+}
+
+function addFrontendSkippedFindings(source, rel, ranges, findings) {
+  const patterns = [
+    /\b(describe|it|test)(?:\s*\.\s*(?:only|concurrent))*\s*\.\s*(skip|todo)\s*\(\s*(['"`])([^'"`]+)\3/g,
+    /\b(describe|it|test)(?:\s*\.\s*(?:only|concurrent))*\s*\.\s*(skip|todo)\s*\.\s*each\s*\([\s\S]*?\)\s*\(\s*(['"`])([^'"`]+)\3/g,
+    /\b(describe|it|test)\s*\.\s*each\s*\([\s\S]*?\)\s*\.\s*(skip|todo)\s*\(\s*(['"`])([^'"`]+)\3/g,
+    /\b(it|test)\s*\.\s*concurrent\s*\.\s*(skip|todo)\s*\(\s*(['"`])([^'"`]+)\3/g,
+  ];
+
+  for (const re of patterns) {
+    let match;
+    while ((match = re.exec(source)) !== null) {
+      const kind = match[1];
+      const name = match[4];
+      const suite = kind === 'describe' ? suiteAt(ranges, match.index) : suiteAt(ranges, match.index);
+      const id = frontendId(rel, suite, name);
+      if (!findings.some((item) => item.category === 'skipped-frontend-test' && item.id === id)) {
+        findings.push({
+          category: 'skipped-frontend-test',
+          id,
+          file: rel,
+          line: lineOf(source, match.index),
+        });
+      }
+    }
+  }
+}
+
+function callbackBody(source, masked, fromIndex) {
+  const open = masked.indexOf('{', fromIndex);
+  if (open === -1) return null;
+  const close = findMatchingBrace(masked, open);
+  if (close === -1) return null;
+  return {
+    start: open,
+    end: close,
+    body: source.slice(open + 1, close),
+    maskedBody: maskComments(source.slice(open + 1, close)),
+  };
+}
+
+function isFrontendPlaceholder(body) {
+  const trimmed = maskComments(body).trim();
+  if (trimmed === '') return true;
+  if (/^return\s*;?$/.test(trimmed)) return true;
+  if (/^expect\s*\(\s*true\s*\)\s*\.\s*toBe\s*\(\s*true\s*\)\s*;?$/.test(trimmed)) return true;
+  if (/^assert\s*\.\s*ok\s*\(\s*true\s*\)\s*;?$/.test(trimmed)) return true;
+  return false;
+}
+
+function addFrontendPlaceholderFindings(source, rel, ranges, findings, warnings) {
+  const masked = maskCommentsAndStrings(source);
+  const re = /\b(it|test)(?:\s*\.\s*(?:only|concurrent))*\s*\(\s*(['"`])([^'"`]+)\2\s*,/g;
+  let match;
+  while ((match = re.exec(source)) !== null) {
+    const name = match[3];
+    const body = callbackBody(source, masked, re.lastIndex);
+    if (!body) {
+      continue;
+    }
+    if (isFrontendPlaceholder(body.body)) {
+      findings.push({
+        category: 'placeholder-frontend-test',
+        id: frontendId(rel, suiteAt(ranges, match.index), name),
+        file: rel,
+        line: lineOf(source, match.index),
+      });
+    }
+  }
+}
+
+function scanFrontendFile(root, filePath) {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const rel = relPath(root, filePath);
+  const ranges = describeRanges(source);
+  const findings = [];
+  const warnings = [];
+  addFrontendSkippedFindings(source, rel, ranges, findings);
+  addFrontendPlaceholderFindings(source, rel, ranges, findings, warnings);
+  return { findings, warnings };
+}
+
+function scan(root) {
+  const findings = [];
+  const warnings = [];
+  for (const file of discoverFiles(root)) {
+    const rel = relPath(root, file);
+    const result = rel.endsWith('.rs') ? scanRustFile(root, file) : scanFrontendFile(root, file);
+    findings.push(...result.findings);
+    warnings.push(...result.warnings);
+  }
+  findings.sort((a, b) => `${a.category}:${a.id}`.localeCompare(`${b.category}:${b.id}`));
+  warnings.sort((a, b) => a.id.localeCompare(b.id));
+  return { findings, warnings };
+}
+
+function keyOf(item) {
+  return `${item.category}\u0000${item.id}`;
+}
+
+function loadAllowlist(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const parsed = JSON.parse(raw);
+  const errors = [];
+  if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.entries)) {
+    errors.push('allowlist must be an object with version 1 and entries array');
+    return { entries: [], errors };
+  }
+
+  const seen = new Set();
+  const entries = [];
+  parsed.entries.forEach((entry, index) => {
+    const prefix = `entries[${index}]`;
+    if (!entry || typeof entry !== 'object') {
+      errors.push(`${prefix} must be an object`);
+      return;
+    }
+    for (const field of ['id', 'category', 'owner', 'reason', 'resolution']) {
+      if (typeof entry[field] !== 'string' || entry[field].trim() === '') {
+        errors.push(`${prefix}.${field} must be a non-empty string`);
+      }
+    }
+    if (!Number.isInteger(entry.issue) || entry.issue <= 0) {
+      errors.push(`${prefix}.issue must be a positive integer`);
+    }
+    if (!CATEGORIES.has(entry.category)) {
+      errors.push(`${prefix}.category must be one of ${Array.from(CATEGORIES).join(', ')}`);
+    }
+    const key = keyOf(entry);
+    if (seen.has(key)) {
+      errors.push(`${prefix} duplicates category/id ${entry.category} ${entry.id}`);
+    }
+    seen.add(key);
+    entries.push(entry);
+  });
+  return { entries, errors };
+}
+
+function compare(findings, warnings, entries) {
+  const findingKeys = new Set(findings.map(keyOf));
+  const allowKeys = new Set(entries.map(keyOf));
+  const unallowlisted = findings.filter((finding) => !allowKeys.has(keyOf(finding)));
+  const stale = entries.filter((entry) => !findingKeys.has(keyOf(entry)));
+  const allowlisted = findings.filter((finding) => allowKeys.has(keyOf(finding)));
+  return { allowlisted, unallowlisted, stale, warnings };
+}
+
+function summarizeCategory(findings, comparison, category) {
+  const discovered = findings.filter((item) => item.category === category).length;
+  const allowlisted = comparison.allowlisted.filter((item) => item.category === category).length;
+  const unallowlisted = comparison.unallowlisted.filter((item) => item.category === category).length;
+  return { discovered, allowlisted, unallowlisted };
+}
+
+function printReport(findings, comparison, shapeErrors) {
+  const ignoredRust = summarizeCategory(findings, comparison, 'ignored-rust-test');
+  const placeholders = findings.filter((item) => item.category.includes('placeholder'));
+  const placeholderAllowlisted = comparison.allowlisted.filter((item) => item.category.includes('placeholder')).length;
+  const placeholderUnallowlisted = comparison.unallowlisted.filter((item) => item.category.includes('placeholder')).length;
+  const skippedFrontend = summarizeCategory(findings, comparison, 'skipped-frontend-test');
+
+  console.log(`Ignored Rust tests: ${ignoredRust.discovered} discovered, ${ignoredRust.allowlisted} allowlisted, ${ignoredRust.unallowlisted} unallowlisted`);
+  console.log(`Placeholder tests: ${placeholders.length} discovered, ${placeholderAllowlisted} allowlisted, ${placeholderUnallowlisted} unallowlisted`);
+  console.log(`Skipped frontend tests: ${skippedFrontend.discovered} discovered, ${skippedFrontend.allowlisted} allowlisted, ${skippedFrontend.unallowlisted} unallowlisted`);
+
+  for (const finding of findings) {
+    const status = comparison.allowlisted.some((item) => keyOf(item) === keyOf(finding)) ? 'allowlisted' : 'unallowlisted';
+    console.log(`${status}: ${finding.category} ${finding.id} (${finding.file}:${finding.line})`);
+  }
+  for (const warning of comparison.warnings) {
+    console.log(`parse-warning: ${warning.id} (${warning.file}:${warning.line}) ${warning.message}`);
+  }
+  for (const stale of comparison.stale) {
+    console.log(`stale-allowlist: ${stale.category} ${stale.id}`);
+  }
+  for (const error of shapeErrors) {
+    console.log(`allowlist-error: ${error}`);
+  }
+}
+
+function runGuard(options) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const allowlistPath = path.resolve(root, options.allowlist ?? 'test-debt.allowlist.json');
+  const { findings, warnings } = scan(root);
+  const { entries, errors } = loadAllowlist(allowlistPath);
+  const comparison = compare(findings, warnings, entries);
+  printReport(findings, comparison, errors);
+  return errors.length === 0 &&
+    comparison.unallowlisted.length === 0 &&
+    comparison.stale.length === 0 &&
+    comparison.warnings.length === 0 ? 0 : 1;
+}
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function writeAllowlist(root, entries) {
+  const file = path.join(root, 'test-debt.allowlist.json');
+  fs.writeFileSync(file, `${JSON.stringify({ version: 1, entries }, null, 2)}\n`);
+  return file;
+}
+
+function assertSelf(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function runFixture(root, entries = []) {
+  writeAllowlist(root, entries);
+  const { findings, warnings } = scan(root);
+  const { entries: allowEntries, errors } = loadAllowlist(path.join(root, 'test-debt.allowlist.json'));
+  const comparison = compare(findings, warnings, allowEntries);
+  return {
+    findings,
+    warnings,
+    errors,
+    comparison,
+    code: errors.length === 0 &&
+      comparison.unallowlisted.length === 0 &&
+      comparison.stale.length === 0 &&
+      comparison.warnings.length === 0 ? 0 : 1,
+  };
+}
+
+function selfTest() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ac-test-debt-'));
+  try {
+    writeFile(path.join(root, 'src-tauri/tests/clean.rs'), `
+#[test]
+fn clean_rust() {
+    assert_eq!(1, 1);
+}
+`);
+    writeFile(path.join(root, 'src/clean.test.ts'), `
+import { describe, expect, it } from "vitest";
+describe("clean suite", () => {
+  it("clean frontend", () => {
+    expect(1).toBe(1);
+  });
+});
+`);
+    let result = runFixture(root);
+    assertSelf(result.code === 0, 'clean fixture should pass');
+
+    writeFile(path.join(root, 'src-tauri/tests/ignored.rs'), `
+#[test]
+#[ignore = "manual"]
+fn ignored_case() {
+    assert!(true);
+}
+
+#[test]
+fn empty_case() {}
+
+#[test]
+fn comment_only_case() {
+    /* future */
+}
+
+#[test]
+#[ignore = "manual placeholder"]
+fn ignored_empty_case() {}
+`);
+    writeFile(path.join(root, 'src/frontend/example.test.ts'), `
+import { describe, expect, it, test } from "vitest";
+describe("frontend debt", () => {
+  it.skip("skipped", () => {});
+  it.concurrent.skip("concurrent skipped", () => {});
+  test.todo("todo");
+  test.skip.each([[1]])("skip each", () => {});
+  test.each([[1]]).skip("each skip", () => {});
+  describe.skip.each([[1]])("describe skip each", () => {});
+  it("empty", () => {});
+  test("tautology", () => {
+    expect(true).toBe(true);
+  });
+});
+`);
+    writeFile(path.join(root, 'src-tauri/tests/comment_false_positive.rs'), `
+// #[ignore]
+#[test]
+fn real_test() {
+    assert!(true);
+}
+`);
+    result = runFixture(root);
+    assertSelf(result.code === 1, 'debt fixture without allowlist should fail');
+    assertSelf(result.findings.some((f) => f.category === 'ignored-rust-test' && f.id.endsWith('ignored.rs::ignored_case')), 'ignored Rust finding missing');
+    assertSelf(result.findings.some((f) => f.category === 'placeholder-rust-test' && f.id.endsWith('ignored.rs::empty_case')), 'empty Rust finding missing');
+    assertSelf(result.findings.some((f) => f.category === 'placeholder-rust-test' && f.id.endsWith('ignored.rs::comment_only_case')), 'comment-only Rust finding missing');
+    assertSelf(result.findings.some((f) => f.category === 'skipped-frontend-test' && f.id.includes('skip each')), 'skip.each finding missing');
+    assertSelf(result.findings.some((f) => f.category === 'skipped-frontend-test' && f.id.includes('each skip')), 'each(...).skip finding missing');
+    assertSelf(!result.findings.some((f) => f.id.endsWith('comment_false_positive.rs::real_test') && f.category === 'ignored-rust-test'), 'comment false positive detected');
+
+    const entries = result.findings.map((finding) => ({
+      id: finding.id,
+      category: finding.category,
+      owner: finding.category.includes('frontend') ? 'dev-webpage-ui' : 'dev-rust',
+      issue: 489,
+      reason: `Self-test allowlist for ${finding.category}.`,
+      resolution: 'Self-test fixture debt.',
+    }));
+    result = runFixture(root, entries);
+    assertSelf(result.code === 0, 'exact allowlist should pass');
+
+    const ignoredOnly = entries.filter((entry) => !(entry.category === 'placeholder-rust-test' && entry.id.endsWith('ignored.rs::ignored_empty_case')));
+    result = runFixture(root, ignoredOnly);
+    assertSelf(result.code === 1, 'ignored empty Rust test needs separate placeholder allowlist entry');
+    assertSelf(result.comparison.unallowlisted.some((f) => f.category === 'placeholder-rust-test' && f.id.endsWith('ignored.rs::ignored_empty_case')), 'missing placeholder debt was not reported');
+
+    result = runFixture(root, entries.filter((entry) => !entry.id.endsWith('ignored.rs::ignored_case')));
+    assertSelf(result.code === 1, 'missing allowlist entry should fail');
+
+    result = runFixture(root, [...entries, {
+      id: 'rust:src-tauri/tests/stale.rs::stale_case',
+      category: 'ignored-rust-test',
+      owner: 'dev-rust',
+      issue: 489,
+      reason: 'stale entry self-test',
+      resolution: 'remove stale entry',
+    }]);
+    assertSelf(result.code === 1 && result.comparison.stale.length === 1, 'stale allowlist entry should fail');
+
+    const missingReason = entries.map((entry, index) => index === 0 ? { ...entry, reason: '' } : entry);
+    result = runFixture(root, missingReason);
+    assertSelf(result.code === 1 && result.errors.some((error) => error.includes('reason')), 'missing rationale should fail');
+
+    const duplicate = [...entries, entries[0]];
+    result = runFixture(root, duplicate);
+    assertSelf(result.code === 1 && result.errors.some((error) => error.includes('duplicates')), 'duplicate category/id should fail');
+
+    console.log('check-test-debt self-test passed');
+    return 0;
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--self-test') {
+      options.selfTest = true;
+    } else if (arg === '--root') {
+      i += 1;
+      options.root = argv[i];
+    } else if (arg === '--allowlist') {
+      i += 1;
+      options.allowlist = argv[i];
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  process.exitCode = options.selfTest ? selfTest() : runGuard(options);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/test-debt.allowlist.json
+++ b/test-debt.allowlist.json
@@ -1,0 +1,157 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "id": "rust:src-tauri/tests/cli_powershell_capture.rs::list_peers_outputs_valid_json_under_powershell_noninteractive",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 129,
+      "reason": "Release-only Windows subsystem regression coverage cannot run in debug cargo test.",
+      "resolution": "Run manually with cargo test --release --test cli_powershell_capture -- --ignored until a release-mode CI lane exists."
+    },
+    {
+      "id": "rust:src-tauri/tests/cli_powershell_capture.rs::send_help_outputs_under_powershell_noninteractive",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 129,
+      "reason": "Release-only Windows subsystem stdout coverage cannot run in debug cargo test.",
+      "resolution": "Run manually with cargo test --release --test cli_powershell_capture -- --ignored until a release-mode CI lane exists."
+    },
+    {
+      "id": "rust:src-tauri/tests/cli_powershell_capture.rs::send_unknown_flag_emits_stderr_under_powershell_noninteractive",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 129,
+      "reason": "Release-only Windows subsystem stderr coverage cannot run in debug cargo test.",
+      "resolution": "Run manually with cargo test --release --test cli_powershell_capture -- --ignored until a release-mode CI lane exists."
+    },
+    {
+      "id": "rust:src-tauri/tests/cli_powershell_capture.rs::list_peers_outputs_valid_json_under_pwsh_noninteractive",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 129,
+      "reason": "Release-only Windows subsystem coverage also depends on optional pwsh.exe availability.",
+      "resolution": "Run manually with cargo test --release --test cli_powershell_capture -- --ignored on a machine with pwsh.exe."
+    },
+    {
+      "id": "rust:src-tauri/tests/cli_test_reset.rs::junction_target_refuses_and_deletes_nothing",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 489,
+      "reason": "Manual Windows junction smoke coverage needs mklink junction support in the test runner.",
+      "resolution": "Run manually on Windows with cargo test --test cli_test_reset junction_target_refuses_and_deletes_nothing -- --ignored."
+    },
+    {
+      "id": "rust:src-tauri/src/commands/telegram.rs::attach_detach_persistence_tests::telegram_attach_detach_persistence_ordering_harness_note",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 295,
+      "reason": "Full attach and detach ordering regression needs a Tauri AppHandle fixture with injectable persistence failure.",
+      "resolution": "Convert to an executable integration test when a command-level Tauri fixture is available."
+    },
+    {
+      "id": "rust:src-tauri/src/commands/telegram.rs::attach_detach_persistence_tests::telegram_attach_detach_persistence_ordering_harness_note",
+      "category": "placeholder-rust-test",
+      "owner": "dev-rust",
+      "issue": 295,
+      "reason": "The test body is a harness note documenting required fixture shape and has no executable assertions.",
+      "resolution": "Replace the note with an executable attach and detach persistence regression test."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::close_session_rejects_direct_outbox_write_with_unqualified_target",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "Full mailbox pipeline coverage needs a two-project Tauri AppHandle fixture.",
+      "resolution": "Convert to an end-to-end mailbox test when the fixture exists."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::close_session_rejects_direct_outbox_write_with_unqualified_target",
+      "category": "placeholder-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "The body is a comment-only stub that points to lower-level resolver coverage.",
+      "resolution": "Replace with executable full-pipeline close-session coverage."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::deliver_wake_rejects_unqualified_to_with_cross_project_matches",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "Full wake routing coverage needs a two-project Tauri AppHandle fixture.",
+      "resolution": "Convert to an end-to-end mailbox wake routing test when the fixture exists."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::deliver_wake_rejects_unqualified_to_with_cross_project_matches",
+      "category": "placeholder-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "The body is a comment-only stub that points to resolver-layer coverage.",
+      "resolution": "Replace with executable full-pipeline wake routing coverage."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::resolve_repo_path_wg_fallback_honors_target_project",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "Full resolve_repo_path fixture coverage needs filesystem setup under a Tauri AppHandle.",
+      "resolution": "Convert to an executable integration test when the AppHandle filesystem fixture exists."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::resolve_repo_path_wg_fallback_honors_target_project",
+      "category": "placeholder-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "The ignored test currently has an empty body.",
+      "resolution": "Replace with executable target-project fallback coverage."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::resolve_repo_path_returns_none_on_ambiguous_unqualified",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "Full ambiguous unqualified target coverage needs AppHandle and session CWD fixtures.",
+      "resolution": "Convert to an executable integration test when the mailbox fixture exists."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::resolve_repo_path_returns_none_on_ambiguous_unqualified",
+      "category": "placeholder-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "The ignored test currently has an empty body.",
+      "resolution": "Replace with executable ambiguous target coverage."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::deliver_wake_spawned_session_name_has_no_colon",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "Full spawned-session naming coverage needs a Tauri runtime and session manager fixture.",
+      "resolution": "Convert to an executable integration test when the mailbox fixture exists."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::deliver_wake_spawned_session_name_has_no_colon",
+      "category": "placeholder-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "The ignored test currently has an empty body.",
+      "resolution": "Replace with executable spawned-session naming coverage."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::resolve_to_target_round_trip_integration",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "Full round-trip CLI send and mailbox route coverage needs a two-project fixture.",
+      "resolution": "Convert to an executable full round-trip integration test when the fixture exists."
+    },
+    {
+      "id": "rust:src-tauri/src/phone/mailbox.rs::tests::resolve_to_target_round_trip_integration",
+      "category": "placeholder-rust-test",
+      "owner": "dev-rust",
+      "issue": 228,
+      "reason": "The ignored test currently has an empty body.",
+      "resolution": "Replace with executable CLI send to mailbox round-trip coverage."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add a dependency-free test debt scanner for ignored Rust tests, Rust placeholder tests, skipped/todo frontend tests, and placeholder frontend tests.
- Add `test-debt.allowlist.json` with explicit metadata for current ignored/placeholder debt.
- Add `test:debt` and `test:debt:self` npm scripts.
- Add a separate CI `test-debt` job outside the tolerated npm regression job.
- Fix edge cases found in adversarial review: assignment-only Rust placeholders, parameterized frontend placeholders, and commented frontend skip false positives.

Closes #489

## Validation

- `npm run test:debt`
- `npm run test:debt:self`
- `node --check scripts/check-test-debt.mjs`
- `npm run typecheck`
- `npm test`
- `git diff --check origin/main...HEAD`
- `npx tauri build`
- `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe --help`

## Notes

Full Rust tests were not rerun after the JS-only review fix. Earlier full Rust validation hit existing `cli_close_session` subprocess timeouts, assessed as unrelated because this branch changes workflow/package/script/allowlist files and the JS guard.