### PR TITLE
fix(opencode): last-prompt OSC strip (#533) + Entire-Workgroup agent propagation (#534)

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.9.3"; // Must match package.json
+const VERSION = "0.9.4"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -190,6 +190,7 @@ fn normalize_agent_for_wake(
 fn resolve_wake_agent_command_from_sources(
     agents: &[AgentConfig],
     preferred_agent: &str,
+    destination_current_agent: Option<&str>,
     destination_last_agent: Option<&str>,
     destination_config_path: Option<&Path>,
     sender_agent: Option<&str>,
@@ -205,6 +206,22 @@ fn resolve_wake_agent_command_from_sources(
         log::warn!(
             "[mailbox] wake: preferredAgent '{}' did not match a configured agent id; falling back to auto resolution",
             preferred_agent
+        );
+    }
+
+    // The Selection UI assignment (currentCodingAgent) is an explicit user choice
+    // and is what the "Entire Workgroup" coding-agent assignment writes to each
+    // replica. Honor it before launch history (lastCodingAgent) so the assignment
+    // propagates to freshly-spawned members that have never recorded a
+    // lastCodingAgent, and so a new selection overrides a stale launch history.
+    if let Some(agent_id) = destination_current_agent {
+        if let Some(agent) = agents.iter().find(|a| a.id == agent_id) {
+            return normalize_agent_for_wake(agent, format!("currentCodingAgent '{}'", agent_id))
+                .map(Some);
+        }
+        log::debug!(
+            "[mailbox] wake: currentCodingAgent '{}' did not match a configured agent id; falling back",
+            agent_id
         );
     }
 
@@ -2956,11 +2973,20 @@ impl MailboxPoller {
             cfg.agents.clone()
         };
 
+        let mut destination_current_agent: Option<String> = None;
         let mut destination_last_agent: Option<String> = None;
         let mut destination_config_path: Option<PathBuf> = None;
 
         if let Some(dest_path) = self.resolve_repo_path(&msg.to, app).await {
-            let config_path = Path::new(&dest_path)
+            let dest = Path::new(&dest_path);
+            // The Selection UI assignment (currentCodingAgent), including the
+            // "Entire Workgroup" path, is written to the replica's top-level
+            // config.json by set_replica_coding_agent_selection, not to the
+            // per-instance agent_local_dir config that holds lastCodingAgent.
+            destination_current_agent =
+                crate::config::coding_agent_profiles::read_replica_current_coding_agent(dest);
+
+            let config_path = dest
                 .join(crate::config::agent_local_dir_name())
                 .join("config.json");
             destination_config_path = Some(config_path.clone());
@@ -2975,6 +3001,7 @@ impl MailboxPoller {
         resolve_wake_agent_command_from_sources(
             &agents,
             &msg.preferred_agent,
+            destination_current_agent.as_deref(),
             destination_last_agent.as_deref(),
             destination_config_path.as_deref(),
             msg.sender_agent.as_deref(),
@@ -3682,9 +3709,16 @@ mod tests {
         let agents = wake_agents();
 
         let resolved =
-            resolve_wake_agent_command_from_sources(&agents, "codex", Some("claude"), None, None)
-                .unwrap()
-                .unwrap();
+            resolve_wake_agent_command_from_sources(
+                &agents,
+                "codex",
+                None,
+                Some("claude"),
+                None,
+                None,
+            )
+            .unwrap()
+            .unwrap();
 
         assert_eq!(resolved.shell, "codex");
         assert_eq!(resolved.shell_args, vec!["--yolo"]);
@@ -3700,6 +3734,7 @@ mod tests {
         let resolved = resolve_wake_agent_command_from_sources(
             &agents,
             "missing",
+            None,
             Some("codex"),
             Some(config_path),
             Some("claude"),
@@ -3717,9 +3752,16 @@ mod tests {
         let agents = wake_agents();
 
         let resolved =
-            resolve_wake_agent_command_from_sources(&agents, "auto", Some("codex"), None, None)
-                .unwrap()
-                .unwrap();
+            resolve_wake_agent_command_from_sources(
+                &agents,
+                "auto",
+                None,
+                Some("codex"),
+                None,
+                None,
+            )
+            .unwrap()
+            .unwrap();
 
         assert_eq!(resolved.shell, "codex");
         assert_eq!(resolved.shell_args, vec!["--yolo"]);
@@ -3733,6 +3775,7 @@ mod tests {
         let resolved = resolve_wake_agent_command_from_sources(
             &agents,
             "auto",
+            None,
             Some("missing"),
             None,
             Some("claude"),
@@ -3753,6 +3796,7 @@ mod tests {
         let resolved = resolve_wake_agent_command_from_sources(
             &agents,
             "auto",
+            None,
             Some("missing"),
             None,
             Some("also-missing"),
@@ -3767,10 +3811,53 @@ mod tests {
     }
 
     #[test]
+    fn wake_agent_command_prefers_current_coding_agent_over_last() {
+        let agents = wake_agents();
+
+        let resolved = resolve_wake_agent_command_from_sources(
+            &agents,
+            "auto",
+            Some("claude"),
+            Some("codex"),
+            None,
+            None,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(resolved.shell, "claude");
+        assert_eq!(resolved.agent_id.as_deref(), Some("claude"));
+        assert!(resolved.source.contains("currentCodingAgent 'claude'"));
+    }
+
+    #[test]
+    fn wake_agent_command_uses_current_coding_agent_when_last_missing() {
+        // The "Entire Workgroup" assignment writes currentCodingAgent to a
+        // freshly-spawned member that has no lastCodingAgent yet. Without it the
+        // resolver would fall through to senderAgent / first configured agent.
+        let agents = wake_agents();
+
+        let resolved = resolve_wake_agent_command_from_sources(
+            &agents,
+            "auto",
+            Some("codex"),
+            None,
+            None,
+            Some("claude"),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(resolved.shell, "codex");
+        assert_eq!(resolved.agent_id.as_deref(), Some("codex"));
+        assert!(resolved.source.contains("currentCodingAgent 'codex'"));
+    }
+
+    #[test]
     fn wake_agent_command_rejects_invalid_quoted_command_with_source() {
         let agents = vec![wake_agent("codex", "Codex", "codex \"unterminated")];
 
-        let err = resolve_wake_agent_command_from_sources(&agents, "codex", None, None, None)
+        let err = resolve_wake_agent_command_from_sources(&agents, "codex", None, None, None, None)
             .unwrap_err();
 
         assert!(err.contains("preferredAgent 'codex'"));
@@ -3785,9 +3872,16 @@ mod tests {
         let agents = wake_agents();
 
         let resolved =
-            resolve_wake_agent_command_from_sources(&agents, "codex", None, None, Some("claude"))
-                .unwrap()
-                .unwrap();
+            resolve_wake_agent_command_from_sources(
+                &agents,
+                "codex",
+                None,
+                None,
+                None,
+                Some("claude"),
+            )
+            .unwrap()
+            .unwrap();
 
         assert_eq!(resolved.shell, "codex");
         assert_eq!(resolved.shell_args, vec!["--yolo"]);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {

--- a/src/terminal/components/prompt-input-capture.test.ts
+++ b/src/terminal/components/prompt-input-capture.test.ts
@@ -46,4 +46,57 @@ describe("updatePromptCapture", () => {
       submittedPrompt: "abd",
     });
   });
+
+  it("strips a BEL-terminated OSC-4 colour reply that precedes typed text (#533)", () => {
+    // OpenCode answers an OSC-4 palette query on the input channel; previously
+    // only the leading ESC was dropped and "]4;0;rgb:..." leaked into the prompt.
+    const oscReply = "\x1b]4;0;rgb:1a1a/1a1a/2e2e\x07";
+    expect(
+      applyChunks([`${oscReply}Mandale un saludo a tu team`, "\r"]),
+    ).toEqual({
+      buffer: "",
+      submittedPrompt: "Mandale un saludo a tu team",
+    });
+  });
+
+  it("strips an OSC sequence terminated by ST (ESC \\) between typed text", () => {
+    const osc = "\x1b]0;window title\x1b\\";
+    expect(applyChunks([`before ${osc}after`, "\r"])).toEqual({
+      buffer: "",
+      submittedPrompt: "before after",
+    });
+  });
+
+  it("strips a DCS sequence terminated by ST", () => {
+    const dcs = "\x1bP1;2|payload\x1b\\";
+    expect(applyChunks([`x${dcs}y`, "\r"])).toEqual({
+      buffer: "",
+      submittedPrompt: "xy",
+    });
+  });
+
+  it("does not let a BEL inside a DCS payload terminate it early (DCS ends only at ST)", () => {
+    // Only OSC accepts BEL; a literal BEL in a DCS payload must be consumed, not
+    // treated as a terminator, or the tail would leak into the captured prompt.
+    const dcs = "\x1bPdata\x07more\x1b\\";
+    expect(applyChunks([`x${dcs}y`, "\r"])).toEqual({
+      buffer: "",
+      submittedPrompt: "xy",
+    });
+  });
+
+  it("strips an 8-bit OSC introducer (\\x9d) terminated by 8-bit ST (\\x9c)", () => {
+    expect(applyChunks(["a\x9d4;0;rgb:1/2/3\x9cb", "\r"])).toEqual({
+      buffer: "",
+      submittedPrompt: "ab",
+    });
+  });
+
+  it("keeps literal brackets that are not part of an OSC sequence", () => {
+    // A bare "]" (not preceded by ESC) is ordinary prompt text, not a control byte.
+    expect(applyChunks(["arr[0] = list[ ]", "\r"])).toEqual({
+      buffer: "",
+      submittedPrompt: "arr[0] = list[ ]",
+    });
+  });
 });

--- a/src/terminal/components/prompt-input-capture.ts
+++ b/src/terminal/components/prompt-input-capture.ts
@@ -19,26 +19,91 @@ function findPasteEnd(data: string, fromIndex: number) {
     : { index: end8, marker: PASTE_END_8BIT };
 }
 
-function skipControlSequence(data: string, index: number) {
-  const next = data[index + 1];
-  if (data[index] === "\x1b" && next === "[") {
-    for (let i = index + 2; i < data.length; i += 1) {
-      const code = data.charCodeAt(i);
-      if (code >= 0x40 && code <= 0x7e) {
-        return i + 1;
-      }
+// 8-bit C1 OSC introducer. OSC (7-bit `ESC ]`) is handled apart from the other
+// string controls because it alone accepts BEL as a terminator (see below).
+const OSC_INTRO_8BIT = "\x9d";
+
+// The remaining ECMA-48 "string" controls, which terminate ONLY at ST: DCS, SOS,
+// PM, APC. 7-bit finals after ESC: P (DCS), X (SOS), ^ (PM), _ (APC).
+const STRING_SEQ_INTRO_7BIT = new Set(["P", "X", "^", "_"]);
+// 8-bit C1 equivalents: \x90 (DCS), \x98 (SOS), \x9e (PM), \x9f (APC).
+const STRING_SEQ_INTRO_8BIT = new Set(["\x90", "\x98", "\x9e", "\x9f"]);
+
+// Bytes that begin a control sequence we must skip rather than capture as prompt
+// text: ESC (every 7-bit sequence), 8-bit CSI (\x9b, also the bracketed-paste
+// prefix handled before this check), and the 8-bit string introducers (OSC + the
+// ST-only family).
+function isControlIntroducer(char: string): boolean {
+  return (
+    char === "\x1b" ||
+    char === "\x9b" ||
+    char === OSC_INTRO_8BIT ||
+    STRING_SEQ_INTRO_8BIT.has(char)
+  );
+}
+
+// CSI: consume up to and including the final byte (0x40–0x7e).
+function skipCsi(data: string, bodyStart: number): number {
+  for (let i = bodyStart; i < data.length; i += 1) {
+    const code = data.charCodeAt(i);
+    if (code >= 0x40 && code <= 0x7e) {
+      return i + 1;
     }
-    return data.length;
+  }
+  return data.length;
+}
+
+// OSC/DCS/SOS/PM/APC: consume the whole "string" sequence up to its terminator.
+// All end at ST (`ESC \` or 8-bit \x9c); OSC additionally accepts BEL (\x07) —
+// the xterm convention OpenCode uses for its OSC-4 colour-palette reply (#533).
+// For DCS/SOS/PM/APC, `belTerminates` is false, so a stray BEL inside the payload
+// is consumed rather than mistaken for a terminator.
+function skipStringSequence(
+  data: string,
+  bodyStart: number,
+  belTerminates: boolean,
+): number {
+  for (let i = bodyStart; i < data.length; i += 1) {
+    const code = data.charCodeAt(i);
+    if (code === 0x9c || (belTerminates && code === 0x07)) {
+      return i + 1; // 8-bit ST, or BEL for OSC
+    }
+    if (code === 0x1b && data[i + 1] === "\\") {
+      return i + 2; // 7-bit ST: ESC \
+    }
+  }
+  return data.length;
+}
+
+function skipControlSequence(data: string, index: number): number {
+  const char = data[index];
+
+  if (char === "\x1b") {
+    const next = data[index + 1];
+    if (next === "[") {
+      return skipCsi(data, index + 2); // CSI: ESC [
+    }
+    if (next === "]") {
+      return skipStringSequence(data, index + 2, true); // OSC: ST or BEL
+    }
+    if (next !== undefined && STRING_SEQ_INTRO_7BIT.has(next)) {
+      return skipStringSequence(data, index + 2, false); // DCS/SOS/PM/APC: ST only
+    }
+    // Lone trailing ESC or a short escape this helper does not model — drop just
+    // the ESC, preserving prior behaviour for those cases.
+    return index + 1;
   }
 
-  if (data[index] === "\x9b") {
-    for (let i = index + 1; i < data.length; i += 1) {
-      const code = data.charCodeAt(i);
-      if (code >= 0x40 && code <= 0x7e) {
-        return i + 1;
-      }
-    }
-    return data.length;
+  if (char === "\x9b") {
+    return skipCsi(data, index + 1); // 8-bit CSI
+  }
+
+  if (char === OSC_INTRO_8BIT) {
+    return skipStringSequence(data, index + 1, true); // 8-bit OSC: ST or BEL
+  }
+
+  if (STRING_SEQ_INTRO_8BIT.has(char)) {
+    return skipStringSequence(data, index + 1, false); // 8-bit DCS/SOS/PM/APC: ST only
   }
 
   return index + 1;
@@ -67,7 +132,7 @@ function promptTextFromInputChunk(data: string) {
     }
 
     const char = data[index];
-    if (char === "\x1b" || char === "\x9b") {
+    if (isControlIntroducer(char)) {
       index = skipControlSequence(data, index);
       continue;
     }


### PR DESCRIPTION
## Summary
Two OpenCode-integration fixes; version bumped to v0.9.4.

- **#533** — The LAST PROMPT display leaked a raw terminal OSC escape sequence (`]4;0;rgb:…`) prepended to the user's text. Fixed by extending the prompt-capture helper (`src/terminal/components/prompt-input-capture.ts`) to consume full OSC/DCS/SOS/PM/APC control sequences (7- and 8-bit), not just CSI. The capture path is **agent-agnostic**, so the fix is global (OpenCode was only the trigger). CSI + bracketed-paste handling unchanged; literal user input preserved.
- **#534** — Assigning a coding agent with the **"Entire Workgroup"** option didn't propagate to woken team members (they spawned as the default, Claude Code). Fixed in the member wake path (`src-tauri/src/phone/mailbox.rs`) to read `tooling.currentCodingAgent` (what the selection writes), ranked above launch history (`lastCodingAgent`) and below an explicit per-wake `preferredAgent`.

## Not included
- **#531 (DIFF badge)** was implemented and then **removed** in this branch — the comparison proved useless (a raw cross-agent command-string compare that is trivially always-on between two different agents, redundant with CONFIGURED). **#531 stays open** to be redesigned. (Intentionally no `Closes #531`.)
- **#535** filed for a pre-existing same-class bug in the Loop self-wake path (`loops/delivery.rs`) — not addressed here.

## Validation
- Implemented by dev-rust (#534) + dev-webpage-ui (#533); root causes localized, no architectural change.
- Backend full suite green (`cargo test --lib --bins --tests`, 1128 passed); frontend green (vitest 319 passed, `tsc --noEmit` clean); `cargo check` clean.
- Adversarial review (dev-rust-grinch): PASS, no HIGH/MED findings; re-reviewed the #531 removal — clean, zero collateral, net diff vs main = only #533 + #534 + version bump.
- **Manually validated by the maintainer** in a local wg-10 build: #533 and #534 confirmed working. Acceptance-testing was intentionally skipped for this development at the maintainer's request (manual verification).
- Version synced 0.9.3 → 0.9.4 across all locations.

Closes #533
Closes #534
