### PR TITLE
Harden outbound network resource handling

### DIFF
--- a/src-tauri/src/cli/agency_templates.rs
+++ b/src-tauri/src/cli/agency_templates.rs
@@ -1,8 +1,8 @@
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{self, Command};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::process::{self, Command, Output, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use clap::{Args, Subcommand};
 use serde::Serialize;
@@ -17,6 +17,9 @@ use crate::commands::role_templates::{
 
 pub const DEFAULT_REPO: &str = "https://github.com/msitarzewski/agency-agents";
 pub const DEFAULT_REFERENCE: &str = "main";
+const GIT_LS_REMOTE_TIMEOUT: Duration = Duration::from_secs(30);
+const GIT_FETCH_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+const GIT_CHECKOUT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Args)]
 #[command(after_help = "\
@@ -491,6 +494,108 @@ fn parse_github_repo(input: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn run_git_with_timeout(
+    current_dir: Option<&Path>,
+    args: &[&str],
+    timeout: Duration,
+) -> Result<Output, String> {
+    run_process_with_timeout("git", current_dir, args, timeout)
+        .map_err(|e| format!("Failed to run git {:?}: {}", args, e))
+}
+
+fn run_process_with_timeout(
+    program: &str,
+    current_dir: Option<&Path>,
+    args: &[&str],
+    timeout: Duration,
+) -> Result<Output, String> {
+    let mut cmd = Command::new(program);
+    crate::pty::credentials::scrub_credentials_from_std_command(&mut cmd);
+    if let Some(dir) = current_dir {
+        cmd.current_dir(dir);
+    }
+    cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("spawn failed for {} {:?}: {}", program, args, e))?;
+
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture stdout".to_string())?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "failed to capture stderr".to_string())?;
+
+    let stdout_reader = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let result = stdout.read_to_end(&mut bytes);
+        (result, bytes)
+    });
+    let stderr_reader = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let result = stderr.read_to_end(&mut bytes);
+        (result, bytes)
+    });
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| format!("wait failed for {} {:?}: {}", program, args, e))?
+        {
+            break status;
+        }
+
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            let stdout = join_reader(stdout_reader, "stdout")?;
+            let stderr = join_reader(stderr_reader, "stderr")?;
+            let stderr_text = String::from_utf8_lossy(&stderr);
+            return Err(format!(
+                "{} {:?} timed out after {} seconds; killed and reaped. stderr: {} stdout_bytes={}",
+                program,
+                args,
+                timeout.as_secs(),
+                stderr_text.trim(),
+                stdout.len()
+            ));
+        }
+
+        std::thread::sleep(Duration::from_millis(50));
+    };
+
+    let stdout = join_reader(stdout_reader, "stdout")?;
+    let stderr = join_reader(stderr_reader, "stderr")?;
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+fn join_reader(
+    reader: std::thread::JoinHandle<(std::io::Result<usize>, Vec<u8>)>,
+    stream_name: &str,
+) -> Result<Vec<u8>, String> {
+    let (result, bytes) = reader
+        .join()
+        .map_err(|_| format!("{stream_name} reader thread panicked"))?;
+    result.map_err(|e| format!("{stream_name} read failed: {e}"))?;
+    Ok(bytes)
+}
+
 fn resolve_commit_with_git(repo: &str, reference: &str) -> Result<String, String> {
     #[cfg(test)]
     if let Ok(commit) = std::env::var("AGENTSCOMMANDER_AGENCY_TEST_COMMIT") {
@@ -498,9 +603,7 @@ fn resolve_commit_with_git(repo: &str, reference: &str) -> Result<String, String
         return Ok(commit);
     }
 
-    let output = Command::new("git")
-        .args(["ls-remote", repo, reference])
-        .output()
+    let output = run_git_with_timeout(None, &["ls-remote", repo, reference], GIT_LS_REMOTE_TIMEOUT)
         .map_err(|e| {
             format!(
                 "Failed to run git. Install git or use an environment where git is on PATH: {}",
@@ -538,12 +641,8 @@ fn fetch_repo_with_git(repo: &str, commit: &str, config_dir: &Path) -> Result<Pa
             e
         )
     })?;
-    let run = |args: &[&str]| -> Result<(), String> {
-        let output = Command::new("git")
-            .current_dir(&temp)
-            .args(args)
-            .output()
-            .map_err(|e| format!("Failed to run git {:?}: {}", args, e))?;
+    let run = |args: &[&str], timeout: Duration| -> Result<(), String> {
+        let output = run_git_with_timeout(Some(&temp), args, timeout)?;
         if output.status.success() {
             Ok(())
         } else {
@@ -554,10 +653,16 @@ fn fetch_repo_with_git(repo: &str, commit: &str, config_dir: &Path) -> Result<Pa
             ))
         }
     };
-    run(&["init", "--quiet"])?;
-    run(&["remote", "add", "origin", repo])?;
-    run(&["fetch", "--depth", "1", "origin", commit])?;
-    run(&["checkout", "--quiet", "--detach", commit])?;
+    run(&["init", "--quiet"], GIT_CHECKOUT_TIMEOUT)?;
+    run(&["remote", "add", "origin", repo], GIT_CHECKOUT_TIMEOUT)?;
+    run(
+        &["fetch", "--depth", "1", "origin", commit],
+        GIT_FETCH_TIMEOUT,
+    )?;
+    run(
+        &["checkout", "--quiet", "--detach", commit],
+        GIT_CHECKOUT_TIMEOUT,
+    )?;
     Ok(temp)
 }
 
@@ -921,6 +1026,23 @@ mod tests {
             serde_json::to_string_pretty(&manifest(1)).expect("manifest json"),
         )
         .expect("write manifest");
+    }
+
+    #[test]
+    fn bounded_process_timeout_kills_and_reaps_child() {
+        #[cfg(windows)]
+        let (program, args) = (
+            "powershell.exe",
+            vec!["-NoProfile", "-Command", "Start-Sleep -Seconds 5"],
+        );
+        #[cfg(not(windows))]
+        let (program, args) = ("sh", vec!["-c", "sleep 5"]);
+
+        let err =
+            run_process_with_timeout(program, None, &args, Duration::from_millis(100)).unwrap_err();
+
+        assert!(err.contains("timed out"), "unexpected error: {err}");
+        assert!(err.contains("killed and reaped"), "unexpected error: {err}");
     }
 
     #[test]

--- a/src-tauri/src/cli/telegram_send_image.rs
+++ b/src-tauri/src/cli/telegram_send_image.rs
@@ -144,7 +144,16 @@ pub fn execute(args: TelegramSendImageArgs) -> i32 {
         }
     };
 
+    let network = match crate::network::OutboundNetwork::new() {
+        Ok(network) => network,
+        Err(e) => {
+            eprintln!("Error: failed to build network client: {}", e);
+            return 1;
+        }
+    };
+
     let result = rt.block_on(crate::commands::telegram::perform_send_image(
+        &network,
         &bot,
         &args.path,
         args.caption.as_deref(),

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
+use std::time::Duration;
 use tauri::State;
 
 use crate::config::claude_settings::{ensure_rtk_pretool_hook, enumerate_managed_agent_dirs};
 use crate::config::settings::{load_settings, save_settings, AppSettings, SettingsState};
+use crate::network::OutboundNetwork;
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
 use crate::web::auth::WebAccessToken;
@@ -14,6 +16,7 @@ const HOME_MARKDOWN_URL: &str =
 
 const HOME_MARKDOWN_MAX_BYTES: usize = 256 * 1024; // 256 KB
 const HOME_MARKDOWN_TIMEOUT_SECS: u64 = 5;
+const WEB_STATUS_CONNECT_TIMEOUT_MS: u64 = 500;
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -127,7 +130,7 @@ pub async fn start_web_server(
 
     // Check if already listening
     let addr = format!("{}:{}", bind, port);
-    if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+    if is_tcp_listening(&addr).await {
         return Ok(false); // already running
     }
 
@@ -165,11 +168,18 @@ pub async fn get_web_server_status(settings: State<'_, SettingsState>) -> Result
     let s = settings.read().await;
     let addr = format!("{}:{}", s.web_server_bind, s.web_server_port);
     drop(s);
-    // Probe the port to check if the server is actually listening
-    match tokio::net::TcpStream::connect(&addr).await {
-        Ok(_) => Ok(true),
-        Err(_) => Ok(false),
-    }
+    Ok(is_tcp_listening(&addr).await)
+}
+
+async fn is_tcp_listening(addr: &str) -> bool {
+    matches!(
+        tokio::time::timeout(
+            Duration::from_millis(WEB_STATUS_CONNECT_TIMEOUT_MS),
+            tokio::net::TcpStream::connect(addr),
+        )
+        .await,
+        Ok(Ok(_))
+    )
 }
 
 /// Returns the runtime instance label for the titlebar badge.
@@ -356,18 +366,22 @@ pub async fn get_rtk_startup_status(
 /// Errors are returned as user-facing strings; the frontend renders them in
 /// the Home view's error state.
 #[tauri::command]
-pub async fn fetch_home_markdown() -> Result<String, String> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(HOME_MARKDOWN_TIMEOUT_SECS))
-        .user_agent(concat!("agentscommander/", env!("CARGO_PKG_VERSION")))
-        .build()
-        .map_err(|e| format!("Failed to build HTTP client: {}", e))?;
-
-    let resp = client
-        .get(HOME_MARKDOWN_URL)
-        .send()
-        .await
-        .map_err(|e| format!("Network error: {}", e))?;
+pub async fn fetch_home_markdown(network: State<'_, OutboundNetwork>) -> Result<String, String> {
+    let _permit = network.acquire("docs.fetch_home_markdown").await?;
+    let resp = tokio::time::timeout(
+        Duration::from_secs(HOME_MARKDOWN_TIMEOUT_SECS),
+        network
+            .general()
+            .get(HOME_MARKDOWN_URL)
+            .header(
+                reqwest::header::USER_AGENT,
+                concat!("agentscommander/", env!("CARGO_PKG_VERSION")),
+            )
+            .send(),
+    )
+    .await
+    .map_err(|_| "Network error: request timed out".to_string())?
+    .map_err(|e| format!("Network error: {}", e))?;
 
     if !resp.status().is_success() {
         return Err(format!("Server returned status {}", resp.status().as_u16()));

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -2214,11 +2214,14 @@ pub(crate) fn determine_next_wg_number(workspace_dir: &Path) -> u32 {
 async fn git_clone_async(url: &str, target: &Path) -> Result<(), String> {
     #[cfg(windows)]
     const CREATE_NO_WINDOW: u32 = 0x08000000;
+    const GIT_CLONE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+    const GIT_RESET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
     let mut cmd = tokio::process::Command::new("git");
     crate::pty::credentials::scrub_credentials_from_tokio_command(&mut cmd);
     cmd.args(["-c", "core.longpaths=true", "clone", "--depth", "1", url])
         .arg(target.as_os_str());
+    cmd.kill_on_drop(true);
 
     #[cfg(windows)]
     {
@@ -2227,9 +2230,14 @@ async fn git_clone_async(url: &str, target: &Path) -> Result<(), String> {
         cmd.creation_flags(CREATE_NO_WINDOW);
     }
 
-    let output = cmd
-        .output()
+    let output = tokio::time::timeout(GIT_CLONE_TIMEOUT, cmd.output())
         .await
+        .map_err(|_| {
+            format!(
+                "git clone timed out after {} seconds",
+                GIT_CLONE_TIMEOUT.as_secs()
+            )
+        })?
         .map_err(|e| format!("Failed to spawn git clone: {}", e))?;
 
     if !output.status.success() {
@@ -2252,13 +2260,37 @@ async fn git_clone_async(url: &str, target: &Path) -> Result<(), String> {
         let mut reset_cmd = tokio::process::Command::new("git");
         crate::pty::credentials::scrub_credentials_from_tokio_command(&mut reset_cmd);
         reset_cmd.args(["reset"]).current_dir(target);
+        reset_cmd.kill_on_drop(true);
         #[cfg(windows)]
         {
             #[allow(unused_imports)]
             use std::os::windows::process::CommandExt;
             reset_cmd.creation_flags(CREATE_NO_WINDOW);
         }
-        let _ = reset_cmd.output().await;
+        match tokio::time::timeout(GIT_RESET_TIMEOUT, reset_cmd.output()).await {
+            Ok(Ok(output)) if output.status.success() => {}
+            Ok(Ok(output)) => {
+                log::warn!(
+                    "[entity_creation] fallback git reset failed for {}: {}",
+                    url,
+                    String::from_utf8_lossy(&output.stderr).trim()
+                );
+            }
+            Ok(Err(e)) => {
+                log::warn!(
+                    "[entity_creation] failed to spawn fallback git reset for {}: {}",
+                    url,
+                    e
+                );
+            }
+            Err(_) => {
+                log::warn!(
+                    "[entity_creation] fallback git reset timed out after {} seconds for {}",
+                    GIT_RESET_TIMEOUT.as_secs(),
+                    url
+                );
+            }
+        }
     }
 
     Ok(())

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1320,17 +1320,21 @@ async fn destroy_session_inner_with_options<R: tauri::Runtime>(
     }
 
     // Auto-detach Telegram bridge if active
+    let mut bridge_shutdown = None;
     {
         let tg_mgr = app.state::<TelegramBridgeState>();
         let mut tg = tg_mgr.lock().await;
         if tg.has_bridge(uuid) {
-            let _ = tg.detach(uuid);
+            bridge_shutdown = tg.detach(uuid).ok();
             mgr.set_telegram_bot_id(uuid, None).await;
             let _ = app.emit(
                 "telegram_bridge_detached",
                 serde_json::json!({ "sessionId": id }),
             );
         }
+    }
+    if let Some(shutdown) = bridge_shutdown.take() {
+        shutdown.spawn_wait_or_abort();
     }
 
     // Kill the PTY first

--- a/src-tauri/src/commands/telegram.rs
+++ b/src-tauri/src/commands/telegram.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 
 use crate::config::sessions_persistence::persist_current_state_result;
 use crate::config::settings::SettingsState;
+use crate::network::OutboundNetwork;
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
 use crate::session::profile::CodingAgentKind;
@@ -86,6 +87,7 @@ pub(crate) async fn attach_telegram_bot_by_id<R: tauri::Runtime>(
     let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
     let tg_mgr = app.state::<TelegramBridgeState>();
     let settings = app.state::<SettingsState>();
+    let network = app.state::<OutboundNetwork>().inner().clone();
 
     let (agent_kind, shell, shell_args, working_directory) = {
         let mgr = session_mgr.read().await;
@@ -137,6 +139,7 @@ pub(crate) async fn attach_telegram_bot_by_id<R: tauri::Runtime>(
                 session_id,
                 &bot,
                 pty_mgr.inner().clone(),
+                network.clone(),
                 app.clone(),
                 reader,
             )
@@ -146,7 +149,7 @@ pub(crate) async fn attach_telegram_bot_by_id<R: tauri::Runtime>(
             .await;
         if let Err(e) = persist_current_state_result(&mgr).await {
             mgr.set_telegram_bot_id(session_id, None).await;
-            let _ = tg.detach(session_id);
+            let shutdown = tg.detach(session_id).ok();
             let err_msg = format!(
                 "Telegram bridge attached but sessions.json could not be persisted; rolled back live bridge for session {}: {}",
                 session_id, e
@@ -159,6 +162,11 @@ pub(crate) async fn attach_telegram_bot_by_id<R: tauri::Runtime>(
                     "error": err_msg,
                 }),
             );
+            drop(tg);
+            drop(mgr);
+            if let Some(shutdown) = shutdown {
+                shutdown.spawn_wait_or_abort();
+            }
             return Err(err_msg);
         }
         info
@@ -188,13 +196,15 @@ pub async fn telegram_detach(
     session_id: String,
 ) -> Result<(), String> {
     let uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+    let mut shutdown = Some({
+        let mut tg = tg_mgr.lock().await;
+        tg.detach(uuid).map_err(|e| e.to_string())?
+    });
 
     {
         let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
         let mgr = session_mgr.read().await;
-        let mut tg = tg_mgr.lock().await;
 
-        tg.detach(uuid).map_err(|e| e.to_string())?;
         mgr.set_telegram_bot_id(uuid, None).await;
         if let Err(e) = persist_current_state_result(&mgr).await {
             let err_msg = format!(
@@ -209,8 +219,14 @@ pub async fn telegram_detach(
                     "error": err_msg,
                 }),
             );
+            if let Some(shutdown) = shutdown.take() {
+                shutdown.spawn_wait_or_abort();
+            }
             return Err(err_msg);
         }
+    }
+    if let Some(shutdown) = shutdown.take() {
+        shutdown.spawn_wait_or_abort();
     }
 
     let _ = app.emit(
@@ -266,14 +282,12 @@ mod attach_detach_persistence_tests {
 /// sends a confirmation message back, and returns the discovered chat_id.
 /// The user just needs to send any message to the bot before clicking Test.
 #[tauri::command]
-pub async fn telegram_send_test(token: String) -> Result<i64, String> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| e.to_string())?;
-
+pub async fn telegram_send_test(
+    network: State<'_, OutboundNetwork>,
+    token: String,
+) -> Result<i64, String> {
     // Fetch recent updates to discover chat_id
-    let updates = crate::telegram::api::get_updates(&client, &token, 0, 0)
+    let updates = crate::telegram::api::get_updates(&network, &token, 0, 0)
         .await
         .map_err(|e| e.to_string())?;
 
@@ -282,7 +296,7 @@ pub async fn telegram_send_test(token: String) -> Result<i64, String> {
         .map(|u| u.chat_id)
         .ok_or_else(|| "No messages found. Send any message to your bot in Telegram first, then click Test again.".to_string())?;
 
-    crate::telegram::api::send_message(&client, &token, chat_id, "agentscommander connected")
+    crate::telegram::api::send_message(&network, &token, chat_id, "agentscommander connected")
         .await
         .map_err(|e| e.to_string())?;
 
@@ -390,6 +404,7 @@ fn truncate_caption(input: &str) -> String {
 /// command `telegram_send_image` and the `telegram-send-image` CLI verb so
 /// validation/multipart logic lives in exactly one place.
 pub(crate) async fn perform_send_image(
+    network: &OutboundNetwork,
     bot: &TelegramBotConfig,
     path: &str,
     caption: Option<&str>,
@@ -462,14 +477,9 @@ pub(crate) async fn perform_send_image(
         mime
     );
 
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(60))
-        .build()
-        .map_err(|e| e.to_string())?;
-
     let result = match endpoint {
         Endpoint::Photo => crate::telegram::api::send_photo(
-            &client,
+            network,
             &bot.token,
             bot.chat_id,
             bytes,
@@ -480,7 +490,7 @@ pub(crate) async fn perform_send_image(
         .await
         .map_err(|e| e.to_string()),
         Endpoint::Document => crate::telegram::api::send_document(
-            &client,
+            network,
             &bot.token,
             bot.chat_id,
             bytes,
@@ -501,6 +511,7 @@ pub(crate) async fn perform_send_image(
 #[tauri::command]
 pub async fn telegram_send_image(
     settings: State<'_, SettingsState>,
+    network: State<'_, OutboundNetwork>,
     bot_id: String,
     path: String,
     caption: Option<String>,
@@ -514,7 +525,7 @@ pub async fn telegram_send_image(
         .clone();
     drop(cfg);
 
-    perform_send_image(&bot, &path, caption.as_deref()).await
+    perform_send_image(&network, &bot, &path, caption.as_deref()).await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -2,6 +2,7 @@ use base64::Engine;
 use tauri::State;
 
 use crate::config::settings::SettingsState;
+use crate::network::OutboundNetwork;
 use crate::voice::tracker::VoiceTrackingState;
 
 #[derive(serde::Deserialize)]
@@ -132,9 +133,21 @@ pub async fn transcribe_audio(
     Ok(text)
 }
 
+pub async fn transcribe_audio_with_network(
+    network: &OutboundNetwork,
+    audio_bytes: &[u8],
+    mime_type: &str,
+    api_key: &str,
+    model: &str,
+) -> Result<String, String> {
+    let _permit = network.acquire("gemini.transcribe_audio").await?;
+    transcribe_audio(network.gemini(), audio_bytes, mime_type, api_key, model).await
+}
+
 #[tauri::command]
 pub async fn voice_transcribe(
     settings: State<'_, SettingsState>,
+    network: State<'_, OutboundNetwork>,
     audio: Vec<u8>,
     mime_type: String,
 ) -> Result<String, String> {
@@ -157,12 +170,7 @@ pub async fn voice_transcribe(
         return Err("No audio data provided".to_string());
     }
 
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|e| e.to_string())?;
-
-    transcribe_audio(&client, &audio, &mime_type, &api_key, &model).await
+    transcribe_audio_with_network(&network, &audio, &mime_type, &api_key, &model).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ pub mod commands;
 pub mod config;
 pub mod errors;
 pub mod logging;
+pub mod network;
 pub mod phone;
 pub mod pty;
 pub mod session;
@@ -308,6 +309,7 @@ pub fn run(
         .manage(app_outbox)
         .manage(session_mgr)
         .manage(tg_mgr)
+        .manage(network::OutboundNetwork::new().expect("failed to build shared network clients"))
         .manage(voice_tracking)
         .manage(settings)
         .manage(detached_sessions.clone())
@@ -1695,9 +1697,12 @@ pub fn run(
                 }
                 tauri::RunEvent::Exit => {
                     // Cancel all active Telegram bridges before general shutdown
-                    {
-                        let tg = tauri::async_runtime::block_on(tg_mgr_for_exit.lock());
-                        tg.cancel_all();
+                    let bridge_shutdowns = {
+                        let mut tg = tauri::async_runtime::block_on(tg_mgr_for_exit.lock());
+                        tg.cancel_all()
+                    };
+                    for shutdown in bridge_shutdowns {
+                        shutdown.spawn_wait_or_abort();
                     }
 
                     log::info!("[shutdown] Triggering background task shutdown (async, not awaited)...");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1702,7 +1702,7 @@ pub fn run(
                         tg.cancel_all()
                     };
                     for shutdown in bridge_shutdowns {
-                        shutdown.spawn_wait_or_abort();
+                        shutdown.abort_now();
                     }
 
                     log::info!("[shutdown] Triggering background task shutdown (async, not awaited)...");

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -112,15 +112,26 @@ pub struct NetworkBackoff {
     attempt: u32,
     min: Duration,
     max: Duration,
+    salt: u64,
 }
 
 impl NetworkBackoff {
-    pub fn new(min: Duration, max: Duration) -> Self {
+    pub fn new(min: Duration, max: Duration, salt: u64) -> Self {
         Self {
             attempt: 0,
             min,
             max,
+            salt,
         }
+    }
+
+    pub fn salt_from_str(input: &str) -> u64 {
+        let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+        for byte in input.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        hash
     }
 
     pub fn reset(&mut self) {
@@ -133,20 +144,25 @@ impl NetworkBackoff {
         let shift = self.attempt.min(10);
         let exponential = base_ms.saturating_mul(1_u64 << shift);
         let capped = exponential.min(max_ms);
-        let jitter = deterministic_jitter_ms(self.attempt, capped);
+        let jitter = deterministic_jitter_ms(self.attempt, capped, self.salt);
         self.attempt = self.attempt.saturating_add(1);
-        Duration::from_millis((capped + jitter).min(max_ms))
+        if capped >= max_ms {
+            Duration::from_millis(max_ms.saturating_sub(jitter))
+        } else {
+            Duration::from_millis((capped + jitter).min(max_ms))
+        }
     }
 }
 
-fn deterministic_jitter_ms(attempt: u32, cap_ms: u64) -> u64 {
+fn deterministic_jitter_ms(attempt: u32, cap_ms: u64, salt: u64) -> u64 {
     if cap_ms == 0 {
         return 0;
     }
     let jitter_cap = (cap_ms / 4).max(1);
-    let mixed = (attempt as u64)
-        .wrapping_mul(1_103_515_245)
-        .wrapping_add(12_345);
+    let mixed = salt
+        ^ (attempt as u64)
+            .wrapping_mul(1_103_515_245)
+            .wrapping_add(12_345);
     mixed % jitter_cap
 }
 
@@ -165,7 +181,8 @@ mod tests {
 
     #[test]
     fn backoff_grows_and_resets_within_cap() {
-        let mut backoff = NetworkBackoff::new(Duration::from_millis(100), Duration::from_secs(2));
+        let mut backoff =
+            NetworkBackoff::new(Duration::from_millis(100), Duration::from_secs(2), 42);
         let first = backoff.next_delay();
         let second = backoff.next_delay();
         let third = backoff.next_delay();
@@ -177,5 +194,27 @@ mod tests {
         backoff.reset();
         let reset = backoff.next_delay();
         assert_eq!(reset, first);
+    }
+
+    #[test]
+    fn backoff_salt_desynchronizes_same_attempts() {
+        let mut first = NetworkBackoff::new(
+            Duration::from_secs(3),
+            Duration::from_secs(60),
+            NetworkBackoff::salt_from_str("session-a"),
+        );
+        let mut second = NetworkBackoff::new(
+            Duration::from_secs(3),
+            Duration::from_secs(60),
+            NetworkBackoff::salt_from_str("session-b"),
+        );
+        let first_delay = first.next_delay();
+        let second_delay = second.next_delay();
+
+        assert_ne!(first_delay, second_delay);
+        assert!(first_delay >= Duration::from_secs(3));
+        assert!(second_delay >= Duration::from_secs(3));
+        assert!(first_delay <= Duration::from_secs(60));
+        assert!(second_delay <= Duration::from_secs(60));
     }
 }

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -1,0 +1,181 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+const OUTBOUND_NETWORK_PERMITS: usize = 64;
+const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+const POOL_MAX_IDLE_PER_HOST: usize = 8;
+
+#[derive(Clone)]
+pub struct OutboundNetwork {
+    inner: Arc<OutboundNetworkInner>,
+}
+
+struct OutboundNetworkInner {
+    semaphore: Arc<Semaphore>,
+    telegram: reqwest::Client,
+    telegram_upload: reqwest::Client,
+    gemini: reqwest::Client,
+    general: reqwest::Client,
+    #[cfg(test)]
+    acquired_labels: std::sync::Mutex<Vec<&'static str>>,
+}
+
+pub struct OutboundPermit {
+    _permit: OwnedSemaphorePermit,
+}
+
+impl OutboundNetwork {
+    pub fn new() -> Result<Self, reqwest::Error> {
+        Self::with_permit_count(OUTBOUND_NETWORK_PERMITS)
+    }
+
+    #[cfg(test)]
+    pub fn new_for_tests(permits: usize) -> Self {
+        Self::with_permit_count(permits).expect("test reqwest clients should build")
+    }
+
+    fn with_permit_count(permits: usize) -> Result<Self, reqwest::Error> {
+        Ok(Self {
+            inner: Arc::new(OutboundNetworkInner {
+                semaphore: Arc::new(Semaphore::new(permits)),
+                telegram: build_client(Duration::from_secs(15))?,
+                telegram_upload: build_client(Duration::from_secs(60))?,
+                gemini: build_client(Duration::from_secs(30))?,
+                general: build_client(Duration::from_secs(15))?,
+                #[cfg(test)]
+                acquired_labels: std::sync::Mutex::new(Vec::new()),
+            }),
+        })
+    }
+
+    pub async fn acquire(&self, label: &'static str) -> Result<OutboundPermit, String> {
+        let permit = self
+            .inner
+            .semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| format!("network limiter closed before {label}"))?;
+        #[cfg(test)]
+        {
+            self.inner
+                .acquired_labels
+                .lock()
+                .expect("network test labels mutex poisoned")
+                .push(label);
+        }
+        Ok(OutboundPermit { _permit: permit })
+    }
+
+    pub fn telegram(&self) -> &reqwest::Client {
+        &self.inner.telegram
+    }
+
+    pub fn telegram_upload(&self) -> &reqwest::Client {
+        &self.inner.telegram_upload
+    }
+
+    pub fn gemini(&self) -> &reqwest::Client {
+        &self.inner.gemini
+    }
+
+    pub fn general(&self) -> &reqwest::Client {
+        &self.inner.general
+    }
+
+    #[cfg(test)]
+    pub fn available_permits_for_tests(&self) -> usize {
+        self.inner.semaphore.available_permits()
+    }
+
+    #[cfg(test)]
+    pub fn acquired_labels_for_tests(&self) -> Vec<&'static str> {
+        self.inner
+            .acquired_labels
+            .lock()
+            .expect("network test labels mutex poisoned")
+            .clone()
+    }
+}
+
+fn build_client(timeout: Duration) -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .pool_idle_timeout(Some(POOL_IDLE_TIMEOUT))
+        .pool_max_idle_per_host(POOL_MAX_IDLE_PER_HOST)
+        .build()
+}
+
+pub struct NetworkBackoff {
+    attempt: u32,
+    min: Duration,
+    max: Duration,
+}
+
+impl NetworkBackoff {
+    pub fn new(min: Duration, max: Duration) -> Self {
+        Self {
+            attempt: 0,
+            min,
+            max,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.attempt = 0;
+    }
+
+    pub fn next_delay(&mut self) -> Duration {
+        let base_ms = self.min.as_millis() as u64;
+        let max_ms = self.max.as_millis() as u64;
+        let shift = self.attempt.min(10);
+        let exponential = base_ms.saturating_mul(1_u64 << shift);
+        let capped = exponential.min(max_ms);
+        let jitter = deterministic_jitter_ms(self.attempt, capped);
+        self.attempt = self.attempt.saturating_add(1);
+        Duration::from_millis((capped + jitter).min(max_ms))
+    }
+}
+
+fn deterministic_jitter_ms(attempt: u32, cap_ms: u64) -> u64 {
+    if cap_ms == 0 {
+        return 0;
+    }
+    let jitter_cap = (cap_ms / 4).max(1);
+    let mixed = (attempt as u64)
+        .wrapping_mul(1_103_515_245)
+        .wrapping_add(12_345);
+    mixed % jitter_cap
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn permit_is_released_on_drop() {
+        let network = OutboundNetwork::new_for_tests(1);
+        let permit = network.acquire("test").await.unwrap();
+        assert_eq!(network.available_permits_for_tests(), 0);
+        drop(permit);
+        assert_eq!(network.available_permits_for_tests(), 1);
+    }
+
+    #[test]
+    fn backoff_grows_and_resets_within_cap() {
+        let mut backoff = NetworkBackoff::new(Duration::from_millis(100), Duration::from_secs(2));
+        let first = backoff.next_delay();
+        let second = backoff.next_delay();
+        let third = backoff.next_delay();
+        assert!(first >= Duration::from_millis(100));
+        assert!(second >= first);
+        assert!(third >= second);
+        assert!(third <= Duration::from_secs(2));
+
+        backoff.reset();
+        let reset = backoff.next_delay();
+        assert_eq!(reset, first);
+    }
+}

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -15,7 +15,7 @@ use crate::telegram::manager::OutputSenderMap;
 struct PtyInstance {
     master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
-    _child: Box<dyn portable_pty::Child + Send + Sync>,
+    child: Option<Box<dyn portable_pty::Child + Send + Sync>>,
 }
 
 /// Tracks active response marker watchers per session.
@@ -362,6 +362,11 @@ impl PtyManager {
             .slave
             .spawn_command(command)
             .map_err(|e| AppError::PtyError(e.to_string()))?;
+        log::info!(
+            "[pty] Spawned session {} with child pid {:?}",
+            id,
+            child.process_id()
+        );
 
         // Drop the slave side — we only need the master
         drop(pair.slave);
@@ -379,7 +384,7 @@ impl PtyManager {
         let instance = PtyInstance {
             master: Arc::new(Mutex::new(pair.master)),
             writer: Arc::new(Mutex::new(writer)),
-            _child: child,
+            child: Some(child),
         };
 
         self.ptys.lock().unwrap().insert(id, instance);
@@ -552,9 +557,55 @@ impl PtyManager {
     }
 
     pub fn kill(&self, id: Uuid) -> Result<(), AppError> {
-        let mut ptys = self.ptys.lock().unwrap();
-        // Dropping the PtyInstance will close the master, which signals the child
-        ptys.remove(&id);
+        let instance = {
+            let mut ptys = self.ptys.lock().unwrap();
+            ptys.remove(&id)
+        };
+
+        if let Some(mut instance) = instance {
+            if let Some(mut child) = instance.child.take() {
+                let pid = child.process_id();
+                match child.try_wait() {
+                    Ok(Some(status)) => {
+                        log::info!(
+                            "[pty] Session {} child pid {:?} already exited: {:?}",
+                            id,
+                            pid,
+                            status
+                        );
+                    }
+                    Ok(None) => {
+                        if let Err(e) = child.kill() {
+                            log::warn!(
+                                "[pty] Failed to kill session {} child pid {:?}: {}",
+                                id,
+                                pid,
+                                e
+                            );
+                        }
+                        reap_child_in_background(id, pid, child);
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "[pty] Failed to poll session {} child pid {:?}: {}",
+                            id,
+                            pid,
+                            e
+                        );
+                        if let Err(kill_err) = child.kill() {
+                            log::warn!(
+                                "[pty] Failed to kill session {} child pid {:?} after poll error: {}",
+                                id,
+                                pid,
+                                kill_err
+                            );
+                        }
+                        reap_child_in_background(id, pid, child);
+                    }
+                }
+            }
+        }
+
         self.idle_detector.remove_session(id);
         self.git_watcher.remove_session(id);
 
@@ -604,6 +655,31 @@ impl PtyManager {
             );
         }
     }
+}
+
+fn reap_child_in_background(
+    session_id: Uuid,
+    pid: Option<u32>,
+    mut child: Box<dyn portable_pty::Child + Send + Sync>,
+) {
+    std::thread::spawn(move || match child.wait() {
+        Ok(status) => {
+            log::info!(
+                "[pty] Reaped session {} child pid {:?}: {:?}",
+                session_id,
+                pid,
+                status
+            );
+        }
+        Err(e) => {
+            log::warn!(
+                "[pty] Failed to reap session {} child pid {:?}: {}",
+                session_id,
+                pid,
+                e
+            );
+        }
+    });
 }
 
 /// Scan PTY output text for %%AC_RESPONSE::<rid>::START/END%% markers.

--- a/src-tauri/src/telegram/api.rs
+++ b/src-tauri/src/telegram/api.rs
@@ -1,4 +1,5 @@
 use crate::errors::AppError;
+use crate::network::{OutboundNetwork, OutboundPermit};
 use crate::telegram::redact::redact;
 
 #[derive(Debug, serde::Deserialize)]
@@ -49,14 +50,57 @@ pub struct TelegramUpdate {
     pub chat_id: i64,
 }
 
+#[derive(Clone, Copy)]
+enum TelegramApiMethod {
+    SendMessage,
+    GetUpdates,
+    GetFile,
+    DownloadFile,
+    SendPhoto,
+    SendDocument,
+}
+
+impl TelegramApiMethod {
+    fn label(self) -> &'static str {
+        match self {
+            Self::SendMessage => "telegram.send_message",
+            Self::GetUpdates => "telegram.get_updates",
+            Self::GetFile => "telegram.get_file",
+            Self::DownloadFile => "telegram.download_file",
+            Self::SendPhoto => "telegram.send_photo",
+            Self::SendDocument => "telegram.send_document",
+        }
+    }
+}
+
+async fn acquire_api_permit(
+    network: &OutboundNetwork,
+    method: TelegramApiMethod,
+) -> Result<OutboundPermit, AppError> {
+    network
+        .acquire(method.label())
+        .await
+        .map_err(AppError::Telegram)
+}
+
+fn telegram_reqwest_error(e: reqwest::Error) -> AppError {
+    telegram_request_error_message(&e.to_string())
+}
+
+fn telegram_request_error_message(message: &str) -> AppError {
+    AppError::Telegram(redact(message))
+}
+
 pub async fn send_message(
-    client: &reqwest::Client,
+    network: &OutboundNetwork,
     token: &str,
     chat_id: i64,
     text: &str,
 ) -> Result<(), AppError> {
     let url = format!("https://api.telegram.org/bot{}/sendMessage", token);
-    let resp = client
+    let _permit = acquire_api_permit(network, TelegramApiMethod::SendMessage).await?;
+    let resp = network
+        .telegram()
         .post(&url)
         .json(&serde_json::json!({
             "chat_id": chat_id,
@@ -64,12 +108,10 @@ pub async fn send_message(
         }))
         .send()
         .await
-        .map_err(|e| AppError::Telegram(redact(&e.to_string())))?;
+        .map_err(telegram_reqwest_error)?;
 
-    let body: TelegramResponse<serde_json::Value> = resp
-        .json()
-        .await
-        .map_err(|e| AppError::Telegram(redact(&e.to_string())))?;
+    let body: TelegramResponse<serde_json::Value> =
+        resp.json().await.map_err(telegram_reqwest_error)?;
 
     if !body.ok {
         return Err(AppError::Telegram(
@@ -82,13 +124,15 @@ pub async fn send_message(
 }
 
 pub async fn get_updates(
-    client: &reqwest::Client,
+    network: &OutboundNetwork,
     token: &str,
     offset: i64,
     timeout: u64,
 ) -> Result<Vec<TelegramUpdate>, AppError> {
     let url = format!("https://api.telegram.org/bot{}/getUpdates", token);
-    let resp = client
+    let _permit = acquire_api_permit(network, TelegramApiMethod::GetUpdates).await?;
+    let resp = network
+        .telegram()
         .get(&url)
         .query(&[
             ("offset", offset.to_string()),
@@ -96,12 +140,9 @@ pub async fn get_updates(
         ])
         .send()
         .await
-        .map_err(|e| AppError::Telegram(redact(&e.to_string())))?;
+        .map_err(telegram_reqwest_error)?;
 
-    let body: TelegramResponse<Vec<Update>> = resp
-        .json()
-        .await
-        .map_err(|e| AppError::Telegram(redact(&e.to_string())))?;
+    let body: TelegramResponse<Vec<Update>> = resp.json().await.map_err(telegram_reqwest_error)?;
 
     if !body.ok {
         return Err(AppError::Telegram(
@@ -149,22 +190,22 @@ pub async fn get_updates(
 }
 
 pub async fn get_file(
-    client: &reqwest::Client,
+    network: &OutboundNetwork,
     token: &str,
     file_id: &str,
 ) -> Result<String, AppError> {
     let url = format!("https://api.telegram.org/bot{}/getFile", token);
-    let resp = client
+    let _permit = acquire_api_permit(network, TelegramApiMethod::GetFile).await?;
+    let resp = network
+        .telegram()
         .get(&url)
         .query(&[("file_id", file_id)])
         .send()
         .await
-        .map_err(|e| AppError::Telegram(redact(&e.to_string())))?;
+        .map_err(telegram_reqwest_error)?;
 
-    let body: TelegramResponse<serde_json::Value> = resp
-        .json()
-        .await
-        .map_err(|e| AppError::Telegram(redact(&e.to_string())))?;
+    let body: TelegramResponse<serde_json::Value> =
+        resp.json().await.map_err(telegram_reqwest_error)?;
 
     if !body.ok {
         return Err(AppError::Telegram(
@@ -179,16 +220,18 @@ pub async fn get_file(
 }
 
 pub async fn download_file(
-    client: &reqwest::Client,
+    network: &OutboundNetwork,
     token: &str,
     file_path: &str,
 ) -> Result<Vec<u8>, AppError> {
     let url = format!("https://api.telegram.org/file/bot{}/{}", token, file_path);
-    let resp = client
+    let _permit = acquire_api_permit(network, TelegramApiMethod::DownloadFile).await?;
+    let resp = network
+        .telegram()
         .get(&url)
         .send()
         .await
-        .map_err(|e| AppError::Telegram(redact(&e.to_string())))?;
+        .map_err(telegram_reqwest_error)?;
 
     if !resp.status().is_success() {
         return Err(AppError::Telegram(format!(
@@ -200,7 +243,7 @@ pub async fn download_file(
     resp.bytes()
         .await
         .map(|b| b.to_vec())
-        .map_err(|e| AppError::Telegram(redact(&e.to_string())))
+        .map_err(telegram_reqwest_error)
 }
 
 /// Telegram `sendPhoto`. Used for static images <= 10 MB whose extension
@@ -209,7 +252,7 @@ pub async fn download_file(
 /// matching `mime` string; this primitive is dumb on purpose so callers can
 /// swap to `send_document` for the fallback path without redoing validation.
 pub async fn send_photo(
-    client: &reqwest::Client,
+    network: &OutboundNetwork,
     token: &str,
     chat_id: i64,
     bytes: Vec<u8>,
@@ -232,17 +275,17 @@ pub async fn send_photo(
         form = form.text("caption", c.to_string());
     }
 
-    let resp = client
+    let _permit = acquire_api_permit(network, TelegramApiMethod::SendPhoto).await?;
+    let resp = network
+        .telegram_upload()
         .post(&url)
         .multipart(form)
         .send()
         .await
-        .map_err(|e| AppError::Telegram(e.to_string()))?;
+        .map_err(telegram_reqwest_error)?;
 
-    let body: TelegramResponse<serde_json::Value> = resp
-        .json()
-        .await
-        .map_err(|e| AppError::Telegram(e.to_string()))?;
+    let body: TelegramResponse<serde_json::Value> =
+        resp.json().await.map_err(telegram_reqwest_error)?;
 
     if !body.ok {
         return Err(AppError::Telegram(
@@ -259,7 +302,7 @@ pub async fn send_photo(
 /// as a photo. Hard upper bound (50 MB) is enforced by the caller; this
 /// primitive will happily forward whatever the caller passes.
 pub async fn send_document(
-    client: &reqwest::Client,
+    network: &OutboundNetwork,
     token: &str,
     chat_id: i64,
     bytes: Vec<u8>,
@@ -282,17 +325,17 @@ pub async fn send_document(
         form = form.text("caption", c.to_string());
     }
 
-    let resp = client
+    let _permit = acquire_api_permit(network, TelegramApiMethod::SendDocument).await?;
+    let resp = network
+        .telegram_upload()
         .post(&url)
         .multipart(form)
         .send()
         .await
-        .map_err(|e| AppError::Telegram(e.to_string()))?;
+        .map_err(telegram_reqwest_error)?;
 
-    let body: TelegramResponse<serde_json::Value> = resp
-        .json()
-        .await
-        .map_err(|e| AppError::Telegram(e.to_string()))?;
+    let body: TelegramResponse<serde_json::Value> =
+        resp.json().await.map_err(telegram_reqwest_error)?;
 
     if !body.ok {
         return Err(AppError::Telegram(
@@ -302,4 +345,65 @@ pub async fn send_document(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn every_telegram_api_method_acquires_a_network_permit() {
+        let network = OutboundNetwork::new_for_tests(1);
+        for method in [
+            TelegramApiMethod::SendMessage,
+            TelegramApiMethod::GetUpdates,
+            TelegramApiMethod::GetFile,
+            TelegramApiMethod::DownloadFile,
+            TelegramApiMethod::SendPhoto,
+            TelegramApiMethod::SendDocument,
+        ] {
+            let permit = acquire_api_permit(&network, method).await.unwrap();
+            assert_eq!(network.available_permits_for_tests(), 0);
+            drop(permit);
+            assert_eq!(network.available_permits_for_tests(), 1);
+        }
+
+        assert_eq!(
+            network.acquired_labels_for_tests(),
+            vec![
+                "telegram.send_message",
+                "telegram.get_updates",
+                "telegram.get_file",
+                "telegram.download_file",
+                "telegram.send_photo",
+                "telegram.send_document",
+            ]
+        );
+    }
+
+    #[test]
+    fn send_photo_error_redacts_fake_token() {
+        let fake_token = "123456:FAKE_SECRET_TOKEN";
+        let error = telegram_request_error_message(&format!(
+            "request failed for https://api.telegram.org/bot{fake_token}/sendPhoto"
+        ));
+        let AppError::Telegram(message) = error else {
+            panic!("expected Telegram error");
+        };
+        assert!(!message.contains(fake_token));
+        assert!(message.contains("/bot***/sendPhoto"));
+    }
+
+    #[test]
+    fn send_document_error_redacts_fake_token() {
+        let fake_token = "123456:FAKE_SECRET_TOKEN";
+        let error = telegram_request_error_message(&format!(
+            "request failed for https://api.telegram.org/bot{fake_token}/sendDocument"
+        ));
+        let AppError::Telegram(message) = error else {
+            panic!("expected Telegram error");
+        };
+        assert!(!message.contains(fake_token));
+        assert!(message.contains("/bot***/sendDocument"));
+    }
 }

--- a/src-tauri/src/telegram/bridge.rs
+++ b/src-tauri/src/telegram/bridge.rs
@@ -997,7 +997,7 @@ async fn poll_task<R: tauri::Runtime>(
         cfg.telegram_network_poll_error_logging.clone()
     };
     let mut network_error_state = PollNetworkErrorState::new();
-    let mut poll_backoff = NetworkBackoff::new(Duration::from_secs(1), Duration::from_secs(30));
+    let mut poll_backoff = new_poll_backoff(&session_id_str);
 
     // Skip old messages
     match api::get_updates(&network, &token, 0, 0).await {
@@ -1065,7 +1065,9 @@ async fn poll_task<R: tauri::Runtime>(
                     msg
                 );
             }
-            if !sleep_backoff_or_cancel(&cancel, &mut poll_backoff).await {
+            if !sleep_backoff_or_cancel(&cancel, &mut poll_backoff, &mut logger, &session_id_str)
+                .await
+            {
                 return;
             }
         }
@@ -1219,7 +1221,14 @@ async fn poll_task<R: tauri::Runtime>(
                                 token_prefix,
                                 msg
                             );
-                            if !sleep_backoff_or_cancel(&cancel, &mut poll_backoff).await {
+                            if !sleep_backoff_or_cancel(
+                                &cancel,
+                                &mut poll_backoff,
+                                &mut logger,
+                                &session_id_str,
+                            )
+                            .await
+                            {
                                 break;
                             }
                             continue;
@@ -1266,7 +1275,14 @@ async fn poll_task<R: tauri::Runtime>(
                                 unreachable!("record_network_failure only returns Failure or Suppressed")
                             }
                         }
-                        if !sleep_backoff_or_cancel(&cancel, &mut poll_backoff).await {
+                        if !sleep_backoff_or_cancel(
+                            &cancel,
+                            &mut poll_backoff,
+                            &mut logger,
+                            &session_id_str,
+                        )
+                        .await
+                        {
                             break;
                         }
                     }
@@ -1276,17 +1292,52 @@ async fn poll_task<R: tauri::Runtime>(
     }
 }
 
-async fn sleep_backoff_or_cancel(cancel: &CancellationToken, backoff: &mut NetworkBackoff) -> bool {
+async fn sleep_backoff_or_cancel(
+    cancel: &CancellationToken,
+    backoff: &mut NetworkBackoff,
+    logger: &mut BridgeLogger,
+    session_id: &str,
+) -> bool {
     let delay = backoff.next_delay();
+    let sleep_ms = delay.as_millis();
+    logger.log("POLL_BACKOFF", session_id, &format!("sleep_ms={sleep_ms}"));
+    log::debug!(
+        "[bridge] POLL_BACKOFF session_id={} sleep_ms={}",
+        session_id,
+        sleep_ms
+    );
     tokio::select! {
         _ = cancel.cancelled() => false,
         _ = tokio::time::sleep(delay) => true,
     }
 }
 
+fn new_poll_backoff(session_id: &str) -> NetworkBackoff {
+    NetworkBackoff::new(
+        Duration::from_secs(3),
+        Duration::from_secs(60),
+        NetworkBackoff::salt_from_str(session_id),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn poll_backoff_uses_plan_bounds_and_session_salt() {
+        let mut first = new_poll_backoff("session-a");
+        let mut second = new_poll_backoff("session-b");
+
+        let first_delay = first.next_delay();
+        let second_delay = second.next_delay();
+
+        assert!(first_delay >= Duration::from_secs(3));
+        assert!(second_delay >= Duration::from_secs(3));
+        assert!(first_delay <= Duration::from_secs(60));
+        assert!(second_delay <= Duration::from_secs(60));
+        assert_ne!(first_delay, second_delay);
+    }
 
     // ── #280 §3.2 — TelegramErrKind::classify ────────────────────
 

--- a/src-tauri/src/telegram/bridge.rs
+++ b/src-tauri/src/telegram/bridge.rs
@@ -5,11 +5,13 @@ use std::sync::{Arc, Mutex};
 
 use tauri::{Emitter, Manager};
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::config::settings::TelegramNetworkPollErrorLogging;
+use crate::network::{NetworkBackoff, OutboundNetwork};
 use crate::pty::manager::PtyManager;
 use crate::telegram::api;
 use crate::telegram::types::BridgeInfo;
@@ -629,72 +631,32 @@ pub struct BridgeHandle {
     pub info: BridgeInfo,
     pub cancel: CancellationToken,
     pub output_sender: mpsc::Sender<Vec<u8>>,
+    pub tasks: Vec<JoinHandle<()>>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_bridge<R: tauri::Runtime>(
     bot_token: String,
     chat_id: i64,
     session_id: Uuid,
     info: BridgeInfo,
     pty_mgr: Arc<Mutex<PtyManager>>,
+    network: OutboundNetwork,
     app_handle: tauri::AppHandle<R>,
     reader: Option<SessionReaderKind>,
 ) -> BridgeHandle {
     let cancel = CancellationToken::new();
     let (tx, rx) = mpsc::channel::<Vec<u8>>(256);
+    let mut tasks = Vec::new();
 
     let session_id_str = session_id.to_string();
 
     match reader {
         Some(SessionReaderKind::Claude { project_dir }) => {
-            drop(rx); // not needed — no PTY bytes feed
-            super::claude_watcher::spawn_watch_task(
+            drop(rx);
+            tasks.push(super::claude_watcher::spawn_watch_task(
                 project_dir,
-                bot_token.clone(),
-                chat_id,
-                session_id_str.clone(),
-                cancel.clone(),
-                app_handle.clone(),
-            );
-        }
-        Some(SessionReaderKind::Codex {
-            search_root,
-            cwd,
-            attach_time,
-        }) => {
-            drop(rx);
-            super::codex_watcher::spawn_watch_task(
-                search_root,
-                cwd,
-                attach_time,
-                bot_token.clone(),
-                chat_id,
-                session_id_str.clone(),
-                cancel.clone(),
-                app_handle.clone(),
-            );
-        }
-        Some(SessionReaderKind::Gemini {
-            gemini_home,
-            cwd,
-            attach_time,
-        }) => {
-            drop(rx);
-            super::gemini_watcher::spawn_watch_task(
-                gemini_home,
-                cwd,
-                attach_time,
-                bot_token.clone(),
-                chat_id,
-                session_id_str.clone(),
-                cancel.clone(),
-                app_handle.clone(),
-            );
-        }
-        None => {
-            // PTY mode: existing 6-phase pipeline
-            tokio::spawn(output_task(
-                rx,
+                network.clone(),
                 bot_token.clone(),
                 chat_id,
                 session_id_str.clone(),
@@ -702,23 +664,72 @@ pub fn spawn_bridge<R: tauri::Runtime>(
                 app_handle.clone(),
             ));
         }
+        Some(SessionReaderKind::Codex {
+            search_root,
+            cwd,
+            attach_time,
+        }) => {
+            drop(rx);
+            tasks.push(super::codex_watcher::spawn_watch_task(
+                search_root,
+                cwd,
+                attach_time,
+                network.clone(),
+                bot_token.clone(),
+                chat_id,
+                session_id_str.clone(),
+                cancel.clone(),
+                app_handle.clone(),
+            ));
+        }
+        Some(SessionReaderKind::Gemini {
+            gemini_home,
+            cwd,
+            attach_time,
+        }) => {
+            drop(rx);
+            tasks.push(super::gemini_watcher::spawn_watch_task(
+                gemini_home,
+                cwd,
+                attach_time,
+                network.clone(),
+                bot_token.clone(),
+                chat_id,
+                session_id_str.clone(),
+                cancel.clone(),
+                app_handle.clone(),
+            ));
+        }
+        None => {
+            tasks.push(tokio::spawn(output_task(
+                rx,
+                network.clone(),
+                bot_token.clone(),
+                chat_id,
+                session_id_str.clone(),
+                cancel.clone(),
+                app_handle.clone(),
+            )));
+        }
     }
 
     // Poll task: Telegram getUpdates -> write to PTY stdin (runs in BOTH modes)
-    tokio::spawn(poll_task(
+    tasks.push(tokio::spawn(poll_task(
         bot_token,
         chat_id,
         session_id,
         session_id_str,
         pty_mgr,
+        network,
         cancel.clone(),
         app_handle,
-    ));
+    )));
 
     BridgeHandle {
         info,
         cancel,
         output_sender: tx,
+        tasks,
     }
 }
 
@@ -740,17 +751,13 @@ const FLUSH_DELAY_MS: u64 = 500;
 
 async fn output_task<R: tauri::Runtime>(
     mut rx: mpsc::Receiver<Vec<u8>>,
+    network: OutboundNetwork,
     token: String,
     chat_id: i64,
     session_id: String,
     cancel: CancellationToken,
     app: tauri::AppHandle<R>,
 ) {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .unwrap_or_default();
-
     let mut logger = BridgeLogger::new(&session_id);
     let mut diag = DiagLogger::new();
     let mut buffer = String::new();
@@ -807,7 +814,7 @@ async fn output_task<R: tauri::Runtime>(
                     let buf_len = buffer.trim().len();
                     if since_last >= flush_delay || buf_len > 2000 {
                         flush_buffer(
-                            &mut buffer, &client, &token, chat_id,
+                            &mut buffer, &network, &token, chat_id,
                             &session_id, &app, &mut logger, &mut diag,
                             false,
                         ).await;
@@ -846,7 +853,7 @@ async fn output_task<R: tauri::Runtime>(
     if !buffer.is_empty() {
         flush_buffer(
             &mut buffer,
-            &client,
+            &network,
             &token,
             chat_id,
             &session_id,
@@ -866,7 +873,7 @@ async fn output_task<R: tauri::Runtime>(
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn flush_buffer<R: tauri::Runtime>(
     buffer: &mut String,
-    client: &reqwest::Client,
+    network: &OutboundNetwork,
     token: &str,
     chat_id: i64,
     session_id: &str,
@@ -902,7 +909,7 @@ pub(super) async fn flush_buffer<R: tauri::Runtime>(
         logger.log("SEND_TG", session_id, &chunk);
         diag.log_sent(&chunk);
 
-        if let Err(e) = api::send_message(client, token, chat_id, &chunk).await {
+        if let Err(e) = api::send_message(network, token, chat_id, &chunk).await {
             // #280 — defense-in-depth scrub before `msg` reaches the
             // `telegram_bridge_error` Tauri event payload (which bypasses
             // the env_logger format closure that protects stderr/app.log).
@@ -971,20 +978,17 @@ pub(super) fn chunk_text(text: &str, max_len: usize) -> Vec<String> {
 
 // ── Poll task (Telegram -> PTY) ──────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 async fn poll_task<R: tauri::Runtime>(
     token: String,
     chat_id: i64,
     session_id: Uuid,
     session_id_str: String,
     _pty_mgr: Arc<Mutex<PtyManager>>,
+    network: OutboundNetwork,
     cancel: CancellationToken,
     app: tauri::AppHandle<R>,
 ) {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(15))
-        .build()
-        .unwrap_or_default();
-
     let mut logger = BridgeLogger::new(&session_id_str);
     let mut offset: i64 = 0;
     let network_error_policy = {
@@ -993,10 +997,12 @@ async fn poll_task<R: tauri::Runtime>(
         cfg.telegram_network_poll_error_logging.clone()
     };
     let mut network_error_state = PollNetworkErrorState::new();
+    let mut poll_backoff = NetworkBackoff::new(Duration::from_secs(1), Duration::from_secs(30));
 
     // Skip old messages
-    match api::get_updates(&client, &token, 0, 0).await {
+    match api::get_updates(&network, &token, 0, 0).await {
         Ok(updates) => {
+            poll_backoff.reset();
             if let Some(last) = updates.last() {
                 offset = last.update_id + 1;
                 logger.log(
@@ -1059,15 +1065,19 @@ async fn poll_task<R: tauri::Runtime>(
                     msg
                 );
             }
+            if !sleep_backoff_or_cancel(&cancel, &mut poll_backoff).await {
+                return;
+            }
         }
     }
 
     loop {
         tokio::select! {
             _ = cancel.cancelled() => break,
-            result = api::get_updates(&client, &token, offset, 5) => {
+            result = api::get_updates(&network, &token, offset, 5) => {
                 match result {
                     Ok(updates) => {
+                        poll_backoff.reset();
                         match network_error_state.record_success(&network_error_policy) {
                             PollNetworkLogAction::Recovery {
                                 level,
@@ -1124,43 +1134,37 @@ async fn poll_task<R: tauri::Runtime>(
 
                                     if api_key.is_empty() {
                                         log::warn!("[bridge] Voice message received but no Gemini API key configured");
-                                        let _ = api::send_message(&client, &token, chat_id, "Cannot transcribe voice: Gemini API key not configured").await;
+                                        let _ = api::send_message(&network, &token, chat_id, "Cannot transcribe voice: Gemini API key not configured").await;
                                         continue;
                                     }
 
-                                    let file_path = match api::get_file(&client, &token, &file_id).await {
+                                    let file_path = match api::get_file(&network, &token, &file_id).await {
                                         Ok(fp) => fp,
                                         Err(e) => {
                                             logger.log("VOICE_ERR", &session_id_str, &format!("get_file failed: {}", e));
-                                            let _ = api::send_message(&client, &token, chat_id, &format!("Failed to get voice file: {}", e)).await;
+                                            let _ = api::send_message(&network, &token, chat_id, &format!("Failed to get voice file: {}", e)).await;
                                             continue;
                                         }
                                     };
 
-                                    let audio_bytes = match api::download_file(&client, &token, &file_path).await {
+                                    let audio_bytes = match api::download_file(&network, &token, &file_path).await {
                                         Ok(bytes) => bytes,
                                         Err(e) => {
                                             logger.log("VOICE_ERR", &session_id_str, &format!("download failed: {}", e));
-                                            let _ = api::send_message(&client, &token, chat_id, &format!("Failed to download voice: {}", e)).await;
+                                            let _ = api::send_message(&network, &token, chat_id, &format!("Failed to download voice: {}", e)).await;
                                             continue;
                                         }
                                     };
 
-                                    // Dedicated client with 30s timeout for Gemini (poll client is 15s)
-                                    let gemini_client = reqwest::Client::builder()
-                                        .timeout(std::time::Duration::from_secs(30))
-                                        .build()
-                                        .unwrap_or_default();
-
-                                    match crate::commands::voice::transcribe_audio(&gemini_client, &audio_bytes, "audio/ogg", &api_key, &model).await {
+                                    match crate::commands::voice::transcribe_audio_with_network(&network, &audio_bytes, "audio/ogg", &api_key, &model).await {
                                         Ok(text) => {
                                             logger.log("VOICE_OK", &session_id_str, &format!("transcribed {} chars", text.len()));
-                                            let _ = api::send_message(&client, &token, chat_id, &format!("Transcribed: {}", text)).await;
+                                            let _ = api::send_message(&network, &token, chat_id, &format!("Transcribed: {}", text)).await;
                                             text
                                         }
                                         Err(e) => {
                                             logger.log("VOICE_ERR", &session_id_str, &format!("transcription failed: {}", e));
-                                            let _ = api::send_message(&client, &token, chat_id, &format!("Transcription failed: {}", e)).await;
+                                            let _ = api::send_message(&network, &token, chat_id, &format!("Transcription failed: {}", e)).await;
                                             continue;
                                         }
                                     }
@@ -1215,7 +1219,9 @@ async fn poll_task<R: tauri::Runtime>(
                                 token_prefix,
                                 msg
                             );
-                            tokio::time::sleep(Duration::from_secs(3)).await;
+                            if !sleep_backoff_or_cancel(&cancel, &mut poll_backoff).await {
+                                break;
+                            }
                             continue;
                         }
 
@@ -1260,11 +1266,21 @@ async fn poll_task<R: tauri::Runtime>(
                                 unreachable!("record_network_failure only returns Failure or Suppressed")
                             }
                         }
-                        tokio::time::sleep(Duration::from_secs(3)).await;
+                        if !sleep_backoff_or_cancel(&cancel, &mut poll_backoff).await {
+                            break;
+                        }
                     }
                 }
             }
         }
+    }
+}
+
+async fn sleep_backoff_or_cancel(cancel: &CancellationToken, backoff: &mut NetworkBackoff) -> bool {
+    let delay = backoff.next_delay();
+    tokio::select! {
+        _ = cancel.cancelled() => false,
+        _ = tokio::time::sleep(delay) => true,
     }
 }
 

--- a/src-tauri/src/telegram/claude_watcher.rs
+++ b/src-tauri/src/telegram/claude_watcher.rs
@@ -13,6 +13,7 @@ use tauri::Emitter;
 use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
+use crate::network::OutboundNetwork;
 use crate::telegram::bridge::{flush_buffer, BridgeLogger, DiagLogger};
 use crate::telegram::jsonl_kernel::{
     find_latest_jsonl, read_new_lines, read_preamble_for_race, POLL_INTERVAL_MS,
@@ -29,6 +30,7 @@ const FLUSH_DELAY_MS: u64 = 500;
 /// so wrapper-driven `CLAUDE_CONFIG_DIR` overrides like `claude-mb` are honored).
 pub fn spawn_watch_task<R: tauri::Runtime>(
     project_dir: PathBuf,
+    network: OutboundNetwork,
     bot_token: String,
     chat_id: i64,
     session_id: String,
@@ -38,6 +40,7 @@ pub fn spawn_watch_task<R: tauri::Runtime>(
     tokio::spawn(async move {
         watch_loop(
             project_dir,
+            network,
             bot_token,
             chat_id,
             session_id.clone(),
@@ -112,17 +115,13 @@ fn extract_assistant_text(line: &str) -> Option<String> {
 
 async fn watch_loop<R: tauri::Runtime>(
     project_dir: PathBuf,
+    network: OutboundNetwork,
     token: String,
     chat_id: i64,
     session_id: String,
     cancel: CancellationToken,
     app: tauri::AppHandle<R>,
 ) {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .unwrap_or_default();
-
     let mut logger = BridgeLogger::new(&session_id);
     let mut diag = DiagLogger::new();
     let mut buffer = String::new();
@@ -254,7 +253,7 @@ async fn watch_loop<R: tauri::Runtime>(
                     let elapsed = last_buffer_add.elapsed();
                     if elapsed >= flush_delay || buffer.len() > 2000 {
                         flush_buffer(
-                            &mut buffer, &client, &token, chat_id,
+                            &mut buffer, &network, &token, chat_id,
                             &session_id, &app, &mut logger, &mut diag,
                             true, // skip_dedup: JSONL text is clean, repeated lines are legitimate
                         ).await;
@@ -278,7 +277,7 @@ async fn watch_loop<R: tauri::Runtime>(
     if !buffer.is_empty() {
         flush_buffer(
             &mut buffer,
-            &client,
+            &network,
             &token,
             chat_id,
             &session_id,

--- a/src-tauri/src/telegram/codex_watcher.rs
+++ b/src-tauri/src/telegram/codex_watcher.rs
@@ -15,6 +15,7 @@ use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 use crate::commands::codex_resolver::canonicalize_cwd_for_codex;
+use crate::network::OutboundNetwork;
 use crate::telegram::bridge::{flush_buffer, BridgeLogger, DiagLogger};
 use crate::telegram::jsonl_kernel::{
     read_new_lines, read_preamble_for_race, POLL_INTERVAL_MS, ROTATION_STALE_SECS,
@@ -39,6 +40,7 @@ pub fn spawn_watch_task<R: tauri::Runtime>(
     search_root: PathBuf,
     expected_cwd: String,
     attach_time: DateTime<Utc>,
+    network: OutboundNetwork,
     bot_token: String,
     chat_id: i64,
     session_id: String,
@@ -50,6 +52,7 @@ pub fn spawn_watch_task<R: tauri::Runtime>(
             search_root,
             expected_cwd,
             attach_time,
+            network,
             bot_token,
             chat_id,
             session_id.clone(),
@@ -209,17 +212,13 @@ async fn watch_loop<R: tauri::Runtime>(
     search_root: PathBuf,
     expected_cwd: String,
     attach_time: DateTime<Utc>,
+    network: OutboundNetwork,
     token: String,
     chat_id: i64,
     session_id: String,
     cancel: CancellationToken,
     app: tauri::AppHandle<R>,
 ) {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .unwrap_or_default();
-
     let mut logger = BridgeLogger::new(&session_id);
     let mut diag = DiagLogger::new();
     let mut buffer = String::new();
@@ -347,7 +346,7 @@ async fn watch_loop<R: tauri::Runtime>(
                     let elapsed = last_buffer_add.elapsed();
                     if elapsed >= flush_delay || buffer.len() > FLUSH_BYTES {
                         flush_buffer(
-                            &mut buffer, &client, &token, chat_id,
+                            &mut buffer, &network, &token, chat_id,
                             &session_id, &app, &mut logger, &mut diag,
                             true,
                         ).await;
@@ -371,7 +370,7 @@ async fn watch_loop<R: tauri::Runtime>(
     if !buffer.is_empty() {
         flush_buffer(
             &mut buffer,
-            &client,
+            &network,
             &token,
             chat_id,
             &session_id,

--- a/src-tauri/src/telegram/gemini_watcher.rs
+++ b/src-tauri/src/telegram/gemini_watcher.rs
@@ -17,6 +17,7 @@ use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 use crate::commands::gemini_resolver::lookup_chats_dir_for_cwd;
+use crate::network::OutboundNetwork;
 use crate::telegram::bridge::{flush_buffer, BridgeLogger, DiagLogger};
 use crate::telegram::jsonl_kernel::{
     read_new_lines, read_preamble_for_race, POLL_INTERVAL_MS, ROTATION_STALE_SECS,
@@ -31,6 +32,7 @@ pub fn spawn_watch_task<R: tauri::Runtime>(
     gemini_home: PathBuf,
     cwd: String,
     attach_time: DateTime<Utc>,
+    network: OutboundNetwork,
     bot_token: String,
     chat_id: i64,
     session_id: String,
@@ -42,6 +44,7 @@ pub fn spawn_watch_task<R: tauri::Runtime>(
             gemini_home,
             cwd,
             attach_time,
+            network,
             bot_token,
             chat_id,
             session_id.clone(),
@@ -151,17 +154,13 @@ async fn watch_loop<R: tauri::Runtime>(
     gemini_home: PathBuf,
     cwd: String,
     attach_time: DateTime<Utc>,
+    network: OutboundNetwork,
     token: String,
     chat_id: i64,
     session_id: String,
     cancel: CancellationToken,
     app: tauri::AppHandle<R>,
 ) {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .unwrap_or_default();
-
     let mut logger = BridgeLogger::new(&session_id);
     let mut diag = DiagLogger::new();
     let mut buffer = String::new();
@@ -359,7 +358,7 @@ async fn watch_loop<R: tauri::Runtime>(
                     let elapsed = last_buffer_add.elapsed();
                     if elapsed >= flush_delay || buffer.len() > FLUSH_BYTES {
                         flush_buffer(
-                            &mut buffer, &client, &token, chat_id,
+                            &mut buffer, &network, &token, chat_id,
                             &session_id, &app, &mut logger, &mut diag,
                             true,
                         ).await;
@@ -385,7 +384,7 @@ async fn watch_loop<R: tauri::Runtime>(
     if !buffer.is_empty() {
         flush_buffer(
             &mut buffer,
-            &client,
+            &network,
             &token,
             chat_id,
             &session_id,

--- a/src-tauri/src/telegram/manager.rs
+++ b/src-tauri/src/telegram/manager.rs
@@ -1,9 +1,13 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
+use tokio::task::JoinHandle;
+use tokio::time::{timeout_at, Instant};
 use uuid::Uuid;
 
 use crate::errors::AppError;
+use crate::network::OutboundNetwork;
 use crate::pty::manager::PtyManager;
 use crate::telegram::bridge::{self, BridgeHandle, SessionReaderKind};
 use crate::telegram::types::{BridgeInfo, BridgeStatus, TelegramBotConfig};
@@ -21,6 +25,55 @@ pub struct TelegramBridgeManager {
 
 pub type TelegramBridgeState = Arc<tokio::sync::Mutex<TelegramBridgeManager>>;
 
+#[must_use = "BridgeShutdown must be consumed with spawn_wait_or_abort() or abort_now() after releasing TelegramBridgeState"]
+pub struct BridgeShutdown {
+    session_id: Uuid,
+    tasks: Vec<JoinHandle<()>>,
+}
+
+impl BridgeShutdown {
+    pub fn spawn_wait_or_abort(self) {
+        tokio::spawn(async move {
+            self.wait_or_abort().await;
+        });
+    }
+
+    pub fn abort_now(self) {
+        for task in self.tasks {
+            task.abort();
+        }
+    }
+
+    async fn wait_or_abort(self) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        for mut task in self.tasks {
+            if Instant::now() >= deadline {
+                task.abort();
+                continue;
+            }
+
+            match timeout_at(deadline, &mut task).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) if e.is_cancelled() => {}
+                Ok(Err(e)) => {
+                    log::warn!(
+                        "[telegram] Bridge task for session {} ended with error: {}",
+                        self.session_id,
+                        e
+                    );
+                }
+                Err(_) => {
+                    task.abort();
+                    log::warn!(
+                        "[telegram] Bridge task for session {} did not stop within timeout",
+                        self.session_id
+                    );
+                }
+            }
+        }
+    }
+}
+
 impl TelegramBridgeManager {
     pub fn new(output_senders: OutputSenderMap) -> Self {
         Self {
@@ -35,6 +88,7 @@ impl TelegramBridgeManager {
         session_id: Uuid,
         bot: &TelegramBotConfig,
         pty_mgr: Arc<Mutex<PtyManager>>,
+        network: OutboundNetwork,
         app_handle: tauri::AppHandle<R>,
         reader: Option<SessionReaderKind>,
     ) -> Result<BridgeInfo, AppError> {
@@ -70,6 +124,7 @@ impl TelegramBridgeManager {
             session_id,
             info.clone(),
             pty_mgr,
+            network,
             app_handle,
             reader,
         );
@@ -88,7 +143,7 @@ impl TelegramBridgeManager {
         Ok(info)
     }
 
-    pub fn detach(&mut self, session_id: Uuid) -> Result<(), AppError> {
+    pub fn detach(&mut self, session_id: Uuid) -> Result<BridgeShutdown, AppError> {
         let handle = self.bridges.remove(&session_id).ok_or_else(|| {
             AppError::Telegram(format!("No bridge attached to session {}", session_id))
         })?;
@@ -101,7 +156,10 @@ impl TelegramBridgeManager {
 
         self.bot_assignments.retain(|_, sid| *sid != session_id);
 
-        Ok(())
+        Ok(BridgeShutdown {
+            session_id,
+            tasks: handle.tasks,
+        })
     }
 
     pub fn list_bridges(&self) -> Vec<BridgeInfo> {
@@ -117,15 +175,76 @@ impl TelegramBridgeManager {
     }
 
     /// Cancel all active bridges. Called during app shutdown.
-    pub fn cancel_all(&self) {
-        for handle in self.bridges.values() {
+    pub fn cancel_all(&mut self) -> Vec<BridgeShutdown> {
+        let mut shutdowns = Vec::new();
+        for (session_id, handle) in self.bridges.drain() {
             handle.cancel.cancel();
+            shutdowns.push(BridgeShutdown {
+                session_id,
+                tasks: handle.tasks,
+            });
         }
-        if !self.bridges.is_empty() {
+        if let Ok(mut senders) = self.output_senders.lock() {
+            senders.clear();
+        }
+        self.bot_assignments.clear();
+        if !shutdowns.is_empty() {
             log::info!(
                 "[telegram] Cancelled {} active bridges for shutdown",
-                self.bridges.len()
+                shutdowns.len()
             );
+        }
+        shutdowns
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    #[tokio::test]
+    async fn cancel_all_drains_bridge_state_and_returns_shutdowns() {
+        let output_senders: OutputSenderMap = Arc::new(Mutex::new(HashMap::new()));
+        let mut manager = TelegramBridgeManager::new(Arc::clone(&output_senders));
+        let session_id = Uuid::new_v4();
+        let cancel = CancellationToken::new();
+        let (tx, _rx) = mpsc::channel(1);
+        let task = tokio::spawn(async {
+            std::future::pending::<()>().await;
+        });
+
+        manager.bot_assignments.insert("bot-1".into(), session_id);
+        output_senders
+            .lock()
+            .unwrap()
+            .insert(session_id, tx.clone());
+        manager.bridges.insert(
+            session_id,
+            BridgeHandle {
+                info: BridgeInfo {
+                    bot_id: "bot-1".into(),
+                    bot_label: "Bot 1".into(),
+                    session_id: session_id.to_string(),
+                    status: BridgeStatus::Active,
+                    color: "#229ED9".into(),
+                },
+                cancel: cancel.clone(),
+                output_sender: tx,
+                tasks: vec![task],
+            },
+        );
+
+        let shutdowns = manager.cancel_all();
+
+        assert!(cancel.is_cancelled());
+        assert!(manager.bridges.is_empty());
+        assert!(manager.bot_assignments.is_empty());
+        assert!(output_senders.lock().unwrap().is_empty());
+        assert_eq!(shutdowns.len(), 1);
+        for shutdown in shutdowns {
+            shutdown.abort_now();
         }
     }
 }

--- a/src-tauri/src/telegram/manager.rs
+++ b/src-tauri/src/telegram/manager.rs
@@ -33,7 +33,7 @@ pub struct BridgeShutdown {
 
 impl BridgeShutdown {
     pub fn spawn_wait_or_abort(self) {
-        tokio::spawn(async move {
+        tauri::async_runtime::spawn(async move {
             self.wait_or_abort().await;
         });
     }

--- a/src-tauri/src/web/broadcast.rs
+++ b/src-tauri/src/web/broadcast.rs
@@ -1,6 +1,8 @@
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 
+const WS_CLIENT_QUEUE_CAP: usize = 1024;
+
 /// Message types sent to WebSocket clients.
 #[derive(Clone, Debug)]
 pub enum WsOutMsg {
@@ -14,7 +16,7 @@ pub enum WsOutMsg {
 /// Thread-safe (Mutex-based) so it can be called from native PTY read threads.
 #[derive(Clone)]
 pub struct WsBroadcaster {
-    senders: Arc<Mutex<Vec<mpsc::UnboundedSender<WsOutMsg>>>>,
+    senders: Arc<Mutex<Vec<mpsc::Sender<WsOutMsg>>>>,
 }
 
 impl Default for WsBroadcaster {
@@ -31,8 +33,8 @@ impl WsBroadcaster {
     }
 
     /// Register a new client's sender. Returns the receiver for the WS write loop.
-    pub fn subscribe(&self) -> mpsc::UnboundedReceiver<WsOutMsg> {
-        let (tx, rx) = mpsc::unbounded_channel();
+    pub fn subscribe(&self) -> mpsc::Receiver<WsOutMsg> {
+        let (tx, rx) = mpsc::channel(WS_CLIENT_QUEUE_CAP);
         let mut senders = self.senders.lock().unwrap();
         senders.push(tx);
         rx
@@ -46,7 +48,7 @@ impl WsBroadcaster {
         let out = WsOutMsg::Text(text);
 
         let mut senders = self.senders.lock().unwrap();
-        senders.retain(|tx| tx.send(out.clone()).is_ok());
+        senders.retain(|tx| tx.try_send(out.clone()).is_ok());
     }
 
     /// Broadcast PTY output as binary frame: 36-byte UUID ASCII + raw bytes.
@@ -65,11 +67,31 @@ impl WsBroadcaster {
 
         let out = WsOutMsg::Binary(frame);
         let mut senders = self.senders.lock().unwrap();
-        senders.retain(|tx| tx.send(out.clone()).is_ok());
+        senders.retain(|tx| tx.try_send(out.clone()).is_ok());
     }
 
     /// Number of connected clients (for diagnostics).
     pub fn client_count(&self) -> usize {
         self.senders.lock().unwrap().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drops_slow_client_when_queue_is_full() {
+        let broadcaster = WsBroadcaster::new();
+        let _slow_rx = broadcaster.subscribe();
+        assert_eq!(broadcaster.client_count(), 1);
+
+        for n in 0..WS_CLIENT_QUEUE_CAP {
+            broadcaster.broadcast_event("tick", &serde_json::json!({ "n": n }));
+            assert_eq!(broadcaster.client_count(), 1);
+        }
+
+        broadcaster.broadcast_event("tick", &serde_json::json!({ "n": "overflow" }));
+        assert_eq!(broadcaster.client_count(), 0);
     }
 }

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -204,7 +204,7 @@ async fn handle_ws_connection(socket: WebSocket, ws_state: WsState) {
     let mut broadcast_rx = ws_state.broadcaster.subscribe();
 
     // Forward broadcasts to this client
-    let send_task = tokio::spawn(async move {
+    let mut send_task = tokio::spawn(async move {
         while let Some(msg) = broadcast_rx.recv().await {
             let ws_msg = match msg {
                 broadcast::WsOutMsg::Text(text) => Message::Text(text.into()),
@@ -218,7 +218,7 @@ async fn handle_ws_connection(socket: WebSocket, ws_state: WsState) {
 
     // Read commands from client
     let state_clone = ws_state.clone();
-    let recv_task = tokio::spawn(async move {
+    let mut recv_task = tokio::spawn(async move {
         while let Some(Ok(msg)) = StreamExt::next(&mut ws_receiver).await {
             match msg {
                 Message::Text(text) => {
@@ -233,10 +233,16 @@ async fn handle_ws_connection(socket: WebSocket, ws_state: WsState) {
         }
     });
 
-    // Wait for either task to finish, then abort the other
+    // Wait for either task to finish, then abort and reap the other.
     tokio::select! {
-        _ = send_task => {}
-        _ = recv_task => {}
+        _ = &mut send_task => {
+            recv_task.abort();
+            let _ = recv_task.await;
+        }
+        _ = &mut recv_task => {
+            send_task.abort();
+            let _ = send_task.await;
+        }
     }
 }
 

--- a/src/shared/transport-ws.ts
+++ b/src/shared/transport-ws.ts
@@ -15,6 +15,8 @@ export class WsTransport implements Transport {
   private reconnectDelay = 1000;
   private maxReconnectDelay = 10000;
   private connected = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private closed = false;
   private url: string;
 
   constructor() {
@@ -26,17 +28,25 @@ export class WsTransport implements Transport {
   }
 
   private connect() {
-    try {
-      this.ws = new WebSocket(this.url);
-      this.ws.binaryType = "arraybuffer";
+    if (this.closed) return;
 
-      this.ws.onopen = () => {
+    try {
+      const socket = new WebSocket(this.url);
+      this.ws = socket;
+      socket.binaryType = "arraybuffer";
+
+      socket.onopen = () => {
+        if (this.ws !== socket || this.closed) {
+          socket.close();
+          return;
+        }
         this.connected = true;
         this.reconnectDelay = 1000;
         console.log("[ws-transport] Connected");
       };
 
-      this.ws.onmessage = (event) => {
+      socket.onmessage = (event) => {
+        if (this.ws !== socket || this.closed) return;
         if (event.data instanceof ArrayBuffer) {
           this.handleBinary(new Uint8Array(event.data));
         } else {
@@ -44,13 +54,15 @@ export class WsTransport implements Transport {
         }
       };
 
-      this.ws.onclose = () => {
+      socket.onclose = () => {
+        if (this.ws !== socket) return;
+        this.ws = null;
         this.connected = false;
         this.rejectAllPending("WebSocket closed");
         this.scheduleReconnect();
       };
 
-      this.ws.onerror = () => {
+      socket.onerror = () => {
         // onclose will fire after this
       };
     } catch {
@@ -59,16 +71,49 @@ export class WsTransport implements Transport {
   }
 
   private scheduleReconnect() {
-    setTimeout(() => {
+    if (this.closed || this.reconnectTimer) return;
+
+    const delay =
+      this.reconnectDelay +
+      Math.floor(Math.random() * Math.min(250, this.reconnectDelay));
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.closed) return;
+      if (
+        this.ws &&
+        (this.ws.readyState === WebSocket.OPEN ||
+          this.ws.readyState === WebSocket.CONNECTING)
+      ) {
+        return;
+      }
       console.log(
-        `[ws-transport] Reconnecting in ${this.reconnectDelay}ms...`
+        `[ws-transport] Reconnecting after ${delay}ms...`
       );
       this.connect();
       this.reconnectDelay = Math.min(
         this.reconnectDelay * 2,
         this.maxReconnectDelay
       );
-    }, this.reconnectDelay);
+    }, delay);
+  }
+
+  close() {
+    this.closed = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    const socket = this.ws;
+    this.ws = null;
+    this.connected = false;
+    if (
+      socket &&
+      (socket.readyState === WebSocket.OPEN ||
+        socket.readyState === WebSocket.CONNECTING)
+    ) {
+      socket.close();
+    }
+    this.rejectAllPending("WebSocket closed");
   }
 
   private rejectAllPending(reason: string) {


### PR DESCRIPTION
Closes #501

## Summary
- Add shared outbound network state with bounded semaphore, shared reqwest clients, pool caps, and deterministic salted backoff.
- Route Telegram API, bridge polling/output, JSONL watchers, voice transcription, Home markdown fetch, Telegram test send, and image uploads through the shared limiter.
- Redact Telegram upload errors for `sendPhoto` and `sendDocument`.
- Make Telegram bridge shutdown handles `#[must_use]`, consume them on detach/rollback/auto-detach/app shutdown, and use immediate abort during app exit.
- Bound WebSocket queues, add stale reconnect guards, harden PTY child kill/reap, and add git subprocess timeouts.

## Validation
- `cargo test network::`
- `cargo test telegram::api::tests`
- `cargo test telegram::manager::tests`
- `cargo test web::broadcast::tests`
- `cargo test cli::agency_templates::tests::bounded_process_timeout_kills_and_reaps_child`
- `cargo test telegram::bridge::tests::poll_backoff_uses_plan_bounds_and_session_salt`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib` (`1004 passed, 7 ignored`)
- Shipper `npx tauri build` after `npm ci`
- Deployed and smoke-tested `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-2.exe --help`

## Notes
- `npm ci` was required because local `node_modules/mermaid` was missing.
- Live-host recursive descendant PID and WSL-owned socket observation remains the follow-up validation for the original outage mode; if those counts keep growing after session close, the next design should be Windows Job Object containment.