### PR TITLE
fix(profiles): every coding-agent profile cell always shows its command box (#538)

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.9.5"; // Must match package.json
+const VERSION = "0.9.6"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.9.6"; // Must match package.json
+const VERSION = "0.9.7"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -390,11 +390,24 @@ describe("SettingsModal automation hooks", () => {
     expect(byTestId<HTMLInputElement>("settings.profileCard.0.A.envRow.0.key").value).toBe("OPENAI_ORG");
     expect(byTestId<HTMLInputElement>("settings.profileCard.0.A.envRow.0.value").value).toBe("ac-prod");
 
-    // Profile B slot is configured on Claude but not on codex → MISSING with Add.
+    // #538: codex has no B cell, but B no longer shows an "Add cell" / missing
+    // box. The badge still honestly reports MISSING (codex's B falls back to its
+    // base command until a command is typed).
     expect(byTestId("settings.profileCard.0.B").getAttribute("data-ac-state")).toBe("missing");
     expect(byTestId("settings.profileCard.0.B.badge").textContent).toContain("MISSING");
-    expect(byTestId("settings.profileCard.0.B.missing")).toBeTruthy();
-    expect(byTestId<HTMLButtonElement>("settings.profileCard.0.B.add")).toBeTruthy();
+    // #538: the sub-line states what the cell launches via fallback (consistent
+    // with the MISSING badge) instead of a contradictory bare "Configured".
+    expect(
+      byTestId("settings.profileCard.0.B").querySelector(".settings-profile-card-sub")?.textContent,
+    ).toBe("Launches A");
+    expect(document.querySelector('[data-ac-testid="settings.profileCard.0.B.missing"]')).toBeNull();
+    expect(document.querySelector('[data-ac-testid="settings.profileCard.0.B.add"]')).toBeNull();
+    // Instead it exposes the same expand/edit affordance as every cell: a chevron
+    // toggle that reveals an (empty) command input the user can fill in.
+    expect(byTestId<HTMLButtonElement>("settings.profileCard.0.B.toggle")).toBeTruthy();
+    byTestId<HTMLButtonElement>("settings.profileCard.0.B.toggle").click();
+    await settle();
+    expect(byTestId<HTMLInputElement>("settings.profileCard.0.B.command").value).toBe("");
     // Claude rail: B has its own enabled cell (non-A, direct match) → CONFIGURED,
     // NOT MATCH. MATCH is reserved for the A baseline (#526).
     expect(byTestId("settings.profileCard.1.B").getAttribute("data-ac-state")).toBe("configured");

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -288,42 +288,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     }));
   };
 
-  const addProfileCell = (agentId: string, letter: string) => {
-    setProfileCell(agentId, letter, emptyProfileCell());
-    const key = profileCellKey(agentId, letter);
-    setProfileCellText(key, "");
-    setProfileCellErrors(key, "");
-    setProfileCellEnvRows(key, []);
-  };
-
-  const removeProfileCell = (agentId: string, letter: string) => {
-    if (!settings.data || letter === "A") return;
-    setDraftDirty(true);
-    const cells = settings.data.codingAgentProfiles.profilesByAgent[agentId] ?? {};
-    const nextCells = { ...cells };
-    delete nextCells[letter];
-    setSettings("data", "codingAgentProfiles", "profilesByAgent", (byAgent) => ({
-      ...byAgent,
-      [agentId]: nextCells,
-    }));
-    const key = profileCellKey(agentId, letter);
-    setProfileCellText((prev) => {
-      const next = { ...prev };
-      delete next[key];
-      return next;
-    });
-    setProfileCellErrors((prev) => {
-      const next = { ...prev };
-      delete next[key];
-      return next;
-    });
-    setProfileCellEnvRows((prev) => {
-      const next = { ...prev };
-      delete next[key];
-      return next;
-    });
-  };
-
   const updateProfileLabel = (letter: string, label: string) => {
     if (!settings.data) return;
     setDraftDirty(true);
@@ -1302,19 +1266,24 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   // split into separate fields (#384). The two comparison rails render the slots
   // A..Z of two coding agents side by side; cards are addressed by rail index.
   const renderProfileCard = (agent: AgentConfig, railIndex: number, letter: string) => {
-    const cell = () => profileCell(agent.id, letter);
-    const configured = () => letter === "A" || Boolean(cell()?.enabled);
     const badge = () => profileCellBadge(agent.id, letter);
-    const preview = () =>
-      resolveProfilePreview(settings.data!.codingAgentProfiles, agent.id, letter);
     const command = () => displayedProfileCellCommand(agent.id, letter);
     const cellError = () => profileCellErrors[profileCellKey(agent.id, letter)];
     const cardId = `settings.profileCard.${railIndex}.${letter}`;
     const expanded = () => isCellExpanded(agent.id, letter);
+    const preview = () =>
+      resolveProfilePreview(settings.data!.codingAgentProfiles, agent.id, letter);
+    // #538: every cell always exposes its command editor (no "Add cell" / missing
+    // box). The badge reports the real match/configured/fallback/missing state; the
+    // sub-line shows the cell's own executable, or — when it has no command of its
+    // own — what it launches via fallback, so it never contradicts a MISSING or
+    // FALLBACK badge by claiming "Configured".
     const subLine = () => {
-      if (!configured()) return `Configured elsewhere; launches ${preview().effectiveProfile}`;
       if (cellError()) return "Command syntax error";
-      return commandExecutableBasename(command()) || "Configured";
+      const ownCommand = commandExecutableBasename(command());
+      if (ownCommand) return ownCommand;
+      const resolved = preview();
+      return resolved.fallbackApplied ? `Launches ${resolved.effectiveProfile}` : "Configured";
     };
     return (
       <article
@@ -1355,57 +1324,19 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             </div>
             <div class="settings-profile-card-sub">{subLine()}</div>
           </div>
-          <Show when={configured()}>
-            <button
-              class="settings-profile-chevron"
-              onClick={() => toggleCell(agent.id, letter)}
-              title={expanded() ? "Collapse" : "Expand"}
-              aria-expanded={expanded()}
-              data-ac-testid={`${cardId}.toggle`}
-              data-ac-role="button"
-            >
-              {expanded() ? "▾" : "▸"}
-            </button>
-          </Show>
+          <button
+            class="settings-profile-chevron"
+            onClick={() => toggleCell(agent.id, letter)}
+            title={expanded() ? "Collapse" : "Expand"}
+            aria-expanded={expanded()}
+            data-ac-testid={`${cardId}.toggle`}
+            data-ac-role="button"
+          >
+            {expanded() ? "▾" : "▸"}
+          </button>
         </div>
 
-        <Show
-          when={configured()}
-          fallback={
-            <div
-              class="settings-profile-missing"
-              data-ac-testid={`${cardId}.missing`}
-              data-ac-role="status"
-            >
-              <span>
-                {letter} &rarr; {preview().effectiveProfile} (fallback)
-              </span>
-              <div class="settings-profile-missing-actions">
-                <button
-                  class="settings-profile-cell-btn"
-                  onClick={() => addProfileCell(agent.id, letter)}
-                  data-ac-testid={`${cardId}.add`}
-                  data-ac-role="button"
-                >
-                  Add cell
-                </button>
-                {/* #526: slot-level delete — drops the whole letter from every
-                    coding agent (draft-reversible). Distinct from per-agent
-                    "Delete cell". */}
-                <button
-                  class="settings-profile-cell-btn settings-profile-delete-profile"
-                  onClick={() => removeProfileLetter(letter)}
-                  title={`Delete the entire ${letter} profile slot from all coding agents`}
-                  data-ac-testid={`${cardId}.deleteProfile`}
-                  data-ac-role="button"
-                >
-                  Delete Profile
-                </button>
-              </div>
-            </div>
-          }
-        >
-          <Show when={expanded()}>
+        <Show when={expanded()}>
           <label class="settings-profile-field-label">Command</label>
           <input
             class="settings-input settings-profile-command"
@@ -1518,17 +1449,9 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
 
           <Show when={letter !== "A"}>
             <div class="settings-profile-card-footer">
-              {/* "Delete cell" clears only this agent's cell for the letter;
-                  "Delete Profile" removes the whole slot across all agents (#526). */}
-              <button
-                class="settings-profile-cell-btn settings-profile-delete-cell"
-                onClick={() => removeProfileCell(agent.id, letter)}
-                title={`Remove ${agent.label || agent.id}'s ${letter} cell (keeps the slot)`}
-                data-ac-testid={`${cardId}.delete`}
-                data-ac-role="button"
-              >
-                Delete cell
-              </button>
+              {/* #538: per-cell "Delete cell" removed — cells are never deleted
+                  individually. Slot-level "Delete Profile" (drops the letter from
+                  every agent; A is immutable) stays so added letters stay removable. */}
               <button
                 class="settings-profile-cell-btn settings-profile-delete-profile"
                 onClick={() => removeProfileLetter(letter)}
@@ -1539,7 +1462,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                 Delete Profile
               </button>
             </div>
-          </Show>
           </Show>
         </Show>
       </article>

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -1451,11 +1451,8 @@ html.light-theme .root-agent-avatar {
   color: var(--sidebar-accent);
 }
 
-.settings-profile-delete-cell {
-  align-self: flex-start;
-}
-
-/* Footer holding the per-agent "Delete cell" + slot-level "Delete Profile". */
+/* Footer holding the slot-level "Delete Profile" affordance (#538: the per-cell
+   "Delete cell" button was removed). */
 .settings-profile-card-footer {
   display: flex;
   flex-wrap: wrap;
@@ -1464,7 +1461,7 @@ html.light-theme .root-agent-avatar {
 }
 
 /* Slot-level delete is destructive (drops the letter from every agent) — give it
-   a muted-red affordance that intensifies on hover, distinct from "Delete cell". */
+   a muted-red affordance that intensifies on hover. */
 .settings-profile-delete-profile {
   color: var(--status-exited, #ff5d5d);
   border-color: rgba(255, 93, 93, 0.4);
@@ -1473,22 +1470,6 @@ html.light-theme .root-agent-avatar {
 .settings-profile-delete-profile:hover:not(:disabled) {
   color: var(--status-exited, #ff5d5d);
   border-color: var(--status-exited, #ff5d5d);
-}
-
-.settings-profile-missing {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  min-height: 22px;
-  justify-content: space-between;
-  color: var(--sidebar-fg-dim);
-  font-size: var(--font-size-sm);
-}
-
-.settings-profile-missing-actions {
-  display: flex;
-  gap: var(--spacing-xs);
-  flex: 0 0 auto;
 }
 
 .settings-profile-cell-btn {


### PR DESCRIPTION
## Summary

Makes every coding-agent profile cell behave like profile `A`: every cell always shows its command text box, the per-cell **"Add cell"** and **"Delete cell"** affordances are removed, and multi-profile support is preserved (**"Add Profile" / "Delete Profile"** for whole profile letters still work; `A` immutable).

Frontend-only change in `src/sidebar/components/SettingsModal.tsx` + `src/sidebar/styles/sidebar.css` + automation test. Also bumps version `0.9.5 → 0.9.6`.

## What changed

- Removed the `configured()` gate so every cell renders its command editor (the post-"Add cell" state).
- Deleted the "Add cell" button + the MISSING/fallback box and the per-cell "Delete cell" button (plus now-dead handlers and CSS rules).
- Made the card sub-line fallback-aware (shows e.g. "Launches A" for an empty cell, consistent with the badge).
- Kept "Add Profile" / whole-letter "Delete Profile"; `A` stays immutable and non-removable.

## Testing

- `tsc --noEmit` clean; `vitest run` → 334 tests pass.
- `/code-review` (high effort) run by dev; a sub-line/badge contradiction was found and fixed.
- Adversarial review by dev-rust-grinch: **CLEAN** at the implementation, and **PASS** on the focused re-review after merging the latest `origin/main`.
- Shipper built the wg-7 standalone exe and deployed it to `0_AC`; the **user manually tested the exe and approved it**.

## Follow-up

- #544 (LOW): prune enabled empty-command non-`A` cells on save (a pre-existing edge case, deferred by decision).

Closes #538
