### PR TITLE
feat(coding-agent): disable "Assign to this replica" when the replica already uses that Coding Agent + Profile (#551)

### DIFF
--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -320,6 +320,7 @@ function renderPicker(
     sessionName: string;
     agentPath: string | null;
     currentAgentId: string | null;
+    explicitCurrentAgentId: string | null;
     currentRequestedProfile: string | null;
     scopeContext: AgentPickerScopeContext | undefined;
     disableRedundantReplicaAssign: boolean;
@@ -337,6 +338,13 @@ function renderPicker(
         sessionName={overrides.sessionName ?? "architect"}
         agentPath={overrides.agentPath === undefined ? ORIGIN_AGENT_PATH : overrides.agentPath}
         currentAgentId={overrides.currentAgentId ?? "codex"}
+        // Defaults to the currentAgentId baseline (simulating an explicitly-assigned
+        // replica / live session); the never-assigned case passes null explicitly.
+        explicitCurrentAgentId={
+          overrides.explicitCurrentAgentId !== undefined
+            ? overrides.explicitCurrentAgentId
+            : overrides.currentAgentId ?? "codex"
+        }
         currentRequestedProfile={overrides.currentRequestedProfile}
         scopeContext={overrides.scopeContext}
         disableRedundantReplicaAssign={overrides.disableRedundantReplicaAssign}
@@ -957,6 +965,74 @@ describe("AgentPickerModal", () => {
       await settle();
       expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
       expect(target("agentPicker.apply").getAttribute("title")).toBe(REDUNDANT_TOOLTIP);
+
+      dispose();
+    });
+
+    it("uses the origin default profile tier as the baseline (#551 FIX 1)", async () => {
+      // Replica with an origin-matrix default profile of "C" (set via "set default
+      // profile") and NO instance override / explicit requested profile. The backend
+      // fallback chain ranks origin_default above agent_default, so the redundancy
+      // baseline must be the origin "C" — not the local defaultProfileByAgent ("B"
+      // for "architect" in the fixture), which the buggy memo read instead.
+      mockSettingsApi.resolveCodingAgentProfile.mockResolvedValue(
+        resolution({
+          requestedProfile: "B",
+          effectiveProfile: "B",
+          fallbackChain: ["B"],
+          instanceProfileOverride: null,
+          originDefaultProfile: "C",
+          agentDefaultProfile: "B",
+        }),
+      );
+      const { dispose } = renderPicker({
+        currentAgentId: "codex",
+        currentRequestedProfile: null,
+        disableRedundantReplicaAssign: true,
+      });
+      await settle();
+
+      // Selecting the origin-default letter "C" is the replica's current pair → no-op
+      // → disabled. (The buggy memo resolved the baseline to "B" and wrongly enabled.)
+      target<HTMLButtonElement>("agentPicker.profile.C").click();
+      await settle();
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
+      expect(target("agentPicker.apply").getAttribute("title")).toBe(REDUNDANT_TOOLTIP);
+
+      // Selecting the local agent-default letter "B" is a genuine change away from the
+      // origin default → enabled. (The buggy memo treated "B" as current → disabled.)
+      target<HTMLButtonElement>("agentPicker.profile.B").click();
+      await settle();
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(false);
+      expect(target("agentPicker.apply").getAttribute("title")).toBeNull();
+
+      dispose();
+    });
+
+    it("keeps assign enabled for a never-assigned replica on its preferred-agent hint (#551 FIX 2)", async () => {
+      // Gray replica that was never assigned a coding agent (no currentCodingAgentId)
+      // but carries a lastCodingAgent/preferredAgentId hint ("codex"). The picker
+      // opens pre-selected on that hint, but with no EXPLICIT current agent the assign
+      // is a genuine first pin — never a redundant no-op — so it must stay enabled.
+      const { dispose } = renderPicker({
+        currentAgentId: "codex", // preferredAgentId hint → pre-selects the picker
+        explicitCurrentAgentId: null, // never assigned → no explicit current agent
+        currentRequestedProfile: null,
+        disableRedundantReplicaAssign: true,
+      });
+      await settle();
+
+      // Pre-selected on the preferred agent + its default profile, yet enabled.
+      const apply = target<HTMLButtonElement>("agentPicker.apply");
+      expect(apply.disabled).toBe(false);
+      expect(apply.getAttribute("title")).toBeNull();
+
+      // Re-affirming the preferred agent and its default profile keeps it enabled —
+      // the user can pin the hinted pair in one click.
+      target<HTMLButtonElement>("agentPicker.provider.codex").click();
+      target<HTMLButtonElement>("agentPicker.profile.A").click();
+      await settle();
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(false);
 
       dispose();
     });

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -322,6 +322,7 @@ function renderPicker(
     currentAgentId: string | null;
     currentRequestedProfile: string | null;
     scopeContext: AgentPickerScopeContext | undefined;
+    disableRedundantReplicaAssign: boolean;
     onSelect: (selection: AgentPickerSelection) => void | Promise<void>;
     onClose: () => void;
   }> = {},
@@ -338,6 +339,7 @@ function renderPicker(
         currentAgentId={overrides.currentAgentId ?? "codex"}
         currentRequestedProfile={overrides.currentRequestedProfile}
         scopeContext={overrides.scopeContext}
+        disableRedundantReplicaAssign={overrides.disableRedundantReplicaAssign}
         onSelect={overrides.onSelect ?? onSelect}
         onClose={overrides.onClose ?? onClose}
       />
@@ -817,5 +819,146 @@ describe("AgentPickerModal", () => {
     expect(text("agentPicker.profile.B.pill")).toContain("MISSING");
 
     dispose();
+  });
+
+  // #551: disable "Assign to this replica" when the pending selection still equals
+  // the replica's current Coding Agent + Profile (assign flows opt in).
+  describe("redundant replica assignment (#551)", () => {
+    const REDUNDANT_TOOLTIP = "This replica already uses this Coding Agent + Profile.";
+
+    it("disables apply with a tooltip while the selection matches the current pair", async () => {
+      const { dispose } = renderPicker({
+        currentAgentId: "codex",
+        currentRequestedProfile: "B",
+        disableRedundantReplicaAssign: true,
+      });
+      await settle();
+
+      const apply = target<HTMLButtonElement>("agentPicker.apply");
+      expect(text("agentPicker.apply")).toContain("Assign to this replica");
+      expect(apply.disabled).toBe(true);
+      expect(apply.getAttribute("title")).toBe(REDUNDANT_TOOLTIP);
+
+      dispose();
+    });
+
+    it("re-enables apply when a different coding agent is selected", async () => {
+      const { dispose } = renderPicker({
+        currentAgentId: "codex",
+        currentRequestedProfile: "B",
+        disableRedundantReplicaAssign: true,
+      });
+      await settle();
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
+
+      target<HTMLButtonElement>("agentPicker.provider.claude").click();
+      await settle();
+
+      const apply = target<HTMLButtonElement>("agentPicker.apply");
+      expect(apply.disabled).toBe(false);
+      expect(apply.getAttribute("title")).toBeNull();
+
+      dispose();
+    });
+
+    it("re-enables apply on a different profile and re-disables when the current pair returns", async () => {
+      const { dispose } = renderPicker({
+        currentAgentId: "codex",
+        currentRequestedProfile: "B",
+        disableRedundantReplicaAssign: true,
+      });
+      await settle();
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
+
+      // codex configures A and B; A differs from the current B.
+      target<HTMLButtonElement>("agentPicker.profile.A").click();
+      await settle();
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(false);
+
+      // Returning to the current letter re-disables (value comparison, not a touched flag).
+      target<HTMLButtonElement>("agentPicker.profile.B").click();
+      await settle();
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
+
+      dispose();
+    });
+
+    it("leaves apply enabled for a redundant pair when the opt-in is off (launch flow)", async () => {
+      const { dispose } = renderPicker({
+        currentAgentId: "codex",
+        currentRequestedProfile: "B",
+        // disableRedundantReplicaAssign omitted → unchanged launch/legacy behavior
+      });
+      await settle();
+
+      const apply = target<HTMLButtonElement>("agentPicker.apply");
+      expect(apply.disabled).toBe(false);
+      expect(apply.getAttribute("title")).toBeNull();
+
+      dispose();
+    });
+
+    it("scopes the disable to replica scope for a WG replica", async () => {
+      const { dispose } = renderPicker({
+        agentPath: WG_REPLICA_PATH,
+        scopeContext: WG_SCOPE_CONTEXT,
+        currentAgentId: "codex",
+        currentRequestedProfile: "A",
+        disableRedundantReplicaAssign: true,
+      });
+      await settle();
+
+      // Replica scope + current pair → disabled with tooltip.
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
+      expect(target("agentPicker.apply").getAttribute("title")).toBe(REDUNDANT_TOOLTIP);
+
+      // A different profile re-enables replica scope (redundancy is replica-only).
+      target<HTMLButtonElement>("agentPicker.profile.B").click();
+      await settle();
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(false);
+      expect(target("agentPicker.apply").getAttribute("title")).toBeNull();
+
+      dispose();
+    });
+
+    it("uses the backend instance override as the baseline so a stale session profile can't leak a no-op", async () => {
+      // Live-session flow where the replica's persisted instance override ("C")
+      // differs from the session's launch-time requested profile ("B"). The
+      // backend ranks the override first (resolve_profile), so the modal resolves
+      // to "C"; the redundancy baseline must be "C", not the stale "B".
+      mockSettingsApi.resolveCodingAgentProfile.mockResolvedValue(
+        resolution({
+          requestedProfile: "C",
+          effectiveProfile: "C",
+          fallbackChain: ["C"],
+          instanceProfileOverride: "C",
+        }),
+      );
+      const { dispose } = renderPicker({
+        currentAgentId: "codex",
+        currentRequestedProfile: "B",
+        disableRedundantReplicaAssign: true,
+      });
+      await settle();
+
+      // Opens resolved to the override "C" → redundant → disabled.
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
+
+      // Picking a different letter ("A") is a real change → enabled.
+      target<HTMLButtonElement>("agentPicker.profile.A").click();
+      await settle();
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(false);
+
+      // Picking the override letter "C" is the replica's current pair → disabled
+      // again. Without the override-aware baseline this would compare against the
+      // stale "B" and wrongly stay enabled (a no-op assign + needless restart
+      // prompt — exactly what #551 blocks).
+      target<HTMLButtonElement>("agentPicker.profile.C").click();
+      await settle();
+      expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
+      expect(target("agentPicker.apply").getAttribute("title")).toBe(REDUNDANT_TOOLTIP);
+
+      dispose();
+    });
   });
 });

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -78,6 +78,14 @@ const AgentPickerModal: Component<{
   sessionName: string;
   agentPath?: string | null;
   currentAgentId?: string | null;
+  // #551 FIX 2: the EXPLICIT persisted current coding agent — the replica's
+  // `currentCodingAgentId` (or a live session's `agentId`). The redundancy disable
+  // keys off THIS, never off `currentAgentId` (which may carry a soft
+  // `preferredAgentId` / `lastCodingAgent` hint used only to pre-select the picker).
+  // A never-assigned replica has no explicit current agent (undefined/null here), so
+  // its "Assign to this replica" stays enabled — the user can still pin the hinted
+  // agent as a genuine first assignment.
+  explicitCurrentAgentId?: string | null;
   currentRequestedProfile?: string | null;
   scopeContext?: AgentPickerScopeContext;
   // #551: opt-in for the replica *assign* flows. When set, the "Assign to this
@@ -426,20 +434,29 @@ const AgentPickerModal: Component<{
   });
 
   // #551: the replica's *current* profile letter — the baseline for the redundant
-  // selection check. The backend ranks the replica's persisted instance override
-  // ahead of the launch-time requested profile (resolve_profile:
-  // instance_override.or(explicit)…), so when present it — not
-  // props.currentRequestedProfile — is what the modal resolves to and applies on
-  // open. It is read from disk independently of the requested input, so it stays a
-  // stable baseline even after the user picks a different profile (which would
+  // selection check. It must mirror the backend's resolve_profile fallback chain
+  // exactly (coding_agent_profiles.rs):
+  //   instance_override → explicit (requested) → origin_default → agent_default → "A"
+  // The backend ranks the persisted instance override ahead of the launch-time
+  // requested profile, so when present it — not props.currentRequestedProfile — is
+  // what the modal resolves to and applies on open. The origin_default and
+  // agent_default tiers are read from the backend resolution fields (request-
+  // independent, computed from disk/settings — same as configuredDefault()), so the
+  // baseline stays stable even after the user picks a different profile (which would
   // otherwise let a stale session.requestedProfile wrongly enable a no-op assign).
-  // Falls back to the explicit requested profile, then the AC default, then "A",
-  // mirroring onMount's initial selection when there is no override.
+  // The local-settings read is only a last-resort fallback for when the backend
+  // preview is unavailable (non-AC path or a resolution error) — the same
+  // agent_default tier, read locally.
   const currentProfileLetter = createMemo(() => {
-    const override = normalizeProfileLetter(backendPreview()?.instanceProfileOverride);
+    const preview = backendPreview();
+    const override = normalizeProfileLetter(preview?.instanceProfileOverride);
     if (override) return override;
     const explicit = normalizeProfileLetter(props.currentRequestedProfile);
     if (explicit) return explicit;
+    const originDefault = normalizeProfileLetter(preview?.originDefaultProfile);
+    if (originDefault) return originDefault;
+    const agentDefault = normalizeProfileLetter(preview?.agentDefaultProfile);
+    if (agentDefault) return agentDefault;
     const current = settings();
     if (current && isAcAgentPath(targetReplicaPath())) {
       const acDefault = normalizeProfileLetter(
@@ -455,12 +472,17 @@ const AgentPickerModal: Component<{
   // via the assign flows). The untouched short-circuit covers the just-opened
   // state robustly even if a backend default differs from the front-end default;
   // once the user picks a profile, an explicit letter match is required.
+  // FIX 2: the agent-equality baseline is the EXPLICIT current coding agent
+  // (explicitCurrentAgentId), never the pre-select hint in currentAgentId. A
+  // never-assigned replica (no explicit current agent) is never redundant, so its
+  // assign stays enabled even though the picker opens on a preferred-agent hint.
   const isRedundantReplicaSelection = createMemo(() => {
     if (!props.disableRedundantReplicaAssign) return false;
     if (selectedScope() !== "replica") return false;
     const agent = selectedAgent();
-    if (!agent || !props.currentAgentId) return false;
-    if (agent.id !== props.currentAgentId) return false;
+    const baselineAgentId = props.explicitCurrentAgentId;
+    if (!agent || !baselineAgentId) return false;
+    if (agent.id !== baselineAgentId) return false;
     if (!profileTouched()) return true;
     return selectedProfile() === currentProfileLetter();
   });

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -69,12 +69,24 @@ const SELECTION_PILL_LABEL: Record<Exclude<ProfileBadgeKind, "invalid">, string>
   missing: "MISSING",
 };
 
+// #551: shown on the disabled "Assign to this replica" button when the pending
+// selection still equals the replica's current Coding Agent + Profile.
+const REDUNDANT_REPLICA_ASSIGN_TOOLTIP =
+  "This replica already uses this Coding Agent + Profile.";
+
 const AgentPickerModal: Component<{
   sessionName: string;
   agentPath?: string | null;
   currentAgentId?: string | null;
   currentRequestedProfile?: string | null;
   scopeContext?: AgentPickerScopeContext;
+  // #551: opt-in for the replica *assign* flows. When set, the "Assign to this
+  // replica" button is disabled (with a tooltip) while the pending selection
+  // still equals the replica's current Coding Agent + Profile — re-assigning the
+  // same pair is a no-op and (since #537) pops a needless "Restart now?" prompt.
+  // The launch flow leaves this off so a replica can always be started with its
+  // configured agent.
+  disableRedundantReplicaAssign?: boolean;
   onSelect: (selection: AgentPickerSelection) => void | Promise<void>;
   onClose: () => void;
 }> = (props) => {
@@ -413,10 +425,50 @@ const AgentPickerModal: Component<{
     return `Overwrite ${count}${wg ? ` in ${wg}` : " in this workgroup"}`;
   });
 
+  // #551: the replica's *current* profile letter — the baseline for the redundant
+  // selection check. The backend ranks the replica's persisted instance override
+  // ahead of the launch-time requested profile (resolve_profile:
+  // instance_override.or(explicit)…), so when present it — not
+  // props.currentRequestedProfile — is what the modal resolves to and applies on
+  // open. It is read from disk independently of the requested input, so it stays a
+  // stable baseline even after the user picks a different profile (which would
+  // otherwise let a stale session.requestedProfile wrongly enable a no-op assign).
+  // Falls back to the explicit requested profile, then the AC default, then "A",
+  // mirroring onMount's initial selection when there is no override.
+  const currentProfileLetter = createMemo(() => {
+    const override = normalizeProfileLetter(backendPreview()?.instanceProfileOverride);
+    if (override) return override;
+    const explicit = normalizeProfileLetter(props.currentRequestedProfile);
+    if (explicit) return explicit;
+    const current = settings();
+    if (current && isAcAgentPath(targetReplicaPath())) {
+      const acDefault = normalizeProfileLetter(
+        current.codingAgentProfiles.defaultProfileByAgent[targetName()],
+      );
+      if (acDefault) return acDefault;
+    }
+    return "A";
+  });
+
+  // #551: true while the pending selection still equals the replica's current
+  // Coding Agent + Profile (replica scope only, and only when the caller opted in
+  // via the assign flows). The untouched short-circuit covers the just-opened
+  // state robustly even if a backend default differs from the front-end default;
+  // once the user picks a profile, an explicit letter match is required.
+  const isRedundantReplicaSelection = createMemo(() => {
+    if (!props.disableRedundantReplicaAssign) return false;
+    if (selectedScope() !== "replica") return false;
+    const agent = selectedAgent();
+    if (!agent || !props.currentAgentId) return false;
+    if (agent.id !== props.currentAgentId) return false;
+    if (!profileTouched()) return true;
+    return selectedProfile() === currentProfileLetter();
+  });
+
   const applyEnabled = createMemo(() => {
     if (busy() || profileResolving() || !selectedAgent()) return false;
     const scope = selectedScope();
-    if (scope === "replica") return true;
+    if (scope === "replica") return !isRedundantReplicaSelection();
     if (!isWgReplica()) return false;
     if (scopePreviewBusy() || !scopePreview()) return false;
     if (scope === "workgroup") return dangerArmed();
@@ -1035,6 +1087,7 @@ const AgentPickerModal: Component<{
               class="modal-btn modal-btn-save agent-picker-apply"
               classList={{ danger: selectedScope() !== "replica" }}
               disabled={!applyEnabled()}
+              title={isRedundantReplicaSelection() ? REDUNDANT_REPLICA_ASSIGN_TOOLTIP : undefined}
               onClick={() => void apply()}
               {...automationAttrs(
                 "agentPicker.apply",

--- a/src/sidebar/components/ProjectPanel.restart-prompt.test.tsx
+++ b/src/sidebar/components/ProjectPanel.restart-prompt.test.tsx
@@ -51,6 +51,22 @@ function codexAgent(): AgentConfig {
   };
 }
 
+// #551: a second coding agent so the test can make a *real* re-assignment.
+// Re-assigning the live session's current agent (codex) is now disabled, so the
+// restart prompt is reached by switching to a different coding agent.
+function claudeAgent(): AgentConfig {
+  return {
+    id: "claude",
+    label: "Claude Code",
+    command: "claude",
+    color: "#d97706",
+    gitPullBefore: false,
+    excludeGlobalClaudeMd: false,
+    envs: [],
+    isolatedHome: false,
+  };
+}
+
 function resolution(): CodingAgentProfileResolution {
   return {
     requestedProfile: "A",
@@ -127,7 +143,10 @@ function discoveryResult() {
 function setupTransport(fake: FakeTransport): void {
   fake.resolve("new_project", { path: projectPath, registered: true, created: false });
   fake.resolve("discover_project", discoveryResult());
-  fake.resolve("get_settings", baseSettings({ agents: [codexAgent()] }) satisfies AppSettings);
+  fake.resolve(
+    "get_settings",
+    baseSettings({ agents: [codexAgent(), claudeAgent()] }) satisfies AppSettings,
+  );
   fake.resolve("resolve_coding_agent_profile", resolution());
   fake.resolve("preview_coding_agent_profile_selection", previewResult());
   fake.resolve("apply_coding_agent_profile_selection", applyResult());
@@ -175,6 +194,12 @@ async function driveToRestartPrompt(root: HTMLElement): Promise<void> {
   click(findButtonByText("Coding Agent"));
 
   await waitFor(() => expect(q("agentPicker.modal")).toBeTruthy());
+  // #551: the picker opens pre-selected to the live session's current Coding Agent
+  // (codex), so "Assign to this replica" starts disabled (re-assigning the same
+  // pair is a no-op). Switch to a different coding agent to make it a real
+  // re-assignment that enables apply and pops the post-assign restart prompt.
+  await waitFor(() => expect(q("agentPicker.provider.claude")).toBeTruthy());
+  click(q<HTMLButtonElement>("agentPicker.provider.claude")!);
   await waitFor(() => {
     const apply = q<HTMLButtonElement>("agentPicker.apply");
     expect(apply && apply.disabled).toBe(false);
@@ -247,7 +272,7 @@ describe("ProjectPanel post-assign restart prompt (#537)", () => {
       expect(fake.lastCall("restart_session")?.args).toEqual(
         expect.objectContaining({
           id: sessionId,
-          agentId: "codex",
+          agentId: "claude",
           requestedProfile: "A",
         }),
       );

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -2392,6 +2392,9 @@ const ProjectPanel: Component = () => {
                     sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId),
                     replicaCodingAgentTarget()!.sessionName,
                   )}
+                  // #551: re-assigning the running agent+profile is a no-op and
+                  // pops a needless restart prompt — disable it with a tooltip.
+                  disableRedundantReplicaAssign
                   onSelect={async (selection) => {
                     // The picker already persisted the selection through the backend
                     // (config write) for WG replicas. For a non-WG agent session there
@@ -2438,6 +2441,9 @@ const ProjectPanel: Component = () => {
                     currentAgentId={target().replica.currentCodingAgentId ?? target().replica.preferredAgentId}
                     currentRequestedProfile={target().replica.currentProfile ?? null}
                     scopeContext={replicaScopeContext(target().wg, target().replica)}
+                    // #551: pre-launch "Set Coding Agent" opens pre-selected to the
+                    // replica's current pair; re-assigning it is a no-op, so disable.
+                    disableRedundantReplicaAssign
                     onSelect={async () => {
                       // WG replica: the picker already wrote the coding-agent
                       // selection via the backend (no restart — the agent isn't

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -2387,6 +2387,9 @@ const ProjectPanel: Component = () => {
                   sessionName={replicaCodingAgentTarget()!.sessionName}
                   agentPath={sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId)?.workingDirectory}
                   currentAgentId={sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId)?.agentId}
+                  // #551 FIX 2: a live session's agent IS the explicit current
+                  // coding agent, so it doubles as the redundancy baseline.
+                  explicitCurrentAgentId={sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId)?.agentId}
                   currentRequestedProfile={sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId)?.requestedProfile}
                   scopeContext={deriveScopeContextFromSession(
                     sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId),
@@ -2439,6 +2442,11 @@ const ProjectPanel: Component = () => {
                     sessionName={replicaSessionName(target().wg, target().replica)}
                     agentPath={target().replica.path}
                     currentAgentId={target().replica.currentCodingAgentId ?? target().replica.preferredAgentId}
+                    // #551 FIX 2: redundancy keys off the EXPLICIT currentCodingAgentId
+                    // only — never the preferredAgentId hint above. A never-assigned gray
+                    // replica (no currentCodingAgentId) keeps "Assign" enabled so its
+                    // preferred agent can be pinned in one click.
+                    explicitCurrentAgentId={target().replica.currentCodingAgentId ?? null}
                     currentRequestedProfile={target().replica.currentProfile ?? null}
                     scopeContext={replicaScopeContext(target().wg, target().replica)}
                     // #551: pre-launch "Set Coding Agent" opens pre-selected to the


### PR DESCRIPTION
## Summary

Disables the **"Assign to this replica"** button when the pending Coding Agent + Profile selection already equals the replica's persisted current configuration, and shows a tooltip explaining why ("This replica already uses this Coding Agent + Profile."). The button re-enables as soon as a different Coding Agent **or** Profile is selected. This prevents a confusing no-op assign and the needless "Restart now?" prompt it triggered (surfaced while finishing #537).

Frontend only — no backend change. The replica's current `currentCodingAgent` + profile is already available to the frontend.

## What changed

- `src/sidebar/components/AgentPickerModal.tsx` — redundancy detection (`isRedundantReplicaSelection`) folded into `applyEnabled()` for the **replica scope only**; native tooltip via `title=`; opt-in props `disableRedundantReplicaAssign` and `explicitCurrentAgentId`.
- `src/sidebar/components/ProjectPanel.tsx` — wires the opt-in on the **two assign call sites** (live-session reassign + gray/red "Set Coding Agent"); the **launch flow is deliberately left untouched** (disabling there would block launching a replica with its configured agent).
- Tests: new "redundant replica assignment (#551)" suite in `AgentPickerModal.test.tsx`; the #537 restart-prompt test updated to drive a *real* re-assignment (the old test used a same-pair no-op, which #551 now disables).

## Review notes (grinch adversarial review)

Two issues were found and fixed before merge:

1. **(MEDIUM)** `currentProfileLetter` baseline omitted the `originDefaultProfile` tier — the exact tier the user-facing "set default profile" action writes — which could false-enable a true no-op and false-disable a legit change. Fixed by mirroring the backend `resolve_profile` chain exactly (`instance_override → explicit → origin_default → agent_default → "A"`).
2. **(LOW)** Redundancy keyed off the `preferredAgentId` fallback instead of the explicit `currentCodingAgent`. Fixed: redundancy now requires an explicit `currentCodingAgentId`, so a never-assigned gray replica (only a soft `lastCodingAgent` hint) keeps the button enabled (matches the issue's "compare against `currentCodingAgent`" wording).

## Testing

- `tsc --noEmit` clean; full frontend suite green (399 tests / 48 files after the main re-sync), including the new #551 regression tests.
- grinch adversarial review: **CLEAN** on the implementation, and a focused **CLEAN** re-review of the `origin/main` re-sync merge (verified #551 coexists with main's #563/#552/#573; `git show --remerge-diff` empty = no evil-merge).
- Branch re-synced with latest `origin/main` (clean auto-merge), shipper-built, and the wg-10 exe deployed to `0_AC` for manual testing.

Closes #551
