### PR TITLE
Fix coordinator repo badges for discovered workgroups

### DIFF
--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -18,6 +18,12 @@ import AgentPickerModal from "./AgentPickerModal";
 import EditTeamModal from "./EditTeamModal";
 import { TelegramIcon } from "./TelegramIcon";
 import { normalizeBlockerReport } from "./workgroup-delete-diagnostics";
+import {
+  automationIdPart,
+  configuredReplicaRepoBadges,
+  formatReplicaRepoBadgeLabel,
+  repoLabelFromPath,
+} from "./replica-repo-badges";
 
 interface PendingLaunch {
   path: string;
@@ -28,25 +34,11 @@ interface PendingLaunch {
 /** Build the gitRepos list for a replica. Order = replica.repoPaths order (invariant §3.1.2). */
 function buildGitRepos(replica: AcAgentReplica): SessionRepoInput[] {
   return (replica.repoPaths ?? []).map((p) => {
-    const dir = p.replace(/\\/g, "/").split("/").pop() ?? "";
-    const label = dir.startsWith("repo-") ? dir.slice(5) : dir;
-    return { label, sourcePath: p };
+    return { label: repoLabelFromPath(p), sourcePath: p };
   });
 }
 
 const CONTEXT_MENU_VIEWPORT_MARGIN = 8;
-
-/** Strip 'repo-' prefix from a directory name */
-function stripRepoPrefix(name: string): string {
-  return name.startsWith("repo-") ? name.slice(5) : name;
-}
-
-/** Derive the repo name from a replica's repoPaths (strip 'repo-' prefix) */
-function replicaRepoName(replica: AcAgentReplica): string | undefined {
-  if (!replica.repoPaths?.length) return undefined;
-  const dirName = replica.repoPaths[0].replace(/\\/g, "/").split("/").pop() ?? "";
-  return stripRepoPrefix(dirName);
-}
 
 /** Build the session name used to link a replica to its session */
 function replicaSessionName(wg: AcWorkgroup, replica: AcAgentReplica): string {
@@ -554,12 +546,24 @@ const ProjectPanel: Component = () => {
           wg: AcWorkgroup,
           extraBadge?: string,
           runningPeers?: () => AcAgentReplica[],
-          taskTitle?: string | null
+          taskTitle?: string | null,
+          rowContext = "workgroups"
         ) => {
           const dotClass = () => replicaDotClass(wg, replica);
           const isCoord = () => replica.isCoordinator;
-          const rn = () => replicaRepoName(replica) || stripRepoPrefix(wg.repoPath?.replace(/\\/g, "/").split("/").pop() ?? "") || proj.folderName;
           const session = () => replicaSession(wg, replica);
+          const repoBadges = createMemo(() => {
+            const s = session();
+            return s && s.gitRepos.length > 0
+              ? s.gitRepos
+              : configuredReplicaRepoBadges(replica, wg);
+          });
+          const rowTestId = () =>
+            `replica.row.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}`;
+          const badgesTestId = () =>
+            `replica.badges.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}`;
+          const repoBadgeTestId = (label: string, index: number) =>
+            `replica.repoBadge.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}.${index}.${automationIdPart(label)}`;
           const liveAgentLabel = () => {
             const s = session();
             if (!s) return null;
@@ -640,6 +644,7 @@ const ProjectPanel: Component = () => {
             <div
               class="replica-item"
               classList={{ active: session()?.id === sessionsStore.activeId }}
+              data-ac-testid={rowTestId()}
               onClick={() => handleReplicaClick(replica, wg)}
               onContextMenu={(e) => {
                 const s = session();
@@ -653,7 +658,7 @@ const ProjectPanel: Component = () => {
                   <span class="coord-task-title" title={taskTitle ?? undefined}>{taskTitle}</span>
                 </Show>
                 <span class="replica-item-name">{replica.originProject ? `${replica.name}@${replica.originProject}` : replica.name}</span>
-                <div class="ac-discovery-badges">
+                <div class="ac-discovery-badges" data-ac-testid={badgesTestId()}>
                   <Show when={runningPeers && runningPeers()!.length > 0}>
                     <For each={runningPeers!()}>
                       {(peer) => (
@@ -666,27 +671,18 @@ const ProjectPanel: Component = () => {
                       )}
                     </For>
                   </Show>
-                  <Show when={isCoord()}>
-                    <Show
-                      when={(() => { const s = session(); return s && s.gitRepos.length > 0 ? s : undefined; })()}
-                      fallback={
-                        <Show when={replica.repoPaths.length === 1 && replica.repoBranch}>
-                          <span class="ac-discovery-badge branch">
-                            {rn()}/{replica.repoBranch}
-                          </span>
-                        </Show>
-                      }
-                    >
-                      {(s) => (
-                        <For each={s().gitRepos}>
-                          {(repo) => (
-                            <span class="ac-discovery-badge branch">
-                              {repo.label}{repo.branch ? `/${repo.branch}` : ""}
-                            </span>
-                          )}
-                        </For>
+                  <Show when={isCoord() && repoBadges().length > 0}>
+                    <For each={repoBadges()}>
+                      {(repo, index) => (
+                        <span
+                          class="ac-discovery-badge branch"
+                          title={repo.sourcePath}
+                          data-ac-testid={repoBadgeTestId(repo.label, index())}
+                        >
+                          {formatReplicaRepoBadgeLabel(repo)}
+                        </span>
                       )}
-                    </Show>
+                    </For>
                   </Show>
                   <Show when={liveAgentLabel()}>
                     <span class="ac-discovery-badge agent">{liveAgentLabel()}</span>
@@ -743,7 +739,7 @@ const ProjectPanel: Component = () => {
           );
         };
 
-        const renderWorkgroupSubgroup = (wg: AcWorkgroup) => {
+        const renderWorkgroupSubgroup = (wg: AcWorkgroup, rowContext: string) => {
           const [wgCollapsed, setWgCollapsed] = createSignal(false);
           return (
             <div class="ac-wg-subgroup">
@@ -765,7 +761,7 @@ const ProjectPanel: Component = () => {
               </div>
               <Show when={!wgCollapsed()}>
                 <For each={wg.agents}>
-                  {(replica) => renderReplicaItem(replica, wg)}
+                  {(replica) => renderReplicaItem(replica, wg, undefined, undefined, undefined, rowContext)}
                 </For>
               </Show>
             </div>
@@ -872,7 +868,7 @@ const ProjectPanel: Component = () => {
                                 return dot === "running" || dot === "active";
                               })
                             );
-                            return renderReplicaItem(item.replica, item.wg, item.wg.name, runningPeers, item.wg.taskTitle);
+                            return renderReplicaItem(item.replica, item.wg, item.wg.name, runningPeers, item.wg.taskTitle, "quick");
                           }}
                         </For>
                       </div>
@@ -901,7 +897,7 @@ const ProjectPanel: Component = () => {
                         <Show when={!selectedCollapsed()}>
                           <Show when={selectedWorkgroup()} fallback={<div class="ac-empty-hint">No selected workgroup</div>}>
                             <For each={[selectedWorkgroup()!]}>
-                              {(wg) => renderWorkgroupSubgroup(wg)}
+                              {(wg) => renderWorkgroupSubgroup(wg, "selected")}
                             </For>
                           </Show>
                         </Show>
@@ -961,7 +957,7 @@ const ProjectPanel: Component = () => {
                           fallback={<div class="ac-empty-hint">No workgroups</div>}
                         >
                           <For each={proj.workgroups}>
-                            {(wg) => renderWorkgroupSubgroup(wg)}
+                            {(wg) => renderWorkgroupSubgroup(wg, "workgroups")}
                           </For>
                         </Show>
                       </Show>

--- a/src/sidebar/components/replica-repo-badges.test.ts
+++ b/src/sidebar/components/replica-repo-badges.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  automationIdPart,
+  configuredReplicaRepoBadges,
+  formatReplicaRepoBadgeLabel,
+  repoLabelFromPath,
+} from "./replica-repo-badges";
+
+describe("replica repo badges", () => {
+  it("renders every configured repo path for dormant coordinator rows", () => {
+    const badges = configuredReplicaRepoBadges(
+      {
+        repoPaths: [
+          "../repo-Hello-World",
+          "../repo-Spoon-Knife",
+          "../repo-octocat.github.io",
+        ],
+        repoBranch: "main",
+      },
+      { repoPath: "../repo-Hello-World" }
+    );
+
+    expect(badges.map(formatReplicaRepoBadgeLabel)).toEqual([
+      "Hello-World",
+      "Spoon-Knife",
+      "octocat.github.io",
+    ]);
+    expect(badges.map((badge) => badge.branch)).toEqual([null, null, null]);
+  });
+
+  it("keeps branch context for a single configured repo path", () => {
+    const badges = configuredReplicaRepoBadges(
+      {
+        repoPaths: ["C:\\work\\repo-Hello-World"],
+        repoBranch: "feature/repo-badges",
+      },
+      { repoPath: undefined }
+    );
+
+    expect(badges.map(formatReplicaRepoBadgeLabel)).toEqual([
+      "Hello-World/feature/repo-badges",
+    ]);
+  });
+
+  it("falls back to the workgroup repo path for legacy single-repo discovery data", () => {
+    const badges = configuredReplicaRepoBadges(
+      { repoPaths: [], repoBranch: "main" },
+      { repoPath: "C:/work/repo-Spoon-Knife" }
+    );
+
+    expect(badges.map(formatReplicaRepoBadgeLabel)).toEqual(["Spoon-Knife/main"]);
+  });
+
+  it("normalizes labels and automation id parts", () => {
+    expect(repoLabelFromPath("C:/work/repo-octocat.github.io/")).toBe("octocat.github.io");
+    expect(automationIdPart("wg 1/badge main")).toBe("wg-1-badge-main");
+  });
+});

--- a/src/sidebar/components/replica-repo-badges.ts
+++ b/src/sidebar/components/replica-repo-badges.ts
@@ -1,0 +1,40 @@
+import type { AcAgentReplica, AcWorkgroup, SessionRepo } from "../../shared/types";
+
+export function stripRepoPrefix(name: string): string {
+  return name.startsWith("repo-") ? name.slice(5) : name;
+}
+
+export function repoLabelFromPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  const dirName = normalized.split("/").pop() ?? "";
+  return stripRepoPrefix(dirName);
+}
+
+export function formatReplicaRepoBadgeLabel(repo: Pick<SessionRepo, "label" | "branch">): string {
+  return `${repo.label}${repo.branch ? `/${repo.branch}` : ""}`;
+}
+
+export function configuredReplicaRepoBadges(
+  replica: Pick<AcAgentReplica, "repoPaths" | "repoBranch">,
+  workgroup: Pick<AcWorkgroup, "repoPath">
+): SessionRepo[] {
+  const repoPaths = replica.repoPaths ?? [];
+  const sourcePaths = repoPaths.length > 0
+    ? repoPaths
+    : workgroup.repoPath
+      ? [workgroup.repoPath]
+      : [];
+  const branch = sourcePaths.length === 1 ? replica.repoBranch ?? null : null;
+
+  return sourcePaths
+    .map((sourcePath) => ({
+      label: repoLabelFromPath(sourcePath),
+      sourcePath,
+      branch,
+    }))
+    .filter((repo) => repo.label.length > 0);
+}
+
+export function automationIdPart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "unknown";
+}


### PR DESCRIPTION
Closes #495

## Summary
- Render repo badges for discovered/dormant coordinator rows when no live session git repo data is available.
- Add stable semantic selectors for replica rows, badge containers, and repo badge entries so GUI acceptance can verify multi-repo coordinator state.
- Cover the badge helper behavior with targeted tests.

## Validation
- `npm test -- replica-repo-badges`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- Shipper build/deploy: `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-9.exe`, SHA256 `BF37C21910CE8642A51E9AAD7863E4B86927B5E3520AB8551B76B2A741A24ADE`
- WG-8 acceptance PASS: `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-8-acceptance-testing\messaging\20260613-164337-wg8-acceptance-coordinator-to-wg9-tech-lead-pass-rerun-495-badges.md`
- Evidence: `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-8-acceptance-testing\__agent_ac-cli-and-gui-tester\artifacts\retry-495-coordinator-repo-badges-evidence`