### PR TITLE
Add semantic GUI automation bridge

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -70,6 +70,12 @@ After launch, query the target window from a separate process:
 
 Historical reference: the old placement `--window-x -2891 --window-y -11 --window-width 1942 --window-height 1102` is obsolete and should not be used as a live visual-test baseline.
 
+## Semantic UI Automation
+
+When the testable GUI is launched with `--ui-automation`, prefer semantic `ui-*` commands over coordinate clicks for WebView controls. Stable targets use exact `data-ac-testid` selectors; screenshots remain evidence, not the action mechanism.
+
+The selector seed and missing-affordance tracker lives in [semantic-ui-automation-affordance-matrix.md](semantic-ui-automation-affordance-matrix.md). If acceptance can perform a behavior with screen and mouse but cannot inspect or operate it semantically, report the missing selector/action there.
+
 ## Test Reset
 
 Use the explicit reset command only from `agentscommander_testeable.exe` and only when the testable GUI is not running:

--- a/docs/testing/semantic-ui-automation-affordance-matrix.md
+++ b/docs/testing/semantic-ui-automation-affordance-matrix.md
@@ -46,7 +46,7 @@ This matrix seeds issue #497 acceptance coverage. It tracks user-visible screen/
 |---|---|---|
 | Detect settings dialog | `settings.modal` | `query`, `wait` |
 | Switch settings tab | `settings.tab.<tabKey>` | `click` |
-| Add preset coding agent | `settings.agentPreset.<presetKey>` | `click` |
+| Detect/add preset coding agent | `settings.agentPreset.<presetKey>` | `query`, `click` when `data-ac-state="available"` |
 | Add custom coding agent row | `settings.agent.addCustom` | `click` |
 | Detect coding agent row | `settings.agentRow.<index>` | `query` |
 | Set coding agent label | `settings.agentRow.<index>.label` | `setValue` |

--- a/docs/testing/semantic-ui-automation-affordance-matrix.md
+++ b/docs/testing/semantic-ui-automation-affordance-matrix.md
@@ -48,6 +48,12 @@ This matrix seeds issue #497 acceptance coverage. It tracks user-visible screen/
 | Switch settings tab | `settings.tab.<tabKey>` | `click` |
 | Add preset coding agent | `settings.agentPreset.<presetKey>` | `click` |
 | Add custom coding agent row | `settings.agent.addCustom` | `click` |
+| Detect coding agent row | `settings.agentRow.<index>` | `query` |
+| Set coding agent label | `settings.agentRow.<index>.label` | `setValue` |
+| Set coding agent command | `settings.agentRow.<index>.command` | `setValue` |
+| Set coding agent color text value | `settings.agentRow.<index>.color` | `setValue` |
+| Set coding agent color picker | `settings.agentRow.<index>.colorPicker` | `setValue` |
+| Remove coding agent row | `settings.agentRow.<index>.remove` | `click` |
 | Save settings | `settings.save` | `click` |
 | Cancel settings | `settings.cancel` | `click` |
 

--- a/docs/testing/semantic-ui-automation-affordance-matrix.md
+++ b/docs/testing/semantic-ui-automation-affordance-matrix.md
@@ -1,0 +1,63 @@
+# Semantic UI Automation Affordance Matrix
+
+This matrix seeds issue #497 acceptance coverage. It tracks user-visible screen/mouse behaviors that currently have stable `data-ac-testid` hooks. Acceptance should report missing GUI automation as selector/action gaps.
+
+## First-Run Onboarding
+
+| Behavior | Selector | Action |
+|---|---|---|
+| Detect onboarding dialog | `onboarding.modal` | `query`, `wait` |
+| Select Claude Code preset | `onboarding.agentPreset.claude` | `click` |
+| Select Codex preset | `onboarding.agentPreset.codex` | `click` |
+| Select Gemini preset | `onboarding.agentPreset.gemini` | `click` |
+| Select custom preset | `onboarding.agentPreset.custom` | `click` |
+| Enter custom label | `onboarding.custom.label` | `setValue` |
+| Enter custom command | `onboarding.custom.command` | `setValue` |
+| Skip onboarding | `onboarding.skip` | `click` |
+| Confirm selected agent | `onboarding.confirm` | `query`, `click` |
+| Detect done state | `onboarding.done` | `query`, `wait` |
+| Close done dialog | `onboarding.done.close` | `click` |
+
+## Already-Open GUI Seed
+
+| Behavior | Selector | Action |
+|---|---|---|
+| Detect main WebView root | `main.root` | `query` |
+| Detect sidebar root | `sidebar.root` | `query` |
+| Detect terminal root | `terminal.root` | `query` |
+| Open New/Open menu | `actionBar.newOpen` | `click` |
+| Create project from menu | `actionBar.menu.newProject` | `click` |
+| Open project from menu | `actionBar.menu.openProject` | `click` |
+| Open settings | `actionBar.settings` | `click` |
+| Toggle theme | `actionBar.theme` | `click` |
+| Toggle home | `actionBar.home` | `click` |
+| Toggle coordinator sort | `actionBar.sortCoordinators` | `click` |
+| Toggle sounds | `actionBar.sounds` | `click` |
+| Toggle category visibility | `actionBar.categories` | `click` |
+| Toggle selected workgroup pin | `actionBar.pinSelectedWorkgroup` | `click` |
+| Open guide | `actionBar.guide` | `click` |
+| Open spec board when enabled | `actionBar.specBoard` | `click` |
+| Detect terminal empty state | `terminal.empty` | `query` |
+| Start a new empty terminal session | `terminal.empty.newSession` | `click` |
+
+## Settings Seed
+
+| Behavior | Selector | Action |
+|---|---|---|
+| Detect settings dialog | `settings.modal` | `query`, `wait` |
+| Switch settings tab | `settings.tab.<tabKey>` | `click` |
+| Add preset coding agent | `settings.agentPreset.<presetKey>` | `click` |
+| Add custom coding agent row | `settings.agent.addCustom` | `click` |
+| Save settings | `settings.save` | `click` |
+| Cancel settings | `settings.cancel` | `click` |
+
+## Known Gaps For Follow-Up
+
+| Surface | Missing action/selector family |
+|---|---|
+| Project panel rows | `project.row.*`, `workgroup.row.*`, `team.row.*`, `agent.row.*`, `replica.row.*` |
+| Session rows | `session.row.<sessionId>` and row action selectors for close, detach, Telegram, explorer, mic |
+| Context menus | `contextMenu` action plus `menu.<surface>.<action>` selectors |
+| Agent/open/new-agent modals | Dialog roots, list rows, form fields, launch actions |
+| Terminal internals | xterm buffer inspection is out of DOM-selector scope for #497 |
+| Drag/hold gestures | Future pointer actions for splitters and hold-to-record |

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -105,6 +105,10 @@ pub struct Cli {
     #[arg(long)]
     pub window_maximized: bool,
 
+    /// Test-only GUI automation bridge opt-in
+    #[arg(long)]
+    pub ui_automation: bool,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }
@@ -149,6 +153,14 @@ pub enum Commands {
     TestReset(crate::testability::reset::TestResetArgs),
     /// Inspect running AgentsCommander GUI windows for this binary identity
     WindowInfo(crate::testability::window_info::WindowInfoArgs),
+    /// Query a WebView automation target by data-ac-testid
+    UiQuery(crate::testability::ui_automation::UiQueryArgs),
+    /// Click a WebView automation target by data-ac-testid
+    UiClick(crate::testability::ui_automation::UiClickArgs),
+    /// Set an input/select WebView automation target by data-ac-testid
+    UiSet(crate::testability::ui_automation::UiSetArgs),
+    /// Wait until a WebView automation target is available by data-ac-testid
+    UiWait(crate::testability::ui_automation::UiWaitArgs),
 }
 
 /// Attach to parent console (or allocate a new one) ONLY if both stdout and stderr
@@ -273,6 +285,10 @@ pub fn handle_cli(cmd: Commands) -> i32 {
         Commands::Harness(args) => harness::execute(args),
         Commands::TestReset(args) => crate::testability::reset::execute(args),
         Commands::WindowInfo(args) => crate::testability::window_info::execute(args),
+        Commands::UiQuery(args) => crate::testability::ui_automation::execute_query(args),
+        Commands::UiClick(args) => crate::testability::ui_automation::execute_click(args),
+        Commands::UiSet(args) => crate::testability::ui_automation::execute_set(args),
+        Commands::UiWait(args) => crate::testability::ui_automation::execute_wait(args),
     };
 
     flush_outputs();

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -2215,10 +2215,11 @@ async fn git_clone_async(url: &str, target: &Path) -> Result<(), String> {
     #[cfg(windows)]
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
+    let git_target = git_cli_path(target);
     let mut cmd = tokio::process::Command::new("git");
     crate::pty::credentials::scrub_credentials_from_tokio_command(&mut cmd);
     cmd.args(["-c", "core.longpaths=true", "clone", "--depth", "1", url])
-        .arg(target.as_os_str());
+        .arg(git_target.as_os_str());
 
     #[cfg(windows)]
     {
@@ -2251,7 +2252,7 @@ async fn git_clone_async(url: &str, target: &Path) -> Result<(), String> {
         );
         let mut reset_cmd = tokio::process::Command::new("git");
         crate::pty::credentials::scrub_credentials_from_tokio_command(&mut reset_cmd);
-        reset_cmd.args(["reset"]).current_dir(target);
+        reset_cmd.args(["reset"]).current_dir(&git_target);
         #[cfg(windows)]
         {
             #[allow(unused_imports)]
@@ -2264,6 +2265,23 @@ async fn git_clone_async(url: &str, target: &Path) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(windows)]
+fn git_cli_path(path: &Path) -> PathBuf {
+    let s = path.as_os_str().to_string_lossy();
+    if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+        PathBuf::from(format!(r"\\{}", rest))
+    } else if let Some(rest) = s.strip_prefix(r"\\?\") {
+        PathBuf::from(rest)
+    } else {
+        path.to_path_buf()
+    }
+}
+
+#[cfg(not(windows))]
+fn git_cli_path(path: &Path) -> PathBuf {
+    path.to_path_buf()
+}
+
 #[cfg(test)]
 mod tests {
     //! Tests for Agent Matrix/replica layout invariants, the preflight-rename
@@ -2271,6 +2289,26 @@ mod tests {
     //! the #107 helper `parse_task_title`.
 
     use super::*;
+
+    #[test]
+    #[cfg(windows)]
+    fn git_cli_path_strips_windows_verbatim_prefix() {
+        assert_eq!(
+            git_cli_path(Path::new(r"\\?\C:\tmp\repo-Hello-World")),
+            PathBuf::from(r"C:\tmp\repo-Hello-World")
+        );
+        assert_eq!(
+            git_cli_path(Path::new(r"\\?\UNC\server\share\repo-Hello-World")),
+            PathBuf::from(r"\\server\share\repo-Hello-World")
+        );
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn git_cli_path_preserves_non_windows_path() {
+        let path = Path::new("/tmp/repo-Hello-World");
+        assert_eq!(git_cli_path(path), path);
+    }
 
     #[test]
     fn create_agent_matrix_layout_creates_root_and_canonical_subdirs() {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod session;
 pub mod spec_board;
 pub mod task;
 pub mod telegram;
+pub mod testability;
 pub mod voice;
 pub mod wg_delete_diagnostic;
 pub mod window;

--- a/src-tauri/src/commands/testability.rs
+++ b/src-tauri/src/commands/testability.rs
@@ -1,0 +1,26 @@
+use tauri::{State, WebviewWindow};
+
+#[tauri::command]
+pub fn ui_automation_enabled(
+    state: State<'_, crate::testability::ui_automation::UiAutomationState>,
+) -> bool {
+    state.enabled()
+}
+
+#[tauri::command]
+pub fn ui_automation_frontend_ready(
+    webview: WebviewWindow,
+    window: Option<String>,
+    state: State<'_, crate::testability::ui_automation::UiAutomationState>,
+) -> Result<(), String> {
+    state.mark_frontend_ready(webview.label(), window.as_deref())
+}
+
+#[tauri::command]
+pub fn ui_automation_complete(
+    webview: WebviewWindow,
+    result: crate::testability::ui_automation::UiAutomationResponse,
+    state: State<'_, crate::testability::ui_automation::UiAutomationState>,
+) -> Result<(), String> {
+    state.complete(webview.label(), result)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -160,6 +160,7 @@ pub(crate) fn should_auto_create_root_agent_on_first_restore(
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run(
     test_window_placement: Option<crate::testability::window_placement::TestWindowPlacement>,
+    ui_automation_enabled: bool,
 ) {
     // Same backend the CLI path now installs in `main.rs` — see `logging.rs`
     // for the rationale. Idempotent, so a hypothetical second call (or the
@@ -185,6 +186,10 @@ pub fn run(
     let app_outbox_path = instances_dir.join(&instance_id).join("outbox");
     std::fs::create_dir_all(&app_outbox_path).expect("Failed to create app outbox directory");
     let app_outbox = AppOutbox::new(app_outbox_path.to_string_lossy().to_string());
+    let ui_automation_state = crate::testability::ui_automation::UiAutomationState::new(
+        ui_automation_enabled,
+        config_dir.clone(),
+    );
 
     // Generate web access token — separate from master token for limited blast radius
     let web_access_token = Arc::new(WebAccessToken::new(uuid::Uuid::new_v4().to_string()));
@@ -301,6 +306,8 @@ pub fn run(
     let shutdown_for_setup = shutdown_signal.clone();
     let shutdown_for_exit = shutdown_signal.clone();
     let tg_mgr_for_exit = tg_mgr.clone();
+    let ui_automation_state_for_setup = ui_automation_state.clone();
+    let ui_automation_state_for_exit = ui_automation_state.clone();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
@@ -317,6 +324,7 @@ pub fn run(
         .manage(WebServerHandle::default())
         .manage(rtk_sweep_lock)
         .manage(rtk_startup_mode)
+        .manage(ui_automation_state)
         .manage(shutdown_signal)
         .manage(Arc::new(RestoreInProgress(AtomicBool::new(false))))
         .setup(move |app| {
@@ -890,6 +898,8 @@ pub fn run(
             if saved_settings.main_always_on_top {
                 let _ = main_win.set_always_on_top(true);
             }
+
+            ui_automation_state_for_setup.start(app.handle().clone(), shutdown_for_setup.clone());
 
             // Suppress unused variable warning
             let _ = &main_win;
@@ -1576,6 +1586,9 @@ pub fn run(
             commands::telegram::telegram_get_bridge,
             commands::telegram::telegram_send_test,
             commands::telegram::telegram_send_image,
+            commands::testability::ui_automation_enabled,
+            commands::testability::ui_automation_frontend_ready,
+            commands::testability::ui_automation_complete,
             commands::window::detach_terminal,
             commands::window::attach_terminal,
             commands::window::list_detached_sessions,
@@ -1717,6 +1730,7 @@ pub fn run(
                     // Still runs before process exit — subsequent CLI invocations
                     // see NoPidFile (not StalePidFile) once we return.
                     crate::config::daemon_pid::remove_pid_file();
+                    ui_automation_state_for_exit.cleanup_session_file();
                 }
                 _ => {}
             }

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -33,6 +33,10 @@ const APP_LOG_MAX_BYTES: u64 = 50 * 1024 * 1024;
 /// `.KEEP` via `std::fs::rename`'s replace semantics — see `rotate()`.
 const APP_LOG_KEEP: u32 = 5;
 
+fn machine_output_enabled() -> bool {
+    std::env::var_os("AC_MACHINE_OUTPUT").is_some()
+}
+
 /// #280 §2 — log file plus a bookkeeping counter for size-based rotation.
 /// `bytes` is read/written with `Relaxed` ordering: it's a best-effort cap
 /// counter, not a synchronization primitive. A small over-shoot at the
@@ -70,20 +74,24 @@ fn rotate(state: &AppLogFile) {
     let parent = match base.parent() {
         Some(p) => p,
         None => {
-            eprintln!(
-                "[log] rotate: cannot resolve parent for {} — skipping",
-                base.display()
-            );
+            if !machine_output_enabled() {
+                eprintln!(
+                    "[log] rotate: cannot resolve parent for {}, skipping",
+                    base.display()
+                );
+            }
             return;
         }
     };
     let stem = match base.file_name().and_then(|n| n.to_str()) {
         Some(s) => s,
         None => {
-            eprintln!(
-                "[log] rotate: cannot extract file name for {} — skipping",
-                base.display()
-            );
+            if !machine_output_enabled() {
+                eprintln!(
+                    "[log] rotate: cannot extract file name for {}, skipping",
+                    base.display()
+                );
+            }
             return;
         }
     };
@@ -101,12 +109,14 @@ fn rotate(state: &AppLogFile) {
             }
             let to = numbered(i + 1);
             if let Err(e) = std::fs::rename(&from, &to) {
-                eprintln!(
-                    "[log] rotate: failed to rename {} → {}: {} (continuing)",
-                    from.display(),
-                    to.display(),
-                    e
-                );
+                if !machine_output_enabled() {
+                    eprintln!(
+                        "[log] rotate: failed to rename {} to {}: {} (continuing)",
+                        from.display(),
+                        to.display(),
+                        e
+                    );
+                }
             }
         }
     } else {
@@ -119,22 +129,26 @@ fn rotate(state: &AppLogFile) {
     if APP_LOG_KEEP >= 1 {
         let one = numbered(1);
         if let Err(e) = std::fs::rename(base, &one) {
-            eprintln!(
-                "[log] rotate: failed to rename {} → {}: {} — leaving active file in place",
-                base.display(),
-                one.display(),
-                e
-            );
+            if !machine_output_enabled() {
+                eprintln!(
+                    "[log] rotate: failed to rename {} to {}: {}, leaving active file in place",
+                    base.display(),
+                    one.display(),
+                    e
+                );
+            }
             // Active file stays — next writes append to it; cap will be
             // breached temporarily.
             return;
         }
     } else if let Err(e) = std::fs::remove_file(base) {
-        eprintln!(
-            "[log] rotate: KEEP=0 and failed to remove {}: {} — leaving active file in place",
-            base.display(),
-            e
-        );
+        if !machine_output_enabled() {
+            eprintln!(
+                "[log] rotate: KEEP=0 and failed to remove {}: {}, leaving active file in place",
+                base.display(),
+                e
+            );
+        }
         return;
     }
 
@@ -147,11 +161,13 @@ fn rotate(state: &AppLogFile) {
         .or_else(|e| {
             // Fallback: another process already created it. Open append-mode
             // so we don't truncate their content. Log to stderr for visibility.
-            eprintln!(
-                "[log] rotate: create_new failed for {} ({}); falling back to append",
-                base.display(),
-                e
-            );
+            if !machine_output_enabled() {
+                eprintln!(
+                    "[log] rotate: create_new failed for {} ({}); falling back to append",
+                    base.display(),
+                    e
+                );
+            }
             std::fs::OpenOptions::new()
                 .create(true)
                 .append(true)
@@ -164,11 +180,13 @@ fn rotate(state: &AppLogFile) {
             state.bytes.store(0, Ordering::Relaxed);
         }
         Err(e) => {
-            eprintln!(
-                "[log] rotate: failed to open fresh active file at {}: {}",
-                base.display(),
-                e
-            );
+            if !machine_output_enabled() {
+                eprintln!(
+                    "[log] rotate: failed to open fresh active file at {}: {}",
+                    base.display(),
+                    e
+                );
+            }
             // Counter NOT reset — next writes will see "over cap" and try
             // rotating again. Active fd in `file_guard` is now stale: on
             // both Unix and Windows the open handle survives `rename()` and
@@ -207,7 +225,7 @@ fn init_logger_inner() {
             .open(&path)
             .ok()
             .map(|f| {
-                if std::env::var("AC_MACHINE_OUTPUT").is_err() {
+                if !machine_output_enabled() {
                     eprintln!("[log] file logging to {}", path.display());
                 }
                 let initial_bytes = f.metadata().map(|m| m.len()).unwrap_or(0);
@@ -272,7 +290,7 @@ fn init_logger_inner() {
                 if should_capture(record) {
                     error_sink().capture(ErrorLogEntry::from_record(ts.to_string(), record));
                 }
-                if std::env::var("AC_MACHINE_OUTPUT").is_err() || record.level() == log::Level::Error {
+                if !machine_output_enabled() {
                     buf.write_all(line.as_bytes())?;
                 }
                 if let Some(ref state) = *log_state {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -34,6 +34,10 @@ fn main() {
                                 | agentscommander_lib::cli::Commands::ListPeersLean(_)
                                 | agentscommander_lib::cli::Commands::ListSessions(_)
                                 | agentscommander_lib::cli::Commands::AgencyTemplates(_)
+                                | agentscommander_lib::cli::Commands::UiQuery(_)
+                                | agentscommander_lib::cli::Commands::UiClick(_)
+                                | agentscommander_lib::cli::Commands::UiSet(_)
+                                | agentscommander_lib::cli::Commands::UiWait(_)
                         ) {
                             std::env::set_var("AC_MACHINE_OUTPUT", "1");
                         }
@@ -66,11 +70,33 @@ fn main() {
                             }
                         };
 
+                        let ui_automation_enabled = match agentscommander_lib::testability::ui_automation::resolve_enabled_from_cli_or_env(cli.ui_automation) {
+                            Ok(enabled) => enabled,
+                            Err(e) => {
+                                agentscommander_lib::cli::attach_parent_console();
+                                eprintln!("{}", e);
+                                agentscommander_lib::cli::flush_outputs();
+                                std::process::exit(1);
+                            }
+                        };
+
                         if !try_acquire_single_instance() {
+                            if ui_automation_enabled {
+                                if agentscommander_lib::testability::ui_automation::existing_enabled_session_for_current_config() {
+                                    std::process::exit(0);
+                                }
+                                agentscommander_lib::cli::attach_parent_console();
+                                eprintln!(
+                                    "{}",
+                                    agentscommander_lib::testability::ui_automation::automation_not_enabled_json()
+                                );
+                                agentscommander_lib::cli::flush_outputs();
+                                std::process::exit(1);
+                            }
                             // Another GUI instance is already running; exit silently
                             std::process::exit(0);
                         }
-                        agentscommander_lib::run(placement);
+                        agentscommander_lib::run(placement, ui_automation_enabled);
                     }
                 },
                 Err(e) => {

--- a/src-tauri/src/testability/mod.rs
+++ b/src-tauri/src/testability/mod.rs
@@ -1,4 +1,5 @@
 pub mod reset;
+pub mod ui_automation;
 pub mod window_info;
 pub mod window_placement;
 

--- a/src-tauri/src/testability/ui_automation.rs
+++ b/src-tauri/src/testability/ui_automation.rs
@@ -190,6 +190,7 @@ impl UiAutomationState {
 
     pub fn start(&self, app: AppHandle, shutdown: ShutdownSignal) {
         if !self.inner.enabled {
+            self.cleanup_session_file_unchecked();
             return;
         }
 
@@ -214,14 +215,18 @@ impl UiAutomationState {
     }
 
     pub fn cleanup_session_file(&self) {
-        if self.enabled() {
-            if let Err(e) = retry_remove_file(&self.inner.session_path) {
-                log::warn!(
-                    "[ui-automation] failed to remove session file {}: {}",
-                    self.inner.session_path.display(),
-                    e
-                );
-            }
+        if self.inner.enabled {
+            self.cleanup_session_file_unchecked();
+        }
+    }
+
+    fn cleanup_session_file_unchecked(&self) {
+        if let Err(e) = retry_remove_file(&self.inner.session_path) {
+            log::warn!(
+                "[ui-automation] failed to remove session file {}: {}",
+                self.inner.session_path.display(),
+                e
+            );
         }
     }
 
@@ -645,7 +650,7 @@ pub fn execute_wait(args: UiWaitArgs) -> i32 {
                 Some("Automation wait timed out before the selector became available.".to_string());
             timeout.timeout_ms = Some(args.timeout_ms);
             timeout.phase = Some("wait_condition_not_met".to_string());
-            print_stderr_json(&timeout);
+            print_stdout_json(&timeout);
             return 1;
         }
 
@@ -666,7 +671,7 @@ pub fn execute_wait(args: UiWaitArgs) -> i32 {
                 last_response = Some(response);
             }
             Err(error) => {
-                print_stderr_json(&error);
+                print_stdout_json(&error);
                 return 1;
             }
         }
@@ -682,11 +687,11 @@ fn execute_cli(input: CliRequest) -> i32 {
             0
         }
         Ok(response) => {
-            print_stderr_json(&response);
+            print_stdout_json(&response);
             1
         }
         Err(error) => {
-            print_stderr_json(&error);
+            print_stdout_json(&error);
             1
         }
     }
@@ -846,24 +851,25 @@ pub fn existing_enabled_session_for_current_config() -> bool {
 }
 
 pub fn automation_not_enabled_json() -> String {
+    automation_not_enabled_error().to_string()
+}
+
+fn automation_not_enabled_error() -> Value {
     preflight_error(
         "automation_not_enabled",
         "A testable GUI is already running without UI automation enabled. Restart it with --ui-automation or AC_UI_AUTOMATION=1.",
         None,
     )
-    .to_string()
 }
 
 fn load_session_for_cli(path: &Path, requested_window: &str) -> Result<UiAutomationSession, Value> {
     let raw = match read_session_file_with_retry(path) {
         Ok(raw) => raw,
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            let state = crate::config::daemon_pid::detect_daemon_state();
-            let (error, message) = match state {
-                crate::config::daemon_pid::DaemonState::Running { .. } => (
-                    "automation_not_enabled",
-                    "The testable GUI is running, but UI automation was not enabled at startup.",
-                ),
+            let (error, message) = match crate::config::daemon_pid::detect_daemon_state() {
+                crate::config::daemon_pid::DaemonState::Running { .. } => {
+                    return Err(automation_not_enabled_error());
+                }
                 _ => (
                     "automation_session_missing",
                     "No UI automation session file exists for this testable binary.",
@@ -892,7 +898,16 @@ fn load_session_for_cli(path: &Path, requested_window: &str) -> Result<UiAutomat
         )
     })?;
 
-    validate_session_liveness(&session)?;
+    if let Err(e) = validate_session_liveness(&session) {
+        if matches!(
+            crate::config::daemon_pid::detect_daemon_state(),
+            crate::config::daemon_pid::DaemonState::Running { .. }
+        ) {
+            let _ = retry_remove_file(path);
+            return Err(automation_not_enabled_error());
+        }
+        return Err(e);
+    }
     if !session
         .window_labels
         .iter()
@@ -1036,16 +1051,6 @@ fn print_stdout_json<T: Serialize>(value: &T) {
     match serde_json::to_string(value) {
         Ok(json) => crate::cli_println!("{json}"),
         Err(e) => crate::cli_println!(
-            "{{\"ok\":false,\"error\":\"json_serialize_failed\",\"message\":{}}}",
-            serde_json::to_string(&e.to_string()).unwrap_or_else(|_| "\"unknown\"".to_string())
-        ),
-    }
-}
-
-fn print_stderr_json<T: Serialize>(value: &T) {
-    match serde_json::to_string(value) {
-        Ok(json) => eprintln!("{json}"),
-        Err(e) => eprintln!(
             "{{\"ok\":false,\"error\":\"json_serialize_failed\",\"message\":{}}}",
             serde_json::to_string(&e.to_string()).unwrap_or_else(|_| "\"unknown\"".to_string())
         ),

--- a/src-tauri/src/testability/ui_automation.rs
+++ b/src-tauri/src/testability/ui_automation.rs
@@ -26,6 +26,8 @@ const FS_RETRY_COUNT: usize = 8;
 const FS_RETRY_DELAY_MS: u64 = 25;
 const SESSION_READ_RETRY_COUNT: usize = 8;
 const SESSION_READ_RETRY_DELAY_MS: u64 = 25;
+const CLI_MAX_AVAILABLE_TARGETS: usize = 8;
+const CLI_MAX_TARGET_TEXT_CHARS: usize = 80;
 
 #[derive(Debug, Args)]
 pub struct UiQueryArgs {
@@ -818,7 +820,7 @@ fn run_cli_request(input: &CliRequest) -> Result<UiAutomationResponse, Value> {
             let _ = retry_remove_file(&response_path);
             let _ = retry_remove_file(&request_path);
             let _ = retry_remove_file(&inflight_path);
-            return Ok(response);
+            return Ok(sanitize_response_for_cli(response));
         }
 
         if Instant::now() >= deadline {
@@ -1071,6 +1073,66 @@ fn expired_response_for_request(request: &UiAutomationRequest) -> UiAutomationRe
     );
     response.diagnostics = Some(json!({ "expiresAtUnixMs": request.expires_at_unix_ms }));
     response
+}
+
+fn sanitize_response_for_cli(mut response: UiAutomationResponse) -> UiAutomationResponse {
+    let truncation = response.available.as_mut().and_then(|available| {
+        let total = available.len();
+        for target in available.iter_mut() {
+            sanitize_target_for_cli(target);
+        }
+        if total > CLI_MAX_AVAILABLE_TARGETS {
+            available.truncate(CLI_MAX_AVAILABLE_TARGETS);
+            Some((total, CLI_MAX_AVAILABLE_TARGETS))
+        } else {
+            None
+        }
+    });
+
+    if let Some((total, limit)) = truncation {
+        add_cli_truncation_diagnostics(&mut response, total, limit);
+    }
+
+    response
+}
+
+fn sanitize_target_for_cli(target: &mut Value) {
+    let Some(obj) = target.as_object_mut() else {
+        return;
+    };
+    let Some(Value::String(text)) = obj.get_mut("text") else {
+        return;
+    };
+    if text.chars().count() <= CLI_MAX_TARGET_TEXT_CHARS {
+        return;
+    }
+    let mut truncated = text
+        .chars()
+        .take(CLI_MAX_TARGET_TEXT_CHARS)
+        .collect::<String>();
+    truncated.push_str("...");
+    *text = truncated;
+}
+
+fn add_cli_truncation_diagnostics(
+    response: &mut UiAutomationResponse,
+    available_total: usize,
+    available_limit: usize,
+) {
+    let mut diagnostics = response
+        .diagnostics
+        .take()
+        .filter(|value| value.is_object())
+        .and_then(|value| match value {
+            Value::Object(map) => Some(map),
+            _ => None,
+        })
+        .unwrap_or_default();
+
+    diagnostics.insert("availableTotal".to_string(), json!(available_total));
+    diagnostics.insert("availableLimit".to_string(), json!(available_limit));
+    diagnostics.insert("availableTruncated".to_string(), json!(true));
+    response.diagnostics = Some(Value::Object(diagnostics));
 }
 
 fn print_stdout_json<T: Serialize>(value: &T) {

--- a/src-tauri/src/testability/ui_automation.rs
+++ b/src-tauri/src/testability/ui_automation.rs
@@ -1,0 +1,1344 @@
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tauri::{AppHandle, Emitter, Manager};
+use uuid::Uuid;
+
+use crate::shutdown::ShutdownSignal;
+use crate::testability::window_placement::TESTABLE_EXE_NAME;
+
+pub const UI_AUTOMATION_DIR: &str = "ui-automation";
+pub const SESSION_FILE: &str = "session.json";
+pub const REQUESTS_DIR: &str = "requests";
+pub const RESPONSES_DIR: &str = "responses";
+pub const ENV_ENABLE: &str = "AC_UI_AUTOMATION";
+
+const DEFAULT_TIMEOUT_MS: u64 = 5_000;
+const POLL_MS: u64 = 50;
+const FS_RETRY_COUNT: usize = 8;
+const FS_RETRY_DELAY_MS: u64 = 25;
+
+#[derive(Debug, Args)]
+pub struct UiQueryArgs {
+    #[arg(long, default_value = "main")]
+    pub window: String,
+    #[arg(long)]
+    pub selector: String,
+    #[arg(long, default_value_t = DEFAULT_TIMEOUT_MS)]
+    pub timeout_ms: u64,
+}
+
+#[derive(Debug, Args)]
+pub struct UiClickArgs {
+    #[arg(long, default_value = "main")]
+    pub window: String,
+    #[arg(long)]
+    pub selector: String,
+    #[arg(long, default_value_t = DEFAULT_TIMEOUT_MS)]
+    pub timeout_ms: u64,
+}
+
+#[derive(Debug, Args)]
+pub struct UiSetArgs {
+    #[arg(long, default_value = "main")]
+    pub window: String,
+    #[arg(long)]
+    pub selector: String,
+    #[arg(long)]
+    pub value: String,
+    #[arg(long, default_value_t = DEFAULT_TIMEOUT_MS)]
+    pub timeout_ms: u64,
+}
+
+#[derive(Debug, Args)]
+pub struct UiWaitArgs {
+    #[arg(long, default_value = "main")]
+    pub window: String,
+    #[arg(long)]
+    pub selector: String,
+    #[arg(long, default_value_t = DEFAULT_TIMEOUT_MS)]
+    pub timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiAutomationSession {
+    pub pid: u32,
+    pub token: String,
+    pub exe_path: String,
+    pub config_dir: String,
+    pub window_labels: Vec<String>,
+    pub ready_window_labels: Vec<String>,
+    pub started_at_unix_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiAutomationRequest {
+    pub request_id: String,
+    pub token: String,
+    pub window: String,
+    pub action: UiAutomationAction,
+    pub selector: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum UiAutomationAction {
+    Query,
+    Click,
+    SetValue,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiAutomationResponse {
+    pub ok: bool,
+    pub request_id: String,
+    pub window: String,
+    pub action: UiAutomationAction,
+    pub selector: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available: Option<Vec<Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostics: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_windows: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingRequest {
+    request: UiAutomationRequest,
+    response_path: PathBuf,
+    inflight_path: PathBuf,
+}
+
+#[derive(Clone)]
+pub struct UiAutomationState {
+    inner: Arc<UiAutomationInner>,
+}
+
+struct UiAutomationInner {
+    enabled: bool,
+    token: String,
+    config_dir: PathBuf,
+    automation_dir: PathBuf,
+    session_path: PathBuf,
+    window_labels: Mutex<HashSet<String>>,
+    ready_window_labels: Mutex<HashSet<String>>,
+    pending: Mutex<HashMap<String, PendingRequest>>,
+    exe_path: String,
+    started_at_unix_ms: i64,
+}
+
+impl UiAutomationState {
+    pub fn new(enabled: bool, config_dir: PathBuf) -> Self {
+        let automation_dir = config_dir.join(UI_AUTOMATION_DIR);
+        let session_path = automation_dir.join(SESSION_FILE);
+        let exe_path = current_exe_path_string();
+        let mut window_labels = HashSet::new();
+        window_labels.insert("main".to_string());
+
+        Self {
+            inner: Arc::new(UiAutomationInner {
+                enabled,
+                token: if enabled {
+                    Uuid::new_v4().to_string()
+                } else {
+                    String::new()
+                },
+                config_dir,
+                automation_dir,
+                session_path,
+                window_labels: Mutex::new(window_labels),
+                ready_window_labels: Mutex::new(HashSet::new()),
+                pending: Mutex::new(HashMap::new()),
+                exe_path,
+                started_at_unix_ms: now_unix_ms(),
+            }),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.inner.enabled
+    }
+
+    pub fn start(&self, app: AppHandle, shutdown: ShutdownSignal) {
+        if !self.enabled() {
+            return;
+        }
+
+        if let Err(e) = self.initialize_files() {
+            log::error!("[ui-automation] failed to initialize files: {}", e);
+            return;
+        }
+
+        let state = self.clone();
+        let shutdown = shutdown.token().clone();
+        tauri::async_runtime::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_millis(POLL_MS));
+            loop {
+                tokio::select! {
+                    _ = shutdown.cancelled() => break,
+                    _ = interval.tick() => state.poll_once(&app),
+                }
+            }
+        });
+    }
+
+    pub fn cleanup_session_file(&self) {
+        if self.enabled() {
+            if let Err(e) = retry_remove_file(&self.inner.session_path) {
+                log::warn!(
+                    "[ui-automation] failed to remove session file {}: {}",
+                    self.inner.session_path.display(),
+                    e
+                );
+            }
+        }
+    }
+
+    pub fn mark_frontend_ready(
+        &self,
+        caller_label: &str,
+        claimed_label: Option<&str>,
+    ) -> Result<(), String> {
+        if !self.enabled() {
+            return Err("automation_not_enabled".to_string());
+        }
+        if let Some(claimed_label) = claimed_label {
+            if claimed_label != caller_label {
+                return Err("frontend_ready_window_mismatch".to_string());
+            }
+        }
+        {
+            let labels = self
+                .inner
+                .window_labels
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if !labels.contains(caller_label) {
+                return Err("window_unavailable".to_string());
+            }
+        }
+        {
+            let mut ready = self
+                .inner
+                .ready_window_labels
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            ready.insert(caller_label.to_string());
+        }
+        self.write_session_snapshot().map_err(|e| e.to_string())
+    }
+
+    pub fn complete(&self, caller_label: &str, result: UiAutomationResponse) -> Result<(), String> {
+        if !self.enabled() {
+            return Err("automation_not_enabled".to_string());
+        }
+
+        let pending = {
+            let mut pending = self.inner.pending.lock().unwrap_or_else(|e| e.into_inner());
+            pending.remove(&result.request_id)
+        };
+        let Some(pending) = pending else {
+            return Err("unknown_request_id".to_string());
+        };
+
+        let response = if caller_label != pending.request.window
+            || result.window != pending.request.window
+            || result.action != pending.request.action
+            || result.selector != pending.request.selector
+        {
+            UiAutomationResponse::error_for_request(
+                &pending.request,
+                "completion_mismatch",
+                "Frontend completion did not match the pending automation request.",
+            )
+        } else {
+            result
+        };
+
+        write_json_atomic_new(&pending.response_path, &response).map_err(|e| e.to_string())?;
+        let _ = retry_remove_file(&pending.inflight_path);
+        Ok(())
+    }
+
+    fn initialize_files(&self) -> io::Result<()> {
+        cleanup_stale_automation_files(&self.inner.automation_dir)?;
+        fs::create_dir_all(self.requests_dir())?;
+        fs::create_dir_all(self.responses_dir())?;
+        self.write_session_snapshot()
+    }
+
+    fn write_session_snapshot(&self) -> io::Result<()> {
+        let window_labels = sorted_labels(
+            &self
+                .inner
+                .window_labels
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()),
+        );
+        let ready_window_labels = sorted_labels(
+            &self
+                .inner
+                .ready_window_labels
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()),
+        );
+        let session = UiAutomationSession {
+            pid: std::process::id(),
+            token: self.inner.token.clone(),
+            exe_path: self.inner.exe_path.clone(),
+            config_dir: self.inner.config_dir.to_string_lossy().into_owned(),
+            window_labels,
+            ready_window_labels,
+            started_at_unix_ms: self.inner.started_at_unix_ms,
+        };
+        write_json_atomic_replace(&self.inner.session_path, &session)
+    }
+
+    fn poll_once(&self, app: &AppHandle) {
+        if let Err(e) = self.poll_once_inner(app) {
+            log::warn!("[ui-automation] poll failed: {}", e);
+        }
+    }
+
+    fn poll_once_inner(&self, app: &AppHandle) -> io::Result<()> {
+        let requests_dir = self.requests_dir();
+        let entries = match fs::read_dir(&requests_dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(e),
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(request_file) = RequestFile::from_path(&path) else {
+                continue;
+            };
+            if self.is_pending(&request_file.request_id) {
+                continue;
+            }
+            self.process_request_file(app, request_file);
+        }
+
+        Ok(())
+    }
+
+    fn process_request_file(&self, app: &AppHandle, request_file: RequestFile) {
+        let raw = match fs::read_to_string(&request_file.path) {
+            Ok(raw) => raw,
+            Err(e) => {
+                log::warn!(
+                    "[ui-automation] failed to read request {}: {}",
+                    request_file.path.display(),
+                    e
+                );
+                return;
+            }
+        };
+        let request: UiAutomationRequest = match serde_json::from_str(&raw) {
+            Ok(request) => request,
+            Err(e) => {
+                let response = UiAutomationResponse::minimal_error(
+                    &request_file.request_id,
+                    "main",
+                    UiAutomationAction::Query,
+                    "",
+                    "malformed_request",
+                    &format!("Request file was not valid JSON: {e}"),
+                );
+                let _ = self.write_direct_response(&request_file, &response);
+                return;
+            }
+        };
+
+        if request.request_id != request_file.request_id {
+            let response = UiAutomationResponse::error_for_request(
+                &request,
+                "malformed_request",
+                "Request id did not match its request filename.",
+            );
+            let _ = self.write_direct_response(&request_file, &response);
+            return;
+        }
+
+        if request.token != self.inner.token {
+            let response = UiAutomationResponse::error_for_request(
+                &request,
+                "automation_session_stale",
+                "Automation token did not match the running GUI session.",
+            );
+            let _ = self.write_direct_response(&request_file, &response);
+            return;
+        }
+
+        let available_windows = available_window_labels(app);
+        if !available_windows
+            .iter()
+            .any(|label| label == &request.window)
+        {
+            let mut response = UiAutomationResponse::error_for_request(
+                &request,
+                "window_unavailable",
+                "Requested automation window is not live.",
+            );
+            response.available_windows = Some(available_windows);
+            let _ = self.write_direct_response(&request_file, &response);
+            return;
+        }
+
+        let inflight_path = match self.ensure_inflight(&request_file) {
+            Ok(path) => path,
+            Err(e) => {
+                let mut response = UiAutomationResponse::error_for_request(
+                    &request,
+                    "automation_filesystem_error",
+                    "Failed to mark automation request as inflight.",
+                );
+                response.diagnostics = Some(json!({
+                    "operation": "rename_request_inflight",
+                    "path": request_file.path.to_string_lossy(),
+                    "message": e.to_string(),
+                }));
+                let _ = self.write_direct_response(&request_file, &response);
+                return;
+            }
+        };
+
+        if !self.is_window_ready(&request.window) {
+            return;
+        }
+
+        let response_path = self.response_path(&request.request_id);
+        let pending = PendingRequest {
+            request: request.clone(),
+            response_path,
+            inflight_path,
+        };
+        {
+            let mut pending_map = self.inner.pending.lock().unwrap_or_else(|e| e.into_inner());
+            pending_map.insert(request.request_id.clone(), pending);
+        }
+
+        if let Err(e) = app.emit_to(&request.window, "ui_automation_request", &request) {
+            let pending = {
+                let mut pending_map = self.inner.pending.lock().unwrap_or_else(|e| e.into_inner());
+                pending_map.remove(&request.request_id)
+            };
+            if let Some(pending) = pending {
+                let mut response = UiAutomationResponse::error_for_request(
+                    &request,
+                    "webview_unavailable",
+                    "Failed to emit automation request to the requested WebView.",
+                );
+                response.available_windows = Some(available_window_labels(app));
+                response.diagnostics = Some(json!({ "message": e.to_string() }));
+                let _ = write_json_atomic_new(&pending.response_path, &response);
+                let _ = retry_remove_file(&pending.inflight_path);
+            }
+        }
+    }
+
+    fn is_pending(&self, request_id: &str) -> bool {
+        self.inner
+            .pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(request_id)
+    }
+
+    fn is_window_ready(&self, window: &str) -> bool {
+        self.inner
+            .ready_window_labels
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains(window)
+    }
+
+    fn ensure_inflight(&self, request_file: &RequestFile) -> io::Result<PathBuf> {
+        match request_file.kind {
+            RequestFileKind::Inflight => Ok(request_file.path.clone()),
+            RequestFileKind::Ready => {
+                let inflight_path = self.inflight_path(&request_file.request_id);
+                retry_rename(&request_file.path, &inflight_path)?;
+                Ok(inflight_path)
+            }
+        }
+    }
+
+    fn write_direct_response(
+        &self,
+        request_file: &RequestFile,
+        response: &UiAutomationResponse,
+    ) -> io::Result<()> {
+        let response_path = self.response_path(&request_file.request_id);
+        write_json_atomic_new(&response_path, response)?;
+        let _ = retry_remove_file(&request_file.path);
+        Ok(())
+    }
+
+    fn requests_dir(&self) -> PathBuf {
+        self.inner.automation_dir.join(REQUESTS_DIR)
+    }
+
+    fn responses_dir(&self) -> PathBuf {
+        self.inner.automation_dir.join(RESPONSES_DIR)
+    }
+
+    fn inflight_path(&self, request_id: &str) -> PathBuf {
+        self.requests_dir()
+            .join(format!("{request_id}.inflight.json"))
+    }
+
+    fn response_path(&self, request_id: &str) -> PathBuf {
+        self.responses_dir().join(format!("{request_id}.json"))
+    }
+}
+
+impl UiAutomationResponse {
+    fn minimal_error(
+        request_id: &str,
+        window: &str,
+        action: UiAutomationAction,
+        selector: &str,
+        error: &str,
+        message: &str,
+    ) -> Self {
+        Self {
+            ok: false,
+            request_id: request_id.to_string(),
+            window: window.to_string(),
+            action,
+            selector: selector.to_string(),
+            target: None,
+            error: Some(error.to_string()),
+            message: Some(message.to_string()),
+            available: None,
+            diagnostics: None,
+            available_windows: None,
+            timeout_ms: None,
+            phase: None,
+        }
+    }
+
+    fn error_for_request(request: &UiAutomationRequest, error: &str, message: &str) -> Self {
+        Self::minimal_error(
+            &request.request_id,
+            &request.window,
+            request.action,
+            &request.selector,
+            error,
+            message,
+        )
+    }
+}
+
+#[derive(Debug)]
+struct CliRequest {
+    window: String,
+    selector: String,
+    action: UiAutomationAction,
+    value: Option<String>,
+    timeout_ms: u64,
+}
+
+pub fn execute_query(args: UiQueryArgs) -> i32 {
+    execute_cli(CliRequest {
+        window: args.window,
+        selector: args.selector,
+        action: UiAutomationAction::Query,
+        value: None,
+        timeout_ms: args.timeout_ms,
+    })
+}
+
+pub fn execute_click(args: UiClickArgs) -> i32 {
+    execute_cli(CliRequest {
+        window: args.window,
+        selector: args.selector,
+        action: UiAutomationAction::Click,
+        value: None,
+        timeout_ms: args.timeout_ms,
+    })
+}
+
+pub fn execute_set(args: UiSetArgs) -> i32 {
+    execute_cli(CliRequest {
+        window: args.window,
+        selector: args.selector,
+        action: UiAutomationAction::SetValue,
+        value: Some(args.value),
+        timeout_ms: args.timeout_ms,
+    })
+}
+
+pub fn execute_wait(args: UiWaitArgs) -> i32 {
+    let deadline = Instant::now() + Duration::from_millis(args.timeout_ms);
+    let mut last_response: Option<UiAutomationResponse> = None;
+
+    loop {
+        let remaining_ms = deadline
+            .checked_duration_since(Instant::now())
+            .map(|d| d.as_millis().min(u128::from(u64::MAX)) as u64)
+            .unwrap_or(0);
+        if remaining_ms == 0 {
+            let timeout = last_response.unwrap_or_else(|| {
+                UiAutomationResponse::minimal_error(
+                    &Uuid::new_v4().to_string(),
+                    &args.window,
+                    UiAutomationAction::Query,
+                    &args.selector,
+                    "timeout",
+                    "Automation wait timed out before the selector became available.",
+                )
+            });
+            let mut timeout = timeout;
+            timeout.ok = false;
+            timeout.error = Some("timeout".to_string());
+            timeout.message =
+                Some("Automation wait timed out before the selector became available.".to_string());
+            timeout.timeout_ms = Some(args.timeout_ms);
+            timeout.phase = Some("wait_condition_not_met".to_string());
+            print_stderr_json(&timeout);
+            return 1;
+        }
+
+        let input = CliRequest {
+            window: args.window.clone(),
+            selector: args.selector.clone(),
+            action: UiAutomationAction::Query,
+            value: None,
+            timeout_ms: remaining_ms.min(500),
+        };
+
+        match run_cli_request(&input) {
+            Ok(response) if response.ok => {
+                print_stdout_json(&response);
+                return 0;
+            }
+            Ok(response) => {
+                last_response = Some(response);
+            }
+            Err(error) => {
+                print_stderr_json(&error);
+                return 1;
+            }
+        }
+
+        std::thread::sleep(Duration::from_millis(POLL_MS));
+    }
+}
+
+fn execute_cli(input: CliRequest) -> i32 {
+    match run_cli_request(&input) {
+        Ok(response) if response.ok => {
+            print_stdout_json(&response);
+            0
+        }
+        Ok(response) => {
+            print_stderr_json(&response);
+            1
+        }
+        Err(error) => {
+            print_stderr_json(&error);
+            1
+        }
+    }
+}
+
+fn run_cli_request(input: &CliRequest) -> Result<UiAutomationResponse, Value> {
+    ensure_current_exe_is_testable()?;
+
+    let config_dir = config_dir_or_error()?;
+    let automation_dir = config_dir.join(UI_AUTOMATION_DIR);
+    let session_path = automation_dir.join(SESSION_FILE);
+    let session = load_session_for_cli(&session_path, &input.window)?;
+
+    fs::create_dir_all(automation_dir.join(REQUESTS_DIR)).map_err(|e| {
+        preflight_error(
+            "automation_filesystem_error",
+            "Failed to create automation request directory.",
+            Some(json!({
+                "operation": "create_requests_dir",
+                "path": automation_dir.join(REQUESTS_DIR).to_string_lossy(),
+                "message": e.to_string(),
+            })),
+        )
+    })?;
+    fs::create_dir_all(automation_dir.join(RESPONSES_DIR)).map_err(|e| {
+        preflight_error(
+            "automation_filesystem_error",
+            "Failed to create automation response directory.",
+            Some(json!({
+                "operation": "create_responses_dir",
+                "path": automation_dir.join(RESPONSES_DIR).to_string_lossy(),
+                "message": e.to_string(),
+            })),
+        )
+    })?;
+
+    let request_id = Uuid::new_v4().to_string();
+    let request = UiAutomationRequest {
+        request_id: request_id.clone(),
+        token: session.token,
+        window: input.window.clone(),
+        action: input.action,
+        selector: input.selector.clone(),
+        value: input.value.clone(),
+    };
+
+    let request_path = automation_dir
+        .join(REQUESTS_DIR)
+        .join(format!("{request_id}.json"));
+    let inflight_path = automation_dir
+        .join(REQUESTS_DIR)
+        .join(format!("{request_id}.inflight.json"));
+    let response_path = automation_dir
+        .join(RESPONSES_DIR)
+        .join(format!("{request_id}.json"));
+
+    write_json_atomic_new(&request_path, &request).map_err(|e| {
+        response_error_value(
+            &request,
+            "automation_filesystem_error",
+            "Failed to write automation request file.",
+            Some(json!({
+                "operation": "write_request",
+                "path": request_path.to_string_lossy(),
+                "message": e.to_string(),
+            })),
+        )
+    })?;
+
+    let deadline = Instant::now() + Duration::from_millis(input.timeout_ms);
+    loop {
+        if response_path.exists() {
+            let raw = fs::read_to_string(&response_path).map_err(|e| {
+                response_error_value(
+                    &request,
+                    "automation_filesystem_error",
+                    "Failed to read automation response file.",
+                    Some(json!({
+                        "operation": "read_response",
+                        "path": response_path.to_string_lossy(),
+                        "message": e.to_string(),
+                    })),
+                )
+            })?;
+            let response: UiAutomationResponse = serde_json::from_str(&raw).map_err(|e| {
+                response_error_value(
+                    &request,
+                    "automation_filesystem_error",
+                    "Automation response file was not valid JSON.",
+                    Some(json!({
+                        "operation": "parse_response",
+                        "path": response_path.to_string_lossy(),
+                        "message": e.to_string(),
+                    })),
+                )
+            })?;
+            let _ = retry_remove_file(&response_path);
+            let _ = retry_remove_file(&request_path);
+            let _ = retry_remove_file(&inflight_path);
+            return Ok(response);
+        }
+
+        if Instant::now() >= deadline {
+            let mut timeout = UiAutomationResponse::error_for_request(
+                &request,
+                "timeout",
+                "Automation request timed out before the GUI returned a response.",
+            );
+            timeout.timeout_ms = Some(input.timeout_ms);
+            timeout.phase = Some(timeout_phase(
+                &request_path,
+                &inflight_path,
+                &session_path,
+                &input.window,
+            ));
+            let _ = retry_remove_file(&request_path);
+            return Ok(timeout);
+        }
+
+        std::thread::sleep(Duration::from_millis(POLL_MS));
+    }
+}
+
+pub fn resolve_enabled_from_cli_or_env(ui_automation: bool) -> Result<bool, String> {
+    let env_enabled = std::env::var(ENV_ENABLE)
+        .ok()
+        .is_some_and(|value| value == "1");
+    let requested = ui_automation || env_enabled;
+    if !requested {
+        return Ok(false);
+    }
+    if !current_exe_is_testable() {
+        return Err(preflight_error(
+            "refusing_non_testeable_binary",
+            "UI automation is only available from agentscommander_testeable.exe.",
+            Some(json!({ "expected": TESTABLE_EXE_NAME })),
+        )
+        .to_string());
+    }
+    Ok(true)
+}
+
+pub fn existing_enabled_session_for_current_config() -> bool {
+    let Some(config_dir) = crate::config::config_dir() else {
+        return false;
+    };
+    let session_path = config_dir.join(UI_AUTOMATION_DIR).join(SESSION_FILE);
+    let Ok(raw) = fs::read_to_string(&session_path) else {
+        return false;
+    };
+    let Ok(session) = serde_json::from_str::<UiAutomationSession>(&raw) else {
+        return false;
+    };
+    validate_session_liveness(&session).is_ok()
+}
+
+pub fn automation_not_enabled_json() -> String {
+    preflight_error(
+        "automation_not_enabled",
+        "A testable GUI is already running without UI automation enabled. Restart it with --ui-automation or AC_UI_AUTOMATION=1.",
+        None,
+    )
+    .to_string()
+}
+
+fn load_session_for_cli(path: &Path, requested_window: &str) -> Result<UiAutomationSession, Value> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            let state = crate::config::daemon_pid::detect_daemon_state();
+            let (error, message) = match state {
+                crate::config::daemon_pid::DaemonState::Running { .. } => (
+                    "automation_not_enabled",
+                    "The testable GUI is running, but UI automation was not enabled at startup.",
+                ),
+                _ => (
+                    "automation_session_missing",
+                    "No UI automation session file exists for this testable binary.",
+                ),
+            };
+            return Err(preflight_error(error, message, None));
+        }
+        Err(e) => {
+            return Err(preflight_error(
+                "automation_filesystem_error",
+                "Failed to read UI automation session file.",
+                Some(json!({
+                    "operation": "read_session",
+                    "path": path.to_string_lossy(),
+                    "message": e.to_string(),
+                })),
+            ));
+        }
+    };
+
+    let session: UiAutomationSession = serde_json::from_str(&raw).map_err(|e| {
+        preflight_error(
+            "automation_session_stale",
+            "UI automation session file is malformed.",
+            Some(json!({ "message": e.to_string() })),
+        )
+    })?;
+
+    validate_session_liveness(&session)?;
+    if !session
+        .window_labels
+        .iter()
+        .any(|label| label == requested_window)
+    {
+        let mut value = preflight_error(
+            "window_unavailable",
+            "Requested automation window is not registered in the running session.",
+            None,
+        );
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert("availableWindows".to_string(), json!(session.window_labels));
+        }
+        return Err(value);
+    }
+    Ok(session)
+}
+
+fn validate_session_liveness(session: &UiAutomationSession) -> Result<(), Value> {
+    if session.pid == 0 || !pid_is_alive(session.pid) {
+        return Err(preflight_error(
+            "automation_session_stale",
+            "UI automation session PID is not alive.",
+            Some(json!({ "pid": session.pid })),
+        ));
+    }
+
+    let current_exe = current_exe_path_string();
+    if !paths_equal_for_compare(
+        &PathBuf::from(&session.exe_path),
+        &PathBuf::from(&current_exe),
+    ) {
+        return Err(preflight_error(
+            "automation_session_stale",
+            "UI automation session belongs to a different executable path.",
+            Some(json!({ "sessionExePath": session.exe_path })),
+        ));
+    }
+
+    #[cfg(target_os = "windows")]
+    if let Some(process_path) = process_path(session.pid) {
+        if !paths_equal_for_compare(&process_path, &PathBuf::from(&session.exe_path)) {
+            return Err(preflight_error(
+                "automation_session_stale",
+                "UI automation session PID now belongs to a different executable.",
+                Some(json!({ "pid": session.pid })),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_current_exe_is_testable() -> Result<(), Value> {
+    if current_exe_is_testable() {
+        Ok(())
+    } else {
+        Err(preflight_error(
+            "refusing_non_testeable_binary",
+            "UI automation is only available from agentscommander_testeable.exe.",
+            Some(json!({ "expected": TESTABLE_EXE_NAME })),
+        ))
+    }
+}
+
+fn current_exe_is_testable() -> bool {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .is_some_and(|name| name == TESTABLE_EXE_NAME)
+}
+
+fn config_dir_or_error() -> Result<PathBuf, Value> {
+    crate::config::config_dir().ok_or_else(|| {
+        preflight_error(
+            "automation_filesystem_error",
+            "Could not resolve the current binary config directory.",
+            None,
+        )
+    })
+}
+
+fn preflight_error(error: &str, message: &str, diagnostics: Option<Value>) -> Value {
+    let mut value = json!({
+        "ok": false,
+        "error": error,
+        "message": message,
+        "currentExePath": current_exe_path_string(),
+    });
+    if let Some(config_dir) = crate::config::config_dir() {
+        value["configDir"] = json!(config_dir.to_string_lossy().into_owned());
+    }
+    if let Some(diagnostics) = diagnostics {
+        value["diagnostics"] = diagnostics;
+    }
+    value
+}
+
+fn response_error_value(
+    request: &UiAutomationRequest,
+    error: &str,
+    message: &str,
+    diagnostics: Option<Value>,
+) -> Value {
+    let mut response = UiAutomationResponse::error_for_request(request, error, message);
+    response.diagnostics = diagnostics;
+    serde_json::to_value(response).unwrap_or_else(|_| {
+        json!({
+            "ok": false,
+            "error": "json_serialize_failed",
+            "message": "Failed to serialize automation response."
+        })
+    })
+}
+
+fn print_stdout_json<T: Serialize>(value: &T) {
+    match serde_json::to_string(value) {
+        Ok(json) => crate::cli_println!("{json}"),
+        Err(e) => crate::cli_println!(
+            "{{\"ok\":false,\"error\":\"json_serialize_failed\",\"message\":{}}}",
+            serde_json::to_string(&e.to_string()).unwrap_or_else(|_| "\"unknown\"".to_string())
+        ),
+    }
+}
+
+fn print_stderr_json<T: Serialize>(value: &T) {
+    match serde_json::to_string(value) {
+        Ok(json) => eprintln!("{json}"),
+        Err(e) => eprintln!(
+            "{{\"ok\":false,\"error\":\"json_serialize_failed\",\"message\":{}}}",
+            serde_json::to_string(&e.to_string()).unwrap_or_else(|_| "\"unknown\"".to_string())
+        ),
+    }
+}
+
+fn timeout_phase(
+    request_path: &Path,
+    inflight_path: &Path,
+    session_path: &Path,
+    window: &str,
+) -> String {
+    if request_path.exists() {
+        return "awaiting_gui_poller".to_string();
+    }
+    if inflight_path.exists() {
+        if session_ready_for_window(session_path, window) {
+            "awaiting_frontend_response".to_string()
+        } else {
+            "awaiting_frontend_ready".to_string()
+        }
+    } else {
+        "awaiting_gui_poller".to_string()
+    }
+}
+
+fn session_ready_for_window(path: &Path, window: &str) -> bool {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<UiAutomationSession>(&raw).ok())
+        .is_some_and(|session| {
+            session
+                .ready_window_labels
+                .iter()
+                .any(|label| label == window)
+        })
+}
+
+fn write_json_atomic_new<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+    write_json_atomic(path, value, false)
+}
+
+fn write_json_atomic_replace<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+    write_json_atomic(path, value, true)
+}
+
+fn write_json_atomic<T: Serialize>(path: &Path, value: &T, replace: bool) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    if !replace && path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("destination already exists: {}", path.display()),
+        ));
+    }
+
+    let tmp_path = path.with_extension("tmp");
+    let mut file = if replace {
+        OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp_path)?
+    } else {
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)?
+    };
+    serde_json::to_writer(&mut file, value)?;
+    file.flush()?;
+    drop(file);
+
+    if replace {
+        let _ = retry_remove_file(path);
+    } else if path.exists() {
+        let _ = retry_remove_file(&tmp_path);
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("destination already exists: {}", path.display()),
+        ));
+    }
+    retry_rename(&tmp_path, path)
+}
+
+fn retry_rename(from: &Path, to: &Path) -> io::Result<()> {
+    retry_fs(|| fs::rename(from, to))
+}
+
+fn retry_remove_file(path: &Path) -> io::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    retry_fs(|| fs::remove_file(path))
+}
+
+fn retry_fs(mut op: impl FnMut() -> io::Result<()>) -> io::Result<()> {
+    let mut last_err = None;
+    for attempt in 0..FS_RETRY_COUNT {
+        match op() {
+            Ok(()) => return Ok(()),
+            Err(e) if is_transient_fs_error(&e) && attempt + 1 < FS_RETRY_COUNT => {
+                last_err = Some(e);
+                std::thread::sleep(Duration::from_millis(FS_RETRY_DELAY_MS));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| io::Error::other("filesystem retry failed")))
+}
+
+fn is_transient_fs_error(e: &io::Error) -> bool {
+    e.kind() == io::ErrorKind::PermissionDenied || matches!(e.raw_os_error(), Some(32) | Some(33))
+}
+
+fn cleanup_stale_automation_files(automation_dir: &Path) -> io::Result<()> {
+    let requests = automation_dir.join(REQUESTS_DIR);
+    let responses = automation_dir.join(RESPONSES_DIR);
+    if requests.exists() {
+        fs::remove_dir_all(&requests)?;
+    }
+    if responses.exists() {
+        fs::remove_dir_all(&responses)?;
+    }
+    Ok(())
+}
+
+fn sorted_labels(labels: &HashSet<String>) -> Vec<String> {
+    let mut labels: Vec<String> = labels.iter().cloned().collect();
+    labels.sort();
+    labels
+}
+
+fn available_window_labels(app: &AppHandle) -> Vec<String> {
+    let mut labels: Vec<String> = app.webview_windows().keys().cloned().collect();
+    labels.sort();
+    labels
+}
+
+fn current_exe_path_string() -> String {
+    std::env::current_exe()
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| String::new())
+}
+
+fn paths_equal_for_compare(a: &Path, b: &Path) -> bool {
+    let a = canonical_for_compare(a);
+    let b = canonical_for_compare(b);
+    #[cfg(target_os = "windows")]
+    {
+        a.to_string_lossy()
+            .eq_ignore_ascii_case(&b.to_string_lossy())
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        a == b
+    }
+}
+
+fn canonical_for_compare(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn now_unix_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(target_os = "windows")]
+pub fn pid_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_ACCESS_DENIED, FALSE, STILL_ACTIVE,
+    };
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+        if handle.is_null() {
+            return GetLastError() == ERROR_ACCESS_DENIED;
+        }
+        let mut code: u32 = 0;
+        let got_code = GetExitCodeProcess(handle, &mut code);
+        CloseHandle(handle);
+        got_code != 0 && code == STILL_ACTIVE as u32
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn pid_is_alive(_pid: u32) -> bool {
+    true
+}
+
+#[cfg(target_os = "windows")]
+fn process_path(pid: u32) -> Option<PathBuf> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return None;
+        }
+        let mut buf = vec![0u16; 32768];
+        let mut len = buf.len() as u32;
+        let ok = QueryFullProcessImageNameW(handle, 0, buf.as_mut_ptr(), &mut len);
+        let _ = CloseHandle(handle);
+        if ok == 0 || len == 0 {
+            return None;
+        }
+        Some(PathBuf::from(String::from_utf16_lossy(
+            &buf[..len as usize],
+        )))
+    }
+}
+
+#[derive(Debug)]
+struct RequestFile {
+    path: PathBuf,
+    request_id: String,
+    kind: RequestFileKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RequestFileKind {
+    Ready,
+    Inflight,
+}
+
+impl RequestFile {
+    fn from_path(path: &Path) -> Option<Self> {
+        let name = path.file_name()?.to_str()?;
+        if name.ends_with(".tmp") {
+            return None;
+        }
+
+        let (request_id, kind) = if let Some(id) = name.strip_suffix(".inflight.json") {
+            (id, RequestFileKind::Inflight)
+        } else if let Some(id) = name.strip_suffix(".json") {
+            (id, RequestFileKind::Ready)
+        } else {
+            return None;
+        };
+
+        if Uuid::parse_str(request_id).is_err() {
+            return None;
+        }
+
+        Some(Self {
+            path: path.to_path_buf(),
+            request_id: request_id.to_string(),
+            kind,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn action_serializes_camel_case() {
+        assert_eq!(
+            serde_json::to_string(&UiAutomationAction::Query).unwrap(),
+            "\"query\""
+        );
+        assert_eq!(
+            serde_json::to_string(&UiAutomationAction::SetValue).unwrap(),
+            "\"setValue\""
+        );
+    }
+
+    #[test]
+    fn request_file_parses_ready_and_inflight_names() {
+        let id = Uuid::new_v4().to_string();
+        let ready = RequestFile::from_path(Path::new(&format!("{id}.json"))).unwrap();
+        assert_eq!(ready.request_id, id);
+        matches!(ready.kind, RequestFileKind::Ready);
+
+        let inflight = RequestFile::from_path(Path::new(&format!("{id}.inflight.json"))).unwrap();
+        assert_eq!(inflight.request_id, id);
+        matches!(inflight.kind, RequestFileKind::Inflight);
+
+        assert!(RequestFile::from_path(Path::new("not-a-uuid.json")).is_none());
+        assert!(RequestFile::from_path(Path::new(&format!("{id}.tmp"))).is_none());
+    }
+
+    #[test]
+    fn timeout_phase_uses_ready_window_labels_for_inflight() {
+        let tmp = tempfile::tempdir().unwrap();
+        let request_path = tmp.path().join("request.json");
+        let inflight_path = tmp.path().join("request.inflight.json");
+        let session_path = tmp.path().join(SESSION_FILE);
+        fs::write(&request_path, "{}").unwrap();
+        assert_eq!(
+            timeout_phase(&request_path, &inflight_path, &session_path, "main"),
+            "awaiting_gui_poller"
+        );
+
+        fs::remove_file(&request_path).unwrap();
+        fs::write(&inflight_path, "{}").unwrap();
+        fs::write(
+            &session_path,
+            serde_json::to_string(&UiAutomationSession {
+                pid: std::process::id(),
+                token: "token".to_string(),
+                exe_path: current_exe_path_string(),
+                config_dir: tmp.path().to_string_lossy().into_owned(),
+                window_labels: vec!["main".to_string()],
+                ready_window_labels: vec![],
+                started_at_unix_ms: 1,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            timeout_phase(&request_path, &inflight_path, &session_path, "main"),
+            "awaiting_frontend_ready"
+        );
+
+        fs::write(
+            &session_path,
+            serde_json::to_string(&UiAutomationSession {
+                pid: std::process::id(),
+                token: "token".to_string(),
+                exe_path: current_exe_path_string(),
+                config_dir: tmp.path().to_string_lossy().into_owned(),
+                window_labels: vec!["main".to_string()],
+                ready_window_labels: vec!["main".to_string()],
+                started_at_unix_ms: 1,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            timeout_phase(&request_path, &inflight_path, &session_path, "main"),
+            "awaiting_frontend_response"
+        );
+    }
+}

--- a/src-tauri/src/testability/ui_automation.rs
+++ b/src-tauri/src/testability/ui_automation.rs
@@ -341,6 +341,8 @@ impl UiAutomationState {
     }
 
     fn poll_once_inner(&self, app: &AppHandle) -> io::Result<()> {
+        self.expire_pending_requests();
+
         let requests_dir = self.requests_dir();
         let entries = match fs::read_dir(&requests_dir) {
             Ok(entries) => entries,
@@ -360,6 +362,30 @@ impl UiAutomationState {
         }
 
         Ok(())
+    }
+
+    fn expire_pending_requests(&self) {
+        let now = now_unix_ms();
+        let expired = {
+            let mut pending_map = self.inner.pending.lock().unwrap_or_else(|e| e.into_inner());
+            let expired_ids: Vec<String> = pending_map
+                .iter()
+                .filter(|(_, pending)| request_expired(&pending.request, now))
+                .map(|(request_id, _)| request_id.clone())
+                .collect();
+            expired_ids
+                .into_iter()
+                .filter_map(|request_id| pending_map.remove(&request_id))
+                .collect::<Vec<_>>()
+        };
+
+        for pending in expired {
+            let response = expired_response_for_request(&pending.request);
+            if !pending.response_path.exists() {
+                let _ = write_json_atomic_new(&pending.response_path, &response);
+            }
+            let _ = retry_remove_file(&pending.inflight_path);
+        }
     }
 
     fn process_request_file(&self, app: &AppHandle, request_file: RequestFile) {
@@ -1461,6 +1487,38 @@ mod tests {
         assert!(!written.ok);
         assert_eq!(written.error.as_deref(), Some("completion_mismatch"));
         assert!(!inflight_path.exists());
+    }
+
+    #[test]
+    fn expire_pending_requests_writes_timeout_response() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = UiAutomationState::new(true, tmp.path().to_path_buf());
+        fs::create_dir_all(state.requests_dir()).unwrap();
+        fs::create_dir_all(state.responses_dir()).unwrap();
+
+        let request_id = Uuid::new_v4().to_string();
+        let mut request = sample_request(request_id.clone(), "missing.target");
+        request.expires_at_unix_ms = Some(now_unix_ms() - 1);
+        let response_path = state.response_path(&request_id);
+        let inflight_path = state.inflight_path(&request_id);
+        fs::write(&inflight_path, "{}").unwrap();
+        state.inner.pending.lock().unwrap().insert(
+            request_id,
+            PendingRequest {
+                request,
+                response_path: response_path.clone(),
+                inflight_path: inflight_path.clone(),
+            },
+        );
+
+        state.expire_pending_requests();
+
+        let raw = fs::read_to_string(response_path).unwrap();
+        let written: UiAutomationResponse = serde_json::from_str(&raw).unwrap();
+        assert!(!written.ok);
+        assert_eq!(written.error.as_deref(), Some("timeout"));
+        assert!(!inflight_path.exists());
+        assert!(state.inner.pending.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/testability/ui_automation.rs
+++ b/src-tauri/src/testability/ui_automation.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager};
@@ -23,6 +24,8 @@ const DEFAULT_TIMEOUT_MS: u64 = 5_000;
 const POLL_MS: u64 = 50;
 const FS_RETRY_COUNT: usize = 8;
 const FS_RETRY_DELAY_MS: u64 = 25;
+const SESSION_READ_RETRY_COUNT: usize = 8;
+const SESSION_READ_RETRY_DELAY_MS: u64 = 25;
 
 #[derive(Debug, Args)]
 pub struct UiQueryArgs {
@@ -88,6 +91,8 @@ pub struct UiAutomationRequest {
     pub selector: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at_unix_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -145,6 +150,7 @@ struct UiAutomationInner {
     window_labels: Mutex<HashSet<String>>,
     ready_window_labels: Mutex<HashSet<String>>,
     pending: Mutex<HashMap<String, PendingRequest>>,
+    available: AtomicBool,
     exe_path: String,
     started_at_unix_ms: i64,
 }
@@ -171,6 +177,7 @@ impl UiAutomationState {
                 window_labels: Mutex::new(window_labels),
                 ready_window_labels: Mutex::new(HashSet::new()),
                 pending: Mutex::new(HashMap::new()),
+                available: AtomicBool::new(enabled),
                 exe_path,
                 started_at_unix_ms: now_unix_ms(),
             }),
@@ -178,18 +185,20 @@ impl UiAutomationState {
     }
 
     pub fn enabled(&self) -> bool {
-        self.inner.enabled
+        self.inner.enabled && self.inner.available.load(Ordering::SeqCst)
     }
 
     pub fn start(&self, app: AppHandle, shutdown: ShutdownSignal) {
-        if !self.enabled() {
+        if !self.inner.enabled {
             return;
         }
 
         if let Err(e) = self.initialize_files() {
+            self.mark_unavailable();
             log::error!("[ui-automation] failed to initialize files: {}", e);
             return;
         }
+        self.inner.available.store(true, Ordering::SeqCst);
 
         let state = self.clone();
         let shutdown = shutdown.token().clone();
@@ -289,6 +298,10 @@ impl UiAutomationState {
         self.write_session_snapshot()
     }
 
+    fn mark_unavailable(&self) {
+        self.inner.available.store(false, Ordering::SeqCst);
+    }
+
     fn write_session_snapshot(&self) -> io::Result<()> {
         let window_labels = sorted_labels(
             &self
@@ -382,6 +395,12 @@ impl UiAutomationState {
             return;
         }
 
+        if request_expired(&request, now_unix_ms()) {
+            let response = expired_response_for_request(&request);
+            let _ = self.write_direct_response(&request_file, &response);
+            return;
+        }
+
         if request.token != self.inner.token {
             let response = UiAutomationResponse::error_for_request(
                 &request,
@@ -407,6 +426,10 @@ impl UiAutomationState {
             return;
         }
 
+        if !self.is_window_ready(&request.window) {
+            return;
+        }
+
         let inflight_path = match self.ensure_inflight(&request_file) {
             Ok(path) => path,
             Err(e) => {
@@ -425,7 +448,10 @@ impl UiAutomationState {
             }
         };
 
-        if !self.is_window_ready(&request.window) {
+        if request_expired(&request, now_unix_ms()) {
+            let response = expired_response_for_request(&request);
+            let _ = write_json_atomic_new(&self.response_path(&request.request_id), &response);
+            let _ = retry_remove_file(&inflight_path);
             return;
         }
 
@@ -705,6 +731,7 @@ fn run_cli_request(input: &CliRequest) -> Result<UiAutomationResponse, Value> {
         action: input.action,
         selector: input.selector.clone(),
         value: input.value.clone(),
+        expires_at_unix_ms: Some(request_expires_at_unix_ms(input.timeout_ms)),
     };
 
     let request_path = automation_dir
@@ -777,6 +804,7 @@ fn run_cli_request(input: &CliRequest) -> Result<UiAutomationResponse, Value> {
                 &input.window,
             ));
             let _ = retry_remove_file(&request_path);
+            let _ = retry_remove_file(&inflight_path);
             return Ok(timeout);
         }
 
@@ -808,7 +836,7 @@ pub fn existing_enabled_session_for_current_config() -> bool {
         return false;
     };
     let session_path = config_dir.join(UI_AUTOMATION_DIR).join(SESSION_FILE);
-    let Ok(raw) = fs::read_to_string(&session_path) else {
+    let Ok(raw) = read_session_file_with_retry(&session_path) else {
         return false;
     };
     let Ok(session) = serde_json::from_str::<UiAutomationSession>(&raw) else {
@@ -827,7 +855,7 @@ pub fn automation_not_enabled_json() -> String {
 }
 
 fn load_session_for_cli(path: &Path, requested_window: &str) -> Result<UiAutomationSession, Value> {
-    let raw = match fs::read_to_string(path) {
+    let raw = match read_session_file_with_retry(path) {
         Ok(raw) => raw,
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
             let state = crate::config::daemon_pid::detect_daemon_state();
@@ -983,6 +1011,27 @@ fn response_error_value(
     })
 }
 
+fn request_expires_at_unix_ms(timeout_ms: u64) -> i64 {
+    let timeout_ms = timeout_ms.min(i64::MAX as u64) as i64;
+    now_unix_ms().saturating_add(timeout_ms)
+}
+
+fn request_expired(request: &UiAutomationRequest, now_ms: i64) -> bool {
+    request
+        .expires_at_unix_ms
+        .is_some_and(|expires_at| expires_at <= now_ms)
+}
+
+fn expired_response_for_request(request: &UiAutomationRequest) -> UiAutomationResponse {
+    let mut response = UiAutomationResponse::error_for_request(
+        request,
+        "timeout",
+        "Automation request expired before the GUI emitted it to the frontend.",
+    );
+    response.diagnostics = Some(json!({ "expiresAtUnixMs": request.expires_at_unix_ms }));
+    response
+}
+
 fn print_stdout_json<T: Serialize>(value: &T) {
     match serde_json::to_string(value) {
         Ok(json) => crate::cli_println!("{json}"),
@@ -1024,7 +1073,7 @@ fn timeout_phase(
 }
 
 fn session_ready_for_window(path: &Path, window: &str) -> bool {
-    fs::read_to_string(path)
+    read_session_file_with_retry(path)
         .ok()
         .and_then(|raw| serde_json::from_str::<UiAutomationSession>(&raw).ok())
         .is_some_and(|session| {
@@ -1041,6 +1090,29 @@ fn write_json_atomic_new<T: Serialize>(path: &Path, value: &T) -> io::Result<()>
 
 fn write_json_atomic_replace<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
     write_json_atomic(path, value, true)
+}
+
+fn read_session_file_with_retry(path: &Path) -> io::Result<String> {
+    let mut last_not_found = None;
+    for attempt in 0..SESSION_READ_RETRY_COUNT {
+        match fs::read_to_string(path) {
+            Ok(raw) => return Ok(raw),
+            Err(e)
+                if e.kind() == io::ErrorKind::NotFound
+                    && attempt + 1 < SESSION_READ_RETRY_COUNT =>
+            {
+                last_not_found = Some(e);
+                std::thread::sleep(Duration::from_millis(SESSION_READ_RETRY_DELAY_MS));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(last_not_found.unwrap_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("session file not found: {}", path.display()),
+        )
+    }))
 }
 
 fn write_json_atomic<T: Serialize>(path: &Path, value: &T, replace: bool) -> io::Result<()> {
@@ -1095,6 +1167,13 @@ fn retry_remove_file(path: &Path) -> io::Result<()> {
     retry_fs(|| fs::remove_file(path))
 }
 
+fn retry_remove_dir_all(path: &Path) -> io::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    retry_fs(|| fs::remove_dir_all(path))
+}
+
 fn retry_fs(mut op: impl FnMut() -> io::Result<()>) -> io::Result<()> {
     let mut last_err = None;
     for attempt in 0..FS_RETRY_COUNT {
@@ -1118,10 +1197,10 @@ fn cleanup_stale_automation_files(automation_dir: &Path) -> io::Result<()> {
     let requests = automation_dir.join(REQUESTS_DIR);
     let responses = automation_dir.join(RESPONSES_DIR);
     if requests.exists() {
-        fs::remove_dir_all(&requests)?;
+        retry_remove_dir_all(&requests)?;
     }
     if responses.exists() {
-        fs::remove_dir_all(&responses)?;
+        retry_remove_dir_all(&responses)?;
     }
     Ok(())
 }
@@ -1262,6 +1341,18 @@ impl RequestFile {
 mod tests {
     use super::*;
 
+    fn sample_request(request_id: String, selector: &str) -> UiAutomationRequest {
+        UiAutomationRequest {
+            request_id,
+            token: "token".to_string(),
+            window: "main".to_string(),
+            action: UiAutomationAction::Query,
+            selector: selector.to_string(),
+            value: None,
+            expires_at_unix_ms: Some(now_unix_ms() + 1_000),
+        }
+    }
+
     #[test]
     fn action_serializes_camel_case() {
         assert_eq!(
@@ -1287,6 +1378,128 @@ mod tests {
 
         assert!(RequestFile::from_path(Path::new("not-a-uuid.json")).is_none());
         assert!(RequestFile::from_path(Path::new(&format!("{id}.tmp"))).is_none());
+    }
+
+    #[test]
+    fn request_expiry_uses_optional_deadline() {
+        let mut request = sample_request(Uuid::new_v4().to_string(), "target");
+        request.expires_at_unix_ms = None;
+        assert!(!request_expired(&request, 100));
+
+        request.expires_at_unix_ms = Some(99);
+        assert!(request_expired(&request, 100));
+
+        request.expires_at_unix_ms = Some(101);
+        assert!(!request_expired(&request, 100));
+    }
+
+    #[test]
+    fn complete_rejects_unknown_request_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = UiAutomationState::new(true, tmp.path().to_path_buf());
+        let response = UiAutomationResponse::minimal_error(
+            &Uuid::new_v4().to_string(),
+            "main",
+            UiAutomationAction::Query,
+            "target",
+            "frontend_error",
+            "frontend failed",
+        );
+
+        assert_eq!(
+            state.complete("main", response).unwrap_err(),
+            "unknown_request_id"
+        );
+    }
+
+    #[test]
+    fn complete_writes_completion_mismatch_response() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = UiAutomationState::new(true, tmp.path().to_path_buf());
+        fs::create_dir_all(state.requests_dir()).unwrap();
+        fs::create_dir_all(state.responses_dir()).unwrap();
+
+        let request_id = Uuid::new_v4().to_string();
+        let request = sample_request(request_id.clone(), "expected");
+        let response_path = state.response_path(&request_id);
+        let inflight_path = state.inflight_path(&request_id);
+        fs::write(&inflight_path, "{}").unwrap();
+        state.inner.pending.lock().unwrap().insert(
+            request_id.clone(),
+            PendingRequest {
+                request,
+                response_path: response_path.clone(),
+                inflight_path: inflight_path.clone(),
+            },
+        );
+
+        let result = UiAutomationResponse {
+            ok: true,
+            request_id,
+            window: "main".to_string(),
+            action: UiAutomationAction::Query,
+            selector: "different".to_string(),
+            target: Some(json!({ "testId": "different" })),
+            error: None,
+            message: None,
+            available: None,
+            diagnostics: None,
+            available_windows: None,
+            timeout_ms: None,
+            phase: None,
+        };
+
+        state.complete("main", result).unwrap();
+
+        let raw = fs::read_to_string(response_path).unwrap();
+        let written: UiAutomationResponse = serde_json::from_str(&raw).unwrap();
+        assert!(!written.ok);
+        assert_eq!(written.error.as_deref(), Some("completion_mismatch"));
+        assert!(!inflight_path.exists());
+    }
+
+    #[test]
+    fn session_read_retries_transient_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join(SESSION_FILE);
+        let writer_path = path.clone();
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(SESSION_READ_RETRY_DELAY_MS));
+            fs::write(writer_path, "{\"ok\":true}").unwrap();
+        });
+
+        let raw = read_session_file_with_retry(&path).unwrap();
+        writer.join().unwrap();
+        assert_eq!(raw, "{\"ok\":true}");
+    }
+
+    #[test]
+    fn initialization_failure_can_disable_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = UiAutomationState::new(true, tmp.path().to_path_buf());
+        fs::create_dir_all(&state.inner.automation_dir).unwrap();
+        fs::write(state.requests_dir(), "not a directory").unwrap();
+
+        assert!(state.initialize_files().is_err());
+        state.mark_unavailable();
+        assert!(!state.enabled());
+    }
+
+    #[test]
+    fn cleanup_stale_automation_files_removes_request_and_response_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let automation_dir = tmp.path().join(UI_AUTOMATION_DIR);
+        let requests_dir = automation_dir.join(REQUESTS_DIR);
+        let responses_dir = automation_dir.join(RESPONSES_DIR);
+        fs::create_dir_all(&requests_dir).unwrap();
+        fs::create_dir_all(&responses_dir).unwrap();
+        fs::write(requests_dir.join("stale.json"), "{}").unwrap();
+        fs::write(responses_dir.join("stale.json"), "{}").unwrap();
+
+        cleanup_stale_automation_files(&automation_dir).unwrap();
+
+        assert!(!requests_dir.exists());
+        assert!(!responses_dir.exists());
     }
 
     #[test]

--- a/src-tauri/tests/cli_ui_automation.rs
+++ b/src-tauri/tests/cli_ui_automation.rs
@@ -1,8 +1,15 @@
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Mutex, MutexGuard};
 use std::thread;
 use std::time::{Duration, Instant};
+
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn test_lock() -> MutexGuard<'static, ()> {
+    TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
 
 struct Tmp(PathBuf);
 
@@ -112,6 +119,12 @@ fn write_session(bin: &Path, pid: u32, ready_windows: &[&str]) {
     .unwrap();
 }
 
+fn write_daemon_pid(bin: &Path, pid: u32) {
+    let config_dir = config_dir_for(bin);
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(config_dir.join("daemon.pid"), pid.to_string()).unwrap();
+}
+
 #[cfg(target_os = "windows")]
 fn fake_live_pid() -> Option<u32> {
     let pid = 4u32;
@@ -124,7 +137,8 @@ fn fake_live_pid() -> Option<u32> {
 }
 
 #[test]
-fn normal_binary_refuses_ui_click_with_json_only_stderr() {
+fn normal_binary_refuses_ui_click_with_json_only_stdout() {
+    let _guard = test_lock();
     let tmp = Tmp::new("ui-non-testable");
     let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
     let (code, stdout, stderr) = run(
@@ -138,13 +152,14 @@ fn normal_binary_refuses_ui_click_with_json_only_stderr() {
         ],
     );
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
-    assert_empty_output("stdout", &stdout);
-    let parsed = first_json(&stderr);
+    assert_empty_output("stderr", &stderr);
+    let parsed = first_json(&stdout);
     assert_eq!(parsed["error"], "refusing_non_testeable_binary");
 }
 
 #[test]
 fn workgroup_binary_refuses_ui_click() {
+    let _guard = test_lock();
     let tmp = Tmp::new("ui-workgroup-refuse");
     let bin = copy_binary_as(tmp.path(), "agentscommander_wg1-dev-team.exe");
     let (code, stdout, stderr) = run(
@@ -158,15 +173,16 @@ fn workgroup_binary_refuses_ui_click() {
         ],
     );
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
-    assert_empty_output("stdout", &stdout);
+    assert_empty_output("stderr", &stderr);
     assert_eq!(
-        first_json(&stderr)["error"],
+        first_json(&stdout)["error"],
         "refusing_non_testeable_binary"
     );
 }
 
 #[test]
 fn normal_gui_binary_refuses_ui_automation_flag() {
+    let _guard = test_lock();
     let tmp = Tmp::new("ui-gui-flag-refuse");
     let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
     let (code, stdout, stderr) = run(&bin, &["--app", "--ui-automation"]);
@@ -180,6 +196,7 @@ fn normal_gui_binary_refuses_ui_automation_flag() {
 
 #[test]
 fn normal_gui_binary_refuses_ui_automation_env() {
+    let _guard = test_lock();
     let tmp = Tmp::new("ui-gui-env-refuse");
     let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
     let (code, stdout, stderr) = run_with_env(&bin, "AC_UI_AUTOMATION", "1", &[]);
@@ -193,6 +210,7 @@ fn normal_gui_binary_refuses_ui_automation_env() {
 
 #[test]
 fn ui_automation_env_does_not_affect_cli_subcommands() {
+    let _guard = test_lock();
     let tmp = Tmp::new("ui-env-cli-subcommand");
     let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
     let (code, stdout, stderr) = run_with_env(&bin, "AC_UI_AUTOMATION", "1", &["list-sessions"]);
@@ -206,6 +224,7 @@ fn ui_automation_env_does_not_affect_cli_subcommands() {
 
 #[test]
 fn missing_session_file_reports_automation_session_missing() {
+    let _guard = test_lock();
     let tmp = Tmp::new("ui-missing-session");
     let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
     let (code, stdout, stderr) = run(
@@ -219,12 +238,13 @@ fn missing_session_file_reports_automation_session_missing() {
         ],
     );
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
-    assert_empty_output("stdout", &stdout);
-    assert_eq!(first_json(&stderr)["error"], "automation_session_missing");
+    assert_empty_output("stderr", &stderr);
+    assert_eq!(first_json(&stdout)["error"], "automation_session_missing");
 }
 
 #[test]
 fn dead_session_pid_reports_stale_session() {
+    let _guard = test_lock();
     let tmp = Tmp::new("ui-stale-session");
     let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
     write_session(&bin, u32::MAX, &["main"]);
@@ -239,12 +259,13 @@ fn dead_session_pid_reports_stale_session() {
         ],
     );
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
-    assert_empty_output("stdout", &stdout);
-    assert_eq!(first_json(&stderr)["error"], "automation_session_stale");
+    assert_empty_output("stderr", &stderr);
+    assert_eq!(first_json(&stdout)["error"], "automation_session_stale");
 }
 
 #[test]
 fn fake_response_makes_ui_query_succeed() {
+    let _guard = test_lock();
     let Some(pid) = fake_live_pid() else {
         eprintln!("skip: no fake live pid available");
         return;
@@ -325,6 +346,7 @@ fn fake_response_makes_ui_query_succeed() {
 
 #[test]
 fn ui_query_timeout_reports_awaiting_gui_poller_phase() {
+    let _guard = test_lock();
     let Some(pid) = fake_live_pid() else {
         eprintln!("skip: no fake live pid available");
         return;
@@ -345,14 +367,15 @@ fn ui_query_timeout_reports_awaiting_gui_poller_phase() {
         ],
     );
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
-    assert_empty_output("stdout", &stdout);
-    let parsed = first_json(&stderr);
+    assert_empty_output("stderr", &stderr);
+    let parsed = first_json(&stdout);
     assert_eq!(parsed["error"], "timeout");
     assert_eq!(parsed["phase"], "awaiting_gui_poller");
 }
 
 #[test]
-fn ui_click_timeout_removes_inflight_request_with_json_only_stderr() {
+fn ui_click_timeout_removes_inflight_request_with_json_only_stdout() {
+    let _guard = test_lock();
     let Some(pid) = fake_live_pid() else {
         eprintln!("skip: no fake live pid available");
         return;
@@ -406,8 +429,8 @@ fn ui_click_timeout_removes_inflight_request_with_json_only_stderr() {
     );
     mover.join().unwrap();
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
-    assert_empty_output("stdout", &stdout);
-    let parsed = first_json(&stderr);
+    assert_empty_output("stderr", &stderr);
+    let parsed = first_json(&stdout);
     assert_eq!(parsed["error"], "timeout");
     assert_eq!(parsed["phase"], "awaiting_frontend_ready");
 
@@ -423,6 +446,7 @@ fn ui_click_timeout_removes_inflight_request_with_json_only_stderr() {
 
 #[test]
 fn ui_query_retries_transient_missing_session_file() {
+    let _guard = test_lock();
     let Some(pid) = fake_live_pid() else {
         eprintln!("skip: no fake live pid available");
         return;
@@ -450,8 +474,37 @@ fn ui_query_retries_transient_missing_session_file() {
     writer.join().unwrap();
 
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
-    assert_empty_output("stdout", &stdout);
-    let parsed = first_json(&stderr);
+    assert_empty_output("stderr", &stderr);
+    let parsed = first_json(&stdout);
     assert_eq!(parsed["error"], "timeout");
     assert_ne!(parsed["error"], "automation_session_missing");
+}
+
+#[test]
+fn stale_prior_session_with_running_daemon_reports_automation_not_enabled_on_stdout() {
+    let _guard = test_lock();
+    let Some(pid) = fake_live_pid() else {
+        eprintln!("skip: no fake live pid available");
+        return;
+    };
+    let tmp = Tmp::new("ui-disabled-stale-session");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    write_session(&bin, u32::MAX, &["main"]);
+    write_daemon_pid(&bin, pid);
+
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "ui-query",
+            "--window",
+            "main",
+            "--selector",
+            "onboarding.modal",
+        ],
+    );
+
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stderr", &stderr);
+    let parsed = first_json(&stdout);
+    assert_eq!(parsed["error"], "automation_not_enabled");
 }

--- a/src-tauri/tests/cli_ui_automation.rs
+++ b/src-tauri/tests/cli_ui_automation.rs
@@ -1,0 +1,337 @@
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+struct Tmp(PathBuf);
+
+impl Drop for Tmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+impl Tmp {
+    fn new(prefix: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "ac-{}-{}-{}",
+            prefix,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&path).expect("create tmp dir");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+fn copy_binary_as(tmp: &Path, name: &str) -> PathBuf {
+    let src = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let dst = tmp.join(name);
+    std::fs::copy(src, &dst).expect("copy binary");
+    dst
+}
+
+fn run(bin: &Path, args: &[&str]) -> (Option<i32>, String, String) {
+    let out = Command::new(bin).args(args).output().expect("spawn binary");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn run_with_env(
+    bin: &Path,
+    env_name: &str,
+    env_value: &str,
+    args: &[&str],
+) -> (Option<i32>, String, String) {
+    let out = Command::new(bin)
+        .env(env_name, env_value)
+        .args(args)
+        .output()
+        .expect("spawn binary");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn first_json(stderr_or_stdout: &str) -> Value {
+    let line = stderr_or_stdout
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .expect("json output line");
+    serde_json::from_str(line).expect("parse json")
+}
+
+fn config_dir_for(bin: &Path) -> PathBuf {
+    let stem = bin.file_stem().unwrap().to_string_lossy();
+    bin.parent().unwrap().join(format!(".{stem}"))
+}
+
+fn write_session(bin: &Path, pid: u32, ready_windows: &[&str]) {
+    let config_dir = config_dir_for(bin);
+    let automation_dir = config_dir.join("ui-automation");
+    std::fs::create_dir_all(automation_dir.join("requests")).unwrap();
+    std::fs::create_dir_all(automation_dir.join("responses")).unwrap();
+    let session = json!({
+        "pid": pid,
+        "token": "00000000-0000-0000-0000-000000000497",
+        "exePath": bin.to_string_lossy(),
+        "configDir": config_dir.to_string_lossy(),
+        "windowLabels": ["main"],
+        "readyWindowLabels": ready_windows,
+        "startedAtUnixMs": 1
+    });
+    std::fs::write(
+        automation_dir.join("session.json"),
+        serde_json::to_string(&session).unwrap(),
+    )
+    .unwrap();
+}
+
+#[cfg(target_os = "windows")]
+fn fake_live_pid() -> Option<u32> {
+    let pid = 4u32;
+    agentscommander_lib::testability::ui_automation::pid_is_alive(pid).then_some(pid)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn fake_live_pid() -> Option<u32> {
+    Some(std::process::id())
+}
+
+#[test]
+fn normal_binary_refuses_ui_click_with_json_only_stderr() {
+    let tmp = Tmp::new("ui-non-testable");
+    let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "ui-click",
+            "--window",
+            "main",
+            "--selector",
+            "onboarding.confirm",
+        ],
+    );
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(stdout.trim().is_empty(), "stdout should be empty: {stdout}");
+    assert!(
+        stderr.trim_start().starts_with('{'),
+        "stderr should start with JSON, got: {stderr}"
+    );
+    let parsed = first_json(&stderr);
+    assert_eq!(parsed["error"], "refusing_non_testeable_binary");
+}
+
+#[test]
+fn workgroup_binary_refuses_ui_click() {
+    let tmp = Tmp::new("ui-workgroup-refuse");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_wg1-dev-team.exe");
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "ui-click",
+            "--window",
+            "main",
+            "--selector",
+            "onboarding.confirm",
+        ],
+    );
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(
+        first_json(&stderr)["error"],
+        "refusing_non_testeable_binary"
+    );
+}
+
+#[test]
+fn normal_gui_binary_refuses_ui_automation_flag() {
+    let tmp = Tmp::new("ui-gui-flag-refuse");
+    let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
+    let (code, stdout, stderr) = run(&bin, &["--app", "--ui-automation"]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(
+        first_json(&stderr)["error"],
+        "refusing_non_testeable_binary"
+    );
+}
+
+#[test]
+fn normal_gui_binary_refuses_ui_automation_env() {
+    let tmp = Tmp::new("ui-gui-env-refuse");
+    let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
+    let (code, stdout, stderr) = run_with_env(&bin, "AC_UI_AUTOMATION", "1", &[]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(
+        first_json(&stderr)["error"],
+        "refusing_non_testeable_binary"
+    );
+}
+
+#[test]
+fn ui_automation_env_does_not_affect_cli_subcommands() {
+    let tmp = Tmp::new("ui-env-cli-subcommand");
+    let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
+    let (code, stdout, stderr) = run_with_env(&bin, "AC_UI_AUTOMATION", "1", &["list-sessions"]);
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        !stderr.contains("refusing_non_testeable_binary"),
+        "stderr: {stderr}"
+    );
+    serde_json::from_str::<Value>(&stdout).expect("list-sessions stdout should be JSON");
+}
+
+#[test]
+fn missing_session_file_reports_automation_session_missing() {
+    let tmp = Tmp::new("ui-missing-session");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "ui-query",
+            "--window",
+            "main",
+            "--selector",
+            "onboarding.modal",
+        ],
+    );
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(first_json(&stderr)["error"], "automation_session_missing");
+}
+
+#[test]
+fn dead_session_pid_reports_stale_session() {
+    let tmp = Tmp::new("ui-stale-session");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    write_session(&bin, u32::MAX, &["main"]);
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "ui-query",
+            "--window",
+            "main",
+            "--selector",
+            "onboarding.modal",
+        ],
+    );
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(first_json(&stderr)["error"], "automation_session_stale");
+}
+
+#[test]
+fn fake_response_makes_ui_query_succeed() {
+    let Some(pid) = fake_live_pid() else {
+        eprintln!("skip: no fake live pid available");
+        return;
+    };
+    let tmp = Tmp::new("ui-fake-response");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    write_session(&bin, pid, &["main"]);
+    let automation_dir = config_dir_for(&bin).join("ui-automation");
+    let requests_dir = automation_dir.join("requests");
+    let responses_dir = automation_dir.join("responses");
+
+    let responder = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let entries: Vec<PathBuf> = std::fs::read_dir(&requests_dir)
+                .unwrap()
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("json"))
+                .collect();
+            if let Some(path) = entries.first() {
+                let raw = std::fs::read_to_string(path).unwrap();
+                let request: Value = serde_json::from_str(&raw).unwrap();
+                assert_eq!(request["window"], "main");
+                assert_eq!(request["action"], "query");
+                assert_eq!(request["selector"], "onboarding.confirm");
+                let request_id = request["requestId"].as_str().unwrap();
+                let response = json!({
+                    "ok": true,
+                    "requestId": request_id,
+                    "window": "main",
+                    "action": "query",
+                    "selector": "onboarding.confirm",
+                    "target": {
+                        "testId": "onboarding.confirm",
+                        "role": "button",
+                        "state": "ready",
+                        "tag": "button",
+                        "visible": true,
+                        "disabled": false,
+                        "checked": null,
+                        "selected": null,
+                        "pressed": null,
+                        "expanded": null,
+                        "rect": null
+                    }
+                });
+                std::fs::write(
+                    responses_dir.join(format!("{request_id}.json")),
+                    serde_json::to_string(&response).unwrap(),
+                )
+                .unwrap();
+                return;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for request");
+            thread::sleep(Duration::from_millis(25));
+        }
+    });
+
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "ui-query",
+            "--window",
+            "main",
+            "--selector",
+            "onboarding.confirm",
+            "--timeout-ms",
+            "3000",
+        ],
+    );
+    responder.join().unwrap();
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    let parsed = first_json(&stdout);
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["target"]["testId"], "onboarding.confirm");
+}
+
+#[test]
+fn ui_query_timeout_reports_awaiting_gui_poller_phase() {
+    let Some(pid) = fake_live_pid() else {
+        eprintln!("skip: no fake live pid available");
+        return;
+    };
+    let tmp = Tmp::new("ui-timeout-poller");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    write_session(&bin, pid, &["main"]);
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "ui-query",
+            "--window",
+            "main",
+            "--selector",
+            "onboarding.confirm",
+            "--timeout-ms",
+            "100",
+        ],
+    );
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    let parsed = first_json(&stderr);
+    assert_eq!(parsed["error"], "timeout");
+    assert_eq!(parsed["phase"], "awaiting_gui_poller");
+}

--- a/src-tauri/tests/cli_ui_automation.rs
+++ b/src-tauri/tests/cli_ui_automation.rs
@@ -67,11 +67,23 @@ fn run_with_env(
 }
 
 fn first_json(stderr_or_stdout: &str) -> Value {
-    let line = stderr_or_stdout
+    let lines: Vec<&str> = stderr_or_stdout
         .lines()
-        .find(|line| !line.trim().is_empty())
-        .expect("json output line");
-    serde_json::from_str(line).expect("parse json")
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "expected exactly one JSON output line, got: {stderr_or_stdout}"
+    );
+    serde_json::from_str(lines[0]).expect("parse json")
+}
+
+fn assert_empty_output(name: &str, output: &str) {
+    assert!(
+        output.trim().is_empty(),
+        "{name} should be empty, got: {output}"
+    );
 }
 
 fn config_dir_for(bin: &Path) -> PathBuf {
@@ -126,11 +138,7 @@ fn normal_binary_refuses_ui_click_with_json_only_stderr() {
         ],
     );
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
-    assert!(stdout.trim().is_empty(), "stdout should be empty: {stdout}");
-    assert!(
-        stderr.trim_start().starts_with('{'),
-        "stderr should start with JSON, got: {stderr}"
-    );
+    assert_empty_output("stdout", &stdout);
     let parsed = first_json(&stderr);
     assert_eq!(parsed["error"], "refusing_non_testeable_binary");
 }
@@ -150,6 +158,7 @@ fn workgroup_binary_refuses_ui_click() {
         ],
     );
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stdout", &stdout);
     assert_eq!(
         first_json(&stderr)["error"],
         "refusing_non_testeable_binary"
@@ -162,6 +171,7 @@ fn normal_gui_binary_refuses_ui_automation_flag() {
     let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
     let (code, stdout, stderr) = run(&bin, &["--app", "--ui-automation"]);
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stdout", &stdout);
     assert_eq!(
         first_json(&stderr)["error"],
         "refusing_non_testeable_binary"
@@ -174,6 +184,7 @@ fn normal_gui_binary_refuses_ui_automation_env() {
     let bin = copy_binary_as(tmp.path(), "agentscommander.exe");
     let (code, stdout, stderr) = run_with_env(&bin, "AC_UI_AUTOMATION", "1", &[]);
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stdout", &stdout);
     assert_eq!(
         first_json(&stderr)["error"],
         "refusing_non_testeable_binary"
@@ -208,6 +219,7 @@ fn missing_session_file_reports_automation_session_missing() {
         ],
     );
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stdout", &stdout);
     assert_eq!(first_json(&stderr)["error"], "automation_session_missing");
 }
 
@@ -227,6 +239,7 @@ fn dead_session_pid_reports_stale_session() {
         ],
     );
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stdout", &stdout);
     assert_eq!(first_json(&stderr)["error"], "automation_session_stale");
 }
 
@@ -304,6 +317,7 @@ fn fake_response_makes_ui_query_succeed() {
     );
     responder.join().unwrap();
     assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stderr", &stderr);
     let parsed = first_json(&stdout);
     assert_eq!(parsed["ok"], true);
     assert_eq!(parsed["target"]["testId"], "onboarding.confirm");
@@ -331,7 +345,113 @@ fn ui_query_timeout_reports_awaiting_gui_poller_phase() {
         ],
     );
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stdout", &stdout);
     let parsed = first_json(&stderr);
     assert_eq!(parsed["error"], "timeout");
     assert_eq!(parsed["phase"], "awaiting_gui_poller");
+}
+
+#[test]
+fn ui_click_timeout_removes_inflight_request_with_json_only_stderr() {
+    let Some(pid) = fake_live_pid() else {
+        eprintln!("skip: no fake live pid available");
+        return;
+    };
+    let tmp = Tmp::new("ui-timeout-inflight");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    write_session(&bin, pid, &[]);
+    let automation_dir = config_dir_for(&bin).join("ui-automation");
+    let requests_dir = automation_dir.join("requests");
+
+    let mover_dir = requests_dir.clone();
+    let mover = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let entries: Vec<PathBuf> = std::fs::read_dir(&mover_dir)
+                .unwrap()
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .filter(|path| {
+                    path.extension().and_then(|e| e.to_str()) == Some("json")
+                        && !path
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .is_some_and(|name| name.ends_with(".inflight.json"))
+                })
+                .collect();
+            if let Some(path) = entries.first() {
+                let raw = std::fs::read_to_string(path).unwrap();
+                let request: Value = serde_json::from_str(&raw).unwrap();
+                assert_eq!(request["action"], "click");
+                let request_id = request["requestId"].as_str().unwrap();
+                std::fs::rename(path, mover_dir.join(format!("{request_id}.inflight.json")))
+                    .unwrap();
+                return;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for request");
+            thread::sleep(Duration::from_millis(10));
+        }
+    });
+
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "ui-click",
+            "--window",
+            "main",
+            "--selector",
+            "onboarding.confirm",
+            "--timeout-ms",
+            "250",
+        ],
+    );
+    mover.join().unwrap();
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stdout", &stdout);
+    let parsed = first_json(&stderr);
+    assert_eq!(parsed["error"], "timeout");
+    assert_eq!(parsed["phase"], "awaiting_frontend_ready");
+
+    let remaining: Vec<PathBuf> = std::fs::read_dir(&requests_dir)
+        .unwrap()
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .collect();
+    assert!(
+        remaining.is_empty(),
+        "timed-out request files should be removed: {remaining:?}"
+    );
+}
+
+#[test]
+fn ui_query_retries_transient_missing_session_file() {
+    let Some(pid) = fake_live_pid() else {
+        eprintln!("skip: no fake live pid available");
+        return;
+    };
+    let tmp = Tmp::new("ui-session-read-race");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    let writer_bin = bin.clone();
+    let writer = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(50));
+        write_session(&writer_bin, pid, &["main"]);
+    });
+
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "ui-query",
+            "--window",
+            "main",
+            "--selector",
+            "onboarding.confirm",
+            "--timeout-ms",
+            "100",
+        ],
+    );
+    writer.join().unwrap();
+
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stdout", &stdout);
+    let parsed = first_json(&stderr);
+    assert_eq!(parsed["error"], "timeout");
+    assert_ne!(parsed["error"], "automation_session_missing");
 }

--- a/src-tauri/tests/cli_ui_automation.rs
+++ b/src-tauri/tests/cli_ui_automation.rs
@@ -1,6 +1,7 @@
 use serde_json::{json, Value};
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::{Mutex, MutexGuard};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -71,6 +72,49 @@ fn run_with_env(
         String::from_utf8_lossy(&out.stdout).into_owned(),
         String::from_utf8_lossy(&out.stderr).into_owned(),
     )
+}
+
+fn run_without_draining_output_until_exit(
+    bin: &Path,
+    args: &[&str],
+    timeout: Duration,
+) -> (Option<i32>, String, String, bool) {
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn binary");
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().expect("poll child") {
+            Some(status) => {
+                let mut stdout = String::new();
+                let mut stderr = String::new();
+                if let Some(mut pipe) = child.stdout.take() {
+                    pipe.read_to_string(&mut stdout).expect("read stdout");
+                }
+                if let Some(mut pipe) = child.stderr.take() {
+                    pipe.read_to_string(&mut stderr).expect("read stderr");
+                }
+                return (status.code(), stdout, stderr, false);
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let status = child.wait().expect("wait killed child");
+                let mut stdout = String::new();
+                let mut stderr = String::new();
+                if let Some(mut pipe) = child.stdout.take() {
+                    let _ = pipe.read_to_string(&mut stdout);
+                }
+                if let Some(mut pipe) = child.stderr.take() {
+                    let _ = pipe.read_to_string(&mut stderr);
+                }
+                return (status.code(), stdout, stderr, true);
+            }
+            None => thread::sleep(Duration::from_millis(10)),
+        }
+    }
 }
 
 fn first_json(stderr_or_stdout: &str) -> Value {
@@ -371,6 +415,185 @@ fn ui_query_timeout_reports_awaiting_gui_poller_phase() {
     let parsed = first_json(&stdout);
     assert_eq!(parsed["error"], "timeout");
     assert_eq!(parsed["phase"], "awaiting_gui_poller");
+}
+
+#[test]
+fn ui_query_timeout_after_frontend_accepts_request_returns_bounded_stdout() {
+    let _guard = test_lock();
+    let Some(pid) = fake_live_pid() else {
+        eprintln!("skip: no fake live pid available");
+        return;
+    };
+    let tmp = Tmp::new("ui-query-inflight-timeout");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    write_session(&bin, pid, &["main"]);
+    let automation_dir = config_dir_for(&bin).join("ui-automation");
+    let requests_dir = automation_dir.join("requests");
+
+    let mover_dir = requests_dir.clone();
+    let mover = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let entries: Vec<PathBuf> = std::fs::read_dir(&mover_dir)
+                .unwrap()
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .filter(|path| {
+                    path.extension().and_then(|e| e.to_str()) == Some("json")
+                        && !path
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .is_some_and(|name| name.ends_with(".inflight.json"))
+                })
+                .collect();
+            if let Some(path) = entries.first() {
+                let raw = std::fs::read_to_string(path).unwrap();
+                let request: Value = serde_json::from_str(&raw).unwrap();
+                assert_eq!(request["action"], "query");
+                let request_id = request["requestId"].as_str().unwrap();
+                std::fs::rename(path, mover_dir.join(format!("{request_id}.inflight.json")))
+                    .unwrap();
+                return;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for request");
+            thread::sleep(Duration::from_millis(10));
+        }
+    });
+
+    let start = Instant::now();
+    let (code, stdout, stderr) = run(
+        &bin,
+        &[
+            "ui-query",
+            "--window",
+            "main",
+            "--selector",
+            "does.not.exist",
+            "--timeout-ms",
+            "250",
+        ],
+    );
+    mover.join().unwrap();
+
+    assert!(
+        start.elapsed() < Duration::from_secs(5),
+        "ui-query should not hang"
+    );
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stderr", &stderr);
+    let parsed = first_json(&stdout);
+    assert_eq!(parsed["error"], "timeout");
+    assert_eq!(parsed["phase"], "awaiting_frontend_response");
+}
+
+#[test]
+fn ui_query_large_missing_selector_response_is_bounded_stdout() {
+    let _guard = test_lock();
+    let Some(pid) = fake_live_pid() else {
+        eprintln!("skip: no fake live pid available");
+        return;
+    };
+    let tmp = Tmp::new("ui-large-missing-selector");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    write_session(&bin, pid, &["main"]);
+    let automation_dir = config_dir_for(&bin).join("ui-automation");
+    let requests_dir = automation_dir.join("requests");
+    let responses_dir = automation_dir.join("responses");
+
+    let responder = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let entries: Vec<PathBuf> = std::fs::read_dir(&requests_dir)
+                .unwrap()
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("json"))
+                .collect();
+            if let Some(path) = entries.first() {
+                let raw = std::fs::read_to_string(path).unwrap();
+                let request: Value = serde_json::from_str(&raw).unwrap();
+                let request_id = request["requestId"].as_str().unwrap();
+                let available: Vec<Value> = (0..256)
+                    .map(|i| {
+                        json!({
+                            "testId": format!("target.{i}"),
+                            "role": "button",
+                            "state": "ready",
+                            "tag": "button",
+                            "text": "x".repeat(2000),
+                            "visible": true,
+                            "disabled": false,
+                            "checked": null,
+                            "selected": null,
+                            "pressed": null,
+                            "expanded": null,
+                            "rect": {
+                                "x": i,
+                                "y": i,
+                                "width": 100,
+                                "height": 30
+                            }
+                        })
+                    })
+                    .collect();
+                let response = json!({
+                    "ok": false,
+                    "requestId": request_id,
+                    "window": "main",
+                    "action": "query",
+                    "selector": "does.not.exist",
+                    "error": "missing_selector",
+                    "message": "No automation target matched data-ac-testid=\"does.not.exist\" in window \"main\".",
+                    "available": available,
+                    "diagnostics": {
+                        "devicePixelRatio": 1,
+                        "viewport": { "width": 1280, "height": 720 }
+                    }
+                });
+                std::fs::write(
+                    responses_dir.join(format!("{request_id}.json")),
+                    serde_json::to_string(&response).unwrap(),
+                )
+                .unwrap();
+                return;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for request");
+            thread::sleep(Duration::from_millis(10));
+        }
+    });
+
+    let start = Instant::now();
+    let (code, stdout, stderr, timed_out) = run_without_draining_output_until_exit(
+        &bin,
+        &[
+            "ui-query",
+            "--window",
+            "main",
+            "--selector",
+            "does.not.exist",
+            "--timeout-ms",
+            "3000",
+        ],
+        Duration::from_secs(5),
+    );
+    responder.join().unwrap();
+
+    assert!(!timed_out, "ui-query should not hang");
+    assert!(start.elapsed() < Duration::from_secs(5));
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_empty_output("stderr", &stderr);
+    assert!(
+        stdout.len() < 4096,
+        "stdout should stay below common pipe buffers, got {} bytes",
+        stdout.len()
+    );
+    let parsed = first_json(&stdout);
+    assert_eq!(parsed["error"], "missing_selector");
+    assert_eq!(parsed["available"].as_array().unwrap().len(), 8);
+    assert_eq!(parsed["diagnostics"]["availableTotal"], 256);
+    assert_eq!(parsed["diagnostics"]["availableLimit"], 8);
+    assert_eq!(parsed["diagnostics"]["availableTruncated"], true);
+    let text = parsed["available"][0]["text"].as_str().unwrap();
+    assert!(text.ends_with("..."));
+    assert!(text.len() <= 83);
 }
 
 #[test]

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import GuideApp from "./guide/App";
 import BrowserApp from "./browser/App";
 import SpecBoardApp from "./spec-board/App";
 import MainApp from "./main/App";
+import { initAutomationBridge } from "./shared/automation-bridge";
 
 const params = new URLSearchParams(window.location.search);
 const windowType = params.get("window");
@@ -18,6 +19,10 @@ if (remoteToken) {
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Root element not found");
+
+if (isTauri) {
+  void initAutomationBridge();
+}
 
 // Browser mode (no Tauri): BrowserApp regardless of ?window param.
 // Remote web clients load ?window=main but still need the split-browser UX.

--- a/src/main/App.tsx
+++ b/src/main/App.tsx
@@ -220,6 +220,9 @@ const MainApp: Component = () => {
         "main-dragging": dragging(),
         "main-sidebar-right": sidebarSide() === "right",
       }}
+      data-ac-testid="main.root"
+      data-ac-role="surface"
+      data-ac-state={dragging() ? "dragging" : "idle"}
     >
       <Titlebar />
       <RtkBanner />
@@ -240,6 +243,9 @@ const MainApp: Component = () => {
           aria-valuemin={MAIN_SIDEBAR_MIN_WIDTH}
           aria-valuemax={MAIN_SIDEBAR_MAX_WIDTH}
           tabindex="0"
+          data-ac-testid="main.splitter"
+          data-ac-role="separator"
+          data-ac-state={dragging() ? "dragging" : "idle"}
         />
         <div class="main-terminal-pane">
           <TerminalApp embedded />

--- a/src/shared/automation-bridge.test.ts
+++ b/src/shared/automation-bridge.test.ts
@@ -191,6 +191,21 @@ describe("automation bridge", () => {
     });
   });
 
+  it("briefly retries queries for asynchronously rendered targets", async () => {
+    window.setTimeout(() => {
+      addTarget("button", "settings.agent.addCustom", "+ Custom Agent");
+    }, 10);
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("query", "settings.agent.addCustom"),
+    );
+
+    expect(response.ok).toBe(true);
+    if (!response.ok) throw new Error(response.message);
+    expect(response.target.testId).toBe("settings.agent.addCustom");
+  });
+
   it("sets input values and dispatches input plus change", async () => {
     const input = addTarget("input", "onboarding.custom.command");
     topmostElement = input;

--- a/src/shared/automation-bridge.test.ts
+++ b/src/shared/automation-bridge.test.ts
@@ -18,6 +18,7 @@ function request(
   action: UiAutomationAction,
   selector: string,
   value?: string,
+  expiresAtUnixMs?: number | null,
 ): UiAutomationRequest {
   return {
     requestId: `request-${action}-${selector}`,
@@ -26,6 +27,7 @@ function request(
     action,
     selector,
     value,
+    expiresAtUnixMs,
   };
 }
 
@@ -145,6 +147,52 @@ describe("automation bridge", () => {
     expect(input.value).toBe("codex");
     expect(onInput).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not click when the request expires before mutation", async () => {
+    const button = addTarget("button", "expired.click", "Expired");
+    topmostElement = button;
+    const onClick = vi.fn();
+    const focus = vi.spyOn(button, "focus");
+    button.addEventListener("click", onClick);
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("click", "expired.click", undefined, Date.now() - 1),
+    );
+
+    expect(response.ok).toBe(false);
+    if (response.ok) throw new Error("expected timeout");
+    expect(response.error).toBe("timeout");
+    expect(response.diagnostics?.expiresAtUnixMs).toBeLessThanOrEqual(Date.now());
+    expect(response.available?.map((target) => target.testId)).toContain("expired.click");
+    expect(onClick).not.toHaveBeenCalled();
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("does not set values when the request expires before mutation", async () => {
+    const input = addTarget("input", "expired.set");
+    topmostElement = input;
+    const onInput = vi.fn();
+    const onChange = vi.fn();
+    const focus = vi.spyOn(input, "focus");
+    input.value = "before";
+    input.addEventListener("input", onInput);
+    input.addEventListener("change", onChange);
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("setValue", "expired.set", "after", Date.now() - 1),
+    );
+
+    expect(response.ok).toBe(false);
+    if (response.ok) throw new Error("expected timeout");
+    expect(response.error).toBe("timeout");
+    expect(response.diagnostics?.expiresAtUnixMs).toBeLessThanOrEqual(Date.now());
+    expect(input.value).toBe("before");
+    expect(onInput).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(focus).not.toHaveBeenCalled();
   });
 
   it("reports missing selectors with available targets", async () => {

--- a/src/shared/automation-bridge.test.ts
+++ b/src/shared/automation-bridge.test.ts
@@ -90,6 +90,7 @@ describe("automation bridge", () => {
 
   afterEach(() => {
     document.body.innerHTML = "";
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -204,6 +205,27 @@ describe("automation bridge", () => {
     expect(response.ok).toBe(true);
     if (!response.ok) throw new Error(response.message);
     expect(response.target.testId).toBe("settings.agent.addCustom");
+  });
+
+  it("does not return a retry query success after the request expires", async () => {
+    vi.useFakeTimers();
+    window.setTimeout(() => {
+      addTarget("button", "settings.agent.late", "Late target");
+    }, 10);
+
+    const responsePromise = executeAutomationRequest(
+      "main",
+      request("query", "settings.agent.late", undefined, Date.now() + 5),
+    );
+
+    await vi.advanceTimersByTimeAsync(5);
+    const response = await responsePromise;
+
+    expect(response.ok).toBe(false);
+    if (response.ok) throw new Error("expected timeout");
+    expect(response.error).toBe("timeout");
+
+    await vi.advanceTimersByTimeAsync(5);
   });
 
   it("sets input values and dispatches input plus change", async () => {

--- a/src/shared/automation-bridge.test.ts
+++ b/src/shared/automation-bridge.test.ts
@@ -130,6 +130,40 @@ describe("automation bridge", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it("waits for click-driven dynamic targets before completing", async () => {
+    const button = addTarget("button", "settings.agent.addCustom", "+ Custom Agent");
+    topmostElement = button;
+    button.addEventListener("click", () => {
+      void Promise.resolve().then(() => {
+        addTarget("div", "settings.agentRow.1", "New Agent");
+        addTarget("input", "settings.agentRow.1.label");
+        addTarget("button", "settings.agentRow.1.remove", "Remove agent");
+      });
+    });
+
+    const clickResponse = await executeAutomationRequest(
+      "main",
+      request("click", "settings.agent.addCustom"),
+    );
+    const rowResponse = await executeAutomationRequest(
+      "main",
+      request("query", "settings.agentRow.1"),
+    );
+    const labelResponse = await executeAutomationRequest(
+      "main",
+      request("query", "settings.agentRow.1.label"),
+    );
+    const removeResponse = await executeAutomationRequest(
+      "main",
+      request("query", "settings.agentRow.1.remove"),
+    );
+
+    expect(clickResponse.ok).toBe(true);
+    expect(rowResponse.ok).toBe(true);
+    expect(labelResponse.ok).toBe(true);
+    expect(removeResponse.ok).toBe(true);
+  });
+
   it("sets input values and dispatches input plus change", async () => {
     const input = addTarget("input", "onboarding.custom.command");
     topmostElement = input;

--- a/src/shared/automation-bridge.test.ts
+++ b/src/shared/automation-bridge.test.ts
@@ -1,0 +1,268 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeAutomationRequest } from "./automation-bridge";
+import type { UiAutomationAction, UiAutomationRequest } from "./types";
+
+vi.mock("./ipc", () => ({
+  AutomationAPI: {
+    complete: vi.fn(() => Promise.resolve()),
+    enabled: vi.fn(() => Promise.resolve(false)),
+    frontendReady: vi.fn(() => Promise.resolve()),
+  },
+  onUiAutomationRequest: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+let topmostElement: Element | null = null;
+
+function request(
+  action: UiAutomationAction,
+  selector: string,
+  value?: string,
+): UiAutomationRequest {
+  return {
+    requestId: `request-${action}-${selector}`,
+    token: "token",
+    window: "main",
+    action,
+    selector,
+    value,
+  };
+}
+
+function domRect(x = 10, y = 20, width = 120, height = 30): DOMRect {
+  return {
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    right: x + width,
+    bottom: y + height,
+    left: x,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function domRectList(rect: DOMRect): DOMRectList {
+  const list = [rect] as unknown as DOMRectList;
+  Object.defineProperty(list, "item", {
+    configurable: true,
+    value: (index: number) => list[index] ?? null,
+  });
+  return list;
+}
+
+function makeVisible<T extends HTMLElement>(element: T, rect = domRect()): T {
+  Object.defineProperty(element, "getBoundingClientRect", {
+    configurable: true,
+    value: () => rect,
+  });
+  Object.defineProperty(element, "getClientRects", {
+    configurable: true,
+    value: () => domRectList(rect),
+  });
+  return element;
+}
+
+function addTarget<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  testId: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const element = document.createElement(tag);
+  makeVisible(element);
+  element.setAttribute("data-ac-testid", testId);
+  if (text) element.textContent = text;
+  document.body.append(element);
+  return element;
+}
+
+describe("automation bridge", () => {
+  beforeEach(() => {
+    topmostElement = null;
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: vi.fn(() => topmostElement),
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("queries a visible button target", async () => {
+    const button = addTarget("button", "onboarding.confirm", "Set up Coding Agent");
+    button.setAttribute("data-ac-role", "button");
+    button.setAttribute("data-ac-state", "ready");
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("query", "onboarding.confirm"),
+    );
+
+    expect(response.ok).toBe(true);
+    if (!response.ok) throw new Error(response.message);
+    expect(response.target).toMatchObject({
+      testId: "onboarding.confirm",
+      role: "button",
+      state: "ready",
+      text: "Set up Coding Agent",
+      visible: true,
+      disabled: false,
+    });
+  });
+
+  it("clicks a visible enabled target", async () => {
+    const button = addTarget("button", "onboarding.agentPreset.codex", "Codex");
+    topmostElement = button;
+    const onClick = vi.fn();
+    button.addEventListener("click", onClick);
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("click", "onboarding.agentPreset.codex"),
+    );
+
+    expect(response.ok).toBe(true);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets input values and dispatches input plus change", async () => {
+    const input = addTarget("input", "onboarding.custom.command");
+    topmostElement = input;
+    const onInput = vi.fn();
+    const onChange = vi.fn();
+    input.addEventListener("input", onInput);
+    input.addEventListener("change", onChange);
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("setValue", "onboarding.custom.command", "codex"),
+    );
+
+    expect(response.ok).toBe(true);
+    expect(input.value).toBe("codex");
+    expect(onInput).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports missing selectors with available targets", async () => {
+    addTarget("button", "onboarding.modal", "Welcome");
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("query", "onboarding.agentPreset.codex"),
+    );
+
+    expect(response.ok).toBe(false);
+    if (response.ok) throw new Error("expected missing_selector");
+    expect(response.error).toBe("missing_selector");
+    expect(response.available?.map((target) => target.testId)).toContain("onboarding.modal");
+  });
+
+  it("reports duplicate selectors and does not click either target", async () => {
+    const first = addTarget("button", "duplicate.target", "First");
+    const second = addTarget("button", "duplicate.target", "Second");
+    topmostElement = first;
+    const onFirstClick = vi.fn();
+    const onSecondClick = vi.fn();
+    first.addEventListener("click", onFirstClick);
+    second.addEventListener("click", onSecondClick);
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("click", "duplicate.target"),
+    );
+
+    expect(response.ok).toBe(false);
+    if (response.ok) throw new Error("expected duplicate_selector");
+    expect(response.error).toBe("duplicate_selector");
+    expect(response.available).toHaveLength(2);
+    expect(onFirstClick).not.toHaveBeenCalled();
+    expect(onSecondClick).not.toHaveBeenCalled();
+  });
+
+  it("reports hidden targets", async () => {
+    const button = addTarget("button", "hidden.target", "Hidden");
+    button.style.visibility = "hidden";
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("query", "hidden.target"),
+    );
+
+    expect(response.ok).toBe(false);
+    if (response.ok) throw new Error("expected target_hidden");
+    expect(response.error).toBe("target_hidden");
+  });
+
+  it("reports disabled action targets", async () => {
+    const button = addTarget("button", "disabled.target", "Disabled");
+    button.disabled = true;
+    topmostElement = button;
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("click", "disabled.target"),
+    );
+
+    expect(response.ok).toBe(false);
+    if (response.ok) throw new Error("expected target_disabled");
+    expect(response.error).toBe("target_disabled");
+  });
+
+  it("reports obscured action targets", async () => {
+    addTarget("button", "covered.target", "Covered");
+    const blocker = addTarget("div", "dialog.blocker", "Modal");
+    blocker.setAttribute("data-ac-role", "dialog");
+    topmostElement = blocker;
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("click", "covered.target"),
+    );
+
+    expect(response.ok).toBe(false);
+    if (response.ok) throw new Error("expected target_obscured");
+    expect(response.error).toBe("target_obscured");
+    expect(response.diagnostics?.topmost?.testId).toBe("dialog.blocker");
+  });
+
+  it("finds targets outside #root for portal-rendered surfaces", async () => {
+    const root = document.createElement("div");
+    root.id = "root";
+    document.body.append(root);
+    const menuItem = addTarget("button", "menu.session.restart", "Restart Session");
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("query", "menu.session.restart"),
+    );
+
+    expect(response.ok).toBe(true);
+    if (!response.ok) throw new Error(response.message);
+    expect(response.target.testId).toBe("menu.session.restart");
+    expect(root.contains(menuItem)).toBe(false);
+  });
+
+  it("traverses open shadow roots and redacts input text", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    const input = makeVisible(document.createElement("input"));
+    input.setAttribute("data-ac-testid", "shadow.secret");
+    input.value = "AIza123456789012345678901234567890";
+    shadow.append(input);
+
+    const response = await executeAutomationRequest(
+      "main",
+      request("query", "shadow.secret"),
+    );
+
+    expect(response.ok).toBe(true);
+    if (!response.ok) throw new Error(response.message);
+    expect(response.target.testId).toBe("shadow.secret");
+    expect(response.target.text).toBe("");
+  });
+});

--- a/src/shared/automation-bridge.test.ts
+++ b/src/shared/automation-bridge.test.ts
@@ -164,6 +164,33 @@ describe("automation bridge", () => {
     expect(removeResponse.ok).toBe(true);
   });
 
+  it("queries settings row parents and disabled preset targets", async () => {
+    const row = addTarget("div", "settings.agentRow.0");
+    row.setAttribute("data-ac-role", "group");
+    const preset = addTarget("button", "settings.agentPreset.codex", "+ Codex");
+    preset.setAttribute("data-ac-role", "button");
+    preset.setAttribute("data-ac-state", "disabled");
+    preset.disabled = true;
+
+    const rowResponse = await executeAutomationRequest(
+      "main",
+      request("query", "settings.agentRow.0"),
+    );
+    const presetResponse = await executeAutomationRequest(
+      "main",
+      request("query", "settings.agentPreset.codex"),
+    );
+
+    expect(rowResponse.ok).toBe(true);
+    expect(presetResponse.ok).toBe(true);
+    if (!presetResponse.ok) throw new Error(presetResponse.message);
+    expect(presetResponse.target).toMatchObject({
+      testId: "settings.agentPreset.codex",
+      disabled: true,
+      state: "disabled",
+    });
+  });
+
   it("sets input values and dispatches input plus change", async () => {
     const input = addTarget("input", "onboarding.custom.command");
     topmostElement = input;

--- a/src/shared/automation-bridge.ts
+++ b/src/shared/automation-bridge.ts
@@ -135,6 +135,8 @@ function executeAutomationRequestInner(
   }
 
   if (request.action === "click") {
+    const expired = expiredMutationResponse(windowLabel, request, diagnostics);
+    if (expired) return expired;
     element.focus();
     element.click();
     return successResponse(windowLabel, request, snapshotTarget(element), diagnostics);
@@ -175,11 +177,40 @@ function setElementValue(
     );
   }
 
+  const expired = expiredMutationResponse(windowLabel, request, diagnostics);
+  if (expired) return expired;
+
   element.focus();
   element.value = request.value ?? "";
   element.dispatchEvent(new Event("input", { bubbles: true }));
   element.dispatchEvent(new Event("change", { bubbles: true }));
   return successResponse(windowLabel, request, snapshotTarget(element), diagnostics);
+}
+
+function expiredMutationResponse(
+  windowLabel: string,
+  request: UiAutomationRequest,
+  diagnostics: UiAutomationDiagnostics,
+): UiAutomationResponse | null {
+  const nowUnixMs = Date.now();
+  if (!requestExpired(request, nowUnixMs)) return null;
+
+  return errorResponse(
+    windowLabel,
+    request,
+    "timeout",
+    `Automation request "${request.requestId}" expired before the frontend could perform "${request.action}".`,
+    availableTargets(),
+    {
+      ...diagnostics,
+      expiresAtUnixMs: request.expiresAtUnixMs ?? null,
+      nowUnixMs,
+    },
+  );
+}
+
+function requestExpired(request: UiAutomationRequest, nowUnixMs: number): boolean {
+  return typeof request.expiresAtUnixMs === "number" && request.expiresAtUnixMs <= nowUnixMs;
 }
 
 function successResponse(

--- a/src/shared/automation-bridge.ts
+++ b/src/shared/automation-bridge.ts
@@ -11,6 +11,8 @@ import type {
 
 const MAX_AVAILABLE_TARGETS = 50;
 const MAX_SNAPSHOT_TEXT = 120;
+const MISSING_SELECTOR_RETRY_MS = 250;
+const MISSING_SELECTOR_RETRY_INTERVAL_MS = 25;
 const REDACTED_TEXT = "[redacted]";
 
 type UiAutomationErrorCode = Extract<UiAutomationResponse, { ok: false }>["error"];
@@ -70,7 +72,7 @@ async function executeAutomationRequestInner(
   windowLabel: string,
   request: UiAutomationRequest,
 ): Promise<UiAutomationResponse> {
-  const matches = queryAutomationTargets(request.selector);
+  const matches = await queryAutomationTargetsWithBriefRetry(request);
   const diagnostics = baseDiagnostics();
 
   if (matches.length === 0) {
@@ -261,6 +263,32 @@ function errorResponse(
 function queryAutomationTargets(testId: string): HTMLElement[] {
   const selector = `[data-ac-testid="${cssEscape(testId)}"]`;
   return queryAcrossOpenRoots(selector);
+}
+
+async function queryAutomationTargetsWithBriefRetry(
+  request: UiAutomationRequest,
+): Promise<HTMLElement[]> {
+  let matches = queryAutomationTargets(request.selector);
+  if (matches.length > 0) return matches;
+
+  const retryMs = missingSelectorRetryBudgetMs(request);
+  if (retryMs <= 0) return matches;
+
+  const deadline = Date.now() + retryMs;
+  while (Date.now() < deadline) {
+    await new Promise<void>((resolve) =>
+      window.setTimeout(resolve, MISSING_SELECTOR_RETRY_INTERVAL_MS),
+    );
+    matches = queryAutomationTargets(request.selector);
+    if (matches.length > 0) return matches;
+  }
+
+  return matches;
+}
+
+function missingSelectorRetryBudgetMs(request: UiAutomationRequest): number {
+  if (typeof request.expiresAtUnixMs !== "number") return MISSING_SELECTOR_RETRY_MS;
+  return Math.max(0, Math.min(MISSING_SELECTOR_RETRY_MS, request.expiresAtUnixMs - Date.now() - 1));
 }
 
 function availableTargets(): UiAutomationTarget[] {

--- a/src/shared/automation-bridge.ts
+++ b/src/shared/automation-bridge.ts
@@ -72,8 +72,13 @@ async function executeAutomationRequestInner(
   windowLabel: string,
   request: UiAutomationRequest,
 ): Promise<UiAutomationResponse> {
-  const matches = await queryAutomationTargetsWithBriefRetry(request);
   const diagnostics = baseDiagnostics();
+  const expiredBeforeQuery = expiredRequestResponse(windowLabel, request, diagnostics);
+  if (expiredBeforeQuery) return expiredBeforeQuery;
+
+  const matches = await queryAutomationTargetsWithBriefRetry(request);
+  const expiredAfterQuery = expiredRequestResponse(windowLabel, request, diagnostics);
+  if (expiredAfterQuery) return expiredAfterQuery;
 
   if (matches.length === 0) {
     return errorResponse(
@@ -201,6 +206,14 @@ function expiredMutationResponse(
   request: UiAutomationRequest,
   diagnostics: UiAutomationDiagnostics,
 ): UiAutomationResponse | null {
+  return expiredRequestResponse(windowLabel, request, diagnostics);
+}
+
+function expiredRequestResponse(
+  windowLabel: string,
+  request: UiAutomationRequest,
+  diagnostics: UiAutomationDiagnostics,
+): UiAutomationResponse | null {
   const nowUnixMs = Date.now();
   if (!requestExpired(request, nowUnixMs)) return null;
 
@@ -208,7 +221,7 @@ function expiredMutationResponse(
     windowLabel,
     request,
     "timeout",
-    `Automation request "${request.requestId}" expired before the frontend could perform "${request.action}".`,
+    `Automation request "${request.requestId}" expired before the frontend could complete "${request.action}".`,
     availableTargets(),
     {
       ...diagnostics,
@@ -276,9 +289,21 @@ async function queryAutomationTargetsWithBriefRetry(
 
   const deadline = Date.now() + retryMs;
   while (Date.now() < deadline) {
-    await new Promise<void>((resolve) =>
-      window.setTimeout(resolve, MISSING_SELECTOR_RETRY_INTERVAL_MS),
+    const nowUnixMs = Date.now();
+    if (requestExpired(request, nowUnixMs)) return [];
+    const remainingBudgetMs = deadline - nowUnixMs;
+    const remainingExpiryMs = requestExpiryRemainingMs(request, nowUnixMs);
+    const sleepMs = Math.min(
+      MISSING_SELECTOR_RETRY_INTERVAL_MS,
+      remainingBudgetMs,
+      remainingExpiryMs ?? MISSING_SELECTOR_RETRY_INTERVAL_MS,
     );
+
+    await new Promise<void>((resolve) =>
+      window.setTimeout(resolve, sleepMs),
+    );
+    if (requestExpired(request, Date.now())) return [];
+
     matches = queryAutomationTargets(request.selector);
     if (matches.length > 0) return matches;
   }
@@ -288,7 +313,12 @@ async function queryAutomationTargetsWithBriefRetry(
 
 function missingSelectorRetryBudgetMs(request: UiAutomationRequest): number {
   if (typeof request.expiresAtUnixMs !== "number") return MISSING_SELECTOR_RETRY_MS;
-  return Math.max(0, Math.min(MISSING_SELECTOR_RETRY_MS, request.expiresAtUnixMs - Date.now() - 1));
+  return Math.max(0, Math.min(MISSING_SELECTOR_RETRY_MS, request.expiresAtUnixMs - Date.now()));
+}
+
+function requestExpiryRemainingMs(request: UiAutomationRequest, nowUnixMs: number): number | null {
+  if (typeof request.expiresAtUnixMs !== "number") return null;
+  return Math.max(0, request.expiresAtUnixMs - nowUnixMs);
 }
 
 function availableTargets(): UiAutomationTarget[] {

--- a/src/shared/automation-bridge.ts
+++ b/src/shared/automation-bridge.ts
@@ -55,7 +55,7 @@ export async function executeAutomationRequest(
   request: UiAutomationRequest,
 ): Promise<UiAutomationResponse> {
   try {
-    return executeAutomationRequestInner(windowLabel, request);
+    return await executeAutomationRequestInner(windowLabel, request);
   } catch (error) {
     return errorResponse(
       windowLabel,
@@ -66,10 +66,10 @@ export async function executeAutomationRequest(
   }
 }
 
-function executeAutomationRequestInner(
+async function executeAutomationRequestInner(
   windowLabel: string,
   request: UiAutomationRequest,
-): UiAutomationResponse {
+): Promise<UiAutomationResponse> {
   const matches = queryAutomationTargets(request.selector);
   const diagnostics = baseDiagnostics();
 
@@ -139,6 +139,7 @@ function executeAutomationRequestInner(
     if (expired) return expired;
     element.focus();
     element.click();
+    await settleAfterDomMutation();
     return successResponse(windowLabel, request, snapshotTarget(element), diagnostics);
   }
 
@@ -156,12 +157,12 @@ function executeAutomationRequestInner(
   );
 }
 
-function setElementValue(
+async function setElementValue(
   windowLabel: string,
   request: UiAutomationRequest,
   element: HTMLElement,
   diagnostics: UiAutomationDiagnostics,
-): UiAutomationResponse {
+): Promise<UiAutomationResponse> {
   if (
     !(element instanceof HTMLInputElement) &&
     !(element instanceof HTMLTextAreaElement) &&
@@ -184,7 +185,13 @@ function setElementValue(
   element.value = request.value ?? "";
   element.dispatchEvent(new Event("input", { bubbles: true }));
   element.dispatchEvent(new Event("change", { bubbles: true }));
+  await settleAfterDomMutation();
   return successResponse(windowLabel, request, snapshotTarget(element), diagnostics);
+}
+
+async function settleAfterDomMutation(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
 }
 
 function expiredMutationResponse(

--- a/src/shared/automation-bridge.ts
+++ b/src/shared/automation-bridge.ts
@@ -1,0 +1,425 @@
+import { AutomationAPI, onUiAutomationRequest } from "./ipc";
+import { isTauri } from "./platform";
+import type {
+  UiAutomationAction,
+  UiAutomationDiagnostics,
+  UiAutomationRequest,
+  UiAutomationResponse,
+  UiAutomationTarget,
+  UiAutomationTargetRect,
+} from "./types";
+
+const MAX_AVAILABLE_TARGETS = 50;
+const MAX_SNAPSHOT_TEXT = 120;
+const REDACTED_TEXT = "[redacted]";
+
+type UiAutomationErrorCode = Extract<UiAutomationResponse, { ok: false }>["error"];
+
+let started = false;
+
+async function resolveAutomationWindowLabel(explicit?: string): Promise<string> {
+  if (explicit) return explicit;
+  const { getCurrentWindow } = await import("@tauri-apps/api/window");
+  return getCurrentWindow().label;
+}
+
+export async function initAutomationBridge(windowLabel?: string): Promise<void> {
+  if (started || !isTauri) return;
+
+  const enabled = await AutomationAPI.enabled().catch(() => false);
+  if (!enabled) return;
+
+  const resolvedWindowLabel = await resolveAutomationWindowLabel(windowLabel);
+  await onUiAutomationRequest((request) => {
+    if (request.window !== resolvedWindowLabel) return;
+
+    void executeAutomationRequest(resolvedWindowLabel, request)
+      .then((response) => AutomationAPI.complete(response))
+      .catch((error) => {
+        console.error("[automation] failed to complete request:", error);
+      });
+  });
+
+  started = true;
+  await AutomationAPI.frontendReady(resolvedWindowLabel).catch((error) => {
+    console.error("[automation] frontend readiness failed:", error);
+  });
+}
+
+export function resetAutomationBridgeForTests(): void {
+  started = false;
+}
+
+export async function executeAutomationRequest(
+  windowLabel: string,
+  request: UiAutomationRequest,
+): Promise<UiAutomationResponse> {
+  try {
+    return executeAutomationRequestInner(windowLabel, request);
+  } catch (error) {
+    return errorResponse(
+      windowLabel,
+      request,
+      "automation_bridge_exception",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function executeAutomationRequestInner(
+  windowLabel: string,
+  request: UiAutomationRequest,
+): UiAutomationResponse {
+  const matches = queryAutomationTargets(request.selector);
+  const diagnostics = baseDiagnostics();
+
+  if (matches.length === 0) {
+    return errorResponse(
+      windowLabel,
+      request,
+      "missing_selector",
+      `No automation target matched data-ac-testid="${request.selector}" in window "${windowLabel}".`,
+      availableTargets(),
+      diagnostics,
+    );
+  }
+
+  if (matches.length > 1) {
+    return errorResponse(
+      windowLabel,
+      request,
+      "duplicate_selector",
+      `Multiple automation targets matched data-ac-testid="${request.selector}" in window "${windowLabel}".`,
+      matches.map((element) => snapshotTarget(element)),
+      diagnostics,
+    );
+  }
+
+  const element = matches[0];
+  if (!isElementVisible(element)) {
+    return errorResponse(
+      windowLabel,
+      request,
+      "target_hidden",
+      `Automation target "${request.selector}" is hidden in window "${windowLabel}".`,
+      availableTargets(),
+      diagnostics,
+    );
+  }
+
+  if (request.action === "query") {
+    return successResponse(windowLabel, request, snapshotTarget(element), diagnostics);
+  }
+
+  if (isElementDisabled(element)) {
+    return errorResponse(
+      windowLabel,
+      request,
+      "target_disabled",
+      `Automation target "${request.selector}" is disabled in window "${windowLabel}".`,
+      availableTargets(),
+      diagnostics,
+    );
+  }
+
+  const topmost = topmostElementAtCenter(element);
+  if (!topmost.ok) {
+    return errorResponse(
+      windowLabel,
+      request,
+      "target_obscured",
+      `Automation target "${request.selector}" is obscured in window "${windowLabel}".`,
+      availableTargets(),
+      { ...diagnostics, topmost: topmost.element ? snapshotTarget(topmost.element) : null },
+    );
+  }
+
+  if (request.action === "click") {
+    element.focus();
+    element.click();
+    return successResponse(windowLabel, request, snapshotTarget(element), diagnostics);
+  }
+
+  if (request.action === "setValue") {
+    return setElementValue(windowLabel, request, element, diagnostics);
+  }
+
+  return errorResponse(
+    windowLabel,
+    request,
+    "unsupported_action",
+    `Unsupported automation action "${request.action as UiAutomationAction}".`,
+    availableTargets(),
+    diagnostics,
+  );
+}
+
+function setElementValue(
+  windowLabel: string,
+  request: UiAutomationRequest,
+  element: HTMLElement,
+  diagnostics: UiAutomationDiagnostics,
+): UiAutomationResponse {
+  if (
+    !(element instanceof HTMLInputElement) &&
+    !(element instanceof HTMLTextAreaElement) &&
+    !(element instanceof HTMLSelectElement)
+  ) {
+    return errorResponse(
+      windowLabel,
+      request,
+      "value_not_supported",
+      `Automation target "${request.selector}" does not support setValue.`,
+      availableTargets(),
+      diagnostics,
+    );
+  }
+
+  element.focus();
+  element.value = request.value ?? "";
+  element.dispatchEvent(new Event("input", { bubbles: true }));
+  element.dispatchEvent(new Event("change", { bubbles: true }));
+  return successResponse(windowLabel, request, snapshotTarget(element), diagnostics);
+}
+
+function successResponse(
+  windowLabel: string,
+  request: UiAutomationRequest,
+  target: UiAutomationTarget,
+  diagnostics?: UiAutomationDiagnostics,
+): UiAutomationResponse {
+  return {
+    ok: true,
+    requestId: request.requestId,
+    window: windowLabel,
+    action: request.action,
+    selector: request.selector,
+    target,
+    diagnostics,
+  };
+}
+
+function errorResponse(
+  windowLabel: string,
+  request: UiAutomationRequest,
+  error: UiAutomationErrorCode,
+  message: string,
+  available?: UiAutomationTarget[],
+  diagnostics?: UiAutomationDiagnostics,
+): UiAutomationResponse {
+  return {
+    ok: false,
+    requestId: request.requestId,
+    window: windowLabel,
+    action: request.action,
+    selector: request.selector,
+    error,
+    message,
+    available,
+    diagnostics,
+  };
+}
+
+function queryAutomationTargets(testId: string): HTMLElement[] {
+  const selector = `[data-ac-testid="${cssEscape(testId)}"]`;
+  return queryAcrossOpenRoots(selector);
+}
+
+function availableTargets(): UiAutomationTarget[] {
+  return queryAcrossOpenRoots("[data-ac-testid]")
+    .map((element) => snapshotTarget(element))
+    .sort((a, b) => a.testId.localeCompare(b.testId))
+    .slice(0, MAX_AVAILABLE_TARGETS);
+}
+
+function queryAcrossOpenRoots(selector: string): HTMLElement[] {
+  const matches: HTMLElement[] = [];
+  const visit = (root: Document | ShadowRoot) => {
+    matches.push(...Array.from(root.querySelectorAll<HTMLElement>(selector)));
+    for (const element of Array.from(root.querySelectorAll<HTMLElement>("*"))) {
+      if (element.shadowRoot) {
+        visit(element.shadowRoot);
+      }
+    }
+  };
+
+  visit(document);
+  return matches;
+}
+
+function cssEscape(value: string): string {
+  const css = globalThis.CSS as { escape?: (value: string) => string } | undefined;
+  if (css?.escape) return css.escape(value);
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function snapshotTarget(element: HTMLElement): UiAutomationTarget {
+  return {
+    testId: element.getAttribute("data-ac-testid") ?? "",
+    role: element.getAttribute("data-ac-role") ?? element.getAttribute("role"),
+    state: element.getAttribute("data-ac-state"),
+    tag: element.tagName.toLowerCase(),
+    text: snapshotText(element),
+    visible: isElementVisible(element),
+    disabled: isElementDisabled(element),
+    checked: boolState(element, "checked"),
+    selected: boolState(element, "selected"),
+    pressed: ariaBool(element, "aria-pressed"),
+    expanded: ariaBool(element, "aria-expanded"),
+    rect: targetRect(element),
+  };
+}
+
+function snapshotText(element: HTMLElement): string {
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    return "";
+  }
+
+  const role = element.getAttribute("data-ac-role") ?? element.getAttribute("role") ?? "";
+  const allowText =
+    role === "agent-preset" ||
+    role === "button" ||
+    role === "checkbox" ||
+    role === "menuitem" ||
+    role === "tab" ||
+    element instanceof HTMLButtonElement;
+
+  if (!allowText) return "";
+
+  const text = (element.textContent ?? "").replace(/\s+/g, " ").trim();
+  return redactSnapshotText(text).slice(0, MAX_SNAPSHOT_TEXT);
+}
+
+function redactSnapshotText(text: string): string {
+  return text
+    .replace(/AIza[0-9A-Za-z_-]{20,}/g, REDACTED_TEXT)
+    .replace(/\b[A-Za-z0-9_=-]{32,}\b/g, REDACTED_TEXT);
+}
+
+function boolState(element: HTMLElement, state: "checked" | "selected"): boolean | null {
+  if (state === "checked") {
+    if (element instanceof HTMLInputElement && ["checkbox", "radio"].includes(element.type)) {
+      return element.checked;
+    }
+    return ariaBool(element, "aria-checked");
+  }
+
+  if (element instanceof HTMLOptionElement) {
+    return element.selected;
+  }
+  return ariaBool(element, "aria-selected");
+}
+
+function ariaBool(element: HTMLElement, attr: string): boolean | null {
+  const value = element.getAttribute(attr);
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return null;
+}
+
+function isElementDisabled(element: HTMLElement): boolean {
+  if (
+    (element instanceof HTMLButtonElement ||
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLSelectElement ||
+      element instanceof HTMLTextAreaElement) &&
+    element.disabled
+  ) {
+    return true;
+  }
+
+  return element.getAttribute("aria-disabled") === "true" ||
+    element.getAttribute("data-ac-state") === "disabled";
+}
+
+function isElementVisible(element: HTMLElement): boolean {
+  if (isTreeHidden(element)) return false;
+  const rects = element.getClientRects();
+  if (rects.length === 0) return false;
+  const rect = element.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
+
+function isTreeHidden(element: HTMLElement): boolean {
+  let current: HTMLElement | null = element;
+  while (current) {
+    if (
+      current.hidden ||
+      current.hasAttribute("inert") ||
+      current.getAttribute("aria-hidden") === "true"
+    ) {
+      return true;
+    }
+
+    const style = window.getComputedStyle(current);
+    if (style.display === "none" || style.visibility === "hidden") {
+      return true;
+    }
+
+    current = parentElementOrHost(current);
+  }
+
+  return false;
+}
+
+function parentElementOrHost(element: HTMLElement): HTMLElement | null {
+  if (element.parentElement) return element.parentElement;
+  const root = element.getRootNode();
+  if (root instanceof ShadowRoot && root.host instanceof HTMLElement) {
+    return root.host;
+  }
+  return null;
+}
+
+function topmostElementAtCenter(element: HTMLElement): { ok: true } | { ok: false; element: HTMLElement | null } {
+  if (typeof document.elementFromPoint !== "function") {
+    return { ok: true };
+  }
+
+  const rect = element.getBoundingClientRect();
+  const top = document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2);
+  if (!top) {
+    return { ok: false, element: null };
+  }
+
+  if (isSameOrComposedDescendant(element, top)) {
+    return { ok: true };
+  }
+
+  return { ok: false, element: top instanceof HTMLElement ? top : null };
+}
+
+function isSameOrComposedDescendant(parent: HTMLElement, child: Element): boolean {
+  let current: Node | null = child;
+  while (current) {
+    if (current === parent) return true;
+    if (current.parentNode) {
+      current = current.parentNode;
+      continue;
+    }
+    const root = current.getRootNode();
+    current = root instanceof ShadowRoot ? root.host : null;
+  }
+  return false;
+}
+
+function targetRect(element: HTMLElement): UiAutomationTargetRect | null {
+  const rect = element.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return null;
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function baseDiagnostics(): UiAutomationDiagnostics {
+  return {
+    devicePixelRatio: window.devicePixelRatio || 1,
+    viewport: {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    },
+  };
+}

--- a/src/shared/automation-hooks.ts
+++ b/src/shared/automation-hooks.ts
@@ -1,0 +1,39 @@
+export type AutomationRole =
+  | "agent-preset"
+  | "button"
+  | "checkbox"
+  | "dialog"
+  | "list"
+  | "menu"
+  | "menuitem"
+  | "overlay"
+  | "row"
+  | "separator"
+  | "status"
+  | "surface"
+  | "tab"
+  | "textbox";
+
+export function automationAttrs(
+  testId: string,
+  role: AutomationRole,
+  state?: string,
+  extra?: Record<string, string | boolean | number | null | undefined>,
+): Record<string, string> {
+  const attrs: Record<string, string> = {
+    "data-ac-testid": testId,
+    "data-ac-role": role,
+  };
+
+  if (state) {
+    attrs["data-ac-state"] = state;
+  }
+
+  for (const [key, value] of Object.entries(extra ?? {})) {
+    if (value !== null && value !== undefined) {
+      attrs[`data-ac-${key}`] = String(value);
+    }
+  }
+
+  return attrs;
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -24,7 +24,9 @@ import type {
   RoleTemplateMeta,
   SpecBoardDocument,
   SpecBoardSnapshot,
-  SpecBoardChangedEvent
+  SpecBoardChangedEvent,
+  UiAutomationRequest,
+  UiAutomationResponse
 } from "./types";
 
 export interface SessionRepoInput {
@@ -224,6 +226,20 @@ export const DebugAPI = {
   drainErrorLogs: () =>
     transport.invoke<ErrorLogEntry[]>("drain_error_logs"),
 };
+
+export const AutomationAPI = {
+  enabled: () => transport.invoke<boolean>("ui_automation_enabled"),
+  frontendReady: (window: string) =>
+    transport.invoke<void>("ui_automation_frontend_ready", { window }),
+  complete: (result: UiAutomationResponse) =>
+    transport.invoke<void>("ui_automation_complete", { result }),
+};
+
+export function onUiAutomationRequest(
+  callback: (request: UiAutomationRequest) => void
+): Promise<UnlistenFn> {
+  return transport.listen<UiAutomationRequest>("ui_automation_request", callback);
+}
 
 // #264 — content-free ping fired when a new ERROR-level log entry is captured.
 // The listener responds by calling DebugAPI.drainErrorLogs().

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -197,6 +197,7 @@ export interface UiAutomationRequest {
   action: UiAutomationAction;
   selector: string;
   value?: string | null;
+  expiresAtUnixMs?: number | null;
 }
 
 export interface UiAutomationTargetRect {
@@ -225,6 +226,8 @@ export interface UiAutomationDiagnostics {
   devicePixelRatio: number;
   viewport: { width: number; height: number };
   topmost?: UiAutomationTarget | null;
+  expiresAtUnixMs?: number | null;
+  nowUnixMs?: number;
 }
 
 export type UiAutomationResponse =
@@ -249,6 +252,7 @@ export type UiAutomationResponse =
         | "target_hidden"
         | "target_obscured"
         | "target_disabled"
+        | "timeout"
         | "unsupported_action"
         | "value_not_supported"
         | "automation_bridge_exception";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -188,6 +188,75 @@ export interface AppSettings {
   specBoardEnabled: boolean;
 }
 
+export type UiAutomationAction = "query" | "click" | "setValue";
+
+export interface UiAutomationRequest {
+  requestId: string;
+  token: string;
+  window: string;
+  action: UiAutomationAction;
+  selector: string;
+  value?: string | null;
+}
+
+export interface UiAutomationTargetRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface UiAutomationTarget {
+  testId: string;
+  role: string | null;
+  state: string | null;
+  tag: string;
+  text: string;
+  visible: boolean;
+  disabled: boolean;
+  checked: boolean | null;
+  selected: boolean | null;
+  pressed: boolean | null;
+  expanded: boolean | null;
+  rect: UiAutomationTargetRect | null;
+}
+
+export interface UiAutomationDiagnostics {
+  devicePixelRatio: number;
+  viewport: { width: number; height: number };
+  topmost?: UiAutomationTarget | null;
+}
+
+export type UiAutomationResponse =
+  | {
+      ok: true;
+      requestId: string;
+      window: string;
+      action: UiAutomationAction;
+      selector: string;
+      target: UiAutomationTarget;
+      diagnostics?: UiAutomationDiagnostics;
+    }
+  | {
+      ok: false;
+      requestId: string;
+      window: string;
+      action: UiAutomationAction;
+      selector: string;
+      error:
+        | "missing_selector"
+        | "duplicate_selector"
+        | "target_hidden"
+        | "target_obscured"
+        | "target_disabled"
+        | "unsupported_action"
+        | "value_not_supported"
+        | "automation_bridge_exception";
+      message: string;
+      available?: UiAutomationTarget[];
+      diagnostics?: UiAutomationDiagnostics;
+    };
+
 // Team grouping for sidebar
 export interface TeamSessionGroup {
   team: Team;

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -311,6 +311,8 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
         class="sidebar-layout"
         onPointerEnter={() => sessionsStore.setSidebarPointerInside(true)}
         onPointerLeave={() => sessionsStore.setSidebarPointerInside(false)}
+        data-ac-testid="sidebar.root"
+        data-ac-role="surface"
       >
         <Show when={!props.embedded}>
           <Titlebar />

--- a/src/sidebar/components/ActionBar.tsx
+++ b/src/sidebar/components/ActionBar.tsx
@@ -185,12 +185,20 @@ const ActionBar: Component = () => {
 
   return (
     <>
-      <div class="action-bar">
+      <div
+        class="action-bar"
+        data-ac-testid="actionBar"
+        data-ac-role="surface"
+      >
         <div class="action-bar-dropdown" ref={dropdownRef}>
           <button
             class="action-bar-dropdown-btn"
             disabled={isPendingDialog()}
             onClick={() => setShowDropdown(!showDropdown())}
+            aria-expanded={showDropdown()}
+            data-ac-testid="actionBar.newOpen"
+            data-ac-role="button"
+            data-ac-state={isPendingDialog() ? "disabled" : showDropdown() ? "open" : "closed"}
           >
             New / Open
             <svg class="action-bar-chevron" width="10" height="6" viewBox="0 0 10 6" fill="none">
@@ -198,11 +206,29 @@ const ActionBar: Component = () => {
             </svg>
           </button>
           <Show when={showDropdown()}>
-            <div class="action-bar-menu">
-              <button class="action-bar-menu-item" disabled={isPendingDialog()} onClick={handleNewProject}>
+            <div
+              class="action-bar-menu"
+              data-ac-testid="actionBar.menu"
+              data-ac-role="menu"
+            >
+              <button
+                class="action-bar-menu-item"
+                disabled={isPendingDialog()}
+                onClick={handleNewProject}
+                data-ac-testid="actionBar.menu.newProject"
+                data-ac-role="menuitem"
+                data-ac-state={isPendingDialog() ? "disabled" : "ready"}
+              >
                 &#x1F4C1; New Project
               </button>
-              <button class="action-bar-menu-item" disabled={isPendingDialog()} onClick={handleOpenProject}>
+              <button
+                class="action-bar-menu-item"
+                disabled={isPendingDialog()}
+                onClick={handleOpenProject}
+                data-ac-testid="actionBar.menu.openProject"
+                data-ac-role="menuitem"
+                data-ac-state={isPendingDialog() ? "disabled" : "ready"}
+              >
                 &#x1F4C2; Open Project
               </button>
             </div>
@@ -210,7 +236,13 @@ const ActionBar: Component = () => {
         </div>
         <div class="action-bar-icons">
           <Show when={settingsStore.current?.specBoardEnabled === true}>
-            <button class="toolbar-gear-btn" onClick={() => SpecBoardAPI.open()} title="Spec board">
+            <button
+              class="toolbar-gear-btn"
+              onClick={() => SpecBoardAPI.open()}
+              title="Spec board"
+              data-ac-testid="actionBar.specBoard"
+              data-ac-role="button"
+            >
               &#x25A7;
             </button>
           </Show>
@@ -221,6 +253,9 @@ const ActionBar: Component = () => {
             title={homeStore.visible ? "Hide Home" : "Show Home"}
             aria-label={homeStore.visible ? "Hide Home" : "Show Home"}
             aria-pressed={homeStore.visible}
+            data-ac-testid="actionBar.home"
+            data-ac-role="button"
+            data-ac-state={homeStore.visible ? "visible" : "hidden"}
           >
             &#x1F3E0;
           </button>
@@ -229,6 +264,10 @@ const ActionBar: Component = () => {
             disabled={!sessionsStore.hydrated || sessionsStore.toggleInFlight}
             onClick={() => sessionsStore.toggleCoordSortByActivity()}
             title={sessionsStore.coordSortByActivity ? "Show recent coordinators first" : "Show coordinators in default order"}
+            aria-pressed={sessionsStore.coordSortByActivity}
+            data-ac-testid="actionBar.sortCoordinators"
+            data-ac-role="button"
+            data-ac-state={!sessionsStore.hydrated || sessionsStore.toggleInFlight ? "disabled" : sessionsStore.coordSortByActivity ? "recent" : "default"}
           >
             &#x1F525;
           </button>
@@ -238,6 +277,10 @@ const ActionBar: Component = () => {
             onClick={handleToggleMute}
             title={isSoundsEnabled() ? "Mute all app sounds" : "Unmute app sounds"}
             aria-label={isSoundsEnabled() ? "Mute all app sounds" : "Unmute app sounds"}
+            aria-pressed={!isSoundsEnabled()}
+            data-ac-testid="actionBar.sounds"
+            data-ac-role="button"
+            data-ac-state={!settingsStore.current ? "disabled" : isSoundsEnabled() ? "audible" : "muted"}
           >
             {isSoundsEnabled() ? "🔊" : "🔇"}
           </button>
@@ -245,6 +288,10 @@ const ActionBar: Component = () => {
             class={`toolbar-gear-btn show-categories-btn ${sessionsStore.showCategories ? "active" : ""}`}
             onClick={() => sessionsStore.toggleShowCategories()}
             title={sessionsStore.showCategories ? "Hide category sections" : "Show category sections"}
+            aria-pressed={sessionsStore.showCategories}
+            data-ac-testid="actionBar.categories"
+            data-ac-role="button"
+            data-ac-state={sessionsStore.showCategories ? "visible" : "hidden"}
           >
             &#x1F441;
           </button>
@@ -252,10 +299,20 @@ const ActionBar: Component = () => {
             class={`toolbar-gear-btn show-categories-btn ${sessionsStore.alwaysShowSelectedWorkgroup ? "active" : ""}`}
             onClick={() => sessionsStore.toggleAlwaysShowSelectedWorkgroup()}
             title={sessionsStore.alwaysShowSelectedWorkgroup ? "Don't force 'Selected Workgroup' visible" : "Always show 'Selected Workgroup'"}
+            aria-pressed={sessionsStore.alwaysShowSelectedWorkgroup}
+            data-ac-testid="actionBar.pinSelectedWorkgroup"
+            data-ac-role="button"
+            data-ac-state={sessionsStore.alwaysShowSelectedWorkgroup ? "pinned" : "default"}
           >
             &#x1F4CC;
           </button>
-          <button class="toolbar-gear-btn" onClick={() => GuideAPI.open()} title="Hints">
+          <button
+            class="toolbar-gear-btn"
+            onClick={() => GuideAPI.open()}
+            title="Hints"
+            data-ac-testid="actionBar.guide"
+            data-ac-role="button"
+          >
             &#x1F4A1;
           </button>
           <button
@@ -263,6 +320,9 @@ const ActionBar: Component = () => {
             disabled={!settingsStore.current}
             onClick={handleToggleTheme}
             title="Toggle theme"
+            data-ac-testid="actionBar.theme"
+            data-ac-role="button"
+            data-ac-state={!settingsStore.current ? "disabled" : isLight() ? "light" : "dark"}
           >
             {isLight() ? "\u2600\uFE0F" : "\uD83C\uDF19"}
           </button>
@@ -270,6 +330,8 @@ const ActionBar: Component = () => {
             class="toolbar-gear-btn"
             onClick={() => { setPendingSection(undefined); setShowSettings(true); }}
             title="Settings"
+            data-ac-testid="actionBar.settings"
+            data-ac-role="button"
           >
             &#x2699;
           </button>
@@ -283,17 +345,38 @@ const ActionBar: Component = () => {
         />
       )}
       <Show when={confirmPath()}>
-        <div class="confirm-overlay">
-          <div class="confirm-dialog" onClick={(e) => e.stopPropagation()}>
+        <div
+          class="confirm-overlay"
+          data-ac-testid="project.createConfirm.overlay"
+          data-ac-role="overlay"
+        >
+          <div
+            class="confirm-dialog"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            data-ac-testid="project.createConfirm.dialog"
+            data-ac-role="dialog"
+          >
             <p class="confirm-text">
               This folder does not have an AC project. Do you want to create a new project here?
             </p>
             <p class="confirm-path">{confirmPath()}</p>
             <div class="confirm-actions">
-              <button class="confirm-btn confirm-btn-yes" onClick={handleConfirmCreate}>
+              <button
+                class="confirm-btn confirm-btn-yes"
+                onClick={handleConfirmCreate}
+                data-ac-testid="project.createConfirm.confirm"
+                data-ac-role="button"
+              >
                 Yes, create project
               </button>
-              <button class="confirm-btn confirm-btn-no" onClick={() => setConfirmPath(null)}>
+              <button
+                class="confirm-btn confirm-btn-no"
+                onClick={() => setConfirmPath(null)}
+                data-ac-testid="project.createConfirm.cancel"
+                data-ac-role="button"
+              >
                 Cancel
               </button>
             </div>

--- a/src/sidebar/components/OnboardingModal.tsx
+++ b/src/sidebar/components/OnboardingModal.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, onMount, Show } from "solid-js";
+import { Component, createSignal, For, onMount, Show } from "solid-js";
 import type { AgentConfig, AppSettings } from "../../shared/types";
 import { SettingsAPI } from "../../shared/ipc";
 import { settingsStore } from "../../shared/stores/settings";
@@ -121,15 +121,35 @@ const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
   onMount(() => overlayRef.focus());
 
   return (
-    <div class="modal-overlay" ref={overlayRef} onKeyDown={handleKeyDown} tabIndex={0}>
-      <div class="agent-modal onboarding-modal" ref={modalRef}>
+    <div
+      class="modal-overlay"
+      ref={overlayRef}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+      data-ac-testid="onboarding.overlay"
+      data-ac-role="overlay"
+    >
+      <div
+        class="agent-modal onboarding-modal"
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Set up your first Coding Agent"
+        data-ac-testid="onboarding.modal"
+        data-ac-role="dialog"
+        data-ac-state={done() ? "done" : "selecting"}
+      >
         <div class="agent-modal-header">
           <span class="agent-modal-title">Welcome</span>
         </div>
 
         <div class="wizard-body onboarding-body">
           <Show when={!done()} fallback={
-            <div class="onboarding-done">
+            <div
+              class="onboarding-done"
+              data-ac-testid="onboarding.done"
+              data-ac-role="status"
+            >
               <div class="onboarding-done-icon">&#x2713;</div>
               <div class="onboarding-done-text">
                 <strong>{addedLabel()}</strong> configured!
@@ -144,24 +164,32 @@ const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
             </p>
 
             <div class="onboarding-cards">
-              {ALL_PRESETS.map((preset) => (
-                <button
-                  class={`onboarding-card ${selectedPreset() === preset.key ? "selected" : ""}`}
-                  onClick={() => handleSelect(preset.key)}
-                  style={{ "--card-accent": preset.color }}
-                >
-                  <div
-                    class="onboarding-card-icon"
-                    style={{ background: preset.color }}
+              <For each={ALL_PRESETS}>
+                {(preset) => (
+                  <button
+                    class={`onboarding-card ${selectedPreset() === preset.key ? "selected" : ""}`}
+                    onClick={() => handleSelect(preset.key)}
+                    style={{ "--card-accent": preset.color }}
+                    aria-pressed={selectedPreset() === preset.key}
+                    aria-label={`Select ${preset.label}`}
+                    data-ac-testid={`onboarding.agentPreset.${preset.key}`}
+                    data-ac-role="agent-preset"
+                    data-ac-state={selectedPreset() === preset.key ? "selected" : "idle"}
+                    data-ac-agent-key={preset.key}
                   >
-                    {preset.label[0]}
-                  </div>
-                  <div class="onboarding-card-info">
-                    <div class="onboarding-card-name">{preset.label}</div>
-                    <div class="onboarding-card-desc">{preset.description}</div>
-                  </div>
-                </button>
-              ))}
+                    <div
+                      class="onboarding-card-icon"
+                      style={{ background: preset.color }}
+                    >
+                      {preset.label[0]}
+                    </div>
+                    <div class="onboarding-card-info">
+                      <div class="onboarding-card-name">{preset.label}</div>
+                      <div class="onboarding-card-desc">{preset.description}</div>
+                    </div>
+                  </button>
+                )}
+              </For>
             </div>
 
             <Show when={isCustom()}>
@@ -174,6 +202,8 @@ const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
                     placeholder="My Agent"
                     value={customLabel()}
                     onInput={(e) => setCustomLabel(e.currentTarget.value)}
+                    data-ac-testid="onboarding.custom.label"
+                    data-ac-role="textbox"
                   />
                 </label>
                 <label class="onboarding-field-label">
@@ -184,6 +214,8 @@ const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
                     placeholder="my-agent --flag"
                     value={customCommand()}
                     onInput={(e) => setCustomCommand(e.currentTarget.value)}
+                    data-ac-testid="onboarding.custom.command"
+                    data-ac-role="textbox"
                   />
                 </label>
               </div>
@@ -194,19 +226,32 @@ const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
         <div class="new-agent-footer">
           <Show when={done()} fallback={
             <>
-              <button class="new-agent-cancel-btn" onClick={() => void dismissAndClose()}>
+              <button
+                class="new-agent-cancel-btn"
+                onClick={() => void dismissAndClose()}
+                data-ac-testid="onboarding.skip"
+                data-ac-role="button"
+              >
                 Skip
               </button>
               <button
                 class="new-agent-create-btn"
                 disabled={!canConfirm() || saving()}
                 onClick={handleConfirm}
+                data-ac-testid="onboarding.confirm"
+                data-ac-role="button"
+                data-ac-state={saving() ? "saving" : canConfirm() ? "ready" : "disabled"}
               >
                 {saving() ? "Setting up..." : "Set up Coding Agent"}
               </button>
             </>
           }>
-            <button class="new-agent-create-btn" onClick={props.onClose}>
+            <button
+              class="new-agent-create-btn"
+              onClick={props.onClose}
+              data-ac-testid="onboarding.done.close"
+              data-ac-role="button"
+            >
               Get started
             </button>
           </Show>

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "solid-js/web";
 import SettingsModal from "./SettingsModal";
 import type { AppSettings } from "../../shared/types";
+import { SettingsAPI } from "../../shared/ipc";
 
 vi.mock("../../shared/ipc", () => ({
   SettingsAPI: {
@@ -41,7 +42,7 @@ vi.mock("../stores/sessions", () => ({
   },
 }));
 
-function settings(): AppSettings {
+function settings(overrides: Partial<AppSettings> = {}): AppSettings {
   return {
     defaultShell: "pwsh",
     defaultShellArgs: [],
@@ -100,6 +101,7 @@ function settings(): AppSettings {
     autoGenerateTaskTitle: true,
     agentTemplatesPath: null,
     specBoardEnabled: false,
+    ...overrides,
   };
 }
 
@@ -159,6 +161,77 @@ describe("SettingsModal automation hooks", () => {
     expect(document.querySelector('[data-ac-testid="settings.agentPreset.codex"]')).toBeTruthy();
     expect(document.querySelector('[data-ac-testid="settings.agent.addCustom"]')).toBeTruthy();
 
+    dispose();
+  });
+
+  it("keeps an early custom agent draft when the fresh load resolves late", async () => {
+    let resolveLoadedSettings: (value: AppSettings) => void = () => {};
+    vi.mocked(SettingsAPI.get).mockReturnValueOnce(
+      new Promise<AppSettings>((resolve) => {
+        resolveLoadedSettings = resolve;
+      }),
+    );
+
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+
+    const addCustom = document.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="settings.agent.addCustom"]',
+    );
+    addCustom?.click();
+    await settle();
+
+    expect(document.querySelector('[data-ac-testid="settings.agentRow.1"]')).toBeTruthy();
+    expect(document.querySelector('[data-ac-testid="settings.agentRow.1.label"]')).toBeTruthy();
+
+    resolveLoadedSettings(settings());
+    await settle();
+
+    expect(document.querySelector('[data-ac-testid="settings.agentRow.1"]')).toBeTruthy();
+    expect(document.querySelector('[data-ac-testid="settings.agentRow.1.label"]')).toBeTruthy();
+
+    dispose();
+  });
+
+  it("uses the seeded RTK baseline when saving before the fresh load resolves", async () => {
+    let resolveLoadedSettings: (value: AppSettings) => void = () => {};
+    vi.mocked(SettingsAPI.get).mockReturnValueOnce(
+      new Promise<AppSettings>((resolve) => {
+        resolveLoadedSettings = resolve;
+      }),
+    );
+
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {} }),
+      root,
+    );
+    await settle();
+
+    const rtkField = Array.from(
+      document.querySelectorAll<HTMLLabelElement>(".settings-checkbox-field"),
+    ).find((label) => label.textContent?.includes("Inject RTK hook"));
+    const rtkCheckbox = rtkField?.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    if (!rtkCheckbox) throw new Error("missing RTK checkbox");
+    rtkCheckbox.checked = true;
+    rtkCheckbox.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+
+    document.querySelector<HTMLButtonElement>('[data-ac-testid="settings.save"]')?.click();
+    await settle();
+
+    expect(SettingsAPI.update).toHaveBeenCalledWith(
+      expect.objectContaining({ injectRtkHook: true }),
+    );
+    expect(SettingsAPI.sweepRtkHook).toHaveBeenCalledWith(true);
+
+    resolveLoadedSettings(settings());
     dispose();
   });
 });

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "solid-js/web";
+import SettingsModal from "./SettingsModal";
+import type { AppSettings } from "../../shared/types";
+
+vi.mock("../../shared/ipc", () => ({
+  SettingsAPI: {
+    get: vi.fn(() => Promise.resolve(settings())),
+    update: vi.fn(() => Promise.resolve()),
+    getWebServerStatus: vi.fn(() => Promise.resolve(false)),
+    openWebRemote: vi.fn(() => Promise.resolve()),
+    startWebServer: vi.fn(() => Promise.resolve(false)),
+    stopWebServer: vi.fn(() => Promise.resolve(false)),
+    sweepRtkHook: vi.fn(() => Promise.resolve({ total: 0, updated: 0, errors: [] })),
+  },
+  TelegramAPI: {
+    sendTest: vi.fn(() => Promise.resolve(0)),
+  },
+  ReposAPI: {
+    search: vi.fn(() => Promise.resolve([])),
+  },
+}));
+
+vi.mock("../../shared/stores/settings", () => ({
+  settingsStore: {
+    refresh: vi.fn(),
+  },
+}));
+
+vi.mock("../../shared/sound", () => ({
+  setSoundsEnabled: vi.fn(),
+}));
+
+vi.mock("../stores/sessions", () => ({
+  sessionsStore: {
+    setRepos: vi.fn(),
+  },
+}));
+
+function settings(): AppSettings {
+  return {
+    defaultShell: "pwsh",
+    defaultShellArgs: [],
+    sidebarAlwaysOnTop: false,
+    sidebarStyle: "noir-minimal",
+    themeLight: true,
+    telegramNetworkPollErrorLogging: {
+      firstFailureLevel: "warn",
+      transientRepeatLevel: "debug",
+      sustainedLevel: "warn",
+      sustainedAfterSeconds: 60,
+      sustainedRepeatSeconds: 300,
+      recoveryLevel: "info",
+    },
+    raiseTerminalOnClick: true,
+    coordSortByActivity: false,
+    alwaysShowSelectedWorkgroup: true,
+    restoreCoordinatorWakeState: true,
+    soundsEnabled: true,
+    teamIdleBeepEnabled: true,
+    injectRtkHook: false,
+    informWhenRtkInstalled: true,
+    webServerEnabled: false,
+    webServerPort: 8765,
+    webServerBind: "127.0.0.1",
+    voiceToTextEnabled: false,
+    voiceAutoExecute: false,
+    voiceAutoExecuteDelay: 15,
+    geminiApiKey: "",
+    geminiModel: "gemini-2.5-flash",
+    sidebarZoom: 1,
+    terminalZoom: 1,
+    guideZoom: 1,
+    mainZoom: 1,
+    sidebarGeometry: null,
+    terminalGeometry: null,
+    mainGeometry: null,
+    mainSidebarWidth: 360,
+    mainSidebarSide: "right",
+    mainAlwaysOnTop: false,
+    agents: [
+      {
+        id: "codex",
+        label: "Codex",
+        command: "codex",
+        color: "#10b981",
+        gitPullBefore: false,
+        excludeGlobalClaudeMd: true,
+      },
+    ],
+    telegramBots: [],
+    onboardingDismissed: true,
+    projectPaths: [],
+    projectPath: null,
+    rtkPromptDismissed: false,
+    autoGenerateTaskTitle: true,
+    agentTemplatesPath: null,
+    specBoardEnabled: false,
+  };
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+describe("SettingsModal automation hooks", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("keeps row parent and disabled Codex preset selectors addressable", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+
+    const row = document.querySelector('[data-ac-testid="settings.agentRow.0"]');
+    const label = document.querySelector('[data-ac-testid="settings.agentRow.0.label"]');
+    const codexPreset = document.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="settings.agentPreset.codex"]',
+    );
+
+    expect(row).toBeTruthy();
+    expect(label).toBeTruthy();
+    expect(codexPreset).toBeTruthy();
+    expect(codexPreset?.disabled).toBe(true);
+    expect(codexPreset?.getAttribute("data-ac-state")).toBe("disabled");
+
+    dispose();
+  });
+});

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -24,6 +24,9 @@ vi.mock("../../shared/ipc", () => ({
 
 vi.mock("../../shared/stores/settings", () => ({
   settingsStore: {
+    get current() {
+      return settings();
+    },
     refresh: vi.fn(),
   },
 }));
@@ -131,6 +134,30 @@ describe("SettingsModal automation hooks", () => {
     expect(codexPreset).toBeTruthy();
     expect(codexPreset?.disabled).toBe(true);
     expect(codexPreset?.getAttribute("data-ac-state")).toBe("disabled");
+
+    dispose();
+  });
+
+  it("renders agents selectors after clicking the Coding Agents tab", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {} }),
+      root,
+    );
+    await settle();
+
+    const agentsTab = document.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="settings.tab.agents"]',
+    );
+    agentsTab?.click();
+    await settle();
+
+    expect(agentsTab?.getAttribute("data-ac-state")).toBe("active");
+    expect(document.querySelector('[data-ac-testid="settings.agentRow.0"]')).toBeTruthy();
+    expect(document.querySelector('[data-ac-testid="settings.agentRow.0.label"]')).toBeTruthy();
+    expect(document.querySelector('[data-ac-testid="settings.agentPreset.codex"]')).toBeTruthy();
+    expect(document.querySelector('[data-ac-testid="settings.agent.addCustom"]')).toBeTruthy();
 
     dispose();
   });

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -494,7 +494,11 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
 
       <For each={settings.data!.agents}>
         {(agent, i) => (
-          <div class="settings-button-card">
+          <div
+            class="settings-button-card"
+            data-ac-testid={`settings.agentRow.${i()}`}
+            data-ac-role="group"
+          >
             <div class="settings-button-card-header">
               <div
                 class="settings-color-dot"
@@ -505,6 +509,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                 class="settings-agent-remove"
                 onClick={() => removeAgent(i())}
                 title="Remove agent"
+                data-ac-testid={`settings.agentRow.${i()}.remove`}
+                data-ac-role="button"
               >
                 &#x2715;
               </button>
@@ -518,6 +524,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                   updateAgent(i(), "label", e.currentTarget.value)
                 }
                 placeholder="My Agent"
+                data-ac-testid={`settings.agentRow.${i()}.label`}
+                data-ac-role="textbox"
               />
             </label>
             <label class="settings-field">
@@ -529,6 +537,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                   updateAgent(i(), "command", e.currentTarget.value)
                 }
                 placeholder="agent-cli"
+                data-ac-testid={`settings.agentRow.${i()}.command`}
+                data-ac-role="textbox"
               />
             </label>
             <label class="settings-field">
@@ -541,6 +551,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                   onInput={(e) =>
                     updateAgent(i(), "color", e.currentTarget.value)
                   }
+                  data-ac-testid={`settings.agentRow.${i()}.colorPicker`}
+                  data-ac-role="input"
                 />
                 <input
                   class="settings-input settings-input-sm"
@@ -548,6 +560,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                   onInput={(e) =>
                     updateAgent(i(), "color", e.currentTarget.value)
                   }
+                  data-ac-testid={`settings.agentRow.${i()}.color`}
+                  data-ac-role="textbox"
                 />
               </div>
             </label>

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -34,7 +34,9 @@ const isValidSettingsTab = (s: string): s is SettingsTab =>
   TABS.some((t) => t.key === s);
 
 const SettingsModal: Component<{ onClose: () => void; section?: string }> = (props) => {
-  const [settings, setSettings] = createStore<{ data: AppSettings | null }>({ data: null });
+  const [settings, setSettings] = createStore<{ data: AppSettings | null }>({
+    data: settingsStore.current,
+  });
   const [saving, setSaving] = createSignal(false);
   const [testingBot, setTestingBot] = createSignal<string | null>(null);
   const [testResult, setTestResult] = createSignal<{

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -33,10 +33,18 @@ const TABS: { key: SettingsTab; label: string }[] = [
 const isValidSettingsTab = (s: string): s is SettingsTab =>
   TABS.some((t) => t.key === s);
 
+const cloneSettings = (value: AppSettings | null): AppSettings | null => {
+  if (!value) return null;
+  if (typeof structuredClone === "function") return structuredClone(value);
+  return JSON.parse(JSON.stringify(value)) as AppSettings;
+};
+
 const SettingsModal: Component<{ onClose: () => void; section?: string }> = (props) => {
+  const seededSettings = cloneSettings(settingsStore.current);
   const [settings, setSettings] = createStore<{ data: AppSettings | null }>({
-    data: settingsStore.current,
+    data: seededSettings,
   });
+  const [draftDirty, setDraftDirty] = createSignal(false);
   const [saving, setSaving] = createSignal(false);
   const [testingBot, setTestingBot] = createSignal<string | null>(null);
   const [testResult, setTestResult] = createSignal<{
@@ -62,7 +70,9 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   // against the live form value to decide whether to fire sweepRtkHook.
   // updateField is local-only (mutates the form draft), so the sweep only
   // dispatches when the user actually clicks Save and the value changed.
-  const [initialInjectRtk, setInitialInjectRtk] = createSignal<boolean | null>(null);
+  const [initialInjectRtk, setInitialInjectRtk] = createSignal<boolean | null>(
+    seededSettings?.injectRtkHook ?? null,
+  );
   // Disables the Save button and the rtk checkbox while the per-replica sweep
   // is in flight, preventing a rapid double-Save from queuing two concurrent
   // sweeps with opposite enabled values (silent partial state).
@@ -75,9 +85,11 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       SettingsAPI.get(),
       SettingsAPI.getWebServerStatus().catch(() => false),
     ]);
-    setSettings("data", loaded);
-    setInitialInjectRtk(loaded.injectRtkHook);
     setWebServerRunning(wsRunning);
+    if (!draftDirty()) {
+      setSettings("data", cloneSettings(loaded));
+      setInitialInjectRtk(loaded.injectRtkHook);
+    }
   });
 
   // ── Generic field updater ──
@@ -86,6 +98,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     value: AppSettings[K]
   ) => {
     if (!settings.data) return;
+    setDraftDirty(true);
     setSettings("data", key as any, value as any);
   };
 
@@ -96,11 +109,13 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     value: string | boolean | string[]
   ) => {
     if (!settings.data) return;
+    setDraftDirty(true);
     setSettings("data", "agents", index, field as any, value as any);
   };
 
   const addAgent = (preset?: Omit<AgentConfig, "id">) => {
     if (!settings.data) return;
+    setDraftDirty(true);
     const agent: AgentConfig = preset
       ? { id: newAgentId(), ...preset }
       : {
@@ -116,6 +131,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
 
   const removeAgent = (index: number) => {
     if (!settings.data) return;
+    setDraftDirty(true);
     setSettings("data", "agents", (prev) => prev.filter((_, i) => i !== index));
   };
 
@@ -126,11 +142,13 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     value: string | number
   ) => {
     if (!settings.data) return;
+    setDraftDirty(true);
     setSettings("data", "telegramBots", index, field as any, value as any);
   };
 
   const addBot = () => {
     if (!settings.data) return;
+    setDraftDirty(true);
     const bot: TelegramBotConfig = {
       id: newAgentId(),
       label: "",
@@ -143,6 +161,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
 
   const removeBot = (index: number) => {
     if (!settings.data) return;
+    setDraftDirty(true);
     setSettings("data", "telegramBots", (prev) => (prev || []).filter((_, i) => i !== index));
   };
 

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -582,6 +582,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           <button
             class="settings-preset-btn"
             onClick={() => addAgent(AGENT_PRESET_MAP.claude)}
+            data-ac-testid="settings.agentPreset.claude"
+            data-ac-role="button"
           >
             <span
               class="settings-color-dot"
@@ -594,6 +596,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           <button
             class="settings-preset-btn"
             onClick={() => addAgent(AGENT_PRESET_MAP.codex)}
+            data-ac-testid="settings.agentPreset.codex"
+            data-ac-role="button"
           >
             <span
               class="settings-color-dot"
@@ -606,6 +610,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           <button
             class="settings-preset-btn"
             onClick={() => addAgent(AGENT_PRESET_MAP.gemini)}
+            data-ac-testid="settings.agentPreset.gemini"
+            data-ac-role="button"
           >
             <span
               class="settings-color-dot"
@@ -614,7 +620,12 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             + Gemini CLI
           </button>
         </Show>
-        <button class="settings-add-btn" onClick={() => addAgent()}>
+        <button
+          class="settings-add-btn"
+          onClick={() => addAgent()}
+          data-ac-testid="settings.agent.addCustom"
+          data-ac-role="button"
+        >
           + Custom Agent
         </button>
       </div>
@@ -796,8 +807,19 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   );
 
   return (
-    <div class="modal-overlay">
-      <div class="modal-container modal-container-lg">
+    <div
+      class="modal-overlay"
+      data-ac-testid="settings.overlay"
+      data-ac-role="overlay"
+    >
+      <div
+        class="modal-container modal-container-lg"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Settings"
+        data-ac-testid="settings.modal"
+        data-ac-role="dialog"
+      >
         <div class="modal-header">
           <span class="modal-title">Settings</span>
         </div>
@@ -809,6 +831,11 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
               <button
                 class={`settings-tab ${activeTab() === tab.key ? "active" : ""}`}
                 onClick={() => setActiveTab(tab.key)}
+                role="tab"
+                aria-selected={activeTab() === tab.key}
+                data-ac-testid={`settings.tab.${tab.key}`}
+                data-ac-role="tab"
+                data-ac-state={activeTab() === tab.key ? "active" : "idle"}
               >
                 {tab.label}
               </button>
@@ -837,13 +864,21 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           <Show when={saveError()}>
             <span class="modal-save-error">{saveError()}</span>
           </Show>
-          <button class="modal-btn modal-btn-cancel" onClick={props.onClose}>
+          <button
+            class="modal-btn modal-btn-cancel"
+            onClick={props.onClose}
+            data-ac-testid="settings.cancel"
+            data-ac-role="button"
+          >
             Cancel
           </button>
           <button
             class="modal-btn modal-btn-save"
             onClick={handleSave}
             disabled={saving() || rtkSweepInFlight()}
+            data-ac-testid="settings.save"
+            data-ac-role="button"
+            data-ac-state={saving() ? "saving" : rtkSweepInFlight() ? "sweeping" : "ready"}
           >
             {saving() ? "Saving..." : rtkSweepInFlight() ? "Sweeping..." : "Save"}
           </button>

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -494,12 +494,12 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
 
       <For each={settings.data!.agents}>
         {(agent, i) => (
-          <div
-            class="settings-button-card"
-            data-ac-testid={`settings.agentRow.${i()}`}
-            data-ac-role="group"
-          >
-            <div class="settings-button-card-header">
+          <div class="settings-button-card">
+            <div
+              class="settings-button-card-header"
+              data-ac-testid={`settings.agentRow.${i()}`}
+              data-ac-role="group"
+            >
               <div
                 class="settings-color-dot"
                 style={{ background: agent.color }}
@@ -592,48 +592,48 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       </For>
 
       <div class="settings-agent-actions">
-        <Show when={!hasAgentByCommand("claude")}>
-          <button
-            class="settings-preset-btn"
-            onClick={() => addAgent(AGENT_PRESET_MAP.claude)}
-            data-ac-testid="settings.agentPreset.claude"
-            data-ac-role="button"
-          >
-            <span
-              class="settings-color-dot"
-              style={{ background: AGENT_PRESET_MAP.claude.color }}
-            />
-            + Claude Code
-          </button>
-        </Show>
-        <Show when={!hasAgentByCommand("codex")}>
-          <button
-            class="settings-preset-btn"
-            onClick={() => addAgent(AGENT_PRESET_MAP.codex)}
-            data-ac-testid="settings.agentPreset.codex"
-            data-ac-role="button"
-          >
-            <span
-              class="settings-color-dot"
-              style={{ background: AGENT_PRESET_MAP.codex.color }}
-            />
-            + Codex
-          </button>
-        </Show>
-        <Show when={!hasAgentByCommand("gemini")}>
-          <button
-            class="settings-preset-btn"
-            onClick={() => addAgent(AGENT_PRESET_MAP.gemini)}
-            data-ac-testid="settings.agentPreset.gemini"
-            data-ac-role="button"
-          >
-            <span
-              class="settings-color-dot"
-              style={{ background: AGENT_PRESET_MAP.gemini.color }}
-            />
-            + Gemini CLI
-          </button>
-        </Show>
+        <button
+          class="settings-preset-btn"
+          onClick={() => addAgent(AGENT_PRESET_MAP.claude)}
+          disabled={hasAgentByCommand("claude")}
+          data-ac-testid="settings.agentPreset.claude"
+          data-ac-role="button"
+          data-ac-state={hasAgentByCommand("claude") ? "disabled" : "available"}
+        >
+          <span
+            class="settings-color-dot"
+            style={{ background: AGENT_PRESET_MAP.claude.color }}
+          />
+          + Claude Code
+        </button>
+        <button
+          class="settings-preset-btn"
+          onClick={() => addAgent(AGENT_PRESET_MAP.codex)}
+          disabled={hasAgentByCommand("codex")}
+          data-ac-testid="settings.agentPreset.codex"
+          data-ac-role="button"
+          data-ac-state={hasAgentByCommand("codex") ? "disabled" : "available"}
+        >
+          <span
+            class="settings-color-dot"
+            style={{ background: AGENT_PRESET_MAP.codex.color }}
+          />
+          + Codex
+        </button>
+        <button
+          class="settings-preset-btn"
+          onClick={() => addAgent(AGENT_PRESET_MAP.gemini)}
+          disabled={hasAgentByCommand("gemini")}
+          data-ac-testid="settings.agentPreset.gemini"
+          data-ac-role="button"
+          data-ac-state={hasAgentByCommand("gemini") ? "disabled" : "available"}
+        >
+          <span
+            class="settings-color-dot"
+            style={{ background: AGENT_PRESET_MAP.gemini.color }}
+          />
+          + Gemini CLI
+        </button>
         <button
           class="settings-add-btn"
           onClick={() => addAgent()}

--- a/src/terminal/App.tsx
+++ b/src/terminal/App.tsx
@@ -254,7 +254,12 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
   });
 
   return (
-    <div class="terminal-layout">
+    <div
+      class="terminal-layout"
+      data-ac-testid="terminal.root"
+      data-ac-role="surface"
+      data-ac-state={terminalStore.activeSessionId ? "active" : "empty"}
+    >
       <Show when={!props.embedded}>
         <Titlebar detached={props.detached} lockedSessionId={props.lockedSessionId} />
       </Show>
@@ -264,7 +269,11 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
         <Show
           when={terminalStore.activeSessionId}
           fallback={
-            <div class="terminal-empty">
+            <div
+              class="terminal-empty"
+              data-ac-testid="terminal.empty"
+              data-ac-role="status"
+            >
               <span>
                 {props.detached
                   ? "Session closed"
@@ -274,6 +283,8 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
                 <button
                   class="terminal-empty-btn"
                   onClick={() => { homeStore.hide(); SessionAPI.create(); }}
+                  data-ac-testid="terminal.empty.newSession"
+                  data-ac-role="button"
                 >
                   + New Session
                 </button>

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -96,6 +96,9 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     const container = document.createElement("div");
     container.className = "terminal-instance";
     container.dataset.sessionId = sessionId;
+    container.setAttribute("data-ac-testid", `terminal.session.${sessionId}`);
+    container.setAttribute("data-ac-role", "surface");
+    container.setAttribute("data-ac-session-id", sessionId);
     container.hidden = true;
     hostRef.appendChild(container);
 
@@ -312,7 +315,14 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     }
   });
 
-  return <div class="terminal-host" ref={hostRef!} />;
+  return (
+    <div
+      class="terminal-host"
+      ref={hostRef!}
+      data-ac-testid="terminal.host"
+      data-ac-role="surface"
+    />
+  );
 };
 
 export default TerminalView;


### PR DESCRIPTION
## Summary

Closes #497.

Adds a gated semantic GUI automation path for testable builds so acceptance can query and operate Tauri WebView controls without coordinate clicks. The implementation includes:

- testable-binary gated `ui-query`, `ui-click`, `ui-set`, and `ui-wait` commands with machine-parseable JSON output;
- a file-backed UI automation bridge with readiness, expiry, stale cleanup, and request validation;
- stable `data-ac-testid` hooks for onboarding, settings, action bar, terminal, and related GUI surfaces;
- bounded diagnostics for missing selectors, timeouts, wrong windows, disabled automation, and available-target snapshots;
- an affordance matrix documenting the initial in-scope screen/mouse automation surface.

## Validation

- `cargo test --test cli_ui_automation`
- `cargo test ui_automation`
- `cargo test --test cli_window_placement`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `npx tsc --noEmit`
- `npm test`
- `npx tauri build`
- Grinch implementation reviews passed through the final settings draft race fix.
- WG-9 shipper deployed `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-9.exe` from `b82d149ff080b4bb38a5d64c4b0ac2912317269d`.
- WG-8 acceptance rerun4 PASS, evidence: `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-8-acceptance-testing\__agent_ac-cli-and-gui-tester\artifacts\acceptance-497-rerun4-semantic-gui-automation-evidence`.

## Acceptance Highlights

- First-run Codex modal semantic path passed without coordinate fallback.
- Already-open GUI bridge and workgroup clone passed.
- Missing selector, timeout, wrong-window, disabled automation diagnostics returned structured stdout JSON with stderr empty.
- Settings selectors and dynamic custom row affordances passed.
- No in-scope missing automation affordances found in final acceptance rerun.