### PR TITLE
fix(resource-monitor): remove ~2-3s destroy latency via subtree-scoped observe_tree (#564)

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.9.13"; // Must match package.json
+const VERSION = "0.9.14"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.9.13"
+version = "0.9.14"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1495,6 +1495,7 @@ async fn destroy_session_inner_with_options<R: tauri::Runtime>(
     {
         let resource_monitor = app.state::<Arc<ResourceMonitorState>>().inner().clone();
         if resource_monitor.has_registered_group(uuid) {
+            let cleanup_started = std::time::Instant::now();
             let monitor = Arc::clone(&resource_monitor);
             let result = tokio::task::spawn_blocking(move || {
                 monitor.kill_group(
@@ -1504,6 +1505,12 @@ async fn destroy_session_inner_with_options<R: tauri::Runtime>(
             })
             .await
             .map_err(|e| e.to_string())??;
+            log::info!(
+                "[session] destroy resource cleanup for {} took {}ms (quarantined={})",
+                id,
+                cleanup_started.elapsed().as_millis(),
+                result.quarantined
+            );
             if result.quarantined {
                 log::warn!(
                     "[session] Resource cleanup for {} quarantined: {}",

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -368,6 +368,7 @@ impl ResourceMonitorState {
         session_id: Uuid,
         reason: ResourceKillReason,
     ) -> Result<ResourceKillResult, String> {
+        let kill_started = Instant::now();
         let (root_identity, previous_targets) = {
             let mut inner = self
                 .inner
@@ -419,7 +420,10 @@ impl ResourceMonitorState {
         let mut current_cleanup_identities = BTreeSet::new();
         let mut pending_identity_errors = Vec::new();
         let mut errors = Vec::new();
-        match self.backend.observe_tree(root_identity) {
+        let observe_started = Instant::now();
+        let observed_tree = self.backend.observe_tree(root_identity);
+        let observe_ms = observe_started.elapsed().as_millis();
+        match observed_tree {
             Ok(tree) => {
                 let current_processes = tree.processes.clone();
                 current_cleanup_identities
@@ -472,6 +476,7 @@ impl ResourceMonitorState {
                 .cmp(&a.depth)
                 .then_with(|| b.identity.cmp(&a.identity))
         });
+        let target_count = targets.len();
 
         let mut killed = Vec::new();
         for process in targets.iter() {
@@ -571,6 +576,17 @@ impl ResourceMonitorState {
                 }
             }
         }
+
+        log::info!(
+            "[resource-monitor] kill_group session={} reason={} observe_tree_ms={} total_ms={} targets={} killed={} quarantined={}",
+            session_id,
+            reason.as_log_reason(),
+            observe_ms,
+            kill_started.elapsed().as_millis(),
+            target_count,
+            killed.len(),
+            quarantined
+        );
 
         Ok(ResourceKillResult {
             session_id: session_id.to_string(),

--- a/src-tauri/src/resource_monitor/windows.rs
+++ b/src-tauri/src/resource_monitor/windows.rs
@@ -44,10 +44,24 @@ mod platform {
             root: ProcessIdentity,
         ) -> Result<ObservedProcessTree, ResourceError> {
             let entries = process_entries()?;
-            let identities = observe_identities(&entries);
-            Ok(build_observed_tree(&entries, &identities, root, |pid| {
-                process_memory(pid).unwrap_or_default()
-            }))
+            // #564 - resolve identities lazily for only the PIDs the walk visits
+            // (root + descendants + their direct parents), not every system PID, and
+            // memoize so a pid referenced both as a node and as a child's parent is
+            // opened at most once and yields one consistent value across the walk
+            // (matching the old single-snapshot identity map). The previous full-system
+            // precompute opened ~498 processes (each a syscall, with a redundant full
+            // snapshot on every permission-denied open) and discarded ~98% of the results.
+            let mut identity_cache: HashMap<u32, Option<ProcessIdentity>> = HashMap::new();
+            Ok(build_observed_tree(
+                &entries,
+                root,
+                |pid| {
+                    *identity_cache
+                        .entry(pid)
+                        .or_insert_with(|| observe_identity(pid).ok().flatten())
+                },
+                |pid| process_memory(pid).unwrap_or_default(),
+            ))
         }
 
         fn observe_identity(&self, pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
@@ -136,8 +150,8 @@ mod platform {
     /// function over the snapshot and can be unit-tested without real processes.
     fn build_observed_tree(
         entries: &HashMap<u32, ProcessEntry>,
-        identities: &HashMap<u32, ProcessIdentity>,
         root: ProcessIdentity,
+        mut identity_for: impl FnMut(u32) -> Option<ProcessIdentity>,
         mut memory_for: impl FnMut(u32) -> ProcessMemory,
     ) -> ObservedProcessTree {
         let mut by_parent: HashMap<u32, Vec<u32>> = HashMap::new();
@@ -158,13 +172,16 @@ mod platform {
                 }
                 continue;
             };
-            let identity = identities.get(&pid).copied().unwrap_or_else(|| {
-                errors.push(format!("identity unavailable for pid {pid}"));
-                ProcessIdentity {
-                    pid,
-                    creation_time_100ns: 0,
+            let identity = match identity_for(pid) {
+                Some(identity) => identity,
+                None => {
+                    errors.push(format!("identity unavailable for pid {pid}"));
+                    ProcessIdentity {
+                        pid,
+                        creation_time_100ns: 0,
+                    }
                 }
-            });
+            };
             if pid == root.pid
                 && root.creation_time_100ns != 0
                 && identity.creation_time_100ns != 0
@@ -179,7 +196,7 @@ mod platform {
             }
             let parent_identity = (entry.parent_pid != 0)
                 .then_some(entry.parent_pid)
-                .and_then(|parent| identities.get(&parent).copied());
+                .and_then(&mut identity_for);
             let memory = memory_for(pid);
             processes.push(ObservedProcess {
                 identity,
@@ -263,18 +280,6 @@ mod platform {
             }
         }
         Ok(entries)
-    }
-
-    fn observe_identities(entries: &HashMap<u32, ProcessEntry>) -> HashMap<u32, ProcessIdentity> {
-        entries
-            .keys()
-            .filter_map(|pid| {
-                observe_identity(*pid)
-                    .ok()
-                    .flatten()
-                    .map(|identity| (*pid, identity))
-            })
-            .collect()
     }
 
     fn observe_identity(pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
@@ -398,7 +403,12 @@ mod platform {
             let identities =
                 HashMap::from([(1000, identity(1000, 111)), (1001, identity(1001, 222))]);
 
-            let tree = build_observed_tree(&entries, &identities, identity(1000, 111), no_memory);
+            let tree = build_observed_tree(
+                &entries,
+                identity(1000, 111),
+                |pid| identities.get(&pid).copied(),
+                no_memory,
+            );
 
             assert!(tree.errors.is_empty(), "unexpected errors: {:?}", tree.errors);
             assert_eq!(tree.processes.len(), 2);
@@ -422,7 +432,12 @@ mod platform {
             let identities =
                 HashMap::from([(1000, identity(1000, 222)), (1001, identity(1001, 333))]);
 
-            let tree = build_observed_tree(&entries, &identities, identity(1000, 111), no_memory);
+            let tree = build_observed_tree(
+                &entries,
+                identity(1000, 111),
+                |pid| identities.get(&pid).copied(),
+                no_memory,
+            );
 
             assert!(
                 tree.processes.is_empty(),
@@ -440,12 +455,54 @@ mod platform {
             let entries: HashMap<u32, ProcessEntry> = HashMap::new();
             let identities: HashMap<u32, ProcessIdentity> = HashMap::new();
 
-            let tree = build_observed_tree(&entries, &identities, identity(1000, 111), no_memory);
+            let tree = build_observed_tree(
+                &entries,
+                identity(1000, 111),
+                |pid| identities.get(&pid).copied(),
+                no_memory,
+            );
 
             assert!(tree.processes.is_empty());
             assert_eq!(
                 tree.errors,
                 vec!["root pid 1000 was not in process snapshot".to_string()]
+            );
+        }
+
+        #[test]
+        fn resolves_identity_only_for_subtree_pids() {
+            // Two unrelated processes (2000/2001) live in the snapshot but are not in
+            // the root's subtree. The identity resolver must never be invoked for them;
+            // that is exactly the ~498-PID cost #564 removes.
+            let entries = HashMap::from([
+                (1000, entry(1000, 4, "agent.exe")),
+                (1001, entry(1001, 1000, "child.exe")),
+                (2000, entry(2000, 4, "unrelated.exe")),
+                (2001, entry(2001, 2000, "unrelated-child.exe")),
+            ]);
+            let identities = HashMap::from([
+                (1000, identity(1000, 111)),
+                (1001, identity(1001, 222)),
+                (2000, identity(2000, 333)),
+                (2001, identity(2001, 444)),
+            ]);
+            let mut probed: Vec<u32> = Vec::new();
+            let tree = build_observed_tree(
+                &entries,
+                identity(1000, 111),
+                |pid| {
+                    probed.push(pid);
+                    identities.get(&pid).copied()
+                },
+                no_memory,
+            );
+
+            assert!(tree.errors.is_empty(), "unexpected errors: {:?}", tree.errors);
+            assert_eq!(tree.processes.len(), 2);
+            assert!(probed.contains(&1000) && probed.contains(&1001));
+            assert!(
+                !probed.contains(&2000) && !probed.contains(&2001),
+                "identity resolver must not touch processes outside the subtree, probed={probed:?}"
             );
         }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {


### PR DESCRIPTION
## Summary

Removes the ~2-3s UI latency on agent **stop / restart / "Assign to this replica"** (#564). The destroy path ran the resource-monitor `kill_group` synchronously before emitting `session_destroyed`, and the costly part was `observe_tree` doing a full-system `OpenProcess` + `GetProcessTimes` over **every** process in the system (~498 under load) — once per `kill_group`, **even when the tree was already gone and there was nothing to kill**. That cost scaled with total system process count, exactly as the report described.

## Fix

Scope identity resolution to the **subtree**. `build_observed_tree` now takes an injected, memoized `identity_for` closure (same pattern as the existing `memory_for`) and resolves identities lazily for only the visited PIDs (root + descendants + their direct parents) instead of all ~498. The dead eager `observe_identities` precompute is deleted. Output is equivalent and kill-safety is untouched: `terminate_verified` and the recycled-root creation-time guard (the #516/#543 PID-reuse safety) are unchanged. Adds `observe_tree_ms` / `total_ms` and destroy-cleanup timing instrumentation so the before/after is measurable under live load (expect `observe_tree_ms` to collapse from ~2000-3000 ms to <100 ms).

## Commits

- `6ac32e5` — add destroy-path timing instrumentation
- `ae5130b` — scope observe_tree identity resolution to the subtree (the fix, incl. memoized per-walk identity cache)
- `195b146` — merge origin/main (v0.9.13, #565 configurable max-concurrent cap) into the branch — clean, zero overlap with the 3 fix files
- `e2ab9bd` — bump version to 0.9.14

## Tests & review

- `cargo test --lib --bins --tests`: **1332 passed / 0 failed** (includes the new `resolves_identity_only_for_subtree_pids` regression guard proving the resolver never touches out-of-subtree PIDs). `cargo clippy --all-targets -- -D warnings`: clean. Run on Windows independently by both dev-rust and dev-rust-grinch.
- **dev-rust /code-review (high effort):** 0 correctness bugs, 0 HIGH-severity findings.
- **dev-rust-grinch Step-7 adversarial review: PASS.** Kill-safety equivalence confirmed four ways; the only divergence (`parent_identity` of an out-of-snapshot parent) is provably inert (write-only, zero read sites, not serialized to the frontend). Merge byte-identity of the 3 fix files (`windows.rs`/`registry.rs`/`session.rs`) verified independently.
- **shipper:** built `agentscommander_standalone_wg-1.exe` v0.9.14 and deployed it to `0_AC`; user gave the go-ahead to land.

## Interaction with #565

#565 (configurable max-concurrent cap, default 32) landed to `main` during implementation and is merged into this branch (clean, zero code overlap). Raising the cap increases concurrent process count, which made this synchronous full-system scan more expensive — so the two are intentionally shipped together.

Closes #564
