### PR TITLE
Add CLI behavior contract tests

### DIFF
--- a/src-tauri/tests/cli_agency_templates.rs
+++ b/src-tauri/tests/cli_agency_templates.rs
@@ -118,6 +118,25 @@ fn seed_cache(config_dir: &Path) {
 }
 
 #[test]
+fn agency_templates_unknown_subcommand_exits_one_with_usage() {
+    let tmp = Tmp::new("agency-unknown-subcommand");
+    let bin = copy_binary_into(tmp.path());
+    let output = Command::new(&bin)
+        .args(["agency-templates", "unknown-subcommand"])
+        .output()
+        .expect("run unknown subcommand");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8(output.stderr).expect("stderr utf8");
+    assert!(
+        stderr.contains("Usage:") || stderr.contains("unrecognized subcommand"),
+        "unexpected stderr:\n{}",
+        stderr
+    );
+}
+
+#[test]
 fn agency_templates_update_prints_json_on_success_and_noop() {
     let tmp = Tmp::new("agency-update-json");
     let bin = copy_binary_into(tmp.path());

--- a/src-tauri/tests/cli_behavior_contract.rs
+++ b/src-tauri/tests/cli_behavior_contract.rs
@@ -1,0 +1,696 @@
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const VALID_TOKEN: &str = "00000000-0000-0000-0000-000000000487";
+const LEAK_PROBE_TOKEN: &str = "zzzz-leakprobe-487-not-a-token";
+
+struct Tmp(PathBuf);
+
+impl Drop for Tmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+impl Tmp {
+    fn new(prefix: &str) -> Self {
+        let path =
+            std::env::temp_dir().join(format!("ac-{}-{}", prefix, uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&path).expect("create tmp dir");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+fn copy_binary_into(tmp: &Path) -> PathBuf {
+    let src = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let dst = tmp.join(src.file_name().expect("binary file name"));
+    std::fs::copy(src, &dst).expect("copy binary");
+    dst
+}
+
+fn copy_binary_as(tmp: &Path, name: &str) -> PathBuf {
+    let src = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let dst = tmp.join(name);
+    std::fs::copy(src, &dst).expect("copy binary");
+    dst
+}
+
+fn config_dir_for_bin(bin: &Path) -> PathBuf {
+    let stem = bin
+        .file_stem()
+        .expect("bin stem")
+        .to_string_lossy()
+        .to_string();
+    bin.parent().expect("bin parent").join(format!(".{}", stem))
+}
+
+fn run(bin: &Path, args: &[&str]) -> (Option<i32>, String, String) {
+    let out = Command::new(bin).args(args).output().expect("spawn");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn assert_no_stdout_on_error(stdout: &str) {
+    assert!(
+        stdout.trim().is_empty(),
+        "error contract should not write stdout, got:\n{}",
+        stdout
+    );
+}
+
+fn assert_success_json_array(stdout: &str) -> Value {
+    let value: Value = serde_json::from_str(stdout.trim()).expect("stdout JSON array");
+    assert!(value.is_array(), "expected JSON array, got {}", value);
+    value
+}
+
+fn assert_success_json_object(stdout: &str) -> Value {
+    let value: Value = serde_json::from_str(stdout.trim()).expect("stdout JSON object");
+    assert!(value.is_object(), "expected JSON object, got {}", value);
+    value
+}
+
+fn write_settings(config_dir: &Path, project_parent: &Path) {
+    std::fs::create_dir_all(config_dir).expect("create config dir");
+    let settings = serde_json::json!({
+        "defaultShell": "powershell.exe",
+        "defaultShellArgs": [],
+        "agents": [],
+        "projectPaths": [project_parent.to_string_lossy().to_string()]
+    });
+    std::fs::write(
+        config_dir.join("settings.json"),
+        serde_json::to_string_pretty(&settings).expect("settings json"),
+    )
+    .expect("write settings");
+}
+
+fn project_with_agents(tmp: &Path, agents: &[&str]) -> PathBuf {
+    let project = tmp.join("ProjectAlpha");
+    let workspace_dir = project.join(".ac");
+    std::fs::create_dir_all(&workspace_dir).expect("create .ac");
+    for agent in agents {
+        let dir = workspace_dir.join(format!("_agent_{}", agent));
+        std::fs::create_dir_all(dir.join("memory")).expect("agent memory");
+        std::fs::write(dir.join("Role.md"), format!("# {}\n", agent)).expect("role");
+    }
+    project
+}
+
+fn run_success_json(bin: &Path, args: &[&str]) -> Value {
+    let (code, stdout, stderr) = run(bin, args);
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    serde_json::from_str(stdout.trim()).expect("stdout json")
+}
+
+fn create_send_fixture(tmp: &Path, bin: &Path, config_dir: &Path) -> (PathBuf, PathBuf) {
+    write_settings(config_dir, tmp);
+    let project = project_with_agents(tmp, &["architect", "dev-rust"]);
+    let _team = run_success_json(
+        bin,
+        &[
+            "team",
+            "create",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--coordinator",
+            "architect",
+            "--agent",
+            "dev-rust",
+        ],
+    );
+    let _wg = run_success_json(
+        bin,
+        &[
+            "workgroup",
+            "add",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+            "--title",
+            "Build",
+        ],
+    );
+    let sender = project
+        .join(".ac")
+        .join("wg-1-dev-team")
+        .join("__agent_architect");
+    assert!(sender.is_dir(), "sender replica root should exist");
+    (project, sender)
+}
+
+#[test]
+fn root_help_lists_public_subcommands() {
+    let bin = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let (code, stdout, stderr) = run(bin, &["--help"]);
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(
+        stderr.trim().is_empty(),
+        "help should not initialize logging: {stderr}"
+    );
+    for command in [
+        "send",
+        "list-peers",
+        "list-peers-lean",
+        "list-sessions",
+        "agency-templates",
+        "create-agent",
+        "create-agent-matrix",
+        "role-experiment",
+        "close-session",
+        "task-set-title",
+        "task-append-body",
+        "open-project",
+        "new-project",
+        "telegram-send-image",
+        "workgroup",
+        "team",
+        "harness",
+        "test-reset",
+        "window-info",
+    ] {
+        assert!(
+            stdout.contains(command),
+            "root help missing {command}:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn unknown_root_subcommand_exits_one_with_usage() {
+    let bin = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let (code, stdout, stderr) = run(bin, &["definitely-not-a-command"]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_no_stdout_on_error(&stdout);
+    assert!(stderr.contains("unrecognized subcommand") || stderr.contains("Usage:"));
+}
+
+#[test]
+fn public_subcommand_help_contracts() {
+    let bin = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let cases: &[(&[&str], &[&str])] = &[
+        (
+            &["send", "--help"],
+            &["DELIVERY MODES", "--token", "--to", "--send", "--mode"],
+        ),
+        (
+            &["list-peers", "--help"],
+            &["OUTPUT", "--token", "--root", "--peer"],
+        ),
+        (
+            &["list-peers-lean", "--help"],
+            &["lean", "--token", "--root"],
+        ),
+        (&["list-sessions", "--help"], &["OUTPUT", "--status"]),
+        (
+            &["agency-templates", "--help"],
+            &["update", "list", "status"],
+        ),
+        (
+            &["agency-templates", "update", "--help"],
+            &["--repo", "--ref"],
+        ),
+        (
+            &["agency-templates", "list", "--help"],
+            &["--json", "--pretty"],
+        ),
+        (
+            &["agency-templates", "status", "--help"],
+            &["--json", "--pretty"],
+        ),
+        (
+            &["create-agent", "--help"],
+            &["--project", "--name", "--description"],
+        ),
+        (
+            &["create-agent-matrix", "--help"],
+            &["--project", "--name", "--description"],
+        ),
+        (
+            &["role-experiment", "--help"],
+            &[
+                "init", "list", "show", "variant", "validate", "run", "report",
+            ],
+        ),
+        (
+            &["role-experiment", "init", "--help"],
+            &["--project", "--source-agent"],
+        ),
+        (&["role-experiment", "list", "--help"], &["--project"]),
+        (&["role-experiment", "show", "--help"], &["--experiment"]),
+        (&["role-experiment", "variant", "--help"], &["set", "diff"]),
+        (
+            &["role-experiment", "variant", "set", "--help"],
+            &["--experiment", "--role-file"],
+        ),
+        (
+            &["role-experiment", "variant", "diff", "--help"],
+            &["--experiment", "--against"],
+        ),
+        (
+            &["role-experiment", "validate", "--help"],
+            &["--experiment"],
+        ),
+        (&["role-experiment", "run", "--help"], &["--experiment"]),
+        (&["role-experiment", "report", "--help"], &["--experiment"]),
+        (
+            &["close-session", "--help"],
+            &["--token", "--root", "--target"],
+        ),
+        (
+            &["task-set-title", "--help"],
+            &["--token", "--root", "--title"],
+        ),
+        (
+            &["task-append-body", "--help"],
+            &["--token", "--root", "--text"],
+        ),
+        (&["open-project", "--help"], &["PATH"]),
+        (&["new-project", "--help"], &["PATH"]),
+        (&["telegram-send-image", "--help"], &["--path", "--caption"]),
+        (&["workgroup", "--help"], &["list", "add", "remove"]),
+        (&["workgroup", "list", "--help"], &["--project"]),
+        (
+            &["workgroup", "add", "--help"],
+            &["--project", "--team", "--title"],
+        ),
+        (
+            &["workgroup", "remove", "--help"],
+            &["--project", "--workgroup"],
+        ),
+        (
+            &["team", "--help"],
+            &["create", "list", "add-member", "remove-member"],
+        ),
+        (
+            &["team", "create", "--help"],
+            &["--project", "--team", "--coordinator"],
+        ),
+        (&["team", "list", "--help"], &["--project"]),
+        (
+            &["team", "add-member", "--help"],
+            &["--project", "--workgroup", "--agent"],
+        ),
+        (
+            &["team", "remove-member", "--help"],
+            &["--project", "--workgroup", "--agent"],
+        ),
+        (&["harness", "--help"], &["--dry-run", "--raw-command"]),
+        (&["test-reset", "--help"], &["--confirm-testeable"]),
+        (&["window-info", "--help"], &["Usage:"]),
+    ];
+
+    for (args, markers) in cases {
+        let (code, stdout, stderr) = run(bin, args);
+        assert_eq!(
+            code,
+            Some(0),
+            "args {args:?}\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        assert!(
+            stderr.trim().is_empty(),
+            "help should not log for {args:?}: {stderr}"
+        );
+        assert!(
+            stdout.contains("Usage:") || stdout.contains("Commands:"),
+            "help missing usage/commands for {args:?}:\n{stdout}"
+        );
+        assert!(!stdout.to_ascii_lowercase().contains("panic"));
+        for marker in *markers {
+            assert!(
+                stdout.contains(marker),
+                "help {args:?} missing {marker}:\n{stdout}"
+            );
+        }
+    }
+}
+
+#[test]
+fn token_gated_commands_missing_token_contracts() {
+    let tmp = Tmp::new("cli-missing-token");
+    let bin = copy_binary_into(tmp.path());
+    let root = tmp.path().join("root");
+    std::fs::create_dir_all(&root).expect("root");
+    let root_s = root.to_string_lossy().to_string();
+    let cases: &[&[&str]] = &[
+        &["send", "--to", "Project:wg-1/dev", "--root", &root_s],
+        &["list-peers", "--root", &root_s],
+        &["list-peers-lean", "--root", &root_s],
+        &[
+            "close-session",
+            "--root",
+            &root_s,
+            "--target",
+            "Project:wg-1/dev",
+        ],
+        &["task-set-title", "--root", &root_s, "--title", "Title"],
+        &["task-append-body", "--root", &root_s, "--text", "Body"],
+    ];
+
+    for args in cases {
+        let (code, stdout, stderr) = run(&bin, args);
+        assert_eq!(
+            code,
+            Some(1),
+            "args {args:?}\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        assert_no_stdout_on_error(&stdout);
+        assert!(
+            stderr.contains("--token") || stderr.contains("AGENTSCOMMANDER_TOKEN"),
+            "missing token stderr for {args:?}: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn token_gated_commands_invalid_token_redaction_contracts() {
+    let tmp = Tmp::new("cli-invalid-token");
+    let bin = copy_binary_into(tmp.path());
+    let root = tmp.path().join("root");
+    std::fs::create_dir_all(&root).expect("root");
+    let root_s = root.to_string_lossy().to_string();
+    let cases: &[&[&str]] = &[
+        &[
+            "send",
+            "--token",
+            LEAK_PROBE_TOKEN,
+            "--to",
+            "Project:wg-1/dev",
+            "--root",
+            &root_s,
+        ],
+        &["list-peers", "--token", LEAK_PROBE_TOKEN, "--root", &root_s],
+        &[
+            "list-peers-lean",
+            "--token",
+            LEAK_PROBE_TOKEN,
+            "--root",
+            &root_s,
+        ],
+        &[
+            "close-session",
+            "--token",
+            LEAK_PROBE_TOKEN,
+            "--root",
+            &root_s,
+            "--target",
+            "Project:wg-1/dev",
+        ],
+        &[
+            "task-set-title",
+            "--token",
+            LEAK_PROBE_TOKEN,
+            "--root",
+            &root_s,
+            "--title",
+            "Title",
+        ],
+        &[
+            "task-append-body",
+            "--token",
+            LEAK_PROBE_TOKEN,
+            "--root",
+            &root_s,
+            "--text",
+            "Body",
+        ],
+    ];
+
+    for args in cases {
+        let (code, stdout, stderr) = run(&bin, args);
+        assert_eq!(
+            code,
+            Some(1),
+            "args {args:?}\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        assert_no_stdout_on_error(&stdout);
+        assert!(
+            stderr.contains("invalid token supplied"),
+            "stderr: {stderr}"
+        );
+        assert!(
+            !stderr.contains(LEAK_PROBE_TOKEN),
+            "token leaked in stderr: {stderr}"
+        );
+        assert!(
+            !stderr.contains("leakprobe-487"),
+            "probe leaked in stderr: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn token_gated_commands_missing_root_contracts() {
+    let tmp = Tmp::new("cli-missing-root");
+    let bin = copy_binary_into(tmp.path());
+    let cases: &[&[&str]] = &[
+        &["list-peers", "--token", VALID_TOKEN],
+        &["list-peers-lean", "--token", VALID_TOKEN],
+        &[
+            "close-session",
+            "--token",
+            VALID_TOKEN,
+            "--target",
+            "Project:wg-1/dev",
+        ],
+        &["task-set-title", "--token", VALID_TOKEN, "--title", "Title"],
+        &["task-append-body", "--token", VALID_TOKEN, "--text", "Body"],
+    ];
+    for args in cases {
+        let (code, stdout, stderr) = run(&bin, args);
+        assert_eq!(
+            code,
+            Some(1),
+            "args {args:?}\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        assert_no_stdout_on_error(&stdout);
+        assert!(stderr.contains("--root"), "stderr: {stderr}");
+    }
+}
+
+#[test]
+fn read_only_json_commands_missing_config_contracts() {
+    let tmp = Tmp::new("cli-json-missing-config");
+    let bin = copy_binary_into(tmp.path());
+    let root = tmp.path().join("empty-root");
+    std::fs::create_dir_all(&root).expect("root");
+    let root_s = root.to_string_lossy().to_string();
+
+    let (code, stdout, stderr) = run(&bin, &["list-sessions"]);
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(assert_success_json_array(&stdout), serde_json::json!([]));
+
+    let (code, stdout, stderr) = run(&bin, &["agency-templates", "list", "--json"]);
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(assert_success_json_array(&stdout), serde_json::json!([]));
+
+    let (code, stdout, stderr) = run(&bin, &["agency-templates", "status", "--json"]);
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    let status = assert_success_json_object(&stdout);
+    assert_eq!(status["available"], false);
+    assert!(
+        status.get("reason").is_some(),
+        "status should include reason: {status}"
+    );
+
+    for args in [
+        vec!["list-peers", "--token", VALID_TOKEN, "--root", &root_s],
+        vec!["list-peers-lean", "--token", VALID_TOKEN, "--root", &root_s],
+    ] {
+        let (code, stdout, stderr) = run(&bin, &args);
+        assert_eq!(
+            code,
+            Some(0),
+            "args {args:?}\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        assert_success_json_array(&stdout);
+    }
+}
+
+#[test]
+fn simple_bad_path_contracts() {
+    let tmp = Tmp::new("cli-bad-paths");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    let sentinel = config_dir.join("sentinel.txt");
+    std::fs::create_dir_all(&config_dir).expect("config dir");
+    std::fs::write(&sentinel, "keep").expect("sentinel");
+
+    let missing_project = tmp.path().join("MissingProject");
+    let missing_project_s = missing_project.to_string_lossy().to_string();
+    let (code, stdout, stderr) = run(&bin, &["open-project", &missing_project_s]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_no_stdout_on_error(&stdout);
+    assert!(stderr.contains("Error:"));
+    assert!(sentinel.is_file(), "config sentinel should remain");
+    assert!(
+        !config_dir.join("project-refresh-requests").exists(),
+        "bad open-project must not write refresh requests"
+    );
+
+    let missing_image = tmp.path().join("missing.png");
+    let missing_image_s = missing_image.to_string_lossy().to_string();
+    let (code, stdout, stderr) = run(&bin, &["telegram-send-image", "--path", &missing_image_s]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_no_stdout_on_error(&stdout);
+    assert!(
+        stderr.contains("No Telegram bots are configured"),
+        "stderr: {stderr}"
+    );
+
+    let send_tmp = Tmp::new("cli-send-bad-path");
+    let send_bin = copy_binary_into(send_tmp.path());
+    let send_config = config_dir_for_bin(&send_bin);
+    let (project, sender) = create_send_fixture(send_tmp.path(), &send_bin, &send_config);
+    let sender_s = sender.to_string_lossy().to_string();
+    let peer = "ProjectAlpha:wg-1-dev-team/dev-rust";
+    let (code, stdout, stderr) = run(
+        &send_bin,
+        &[
+            "send",
+            "--token",
+            VALID_TOKEN,
+            "--root",
+            &sender_s,
+            "--to",
+            peer,
+            "--send",
+            "path/with/separator.md",
+        ],
+    );
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_no_stdout_on_error(&stdout);
+    assert!(
+        stderr.contains("filename") || stderr.contains("separator") || stderr.contains("traversal"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !sender.join(".agentscommander-new").join("outbox").exists(),
+        "send filename refusal must not create sender outbox"
+    );
+    assert!(
+        !send_config.join("outbox").exists() && !send_config.join("app-outbox-path.txt").exists(),
+        "send filename refusal must not create app outbox artifacts"
+    );
+    assert!(
+        !project
+            .join(".ac")
+            .join("wg-1-dev-team")
+            .join("__agent_dev-rust")
+            .join(".agentscommander-new")
+            .join("outbox")
+            .exists(),
+        "send filename refusal must not create peer outbox"
+    );
+}
+
+#[test]
+fn missing_required_args_contracts() {
+    let tmp = Tmp::new("cli-missing-required");
+    let bin = copy_binary_into(tmp.path());
+    let cases: &[&[&str]] = &[
+        &["create-agent"],
+        &["create-agent-matrix"],
+        &["new-project"],
+        &["open-project"],
+        &["role-experiment"],
+        &["workgroup", "list"],
+        &["workgroup", "add", "--project", "ProjectAlpha"],
+        &[
+            "team",
+            "create",
+            "--project",
+            "ProjectAlpha",
+            "--team",
+            "Dev Team",
+        ],
+        &[
+            "team",
+            "add-member",
+            "--project",
+            "ProjectAlpha",
+            "--workgroup",
+            "wg-1-dev-team",
+        ],
+        &["harness"],
+        &["telegram-send-image"],
+    ];
+
+    for args in cases {
+        let (code, stdout, stderr) = run(&bin, args);
+        assert_eq!(
+            code,
+            Some(1),
+            "args {args:?}\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        assert_no_stdout_on_error(&stdout);
+        assert!(
+            stderr.contains("Usage:") || stderr.contains("required") || stderr.contains("command"),
+            "stderr for {args:?}: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn list_sessions_invalid_status_contract() {
+    let tmp = Tmp::new("cli-list-sessions-invalid");
+    let bin = copy_binary_into(tmp.path());
+    let (code, stdout, stderr) = run(&bin, &["list-sessions", "--status", "bogus"]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_no_stdout_on_error(&stdout);
+    assert!(stderr.contains("valid statuses") || stderr.contains("running"));
+}
+
+#[test]
+fn telegram_send_image_empty_and_missing_config_contracts() {
+    let tmp = Tmp::new("cli-telegram-contracts");
+    let bin = copy_binary_into(tmp.path());
+    let (code, stdout, stderr) = run(&bin, &["telegram-send-image", "--path", "   "]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_no_stdout_on_error(&stdout);
+    assert!(stderr.contains("--path must not be empty"));
+
+    let image = tmp.path().join("image.png");
+    std::fs::write(&image, b"not really png").expect("write image");
+    let image_s = image.to_string_lossy().to_string();
+    let (code, stdout, stderr) = run(&bin, &["telegram-send-image", "--path", &image_s]);
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert_no_stdout_on_error(&stdout);
+    assert!(stderr.contains("No Telegram bots are configured"));
+}
+
+#[test]
+fn window_info_no_gui_contract() {
+    let tmp = Tmp::new("cli-window-info");
+    let bin = copy_binary_as(tmp.path(), "agentscommander_testeable.exe");
+    let (code, stdout, stderr) = run(&bin, &["window-info"]);
+    #[cfg(target_os = "windows")]
+    {
+        assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+        let json = assert_success_json_object(&stdout);
+        assert_eq!(json["ok"], true);
+        assert_eq!(json["supported"], true);
+        assert!(
+            json["windows"].is_array(),
+            "windows should be array: {json}"
+        );
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+        let json = assert_success_json_object(&stdout);
+        assert_eq!(json["supported"], false);
+        assert_eq!(json["error"], "window_info_unsupported_on_platform");
+    }
+}

--- a/src-tauri/tests/cli_project_registration.rs
+++ b/src-tauri/tests/cli_project_registration.rs
@@ -129,6 +129,33 @@ fn run_failure(bin: &Path, args: &[&str]) {
     );
 }
 
+fn assert_no_ac_side_effect_dirs(root: &Path) {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for entry in entries {
+            let path = entry.expect("entry").path();
+            if path.is_dir() {
+                let name = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("");
+                assert!(
+                    !(name.starts_with("wg-")
+                        || name.starts_with("_team_")
+                        || name.starts_with("_agent_")),
+                    "unexpected side-effect directory {}",
+                    path.display()
+                );
+                stack.push(path);
+            }
+        }
+    }
+}
+
 #[test]
 fn new_project_writes_project_registered_refresh() {
     let tmp = Tmp::new("cli-new-project-refresh");
@@ -174,6 +201,41 @@ fn open_project_noop_does_not_write_refresh() {
     run_success(&bin, &["open-project", &project_arg]);
 
     assert!(project_refresh_request_paths(&config_dir).is_empty());
+}
+
+#[test]
+fn new_project_bad_parent_path_does_not_write_settings_or_refresh() {
+    let tmp = Tmp::new("cli-new-project-bad-parent");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    let config_sentinel = config_dir.join("sentinel.txt");
+    std::fs::write(&config_sentinel, "keep").expect("write config sentinel");
+    let outside_sentinel = tmp.path().join("outside-sentinel.txt");
+    std::fs::write(&outside_sentinel, "keep").expect("write outside sentinel");
+
+    let parent_file = tmp.path().join("parent-file");
+    std::fs::write(&parent_file, "not a dir").expect("write parent file");
+    let bad_project = parent_file.join("ChildProject");
+    let bad_project_arg = bad_project.to_string_lossy().to_string();
+
+    run_failure(&bin, &["new-project", &bad_project_arg]);
+
+    assert!(!bad_project.exists());
+    assert!(
+        !config_dir.join("settings.json").exists(),
+        "settings.json should not be written on failed new-project"
+    );
+    assert!(project_refresh_request_paths(&config_dir).is_empty());
+    assert_eq!(
+        std::fs::read_to_string(&config_sentinel).expect("read config sentinel"),
+        "keep"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&outside_sentinel).expect("read outside sentinel"),
+        "keep"
+    );
+    assert_no_ac_side_effect_dirs(tmp.path());
 }
 
 #[test]

--- a/src-tauri/tests/cli_task_logger.rs
+++ b/src-tauri/tests/cli_task_logger.rs
@@ -1,4 +1,4 @@
-//! Plan #137 follow-up — pin runtime emission of `[task]` audit log lines
+//! Plan #137 follow-up: pin runtime emission of `[task]` audit log lines
 //! from the CLI path.
 //!
 //! Pre-fix bug: `main.rs` jumped straight into `cli::handle_cli` without
@@ -59,6 +59,35 @@ fn copy_binary_into(tmp: &Path) -> PathBuf {
     dst
 }
 
+fn config_dir_for_bin(bin: &Path) -> PathBuf {
+    let stem = bin
+        .file_stem()
+        .expect("bin has stem")
+        .to_string_lossy()
+        .to_string();
+    bin.parent().expect("bin parent").join(format!(".{}", stem))
+}
+
+fn seed_master_token(config_dir: &Path, token: &str) {
+    std::fs::create_dir_all(config_dir).expect("create config dir");
+    std::fs::write(config_dir.join("master-token.txt"), token).expect("write master-token.txt");
+}
+
+fn backup_paths(task_path: &Path) -> Vec<PathBuf> {
+    let task_dir = task_path.parent().expect("TASK.md parent");
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(task_dir)
+        .expect("read task dir")
+        .map(|entry| entry.expect("entry").path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("TASK.") && name.ends_with(".bak.md"))
+        })
+        .collect();
+    paths.sort();
+    paths
+}
+
 /// Build a workgroup fixture so `crate::phone::messaging::workgroup_root`
 /// resolves under `--root`.
 fn make_wg_fixture(tmp: &Path) -> PathBuf {
@@ -75,21 +104,21 @@ fn make_wg_fixture(tmp: &Path) -> PathBuf {
 fn task_set_title_audit_line_reaches_file_sink() {
     let tmp = Tmp::new("task-logger");
     let bin = copy_binary_into(tmp.path());
-
-    let stem = bin
-        .file_stem()
-        .expect("bin has stem")
-        .to_string_lossy()
-        .to_string();
-    let cfg_dir = tmp.path().join(format!(".{}", stem));
-    std::fs::create_dir_all(&cfg_dir).expect("create config dir");
+    let cfg_dir = config_dir_for_bin(&bin);
 
     // Pre-seed master-token so `validate_cli_token` returns is_root=true and
     // the coordinator gate is bypassed without needing a teams fixture.
     let master = "test-master-token-cli-logger".to_string();
-    std::fs::write(cfg_dir.join("master-token.txt"), &master).expect("write master-token.txt");
+    seed_master_token(&cfg_dir, &master);
 
     let agent_root = make_wg_fixture(tmp.path());
+    let task_path = agent_root
+        .parent()
+        .expect("agent root has wg parent")
+        .join("TASK.md");
+    std::fs::write(&task_path, "# Old title\n\nOriginal body\n").expect("seed TASK.md");
+    let outside_sentinel = tmp.path().join("outside-sentinel.txt");
+    std::fs::write(&outside_sentinel, "keep").expect("write outside sentinel");
 
     let out = Command::new(&bin)
         .args([
@@ -105,7 +134,7 @@ fn task_set_title_audit_line_reaches_file_sink() {
         // (`cargo test`) shell's env. Without this, running
         // `RUST_LOG=warn cargo test --tests` filters out the `info!`
         // audit line and the `[task] set-title:` check below
-        // false-fails — production behavior is unchanged.
+        // false-fails; production behavior is unchanged.
         .env("RUST_LOG", "agentscommander=info")
         .output()
         .expect("spawn binary");
@@ -135,15 +164,93 @@ fn task_set_title_audit_line_reaches_file_sink() {
 
     // Cross-check: the TASK.md write actually happened, so the log line
     // we observed is from the live happy path (not a zombie line cached on
-    // disk from a prior test run — we copied to a fresh tmp dir, but be
+    // disk from a prior test run. We copied to a fresh tmp dir, but be
     // defensive about future test refactors).
+    let task_contents = std::fs::read_to_string(&task_path).expect("read TASK.md");
+    assert!(
+        task_contents.contains("title: 'cli-logger smoke title'"),
+        "unexpected TASK.md contents:\n{}",
+        task_contents
+    );
+    assert!(task_contents.contains("# Old title\n\nOriginal body"));
+    assert_eq!(
+        std::fs::read_to_string(&outside_sentinel).expect("read outside sentinel"),
+        "keep"
+    );
+    assert_eq!(
+        backup_paths(&task_path).len(),
+        1,
+        "expected one TASK.md backup"
+    );
+}
+
+#[test]
+fn task_append_body_audit_line_reaches_file_sink_and_preserves_title() {
+    let tmp = Tmp::new("task-append-logger");
+    let bin = copy_binary_into(tmp.path());
+    let cfg_dir = config_dir_for_bin(&bin);
+    let master = "test-master-token-cli-append-logger".to_string();
+    seed_master_token(&cfg_dir, &master);
+
+    let agent_root = make_wg_fixture(tmp.path());
     let task_path = agent_root
         .parent()
         .expect("agent root has wg parent")
         .join("TASK.md");
+    std::fs::write(&task_path, "# Existing title\n\nOriginal body\n").expect("seed TASK.md");
+    let outside_sentinel = tmp.path().join("outside-sentinel.txt");
+    std::fs::write(&outside_sentinel, "keep").expect("write outside sentinel");
+
+    let out = Command::new(&bin)
+        .args([
+            "task-append-body",
+            "--token",
+            &master,
+            "--root",
+            &agent_root.to_string_lossy(),
+            "--text",
+            "Appended body from subprocess",
+        ])
+        .env("RUST_LOG", "agentscommander=info")
+        .output()
+        .expect("spawn binary");
+
     assert!(
-        task_path.exists(),
-        "TASK.md was not created at {} — log line may be from an unrelated path",
-        task_path.display(),
+        out.status.success(),
+        "task-append-body exited non-zero ({:?})\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let task_contents = std::fs::read_to_string(&task_path).expect("read TASK.md");
+    assert!(
+        task_contents.starts_with("# Existing title\n\nOriginal body"),
+        "unexpected TASK.md prefix:\n{}",
+        task_contents
+    );
+    assert!(
+        task_contents.contains("Appended body from subprocess"),
+        "TASK.md did not contain appended body:\n{}",
+        task_contents
+    );
+    assert_eq!(
+        std::fs::read_to_string(&outside_sentinel).expect("read outside sentinel"),
+        "keep"
+    );
+    assert_eq!(
+        backup_paths(&task_path).len(),
+        1,
+        "expected one TASK.md backup"
+    );
+
+    let log_path = cfg_dir.join("app.log");
+    let log_contents = std::fs::read_to_string(&log_path).unwrap_or_default();
+    assert!(
+        log_contents.contains("[task] append-body:"),
+        "app.log at {} did not contain a [task] append-body line.\nstderr was:\n{}\nfile contents:\n{}",
+        log_path.display(),
+        String::from_utf8_lossy(&out.stderr),
+        log_contents,
     );
 }

--- a/src-tauri/tests/cli_workgroup_team.rs
+++ b/src-tauri/tests/cli_workgroup_team.rs
@@ -322,6 +322,33 @@ fn open_without_delete_share(path: &Path) -> std::fs::File {
         .expect("open with restricted share mode")
 }
 
+fn assert_no_side_effect_dirs(root: &Path) {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for entry in entries {
+            let path = entry.expect("entry").path();
+            if path.is_dir() {
+                let name = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("");
+                assert!(
+                    !(name.starts_with("wg-")
+                        || name.starts_with("_team_")
+                        || name.starts_with("_agent_")),
+                    "unexpected side-effect directory {}",
+                    path.display()
+                );
+                stack.push(path);
+            }
+        }
+    }
+}
+
 #[test]
 fn team_help_describes_existing_agents_and_workgroup_scoped_membership() {
     let tmp = Tmp::new("cli-team-help");
@@ -349,6 +376,58 @@ fn workgroup_add_help_hides_team_definition_flags() {
     assert!(!help.contains("--agent"));
     assert!(!help.contains("--repo"));
     assert!(!help.to_ascii_lowercase().contains("deprecated"));
+}
+
+#[test]
+fn workgroup_list_missing_project_errors_without_writes() {
+    let tmp = Tmp::new("cli-workgroup-list-missing-project");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let config_sentinel = config_dir.join("sentinel.txt");
+    std::fs::write(&config_sentinel, "keep").expect("write config sentinel");
+    let outside_sentinel = tmp.path().join("outside-sentinel.txt");
+    std::fs::write(&outside_sentinel, "keep").expect("write outside sentinel");
+
+    let stderr = run_fail(&bin, &["workgroup", "list", "--project", "MissingProject"]);
+
+    assert!(stderr.contains("MissingProject"), "stderr was:\n{}", stderr);
+    assert!(project_refresh_request_paths(&config_dir).is_empty());
+    assert_eq!(
+        std::fs::read_to_string(&config_sentinel).expect("read config sentinel"),
+        "keep"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&outside_sentinel).expect("read outside sentinel"),
+        "keep"
+    );
+    assert_no_side_effect_dirs(tmp.path());
+}
+
+#[test]
+fn team_list_missing_project_errors_without_writes() {
+    let tmp = Tmp::new("cli-team-list-missing-project");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    write_settings(&config_dir, tmp.path());
+    let config_sentinel = config_dir.join("sentinel.txt");
+    std::fs::write(&config_sentinel, "keep").expect("write config sentinel");
+    let outside_sentinel = tmp.path().join("outside-sentinel.txt");
+    std::fs::write(&outside_sentinel, "keep").expect("write outside sentinel");
+
+    let stderr = run_fail(&bin, &["team", "list", "--project", "MissingProject"]);
+
+    assert!(stderr.contains("MissingProject"), "stderr was:\n{}", stderr);
+    assert!(project_refresh_request_paths(&config_dir).is_empty());
+    assert_eq!(
+        std::fs::read_to_string(&config_sentinel).expect("read config sentinel"),
+        "keep"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&outside_sentinel).expect("read outside sentinel"),
+        "keep"
+    );
+    assert_no_side_effect_dirs(tmp.path());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add focused public CLI behavior contract coverage for help, validation, JSON/list outputs, token redaction, and no-GUI window-info behavior
- extend adjacent CLI integration suites for agency templates, project registration, task audit logging, and workgroup/team missing-project surfaces
- assert side-effect isolation for read-only and error paths using disposable roots/configs

## Validation
- Dev PASS on `f9c029419a8d6c87eca688f674309f842e55c556`
- Grinch rereview PASS on `f9c029419a8d6c87eca688f674309f842e55c556`
- Shipper rebuild PASS for `agentscommander_standalone_wg-1.exe`, SHA256 `BF7A80812AEB9AEDB58257C7C9C384A4F9A998BCAB3D7F3D2D0EC3C3251982DB`
- WG13 acceptance PASS with evidence at `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-13-acceptance-testing\__agent_ac-cli-and-gui-tester\artifacts\issue-487-cli-contract-20260614-035531`

Closes #487