### PR TITLE
chore(release): v0.9.0 Project Loops + compound-the-compound messaging (#520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable user-facing changes are tracked here and in [GitHub Releases](https:
 
 This file follows a lightweight [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) shape: one section per release in reverse-chronological order. Each entry groups changes under **Added / Changed / Removed / Fixed / Security** where useful.
 
+## 0.9.0 – 2026-06-15
+
+Feature release: **Project Loops** (scheduled, recurring agent runs), a public marketing-copy overhaul around the "compound your coding agents" message, OpenCode documented as usable (provider-agnostic), and a large test/CI regression-hardening pass.
+
+### Added
+
+- **Project Loops**: scheduled, recurring agent runs. Define a cron-style schedule that re-triggers a coordinator, workgroup, or agent; ships the scheduler backend, the sidebar UI, and scheduler safety guards. ([#354](https://github.com/mblua/AgentsCommander/issues/354))
+- **Agency template install in the New Agent modal**: browse and install [@msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents) role templates directly from the create-agent flow, wired over the embedded WebSocket. ([#465](https://github.com/mblua/AgentsCommander/issues/465))
+- **Semantic GUI automation bridge**: a CLI and UI context-click automation surface for deterministic, scriptable GUI interactions. ([#499](https://github.com/mblua/AgentsCommander/issues/499))
+- **External link confirmation for terminal links**: clicking an external link in an xterm session now asks for confirmation before opening, in both desktop and browser modes. ([#474](https://github.com/mblua/AgentsCommander/issues/474))
+- **Deterministic GUI test mode**: a fake-transport mode that makes browser and GUI flows reproducible in CI.
+
+### Changed
+
+- **Public marketing copy overhaul**: README and docs now lead with the "compound your coding agents" message: bring any coding agent at full power, put a Fusion team on a Loop, and let scheduled runs compound toward the best answer. Positioned around "only adds, never subtracts." ([#520](https://github.com/mblua/AgentsCommander/issues/520))
+- **OpenCode documented as supported (provider-agnostic)**: OpenCode can be run today via the custom coding-agent path and pointed at any provider or model. A first-class tuned profile (its own `CodingAgentKind`, resume tokens, idle tuning) remains planned. ([#315](https://github.com/mblua/AgentsCommander/issues/315))
+- **Profile modal layout**: enlarged desktop layout and fixed intermediate stacking. ([#471](https://github.com/mblua/AgentsCommander/issues/471))
+- **Test and CI regression-hardening pass**: PR regression gates, GUI regression suites, PTY lifecycle coverage, mailbox wake-routing tests, close-session integration fixtures, CLI behavior contract tests, and a Windows release CLI smoke test. ([#475](https://github.com/mblua/AgentsCommander/issues/475), [#479](https://github.com/mblua/AgentsCommander/issues/479), [#485](https://github.com/mblua/AgentsCommander/issues/485))
+
+### Fixed
+
+- **Coordinator repo badges for discovered workgroups**: workgroups discovered on disk now show their repo badge correctly. ([#500](https://github.com/mblua/AgentsCommander/issues/500))
+- **Outbound network port exhaustion**: hardened outbound network resource handling and fixed bridge shutdown and poll backoff so repeated outbound requests no longer exhaust ports. ([#501](https://github.com/mblua/AgentsCommander/issues/501), [#502](https://github.com/mblua/AgentsCommander/issues/502))
+- **Frontend websocket rejections**: fixed spurious rejection of valid frontend WebSocket connections. ([#480](https://github.com/mblua/AgentsCommander/issues/480), [#491](https://github.com/mblua/AgentsCommander/issues/491))
+- **Project Loops scheduler races**: scheduler safety hardening, stale-prompt pre-write race, stale-delivery revalidation, enable and disable UI refresh, and delete-modal concurrency.
+
+### Security
+
+- **Hardened destructive filesystem delete paths**: tightened guards around destructive delete operations and closed review gaps found during the hardening pass. ([#512](https://github.com/mblua/AgentsCommander/issues/512))
+
 ## 0.8.43 — 2026-05-27
 
 Public-push release: repo cleanup, documentation rewrite scaffolding, and factual corrections to public copy. See umbrella issue [#313](https://github.com/mblua/AgentsCommander/issues/313).

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 <h1 align="center">Agents Commander</h1>
 
 <p align="center">
-  Run multiple teams of AI coding agents (Claude Code, Codex, Gemini) across separate workgroup instances.<br/>
-  Root Agent coordination, visible terminals, and file-based workflows you can inspect.
+  <b>Compound your coding agents.</b> Bring any CLI coding agent at full power, put your Fusion team on a <b>Loop</b>, and let scheduled, recurring runs compound toward the best answer, while you sleep. <b>AgentsCommander only adds, never subtracts.</b> <i>Road to the Dark Factory.</i>
+</p>
+
+<p align="center">
+  <sub><i>A Fusion team combines multiple models in one team: point OpenCode at any provider and any model can join, even OpenRouter Fusion.</i></sub>
 </p>
 
 <p align="center">
@@ -51,13 +54,17 @@ Prefer a desktop installer or a manual download? Get the signed Windows installe
 
 ## The 30-second pitch
 
-- **Pick the coding agent per role.** Claude Code on architecture, Codex on dev, Gemini on review, or any mix. Each runs in its own real terminal with a full PTY, not a command runner.
+> **A Dark Factory runs with the lights off, no humans on the floor.** AgentsCommander is how you get there: bring any coding agent at full power, put a Fusion team of cheaper models on a **Loop**, and let scheduled runs compound toward the best answer. We only add, never subtract.
+
+- **Pick the coding agent per role (Claude Code, Codex, Gemini, or OpenCode) at full power.** Each runs in its own real terminal with a full PTY, not a command runner. AgentsCommander only adds capability; it never wraps, sandboxes, or nerfs your agent.
 - **Direct multiple workgroups from the Root Agent.** The Agent Commander / Root Agent gives you one place to steer work across teams. Ask it to talk to workgroup coordinators, send work to different teams, and keep initiatives aligned across parallel workgroups.
 - **Multi-agent Teams that coordinate through files.** Agents exchange markdown messages in a `messaging/` folder you can `cat`, `git diff`, and audit. The whole org fits in `ls`.
 - **Phone-ready updates with images.** The Telegram bridge can stream session output and send photos or screenshots captured by agents, so remote status can include the actual screen or report.
 - **Local state, no telemetry.** All state lives in plain JSON, TOML, and markdown next to the binary. Portable: copy the `.exe` to any drive and it carries its own config.
 
 You bring the coding agents. AgentsCommander coordinates them.
+
+> **OpenRouter Fusion compounds models on a single request. AgentsCommander compounds agents, models, and Fusion itself: on a Loop, across a team.** Point OpenCode at any provider and bring any model (including OpenRouter Fusion) into the team.
 
 ## See it work
 
@@ -84,13 +91,13 @@ You bring the coding agents. AgentsCommander coordinates them.
    Prefer a desktop installer or portable binary? Use [GitHub Releases](https://github.com/mblua/AgentsCommander/releases/latest).
 2. **Open a project**: click `New Project` in the sidebar and point it at an empty folder. AC creates a Project AC Root (`.ac/`) there.
 3. **Create a Team**: add a coordinator and one worker agent, each with a role prompt. [Teams and workgroups](docs/agents/teams-and-workgroups.md) walks through this.
-4. **Launch the coordinator**: pick Claude Code, Codex, or Gemini from the dropdown. Ask it to send the worker a hello message. The worker terminal receives a file notification and responds in real time.
+4. **Launch the coordinator**: pick Claude Code, Codex, Gemini, or OpenCode from the dropdown. Ask it to send the worker a hello message. The worker terminal receives a file notification and responds in real time.
 
 Full walkthrough: [`docs/quickstart.md`](docs/quickstart.md).
 
 ## Why this exists
 
-Most agent tools focus on in-process orchestration or one interactive session. AgentsCommander starts with the **coding agents you already use** (Claude Code, Codex, Gemini), runs them as real OS processes, and lets them coordinate through plain markdown files that any human, any tool, and any `git diff` can inspect. You see every step in a real terminal, and the coordination state stays visible on disk.
+Most agent tools focus on in-process orchestration or one interactive session. AgentsCommander starts with the **coding agents you already use** (Claude Code, Codex, Gemini, OpenCode), runs them as real OS processes, and lets them coordinate through plain markdown files that any human, any tool, and any `git diff` can inspect. You see every step in a real terminal, and the coordination state stays visible on disk.
 
 ## What you can build
 
@@ -107,7 +114,7 @@ Full recipes: [`docs/use-cases.md`](docs/use-cases.md).
 
 | | AgentsCommander | LangGraph | AutoGen / AG2 | CrewAI | Aider | Claude Code alone |
 |---|---|---|---|---|---|---|
-| **Operates real CLI coding agents** | ✅ Claude Code, Codex, Gemini | ❌ Python LLM calls | ❌ Python conversation | ❌ Python library | Partial (one agent) | ✅ (one agent) |
+| **Operates real CLI coding agents** | ✅ Claude Code, Codex, Gemini, OpenCode | ❌ Python LLM calls | ❌ Python conversation | ❌ Python library | Partial (one agent) | ✅ (one agent) |
 | **Real PTY per agent** | ✅ ConPTY / Unix PTY | ❌ | ❌ | ❌ | ✅ | ✅ |
 | **Filesystem-first messaging** | ✅ Markdown in `messaging/` | ❌ DB / Python state | ❌ Python objects | ❌ Python tasks | n/a | n/a |
 | **Standalone runtime** | ✅ Rust / Tauri | ❌ Python library | ❌ Python library | ❌ Python library | ❌ Python app | ✅ standalone CLI |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,7 @@ This file is a snapshot. The authoritative status for any item lives in its link
 
 - Multi-agent workgroups with file-based inter-agent messaging
 - Cross-coding-agent profiles: Claude Code · Codex · Gemini
+- OpenCode usable today via the custom coding-agent path (provider-agnostic: point it at any provider or model, including OpenRouter Fusion)
 - Agents Agency role-template picker (explicit downloaded cache from [@msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents))
 - Telegram bridge (PTY-mode + JSONL reader-mode per agent, plus photo/image sends for screenshots and artifacts)
 - Voice-to-text via Gemini API with auto-execute
@@ -20,7 +21,7 @@ This file is a snapshot. The authoritative status for any item lives in its link
 
 ### Coding-agent integrations
 
-- **OpenCode** - first-class profile alongside Claude Code, Codex, Gemini. ([#315](https://github.com/mblua/AgentsCommander/issues/315))
+- **OpenCode first-class profile** - OpenCode already runs via the custom coding-agent path (provider-agnostic). Remaining work: a tuned `CodingAgentKind` profile with resume tokens and idle tuning, alongside Claude Code, Codex, Gemini. ([#315](https://github.com/mblua/AgentsCommander/issues/315))
 - **NVIDIA OpenShell** - sandbox-runtime integration (not a coding-agent profile; OpenShell hosts other coding agents inside a policy-driven sandbox). ([#316](https://github.com/mblua/AgentsCommander/issues/316))
 
 ### Per-agent configuration

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,11 +8,11 @@ No. AC does not include an LLM. It spawns and coordinates the coding-agent CLIs 
 
 ## Which coding agents are supported?
 
-Claude Code, Codex, and Gemini. Adding more is on the [roadmap](../ROADMAP.md) — OpenCode and a Nvidia agent are the next two slots.
+Claude Code, Codex, and Gemini have first-class tuned profiles (resume tokens, idle tuning). OpenCode works today too, through the custom coding-agent path: because OpenCode is provider-agnostic you can point it at any provider or model. A first-class OpenCode profile and an Nvidia agent are on the [roadmap](../ROADMAP.md).
 
 ## What about OpenCode?
 
-Planned, not yet wired. See `session/profile.rs::CodingAgentKind` for the current enum; OpenCode will join when the per-agent profile work lands. Track it on the [roadmap](../ROADMAP.md).
+Usable today. OpenCode is provider-agnostic, so you add it as a custom coding agent (Settings, Coding Agents, Add agent) and point it at any provider or model. That is what lets AC drive any model through it, including OpenRouter Fusion. What is still planned is a first-class tuned profile: its own `CodingAgentKind` variant with resume tokens and idle tuning. The current enum is in `session/profile.rs::CodingAgentKind`. Track the tuned profile on the [roadmap](../ROADMAP.md).
 
 ## Do I need Python or LangChain?
 

--- a/docs/integrations/coding-agents.md
+++ b/docs/integrations/coding-agents.md
@@ -12,6 +12,8 @@ AgentsCommander is **not** a coding agent. It spawns coding-agent processes and 
 | **Codex** | `codex` | `resume --last` | OpenAI's coding agent CLI. |
 | **Gemini** | `gemini` | `--resume latest` | Google's CLI. |
 
+> **OpenCode** runs today through the custom coding-agent path (see [Adding a custom coding-agent profile](#adding-a-custom-coding-agent-profile)). OpenCode is provider-agnostic, so you can point it at any provider or model, including OpenRouter Fusion. It does not yet have a first-class tuned profile (resume tokens, idle tuning); that work is tracked as [#315](https://github.com/mblua/AgentsCommander/issues/315).
+
 Detection rule: AC inspects the shell command + args, takes each token's executable basename (lowercased, `.exe` stripped), and matches by **prefix** with precedence Claude > Codex > Gemini. Wrappers named `claude-foo` or `codex-bar` match automatically. Anything else falls through to the plain-shell behavior (no resume tokens, generic idle tuning).
 
 The full enum is in `session/profile.rs::CodingAgentKind`.
@@ -79,7 +81,7 @@ To make AC recognise a new CLI (e.g. a custom wrapper) under the **Coding Agents
 
 The new entry appears in the launcher dropdown immediately. AC will spawn the binary as-is — no resume tokens are injected unless the binary's basename starts with `claude`, `codex`, or `gemini`.
 
-For deeper integration (a new `CodingAgentKind` with its own resume tokens and idle tuning), you need to add a profile to `src-tauri/src/session/profile.rs` and rebuild. Track the OpenCode integration on the [roadmap](../../ROADMAP.md) for the canonical example of how this is done.
+For deeper integration (a new `CodingAgentKind` with its own resume tokens and idle tuning), you need to add a profile to `src-tauri/src/session/profile.rs` and rebuild. OpenCode already runs through the custom-agent steps above; its first-class tuned profile is tracked on the [roadmap](../../ROADMAP.md) ([#315](https://github.com/mblua/AgentsCommander/issues/315)) as the canonical example of how a new `CodingAgentKind` is added.
 
 ## Authentication and secrets
 
@@ -98,4 +100,4 @@ If you use the AC-managed agent directories, AC may write minimal `.claude/setti
 - [Creating agents](../agents/creating-agents.md) — make a new agent dir
 - [Settings reference](../reference/settings.md) — full schema for `agents[]`
 - [RTK integration](../features/rtk-integration.md) — Claude Code Bash-tool compression
-- [Roadmap — coding agents](../../ROADMAP.md) — OpenCode, Nvidia agent, more
+- [Roadmap: coding agents](../../ROADMAP.md): OpenCode first-class profile, Nvidia agent, more

--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.8.53"; // Must match package.json
+const VERSION = "0.9.0"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.8.53",
+  "version": "0.9.0",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.8.53",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.8.53",
+      "version": "0.9.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.8.53",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.8.53"
+version = "0.9.0"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.8.53"
+version = "0.9.0"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.8.53",
+  "version": "0.9.0",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {


### PR DESCRIPTION
## Summary

Cuts release **v0.9.0** and overhauls the public marketing copy ("speech") to be more impactful. v0.9.0 is the milestone that surfaces the already-merged **Project Loops** feature (#354) plus the accumulated work since v0.8.51, and rebrands the pitch around the **compound / Loop / Fusion team / only-adds** narrative.

Closes #520.

## Changes

**Version: bumped to 0.9.0 across all 8 surfaces** (verified by `node scripts/check-version-sync.mjs`, EXIT 0):
`src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`, `package.json`, `npm/package.json`, `package-lock.json` (root + `packages[""]`), and `npm/install.js` (`VERSION`).

**Marketing copy (README), "compound the compound" direction:**
- New hero: "Compound your coding agents. ... put your Fusion team on a Loop ... only adds, never subtracts. Road to the Dark Factory."
- Fusion clarifier, 30-second-pitch lead, reworked first pitch bullet, and a "compound the compound" callout positioning AgentsCommander as complementary to OpenRouter Fusion (bring any model via OpenCode).
- "Loop" framed as scheduled/recurring runs (matches the `/loop` convention and Project Loops).

**OpenCode documented as supported (provider-agnostic, via the custom-agent path):**
- README supported-agents lists (hero clarifier, pitch bullet, comparison table) now include OpenCode.
- `docs/faq.md`, `ROADMAP.md`, `docs/integrations/coding-agents.md` updated: OpenCode is usable today; the old "planned / not yet wired" wording is gone; #315 is scoped to the first-class tuned profile only.

**CHANGELOG.md:** new `0.9.0` entry (Added / Changed / Fixed / Security) derived from `v0.8.51..HEAD`.

## Testing / validation

- **Review gate (technical-writer): APPROVE.** Factual accuracy of claims verified against `CodingAgentKind`; cross-file consistency; markdown/HTML rendering; em-dash audit clean.
- **Build (shipper): SUCCESS.** `npx tauri build` exit 0; deployed wg-12 standalone exe at 0.9.0; installer bundles named `Agents Commander_0.9.0_x64...` (the prior 0.8.53 bundle skew was fixed).
- **Acceptance (WG-13): ACCEPTANCE_PASSED** on commit `cbb704f`.
  - Version gate `node scripts/check-version-sync.mjs` -> EXIT 0 (all 8 surfaces at 0.9.0).
  - Build-from-source: `cargo build --release` exit 0, `Compiling agentscommander-new v0.9.0`.
  - Built binary embeds `agentscommander/0.9.0`; `--help` smoke exits 0.
  - Docs evidence: OpenCode wording correct; #315 scoped to tuned profile; CHANGELOG 0.9.0 present; README renders.
  - Cleanup verified; WG-13 checkout restored to `main`.

## Notes

- A version-bump blocker (`npm/install.js` still at 0.8.53) was caught by acceptance and fixed in `cbb704f` using the authoritative `npm run version:bump`. The `.js`/`.lock` surfaces are now part of the standard release-cut check via `scripts/check-version-sync.mjs`.
- The release artifacts (multi-platform installers + raw binaries + checksums) are produced by `release.yml` on the `v0.9.0` tag push.
