### PR TITLE
Add browser UI fake transport workflow tests

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -56,7 +56,7 @@ const BrowserApp: Component = () => {
   return (
     <div class="browser-layout" classList={{ "browser-dragging": dragging() }}>
       <div class="browser-sidebar" style={{ width: `${sidebarWidth()}px` }}>
-        <SidebarApp />
+        <SidebarApp embedded />
       </div>
       <div
         class="browser-divider"
@@ -66,7 +66,7 @@ const BrowserApp: Component = () => {
         <div class="browser-divider-handle" />
       </div>
       <div class="browser-terminal">
-        <TerminalApp />
+        <TerminalApp embedded />
       </div>
     </div>
   );

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -1,6 +1,8 @@
-import { Component, createSignal, onCleanup } from "solid-js";
+import { Component, createSignal, onCleanup, onMount } from "solid-js";
 import SidebarApp from "../sidebar/App";
 import TerminalApp from "../terminal/App";
+import type { UnlistenFn } from "../shared/transport";
+import { SettingsAPI, onThemeChanged } from "../shared/ipc";
 import "../sidebar/styles/sidebar.css";
 import "../terminal/styles/terminal.css";
 import "./styles/browser.css";
@@ -12,6 +14,42 @@ import "./styles/browser.css";
 const BrowserApp: Component = () => {
   const [sidebarWidth, setSidebarWidth] = createSignal(300);
   const [dragging, setDragging] = createSignal(false);
+  let disposed = false;
+  let unlistenThemeChanged: UnlistenFn | null = null;
+
+  const applyTheme = (light: boolean) => {
+    document.documentElement.classList.toggle("light-theme", light);
+  };
+
+  onMount(async () => {
+    // BrowserApp owns the document theme because its children are embedded to
+    // suppress titlebars/window geometry. Match MainApp's optimistic light
+    // first paint, then correct from persisted settings.
+    applyTheme(true);
+
+    const unlisten = await onThemeChanged(({ light }) => {
+      applyTheme(light);
+    });
+    if (disposed) {
+      unlisten();
+      return;
+    }
+    unlistenThemeChanged = unlisten;
+
+    try {
+      const settings = await SettingsAPI.get();
+      if (!disposed) {
+        applyTheme(settings.themeLight);
+      }
+    } catch (err) {
+      console.error("[browser] failed to load theme setting:", err);
+    }
+  });
+
+  onCleanup(() => {
+    disposed = true;
+    unlistenThemeChanged?.();
+  });
 
   const onMouseDown = (e: MouseEvent) => {
     e.preventDefault();

--- a/src/browser/App.workflow.test.tsx
+++ b/src/browser/App.workflow.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import BrowserApp from "./App";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../shared/testing/ui-harness";
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    element: HTMLElement | null = null;
+    loadAddon(): void {}
+    open(element: HTMLElement): void {
+      this.element = element;
+    }
+    focus(): void {}
+    dispose(): void {}
+    write(): void {}
+    scrollToBottom(): void {}
+    paste(): void {}
+    hasSelection(): boolean {
+      return false;
+    }
+    getSelection(): string {
+      return "";
+    }
+    attachCustomKeyEventHandler(): void {}
+    onData(): { dispose: () => void } {
+      return { dispose: () => {} };
+    }
+    onResize(): { dispose: () => void } {
+      return { dispose: () => {} };
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit = vi.fn();
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: class {
+    onContextLoss = vi.fn();
+    dispose = vi.fn();
+  },
+}));
+
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+const projectPath = "C:\\Project";
+const architectSession = session({
+  id: "session-architect",
+  name: "wg-1-dev-team/architect",
+  workingDirectory: `${projectPath}\\.ac\\wg-1-dev-team\\__agent_architect`,
+  isCoordinator: true,
+});
+
+function browserDiscovery() {
+  return discovery({
+    teams: [
+      {
+        name: "dev-team",
+        agents: ["architect", "dev-webpage-ui"],
+        coordinator: "architect",
+      },
+    ],
+    workgroups: [
+      {
+        name: "wg-1-dev-team",
+        path: `${projectPath}\\.ac\\wg-1-dev-team`,
+        task: null,
+        taskTitle: "Browser UI tests",
+        teamName: "dev-team",
+        agents: [
+          {
+            name: "architect",
+            path: architectSession.workingDirectory,
+            repoPaths: [],
+            isCoordinator: true,
+          },
+          {
+            name: "dev-webpage-ui",
+            path: `${projectPath}\\.ac\\wg-1-dev-team\\__agent_dev-webpage-ui`,
+            repoPaths: [],
+            isCoordinator: false,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function setupBrowserTransport(fake: FakeTransport): void {
+  fake.resolve(
+    "get_settings",
+    baseSettings({
+      projectPaths: [projectPath],
+      projectPath,
+      telegramBots: [],
+    })
+  );
+  fake.resolve("open_project", {
+    path: projectPath,
+    registered: true,
+    created: false,
+  });
+  fake.resolve("discover_project", browserDiscovery());
+  fake.resolve("search_repos", []);
+  fake.resolve("list_sessions", [architectSession]);
+  fake.resolve("get_active_session", architectSession.id);
+  fake.resolve("list_detached_sessions", []);
+  fake.resolve("telegram_list_bridges", []);
+  fake.resolve("pty_resize", undefined);
+}
+
+describe("BrowserApp workflow", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+  });
+
+  it("loads sidebar and terminal panes from fake transport", async () => {
+    const fake = new FakeTransport();
+    setupBrowserTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <BrowserApp />, fake);
+    try {
+      await waitFor(() => {
+        expect(rendered.root.querySelector(".browser-layout")).not.toBeNull();
+        expect(rendered.root.querySelector(".browser-sidebar")).not.toBeNull();
+        expect(rendered.root.querySelector(".browser-terminal")).not.toBeNull();
+        expect(rendered.root.textContent).toContain("wg-1-dev-team");
+        expect(rendered.root.textContent).toContain("architect");
+      });
+
+      expect(fake.callsFor("get_settings").length).toBeGreaterThan(0);
+      expect(fake.lastCall("open_project")?.args).toEqual({ path: projectPath });
+      expect(fake.lastCall("discover_project")?.args).toEqual({ path: projectPath });
+      expect(fake.callsFor("list_sessions").length).toBeGreaterThan(0);
+      expect(fake.callsFor("get_active_session").length).toBeGreaterThan(0);
+      expect(fake.callsFor("list_detached_sessions").length).toBeGreaterThan(0);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("updates sidebar width when the browser divider is dragged", async () => {
+    const fake = new FakeTransport();
+    setupBrowserTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <BrowserApp />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".browser-divider")).not.toBeNull()
+      );
+      await waitFor(() => {
+        expect(fake.callsFor("telegram_list_bridges").length).toBeGreaterThan(0);
+        expect(fake.callsFor("get_active_session").length).toBeGreaterThan(0);
+      });
+
+      const sidebar = rendered.root.querySelector(".browser-sidebar") as HTMLElement;
+      const divider = rendered.root.querySelector(".browser-divider") as HTMLElement;
+      expect(sidebar.style.width).toBe("300px");
+
+      divider.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true })
+      );
+      document.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          cancelable: true,
+          clientX: 480,
+        })
+      );
+      document.dispatchEvent(
+        new MouseEvent("mouseup", { bubbles: true, cancelable: true })
+      );
+
+      expect(sidebar.style.width).toBe("480px");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/browser/App.workflow.test.tsx
+++ b/src/browser/App.workflow.test.tsx
@@ -100,13 +100,17 @@ function browserDiscovery() {
   });
 }
 
-function setupBrowserTransport(fake: FakeTransport): void {
+function setupBrowserTransport(
+  fake: FakeTransport,
+  settingsOverrides: Parameters<typeof baseSettings>[0] = {}
+): void {
   fake.resolve(
     "get_settings",
     baseSettings({
       projectPaths: [projectPath],
       projectPath,
       telegramBots: [],
+      ...settingsOverrides,
     })
   );
   fake.resolve("open_project", {
@@ -129,12 +133,14 @@ describe("BrowserApp workflow", () => {
   beforeEach(() => {
     cleanupDom = installBrowserDomStubs();
     resetUiStoresForTests();
+    document.documentElement.classList.remove("light-theme");
   });
 
   afterEach(() => {
     cleanupDom?.();
     cleanupDom = null;
     resetUiStoresForTests();
+    document.documentElement.classList.remove("light-theme");
   });
 
   it("loads sidebar and terminal panes from fake transport", async () => {
@@ -195,6 +201,59 @@ describe("BrowserApp workflow", () => {
       );
 
       expect(sidebar.style.width).toBe("480px");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("applies persisted light theme while children are embedded", async () => {
+    const fake = new FakeTransport();
+    setupBrowserTransport(fake, { themeLight: true });
+
+    const rendered = renderWithFakeTransport(() => <BrowserApp />, fake);
+    try {
+      await waitFor(() => expect(fake.callsFor("get_settings").length).toBeGreaterThan(0));
+      expect(document.documentElement.classList.contains("light-theme")).toBe(true);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("removes optimistic light theme for persisted dark setting", async () => {
+    const fake = new FakeTransport();
+    setupBrowserTransport(fake, { themeLight: false });
+    document.documentElement.classList.add("light-theme");
+
+    const rendered = renderWithFakeTransport(() => <BrowserApp />, fake);
+    try {
+      await waitFor(() =>
+        expect(document.documentElement.classList.contains("light-theme")).toBe(false)
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("follows backend theme_changed events in browser mode", async () => {
+    const fake = new FakeTransport();
+    setupBrowserTransport(fake, { themeLight: false });
+    document.documentElement.classList.add("light-theme");
+
+    const rendered = renderWithFakeTransport(() => <BrowserApp />, fake);
+    try {
+      await waitFor(() =>
+        expect(document.documentElement.classList.contains("light-theme")).toBe(false)
+      );
+
+      fake.emitFromBackend("theme_changed", { light: true });
+      await waitFor(() =>
+        expect(document.documentElement.classList.contains("light-theme")).toBe(true)
+      );
+
+      fake.emitFromBackend("theme_changed", { light: false });
+      await waitFor(() =>
+        expect(document.documentElement.classList.contains("light-theme")).toBe(false)
+      );
     } finally {
       rendered.cleanup();
     }

--- a/src/shared/ipc.transport.test.ts
+++ b/src/shared/ipc.transport.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FakeTransport } from "./testing/fake-transport";
+import { baseSettings } from "./testing/ui-harness";
+
+describe("shared ipc transport seam", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("does not construct WebSocket transport on jsdom import before fake install", async () => {
+    vi.resetModules();
+    const websocketCtor = vi.fn(() => {
+      throw new Error("real WebSocket should not be constructed");
+    });
+    vi.stubGlobal("WebSocket", websocketCtor);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const ipc = await import("./ipc");
+
+    expect(websocketCtor).not.toHaveBeenCalled();
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", baseSettings());
+    const restore = ipc.__setTransportForTests(fake);
+    try {
+      await expect(ipc.SettingsAPI.get()).resolves.toMatchObject({
+        defaultShell: "pwsh",
+      });
+    } finally {
+      restore();
+    }
+
+    expect(fake.lastCall("get_settings")?.args).toEqual({});
+    expect(websocketCtor).not.toHaveBeenCalled();
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -46,8 +46,39 @@ export interface RtkSweepResult {
   errors: { path: string; error: string }[];
 }
 
-// Select transport based on runtime environment
-const transport: Transport = isTauri ? new TauriTransport() : new WsTransport();
+function createDefaultTransport(): Transport {
+  return isTauri ? new TauriTransport() : new WsTransport();
+}
+
+let defaultTransport: Transport | null = null;
+let testTransport: Transport | null = null;
+
+function currentTransport(): Transport {
+  if (testTransport) return testTransport;
+  defaultTransport ??= createDefaultTransport();
+  return defaultTransport;
+}
+
+export function __setTransportForTests(next: Transport): () => void {
+  if (import.meta.env.MODE !== "test") {
+    throw new Error("__setTransportForTests is test-only");
+  }
+
+  const previous = testTransport;
+  testTransport = next;
+  return () => {
+    testTransport = previous;
+  };
+}
+
+const transport: Pick<Transport, "invoke" | "listen" | "emit"> = {
+  invoke: <T>(cmd: string, args?: Record<string, unknown>) =>
+    currentTransport().invoke<T>(cmd, args),
+  listen: <T>(event: string, callback: (payload: T) => void) =>
+    currentTransport().listen<T>(event, callback),
+  emit: <T>(event: string, payload: T) =>
+    currentTransport().emit<T>(event, payload),
+};
 
 export interface CreateSessionOptions {
   shell?: string;
@@ -116,6 +147,7 @@ export const SessionAPI = {
 
 export const PtyAPI = {
   write: (sessionId: string, data: Uint8Array) => {
+    const transport = currentTransport();
     // Use efficient binary transport if available (WS mode)
     if (transport.writePtyBinary) {
       transport.writePtyBinary(sessionId, data);

--- a/src/shared/testing/fake-transport.test.ts
+++ b/src/shared/testing/fake-transport.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { FakeTransport } from "./fake-transport";
+
+describe("FakeTransport", () => {
+  it("records invoke payloads before resolving", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", { ok: true });
+
+    await expect(fake.invoke("get_settings", { value: 1 })).resolves.toEqual({
+      ok: true,
+    });
+
+    expect(fake.calls).toEqual([
+      { cmd: "get_settings", args: { value: 1 } },
+    ]);
+  });
+
+  it("fails loudly for unhandled invokes", async () => {
+    const fake = new FakeTransport();
+
+    await expect(fake.invoke("missing_command")).rejects.toThrow(
+      "Unhandled fake transport invoke: missing_command"
+    );
+    expect(fake.lastCall("missing_command")?.args).toEqual({});
+  });
+
+  it("delivers backend events and removes listeners", async () => {
+    const fake = new FakeTransport();
+    const listener = vi.fn();
+    const unlisten = await fake.listen("session_switched", listener);
+
+    fake.emitFromBackend("session_switched", { id: "session-1" });
+    unlisten();
+    fake.emitFromBackend("session_switched", { id: "session-2" });
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith({ id: "session-1" });
+  });
+
+  it("records broadcast events without requiring a handler", async () => {
+    const fake = new FakeTransport();
+
+    await expect(fake.emit("open_settings", { section: "integrations" })).resolves.toBeUndefined();
+
+    expect(fake.lastCall("broadcast_event")).toEqual({
+      cmd: "broadcast_event",
+      args: {
+        event: "open_settings",
+        payload: { section: "integrations" },
+      },
+    });
+  });
+
+  it("records binary PTY writes only when enabled", () => {
+    const jsonOnly = new FakeTransport();
+    expect(jsonOnly.writePtyBinary).toBeUndefined();
+
+    const binary = new FakeTransport({ binaryPty: true });
+    binary.writePtyBinary?.("session-1", new Uint8Array([65, 66]));
+
+    expect(binary.binaryWrites).toEqual([
+      { sessionId: "session-1", data: [65, 66] },
+    ]);
+    expect(binary.calls).toEqual([]);
+  });
+});

--- a/src/shared/testing/fake-transport.ts
+++ b/src/shared/testing/fake-transport.ts
@@ -1,0 +1,109 @@
+import type { Transport, UnlistenFn } from "../transport";
+
+export interface InvokeCall {
+  cmd: string;
+  args: Record<string, unknown>;
+}
+
+type InvokeHandler = (
+  args: Record<string, unknown>
+) => unknown | Promise<unknown>;
+
+interface FakeTransportOptions {
+  binaryPty?: boolean;
+}
+
+export class FakeTransport implements Transport {
+  readonly calls: InvokeCall[] = [];
+  readonly binaryWrites: { sessionId: string; data: number[] }[] = [];
+  writePtyBinary?: (sessionId: string, data: Uint8Array) => void;
+
+  private readonly handlers = new Map<string, InvokeHandler>();
+  private readonly listeners = new Map<string, Set<(payload: unknown) => void>>();
+
+  constructor(opts?: FakeTransportOptions) {
+    if (opts?.binaryPty) {
+      this.writePtyBinary = (sessionId, data) => {
+        this.binaryWrites.push({ sessionId, data: Array.from(data) });
+      };
+    }
+  }
+
+  onInvoke(cmd: string, handler: InvokeHandler): void {
+    this.handlers.set(cmd, handler);
+  }
+
+  resolve(cmd: string, value: unknown): void {
+    this.onInvoke(cmd, () => value);
+  }
+
+  reject(cmd: string, reason: string): void {
+    this.onInvoke(cmd, () => {
+      throw reason;
+    });
+  }
+
+  async invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+    const normalizedArgs = args ?? {};
+    this.calls.push({ cmd, args: normalizedArgs });
+
+    const handler = this.handlers.get(cmd);
+    if (!handler) {
+      throw new Error(`Unhandled fake transport invoke: ${cmd}`);
+    }
+
+    return (await handler(normalizedArgs)) as T;
+  }
+
+  async listen<T>(
+    event: string,
+    callback: (payload: T) => void
+  ): Promise<UnlistenFn> {
+    let callbacks = this.listeners.get(event);
+    if (!callbacks) {
+      callbacks = new Set();
+      this.listeners.set(event, callbacks);
+    }
+
+    const wrapped = callback as (payload: unknown) => void;
+    callbacks.add(wrapped);
+
+    return () => {
+      const set = this.listeners.get(event);
+      if (!set) return;
+      set.delete(wrapped);
+      if (set.size === 0) {
+        this.listeners.delete(event);
+      }
+    };
+  }
+
+  async emit<T>(event: string, payload: T): Promise<void> {
+    this.calls.push({
+      cmd: "broadcast_event",
+      args: { event, payload },
+    });
+  }
+
+  emitFromBackend<T>(event: string, payload: T): void {
+    const callbacks = this.listeners.get(event);
+    if (!callbacks) return;
+
+    for (const callback of Array.from(callbacks)) {
+      callback(payload);
+    }
+  }
+
+  callsFor(cmd: string): InvokeCall[] {
+    return this.calls.filter((call) => call.cmd === cmd);
+  }
+
+  lastCall(cmd: string): InvokeCall | undefined {
+    const calls = this.callsFor(cmd);
+    return calls[calls.length - 1];
+  }
+
+  clearCalls(): void {
+    this.calls.length = 0;
+  }
+}

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -1,0 +1,296 @@
+import { render } from "solid-js/web";
+import type { JSX } from "solid-js";
+import { __setTransportForTests } from "../ipc";
+import type {
+  AcDiscoveryResult,
+  AppSettings,
+  BridgeInfo,
+  Session,
+} from "../types";
+import { FakeTransport } from "./fake-transport";
+import { projectStore } from "../../sidebar/stores/project";
+import { sessionsStore } from "../../sidebar/stores/sessions";
+import { bridgesStore } from "../../sidebar/stores/bridges";
+import { terminalStore } from "../../terminal/stores/terminal";
+import { __resetHomeStoreForTests } from "../../main/stores/home";
+
+export function renderWithFakeTransport(
+  component: () => JSX.Element,
+  fake = new FakeTransport()
+): {
+  fake: FakeTransport;
+  root: HTMLDivElement;
+  cleanup: () => void;
+} {
+  const restoreTransport = __setTransportForTests(fake);
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  const dispose = render(component, root);
+
+  return {
+    fake,
+    root,
+    cleanup: () => {
+      dispose();
+      restoreTransport();
+      root.remove();
+    },
+  };
+}
+
+export function click(el: Element): void {
+  el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+}
+
+export function contextMenu(el: Element): void {
+  el.dispatchEvent(
+    new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 80,
+      clientY: 96,
+    })
+  );
+}
+
+export function input(el: HTMLInputElement, value: string): void {
+  el.value = value;
+  el.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
+}
+
+export async function waitFor(
+  assertion: () => void | Promise<void>,
+  timeoutMs = 1000
+): Promise<void> {
+  const started = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - started < timeoutMs) {
+    try {
+      await assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+export function baseSettings(overrides: Partial<AppSettings> = {}): AppSettings {
+  return {
+    defaultShell: "pwsh",
+    defaultShellArgs: [],
+    agents: [],
+    telegramBots: [],
+    telegramNetworkPollErrorLogging: {
+      firstFailureLevel: "warn",
+      transientRepeatLevel: "debug",
+      sustainedLevel: "warn",
+      sustainedAfterSeconds: 60,
+      sustainedRepeatSeconds: 300,
+      recoveryLevel: "info",
+    },
+    restoreCoordinatorWakeState: true,
+    sidebarAlwaysOnTop: false,
+    raiseTerminalOnClick: true,
+    soundsEnabled: false,
+    teamIdleBeepEnabled: false,
+    voiceToTextEnabled: false,
+    geminiApiKey: "",
+    geminiModel: "gemini-2.5-flash",
+    voiceAutoExecute: false,
+    voiceAutoExecuteDelay: 15,
+    sidebarZoom: 1,
+    terminalZoom: 1,
+    guideZoom: 1,
+    mainZoom: 1,
+    sidebarGeometry: null,
+    terminalGeometry: null,
+    mainGeometry: null,
+    mainSidebarWidth: 360,
+    mainSidebarSide: "right",
+    mainAlwaysOnTop: false,
+    webServerEnabled: false,
+    webServerPort: 8765,
+    webServerBind: "127.0.0.1",
+    projectPath: null,
+    projectPaths: [],
+    sidebarStyle: "noir-minimal",
+    onboardingDismissed: true,
+    coordSortByActivity: false,
+    alwaysShowSelectedWorkgroup: true,
+    injectRtkHook: false,
+    rtkPromptDismissed: false,
+    informWhenRtkInstalled: true,
+    autoGenerateTaskTitle: true,
+    agentTemplatesPath: null,
+    themeLight: true,
+    specBoardEnabled: false,
+    ...overrides,
+  };
+}
+
+export function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "session-1",
+    name: "wg-1-dev-team/architect",
+    shell: "pwsh",
+    shellArgs: [],
+    effectiveShellArgs: [],
+    createdAt: "2026-06-13T00:00:00.000Z",
+    workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+    status: "running",
+    waitingForInput: false,
+    pendingReview: false,
+    lastPrompt: null,
+    agentId: null,
+    agentLabel: null,
+    gitRepos: [],
+    workgroupTask: null,
+    isCoordinator: false,
+    isRootAgent: false,
+    token: "",
+    agentKind: "codex",
+    ...overrides,
+  };
+}
+
+export function discovery(
+  overrides: Partial<AcDiscoveryResult> = {}
+): AcDiscoveryResult {
+  return {
+    agents: [],
+    teams: [],
+    workgroups: [],
+    ...overrides,
+  };
+}
+
+export function bridge(overrides: Partial<BridgeInfo> = {}): BridgeInfo {
+  return {
+    sessionId: "session-1",
+    botId: "bot-1",
+    botLabel: "Ops Bot",
+    status: "active",
+    color: "#4ade80",
+    ...overrides,
+  };
+}
+
+export function resetUiStoresForTests(): void {
+  projectStore.clear();
+  sessionsStore.setSessions([]);
+  sessionsStore.setActiveId(null);
+  sessionsStore.setTeams([]);
+  sessionsStore.setRepos([]);
+  sessionsStore.setAlwaysShowSelectedWorkgroup(true);
+  sessionsStore.setCoordSortByActivity(false);
+  sessionsStore.clearDetached();
+  bridgesStore.setBridges([]);
+  terminalStore.setActiveSession(null, "", "", null, "", null);
+  terminalStore.setActiveWorkgroupTask(null);
+  __resetHomeStoreForTests();
+}
+
+export function installBrowserDomStubs(): () => void {
+  const previousResizeObserver = globalThis.ResizeObserver;
+  const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const previousCancelAnimationFrame = globalThis.cancelAnimationFrame;
+  const previousClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+  const previousCanvasGetContext = HTMLCanvasElement.prototype.getContext;
+
+  class NoopResizeObserver implements ResizeObserver {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    writable: true,
+    value: previousResizeObserver ?? NoopResizeObserver,
+  });
+
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    writable: true,
+    value:
+      previousRequestAnimationFrame ??
+      ((callback: FrameRequestCallback) =>
+        window.setTimeout(() => callback(performance.now()), 0)),
+  });
+
+  Object.defineProperty(globalThis, "cancelAnimationFrame", {
+    configurable: true,
+    writable: true,
+    value: previousCancelAnimationFrame ?? ((handle: number) => window.clearTimeout(handle)),
+  });
+
+  if (!navigator.clipboard) {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        readText: async () => "",
+        writeText: async () => {},
+      },
+    });
+  }
+
+  const getContextStub = function getContext(this: HTMLCanvasElement) {
+    return {
+      canvas: this,
+      clearRect: () => {},
+      fillRect: () => {},
+      getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+      putImageData: () => {},
+      createImageData: () => ({ data: new Uint8ClampedArray(4) }),
+      setTransform: () => {},
+      drawImage: () => {},
+      save: () => {},
+      restore: () => {},
+      beginPath: () => {},
+      moveTo: () => {},
+      lineTo: () => {},
+      closePath: () => {},
+      stroke: () => {},
+      translate: () => {},
+      scale: () => {},
+      rotate: () => {},
+      arc: () => {},
+      fill: () => {},
+      measureText: () => ({ width: 0 }),
+      transform: () => {},
+      rect: () => {},
+      clip: () => {},
+    } as unknown as CanvasRenderingContext2D;
+  } as unknown as typeof HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = getContextStub;
+
+  return () => {
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      writable: true,
+      value: previousResizeObserver,
+    });
+    Object.defineProperty(globalThis, "requestAnimationFrame", {
+      configurable: true,
+      writable: true,
+      value: previousRequestAnimationFrame,
+    });
+    Object.defineProperty(globalThis, "cancelAnimationFrame", {
+      configurable: true,
+      writable: true,
+      value: previousCancelAnimationFrame,
+    });
+    if (previousClipboard) {
+      Object.defineProperty(navigator, "clipboard", previousClipboard);
+    } else {
+      delete (navigator as unknown as { clipboard?: Clipboard }).clipboard;
+    }
+    HTMLCanvasElement.prototype.getContext = previousCanvasGetContext;
+  };
+}

--- a/src/sidebar/App.messaging.workflow.test.tsx
+++ b/src/sidebar/App.messaging.workflow.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SidebarApp from "./App";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import {
+  baseSettings,
+  bridge,
+  click,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../shared/testing/ui-harness";
+
+const projectPath = "C:\\Project";
+const agentPath = `${projectPath}\\.ac\\_agent_General`;
+const generalSession = session({
+  id: "session-1",
+  name: "General",
+  workingDirectory: agentPath,
+  status: "active",
+});
+const bridgePayload = bridge({
+  sessionId: "session-1",
+  botId: "bot-1",
+  botLabel: "Ops Bot",
+  color: "#4ade80",
+  status: "active",
+});
+
+function setupMessagingTransport(fake: FakeTransport): void {
+  fake.resolve(
+    "get_settings",
+    baseSettings({
+      projectPaths: [projectPath],
+      projectPath,
+      telegramBots: [
+        {
+          id: "bot-1",
+          label: "Ops Bot",
+          token: "redacted",
+          chatId: 123,
+          color: "#4ade80",
+        },
+      ],
+    })
+  );
+  fake.resolve("open_project", {
+    path: projectPath,
+    registered: true,
+    created: false,
+  });
+  fake.resolve(
+    "discover_project",
+    discovery({
+      agents: [
+        {
+          name: "General",
+          path: agentPath,
+          roleExists: true,
+        },
+      ],
+      teams: [],
+      workgroups: [],
+    })
+  );
+  fake.resolve("search_repos", []);
+  fake.resolve("list_sessions", [generalSession]);
+  fake.resolve("get_active_session", "session-1");
+  fake.resolve("list_detached_sessions", []);
+  fake.resolve("telegram_list_bridges", []);
+  fake.resolve("telegram_attach", bridgePayload);
+  fake.resolve("telegram_detach", undefined);
+}
+
+describe("SidebarApp Telegram messaging workflow", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+  });
+
+  it("invokes telegram_attach and updates from bridge attached event", async () => {
+    const fake = new FakeTransport();
+    setupMessagingTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("General");
+        expect(rendered.root.querySelector(".session-item-telegram")).not.toBeNull();
+      });
+
+      const button = rendered.root.querySelector(".session-item-telegram")!;
+      click(button);
+
+      await waitFor(() =>
+        expect(fake.lastCall("telegram_attach")?.args).toEqual({
+          sessionId: "session-1",
+          botId: "bot-1",
+        })
+      );
+
+      fake.emitFromBackend("telegram_bridge_attached", bridgePayload);
+
+      await waitFor(() => {
+        const activeButton = rendered.root.querySelector(".session-item-telegram.active");
+        const dot = rendered.root.querySelector(".session-item-bridge-dot");
+        expect(activeButton).not.toBeNull();
+        expect(dot?.getAttribute("title")).toBe("Telegram: Ops Bot");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("invokes telegram_detach from an active bridge and updates from detach event", async () => {
+    const fake = new FakeTransport();
+    setupMessagingTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".session-item-telegram")).not.toBeNull()
+      );
+
+      fake.emitFromBackend("telegram_bridge_attached", bridgePayload);
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".session-item-telegram.active")).not.toBeNull()
+      );
+
+      click(rendered.root.querySelector(".session-item-telegram.active")!);
+
+      await waitFor(() =>
+        expect(fake.lastCall("telegram_detach")?.args).toEqual({
+          sessionId: "session-1",
+        })
+      );
+
+      fake.emitFromBackend("telegram_bridge_detached", { sessionId: "session-1" });
+
+      await waitFor(() => {
+        expect(rendered.root.querySelector(".session-item-telegram.active")).toBeNull();
+        expect(rendered.root.querySelector(".session-item-bridge-dot")).toBeNull();
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.delete-diagnostics.workflow.test.tsx
+++ b/src/sidebar/components/ProjectPanel.delete-diagnostics.workflow.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import type { BlockerReport } from "../../shared/types";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  contextMenu,
+  discovery,
+  installBrowserDomStubs,
+  input,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+
+const projectPath = "C:\\Project";
+const workgroupPath = `${projectPath}\\.ac\\wg-1-dev-team`;
+
+function initialDiscovery() {
+  return discovery({
+    agents: [],
+    teams: [
+      {
+        name: "dev-team",
+        agents: ["architect"],
+        coordinator: "architect",
+      },
+    ],
+    workgroups: [
+      {
+        name: "wg-1-dev-team",
+        path: workgroupPath,
+        task: null,
+        taskTitle: "Delete diagnostics",
+        teamName: "dev-team",
+        agents: [
+          {
+            name: "architect",
+            path: `${workgroupPath}\\__agent_architect`,
+            repoPaths: [],
+            isCoordinator: true,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+const blockerReport: BlockerReport = {
+  workgroup: "wg-1-dev-team",
+  platform: "windows",
+  diagnosticAvailable: true,
+  rawOsError: "sharing violation",
+  sessions: [],
+  processes: [],
+  liveSessions: [
+    {
+      sessionId: "session-1",
+      agentName: "dev-webpage-ui",
+      cwd: `${workgroupPath}\\__agent_dev-webpage-ui`,
+    },
+  ],
+  externalProcesses: [
+    {
+      pid: 4242,
+      name: "node.exe",
+      cwd: projectPath,
+      files: [`${workgroupPath}\\package.json`],
+    },
+  ],
+};
+
+function findButton(text: string): HTMLButtonElement {
+  const button = Array.from(document.body.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === text
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${text}`);
+  }
+  return button;
+}
+
+function findWorkgroupHeader(root: ParentNode): Element {
+  const header = Array.from(root.querySelectorAll(".ac-wg-header")).find(
+    (candidate) =>
+      candidate.getAttribute("title") === workgroupPath &&
+      candidate.textContent?.includes("wg-1-dev-team")
+  );
+  if (!header) {
+    throw new Error("Workgroup header not found");
+  }
+  return header;
+}
+
+describe("ProjectPanel workgroup delete diagnostics workflow", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("shows blocker diagnostics and retries delete with the same force flag", async () => {
+    const fake = new FakeTransport();
+    let deleteAttempts = 0;
+
+    fake.resolve("new_project", {
+      path: projectPath,
+      registered: true,
+      created: false,
+    });
+    fake.onInvoke("discover_project", () =>
+      deleteAttempts > 1 ? discovery({ teams: [], workgroups: [], agents: [] }) : initialDiscovery()
+    );
+    fake.onInvoke("delete_workgroup", () => {
+      deleteAttempts += 1;
+      if (deleteAttempts === 1) {
+        throw `BLOCKERS:${JSON.stringify(blockerReport)}`;
+      }
+      return undefined;
+    });
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("wg-1-dev-team"));
+
+      contextMenu(findWorkgroupHeader(rendered.root));
+      await waitFor(() => expect(document.body.textContent).toContain("Delete Workgroup"));
+      click(findButton("Delete Workgroup"));
+
+      await waitFor(() => expect(document.body.textContent).toContain("This action cannot be undone"));
+      click(findButton("Delete"));
+
+      await waitFor(() => expect(fake.callsFor("delete_workgroup")).toHaveLength(1));
+      expect(fake.callsFor("delete_workgroup")[0].args).toEqual({
+        projectPath,
+        workgroupName: "wg-1-dev-team",
+        force: false,
+      });
+
+      await waitFor(() => {
+        expect(document.body.textContent).toContain("dev-webpage-ui");
+        expect(document.body.textContent).toContain("node.exe");
+      });
+
+      click(findButton("Retry"));
+
+      await waitFor(() => expect(fake.callsFor("delete_workgroup")).toHaveLength(2));
+      expect(fake.callsFor("delete_workgroup")[1].args).toEqual({
+        projectPath,
+        workgroupName: "wg-1-dev-team",
+        force: false,
+      });
+      await waitFor(() => expect(fake.callsFor("discover_project").length).toBeGreaterThan(1));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("requires confirmation and retries dirty repo deletes with force", async () => {
+    const fake = new FakeTransport();
+    let deleteAttempts = 0;
+
+    fake.resolve("new_project", {
+      path: projectPath,
+      registered: true,
+      created: false,
+    });
+    fake.onInvoke("discover_project", () =>
+      deleteAttempts > 1 ? discovery({ teams: [], workgroups: [], agents: [] }) : initialDiscovery()
+    );
+    fake.onInvoke("delete_workgroup", () => {
+      deleteAttempts += 1;
+      if (deleteAttempts === 1) {
+        throw "DIRTY_REPOS:repo has uncommitted changes";
+      }
+      return undefined;
+    });
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("wg-1-dev-team"));
+
+      contextMenu(findWorkgroupHeader(rendered.root));
+      await waitFor(() => expect(document.body.textContent).toContain("Delete Workgroup"));
+      click(findButton("Delete Workgroup"));
+
+      await waitFor(() => expect(document.body.textContent).toContain("This action cannot be undone"));
+      click(findButton("Delete"));
+
+      await waitFor(() => expect(document.body.textContent).toContain("repo has uncommitted changes"));
+
+      const confirmInput = document.body.querySelector(".new-agent-input");
+      if (!(confirmInput instanceof HTMLInputElement)) {
+        throw new Error("Dirty repo confirmation input not found");
+      }
+      input(confirmInput, "wg-1-dev-team");
+      click(findButton("Delete"));
+
+      await waitFor(() => expect(fake.callsFor("delete_workgroup")).toHaveLength(2));
+      expect(fake.callsFor("delete_workgroup")[1].args).toEqual({
+        projectPath,
+        workgroupName: "wg-1-dev-team",
+        force: true,
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/terminal/App.workflow.test.tsx
+++ b/src/terminal/App.workflow.test.tsx
@@ -1,0 +1,226 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TerminalApp from "./App";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import {
+  baseSettings,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../shared/testing/ui-harness";
+
+interface FakeTerminalInstance {
+  cols: number;
+  rows: number;
+  element: HTMLElement | null;
+  writes: unknown[];
+  emitData(data: string): void;
+  emitResize(cols: number, rows: number): void;
+}
+
+const xterm = vi.hoisted(() => ({
+  instances: [] as FakeTerminalInstance[],
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class implements FakeTerminalInstance {
+    cols = 80;
+    rows = 24;
+    element: HTMLElement | null = null;
+    writes: unknown[] = [];
+    private dataHandlers = new Set<(data: string) => void>();
+    private resizeHandlers = new Set<(size: { cols: number; rows: number }) => void>();
+
+    constructor() {
+      xterm.instances.push(this);
+    }
+
+    loadAddon(): void {}
+
+    open(element: HTMLElement): void {
+      this.element = element;
+    }
+
+    focus(): void {}
+
+    dispose(): void {
+      this.dataHandlers.clear();
+      this.resizeHandlers.clear();
+    }
+
+    write(data: unknown): void {
+      this.writes.push(data);
+    }
+
+    scrollToBottom(): void {}
+
+    paste(): void {}
+
+    hasSelection(): boolean {
+      return false;
+    }
+
+    getSelection(): string {
+      return "";
+    }
+
+    attachCustomKeyEventHandler(): void {}
+
+    onData(handler: (data: string) => void): { dispose: () => void } {
+      this.dataHandlers.add(handler);
+      return { dispose: () => this.dataHandlers.delete(handler) };
+    }
+
+    onResize(
+      handler: (size: { cols: number; rows: number }) => void
+    ): { dispose: () => void } {
+      this.resizeHandlers.add(handler);
+      return { dispose: () => this.resizeHandlers.delete(handler) };
+    }
+
+    emitData(data: string): void {
+      for (const handler of Array.from(this.dataHandlers)) {
+        handler(data);
+      }
+    }
+
+    emitResize(cols: number, rows: number): void {
+      this.cols = cols;
+      this.rows = rows;
+      for (const handler of Array.from(this.resizeHandlers)) {
+        handler({ cols, rows });
+      }
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit = vi.fn();
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: class {
+    onContextLoss = vi.fn();
+    dispose = vi.fn();
+  },
+}));
+
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+function setupTerminalTransport(fake: FakeTransport, sessions = [session()]): void {
+  fake.resolve("get_settings", baseSettings());
+  fake.resolve("get_active_session", sessions[0]?.id ?? null);
+  fake.onInvoke("list_sessions", () => sessions);
+  fake.resolve("pty_write", undefined);
+  fake.resolve("pty_resize", undefined);
+  fake.resolve("set_last_prompt", undefined);
+}
+
+describe("TerminalApp workflow", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+    xterm.instances.length = 0;
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    xterm.instances.length = 0;
+  });
+
+  it("wires active-session PTY input, prompt capture, and PTY output", async () => {
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake, [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      const terminal = xterm.instances[0];
+
+      terminal.emitData("hello");
+      await waitFor(() =>
+        expect(fake.lastCall("pty_write")?.args).toEqual({
+          sessionId: "session-1",
+          data: [104, 101, 108, 108, 111],
+        })
+      );
+
+      terminal.emitData("\r");
+      await waitFor(() =>
+        expect(fake.lastCall("set_last_prompt")?.args).toEqual({
+          id: "session-1",
+          text: "hello",
+        })
+      );
+
+      terminal.emitResize(100, 32);
+      expect(fake.lastCall("pty_resize")?.args).toEqual({
+        sessionId: "session-1",
+        cols: 100,
+        rows: 32,
+      });
+
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: [111, 107],
+      });
+
+      expect(terminal.writes).toHaveLength(1);
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([111, 107]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("follows session_switched events through backend state", async () => {
+    const sessions = [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+      }),
+      session({
+        id: "session-2",
+        name: "wg-1-dev-team/dev-webpage-ui",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_dev-webpage-ui",
+      }),
+    ];
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake, sessions);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+
+      fake.clearCalls();
+      fake.emitFromBackend("session_switched", { id: "session-2" });
+
+      await waitFor(() => expect(xterm.instances).toHaveLength(2));
+      expect(fake.callsFor("list_sessions").length).toBeGreaterThan(0);
+
+      xterm.instances[1].emitData("z");
+      await waitFor(() =>
+        expect(fake.lastCall("pty_write")?.args).toEqual({
+          sessionId: "session-2",
+          data: [122],
+        })
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,12 @@ import solidPlugin from "vite-plugin-solid";
 
 export default defineConfig({
   plugins: [solidPlugin({ hot: false })],
+  define: {
+    __APP_VERSION__: JSON.stringify("test"),
+    __BUILD_PROFILE__: JSON.stringify("test"),
+  },
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
   },
 });


### PR DESCRIPTION
## Summary
- add a deterministic fake transport test seam for browser/UI workflow tests
- add browser, sidebar, terminal, and ProjectPanel workflow coverage against fake backend state
- make BrowserApp own browser-mode document theme while keeping embedded child layout behavior

## Validation
- Dev-webpage-ui PASS on `b537cc7e5bbdb66bdc48023b3ae4017b205cb4ce`
- Grinch rereview PASS on `b537cc7e5bbdb66bdc48023b3ae4017b205cb4ce`
- Shipper PASS for `agentscommander_standalone_wg-1.exe`, SHA256 `30B283BC09298C5D125DC490F67711715F3BA11D25B32C5538A3B7AF82B3560F`
- WG13 acceptance PASS with evidence at `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-13-acceptance-testing\__agent_ac-cli-and-gui-tester\artifacts\issue-488-browser-ui-fake-transport-20260614-081220`

Accepted residual:
- WG13 accepted a residual coverage gap: no direct BrowserApp post-cleanup `theme_changed` mutation assertion. Source cleanup and FakeTransport unlisten coverage were reviewed; follow-up can add this narrower assertion.

Closes #488