### PR TITLE
fix(sidebar): surface failed post-assign "Restart now" in the prompt modal (#573)

### DIFF
--- a/src/sidebar/components/ProjectPanel.restart-prompt.test.tsx
+++ b/src/sidebar/components/ProjectPanel.restart-prompt.test.tsx
@@ -258,4 +258,42 @@ describe("ProjectPanel post-assign restart prompt (#537)", () => {
       rendered.cleanup();
     }
   });
+
+  // #573: a rejected SessionAPI.restart used to be swallowed (consume-and-clear +
+  // bare console.error), so the user thought the new agent applied while the old
+  // one kept running. The modal must now stay open and surface the failure.
+  it("keeps the prompt open and surfaces the error when the restart fails, then closes on a successful retry", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    // The Resource Monitor concurrency cap is the most likely relaunch failure;
+    // launchErrorMessage rephrases it into actionable copy.
+    fake.reject("restart_session", "Resource Monitor cap reached: 16/16 agent groups are active");
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await driveToRestartPrompt(rendered.root);
+
+      click(q<HTMLButtonElement>("restartPrompt.restart")!);
+
+      // The restart was attempted, but it rejected — the modal must stay open with
+      // the surfaced (friendly) error rather than silently closing.
+      await waitFor(() => expect(fake.callsFor("restart_session")).toHaveLength(1));
+      await waitFor(() => expect(q("restartPrompt.error")).toBeTruthy());
+      expect(q("restartPrompt.error")?.textContent ?? "").toContain("Resource Monitor cap reached");
+      expect(q("restartPrompt.modal")).toBeTruthy();
+
+      // Retry now succeeds: the in-flight guard reset lets the click through, the
+      // restart fires again, and the modal closes once it resolves.
+      fake.resolve(
+        "restart_session",
+        session({ id: sessionId, name: sessionName, workingDirectory: replicaPath }),
+      );
+      click(q<HTMLButtonElement>("restartPrompt.restart")!);
+
+      await waitFor(() => expect(fake.callsFor("restart_session")).toHaveLength(2));
+      await waitFor(() => expect(q("restartPrompt.modal")).toBeNull());
+    } finally {
+      rendered.cleanup();
+    }
+  });
 });

--- a/src/sidebar/components/ProjectPanel.restart-prompt.test.tsx
+++ b/src/sidebar/components/ProjectPanel.restart-prompt.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import ProjectPanel from "./ProjectPanel";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ProjectPanel, { RESTART_TIMEOUT_MS } from "./ProjectPanel";
 import type {
   AgentConfig,
   ApplyCodingAgentProfileSelectionResult,
@@ -193,6 +193,10 @@ describe("ProjectPanel post-assign restart prompt (#537)", () => {
   });
 
   afterEach(() => {
+    // Defensive: the never-settles test installs fake timers. Restore real
+    // timers here too (no-op for the real-timer tests) so a future throw inside
+    // its fake-timer window can't leak frozen timers into the next test.
+    vi.useRealTimers();
     cleanupDom?.();
     cleanupDom = null;
     resetUiStoresForTests();
@@ -292,6 +296,63 @@ describe("ProjectPanel post-assign restart prompt (#537)", () => {
 
       await waitFor(() => expect(fake.callsFor("restart_session")).toHaveLength(2));
       await waitFor(() => expect(q("restartPrompt.modal")).toBeNull());
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // #573 (grinch Step-7, Finding 1): a backend `restart_session` that neither
+  // resolves nor rejects (write-lock stall, ConPTY respawn hang, dropped IPC
+  // reply) must not trap the modal. The Tauri IPC transport has no timeout, so
+  // without the bounded race `restarting()` would stay true forever — and with
+  // both buttons disabled and dismiss gated while restarting, the modal could
+  // only be cleared by killing the app. The 30s timeout (WS parity) must clear
+  // `restarting()`, surface a timeout error inline, and make the modal escapable.
+  it("times out a never-settling restart and re-enables the modal", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    // A restart that never settles — emulates a wedged backend / dropped reply.
+    fake.onInvoke("restart_session", () => new Promise(() => {}));
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await driveToRestartPrompt(rendered.root);
+
+      // Fake timers must own the production window.setTimeout BEFORE the restart
+      // fires, so advanceTimers controls the bound. Setup above ran on real timers
+      // (waitFor polls real time); the synchronous click + assertions below need
+      // no waitFor, so the switch is safe only from here on.
+      vi.useFakeTimers();
+      try {
+        click(q<HTMLButtonElement>("restartPrompt.restart")!);
+
+        // In flight: the restart was invoked and the modal is busy (both buttons
+        // disabled, dismiss gated) with no error yet. All synchronous — the call
+        // is recorded and restarting() flips before the first await.
+        expect(fake.callsFor("restart_session")).toHaveLength(1);
+        expect(q<HTMLButtonElement>("restartPrompt.restart")?.disabled).toBe(true);
+        expect(q<HTMLButtonElement>("restartPrompt.later")?.disabled).toBe(true);
+        expect(q("restartPrompt.error")).toBeNull();
+
+        // Advance past the bound: the timeout wins the race and rejects.
+        await vi.advanceTimersByTimeAsync(RESTART_TIMEOUT_MS);
+
+        // restarting() cleared, the timeout error surfaced, and the modal stayed
+        // open and interactive again — the exact regression Finding 1 describes.
+        expect(q("restartPrompt.error")?.textContent ?? "").toContain(
+          "Command timeout: restart_session",
+        );
+        expect(q("restartPrompt.modal")).toBeTruthy();
+        expect(q<HTMLButtonElement>("restartPrompt.restart")?.disabled).toBe(false);
+        expect(q<HTMLButtonElement>("restartPrompt.later")?.disabled).toBe(false);
+
+        // Genuinely escapable now: the dismiss gate no longer traps because
+        // restarting() is false, so Later closes the modal.
+        click(q<HTMLButtonElement>("restartPrompt.later")!);
+        expect(q("restartPrompt.modal")).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -126,6 +126,19 @@ function deriveScopeContextFromSession(
 
 const CONTEXT_MENU_VIEWPORT_MARGIN = 8;
 
+/**
+ * #573 (grinch Step-7): upper bound for the post-assign restart await. The Tauri
+ * IPC transport (`transport-tauri.ts`) has NO timeout, unlike `WsTransport.invoke`
+ * (`transport-ws.ts`), which rejects after 30s with `Command timeout: <cmd>`. If
+ * the backend `restart_session` neither resolves nor rejects (session-manager
+ * write-lock stall, ConPTY respawn hang, dropped IPC reply), `restarting()` would
+ * stay true forever and trap the modal (both buttons disabled + dismiss gated →
+ * app-kill required). Racing this timeout lets the desktop modal self-heal exactly
+ * as it already does on WS/remote — intentional parity, so mirror the WS value.
+ * The WS 30s is a bare literal there (not exported), hence a local named const.
+ */
+export const RESTART_TIMEOUT_MS = 30_000;
+
 /** Build the session name used to link a replica to its session */
 function replicaSessionName(wg: AcWorkgroup, replica: AcAgentReplica): string {
   return `${wg.name}/${replica.name}`;
@@ -219,16 +232,35 @@ const ProjectPanel: Component = () => {
     if (!prompt || restarting()) return;
     setRestarting(true);
     setRestartError("");
+    // #573 (grinch Step-7): bound the await with RESTART_TIMEOUT_MS. The Tauri IPC
+    // transport never times out, so a wedged backend would leave `restarting()`
+    // true forever and trap the modal (buttons disabled + dismiss gated). Racing a
+    // timeout guarantees `finally` runs within the bound, surfacing the error
+    // inline and re-enabling the modal — matching WsTransport.invoke's self-heal.
+    let timeoutTimer: number | undefined;
     try {
-      await SessionAPI.restart(prompt.sessionId, {
-        agentId: prompt.agentId,
-        requestedProfile: prompt.requestedProfile,
-      });
+      await Promise.race([
+        SessionAPI.restart(prompt.sessionId, {
+          agentId: prompt.agentId,
+          requestedProfile: prompt.requestedProfile,
+        }),
+        // Mirror WsTransport.invoke's reject (a bare `Command timeout: <cmd>`
+        // string) so launchErrorMessage yields identical copy on desktop and WS.
+        new Promise<never>((_, reject) => {
+          timeoutTimer = window.setTimeout(
+            () => reject("Command timeout: restart_session"),
+            RESTART_TIMEOUT_MS,
+          );
+        }),
+      ]);
       setRestartPrompt(null);
     } catch (e) {
       console.error("Failed to restart session:", e);
       setRestartError(launchErrorMessage(e));
     } finally {
+      // Timer hygiene: cancel the pending timeout when the restart settles first,
+      // so a successful restart can't leave a dangling timer / late rejection.
+      window.clearTimeout(timeoutTimer);
       setRestarting(false);
     }
   };

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -5,6 +5,7 @@ import { SessionAPI, WindowAPI, EntityAPI, LoopAPI, TelegramAPI, SettingsAPI, Ta
 import type { SessionRepoInput } from "../../shared/ipc";
 import { isTauri } from "../../shared/platform";
 import { stripFrontmatter } from "../../shared/markdown";
+import { launchErrorMessage } from "../../shared/launch-errors";
 import { projectStore } from "../stores/project";
 import { sessionsStore } from "../stores/sessions";
 import { bridgesStore } from "../stores/bridges";
@@ -199,18 +200,46 @@ const ProjectPanel: Component = () => {
     agentLabel: string;
     requestedProfile: string | null;
   } | null>(null);
+  // #573: in-flight + error state for the prompt's restart. The old code did a
+  // consume-and-clear (setRestartPrompt(null) before the async settled) with a
+  // bare `.catch(console.error)`, so a failed restart vanished silently and the
+  // user thought the new agent applied while the old one kept running. We now
+  // keep the modal open, surface the failure, and let the user retry — mirroring
+  // AgentPickerModal.apply() and Resource Monitor's confirmKill.
+  const [restarting, setRestarting] = createSignal(false);
+  const [restartError, setRestartError] = createSignal("");
 
   // Restart the live session on the newly-assigned agent (same SessionAPI.restart
-  // the Restart button uses; honors currentCodingAgent, 0b03ad7). Consume-and-clear
-  // so a single click cannot fire twice.
-  const applyRestartPrompt = () => {
+  // the Restart button uses; honors currentCodingAgent, 0b03ad7). The `restarting`
+  // guard replaces the old early setRestartPrompt(null) as the double-fire guard:
+  // re-entry is refused while a restart is in flight. On success the modal closes;
+  // on failure it stays open with the error so the user can retry.
+  const applyRestartPrompt = async () => {
     const prompt = restartPrompt();
+    if (!prompt || restarting()) return;
+    setRestarting(true);
+    setRestartError("");
+    try {
+      await SessionAPI.restart(prompt.sessionId, {
+        agentId: prompt.agentId,
+        requestedProfile: prompt.requestedProfile,
+      });
+      setRestartPrompt(null);
+    } catch (e) {
+      console.error("Failed to restart session:", e);
+      setRestartError(launchErrorMessage(e));
+    } finally {
+      setRestarting(false);
+    }
+  };
+
+  // Close the prompt, clearing any error. Refused while a restart is in flight so
+  // neither the Later button nor an overlay click can tear the modal down before
+  // the restart settles (the buttons are also disabled via `busy`).
+  const dismissRestartPrompt = () => {
+    if (restarting()) return;
+    setRestartError("");
     setRestartPrompt(null);
-    if (!prompt) return;
-    void SessionAPI.restart(prompt.sessionId, {
-      agentId: prompt.agentId,
-      requestedProfile: prompt.requestedProfile,
-    }).catch((e) => console.error("Failed to restart session:", e));
   };
 
   const handleReplicaClick = async (replica: AcAgentReplica, wg: AcWorkgroup) => {
@@ -2413,6 +2442,11 @@ const ProjectPanel: Component = () => {
                     // old agent. Offer an immediate restart when there is a live session.
                     if (shouldOfferRestartAfterAssign(selection, session)) {
                       const slash = target.sessionName.lastIndexOf("/");
+                      // #573: clear any error left over from a prior failed restart
+                      // so a fresh prompt never opens showing a stale message. (No
+                      // need to reset `restarting`: dismiss is blocked while it is
+                      // true, so the picker can't reopen to reach here mid-flight.)
+                      setRestartError("");
                       setRestartPrompt({
                         sessionId: target.sessionId,
                         replicaName: slash >= 0 ? target.sessionName.slice(slash + 1) : target.sessionName,
@@ -2785,8 +2819,10 @@ const ProjectPanel: Component = () => {
         <RestartPromptModal
           agentLabel={restartPrompt()!.agentLabel}
           replicaName={restartPrompt()!.replicaName}
+          error={restartError()}
+          busy={restarting()}
           onRestart={applyRestartPrompt}
-          onLater={() => setRestartPrompt(null)}
+          onLater={dismissRestartPrompt}
         />
       </Portal>
     )}

--- a/src/sidebar/components/RestartPromptModal.test.tsx
+++ b/src/sidebar/components/RestartPromptModal.test.tsx
@@ -13,6 +13,8 @@ function renderModal(
   overrides: Partial<{
     agentLabel: string;
     replicaName: string;
+    error: string;
+    busy: boolean;
     onRestart: () => void;
     onLater: () => void;
   }> = {},
@@ -26,6 +28,8 @@ function renderModal(
       <RestartPromptModal
         agentLabel={overrides.agentLabel ?? "Codex"}
         replicaName={overrides.replicaName ?? "dev-webpage-ui"}
+        error={overrides.error}
+        busy={overrides.busy}
         onRestart={overrides.onRestart ?? onRestart}
         onLater={overrides.onLater ?? onLater}
       />
@@ -79,6 +83,45 @@ describe("RestartPromptModal (#537)", () => {
     target("restartPrompt.modal").click();
     expect(onLater).not.toHaveBeenCalled();
     expect(onRestart).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  // #573: a swallowed restart failure used to leave the old agent running while
+  // the UI looked applied. The modal now surfaces the error and exposes a busy
+  // state so the caller can keep it open for a retry.
+  it("renders no error chip and an idle, enabled confirm button by default", () => {
+    const { dispose } = renderModal();
+    expect(document.querySelector('[data-ac-testid="restartPrompt.error"]')).toBeNull();
+    const restart = target<HTMLButtonElement>("restartPrompt.restart");
+    expect(restart.disabled).toBe(false);
+    expect(restart.textContent?.trim()).toBe("Restart now");
+    dispose();
+  });
+
+  it("surfaces a failed restart inline while leaving the buttons usable for retry", () => {
+    const { dispose } = renderModal({
+      error: "Resource Monitor cap reached (16/16). Close an agent or raise the limit in Settings > Resources.",
+    });
+    const chip = target("restartPrompt.error");
+    expect(chip.textContent ?? "").toContain("Resource Monitor cap reached");
+    // Not busy → the user can immediately retry from the still-open modal.
+    expect(target<HTMLButtonElement>("restartPrompt.restart").disabled).toBe(false);
+    expect(target<HTMLButtonElement>("restartPrompt.later").disabled).toBe(false);
+    dispose();
+  });
+
+  it("disables both buttons and shows a progress label while busy", () => {
+    const { dispose, onRestart, onLater } = renderModal({ busy: true });
+    const restart = target<HTMLButtonElement>("restartPrompt.restart");
+    const later = target<HTMLButtonElement>("restartPrompt.later");
+    expect(restart.disabled).toBe(true);
+    expect(later.disabled).toBe(true);
+    expect(restart.textContent?.trim()).toBe("Restarting…");
+    // A disabled control must not fire its callback (no double-restart).
+    restart.click();
+    later.click();
+    expect(onRestart).not.toHaveBeenCalled();
+    expect(onLater).not.toHaveBeenCalled();
     dispose();
   });
 });

--- a/src/sidebar/components/RestartPromptModal.tsx
+++ b/src/sidebar/components/RestartPromptModal.tsx
@@ -1,4 +1,4 @@
-import { Component } from "solid-js";
+import { Component, Show } from "solid-js";
 import { automationAttrs } from "../../shared/automation-hooks";
 
 /**
@@ -10,10 +10,18 @@ import { automationAttrs } from "../../shared/automation-hooks";
  * Presentational only: the caller decides when to show it (a live session must exist)
  * and supplies the restart action. Mirrors the Delete-Workgroup modal shell
  * (`modal-overlay` + `agent-modal` + `new-agent-footer`).
+ *
+ * #573: the restart can fail (e.g. the Resource Monitor concurrency cap re-trips on
+ * the relaunch). The caller drives `error`/`busy` so a rejected restart stays visible
+ * — the modal keeps itself open, shows the failure, and lets the user retry, instead
+ * of silently closing while the old agent still runs. Mirrors the inline-error pattern
+ * in `AgentPickerModal.apply()` and Resource Monitor's `confirmKill`.
  */
 const RestartPromptModal: Component<{
   agentLabel: string;
   replicaName: string;
+  error?: string;
+  busy?: boolean;
   onRestart: () => void;
   onLater: () => void;
 }> = (props) => {
@@ -40,10 +48,22 @@ const RestartPromptModal: Component<{
             <strong>{props.agentLabel}</strong> assigned to <strong>{props.replicaName}</strong>.
             Restart the session now to apply it?
           </p>
+          {/* #573: surface a failed restart inline (reusing `.agent-picker-error`)
+              and keep the modal open so the user can retry — a swallowed rejection
+              would leave the old agent running while the UI looks applied. */}
+          <Show when={props.error}>
+            <div
+              class="agent-picker-error"
+              {...automationAttrs("restartPrompt.error", "status")}
+            >
+              {props.error}
+            </div>
+          </Show>
           <div class="new-agent-footer">
             <button
               class="new-agent-cancel-btn"
               onClick={props.onLater}
+              disabled={props.busy}
               {...automationAttrs("restartPrompt.later", "button")}
             >
               Later
@@ -51,9 +71,10 @@ const RestartPromptModal: Component<{
             <button
               class="new-agent-create-btn"
               onClick={props.onRestart}
+              disabled={props.busy}
               {...automationAttrs("restartPrompt.restart", "button")}
             >
-              Restart now
+              {props.busy ? "Restarting…" : "Restart now"}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Fixes #573 — the post-assign **"Restart now"** prompt silently swallowed `SessionAPI.restart` failures (`.catch(console.error)` after a consume-and-clear), so a failed restart was invisible in the testable build and the user believed the newly-assigned coding agent applied while the live session still ran the old one.

## Changes

- `applyRestartPrompt` is now `async` with an in-flight guard (`restarting()`); on failure it surfaces `setRestartError(launchErrorMessage(e))` and **keeps the modal open** for retry — mirrors the existing `AgentPickerModal.apply()` / `confirmKill` confirm-modals (no toast system needed).
- The restart await is bounded by a **30s timeout** via `Promise.race` (`RESTART_TIMEOUT_MS = 30_000`), matching the WS transport's existing per-command timeout. This closes a desktop/Tauri-only failure mode where a wedged `restart_session` (no transport timeout) would leave `restarting()` true forever and trap the modal undismissably — the `finally` now always clears it.
- `RestartPromptModal` gains `error?` / `busy?` props: inline error chip (reusing `.agent-picker-error` styling) + `data-ac-testid="restartPrompt.error"` automation hook + disabled buttons / "Restarting…" label while busy.
- Tests: added the reject→surface→retry→close path and a never-settles (timeout) case; both new suites pass.

## Testing & review

- **dev `/code-review`** (high effort): no HIGH findings.
- **Grinch adversarial review**: round 1 caught a MEDIUM desktop-only regression (undismissable modal on a wedged restart) → fixed via the 30s timeout → round 2 **PASS**; post-resync merge re-review **PASS** (exact 3-way union, no lifecycle collision).
- **Shipper**: built `agentscommander_standalone_wg-2.exe` and deployed to the user's `0_AC` install dir; **user gave the go-ahead to land**.
- **Re-synced with latest `origin/main`**: clean auto-merge with #552 (coordinator idle badge); both features coexist. `tsc --noEmit` clean, `vitest` **391/391 (48 files)**, `vite build` success.

## Follow-up

- #574 — the sibling `restartReplicaSession` (per-row ctx-menu + non-WG-replica assign paths) still swallows restart failures silently; same class, deferred to a separate issue.

Closes #573
