### PR TITLE
fix(terminal): remove dead Ctrl+Shift+N shortcut and "+ New Session" button (#542)

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -235,7 +235,7 @@ graph LR
 
         SSTORE["stores/settings.ts<br/>Global settings signal<br/>voiceEnabled computed"]
 
-        SHORTS["shortcuts.ts<br/>Ctrl+Shift+N/W/R"]
+        SHORTS["shortcuts.ts<br/>Ctrl+Shift+W/R"]
 
         CONST["constants.ts<br/>WINDOW_TYPE,<br/>IS_SIDEBAR, IS_TERMINAL"]
     end
@@ -598,7 +598,7 @@ graph TD
 | `main.tsx` | Entry, window routing by query param |
 | `shared/types.ts` | All TypeScript interfaces |
 | `shared/ipc.ts` | All API wrappers + event listeners |
-| `shared/shortcuts.ts` | Global keyboard shortcuts (Ctrl+Shift+N/W/R) |
+| `shared/shortcuts.ts` | Global keyboard shortcuts (Ctrl+Shift+W/R) |
 | `shared/constants.ts` | `WINDOW_TYPE`, `IS_SIDEBAR`, `IS_TERMINAL` |
 | `shared/voice-recorder.ts` | Mic recording → Gemini → PTY inject |
 | `shared/console-capture.ts` | Console monkey-patch, 500 entries buffer |

--- a/docs/testing/semantic-ui-automation-affordance-matrix.md
+++ b/docs/testing/semantic-ui-automation-affordance-matrix.md
@@ -38,7 +38,6 @@ This matrix seeds issue #497 acceptance coverage. It tracks user-visible screen/
 | Open guide | `actionBar.guide` | `click` |
 | Open spec board when enabled | `actionBar.specBoard` | `click` |
 | Detect terminal empty state | `terminal.empty` | `query` |
-| Start a new empty terminal session | `terminal.empty.newSession` | `click` |
 
 ## Settings Seed
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.9.9"; // Must match package.json
+const VERSION = "0.9.10"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.9.9"
+version = "0.9.10"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {

--- a/src/shared/shortcuts.ts
+++ b/src/shared/shortcuts.ts
@@ -1,6 +1,5 @@
 import { SessionAPI } from "./ipc";
 import { voiceRecorder } from "./voice-recorder";
-import { homeStore } from "../main/stores/home";
 
 type ShortcutHandler = (e: KeyboardEvent) => void;
 
@@ -10,12 +9,6 @@ const shortcuts: Array<{
   key: string;
   handler: () => void;
 }> = [
-  {
-    ctrl: true,
-    shift: true,
-    key: "n",
-    handler: () => { homeStore.hide(); SessionAPI.create(); },
-  },
   {
     ctrl: true,
     shift: true,

--- a/src/terminal/App.tsx
+++ b/src/terminal/App.tsx
@@ -279,16 +279,6 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
                   ? "Session closed"
                   : "No active session"}
               </span>
-              <Show when={!props.detached}>
-                <button
-                  class="terminal-empty-btn"
-                  onClick={() => { homeStore.hide(); SessionAPI.create(); }}
-                  data-ac-testid="terminal.empty.newSession"
-                  data-ac-role="button"
-                >
-                  + New Session
-                </button>
-              </Show>
             </div>
           }
         >

--- a/src/terminal/styles/terminal.css
+++ b/src/terminal/styles/terminal.css
@@ -704,19 +704,3 @@ html.light-theme .last-prompt-panel::-webkit-scrollbar-thumb {
   color: var(--statusbar-fg);
   font-size: var(--font-size-md);
 }
-
-.terminal-empty-btn {
-  padding: var(--spacing-sm) var(--spacing-md);
-  border: 1px solid rgba(0, 212, 255, 0.3);
-  background: rgba(0, 212, 255, 0.08);
-  color: var(--statusbar-accent);
-  font-family: var(--font-ui);
-  font-size: var(--font-size-sm);
-  cursor: pointer;
-  border-radius: 6px;
-  transition: background var(--transition-fast);
-}
-
-.terminal-empty-btn:hover {
-  background: rgba(0, 212, 255, 0.15);
-}


### PR DESCRIPTION
Resolves #542 (follow-up to #516) by **removal**.

#516 added a global agent-concurrency cap whose rejection was surfaced in all modal-based launch paths. Two no-arg quick-create paths still fired `SessionAPI.create()` fire-and-forget, so the cap rejection was **silent** there:
- the terminal-window **"+ New Session"** button (`src/terminal/App.tsx`) — already practically unreachable (always painted under the opaque Home overlay);
- the **Ctrl+Shift+N** global shortcut (`src/shared/shortcuts.ts`) — never used.

Per the maintainer's decision, both dead paths are **deleted** rather than wired to a new cross-window notification surface. With these gone, every remaining `SessionAPI.create()` caller passes explicit config and already surfaces errors — **no silent agent-cap-rejection path remains**.

## Changes
- Remove the `Ctrl+Shift+N` shortcut + the now-unused `homeStore` import from `src/shared/shortcuts.ts` (Ctrl+Shift+W / Ctrl+Shift+R left intact).
- Remove the dead "+ New Session" button from `src/terminal/App.tsx` (the empty-state message is retained).
- Remove the dead `.terminal-empty-btn` CSS rules.
- Update docs (`docs/reference/architecture.md`, `docs/testing/semantic-ui-automation-affordance-matrix.md`) to drop the Ctrl+Shift+N / button references.
- Version bump 0.9.9 → 0.9.10.

## Testing / review
- `tsc --noEmit` clean; `vite build` passes.
- `/code-review` @ high effort: zero findings.
- Adversarial review (Grinch): CLEAN on the implementation (`20060b2`) and CLEAN again on the re-sync with `origin/main` (`1247d51`).
- Shipper built the wg-5 standalone and deployed to `0_AC`; the **maintainer manually tested** the exe — Ctrl+Shift+N is a no-op, the "+ New Session" button is gone, and Ctrl+Shift+W/R + normal session creation still work.
- Re-synced with latest `origin/main` (#553); clean auto-merge, no conflicts.

Closes #542
