### PR TITLE
feat(resource-monitor): configurable max concurrent agent cap, default 32, no upper limit (#565)

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.9.12"; // Must match package.json
+const VERSION = "0.9.13"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -463,7 +463,7 @@ fn default_resource_monitor_enabled() -> bool {
 }
 
 fn default_max_concurrent_agent_processes() -> u32 {
-    16
+    32
 }
 
 fn default_resource_watchdog_action() -> ResourceWatchdogAction {
@@ -1228,8 +1228,10 @@ fn validate_agent_command_text(context: &str, command: &str) -> Result<(), Strin
 }
 
 pub fn validate_resource_settings(settings: &AppSettings) -> Result<(), String> {
-    if !(1..=16).contains(&settings.max_concurrent_agent_processes) {
-        return Err("maxConcurrentAgentProcesses must be between 1 and 16".to_string());
+    // Floor at 1 (a value of 0 would block every agent launch); no upper ceiling.
+    // The user sets this deliberately and is responsible for sizing it to their machine.
+    if settings.max_concurrent_agent_processes == 0 {
+        return Err("maxConcurrentAgentProcesses must be at least 1".to_string());
     }
     if settings.agent_group_warn_private_bytes > settings.agent_group_kill_private_bytes {
         return Err(
@@ -2232,7 +2234,7 @@ mod tests {
     fn resource_monitor_settings_round_trip_through_serde() {
         let mut s = AppSettings::default();
         assert!(s.resource_monitor_enabled);
-        assert_eq!(s.max_concurrent_agent_processes, 16);
+        assert_eq!(s.max_concurrent_agent_processes, 32);
         assert_eq!(s.resource_watchdog_action, ResourceWatchdogAction::Warn);
         assert_eq!(s.agent_group_warn_private_bytes, 8 * 1024 * 1024 * 1024);
         assert_eq!(s.agent_group_kill_private_bytes, 12 * 1024 * 1024 * 1024);
@@ -2278,14 +2280,6 @@ mod tests {
             .contains("maxConcurrentAgentProcesses"));
 
         let s = AppSettings {
-            max_concurrent_agent_processes: 17,
-            ..AppSettings::default()
-        };
-        assert!(validate_resource_settings(&s)
-            .unwrap_err()
-            .contains("maxConcurrentAgentProcesses"));
-
-        let s = AppSettings {
             agent_group_warn_private_bytes: 10,
             agent_group_kill_private_bytes: 9,
             ..AppSettings::default()
@@ -2312,6 +2306,22 @@ mod tests {
         assert!(validate_resource_settings(&s)
             .unwrap_err()
             .contains("agentProcessKillPrivateBytes"));
+    }
+
+    #[test]
+    fn validate_resource_settings_accepts_max_concurrent_above_legacy_cap() {
+        // #565: the old 1..=16 upper ceiling is gone. Any value >= 1 is accepted;
+        // the user is responsible for sizing it to their machine.
+        for value in [17u32, 32, 64, 256, 10_000] {
+            let s = AppSettings {
+                max_concurrent_agent_processes: value,
+                ..AppSettings::default()
+            };
+            assert!(
+                validate_resource_settings(&s).is_ok(),
+                "expected max_concurrent_agent_processes={value} to validate"
+            );
+        }
     }
 
     #[test]
@@ -2737,7 +2747,7 @@ mod tests {
 
         let s: AppSettings = serde_json::from_str(json).expect("deserialize old json");
         assert!(s.resource_monitor_enabled);
-        assert_eq!(s.max_concurrent_agent_processes, 16);
+        assert_eq!(s.max_concurrent_agent_processes, 32);
         assert_eq!(s.resource_watchdog_action, ResourceWatchdogAction::Warn);
         assert!(validate_resource_settings(&s).is_ok());
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -602,12 +602,14 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     const data = settings.data;
     if (!data) return null;
 
+    // #565: mirror the backend (validate_resource_settings) — floor at 1, NO
+    // upper ceiling. The user sets this deliberately; the hard cap was replaced
+    // by an adjacent latency warning (see below), not a maximum.
     if (
       !Number.isInteger(data.maxConcurrentAgentProcesses) ||
-      data.maxConcurrentAgentProcesses < 1 ||
-      data.maxConcurrentAgentProcesses > 16
+      data.maxConcurrentAgentProcesses < 1
     ) {
-      return "Resources: max concurrent agent processes must be between 1 and 16";
+      return "Resources: max concurrent agent processes must be at least 1";
     }
 
     const warn = data.agentGroupWarnPrivateBytes;
@@ -1364,7 +1366,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             class="settings-input settings-input-sm"
             type="number"
             min="1"
-            max="16"
             step="1"
             value={settings.data!.maxConcurrentAgentProcesses}
             onInput={(e) => {
@@ -1377,6 +1378,15 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             data-ac-role="spinbutton"
           />
         </label>
+        <div
+          class="settings-hint settings-hint-warning"
+          data-ac-testid="settings.resources.maxConcurrentAgentProcesses.warning"
+          data-ac-role="status"
+        >
+          No upper limit (default 32). Higher values let more agent processes run
+          at once, but can worsen stop / restart / assign latency — per-group
+          cleanup on the destroy path gets more expensive as the cap grows.
+        </div>
       </div>
 
       <div class="settings-section">

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2490,6 +2490,19 @@ html.light-theme .root-agent-avatar {
   margin: 0 0 var(--spacing-sm) 0;
 }
 
+/* Warning variant of the settings hint — amber caution text (#565). Reuses the
+   base .settings-hint layout and only shifts the color. Dark theme uses the
+   bright amber already used by .settings-codex-home-preview.warning; the light
+   theme overrides to a darker amber so 11px text keeps adequate contrast on the
+   light background (mirrors the per-theme override convention used in this file). */
+.settings-hint-warning {
+  color: #fbbf24;
+}
+
+html.light-theme .settings-hint-warning {
+  color: #b45309;
+}
+
 /* Empty state */
 .empty-state {
   display: flex;


### PR DESCRIPTION
## Summary
Makes the Resource Monitor's **Max Concurrent agent processes** cap user-configurable in Settings → Resources, raises the default 16 → **32**, and removes the hard upper ceiling (per user decision: no max, a UI warning instead).

### Backend (`src-tauri/src/config/settings.rs`)
- `default_max_concurrent_agent_processes()` now returns **32** (was 16).
- Validation rejects only `0` ("must be at least 1") — **no upper bound**.
- Tests updated (defaults 16→32; removed the obsolete "17 rejected" test; added a test asserting 17/32/64/256/10000 all validate).
- Value flows live per launch (`session.rs` → `ResourceLimits::from` → `try_reserve_agent_slot`); existing explicit `settings.json` values are preserved (serde default applies only when the field is absent).

### Frontend (`src/sidebar/components/SettingsModal.tsx`, `src/sidebar/styles/sidebar.css`)
- Lifted the stale `1..16` ceiling on the existing "Max Concurrent Agent Processes" control (removed `max="16"` + the `>16` validator); now rejects only `<1`/non-integer, mirroring the backend.
- Added a warning hint under the input about high values worsening lifecycle latency; made it theme-aware (light-theme contrast fix).
- Resource Monitor header `ACTIVE GROUPS x / y` reads the live cap (no hardcoded 16 remains).

## Testing
- **dev-rust:** `cargo test --lib --bins --tests` → 1331 passed, 0 failed; clippy clean; `/code-review` high effort → 0 HIGH.
- **dev-webpage-ui:** `tsc --noEmit` pass; `vitest` 360 tests pass; `vite build` pass; `/code-review` fixed a light-theme contrast issue.
- **Adversarial review (grinch):** CLEAN — verified flow, migration, numeric edges, concurrency, test integrity.
- **Shipper:** built the wg-5 release exe and deployed to `0_AC`.
- **User:** manually tested the deployed `0_AC` wg-5 exe and approved landing.

## Notes
- Version bumped 0.9.12 → 0.9.13.
- Accepted tradeoff: until #564 (destroy-path latency) lands, a higher cap can make the ~2-3s lifecycle latency more noticeable. Sequenced per user decision.
- Follow-up #566 filed for the stale `MAX_TERMINATED_RETAINED` comment.

Closes #565