### PR TITLE
feat(sidebar): regex filter control (#515)

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.9.4"; // Must match package.json
+const VERSION = "0.9.5"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {

--- a/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import ProjectPanel from "./ProjectPanel";
 import { FakeTransport } from "../../shared/testing/fake-transport";
 import {
+  baseSettings,
   click,
   discovery,
   input,
@@ -14,7 +15,8 @@ import {
 } from "../../shared/testing/ui-harness";
 import { projectStore } from "../stores/project";
 import { sessionsStore } from "../stores/sessions";
-import type { AcLoopSummary } from "../../shared/types";
+import { settingsStore } from "../../shared/stores/settings";
+import type { AcLoopSummary, AgentConfig } from "../../shared/types";
 
 const projectPath = "C:\\Project";
 const workgroupPath = `${projectPath}\\.ac\\wg-2-dev-team`;
@@ -125,6 +127,21 @@ function findByTestId<T extends Element>(root: ParentNode, testId: string): T {
     throw new Error(`Element not found: ${testId}`);
   }
   return element as T;
+}
+
+/** Minimal valid coding-agent config so a session's `agentId` resolves to a
+ *  badge label via settings (the `agent_label: None` runtime path). */
+function agentConfig(
+  fields: Pick<AgentConfig, "id" | "label" | "command">
+): AgentConfig {
+  return {
+    color: "#888888",
+    gitPullBefore: false,
+    excludeGlobalClaudeMd: false,
+    envs: [],
+    isolatedHome: false,
+    ...fields,
+  };
 }
 
 describe("ProjectPanel regex filter", () => {
@@ -696,6 +713,193 @@ describe("ProjectPanel regex filter", () => {
         new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
       );
       await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("false"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("matches an agent row by its coding-agent badge resolved from agentId, per row (#515)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve(
+      "discover_project",
+      discovery({
+        agents: [
+          { name: "AgentsCommander_ac/__agent_alpha", path: `${projectPath}\\.ac\\_agent_alpha`, roleExists: true },
+          { name: "AgentsCommander_ac/__agent_bravo", path: `${projectPath}\\.ac\\_agent_bravo`, roleExists: true },
+        ],
+      })
+    );
+    // The badge label is resolved from agentId via settings (agent_label: None).
+    fake.resolve(
+      "get_settings",
+      baseSettings({
+        agents: [
+          agentConfig({ id: "claude", label: "Claude Code", command: "claude" }),
+          agentConfig({ id: "opencode", label: "opencode", command: "opencode" }),
+        ],
+      })
+    );
+
+    sessionsStore.setSessions([
+      session({
+        id: "alpha-session",
+        name: "AgentsCommander_ac/__agent_alpha",
+        workingDirectory: `${projectPath}\\.ac\\_agent_alpha`,
+        status: "running",
+        agentId: "claude",
+        agentLabel: null,
+      }),
+      session({
+        id: "bravo-session",
+        name: "AgentsCommander_ac/__agent_bravo",
+        workingDirectory: `${projectPath}\\.ac\\_agent_bravo`,
+        status: "running",
+        agentId: "opencode",
+        agentLabel: null,
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("alpha"));
+      // Each row renders its resolved coding-agent badge.
+      expect(rendered.root.textContent).toContain("Claude Code");
+      expect(rendered.root.textContent).toContain("opencode");
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      // The coding-agent badge is now matchable — and only on the row that shows
+      // it (the name "alpha" never contains "Claude Code", so the match is the badge).
+      input(filterInput, "Claude Code");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("alpha");
+        expect(rendered.root.textContent).not.toContain("bravo");
+      });
+
+      input(filterInput, "opencode");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("bravo");
+        expect(rendered.root.textContent).not.toContain("alpha");
+      });
+
+      // Both still match by their visible names.
+      input(filterInput, "a"); // matches alpha and bravo
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("alpha");
+        expect(rendered.root.textContent).toContain("bravo");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("matches an agent row by its visible profile letter when the meta badge is shown (#515)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve(
+      "discover_project",
+      discovery({
+        agents: [
+          { name: "AgentsCommander_ac/__agent_charlie", path: `${projectPath}\\.ac\\_agent_charlie`, roleExists: true },
+        ],
+      })
+    );
+    fake.resolve(
+      "get_settings",
+      baseSettings({ agents: [agentConfig({ id: "claude", label: "Claude Code", command: "claude" })] })
+    );
+
+    sessionsStore.setSessions([
+      // A resolvable agentId renders the meta block, so the profile letter inside
+      // it is shown — and therefore must be matchable (the bug-2 gate, verified
+      // here for the resolved-label path the user hit).
+      session({
+        id: "charlie-session",
+        name: "AgentsCommander_ac/__agent_charlie",
+        workingDirectory: `${projectPath}\\.ac\\_agent_charlie`,
+        status: "running",
+        agentId: "claude",
+        agentLabel: null,
+        requestedProfile: "Z",
+        effectiveProfile: "Z",
+        profileFallbackApplied: false,
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("charlie"));
+      expect(rendered.root.textContent).toContain("Z"); // profile badge shown
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      // The shown profile letter matches the row.
+      input(filterInput, "Z");
+      await waitFor(() => expect(rendered.root.textContent).toContain("charlie"));
+
+      // A profile letter that is NOT shown hides the row — confirms the match was
+      // the profile badge, not the name or the coding-agent label.
+      input(filterInput, "Q");
+      await waitFor(() => expect(rendered.root.textContent).not.toContain("charlie"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("matches a coordinator quick-access row by its visible task title (#515)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve(
+      "discover_project",
+      discovery({
+        workgroups: [
+          {
+            name: "wg-2-dev-team",
+            path: workgroupPath,
+            task: null,
+            taskTitle: "Quasar telemetry rollout",
+            agents: [
+              {
+                name: "dev-webpage-ui",
+                path: `${workgroupPath}\\__agent_dev-webpage-ui`,
+                repoPaths: [],
+                isCoordinator: true,
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("Quasar telemetry rollout"));
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      // "telemetry" appears only in the task title, yet the coordinator row that
+      // displays it stays visible — the task title is matchable.
+      input(filterInput, "telemetry");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).toContain("Quasar telemetry rollout");
+      });
+
+      // A token shown nowhere hides the row.
+      input(filterInput, "nonsensetoken");
+      await waitFor(() => expect(rendered.root.textContent).not.toContain("dev-webpage-ui"));
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  discovery,
+  input,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+  session,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
+
+const projectPath = "C:\\Project";
+const workgroupPath = `${projectPath}\\.ac\\wg-2-dev-team`;
+
+function projectDiscovery() {
+  return discovery({
+    agents: [],
+    teams: [
+      {
+        name: "frontend-team",
+        agents: ["AgentsCommander_ac/__agent_dev-webpage-ui"],
+        coordinator: "AgentsCommander_ac/__agent_dev-webpage-ui",
+      },
+    ],
+    workgroups: [
+      {
+        name: "wg-2-dev-team",
+        path: workgroupPath,
+        task: null,
+        taskTitle: "Sidebar regex filter",
+        agents: [
+          {
+            name: "dev-webpage-ui",
+            path: `${workgroupPath}\\__agent_dev-webpage-ui`,
+            repoPaths: [],
+            isCoordinator: true,
+          },
+          {
+            name: "dev-rust",
+            path: `${workgroupPath}\\__agent_dev-rust`,
+            repoPaths: [],
+            isCoordinator: false,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function findByTestId<T extends Element>(root: ParentNode, testId: string): T {
+  const element = root.querySelector(`[data-ac-testid="${testId}"]`);
+  if (!element) {
+    throw new Error(`Element not found: ${testId}`);
+  }
+  return element as T;
+}
+
+describe("ProjectPanel regex filter", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("opens inline, filters presentation, reports invalid regex, and clears with Escape", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", {
+      path: projectPath,
+      registered: true,
+      created: false,
+    });
+    fake.resolve("discover_project", projectDiscovery());
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+      expect(rendered.root.textContent).toContain("dev-rust");
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+      await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("true"));
+      await waitFor(() => expect(document.activeElement).toBe(filterInput));
+
+      input(filterInput, "webpage");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).not.toContain("dev-rust");
+      });
+
+      input(filterInput, "(");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("Invalid regex");
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).toContain("dev-rust");
+      });
+
+      filterInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+      await waitFor(() => {
+        expect(filterInput.value).toBe("");
+        expect(rendered.root.textContent).not.toContain("Invalid regex");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("matches visible team project labels and quick-access running-peer badges", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", {
+      path: projectPath,
+      registered: true,
+      created: false,
+    });
+    fake.resolve("discover_project", projectDiscovery());
+
+    sessionsStore.setSessions([
+      session({
+        id: "coord-session",
+        name: "wg-2-dev-team/dev-webpage-ui",
+        workingDirectory: `${workgroupPath}\\__agent_dev-webpage-ui`,
+        status: "running",
+      }),
+      session({
+        id: "peer-session",
+        name: "wg-2-dev-team/dev-rust",
+        workingDirectory: `${workgroupPath}\\__agent_dev-rust`,
+        status: "running",
+      }),
+    ]);
+    sessionsStore.setActiveId("coord-session");
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("frontend-team"));
+      const teamHeader = Array.from(rendered.root.querySelectorAll(".ac-team-header")).find((header) =>
+        header.textContent?.includes("frontend-team")
+      );
+      if (!teamHeader) {
+        throw new Error("Team header not found");
+      }
+      click(teamHeader);
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      input(filterInput, "AgentsCommander_ac");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("dev-webpage-ui@AgentsCommander_ac");
+        expect(rendered.root.textContent).toContain("frontend-team");
+      });
+
+      input(filterInput, "RUNNING");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).toContain("dev-rust RUNNING");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../shared/testing/ui-harness";
 import { projectStore } from "../stores/project";
 import { sessionsStore } from "../stores/sessions";
+import type { AcLoopSummary } from "../../shared/types";
 
 const projectPath = "C:\\Project";
 const workgroupPath = `${projectPath}\\.ac\\wg-2-dev-team`;
@@ -46,6 +47,71 @@ function projectDiscovery() {
             path: `${workgroupPath}\\__agent_dev-rust`,
             repoPaths: [],
             isCoordinator: false,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function loop(overrides: Partial<AcLoopSummary> = {}): AcLoopSummary {
+  return {
+    id: "loop-standup",
+    name: "Weekday standup",
+    enabled: true,
+    expr: "0 9 * * 1-5",
+    timezone: "local",
+    targetKind: "workgroupCoordinator",
+    workgroup: "wg-2-dev-team",
+    promptPreview: "scheduled run",
+    busyCoordinator: "skip",
+    path: `${projectPath}\\.ac\\_loop_standup`,
+    configPath: `${projectPath}\\.ac\\_loop_standup\\config.toml`,
+    lastCheckedAt: null,
+    lastDueAt: null,
+    lastDeliveredAt: null,
+    lastResult: null,
+    pendingDueAt: null,
+    lastMissedClosedAt: null,
+    nextDueAt: null,
+    ...overrides,
+  };
+}
+
+function discoveryWithLoops(loops: AcLoopSummary[]) {
+  return { ...projectDiscovery(), loops };
+}
+
+function twoWorkgroupDiscovery() {
+  return discovery({
+    agents: [],
+    teams: [],
+    workgroups: [
+      {
+        name: "wg-2-dev-team",
+        path: workgroupPath,
+        task: null,
+        taskTitle: "Sidebar regex filter",
+        agents: [
+          {
+            name: "dev-webpage-ui",
+            path: `${workgroupPath}\\__agent_dev-webpage-ui`,
+            repoPaths: [],
+            isCoordinator: true,
+          },
+        ],
+      },
+      {
+        name: "wg-3-ops-team",
+        path: `${projectPath}\\.ac\\wg-3-ops-team`,
+        task: null,
+        taskTitle: "Ops rotation",
+        agents: [
+          {
+            name: "ops-lead",
+            path: `${projectPath}\\.ac\\wg-3-ops-team\\__agent_ops-lead`,
+            repoPaths: [],
+            isCoordinator: true,
           },
         ],
       },
@@ -172,6 +238,128 @@ describe("ProjectPanel regex filter", () => {
       await waitFor(() => {
         expect(rendered.root.textContent).toContain("dev-webpage-ui");
         expect(rendered.root.textContent).toContain("dev-rust RUNNING");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("filters loop rows and treats the Loops section label as matchable", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve(
+      "discover_project",
+      discoveryWithLoops([
+        loop({ id: "loop-standup", name: "Weekday standup", promptPreview: "morning sync" }),
+        loop({
+          id: "loop-backup",
+          name: "Nightly backup",
+          expr: "0 2 * * *",
+          promptPreview: "archive job",
+          path: `${projectPath}\\.ac\\_loop_backup`,
+          configPath: `${projectPath}\\.ac\\_loop_backup\\config.toml`,
+        }),
+      ])
+    );
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("Weekday standup"));
+      expect(rendered.root.textContent).toContain("Nightly backup");
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      input(filterInput, "standup");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("Weekday standup");
+        expect(rendered.root.textContent).not.toContain("Nightly backup");
+      });
+
+      // The section label itself is matchable -> every loop shows again.
+      input(filterInput, "Loops");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("Weekday standup");
+        expect(rendered.root.textContent).toContain("Nightly backup");
+      });
+
+      // No match anywhere -> loop rows hide cleanly with no empty-state hint.
+      input(filterInput, "zzz-no-such-loop");
+      await waitFor(() => {
+        expect(rendered.root.textContent).not.toContain("Weekday standup");
+        expect(rendered.root.textContent).not.toContain("Nightly backup");
+        expect(rendered.root.textContent).not.toContain("No loops");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("updates the Workgroups section count to reflect filtered matches", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", twoWorkgroupDiscovery());
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("wg-3-ops-team"));
+
+      const workgroupsCount = () => {
+        const header = Array.from(rendered.root.querySelectorAll(".ac-wg-header")).find(
+          (h) => h.querySelector(".ac-wg-name")?.textContent === "Workgroups"
+        );
+        return header?.querySelector(".ac-team-count")?.textContent ?? null;
+      };
+
+      await waitFor(() => expect(workgroupsCount()).toBe("2"));
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      input(filterInput, "ops-team");
+      await waitFor(() => {
+        expect(workgroupsCount()).toBe("1");
+        expect(rendered.root.textContent).toContain("wg-3-ops-team");
+        expect(rendered.root.textContent).not.toContain("wg-2-dev-team");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("closes and clears the active filter when the magnifier is toggled", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", projectDiscovery());
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+      await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("true"));
+
+      input(filterInput, "webpage");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).not.toContain("dev-rust");
+      });
+
+      // Toggling the magnifier closes the field AND drops the filter so no
+      // active-but-hidden filter survives.
+      click(toggle);
+      await waitFor(() => {
+        expect(toggle.getAttribute("aria-expanded")).toBe("false");
+        expect(filterInput.value).toBe("");
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).toContain("dev-rust");
       });
     } finally {
       rendered.cleanup();

--- a/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
@@ -365,4 +365,339 @@ describe("ProjectPanel regex filter", () => {
       rendered.cleanup();
     }
   });
+
+  it("is presentation-only — an active filter never mutates project/session data", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve(
+      "discover_project",
+      discoveryWithLoops([loop({ id: "loop-standup", name: "Weekday standup" })])
+    );
+
+    sessionsStore.setSessions([
+      session({
+        id: "coord-session",
+        name: "wg-2-dev-team/dev-webpage-ui",
+        workingDirectory: `${workgroupPath}\\__agent_dev-webpage-ui`,
+        status: "running",
+        isCoordinator: true,
+      }),
+      session({
+        id: "peer-session",
+        name: "wg-2-dev-team/dev-rust",
+        workingDirectory: `${workgroupPath}\\__agent_dev-rust`,
+        // Exited (not a running peer) so the matched coordinator does not render
+        // a legitimate "dev-rust RUNNING" peer badge — keeps the hide assertion
+        // about the dev-rust *row*, not data integrity.
+        status: { exited: 0 },
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-rust"));
+
+      const wgAgents = () => projectStore.projects[0].workgroups[0].agents.map((a) => a.name);
+      const sessionIds = () => sessionsStore.sessions.map((s) => s.id).sort();
+      const beforeAgents = wgAgents();
+      const beforeSessions = sessionIds();
+      const beforeLoops = projectStore.projects[0].loops.map((l) => l.id);
+      const beforeTeams = projectStore.projects[0].teams.map((t) => t.name);
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      // A filter that hides the non-matching rows.
+      input(filterInput, "webpage");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).not.toContain("dev-rust");
+      });
+
+      // The store-backed source data is untouched — only DOM visibility changed.
+      expect(wgAgents()).toEqual(beforeAgents);
+      expect(sessionIds()).toEqual(beforeSessions);
+      expect(projectStore.projects[0].loops.map((l) => l.id)).toEqual(beforeLoops);
+      expect(projectStore.projects[0].teams.map((t) => t.name)).toEqual(beforeTeams);
+
+      // Clearing the filter restores the hidden row from the same untouched data.
+      input(filterInput, "");
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-rust"));
+      expect(wgAgents()).toEqual(beforeAgents);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("does not surface a non-coordinator row by its hidden branch, yet a coordinator's shown branch still matches (bug 1)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", projectDiscovery());
+
+    sessionsStore.setSessions([
+      session({
+        id: "coord-session",
+        name: "wg-2-dev-team/dev-webpage-ui",
+        workingDirectory: `${workgroupPath}\\__agent_dev-webpage-ui`,
+        status: "running",
+        isCoordinator: true,
+        gitRepos: [{ label: "uirepo", sourcePath: "C:\\repo-ui", branch: "coordbranch" }],
+      }),
+      session({
+        id: "peer-session",
+        name: "wg-2-dev-team/dev-rust",
+        workingDirectory: `${workgroupPath}\\__agent_dev-rust`,
+        status: "running",
+        isCoordinator: false,
+        gitRepos: [{ label: "rustrepo", sourcePath: "C:\\repo-rust", branch: "peerbranch" }],
+      }),
+    ]);
+    sessionsStore.setActiveId("coord-session");
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-rust"));
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      // The non-coordinator's branch badge is never rendered, so its branch is
+      // not matchable — dev-rust must NOT be surfaced (the bug).
+      input(filterInput, "peerbranch");
+      await waitFor(() => expect(rendered.root.textContent).not.toContain("dev-rust"));
+
+      // dev-rust still matches by a field that IS visible (its name).
+      input(filterInput, "dev-rust");
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-rust"));
+
+      // The coordinator's branch badge IS rendered, so its branch stays matchable.
+      input(filterInput, "coordbranch");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).toContain("uirepo/coordbranch");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("does not match a session's hidden shell string (bug 1)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", projectDiscovery());
+
+    sessionsStore.setSessions([
+      session({
+        id: "coord-session",
+        name: "wg-2-dev-team/dev-webpage-ui",
+        workingDirectory: `${workgroupPath}\\__agent_dev-webpage-ui`,
+        status: "running",
+        isCoordinator: true,
+        shell: "bash",
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      // `shell` is never rendered on a row, so filtering by it surfaces nothing.
+      input(filterInput, "bash");
+      await waitFor(() => expect(rendered.root.textContent).not.toContain("dev-webpage-ui"));
+
+      // The same row still matches by its visible name.
+      input(filterInput, "webpage");
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("does not match a loop's promptPreview (hover-only), but the loop name still matches (bug 1)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve(
+      "discover_project",
+      discoveryWithLoops([
+        loop({ id: "loop-standup", name: "Weekday standup", promptPreview: "secretpreviewtoken" }),
+      ])
+    );
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("Weekday standup"));
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      // promptPreview renders only as the row's hover title, so it is not matchable.
+      input(filterInput, "secretpreviewtoken");
+      await waitFor(() => expect(rendered.root.textContent).not.toContain("Weekday standup"));
+
+      // The loop's visible name still matches.
+      input(filterInput, "standup");
+      await waitFor(() => expect(rendered.root.textContent).toContain("Weekday standup"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("matches a row by its visible profile badge token (bug 2)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", projectDiscovery());
+
+    sessionsStore.setSessions([
+      session({
+        id: "coord-session",
+        name: "wg-2-dev-team/dev-webpage-ui",
+        workingDirectory: `${workgroupPath}\\__agent_dev-webpage-ui`,
+        status: "running",
+        isCoordinator: true,
+        requestedProfile: "A",
+        effectiveProfile: "B",
+        profileFallbackApplied: true,
+      }),
+    ]);
+    sessionsStore.setActiveId("coord-session");
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      // The A->B badge is rendered on the coordinator row.
+      await waitFor(() => expect(rendered.root.textContent).toContain("A->B"));
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      // Filtering by the shown badge keeps the row visible (no "false hide").
+      input(filterInput, "A->B");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).toContain("A->B");
+      });
+
+      // A profile token that is NOT shown hides the row (confirms the match was
+      // the badge, not something else).
+      input(filterInput, "C->D");
+      await waitFor(() => expect(rendered.root.textContent).not.toContain("dev-webpage-ui"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("only matches an agent SessionItem's profile badge when that badge is actually shown (bug 1)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve(
+      "discover_project",
+      discovery({
+        agents: [
+          { name: "AgentsCommander_ac/__agent_solohidden", path: `${projectPath}\\.ac\\_agent_solohidden`, roleExists: true },
+          { name: "AgentsCommander_ac/__agent_soloshown", path: `${projectPath}\\.ac\\_agent_soloshown`, roleExists: true },
+        ],
+      })
+    );
+
+    sessionsStore.setSessions([
+      // No agent label resolves and not a coordinator-with-repos → SessionItem's
+      // meta block (and thus its profile badge) is NOT rendered.
+      session({
+        id: "solohidden-session",
+        name: "AgentsCommander_ac/__agent_solohidden",
+        workingDirectory: `${projectPath}\\.ac\\_agent_solohidden`,
+        status: "running",
+        isCoordinator: false,
+        agentId: null,
+        agentLabel: null,
+        gitRepos: [],
+        requestedProfile: "A",
+        effectiveProfile: "B",
+        profileFallbackApplied: true,
+      }),
+      // Coordinator with repos → meta block renders, so its profile badge shows.
+      session({
+        id: "soloshown-session",
+        name: "AgentsCommander_ac/__agent_soloshown",
+        workingDirectory: `${projectPath}\\.ac\\_agent_soloshown`,
+        status: "running",
+        isCoordinator: true,
+        agentId: null,
+        agentLabel: null,
+        gitRepos: [{ label: "shownrepo", sourcePath: "C:\\repo-shown", branch: "x" }],
+        requestedProfile: "C",
+        effectiveProfile: "D",
+        profileFallbackApplied: true,
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("solohidden"));
+      // The hidden agent's badge is genuinely absent; the shown agent's is present.
+      expect(rendered.root.textContent).not.toContain("A->B");
+      expect(rendered.root.textContent).toContain("C->D");
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      // Hidden badge → not matchable (must not surface the row).
+      input(filterInput, "A->B");
+      await waitFor(() => expect(rendered.root.textContent).not.toContain("solohidden"));
+
+      // Shown badge → matchable (surfaces only the row that displays it).
+      input(filterInput, "C->D");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("soloshown");
+        expect(rendered.root.textContent).not.toContain("solohidden");
+      });
+
+      // Both still match by their visible names.
+      input(filterInput, "solohidden");
+      await waitFor(() => expect(rendered.root.textContent).toContain("solohidden"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("closes the filter when Escape is pressed on an empty field", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", projectDiscovery());
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+      await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("true"));
+      expect(filterInput.value).toBe("");
+
+      // Escape on an already-empty field closes the filter outright — the
+      // previously untested empty branch of handleFilterKeyDown.
+      filterInput.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
+      );
+      await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("false"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
 });

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -479,17 +479,32 @@ const ProjectPanel: Component = () => {
           if (!regex) return true;
           return regex.test(joinSearchText(...parts));
         };
+        // Search text for the session fields visible on EVERY row that shows this
+        // session (shared by replica rows and agent SessionItems): name, agent
+        // label, and the status dot's state. Conditionally-rendered badges are
+        // contributed by the per-row callers under the gate that matches their
+        // render — repo/branch (replicaSearchText / sessionRepoSearchText) and the
+        // profile badge — so "what you match == what you see" (#515 bug 1).
+        // `shell` is dropped: it is never shown on any row. status/waiting/pending
+        // stay — they are the visible status dot's state, so dropping them would
+        // hide a row whose dot the user can see.
         const sessionSearchText = (session: Session | undefined) => {
           if (!session) return "";
           return joinSearchText(
             session.name,
             session.agentLabel,
-            session.shell,
             sessionStatusSearchText(session.status),
             session.waitingForInput ? "waiting" : null,
-            session.pendingReview ? "pending" : null,
-            session.gitRepos.map((repo) => `${repo.label}${repo.branch ? `/${repo.branch}` : ""}`).join(" ")
+            session.pendingReview ? "pending" : null
           );
+        };
+        // Repo/branch chips on an agent SessionItem render only for a coordinator
+        // session with repos (SessionItem gate `isCoordinator && !inactive &&
+        // gitRepos.length`). Gate the search text identically so a non-coordinator
+        // agent row is never surfaced by a branch it isn't showing (#515 bug 1).
+        const sessionRepoSearchText = (session: Session | undefined) => {
+          if (!session || !session.isCoordinator || session.id.startsWith("inactive-")) return "";
+          return session.gitRepos.map((repo) => formatReplicaRepoBadgeLabel(repo)).join(" ");
         };
         const liveAgentLabel = (session: Session | undefined) => {
           if (!session) return null;
@@ -511,8 +526,17 @@ const ProjectPanel: Component = () => {
             taskTitle,
             stripFrontmatter(taskTitle ?? ""),
             replica.originProject ? `${replica.name}@${replica.originProject}` : replica.name,
-            repos.map((repo) => formatReplicaRepoBadgeLabel(repo)).join(" "),
+            // Repo/branch badges render only for coordinators (renderReplicaItem
+            // gate `isCoord() && repoBadges().length>0`). Match the same gate so a
+            // non-coordinator row is never surfaced by a badge it isn't showing
+            // (#515 bug 1).
+            replica.isCoordinator
+              ? repos.map((repo) => formatReplicaRepoBadgeLabel(repo)).join(" ")
+              : null,
             liveAgentLabel(session),
+            // A replica row renders the profile badge unconditionally whenever the
+            // session has one (renderReplicaItem) → always matchable here (#515 bug 2).
+            session ? sessionProfileBadge(session) : null,
             replica.isCoordinator ? "coordinator" : null,
             extraBadge,
             sessionSearchText(session)
@@ -540,8 +564,22 @@ const ProjectPanel: Component = () => {
           }
           return wg.agents.filter((replica) => replicaMatches(replica, wg));
         };
-        const agentMatches = (agent: { name: string; path: string; preferredAgentId?: string }) =>
-          matchesFilterText(agentDisplayName(agent.name), sessionSearchText(sessionsStore.findSessionByName(agent.name)));
+        const agentMatches = (agent: { name: string; path: string; preferredAgentId?: string }) => {
+          const session = sessionsStore.findSessionByName(agent.name);
+          const repoText = sessionRepoSearchText(session);
+          // On an agent SessionItem the profile badge lives inside the meta block,
+          // which renders only when an agent label resolves OR a coordinator's
+          // repos show (SessionItem outer <Show>). Mirror that gate so the filter
+          // never surfaces an agent by a profile badge it isn't showing (#515 bug
+          // 1) — unlike replica rows, which render it unconditionally.
+          const metaVisible = !!liveAgentLabel(session) || repoText !== "";
+          return matchesFilterText(
+            agentDisplayName(agent.name),
+            sessionSearchText(session),
+            repoText,
+            metaVisible && session ? sessionProfileBadge(session) : null
+          );
+        };
         const teamMemberMatches = (team: AcTeam, agentName: string) =>
           matchesFilterText(teamMemberDisplayLabel(agentName), agentName === team.coordinator ? "coordinator" : null);
         const teamOwnMatches = (team: AcTeam) => matchesFilterText(team.name);
@@ -551,27 +589,26 @@ const ProjectPanel: Component = () => {
           if (!filterActive() || matchesFilterText("Teams") || teamOwnMatches(team)) return team.agents;
           return team.agents.filter((agentName) => teamMemberMatches(team, agentName));
         };
-        const filteredCoordinatorItems = () => {
-          const items = coordinatorItems();
-          if (!filterActive()) return items;
-          return items.filter((item) =>
-            workgroupOwnMatches(item.wg) ||
-            replicaMatches(item.replica, item.wg, item.wg.name, item.wg.taskTitle) ||
-            matchesFilterText(runningCoordinatorPeers(item.wg, item.replica).map((peer) => `${peer.name} RUNNING`).join(" "))
-          );
-        };
-        const filteredWorkgroups = () => {
+        // Memoized so each section reads one cached pass per (filter, store)
+        // change instead of rebuilding search text + re-running regex.test on
+        // every access (these are read 3-4× per render). Dependencies are all
+        // reactive (filterPattern signal, sessionsStore, projectStore via proj),
+        // so sections still update live as the user types (#515 bug 3).
+        // NOTE: filteredCoordinatorItems is defined further down, right after the
+        // coordinatorItems memo it reads — createMemo runs eagerly, so it must
+        // follow that declaration (not lead it) to avoid a temporal dead zone.
+        const filteredWorkgroups = createMemo(() => {
           if (!filterActive() || matchesFilterText("Workgroups")) return proj.workgroups;
           return proj.workgroups.filter((wg) => workgroupMatches(wg, "Workgroups"));
-        };
-        const filteredAgents = () => {
+        });
+        const filteredAgents = createMemo(() => {
           if (!filterActive() || matchesFilterText("Agents")) return proj.agents;
           return proj.agents.filter((agent) => agentMatches(agent));
-        };
-        const filteredTeams = () => {
+        });
+        const filteredTeams = createMemo(() => {
           if (!filterActive() || matchesFilterText("Teams")) return proj.teams;
           return proj.teams.filter((team) => teamMatches(team));
-        };
+        });
         const selectedWorkgroupVisible = () => {
           const wg = selectedWorkgroup();
           return !filterActive() || matchesFilterText("Selected Workgroup") || (wg ? workgroupMatches(wg, "Selected Workgroup") : false);
@@ -581,20 +618,23 @@ const ProjectPanel: Component = () => {
         const loopStatusText = (loop: AcLoopSummary) =>
           loop.lastResult?.message ?? (loop.nextDueAt ? `Next: ${new Date(loop.nextDueAt).toLocaleString()}` : "No runs yet");
         const loopSearchText = (loop: AcLoopSummary) =>
+          // promptPreview is intentionally NOT matched: it renders only as the
+          // row's hover `title` (not visible text), so matching it would surface a
+          // loop with no on-screen reason — the case the comment above warned
+          // about (#515 bug 1).
           joinSearchText(
             loop.name,
             loop.workgroup,
             loop.expr,
-            loop.promptPreview,
             loopStatusText(loop),
             loop.enabled ? null : "disabled",
             loop.pendingDueAt ? "pending" : null
           );
         const loopMatches = (loop: AcLoopSummary) => matchesFilterText(loopSearchText(loop));
-        const filteredLoops = () => {
+        const filteredLoops = createMemo(() => {
           if (!filterActive() || matchesFilterText("Loops")) return proj.loops;
           return proj.loops.filter((loop) => loopMatches(loop));
-        };
+        });
 
         let replicaCtxMenuEl: HTMLDivElement | undefined;
         let dismissCtx: (() => void) | null = null;
@@ -747,6 +787,19 @@ const ProjectPanel: Component = () => {
           }
           if (!prev) return null;
             return proj.workgroups.find(w => w.name === prev.name) ?? null;
+        });
+
+        // Memoized like the other filtered collections (#515 bug 3); placed here
+        // because createMemo is eager and this reads the coordinatorItems memo
+        // defined just above.
+        const filteredCoordinatorItems = createMemo(() => {
+          const items = coordinatorItems();
+          if (!filterActive()) return items;
+          return items.filter((item) =>
+            workgroupOwnMatches(item.wg) ||
+            replicaMatches(item.replica, item.wg, item.wg.name, item.wg.taskTitle) ||
+            matchesFilterText(runningCoordinatorPeers(item.wg, item.replica).map((peer) => `${peer.name} RUNNING`).join(" "))
+          );
         });
 
         const runLoopAction = async (

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -448,7 +448,15 @@ const ProjectPanel: Component = () => {
           }
           window.setTimeout(focus, 0);
         };
-        const openFilter = () => {
+        const toggleFilter = () => {
+          // Magnifier acts as a toggle. Closing also drops any in-flight
+          // pattern so we never leave an active-but-hidden filter applied
+          // (the input is the only surface that reveals one is running).
+          if (filterOpen()) {
+            setFilterOpen(false);
+            setFilterPattern("");
+            return;
+          }
           setFilterOpen(true);
           focusFilterInput();
         };
@@ -567,6 +575,25 @@ const ProjectPanel: Component = () => {
         const selectedWorkgroupVisible = () => {
           const wg = selectedWorkgroup();
           return !filterActive() || matchesFilterText("Selected Workgroup") || (wg ? workgroupMatches(wg, "Selected Workgroup") : false);
+        };
+        // Status line shown on each loop row — shared with the filter search
+        // text so what the regex matches always equals what the user sees.
+        const loopStatusText = (loop: AcLoopSummary) =>
+          loop.lastResult?.message ?? (loop.nextDueAt ? `Next: ${new Date(loop.nextDueAt).toLocaleString()}` : "No runs yet");
+        const loopSearchText = (loop: AcLoopSummary) =>
+          joinSearchText(
+            loop.name,
+            loop.workgroup,
+            loop.expr,
+            loop.promptPreview,
+            loopStatusText(loop),
+            loop.enabled ? null : "disabled",
+            loop.pendingDueAt ? "pending" : null
+          );
+        const loopMatches = (loop: AcLoopSummary) => matchesFilterText(loopSearchText(loop));
+        const filteredLoops = () => {
+          if (!filterActive() || matchesFilterText("Loops")) return proj.loops;
+          return proj.loops.filter((loop) => loopMatches(loop));
         };
 
         let replicaCtxMenuEl: HTMLDivElement | undefined;
@@ -1160,11 +1187,11 @@ const ProjectPanel: Component = () => {
               <button
                 type="button"
                 class="project-filter-toggle"
-                title="Open regex filter"
-                aria-label="Open regex filter"
+                title={filterOpen() ? "Hide regex filter" : "Filter sidebar (regex)"}
+                aria-label={filterOpen() ? "Hide regex filter" : "Filter sidebar (regex)"}
                 aria-expanded={filterOpen()}
                 data-ac-testid="project.regexFilter.toggle"
-                onClick={openFilter}
+                onClick={toggleFilter}
               >
                 <svg viewBox="0 0 24 24" aria-hidden="true">
                   <circle cx="11" cy="11" r="7" />
@@ -1174,7 +1201,7 @@ const ProjectPanel: Component = () => {
             </div>
             <Show when={filterError()}>
               {(error) => (
-                <div class="project-filter-error" data-ac-testid="project.regexFilter.error">
+                <div class="project-filter-error" role="alert" data-ac-testid="project.regexFilter.error">
                   {error()}
                 </div>
               )}
@@ -1454,7 +1481,7 @@ const ProjectPanel: Component = () => {
 
                   return (
                     <>
-                    <Show when={sessionsStore.showCategories}>
+                    <Show when={sessionsStore.showCategories && (!filterActive() || matchesFilterText("Loops") || filteredLoops().length > 0)}>
                     <div class="ac-wg-group ac-loop-group">
                       <div
                         class="ac-wg-header ac-wg-header--collapsible"
@@ -1468,14 +1495,14 @@ const ProjectPanel: Component = () => {
                         <div class="ac-wg-header-text">
                           <span class="ac-wg-name">Loops</span>
                         </div>
-                        <span class="ac-team-count">{proj.loops.length}</span>
+                        <span class="ac-team-count">{filteredLoops().length}</span>
                       </div>
                       <Show when={!loopsCollapsed()}>
                         <Show
-                          when={proj.loops.length > 0}
+                          when={filteredLoops().length > 0}
                           fallback={<div class="ac-empty-hint">No loops</div>}
                         >
-                          <For each={proj.loops}>
+                          <For each={filteredLoops()}>
                             {(loop) => (
                               <div
                                 class="ac-loop-row"
@@ -1507,7 +1534,7 @@ const ProjectPanel: Component = () => {
                                   </Show>
                                 </div>
                                 <div class="ac-loop-status">
-                                  {loop.lastResult?.message ?? (loop.nextDueAt ? `Next: ${new Date(loop.nextDueAt).toLocaleString()}` : "No runs yet")}
+                                  {loopStatusText(loop)}
                                 </div>
                               </div>
                             )}

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -567,15 +567,25 @@ const ProjectPanel: Component = () => {
         const agentMatches = (agent: { name: string; path: string; preferredAgentId?: string }) => {
           const session = sessionsStore.findSessionByName(agent.name);
           const repoText = sessionRepoSearchText(session);
+          // The coding-agent badge shows the RESOLVED label (session.agentLabel,
+          // else the agentId→settings lookup). sessionSearchText only carries the
+          // raw agentLabel, so a session with a null agentLabel but a resolvable
+          // agentId would render the badge yet stay unmatchable. Include the
+          // resolved label here so the coding-agent badge is matchable wherever it
+          // renders — the headline #515 ask (filter agents by their coding agent).
+          // It is null exactly when no label resolves, i.e. when the badge is also
+          // hidden, so this never matches a badge that isn't shown.
+          const codingAgentLabel = liveAgentLabel(session);
           // On an agent SessionItem the profile badge lives inside the meta block,
           // which renders only when an agent label resolves OR a coordinator's
           // repos show (SessionItem outer <Show>). Mirror that gate so the filter
           // never surfaces an agent by a profile badge it isn't showing (#515 bug
           // 1) — unlike replica rows, which render it unconditionally.
-          const metaVisible = !!liveAgentLabel(session) || repoText !== "";
+          const metaVisible = !!codingAgentLabel || repoText !== "";
           return matchesFilterText(
             agentDisplayName(agent.name),
             sessionSearchText(session),
+            codingAgentLabel,
             repoText,
             metaVisible && session ? sessionProfileBadge(session) : null
           );

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -37,6 +37,30 @@ interface PendingLaunch {
   scopeContext?: AgentPickerScopeContext;
 }
 
+function joinSearchText(...parts: Array<string | null | undefined | false>): string {
+  return parts
+    .filter((part): part is string => typeof part === "string" && part.trim().length > 0)
+    .join(" ");
+}
+
+function agentDisplayName(name: string): string {
+  const normalized = name.replace(/\\/g, "/");
+  return normalized
+    .slice(normalized.lastIndexOf("/") + 1)
+    .replace(/^__?agent_/, "");
+}
+
+function teamMemberDisplayLabel(agentName: string): string {
+  const parts = agentName.replace(/\\/g, "/").split("/");
+  const agent = parts[parts.length - 1].replace(/^__?agent_/, "");
+  const project = parts[0];
+  return project && project !== agent ? `${agent}@${project}` : agent;
+}
+
+function sessionStatusSearchText(status: Session["status"]): string {
+  return typeof status === "string" ? status : `exited ${status.exited}`;
+}
+
 /** Build the gitRepos list for a replica. Order = replica.repoPaths order (invariant §3.1.2). */
 function buildGitRepos(replica: AcAgentReplica): SessionRepoInput[] {
   return (replica.repoPaths ?? []).map((p) => {
@@ -127,6 +151,14 @@ function coordinatorItemKey(item: { replica: AcAgentReplica; wg: AcWorkgroup }):
 /** Get replicas in a workgroup that have active (live) sessions */
 function getActiveReplicasForWg(wg: AcWorkgroup): AcAgentReplica[] {
   return (wg.agents ?? []).filter(replica => isSessionLive(replicaSession(wg, replica)));
+}
+
+function runningCoordinatorPeers(wg: AcWorkgroup, replica: AcAgentReplica): AcAgentReplica[] {
+  return (wg.agents ?? []).filter((peer) => {
+    if (peer.name === replica.name) return false;
+    const dot = replicaDotClass(wg, peer);
+    return dot === "running" || dot === "active";
+  });
 }
 
 const ProjectPanel: Component = () => {
@@ -278,6 +310,9 @@ const ProjectPanel: Component = () => {
         const [wgRetryInProgress, setWgRetryInProgress] = createSignal(false);
         const [wgLastForceUsed, setWgLastForceUsed] = createSignal(false);
         let retryGen = 0;
+        const [filterOpen, setFilterOpen] = createSignal(false);
+        const [filterPattern, setFilterPattern] = createSignal("");
+        let filterInputEl: HTMLInputElement | undefined;
         const [agentCtxMenu, setAgentCtxMenu] = createSignal<{ agent: { name: string; path: string; preferredAgentId?: string }; x: number; y: number } | null>(null);
         const [agentsHeaderCtxMenu, setAgentsHeaderCtxMenu] = createSignal<{ x: number; y: number } | null>(null);
         const [workgroupsHeaderCtxMenu, setWorkgroupsHeaderCtxMenu] = createSignal<{ x: number; y: number } | null>(null);
@@ -391,6 +426,148 @@ const ProjectPanel: Component = () => {
           const wg = deletingWg();
           return wg ? getActiveReplicasForWg(wg) : [];
         });
+        const filterState = createMemo(() => {
+          const pattern = filterPattern().trim();
+          if (!pattern) return { pattern, regex: null, error: "" };
+          try {
+            return { pattern, regex: new RegExp(pattern, "i"), error: "" };
+          } catch {
+            return { pattern, regex: null, error: "Invalid regex" };
+          }
+        });
+        const filterActive = () => filterState().regex !== null;
+        const filterError = () => filterState().error;
+        const focusFilterInput = () => {
+          const focus = () => {
+            filterInputEl?.focus();
+            filterInputEl?.select();
+          };
+          if (typeof window.requestAnimationFrame === "function") {
+            window.requestAnimationFrame(focus);
+            return;
+          }
+          window.setTimeout(focus, 0);
+        };
+        const openFilter = () => {
+          setFilterOpen(true);
+          focusFilterInput();
+        };
+        const clearFilter = () => {
+          setFilterPattern("");
+          focusFilterInput();
+        };
+        const handleFilterKeyDown = (e: KeyboardEvent) => {
+          if (e.key !== "Escape") return;
+          e.stopPropagation();
+          if (filterPattern()) {
+            setFilterPattern("");
+            focusFilterInput();
+            return;
+          }
+          setFilterOpen(false);
+        };
+        const matchesFilterText = (...parts: Array<string | null | undefined | false>) => {
+          const regex = filterState().regex;
+          if (!regex) return true;
+          return regex.test(joinSearchText(...parts));
+        };
+        const sessionSearchText = (session: Session | undefined) => {
+          if (!session) return "";
+          return joinSearchText(
+            session.name,
+            session.agentLabel,
+            session.shell,
+            sessionStatusSearchText(session.status),
+            session.waitingForInput ? "waiting" : null,
+            session.pendingReview ? "pending" : null,
+            session.gitRepos.map((repo) => `${repo.label}${repo.branch ? `/${repo.branch}` : ""}`).join(" ")
+          );
+        };
+        const liveAgentLabel = (session: Session | undefined) => {
+          if (!session) return null;
+          if (session.agentLabel) return session.agentLabel;
+          if (!session.agentId) return null;
+          return settingsStore.current?.agents?.find((a) => a.id === session.agentId)?.label ?? null;
+        };
+        const replicaSearchText = (
+          replica: AcAgentReplica,
+          wg: AcWorkgroup,
+          extraBadge?: string,
+          taskTitle?: string | null
+        ) => {
+          const session = replicaSession(wg, replica);
+          const repos = session && session.gitRepos.length > 0
+            ? session.gitRepos
+            : configuredReplicaRepoBadges(replica, wg);
+          return joinSearchText(
+            taskTitle,
+            stripFrontmatter(taskTitle ?? ""),
+            replica.originProject ? `${replica.name}@${replica.originProject}` : replica.name,
+            repos.map((repo) => formatReplicaRepoBadgeLabel(repo)).join(" "),
+            liveAgentLabel(session),
+            replica.isCoordinator ? "coordinator" : null,
+            extraBadge,
+            sessionSearchText(session)
+          );
+        };
+        const replicaMatches = (
+          replica: AcAgentReplica,
+          wg: AcWorkgroup,
+          extraBadge?: string,
+          taskTitle?: string | null
+        ) => matchesFilterText(replicaSearchText(replica, wg, extraBadge, taskTitle));
+        const workgroupOwnMatches = (wg: AcWorkgroup, sectionLabel?: string) =>
+          matchesFilterText(sectionLabel, wg.name, wg.taskTitle, stripFrontmatter(wg.taskTitle ?? ""));
+        const workgroupMatches = (wg: AcWorkgroup, sectionLabel?: string) =>
+          workgroupOwnMatches(wg, sectionLabel) ||
+          wg.agents.some((replica) => replicaMatches(replica, wg));
+        const filteredReplicasForWorkgroup = (wg: AcWorkgroup, rowContext: string) => {
+          const sectionLabel = rowContext === "selected"
+            ? "Selected Workgroup"
+            : rowContext === "workgroups"
+              ? "Workgroups"
+              : undefined;
+          if (!filterActive() || matchesFilterText(sectionLabel) || workgroupOwnMatches(wg, sectionLabel)) {
+            return wg.agents;
+          }
+          return wg.agents.filter((replica) => replicaMatches(replica, wg));
+        };
+        const agentMatches = (agent: { name: string; path: string; preferredAgentId?: string }) =>
+          matchesFilterText(agentDisplayName(agent.name), sessionSearchText(sessionsStore.findSessionByName(agent.name)));
+        const teamMemberMatches = (team: AcTeam, agentName: string) =>
+          matchesFilterText(teamMemberDisplayLabel(agentName), agentName === team.coordinator ? "coordinator" : null);
+        const teamOwnMatches = (team: AcTeam) => matchesFilterText(team.name);
+        const teamMatches = (team: AcTeam) =>
+          teamOwnMatches(team) || team.agents.some((agentName) => teamMemberMatches(team, agentName));
+        const filteredTeamMembers = (team: AcTeam) => {
+          if (!filterActive() || matchesFilterText("Teams") || teamOwnMatches(team)) return team.agents;
+          return team.agents.filter((agentName) => teamMemberMatches(team, agentName));
+        };
+        const filteredCoordinatorItems = () => {
+          const items = coordinatorItems();
+          if (!filterActive()) return items;
+          return items.filter((item) =>
+            workgroupOwnMatches(item.wg) ||
+            replicaMatches(item.replica, item.wg, item.wg.name, item.wg.taskTitle) ||
+            matchesFilterText(runningCoordinatorPeers(item.wg, item.replica).map((peer) => `${peer.name} RUNNING`).join(" "))
+          );
+        };
+        const filteredWorkgroups = () => {
+          if (!filterActive() || matchesFilterText("Workgroups")) return proj.workgroups;
+          return proj.workgroups.filter((wg) => workgroupMatches(wg, "Workgroups"));
+        };
+        const filteredAgents = () => {
+          if (!filterActive() || matchesFilterText("Agents")) return proj.agents;
+          return proj.agents.filter((agent) => agentMatches(agent));
+        };
+        const filteredTeams = () => {
+          if (!filterActive() || matchesFilterText("Teams")) return proj.teams;
+          return proj.teams.filter((team) => teamMatches(team));
+        };
+        const selectedWorkgroupVisible = () => {
+          const wg = selectedWorkgroup();
+          return !filterActive() || matchesFilterText("Selected Workgroup") || (wg ? workgroupMatches(wg, "Selected Workgroup") : false);
+        };
 
         let replicaCtxMenuEl: HTMLDivElement | undefined;
         let dismissCtx: (() => void) | null = null;
@@ -929,7 +1106,7 @@ const ProjectPanel: Component = () => {
                 </div>
               </div>
               <Show when={!wgCollapsed()}>
-                <For each={wg.agents}>
+                <For each={filteredReplicasForWorkgroup(wg, rowContext)}>
                   {(replica) => renderReplicaItem(replica, wg, undefined, undefined, undefined, rowContext)}
                 </For>
               </Show>
@@ -950,6 +1127,58 @@ const ProjectPanel: Component = () => {
               </span>
               <span class="project-title">Project: {proj.folderName}</span>
             </button>
+            <div
+              class="project-filter-row"
+              classList={{ open: filterOpen(), active: filterActive(), invalid: !!filterError() }}
+              data-ac-testid="project.regexFilter.row"
+            >
+              <div class="project-filter-field" classList={{ open: filterOpen() }}>
+                <input
+                  ref={filterInputEl}
+                  class="project-filter-input"
+                  value={filterPattern()}
+                  placeholder="wg-2.*"
+                  aria-label="Sidebar regex filter"
+                  aria-invalid={!!filterError()}
+                  data-ac-testid="project.regexFilter.input"
+                  onInput={(e) => setFilterPattern(e.currentTarget.value)}
+                  onKeyDown={handleFilterKeyDown}
+                />
+                <Show when={filterPattern()}>
+                  <button
+                    type="button"
+                    class="project-filter-clear"
+                    title="Clear regex filter"
+                    aria-label="Clear regex filter"
+                    data-ac-testid="project.regexFilter.clear"
+                    onClick={clearFilter}
+                  >
+                    &#x2715;
+                  </button>
+                </Show>
+              </div>
+              <button
+                type="button"
+                class="project-filter-toggle"
+                title="Open regex filter"
+                aria-label="Open regex filter"
+                aria-expanded={filterOpen()}
+                data-ac-testid="project.regexFilter.toggle"
+                onClick={openFilter}
+              >
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <circle cx="11" cy="11" r="7" />
+                  <path d="m20 20-4.2-4.2" />
+                </svg>
+              </button>
+            </div>
+            <Show when={filterError()}>
+              {(error) => (
+                <div class="project-filter-error" data-ac-testid="project.regexFilter.error">
+                  {error()}
+                </div>
+              )}
+            </Show>
 
             {/* Project context menu */}
             {showCtxMenu() && (
@@ -1058,16 +1287,12 @@ const ProjectPanel: Component = () => {
                 {/* Coordinator Quick-Access — shown by styles that enable it via CSS */}
                 {(() => {
                   return (
-                    <Show when={coordinatorItems().length > 0}>
+                    <Show when={filteredCoordinatorItems().length > 0}>
                       <div class="coord-quick-access">
-                        <For each={coordinatorItems()}>
+                        <For each={filteredCoordinatorItems()}>
                           {(item) => {
                             const runningPeers = createMemo(() =>
-                              item.wg.agents.filter((peer) => {
-                                if (peer.name === item.replica.name) return false;
-                                const dot = replicaDotClass(item.wg, peer);
-                                return dot === "running" || dot === "active";
-                              })
+                              runningCoordinatorPeers(item.wg, item.replica)
                             );
                             return renderReplicaItem(item.replica, item.wg, item.wg.name, runningPeers, item.wg.taskTitle, "quick");
                           }}
@@ -1081,7 +1306,7 @@ const ProjectPanel: Component = () => {
                   const [selectedCollapsed, setSelectedCollapsed] = createSignal(false);
 
                   return (
-                    <Show when={sessionsStore.showCategories || sessionsStore.alwaysShowSelectedWorkgroup}>
+                    <Show when={(sessionsStore.showCategories || sessionsStore.alwaysShowSelectedWorkgroup) && selectedWorkgroupVisible()}>
                       <div class="ac-wg-group">
                         <div
                           class="ac-wg-header ac-wg-header--collapsible"
@@ -1139,7 +1364,7 @@ const ProjectPanel: Component = () => {
 
                   return (
                     <>
-                    <Show when={sessionsStore.showCategories}>
+                    <Show when={sessionsStore.showCategories && (!filterActive() || matchesFilterText("Workgroups") || filteredWorkgroups().length > 0)}>
                     <div class="ac-wg-group">
                       <div
                         class="ac-wg-header ac-wg-header--collapsible"
@@ -1152,14 +1377,14 @@ const ProjectPanel: Component = () => {
                         <div class="ac-wg-header-text">
                           <span class="ac-wg-name">Workgroups</span>
                         </div>
-                        <span class="ac-team-count">{proj.workgroups.length}</span>
+                        <span class="ac-team-count">{filteredWorkgroups().length}</span>
                       </div>
                       <Show when={!wgsCollapsed()}>
                         <Show
-                          when={proj.workgroups.length > 0}
+                          when={filteredWorkgroups().length > 0}
                           fallback={<div class="ac-empty-hint">No workgroups</div>}
                         >
-                          <For each={proj.workgroups}>
+                          <For each={filteredWorkgroups()}>
                             {(wg) => renderWorkgroupSubgroup(wg, "workgroups")}
                           </For>
                         </Show>
@@ -1379,7 +1604,7 @@ const ProjectPanel: Component = () => {
 
                   return (
                     <>
-                    <Show when={sessionsStore.showCategories}>
+                    <Show when={sessionsStore.showCategories && (!filterActive() || matchesFilterText("Agents") || filteredAgents().length > 0)}>
                     <div class="ac-wg-group">
                       <div
                         class="ac-wg-header ac-wg-header--collapsible"
@@ -1395,10 +1620,10 @@ const ProjectPanel: Component = () => {
                       </div>
                       <Show when={!matrixCollapsed()}>
                         <Show
-                          when={proj.agents.length > 0}
+                          when={filteredAgents().length > 0}
                           fallback={<div class="ac-empty-hint">No agents</div>}
                         >
-                          <For each={proj.agents}>
+                          <For each={filteredAgents()}>
                             {(agent) => {
                               const session = () => sessionsStore.findSessionByName(agent.name);
                               return (
@@ -1572,7 +1797,7 @@ const ProjectPanel: Component = () => {
 
                   return (
                     <>
-                    <Show when={sessionsStore.showCategories}>
+                    <Show when={sessionsStore.showCategories && (!filterActive() || matchesFilterText("Teams") || filteredTeams().length > 0)}>
                     <div class="ac-wg-group">
                       <div
                         class="ac-wg-header ac-wg-header--collapsible"
@@ -1588,12 +1813,13 @@ const ProjectPanel: Component = () => {
                       </div>
                       <Show when={!teamsCollapsed()}>
                         <Show
-                          when={proj.teams.length > 0}
+                          when={filteredTeams().length > 0}
                           fallback={<div class="ac-empty-hint">No teams</div>}
                         >
-                          <For each={proj.teams}>
+                          <For each={filteredTeams()}>
                             {(team) => {
                               const [teamExpanded, setTeamExpanded] = createSignal(false);
+                              const visibleTeamMembers = () => filteredTeamMembers(team);
                               return (
                                 <div class="ac-team-group">
                                   <div
@@ -1605,21 +1831,15 @@ const ProjectPanel: Component = () => {
                                       &#x25BE;
                                     </span>
                                     <span class="ac-team-name">{team.name}</span>
-                                    <span class="ac-team-count">{team.agents.length}</span>
+                                    <span class="ac-team-count">{visibleTeamMembers().length}</span>
                                   </div>
                                   <Show when={teamExpanded()}>
                                     <div class="ac-team-members">
-                                      <For each={team.agents}>
+                                      <For each={visibleTeamMembers()}>
                                         {(agentName) => {
-                                          const shortName = () => {
-                                            const parts = agentName.replace(/\\/g, "/").split("/");
-                                            const agent = parts[parts.length - 1].replace(/^__?agent_/, "");
-                                            const project = parts[0];
-                                            return project && project !== agent ? `${agent}@${project}` : agent;
-                                          };
                                           return (
                                             <div class="ac-team-member" title={agentName}>
-                                              <span class="ac-team-member-name">{shortName()}</span>
+                                              <span class="ac-team-member-name">{teamMemberDisplayLabel(agentName)}</span>
                                               <Show when={agentName === team.coordinator}>
                                                 <span class="ac-discovery-badge coord">coordinator</span>
                                               </Show>

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -3605,6 +3605,115 @@ html.light-theme .root-agent-avatar {
   color: var(--sidebar-accent);
 }
 
+.project-filter-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  min-height: 34px;
+  padding: 4px var(--spacing-md);
+  background: var(--sidebar-bg);
+  border-bottom: 1px solid var(--sidebar-border);
+}
+
+.project-filter-row.open,
+.project-filter-row.active {
+  background: rgba(0, 212, 255, 0.04);
+}
+
+.project-filter-row.invalid {
+  background: rgba(255, 107, 107, 0.04);
+}
+
+.project-filter-field {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 0;
+  min-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  pointer-events: none;
+  transition: width 180ms ease-out, opacity 150ms ease-out;
+}
+
+.project-filter-field.open {
+  width: min(230px, calc(100% - 32px));
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.project-filter-input {
+  width: 100%;
+  min-width: 0;
+  height: 26px;
+  padding: 0 8px;
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-sm);
+  background: var(--sidebar-surface);
+  color: var(--sidebar-fg);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  outline: none;
+}
+
+.project-filter-input:focus {
+  border-color: var(--sidebar-accent);
+}
+
+.project-filter-input[aria-invalid="true"] {
+  border-color: var(--danger, #ff6b6b);
+}
+
+.project-filter-toggle,
+.project-filter-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  flex: 0 0 auto;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--sidebar-fg-dim);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.project-filter-toggle:hover,
+.project-filter-toggle[aria-expanded="true"],
+.project-filter-row.active .project-filter-toggle {
+  background: rgba(0, 212, 255, 0.1);
+  border-color: rgba(0, 212, 255, 0.18);
+  color: var(--sidebar-accent);
+}
+
+.project-filter-clear:hover {
+  background: var(--sidebar-hover);
+  color: var(--sidebar-fg);
+}
+
+.project-filter-toggle svg,
+.project-filter-clear svg {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.project-filter-error {
+  padding: 2px var(--spacing-md) 6px;
+  border-bottom: 1px solid rgba(255, 107, 107, 0.18);
+  background: rgba(255, 107, 107, 0.05);
+  color: var(--danger, #ff6b6b);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
 .project-title {
   font-weight: 600;
   letter-spacing: 0.3px;


### PR DESCRIPTION
## Summary

Adds a **regex filter control to the sidebar** (#515). A magnifier toggle on its own row directly below the `Project:` row (right-aligned) opens an input; a case-insensitive regular expression filters the visible sidebar items — workgroups, agents, teams, loops, replicas, and section labels.

Filtering is **presentation-only**: it hides non-matching items and updates section counts, never mutating underlying project/session data. Invalid regex shows inline feedback and falls back to showing everything. Escape clears then closes; ✕ clears; clicking the magnifier while open closes and clears.

The filter matches against the **visible** text of each row — names, the (resolved) coding-agent badge, profile badge, repo/branch badges where shown, status, task titles, loop fields, and section labels — under a strict "what you match = what you see" (match-set == visible-set) invariant.

## What changed

- Sidebar `ProjectPanel`: magnifier filter row; per-section regex filtering; presentation-only hiding; invalid-regex handling; keyboard (Escape / clear / focus); memoized filtered collections.
- Search coverage spans all visible badges, including the coding-agent badge resolved from `agentId`, the profile letter, and the agent task title.
- Version bumped `0.9.4` → `0.9.5`.

## Testing / review

- **dev-webpage-ui** — implementation + `/code-review` (high effort) self-review; all HIGH-severity findings fixed.
- **dev-rust-grinch** — adversarial review + re-review across the feature and each follow-up; final verdict **CLEAN** (verified match==visible, no false-show / no false-hide, memoization introduces no reactivity regression).
- Full frontend suite **334 tests passing**, `tsc --noEmit` clean, production `vite build` clean.
- **shipper** — built the wg-2 standalone exe and deployed it to the user's test dir (`0_AC`).
- **User manual test** of the deployed exe — confirmed working, both the initial filter and the coding-agent / profile / task-title badge search.

## Known / deferred (not a blocker)

When the filter matches a **workgroup/team's own name** (e.g. a team named "OpenCode Team"), that group currently reveals all its members rather than filtering them individually. The user chose to defer this at landing time; tracked in **#540**.

Closes #515
