### PR TITLE
feat(coding-agents): Config/Selection B2C1a rework + per-agent instructions file + OpenCode (#526, #527, #529)

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.9.2"; // Must match package.json
+const VERSION = "0.9.3"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -157,6 +157,7 @@ mod tests {
             exclude_global_claude_md: false,
             envs: Vec::new(),
             isolated_home: false,
+            instructions_filename: None,
         }
     }
 

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1315,6 +1315,7 @@ mod tests {
                 exclude_global_claude_md: false,
                 envs: Vec::new(),
                 isolated_home: false,
+                instructions_filename: None,
             }],
             ..AppSettings::default()
         }

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -2690,6 +2690,7 @@ mod tests {
                 exclude_global_claude_md: false,
                 envs: Vec::new(),
                 isolated_home: false,
+                instructions_filename: None,
             },
             crate::config::settings::AgentConfig {
                 id: "claude".to_string(),
@@ -2700,6 +2701,7 @@ mod tests {
                 exclude_global_claude_md: true,
                 envs: Vec::new(),
                 isolated_home: false,
+                instructions_filename: None,
             },
         ];
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -859,10 +859,28 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         }
     }
 
-    let materialized_context_path = if let Some(target) = context_target {
-        match crate::config::session_context::materialize_agent_context_file(
+    // #529 - resolve the instructions filename from the configured coding agent
+    // (falling back to detection for ad-hoc launches), plus the union of every
+    // configured agent's filename for cleanup. Computed under a single settings
+    // read guard that is dropped before any filesystem I/O (no guard across the
+    // materialize call).
+    let (target_filename, managed_filenames): (Option<String>, Vec<String>) = {
+        let settings_state = app.state::<SettingsState>();
+        let cfg = settings_state.read().await;
+        let managed = crate::config::agent_command::managed_instructions_filenames(&cfg);
+        let target = crate::config::agent_command::resolve_target_filename(
+            agent_id.as_deref(),
+            &cfg,
+            context_target,
+        );
+        (target, managed)
+    };
+
+    let materialized_context_path = if let Some(ref target_filename) = target_filename {
+        match crate::config::session_context::materialize_agent_context_file_with_filename(
             &cwd,
-            target,
+            target_filename,
+            &managed_filenames,
             is_coordinator,
         ) {
             Ok(context) => context,
@@ -2307,6 +2325,7 @@ mod tests {
                     exclude_global_claude_md: false,
                     envs: Vec::new(),
                     isolated_home: false,
+                    instructions_filename: None,
                 },
                 AgentConfig {
                     id: "codex".to_string(),
@@ -2317,6 +2336,7 @@ mod tests {
                     exclude_global_claude_md: false,
                     envs: Vec::new(),
                     isolated_home: false,
+                    instructions_filename: None,
                 },
             ],
             ..AppSettings::default()
@@ -2787,6 +2807,7 @@ mod tests {
             exclude_global_claude_md: false,
             envs: Vec::new(),
             isolated_home: false,
+            instructions_filename: None,
         });
 
         let resolved = resolve_actual_agent(
@@ -2864,6 +2885,7 @@ mod tests {
             exclude_global_claude_md: false,
             envs: Vec::new(),
             isolated_home: false,
+            instructions_filename: None,
         }];
 
         let resolved = resolve_agent_from_shell("codex", &[], &settings);

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -9,6 +9,7 @@ use crate::config::placeholders::{
     placeholder_context_for_launch_root, reject_unexpanded_markers, value_contains_ac_root,
     PlaceholderContext,
 };
+use crate::config::session_context::ManagedContextTarget;
 use crate::config::settings::{
     is_codex_home_key, normalize_env_key_for_platform, validate_expanded_codex_home_value,
     validate_user_env_key, AgentConfig, AppSettings,
@@ -117,6 +118,141 @@ pub fn normalize_legacy_agent_command(command: &str) -> Result<NormalizedAgentCo
         shell: shell.clone(),
         shell_args: args.to_vec(),
     })
+}
+
+// ---------------------------------------------------------------------------
+// #529 - per-coding-agent instructions filename (written to the agent root at
+// launch; content is the same AC context + Role.md AC already generates).
+// ---------------------------------------------------------------------------
+
+/// Per-command default when no explicit filename is configured. Derives the
+/// filename from the command via the same `CodingAgentKind::detect` the launch
+/// path uses, so a configured agent's default matches what detection would pick.
+pub fn default_instructions_filename_for_command(command: &str) -> &'static str {
+    match normalize_legacy_agent_command(command) {
+        Ok(n) => match CodingAgentKind::detect(&n.shell, &n.shell_args) {
+            Some(CodingAgentKind::Claude) => "CLAUDE.md",
+            Some(CodingAgentKind::Gemini) => "GEMINI.md",
+            // Codex, OpenCode, custom, and unknown all use AGENTS.md.
+            _ => "AGENTS.md",
+        },
+        Err(_) => "AGENTS.md",
+    }
+}
+
+/// Resolved instructions filename for a configured coding agent: the explicit
+/// (trimmed, validated) value when set, else the command-derived default. An
+/// empty/whitespace/unsafe stored value silently falls back to the default, so
+/// a hand-edited `settings.json` with a bad value never reaches the writer.
+pub fn resolve_instructions_filename(agent: &AgentConfig) -> String {
+    match agent.instructions_filename.as_deref().map(str::trim) {
+        Some(f) if !f.is_empty() && is_safe_instructions_filename(f) => f.to_string(),
+        _ => default_instructions_filename_for_command(&agent.command).to_string(),
+    }
+}
+
+/// Union of every configured agent's resolved filename, used as the writer's
+/// extra-cleanup set so launching one agent removes another's stale file. The
+/// built-in managed names are always added by the writer itself; this only
+/// contributes the configured + custom names.
+pub fn managed_instructions_filenames(settings: &AppSettings) -> Vec<String> {
+    let mut set: Vec<String> = Vec::new();
+    for agent in &settings.agents {
+        let f = resolve_instructions_filename(agent);
+        if !set.contains(&f) {
+            set.push(f);
+        }
+    }
+    set
+}
+
+/// Pure launch-time resolver (R1.9): pick the instructions filename for a
+/// launch given the post-resolution `agent_id`, the settings, and the
+/// detection-derived target. Four branches:
+///   1. configured agent with explicit valid filename -> that filename;
+///   2. configured agent without one -> command-derived default;
+///   3. no configured agent but a detected kind -> the detected filename;
+///   4. neither -> `None` (no instructions file is materialized).
+pub fn resolve_target_filename(
+    agent_id: Option<&str>,
+    settings: &AppSettings,
+    detected: Option<ManagedContextTarget>,
+) -> Option<String> {
+    agent_id
+        .and_then(|aid| settings.agents.iter().find(|a| a.id == aid))
+        .map(resolve_instructions_filename)
+        .or_else(|| detected.map(|t| t.filename().to_string()))
+}
+
+/// True only for a bare, safe `*.md` filename that can be `cwd.join`ed and
+/// written without escaping the agent root (R1.5 + G9). This is a strict
+/// predicate: callers trim before calling, so any surrounding whitespace here
+/// is a genuine rejection (Windows silently strips trailing space/dot, which
+/// would desync the validated, written, and cleanup names).
+pub fn is_safe_instructions_filename(filename: &str) -> bool {
+    if filename.is_empty() {
+        return false;
+    }
+    // Length cap so `root + filename` stays well under MAX_PATH.
+    if filename.chars().count() > 128 {
+        return false;
+    }
+    // No path separators or parent-dir traversal.
+    if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+        return false;
+    }
+    // No colon: rejects a drive prefix (`C:x.md`) AND an NTFS Alternate Data
+    // Stream (`AGENTS.md:evil`).
+    if filename.contains(':') {
+        return false;
+    }
+    // No control chars.
+    if filename.chars().any(|c| c.is_control()) {
+        return false;
+    }
+    // No leading/trailing whitespace and no trailing dot (Windows strips them).
+    if filename.starts_with(char::is_whitespace)
+        || filename.ends_with(char::is_whitespace)
+        || filename.ends_with('.')
+    {
+        return false;
+    }
+    // Require a `.md` extension, matched case-insensitively (accept `AGENTS.MD`);
+    // the caller keeps the user's original spelling.
+    let lower = filename.to_ascii_lowercase();
+    let Some(stem) = lower.strip_suffix(".md") else {
+        return false;
+    };
+    // Non-empty stem (reject bare `.md`) and no space immediately before `.md`.
+    if stem.is_empty() || stem.ends_with(char::is_whitespace) {
+        return false;
+    }
+    // G9: reject the exact AC-internal sentinel (case-insensitive). The
+    // user-facing built-ins CLAUDE.md / GEMINI.md / AGENTS.md stay allowed.
+    if filename.eq_ignore_ascii_case("last_ac_context.md") {
+        return false;
+    }
+    // Windows reserved device names, checked case-insensitively on the segment
+    // BEFORE THE FIRST DOT: Windows resolves a device by that base segment and
+    // ignores the extension, so `CON.md` AND `CON.foo.md` both hit the CON
+    // device. CON, PRN, AUX, NUL, COM1..COM9, LPT1..LPT9.
+    let device_segment = stem.split('.').next().unwrap_or(stem);
+    if is_reserved_device_segment(device_segment) {
+        return false;
+    }
+    true
+}
+
+/// True iff `segment` (already lowercased) is a Windows reserved device name.
+/// COM/LPT match digits 1-9 only (COM0/LPT0 are not devices).
+fn is_reserved_device_segment(segment: &str) -> bool {
+    if matches!(segment, "con" | "prn" | "aux" | "nul") {
+        return true;
+    }
+    let bytes = segment.as_bytes();
+    bytes.len() == 4
+        && (segment.starts_with("com") || segment.starts_with("lpt"))
+        && matches!(bytes[3], b'1'..=b'9')
 }
 
 pub fn stringify_agent_command_tokens(tokens: &[String]) -> String {
@@ -533,7 +669,11 @@ pub fn build_agent_spawn_command(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_agent_spawn_command, normalize_legacy_agent_command};
+    use super::{
+        build_agent_spawn_command, default_instructions_filename_for_command,
+        is_safe_instructions_filename, managed_instructions_filenames,
+        normalize_legacy_agent_command, resolve_instructions_filename, resolve_target_filename,
+    };
     use crate::config::settings::{
         AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ProfileCellConfig,
     };
@@ -653,6 +793,7 @@ mod tests {
             exclude_global_claude_md: false,
             envs: Vec::new(),
             isolated_home: false,
+            instructions_filename: None,
         }
     }
 
@@ -958,5 +1099,188 @@ mod tests {
 
         let err = build_agent_spawn_command(&settings, "codex", None, Some("A")).unwrap_err();
         assert!(err.contains("unknown placeholder"), "{err}");
+    }
+
+    // #529 - instructions filename resolver + safety validation.
+
+    #[test]
+    fn default_instructions_filename_maps_by_detected_kind() {
+        assert_eq!(
+            default_instructions_filename_for_command("claude"),
+            "CLAUDE.md"
+        );
+        assert_eq!(
+            default_instructions_filename_for_command("claude-mb --effort max"),
+            "CLAUDE.md"
+        );
+        assert_eq!(
+            default_instructions_filename_for_command("cmd.exe /c claude"),
+            "CLAUDE.md"
+        );
+        assert_eq!(
+            default_instructions_filename_for_command("gemini -m gpt-5"),
+            "GEMINI.md"
+        );
+        assert_eq!(default_instructions_filename_for_command("codex"), "AGENTS.md");
+        assert_eq!(
+            default_instructions_filename_for_command("opencode"),
+            "AGENTS.md"
+        );
+        assert_eq!(
+            default_instructions_filename_for_command("my-custom-agent"),
+            "AGENTS.md"
+        );
+        // Unparseable (unclosed quote) and empty both fall back to AGENTS.md.
+        assert_eq!(
+            default_instructions_filename_for_command("codex \"unterminated"),
+            "AGENTS.md"
+        );
+        assert_eq!(default_instructions_filename_for_command(""), "AGENTS.md");
+    }
+
+    #[test]
+    fn resolve_instructions_filename_prefers_valid_explicit() {
+        let mut a = agent("x", "codex");
+        // No explicit value -> command-derived default.
+        assert_eq!(resolve_instructions_filename(&a), "AGENTS.md");
+        // Valid explicit value wins.
+        a.instructions_filename = Some("Squad.md".to_string());
+        assert_eq!(resolve_instructions_filename(&a), "Squad.md");
+        // Surrounding whitespace is trimmed.
+        a.instructions_filename = Some("  Squad.md  ".to_string());
+        assert_eq!(resolve_instructions_filename(&a), "Squad.md");
+        // Whitespace-only -> command default.
+        a.instructions_filename = Some("   ".to_string());
+        assert_eq!(resolve_instructions_filename(&a), "AGENTS.md");
+        // Unsafe value (path escape) silently falls back to the default; it never
+        // reaches the writer.
+        a.instructions_filename = Some("../escape.md".to_string());
+        assert_eq!(resolve_instructions_filename(&a), "AGENTS.md");
+        // Claude command default is CLAUDE.md when no explicit value is set.
+        let claude = agent("c", "claude");
+        assert_eq!(resolve_instructions_filename(&claude), "CLAUDE.md");
+    }
+
+    #[test]
+    fn managed_instructions_filenames_dedupes_across_agents() {
+        let settings = AppSettings {
+            agents: vec![
+                agent("claude", "claude"),     // CLAUDE.md
+                agent("codex", "codex"),       // AGENTS.md
+                agent("gemini", "gemini"),     // GEMINI.md
+                agent("opencode", "opencode"), // AGENTS.md (dup of codex)
+            ],
+            ..AppSettings::default()
+        };
+        let mut got = managed_instructions_filenames(&settings);
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                "AGENTS.md".to_string(),
+                "CLAUDE.md".to_string(),
+                "GEMINI.md".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_target_filename_covers_all_four_branches() {
+        use crate::config::session_context::ManagedContextTarget;
+        let mut configured = agent("opencode", "opencode");
+        configured.instructions_filename = Some("Team.md".to_string());
+        let settings = AppSettings {
+            agents: vec![configured, agent("codex", "codex")],
+            ..AppSettings::default()
+        };
+
+        // 1. configured agent with explicit valid filename wins.
+        assert_eq!(
+            resolve_target_filename(Some("opencode"), &settings, None).as_deref(),
+            Some("Team.md")
+        );
+        // 2. configured agent without explicit -> command default (overrides detection).
+        assert_eq!(
+            resolve_target_filename(Some("codex"), &settings, Some(ManagedContextTarget::Claude))
+                .as_deref(),
+            Some("AGENTS.md")
+        );
+        // 3. unknown id -> detection fallback.
+        assert_eq!(
+            resolve_target_filename(Some("ghost"), &settings, Some(ManagedContextTarget::Gemini))
+                .as_deref(),
+            Some("GEMINI.md")
+        );
+        // 3b. no id -> detection fallback.
+        assert_eq!(
+            resolve_target_filename(None, &settings, Some(ManagedContextTarget::Codex)).as_deref(),
+            Some("AGENTS.md")
+        );
+        // 4. neither configured agent nor detection -> None.
+        assert_eq!(resolve_target_filename(None, &settings, None), None);
+        assert_eq!(resolve_target_filename(Some("ghost"), &settings, None), None);
+    }
+
+    #[test]
+    fn is_safe_instructions_filename_accepts_bare_md_names() {
+        for ok in [
+            "AGENTS.md",
+            "CLAUDE.md",
+            "GEMINI.md",
+            "MyTeam.md",
+            "AGENTS.MD",
+            "a.md",
+            "my-notes.md",
+            // COM0/LPT0 are NOT reserved devices.
+            "COM0.md",
+            "LPT0.md",
+        ] {
+            assert!(is_safe_instructions_filename(ok), "should accept {ok:?}");
+        }
+    }
+
+    #[test]
+    fn is_safe_instructions_filename_rejects_unsafe_names() {
+        let bad = [
+            "",                 // empty
+            "   ",              // whitespace only
+            ".md",              // empty stem
+            "AGENTS.txt",       // wrong extension
+            "AGENTS",           // no extension
+            "a/b.md",           // forward separator
+            "a\\b.md",          // backslash separator
+            "..\\x.md",         // traversal + separator
+            "../x.md",          // traversal
+            "a..md",            // contains ..
+            "C:x.md",           // drive prefix (colon)
+            "AGENTS.md:evil",   // NTFS Alternate Data Stream (colon)
+            "AGENTS.md ",       // trailing space
+            "AGENTS.md.",       // trailing dot
+            "AGENTS .md",       // space immediately before extension
+            "a\nb.md",          // control char
+            "CON.md",           // reserved device
+            "con.md",           // reserved device (case-insensitive)
+            "PRN.md",
+            "aux.md",
+            "NUL.md",
+            "nul.md",
+            "COM1.md",
+            "com9.md",
+            "LPT1.md",
+            "lpt9.md",
+            "CON.foo.md", // device name resolved by the segment before the first dot
+            "nul.x.md",   // device name (case-insensitive) with extra dot segment
+            "last_ac_context.md", // G9 internal sentinel
+            "LAST_AC_CONTEXT.md", // G9 (case-insensitive)
+        ];
+        for name in bad {
+            assert!(!is_safe_instructions_filename(name), "should reject {name:?}");
+        }
+        // Length cap (> 128 chars).
+        let long = format!("{}.md", "a".repeat(130));
+        assert!(
+            !is_safe_instructions_filename(&long),
+            "should reject an over-long name"
+        );
     }
 }

--- a/src-tauri/src/config/coding_agent_profiles.rs
+++ b/src-tauri/src/config/coding_agent_profiles.rs
@@ -756,6 +756,7 @@ mod tests {
             exclude_global_claude_md: false,
             envs: Vec::new(),
             isolated_home: false,
+            instructions_filename: None,
         }];
         settings
     }

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -82,7 +82,10 @@ pub enum ManagedContextTarget {
 }
 
 impl ManagedContextTarget {
-    fn filename(self) -> &'static str {
+    /// `pub` since #529: the launch-time resolver in `agent_command.rs` and the
+    /// detection fallback in `commands/session.rs` map a detected target to its
+    /// filename.
+    pub fn filename(self) -> &'static str {
         match self {
             Self::Claude => "CLAUDE.md",
             Self::Gemini => "GEMINI.md",
@@ -1621,11 +1624,23 @@ fn resolve_session_context_content(
 }
 
 /// Delete stale agent-specific context files from a replica cwd and rewrite the
-/// current resolved context into the single provider-specific filename required
-/// by the coding agent being launched.
-pub fn materialize_agent_context_file(
+/// current resolved context into the single configured filename required by the
+/// coding agent being launched. `extra_managed_filenames` are additional names
+/// to clean up (the union of every configured agent's resolved filename), so
+/// switching a replica between agents removes the previous file before writing
+/// the new one. Returns `Ok(None)` when `cwd` is not an AC-managed agent root.
+///
+/// G1 (symlink/junction-safe): cleanup uses `symlink_metadata` (not `exists`)
+/// so a link/reparse point is detected and the link ENTRY removed, never its
+/// target; and the writer refuses to write THROUGH a surviving link. #529
+/// broadens the cleanup/write set from 3 fixed names to N configured + custom
+/// names, which is why this writer is hardened against a stray link at one of
+/// those names (an arbitrary-overwrite primitive, and a junction would brick
+/// every launch via remove_file -> Err -> rollback).
+pub fn materialize_agent_context_file_with_filename(
     cwd: &str,
-    target: ManagedContextTarget,
+    target_filename: &str,
+    extra_managed_filenames: &[String],
     is_coordinator: bool,
 ) -> Result<Option<String>, String> {
     let content = match resolve_session_context_content(cwd, is_coordinator)? {
@@ -1633,10 +1648,64 @@ pub fn materialize_agent_context_file(
         None => return Ok(None),
     };
 
+    // String-level guard (path escape): never write outside the root, even if a
+    // direct `pub` caller bypassed settings validation. The on-disk link checks
+    // below guard against state no string validation can detect.
+    if target_filename.contains('/') || target_filename.contains('\\') {
+        return Err(format!(
+            "Refusing to write context to a path with separators: {}",
+            target_filename
+        ));
+    }
+
     let cwd_path = std::path::Path::new(cwd);
-    for filename in MANAGED_CONTEXT_FILENAMES {
+
+    // Cleanup set: built-ins ∪ all configured filenames ∪ target, deduped so the
+    // target (usually already present via managed_instructions_filenames) is not
+    // stat'd twice.
+    let mut cleanup: Vec<&str> = MANAGED_CONTEXT_FILENAMES.to_vec();
+    for f in extra_managed_filenames {
+        if !cleanup.contains(&f.as_str()) {
+            cleanup.push(f.as_str());
+        }
+    }
+    if !cleanup.contains(&target_filename) {
+        cleanup.push(target_filename);
+    }
+
+    for filename in cleanup {
         let path = cwd_path.join(filename);
-        if path.exists() {
+        let meta = match std::fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                return Err(format!(
+                    "Failed to stat context file {}: {}",
+                    path.display(),
+                    e
+                ))
+            }
+        };
+        if is_link_or_reparse(&meta) {
+            // Remove the link/junction ENTRY itself (never its target): try file
+            // (file symlink) first, then dir (dir symlink / junction).
+            std::fs::remove_file(&path)
+                .or_else(|_| std::fs::remove_dir(&path))
+                .map_err(|e| {
+                    format!(
+                        "Failed to remove link at context path {}: {}",
+                        path.display(),
+                        e
+                    )
+                })?;
+        } else if meta.is_dir() {
+            // A real directory named like a managed file is a genuine problem;
+            // refuse rather than delete a directory tree.
+            return Err(format!(
+                "Refusing to launch: managed context path {} is a real directory, not a file",
+                path.display()
+            ));
+        } else {
             std::fs::remove_file(&path).map_err(|e| {
                 format!(
                     "Failed to remove stale context file {}: {}",
@@ -1647,7 +1716,17 @@ pub fn materialize_agent_context_file(
         }
     }
 
-    let target_path = cwd_path.join(target.filename());
+    let target_path = cwd_path.join(target_filename);
+    // Defensive: the target is always in `cleanup`, so a surviving link here is
+    // unexpected; never write THROUGH one (belt-and-suspenders for direct callers).
+    if let Ok(meta) = std::fs::symlink_metadata(&target_path) {
+        if is_link_or_reparse(&meta) {
+            return Err(format!(
+                "Refusing to write context through a link at {}",
+                target_path.display()
+            ));
+        }
+    }
     std::fs::write(&target_path, &content)
         .map_err(|e| format!("Failed to write {}: {}", target_path.display(), e))?;
 
@@ -1658,6 +1737,37 @@ pub fn materialize_agent_context_file(
     );
 
     Ok(Some(target_path.to_string_lossy().to_string()))
+}
+
+/// True iff `meta` is a symlink or (Windows) any reparse point (junction).
+/// Local copy of the gate at `cli/agency_templates.rs:867-880`; kept private to
+/// this module to avoid widening another module's API (the codebase already
+/// inlines this same check in `claude_settings.rs` and `coding_agent_profiles.rs`;
+/// do NOT refactor those into one helper here).
+fn is_link_or_reparse(meta: &std::fs::Metadata) -> bool {
+    if meta.file_type().is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return true;
+        }
+    }
+    false
+}
+
+/// Enum-based entry point preserved as a thin wrapper so the existing test call
+/// sites (`materialize_agent_context_file(cwd, ManagedContextTarget::X, bool)`)
+/// keep compiling unchanged.
+pub fn materialize_agent_context_file(
+    cwd: &str,
+    target: ManagedContextTarget,
+    is_coordinator: bool,
+) -> Result<Option<String>, String> {
+    materialize_agent_context_file_with_filename(cwd, target.filename(), &[], is_coordinator)
 }
 
 /// Simple deterministic hash for a string (for temp file naming).
@@ -4118,6 +4228,188 @@ mod tests {
 
         assert!(err.contains("not valid UTF-8"));
         assert!(err.contains(GLOBAL_CONTEXT_TEMPLATE_FILENAME));
+    }
+
+    // #529 - filename-based writer (materialize_agent_context_file_with_filename).
+
+    #[test]
+    fn materialize_with_filename_writes_custom_and_cleans_builtins_and_extra() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        // Pre-existing managed files that must be removed before the new write.
+        std::fs::write(matrix_root.join("CLAUDE.md"), "stale claude").expect("write CLAUDE.md");
+        std::fs::write(matrix_root.join("AGENTS.md"), "stale agents").expect("write AGENTS.md");
+        std::fs::write(matrix_root.join("MyTeam.md"), "stale custom").expect("write MyTeam.md");
+
+        let materialized = materialize_agent_context_file_with_filename(
+            &path_string(&matrix_root),
+            "Squad.md",
+            &["MyTeam.md".to_string()],
+            false,
+        )
+        .expect("materialize")
+        .expect("context path");
+
+        assert!(materialized.ends_with("Squad.md"));
+        assert!(matrix_root.join("Squad.md").is_file());
+        assert!(!matrix_root.join("CLAUDE.md").exists());
+        assert!(!matrix_root.join("AGENTS.md").exists());
+        assert!(
+            !matrix_root.join("MyTeam.md").exists(),
+            "a configured custom name in the cleanup set must be removed"
+        );
+        let content = std::fs::read_to_string(matrix_root.join("Squad.md")).expect("read Squad.md");
+        assert!(!content.is_empty());
+        assert_ne!(content, "stale custom");
+    }
+
+    #[test]
+    fn materialize_with_filename_orphans_unlisted_custom_name() {
+        // R1.6 documented limitation: a custom name NOT in the cleanup set is not
+        // removed (a *.md sweep would be too aggressive). This locks the behavior.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        std::fs::write(matrix_root.join("MyTeam.md"), "stale custom").expect("write MyTeam.md");
+
+        materialize_agent_context_file_with_filename(
+            &path_string(&matrix_root),
+            "Squad.md",
+            &[], // MyTeam.md intentionally not listed -> it survives.
+            false,
+        )
+        .expect("materialize")
+        .expect("context path");
+
+        assert!(
+            matrix_root.join("MyTeam.md").is_file(),
+            "an unlisted custom name is intentionally orphaned, not swept"
+        );
+        assert_eq!(
+            std::fs::read_to_string(matrix_root.join("MyTeam.md")).expect("read MyTeam.md"),
+            "stale custom"
+        );
+        assert!(matrix_root.join("Squad.md").is_file());
+    }
+
+    #[test]
+    fn materialize_with_filename_rejects_path_separators() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+
+        let err = materialize_agent_context_file_with_filename(
+            &path_string(&matrix_root),
+            "sub/evil.md",
+            &[],
+            false,
+        )
+        .expect_err("a filename with separators must be rejected by the writer");
+        assert!(err.contains("separators"), "{err}");
+    }
+
+    #[test]
+    fn materialize_with_filename_refuses_to_write_through_file_symlink() {
+        // G1: AGENTS.md is a FILE symlink to an out-of-root target. The writer
+        // must remove the link entry and write a fresh regular file, never write
+        // THROUGH the link to its target.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        let outside = temp.path().join("outside-secret.txt");
+        std::fs::write(&outside, "SENTINEL").expect("write outside target");
+        let link = matrix_root.join("AGENTS.md");
+
+        #[cfg(unix)]
+        {
+            if std::os::unix::fs::symlink(&outside, &link).is_err() {
+                return;
+            }
+        }
+        #[cfg(windows)]
+        {
+            if std::os::windows::fs::symlink_file(&outside, &link).is_err() {
+                return; // symlink creation can need privilege; skip where unsupported.
+            }
+        }
+
+        let materialized = materialize_agent_context_file_with_filename(
+            &path_string(&matrix_root),
+            "AGENTS.md",
+            &[],
+            false,
+        )
+        .expect("materialize should succeed by replacing the link")
+        .expect("context path");
+
+        assert_eq!(
+            std::fs::read_to_string(&outside).expect("read outside target"),
+            "SENTINEL",
+            "the writer must NOT write through the symlink to its out-of-root target"
+        );
+        let meta = std::fs::symlink_metadata(&link).expect("stat AGENTS.md");
+        assert!(
+            !is_link_or_reparse(&meta),
+            "AGENTS.md must be a regular file after materialize, not a link"
+        );
+        let content = std::fs::read_to_string(&materialized).expect("read materialized");
+        assert_ne!(content, "SENTINEL");
+        assert!(!content.is_empty());
+    }
+
+    #[test]
+    fn materialize_with_filename_replaces_dir_link_without_touching_target() {
+        // G1: AGENTS.md is a DIRECTORY symlink/junction (a reparse point). The
+        // writer must remove the link entry (not the target tree) and write a
+        // regular file. Pre-#529 this bricked the launch (remove_file on a dir
+        // failed -> Err -> "context files missing" + rollback).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        let outside_dir = temp.path().join("outside-dir");
+        std::fs::create_dir_all(&outside_dir).expect("create outside dir");
+        std::fs::write(outside_dir.join("keep.txt"), "KEEP").expect("write inside outside dir");
+        let link = matrix_root.join("AGENTS.md");
+
+        #[cfg(unix)]
+        {
+            if std::os::unix::fs::symlink(&outside_dir, &link).is_err() {
+                return;
+            }
+        }
+        #[cfg(windows)]
+        {
+            if std::os::windows::fs::symlink_dir(&outside_dir, &link).is_err() {
+                return; // dir symlink/junction creation can need privilege.
+            }
+        }
+
+        materialize_agent_context_file_with_filename(
+            &path_string(&matrix_root),
+            "AGENTS.md",
+            &[],
+            false,
+        )
+        .expect("materialize should replace the dir link, not brick the launch")
+        .expect("context path");
+
+        assert!(
+            outside_dir.join("keep.txt").is_file(),
+            "the out-of-root directory and contents must survive (link entry removed, not target)"
+        );
+        assert_eq!(
+            std::fs::read_to_string(outside_dir.join("keep.txt")).expect("read keep"),
+            "KEEP"
+        );
+        let meta = std::fs::symlink_metadata(&link).expect("stat AGENTS.md");
+        assert!(!is_link_or_reparse(&meta));
+        assert!(meta.is_file());
     }
 
     #[test]

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -26,6 +26,12 @@ pub struct AgentConfig {
     /// When true for Codex, AC provides an isolated CODEX_HOME at spawn time.
     #[serde(default, alias = "isolateCodexHome")]
     pub isolated_home: bool,
+    /// #529 - filename AC writes into the agent root at launch (content = AC
+    /// context + Role.md). `None`/empty falls back to the command-derived default
+    /// (Claude -> CLAUDE.md, Gemini -> GEMINI.md, else AGENTS.md). Serialized as
+    /// `instructionsFilename`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions_filename: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1069,6 +1075,19 @@ pub fn validate_agent_commands(settings: &AppSettings) -> Result<(), String> {
             &agent.envs,
             &format!("Agent \"{}\" env settings", agent.label),
         )?;
+
+        // #529 (G8): reject a bad instructions filename here so the user gets a
+        // clear IPC error at save, not a silent fallback at launch. Empty/absent
+        // is allowed (means "use the command-derived default").
+        if let Some(f) = agent.instructions_filename.as_deref() {
+            let f = f.trim();
+            if !f.is_empty() && !crate::config::agent_command::is_safe_instructions_filename(f) {
+                return Err(format!(
+                    "Agent \"{}\" instructions filename is invalid: must be a bare .md filename with no path separators",
+                    agent.label
+                ));
+            }
+        }
     }
 
     for (agent_id, cells) in &settings.coding_agent_profiles.profiles_by_agent {
@@ -1478,6 +1497,7 @@ mod tests {
                     exclude_global_claude_md: false,
                     envs: Vec::new(),
                     isolated_home: false,
+                    instructions_filename: None,
                 })
                 .collect(),
             ..AppSettings::default()
@@ -1793,6 +1813,64 @@ mod tests {
         let settings =
             settings_with_agents(&[("Codex", "codex -c instruction=\"resume later\" --search")]);
         assert!(validate_agent_commands(&settings).is_ok());
+    }
+
+    // #529 - instructions filename validation surfaces at settings save (G8/Q6).
+
+    #[test]
+    fn validate_agent_commands_rejects_unsafe_instructions_filename() {
+        for bad in [
+            "../x.md",
+            "a/b.md",
+            "a\\b.md",
+            "C:x.md",
+            "CON.md",
+            "last_ac_context.md",
+        ] {
+            let mut settings = settings_with_agents(&[("Codex", "codex")]);
+            settings.agents[0].instructions_filename = Some(bad.to_string());
+            let err = validate_agent_commands(&settings).unwrap_err();
+            assert!(
+                err.contains("instructions filename is invalid"),
+                "{bad:?} should be rejected, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_agent_commands_allows_safe_or_empty_instructions_filename() {
+        // Valid names plus empty/whitespace (which means "use the default").
+        for ok in ["AGENTS.md", "CLAUDE.md", "MyTeam.md", "  ", ""] {
+            let mut settings = settings_with_agents(&[("Codex", "codex")]);
+            settings.agents[0].instructions_filename = Some(ok.to_string());
+            assert!(
+                validate_agent_commands(&settings).is_ok(),
+                "{ok:?} should be allowed"
+            );
+        }
+        // Absent (None) is allowed too.
+        let settings = settings_with_agents(&[("Codex", "codex")]);
+        assert!(validate_agent_commands(&settings).is_ok());
+    }
+
+    #[test]
+    fn instructions_filename_serde_round_trips_and_omits_when_absent() {
+        // Absent -> omitted (skip_serializing_if) and deserializes back to None.
+        let mut settings = settings_with_agents(&[("Codex", "codex")]);
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(!json.contains("instructionsFilename"));
+        let back: AppSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.agents[0].instructions_filename, None);
+
+        // Present -> serialized under the camelCase key and round-trips.
+        settings.agents[0].instructions_filename = Some("Squad.md".to_string());
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("\"instructionsFilename\":\"Squad.md\""));
+        let back: AppSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.agents[0].instructions_filename.as_deref(),
+            Some("Squad.md")
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1874,6 +1874,7 @@ mod tests {
                 exclude_global_claude_md: false,
                 envs: Vec::new(),
                 isolated_home: false,
+                instructions_filename: None,
             }],
             ..AppSettings::default()
         }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -3402,6 +3402,7 @@ mod tests {
             exclude_global_claude_md: false,
             envs: Vec::new(),
             isolated_home: false,
+            instructions_filename: None,
         }
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {

--- a/src/shared/agent-presets.test.ts
+++ b/src/shared/agent-presets.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_PRESETS, AGENT_PRESET_MAP } from "./agent-presets";
+
+describe("agent presets (#529)", () => {
+  it("carries the default instructions filename on each built-in preset", () => {
+    expect(AGENT_PRESET_MAP.claude.instructionsFilename).toBe("CLAUDE.md");
+    expect(AGENT_PRESET_MAP.codex.instructionsFilename).toBe("AGENTS.md");
+    expect(AGENT_PRESET_MAP.gemini.instructionsFilename).toBe("GEMINI.md");
+  });
+
+  it("ships an OpenCode preset with the bare `opencode` command and AGENTS.md", () => {
+    const opencode = AGENT_PRESETS.find((p) => p.key === "opencode");
+    expect(opencode).toBeTruthy();
+    expect(opencode?.label).toBe("OpenCode");
+    expect(opencode?.config.command).toBe("opencode");
+    expect(opencode?.config.instructionsFilename).toBe("AGENTS.md");
+    // Reachable via the quick-add lookup the Config Screen buttons use.
+    expect(AGENT_PRESET_MAP.opencode?.command).toBe("opencode");
+    expect(AGENT_PRESET_MAP.opencode?.instructionsFilename).toBe("AGENTS.md");
+  });
+});

--- a/src/shared/agent-presets.ts
+++ b/src/shared/agent-presets.ts
@@ -22,6 +22,7 @@ export const AGENT_PRESETS: AgentPreset[] = [
       excludeGlobalClaudeMd: true,
       envs: [],
       isolatedHome: false,
+      instructionsFilename: "CLAUDE.md",
     },
   },
   {
@@ -37,6 +38,7 @@ export const AGENT_PRESETS: AgentPreset[] = [
       excludeGlobalClaudeMd: false,
       envs: [],
       isolatedHome: false,
+      instructionsFilename: "AGENTS.md",
     },
   },
   {
@@ -52,6 +54,23 @@ export const AGENT_PRESETS: AgentPreset[] = [
       excludeGlobalClaudeMd: false,
       envs: [],
       isolatedHome: false,
+      instructionsFilename: "GEMINI.md",
+    },
+  },
+  {
+    key: "opencode",
+    label: "OpenCode",
+    description: "Open-source terminal coding agent by SST",
+    color: "#64748b",
+    config: {
+      label: "OpenCode",
+      command: "opencode",
+      color: "#64748b",
+      gitPullBefore: false,
+      excludeGlobalClaudeMd: false,
+      envs: [],
+      isolatedHome: false,
+      instructionsFilename: "AGENTS.md",
     },
   },
 ];

--- a/src/shared/profile-utils.test.ts
+++ b/src/shared/profile-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentConfig, CodingAgentProfilesConfig } from "./types";
 import {
   commandExecutableBasename,
+  effectiveEnvProjection,
   executableBasename,
   expandAcRootPreview,
   hasAcRootPlaceholder,
@@ -11,6 +12,7 @@ import {
   parseArgvText,
   profileCellCommandText,
   profileDisplayLabel,
+  profileEnvOrigin,
   resolveProfilePreview,
   sessionProfileBadge,
   stringifyArgv,
@@ -174,5 +176,49 @@ describe("profile utils", () => {
         profileFallbackApplied: false,
       }),
     ).toBe("C");
+  });
+});
+
+describe("profileEnvOrigin (#526/#527 env origin badges)", () => {
+  it("classifies an AgentsCommander-managed home path as system", () => {
+    expect(profileEnvOrigin("CODEX_HOME", "%AC_ROOT%\\.codex\\agents\\codex")).toBe("system");
+    expect(profileEnvOrigin("CLAUDE_CONFIG_DIR", "%AC_ROOT%/.claude")).toBe("system");
+  });
+
+  it("classifies a literal absolute path on a managed home key as accepted", () => {
+    expect(profileEnvOrigin("CODEX_HOME", "D:\\manual\\codex")).toBe("accepted");
+    expect(profileEnvOrigin("CODEX_HOME", "/opt/codex")).toBe("accepted");
+  });
+
+  it("classifies plain profile values (and non-home keys) as profile", () => {
+    expect(profileEnvOrigin("OPENAI_ORG", "ac-prod")).toBe("profile");
+    expect(profileEnvOrigin("AC_TRACE", "profile-c")).toBe("profile");
+    // A non-home key keeps the profile origin even with an absolute-looking value.
+    expect(profileEnvOrigin("SOME_PATH", "C:\\x")).toBe("profile");
+  });
+});
+
+describe("effectiveEnvProjection (#527 Env / EFFECTIVE)", () => {
+  it("merges agent env (system/accepted) with profile env (profile), profile wins", () => {
+    const merged = effectiveEnvProjection(
+      [
+        { key: "CODEX_HOME", value: "%AC_ROOT%\\.codex", source: "system", enabled: true },
+        { key: "OPENAI_API_KEY", value: "redacted", source: "user", enabled: true },
+        { key: "DISABLED", value: "x", source: "user", enabled: false },
+      ],
+      { OPENAI_ORG: "ac-prod", OPENAI_API_KEY: "from-profile" },
+      "C:\\root",
+    );
+    // Disabled agent rows are dropped; profile overrides the agent value on key collision.
+    expect(merged).toEqual([
+      { key: "CODEX_HOME", value: "C:\\root\\.codex", origin: "system" },
+      { key: "OPENAI_API_KEY", value: "from-profile", origin: "profile" },
+      { key: "OPENAI_ORG", value: "ac-prod", origin: "profile" },
+    ]);
+  });
+
+  it("returns an empty list when nothing is configured", () => {
+    expect(effectiveEnvProjection([], {}, null)).toEqual([]);
+    expect(effectiveEnvProjection(undefined, undefined, undefined)).toEqual([]);
   });
 });

--- a/src/shared/profile-utils.test.ts
+++ b/src/shared/profile-utils.test.ts
@@ -10,7 +10,9 @@ import {
   isCodexAgent,
   isWgReplicaPath,
   parseArgvText,
+  profileBadgeKind,
   profileCellCommandText,
+  profileConfiguredElsewhere,
   profileDisplayLabel,
   profileEnvOrigin,
   resolveProfilePreview,
@@ -220,5 +222,60 @@ describe("effectiveEnvProjection (#527 Env / EFFECTIVE)", () => {
   it("returns an empty list when nothing is configured", () => {
     expect(effectiveEnvProjection([], {}, null)).toEqual([]);
     expect(effectiveEnvProjection(undefined, undefined, undefined)).toEqual([]);
+  });
+});
+
+describe("profileBadgeKind (#526/#527 shared Config/Selection taxonomy)", () => {
+  // profiles(): codex configures A (empty cmd) + C; B is unconfigured everywhere.
+  it("returns MATCH for the A baseline", () => {
+    expect(profileBadgeKind(profiles(), "codex", "A")).toBe("match");
+  });
+
+  it("returns CONFIGURED for a non-A slot with its own enabled cell", () => {
+    // codex C has its own enabled cell → direct match on a non-baseline slot.
+    expect(profileBadgeKind(profiles(), "codex", "C")).toBe("configured");
+  });
+
+  it("returns FALLBACK for a non-A slot that resolves through a lower letter", () => {
+    // codex B has no cell and is not configured on any other agent → falls back to A.
+    expect(profileBadgeKind(profiles(), "codex", "B")).toBe("fallback");
+  });
+
+  it("returns MISSING for a slot configured on another agent but absent here", () => {
+    const config: CodingAgentProfilesConfig = {
+      schemaVersion: 2,
+      profileSlots: { A: { label: "" }, B: { label: "fast" } },
+      defaultProfileByAgent: {},
+      profilesByAgent: {
+        codex: { A: { enabled: true, command: "codex", env: {}, notes: "" } },
+        claude: {
+          A: { enabled: true, command: "claude", env: {}, notes: "" },
+          B: { enabled: true, command: "claude --model opus", env: {}, notes: "" },
+        },
+      },
+    };
+    // B exists on claude but not on codex → codex B is MISSING (red), not fallback.
+    expect(profileBadgeKind(config, "codex", "B")).toBe("missing");
+    // And it IS configured elsewhere from codex's perspective.
+    expect(profileConfiguredElsewhere(config, "codex", "B")).toBe(true);
+    // From claude's perspective, B is its own cell → CONFIGURED.
+    expect(profileBadgeKind(config, "claude", "B")).toBe("configured");
+    expect(profileConfiguredElsewhere(config, "claude", "B")).toBe(false);
+  });
+
+  it("treats a disabled non-A cell as not configured (falls back, not configured)", () => {
+    const config: CodingAgentProfilesConfig = {
+      schemaVersion: 2,
+      profileSlots: { A: { label: "" }, B: { label: "fast" } },
+      defaultProfileByAgent: {},
+      profilesByAgent: {
+        codex: {
+          A: { enabled: true, command: "codex", env: {}, notes: "" },
+          B: { enabled: false, command: "codex --profile fast", env: {}, notes: "" },
+        },
+      },
+    };
+    // A disabled cell is not a live config → B resolves back to A.
+    expect(profileBadgeKind(config, "codex", "B")).toBe("fallback");
   });
 });

--- a/src/shared/profile-utils.test.ts
+++ b/src/shared/profile-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentConfig, CodingAgentProfilesConfig } from "./types";
 import {
   commandExecutableBasename,
+  defaultInstructionsFilename,
   effectiveEnvProjection,
   executableBasename,
   expandAcRootPreview,
@@ -161,6 +162,29 @@ describe("profile utils", () => {
     expect(isAcAgentPath("C:/repo/.ac/_agent_architect")).toBe(true);
     expect(isAcAgentPath("C:/repo/.ac/wg-7-dev-team/__agent_dev-webpage-ui")).toBe(true);
     expect(isAcAgentPath("C:/repo/worktree")).toBe(false);
+  });
+
+  it("derives the default instructions filename with parity to the Rust resolver (#529, G2)", () => {
+    // Claude family → CLAUDE.md, including wrapped/suffixed/absolute shapes and
+    // — critically — commands carrying trailing flags (the all-token scan, not
+    // first/last token, is what gives parity with the Rust detector here).
+    expect(defaultInstructionsFilename("claude")).toBe("CLAUDE.md");
+    expect(defaultInstructionsFilename("claude --model sonnet")).toBe("CLAUDE.md");
+    expect(defaultInstructionsFilename("cmd.exe /c claude")).toBe("CLAUDE.md");
+    expect(defaultInstructionsFilename("cmd.exe /c claude --continue")).toBe("CLAUDE.md");
+    expect(defaultInstructionsFilename("claude-mb")).toBe("CLAUDE.md");
+    expect(defaultInstructionsFilename("C:\\tools\\claude.exe")).toBe("CLAUDE.md");
+    // Gemini → GEMINI.md, with and without flags.
+    expect(defaultInstructionsFilename("gemini")).toBe("GEMINI.md");
+    expect(defaultInstructionsFilename("gemini --yolo")).toBe("GEMINI.md");
+    // Codex, OpenCode, custom, and empty all fall to AGENTS.md.
+    expect(defaultInstructionsFilename("codex")).toBe("AGENTS.md");
+    expect(defaultInstructionsFilename("codex --sandbox workspace-write")).toBe("AGENTS.md");
+    expect(defaultInstructionsFilename("opencode")).toBe("AGENTS.md");
+    expect(defaultInstructionsFilename("my-agent-cli --flag")).toBe("AGENTS.md");
+    expect(defaultInstructionsFilename("")).toBe("AGENTS.md");
+    // Codex precedence over a later gemini token (mirrors Rust claude>codex>gemini).
+    expect(defaultInstructionsFilename("codex --base gemini")).toBe("AGENTS.md");
   });
 
   it("formats session profile badges with fallback when applied", () => {

--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -249,6 +249,77 @@ export function hasEnabledEnvKey(rows: CodingAgentEnv[], key: string): boolean {
   return rows.some((row) => row.enabled && envKeyCompare(row.key) === target);
 }
 
+/** Origin badge for an env value shown in the Config/Selection projections (#526/#527).
+ *  - `system`   — AgentsCommander-managed home path (%AC_ROOT% placeholder on a known home key)
+ *  - `accepted` — a user literal absolute path kept as-is (nothing to expand)
+ *  - `profile`  — a value defined by the profile cell (the common case) */
+export type EnvOrigin = "system" | "profile" | "accepted";
+
+/** Env keys AgentsCommander manages per replica (isolated home directories). */
+const MANAGED_HOME_ENV_KEYS = new Set([
+  "CODEX_HOME",
+  "CLAUDE_CONFIG_DIR",
+  "CLAUDE_HOME",
+  "GEMINI_HOME",
+]);
+
+function isLiteralAbsolutePath(value: string): boolean {
+  const v = value.trim();
+  // Windows drive (C:\ or C:/), POSIX root, or UNC share.
+  return /^[A-Za-z]:[\\/]/.test(v) || v.startsWith("/") || v.startsWith("\\\\");
+}
+
+/** Classify a profile-cell env value's origin for its badge. A managed home key
+ *  using %AC_ROOT% is AC-managed (`system`); a managed home key with a literal
+ *  absolute path is a user-accepted override (`accepted`); everything else is a
+ *  plain profile-defined value (`profile`). */
+export function profileEnvOrigin(key: string, value: string): EnvOrigin {
+  if (MANAGED_HOME_ENV_KEYS.has(envKeyCompare(key))) {
+    if (hasAcRootPlaceholder(value)) return "system";
+    if (isLiteralAbsolutePath(value)) return "accepted";
+  }
+  return "profile";
+}
+
+export interface EffectiveEnvEntry {
+  key: string;
+  value: string;
+  origin: EnvOrigin;
+}
+
+/** Merge a coding agent's enabled env rows with the selected profile cell's env
+ *  into the effective env that is actually set at launch (#527 Env / EFFECTIVE).
+ *  Agent rows form the base (source `system` → system badge, user → accepted);
+ *  profile env overrides on key collision and carries the `profile` origin.
+ *  `%AC_ROOT%` is expanded for display when a replica root is known. */
+export function effectiveEnvProjection(
+  agentEnvs: CodingAgentEnv[] | undefined,
+  profileEnv: Record<string, string> | undefined,
+  acRoot: string | null | undefined,
+): EffectiveEnvEntry[] {
+  const byKey = new Map<string, EffectiveEnvEntry>();
+  for (const row of agentEnvs ?? []) {
+    if (!row.enabled) continue;
+    const key = row.key.trim();
+    if (!key) continue;
+    byKey.set(envKeyCompare(key), {
+      key,
+      value: expandAcRootPreview(row.value, acRoot),
+      origin: row.source === "system" ? "system" : "accepted",
+    });
+  }
+  for (const [rawKey, rawValue] of Object.entries(profileEnv ?? {})) {
+    const key = rawKey.trim();
+    if (!key) continue;
+    byKey.set(envKeyCompare(key), {
+      key,
+      value: expandAcRootPreview(rawValue, acRoot),
+      origin: profileEnvOrigin(key, rawValue),
+    });
+  }
+  return [...byKey.values()].sort((a, b) => a.key.localeCompare(b.key));
+}
+
 export function executableTokenBasename(token: string): string {
   const normalized = token.replace(/\\/g, "/");
   const leaf = normalized.split("/").pop() || normalized;

--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -392,6 +392,36 @@ export function isCodexAgent(agent: AgentConfig): boolean {
   return agent.id.toLowerCase() === "codex" || executableBasename(agent.command) === "codex";
 }
 
+/**
+ * #529 — display-only default instructions filename derived from a coding
+ * agent's launch command. Used solely as the Config Screen placeholder so a
+ * blank field shows the default the backend will write at launch.
+ *
+ * Best-effort parity (G2) with the Rust resolver
+ * (`default_instructions_filename_for_command` → `CodingAgentKind::detect`):
+ * reduce EVERY whitespace token to its lowercased file-stem basename and match
+ * by prefix in precedence **claude > codex > gemini**, scanning all tokens —
+ * exactly what the Rust detector does. Scanning every token (not just the
+ * first/last) is what gives parity on the common shapes including trailing
+ * flags: `claude`, `claude --model sonnet`, `cmd.exe /c claude`, `claude-mb`,
+ * an absolute-path `claude.exe`, `codex --yolo`, `opencode`, custom. The codex
+ * branch returns `AGENTS.md` (same as the default) but is kept explicit so the
+ * precedence is faithful — e.g. `codex ... gemini` resolves to `AGENTS.md`, not
+ * `GEMINI.md`, matching Rust.
+ *
+ * This deliberately does NOT reproduce the full Rust shell-quote tokenizer, so
+ * an exotic quoted path containing spaces may still diverge — acceptable for a
+ * cosmetic placeholder, since the backend resolves the value authoritatively at
+ * launch.
+ */
+export function defaultInstructionsFilename(command: string): string {
+  const stems = command.trim().split(/\s+/).filter(Boolean).map(executableTokenBasename);
+  if (stems.some((s) => s.startsWith("claude"))) return "CLAUDE.md";
+  if (stems.some((s) => s.startsWith("codex"))) return "AGENTS.md";
+  if (stems.some((s) => s.startsWith("gemini"))) return "GEMINI.md";
+  return "AGENTS.md";
+}
+
 export function agentNameFromPathOrSession(
   path: string | null | undefined,
   sessionName: string,

--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -135,6 +135,53 @@ export function resolveProfilePreview(
   };
 }
 
+/** The data-driven profile-cell badge states. `invalid` (a live command parse
+ *  error) is UI-local and layered on top by the caller; the rest are resolved
+ *  from the persisted profile data. (#526/#527) */
+export type ProfileBadgeKind = "match" | "configured" | "fallback" | "missing" | "invalid";
+
+/** True when `letter` has an enabled cell on some coding agent OTHER than
+ *  `agentId`. Distinguishes a MISSING slot (configured elsewhere, absent here)
+ *  from a plain positional fallback. Excludes the agent itself. (#526/#527) */
+export function profileConfiguredElsewhere(
+  profiles: CodingAgentProfilesConfig,
+  agentId: string,
+  letter: string,
+): boolean {
+  return Object.entries(profiles.profilesByAgent).some(
+    ([id, cells]) => id !== agentId && Boolean(cells[letter]?.enabled),
+  );
+}
+
+/**
+ * Profile-cell badge taxonomy shared 1:1 by the Config rails (SettingsModal) and
+ * the Selection profile cards (AgentPickerModal), so both screens read the same
+ * state for a given (agent, letter). Mirrors the B2C1a prototype:
+ *   - A / baseline               → "match"      (always configured)
+ *   - non-A with its own cell    → "configured" (direct match on a non-baseline slot)
+ *   - non-A, absent, but the slot is configured on another agent → "missing"
+ *   - non-A, absent, resolves through a lower letter             → "fallback"
+ * The `invalid` state is not produced here — a live parse error is decided by the
+ * caller and takes precedence.
+ */
+export function profileBadgeKind(
+  profiles: CodingAgentProfilesConfig,
+  agentId: string,
+  letter: string,
+): Exclude<ProfileBadgeKind, "invalid"> {
+  const cell = profiles.profilesByAgent[agentId]?.[letter];
+  const configuredHere = letter === "A" || Boolean(cell?.enabled);
+  if (configuredHere) {
+    // A is the baseline (MATCH); a non-A slot with its own enabled cell is a
+    // direct match on a non-baseline slot (CONFIGURED).
+    return letter === "A" ? "match" : "configured";
+  }
+  if (profileConfiguredElsewhere(profiles, agentId, letter)) return "missing";
+  return resolveProfilePreview(profiles, agentId, letter).fallbackApplied
+    ? "fallback"
+    : "missing";
+}
+
 export function parseArgvText(input: string): ArgvParseResult {
   const argv: string[] = [];
   let current = "";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -102,6 +102,13 @@ export interface AgentConfig {
    * providers, only Codex consumes this flag. Serialized as `isolatedHome`.
    */
   isolatedHome: boolean;
+  /**
+   * #529 — instructions filename written to the agent root at launch (content =
+   * AC context + Role.md). Empty/undefined falls back to the command-derived
+   * default (Claude → CLAUDE.md, Gemini → GEMINI.md, else AGENTS.md). The empty
+   * string is normalized to omitted before save, so it is never persisted.
+   */
+  instructionsFilename?: string;
 }
 
 /**

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -406,7 +406,8 @@ describe("AgentPickerModal", () => {
     await settle();
 
     expect(target("agentPicker.provider.claude").getAttribute("data-ac-state")).toBe("active");
-    expect(text("agentPicker.projected")).toContain("Selected coding agent: Claude Code");
+    // Effective Projection chosen-pair shows the selected coding agent + resolved command.
+    expect(text("agentPicker.projected")).toContain("Claude Code");
     expect(text("agentPicker.projected")).toContain("claude --dangerously-skip-permissions");
 
     dispose();
@@ -423,7 +424,8 @@ describe("AgentPickerModal", () => {
     expect(text("agentPicker.profile.C")).toContain("Fallback C->B");
     expect(text("agentPicker.fallback")).toContain("C-REVIEW is not configured");
     expect(text("agentPicker.fallback")).toContain("A remains the final fallback");
-    expect(text("agentPicker.projected")).toContain("C-REVIEW resolves to B-FAST via fallback");
+    // Effective Projection chosen-pair Resolution row reports the fallback hop.
+    expect(text("agentPicker.projected")).toContain("C-REVIEW → B-FAST (fallback)");
 
     dispose();
   });
@@ -747,7 +749,7 @@ describe("AgentPickerModal", () => {
     );
     await settle();
     expect(text("agentPicker.fallback")).not.toContain("old warning");
-    expect(text("agentPicker.projected")).toContain("Selected coding agent: Claude Code");
+    expect(text("agentPicker.projected")).toContain("Claude Code");
 
     dispose();
   });

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -753,4 +753,28 @@ describe("AgentPickerModal", () => {
 
     dispose();
   });
+
+  it("renders a per-card status pill (match / configured / fallback / MISSING)", async () => {
+    // Default fixture: codex configures A + B; claude configures A only.
+    const { dispose } = renderPicker({ agentPath: REPO_PATH, currentAgentId: "codex" });
+    await settle();
+
+    // Selected agent = codex. A baseline → MATCH; B has its own cell → CONFIGURED;
+    // C has no cell anywhere → resolves through B → FALLBACK.
+    expect(target("agentPicker.profile.A.pill").getAttribute("data-ac-state")).toBe("match");
+    expect(text("agentPicker.profile.A.pill")).toContain("MATCH");
+    expect(target("agentPicker.profile.B.pill").getAttribute("data-ac-state")).toBe("configured");
+    expect(text("agentPicker.profile.B.pill")).toContain("CONFIGURED");
+    expect(target("agentPicker.profile.C.pill").getAttribute("data-ac-state")).toBe("fallback");
+    expect(text("agentPicker.profile.C.pill")).toContain("FALLBACK");
+
+    // Switch to claude: B has no cell here but is configured on codex → MISSING.
+    target<HTMLButtonElement>("agentPicker.provider.claude").click();
+    await settle();
+    expect(target("agentPicker.profile.A.pill").getAttribute("data-ac-state")).toBe("match");
+    expect(target("agentPicker.profile.B.pill").getAttribute("data-ac-state")).toBe("missing");
+    expect(text("agentPicker.profile.B.pill")).toContain("MISSING");
+
+    dispose();
+  });
 });

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -19,6 +19,8 @@ import {
   isCodexAgent,
   isWgReplicaPath,
   normalizeProfileLetter,
+  profileBadgeKind,
+  type ProfileBadgeKind,
   profileCellCommandText,
   profileDisplayLabel,
   resolveProfilePreview,
@@ -53,6 +55,17 @@ const EMPTY_DISPLAY_CELL: ProfileCellConfig = {
   command: "",
   env: {},
   notes: "",
+};
+
+// #527: per-card status pill labels for the Selection profile cards. Same
+// taxonomy/colors as the Config rails (profileBadgeKind), so a given (agent,
+// letter) reads identically on both screens. `invalid` is Config-only (live
+// command edits), so it never surfaces here.
+const SELECTION_PILL_LABEL: Record<Exclude<ProfileBadgeKind, "invalid">, string> = {
+  match: "MATCH",
+  configured: "CONFIGURED",
+  fallback: "FALLBACK",
+  missing: "MISSING",
 };
 
 const AgentPickerModal: Component<{
@@ -590,6 +603,13 @@ const AgentPickerModal: Component<{
                             fallbackApplied: false,
                           };
                     const cell = () => enabledLaunchCellFor(selectedAgent(), preview().effectiveProfile);
+                    // #527: per-card status pill — shared taxonomy with the Config rails.
+                    const pillKind = (): Exclude<ProfileBadgeKind, "invalid"> => {
+                      const current = settings();
+                      const agent = selectedAgent();
+                      if (!current || !agent) return letter === "A" ? "match" : "fallback";
+                      return profileBadgeKind(current.codingAgentProfiles, agent.id, letter);
+                    };
                     return (
                       <button
                         type="button"
@@ -627,9 +647,19 @@ const AgentPickerModal: Component<{
                                 : `missing; launches ${profileLabel(preview().effectiveProfile)}`}
                             </span>
                           </span>
-                          <Show when={configuredDefault() === letter}>
-                            <span class="agent-profile-default-marker">Default</span>
-                          </Show>
+                          <span class="agent-profile-card-tags">
+                            <span
+                              class={`agent-profile-card-pill ${pillKind()}`}
+                              data-ac-role="status"
+                              data-ac-state={pillKind()}
+                              data-ac-testid={`agentPicker.profile.${letter}.pill`}
+                            >
+                              {SELECTION_PILL_LABEL[pillKind()]}
+                            </span>
+                            <Show when={configuredDefault() === letter}>
+                              <span class="agent-profile-default-marker">Default</span>
+                            </Show>
+                          </span>
                         </span>
                         <span class="agent-profile-param-list">
                           <span class="agent-profile-param">

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -12,6 +12,7 @@ import { SettingsAPI } from "../../shared/ipc";
 import { automationAttrs } from "../../shared/automation-hooks";
 import {
   agentNameFromPathOrSession,
+  effectiveEnvProjection,
   expandAcRootPreview,
   hasAcRootPlaceholder,
   isAcAgentPath,
@@ -183,18 +184,23 @@ const AgentPickerModal: Component<{
     const cmd = profileCellCommandText(projectedCell()) || selectedAgent()?.command || "";
     return expandAcRootPreview(cmd, acRoot());
   });
-  const formattedEnv = (env: Record<string, string>) => {
-    const enabled = Object.keys(env).sort((a, b) => a.localeCompare(b));
-    return enabled.length ? enabled.join(", ") : "none";
-  };
-  const formattedAgentEnv = (agent: AgentConfig | null) => {
-    const keys = (agent?.envs ?? [])
-      .filter((row) => row.enabled)
-      .map((row) => row.key.trim())
-      .filter(Boolean)
-      .sort((a, b) => a.localeCompare(b));
-    return keys.length ? keys.join(", ") : "none";
-  };
+  // #527 Effective Projection: merged effective env (agent env + profile env) with
+  // per-value origin badges, plus the chosen-pair resolution descriptors.
+  const effectiveEnv = createMemo(() =>
+    effectiveEnvProjection(selectedAgent()?.envs, projectedCell().env, acRoot()),
+  );
+  const projectionFallback = createMemo(() => effectivePreview().fallbackApplied);
+  const projectionBadgeKind = createMemo<"match" | "fallback">(() =>
+    projectionFallback() ? "fallback" : "match",
+  );
+  const resolutionText = createMemo(() =>
+    projectionFallback()
+      ? `${profileLabel(effectivePreview().requestedProfile)} → ${profileLabel(effectivePreview().effectiveProfile)} (fallback)`
+      : "Direct match",
+  );
+  const commandUsesAcRoot = createMemo(() =>
+    hasAcRootPlaceholder(profileCellCommandText(projectedCell()) || selectedAgent()?.command || ""),
+  );
   const providerDefaultPreview = (agent: AgentConfig) => {
     const current = settings();
     if (!current) {
@@ -502,7 +508,13 @@ const AgentPickerModal: Component<{
 
         <div class="agent-profile-assignment-body" data-component="Coding Agent profile modal variant C layout">
           <aside class="agent-profile-panel agent-profile-provider-panel" data-component="Coding Agents selector panel">
-            <div class="agent-profile-panel-title">Coding Agents</div>
+            <div class="agent-profile-panel-head">
+              <div class="agent-profile-panel-heading">
+                <div class="agent-profile-panel-title">Coding Agent</div>
+                <div class="agent-profile-panel-kicker">Choose the tool first</div>
+              </div>
+              <span class="agent-profile-step cyan" data-ac-role="status">step 1</span>
+            </div>
             <div
               class="agent-profile-provider-list"
               aria-label="Coding agent choices"
@@ -552,9 +564,12 @@ const AgentPickerModal: Component<{
 
           <div class="agent-profile-assignment-scroll" data-component="Coding Agent profile selector independent scroll area">
             <section class="agent-profile-panel" data-component="Coding Agent profile selector panel">
-              <div>
-                <div class="agent-profile-panel-title">Profiles</div>
-                <div class="agent-profile-panel-kicker">Profiles resolve for the selected coding agent only.</div>
+              <div class="agent-profile-panel-head">
+                <div class="agent-profile-panel-heading">
+                  <div class="agent-profile-panel-title">Profile</div>
+                  <div class="agent-profile-panel-kicker">Choose the profile letter second</div>
+                </div>
+                <span class="agent-profile-step yellow" data-ac-role="status">step 2</span>
               </div>
               <div
                 class="agent-profile-card-list"
@@ -635,46 +650,118 @@ const AgentPickerModal: Component<{
             </section>
 
             <section
-              class="agent-profile-panel"
-              data-component="Selected profile projected parameters panel"
+              class="agent-profile-panel agent-projection-panel"
+              data-component="Effective projection panel"
               {...automationAttrs("agentPicker.projected", "status")}
             >
-              <div class="agent-profile-panel-title">Projected parameters</div>
-              <div
-                class="agent-profile-resolution-status"
-                data-component="Coding Agent profile requested and resolved status"
-              >
-                <strong>Default: {profileLabel(configuredDefault())}</strong>
-                <span>Selected coding agent: {selectedAgent()?.label ?? "none"}</span>
-                <span>
-                  Requested {profileLabel(effectivePreview().requestedProfile)} resolves to{" "}
-                  {profileLabel(effectivePreview().effectiveProfile)}
-                  {effectivePreview().fallbackApplied ? " via fallback" : " as configured"}.
+              <div class="agent-projection-head">
+                <div class="agent-projection-heading">
+                  <div class="agent-profile-panel-title">Effective Projection</div>
+                  <div class="agent-profile-panel-kicker">Projected command and env for the chosen pair</div>
+                </div>
+                <span
+                  class={`agent-projection-badge ${projectionBadgeKind()}`}
+                  data-ac-role="status"
+                  data-ac-state={projectionBadgeKind()}
+                >
+                  {projectionBadgeKind()}
                 </span>
               </div>
-              <div class="agent-profile-active-summary" data-component="Selected profile launch parameter summary">
-                <div class="agent-profile-active-title">
-                  {selectedAgent()?.label ?? "Coding Agent"} / {profileLabel(selectedProfile())}
+
+              {/* Chosen pair — AGENT THEN PROFILE */}
+              <div class="agent-projection-card">
+                <div class="agent-projection-card-head">
+                  <span class="agent-projection-card-title">Chosen pair</span>
+                  <span class="agent-projection-tag cyan">agent then profile</span>
                 </div>
-                <div class="agent-profile-param-list">
-                  <div class="agent-profile-param"><span>Command </span><span>{projectedCommand() || "none"}</span></div>
-                  <Show when={hasAcRootPlaceholder(profileCellCommandText(projectedCell()) || selectedAgent()?.command || "")}>
-                    <div class="agent-profile-param"><span>Placeholder </span><span>%AC_ROOT% expands at launch; backend validates the path.</span></div>
-                  </Show>
-                  <div class="agent-profile-param"><span>Agent env </span><span>{formattedAgentEnv(selectedAgent())}</span></div>
-                  <Show when={selectedIsCodex() || selectedAgent()?.isolatedHome}>
-                    <div class="agent-profile-param"><span>Home isolation </span><span>{selectedAgent()?.isolatedHome ? "enabled" : "disabled"}</span></div>
-                  </Show>
-                  <div class="agent-profile-param"><span>Effective profile </span><span>{profileLabel(effectivePreview().effectiveProfile)}</span></div>
-                  <div class="agent-profile-param"><span>Fallback chain </span><span>{effectivePreview().fallbackChain.join(" -> ") || "none"}</span></div>
-                  <div class="agent-profile-param"><span>Profile env </span><span>{formattedEnv(projectedCell().env)}</span></div>
-                  <Show when={projectedCell().notes}>
-                    <div class="agent-profile-param"><span>Notes </span><span>{projectedCell().notes}</span></div>
-                  </Show>
+                <div class="agent-projection-grid">
+                  <div class="agent-projection-row" data-ac-role="row">
+                    <span class="agent-projection-label">Coding agent</span>
+                    <span class="agent-projection-value" data-component="Selected coding agent">
+                      {selectedAgent()?.label ?? "none"}
+                    </span>
+                    <span class="agent-projection-pill green">selected</span>
+                  </div>
+                  <div class="agent-projection-row" data-ac-role="row">
+                    <span class="agent-projection-label">Profile letter</span>
+                    <span class="agent-projection-value">{effectivePreview().requestedProfile}</span>
+                    <span class={`agent-projection-pill ${projectionBadgeKind() === "fallback" ? "yellow" : "green"}`}>
+                      {projectionBadgeKind()}
+                    </span>
+                  </div>
+                  <div class="agent-projection-row" data-ac-role="row">
+                    <span class="agent-projection-label">Resolution</span>
+                    <span class="agent-projection-value" data-component="Profile resolution">{resolutionText()}</span>
+                    <span class={`agent-projection-pill ${projectionBadgeKind() === "fallback" ? "yellow" : "green"}`}>
+                      {projectionBadgeKind()}
+                    </span>
+                  </div>
                 </div>
               </div>
+
+              {/* Command (RESOLVED) + Env (EFFECTIVE) */}
+              <div class="agent-projection-pair">
+                <div class="agent-projection-card">
+                  <div class="agent-projection-card-head">
+                    <span class="agent-projection-card-title">Command</span>
+                    <span class="agent-projection-tag cyan">resolved</span>
+                  </div>
+                  <div class="agent-projection-command" data-component="Resolved invocation">
+                    <span class="agent-projection-command-label">Invocation</span>
+                    <span class="agent-projection-command-value">{projectedCommand() || "none"}</span>
+                  </div>
+                  <Show when={commandUsesAcRoot()}>
+                    <div class="agent-projection-ph">
+                      <span class="arrow">→</span>
+                      <span>%AC_ROOT% expands at launch; the backend validates the path.</span>
+                    </div>
+                  </Show>
+                  <Show when={selectedIsCodex() || selectedAgent()?.isolatedHome}>
+                    <div class="agent-projection-note">
+                      Home isolation {selectedAgent()?.isolatedHome ? "enabled" : "disabled"}
+                    </div>
+                  </Show>
+                  <Show when={projectedCell().notes}>
+                    <div class="agent-projection-note">Note: {projectedCell().notes}</div>
+                  </Show>
+                </div>
+
+                <div class="agent-projection-card">
+                  <div class="agent-projection-card-head">
+                    <span class="agent-projection-card-title">Env</span>
+                    <span class="agent-projection-tag cyan">effective</span>
+                  </div>
+                  <div class="agent-projection-grid" data-ac-testid="agentPicker.projectedEnv" data-ac-role="list">
+                    <Show
+                      when={effectiveEnv().length > 0}
+                      fallback={
+                        <div class="agent-projection-row">
+                          <span class="agent-projection-label">env</span>
+                          <span class="agent-projection-value">No additional env vars</span>
+                          <span class="agent-projection-pill">none</span>
+                        </div>
+                      }
+                    >
+                      <For each={effectiveEnv()}>
+                        {(entry) => (
+                          <div class="agent-projection-row" data-ac-role="row" data-ac-env-origin={entry.origin}>
+                            <span class="agent-projection-label">{entry.key}</span>
+                            <span class="agent-projection-value">{entry.value}</span>
+                            <span
+                              class={`agent-projection-pill ${entry.origin === "profile" ? "" : "green"}`}
+                            >
+                              {entry.origin}
+                            </span>
+                          </div>
+                        )}
+                      </For>
+                    </Show>
+                  </div>
+                </div>
+              </div>
+
               <div
-                class="agent-profile-warning-strip"
+                class="agent-profile-warning-strip agent-projection-status"
                 classList={{ visible: effectivePreview().fallbackApplied || hasBackendWarnings() }}
                 data-component="Coding Agent profile fallback explanation"
                 {...automationAttrs(

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -837,4 +837,129 @@ describe("SettingsModal automation hooks", () => {
 
     dispose();
   });
+
+  it("exposes the OpenCode quick-add preset and the instructions-file input (#529)", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+
+    // Quick-add OpenCode button is present and enabled (seeded agent is codex).
+    const opencodePreset = byTestId<HTMLButtonElement>("settings.agentPreset.opencode");
+    expect(opencodePreset).toBeTruthy();
+    expect(opencodePreset.disabled).toBe(false);
+    expect(opencodePreset.getAttribute("data-ac-state")).toBe("available");
+
+    // The per-agent instructions-file input lives in the collapsed editor (3-tab
+    // rework) — expand the row first. Placeholder = command-derived default
+    // (seeded command `codex` → AGENTS.md).
+    expandAgentRow(0);
+    await settle();
+    const input = byTestId<HTMLInputElement>("settings.agentRow.0.instructionsFilename");
+    expect(input).toBeTruthy();
+    expect(input.value).toBe("");
+    expect(input.placeholder).toBe("AGENTS.md");
+
+    dispose();
+  });
+
+  it("disables the OpenCode preset when an opencode agent already exists (#529)", async () => {
+    vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
+      agents: [
+        {
+          id: "opencode",
+          label: "OpenCode",
+          command: "opencode",
+          color: "#64748b",
+          gitPullBefore: false,
+          excludeGlobalClaudeMd: false,
+          envs: [],
+          isolatedHome: false,
+          instructionsFilename: "AGENTS.md",
+        },
+      ],
+    }));
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+
+    const opencodePreset = byTestId<HTMLButtonElement>("settings.agentPreset.opencode");
+    expect(opencodePreset.disabled).toBe(true);
+    expect(opencodePreset.getAttribute("data-ac-state")).toBe("disabled");
+
+    dispose();
+  });
+
+  it("round-trips a typed instructions filename through save (#529)", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    const input = byTestId<HTMLInputElement>("settings.agentRow.0.instructionsFilename");
+    input.value = "TEAM.md";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.agents[0]?.instructionsFilename).toBe("TEAM.md");
+
+    dispose();
+  });
+
+  it("omits a cleared instructions filename from the saved draft (#529 G3)", async () => {
+    vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
+      agents: [
+        {
+          id: "claude",
+          label: "Claude Code",
+          command: "claude",
+          color: "#d97706",
+          gitPullBefore: false,
+          excludeGlobalClaudeMd: false,
+          envs: [],
+          isolatedHome: false,
+          instructionsFilename: "CLAUDE.md",
+        },
+      ],
+    }));
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    const input = byTestId<HTMLInputElement>("settings.agentRow.0.instructionsFilename");
+    expect(input.value).toBe("CLAUDE.md");
+    input.value = "";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.agents[0]).not.toHaveProperty("instructionsFilename");
+
+    dispose();
+  });
 });

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -127,6 +127,17 @@ function byTestId<T extends Element = Element>(testId: string): T {
   return element;
 }
 
+// #526: the unified Coding Agents screen keeps each agent's config editor
+// collapsed by default (the resting screen reads as the prototype). Clicking the
+// row head expands the inline editor that holds label/command/env/isolation.
+function expandAgentRow(index = 0): void {
+  const toggle = document.querySelector<HTMLElement>(
+    `[data-ac-testid="settings.agentRow.${index}.toggle"]`,
+  );
+  if (!toggle) throw new Error(`missing agent row toggle ${index}`);
+  toggle.click();
+}
+
 describe("SettingsModal automation hooks", () => {
   afterEach(() => {
     document.body.innerHTML = "";
@@ -140,6 +151,8 @@ describe("SettingsModal automation hooks", () => {
       () => SettingsModal({ onClose: () => {}, section: "agents" }),
       root,
     );
+    await settle();
+    expandAgentRow(0);
     await settle();
 
     const row = document.querySelector('[data-ac-testid="settings.agentRow.0"]');
@@ -171,6 +184,8 @@ describe("SettingsModal automation hooks", () => {
     );
     agentsTab?.click();
     await settle();
+    expandAgentRow(0);
+    await settle();
 
     expect(agentsTab?.getAttribute("data-ac-state")).toBe("active");
     expect(document.querySelector('[data-ac-testid="settings.agentRow.0"]')).toBeTruthy();
@@ -188,6 +203,8 @@ describe("SettingsModal automation hooks", () => {
       () => SettingsModal({ onClose: () => {}, section: "agents" }),
       root,
     );
+    await settle();
+    expandAgentRow(0);
     await settle();
 
     expect(byTestId("settings.agentRow.0.env")).toBeTruthy();
@@ -265,6 +282,8 @@ describe("SettingsModal automation hooks", () => {
       () => SettingsModal({ onClose: () => {}, section: "agents" }),
       root,
     );
+    await settle();
+    expandAgentRow(0);
     await settle();
 
     const addEnv = document.querySelector<HTMLButtonElement>('[data-ac-testid="settings.agentRow.0.env.add"]');
@@ -379,6 +398,97 @@ describe("SettingsModal automation hooks", () => {
     // Claude rail: B is configured → MATCH.
     expect(byTestId("settings.profileCard.1.B").getAttribute("data-ac-state")).toBe("match");
     expect(byTestId<HTMLButtonElement>("settings.profiles.add").disabled).toBe(false);
+
+    dispose();
+  });
+
+  it("collapses non-A profile cards by default and expands them on toggle", async () => {
+    vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
+      agents: [
+        {
+          id: "claude",
+          label: "Claude Code",
+          command: "claude",
+          color: "#d97706",
+          gitPullBefore: false,
+          excludeGlobalClaudeMd: false,
+          envs: [],
+          isolatedHome: false,
+        },
+      ],
+      codingAgentProfiles: {
+        schemaVersion: 2,
+        profileSlots: { A: { label: "" }, B: { label: "fast" } },
+        defaultProfileByAgent: {},
+        profilesByAgent: {
+          claude: {
+            A: { enabled: true, command: "claude", env: {}, notes: "" },
+            B: { enabled: true, command: "claude --model opus", env: {}, notes: "" },
+          },
+        },
+      },
+    }));
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "profiles" }),
+      root,
+    );
+    await settle();
+
+    // The "A" slot is expanded by default → its command input is present.
+    expect(byTestId("settings.profileCard.0.A.command")).toBeTruthy();
+    // A non-A configured slot is collapsed → command hidden until expanded.
+    expect(document.querySelector('[data-ac-testid="settings.profileCard.0.B.command"]')).toBeNull();
+
+    byTestId<HTMLButtonElement>("settings.profileCard.0.B.toggle").click();
+    await settle();
+    expect(byTestId<HTMLInputElement>("settings.profileCard.0.B.command").value).toBe("claude --model opus");
+
+    dispose();
+  });
+
+  it("clears the right comparison rail when the right agent's Remove is clicked", async () => {
+    vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
+      agents: [
+        {
+          id: "codex",
+          label: "Codex",
+          command: "codex",
+          color: "#10b981",
+          gitPullBefore: false,
+          excludeGlobalClaudeMd: true,
+          envs: [],
+          isolatedHome: false,
+        },
+        {
+          id: "claude",
+          label: "Claude Code",
+          command: "claude",
+          color: "#d97706",
+          gitPullBefore: false,
+          excludeGlobalClaudeMd: false,
+          envs: [],
+          isolatedHome: false,
+        },
+      ],
+    }));
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+
+    // The comparison pair seeds left=codex, right=claude (second agent).
+    expect(byTestId("settings.profileRail.1").getAttribute("data-ac-agent-id")).toBe("claude");
+    // Removing the right-rail agent actually empties the rail (no positional re-fill).
+    byTestId<HTMLButtonElement>("settings.agentRow.1.unuse").click();
+    await settle();
+    expect(byTestId("settings.profileRail.1").getAttribute("data-ac-agent-id")).toBeNull();
+    // Claude is now available again and offers "Use" to re-add it.
+    expect(document.querySelector('[data-ac-testid="settings.agentRow.1.use"]')).toBeTruthy();
 
     dispose();
   });

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -395,8 +395,13 @@ describe("SettingsModal automation hooks", () => {
     expect(byTestId("settings.profileCard.0.B.badge").textContent).toContain("MISSING");
     expect(byTestId("settings.profileCard.0.B.missing")).toBeTruthy();
     expect(byTestId<HTMLButtonElement>("settings.profileCard.0.B.add")).toBeTruthy();
-    // Claude rail: B is configured → MATCH.
-    expect(byTestId("settings.profileCard.1.B").getAttribute("data-ac-state")).toBe("match");
+    // Claude rail: B has its own enabled cell (non-A, direct match) → CONFIGURED,
+    // NOT MATCH. MATCH is reserved for the A baseline (#526).
+    expect(byTestId("settings.profileCard.1.B").getAttribute("data-ac-state")).toBe("configured");
+    expect(byTestId("settings.profileCard.1.B.badge").textContent).toContain("CONFIGURED");
+    // Claude A is the baseline → MATCH.
+    expect(byTestId("settings.profileCard.1.A").getAttribute("data-ac-state")).toBe("match");
+    expect(byTestId("settings.profileCard.1.A.badge").textContent).toContain("MATCH");
     expect(byTestId<HTMLButtonElement>("settings.profiles.add").disabled).toBe(false);
 
     dispose();
@@ -632,6 +637,204 @@ describe("SettingsModal automation hooks", () => {
     expect(SettingsAPI.sweepRtkHook).toHaveBeenCalledWith(true);
 
     resolveLoadedSettings(settings());
+    dispose();
+  });
+
+  it("distinguishes MATCH (A), CONFIGURED (own non-A cell), FALLBACK, and MISSING", async () => {
+    vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
+      agents: [
+        {
+          id: "codex",
+          label: "Codex",
+          command: "codex",
+          color: "#10b981",
+          gitPullBefore: false,
+          excludeGlobalClaudeMd: true,
+          envs: [],
+          isolatedHome: false,
+        },
+        {
+          id: "claude",
+          label: "Claude Code",
+          command: "claude",
+          color: "#d97706",
+          gitPullBefore: false,
+          excludeGlobalClaudeMd: false,
+          envs: [],
+          isolatedHome: false,
+        },
+      ],
+      codingAgentProfiles: {
+        schemaVersion: 2,
+        profileSlots: {
+          A: { label: "" },
+          B: { label: "balanced" },
+          C: { label: "review" },
+          D: { label: "full-auto" },
+        },
+        defaultProfileByAgent: {},
+        profilesByAgent: {
+          codex: {
+            A: { enabled: true, command: "codex --sandbox workspace-write", env: {}, notes: "" },
+            // Own enabled non-A cell → CONFIGURED (direct match on a non-baseline slot).
+            B: { enabled: true, command: "codex --model gpt-5-codex --effort medium", env: {}, notes: "" },
+          },
+          // D is configured on claude but not on codex → codex D is MISSING.
+          claude: {
+            A: { enabled: true, command: "claude", env: {}, notes: "" },
+            D: { enabled: true, command: "claude --dangerously-skip-permissions", env: {}, notes: "" },
+          },
+        },
+      },
+    }));
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "profiles" }),
+      root,
+    );
+    await settle();
+
+    // A baseline → MATCH (green).
+    expect(byTestId("settings.profileCard.0.A").getAttribute("data-ac-state")).toBe("match");
+    expect(byTestId("settings.profileCard.0.A.badge").textContent).toContain("MATCH");
+    // B has its own cell on codex → CONFIGURED (cyan), NOT MATCH.
+    expect(byTestId("settings.profileCard.0.B").getAttribute("data-ac-state")).toBe("configured");
+    expect(byTestId("settings.profileCard.0.B.badge").textContent).toContain("CONFIGURED");
+    // C has no cell anywhere → resolves through the configured B → FALLBACK.
+    expect(byTestId("settings.profileCard.0.C").getAttribute("data-ac-state")).toBe("fallback");
+    expect(byTestId("settings.profileCard.0.C.badge").textContent).toContain("FALLBACK");
+    // D is configured on claude but absent on codex → MISSING.
+    expect(byTestId("settings.profileCard.0.D").getAttribute("data-ac-state")).toBe("missing");
+    expect(byTestId("settings.profileCard.0.D.badge").textContent).toContain("MISSING");
+
+    dispose();
+  });
+
+  it("deletes a whole profile slot from every agent via Delete Profile", async () => {
+    vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
+      agents: [
+        {
+          id: "codex",
+          label: "Codex",
+          command: "codex",
+          color: "#10b981",
+          gitPullBefore: false,
+          excludeGlobalClaudeMd: true,
+          envs: [],
+          isolatedHome: false,
+        },
+        {
+          id: "claude",
+          label: "Claude Code",
+          command: "claude",
+          color: "#d97706",
+          gitPullBefore: false,
+          excludeGlobalClaudeMd: false,
+          envs: [],
+          isolatedHome: false,
+        },
+      ],
+      codingAgentProfiles: {
+        schemaVersion: 2,
+        profileSlots: { A: { label: "" }, B: { label: "fast" } },
+        defaultProfileByAgent: {},
+        profilesByAgent: {
+          codex: {
+            A: { enabled: true, command: "codex", env: {}, notes: "" },
+            B: { enabled: true, command: "codex --profile fast", env: {}, notes: "" },
+          },
+          claude: {
+            A: { enabled: true, command: "claude", env: {}, notes: "" },
+            B: { enabled: true, command: "claude --model opus", env: {}, notes: "" },
+          },
+        },
+      },
+    }));
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "profiles" }),
+      root,
+    );
+    await settle();
+
+    // The B card renders on both rails before deletion.
+    expect(byTestId("settings.profileCard.0.B")).toBeTruthy();
+    expect(byTestId("settings.profileCard.1.B")).toBeTruthy();
+
+    // Expand codex's B card to reach the slot-level "Delete Profile" affordance.
+    byTestId<HTMLButtonElement>("settings.profileCard.0.B.toggle").click();
+    await settle();
+    byTestId<HTMLButtonElement>("settings.profileCard.0.B.deleteProfile").click();
+    await settle();
+
+    // Slot B is gone from BOTH rails (it was a whole-slot delete, not per-agent).
+    expect(document.querySelector('[data-ac-testid="settings.profileCard.0.B"]')).toBeNull();
+    expect(document.querySelector('[data-ac-testid="settings.profileCard.1.B"]')).toBeNull();
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.codingAgentProfiles.profileSlots.B).toBeUndefined();
+    expect(saved?.codingAgentProfiles.profilesByAgent.codex?.B).toBeUndefined();
+    expect(saved?.codingAgentProfiles.profilesByAgent.claude?.B).toBeUndefined();
+    // The A baseline is untouched.
+    expect(saved?.codingAgentProfiles.profileSlots.A).toBeTruthy();
+
+    dispose();
+  });
+
+  it("keeps the left rail pinned when swapping with an empty right rail", async () => {
+    vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
+      agents: [
+        {
+          id: "codex",
+          label: "Codex",
+          command: "codex",
+          color: "#10b981",
+          gitPullBefore: false,
+          excludeGlobalClaudeMd: true,
+          envs: [],
+          isolatedHome: false,
+        },
+        {
+          id: "claude",
+          label: "Claude Code",
+          command: "claude",
+          color: "#d97706",
+          gitPullBefore: false,
+          excludeGlobalClaudeMd: false,
+          envs: [],
+          isolatedHome: false,
+        },
+      ],
+    }));
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+
+    // Pin the LEFT rail to claude (a non-first agent). The right rail was showing
+    // claude, so it empties out — left=claude (pinned), right=empty.
+    const leftSelect = byTestId<HTMLSelectElement>("settings.profileRail.0.agentSelect");
+    leftSelect.value = "claude";
+    leftSelect.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+    expect(byTestId("settings.profileRail.0").getAttribute("data-ac-agent-id")).toBe("claude");
+    expect(byTestId("settings.profileRail.1").getAttribute("data-ac-agent-id")).toBeNull();
+
+    // Swap with an empty right rail must be a no-op — NOT drop the left pin to the
+    // positional fallback (codex). The left stays claude; the right stays empty.
+    byTestId<HTMLButtonElement>("settings.agents.swapRails").click();
+    await settle();
+    expect(byTestId("settings.profileRail.0").getAttribute("data-ac-agent-id")).toBe("claude");
+    expect(byTestId("settings.profileRail.1").getAttribute("data-ac-agent-id")).toBeNull();
+
     dispose();
   });
 });

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -1083,10 +1083,10 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             </div>
           </div>
           <div class="settings-agent-row-actions">
-            <Show
-              when={pill() !== "left"}
-              fallback={<span class="settings-rail-pill left">left</span>}
-            >
+            {/* #526: the rail indicator is shown once, on the color line. The
+                left/primary agent has no Use/Remove action here, so render
+                nothing (previously a duplicate "left" pill lived here). */}
+            <Show when={pill() !== "left"}>
               <Show
                 when={pill() === "right"}
                 fallback={

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -16,6 +16,7 @@ import { AGENT_PRESET_MAP, newAgentId } from "../../shared/agent-presets";
 import { mergeSettingsForSavePreservingProjects } from "./settings-save";
 import {
   commandExecutableBasename,
+  defaultInstructionsFilename,
   executableTokenBasename,
   hasAcRootPlaceholder,
   hasEnabledEnvKey,
@@ -464,6 +465,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           excludeGlobalClaudeMd: true,
           envs: [],
           isolatedHome: false,
+          instructionsFilename: "AGENTS.md",
         };
     setSettings("data", "agents", (prev) => [...prev, agent]);
     // A freshly added agent expands its inline editor so it is immediately
@@ -1161,6 +1163,23 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
               />
             </label>
             <label class="settings-field">
+              <span class="settings-label">Instructions file</span>
+              <input
+                class="settings-input"
+                value={agent.instructionsFilename ?? ""}
+                onInput={(e) =>
+                  updateAgent(i(), "instructionsFilename", e.currentTarget.value)
+                }
+                placeholder={defaultInstructionsFilename(agent.command)}
+                data-ac-testid={`settings.agentRow.${i()}.instructionsFilename`}
+                data-ac-role="textbox"
+              />
+            </label>
+            <div class="settings-hint">
+              Filename AC writes into the agent root at launch (its AC context +
+              Role.md). Leave blank to use the default shown.
+            </div>
+            <label class="settings-field">
               <span class="settings-label">Color</span>
               <div class="settings-color-row">
                 <input
@@ -1245,6 +1264,20 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       >
         <span class="settings-color-dot" style={{ background: AGENT_PRESET_MAP.gemini.color }} />
         + Gemini CLI
+      </button>
+      <button
+        class="settings-preset-btn"
+        onClick={() => addAgent(AGENT_PRESET_MAP.opencode)}
+        disabled={hasAgentByCommand("opencode")}
+        data-ac-testid="settings.agentPreset.opencode"
+        data-ac-role="button"
+        data-ac-state={hasAgentByCommand("opencode") ? "disabled" : "available"}
+      >
+        <span
+          class="settings-color-dot"
+          style={{ background: AGENT_PRESET_MAP.opencode.color }}
+        />
+        + OpenCode
       </button>
       <button
         class="settings-add-btn"

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -22,12 +22,19 @@ import {
   isCodexAgent,
   nextAvailableProfileLetter,
   parseArgvText,
+  profileEnvOrigin,
   resolveProfilePreview,
   sortedProfileLetters,
   validateEnvRows,
 } from "../../shared/profile-utils";
 
 type ProfileCellEnvRow = { key: string; value: string };
+
+const ENV_ORIGIN_LABEL: Record<string, string> = {
+  system: "SYSTEM",
+  profile: "PROFILE",
+  accepted: "ACCEPTED",
+};
 
 const GEMINI_MODELS = [
   { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash (recommended)" },
@@ -38,17 +45,24 @@ const GEMINI_MODELS = [
 ];
 
 
-type SettingsTab = "general" | "agents" | "profiles" | "integrations";
+// #526: the former "agents" + "profiles" tabs are merged into one unified
+// "Coding Agents" screen (agent list + dual comparison rails). The "profiles"
+// section name is kept as an alias so existing callers still land on the
+// unified screen.
+type SettingsTab = "general" | "agents" | "integrations";
 
 const TABS: { key: SettingsTab; label: string }[] = [
   { key: "general", label: "General" },
   { key: "agents", label: "Coding Agents" },
-  { key: "profiles", label: "Profiles" },
   { key: "integrations", label: "Integrations" },
 ];
 
-const isValidSettingsTab = (s: string): s is SettingsTab =>
-  TABS.some((t) => t.key === s);
+const resolveSettingsSection = (s: string | undefined): SettingsTab =>
+  s === "agents" || s === "profiles"
+    ? "agents"
+    : s === "integrations"
+      ? "integrations"
+      : "general";
 
 const cloneSettings = (value: AppSettings | null): AppSettings | null => {
   if (!value) return null;
@@ -73,12 +87,11 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   // tab. Invalid or absent → fall back to "general" default. The effect below
   // also snaps to the requested section when props.section changes while the
   // modal is already mounted (double-click on disabled mic re-targets).
-  const initialTab: SettingsTab =
-    props.section && isValidSettingsTab(props.section) ? props.section : "general";
+  const initialTab: SettingsTab = resolveSettingsSection(props.section);
   const [activeTab, setActiveTab] = createSignal<SettingsTab>(initialTab);
   createEffect(() => {
     const s = props.section;
-    if (s && isValidSettingsTab(s)) setActiveTab(s);
+    if (s) setActiveTab(resolveSettingsSection(s));
   });
 
   const [webServerRunning, setWebServerRunning] = createSignal(false);
@@ -103,6 +116,63 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
 
   const s = () => settings.data;
 
+  // ── #526 Config Screen: comparison pair (two rails side by side) + the agent
+  // whose inline config editor is expanded. The LEFT rail is the primary and is
+  // always filled (positional fallback to the first agent). The RIGHT rail is an
+  // explicit comparison slot: it shows exactly the agent in `rightRailId`, and is
+  // empty when that is null — so "Remove" actually clears it. Seeded once on load
+  // (onMount) rather than via an effect, so clearing it does not get re-filled.
+  // The editor is collapsed by default — the resting screen reads as the
+  // prototype (compact agent list + the two comparison rails as the protagonist).
+  const [leftRailId, setLeftRailId] = createSignal<string | null>(null);
+  const [rightRailId, setRightRailId] = createSignal<string | null>(null);
+  const [activeAgentId, setActiveAgentId] = createSignal<string | null>(null);
+
+  const agentList = () => settings.data?.agents ?? [];
+  const agentById = (id: string | null) =>
+    id ? agentList().find((a) => a.id === id) ?? null : null;
+  const leftRailAgent = () => agentById(leftRailId()) ?? agentList()[0] ?? null;
+  const rightRailAgent = () => {
+    const explicit = agentById(rightRailId());
+    return explicit && explicit.id !== leftRailAgent()?.id ? explicit : null;
+  };
+
+  const swapRails = () => {
+    const left = leftRailAgent()?.id ?? null;
+    const right = rightRailAgent()?.id ?? null;
+    setLeftRailId(right);
+    setRightRailId(left);
+  };
+
+  const useAgentInComparison = (agentId: string) => {
+    if (leftRailAgent()?.id === agentId) return;
+    setRightRailId(agentId);
+  };
+
+  type RailPill = "left" | "right" | "available";
+  const railPillFor = (agentId: string): RailPill => {
+    if (leftRailAgent()?.id === agentId) return "left";
+    if (rightRailAgent()?.id === agentId) return "right";
+    return "available";
+  };
+
+  const toggleAgentEditor = (agentId: string) =>
+    setActiveAgentId((prev) => (prev === agentId ? null : agentId));
+
+  // Per profile-cell expand state on the Config rails. Cells collapse to a summary
+  // row (letter + label + status badge); the "A" slot is expanded by default,
+  // matching the prototype. Keyed by `${agentId}:${letter}`.
+  const [expandedCells, setExpandedCells] = createStore<Record<string, boolean | undefined>>({});
+  const isCellExpanded = (agentId: string, letter: string): boolean => {
+    // Read the key directly so the store tracks it even while still unset — a
+    // hasOwnProperty short-circuit would skip the subscription and the card
+    // would never react to a later toggle. `undefined` → default (A expanded).
+    const value = expandedCells[`${agentId}:${letter}`];
+    return value === undefined ? letter === "A" : value;
+  };
+  const toggleCell = (agentId: string, letter: string) =>
+    setExpandedCells(`${agentId}:${letter}`, !isCellExpanded(agentId, letter));
+
   onMount(async () => {
     const [loaded, wsRunning] = await Promise.all([
       SettingsAPI.get(),
@@ -112,6 +182,10 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     if (!draftDirty()) {
       setSettings("data", cloneSettings(loaded));
       setInitialInjectRtk(loaded.injectRtkHook);
+      // Seed the comparison pair from the loaded agents (left primary + right
+      // comparison slot). Only when still unset, so a user's pick isn't clobbered.
+      if (leftRailId() === null && loaded.agents[0]) setLeftRailId(loaded.agents[0].id);
+      if (rightRailId() === null && loaded.agents[1]) setRightRailId(loaded.agents[1].id);
     }
   });
 
@@ -395,12 +469,21 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           isolatedHome: false,
         };
     setSettings("data", "agents", (prev) => [...prev, agent]);
+    // A freshly added agent expands its inline editor so it is immediately
+    // editable (the resting list stays collapsed for existing agents).
+    setActiveAgentId(agent.id);
   };
 
   const removeAgent = (index: number) => {
     if (!settings.data) return;
     setDraftDirty(true);
+    const removed = settings.data.agents[index];
     setSettings("data", "agents", (prev) => prev.filter((_, i) => i !== index));
+    if (removed) {
+      if (activeAgentId() === removed.id) setActiveAgentId(null);
+      if (leftRailId() === removed.id) setLeftRailId(null);
+      if (rightRailId() === removed.id) setRightRailId(null);
+    }
   };
 
   // ── Telegram Bots ──
@@ -953,41 +1036,117 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     );
   };
 
-  const renderAgentsTab = () => (
-    <div class="settings-section">
-      <div class="settings-section-title">Coding Agents</div>
-
-      <For each={settings.data!.agents}>
-        {(agent, i) => (
-          <div class="settings-button-card">
-            <div
-              class="settings-button-card-header"
-              data-ac-testid={`settings.agentRow.${i()}`}
-              data-ac-role="group"
-            >
-              <div
-                class="settings-color-dot"
-                style={{ background: agent.color }}
-              />
-              <span>{agent.label || "New Agent"}</span>
-              <button
-                class="settings-agent-remove"
-                onClick={() => removeAgent(i())}
-                title="Remove agent"
-                data-ac-testid={`settings.agentRow.${i()}.remove`}
-                data-ac-role="button"
-              >
-                &#x2715;
-              </button>
+  // Left-panel agent row: compact prototype-style header (dot, name, command
+  // basename, color swatch+hex, rail pill, Use/Remove) with the full agent
+  // config editor (#384: label/command/color/flags/env/CODEX_HOME isolation)
+  // collapsed behind the head. Collapsed by default — the resting screen reads
+  // as the prototype; the editor is secondary, behind the expand.
+  const renderAgentRow = (agent: AgentConfig, index: () => number) => {
+    const i = () => index();
+    const expanded = () => activeAgentId() === agent.id;
+    const pill = () => railPillFor(agent.id);
+    return (
+      <div
+        class="settings-agent-row"
+        classList={{ expanded: expanded() }}
+        style={{ "--agent-color": agent.color }}
+        data-ac-testid={`settings.agentRow.${i()}`}
+        data-ac-role="group"
+        data-ac-agent-id={agent.id}
+        data-ac-rail={pill()}
+      >
+        <div
+          class="settings-agent-row-head"
+          role="button"
+          tabindex={0}
+          aria-expanded={expanded()}
+          onClick={() => toggleAgentEditor(agent.id)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              toggleAgentEditor(agent.id);
+            }
+          }}
+          data-ac-testid={`settings.agentRow.${i()}.toggle`}
+          data-ac-role="button"
+          data-ac-state={expanded() ? "expanded" : "collapsed"}
+        >
+          <span class="settings-agent-dot" style={{ background: agent.color }} />
+          <div class="settings-agent-row-meta">
+            <div class="settings-agent-row-name">{agent.label || "New Agent"}</div>
+            <div class="settings-agent-row-cmd">
+              {commandExecutableBasename(agent.command) || agent.command || "—"}
             </div>
+            <div class="settings-agent-row-colorline">
+              <span class="settings-agent-swatch" style={{ background: agent.color }} />
+              <span class="settings-agent-color-hex">{agent.color}</span>
+              <span class={`settings-rail-pill ${pill()}`} data-ac-rail={pill()}>
+                {pill()}
+              </span>
+            </div>
+          </div>
+          <div class="settings-agent-row-actions">
+            <Show
+              when={pill() !== "left"}
+              fallback={<span class="settings-rail-pill left">left</span>}
+            >
+              <Show
+                when={pill() === "right"}
+                fallback={
+                  <button
+                    class="settings-row-btn"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      useAgentInComparison(agent.id);
+                    }}
+                    title="Show this agent in the right comparison rail"
+                    data-ac-testid={`settings.agentRow.${i()}.use`}
+                    data-ac-role="button"
+                  >
+                    Use
+                  </button>
+                }
+              >
+                <button
+                  class="settings-row-btn danger"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setRightRailId(null);
+                  }}
+                  title="Remove this agent from the comparison"
+                  data-ac-testid={`settings.agentRow.${i()}.unuse`}
+                  data-ac-role="button"
+                >
+                  Remove
+                </button>
+              </Show>
+            </Show>
+            <button
+              class="settings-agent-remove"
+              onClick={(e) => {
+                e.stopPropagation();
+                removeAgent(i());
+              }}
+              title="Delete agent"
+              data-ac-testid={`settings.agentRow.${i()}.remove`}
+              data-ac-role="button"
+            >
+              &#x2715;
+            </button>
+            <span class="settings-agent-chevron" aria-hidden="true">
+              {expanded() ? "▾" : "▸"}
+            </span>
+          </div>
+        </div>
+
+        <Show when={expanded()}>
+          <div class="settings-agent-editor" data-ac-testid={`settings.agentRow.${i()}.editor`}>
             <label class="settings-field">
               <span class="settings-label">Label</span>
               <input
                 class="settings-input"
                 value={agent.label}
-                onInput={(e) =>
-                  updateAgent(i(), "label", e.currentTarget.value)
-                }
+                onInput={(e) => updateAgent(i(), "label", e.currentTarget.value)}
                 placeholder="My Agent"
                 data-ac-testid={`settings.agentRow.${i()}.label`}
                 data-ac-role="textbox"
@@ -998,9 +1157,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
               <input
                 class="settings-input"
                 value={agent.command}
-                onInput={(e) =>
-                  updateAgent(i(), "command", e.currentTarget.value)
-                }
+                onInput={(e) => updateAgent(i(), "command", e.currentTarget.value)}
                 placeholder="agent-cli"
                 data-ac-testid={`settings.agentRow.${i()}.command`}
                 data-ac-role="textbox"
@@ -1013,18 +1170,14 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                   type="color"
                   class="settings-color-picker"
                   value={agent.color}
-                  onInput={(e) =>
-                    updateAgent(i(), "color", e.currentTarget.value)
-                  }
+                  onInput={(e) => updateAgent(i(), "color", e.currentTarget.value)}
                   data-ac-testid={`settings.agentRow.${i()}.colorPicker`}
                   data-ac-role="input"
                 />
                 <input
                   class="settings-input settings-input-sm"
                   value={agent.color}
-                  onInput={(e) =>
-                    updateAgent(i(), "color", e.currentTarget.value)
-                  }
+                  onInput={(e) => updateAgent(i(), "color", e.currentTarget.value)}
                   data-ac-testid={`settings.agentRow.${i()}.color`}
                   data-ac-role="textbox"
                 />
@@ -1035,9 +1188,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                 type="checkbox"
                 class="settings-checkbox"
                 checked={agent.gitPullBefore}
-                onChange={(e) =>
-                  updateAgent(i(), "gitPullBefore", e.currentTarget.checked)
-                }
+                onChange={(e) => updateAgent(i(), "gitPullBefore", e.currentTarget.checked)}
                 data-ac-testid={`settings.agentRow.${i()}.gitPullBefore`}
                 data-ac-role="checkbox"
                 data-ac-state={agent.gitPullBefore ? "checked" : "unchecked"}
@@ -1049,9 +1200,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                 type="checkbox"
                 class="settings-checkbox"
                 checked={agent.excludeGlobalClaudeMd}
-                onChange={(e) =>
-                  updateAgent(i(), "excludeGlobalClaudeMd", e.currentTarget.checked)
-                }
+                onChange={(e) => updateAgent(i(), "excludeGlobalClaudeMd", e.currentTarget.checked)}
                 data-ac-testid={`settings.agentRow.${i()}.excludeGlobalClaudeMd`}
                 data-ac-role="checkbox"
                 data-ac-state={agent.excludeGlobalClaudeMd ? "checked" : "unchecked"}
@@ -1060,61 +1209,54 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             </label>
             {renderAgentEnvEditor(agent, i())}
           </div>
-        )}
-      </For>
-
-      <div class="settings-agent-actions">
-        <button
-          class="settings-preset-btn"
-          onClick={() => addAgent(AGENT_PRESET_MAP.claude)}
-          disabled={hasAgentByCommand("claude")}
-          data-ac-testid="settings.agentPreset.claude"
-          data-ac-role="button"
-          data-ac-state={hasAgentByCommand("claude") ? "disabled" : "available"}
-        >
-          <span
-            class="settings-color-dot"
-            style={{ background: AGENT_PRESET_MAP.claude.color }}
-          />
-          + Claude Code
-        </button>
-        <button
-          class="settings-preset-btn"
-          onClick={() => addAgent(AGENT_PRESET_MAP.codex)}
-          disabled={hasAgentByCommand("codex")}
-          data-ac-testid="settings.agentPreset.codex"
-          data-ac-role="button"
-          data-ac-state={hasAgentByCommand("codex") ? "disabled" : "available"}
-        >
-          <span
-            class="settings-color-dot"
-            style={{ background: AGENT_PRESET_MAP.codex.color }}
-          />
-          + Codex
-        </button>
-        <button
-          class="settings-preset-btn"
-          onClick={() => addAgent(AGENT_PRESET_MAP.gemini)}
-          disabled={hasAgentByCommand("gemini")}
-          data-ac-testid="settings.agentPreset.gemini"
-          data-ac-role="button"
-          data-ac-state={hasAgentByCommand("gemini") ? "disabled" : "available"}
-        >
-          <span
-            class="settings-color-dot"
-            style={{ background: AGENT_PRESET_MAP.gemini.color }}
-          />
-          + Gemini CLI
-        </button>
-        <button
-          class="settings-add-btn"
-          onClick={() => addAgent()}
-          data-ac-testid="settings.agent.addCustom"
-          data-ac-role="button"
-        >
-          + Custom Agent
-        </button>
+        </Show>
       </div>
+    );
+  };
+
+  const renderAgentPresets = () => (
+    <div class="settings-agent-actions">
+      <button
+        class="settings-preset-btn"
+        onClick={() => addAgent(AGENT_PRESET_MAP.claude)}
+        disabled={hasAgentByCommand("claude")}
+        data-ac-testid="settings.agentPreset.claude"
+        data-ac-role="button"
+        data-ac-state={hasAgentByCommand("claude") ? "disabled" : "available"}
+      >
+        <span class="settings-color-dot" style={{ background: AGENT_PRESET_MAP.claude.color }} />
+        + Claude Code
+      </button>
+      <button
+        class="settings-preset-btn"
+        onClick={() => addAgent(AGENT_PRESET_MAP.codex)}
+        disabled={hasAgentByCommand("codex")}
+        data-ac-testid="settings.agentPreset.codex"
+        data-ac-role="button"
+        data-ac-state={hasAgentByCommand("codex") ? "disabled" : "available"}
+      >
+        <span class="settings-color-dot" style={{ background: AGENT_PRESET_MAP.codex.color }} />
+        + Codex
+      </button>
+      <button
+        class="settings-preset-btn"
+        onClick={() => addAgent(AGENT_PRESET_MAP.gemini)}
+        disabled={hasAgentByCommand("gemini")}
+        data-ac-testid="settings.agentPreset.gemini"
+        data-ac-role="button"
+        data-ac-state={hasAgentByCommand("gemini") ? "disabled" : "available"}
+      >
+        <span class="settings-color-dot" style={{ background: AGENT_PRESET_MAP.gemini.color }} />
+        + Gemini CLI
+      </button>
+      <button
+        class="settings-add-btn"
+        onClick={() => addAgent()}
+        data-ac-testid="settings.agent.addCustom"
+        data-ac-role="button"
+      >
+        + Custom Agent
+      </button>
     </div>
   );
 
@@ -1126,9 +1268,9 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   };
 
   // One full invocation string per profile cell — model/effort/sandbox are NOT
-  // split into separate fields (#384). Each coding agent gets its own rail; rails
-  // wrap into side-by-side columns when the viewport permits (CSS auto-fit).
-  const renderProfileCard = (agent: AgentConfig, agentIndex: number, letter: string) => {
+  // split into separate fields (#384). The two comparison rails render the slots
+  // A..Z of two coding agents side by side; cards are addressed by rail index.
+  const renderProfileCard = (agent: AgentConfig, railIndex: number, letter: string) => {
     const cell = () => profileCell(agent.id, letter);
     const configured = () => letter === "A" || Boolean(cell()?.enabled);
     const badge = () => profileCellBadge(agent.id, letter);
@@ -1136,7 +1278,13 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       resolveProfilePreview(settings.data!.codingAgentProfiles, agent.id, letter);
     const command = () => displayedProfileCellCommand(agent.id, letter);
     const cellError = () => profileCellErrors[profileCellKey(agent.id, letter)];
-    const cardId = `settings.profileCard.${agentIndex}.${letter}`;
+    const cardId = `settings.profileCard.${railIndex}.${letter}`;
+    const expanded = () => isCellExpanded(agent.id, letter);
+    const subLine = () => {
+      if (!configured()) return `Configured elsewhere; launches ${preview().effectiveProfile}`;
+      if (cellError()) return "Command syntax error";
+      return commandExecutableBasename(command()) || "Configured";
+    };
     return (
       <article
         class="settings-profile-card"
@@ -1154,22 +1302,39 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       >
         <div class="settings-profile-card-head">
           <span class="settings-profile-letter-badge">{letter}</span>
-          <input
-            class="settings-input settings-profile-label"
-            value={settings.data!.codingAgentProfiles.profileSlots[letter]?.label ?? ""}
-            onInput={(e) => updateProfileLabel(letter, e.currentTarget.value)}
-            placeholder={letter === "A" ? "Baseline" : "Profile label"}
-            data-ac-testid={`${cardId}.label`}
-            data-ac-role="textbox"
-          />
-          <span
-            class={`settings-profile-badge ${badge()}`}
-            data-ac-testid={`${cardId}.badge`}
-            data-ac-role="status"
-            data-ac-state={badge()}
-          >
-            {BADGE_LABEL[badge()]}
-          </span>
+          <div class="settings-profile-card-heading">
+            <div class="settings-profile-name-line">
+              <input
+                class="settings-input settings-profile-label"
+                value={settings.data!.codingAgentProfiles.profileSlots[letter]?.label ?? ""}
+                onInput={(e) => updateProfileLabel(letter, e.currentTarget.value)}
+                placeholder={letter === "A" ? "Baseline" : "Profile label"}
+                data-ac-testid={`${cardId}.label`}
+                data-ac-role="textbox"
+              />
+              <span
+                class={`settings-profile-badge ${badge()}`}
+                data-ac-testid={`${cardId}.badge`}
+                data-ac-role="status"
+                data-ac-state={badge()}
+              >
+                {BADGE_LABEL[badge()]}
+              </span>
+            </div>
+            <div class="settings-profile-card-sub">{subLine()}</div>
+          </div>
+          <Show when={configured()}>
+            <button
+              class="settings-profile-chevron"
+              onClick={() => toggleCell(agent.id, letter)}
+              title={expanded() ? "Collapse" : "Expand"}
+              aria-expanded={expanded()}
+              data-ac-testid={`${cardId}.toggle`}
+              data-ac-role="button"
+            >
+              {expanded() ? "▾" : "▸"}
+            </button>
+          </Show>
         </div>
 
         <Show
@@ -1194,6 +1359,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             </div>
           }
         >
+          <Show when={expanded()}>
           <label class="settings-profile-field-label">Command</label>
           <input
             class="settings-input settings-profile-command"
@@ -1249,6 +1415,20 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                     data-ac-testid={`${cardId}.envRow.${rowIndex()}.value`}
                     data-ac-role="textbox"
                   />
+                  {(() => {
+                    const origin = profileEnvOrigin(row.key, row.value);
+                    return (
+                      <span
+                        class={`settings-env-origin ${origin}`}
+                        data-ac-testid={`${cardId}.envRow.${rowIndex()}.origin`}
+                        data-ac-role="status"
+                        data-ac-env-origin={origin}
+                        title={`Env value origin: ${ENV_ORIGIN_LABEL[origin]}`}
+                      >
+                        {ENV_ORIGIN_LABEL[origin]}
+                      </span>
+                    );
+                  })()}
                   <button
                     class="settings-env-delete"
                     onClick={() => removeCellEnvRow(agent.id, letter, rowIndex())}
@@ -1300,78 +1480,173 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
               Delete cell
             </button>
           </Show>
+          </Show>
         </Show>
       </article>
     );
   };
 
-  const renderProfilesTab = () => (
-    <div class="settings-section settings-profiles-section" data-ac-testid="settings.profiles.section">
-      <div class="settings-section-title">Profiles</div>
-      <div class="settings-hint">
-        One full command string per profile, plus optional env rows. Each coding
-        agent has its own rail. <span class="settings-profile-ph-token">%AC_ROOT%</span>{" "}
-        is supported in commands and env values; the backend expands and validates it at launch.
-      </div>
-
-      <div
-        class="settings-profile-rails"
-        data-ac-testid="settings.profiles.rails"
-        data-ac-role="list"
-      >
-        <Show
-          when={settings.data!.agents.length > 0}
-          fallback={
-            <div class="settings-empty-note" data-ac-testid="settings.profiles.empty" data-ac-role="status">
-              No coding agents configured. Add one in the Coding Agents tab.
-            </div>
-          }
+  // One comparison rail = the A..Z profile slots of one coding agent. The two
+  // rails sit side by side (the comparison pair); each rail's agent is swappable
+  // via its header select or the panel-level "Swap Rails".
+  const renderRail = (agent: AgentConfig | null, railIndex: number, side: "left" | "right") => {
+    if (!agent) {
+      return (
+        <section
+          class="settings-profile-rail settings-rail-empty"
+          data-ac-testid={`settings.profileRail.${railIndex}`}
+          data-ac-role="surface"
+          data-ac-rail-side={side}
         >
-          <For each={settings.data!.agents}>
-            {(agent, agentIndex) => (
-              <section
-                class="settings-profile-rail"
-                style={{ "--agent-color": agent.color }}
-                data-ac-testid={`settings.profileRail.${agentIndex()}`}
-                data-ac-role="surface"
-                data-ac-agent-id={agent.id}
-              >
-                <div class="settings-profile-rail-header">
-                  <span class="settings-profile-rail-dot" style={{ background: agent.color }} />
-                  <div class="settings-profile-rail-heading">
-                    <div class="settings-profile-rail-title">{agent.label || agent.id}</div>
-                    <div
-                      class="settings-profile-rail-subtitle"
-                      data-ac-testid={`settings.profileRail.${agentIndex()}.subtitle`}
-                      data-ac-role="status"
-                    >
-                      {commandExecutableBasename(agent.command) || agent.command || "—"}
-                    </div>
-                  </div>
-                </div>
-                <div class="settings-profile-rail-body">
-                  <For each={profileLetters()}>
-                    {(letter) => renderProfileCard(agent, agentIndex(), letter)}
-                  </For>
-                </div>
-              </section>
-            )}
-          </For>
-        </Show>
-      </div>
-
-      <button
-        class="settings-add-btn settings-profile-add"
-        onClick={addProfileLetter}
-        disabled={!nextAvailableProfileLetter(settings.data!.codingAgentProfiles)}
-        data-ac-testid="settings.profiles.add"
-        data-ac-role="button"
-        data-ac-state={nextAvailableProfileLetter(settings.data!.codingAgentProfiles) ? "enabled" : "disabled"}
+          <div class="settings-rail-empty-note">
+            {side === "right"
+              ? "Pick a second coding agent (Use, or the rail selector) to compare side by side."
+              : "Add a coding agent to begin."}
+          </div>
+        </section>
+      );
+    }
+    const setRailAgent = (id: string) =>
+      side === "left" ? setLeftRailId(id) : setRightRailId(id);
+    return (
+      <section
+        class="settings-profile-rail"
+        style={{ "--agent-color": agent.color }}
+        data-ac-testid={`settings.profileRail.${railIndex}`}
+        data-ac-role="surface"
+        data-ac-agent-id={agent.id}
+        data-ac-rail-side={side}
       >
-        + Profile
-      </button>
-    </div>
-  );
+        <div class="settings-profile-rail-header">
+          <div class="settings-profile-rail-heading">
+            <div class="settings-profile-rail-title">{(agent.label || agent.id)} rail</div>
+            <div
+              class="settings-profile-rail-subtitle"
+              data-ac-testid={`settings.profileRail.${railIndex}.subtitle`}
+              data-ac-role="status"
+            >
+              {commandExecutableBasename(agent.command) || agent.command || "—"}
+            </div>
+          </div>
+          <select
+            class="settings-input settings-rail-select"
+            value={agent.id}
+            onChange={(e) => setRailAgent(e.currentTarget.value)}
+            data-ac-testid={`settings.profileRail.${railIndex}.agentSelect`}
+            data-ac-role="combobox"
+          >
+            <For each={agentList()}>
+              {(a) => <option value={a.id}>{a.label || a.id}</option>}
+            </For>
+          </select>
+        </div>
+        <div class="settings-profile-rail-body">
+          <For each={profileLetters()}>
+            {(letter) => renderProfileCard(agent, railIndex, letter)}
+          </For>
+          <button
+            class="settings-add-btn settings-profile-add"
+            onClick={addProfileLetter}
+            disabled={!nextAvailableProfileLetter(settings.data!.codingAgentProfiles)}
+            data-ac-testid={railIndex === 0 ? "settings.profiles.add" : `settings.profileRail.${railIndex}.addProfile`}
+            data-ac-role="button"
+            data-ac-state={nextAvailableProfileLetter(settings.data!.codingAgentProfiles) ? "enabled" : "disabled"}
+          >
+            Add Profile
+          </button>
+        </div>
+      </section>
+    );
+  };
+
+  // #526 — the unified Coding Agents screen: compact agent list (left) + the two
+  // comparison rails (right). Replaces the former split "Coding Agents" /
+  // "Profiles" tabs. The `settings.profiles.*` test ids are kept so callers and
+  // automation that opened the old "profiles" view still resolve here.
+  const renderCodingAgentsScreen = () => {
+    const activeIndex = () => agentList().findIndex((a) => a.id === activeAgentId());
+    const canSwap = () => agentList().length > 1;
+    return (
+      <div
+        class="settings-config-screen"
+        data-ac-testid="settings.profiles.section"
+        data-ac-role="region"
+      >
+        <aside class="settings-agents-panel">
+          <div class="settings-agents-panel-header">
+            <div class="settings-agents-panel-heading">
+              <div class="settings-agents-panel-title">Coding Agents</div>
+              <div class="settings-agents-panel-kicker">Colors and selected comparison pair</div>
+            </div>
+            <button
+              class="settings-add-btn settings-agents-add"
+              onClick={() => addAgent()}
+              data-ac-testid="settings.agents.add"
+              data-ac-role="button"
+            >
+              Add Agent
+            </button>
+          </div>
+          <div class="settings-agents-panel-body">
+            <Show
+              when={agentList().length > 0}
+              fallback={
+                <div class="settings-empty-note" data-ac-testid="settings.profiles.empty" data-ac-role="status">
+                  No coding agents configured. Add one below.
+                </div>
+              }
+            >
+              <For each={settings.data!.agents}>
+                {(agent, i) => renderAgentRow(agent, i)}
+              </For>
+            </Show>
+
+            <div class="settings-agents-actions-block">
+              <div class="settings-agents-actions-title">Actions</div>
+              <div class="settings-agents-actions-row">
+                <button
+                  class="settings-row-btn"
+                  onClick={swapRails}
+                  disabled={!canSwap()}
+                  title="Swap the left and right comparison rails"
+                  data-ac-testid="settings.agents.swapRails"
+                  data-ac-role="button"
+                  data-ac-state={canSwap() ? "enabled" : "disabled"}
+                >
+                  Swap Rails
+                </button>
+                <button
+                  class="settings-row-btn danger"
+                  onClick={() => {
+                    const idx = activeIndex();
+                    if (idx >= 0) removeAgent(idx);
+                  }}
+                  disabled={activeIndex() < 0}
+                  title="Delete the expanded coding agent"
+                  data-ac-testid="settings.agents.deleteActive"
+                  data-ac-role="button"
+                  data-ac-state={activeIndex() >= 0 ? "enabled" : "disabled"}
+                >
+                  Delete Agent
+                </button>
+              </div>
+            </div>
+
+            {renderAgentPresets()}
+          </div>
+        </aside>
+
+        <div
+          class="settings-compare-zone"
+          data-ac-testid="settings.profiles.rails"
+          data-ac-role="list"
+        >
+          {renderRail(leftRailAgent(), 0, "left")}
+          {renderRail(rightRailAgent(), 1, "right")}
+        </div>
+      </div>
+    );
+  };
 
   const renderIntegrationsTab = () => (
     <>
@@ -1555,6 +1830,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     >
       <div
         class="modal-container modal-container-lg"
+        classList={{ "modal-container-config": activeTab() === "agents" }}
         role="dialog"
         aria-modal="true"
         aria-label="Settings"
@@ -1592,10 +1868,12 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             </div>
           }
         >
-          <div class="modal-body">
+          <div
+            class="modal-body"
+            classList={{ "modal-body-config": activeTab() === "agents" }}
+          >
             <Show when={activeTab() === "general"}>{renderGeneralTab()}</Show>
-            <Show when={activeTab() === "agents"}>{renderAgentsTab()}</Show>
-            <Show when={activeTab() === "profiles"}>{renderProfilesTab()}</Show>
+            <Show when={activeTab() === "agents"}>{renderCodingAgentsScreen()}</Show>
             <Show when={activeTab() === "integrations"}>
               {renderIntegrationsTab()}
             </Show>

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { Component, createSignal, createEffect, For, Show, onMount, onCleanup } from "solid-js";
-import { createStore } from "solid-js/store";
+import { createStore, produce } from "solid-js/store";
 import { isTauri } from "../../shared/platform";
 import type {
   AppSettings,
@@ -22,6 +22,7 @@ import {
   isCodexAgent,
   nextAvailableProfileLetter,
   parseArgvText,
+  profileBadgeKind,
   profileEnvOrigin,
   resolveProfilePreview,
   sortedProfileLetters,
@@ -140,6 +141,10 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   const swapRails = () => {
     const left = leftRailAgent()?.id ?? null;
     const right = rightRailAgent()?.id ?? null;
+    // #527: no-op when the right rail is empty. Swapping a null right into the
+    // left would drop the left's explicit pin to the positional fallback
+    // (agents[0]) — a surprising jump to a different agent. Keep the left pinned.
+    if (right === null) return;
     setLeftRailId(right);
     setRightRailId(left);
   };
@@ -256,37 +261,14 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   const profileCell = (agentId: string, letter: string): ProfileCellConfig | null =>
     settings.data?.codingAgentProfiles.profilesByAgent[agentId]?.[letter] ?? null;
 
-  // True when this letter has an enabled cell on some OTHER coding agent — used
-  // to distinguish a red MISSING badge (slot exists elsewhere) from a plain
-  // fallback. Excludes the agent itself.
-  const profileConfiguredElsewhere = (agentId: string, letter: string): boolean => {
-    const byAgent = settings.data?.codingAgentProfiles.profilesByAgent ?? {};
-    return Object.entries(byAgent).some(
-      ([id, cells]) => id !== agentId && Boolean(cells[letter]?.enabled),
-    );
-  };
+  type ProfileBadge = "match" | "configured" | "fallback" | "missing" | "invalid";
 
-  type ProfileBadge = "match" | "fallback" | "missing" | "invalid";
-
+  // #526: the data-driven taxonomy lives in profileBadgeKind() (shared 1:1 with
+  // the Selection screen so both read the same state). A live command parse error
+  // is UI-local and takes precedence here as the red "invalid" badge.
   const profileCellBadge = (agentId: string, letter: string): ProfileBadge => {
     if (profileCellErrors[profileCellKey(agentId, letter)]) return "invalid";
-    const cell = profileCell(agentId, letter);
-    const configuredHere = letter === "A" || Boolean(cell?.enabled);
-    if (configuredHere) {
-      const preview = resolveProfilePreview(
-        settings.data!.codingAgentProfiles,
-        agentId,
-        letter,
-      );
-      return preview.fallbackApplied ? "fallback" : "match";
-    }
-    if (profileConfiguredElsewhere(agentId, letter)) return "missing";
-    const preview = resolveProfilePreview(
-      settings.data!.codingAgentProfiles,
-      agentId,
-      letter,
-    );
-    return preview.fallbackApplied ? "fallback" : "missing";
+    return profileBadgeKind(settings.data!.codingAgentProfiles, agentId, letter);
   };
 
   const setProfileCell = (
@@ -361,20 +343,35 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     }));
   };
 
+  // #526: slot-level delete — drop the letter from profileSlots and from every
+  // coding agent's cells. produce() so the keys are actually removed; assigning a
+  // fresh object to a store path merges (keeps absent keys), which would leave the
+  // slot behind and the card would re-render as MISSING instead of vanishing.
   const removeProfileLetter = (letter: string) => {
     if (!settings.data || letter === "A") return;
     setDraftDirty(true);
-    const slots = { ...settings.data.codingAgentProfiles.profileSlots };
-    delete slots[letter];
-    const byAgent = Object.fromEntries(
-      Object.entries(settings.data.codingAgentProfiles.profilesByAgent).map(([agentId, cells]) => {
-        const nextCells = { ...cells };
-        delete nextCells[letter];
-        return [agentId, nextCells];
-      })
+    setSettings(
+      "data",
+      "codingAgentProfiles",
+      produce((profiles) => {
+        delete profiles.profileSlots[letter];
+        for (const cells of Object.values(profiles.profilesByAgent)) {
+          delete cells[letter];
+        }
+      }),
     );
-    setSettings("data", "codingAgentProfiles", "profileSlots", slots);
-    setSettings("data", "codingAgentProfiles", "profilesByAgent", byAgent);
+    // Drop any in-progress per-cell drafts for this letter so a stale parse error
+    // can't block Save and stale env rows don't resurface.
+    const suffix = `:${letter}`;
+    setProfileCellText(produce((draft) => {
+      for (const key of Object.keys(draft)) if (key.endsWith(suffix)) delete draft[key];
+    }));
+    setProfileCellErrors(produce((draft) => {
+      for (const key of Object.keys(draft)) if (key.endsWith(suffix)) delete draft[key];
+    }));
+    setProfileCellEnvRows(produce((draft) => {
+      for (const key of Object.keys(draft)) if (key.endsWith(suffix)) delete draft[key];
+    }));
   };
 
   // ── Profile cell command string (one full invocation per cell) ──
@@ -1262,6 +1259,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
 
   const BADGE_LABEL: Record<ProfileBadge, string> = {
     match: "MATCH",
+    configured: "CONFIGURED",
     fallback: "FALLBACK",
     missing: "MISSING",
     invalid: "invalid",
@@ -1290,6 +1288,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
         class="settings-profile-card"
         classList={{
           match: badge() === "match",
+          configured: badge() === "configured",
           fallback: badge() === "fallback",
           missing: badge() === "missing",
           invalid: badge() === "invalid",
@@ -1348,14 +1347,28 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
               <span>
                 {letter} &rarr; {preview().effectiveProfile} (fallback)
               </span>
-              <button
-                class="settings-profile-cell-btn"
-                onClick={() => addProfileCell(agent.id, letter)}
-                data-ac-testid={`${cardId}.add`}
-                data-ac-role="button"
-              >
-                Add cell
-              </button>
+              <div class="settings-profile-missing-actions">
+                <button
+                  class="settings-profile-cell-btn"
+                  onClick={() => addProfileCell(agent.id, letter)}
+                  data-ac-testid={`${cardId}.add`}
+                  data-ac-role="button"
+                >
+                  Add cell
+                </button>
+                {/* #526: slot-level delete — drops the whole letter from every
+                    coding agent (draft-reversible). Distinct from per-agent
+                    "Delete cell". */}
+                <button
+                  class="settings-profile-cell-btn settings-profile-delete-profile"
+                  onClick={() => removeProfileLetter(letter)}
+                  title={`Delete the entire ${letter} profile slot from all coding agents`}
+                  data-ac-testid={`${cardId}.deleteProfile`}
+                  data-ac-role="button"
+                >
+                  Delete Profile
+                </button>
+              </div>
             </div>
           }
         >
@@ -1471,14 +1484,28 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           </div>
 
           <Show when={letter !== "A"}>
-            <button
-              class="settings-profile-cell-btn settings-profile-delete-cell"
-              onClick={() => removeProfileCell(agent.id, letter)}
-              data-ac-testid={`${cardId}.delete`}
-              data-ac-role="button"
-            >
-              Delete cell
-            </button>
+            <div class="settings-profile-card-footer">
+              {/* "Delete cell" clears only this agent's cell for the letter;
+                  "Delete Profile" removes the whole slot across all agents (#526). */}
+              <button
+                class="settings-profile-cell-btn settings-profile-delete-cell"
+                onClick={() => removeProfileCell(agent.id, letter)}
+                title={`Remove ${agent.label || agent.id}'s ${letter} cell (keeps the slot)`}
+                data-ac-testid={`${cardId}.delete`}
+                data-ac-role="button"
+              >
+                Delete cell
+              </button>
+              <button
+                class="settings-profile-cell-btn settings-profile-delete-profile"
+                onClick={() => removeProfileLetter(letter)}
+                title={`Delete the entire ${letter} profile slot from all coding agents`}
+                data-ac-testid={`${cardId}.deleteProfile`}
+                data-ac-role="button"
+              >
+                Delete Profile
+              </button>
+            </div>
           </Show>
           </Show>
         </Show>

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type { AgentConfig, AppSettings } from "../../shared/types";
+import { mergeSettingsForSavePreservingProjects } from "./settings-save";
+
+function agent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    id: "a1",
+    label: "Agent",
+    command: "claude",
+    color: "#000000",
+    gitPullBefore: false,
+    excludeGlobalClaudeMd: false,
+    envs: [],
+    isolatedHome: false,
+    ...overrides,
+  };
+}
+
+// Mirrors the fix/526 AppSettings shape (e.g. requires alwaysShowSelectedWorkgroup),
+// not the 4-tab branch's shape — kept in sync with the SettingsModal automation test.
+function settings(overrides: Partial<AppSettings> = {}): AppSettings {
+  return {
+    defaultShell: "pwsh",
+    defaultShellArgs: [],
+    sidebarAlwaysOnTop: false,
+    sidebarStyle: "noir-minimal",
+    themeLight: true,
+    telegramNetworkPollErrorLogging: {
+      firstFailureLevel: "warn",
+      transientRepeatLevel: "debug",
+      sustainedLevel: "warn",
+      sustainedAfterSeconds: 60,
+      sustainedRepeatSeconds: 300,
+      recoveryLevel: "info",
+    },
+    raiseTerminalOnClick: true,
+    coordSortByActivity: false,
+    alwaysShowSelectedWorkgroup: true,
+    restoreCoordinatorWakeState: true,
+    soundsEnabled: true,
+    teamIdleBeepEnabled: true,
+    injectRtkHook: false,
+    informWhenRtkInstalled: true,
+    webServerEnabled: false,
+    webServerPort: 8765,
+    webServerBind: "127.0.0.1",
+    voiceToTextEnabled: false,
+    voiceAutoExecute: false,
+    voiceAutoExecuteDelay: 15,
+    geminiApiKey: "",
+    geminiModel: "gemini-2.5-flash",
+    sidebarZoom: 1,
+    terminalZoom: 1,
+    guideZoom: 1,
+    mainZoom: 1,
+    sidebarGeometry: null,
+    terminalGeometry: null,
+    mainGeometry: null,
+    mainSidebarWidth: 360,
+    mainSidebarSide: "right",
+    mainAlwaysOnTop: false,
+    agents: [],
+    codingAgentProfiles: {
+      schemaVersion: 2,
+      profileSlots: { A: { label: "" } },
+      defaultProfileByAgent: {},
+      profilesByAgent: {},
+    },
+    telegramBots: [],
+    onboardingDismissed: true,
+    projectPaths: [],
+    projectPath: null,
+    rtkPromptDismissed: false,
+    autoGenerateTaskTitle: true,
+    agentTemplatesPath: null,
+    specBoardEnabled: false,
+    ...overrides,
+  };
+}
+
+describe("mergeSettingsForSavePreservingProjects (#529 G3 normalization)", () => {
+  it("drops an empty or whitespace-only instructionsFilename so the sentinel never persists", () => {
+    const draft = settings({
+      agents: [
+        agent({ id: "empty", instructionsFilename: "" }),
+        agent({ id: "spaces", instructionsFilename: "   " }),
+        agent({ id: "absent", instructionsFilename: undefined }),
+      ],
+    });
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    for (const a of merged.agents) {
+      expect("instructionsFilename" in a).toBe(false);
+    }
+  });
+
+  it("trims and keeps a non-empty instructionsFilename", () => {
+    const draft = settings({
+      agents: [agent({ id: "set", instructionsFilename: "  TEAM.md  " })],
+    });
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect(merged.agents[0]?.instructionsFilename).toBe("TEAM.md");
+  });
+
+  it("preserves a clean instructionsFilename and unrelated agent fields untouched", () => {
+    const draft = settings({
+      agents: [agent({ id: "claude", command: "claude", instructionsFilename: "CLAUDE.md" })],
+    });
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect(merged.agents[0]).toEqual(
+      agent({ id: "claude", command: "claude", instructionsFilename: "CLAUDE.md" }),
+    );
+  });
+
+  it("still adopts projectPaths/projectPath from the fresh settings", () => {
+    const draft = settings({ projectPath: "C:/stale", projectPaths: ["C:/stale"] });
+    const fresh = settings({ projectPath: "C:/fresh", projectPaths: ["C:/fresh", "C:/other"] });
+    const merged = mergeSettingsForSavePreservingProjects(draft, fresh);
+
+    expect(merged.projectPath).toBe("C:/fresh");
+    expect(merged.projectPaths).toEqual(["C:/fresh", "C:/other"]);
+  });
+});

--- a/src/sidebar/components/settings-save.ts
+++ b/src/sidebar/components/settings-save.ts
@@ -1,4 +1,23 @@
-import type { AppSettings } from "../../shared/types";
+import type { AgentConfig, AppSettings } from "../../shared/types";
+
+/**
+ * #529 (G3) — normalize the optional instructions filename to an honest stored
+ * shape: trim a set value, and drop the field entirely when it is empty or
+ * whitespace. The Config Screen input binds `value={agent.instructionsFilename
+ * ?? ""}` and stores the raw string, so clearing it yields `Some("")`, which
+ * Rust's `skip_serializing_if = "Option::is_none"` does NOT omit — it would
+ * persist `"instructionsFilename": ""`, contradicting the "never persist a
+ * sentinel" rule. Normalizing here, at the single save choke point, keeps the
+ * per-keystroke `updateAgent` setter untouched and guarantees `""` never
+ * reaches the backend. The backend stays tolerant either way (it trims an
+ * empty value back to the command-derived default at launch).
+ */
+function normalizeAgentInstructionsFilename(agent: AgentConfig): AgentConfig {
+  const trimmed = agent.instructionsFilename?.trim();
+  if (trimmed) return { ...agent, instructionsFilename: trimmed };
+  const { instructionsFilename: _drop, ...rest } = agent;
+  return rest;
+}
 
 export function mergeSettingsForSavePreservingProjects(
   draft: AppSettings,
@@ -6,6 +25,7 @@ export function mergeSettingsForSavePreservingProjects(
 ): AppSettings {
   return {
     ...draft,
+    agents: draft.agents.map(normalizeAgentInstructionsFilename),
     projectPaths: fresh.projectPaths ?? [],
     projectPath: fresh.projectPath ?? null,
   };

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -1297,13 +1297,6 @@ html.light-theme .root-agent-avatar {
   flex: 0 0 auto;
 }
 
-.settings-profile-rails {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: var(--spacing-sm);
-  align-items: start;
-}
-
 .settings-profile-rail {
   --agent-color: var(--sidebar-accent);
   display: flex;
@@ -1321,13 +1314,6 @@ html.light-theme .root-agent-avatar {
   align-items: center;
   gap: var(--spacing-xs);
   min-width: 0;
-}
-
-.settings-profile-rail-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  flex: 0 0 auto;
 }
 
 .settings-profile-rail-heading {
@@ -1493,6 +1479,370 @@ html.light-theme .root-agent-avatar {
 
 .settings-profile-add {
   align-self: flex-start;
+}
+
+/* ── #526 Config Screen: unified dual-rail comparison (agent list + 2 rails) ── */
+.modal-container-config {
+  max-width: 1180px;
+  width: 96%;
+  height: 90vh;
+}
+
+.modal-body-config {
+  overflow: hidden;
+  padding: var(--spacing-md);
+  gap: 0;
+}
+
+.settings-config-screen {
+  height: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 250px minmax(0, 1fr);
+  gap: var(--spacing-md);
+}
+
+/* left agent-list panel */
+.settings-agents-panel {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+}
+
+.settings-agents-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm);
+  border-bottom: 1px solid var(--sidebar-border);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.settings-agents-panel-title {
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  color: var(--sidebar-fg);
+}
+
+.settings-agents-panel-kicker {
+  font-size: 10px;
+  color: var(--sidebar-fg-dim);
+}
+
+.settings-agents-add {
+  flex: 0 0 auto;
+}
+
+.settings-agents-panel-body {
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm);
+}
+
+/* compact agent row + expandable editor */
+.settings-agent-row {
+  --agent-color: var(--sidebar-accent);
+  border: 1px solid var(--sidebar-border);
+  border-left: 2px solid var(--agent-color);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.settings-agent-row.expanded {
+  background: rgba(0, 212, 255, 0.05);
+  border-color: rgba(0, 212, 255, 0.28);
+}
+
+.settings-agent-row-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  cursor: pointer;
+}
+
+.settings-agent-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
+.settings-agent-row-meta {
+  min-width: 0;
+}
+
+.settings-agent-row-name {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--sidebar-fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-agent-row-cmd {
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 10px;
+  color: var(--sidebar-fg-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-agent-row-colorline {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 3px;
+  flex-wrap: wrap;
+}
+
+.settings-agent-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+.settings-agent-color-hex {
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 9px;
+  color: var(--sidebar-fg-dim);
+}
+
+.settings-rail-pill {
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 8px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--sidebar-border);
+  color: var(--sidebar-fg-dim);
+}
+
+.settings-rail-pill.left {
+  color: var(--sidebar-accent);
+  border-color: rgba(0, 212, 255, 0.4);
+  background: rgba(0, 212, 255, 0.12);
+}
+
+.settings-rail-pill.right {
+  color: var(--status-active, #35f2a6);
+  border-color: rgba(53, 242, 166, 0.4);
+  background: rgba(53, 242, 166, 0.12);
+}
+
+.settings-agent-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+
+.settings-row-btn {
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-sm);
+  background: var(--sidebar-hover);
+  color: var(--sidebar-fg);
+  font-size: 10px;
+  padding: 3px 8px;
+  cursor: pointer;
+}
+
+.settings-row-btn:hover:not(:disabled) {
+  border-color: var(--sidebar-accent);
+  color: var(--sidebar-accent);
+}
+
+.settings-row-btn.danger {
+  color: var(--status-exited, #ff5d5d);
+  border-color: rgba(255, 93, 93, 0.3);
+  background: rgba(255, 93, 93, 0.08);
+}
+
+.settings-row-btn.danger:hover:not(:disabled) {
+  border-color: var(--status-exited, #ff5d5d);
+  color: var(--status-exited, #ff5d5d);
+}
+
+.settings-row-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.settings-agent-chevron {
+  color: var(--sidebar-fg-dim);
+  font-size: 10px;
+  width: 14px;
+  text-align: center;
+}
+
+.settings-agent-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm) var(--spacing-sm);
+  border-top: 1px solid var(--sidebar-border);
+}
+
+.settings-agents-actions-block {
+  margin-top: var(--spacing-xs);
+  padding: var(--spacing-sm);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.settings-agents-actions-title {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--sidebar-fg-dim);
+  margin-bottom: var(--spacing-xs);
+}
+
+.settings-agents-actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+/* compare zone: two rails side by side */
+.settings-compare-zone {
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--spacing-md);
+  overflow: hidden;
+}
+
+.settings-config-screen .settings-profile-rail {
+  min-height: 0;
+  padding: 0;
+  gap: 0;
+  border: 1px solid var(--sidebar-border);
+  border-left: 2px solid var(--agent-color);
+  background: rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+}
+
+.settings-config-screen .settings-profile-rail-header {
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  border-bottom: 1px solid var(--sidebar-border);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.settings-config-screen .settings-profile-rail-body {
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--spacing-sm);
+}
+
+.settings-rail-select {
+  flex: 0 0 auto;
+  width: auto;
+  min-width: 110px;
+  max-width: 160px;
+}
+
+.settings-rail-empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-rail-empty-note {
+  padding: var(--spacing-lg);
+  color: var(--sidebar-fg-dim);
+  font-size: var(--font-size-sm);
+  text-align: center;
+  line-height: 1.5;
+}
+
+/* origin badge inside profile-cell env rows (SYSTEM / PROFILE / ACCEPTED) */
+.settings-profile-env-row {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr) auto 24px;
+}
+
+.settings-env-origin {
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 8px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  border: 1px solid var(--sidebar-border);
+  color: var(--sidebar-fg-dim);
+  white-space: nowrap;
+  align-self: center;
+}
+
+/* AC-managed (system) and user-accepted literal paths read as green; a plain
+   profile value keeps the neutral default so the origins differ at a glance. */
+.settings-env-origin.system,
+.settings-env-origin.accepted {
+  color: var(--status-active, #35f2a6);
+  border-color: rgba(53, 242, 166, 0.35);
+  background: rgba(53, 242, 166, 0.1);
+}
+
+/* collapsible profile-card head (summary row + chevron) */
+.settings-profile-card-heading {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.settings-profile-name-line {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  min-width: 0;
+}
+
+.settings-profile-name-line .settings-profile-label {
+  flex: 1;
+  min-width: 0;
+}
+
+.settings-profile-card-sub {
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 9px;
+  color: var(--sidebar-fg-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-profile-chevron {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--sidebar-fg-dim);
+  cursor: pointer;
+  font-size: 10px;
+}
+
+.settings-profile-chevron:hover {
+  color: var(--sidebar-accent);
 }
 
 .settings-preset-btn {
@@ -2429,8 +2779,7 @@ html.light-theme .root-agent-avatar {
 }
 
 .agent-profile-provider-name,
-.agent-profile-card-title,
-.agent-profile-active-title {
+.agent-profile-card-title {
   display: block;
   color: var(--sidebar-fg);
   font-size: 12px;
@@ -2497,8 +2846,6 @@ html.light-theme .root-agent-avatar {
   overflow-wrap: anywhere;
 }
 
-.agent-profile-resolution-status,
-.agent-profile-active-summary,
 .agent-profile-warning-strip {
   display: grid;
   gap: 6px;
@@ -2507,13 +2854,6 @@ html.light-theme .root-agent-avatar {
   font-size: 10px;
   line-height: 1.4;
   overflow-wrap: anywhere;
-}
-
-.agent-profile-resolution-status strong {
-  color: var(--sidebar-fg);
-}
-
-.agent-profile-warning-strip {
   border: 1px solid var(--sidebar-border);
   border-radius: 8px;
   padding: 8px;
@@ -2680,6 +3020,227 @@ html.light-theme .root-agent-avatar {
 }
 
 .agent-scope-error-ids {
+  color: var(--sidebar-fg-dim);
+}
+
+/* ── #527 Selection Screen: step guides + Effective Projection ── */
+.agent-profile-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
+.agent-profile-panel-heading {
+  min-width: 0;
+}
+
+.agent-profile-step {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 9px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--sidebar-border);
+  color: var(--sidebar-fg-dim);
+  white-space: nowrap;
+}
+
+.agent-profile-step.cyan {
+  color: var(--sidebar-accent);
+  border-color: rgba(0, 212, 255, 0.4);
+  background: rgba(0, 212, 255, 0.1);
+}
+
+.agent-profile-step.yellow {
+  color: var(--status-pending, #f8c657);
+  border-color: rgba(248, 198, 87, 0.4);
+  background: rgba(248, 198, 87, 0.12);
+}
+
+.agent-projection-panel {
+  align-content: start;
+  gap: 10px;
+}
+
+.agent-projection-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
+.agent-projection-heading {
+  min-width: 0;
+}
+
+.agent-projection-badge {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--sidebar-border);
+  color: var(--sidebar-fg-dim);
+}
+
+.agent-projection-badge.match {
+  color: var(--status-active, #35f2a6);
+  border-color: rgba(53, 242, 166, 0.4);
+  background: rgba(53, 242, 166, 0.12);
+}
+
+.agent-projection-badge.fallback {
+  color: var(--status-pending, #f8c657);
+  border-color: rgba(248, 198, 87, 0.4);
+  background: rgba(248, 198, 87, 0.12);
+}
+
+.agent-projection-card {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--sidebar-border);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.agent-projection-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-xs);
+}
+
+.agent-projection-card-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--sidebar-fg);
+}
+
+.agent-projection-tag {
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  border: 1px solid var(--sidebar-border);
+  color: var(--sidebar-fg-dim);
+  white-space: nowrap;
+}
+
+.agent-projection-tag.cyan {
+  color: var(--sidebar-accent);
+  border-color: rgba(0, 212, 255, 0.28);
+  background: rgba(0, 212, 255, 0.1);
+}
+
+.agent-projection-grid {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.agent-projection-row {
+  display: grid;
+  grid-template-columns: minmax(92px, 0.5fr) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  background: rgba(4, 8, 14, 0.4);
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 10px;
+  min-width: 0;
+}
+
+.agent-projection-label {
+  color: var(--sidebar-fg-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.agent-projection-value {
+  color: var(--sidebar-fg);
+  overflow-wrap: anywhere;
+}
+
+.agent-projection-pill {
+  justify-self: end;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 8px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  border: 1px solid var(--sidebar-border);
+  color: var(--sidebar-fg-dim);
+  white-space: nowrap;
+}
+
+.agent-projection-pill.green {
+  color: var(--status-active, #35f2a6);
+  border-color: rgba(53, 242, 166, 0.35);
+  background: rgba(53, 242, 166, 0.1);
+}
+
+.agent-projection-pill.yellow {
+  color: var(--status-pending, #f8c657);
+  border-color: rgba(248, 198, 87, 0.4);
+  background: rgba(248, 198, 87, 0.12);
+}
+
+.agent-projection-pair {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+  min-width: 0;
+}
+
+.agent-projection-command {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
+  align-items: baseline;
+  padding: 7px 8px;
+  border-radius: var(--radius-sm);
+  background: rgba(4, 8, 14, 0.55);
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 10px;
+}
+
+.agent-projection-command-label {
+  color: var(--sidebar-fg-dim);
+}
+
+.agent-projection-command-value {
+  color: var(--sidebar-fg);
+  overflow-wrap: anywhere;
+}
+
+.agent-projection-ph {
+  display: flex;
+  gap: 6px;
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 9.5px;
+  color: var(--sidebar-fg-dim);
+  line-height: 1.4;
+}
+
+.agent-projection-ph .arrow {
+  color: var(--status-active, #35f2a6);
+  font-weight: 800;
+}
+
+.agent-projection-note {
+  font-size: 10px;
   color: var(--sidebar-fg-dim);
 }
 

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -1317,6 +1317,9 @@ html.light-theme .root-agent-avatar {
 }
 
 .settings-profile-rail-heading {
+  /* Claim the header's free space and stay shrinkable so the title truncates
+     instead of pushing into / overlapping the agent selector. */
+  flex: 1;
   min-width: 0;
 }
 
@@ -1324,6 +1327,9 @@ html.light-theme .root-agent-avatar {
   font-weight: 700;
   font-size: var(--font-size-md);
   color: var(--sidebar-fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settings-profile-rail-subtitle {
@@ -1516,9 +1522,17 @@ html.light-theme .root-agent-avatar {
 }
 
 /* ── #526 Config Screen: unified dual-rail comparison (agent list + 2 rails) ── */
-.modal-container-config {
-  max-width: 1180px;
-  width: 96%;
+/* The dual-rail compare-zone needs width — the user asked explicitly for the
+   Settings modal to span 90% of the screen. The two-class selector is
+   deliberate: the shared `.modal-container-lg` rule (max-width: 520px) is
+   declared LATER in this file, so at equal specificity it would win the cascade
+   and cap the config modal at 520px — that is what left the rails cramped.
+   Bumping specificity here (.modal-container.modal-container-config) lets the
+   90vw floor/ceiling override that cap regardless of source order. */
+.modal-container.modal-container-config {
+  width: 90vw;
+  min-width: 90vw;
+  max-width: 90vw;
   height: 90vh;
 }
 
@@ -1787,9 +1801,13 @@ html.light-theme .root-agent-avatar {
 }
 
 .settings-rail-select {
-  flex: 0 0 auto;
+  /* Shrinkable (0 1 auto) with a small floor: the old `0 0 auto` + 110px floor
+     could not shrink, so in a narrow rail it forced an internal horizontal
+     scrollbar and rode over the title. At comfortable widths it still sizes to
+     its content up to 160px. */
+  flex: 0 1 auto;
   width: auto;
-  min-width: 110px;
+  min-width: 72px;
   max-width: 160px;
 }
 

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -1582,8 +1582,24 @@ html.light-theme .root-agent-avatar {
   color: var(--sidebar-fg-dim);
 }
 
+/* #526: the panel-header "Add Agent" is the primary creation action here, so it
+   gets a clearly visible accent treatment (the dim shared .settings-add-btn was
+   nearly invisible). Mirrors the cyan accent-tint of .settings-rail-pill.left so
+   it reads as an actionable button without being loud. */
 .settings-agents-add {
   flex: 0 0 auto;
+  border: 1px solid rgba(0, 212, 255, 0.45);
+  background: rgba(0, 212, 255, 0.12);
+  color: var(--sidebar-accent);
+  font-weight: 600;
+  transition: border-color var(--transition-fast), color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.settings-agents-add:hover {
+  border-color: var(--sidebar-accent);
+  background: rgba(0, 212, 255, 0.2);
+  color: var(--sidebar-accent);
 }
 
 .settings-agents-panel-body {

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -1352,6 +1352,7 @@ html.light-theme .root-agent-avatar {
 }
 
 .settings-profile-card.match { border-left-color: var(--status-active, #35f2a6); }
+.settings-profile-card.configured { border-left-color: var(--sidebar-accent, #00d4ff); }
 .settings-profile-card.fallback { border-left-color: #e3b341; }
 .settings-profile-card.missing,
 .settings-profile-card.invalid { border-left-color: var(--status-exited, #ff5d5d); }
@@ -1380,6 +1381,13 @@ html.light-theme .root-agent-avatar {
 }
 
 .settings-profile-badge.match { color: var(--status-active, #35f2a6); border-color: rgba(53, 242, 166, 0.4); }
+/* CONFIGURED = a non-A slot with its own cell. Cyan filled chip: a "positive"
+   state like MATCH, deliberately out of the amber fallback family (#526). */
+.settings-profile-badge.configured {
+  color: var(--sidebar-accent, #00d4ff);
+  border-color: rgba(0, 212, 255, 0.4);
+  background: rgba(0, 212, 255, 0.1);
+}
 .settings-profile-badge.fallback { color: #e3b341; border-color: rgba(227, 179, 65, 0.4); }
 .settings-profile-badge.missing,
 .settings-profile-badge.invalid { color: var(--status-exited, #ff5d5d); border-color: rgba(255, 93, 93, 0.4); }
@@ -1441,6 +1449,26 @@ html.light-theme .root-agent-avatar {
   align-self: flex-start;
 }
 
+/* Footer holding the per-agent "Delete cell" + slot-level "Delete Profile". */
+.settings-profile-card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  align-self: flex-start;
+}
+
+/* Slot-level delete is destructive (drops the letter from every agent) — give it
+   a muted-red affordance that intensifies on hover, distinct from "Delete cell". */
+.settings-profile-delete-profile {
+  color: var(--status-exited, #ff5d5d);
+  border-color: rgba(255, 93, 93, 0.4);
+}
+
+.settings-profile-delete-profile:hover:not(:disabled) {
+  color: var(--status-exited, #ff5d5d);
+  border-color: var(--status-exited, #ff5d5d);
+}
+
 .settings-profile-missing {
   display: flex;
   align-items: center;
@@ -1449,6 +1477,12 @@ html.light-theme .root-agent-avatar {
   justify-content: space-between;
   color: var(--sidebar-fg-dim);
   font-size: var(--font-size-sm);
+}
+
+.settings-profile-missing-actions {
+  display: flex;
+  gap: var(--spacing-xs);
+  flex: 0 0 auto;
 }
 
 .settings-profile-cell-btn {
@@ -2816,6 +2850,38 @@ html.light-theme .root-agent-avatar {
 .agent-profile-card.missing {
   border-style: dashed;
 }
+
+/* #527: per-card status pill on the Selection profile cards. Same taxonomy and
+   colors as the Config rails so a given (agent, letter) reads identically on
+   both screens. */
+.agent-profile-card-tags {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.agent-profile-card-pill {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 2px 6px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.agent-profile-card-pill.match { color: var(--status-active, #35f2a6); border-color: rgba(53, 242, 166, 0.4); }
+.agent-profile-card-pill.configured {
+  color: var(--sidebar-accent, #00d4ff);
+  border-color: rgba(0, 212, 255, 0.4);
+  background: rgba(0, 212, 255, 0.1);
+}
+/* Match the Config rail's literal fallback amber (#e3b341) exactly so the same
+   state reads identically on both screens, independent of theme. */
+.agent-profile-card-pill.fallback { color: #e3b341; border-color: rgba(227, 179, 65, 0.4); }
+.agent-profile-card-pill.missing { color: var(--status-exited, #ff5d5d); border-color: rgba(255, 93, 93, 0.4); }
 
 .agent-profile-card-head {
   display: flex;


### PR DESCRIPTION
## Summary

Lands the consolidated Config/Selection screen rework plus the new per-coding-agent instructions-file feature:

- **#526 / #527 (Config + Selection B2C1a rework):** the dual-rail comparison Config Screen (3 tabs: General / Coding Agents / Integrations) + Selection Screen rework, including min-width 90vw, visible "Add Agent", deduped LEFT rail badge, CONFIGURED badge, Selection pills, Delete Profile, swapRails, and the MATCH/CONFIGURED/FALLBACK/MISSING badge set.
- **#529 (instructions file + OpenCode):** configurable per-coding-agent instructions filename generated/deposited in the agent root at launch (content = the existing AC instructions, routed to the coding-agent-appropriate filename), defaults Claude->`CLAUDE.md`, Codex->`AGENTS.md`, Gemini->`GEMINI.md`, OpenCode/others->`AGENTS.md`; plus **OpenCode as a built-in coding agent** (command `opencode`, quick-add button). Backend: optional `instructionsFilename` on `AgentConfig` (additive, back-compat), resolver from config with detection fallback, symlink/junction-safe writer hardening, filename validation (path-traversal + Windows device names). Frontend: "Instructions file" input per agent + OpenCode preset wired into the 3-tab Config Screen, save-time normalization.

Version bumped 0.9.2 -> 0.9.3.

## Validation
- User manual testing of the wg-7 build (Config Screen 3-tab rework + #529 features), explicitly approved for landing. (WG14 acceptance bypassed per standing user instruction; user is acting as tester.)
- Adversarial review (grinch): PASS, no bugs, no regression to the #526/#527 rework, G2 TS/Rust parity verified.
- Tests: Rust `cargo test --lib --bins --tests` 1266 passed / 0 failed; frontend vitest 313/313. `cargo check` + `clippy` clean; `npm run typecheck` clean.

## Issues
Closes #526
Closes #527
Closes #529

Follow-up: the DIFF compare-zone badge (remaining B2C1a item) is split out to #531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
