### PR TITLE
feat(placeholders): AC_REPLICA_ROOT rename + workspace/matrix tokens + opencode config-dir auto-create (#576)

### DIFF
--- a/docs/agent-matrix-conventions.md
+++ b/docs/agent-matrix-conventions.md
@@ -313,7 +313,69 @@ Located at `.ac/project-settings.json`. Defines the coding agent configurations 
 
 ---
 
-## 5. The .gitignore
+## 5. Profile Path Placeholders
+
+Coding-agent **profile** command strings and `env` values may use a small set of `%...%` path placeholders that AgentsCommander expands to absolute paths **at launch**. Everything else in a profile value is passed to the child process **verbatim** — there is no shell, so `$(pwd)`, `${VAR}`, and other `%VAR%` forms are NOT expanded and are taken literally. Only the three tokens below are recognized.
+
+The tokens map onto the matrix layout from the sections above: a replica is a `__agent_<name>` dir under a `wg-*` workgroup, the workspace is the project's `.ac` root, and the matrix is the canonical `_agent_<name>` dir.
+
+| Token | Resolves to | Valid when |
+|---|---|---|
+| `%AC_REPLICA_ROOT%` | The **replica** dir — the launch working directory, canonicalized | A WG replica (`__agent_*` under `wg-*`) **or** the `ac-root-agent` launch root |
+| `%AC_WORKSPACE_ROOT%` | The **`.ac` workspace** root (the nearest `.ac` ancestor of the launch root) | Any launch root **inside** a `.ac` workspace — including non-replica roots (a `repo-*` checkout, a bare `wg-*` dir, an `_agent_*` matrix dir) |
+| `%AC_MATRIX_ROOT%` | The **matrix** dir `<workspace>\_agent_<name>` (the agent's canonical Agent Matrix) | **Only** a WG replica launch |
+
+### Example resolutions
+
+For a WG replica launched at `…\AgentsCommander_ac\.ac\wg-6-dev-team\__agent_tech-lead`:
+
+| Token | Expands to |
+|---|---|
+| `%AC_REPLICA_ROOT%` | `…\AgentsCommander_ac\.ac\wg-6-dev-team\__agent_tech-lead` |
+| `%AC_WORKSPACE_ROOT%` | `…\AgentsCommander_ac\.ac` |
+| `%AC_MATRIX_ROOT%` | `…\AgentsCommander_ac\.ac\_agent_tech-lead` |
+
+### Validity rules and the workspace/replica asymmetry
+
+The three tokens have **different** validity gates. A value is rejected only when it uses a token that does not apply to the current launch root:
+
+- **WG replica** (`__agent_*` under `wg-*`): all three tokens resolve.
+- **Root agent** (`ac-root-agent`): only `%AC_REPLICA_ROOT%` resolves (to the root-agent dir). `%AC_WORKSPACE_ROOT%` and `%AC_MATRIX_ROOT%` are unavailable — the root agent has no `.ac` workspace and no Agent Matrix — and error if used.
+- **Non-replica launch root inside a `.ac` workspace** (a `repo-*` checkout at `…\.ac\wg-6\repo-X`, a bare `wg-*` dir, or an `_agent_*` matrix dir): **only** `%AC_WORKSPACE_ROOT%` resolves (its `.ac` ancestor exists); `%AC_REPLICA_ROOT%` and `%AC_MATRIX_ROOT%` still error there. This "workspace resolves but replica/matrix error" asymmetry is intentional.
+- **Launch root outside any `.ac`** (a normal repo): none of the tokens resolve.
+
+When a token is used where it does not apply, the launch fails with a specific error:
+
+- `%AC_REPLICA_ROOT% requires an AC replica or root-agent launch root`
+- `%AC_WORKSPACE_ROOT% requires a launch root inside an AC (.ac) workspace`
+- `%AC_MATRIX_ROOT% requires an AC workgroup replica launch root`
+
+### Breaking change: `%AC_ROOT%` was removed
+
+There is **no `%AC_ROOT%` token and no alias.** The former `%AC_ROOT%` (which resolved to the replica dir) was renamed to `%AC_REPLICA_ROOT%`. A profile that still contains the literal `%AC_ROOT%`:
+
+- **fails at launch** — any unexpanded `%...%` marker is rejected with an "unknown placeholder marker" error; and
+- for a `CODEX_HOME` value, **also fails at settings save-time** — validation reports `CODEX_HOME contains unknown placeholder %AC_ROOT%`.
+
+Update any old configuration to `%AC_REPLICA_ROOT%` (or one of the new tokens).
+
+### Usage examples
+
+Use a placeholder as the **leading path segment** of an env value; the backend expands it and then validates the resulting absolute path:
+
+```text
+OPENCODE_CONFIG_DIR = %AC_REPLICA_ROOT%\.opencode
+CODEX_HOME          = %AC_MATRIX_ROOT%\.codex
+CLAUDE_CONFIG_DIR   = %AC_REPLICA_ROOT%\.claude
+```
+
+`CODEX_HOME` is validated more strictly than other keys: its value must **start** with a token as a complete leading path segment (or be a literal absolute path). A value like `prefix%AC_MATRIX_ROOT%\x`, where the token is not the leading segment, is rejected at save-time with a "must start with … as a complete path segment" error. `CLAUDE_CONFIG_DIR` and other env keys accept the tokens wherever a path is expected, with no special leading-segment rule.
+
+The backend is the single authority for real expansion and absolute-path validation at launch; the sidebar's profile preview only mirrors these tokens for display.
+
+---
+
+## 6. The .gitignore
 
 **MANDATORY** at `.ac/.gitignore`:
 
@@ -327,7 +389,7 @@ This is non-negotiable. Without it, `git checkout` or `git reset` on the parent 
 
 ---
 
-## 6. Complete Setup Checklist
+## 7. Complete Setup Checklist
 
 When creating a full agent team for a new project:
 
@@ -379,7 +441,7 @@ This should return all team members. If empty, the team config is misconfigured 
 
 ---
 
-## 7. Common Mistakes & How to Avoid Them
+## 8. Common Mistakes & How to Avoid Them
 
 ### Mistake: Agents appear as `@other-project` in sidebar
 **Cause:** Team config.json references `_agent_*` folders from a different project.
@@ -413,7 +475,7 @@ This should return all team members. If empty, the team config is misconfigured 
 
 ---
 
-## 8. Agent Team Archetypes
+## 9. Agent Team Archetypes
 
 These are proven team compositions. Adapt to your project's domain.
 
@@ -444,7 +506,7 @@ These are proven team compositions. Adapt to your project's domain.
 
 ---
 
-## 9. CLI Reference for Agent Management
+## 10. CLI Reference for Agent Management
 
 ### Create an agent programmatically
 

--- a/docs/agent-matrix-conventions.md
+++ b/docs/agent-matrix-conventions.md
@@ -315,7 +315,7 @@ Located at `.ac/project-settings.json`. Defines the coding agent configurations 
 
 ## 5. Profile Path Placeholders
 
-Coding-agent **profile** command strings and `env` values may use a small set of `%...%` path placeholders that AgentsCommander expands to absolute paths **at launch**. Everything else in a profile value is passed to the child process **verbatim** — there is no shell, so `$(pwd)`, `${VAR}`, and other `%VAR%` forms are NOT expanded and are taken literally. Only the three tokens below are recognized.
+Coding-agent **profile** command strings and `env` values may use a small set of `%...%` path placeholders that AgentsCommander expands to absolute paths **at launch**. Only the three tokens below are recognized. There is no shell to evaluate values, so `$`-style forms such as `$(pwd)` and `${VAR}` are **not** expanded — they pass through to the child process **verbatim**. Any other `%WORD%` marker (one that is not one of the three AC tokens) is **not** taken literally: it is **rejected** at launch as an unknown placeholder (fail-closed), and for `CODEX_HOME` it also fails at settings save-time.
 
 The tokens map onto the matrix layout from the sections above: a replica is a `__agent_<name>` dir under a `wg-*` workgroup, the workspace is the project's `.ac` root, and the matrix is the canonical `_agent_<name>` dir.
 

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -11,8 +11,8 @@ use crate::config::placeholders::{
 };
 use crate::config::session_context::ManagedContextTarget;
 use crate::config::settings::{
-    is_codex_home_key, normalize_env_key_for_platform, validate_expanded_codex_home_value,
-    validate_user_env_key, AgentConfig, AppSettings,
+    is_codex_home_key, is_opencode_config_dir_key, normalize_env_key_for_platform,
+    validate_expanded_codex_home_value, validate_user_env_key, AgentConfig, AppSettings,
 };
 use crate::session::profile::CodingAgentKind;
 
@@ -493,6 +493,102 @@ fn compute_codex_home(
     })
 }
 
+/// Outcome of [`ensure_opencode_config_dir`]. Returned for unit testing; the
+/// launch path ignores it (the operation is best-effort, see the fn docs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OpencodeConfigDirOutcome {
+    /// Command does not run opencode, or no `OPENCODE_CONFIG_DIR` is set, or the
+    /// value is not an absolute path: nothing was created.
+    Skipped,
+    /// `create_dir_all` succeeded (dir created, or already existed).
+    Ensured,
+    /// `create_dir_all` failed; the launch proceeds anyway (warning logged).
+    Failed,
+}
+
+/// True when the launch command runs opencode, matched by executable basename.
+/// There is no `CodingAgentKind::OpenCode` (the enum is Claude/Codex/Gemini and
+/// `detect` does not know opencode), so this mirrors the
+/// `executable_basename(shell) == "codex"` fallback in [`compute_codex_home`].
+/// Args are scanned too, so a `cmd /c opencode` wrapper is still recognized.
+/// Called BEFORE the `git_pull_before` wrap, so `shell` is the real command.
+fn command_runs_opencode(shell: &str, shell_args: &[String]) -> bool {
+    if executable_basename(shell) == "opencode" {
+        return true;
+    }
+    shell_args
+        .iter()
+        .flat_map(|arg| arg.split_whitespace())
+        .any(|token| executable_basename(token) == "opencode")
+}
+
+/// Resolved `OPENCODE_CONFIG_DIR` value with profile-over-agent precedence,
+/// mirroring `merge_env_layers` (`generated_env` never carries this key).
+fn find_opencode_config_dir<'a>(
+    agent_env: &'a BTreeMap<String, String>,
+    profile_env: &'a BTreeMap<String, String>,
+) -> Option<&'a String> {
+    profile_env
+        .iter()
+        .find(|(key, _)| is_opencode_config_dir_key(key))
+        .or_else(|| agent_env.iter().find(|(key, _)| is_opencode_config_dir_key(key)))
+        .map(|(_, value)| value)
+}
+
+/// #576 follow-up: opencode does not create its `OPENCODE_CONFIG_DIR`; at
+/// startup it writes a managed `.gitignore` into that dir and exits 1 if the dir
+/// is missing (ENOENT on the parent). When the launch runs opencode and the
+/// resolved (post-expansion) `OPENCODE_CONFIG_DIR` is an absolute path, create
+/// it up front so the child can start.
+///
+/// This mirrors the `create_dir_all` precedent in [`compute_codex_home`], with
+/// one deliberate difference: it is BEST-EFFORT. A `create_dir_all` failure is
+/// logged and the launch proceeds (opencode will surface its own error), so a
+/// transient failure never blocks a spawn, unlike the AC-owned isolated codex
+/// home which aborts. A non-absolute value (relative, empty, or otherwise not a
+/// real path) is skipped, never created.
+///
+/// Scope: only the agent and profile env layers are inspected (the AC-managed,
+/// config-driven sources, same precedence as `compute_codex_home`). An
+/// `OPENCODE_CONFIG_DIR` that AC merely inherits from its own ambient
+/// environment is intentionally NOT created here: AC does not own that value,
+/// and the bug this targets comes from AC-configured replica-local paths.
+fn ensure_opencode_config_dir(
+    shell: &str,
+    shell_args: &[String],
+    agent_env: &BTreeMap<String, String>,
+    profile_env: &BTreeMap<String, String>,
+) -> OpencodeConfigDirOutcome {
+    if !command_runs_opencode(shell, shell_args) {
+        return OpencodeConfigDirOutcome::Skipped;
+    }
+    let Some(value) = find_opencode_config_dir(agent_env, profile_env) else {
+        return OpencodeConfigDirOutcome::Skipped;
+    };
+    let path = PathBuf::from(value);
+    if !path.is_absolute() {
+        log::debug!(
+            "[opencode] OPENCODE_CONFIG_DIR '{}' is not an absolute path; not creating it.",
+            value
+        );
+        return OpencodeConfigDirOutcome::Skipped;
+    }
+    match std::fs::create_dir_all(&path) {
+        Ok(()) => {
+            log::info!("[opencode] Ensured OPENCODE_CONFIG_DIR '{}'", path.display());
+            OpencodeConfigDirOutcome::Ensured
+        }
+        Err(e) => {
+            log::warn!(
+                "[opencode] Failed to create OPENCODE_CONFIG_DIR '{}': {}. Launching anyway.",
+                path.display(),
+                e
+            );
+            OpencodeConfigDirOutcome::Failed
+        }
+    }
+}
+
 fn merge_env_layers(layers: &[&BTreeMap<String, String>]) -> Vec<(String, String)> {
     let mut by_normalized: BTreeMap<String, (String, String)> = BTreeMap::new();
     for layer in layers {
@@ -643,6 +739,10 @@ pub fn build_agent_spawn_command(
     )?;
     let computed_codex_home =
         compute_codex_home(agent, &shell, &shell_args, &agent_env, &profile_env)?;
+    // #576 follow-up: opencode exits 1 if OPENCODE_CONFIG_DIR is missing, so
+    // create it before spawn. Best-effort (never aborts the build); see fn docs.
+    // Runs before the git_pull_before wrap so `shell` is still the real command.
+    ensure_opencode_config_dir(&shell, &shell_args, &agent_env, &profile_env);
     let child_env =
         merge_env_layers(&[&agent_env, &profile_env, &computed_codex_home.generated_env]);
 
@@ -670,9 +770,10 @@ pub fn build_agent_spawn_command(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_agent_spawn_command, default_instructions_filename_for_command,
-        is_safe_instructions_filename, managed_instructions_filenames,
-        normalize_legacy_agent_command, resolve_instructions_filename, resolve_target_filename,
+        build_agent_spawn_command, command_runs_opencode, default_instructions_filename_for_command,
+        ensure_opencode_config_dir, find_opencode_config_dir, is_safe_instructions_filename,
+        managed_instructions_filenames, normalize_legacy_agent_command, resolve_instructions_filename,
+        resolve_target_filename, OpencodeConfigDirOutcome,
     };
     use crate::config::settings::{
         AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ProfileCellConfig,
@@ -1403,6 +1504,153 @@ mod tests {
         assert!(
             !is_safe_instructions_filename(&long),
             "should reject an over-long name"
+        );
+    }
+
+    // #576 follow-up - auto-create OPENCODE_CONFIG_DIR before spawn.
+
+    fn opencode_env(value: &str) -> BTreeMap<String, String> {
+        BTreeMap::from([("OPENCODE_CONFIG_DIR".to_string(), value.to_string())])
+    }
+
+    #[test]
+    fn command_runs_opencode_matches_basename_and_wrapper() {
+        assert!(command_runs_opencode("opencode", &[]));
+        assert!(command_runs_opencode("opencode.exe", &[]));
+        assert!(command_runs_opencode(
+            r"C:\tools\opencode.exe",
+            &["--flag".to_string()]
+        ));
+        // cmd /c opencode wrapper: opencode appears as an arg token.
+        assert!(command_runs_opencode(
+            "cmd.exe",
+            &["/c".to_string(), "opencode".to_string()]
+        ));
+        // Non-opencode commands do not match.
+        assert!(!command_runs_opencode("codex", &[]));
+        assert!(!command_runs_opencode("claude", &["--resume".to_string()]));
+    }
+
+    #[test]
+    fn find_opencode_config_dir_prefers_profile_over_agent() {
+        let agent_env = opencode_env("agent-value");
+        let profile_env = opencode_env("profile-value");
+        assert_eq!(
+            find_opencode_config_dir(&agent_env, &profile_env).map(String::as_str),
+            Some("profile-value")
+        );
+        // Falls back to the agent layer when the profile lacks the key.
+        let empty = BTreeMap::new();
+        assert_eq!(
+            find_opencode_config_dir(&agent_env, &empty).map(String::as_str),
+            Some("agent-value")
+        );
+        // None when neither layer sets it.
+        assert_eq!(find_opencode_config_dir(&empty, &empty), None);
+    }
+
+    #[test]
+    fn ensure_opencode_config_dir_creates_missing_absolute_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        // Nested + missing, to prove create_dir_all builds the whole chain.
+        let target = temp.path().join("nested").join(".opencode");
+        assert!(!target.exists());
+        let profile_env = opencode_env(&target.to_string_lossy());
+
+        let outcome = ensure_opencode_config_dir("opencode", &[], &BTreeMap::new(), &profile_env);
+
+        assert_eq!(outcome, OpencodeConfigDirOutcome::Ensured);
+        assert!(target.is_dir(), "config dir should have been created");
+    }
+
+    #[test]
+    fn ensure_opencode_config_dir_existing_dir_is_noop_success() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join(".opencode");
+        std::fs::create_dir_all(&target).unwrap();
+        let agent_env = opencode_env(&target.to_string_lossy());
+
+        let outcome = ensure_opencode_config_dir("opencode", &[], &agent_env, &BTreeMap::new());
+
+        assert_eq!(outcome, OpencodeConfigDirOutcome::Ensured);
+        assert!(target.is_dir());
+    }
+
+    #[test]
+    fn ensure_opencode_config_dir_skips_relative_value() {
+        // Not an absolute path -> never created (cannot trust where it would land).
+        let profile_env = opencode_env(r"relative\.opencode");
+        let outcome = ensure_opencode_config_dir("opencode", &[], &BTreeMap::new(), &profile_env);
+        assert_eq!(outcome, OpencodeConfigDirOutcome::Skipped);
+    }
+
+    #[test]
+    fn ensure_opencode_config_dir_skips_non_opencode_command() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join(".opencode");
+        let profile_env = opencode_env(&target.to_string_lossy());
+
+        let outcome = ensure_opencode_config_dir("codex", &[], &BTreeMap::new(), &profile_env);
+
+        assert_eq!(outcome, OpencodeConfigDirOutcome::Skipped);
+        assert!(!target.exists(), "must not create the dir for a non-opencode command");
+    }
+
+    #[test]
+    fn ensure_opencode_config_dir_skips_when_unset() {
+        let outcome =
+            ensure_opencode_config_dir("opencode", &[], &BTreeMap::new(), &BTreeMap::new());
+        assert_eq!(outcome, OpencodeConfigDirOutcome::Skipped);
+    }
+
+    #[test]
+    fn ensure_opencode_config_dir_warns_and_continues_on_create_failure() {
+        // Make an ancestor a regular file so create_dir_all cannot succeed.
+        let temp = tempfile::tempdir().unwrap();
+        let blocker = temp.path().join("not-a-dir");
+        std::fs::write(&blocker, b"x").unwrap();
+        let target = blocker.join(".opencode");
+        let profile_env = opencode_env(&target.to_string_lossy());
+
+        let outcome = ensure_opencode_config_dir("opencode", &[], &BTreeMap::new(), &profile_env);
+
+        assert_eq!(outcome, OpencodeConfigDirOutcome::Failed);
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn build_spawn_creates_opencode_config_dir_for_literal_absolute_value() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("nested").join(".opencode");
+        assert!(!target.exists());
+
+        let mut settings = AppSettings {
+            agents: vec![agent("opencode", "opencode")],
+            ..AppSettings::default()
+        };
+        settings
+            .coding_agent_profiles
+            .profiles_by_agent
+            .entry("opencode".to_string())
+            .or_default()
+            .insert(
+                "A".to_string(),
+                ProfileCellConfig {
+                    enabled: true,
+                    command: String::new(),
+                    env: opencode_env(&target.to_string_lossy()),
+                    notes: String::new(),
+                },
+            );
+
+        // launch_path None is fine: a literal absolute value needs no placeholder context.
+        let spawn = build_agent_spawn_command(&settings, "opencode", None, Some("A")).unwrap();
+
+        assert!(target.is_dir(), "build should have created OPENCODE_CONFIG_DIR");
+        let env: BTreeMap<_, _> = spawn.child_env.into_iter().collect();
+        assert_eq!(
+            env.get("OPENCODE_CONFIG_DIR").map(String::as_str),
+            Some(target.to_string_lossy().as_ref())
         );
     }
 }

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -5,8 +5,8 @@ use crate::config::coding_agent_profiles::{
     resolve_profile, ProfileResolution, ProfileResolutionRequest,
 };
 use crate::config::placeholders::{
-    ac_root_error, expand_placeholders, expand_placeholders_in_args,
-    placeholder_context_for_launch_root, reject_unexpanded_markers, value_contains_ac_root,
+    ac_placeholder_error, expand_placeholders, expand_placeholders_in_args,
+    placeholder_context_for_launch_root, reject_unexpanded_markers, value_contains_ac_placeholder,
     PlaceholderContext,
 };
 use crate::config::session_context::ManagedContextTarget;
@@ -371,8 +371,8 @@ fn expand_runtime_value(
             Ok(expanded)
         }
         None => {
-            if value_contains_ac_root(value) {
-                return Err(ac_root_error().to_string());
+            if value_contains_ac_placeholder(value) {
+                return Err(ac_placeholder_error().to_string());
             }
             reject_unexpanded_markers(value, context, strict_path_value)?;
             Ok(value.to_string())
@@ -600,21 +600,21 @@ pub fn build_agent_spawn_command(
     command_tokens.extend(normalized.shell_args);
     let needs_placeholder_context = command_tokens
         .iter()
-        .any(|value| value_contains_ac_root(value))
+        .any(|value| value_contains_ac_placeholder(value))
         || agent
             .envs
             .iter()
             .filter(|row| row.enabled)
-            .any(|row| value_contains_ac_root(&row.value))
+            .any(|row| value_contains_ac_placeholder(&row.value))
         || profile_resolution
             .cell
             .env
             .values()
-            .any(|value| value_contains_ac_root(value));
+            .any(|value| value_contains_ac_placeholder(value));
     let placeholder_context = if needs_placeholder_context {
         Some(
             launch_path
-                .ok_or_else(|| ac_root_error().to_string())
+                .ok_or_else(|| ac_placeholder_error().to_string())
                 .and_then(placeholder_context_for_launch_root)?,
         )
     } else {
@@ -969,7 +969,7 @@ mod tests {
                 "A".to_string(),
                 ProfileCellConfig {
                     enabled: true,
-                    command: "%AC_ROOT%\\bin\\codex.exe --flag".to_string(),
+                    command: "%AC_REPLICA_ROOT%\\bin\\codex.exe --flag".to_string(),
                     env: BTreeMap::new(),
                     notes: String::new(),
                 },
@@ -979,7 +979,7 @@ mod tests {
             .expect("replica launch root should expand");
 
         // build_agent_spawn_command canonicalizes the launch root before expanding
-        // %AC_ROOT% (see placeholders.rs). On Windows, canonicalization resolves an
+        // %AC_REPLICA_ROOT% (see placeholders.rs). On Windows, canonicalization resolves an
         // 8.3 short path component (e.g. a CI runner's RUNNER~1) back to its long
         // form (runneradmin), whereas the temp dir may be reported in 8.3 short form
         // when the username exceeds 8 chars. Normalize the expected value through the
@@ -1005,14 +1005,136 @@ mod tests {
         let repo = temp.path().join("repo-thing");
         std::fs::create_dir_all(&repo).unwrap();
         let settings = AppSettings {
-            agents: vec![agent("codex", "%AC_ROOT%\\bin\\codex.exe")],
+            agents: vec![agent("codex", "%AC_REPLICA_ROOT%\\bin\\codex.exe")],
             ..AppSettings::default()
         };
 
         let err = build_agent_spawn_command(&settings, "codex", Some(&repo), Some("A"))
-            .expect_err("normal repo launch must reject AC_ROOT");
+            .expect_err("normal repo launch must reject AC_REPLICA_ROOT");
 
-        assert!(err.contains("%AC_ROOT% requires an AC replica or root-agent launch root"));
+        assert!(err.contains("%AC_REPLICA_ROOT% requires an AC replica or root-agent launch root"));
+    }
+
+    #[test]
+    fn workspace_and_matrix_placeholders_expand_in_profile_env_for_replica_launch() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = temp
+            .path()
+            .join("root with spaces")
+            .join(".ac")
+            .join("wg-7-dev-team")
+            .join("__agent_dev-rust");
+        std::fs::create_dir_all(&replica).unwrap();
+        let mut settings = AppSettings {
+            agents: vec![agent("claude", "claude")],
+            ..AppSettings::default()
+        };
+        settings
+            .coding_agent_profiles
+            .profiles_by_agent
+            .entry("claude".to_string())
+            .or_default()
+            .insert(
+                "A".to_string(),
+                ProfileCellConfig {
+                    enabled: true,
+                    command: String::new(),
+                    env: BTreeMap::from([
+                        (
+                            "CLAUDE_CONFIG_DIR".to_string(),
+                            "%AC_WORKSPACE_ROOT%\\.claude".to_string(),
+                        ),
+                        (
+                            "CLAUDE_MATRIX_DIR".to_string(),
+                            "%AC_MATRIX_ROOT%\\.claude".to_string(),
+                        ),
+                    ]),
+                    notes: String::new(),
+                },
+            );
+
+        let spawn = build_agent_spawn_command(&settings, "claude", Some(&replica), Some("A"))
+            .expect("replica launch root should expand workspace + matrix placeholders");
+        let env: BTreeMap<_, _> = spawn.child_env.into_iter().collect();
+
+        // Mirror the canonicalize + verbatim-prefix strip the builder applies, then
+        // derive the .ac workspace ancestor and the matrix dir from it.
+        let canonical_root = std::fs::canonicalize(&replica).unwrap();
+        let canonical_text = canonical_root.to_string_lossy();
+        let expected_replica = canonical_text
+            .strip_prefix(r"\\?\")
+            .map(std::path::PathBuf::from)
+            .unwrap_or(canonical_root);
+        let expected_workspace = expected_replica
+            .parent()
+            .and_then(|parent| parent.parent())
+            .expect("replica has a .ac workspace ancestor");
+        let expected_matrix = expected_workspace.join("_agent_dev-rust");
+
+        let expected_config = format!("{}\\.claude", expected_workspace.to_string_lossy());
+        let expected_matrix_claude = format!("{}\\.claude", expected_matrix.to_string_lossy());
+        assert_eq!(env.get("CLAUDE_CONFIG_DIR"), Some(&expected_config));
+        assert_eq!(env.get("CLAUDE_MATRIX_DIR"), Some(&expected_matrix_claude));
+    }
+
+    #[test]
+    fn matrix_codex_home_expands_to_absolute_path_for_replica_launch() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = temp
+            .path()
+            .join("root with spaces")
+            .join(".ac")
+            .join("wg-7-dev-team")
+            .join("__agent_dev-rust");
+        std::fs::create_dir_all(&replica).unwrap();
+        let mut settings = AppSettings {
+            agents: vec![agent("codex", "codex")],
+            ..AppSettings::default()
+        };
+        settings
+            .coding_agent_profiles
+            .profiles_by_agent
+            .entry("codex".to_string())
+            .or_default()
+            .insert(
+                "A".to_string(),
+                ProfileCellConfig {
+                    enabled: true,
+                    command: String::new(),
+                    env: BTreeMap::from([(
+                        "CODEX_HOME".to_string(),
+                        "%AC_MATRIX_ROOT%\\.codex".to_string(),
+                    )]),
+                    notes: String::new(),
+                },
+            );
+
+        let spawn = build_agent_spawn_command(&settings, "codex", Some(&replica), Some("A"))
+            .expect("matrix CODEX_HOME should expand to an absolute path");
+
+        let canonical_root = std::fs::canonicalize(&replica).unwrap();
+        let canonical_text = canonical_root.to_string_lossy();
+        let expected_replica = canonical_text
+            .strip_prefix(r"\\?\")
+            .map(std::path::PathBuf::from)
+            .unwrap_or(canonical_root);
+        let expected_matrix = expected_replica
+            .parent()
+            .and_then(|parent| parent.parent())
+            .expect("replica has a .ac workspace ancestor")
+            .join("_agent_dev-rust");
+
+        let home = spawn
+            .effective_codex_home
+            .expect("codex home resolves from the matrix placeholder");
+        assert!(home.is_absolute(), "{}", home.display());
+        // Mirror the builder's string concatenation (matrix + literal "\.codex"). Comparing
+        // the whole path keeps the assertion exact on Windows and still correct on platforms
+        // where the backslash is an ordinary character rather than a path separator, so the
+        // test does not silently become Windows-only.
+        let expected_home =
+            std::path::PathBuf::from(format!("{}\\.codex", expected_matrix.to_string_lossy()));
+        assert_eq!(home, expected_home);
     }
 
     #[test]

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -304,6 +304,18 @@ fn executable_basename(s: &str) -> String {
         .to_lowercase()
 }
 
+/// Lowercased final path component WITH its extension (unlike
+/// [`executable_basename`], which strips the last extension via `file_stem`).
+/// Used by the opencode arg-scan to match exact executable forms and reject
+/// look-alikes such as `opencode.md`.
+fn executable_filename(s: &str) -> String {
+    std::path::Path::new(s)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(s)
+        .to_lowercase()
+}
+
 fn collect_agent_env(
     agent: &AgentConfig,
     placeholder_context: Option<&PlaceholderContext>,
@@ -506,11 +518,27 @@ enum OpencodeConfigDirOutcome {
     Failed,
 }
 
-/// True when the launch command runs opencode, matched by executable basename.
+/// Executable file_name forms that count as opencode when found among the
+/// command ARGS. The bare `opencode` covers the `cmd /c opencode` wrapper; the
+/// `.exe`/`.cmd`/`.bat` forms cover a direct path or an npm-style shim.
+const OPENCODE_ARG_FORMS: [&str; 4] =
+    ["opencode", "opencode.exe", "opencode.cmd", "opencode.bat"];
+
+/// True when the launch command runs opencode, matched by executable name.
 /// There is no `CodingAgentKind::OpenCode` (the enum is Claude/Codex/Gemini and
 /// `detect` does not know opencode), so this mirrors the
 /// `executable_basename(shell) == "codex"` fallback in [`compute_codex_home`].
-/// Args are scanned too, so a `cmd /c opencode` wrapper is still recognized.
+///
+/// The `shell` (the program being launched) is matched on `file_stem`, like the
+/// codex fallback: an `opencode.exe`/`.cmd` shell still resolves to `opencode`.
+/// Args are scanned with a tighter rule: the token `file_name` (extension kept)
+/// must be one of [`OPENCODE_ARG_FORMS`]. This still recognizes a
+/// `cmd /c opencode` wrapper, but does NOT mistake a non-opencode agent whose
+/// command merely references an `opencode.md` (or `.json`) file for an opencode
+/// launch (a `file_stem` match would, since `file_stem("opencode.md")` is
+/// `opencode`). An arg cannot be a bare-stem executable the way a shell can, so
+/// the extension carries real signal here.
+///
 /// Called BEFORE the `git_pull_before` wrap, so `shell` is the real command.
 fn command_runs_opencode(shell: &str, shell_args: &[String]) -> bool {
     if executable_basename(shell) == "opencode" {
@@ -519,7 +547,7 @@ fn command_runs_opencode(shell: &str, shell_args: &[String]) -> bool {
     shell_args
         .iter()
         .flat_map(|arg| arg.split_whitespace())
-        .any(|token| executable_basename(token) == "opencode")
+        .any(|token| OPENCODE_ARG_FORMS.contains(&executable_filename(token).as_str()))
 }
 
 /// Resolved `OPENCODE_CONFIG_DIR` value with profile-over-agent precedence,
@@ -1526,9 +1554,33 @@ mod tests {
             "cmd.exe",
             &["/c".to_string(), "opencode".to_string()]
         ));
+        // Allowlisted executable forms still match as args (path + npm-style shim).
+        assert!(command_runs_opencode(
+            "cmd.exe",
+            &["/c".to_string(), r"C:\tools\opencode.cmd".to_string()]
+        ));
+        assert!(command_runs_opencode("cmd.exe", &["/c opencode.bat".to_string()]));
         // Non-opencode commands do not match.
         assert!(!command_runs_opencode("codex", &[]));
         assert!(!command_runs_opencode("claude", &["--resume".to_string()]));
+    }
+
+    #[test]
+    fn command_runs_opencode_ignores_opencode_doc_and_config_args() {
+        // Regression (grinch Finding 1): a non-opencode agent whose command merely
+        // references an `opencode.md`/`.json` file must NOT be read as an opencode
+        // launch. `file_stem("opencode.md") == "opencode"`, so the prior arg-scan
+        // false-matched; the file_name allowlist rejects these forms.
+        assert!(!command_runs_opencode(
+            "claude",
+            &["--instructions".to_string(), "opencode.md".to_string()]
+        ));
+        assert!(!command_runs_opencode(
+            "claude",
+            &[r"C:\Users\me\opencode.md".to_string()]
+        ));
+        assert!(!command_runs_opencode("claude", &["opencode.json".to_string()]));
+        assert!(!command_runs_opencode("claude", &["opencode.txt".to_string()]));
     }
 
     #[test]
@@ -1597,6 +1649,31 @@ mod tests {
     }
 
     #[test]
+    fn ensure_opencode_config_dir_skips_opencode_md_arg_with_absolute_value() {
+        // Regression (grinch Finding 1): a non-opencode launch (here `claude`)
+        // whose args reference an `opencode.md` file, even with an absolute
+        // OPENCODE_CONFIG_DIR set, must NOT be read as an opencode launch, so the
+        // dir is never created.
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("nested").join(".opencode");
+        assert!(!target.exists());
+        let profile_env = opencode_env(&target.to_string_lossy());
+
+        let outcome = ensure_opencode_config_dir(
+            "claude",
+            &["--instructions".to_string(), "opencode.md".to_string()],
+            &BTreeMap::new(),
+            &profile_env,
+        );
+
+        assert_eq!(outcome, OpencodeConfigDirOutcome::Skipped);
+        assert!(
+            !target.exists(),
+            "an opencode.md arg must not trigger OPENCODE_CONFIG_DIR creation"
+        );
+    }
+
+    #[test]
     fn ensure_opencode_config_dir_skips_when_unset() {
         let outcome =
             ensure_opencode_config_dir("opencode", &[], &BTreeMap::new(), &BTreeMap::new());
@@ -1651,6 +1728,67 @@ mod tests {
         assert_eq!(
             env.get("OPENCODE_CONFIG_DIR").map(String::as_str),
             Some(target.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn build_spawn_expands_and_creates_opencode_config_dir_for_replica_placeholder() {
+        // Finding 2 (grinch): the literal-value test does not cover the real user
+        // scenario, where OPENCODE_CONFIG_DIR holds %AC_REPLICA_ROOT%\.opencode and
+        // is expanded against the replica launch root before the dir is created.
+        // This drives that path end-to-end: expand -> absolute -> create.
+        let temp = tempfile::tempdir().unwrap();
+        let replica = temp
+            .path()
+            .join("root with spaces")
+            .join(".ac")
+            .join("wg-7-dev-team")
+            .join("__agent_dev-rust");
+        std::fs::create_dir_all(&replica).unwrap();
+
+        let mut settings = AppSettings {
+            agents: vec![agent("opencode", "opencode")],
+            ..AppSettings::default()
+        };
+        settings
+            .coding_agent_profiles
+            .profiles_by_agent
+            .entry("opencode".to_string())
+            .or_default()
+            .insert(
+                "A".to_string(),
+                ProfileCellConfig {
+                    enabled: true,
+                    command: String::new(),
+                    env: opencode_env(r"%AC_REPLICA_ROOT%\.opencode"),
+                    notes: String::new(),
+                },
+            );
+
+        let spawn = build_agent_spawn_command(&settings, "opencode", Some(&replica), Some("A"))
+            .expect("replica launch should expand %AC_REPLICA_ROOT% and build the spawn");
+
+        // Mirror the builder's canonicalize + verbatim-prefix strip, then append the
+        // literal "\.opencode" the way placeholder expansion concatenates it (see the
+        // matrix CODEX_HOME test for why the whole-path comparison stays cross-platform).
+        let canonical_root = std::fs::canonicalize(&replica).unwrap();
+        let canonical_text = canonical_root.to_string_lossy();
+        let expected_replica = canonical_text
+            .strip_prefix(r"\\?\")
+            .map(std::path::PathBuf::from)
+            .unwrap_or(canonical_root);
+        let expected_config = format!("{}\\.opencode", expected_replica.to_string_lossy());
+
+        // The child env carries the fully-expanded absolute path...
+        let env: BTreeMap<_, _> = spawn.child_env.into_iter().collect();
+        assert_eq!(
+            env.get("OPENCODE_CONFIG_DIR").map(String::as_str),
+            Some(expected_config.as_str())
+        );
+        // ...and the build created that exact directory end-to-end.
+        assert!(
+            std::path::Path::new(&expected_config).is_dir(),
+            "build should have created the expanded OPENCODE_CONFIG_DIR at {expected_config}"
         );
     }
 }

--- a/src-tauri/src/config/placeholders.rs
+++ b/src-tauri/src/config/placeholders.rs
@@ -1,7 +1,28 @@
 use std::path::{Path, PathBuf};
 
-const AC_ROOT_PLACEHOLDER: &str = "%AC_ROOT%";
-const AC_ROOT_ERROR: &str = "%AC_ROOT% requires an AC replica or root-agent launch root";
+pub const AC_REPLICA_ROOT_PLACEHOLDER: &str = "%AC_REPLICA_ROOT%";
+pub const AC_WORKSPACE_ROOT_PLACEHOLDER: &str = "%AC_WORKSPACE_ROOT%";
+pub const AC_MATRIX_ROOT_PLACEHOLDER: &str = "%AC_MATRIX_ROOT%";
+
+/// Single source of truth for the AC path-placeholder token set. Every site that
+/// gates on, validates, or scans these tokens MUST iterate this list, so adding a
+/// token wires the gate AND the CODEX_HOME validators at once (the #576 hard rule).
+/// Expansion in `expand_placeholders` stays as explicit per-token `if` blocks: each
+/// token has its own root field + error and fails closed if forgotten, so a loop
+/// there would obscure more than it saves.
+pub const AC_PLACEHOLDER_TOKENS: &[&str] = &[
+    AC_REPLICA_ROOT_PLACEHOLDER,
+    AC_WORKSPACE_ROOT_PLACEHOLDER,
+    AC_MATRIX_ROOT_PLACEHOLDER,
+];
+
+const AC_REPLICA_ROOT_ERROR: &str =
+    "%AC_REPLICA_ROOT% requires an AC replica or root-agent launch root";
+const AC_WORKSPACE_ROOT_ERROR: &str =
+    "%AC_WORKSPACE_ROOT% requires a launch root inside an AC (.ac) workspace";
+const AC_MATRIX_ROOT_ERROR: &str =
+    "%AC_MATRIX_ROOT% requires an AC workgroup replica launch root";
+const AC_PLACEHOLDER_LAUNCH_ROOT_ERROR: &str = "AC path placeholders require an AC launch root";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PlaceholderRootKind {
@@ -11,8 +32,10 @@ pub enum PlaceholderRootKind {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlaceholderContext {
-    pub ac_root: PathBuf,
+    pub replica_root: PathBuf,
     pub root_kind: PlaceholderRootKind,
+    pub workspace_root: Option<PathBuf>,
+    pub matrix_root: Option<PathBuf>,
 }
 
 pub fn placeholder_context_for_launch_root(path: &Path) -> Result<PlaceholderContext, String> {
@@ -39,21 +62,69 @@ pub fn placeholder_context_for_launch_root(path: &Path) -> Result<PlaceholderCon
         PlaceholderRootKind::NormalLaunchCwd
     };
 
+    let workspace_root = crate::config::workspace::find_workspace_ancestor(&canonical);
+    let matrix_root = derive_matrix_root(&canonical, workspace_root.as_deref());
+
     Ok(PlaceholderContext {
-        ac_root: canonical,
+        replica_root: canonical,
         root_kind,
+        workspace_root,
+        matrix_root,
     })
 }
 
+/// Matrix dir for a WG replica launch: `<workspace>/_agent_<name>`.
+/// Derives the agent name the SAME way as the canonical
+/// `crate::config::replica_identity::expected_wg_replica_identity`: strip the
+/// `__agent_` prefix and require a non-empty `[A-Za-z0-9-]` name (the exact rule in
+/// that module's `validate_agent_name`). It INTENTIONALLY omits the canonical
+/// formula's on-disk `validate_local_matrix` (existence + containment) check, because
+/// the placeholder path must stay pure: no filesystem read, no config repair (#576 §8).
+/// Returns None for the root-agent, for normal (non-replica) launch roots, and for a
+/// degenerate/invalid replica leaf (e.g. `__agent_` empty name, or `__agent_bad.name`).
+fn derive_matrix_root(canonical: &Path, workspace_root: Option<&Path>) -> Option<PathBuf> {
+    if !is_ac_replica_dir(canonical) {
+        return None;
+    }
+    let agent_name = canonical
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("__agent_"))
+        .filter(|name| {
+            !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        })?;
+    workspace_root.map(|workspace| workspace.join(format!("_agent_{}", agent_name)))
+}
+
 pub fn expand_placeholders(value: &str, context: &PlaceholderContext) -> Result<String, String> {
-    if !value.contains(AC_ROOT_PLACEHOLDER) {
-        reject_unexpanded_markers(value, "placeholder value", false)?;
-        return Ok(value.to_string());
+    let mut expanded = value.to_string();
+
+    if expanded.contains(AC_REPLICA_ROOT_PLACEHOLDER) {
+        if context.root_kind != PlaceholderRootKind::AcReplicaOrRootAgent {
+            return Err(AC_REPLICA_ROOT_ERROR.to_string());
+        }
+        expanded = expanded.replace(
+            AC_REPLICA_ROOT_PLACEHOLDER,
+            &context.replica_root.to_string_lossy(),
+        );
     }
-    if context.root_kind != PlaceholderRootKind::AcReplicaOrRootAgent {
-        return Err(AC_ROOT_ERROR.to_string());
+
+    if expanded.contains(AC_WORKSPACE_ROOT_PLACEHOLDER) {
+        let workspace = context
+            .workspace_root
+            .as_ref()
+            .ok_or_else(|| AC_WORKSPACE_ROOT_ERROR.to_string())?;
+        expanded = expanded.replace(AC_WORKSPACE_ROOT_PLACEHOLDER, &workspace.to_string_lossy());
     }
-    let expanded = value.replace(AC_ROOT_PLACEHOLDER, &context.ac_root.to_string_lossy());
+
+    if expanded.contains(AC_MATRIX_ROOT_PLACEHOLDER) {
+        let matrix = context
+            .matrix_root
+            .as_ref()
+            .ok_or_else(|| AC_MATRIX_ROOT_ERROR.to_string())?;
+        expanded = expanded.replace(AC_MATRIX_ROOT_PLACEHOLDER, &matrix.to_string_lossy());
+    }
+
     reject_unexpanded_markers(&expanded, "placeholder value", false)?;
     Ok(expanded)
 }
@@ -88,12 +159,12 @@ pub fn reject_unexpanded_markers(
     Ok(())
 }
 
-pub fn value_contains_ac_root(value: &str) -> bool {
-    value.contains(AC_ROOT_PLACEHOLDER)
+pub fn value_contains_ac_placeholder(value: &str) -> bool {
+    AC_PLACEHOLDER_TOKENS.iter().any(|token| value.contains(*token))
 }
 
-pub fn ac_root_error() -> &'static str {
-    AC_ROOT_ERROR
+pub fn ac_placeholder_error() -> &'static str {
+    AC_PLACEHOLDER_LAUNCH_ROOT_ERROR
 }
 
 fn contains_percent_marker(value: &str) -> bool {
@@ -188,5 +259,190 @@ mod tests {
     fn strict_path_values_reject_any_marker() {
         let err = reject_unexpanded_markers("C:/x/$HOME", "CODEX_HOME", true).unwrap_err();
         assert!(err.contains("variable markers"), "{err}");
+    }
+
+    /// Canonicalize + strip the verbatim prefix exactly like
+    /// `placeholder_context_for_launch_root` does, so expected paths match the
+    /// context's `replica_root` even when the OS hands back an 8.3 short form.
+    fn canonical_stripped(path: &Path) -> PathBuf {
+        strip_extended_prefix(std::fs::canonicalize(path).unwrap())
+    }
+
+    /// Create a real WG-replica launch root `<temp>/.ac/wg-7-dev-team/__agent_dev-rust`.
+    fn make_replica(temp: &Path) -> PathBuf {
+        let replica = temp.join(".ac").join("wg-7-dev-team").join("__agent_dev-rust");
+        std::fs::create_dir_all(&replica).unwrap();
+        replica
+    }
+
+    #[test]
+    fn replica_launch_expands_all_three_tokens() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = make_replica(temp.path());
+        let ctx = placeholder_context_for_launch_root(&replica).unwrap();
+
+        let expected_replica = canonical_stripped(&replica);
+        let expected_workspace = expected_replica
+            .parent()
+            .and_then(|parent| parent.parent())
+            .expect("replica has a .ac workspace ancestor");
+        let expected_matrix = expected_workspace.join("_agent_dev-rust");
+
+        assert_eq!(ctx.root_kind, PlaceholderRootKind::AcReplicaOrRootAgent);
+        assert_eq!(ctx.replica_root, expected_replica);
+        assert_eq!(ctx.workspace_root.as_deref(), Some(expected_workspace));
+        assert_eq!(ctx.matrix_root.as_deref(), Some(expected_matrix.as_path()));
+
+        assert_eq!(
+            expand_placeholders(r"%AC_REPLICA_ROOT%\x", &ctx).unwrap(),
+            format!(r"{}\x", expected_replica.to_string_lossy())
+        );
+        assert_eq!(
+            expand_placeholders(r"%AC_WORKSPACE_ROOT%\x", &ctx).unwrap(),
+            format!(r"{}\x", expected_workspace.to_string_lossy())
+        );
+        assert_eq!(
+            expand_placeholders(r"%AC_MATRIX_ROOT%\x", &ctx).unwrap(),
+            format!(r"{}\x", expected_matrix.to_string_lossy())
+        );
+    }
+
+    #[test]
+    fn non_replica_outside_ac_errors_for_every_token() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo-thing");
+        std::fs::create_dir_all(&repo).unwrap();
+        let ctx = placeholder_context_for_launch_root(&repo).unwrap();
+
+        assert_eq!(ctx.root_kind, PlaceholderRootKind::NormalLaunchCwd);
+        assert_eq!(ctx.workspace_root, None);
+        assert_eq!(ctx.matrix_root, None);
+
+        assert_eq!(
+            expand_placeholders(r"%AC_REPLICA_ROOT%\x", &ctx).unwrap_err(),
+            AC_REPLICA_ROOT_ERROR
+        );
+        assert_eq!(
+            expand_placeholders(r"%AC_WORKSPACE_ROOT%\x", &ctx).unwrap_err(),
+            AC_WORKSPACE_ROOT_ERROR
+        );
+        assert_eq!(
+            expand_placeholders(r"%AC_MATRIX_ROOT%\x", &ctx).unwrap_err(),
+            AC_MATRIX_ROOT_ERROR
+        );
+    }
+
+    #[test]
+    fn legacy_ac_root_token_is_now_an_unknown_marker() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = make_replica(temp.path());
+        let ctx = placeholder_context_for_launch_root(&replica).unwrap();
+        // No alias: a leftover %AC_ROOT% is no longer expanded and trips the backstop.
+        let err = expand_placeholders(r"%AC_ROOT%\x", &ctx).unwrap_err();
+        assert!(err.contains("unknown placeholder"), "{err}");
+    }
+
+    #[test]
+    fn value_contains_ac_placeholder_matches_only_known_tokens() {
+        assert!(value_contains_ac_placeholder(r"%AC_REPLICA_ROOT%\x"));
+        assert!(value_contains_ac_placeholder(r"%AC_WORKSPACE_ROOT%\x"));
+        assert!(value_contains_ac_placeholder(r"%AC_MATRIX_ROOT%\x"));
+        assert!(!value_contains_ac_placeholder(r"%AC_ROOT%\x"));
+        assert!(!value_contains_ac_placeholder("%UNKNOWN%"));
+        assert!(!value_contains_ac_placeholder("plain text"));
+    }
+
+    #[test]
+    fn root_agent_and_normal_contexts_resolve_replica_token_only() {
+        // Hermetic: build the context directly because `is_root_agent_dir` reads the
+        // real configured root_agent_dir() from disk and cannot be faked in a unit test.
+        let root_agent = PlaceholderContext {
+            replica_root: PathBuf::from(if cfg!(windows) {
+                r"C:\some\replica"
+            } else {
+                "/some/replica"
+            }),
+            root_kind: PlaceholderRootKind::AcReplicaOrRootAgent,
+            workspace_root: None,
+            matrix_root: None,
+        };
+        assert!(expand_placeholders(r"%AC_REPLICA_ROOT%\x", &root_agent).is_ok());
+        assert_eq!(
+            expand_placeholders(r"%AC_WORKSPACE_ROOT%\x", &root_agent).unwrap_err(),
+            AC_WORKSPACE_ROOT_ERROR
+        );
+        assert_eq!(
+            expand_placeholders(r"%AC_MATRIX_ROOT%\x", &root_agent).unwrap_err(),
+            AC_MATRIX_ROOT_ERROR
+        );
+
+        let normal = PlaceholderContext {
+            replica_root: PathBuf::from(if cfg!(windows) {
+                r"C:\some\cwd"
+            } else {
+                "/some/cwd"
+            }),
+            root_kind: PlaceholderRootKind::NormalLaunchCwd,
+            workspace_root: None,
+            matrix_root: None,
+        };
+        assert_eq!(
+            expand_placeholders(r"%AC_REPLICA_ROOT%\x", &normal).unwrap_err(),
+            AC_REPLICA_ROOT_ERROR
+        );
+    }
+
+    #[test]
+    fn derive_matrix_root_matches_canonical_formula() {
+        let workspace = PathBuf::from(if cfg!(windows) { r"C:\proj\.ac" } else { "/proj/.ac" });
+        let replica = workspace.join("wg-7-dev-team").join("__agent_dev-rust");
+        assert_eq!(
+            derive_matrix_root(&replica, Some(&workspace)),
+            Some(workspace.join("_agent_dev-rust"))
+        );
+
+        // Non-replica leaf -> None.
+        let repo = workspace.join("wg-7-dev-team").join("repo-thing");
+        assert_eq!(derive_matrix_root(&repo, Some(&workspace)), None);
+
+        // Replica leaf but no .ac ancestor -> None (guards the workspace_root.map arm).
+        assert_eq!(derive_matrix_root(&replica, None), None);
+
+        // F1: degenerate / invalid agent name -> None (parity with validate_agent_name).
+        let empty = workspace.join("wg-7-dev-team").join("__agent_");
+        assert_eq!(derive_matrix_root(&empty, Some(&workspace)), None);
+        let dotted = workspace.join("wg-7-dev-team").join("__agent_bad.name");
+        assert_eq!(derive_matrix_root(&dotted, Some(&workspace)), None);
+    }
+
+    #[test]
+    fn non_replica_inside_ac_resolves_workspace_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join(".ac").join("wg-7-dev-team").join("repo-x");
+        std::fs::create_dir_all(&repo).unwrap();
+        let ctx = placeholder_context_for_launch_root(&repo).unwrap();
+
+        assert_eq!(ctx.root_kind, PlaceholderRootKind::NormalLaunchCwd);
+        assert_eq!(ctx.matrix_root, None);
+
+        let expected_replica = canonical_stripped(&repo);
+        let expected_workspace = expected_replica
+            .parent()
+            .and_then(|parent| parent.parent())
+            .expect("repo-x has a .ac workspace ancestor");
+        assert_eq!(ctx.workspace_root.as_deref(), Some(expected_workspace));
+
+        assert_eq!(
+            expand_placeholders(r"%AC_WORKSPACE_ROOT%\x", &ctx).unwrap(),
+            format!(r"{}\x", expected_workspace.to_string_lossy())
+        );
+        assert_eq!(
+            expand_placeholders(r"%AC_REPLICA_ROOT%\x", &ctx).unwrap_err(),
+            AC_REPLICA_ROOT_ERROR
+        );
+        assert_eq!(
+            expand_placeholders(r"%AC_MATRIX_ROOT%\x", &ctx).unwrap_err(),
+            AC_MATRIX_ROOT_ERROR
+        );
     }
 }

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1001,6 +1001,14 @@ pub fn is_codex_home_key(key: &str) -> bool {
     normalize_env_key_for_platform(key) == normalize_env_key_for_platform("CODEX_HOME")
 }
 
+/// True for opencode's config-dir env key. Analogous to [`is_codex_home_key`];
+/// the launch path uses it to auto-create the resolved `OPENCODE_CONFIG_DIR`
+/// before spawn (opencode does not create that dir itself and exits 1 if it is
+/// missing). Case-insensitive on Windows via `normalize_env_key_for_platform`.
+pub fn is_opencode_config_dir_key(key: &str) -> bool {
+    normalize_env_key_for_platform(key) == normalize_env_key_for_platform("OPENCODE_CONFIG_DIR")
+}
+
 pub fn is_reserved_env_key(key: &str) -> bool {
     let normalized = normalize_env_key_for_platform(key);
     let ac_prefix = normalize_env_key_for_platform("AGENTSCOMMANDER_");

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use crate::config::placeholders::AC_PLACEHOLDER_TOKENS;
 use crate::telegram::types::TelegramBotConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1051,18 +1052,34 @@ fn validate_codex_home_basic<'a>(value: &'a str, context: &str) -> Result<&'a st
 
 pub fn validate_codex_home_template_value(value: &str, context: &str) -> Result<(), String> {
     let trimmed = validate_codex_home_basic(value, context)?;
-    if trimmed.contains("%AC_ROOT%") {
-        if !(trimmed == "%AC_ROOT%"
-            || trimmed.starts_with("%AC_ROOT%/")
-            || trimmed.starts_with("%AC_ROOT%\\"))
-        {
-            return Err(format!(
-                "{context}: CODEX_HOME template must start with %AC_ROOT% as a complete path segment"
-            ));
-        }
+
+    // Accept when the value's COMPLETE LEADING path segment is a known token.
+    // Do NOT pick "first token contained anywhere" (it would name the wrong token
+    // for a value that starts with one token but mentions another later; #576 R1 F3).
+    let starts_with_token = AC_PLACEHOLDER_TOKENS.iter().any(|&token| {
+        trimmed == token
+            || trimmed.starts_with(&format!("{token}/"))
+            || trimmed.starts_with(&format!("{token}\\"))
+    });
+    if starts_with_token {
+        // Leading segment OK; the remainder scanner rejects any unknown %marker%
+        // (and skips known tokens that appear later in the path).
         reject_unknown_codex_home_template_markers(trimmed, context)?;
         return Ok(());
     }
+
+    // No valid leading token. If a known token still appears anywhere, the leading
+    // segment is wrong: report the "complete path segment" error naming that token.
+    if let Some(&token) = AC_PLACEHOLDER_TOKENS
+        .iter()
+        .find(|&&token| trimmed.contains(token))
+    {
+        return Err(format!(
+            "{context}: CODEX_HOME template must start with {token} as a complete path segment"
+        ));
+    }
+
+    // No token at all: must already be a literal absolute path.
     reject_unknown_codex_home_template_markers(trimmed, context)?;
     validate_expanded_codex_home_value(trimmed, context).map(|_| ())
 }
@@ -1090,8 +1107,11 @@ fn reject_unknown_codex_home_template_markers(value: &str, context: &str) -> Res
     let mut rest = value;
     while let Some(start) = rest.find('%') {
         rest = &rest[start..];
-        if rest.starts_with("%AC_ROOT%") {
-            rest = &rest["%AC_ROOT%".len()..];
+        if let Some(&token) = AC_PLACEHOLDER_TOKENS
+            .iter()
+            .find(|&&token| rest.starts_with(token))
+        {
+            rest = &rest[token.len()..];
             continue;
         }
         if let Some(end) = rest[1..].find('%') {
@@ -1584,6 +1604,45 @@ mod tests {
         let settings = settings_with_agents(&[("Gemini", "gemini --resume latest")]);
         let err = super::validate_agent_commands(&settings).unwrap_err();
         assert!(err.contains("Gemini commands must not include --resume"));
+    }
+
+    #[test]
+    fn codex_home_template_accepts_each_token_alone_and_as_leading_segment() {
+        for token in ["%AC_REPLICA_ROOT%", "%AC_WORKSPACE_ROOT%", "%AC_MATRIX_ROOT%"] {
+            super::validate_codex_home_template_value(token, "ctx")
+                .unwrap_or_else(|e| panic!("{token} alone should be accepted: {e}"));
+            super::validate_codex_home_template_value(&format!("{token}\\.codex"), "ctx")
+                .unwrap_or_else(|e| panic!("{token}\\.codex should be accepted: {e}"));
+            super::validate_codex_home_template_value(&format!("{token}/.codex"), "ctx")
+                .unwrap_or_else(|e| panic!("{token}/.codex should be accepted: {e}"));
+        }
+    }
+
+    #[test]
+    fn codex_home_template_rejects_token_not_at_leading_segment() {
+        let err = super::validate_codex_home_template_value(r"prefix%AC_MATRIX_ROOT%\x", "ctx")
+            .unwrap_err();
+        assert!(
+            err.contains("complete path segment") && err.contains("%AC_MATRIX_ROOT%"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn codex_home_template_rejects_legacy_ac_root_as_unknown_marker() {
+        // Save-time break: the old token is now an unknown placeholder, named in the error.
+        let err = super::validate_codex_home_template_value(r"%AC_ROOT%\x", "ctx").unwrap_err();
+        assert!(err.contains("%AC_ROOT%"), "{err}");
+    }
+
+    #[test]
+    fn codex_home_template_keys_on_leading_token_not_list_order() {
+        // F3: the leading segment is a valid token; another token appearing later must
+        // NOT trigger a rejection that names the wrong token.
+        super::validate_codex_home_template_value(r"%AC_MATRIX_ROOT%\sub", "ctx")
+            .expect("matrix leading segment is valid");
+        super::validate_codex_home_template_value(r"%AC_MATRIX_ROOT%\%AC_REPLICA_ROOT%\x", "ctx")
+            .expect("leading token valid; remainder tokens are known at shape level");
     }
 
     use super::{

--- a/src/shared/profile-utils.test.ts
+++ b/src/shared/profile-utils.test.ts
@@ -5,8 +5,8 @@ import {
   defaultInstructionsFilename,
   effectiveEnvProjection,
   executableBasename,
-  expandAcRootPreview,
-  hasAcRootPlaceholder,
+  expandAcPlaceholdersPreview,
+  hasAcPlaceholder,
   isAcAgentPath,
   isCodexAgent,
   isWgReplicaPath,
@@ -95,14 +95,31 @@ describe("profile utils", () => {
     expect(isWgReplicaPath(null)).toBe(false);
   });
 
-  it("previews %AC_ROOT% expansion for display only", () => {
-    expect(hasAcRootPlaceholder("%AC_ROOT%\\.codex")).toBe(true);
-    expect(hasAcRootPlaceholder("D:\\manual\\codex")).toBe(false);
-    expect(expandAcRootPreview("%AC_ROOT%\\.codex\\agents\\codex", "C:\\wg\\__agent_codex")).toBe(
-      "C:\\wg\\__agent_codex\\.codex\\agents\\codex",
+  it("previews AC placeholder expansion for display only (3 tokens, #576)", () => {
+    expect(hasAcPlaceholder("%AC_REPLICA_ROOT%\\.codex")).toBe(true);
+    expect(hasAcPlaceholder("%AC_WORKSPACE_ROOT%\\.claude")).toBe(true);
+    expect(hasAcPlaceholder("%AC_MATRIX_ROOT%\\.codex")).toBe(true);
+    expect(hasAcPlaceholder("D:\\manual\\codex")).toBe(false);
+    // Old %AC_ROOT% token is no longer recognized (breaking rename, no alias).
+    expect(hasAcPlaceholder("%AC_ROOT%\\.codex")).toBe(false);
+
+    // %AC_REPLICA_ROOT% → replica root; %AC_WORKSPACE_ROOT% and %AC_MATRIX_ROOT%
+    // derive from a full replica path (…\.ac\wg-*\__agent_<name>).
+    const replica = "C:\\proj\\.ac\\wg-6-dev-team\\__agent_codex";
+    expect(expandAcPlaceholdersPreview("%AC_REPLICA_ROOT%\\.codex\\agents\\codex", replica)).toBe(
+      "C:\\proj\\.ac\\wg-6-dev-team\\__agent_codex\\.codex\\agents\\codex",
     );
+    expect(expandAcPlaceholdersPreview("%AC_WORKSPACE_ROOT%\\.claude", replica)).toBe(
+      "C:\\proj\\.ac\\.claude",
+    );
+    expect(expandAcPlaceholdersPreview("%AC_MATRIX_ROOT%\\.codex", replica)).toBe(
+      "C:\\proj\\.ac\\_agent_codex\\.codex",
+    );
+
     // No root context → returned unchanged (backend expands authoritatively at launch).
-    expect(expandAcRootPreview("%AC_ROOT%\\.codex", null)).toBe("%AC_ROOT%\\.codex");
+    expect(expandAcPlaceholdersPreview("%AC_REPLICA_ROOT%\\.codex", null)).toBe(
+      "%AC_REPLICA_ROOT%\\.codex",
+    );
   });
 
   it("parses and stringifies argv text with quoted values", () => {
@@ -230,8 +247,11 @@ describe("profile utils", () => {
 
 describe("profileEnvOrigin (#526/#527 env origin badges)", () => {
   it("classifies an AgentsCommander-managed home path as system", () => {
-    expect(profileEnvOrigin("CODEX_HOME", "%AC_ROOT%\\.codex\\agents\\codex")).toBe("system");
-    expect(profileEnvOrigin("CLAUDE_CONFIG_DIR", "%AC_ROOT%/.claude")).toBe("system");
+    expect(profileEnvOrigin("CODEX_HOME", "%AC_REPLICA_ROOT%\\.codex\\agents\\codex")).toBe("system");
+    expect(profileEnvOrigin("CLAUDE_CONFIG_DIR", "%AC_REPLICA_ROOT%/.claude")).toBe("system");
+    // Any of the three AC placeholders on a managed home key is system-managed.
+    expect(profileEnvOrigin("CLAUDE_CONFIG_DIR", "%AC_WORKSPACE_ROOT%/.claude")).toBe("system");
+    expect(profileEnvOrigin("CODEX_HOME", "%AC_MATRIX_ROOT%\\.codex")).toBe("system");
   });
 
   it("classifies a literal absolute path on a managed home key as accepted", () => {
@@ -251,7 +271,7 @@ describe("effectiveEnvProjection (#527 Env / EFFECTIVE)", () => {
   it("merges agent env (system/accepted) with profile env (profile), profile wins", () => {
     const merged = effectiveEnvProjection(
       [
-        { key: "CODEX_HOME", value: "%AC_ROOT%\\.codex", source: "system", enabled: true },
+        { key: "CODEX_HOME", value: "%AC_REPLICA_ROOT%\\.codex", source: "system", enabled: true },
         { key: "OPENAI_API_KEY", value: "redacted", source: "user", enabled: true },
         { key: "DISABLED", value: "x", source: "user", enabled: false },
       ],

--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -30,9 +30,16 @@ const EMPTY_CELL: ProfileCellConfig = {
   notes: "",
 };
 
-/** Display-only `%AC_ROOT%` placeholder. The backend is authoritative for the
- *  real expansion + validation at launch (#384 F17). */
-export const AC_ROOT_PLACEHOLDER = "%AC_ROOT%";
+/** Display-only profile path placeholders. The backend is authoritative for real
+ *  expansion + validation at launch (#576 / #384 F17). */
+export const AC_REPLICA_ROOT_PLACEHOLDER = "%AC_REPLICA_ROOT%";
+export const AC_WORKSPACE_ROOT_PLACEHOLDER = "%AC_WORKSPACE_ROOT%";
+export const AC_MATRIX_ROOT_PLACEHOLDER = "%AC_MATRIX_ROOT%";
+export const AC_PLACEHOLDERS = [
+  AC_REPLICA_ROOT_PLACEHOLDER,
+  AC_WORKSPACE_ROOT_PLACEHOLDER,
+  AC_MATRIX_ROOT_PLACEHOLDER,
+] as const;
 
 export function isProfileLetter(value: string): boolean {
   return /^[A-Z]$/.test(value);
@@ -88,22 +95,52 @@ export function profileCellCommandText(cell: ProfileCellConfig | null | undefine
   return cell?.command ?? "";
 }
 
-/** True when a value still contains the `%AC_ROOT%` placeholder (display check). */
-export function hasAcRootPlaceholder(value: string): boolean {
-  return value.includes(AC_ROOT_PLACEHOLDER);
+/** True when a value contains any AC path placeholder (display check). */
+export function hasAcPlaceholder(value: string): boolean {
+  return AC_PLACEHOLDERS.some((token) => value.includes(token));
+}
+
+/** Display-only: the `.ac` workspace ancestor of a replica path, or null. */
+export function deriveWorkspaceRoot(replicaPath: string | null | undefined): string | null {
+  if (!replicaPath) return null;
+  const parts = replicaPath.replace(/\\/g, "/").replace(/\/+$/, "").split("/");
+  const idx = parts.lastIndexOf(".ac");
+  if (idx < 0) return null;
+  const sep = replicaPath.includes("\\") ? "\\" : "/";
+  return parts.slice(0, idx + 1).join(sep);
+}
+
+/** Display-only: the matrix dir `<workspace>/_agent_<name>` for a WG replica path, or null. */
+export function deriveMatrixRoot(replicaPath: string | null | undefined): string | null {
+  if (!replicaPath) return null;
+  const workspace = deriveWorkspaceRoot(replicaPath);
+  if (!workspace) return null;
+  const parts = replicaPath.replace(/\\/g, "/").replace(/\/+$/, "").split("/");
+  const leaf = parts[parts.length - 1] ?? "";
+  const parent = parts[parts.length - 2] ?? "";
+  if (!/^__agent_/.test(leaf) || !/^wg-/.test(parent)) return null;
+  const name = leaf.replace(/^__agent_/, "");
+  const sep = replicaPath.includes("\\") ? "\\" : "/";
+  return `${workspace}${sep}_agent_${name}`;
 }
 
 /**
- * Display-only preview of `%AC_ROOT%` expansion against a known replica root.
- * Returns the value unchanged when no root is available — the backend performs
- * the authoritative expansion and absolute-path validation at launch.
+ * Display-only preview of AC placeholder expansion against a known replica root.
+ * Workspace and matrix are derived from the replica path. Returns the value
+ * unchanged when no replica root is available; the backend performs the
+ * authoritative expansion + absolute-path validation at launch.
  */
-export function expandAcRootPreview(
+export function expandAcPlaceholdersPreview(
   value: string,
-  acRoot: string | null | undefined,
+  replicaRoot: string | null | undefined,
 ): string {
-  if (!acRoot || !hasAcRootPlaceholder(value)) return value;
-  return value.split(AC_ROOT_PLACEHOLDER).join(acRoot);
+  if (!replicaRoot || !hasAcPlaceholder(value)) return value;
+  let out = value.split(AC_REPLICA_ROOT_PLACEHOLDER).join(replicaRoot);
+  const workspace = deriveWorkspaceRoot(replicaRoot);
+  if (workspace) out = out.split(AC_WORKSPACE_ROOT_PLACEHOLDER).join(workspace);
+  const matrix = deriveMatrixRoot(replicaRoot);
+  if (matrix) out = out.split(AC_MATRIX_ROOT_PLACEHOLDER).join(matrix);
+  return out;
 }
 
 export function resolveProfilePreview(
@@ -298,7 +335,7 @@ export function hasEnabledEnvKey(rows: CodingAgentEnv[], key: string): boolean {
 }
 
 /** Origin badge for an env value shown in the Config/Selection projections (#526/#527).
- *  - `system`   — AgentsCommander-managed home path (%AC_ROOT% placeholder on a known home key)
+ *  - `system`   — AgentsCommander-managed home path (an AC path placeholder on a known home key)
  *  - `accepted` — a user literal absolute path kept as-is (nothing to expand)
  *  - `profile`  — a value defined by the profile cell (the common case) */
 export type EnvOrigin = "system" | "profile" | "accepted";
@@ -318,12 +355,12 @@ function isLiteralAbsolutePath(value: string): boolean {
 }
 
 /** Classify a profile-cell env value's origin for its badge. A managed home key
- *  using %AC_ROOT% is AC-managed (`system`); a managed home key with a literal
+ *  using an AC path placeholder is AC-managed (`system`); a managed home key with a literal
  *  absolute path is a user-accepted override (`accepted`); everything else is a
  *  plain profile-defined value (`profile`). */
 export function profileEnvOrigin(key: string, value: string): EnvOrigin {
   if (MANAGED_HOME_ENV_KEYS.has(envKeyCompare(key))) {
-    if (hasAcRootPlaceholder(value)) return "system";
+    if (hasAcPlaceholder(value)) return "system";
     if (isLiteralAbsolutePath(value)) return "accepted";
   }
   return "profile";
@@ -339,7 +376,7 @@ export interface EffectiveEnvEntry {
  *  into the effective env that is actually set at launch (#527 Env / EFFECTIVE).
  *  Agent rows form the base (source `system` → system badge, user → accepted);
  *  profile env overrides on key collision and carries the `profile` origin.
- *  `%AC_ROOT%` is expanded for display when a replica root is known. */
+ *  AC path placeholders are expanded for display when a replica root is known. */
 export function effectiveEnvProjection(
   agentEnvs: CodingAgentEnv[] | undefined,
   profileEnv: Record<string, string> | undefined,
@@ -352,7 +389,7 @@ export function effectiveEnvProjection(
     if (!key) continue;
     byKey.set(envKeyCompare(key), {
       key,
-      value: expandAcRootPreview(row.value, acRoot),
+      value: expandAcPlaceholdersPreview(row.value, acRoot),
       origin: row.source === "system" ? "system" : "accepted",
     });
   }
@@ -361,7 +398,7 @@ export function effectiveEnvProjection(
     if (!key) continue;
     byKey.set(envKeyCompare(key), {
       key,
-      value: expandAcRootPreview(rawValue, acRoot),
+      value: expandAcPlaceholdersPreview(rawValue, acRoot),
       origin: profileEnvOrigin(key, rawValue),
     });
   }

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -14,8 +14,8 @@ import { automationAttrs } from "../../shared/automation-hooks";
 import {
   agentNameFromPathOrSession,
   effectiveEnvProjection,
-  expandAcRootPreview,
-  hasAcRootPlaceholder,
+  expandAcPlaceholdersPreview,
+  hasAcPlaceholder,
   isAcAgentPath,
   isCodexAgent,
   isWgReplicaPath,
@@ -212,10 +212,10 @@ const AgentPickerModal: Component<{
     return enabledLaunchCellFor(agent, effectivePreview().effectiveProfile);
   });
   // The cell command is the full invocation; an empty cell command falls back to
-  // the agent's base command. Display-only %AC_ROOT% expansion uses the replica root.
+  // the agent's base command. Display-only AC placeholder expansion uses the replica root.
   const projectedCommand = createMemo(() => {
     const cmd = profileCellCommandText(projectedCell()) || selectedAgent()?.command || "";
-    return expandAcRootPreview(cmd, acRoot());
+    return expandAcPlaceholdersPreview(cmd, acRoot());
   });
   // #527 Effective Projection: merged effective env (agent env + profile env) with
   // per-value origin badges, plus the chosen-pair resolution descriptors.
@@ -231,8 +231,8 @@ const AgentPickerModal: Component<{
       ? `${profileLabel(effectivePreview().requestedProfile)} → ${profileLabel(effectivePreview().effectiveProfile)} (fallback)`
       : "Direct match",
   );
-  const commandUsesAcRoot = createMemo(() =>
-    hasAcRootPlaceholder(profileCellCommandText(projectedCell()) || selectedAgent()?.command || ""),
+  const commandUsesAcPlaceholder = createMemo(() =>
+    hasAcPlaceholder(profileCellCommandText(projectedCell()) || selectedAgent()?.command || ""),
   );
   const providerDefaultPreview = (agent: AgentConfig) => {
     const current = settings();
@@ -775,10 +775,10 @@ const AgentPickerModal: Component<{
                     <span class="agent-projection-command-label">Invocation</span>
                     <span class="agent-projection-command-value">{projectedCommand() || "none"}</span>
                   </div>
-                  <Show when={commandUsesAcRoot()}>
+                  <Show when={commandUsesAcPlaceholder()}>
                     <div class="agent-projection-ph">
                       <span class="arrow">→</span>
-                      <span>%AC_ROOT% expands at launch; the backend validates the path.</span>
+                      <span>AC path placeholders expand at launch; the backend validates the path.</span>
                     </div>
                   </Show>
                   <Show when={selectedIsCodex() || selectedAgent()?.isolatedHome}>

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -4,6 +4,11 @@ import { render } from "solid-js/web";
 import SettingsModal from "./SettingsModal";
 import type { AppSettings } from "../../shared/types";
 import { SettingsAPI } from "../../shared/ipc";
+import {
+  AC_MATRIX_ROOT_PLACEHOLDER,
+  AC_REPLICA_ROOT_PLACEHOLDER,
+  AC_WORKSPACE_ROOT_PLACEHOLDER,
+} from "../../shared/profile-utils";
 
 vi.mock("../../shared/ipc", () => ({
   SettingsAPI: {
@@ -331,7 +336,7 @@ describe("SettingsModal automation hooks", () => {
     dispose();
   });
 
-  it("renders coding-agent rails, profile cards, command inputs, env rows, and badges", async () => {
+  it("renders coding-agent rails, profile cards, command inputs, env rows, badges, and placeholder help", async () => {
     vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
       agents: [
         {
@@ -401,6 +406,22 @@ describe("SettingsModal automation hooks", () => {
     expect(byTestId("settings.profileCard.0.A.env")).toBeTruthy();
     expect(byTestId<HTMLInputElement>("settings.profileCard.0.A.envRow.0.key").value).toBe("OPENAI_ORG");
     expect(byTestId<HTMLInputElement>("settings.profileCard.0.A.envRow.0.value").value).toBe("ac-prod");
+
+    // #576: an expanded profile card surfaces an always-visible "?" help button
+    // whose native tooltip + aria-label list the three AC path placeholder
+    // tokens. The expected tokens are the shared profile-utils constants (which
+    // mirror the backend), so this asserts the byte-for-byte match end to end.
+    const help = byTestId<HTMLButtonElement>("settings.profileCard.0.A.placeholderHelp");
+    expect(help.tagName).toBe("BUTTON");
+    expect(help.getAttribute("type")).toBe("button");
+    for (const token of [
+      AC_REPLICA_ROOT_PLACEHOLDER,
+      AC_WORKSPACE_ROOT_PLACEHOLDER,
+      AC_MATRIX_ROOT_PLACEHOLDER,
+    ]) {
+      expect(help.getAttribute("title")).toContain(token);
+      expect(help.getAttribute("aria-label")).toContain(token);
+    }
 
     // #538: codex has no B cell, but B no longer shows an "Add cell" / missing
     // box. The badge still honestly reports MISSING (codex's B falls back to its

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -560,7 +560,7 @@ describe("SettingsModal automation hooks", () => {
     dispose();
   });
 
-  it("renders the %AC_ROOT% template preview for env rows", async () => {
+  it("renders the %AC_REPLICA_ROOT% template preview for env rows", async () => {
     vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
       codingAgentProfiles: {
         schemaVersion: 2,
@@ -571,7 +571,7 @@ describe("SettingsModal automation hooks", () => {
             A: {
               enabled: true,
               command: "codex",
-              env: { CODEX_HOME: "%AC_ROOT%\\.codex\\agents\\codex" },
+              env: { CODEX_HOME: "%AC_REPLICA_ROOT%\\.codex\\agents\\codex" },
               notes: "",
             },
           },

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -15,6 +15,9 @@ import { sessionsStore } from "../stores/sessions";
 import { AGENT_PRESET_MAP, newAgentId } from "../../shared/agent-presets";
 import { mergeSettingsForSavePreservingProjects } from "./settings-save";
 import {
+  AC_MATRIX_ROOT_PLACEHOLDER,
+  AC_REPLICA_ROOT_PLACEHOLDER,
+  AC_WORKSPACE_ROOT_PLACEHOLDER,
   commandExecutableBasename,
   defaultInstructionsFilename,
   executableTokenBasename,
@@ -31,6 +34,18 @@ import {
 } from "../../shared/profile-utils";
 
 type ProfileCellEnvRow = { key: string; value: string };
+
+// #576: always-visible reference for the AC path placeholders usable in a
+// profile's command and env values. The token strings are taken from the shared
+// profile-utils constants so they match the backend (placeholders.rs) byte for
+// byte; the backend stays the authority for real expansion + validation at launch.
+const AC_PLACEHOLDER_HELP = [
+  "AC path placeholders (expand at launch):",
+  `${AC_REPLICA_ROOT_PLACEHOLDER} — this replica's working dir`,
+  `${AC_WORKSPACE_ROOT_PLACEHOLDER} — the .ac workspace root`,
+  `${AC_MATRIX_ROOT_PLACEHOLDER} — the canonical _agent_<name> dir`,
+  "Full details: docs/agent-matrix-conventions.md §5",
+].join("\n");
 
 const ENV_ORIGIN_LABEL: Record<string, string> = {
   system: "SYSTEM",
@@ -1641,7 +1656,19 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
         </div>
 
         <Show when={expanded()}>
-          <label class="settings-profile-field-label">Command</label>
+          <div class="settings-profile-field-label-row">
+            <label class="settings-profile-field-label">Command</label>
+            <button
+              type="button"
+              class="settings-field-help"
+              title={AC_PLACEHOLDER_HELP}
+              aria-label={AC_PLACEHOLDER_HELP}
+              data-ac-testid={`${cardId}.placeholderHelp`}
+              data-ac-role="button"
+            >
+              ?
+            </button>
+          </div>
           <input
             class="settings-input settings-profile-command"
             classList={{ invalid: Boolean(cellError()) }}

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -18,7 +18,7 @@ import {
   commandExecutableBasename,
   defaultInstructionsFilename,
   executableTokenBasename,
-  hasAcRootPlaceholder,
+  hasAcPlaceholder,
   hasEnabledEnvKey,
   isCodexAgent,
   nextAvailableProfileLetter,
@@ -1661,10 +1661,12 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
               {cellError()}
             </div>
           </Show>
-          <Show when={hasAcRootPlaceholder(command())}>
+          <Show when={hasAcPlaceholder(command())}>
             <div class="settings-profile-ph-hint" data-ac-testid={`${cardId}.command.placeholder`}>
-              <span class="settings-profile-ph-token">%AC_ROOT%</span> expands to this
-              replica&rsquo;s root at launch; the backend validates the result.
+              <span class="settings-profile-ph-token">%AC_REPLICA_ROOT%</span>,{" "}
+              <span class="settings-profile-ph-token">%AC_WORKSPACE_ROOT%</span>, and{" "}
+              <span class="settings-profile-ph-token">%AC_MATRIX_ROOT%</span> expand at
+              launch; the backend validates the result.
             </div>
           </Show>
 
@@ -1719,14 +1721,14 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                   >
                     &#x2715;
                   </button>
-                  <Show when={hasAcRootPlaceholder(row.value)}>
+                  <Show when={hasAcPlaceholder(row.value)}>
                     <div
                       class="settings-profile-ph-preview"
                       data-ac-testid={`${cardId}.envRow.${rowIndex()}.placeholder`}
                       data-ac-role="status"
                     >
                       <span class="arrow">&rarr;</span>
-                      <span>expands to this replica&rsquo;s root at launch</span>
+                      <span>AC path placeholders expand at launch</span>
                     </div>
                   </Show>
                 </div>

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -1472,6 +1472,39 @@ html.light-theme .root-agent-avatar {
   color: var(--sidebar-fg-dim);
 }
 
+.settings-profile-field-label-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* #576: compact always-visible "?" that surfaces the AC path placeholder
+   reference via a native title tooltip + aria-label (mirrors the existing
+   `title=` hover-help in this modal). Opacity-based separation, no border, per
+   the industrial-dark UI. */
+.settings-field-help {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--sidebar-fg-dim);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: help;
+}
+
+.settings-field-help:hover {
+  background: var(--sidebar-accent, #00d4ff);
+  color: var(--sidebar-bg, #0b0f14);
+}
+
 .settings-profile-command {
   width: 100%;
   font-family: "Cascadia Code", "JetBrains Mono", monospace;


### PR DESCRIPTION
## Summary

Implements #576: profile path placeholders for command/env, plus the OpenCode config-dir auto-create that makes the feature usable end to end.

**Breaking change (no alias, intentional):**
- Renamed `%AC_ROOT%` → `%AC_REPLICA_ROOT%` (the replica / launch-cwd dir). No back-compat — a leftover `%AC_ROOT%` now fails at launch ("unknown placeholder marker") and at CODEX_HOME save-time.

**New placeholders:**
- `%AC_WORKSPACE_ROOT%` → the `.ac` workspace root.
- `%AC_MATRIX_ROOT%` → the origin Agent Matrix dir (`<workspace>\_agent_<name>`).

**Single source of truth:** `AC_PLACEHOLDER_TOKENS` in `placeholders.rs`, consumed by the detection gate and the CODEX_HOME validators (no list drift). Struct field `ac_root` renamed to `replica_root` (+ `workspace_root`/`matrix_root`).

**OpenCode config-dir auto-create:** AC now `create_dir_all`s the resolved `OPENCODE_CONFIG_DIR` before spawn (when the launch command runs opencode and the value is a local absolute path), mirroring `compute_codex_home`. Without this, opencode exits 1 — it writes `.gitignore` into the dir at startup and does not create the dir. Best-effort (warn + continue on failure).

**Frontend:** `profile-utils.ts` mirror (detection + preview for all 3 tokens), helptext updated in `SettingsModal` + `AgentPickerModal`, and a new "?" help button next to the Command field listing the 3 tokens (built from the shared constants, so it can't drift from the backend).

**Docs:** `docs/agent-matrix-conventions.md` §5 documents all 3 tokens, the workspace/replica/matrix validity asymmetry, and the breaking change.

## Testing
- Full Rust suite green (`cargo test --lib --bins --tests`, 0 failed); `cargo clippy --all-targets` 0 warnings.
- Frontend `tsc --noEmit` exit 0; `vitest` all green.
- Adversarial review (grinch) on the plan, the implementation, every re-sync, the "?" help button, and the auto-create + its follow-up findings fix — all PASS.
- OpenCode exit-1 root cause reproduced and fixed (dir absent → exit 1; dir auto-created → boots).
- Re-synced with `origin/main` twice (PR #577/#573 and PR #579/#551) — both features coexist green.
- User manual test of the wg-6 build in `0_AC`.

## Follow-ups (not in this PR)
- #578 — pre-existing `strip_extended_prefix` UNC-path handling bug (out of scope).

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)
