### PR TITLE
Add destructive filesystem regression coverage

### DIFF
--- a/docs/testing/destructive-filesystem-regression.md
+++ b/docs/testing/destructive-filesystem-regression.md
@@ -1,0 +1,27 @@
+# Destructive Filesystem Regression Checks
+
+These checks cover Windows filesystem behaviors that can be unavailable in some CI runners because long paths or junction creation may be disabled by host policy.
+
+## Reset Long Path Check
+
+Run `cargo test --test cli_test_reset long_path_target_deletes_only_allowed_directories -- --nocapture`.
+
+If the test prints a skip message, run the same command on a Windows host with long paths enabled. Confirm the JSON plan contains exactly the two testable reset directories and that unrelated sibling directories remain.
+
+## Reset Junction Reparse Check
+
+Run `cargo test --test cli_test_reset junction_target_refuses_and_deletes_nothing -- --nocapture`.
+
+If the test prints a skip message, create a directory junction with `mklink /J`, then rerun the test on a Windows host where developer mode or elevated junction creation is available. Confirm the reset command reports `reset_candidate_is_reparse_point` and leaves both the junction and target intact.
+
+## Workgroup Long Path Check
+
+Run `cargo test --test cli_workgroup_team workgroup_remove_deletes_long_path_tree -- --nocapture`.
+
+If the test prints a skip message, rerun it on a Windows host with long paths enabled. Confirm `workgroup remove --force-dirty` deletes the workgroup root and does not delete unrelated sibling paths.
+
+## Workgroup Reparse Root Check
+
+Run `cargo test --test cli_workgroup_team workgroup_remove_refuses_reparse_root -- --nocapture`.
+
+If the test prints a skip message, create a workgroup root as a junction with `mklink /J`, then rerun the test on a Windows host where junction creation is available. Confirm deletion is refused before canonicalization and the junction target remains intact.

--- a/docs/testing/destructive-filesystem-regression.md
+++ b/docs/testing/destructive-filesystem-regression.md
@@ -1,27 +1,295 @@
-# Destructive Filesystem Regression Checks
+# Destructive Filesystem Regression Manual Checks
 
-These checks cover Windows filesystem behaviors that can be unavailable in some CI runners because long paths or junction creation may be disabled by host policy.
+These checks are fallback evidence for filesystem behavior that may be blocked by CI or workstation policy, especially Windows long paths and directory junction creation.
+
+## Scope And Safety
+
+Run every manual check inside a fresh temp root that you create only for that check. Do not run these commands inside a real project, user profile, repository checkout, or shared workspace.
+
+Recommended temp root pattern:
+
+```powershell
+$Root = Join-Path $env:TEMP ("ac-destructive-fs-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $Root | Out-Null
+Write-Host $Root
+```
+
+Only remove `$Root` after you have verified it is the temp root you created for the check:
+
+```powershell
+Resolve-Path $Root
+Remove-Item -LiteralPath $Root -Recurse -Force
+```
+
+Do not clean up by deleting parent directories or wildcard paths.
+
+## Evidence Requirements
+
+For each manual check, capture:
+
+- The absolute `$Root` path.
+- The command line used.
+- Stdout and stderr.
+- A directory listing before and after the destructive command.
+- The outside sentinel path and proof that it survived.
+- The expected error code or JSON field when the check is a refusal case.
+
+Use an outside sentinel for every check:
+
+```powershell
+$Outside = Join-Path $Root "outside-sentinel\keep.txt"
+New-Item -ItemType Directory -Path (Split-Path $Outside) | Out-Null
+Set-Content -LiteralPath $Outside -Value "keep"
+```
+
+Verify it after the command:
+
+```powershell
+Test-Path -LiteralPath $Outside
+Get-Content -LiteralPath $Outside
+```
 
 ## Reset Long Path Check
 
-Run `cargo test --test cli_test_reset long_path_target_deletes_only_allowed_directories -- --nocapture`.
+Automated test:
 
-If the test prints a skip message, run the same command on a Windows host with long paths enabled. Confirm the JSON plan contains exactly the two testable reset directories and that unrelated sibling directories remain.
+```powershell
+cargo test --test cli_test_reset long_path_target_deletes_only_allowed_directories -- --nocapture
+```
+
+Manual fallback if the automated test prints a skip:
+
+1. Create `$Root` and `$Outside` as described above.
+2. Build or locate `target\debug\agentscommander-new.exe`.
+3. Create a deep binary parent:
+
+```powershell
+$Base = $Root
+1..10 | ForEach-Object { $Base = Join-Path $Base ("long-segment-{0:D2}-abcdef" -f $_) }
+New-Item -ItemType Directory -Path $Base | Out-Null
+$Bin = Join-Path $Base "agentscommander_testeable.exe"
+Copy-Item -LiteralPath "target\debug\agentscommander-new.exe" -Destination $Bin
+```
+
+4. Create only the allowed reset candidates and one sibling that must survive:
+
+```powershell
+$Config = Join-Path $Base ".agentscommander_testeable\nested"
+$Project = Join-Path $Base "agentscommander_testeable\nested"
+$Sibling = Join-Path $Base ".agentscommander_other"
+New-Item -ItemType Directory -Path $Config,$Project,$Sibling | Out-Null
+```
+
+5. Run reset:
+
+```powershell
+& $Bin test-reset --confirm-testeable
+```
+
+Expected result:
+
+- Exit code is 0.
+- Stdout includes `plannedDelete` with exactly `.agentscommander_testeable` and `agentscommander_testeable`.
+- `.agentscommander_testeable` is gone.
+- `agentscommander_testeable` is gone.
+- `.agentscommander_other` remains.
+- `$Outside` remains.
 
 ## Reset Junction Reparse Check
 
-Run `cargo test --test cli_test_reset junction_target_refuses_and_deletes_nothing -- --nocapture`.
+Automated test:
 
-If the test prints a skip message, create a directory junction with `mklink /J`, then rerun the test on a Windows host where developer mode or elevated junction creation is available. Confirm the reset command reports `reset_candidate_is_reparse_point` and leaves both the junction and target intact.
+```powershell
+cargo test --test cli_test_reset junction_target_refuses_and_deletes_nothing -- --nocapture
+```
+
+Manual fallback if the automated test prints a skip:
+
+1. Create `$Root` and `$Outside` as described above.
+2. Copy the binary into `$Root` as `agentscommander_testeable.exe`:
+
+```powershell
+$Bin = Join-Path $Root "agentscommander_testeable.exe"
+Copy-Item -LiteralPath "target\debug\agentscommander-new.exe" -Destination $Bin
+```
+
+3. Create the target, candidate junction, and second allowed candidate:
+
+```powershell
+$Real = Join-Path $Root "real-dir"
+$Junction = Join-Path $Root ".agentscommander_testeable"
+$Project = Join-Path $Root "agentscommander_testeable"
+New-Item -ItemType Directory -Path $Real,$Project | Out-Null
+cmd /C mklink /J "$Junction" "$Real"
+```
+
+4. Run reset:
+
+```powershell
+& $Bin test-reset --confirm-testeable
+```
+
+Expected result:
+
+- Exit code is 1.
+- Stderr JSON has `"error":"reset_candidate_is_reparse_point"`.
+- `$Junction` remains.
+- `$Real` remains.
+- `$Project` remains.
+- `$Outside` remains.
+
+The automated test creates its own temp root and junction. Creating this manual junction does not make a skipped automated test pass; it only provides equivalent manual evidence.
 
 ## Workgroup Long Path Check
 
-Run `cargo test --test cli_workgroup_team workgroup_remove_deletes_long_path_tree -- --nocapture`.
+Automated test:
 
-If the test prints a skip message, rerun it on a Windows host with long paths enabled. Confirm `workgroup remove --force-dirty` deletes the workgroup root and does not delete unrelated sibling paths.
+```powershell
+cargo test --test cli_workgroup_team workgroup_remove_deletes_long_path_tree -- --nocapture
+```
+
+Manual fallback if the automated test prints a skip:
+
+1. Create `$Root` and `$Outside` as described above.
+2. Copy `target\debug\agentscommander-new.exe` into `$Root` and configure the copied binary:
+
+```powershell
+$Bin = Join-Path $Root "agentscommander-new.exe"
+Copy-Item -LiteralPath "target\debug\agentscommander-new.exe" -Destination $Bin
+$ConfigDir = Join-Path $Root ".agentscommander-new"
+New-Item -ItemType Directory -Path $ConfigDir | Out-Null
+@{
+  defaultShell = "powershell.exe"
+  defaultShellArgs = @()
+  agents = @()
+  projectPaths = @($Root)
+} | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (Join-Path $ConfigDir "settings.json")
+```
+
+3. Create `ProjectAlpha`, `.ac`, `_agent_architect`, and a workgroup with the CLI:
+
+```powershell
+$Project = Join-Path $Root "ProjectAlpha"
+$Agent = Join-Path $Project ".ac\_agent_architect"
+New-Item -ItemType Directory -Path (Join-Path $Agent "memory") | Out-Null
+Set-Content -LiteralPath (Join-Path $Agent "Role.md") -Value "# architect"
+& $Bin workgroup add --project ProjectAlpha --team "Dev Team" --title "Build" --coordinator architect
+```
+
+4. Inside `.ac\wg-1-dev-team`, create a long nested path and payload file:
+
+```powershell
+$Deep = Join-Path $Root "ProjectAlpha\.ac\wg-1-dev-team"
+1..10 | ForEach-Object { $Deep = Join-Path $Deep ("long-segment-{0:D2}-abcdef" -f $_) }
+New-Item -ItemType Directory -Path $Deep | Out-Null
+Set-Content -LiteralPath (Join-Path $Deep "payload.txt") -Value "payload"
+```
+
+5. Run:
+
+```powershell
+& $Bin workgroup remove --project ProjectAlpha --workgroup wg-1-dev-team --force-dirty
+```
+
+Expected result:
+
+- Exit code is 0.
+- Machine output, if enabled, reports `"removed":true`.
+- `.ac\wg-1-dev-team` is gone.
+- `$Outside` remains.
+- Any sibling path outside `.ac\wg-1-dev-team` remains.
 
 ## Workgroup Reparse Root Check
 
-Run `cargo test --test cli_workgroup_team workgroup_remove_refuses_reparse_root -- --nocapture`.
+Automated test:
 
-If the test prints a skip message, create a workgroup root as a junction with `mklink /J`, then rerun the test on a Windows host where junction creation is available. Confirm deletion is refused before canonicalization and the junction target remains intact.
+```powershell
+cargo test --test cli_workgroup_team workgroup_remove_refuses_reparse_root -- --nocapture
+```
+
+Manual fallback if the automated test prints a skip:
+
+1. Create `$Root` and `$Outside` as described above.
+2. Copy `target\debug\agentscommander-new.exe` into `$Root` and configure the copied binary:
+
+```powershell
+$Bin = Join-Path $Root "agentscommander-new.exe"
+Copy-Item -LiteralPath "target\debug\agentscommander-new.exe" -Destination $Bin
+$ConfigDir = Join-Path $Root ".agentscommander-new"
+New-Item -ItemType Directory -Path $ConfigDir | Out-Null
+@{
+  defaultShell = "powershell.exe"
+  defaultShellArgs = @()
+  agents = @()
+  projectPaths = @($Root)
+} | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (Join-Path $ConfigDir "settings.json")
+```
+
+3. Set up a throwaway `ProjectAlpha` and create `wg-1-dev-team` with the CLI:
+
+```powershell
+$Project = Join-Path $Root "ProjectAlpha"
+$Agent = Join-Path $Project ".ac\_agent_architect"
+New-Item -ItemType Directory -Path (Join-Path $Agent "memory") | Out-Null
+Set-Content -LiteralPath (Join-Path $Agent "Role.md") -Value "# architect"
+& $Bin workgroup add --project ProjectAlpha --team "Dev Team" --title "Build" --coordinator architect
+```
+
+4. Remove the real workgroup directory and replace it with a junction:
+
+```powershell
+$Wg = Join-Path $Root "ProjectAlpha\.ac\wg-1-dev-team"
+Remove-Item -LiteralPath $Wg -Recurse -Force
+$Real = Join-Path $Root "real-wg-target"
+New-Item -ItemType Directory -Path $Real | Out-Null
+Set-Content -LiteralPath (Join-Path $Real "sentinel.txt") -Value "target"
+cmd /C mklink /J "$Wg" "$Real"
+```
+
+5. Run:
+
+```powershell
+& $Bin workgroup remove --project ProjectAlpha --workgroup wg-1-dev-team --force-dirty
+```
+
+Expected result:
+
+- Exit code is 1.
+- Stderr contains `delete_root_is_reparse_point`.
+- `$Wg` remains as a junction.
+- `$Real\sentinel.txt` remains.
+- `$Outside` remains.
+- No `workgroupRemoved` project refresh request is written.
+
+The automated test creates its own temp root and junction. Creating this manual junction does not make a skipped automated test pass; it only provides equivalent manual evidence.
+
+## Helper Reparse Root Check
+
+Automated test:
+
+```powershell
+cargo test commands::entity_creation::tests::validate_delete_root_rejects_reparse_root -- --nocapture
+```
+
+Manual fallback if the automated test prints a skip:
+
+1. Create `$Root` and `$Outside` as described above.
+2. Create a real directory and a junction named like a workgroup:
+
+```powershell
+$Real = Join-Path $Root "real"
+$Junction = Join-Path $Root "wg-1-test"
+New-Item -ItemType Directory -Path $Real | Out-Null
+cmd /C mklink /J "$Junction" "$Real"
+```
+
+3. Run the automated helper test again on a Windows host where junction creation is available.
+
+Expected result:
+
+- The helper rejects the root with `delete_root_is_reparse_point`.
+- `$Junction` remains.
+- `$Real` remains.
+- `$Outside` remains.
+
+The automated helper test creates its own temp root and junction. Creating this manual junction does not make a skipped automated test pass; it documents the same expected filesystem condition for manual evidence.

--- a/src-tauri/src/cli/workgroup.rs
+++ b/src-tauri/src/cli/workgroup.rs
@@ -8,8 +8,8 @@ use crate::cli::create_agent_matrix::{write_project_refresh_request, ProjectRefr
 use crate::commands::entity_creation::{
     check_workgroup_repos_dirty, clone_missing_repos_for_workgroup, create_workgroup_on_disk,
     list_workgroup_dirs, read_team_config, resolve_agent_ref, sanitize_name,
-    validate_existing_name, AgentMatrixSettingsFlags, RepoAssignment, TeamConfigResult,
-    WgDeleteOutcome, WorkgroupDiskCreateArgs,
+    validate_delete_root_not_link_or_reparse, validate_existing_name, AgentMatrixSettingsFlags,
+    RepoAssignment, TeamConfigResult, WgDeleteOutcome, WorkgroupDiskCreateArgs,
 };
 use crate::config::projects::resolve_project_reference;
 use crate::config::workspace::existing_workspace_dir;
@@ -248,9 +248,7 @@ fn remove(args: WorkgroupRemoveArgs) -> Result<(), String> {
     let project_path = resolve_cli_project(&args.project)?;
     let workspace_dir = resolve_cli_workspace(&project_path)?;
     let wg_dir = workspace_dir.join(&args.workgroup);
-    if !wg_dir.is_dir() {
-        return Err(format!("Workgroup '{}' not found", args.workgroup));
-    }
+    validate_delete_root_not_link_or_reparse(&wg_dir)?;
     crate::cli::session_safety::ensure_no_live_sessions_under(&wg_dir)?;
     if !args.force_dirty {
         let dirty = check_workgroup_repos_dirty(std::slice::from_ref(&wg_dir));
@@ -270,6 +268,13 @@ fn remove(args: WorkgroupRemoveArgs) -> Result<(), String> {
         WgDeleteOutcome::Deleted => {}
         WgDeleteOutcome::Blocked(e) => {
             return Err(format!("Failed to delete workgroup, file in use: {}", e));
+        }
+        WgDeleteOutcome::Partial { orphan_path, error } => {
+            return Err(format!(
+                "Failed to fully delete workgroup directory; renamed workgroup to orphan '{}', but failed to remove orphan: {}",
+                orphan_path.display(),
+                error
+            ));
         }
         WgDeleteOutcome::Other(e) => {
             return Err(format!("Failed to delete workgroup directory: {}", e));

--- a/src-tauri/src/cli/workgroup.rs
+++ b/src-tauri/src/cli/workgroup.rs
@@ -264,7 +264,33 @@ fn remove(args: WorkgroupRemoveArgs) -> Result<(), String> {
             ));
         }
     }
-    match crate::commands::entity_creation::try_atomic_delete_wg(&wg_dir) {
+    match cli_remove_refresh_decision(crate::commands::entity_creation::try_atomic_delete_wg(
+        &wg_dir,
+    ))? {
+        RemoveRefreshDecision::EmitWorkgroupRemoved => {}
+    }
+    write_refresh(&project_path, &wg_dir, &args.workgroup, "workgroupRemoved");
+    if std::env::var_os("AC_MACHINE_OUTPUT").is_some() {
+        print_json(&serde_json::json!({
+            "workgroup": args.workgroup,
+            "path": wg_dir.to_string_lossy(),
+            "removed": true
+        }))
+    } else {
+        crate::cli_println!("Removed workgroup {}", args.workgroup);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoveRefreshDecision {
+    EmitWorkgroupRemoved,
+}
+
+pub(crate) fn cli_remove_refresh_decision(
+    outcome: WgDeleteOutcome,
+) -> Result<RemoveRefreshDecision, String> {
+    match outcome {
         WgDeleteOutcome::Deleted => {}
         WgDeleteOutcome::Blocked(e) => {
             return Err(format!("Failed to delete workgroup, file in use: {}", e));
@@ -280,17 +306,7 @@ fn remove(args: WorkgroupRemoveArgs) -> Result<(), String> {
             return Err(format!("Failed to delete workgroup directory: {}", e));
         }
     }
-    write_refresh(&project_path, &wg_dir, &args.workgroup, "workgroupRemoved");
-    if std::env::var_os("AC_MACHINE_OUTPUT").is_some() {
-        print_json(&serde_json::json!({
-            "workgroup": args.workgroup,
-            "path": wg_dir.to_string_lossy(),
-            "removed": true
-        }))
-    } else {
-        crate::cli_println!("Removed workgroup {}", args.workgroup);
-        Ok(())
-    }
+    Ok(RemoveRefreshDecision::EmitWorkgroupRemoved)
 }
 
 pub(crate) fn build_new_team_config(
@@ -462,4 +478,34 @@ fn print_json<T: Serialize>(value: &T) -> Result<(), String> {
         .map_err(|e| format!("Failed to serialize JSON output: {}", e))?;
     crate::cli_println!("{}", json);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn partial_delete_outcome_does_not_authorize_removed_refresh() {
+        let outcome = WgDeleteOutcome::Partial {
+            orphan_path: PathBuf::from(".deleting-wg-1-test-orphan"),
+            error: std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "forced remove failure",
+            ),
+        };
+
+        let err = cli_remove_refresh_decision(outcome)
+            .expect_err("partial delete must not authorize workgroupRemoved refresh");
+        assert!(err.contains("Failed to fully delete workgroup directory"));
+        assert!(err.contains(".deleting-wg-1-test-orphan"));
+    }
+
+    #[test]
+    fn clean_delete_outcome_authorizes_removed_refresh() {
+        assert_eq!(
+            cli_remove_refresh_decision(WgDeleteOutcome::Deleted)
+                .expect("deleted outcome should refresh"),
+            RemoveRefreshDecision::EmitWorkgroupRemoved
+        );
+    }
 }

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -15,7 +15,7 @@ use crate::config::settings::{AppSettings, SettingsState};
 use crate::config::workspace::existing_workspace_dir;
 use crate::pty::git_watcher::{CoordinatorChangedPayload, GitWatcher};
 use crate::session::manager::SessionManager;
-use crate::session::session::SessionRepo;
+use crate::session::session::{SessionRepo, SessionStatus};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1468,9 +1468,9 @@ pub async fn delete_workgroup(
     let base = selected_workspace_dir(Path::new(&project_path))?;
 
     let wg_dir = base.join(&workgroup_name);
-    if !wg_dir.exists() {
-        return Err(format!("Workgroup '{}' not found", workgroup_name));
-    }
+    validate_delete_root_not_link_or_reparse(&wg_dir)?;
+
+    ensure_no_live_sessions_under_manager(&wg_dir, session_mgr.inner()).await?;
 
     // Safety check: detect dirty repos before deleting (skip if force)
     if !force.unwrap_or(false) {
@@ -1496,7 +1496,22 @@ pub async fn delete_workgroup(
     // memory-mapped TASK.md), the rename fails atomically — no files touched —
     // and we run the diagnostic on the still-intact tree. On success the dir is
     // re-parented to a sentinel name and removed; the user-visible WG is gone.
-    match try_atomic_delete_wg(&wg_dir) {
+    delete_workgroup_dir_backend(&wg_dir, &workgroup_name, session_mgr.inner()).await?;
+    log::info!(
+        "[entity_creation] Deleted workgroup: {} (force={})",
+        workgroup_name,
+        force.unwrap_or(false)
+    );
+    emit_coordinator_refresh(&app, session_mgr.inner()).await;
+    Ok(())
+}
+
+pub(crate) async fn delete_workgroup_dir_backend(
+    wg_dir: &Path,
+    workgroup_name: &str,
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+) -> Result<(), String> {
+    match try_atomic_delete_wg(wg_dir) {
         WgDeleteOutcome::Deleted => {
             // fall through to success path
         }
@@ -1507,10 +1522,10 @@ pub async fn delete_workgroup(
                 workgroup_name
             );
             let report = crate::commands::wg_delete_diagnostic::diagnose_blockers(
-                &wg_dir,
-                &workgroup_name,
+                wg_dir,
+                workgroup_name,
                 &raw, // raw OS error verbatim — see plan §C.1
-                session_mgr.inner(),
+                session_mgr,
             )
             .await;
             let json = serde_json::to_string(&report).map_err(|se| {
@@ -1521,16 +1536,18 @@ pub async fn delete_workgroup(
             })?;
             return Err(format!("BLOCKERS:{}", json));
         }
+        WgDeleteOutcome::Partial { orphan_path, error } => {
+            return Err(format!(
+                "Partial workgroup delete: renamed '{}' to orphan '{}', but failed to remove orphan: {}",
+                wg_dir.display(),
+                orphan_path.display(),
+                error
+            ));
+        }
         WgDeleteOutcome::Other(e) => {
             return Err(format!("Failed to delete workgroup directory: {}", e));
         }
     }
-    log::info!(
-        "[entity_creation] Deleted workgroup: {} (force={})",
-        workgroup_name,
-        force.unwrap_or(false)
-    );
-    emit_coordinator_refresh(&app, session_mgr.inner()).await;
     Ok(())
 }
 
@@ -2016,10 +2033,15 @@ pub(crate) fn check_workgroup_repos_dirty(wg_dirs: &[PathBuf]) -> Vec<(String, S
 ///
 /// `pub(crate)` so the unit tests can pattern-match on the variants.
 pub(crate) enum WgDeleteOutcome {
-    /// Rename succeeded and the renamed dir was removed (or, in the rare race
-    /// where remove failed after a successful rename, an orphan remains and a
-    /// `log::warn!` was emitted — from the user's perspective the WG is gone).
+    /// Rename succeeded and the renamed dir was removed.
     Deleted,
+    /// Rename succeeded, but deleting the renamed orphan failed. The
+    /// user-visible workgroup name is gone, but callers must report this as a
+    /// partial failure and skip refresh.
+    Partial {
+        orphan_path: PathBuf,
+        error: std::io::Error,
+    },
     /// Rename failed with a Windows file-in-use error. Tree is intact; caller
     /// should run the blocker diagnostic and return `BLOCKERS:` to the frontend.
     Blocked(std::io::Error),
@@ -2044,6 +2066,13 @@ pub(crate) enum WgDeleteOutcome {
 ///
 /// `pub(crate)` so unit tests can drive it directly.
 pub(crate) fn try_atomic_delete_wg(wg_dir: &Path) -> WgDeleteOutcome {
+    try_atomic_delete_wg_with_remove(wg_dir, |path| std::fs::remove_dir_all(path))
+}
+
+pub(crate) fn try_atomic_delete_wg_with_remove(
+    wg_dir: &Path,
+    remove_dir_all: impl FnOnce(&Path) -> std::io::Result<()>,
+) -> WgDeleteOutcome {
     let parent = match wg_dir.parent() {
         Some(p) => p,
         None => {
@@ -2067,10 +2096,7 @@ pub(crate) fn try_atomic_delete_wg(wg_dir: &Path) -> WgDeleteOutcome {
 
     match std::fs::rename(wg_dir, &temp_path) {
         Ok(()) => {
-            if let Err(e) = std::fs::remove_dir_all(&temp_path) {
-                // Rare race: a new handle opened between rename and remove. The
-                // user-visible WG is gone (renamed away); leave the orphan on
-                // disk for future cleanup tooling.
+            if let Err(e) = remove_dir_all(&temp_path) {
                 log::warn!(
                     "[entity_creation] Renamed workgroup '{}' to '{}' but remove_dir_all failed: {}. \
                      User-visible WG is gone; orphan remains on disk.",
@@ -2078,6 +2104,10 @@ pub(crate) fn try_atomic_delete_wg(wg_dir: &Path) -> WgDeleteOutcome {
                     temp_path.display(),
                     e
                 );
+                return WgDeleteOutcome::Partial {
+                    orphan_path: temp_path,
+                    error: e,
+                };
             }
             WgDeleteOutcome::Deleted
         }
@@ -2089,6 +2119,86 @@ pub(crate) fn try_atomic_delete_wg(wg_dir: &Path) -> WgDeleteOutcome {
             }
         }
     }
+}
+
+pub(crate) fn validate_delete_root_not_link_or_reparse(path: &Path) -> Result<(), String> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err("delete_root_not_directory".to_string());
+        }
+        Err(e) => return Err(format!("delete_root_metadata_failed: {e}")),
+    };
+
+    if delete_root_has_windows_reparse_point(&metadata) {
+        return Err("delete_root_is_reparse_point".to_string());
+    }
+    if metadata.file_type().is_symlink() {
+        return Err("delete_root_is_symlink".to_string());
+    }
+    if !metadata.is_dir() {
+        return Err("delete_root_not_directory".to_string());
+    }
+    Ok(())
+}
+
+async fn ensure_no_live_sessions_under_manager(
+    root: &Path,
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+) -> Result<(), String> {
+    let root_key = path_key_for_delete(root);
+    let sessions = { session_mgr.read().await.list_sessions().await };
+    let blockers: Vec<_> = sessions
+        .into_iter()
+        .filter(|session| !matches!(session.status, SessionStatus::Exited(_)))
+        .filter(|session| {
+            let working_dir = Path::new(&session.working_directory);
+            let working_key = path_key_for_delete(working_dir);
+            working_key == root_key || working_key.starts_with(&(root_key.clone() + "/"))
+        })
+        .collect();
+
+    if blockers.is_empty() {
+        return Ok(());
+    }
+
+    let details = blockers
+        .iter()
+        .map(|session| {
+            format!(
+                "  - {} at {} ({:?})",
+                session.name, session.working_directory, session.status
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    Err(format!(
+        "Cannot delete while live sessions exist under {}:\n{}",
+        root.display(),
+        details
+    ))
+}
+
+fn path_key_for_delete(path: &Path) -> String {
+    let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let text = resolved.to_string_lossy();
+    text.strip_prefix(r"\\?\")
+        .unwrap_or(&text)
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
+}
+
+#[cfg(target_os = "windows")]
+fn delete_root_has_windows_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(target_os = "windows"))]
+fn delete_root_has_windows_reparse_point(_metadata: &std::fs::Metadata) -> bool {
+    false
 }
 
 /// True iff the rename-probe error indicates a blocker holds an open handle.
@@ -2957,6 +3067,110 @@ mod tests {
                 panic!("missing dir must NOT classify as Blocked")
             }
             WgDeleteOutcome::Deleted => panic!("missing dir cannot be Deleted"),
+            WgDeleteOutcome::Partial { .. } => panic!("missing dir cannot be Partial"),
+        }
+    }
+
+    #[test]
+    fn try_atomic_delete_wg_reports_partial_orphan_when_remove_fails() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let wg_dir = tmp.path().join("wg-1-test");
+        std::fs::create_dir(&wg_dir).expect("create wg_dir");
+        std::fs::write(wg_dir.join("TASK.md"), "# test\n").expect("write TASK.md");
+
+        let outcome = try_atomic_delete_wg_with_remove(&wg_dir, |_path| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "forced remove failure",
+            ))
+        });
+        match outcome {
+            WgDeleteOutcome::Partial { orphan_path, error } => {
+                assert!(!wg_dir.exists(), "original workgroup path should be gone");
+                assert!(orphan_path.is_dir(), "orphan should remain on disk");
+                assert!(orphan_path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .expect("orphan filename")
+                    .starts_with(".deleting-wg-1-test-"));
+                assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+                assert!(error.to_string().contains("forced remove failure"));
+            }
+            WgDeleteOutcome::Deleted => panic!("remove failure cannot be Deleted"),
+            WgDeleteOutcome::Blocked(e) => panic!("remove failure cannot be Blocked: {}", e),
+            WgDeleteOutcome::Other(e) => panic!("remove failure cannot be Other: {}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn gui_live_session_refusal_precedes_delete() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let wg_dir = tmp.path().join("wg-1-test");
+        std::fs::create_dir(&wg_dir).expect("create wg_dir");
+        let work_dir = wg_dir.join("__agent_dev-rust");
+        std::fs::create_dir_all(&work_dir).expect("create work_dir");
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        {
+            let guard = manager.read().await;
+            guard
+                .create_session(
+                    "shell".to_string(),
+                    Vec::new(),
+                    work_dir.to_string_lossy().to_string(),
+                    None,
+                    None,
+                    Vec::new(),
+                    false,
+                )
+                .await
+                .expect("create live session");
+        }
+
+        let err = ensure_no_live_sessions_under_manager(&wg_dir, &manager)
+            .await
+            .expect_err("live session should block delete");
+        assert!(err.contains("Cannot delete while live sessions exist"));
+        assert!(err.contains("Session 1"));
+        assert!(err.contains("Active"));
+    }
+
+    #[tokio::test]
+    async fn delete_workgroup_dir_backend_returns_blockers_json() {
+        #[cfg(not(windows))]
+        {
+            return;
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt;
+            const FILE_SHARE_READ: u32 = 0x00000001;
+
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let wg_dir = tmp.path().join("wg-1-test");
+            std::fs::create_dir(&wg_dir).expect("create wg_dir");
+            let inside = wg_dir.join("locked.bin");
+            std::fs::write(&inside, b"hold me").expect("write inside file");
+            let _handle = std::fs::OpenOptions::new()
+                .read(true)
+                .share_mode(FILE_SHARE_READ)
+                .open(&inside)
+                .expect("open with restricted share mode");
+            let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+
+            let err = delete_workgroup_dir_backend(&wg_dir, "wg-1-test", &manager)
+                .await
+                .expect_err("blocked delete should return blockers json");
+            let json = err
+                .strip_prefix("BLOCKERS:")
+                .unwrap_or_else(|| panic!("expected BLOCKERS prefix, got {}", err));
+            let report: serde_json::Value = serde_json::from_str(json).expect("blockers json");
+            assert_eq!(report["workgroup"], "wg-1-test");
+            assert!(!report["rawDeleteError"]
+                .as_str()
+                .expect("rawDeleteError")
+                .is_empty());
+            assert!(wg_dir.is_dir(), "blocked tree should remain intact");
         }
     }
 
@@ -3001,6 +3215,9 @@ mod tests {
             }
             WgDeleteOutcome::Other(e) => {
                 panic!("expected Blocked, got Other({:?}={})", e.kind(), e);
+            }
+            WgDeleteOutcome::Partial { .. } => {
+                panic!("blocked rename cannot report Partial");
             }
         }
     }

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -1511,7 +1511,22 @@ pub(crate) async fn delete_workgroup_dir_backend(
     workgroup_name: &str,
     session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
 ) -> Result<(), String> {
-    match try_atomic_delete_wg(wg_dir) {
+    delete_workgroup_dir_backend_with_outcome(
+        wg_dir,
+        workgroup_name,
+        session_mgr,
+        try_atomic_delete_wg(wg_dir),
+    )
+    .await
+}
+
+pub(crate) async fn delete_workgroup_dir_backend_with_outcome(
+    wg_dir: &Path,
+    workgroup_name: &str,
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+    outcome: WgDeleteOutcome,
+) -> Result<(), String> {
+    match outcome {
         WgDeleteOutcome::Deleted => {
             // fall through to success path
         }
@@ -3100,6 +3115,94 @@ mod tests {
             WgDeleteOutcome::Blocked(e) => panic!("remove failure cannot be Blocked: {}", e),
             WgDeleteOutcome::Other(e) => panic!("remove failure cannot be Other: {}", e),
         }
+    }
+
+    #[tokio::test]
+    async fn gui_partial_delete_outcome_returns_error_before_refresh() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let wg_dir = tmp.path().join("wg-1-test");
+        let orphan = tmp.path().join(".deleting-wg-1-test-forced");
+        std::fs::create_dir(&wg_dir).expect("create wg_dir");
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+
+        let err = delete_workgroup_dir_backend_with_outcome(
+            &wg_dir,
+            "wg-1-test",
+            &manager,
+            WgDeleteOutcome::Partial {
+                orphan_path: orphan.clone(),
+                error: std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "forced remove failure",
+                ),
+            },
+        )
+        .await
+        .expect_err("partial delete must error before caller can refresh");
+
+        assert!(err.contains("Partial workgroup delete"));
+        assert!(err.contains(&orphan.to_string_lossy().to_string()));
+    }
+
+    #[test]
+    fn validate_delete_root_rejects_non_directory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("wg-1-test");
+        std::fs::write(&file, "not a dir").expect("write file");
+
+        assert_eq!(
+            validate_delete_root_not_link_or_reparse(&file).unwrap_err(),
+            "delete_root_not_directory"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_delete_root_rejects_symlink_root() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real = tmp.path().join("real");
+        let link = tmp.path().join("wg-1-test");
+        std::fs::create_dir(&real).expect("create real");
+        symlink(&real, &link).expect("create symlink");
+
+        assert_eq!(
+            validate_delete_root_not_link_or_reparse(&link).unwrap_err(),
+            "delete_root_is_symlink"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn validate_delete_root_rejects_reparse_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real = tmp.path().join("real");
+        let junction = tmp.path().join("wg-1-test");
+        std::fs::create_dir(&real).expect("create real");
+        let output = std::process::Command::new("cmd")
+            .args([
+                "/C",
+                "mklink",
+                "/J",
+                junction.to_str().expect("junction path"),
+                real.to_str().expect("real path"),
+            ])
+            .output()
+            .expect("run mklink");
+        if !output.status.success() {
+            println!(
+                "skipping validate_delete_root reparse check; see docs/testing/destructive-filesystem-regression.md#helper-reparse-root-check: stdout: {} stderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        assert_eq!(
+            validate_delete_root_not_link_or_reparse(&junction).unwrap_err(),
+            "delete_root_is_reparse_point"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -443,6 +443,15 @@ pub fn load_sessions_raw() -> Vec<PersistedSession> {
         Some(p) => p,
         None => return vec![],
     };
+    load_sessions_raw_from_path(&path)
+}
+
+#[cfg(debug_assertions)]
+pub fn load_sessions_raw_from_dir_for_test(dir: &Path) -> Vec<PersistedSession> {
+    load_sessions_raw_from_path(&dir.join("sessions.json"))
+}
+
+fn load_sessions_raw_from_path(path: &Path) -> Vec<PersistedSession> {
     if !path.exists() {
         return vec![];
     }

--- a/src-tauri/src/testability/reset.rs
+++ b/src-tauri/src/testability/reset.rs
@@ -113,7 +113,11 @@ fn execute_inner(args: TestResetArgs) -> Result<TestResetOutput, String> {
         validate_candidate(exe_parent, candidate).map_err(|e| {
             error_json(
                 e.as_str(),
-                serde_json::json!({"path": candidate, "exeParent": exe_parent}),
+                serde_json::json!({
+                    "path": candidate,
+                    "exeParent": exe_parent,
+                    "plannedDelete": &candidates,
+                }),
             )
         })?;
 
@@ -121,7 +125,12 @@ fn execute_inner(args: TestResetArgs) -> Result<TestResetOutput, String> {
             std::fs::remove_dir_all(candidate).map_err(|e| {
                 error_json(
                     "remove_dir_all_failed",
-                    serde_json::json!({"path": candidate, "message": e.to_string()}),
+                    serde_json::json!({
+                        "path": candidate,
+                        "message": e.to_string(),
+                        "exeParent": exe_parent,
+                        "plannedDelete": &candidates,
+                    }),
                 )
             })?;
             deleted.push(candidate.clone());
@@ -162,14 +171,14 @@ fn validate_candidate(exe_parent: &Path, candidate: &Path) -> Result<(), String>
         Err(e) => return Err(format!("reset_candidate_metadata_failed: {e}")),
     };
 
+    if has_windows_reparse_point(&metadata) {
+        return Err("reset_candidate_is_reparse_point".to_string());
+    }
     if metadata.file_type().is_symlink() {
         return Err("reset_candidate_is_symlink".to_string());
     }
     if !metadata.is_dir() {
         return Err("reset_candidate_not_directory".to_string());
-    }
-    if has_windows_reparse_point(&metadata) {
-        return Err("reset_candidate_is_reparse_point".to_string());
     }
 
     let canonical_parent = exe_parent

--- a/src-tauri/tests/cli_test_reset.rs
+++ b/src-tauri/tests/cli_test_reset.rs
@@ -182,8 +182,11 @@ fn locked_file_refuses_and_reports_delete_plan() {
     let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
     let config_dir = tmp.path().join(".agentscommander_testeable");
     let project_dir = tmp.path().join("agentscommander_testeable");
+    let outside = tmp.path().join("outside-sentinel").join("keep.txt");
     std::fs::create_dir_all(&config_dir).unwrap();
     std::fs::create_dir_all(&project_dir).unwrap();
+    std::fs::create_dir_all(outside.parent().expect("outside parent")).unwrap();
+    std::fs::write(&outside, "keep").unwrap();
     let locked = config_dir.join("locked.txt");
     std::fs::write(&locked, b"locked").unwrap();
     let _handle = open_without_delete_share(&locked);
@@ -192,6 +195,7 @@ fn locked_file_refuses_and_reports_delete_plan() {
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
     let err = stderr_json(&stderr);
     assert_eq!(err["error"], "remove_dir_all_failed");
+    assert!(!err["message"].as_str().expect("message").is_empty());
     assert!(err["path"]
         .as_str()
         .expect("path")
@@ -208,6 +212,10 @@ fn locked_file_refuses_and_reports_delete_plan() {
     assert!(
         project_dir.exists(),
         "project dir should not be deleted after failure"
+    );
+    assert!(
+        outside.is_file(),
+        "outside sentinel should remain after reset failure"
     );
 }
 

--- a/src-tauri/tests/cli_test_reset.rs
+++ b/src-tauri/tests/cli_test_reset.rs
@@ -73,6 +73,41 @@ fn stderr_json(stderr: &str) -> Value {
     serde_json::from_str(line).expect("parse stderr json")
 }
 
+#[cfg(target_os = "windows")]
+fn create_junction(junction: &Path, target: &Path) -> Result<(), String> {
+    let output = Command::new("cmd")
+        .args([
+            "/C",
+            "mklink",
+            "/J",
+            junction.to_str().expect("junction path"),
+            target.to_str().expect("target path"),
+        ])
+        .output()
+        .map_err(|e| e.to_string())?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "stdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn open_without_delete_share(path: &Path) -> std::fs::File {
+    use std::os::windows::fs::OpenOptionsExt;
+    const FILE_SHARE_READ: u32 = 0x00000001;
+
+    std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ)
+        .open(path)
+        .expect("open with restricted share mode")
+}
+
 #[test]
 fn missing_confirm_refuses() {
     let _guard = testable_reset_identity_lock();
@@ -139,6 +174,92 @@ fn file_target_refuses_and_deletes_nothing() {
     );
 }
 
+#[cfg(target_os = "windows")]
+#[test]
+fn locked_file_refuses_and_reports_delete_plan() {
+    let _guard = testable_reset_identity_lock();
+    let tmp = Tmp::new("reset-locked-file");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    let config_dir = tmp.path().join(".agentscommander_testeable");
+    let project_dir = tmp.path().join("agentscommander_testeable");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::create_dir_all(&project_dir).unwrap();
+    let locked = config_dir.join("locked.txt");
+    std::fs::write(&locked, b"locked").unwrap();
+    let _handle = open_without_delete_share(&locked);
+
+    let (code, stdout, stderr) = run(&bin, &["test-reset", "--confirm-testeable"]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    let err = stderr_json(&stderr);
+    assert_eq!(err["error"], "remove_dir_all_failed");
+    assert!(err["path"]
+        .as_str()
+        .expect("path")
+        .contains(".agentscommander_testeable"));
+    assert_eq!(err["exeParent"], tmp.path().to_string_lossy().as_ref());
+    assert_eq!(
+        err["plannedDelete"]
+            .as_array()
+            .expect("plannedDelete")
+            .len(),
+        2
+    );
+    assert!(config_dir.exists(), "locked config dir should remain");
+    assert!(
+        project_dir.exists(),
+        "project dir should not be deleted after failure"
+    );
+}
+
+#[test]
+fn long_path_target_deletes_only_allowed_directories() {
+    let _guard = testable_reset_identity_lock();
+    let tmp = Tmp::new("reset-long-path");
+    let mut base = tmp.path().to_path_buf();
+    for idx in 0..10 {
+        base = base.join(format!("long-segment-{idx:02}-abcdef"));
+    }
+    if let Err(e) = std::fs::create_dir_all(&base) {
+        println!(
+            "skipping long path reset regression; see docs/testing/destructive-filesystem-regression.md#reset-long-path-check: {}",
+            e
+        );
+        return;
+    }
+    let bin = copy_binary_as(&base, "agentscommander_testeable.exe");
+    if let Err(e) = Command::new(&bin).arg("--help").output() {
+        println!(
+            "skipping long path reset regression; see docs/testing/destructive-filesystem-regression.md#reset-long-path-check: {}",
+            e
+        );
+        return;
+    }
+    let config_dir = base.join(".agentscommander_testeable");
+    let project_dir = base.join("agentscommander_testeable");
+    let keep_dir = base.join(".agentscommander_other");
+    std::fs::create_dir_all(config_dir.join("nested")).unwrap();
+    std::fs::create_dir_all(project_dir.join("nested")).unwrap();
+    std::fs::create_dir_all(&keep_dir).unwrap();
+
+    let (code, stdout, stderr) = run(&bin, &["test-reset", "--confirm-testeable"]);
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    let plan = stdout
+        .lines()
+        .find(|line| line.contains("\"plannedDelete\""))
+        .map(|line| serde_json::from_str::<Value>(line).expect("plan json"))
+        .expect("plan json line");
+    assert_eq!(
+        plan["plannedDelete"]
+            .as_array()
+            .expect("plannedDelete")
+            .len(),
+        2
+    );
+    assert!(!config_dir.exists(), "config dir should be deleted");
+    assert!(!project_dir.exists(), "project dir should be deleted");
+    assert!(keep_dir.exists(), "unrelated dir should remain");
+}
+
 #[cfg(unix)]
 #[test]
 fn symlink_target_refuses_and_deletes_nothing() {
@@ -194,7 +315,6 @@ fn held_testable_mutex_refuses_and_deletes_nothing() {
 
 #[cfg(target_os = "windows")]
 #[test]
-#[ignore = "Manual smoke: requires Windows junction creation support in the test runner"]
 fn junction_target_refuses_and_deletes_nothing() {
     let _guard = testable_reset_identity_lock();
     let tmp = Tmp::new("reset-junction");
@@ -205,17 +325,13 @@ fn junction_target_refuses_and_deletes_nothing() {
     std::fs::create_dir_all(&real).unwrap();
     std::fs::create_dir_all(&project_dir).unwrap();
 
-    let status = Command::new("cmd")
-        .args([
-            "/C",
-            "mklink",
-            "/J",
-            junction.to_str().unwrap(),
-            real.to_str().unwrap(),
-        ])
-        .status()
-        .expect("create junction");
-    assert!(status.success(), "mklink /J failed");
+    if let Err(e) = create_junction(&junction, &real) {
+        println!(
+            "skipping junction reset regression; see docs/testing/destructive-filesystem-regression.md#reset-junction-reparse-check: {}",
+            e
+        );
+        return;
+    }
 
     let (code, stdout, stderr) = run(&bin, &["test-reset", "--confirm-testeable"]);
     assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");

--- a/src-tauri/tests/cli_workgroup_team.rs
+++ b/src-tauri/tests/cli_workgroup_team.rs
@@ -126,6 +126,24 @@ fn has_refresh_reason(config_dir: &Path, reason: &str) -> bool {
         .any(|request| request["reason"] == reason)
 }
 
+fn create_outside_sentinel(project: &Path, name: &str) -> PathBuf {
+    let sentinel = project
+        .join(format!("outside-sentinel-{name}"))
+        .join("keep.txt");
+    std::fs::create_dir_all(sentinel.parent().expect("sentinel parent"))
+        .expect("create outside sentinel parent");
+    std::fs::write(&sentinel, "keep").expect("write outside sentinel");
+    sentinel
+}
+
+fn assert_outside_sentinel_survives(sentinel: &Path) {
+    assert!(
+        sentinel.is_file(),
+        "outside sentinel should survive destructive operation: {}",
+        sentinel.display()
+    );
+}
+
 fn project_with_agents(tmp: &Path, agents: &[&str]) -> PathBuf {
     let project = tmp.join("ProjectAlpha");
     let workspace_dir = project.join(".ac");
@@ -555,8 +573,10 @@ fn workgroup_remove_refuses_dirty_repo_without_force() {
     let tmp = Tmp::new("cli-workgroup-dirty-refuse");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let (_project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
-    create_dirty_repo(&wg_dir.join("repo-dirty"));
+    let (project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let outside = create_outside_sentinel(&project, "dirty-refuse");
+    let dirty_file = wg_dir.join("repo-dirty").join("untracked.txt");
+    create_dirty_repo(dirty_file.parent().expect("dirty repo parent"));
 
     let stderr = run_fail(
         &bin,
@@ -575,6 +595,8 @@ fn workgroup_remove_refuses_dirty_repo_without_force() {
         wg_dir.is_dir(),
         "dirty refusal should leave workgroup intact"
     );
+    assert!(dirty_file.is_file(), "dirty repo file should remain");
+    assert_outside_sentinel_survives(&outside);
     assert!(!has_refresh_reason(&config_dir, "workgroupRemoved"));
 }
 
@@ -588,7 +610,8 @@ fn workgroup_remove_force_dirty_deletes_dirty_repo() {
     let tmp = Tmp::new("cli-workgroup-dirty-force");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let (_project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let (project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let outside = create_outside_sentinel(&project, "dirty-force");
     create_dirty_repo(&wg_dir.join("repo-dirty"));
 
     let removed = run_json_machine(
@@ -605,6 +628,7 @@ fn workgroup_remove_force_dirty_deletes_dirty_repo() {
     );
     assert_eq!(removed["removed"], true);
     assert!(!wg_dir.exists(), "force-dirty should delete workgroup");
+    assert_outside_sentinel_survives(&outside);
     assert!(has_refresh_reason(&config_dir, "workgroupRemoved"));
 }
 
@@ -613,7 +637,8 @@ fn workgroup_remove_refuses_live_persisted_session_even_with_force() {
     let tmp = Tmp::new("cli-workgroup-live-refuse");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let (_project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let (project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let outside = create_outside_sentinel(&project, "live-refuse");
     let session_cwd = wg_dir.join("__agent_architect");
     write_live_session(&config_dir, &session_cwd);
 
@@ -640,6 +665,7 @@ fn workgroup_remove_refuses_live_persisted_session_even_with_force() {
         wg_dir.is_dir(),
         "live session refusal should leave workgroup intact"
     );
+    assert_outside_sentinel_survives(&outside);
     assert!(!has_refresh_reason(&config_dir, "workgroupRemoved"));
 }
 
@@ -649,7 +675,8 @@ fn workgroup_remove_locked_file_reports_blockers_without_refresh() {
     let tmp = Tmp::new("cli-workgroup-locked");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let (_project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let (project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let outside = create_outside_sentinel(&project, "locked");
     let locked = wg_dir.join("locked.bin");
     std::fs::write(&locked, b"locked").expect("write locked file");
     let _handle = open_without_delete_share(&locked);
@@ -669,6 +696,7 @@ fn workgroup_remove_locked_file_reports_blockers_without_refresh() {
     assert!(stderr.contains("file in use") || stderr.contains("Failed to delete workgroup"));
     assert!(wg_dir.is_dir(), "blocked workgroup should remain");
     assert!(locked.is_file(), "locked file should remain");
+    assert_outside_sentinel_survives(&outside);
     assert!(!has_refresh_reason(&config_dir, "workgroupRemoved"));
 }
 
@@ -716,7 +744,8 @@ fn workgroup_remove_refuses_reparse_root() {
     let tmp = Tmp::new("cli-workgroup-reparse-root");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
-    let (_project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let (project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let outside = create_outside_sentinel(&project, "reparse-root");
     std::fs::remove_dir_all(&wg_dir).expect("remove real workgroup");
     let real = tmp.path().join("real-wg-target");
     std::fs::create_dir_all(&real).expect("create real target");
@@ -744,6 +773,7 @@ fn workgroup_remove_refuses_reparse_root() {
     assert!(stderr.contains("delete_root_is_reparse_point"));
     assert!(wg_dir.exists(), "junction should remain");
     assert!(real.join("sentinel.txt").is_file(), "target should remain");
+    assert_outside_sentinel_survives(&outside);
     assert!(!has_refresh_reason(&config_dir, "workgroupRemoved"));
 }
 

--- a/src-tauri/tests/cli_workgroup_team.rs
+++ b/src-tauri/tests/cli_workgroup_team.rs
@@ -1,6 +1,11 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use agentscommander_lib::config::sessions_persistence::{
+    load_sessions_raw_from_dir_for_test, PersistedSession,
+};
+use agentscommander_lib::session::session::SessionStatus;
+
 struct Tmp(PathBuf);
 
 impl Drop for Tmp {
@@ -115,6 +120,12 @@ fn find_refresh_request<'a>(
         .unwrap_or_else(|| panic!("missing refresh request reason {}", reason))
 }
 
+fn has_refresh_reason(config_dir: &Path, reason: &str) -> bool {
+    read_project_refresh_requests(config_dir)
+        .iter()
+        .any(|request| request["reason"] == reason)
+}
+
 fn project_with_agents(tmp: &Path, agents: &[&str]) -> PathBuf {
     let project = tmp.join("ProjectAlpha");
     let workspace_dir = project.join(".ac");
@@ -166,6 +177,20 @@ fn run_fail(bin: &Path, args: &[&str]) -> String {
     String::from_utf8_lossy(&out.stderr).to_string()
 }
 
+fn run_fail_output(bin: &Path, args: &[&str]) -> (String, String) {
+    let out = Command::new(bin).args(args).output().expect("spawn");
+    assert!(
+        !out.status.success(),
+        "expected failure\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
 fn run_stdout(bin: &Path, args: &[&str]) -> String {
     let out = Command::new(bin).args(args).output().expect("spawn");
     assert!(
@@ -176,6 +201,107 @@ fn run_stdout(bin: &Path, args: &[&str]) -> String {
         String::from_utf8_lossy(&out.stderr)
     );
     String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn create_basic_workgroup(tmp: &Path, bin: &Path, config_dir: &Path) -> (PathBuf, PathBuf) {
+    write_settings(config_dir, tmp);
+    let project = project_with_agents(tmp, &["architect"]);
+    let created = run_json(
+        bin,
+        &[
+            "workgroup",
+            "add",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--title",
+            "Build",
+            "--coordinator",
+            "architect",
+        ],
+    );
+    let wg_dir = project.join(".ac").join("wg-1-dev-team");
+    assert_eq!(created["path"], wg_dir.to_string_lossy().as_ref());
+    (project, wg_dir)
+}
+
+fn git_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+fn create_dirty_repo(repo_dir: &Path) {
+    std::fs::create_dir_all(repo_dir).expect("create repo");
+    let init = Command::new("git")
+        .arg("init")
+        .current_dir(repo_dir)
+        .output()
+        .expect("git init");
+    assert!(
+        init.status.success(),
+        "git init failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+    std::fs::write(repo_dir.join("untracked.txt"), "dirty").expect("write dirty file");
+}
+
+fn write_live_session(config_dir: &Path, working_directory: &Path) {
+    let sessions = vec![PersistedSession {
+        name: "Live Rust".to_string(),
+        shell: "powershell.exe".to_string(),
+        shell_args: Vec::new(),
+        working_directory: working_directory.to_string_lossy().to_string(),
+        id: Some(uuid::Uuid::new_v4().to_string()),
+        status: Some(SessionStatus::Running),
+        waiting_for_input: Some(false),
+        created_at: Some("2026-06-13T00:00:00Z".to_string()),
+        ..PersistedSession::default()
+    }];
+    std::fs::write(
+        config_dir.join("sessions.json"),
+        serde_json::to_string_pretty(&sessions).expect("sessions json"),
+    )
+    .expect("write sessions");
+}
+
+#[cfg(target_os = "windows")]
+fn create_junction(junction: &Path, target: &Path) -> Result<(), String> {
+    let output = Command::new("cmd")
+        .args([
+            "/C",
+            "mklink",
+            "/J",
+            junction.to_str().expect("junction path"),
+            target.to_str().expect("target path"),
+        ])
+        .output()
+        .map_err(|e| e.to_string())?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "stdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn open_without_delete_share(path: &Path) -> std::fs::File {
+    use std::os::windows::fs::OpenOptionsExt;
+    const FILE_SHARE_READ: u32 = 0x00000001;
+
+    std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ)
+        .open(path)
+        .expect("open with restricted share mode")
 }
 
 #[test]
@@ -417,6 +543,208 @@ fn workgroup_remove_deletes_and_reuses_number() {
         .as_str()
         .expect("path")
         .ends_with("wg-1-qa-team"));
+}
+
+#[test]
+fn workgroup_remove_refuses_dirty_repo_without_force() {
+    if !git_available() {
+        println!("skipping dirty repo workgroup regression because git is unavailable");
+        return;
+    }
+
+    let tmp = Tmp::new("cli-workgroup-dirty-refuse");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    let (_project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    create_dirty_repo(&wg_dir.join("repo-dirty"));
+
+    let stderr = run_fail(
+        &bin,
+        &[
+            "workgroup",
+            "remove",
+            "--project",
+            "ProjectAlpha",
+            "--workgroup",
+            "wg-1-dev-team",
+        ],
+    );
+    assert!(stderr.contains("pending work"));
+    assert!(stderr.contains("repo-dirty"));
+    assert!(
+        wg_dir.is_dir(),
+        "dirty refusal should leave workgroup intact"
+    );
+    assert!(!has_refresh_reason(&config_dir, "workgroupRemoved"));
+}
+
+#[test]
+fn workgroup_remove_force_dirty_deletes_dirty_repo() {
+    if !git_available() {
+        println!("skipping force dirty workgroup regression because git is unavailable");
+        return;
+    }
+
+    let tmp = Tmp::new("cli-workgroup-dirty-force");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    let (_project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    create_dirty_repo(&wg_dir.join("repo-dirty"));
+
+    let removed = run_json_machine(
+        &bin,
+        &[
+            "workgroup",
+            "remove",
+            "--project",
+            "ProjectAlpha",
+            "--workgroup",
+            "wg-1-dev-team",
+            "--force-dirty",
+        ],
+    );
+    assert_eq!(removed["removed"], true);
+    assert!(!wg_dir.exists(), "force-dirty should delete workgroup");
+    assert!(has_refresh_reason(&config_dir, "workgroupRemoved"));
+}
+
+#[test]
+fn workgroup_remove_refuses_live_persisted_session_even_with_force() {
+    let tmp = Tmp::new("cli-workgroup-live-refuse");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    let (_project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let session_cwd = wg_dir.join("__agent_architect");
+    write_live_session(&config_dir, &session_cwd);
+
+    let parsed = load_sessions_raw_from_dir_for_test(&config_dir);
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].status, Some(SessionStatus::Running));
+    assert!(parsed[0].id.is_some(), "live session fixture must carry id");
+
+    let stderr = run_fail(
+        &bin,
+        &[
+            "workgroup",
+            "remove",
+            "--project",
+            "ProjectAlpha",
+            "--workgroup",
+            "wg-1-dev-team",
+            "--force-dirty",
+        ],
+    );
+    assert!(stderr.contains("Cannot delete while live sessions exist"));
+    assert!(stderr.contains("Live Rust"));
+    assert!(
+        wg_dir.is_dir(),
+        "live session refusal should leave workgroup intact"
+    );
+    assert!(!has_refresh_reason(&config_dir, "workgroupRemoved"));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn workgroup_remove_locked_file_reports_blockers_without_refresh() {
+    let tmp = Tmp::new("cli-workgroup-locked");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    let (_project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let locked = wg_dir.join("locked.bin");
+    std::fs::write(&locked, b"locked").expect("write locked file");
+    let _handle = open_without_delete_share(&locked);
+
+    let (_stdout, stderr) = run_fail_output(
+        &bin,
+        &[
+            "workgroup",
+            "remove",
+            "--project",
+            "ProjectAlpha",
+            "--workgroup",
+            "wg-1-dev-team",
+            "--force-dirty",
+        ],
+    );
+    assert!(stderr.contains("file in use") || stderr.contains("Failed to delete workgroup"));
+    assert!(wg_dir.is_dir(), "blocked workgroup should remain");
+    assert!(locked.is_file(), "locked file should remain");
+    assert!(!has_refresh_reason(&config_dir, "workgroupRemoved"));
+}
+
+#[test]
+fn workgroup_remove_deletes_long_path_tree() {
+    let tmp = Tmp::new("cli-workgroup-long-path");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    let (_project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    let mut deep = wg_dir.clone();
+    for idx in 0..10 {
+        deep = deep.join(format!("long-segment-{idx:02}-abcdef"));
+    }
+    if let Err(e) = std::fs::create_dir_all(&deep) {
+        println!(
+            "skipping long path workgroup regression; see docs/testing/destructive-filesystem-regression.md#workgroup-long-path-check: {}",
+            e
+        );
+        return;
+    }
+    std::fs::write(deep.join("payload.txt"), "payload").expect("write payload");
+    let keep = wg_dir.parent().expect("wg parent").join("keep-sibling");
+    std::fs::create_dir_all(&keep).expect("create keep sibling");
+
+    let removed = run_json_machine(
+        &bin,
+        &[
+            "workgroup",
+            "remove",
+            "--project",
+            "ProjectAlpha",
+            "--workgroup",
+            "wg-1-dev-team",
+            "--force-dirty",
+        ],
+    );
+    assert_eq!(removed["removed"], true);
+    assert!(!wg_dir.exists(), "workgroup should be deleted");
+    assert!(keep.is_dir(), "sibling outside workgroup should remain");
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn workgroup_remove_refuses_reparse_root() {
+    let tmp = Tmp::new("cli-workgroup-reparse-root");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    let (_project, wg_dir) = create_basic_workgroup(tmp.path(), &bin, &config_dir);
+    std::fs::remove_dir_all(&wg_dir).expect("remove real workgroup");
+    let real = tmp.path().join("real-wg-target");
+    std::fs::create_dir_all(&real).expect("create real target");
+    std::fs::write(real.join("sentinel.txt"), "target").expect("write sentinel");
+    if let Err(e) = create_junction(&wg_dir, &real) {
+        println!(
+            "skipping reparse root workgroup regression; see docs/testing/destructive-filesystem-regression.md#workgroup-reparse-root-check: {}",
+            e
+        );
+        return;
+    }
+
+    let stderr = run_fail(
+        &bin,
+        &[
+            "workgroup",
+            "remove",
+            "--project",
+            "ProjectAlpha",
+            "--workgroup",
+            "wg-1-dev-team",
+            "--force-dirty",
+        ],
+    );
+    assert!(stderr.contains("delete_root_is_reparse_point"));
+    assert!(wg_dir.exists(), "junction should remain");
+    assert!(real.join("sentinel.txt").is_file(), "target should remain");
+    assert!(!has_refresh_reason(&config_dir, "workgroupRemoved"));
 }
 
 #[test]

--- a/test-debt.allowlist.json
+++ b/test-debt.allowlist.json
@@ -34,14 +34,6 @@
       "resolution": "Run manually with cargo test --release --test cli_powershell_capture -- --ignored on a machine with pwsh.exe."
     },
     {
-      "id": "rust:src-tauri/tests/cli_test_reset.rs::junction_target_refuses_and_deletes_nothing",
-      "category": "ignored-rust-test",
-      "owner": "dev-rust",
-      "issue": 489,
-      "reason": "Manual Windows junction smoke coverage needs mklink junction support in the test runner.",
-      "resolution": "Run manually on Windows with cargo test --test cli_test_reset junction_target_refuses_and_deletes_nothing -- --ignored."
-    },
-    {
       "id": "rust:src-tauri/src/commands/telegram.rs::attach_detach_persistence_tests::telegram_attach_detach_persistence_ordering_harness_note",
       "category": "ignored-rust-test",
       "owner": "dev-rust",


### PR DESCRIPTION
## Summary
- harden reset deletion validation before destructive deletes and refuse reparse/symlink candidates with clearer diagnostics
- harden workgroup deletion blockers for live sessions, dirty repos, reparse roots, locked files, and partial deletes
- add destructive filesystem regression coverage plus documented Windows long-path fallback evidence

## Validation
- Dev PASS on `61bdcc180cfbd54bea3c5d15878898cea2678e19`
- Grinch PASS on destructive safety review for `61bdcc180cfbd54bea3c5d15878898cea2678e19`
- Shipper PASS for `agentscommander_standalone_wg-1.exe`, SHA256 `D1C813C3A4E51E5A5B94978E6D27B68A18A5695DC4D4A977349104E4A04F9376`
- WG13 acceptance PASS with evidence at `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-13-acceptance-testing\__agent_ac-cli-and-gui-tester\artifacts\issue-486-destructive-fs-20260614-043737`

Closes #486