### PR TITLE
test: add Windows release CLI smoke (#483)

### DIFF
--- a/.github/workflows/pr-regression-gates.yml
+++ b/.github/workflows/pr-regression-gates.yml
@@ -84,6 +84,50 @@ jobs:
         working-directory: src-tauri
         run: cargo test --lib --bins --tests
 
+  windows-release-cli-smoke:
+    name: windows-release-cli-smoke
+    # Skip branch-deletion push events while still requiring pull request validation.
+    if: github.event_name != 'push' || (github.event.deleted != true && github.event.after != '0000000000000000000000000000000000000000')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Pin npm version
+        run: npm install -g npm@11.6.2
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Build Windows release binary
+        run: npm run build:prod
+
+      - name: Run Windows release CLI smoke
+        run: npm run smoke:cli-release-windows
+
+      - name: Upload CLI smoke logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-release-cli-smoke-logs
+          path: artifacts/cli-release-smoke
+          if-no-files-found: ignore
+
   frontend-regression:
     name: frontend-regression
     # Skip branch-deletion push events while still requiring pull request validation.

--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.8.51"; // Must match package.json
+const VERSION = "0.8.52"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.8.51",
+  "version": "0.8.52",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.51",
+  "version": "0.8.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.51",
+      "version": "0.8.52",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.51",
+  "version": "0.8.52",
   "private": true,
   "type": "module",
   "scripts": {
@@ -20,6 +20,7 @@
     "test:debt": "node scripts/check-test-debt.mjs",
     "test:debt:self": "node scripts/check-test-debt.mjs --self-test",
     "test:watch": "vitest",
+    "smoke:cli-release-windows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File ./scripts/smoke-cli-release-windows.ps1",
     "smoke:profile-matrix": "node scripts/smoke-profile-matrix-preview.mjs",
     "smoke:current-app": "node scripts/smoke-current-app-mockup.mjs"
   },

--- a/scripts/smoke-cli-powershell.ps1
+++ b/scripts/smoke-cli-powershell.ps1
@@ -2,27 +2,60 @@
 param(
     [Parameter(Mandatory=$true)]
     [string]$BinaryPath,
+    [string]$Shell = "powershell.exe",
     [string]$Token = "00000000-0000-0000-0000-000000000000",
-    [string]$Root = (New-Item -ItemType Directory -Force -Path (Join-Path $env:TEMP "ac-smoke-$([guid]::NewGuid().ToString('N'))")).FullName
+    [string]$Root = (New-Item -ItemType Directory -Force -Path (Join-Path $env:TEMP "ac-smoke-$([guid]::NewGuid().ToString('N'))")).FullName,
+    [string]$LogDir = (Join-Path $env:TEMP "ac-cli-smoke-logs")
 )
 
 $ErrorActionPreference = "Continue"
 $failed = 0
 
-# Bug-reproducing harness: spawn a fresh `powershell.exe -NonInteractive -NoProfile`
-# and run the AC exe via `&` direct call (no pipeline operators in the inner command).
-# This is the exact shape from verify-prod-binary.ps1 and R2.6's Rust test, and it is
-# the ONLY shape that reproduces issue #129's failure mode.
-#
-# Note on exit codes: PS-NonInteractive bare `&` does NOT propagate $LASTEXITCODE for
-# GUI-subsystem children (PE Subsystem=2 — empirically verified in Round 3, R3.G.3).
-# The outer process always sees ExitCode=0 regardless of the AC binary's true exit
-# code. This is the same bare-`&`-vs-pipeline asymmetry underlying issue #129 itself,
-# and it cannot be worked around in this harness shape (the harness shape is mandatory
-# to reproduce the bug). Tests 1-3 therefore drop exit-code assertions and rely on
-# stdout/stderr presence — those are the bug-relevant signals (Round 4, Option 1).
+if (-not (Test-Path -LiteralPath $BinaryPath -PathType Leaf)) {
+    Write-Host "FAIL: binary not found: $BinaryPath" -ForegroundColor Red
+    exit 1
+}
+
+$shellCmd = Get-Command $Shell -ErrorAction SilentlyContinue
+if ($null -eq $shellCmd) {
+    Write-Host "SKIP: shell not found: $Shell" -ForegroundColor Yellow
+    exit 0
+}
+$ShellPath = $shellCmd.Source
+
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+$summary = New-Object System.Collections.Generic.List[object]
+
+function New-CasePaths {
+    param(
+        [Parameter(Mandatory=$true)] [string]$CaseName
+    )
+    $safeCase = $CaseName -replace '[^A-Za-z0-9_.-]', '_'
+    [pscustomobject]@{
+        StdoutPath = Join-Path $LogDir "$safeCase.stdout.txt"
+        StderrPath = Join-Path $LogDir "$safeCase.stderr.txt"
+        CommandPath = Join-Path $LogDir "$safeCase.command.txt"
+    }
+}
+
+function Write-CaseLogs {
+    param(
+        [Parameter(Mandatory=$true)] [pscustomobject]$Paths,
+        [Parameter(Mandatory=$true)] [string]$Command,
+        [AllowNull()] [string]$Stdout,
+        [AllowNull()] [string]$Stderr
+    )
+    Set-Content -LiteralPath $Paths.CommandPath -Value $Command -Encoding UTF8
+    Set-Content -LiteralPath $Paths.StdoutPath -Value $(if ($null -eq $Stdout) { '' } else { $Stdout }) -Encoding UTF8
+    Set-Content -LiteralPath $Paths.StderrPath -Value $(if ($null -eq $Stderr) { '' } else { $Stderr }) -Encoding UTF8
+}
+
+# Bug-reproducing harness: spawn a fresh PowerShell process with -NonInteractive -NoProfile
+# and run the AC exe via a direct call. This is the mandatory issue #129 shape.
 function Invoke-PSNonInteractiveDirect {
     param(
+        [Parameter(Mandatory=$true)] [string]$ShellPath,
+        [Parameter(Mandatory=$true)] [string]$CaseName,
         [Parameter(Mandatory=$true)] [string]$Exe,
         [Parameter(Mandatory=$true)] [string[]]$ExeArgs
     )
@@ -31,10 +64,12 @@ function Invoke-PSNonInteractiveDirect {
         "'" + ($_ -replace "'", "''") + "'"
     }) -join ' '
     $inner = "& '$escapedExe' $quotedArgs"
+    $arguments = "-NonInteractive -NoProfile -Command `"$inner`""
+    $paths = New-CasePaths -CaseName $CaseName
 
     $psi = New-Object System.Diagnostics.ProcessStartInfo
-    $psi.FileName = 'powershell.exe'
-    $psi.Arguments = "-NonInteractive -NoProfile -Command `"$inner`""
+    $psi.FileName = $ShellPath
+    $psi.Arguments = $arguments
     $psi.UseShellExecute = $false
     $psi.RedirectStandardOutput = $true
     $psi.RedirectStandardError = $true
@@ -45,124 +80,154 @@ function Invoke-PSNonInteractiveDirect {
     $stderrTask = $proc.StandardError.ReadToEndAsync()
     $proc.WaitForExit()
 
+    $stdout = if ($null -eq $stdoutTask.Result) { '' } else { $stdoutTask.Result }
+    $stderr = if ($null -eq $stderrTask.Result) { '' } else { $stderrTask.Result }
+    $commandText = "$ShellPath $arguments"
+    Write-CaseLogs -Paths $paths -Command $commandText -Stdout $stdout -Stderr $stderr
+
+    $case = [pscustomobject]@{
+        name = $CaseName
+        shellPath = $ShellPath
+        binaryPath = $Exe
+        commandPath = $paths.CommandPath
+        stdoutPath = $paths.StdoutPath
+        stderrPath = $paths.StderrPath
+        exitCode = $proc.ExitCode
+    }
+    $summary.Add($case) | Out-Null
+
     [pscustomobject]@{
-        Stdout = if ($null -eq $stdoutTask.Result) { '' } else { $stdoutTask.Result }
-        Stderr = if ($null -eq $stderrTask.Result) { '' } else { $stderrTask.Result }
+        CaseName = $CaseName
+        Stdout = $stdout
+        Stderr = $stderr
+        ExitCode = $proc.ExitCode
+        StdoutPath = $paths.StdoutPath
+        StderrPath = $paths.StderrPath
+        CommandPath = $paths.CommandPath
     }
 }
 
-function Assert-True([string]$Name, [bool]$Cond, [string]$Detail) {
+function New-FailureDetail {
+    param(
+        [Parameter(Mandatory=$true)] [string]$CaseName,
+        [Parameter(Mandatory=$true)] [string]$Detail,
+        [Parameter(Mandatory=$true)] [object]$Result
+    )
+    "binary='$BinaryPath'; shell='$ShellPath'; case='$CaseName'; commandLog='$($Result.CommandPath)'; stdoutLog='$($Result.StdoutPath)'; stderrLog='$($Result.StderrPath)'; detail=$Detail"
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory=$true)] [string]$Name,
+        [Parameter(Mandatory=$true)] [bool]$Cond,
+        [Parameter(Mandatory=$true)] [string]$Detail,
+        [Parameter(Mandatory=$true)] [string]$CaseName,
+        [Parameter(Mandatory=$true)] [object]$Result
+    )
     if ($Cond) {
         Write-Host "PASS: $Name" -ForegroundColor Green
     } else {
-        Write-Host "FAIL: $Name -- $Detail" -ForegroundColor Red
+        Write-Host "FAIL: $Name -- $(New-FailureDetail -CaseName $CaseName -Detail $Detail -Result $Result)" -ForegroundColor Red
         $script:failed++
     }
 }
 
-# Test 1: list-peers -- stdout has JSON, stderr is empty (post-fix contract).
-# Failure mode on unfixed binary (per R2.1 / R3.2): AC binary inherits valid PIPE
-# stdout from PS-NonInteractive's `&` direct call; the unfixed `attach_parent_console`
-# unconditionally calls AttachConsole, which rebinds STD_OUTPUT_HANDLE to PS's hidden
-# console buffer (PIPE -> CHAR); PS-NonInteractive does not surface that buffer to
-# its captured stdout pipe; captured stdout is empty. Test 1's "stdout non-empty"
-# assertion fails. Empirically confirmed in verify-prod-binary.ps1 Test 1.
-$r1 = Invoke-PSNonInteractiveDirect -Exe $BinaryPath -ExeArgs @('list-peers', '--token', $Token, '--root', $Root)
-Assert-True "list-peers stdout non-empty" (-not [string]::IsNullOrWhiteSpace($r1.Stdout)) "stdout was empty (issue #129 not fixed)"
-Assert-True "list-peers stderr empty" ([string]::IsNullOrWhiteSpace($r1.Stderr)) "stderr leaked content: $($r1.Stderr)"
-# NEW-4 fix: layered guard mirroring Test 4's NEW-2 fix. Empty/whitespace stdout is
-# already covered by the prior `stdout non-empty` assertion; only attempt parse when
-# stdout has content, and explicitly fail on `$null -eq $parsed` to avoid the silent
-# false-PASS that `'' | ConvertFrom-Json -ErrorAction Stop` would otherwise produce.
+# Test 1: list-peers stdout must contain JSON, and stderr must be empty.
+$r1 = Invoke-PSNonInteractiveDirect -ShellPath $ShellPath -CaseName "01-list-peers-direct" -Exe $BinaryPath -ExeArgs @('list-peers', '--token', $Token, '--root', $Root)
+Assert-True "list-peers stdout non-empty" (-not [string]::IsNullOrWhiteSpace($r1.Stdout)) "stdout was empty (issue #129 not fixed)" $r1.CaseName $r1
+Assert-True "list-peers stderr empty" ([string]::IsNullOrWhiteSpace($r1.Stderr)) "stderr leaked content; inspect stderr log" $r1.CaseName $r1
 if (-not [string]::IsNullOrWhiteSpace($r1.Stdout)) {
     try {
         $parsed = $r1.Stdout | ConvertFrom-Json -ErrorAction Stop
         if ($null -eq $parsed) {
-            Write-Host "FAIL: list-peers ConvertFrom-Json returned null on non-empty stdout" -ForegroundColor Red
+            Write-Host "FAIL: list-peers ConvertFrom-Json returned null -- $(New-FailureDetail -CaseName $r1.CaseName -Detail 'non-empty stdout parsed to null' -Result $r1)" -ForegroundColor Red
             $failed++
         } else {
             Write-Host "PASS: list-peers stdout parses as JSON" -ForegroundColor Green
         }
     } catch {
-        Write-Host "FAIL: list-peers stdout not valid JSON: $($r1.Stdout)" -ForegroundColor Red
+        Write-Host "FAIL: list-peers stdout not valid JSON -- $(New-FailureDetail -CaseName $r1.CaseName -Detail $_.Exception.Message -Result $r1)" -ForegroundColor Red
         $failed++
     }
 }
-# else: empty case is already counted as a fail by the prior `stdout non-empty` assertion above
 
-# Test 2: send --help -- stdout has clap-rendered help text.
-# Failure mode on unfixed binary: identical to Test 1 — clap writes the help text
-# to stdout; AttachConsole rebinds the inherited PIPE stdout to PS's hidden console
-# buffer; captured stdout is empty. Test 2's "stdout non-empty" assertion fails.
-# Empirically confirmed in verify-prod-binary.ps1 Test 1 (same `send --help` invocation).
-$r2 = Invoke-PSNonInteractiveDirect -Exe $BinaryPath -ExeArgs @('send', '--help')
-Assert-True "send --help stdout non-empty" (-not [string]::IsNullOrWhiteSpace($r2.Stdout)) "stdout was empty (issue #129 not fixed for --help path)"
-Assert-True "send --help mentions --to flag" ($r2.Stdout -match '--to') "stdout missing expected flag mention"
+# Test 2: send --help stdout must contain clap-rendered help text.
+$r2 = Invoke-PSNonInteractiveDirect -ShellPath $ShellPath -CaseName "02-send-help-direct" -Exe $BinaryPath -ExeArgs @('send', '--help')
+Assert-True "send --help stdout non-empty" (-not [string]::IsNullOrWhiteSpace($r2.Stdout)) "stdout was empty (issue #129 not fixed for help path)" $r2.CaseName $r2
+Assert-True "send --help mentions --to flag" ($r2.Stdout -match '--to') "stdout missing expected flag mention" $r2.CaseName $r2
 
-# Test 3: send unknown flag -- stderr has clap usage error.
-# Failure mode on unfixed binary: clap writes the parse-error/usage text to stderr.
-# The AC binary's STD_ERROR_HANDLE is also inherited as a valid PIPE; the unfixed
-# `attach_parent_console` rebinds it to PS's hidden console buffer the same way as
-# stdout; captured stderr is empty. Test 3's "stderr non-empty" assertion fails.
-# Per R3.G.3 / R3.G.5 (Round 3 grinch verification, integrated in Round 4),
-# exit-code propagation is not usable in this harness: PS-NonInteractive bare `&`
-# does NOT update $LASTEXITCODE for GUI-subsystem children, so any `exit non-zero`
-# assertion would fail even on a correctly fixed binary. `stderr non-empty` is the
-# sole — and bug-relevant — signal for this test.
-$r3 = Invoke-PSNonInteractiveDirect -Exe $BinaryPath -ExeArgs @('send', '--bogus-flag-xyz')
-Assert-True "send unknown flag stderr non-empty" (-not [string]::IsNullOrWhiteSpace($r3.Stderr)) "stderr was empty (issue #129 not fixed for clap-error path)"
+# Test 3: send unknown flag stderr must contain clap usage error.
+$r3 = Invoke-PSNonInteractiveDirect -ShellPath $ShellPath -CaseName "03-send-unknown-flag-direct" -Exe $BinaryPath -ExeArgs @('send', '--bogus-flag-xyz')
+Assert-True "send unknown flag stderr non-empty" (-not [string]::IsNullOrWhiteSpace($r3.Stderr)) "stderr was empty (issue #129 not fixed for clap-error path)" $r3.CaseName $r3
 
-# Test 4 (G3 regression check): `2>&1 | ConvertFrom-Json` on list-peers must still work.
-# This test deliberately uses a DIFFERENT inner command shape — pipeline mode with
-# `2>&1 | Out-String`. Pipeline mode bypasses issue #129 (R2.1 confirmed: pipeline
-# operators give the child a PIPE stdout via STARTUPINFO redirection, no NULL → no
-# AttachConsole rebind). So Test 4 PASSES on both fixed and unfixed binary as long
-# as stderr is empty (which it is post-Step-A). Test 4 FAILS only if a future change
-# reintroduces dual-write to stderr — the merged stream would then contain non-JSON
-# stderr content, breaking ConvertFrom-Json. That is the regression Test 4 guards.
-#
-# NEW-2 fix: replace the broken `-replace [char]39, [char]39 + [char]39` (which is a
-# PS parser error -- three args to -replace -- that with $ErrorActionPreference="Continue"
-# silently produced an empty inner command) with string-literal `-replace "'", "''"`
-# (Option B from R2.G.5). Also tighten the assertion: fail on empty merged output
-# regardless of ConvertFrom-Json's silent null-on-empty-input behavior.
-# NEW-5 fix (Round 4): escape and single-quote-wrap $Token consistently with
-# $BinaryPath / $Root. Default Token is a UUID and therefore safe, but a custom
-# -Token containing single quotes would otherwise break the inner command.
+# Test 4: pipeline mode must still produce JSON when stderr is merged.
 $escapedBin = $BinaryPath -replace "'", "''"
 $escapedRoot = $Root -replace "'", "''"
 $escapedToken = $Token -replace "'", "''"
 $inner = "& '$escapedBin' list-peers --token '$escapedToken' --root '$escapedRoot' 2>&1 | Out-String"
+$arguments = "-NonInteractive -NoProfile -Command `"$inner`""
+$paths4 = New-CasePaths -CaseName "04-list-peers-merged-pipeline"
 $psi = New-Object System.Diagnostics.ProcessStartInfo
-$psi.FileName = 'powershell.exe'
-$psi.Arguments = "-NonInteractive -NoProfile -Command `"$inner`""
+$psi.FileName = $ShellPath
+$psi.Arguments = $arguments
 $psi.UseShellExecute = $false
 $psi.RedirectStandardOutput = $true
 $psi.RedirectStandardError = $true
 $psi.CreateNoWindow = $true
 $proc = [System.Diagnostics.Process]::Start($psi)
 $mergedTask = $proc.StandardOutput.ReadToEndAsync()
-$null = $proc.StandardError.ReadToEndAsync()
+$stderrTask = $proc.StandardError.ReadToEndAsync()
 $proc.WaitForExit()
 $mergedOut = if ($null -eq $mergedTask.Result) { '' } else { $mergedTask.Result }
+$test4Stderr = if ($null -eq $stderrTask.Result) { '' } else { $stderrTask.Result }
+Write-CaseLogs -Paths $paths4 -Command "$ShellPath $arguments" -Stdout $mergedOut -Stderr $test4Stderr
+$r4 = [pscustomobject]@{
+    CaseName = "04-list-peers-merged-pipeline"
+    Stdout = $mergedOut
+    Stderr = $test4Stderr
+    ExitCode = $proc.ExitCode
+    StdoutPath = $paths4.StdoutPath
+    StderrPath = $paths4.StderrPath
+    CommandPath = $paths4.CommandPath
+}
+$summary.Add([pscustomobject]@{
+    name = $r4.CaseName
+    shellPath = $ShellPath
+    binaryPath = $BinaryPath
+    commandPath = $r4.CommandPath
+    stdoutPath = $r4.StdoutPath
+    stderrPath = $r4.StderrPath
+    exitCode = $r4.ExitCode
+}) | Out-Null
 
 if ([string]::IsNullOrWhiteSpace($mergedOut)) {
-    Write-Host "FAIL: Test 4 merged output is empty (inner command may have failed or produced no output)" -ForegroundColor Red
+    Write-Host "FAIL: Test 4 merged output is empty -- $(New-FailureDetail -CaseName $r4.CaseName -Detail 'inner command may have failed or produced no output' -Result $r4)" -ForegroundColor Red
     $failed++
 } else {
     try {
         $parsed = $mergedOut | ConvertFrom-Json -ErrorAction Stop
         if ($null -eq $parsed) {
-            Write-Host "FAIL: Test 4 ConvertFrom-Json returned null on non-empty merged output" -ForegroundColor Red
+            Write-Host "FAIL: Test 4 ConvertFrom-Json returned null -- $(New-FailureDetail -CaseName $r4.CaseName -Detail 'non-empty merged output parsed to null' -Result $r4)" -ForegroundColor Red
             $failed++
         } else {
-            Write-Host "PASS: 2>&1 | ConvertFrom-Json continues to work (no dual-write regression)" -ForegroundColor Green
+            Write-Host "PASS: 2>&1 | ConvertFrom-Json continues to work" -ForegroundColor Green
         }
     } catch {
-        Write-Host "FAIL: 2>&1 | ConvertFrom-Json broken -- merged stream is not valid JSON: $mergedOut" -ForegroundColor Red
+        Write-Host "FAIL: 2>&1 | ConvertFrom-Json broken -- $(New-FailureDetail -CaseName $r4.CaseName -Detail $_.Exception.Message -Result $r4)" -ForegroundColor Red
         $failed++
     }
 }
+
+$summaryPath = Join-Path $LogDir "summary.json"
+[pscustomobject]@{
+    binaryPath = $BinaryPath
+    shell = $Shell
+    shellPath = $ShellPath
+    root = $Root
+    failed = $failed
+    cases = @($summary.ToArray())
+} | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $summaryPath -Encoding UTF8
+Write-Host "Smoke log summary: $summaryPath"
 
 if ($failed -gt 0) {
     Write-Host "`n$failed check(s) failed" -ForegroundColor Red

--- a/scripts/smoke-cli-release-windows.ps1
+++ b/scripts/smoke-cli-release-windows.ps1
@@ -1,0 +1,159 @@
+[CmdletBinding()]
+param(
+    [string]$LogDir = "artifacts\cli-release-smoke",
+    [string]$Token = "00000000-0000-0000-0000-000000000000",
+    [string]$Root = (Join-Path $env:TEMP "ac-release-smoke-$([guid]::NewGuid().ToString('N'))")
+)
+
+$ErrorActionPreference = "Continue"
+
+$scriptDir = $PSScriptRoot
+$repoRoot = Split-Path -Parent $scriptDir
+if (-not [System.IO.Path]::IsPathRooted($LogDir)) {
+    $LogDir = Join-Path $repoRoot $LogDir
+}
+if (-not [System.IO.Path]::IsPathRooted($Root)) {
+    $Root = Join-Path $repoRoot $Root
+}
+
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+if (-not $IsWindows -and $env:OS -ne "Windows_NT") {
+    Write-Host "SKIP: Windows release CLI smoke only runs on Windows" -ForegroundColor Yellow
+    [pscustomobject]@{
+        status = "skipped"
+        reason = "not-windows"
+        logDir = $LogDir
+        invocations = @()
+    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (Join-Path $LogDir "summary.json") -Encoding UTF8
+    exit 0
+}
+
+function Convert-ToSafeName {
+    param([Parameter(Mandatory=$true)] [string]$Name)
+    $Name -replace '[^A-Za-z0-9_.-]', '_'
+}
+
+$releaseDir = Join-Path $repoRoot "src-tauri\target\release"
+$binaries = @(
+    (Join-Path $releaseDir "agentscommander.exe"),
+    (Join-Path $releaseDir "agentscommander_testeable.exe")
+)
+$shells = @("powershell.exe", "pwsh.exe")
+$results = New-Object System.Collections.Generic.List[object]
+$failed = 0
+$passed = 0
+$skipped = 0
+
+$missingBinaries = @($binaries | Where-Object { -not (Test-Path -LiteralPath $_ -PathType Leaf) })
+if ($missingBinaries.Count -gt 0) {
+    foreach ($binary in $missingBinaries) {
+        Write-Host "FAIL: expected release smoke binary missing: $binary" -ForegroundColor Red
+        Write-Host "Run npm run build:prod before smoke:cli-release-windows." -ForegroundColor Red
+        $results.Add([pscustomobject]@{
+            binaryPath = $binary
+            shell = $null
+            status = "failed"
+            exitCode = $null
+            root = $null
+            logDir = $null
+            reason = "missing-binary"
+        }) | Out-Null
+    }
+    [pscustomobject]@{
+        passed = 0
+        skipped = 0
+        failed = $missingBinaries.Count
+        logDir = $LogDir
+        invocations = @($results.ToArray())
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $LogDir "summary.json") -Encoding UTF8
+    exit 1
+}
+
+foreach ($binary in $binaries) {
+    $binaryStem = Convert-ToSafeName -Name ([System.IO.Path]::GetFileNameWithoutExtension($binary))
+    foreach ($shell in $shells) {
+        $shellCmd = Get-Command $shell -ErrorAction SilentlyContinue
+        $shellStem = Convert-ToSafeName -Name ([System.IO.Path]::GetFileNameWithoutExtension($shell))
+        $caseLogDir = Join-Path $LogDir (Join-Path $binaryStem $shellStem)
+        $caseRoot = Join-Path $Root (Join-Path $binaryStem $shellStem)
+        New-Item -ItemType Directory -Force -Path $caseLogDir | Out-Null
+        New-Item -ItemType Directory -Force -Path $caseRoot | Out-Null
+
+        if ($null -eq $shellCmd) {
+            if ($shell -ieq "pwsh.exe") {
+                Write-Host "SKIP: optional shell not found: $shell" -ForegroundColor Yellow
+                $skipped++
+                $results.Add([pscustomobject]@{
+                    binaryPath = $binary
+                    shell = $shell
+                    status = "skipped"
+                    exitCode = $null
+                    root = $caseRoot
+                    logDir = $caseLogDir
+                    reason = "optional-shell-missing"
+                }) | Out-Null
+                continue
+            }
+
+            Write-Host "FAIL: required shell not found: $shell" -ForegroundColor Red
+            $failed++
+            $results.Add([pscustomobject]@{
+                binaryPath = $binary
+                shell = $shell
+                status = "failed"
+                exitCode = $null
+                root = $caseRoot
+                logDir = $caseLogDir
+                reason = "required-shell-missing"
+            }) | Out-Null
+            continue
+        }
+
+        & (Join-Path $scriptDir "smoke-cli-powershell.ps1") `
+            -BinaryPath $binary `
+            -Shell $shell `
+            -Token $Token `
+            -Root $caseRoot `
+            -LogDir $caseLogDir
+        $exitCode = $LASTEXITCODE
+
+        if ($exitCode -eq 0) {
+            Write-Host "PASS: $binary under $shell" -ForegroundColor Green
+            $passed++
+            $status = "passed"
+        } else {
+            Write-Host "FAIL: $binary under $shell exited $exitCode" -ForegroundColor Red
+            $failed++
+            $status = "failed"
+        }
+
+        $results.Add([pscustomobject]@{
+            binaryPath = $binary
+            shell = $shell
+            shellPath = $shellCmd.Source
+            status = $status
+            exitCode = $exitCode
+            root = $caseRoot
+            logDir = $caseLogDir
+            reason = $null
+        }) | Out-Null
+    }
+}
+
+$summaryPath = Join-Path $LogDir "summary.json"
+[pscustomobject]@{
+    passed = $passed
+    skipped = $skipped
+    failed = $failed
+    logDir = $LogDir
+    invocations = @($results.ToArray())
+} | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $summaryPath -Encoding UTF8
+
+Write-Host "Windows release CLI smoke summary: passed=$passed skipped=$skipped failed=$failed logs=$LogDir"
+Write-Host "Wrapper summary: $summaryPath"
+
+if ($failed -gt 0) {
+    exit 1
+}
+exit 0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.51"
+version = "0.8.52"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.51"
+version = "0.8.52"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.8.51",
+  "version": "0.8.52",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {

--- a/src-tauri/tests/cli_powershell_capture.rs
+++ b/src-tauri/tests/cli_powershell_capture.rs
@@ -6,6 +6,10 @@
 //! IMPORTANT: marked #[ignore] because the bug only reproduces in release mode
 //! (`windows_subsystem = "windows"` is gated on `not(debug_assertions)`). To run:
 //!     cargo test --release --test cli_powershell_capture -- --ignored
+//!
+//! CI coverage for shipped/testable release executable names lives in:
+//!     npm run build:prod
+//!     npm run smoke:cli-release-windows
 
 use std::process::{Command, Stdio};
 
@@ -59,7 +63,7 @@ fn debug_guard() {
 // from unfixed binaries.
 
 #[test]
-#[ignore = "Requires release build (windows_subsystem=\"windows\"); run with --release --ignored"]
+#[ignore = "Manual developer check; CI uses smoke:cli-release-windows against shipped/testable exe names"]
 fn list_peers_outputs_valid_json_under_powershell_noninteractive() {
     debug_guard();
 
@@ -91,7 +95,7 @@ fn list_peers_outputs_valid_json_under_powershell_noninteractive() {
 }
 
 #[test]
-#[ignore = "Requires release build; run with --release --ignored"]
+#[ignore = "Manual developer check; CI uses smoke:cli-release-windows against shipped/testable exe names"]
 fn send_help_outputs_under_powershell_noninteractive() {
     debug_guard();
 
@@ -111,7 +115,7 @@ fn send_help_outputs_under_powershell_noninteractive() {
 }
 
 #[test]
-#[ignore = "Requires release build; run with --release --ignored"]
+#[ignore = "Manual developer check; CI uses smoke:cli-release-windows against shipped/testable exe names"]
 fn send_unknown_flag_emits_stderr_under_powershell_noninteractive() {
     debug_guard();
 
@@ -125,7 +129,7 @@ fn send_unknown_flag_emits_stderr_under_powershell_noninteractive() {
 
 // G8: parallel pwsh.exe tests. Skip if pwsh not installed.
 #[test]
-#[ignore = "Requires release build + pwsh.exe; run with --release --ignored"]
+#[ignore = "Manual developer check; CI uses smoke:cli-release-windows against shipped/testable exe names when pwsh.exe is installed"]
 fn list_peers_outputs_valid_json_under_pwsh_noninteractive() {
     debug_guard();
 


### PR DESCRIPTION
## Summary

- Add Windows release-mode CLI smoke coverage for shipped executables.
- Cover `agentscommander.exe` and `agentscommander_testeable.exe` under `powershell.exe` and `pwsh.exe` where available.
- Add actionable per-case logs and workflow coverage for the Windows release smoke path.

## Validation

- dev-rust reported passing: `npm run validate-branch-name`, `npm run version:check`, `npm run test:debt`, `npm run build:prod`, `npm run smoke:cli-release-windows`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib --bins --tests`, `git diff --check`, and base ancestry.
- dev-rust-grinch focused re-review returned PASS for commit `c5cbc37629df01dfd7060e2a677085c21d2b6759`.
- Shipper deployed `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe`, SHA256 `B6E93FF7EC0F50F3D8753D59803E07EEB1D4269567BB1123871AD206C7AC838D`.
- WG-13 acceptance returned explicit OK for commit `c5cbc37629df01dfd7060e2a677085c21d2b6759` on base `c7e7794bda76d916084379ce250bb9a0ad4590f6`.
- Acceptance evidence: `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-13-acceptance-testing\__agent_ac-cli-and-gui-tester\artifacts\issue-483-c5cbc376-updated-rerun-20260613-223206`.

Closes #483