### PR TITLE
test: add PTY lifecycle regression suite (#484)

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.8.52"; // Must match package.json
+const VERSION = "0.8.53"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.8.52",
+  "version": "0.8.53",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.52",
+  "version": "0.8.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.52",
+      "version": "0.8.53",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.52",
+  "version": "0.8.53",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.52"
+version = "0.8.53"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.52"
+version = "0.8.53"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1230,8 +1230,8 @@ pub(crate) async fn preserve_deferred_telegram_intent_if_valid(
     }
 }
 
-pub(crate) async fn attach_local_config_telegram_if_any(
-    app: &AppHandle,
+pub(crate) async fn attach_local_config_telegram_if_any<R: tauri::Runtime>(
+    app: &AppHandle<R>,
     session_id: Uuid,
     cwd: &str,
 ) {
@@ -1506,21 +1506,16 @@ fn effective_restart_skip_auto_resume(requested: Option<bool>) -> bool {
 ///
 /// The restarted session is automatically activated, Telegram bridges are
 /// re-attached, and state is persisted.
-// Tauri command: State<> injections push us over clippy's 7-arg threshold.
 #[allow(clippy::too_many_arguments)]
-#[tauri::command]
-pub async fn restart_session(
-    app: AppHandle,
-    session_mgr: State<'_, Arc<tokio::sync::RwLock<SessionManager>>>,
-    pty_mgr: State<'_, Arc<Mutex<PtyManager>>>,
-    _tg_mgr: State<'_, TelegramBridgeState>,
-    settings: State<'_, SettingsState>,
-    id: String,
+pub async fn restart_session_inner<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+    pty_mgr: &Arc<Mutex<PtyManager>>,
+    settings: &SettingsState,
+    uuid: Uuid,
     agent_id: Option<String>,
     skip_auto_resume: Option<bool>,
 ) -> Result<SessionInfo, String> {
-    let uuid = Uuid::parse_str(&id).map_err(|e| e.to_string())?;
-
     // 1. Read config from existing session BEFORE destroying it
     let (
         shell,
@@ -1576,16 +1571,16 @@ pub async fn restart_session(
 
     // 3. Destroy the old session (resolves all State<> internally from app)
     if is_root_agent {
-        force_destroy_session_inner(&app, uuid).await?;
+        force_destroy_session_inner(app, uuid).await?;
     } else {
-        destroy_session_inner(&app, uuid).await?;
+        destroy_session_inner(app, uuid).await?;
     }
 
     // 4. Create new session with same config, or switch to the selected coding agent.
     let session_info = create_session_inner(
-        &app,
-        session_mgr.inner(),
-        pty_mgr.inner(),
+        app,
+        session_mgr,
+        pty_mgr,
         shell,
         shell_args,
         cwd.clone(),
@@ -1614,9 +1609,9 @@ pub async fn restart_session(
 
     // 6. Re-attach Telegram bridge from live persisted intent, or fall back to repo config.
     if telegram_bot_id.is_some() {
-        attach_persisted_telegram_if_configured(&app, new_uuid, telegram_bot_id.as_deref()).await;
+        attach_persisted_telegram_if_configured(app, new_uuid, telegram_bot_id.as_deref()).await;
     } else {
-        attach_local_config_telegram_if_any(&app, new_uuid, &cwd).await;
+        attach_local_config_telegram_if_any(app, new_uuid, &cwd).await;
     }
 
     // 7. Persist state — create_session_inner does NOT persist
@@ -1626,6 +1621,32 @@ pub async fn restart_session(
     }
 
     Ok(session_info)
+}
+
+// Tauri command: State<> injections push us over clippy's 7-arg threshold.
+#[allow(clippy::too_many_arguments)]
+#[tauri::command]
+pub async fn restart_session(
+    app: AppHandle,
+    session_mgr: State<'_, Arc<tokio::sync::RwLock<SessionManager>>>,
+    pty_mgr: State<'_, Arc<Mutex<PtyManager>>>,
+    _tg_mgr: State<'_, TelegramBridgeState>,
+    settings: State<'_, SettingsState>,
+    id: String,
+    agent_id: Option<String>,
+    skip_auto_resume: Option<bool>,
+) -> Result<SessionInfo, String> {
+    let uuid = Uuid::parse_str(&id).map_err(|e| e.to_string())?;
+    restart_session_inner(
+        &app,
+        session_mgr.inner(),
+        pty_mgr.inner(),
+        settings.inner(),
+        uuid,
+        agent_id,
+        skip_auto_resume,
+    )
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -35,6 +35,13 @@ pub fn agent_local_dir_name() -> String {
 pub fn config_dir() -> Option<PathBuf> {
     static DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
     DIR.get_or_init(|| {
+        #[cfg(debug_assertions)]
+        if let Ok(path) = std::env::var("AGENTSCOMMANDER_TEST_CONFIG_DIR") {
+            if !path.trim().is_empty() {
+                return Some(PathBuf::from(path));
+            }
+        }
+
         // Primary: portable config next to the binary
         if let Ok(exe_path) = std::env::current_exe() {
             match (exe_path.parent(), exe_path.file_stem()) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.8.52",
+  "version": "0.8.53",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {

--- a/src-tauri/tests/pty_lifecycle_regression.rs
+++ b/src-tauri/tests/pty_lifecycle_regression.rs
@@ -1,0 +1,982 @@
+#![cfg(target_os = "windows")]
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use agentscommander_lib::commands::session::{
+    create_session_inner, destroy_session_inner, restart_session_inner,
+};
+use agentscommander_lib::config::sessions_persistence::{
+    load_sessions, persist_current_state_result,
+};
+use agentscommander_lib::config::settings::{save_settings, AppSettings, SettingsState};
+use agentscommander_lib::pty::git_watcher::GitWatcher;
+use agentscommander_lib::pty::idle_detector::IdleDetector;
+use agentscommander_lib::pty::manager::PtyManager;
+use agentscommander_lib::session::manager::SessionManager;
+use agentscommander_lib::session::session::{SessionInfo, SessionStatus};
+use agentscommander_lib::shutdown::ShutdownSignal;
+use agentscommander_lib::telegram::manager::{
+    OutputSenderMap, TelegramBridgeManager, TelegramBridgeState,
+};
+use agentscommander_lib::voice::tracker::{VoiceTracker, VoiceTrackingState};
+use agentscommander_lib::web::auth::WebAccessToken;
+use agentscommander_lib::web::broadcast::WsBroadcaster;
+use agentscommander_lib::{
+    AppOutbox, DetachedSessionsState, MasterToken, RestoreInProgress, RtkStartupModeState,
+    RtkSweepLockState, SpecBoardState, WebServerHandle,
+};
+use serde::Deserialize;
+use tauri::{Listener, Manager};
+use uuid::Uuid;
+
+const OUTPUT_TIMEOUT: Duration = Duration::from_secs(10);
+const PID_TIMEOUT: Duration = Duration::from_secs(5);
+const EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+const POLL_INTERVAL: Duration = Duration::from_millis(75);
+
+type PtyCleanupEntries = Arc<Mutex<Vec<(Arc<Mutex<PtyManager>>, Uuid)>>>;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TestPtyOutputPayload {
+    session_id: String,
+    data: Vec<u8>,
+}
+
+struct TestConfigEnvGuard {
+    previous: Option<String>,
+}
+
+impl TestConfigEnvGuard {
+    fn set(path: &Path) -> Self {
+        let previous = std::env::var("AGENTSCOMMANDER_TEST_CONFIG_DIR").ok();
+        std::env::set_var("AGENTSCOMMANDER_TEST_CONFIG_DIR", path);
+        Self { previous }
+    }
+}
+
+impl Drop for TestConfigEnvGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.as_ref() {
+            std::env::set_var("AGENTSCOMMANDER_TEST_CONFIG_DIR", previous);
+        } else {
+            std::env::remove_var("AGENTSCOMMANDER_TEST_CONFIG_DIR");
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LifecycleCleanup {
+    entries: PtyCleanupEntries,
+    pids: Arc<Mutex<Vec<u32>>>,
+}
+
+impl LifecycleCleanup {
+    fn new() -> Self {
+        Self {
+            entries: Arc::new(Mutex::new(Vec::new())),
+            pids: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn record_session(&self, pty_mgr: &Arc<Mutex<PtyManager>>, id: Uuid) {
+        self.entries.lock().unwrap().push((Arc::clone(pty_mgr), id));
+    }
+
+    fn record_pid(&self, pid: u32) {
+        let mut pids = self.pids.lock().unwrap();
+        if !pids.contains(&pid) {
+            pids.push(pid);
+        }
+    }
+}
+
+impl Drop for LifecycleCleanup {
+    fn drop(&mut self) {
+        for (pty_mgr, id) in self.entries.lock().unwrap().iter() {
+            let _ = pty_mgr.lock().unwrap().kill(*id);
+        }
+        for pid in self.pids.lock().unwrap().iter().copied() {
+            if process_exists(pid) {
+                let _ = stop_process(pid);
+            }
+        }
+    }
+}
+
+struct LifecycleFixture {
+    _temp: tempfile::TempDir,
+    _env_guard: TestConfigEnvGuard,
+    cleanup: LifecycleCleanup,
+    repo_root: PathBuf,
+    config_dir: PathBuf,
+    session_cwd: PathBuf,
+    script_path: PathBuf,
+    pid_files: Vec<PathBuf>,
+    captured_output: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    listener_errors: Arc<Mutex<Vec<String>>>,
+    app: tauri::App,
+    session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
+    pty_mgr: Arc<Mutex<PtyManager>>,
+}
+
+fn make_lifecycle_fixture() -> LifecycleFixture {
+    let temp = tempfile::TempDir::new().expect("create temp dir");
+    let repo_root = temp.path().join("repo-pty-lifecycle");
+    let config_dir = temp.path().join("config");
+    let session_cwd = repo_root.clone();
+    let script_path = temp.path().join("pty-child.ps1");
+
+    std::fs::create_dir_all(&repo_root).expect("create repo root");
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    std::fs::write(repo_root.join(".gitignore"), "*\r\n").expect("seed repo file");
+
+    let env_guard = TestConfigEnvGuard::set(&config_dir);
+    assert_eq!(
+        agentscommander_lib::config::config_dir().expect("config dir override"),
+        config_dir
+    );
+    save_settings(&AppSettings {
+        default_shell: "powershell.exe".to_string(),
+        default_shell_args: vec!["-NoLogo".to_string()],
+        project_paths: vec![path_to_string(&repo_root)],
+        ..AppSettings::default()
+    })
+    .expect("seed isolated settings");
+
+    write_child_script(&script_path);
+    run_powershell_preflight();
+
+    let captured_output = Arc::new(Mutex::new(HashMap::new()));
+    let listener_errors = Arc::new(Mutex::new(Vec::new()));
+    let cleanup = LifecycleCleanup::new();
+    let (app, session_mgr, pty_mgr) = make_test_app(
+        &repo_root,
+        &captured_output,
+        &listener_errors,
+        &cleanup,
+        None,
+        None,
+    );
+
+    LifecycleFixture {
+        _temp: temp,
+        _env_guard: env_guard,
+        cleanup,
+        repo_root,
+        config_dir,
+        session_cwd,
+        script_path,
+        pid_files: Vec::new(),
+        captured_output,
+        listener_errors,
+        app,
+        session_mgr,
+        pty_mgr,
+    }
+}
+
+fn make_test_app(
+    repo_root: &Path,
+    captured_output: &Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    listener_errors: &Arc<Mutex<Vec<String>>>,
+    _cleanup: &LifecycleCleanup,
+    session_mgr_override: Option<Arc<tokio::sync::RwLock<SessionManager>>>,
+    _pty_mgr_override: Option<Arc<Mutex<PtyManager>>>,
+) -> (
+    tauri::App,
+    Arc<tokio::sync::RwLock<SessionManager>>,
+    Arc<Mutex<PtyManager>>,
+) {
+    let session_mgr = session_mgr_override
+        .unwrap_or_else(|| Arc::new(tokio::sync::RwLock::new(SessionManager::new())));
+    let output_senders: OutputSenderMap = Arc::new(Mutex::new(HashMap::new()));
+    let tg_mgr: TelegramBridgeState = Arc::new(tokio::sync::Mutex::new(
+        TelegramBridgeManager::new(Arc::clone(&output_senders)),
+    ));
+    let idle_detector = IdleDetector::new(|_| {}, |_| {});
+    let settings: SettingsState = Arc::new(tokio::sync::RwLock::new(AppSettings {
+        default_shell: "powershell.exe".to_string(),
+        default_shell_args: vec!["-NoLogo".to_string()],
+        project_paths: vec![path_to_string(repo_root)],
+        ..AppSettings::default()
+    }));
+    let git_app = Box::leak(Box::new(
+        tauri::Builder::default()
+            .any_thread()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build git watcher handle app"),
+    ));
+    let git_watcher = GitWatcher::new(Arc::clone(&session_mgr), git_app.handle().clone());
+    let pty_mgr = Arc::new(Mutex::new(PtyManager::new(
+        output_senders,
+        idle_detector,
+        Arc::clone(&git_watcher),
+        None,
+    )));
+
+    let detached_sessions: DetachedSessionsState = Arc::new(Mutex::new(HashSet::new()));
+    let voice_tracking: VoiceTrackingState = Arc::new(Mutex::new(VoiceTracker::new()));
+    let spec_board_state: SpecBoardState = Arc::new(tokio::sync::RwLock::new(
+        agentscommander_lib::commands::spec_board::SpecBoardManager::new(),
+    ));
+    let rtk_sweep_lock: RtkSweepLockState = Arc::new(tokio::sync::Mutex::new(()));
+    let rtk_startup_mode: RtkStartupModeState = Arc::new(std::sync::OnceLock::new());
+    let shutdown_signal = ShutdownSignal::new();
+
+    let captured = Arc::clone(captured_output);
+    let listener_errors = Arc::clone(listener_errors);
+    let app = tauri::Builder::default()
+        .any_thread()
+        .manage(MasterToken::new("pty-lifecycle-master-token".into()))
+        .manage(AppOutbox::new(
+            repo_root.join(".app-outbox").to_string_lossy().to_string(),
+        ))
+        .manage(settings)
+        .manage(Arc::clone(&session_mgr))
+        .manage(tg_mgr)
+        .manage(detached_sessions)
+        .manage(voice_tracking)
+        .manage(Arc::new(RestoreInProgress(AtomicBool::new(false))))
+        .manage(shutdown_signal)
+        .manage(Arc::new(WebAccessToken::new(
+            "pty-lifecycle-web-token".into(),
+        )))
+        .manage(WsBroadcaster::new())
+        .manage(WebServerHandle::default())
+        .manage(spec_board_state)
+        .manage(rtk_sweep_lock)
+        .manage(rtk_startup_mode)
+        .manage(git_watcher)
+        .manage(Arc::clone(&pty_mgr))
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("build pty lifecycle test app");
+
+    app.listen_any("pty_output", move |event| {
+        let raw = event.payload().to_string();
+        match serde_json::from_str::<TestPtyOutputPayload>(&raw) {
+            Ok(payload) => {
+                captured
+                    .lock()
+                    .unwrap()
+                    .entry(payload.session_id)
+                    .or_default()
+                    .extend(payload.data);
+            }
+            Err(err) => listener_errors.lock().unwrap().push(format!(
+                "failed to parse pty_output payload: {err}; raw={raw}"
+            )),
+        }
+    });
+
+    (app, session_mgr, pty_mgr)
+}
+
+#[test]
+fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup() {
+    let mut fixture = make_lifecycle_fixture();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+    runtime.block_on(async {
+        let pid_a = fixture.pid_path("a");
+        let session_a = fixture
+            .create_session("PTY lifecycle A", &pid_a)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Phase A create failed: {e}\n{}",
+                    fixture.dump("Phase A", &[], std::slice::from_ref(&pid_a))
+                )
+            });
+        let id_a = parse_session_id(&session_a);
+        fixture.cleanup.record_session(&fixture.pty_mgr, id_a);
+        assert_has_pty(&fixture.pty_mgr, id_a, "Phase A", &fixture);
+        wait_for_output(&fixture, &session_a.id, "AC_READY", OUTPUT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump("Phase A", &[id_a], std::slice::from_ref(&pid_a))
+                )
+            });
+        let pid_a_value = wait_for_pid_file(&pid_a, PID_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump("Phase A", &[id_a], std::slice::from_ref(&pid_a))
+                )
+            });
+        fixture.cleanup.record_pid(pid_a_value);
+        assert!(
+            process_exists(pid_a_value),
+            "Phase A process not alive\n{}",
+            fixture.dump("Phase A", &[id_a], std::slice::from_ref(&pid_a))
+        );
+
+        {
+            fixture
+                .pty_mgr
+                .lock()
+                .unwrap()
+                .write(id_a, b"AC_ECHO hello-from-pty-lifecycle\r\n")
+                .expect("write to pty");
+        }
+        wait_for_output(
+            &fixture,
+            &session_a.id,
+            "AC_ECHOED hello-from-pty-lifecycle",
+            OUTPUT_TIMEOUT,
+        )
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "{e}\n{}",
+                fixture.dump("Phase B", &[id_a], std::slice::from_ref(&pid_a))
+            )
+        });
+        assert_has_pty(&fixture.pty_mgr, id_a, "Phase B", &fixture);
+        assert!(process_exists(pid_a_value));
+
+        {
+            fixture
+                .pty_mgr
+                .lock()
+                .unwrap()
+                .resize(id_a, 80, 24)
+                .expect("resize pty");
+        }
+        let size = { fixture.pty_mgr.lock().unwrap().get_pty_size(id_a) };
+        assert_eq!(
+            size,
+            Some((24, 80)),
+            "Phase C resize mismatch\n{}",
+            fixture.dump("Phase C", &[id_a], std::slice::from_ref(&pid_a))
+        );
+        assert_has_pty(&fixture.pty_mgr, id_a, "Phase C", &fixture);
+        assert!(process_exists(pid_a_value));
+
+        persist_sessions(&fixture.session_mgr).await;
+        assert_persisted_contains(&fixture, "PTY lifecycle A", "Phase D");
+
+        destroy_session_inner(fixture.app.handle(), id_a)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Phase E destroy failed: {e}\n{}",
+                    fixture.dump("Phase E", &[id_a], std::slice::from_ref(&pid_a))
+                )
+            });
+        wait_for_process_exit(pid_a_value, EXIT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump("Phase E", &[id_a], std::slice::from_ref(&pid_a))
+                )
+            });
+        assert_no_pty(&fixture.pty_mgr, id_a, "Phase E", &fixture);
+        assert_session_missing(&fixture.session_mgr, id_a).await;
+        assert_persisted_missing(&fixture, "PTY lifecycle A", "Phase E");
+
+        let pid_restart = fixture.pid_path("restart");
+        let restart_session = fixture
+            .create_session("PTY lifecycle restart", &pid_restart)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Phase F create failed: {e}\n{}",
+                    fixture.dump("Phase F", &[], std::slice::from_ref(&pid_restart))
+                )
+            });
+        let restart_old_id = parse_session_id(&restart_session);
+        fixture
+            .cleanup
+            .record_session(&fixture.pty_mgr, restart_old_id);
+        wait_for_output(&fixture, &restart_session.id, "AC_READY", OUTPUT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase F",
+                        &[restart_old_id],
+                        std::slice::from_ref(&pid_restart)
+                    )
+                )
+            });
+        let restart_old_pid = wait_for_pid_file(&pid_restart, PID_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase F",
+                        &[restart_old_id],
+                        std::slice::from_ref(&pid_restart)
+                    )
+                )
+            });
+        fixture.cleanup.record_pid(restart_old_pid);
+
+        let restarted = restart_session_inner(
+            fixture.app.handle(),
+            &fixture.session_mgr,
+            &fixture.pty_mgr,
+            fixture.app.state::<SettingsState>().inner(),
+            restart_old_id,
+            None,
+            Some(true),
+        )
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "Phase F restart failed: {e}\n{}",
+                fixture.dump(
+                    "Phase F",
+                    &[restart_old_id],
+                    std::slice::from_ref(&pid_restart)
+                )
+            )
+        });
+        let restart_new_id = parse_session_id(&restarted);
+        fixture
+            .cleanup
+            .record_session(&fixture.pty_mgr, restart_new_id);
+        assert_ne!(restart_old_id, restart_new_id);
+        wait_for_process_exit(restart_old_pid, EXIT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase F",
+                        &[restart_old_id, restart_new_id],
+                        std::slice::from_ref(&pid_restart)
+                    )
+                )
+            });
+        let restart_new_pid = wait_for_pid_change(&pid_restart, restart_old_pid, PID_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase F",
+                        &[restart_old_id, restart_new_id],
+                        std::slice::from_ref(&pid_restart)
+                    )
+                )
+            });
+        fixture.cleanup.record_pid(restart_new_pid);
+        assert!(process_exists(restart_new_pid));
+        wait_for_output(&fixture, &restarted.id, "AC_READY", OUTPUT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase F",
+                        &[restart_old_id, restart_new_id],
+                        std::slice::from_ref(&pid_restart)
+                    )
+                )
+            });
+        assert_no_pty(&fixture.pty_mgr, restart_old_id, "Phase F", &fixture);
+        assert_has_pty(&fixture.pty_mgr, restart_new_id, "Phase F", &fixture);
+        assert_active_session(&fixture.session_mgr, restart_new_id).await;
+
+        destroy_session_inner(fixture.app.handle(), restart_new_id)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Phase F destroy failed: {e}\n{}",
+                    fixture.dump(
+                        "Phase F",
+                        &[restart_new_id],
+                        std::slice::from_ref(&pid_restart)
+                    )
+                )
+            });
+        wait_for_process_exit(restart_new_pid, EXIT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase F",
+                        &[restart_new_id],
+                        std::slice::from_ref(&pid_restart)
+                    )
+                )
+            });
+
+        let pid_persisted = fixture.pid_path("persisted");
+        let persisted_session = fixture
+            .create_session("PTY lifecycle persisted", &pid_persisted)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Phase G create failed: {e}\n{}",
+                    fixture.dump("Phase G", &[], std::slice::from_ref(&pid_persisted))
+                )
+            });
+        let persisted_id = parse_session_id(&persisted_session);
+        fixture
+            .cleanup
+            .record_session(&fixture.pty_mgr, persisted_id);
+        wait_for_output(&fixture, &persisted_session.id, "AC_READY", OUTPUT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase G",
+                        &[persisted_id],
+                        std::slice::from_ref(&pid_persisted)
+                    )
+                )
+            });
+        let persisted_old_pid = wait_for_pid_file(&pid_persisted, PID_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase G",
+                        &[persisted_id],
+                        std::slice::from_ref(&pid_persisted)
+                    )
+                )
+            });
+        fixture.cleanup.record_pid(persisted_old_pid);
+        persist_sessions(&fixture.session_mgr).await;
+        assert_persisted_contains(&fixture, "PTY lifecycle persisted", "Phase G");
+
+        {
+            fixture
+                .pty_mgr
+                .lock()
+                .unwrap()
+                .kill(persisted_id)
+                .expect("kill persisted pty");
+        }
+        wait_for_process_exit(persisted_old_pid, EXIT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase G",
+                        &[persisted_id],
+                        std::slice::from_ref(&pid_persisted)
+                    )
+                )
+            });
+        assert_persisted_contains(&fixture, "PTY lifecycle persisted", "Phase G");
+
+        let persisted_row = load_sessions()
+            .into_iter()
+            .find(|row| row.name == "PTY lifecycle persisted")
+            .expect("persisted recipe row");
+        let second_session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let second_captured = Arc::clone(&fixture.captured_output);
+        let second_errors = Arc::clone(&fixture.listener_errors);
+        let (second_app, second_mgr, second_pty_mgr) = make_test_app(
+            &fixture.repo_root,
+            &second_captured,
+            &second_errors,
+            &fixture.cleanup,
+            Some(second_session_mgr),
+            None,
+        );
+
+        let restored = create_session_inner(
+            second_app.handle(),
+            &second_mgr,
+            &second_pty_mgr,
+            persisted_row.shell,
+            persisted_row.shell_args,
+            persisted_row.working_directory,
+            Some(persisted_row.name),
+            persisted_row.agent_id,
+            persisted_row.agent_label,
+            true,
+            persisted_row.git_repos,
+            false,
+        )
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "Phase G restore failed: {e}\n{}",
+                fixture.dump(
+                    "Phase G",
+                    &[persisted_id],
+                    std::slice::from_ref(&pid_persisted)
+                )
+            )
+        });
+        let restored_id = parse_session_id(&restored);
+        fixture.cleanup.record_session(&second_pty_mgr, restored_id);
+        wait_for_output(&fixture, &restored.id, "AC_READY", OUTPUT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase G",
+                        &[persisted_id, restored_id],
+                        std::slice::from_ref(&pid_persisted)
+                    )
+                )
+            });
+        let restored_pid = wait_for_pid_change(&pid_persisted, persisted_old_pid, PID_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase G",
+                        &[persisted_id, restored_id],
+                        std::slice::from_ref(&pid_persisted)
+                    )
+                )
+            });
+        fixture.cleanup.record_pid(restored_pid);
+        assert!(process_exists(restored_pid));
+        assert_has_pty(&second_pty_mgr, restored_id, "Phase G", &fixture);
+
+        destroy_session_inner(second_app.handle(), restored_id)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Phase G restored destroy failed: {e}\n{}",
+                    fixture.dump(
+                        "Phase G",
+                        &[restored_id],
+                        std::slice::from_ref(&pid_persisted)
+                    )
+                )
+            });
+        wait_for_process_exit(restored_pid, EXIT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{e}\n{}",
+                    fixture.dump(
+                        "Phase G",
+                        &[restored_id],
+                        std::slice::from_ref(&pid_persisted)
+                    )
+                )
+            });
+    });
+}
+
+impl LifecycleFixture {
+    fn pid_path(&mut self, label: &str) -> PathBuf {
+        let path = self.config_dir.join(format!("{label}.pid"));
+        self.pid_files.push(path.clone());
+        path
+    }
+
+    async fn create_session(&self, name: &str, pid_file: &Path) -> Result<SessionInfo, String> {
+        create_session_inner(
+            self.app.handle(),
+            &self.session_mgr,
+            &self.pty_mgr,
+            "powershell.exe".to_string(),
+            script_args(&self.script_path, pid_file),
+            path_to_string(&self.session_cwd),
+            Some(name.to_string()),
+            None,
+            None,
+            false,
+            Vec::new(),
+            true,
+        )
+        .await
+    }
+
+    fn dump(&self, phase: &str, session_ids: &[Uuid], pid_files: &[PathBuf]) -> String {
+        let sessions_json = std::fs::read_to_string(self.config_dir.join("sessions.json"))
+            .unwrap_or_else(|e| format!("<unreadable: {e}>"));
+        let captured = self
+            .captured_output
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(id, bytes)| format!("{id}: {}", String::from_utf8_lossy(bytes)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let listener_errors = self.listener_errors.lock().unwrap().join("\n");
+        let pid_info = pid_files
+            .iter()
+            .map(|path| {
+                let content =
+                    std::fs::read_to_string(path).unwrap_or_else(|e| format!("<missing: {e}>"));
+                let parsed = content.trim().parse::<u32>().ok();
+                let exists = parsed.map(process_exists);
+                format!(
+                    "{} => {:?}, exists={exists:?}",
+                    path.display(),
+                    content.trim()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let pty_info = session_ids
+            .iter()
+            .map(|id| {
+                let pty = self.pty_mgr.lock().unwrap();
+                format!(
+                    "{id}: has_session={}, size={:?}",
+                    pty.has_session(*id),
+                    pty.get_pty_size(*id)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!(
+            "phase={phase}\nconfig_dir={}\nrepo_root={}\nsession_cwd={}\nsessions_json={sessions_json}\npids=\n{pid_info}\npty=\n{pty_info}\nlistener_errors=\n{listener_errors}\ncaptured=\n{captured}",
+            self.config_dir.display(),
+            self.repo_root.display(),
+            self.session_cwd.display()
+        )
+    }
+}
+
+fn write_child_script(path: &Path) {
+    let script = r#"param([string]$PidFile)
+$ErrorActionPreference = 'Stop'
+$pid | Set-Content -LiteralPath $PidFile -Encoding ASCII
+[Console]::Out.WriteLine('AC_READY')
+[Console]::Out.Flush()
+while ($true) {
+    $line = [Console]::In.ReadLine()
+    if ($null -eq $line) { break }
+    if ($line -eq 'AC_EXIT') {
+        [Console]::Out.WriteLine('AC_EXITING')
+        [Console]::Out.Flush()
+        exit 0
+    }
+    if ($line.StartsWith('AC_ECHO ')) {
+        [Console]::Out.WriteLine('AC_ECHOED ' + $line.Substring(8))
+        [Console]::Out.Flush()
+    }
+}
+"#;
+    std::fs::write(path, script).expect("write pty child script");
+}
+
+fn script_args(script_path: &Path, pid_file: &Path) -> Vec<String> {
+    vec![
+        "-NoLogo".to_string(),
+        "-NoProfile".to_string(),
+        "-ExecutionPolicy".to_string(),
+        "Bypass".to_string(),
+        "-File".to_string(),
+        path_to_string(script_path),
+        "-PidFile".to_string(),
+        path_to_string(pid_file),
+    ]
+}
+
+fn run_powershell_preflight() {
+    let output = Command::new("powershell.exe")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "Write-Output AC_PS_OK",
+        ])
+        .output()
+        .expect("run PowerShell preflight");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success() && stdout.contains("AC_PS_OK"),
+        "PowerShell preflight failed: status={:?}\nstdout={stdout}\nstderr={stderr}",
+        output.status.code()
+    );
+}
+
+async fn wait_for_output(
+    fixture: &LifecycleFixture,
+    session_id: &str,
+    marker: &str,
+    timeout: Duration,
+) -> Result<(), String> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        let text = {
+            let captured = fixture.captured_output.lock().unwrap();
+            captured
+                .get(session_id)
+                .map(|bytes| String::from_utf8_lossy(bytes).to_string())
+                .unwrap_or_default()
+        };
+        if text.contains(marker) {
+            return Ok(());
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    Err(format!(
+        "timeout waiting for output marker '{marker}' in session {session_id}"
+    ))
+}
+
+async fn wait_for_pid_file(path: &Path, timeout: Duration) -> Result<u32, String> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            if let Ok(pid) = contents.trim().parse::<u32>() {
+                return Ok(pid);
+            }
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    Err(format!("timeout waiting for pid file {}", path.display()))
+}
+
+async fn wait_for_pid_change(path: &Path, old_pid: u32, timeout: Duration) -> Result<u32, String> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            if let Ok(pid) = contents.trim().parse::<u32>() {
+                if pid != old_pid {
+                    return Ok(pid);
+                }
+            }
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    Err(format!(
+        "timeout waiting for pid file {} to change from {old_pid}",
+        path.display()
+    ))
+}
+
+async fn wait_for_process_exit(pid: u32, timeout: Duration) -> Result<(), String> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if !process_exists(pid) {
+            return Ok(());
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    Err(format!("process {pid} still alive after {timeout:?}"))
+}
+
+fn process_exists(pid: u32) -> bool {
+    let status = Command::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            &format!(
+                "if (Get-Process -Id {pid} -ErrorAction SilentlyContinue) {{ exit 0 }} else {{ exit 1 }}"
+            ),
+        ])
+        .status();
+    matches!(status, Ok(status) if status.success())
+}
+
+fn stop_process(pid: u32) -> std::io::Result<()> {
+    Command::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            &format!("Stop-Process -Id {pid} -Force -ErrorAction SilentlyContinue"),
+        ])
+        .status()
+        .map(|_| ())
+}
+
+async fn persist_sessions(session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>) {
+    let mgr = session_mgr.read().await;
+    persist_current_state_result(&mgr)
+        .await
+        .expect("persist current state");
+}
+
+fn assert_persisted_contains(fixture: &LifecycleFixture, name: &str, phase: &str) {
+    let sessions_json = std::fs::read_to_string(fixture.config_dir.join("sessions.json"))
+        .expect("sessions.json exists");
+    assert!(
+        sessions_json.contains(name)
+            && sessions_json.contains("powershell.exe")
+            && sessions_json.contains("shellArgs")
+            && sessions_json.contains("workingDirectory")
+            && sessions_json.contains("status"),
+        "{phase} persisted content missing expected fields\n{}",
+        fixture.dump(phase, &[], &fixture.pid_files)
+    );
+    assert!(
+        load_sessions().iter().any(|row| row.name == name),
+        "{phase} load_sessions missing {name}\n{}",
+        fixture.dump(phase, &[], &fixture.pid_files)
+    );
+}
+
+fn assert_persisted_missing(fixture: &LifecycleFixture, name: &str, phase: &str) {
+    assert!(
+        !load_sessions().iter().any(|row| row.name == name),
+        "{phase} load_sessions still contains {name}\n{}",
+        fixture.dump(phase, &[], &fixture.pid_files)
+    );
+}
+
+fn assert_has_pty(
+    pty_mgr: &Arc<Mutex<PtyManager>>,
+    id: Uuid,
+    phase: &str,
+    fixture: &LifecycleFixture,
+) {
+    assert!(
+        pty_mgr.lock().unwrap().has_session(id),
+        "{phase} expected PTY session {id}\n{}",
+        fixture.dump(phase, &[id], &fixture.pid_files)
+    );
+}
+
+fn assert_no_pty(
+    pty_mgr: &Arc<Mutex<PtyManager>>,
+    id: Uuid,
+    phase: &str,
+    fixture: &LifecycleFixture,
+) {
+    assert!(
+        !pty_mgr.lock().unwrap().has_session(id),
+        "{phase} expected no PTY session {id}\n{}",
+        fixture.dump(phase, &[id], &fixture.pid_files)
+    );
+}
+
+async fn assert_session_missing(session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>, id: Uuid) {
+    let mgr = session_mgr.read().await;
+    assert!(mgr.get_session(id).await.is_none());
+}
+
+async fn assert_active_session(session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>, id: Uuid) {
+    let mgr = session_mgr.read().await;
+    let session = mgr.get_session(id).await.expect("active session exists");
+    assert_eq!(session.status, SessionStatus::Active);
+}
+
+fn parse_session_id(session: &SessionInfo) -> Uuid {
+    Uuid::parse_str(&session.id).expect("session id is uuid")
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().to_string()
+}


### PR DESCRIPTION
## Summary

- Add a real PTY lifecycle regression suite for create/output/input/resize/kill-restart/persist-restore/cleanup behavior.
- Preserve Windows PowerShell/ConPTY coverage expectations with process cleanup evidence.
- Bump version to `0.8.53` after landing #483.

## Validation

- dev-rust reported passing: `npm run validate-branch-name`, `npm run version:check`, `npm run test:debt`, `cargo test --test pty_lifecycle_regression -- --test-threads=1`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib`, `git diff --check`, and base ancestry.
- dev-rust-grinch focused re-review returned PASS for commit `cea1c854817cb67fbea24ac4b0742f37591a3ca4`.
- Shipper deployed `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe`, SHA256 `5B485464086E4DA1602A57450FF164E5E0549127ED6A0A391990129E1C005536`.
- WG-13 acceptance returned explicit OK for commit `cea1c854817cb67fbea24ac4b0742f37591a3ca4` on base `7bc6544bb360930f4662721659d475a50d76e4fe`.
- Acceptance evidence: `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-13-acceptance-testing\__agent_ac-cli-and-gui-tester\artifacts\issue-484-rerun-cea1c854-20260613-234955`.

Closes #484