### PR TITLE
feat(coordinator): unify idle badge & team auto-close on one clock (#580)

### DIFF
--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -110,9 +110,12 @@ pub struct AcAgentReplica {
     /// covers WG-aware suffix matching that simple `originProject/name`
     /// comparison on the frontend misses. See issue #69.
     pub is_coordinator: bool,
-    /// #552 RFC3339 timestamp of the user's last message to this coordinator,
-    /// or None. Only meaningful when `is_coordinator`. Read from the persisted
-    /// CoordinatorClocks store keyed by FQN.
+    /// #552/#580 RFC3339 timestamp of the unified team-idle anchor
+    /// `max(last_user_message_at, last_activity_at)` for this coordinator, or
+    /// None. Only meaningful when `is_coordinator`. The badge displays and
+    /// auto-close triggers on this value (closed time counts). The field keeps
+    /// its #552 name (rename to `idleSinceAt` deferred, Decision C). Read from
+    /// the persisted CoordinatorClocks store keyed by FQN.
     pub last_user_message_at: Option<String>,
     /// #552 RFC3339 timestamp this coordinator's team was auto-closed for
     /// inactivity, or None. Only meaningful when `is_coordinator`. Drives the
@@ -1132,8 +1135,13 @@ pub async fn discover_ac_agents(
                                 } else {
                                     None
                                 };
+                                // (#580) the badge field carries the unified idle
+                                // anchor max(user, activity) (rename deferred,
+                                // Decision C) so a dormant/just-loaded row shows the
+                                // real accumulated idle (closed time included), not
+                                // just the user-message age.
                                 let last_user_message_at = clock_entry
-                                    .and_then(|e| e.last_user_message_at)
+                                    .and_then(|e| e.idle_anchor())
                                     .map(|dt| dt.to_rfc3339());
                                 let auto_closed_at = clock_entry
                                     .and_then(|e| e.auto_closed_at)
@@ -1621,8 +1629,12 @@ pub async fn discover_project(
                         } else {
                             None
                         };
+                        // (#580) the badge field carries the unified idle anchor
+                        // max(user, activity) (rename deferred, Decision C) so a
+                        // dormant/just-loaded row shows the real accumulated idle
+                        // (closed time included), not just the user-message age.
                         let last_user_message_at = clock_entry
-                            .and_then(|e| e.last_user_message_at)
+                            .and_then(|e| e.idle_anchor())
                             .map(|dt| dt.to_rfc3339());
                         let auto_closed_at = clock_entry
                             .and_then(|e| e.auto_closed_at)

--- a/src-tauri/src/config/coordinator_clocks.rs
+++ b/src-tauri/src/config/coordinator_clocks.rs
@@ -11,16 +11,27 @@ use serde::{Deserialize, Serialize};
 const COALESCE_SECS: i64 = 10;
 
 /// Persisted per-coordinator state, keyed by the coordinator FQN
-/// (`<project>:<wg>/<agent>`). One entry holds BOTH #552 persisted facts: the
-/// badge clock (`last_user_message_at`) and the auto-closed marker
-/// (`auto_closed_at`). Both are wall-clock, persisted, FQN-keyed, and survive
-/// restart, so they share one map / one file (one source of truth).
+/// (`<project>:<wg>/<agent>`). One entry holds the persisted facts behind the
+/// unified idle counter (#580): the user-message clock (`last_user_message_at`),
+/// the last-real-activity clock (`last_activity_at`), and the auto-closed marker
+/// (`auto_closed_at`). All are wall-clock, persisted, FQN-keyed, and survive
+/// restart, so they share one map / one file (one source of truth). The badge and
+/// auto-close both read the unified anchor
+/// `team_idle_since = max(last_user_message_at, last_activity_at)`.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClockEntry {
     /// Badge clock: time of the user's last message to this coordinator.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_user_message_at: Option<DateTime<Utc>>,
+    /// (#580) Wall-clock of the last REAL team activity (any member or the
+    /// coordinator), advanced by the auto-close evaluator from the in-memory
+    /// silence clock. With `last_user_message_at` it forms the unified idle
+    /// anchor `team_idle_since = max(last_user_message_at, last_activity_at)`,
+    /// which the badge displays and auto-close triggers on. Persisted so the
+    /// counter survives restart (closed time counts).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_activity_at: Option<DateTime<Utc>>,
     /// Auto-closed marker: set by the auto-close task when this coordinator's
     /// team was terminated for inactivity; cleared on reopen. `Some` => show
     /// the "auto-closed" pill. Only the task sets it, which is what
@@ -28,6 +39,20 @@ pub struct ClockEntry {
     /// error exit.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_closed_at: Option<DateTime<Utc>>,
+}
+
+impl ClockEntry {
+    /// (#580) The unified team-idle anchor for this coordinator: the newer of the
+    /// user-message and last-activity clocks (`max`), or None if neither is set.
+    /// The badge displays and auto-close triggers on this value. Single source for
+    /// the max rule; mirrors `auto_close::team_idle_since_secs`, which folds the
+    /// same two components as i64 seconds on the evaluator's hot path.
+    pub fn idle_anchor(&self) -> Option<DateTime<Utc>> {
+        [self.last_user_message_at, self.last_activity_at]
+            .into_iter()
+            .flatten()
+            .max()
+    }
 }
 
 /// Persisted per-coordinator clocks store. ON DISK this is the flat map
@@ -69,6 +94,7 @@ impl CoordinatorClocks {
             fqn.to_string(),
             ClockEntry {
                 last_user_message_at: Some(now),
+                last_activity_at: None,
                 auto_closed_at: None,
             },
         );
@@ -79,6 +105,25 @@ impl CoordinatorClocks {
     /// Badge clock accessor.
     pub fn last_user_message_at(&self, fqn: &str) -> Option<DateTime<Utc>> {
         self.map.get(fqn).and_then(|e| e.last_user_message_at)
+    }
+
+    /// (#580) Last-real-activity clock accessor.
+    pub fn last_activity_at(&self, fqn: &str) -> Option<DateTime<Utc>> {
+        self.map.get(fqn).and_then(|e| e.last_activity_at)
+    }
+
+    /// (#580) Advance `last_activity_at` for `fqn` to `candidate` iff it is newer
+    /// than the stored value (monotonic forward). Returns true (and dirties the
+    /// store) only when it actually moved, so an idle team (stable candidate) does
+    /// not churn the file each tick. Preserves last_user_message_at / auto_closed_at.
+    pub fn note_activity(&mut self, fqn: &str, candidate: DateTime<Utc>) -> bool {
+        let entry = self.map.entry(fqn.to_string()).or_default();
+        if entry.last_activity_at.is_none_or(|prev| candidate > prev) {
+            entry.last_activity_at = Some(candidate);
+            self.dirty = true;
+            return true;
+        }
+        false
     }
 
     /// Auto-closed marker accessor.
@@ -284,6 +329,82 @@ mod tests {
         );
     }
 
+    #[test]
+    fn note_activity_advances_monotonic_forward_only() {
+        let mut clocks = CoordinatorClocks::default();
+        let fqn = "proj:wg-1-team/coord";
+
+        // First activity: None -> Some advances and dirties.
+        assert!(clocks.note_activity(fqn, ts(100)));
+        assert_eq!(clocks.last_activity_at(fqn), Some(ts(100)));
+        assert!(clocks.take_dirty(), "a real advance dirties the store");
+
+        // A newer candidate advances; clear dirty to isolate the no-op checks.
+        assert!(clocks.note_activity(fqn, ts(200)));
+        assert_eq!(clocks.last_activity_at(fqn), Some(ts(200)));
+        assert!(clocks.take_dirty(), "a forward advance dirties the store");
+
+        // An older candidate is a no-op (monotonic forward) and does not dirty.
+        assert!(!clocks.note_activity(fqn, ts(150)));
+        assert_eq!(clocks.last_activity_at(fqn), Some(ts(200)));
+        assert!(!clocks.take_dirty(), "an older candidate must not dirty the store");
+
+        // An equal candidate is also a no-op (advance is strictly-newer).
+        assert!(!clocks.note_activity(fqn, ts(200)));
+        assert_eq!(clocks.last_activity_at(fqn), Some(ts(200)));
+        assert!(!clocks.take_dirty(), "an equal candidate must not dirty the store");
+    }
+
+    #[test]
+    fn note_activity_preserves_user_message_and_auto_closed() {
+        let mut clocks = CoordinatorClocks::default();
+        let fqn = "proj:wg-1-team/coord";
+
+        clocks.note_user_message(fqn, ts(0));
+        clocks.mark_auto_closed(fqn, ts(1));
+        // Advancing activity must touch ONLY last_activity_at.
+        assert!(clocks.note_activity(fqn, ts(500)));
+        assert_eq!(clocks.last_activity_at(fqn), Some(ts(500)));
+        assert_eq!(
+            clocks.last_user_message_at(fqn),
+            Some(ts(0)),
+            "note_activity must not touch last_user_message_at"
+        );
+        assert_eq!(
+            clocks.auto_closed_at(fqn),
+            Some(ts(1)),
+            "note_activity must not touch auto_closed_at"
+        );
+    }
+
+    #[test]
+    fn idle_anchor_is_max_of_present_components() {
+        assert_eq!(ClockEntry::default().idle_anchor(), None);
+
+        let user_only = ClockEntry {
+            last_user_message_at: Some(ts(100)),
+            ..Default::default()
+        };
+        assert_eq!(user_only.idle_anchor(), Some(ts(100)));
+
+        let activity_only = ClockEntry {
+            last_activity_at: Some(ts(200)),
+            ..Default::default()
+        };
+        assert_eq!(activity_only.idle_anchor(), Some(ts(200)));
+
+        let both = ClockEntry {
+            last_user_message_at: Some(ts(100)),
+            last_activity_at: Some(ts(200)),
+            ..Default::default()
+        };
+        assert_eq!(
+            both.idle_anchor(),
+            Some(ts(200)),
+            "anchor is the max of the two present components"
+        );
+    }
+
     /// B1/H1 trap: exercise the REAL save_map_to + load_from pair (NOT a
     /// hand-rolled map round-trip) so an asymmetry between serialize and
     /// deserialize is caught. Asserts BOTH ClockEntry fields survive.
@@ -297,14 +418,16 @@ mod tests {
             "proj:wg-1-team/coord".to_string(),
             ClockEntry {
                 last_user_message_at: Some(ts(0) + Duration::minutes(45)),
+                last_activity_at: Some(ts(0) + Duration::minutes(50)),
                 auto_closed_at: Some(ts(0) + Duration::minutes(60)),
             },
         );
-        // A second entry exercising the skip_serializing_if absence of one field.
+        // A second entry exercising the skip_serializing_if absence of two fields.
         original.insert(
             "proj:wg-2-team/coord".to_string(),
             ClockEntry {
                 last_user_message_at: Some(ts(0)),
+                last_activity_at: None,
                 auto_closed_at: None,
             },
         );
@@ -317,15 +440,21 @@ mod tests {
             original,
             "the loaded map must equal the saved map (save/load symmetry)"
         );
-        // Spot-check both fields explicitly via the accessors.
+        // Spot-check all three fields explicitly via the accessors.
         assert_eq!(
             loaded.last_user_message_at("proj:wg-1-team/coord"),
             Some(ts(0) + Duration::minutes(45))
         );
         assert_eq!(
+            loaded.last_activity_at("proj:wg-1-team/coord"),
+            Some(ts(0) + Duration::minutes(50)),
+            "last_activity_at must survive save/load (#580)"
+        );
+        assert_eq!(
             loaded.auto_closed_at("proj:wg-1-team/coord"),
             Some(ts(0) + Duration::minutes(60))
         );
+        assert_eq!(loaded.last_activity_at("proj:wg-2-team/coord"), None);
         assert_eq!(loaded.auto_closed_at("proj:wg-2-team/coord"), None);
     }
 }

--- a/src-tauri/src/pty/idle_detector.rs
+++ b/src-tauri/src/pty/idle_detector.rs
@@ -17,6 +17,12 @@ pub struct IdleDetector {
     /// input, and inter-agent delivery. Never read by the idle-dot watcher, so
     /// it cannot mask #260 idle detection.
     silence: Arc<Mutex<HashMap<Uuid, Instant>>>,
+    /// (#580) Per-session "alive since" clock: the `Instant` the PTY was
+    /// registered (spawned). Mirrors `silence` (seeded in `register_session`,
+    /// cleared in `remove_session`). Read via `alive_age` so auto-close can apply
+    /// WAKE_GRACE: a freshly-woken session is neither kill-eligible nor allowed to
+    /// advance the persisted idle anchor until it is alive past the grace.
+    registered_at: Arc<Mutex<HashMap<Uuid, Instant>>>,
     idle_set: Arc<Mutex<HashSet<Uuid>>>,
     resize_grace: Arc<Mutex<HashMap<Uuid, Instant>>>,
     /// Per-session idle tuning, populated by `register_session` at PTY spawn.
@@ -67,6 +73,7 @@ impl IdleDetector {
         Arc::new(Self {
             activity: Arc::new(Mutex::new(HashMap::new())),
             silence: Arc::new(Mutex::new(HashMap::new())),
+            registered_at: Arc::new(Mutex::new(HashMap::new())),
             idle_set: Arc::new(Mutex::new(HashSet::new())),
             resize_grace: Arc::new(Mutex::new(HashMap::new())),
             tuning: Arc::new(Mutex::new(HashMap::new())),
@@ -103,6 +110,12 @@ impl IdleDetector {
         // spawn race; see auto_close.rs). Independent of the #260 activity seed
         // above, which is gated on `seed_initial_activity`.
         self.silence
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(session_id, Instant::now());
+        // (#580) seed the alive-since clock alongside silence so auto-close can
+        // apply WAKE_GRACE (kill-eligibility / anchor-advance gating) from spawn.
+        self.registered_at
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .insert(session_id, Instant::now());
@@ -190,10 +203,27 @@ impl IdleDetector {
             .and_then(|&t| now.checked_duration_since(t))
     }
 
+    /// (#580) Time since this session's PTY was registered (spawned), or None if
+    /// untracked. Used by auto-close to apply WAKE_GRACE: a freshly-woken session
+    /// is neither kill-eligible nor allowed to advance the persisted idle anchor
+    /// until alive past the grace (so wake-time scrollback repaint cannot reset it).
+    pub fn alive_age(&self, session_id: Uuid) -> Option<Duration> {
+        let now = Instant::now();
+        self.registered_at
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&session_id)
+            .and_then(|&t| now.checked_duration_since(t))
+    }
+
     /// Remove a session from tracking (called on session destroy).
     pub fn remove_session(&self, session_id: Uuid) {
         self.activity.lock().unwrap().remove(&session_id);
         self.silence
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&session_id);
+        self.registered_at
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(&session_id);
@@ -470,6 +500,55 @@ mod tests {
         assert!(
             !detector.silence.lock().unwrap().contains_key(&id),
             "remove_session must drop the silence entry"
+        );
+    }
+
+    /// (#580): register_session seeds registered_at; alive_age is Some after
+    /// register and None after remove_session (the WAKE_GRACE clock lifecycle).
+    #[test]
+    fn register_session_seeds_registered_at_and_alive_age() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let id = Uuid::new_v4();
+
+        assert!(
+            detector.alive_age(id).is_none(),
+            "an unregistered session has no alive age"
+        );
+
+        detector.register_session(id, IdleTuning::DEFAULT);
+        assert!(
+            detector.registered_at.lock().unwrap().contains_key(&id),
+            "register_session must seed registered_at (#580)"
+        );
+        assert!(
+            detector.alive_age(id).is_some(),
+            "a registered session has an alive age"
+        );
+
+        detector.remove_session(id);
+        assert!(
+            !detector.registered_at.lock().unwrap().contains_key(&id),
+            "remove_session must drop the registered_at entry"
+        );
+        assert!(
+            detector.alive_age(id).is_none(),
+            "alive_age is None after remove_session"
+        );
+    }
+
+    /// (#580): alive_age grows monotonically (non-decreasing).
+    #[test]
+    fn alive_age_is_monotonic() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let id = Uuid::new_v4();
+        detector.register_session(id, IdleTuning::DEFAULT);
+
+        let first = detector.alive_age(id).expect("tracked after register");
+        std::thread::sleep(Duration::from_millis(10));
+        let second = detector.alive_age(id).expect("still tracked");
+        assert!(
+            second >= first,
+            "alive age must be monotonic non-decreasing ({second:?} >= {first:?})"
         );
     }
 }

--- a/src-tauri/src/session/auto_close.rs
+++ b/src-tauri/src/session/auto_close.rs
@@ -2,26 +2,40 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use tauri::{AppHandle, Emitter, Manager};
 use uuid::Uuid;
 
+use crate::config::coordinator_clocks::CoordinatorClocksState;
 use crate::config::settings::SettingsState;
 use crate::pty::idle_detector::IdleDetector;
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
 
 const TICK: Duration = Duration::from_secs(60);
+/// (#580) A just-woken session replays scrollback for ~1-2s; exclude its first
+/// REPAINT_GRACE of life from the idle-anchor advance so reopening an abandoned
+/// team cannot reset its persisted idle. Feeds `member_post_repaint_silence`.
+const REPAINT_GRACE: Duration = Duration::from_secs(10);
+/// (#580) A session is not kill-eligible until alive past WAKE_GRACE, so a
+/// just-woken (or wake-on-restore) team is visible >=30s before any auto-close.
+/// MUST be > REPAINT_GRACE (a member protects its team via the anchor before it
+/// can be killed) and is also the spawn-race guard (untracked -> not established).
+const WAKE_GRACE: Duration = Duration::from_secs(30);
 
 /// Spawn the auto-close watcher. Mirrors MailboxPoller/LoopScheduler::start
 /// (lib.rs): a tokio task with a `select!` on the shutdown token.
 pub fn start(app: AppHandle, shutdown: crate::shutdown::ShutdownSignal) {
     tauri::async_runtime::spawn(async move {
+        // (#580) per-team last-emitted anchor (seconds) for the badge dedup;
+        // task-local, self-bounded via `retain` in `tick`.
+        let mut last_emitted: HashMap<String, i64> = HashMap::new();
         loop {
             tokio::select! {
                 biased;
                 _ = shutdown.token().cancelled() => break,
                 _ = tokio::time::sleep(TICK) => {
-                    tick(&app).await;
+                    tick(&app, &mut last_emitted).await;
                     flush_clocks(&app); // debounced disk flush for the badge store
                 }
             }
@@ -29,36 +43,75 @@ pub fn start(app: AppHandle, shutdown: crate::shutdown::ShutdownSignal) {
     });
 }
 
-/// Pure decision: team keys whose EVERY member is silent past the timeout.
-/// `members` = (session_id, team_key) for agent-owned LIVE-PTY sessions only.
-/// `age_of(id)` returns the silence age (None = untracked live session = a
-/// spawn race -> treat as NOT silent so we never kill a brand-new session).
-/// Unit-testable without Tauri.
-fn teams_to_close(
-    members: &[(Uuid, String)],
-    timeout: Duration,
-    age_of: &dyn Fn(Uuid) -> Option<Duration>,
-) -> Vec<Uuid> {
-    let mut by_team: HashMap<&str, Vec<Uuid>> = HashMap::new();
-    for (id, key) in members {
-        by_team.entry(key.as_str()).or_default().push(*id);
-    }
-    let mut to_close = Vec::new();
-    for (_team, ids) in by_team {
-        if ids.is_empty() {
-            continue;
-        }
-        let all_silent = ids
-            .iter()
-            .all(|id| age_of(*id).map(|a| a > timeout).unwrap_or(false));
-        if all_silent {
-            to_close.extend(ids);
-        }
-    }
-    to_close
+/// (#580) Effective "post-repaint" silence for ONE live member, or None if the
+/// member must NOT advance the idle anchor this tick. None when:
+///   - untracked (alive_age or silence_age missing) -> spawn race, ignore;
+///   - alive <= REPAINT_GRACE (still inside the wake-repaint window);
+///   - the member's LAST output landed inside its repaint window
+///     (silence_age >= alive_age - REPAINT_GRACE) -> that output was scrollback
+///     replay (or nothing genuine has happened since), so it must not reset the
+///     persisted idle of an abandoned-then-reopened team.
+///
+/// Some(silence_age) ONLY when the last output is genuine post-repaint activity.
+/// Pure; this is the E1 fix and gets its own boundary-tested unit (§8.1).
+fn member_post_repaint_silence(
+    alive_age: Option<Duration>,
+    silence_age: Option<Duration>,
+    repaint_grace: Duration,
+) -> Option<Duration> {
+    let alive = alive_age?;
+    let silence = silence_age?;
+    let window = alive.checked_sub(repaint_grace)?; // None if alive <= grace
+    (silence < window).then_some(silence)
 }
 
-async fn tick(app: &AppHandle) {
+/// (#580) Per-team MIN post-repaint silence across the members, folding the
+/// per-member filter above. A member that does not contribute (untracked, inside
+/// its repaint window, or last output was scrollback replay) is SKIPPED; a team
+/// with NO contributing member is ABSENT from the map, so the caller leaves its
+/// persisted anchor FROZEN (no advance). Pure. Spawn-race safety lives entirely
+/// in the `established` KILL gate, not here.
+fn team_min_silence(
+    members: &[(Uuid, String)],
+    post_repaint_of: &dyn Fn(Uuid) -> Option<Duration>,
+) -> HashMap<String, Duration> {
+    let mut out: HashMap<String, Duration> = HashMap::new();
+    for (id, key) in members {
+        if let Some(age) = post_repaint_of(*id) {
+            out.entry(key.clone())
+                .and_modify(|m| {
+                    if age < *m {
+                        *m = age;
+                    }
+                })
+                .or_insert(age);
+        }
+    }
+    out
+}
+
+/// (#580) Unified idle anchor as whole UNIX seconds: max(user-message, activity).
+/// i64::MIN for an absent component so the present one wins; both absent -> MIN
+/// (caller treats as "no badge"). Pure.
+fn team_idle_since_secs(
+    last_user_message_at: Option<DateTime<Utc>>,
+    last_activity_at: Option<DateTime<Utc>>,
+) -> i64 {
+    let u = last_user_message_at.map_or(i64::MIN, |t| t.timestamp());
+    let a = last_activity_at.map_or(i64::MIN, |t| t.timestamp());
+    u.max(a)
+}
+
+/// (#580) KILL predicate for ONE team: closeable iff it has an ESTABLISHED
+/// member (alive past WAKE_GRACE, the visible-window + spawn-race gate) AND its
+/// unified anchor is idle past the timeout. `anchor_secs` is the output of
+/// `team_idle_since_secs`; i64::MIN (no anchor) is never closeable. Pure, so the
+/// kill rule is unit-tested directly (§8.1) instead of re-implemented in a test.
+fn team_is_closeable(established: bool, anchor_secs: i64, now_secs: i64, timeout_secs: i64) -> bool {
+    established && anchor_secs != i64::MIN && (now_secs - anchor_secs) > timeout_secs
+}
+
+async fn tick(app: &AppHandle, last_emitted: &mut HashMap<String, i64>) {
     let settings = app.state::<SettingsState>();
     let (enabled, timeout_min) = {
         let s = settings.read().await;
@@ -67,10 +120,9 @@ async fn tick(app: &AppHandle) {
             s.coordinator_auto_close_minutes,
         )
     };
-    if !enabled || timeout_min == 0 {
-        return;
-    }
-    let timeout = Duration::from_secs(u64::from(timeout_min) * 60);
+    // NOTE: the enabled/timeout gate moved DOWN: steps 1-2 (advance + badge
+    // emit) run even when auto-close is OFF (the badge is informational). Only
+    // step 3 (kill) is gated.
 
     let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
     let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
@@ -88,8 +140,12 @@ async fn tick(app: &AppHandle) {
             .filter(|(id, _)| pm.has_session(*id))
             .collect()
     };
-
-    let to_close = teams_to_close(&members, timeout, &|id| idle.silence_age(id));
+    // KILL filter: teams with any member alive past WAKE_GRACE (kill-eligible).
+    let established_teams: HashSet<String> = members
+        .iter()
+        .filter(|(id, _)| idle.alive_age(*id).is_some_and(|a| a >= WAKE_GRACE))
+        .map(|(_, k)| k.clone())
+        .collect();
 
     // #552 auto-closed badge: map each member id -> its team key, and snapshot
     // the live coordinator (fqn, cwd) per team BEFORE destroying (destroy removes
@@ -98,27 +154,120 @@ async fn tick(app: &AppHandle) {
         members.iter().map(|(id, k)| (*id, k.clone())).collect();
     let coord_refs = session_mgr.read().await.coordinator_refs_by_team().await;
 
-    let mut closed_teams: HashSet<String> = HashSet::new();
-    for id in to_close {
-        // M2 TOCTOU: re-check immediately before each destroy; skip if the
-        // session became active in the destroy window (cheap in-memory read).
-        if idle.silence_age(id).map(|a| a > timeout).unwrap_or(false) {
-            if let Err(e) = crate::commands::session::destroy_session_inner(app, id).await {
-                log::warn!("[auto-close] destroy {} failed: {}", &id.to_string()[..8], e);
-            } else {
-                log::info!(
-                    "[auto-close] terminated idle session {}",
-                    &id.to_string()[..8]
-                );
-                if let Some(team) = id_to_team.get(&id) {
-                    closed_teams.insert(team.clone());
+    let now_secs = Utc::now().timestamp();
+    let Some(clocks) = app.try_state::<CoordinatorClocksState>() else {
+        return;
+    };
+
+    // (1) ADVANCE last_activity_at from POST-REPAINT members (REPAINT_GRACE filter).
+    let team_sil = team_min_silence(&members, &|id| {
+        member_post_repaint_silence(idle.alive_age(id), idle.silence_age(id), REPAINT_GRACE)
+    });
+    {
+        let mut g = clocks.lock().unwrap_or_else(|e| e.into_inner());
+        for (team, (fqn, _)) in &coord_refs {
+            if let Some(sil) = team_sil.get(team) {
+                if let Some(c) =
+                    DateTime::<Utc>::from_timestamp(now_secs - sil.as_secs() as i64, 0)
+                {
+                    g.note_activity(fqn, c); // monotonic; dirties only on a real move
                 }
             }
-        } else {
+        }
+    } // guard dropped before any emit
+
+    // (2) BADGE: snapshot, RELEASE, then emit the unified anchor per team (deduped).
+    let snap = {
+        let g = clocks.lock().unwrap_or_else(|e| e.into_inner());
+        g.snapshot()
+    };
+    for (team, (fqn, cwd)) in &coord_refs {
+        let e = snap.get(fqn);
+        let anchor = team_idle_since_secs(
+            e.and_then(|e| e.last_user_message_at),
+            e.and_then(|e| e.last_activity_at),
+        );
+        log::debug!(
+            "[auto-close] team={} user={:?} activity={:?} anchor={} idle_s={}",
+            team,
+            e.and_then(|e| e.last_user_message_at),
+            e.and_then(|e| e.last_activity_at),
+            anchor,
+            if anchor == i64::MIN { 0 } else { now_secs - anchor }
+        ); // Decision D: debug-only, no new IPC field
+        if anchor != i64::MIN && last_emitted.get(team).copied() != Some(anchor) {
+            last_emitted.insert(team.clone(), anchor);
+            if let Some(dt) = DateTime::<Utc>::from_timestamp(anchor, 0) {
+                let _ = app.emit(
+                    "coordinator_clock_updated",
+                    serde_json::json!({ "replicaPath": cwd, "lastUserMessageAt": dt.to_rfc3339() }),
+                );
+            }
+        }
+    }
+    last_emitted.retain(|team, _| coord_refs.contains_key(team)); // bound the map
+
+    // (3) KILL: gated on the setting; SAME anchor; established + timeout.
+    if !enabled || timeout_min == 0 {
+        return;
+    }
+    let timeout_secs = i64::from(timeout_min) * 60;
+    // closeable iff: an ESTABLISHED member is present AND idle past timeout.
+    // `snap` already reflects step 1's advance (taken after it) -> reuse, no re-lock.
+    let to_close: Vec<Uuid> = members
+        .iter()
+        .filter(|(_, team)| {
+            let e = coord_refs.get(team).and_then(|(fqn, _)| snap.get(fqn));
+            let anchor = team_idle_since_secs(
+                e.and_then(|e| e.last_user_message_at),
+                e.and_then(|e| e.last_activity_at),
+            );
+            team_is_closeable(
+                established_teams.contains(team),
+                anchor,
+                now_secs,
+                timeout_secs,
+            )
+        })
+        .map(|(id, _)| *id)
+        .collect();
+
+    let mut closed_teams: HashSet<String> = HashSet::new();
+    for id in to_close {
+        // TOCTOU re-check (G2): skip if a user message advanced the anchor since
+        // the snapshot, OR this member emitted within REPAINT_GRACE. The second
+        // clause is REQUIRED: a user message to a NON-coordinator member or a
+        // member's first genuine byte only touches the in-memory silence clock,
+        // never last_user_message_at, so the anchor re-read alone is blind to it.
+        let fresh_anchor = {
+            let g = clocks.lock().unwrap_or_else(|e| e.into_inner());
+            match id_to_team.get(&id).and_then(|t| coord_refs.get(t)) {
+                Some((fqn, _)) => {
+                    team_idle_since_secs(g.last_user_message_at(fqn), g.last_activity_at(fqn))
+                }
+                None => i64::MIN,
+            }
+        }; // guard dropped before the destroy await
+        let anchor_fresh =
+            fresh_anchor != i64::MIN && (now_secs - fresh_anchor) <= timeout_secs;
+        let emitted_recently = idle.silence_age(id).is_some_and(|a| a < REPAINT_GRACE);
+        if anchor_fresh || emitted_recently {
             log::info!(
-                "[auto-close] {} became active during destroy window; skipped",
+                "[auto-close] {} re-activated during destroy window; skipped",
                 &id.to_string()[..8]
             );
+            continue;
+        }
+        if let Err(e) = crate::commands::session::destroy_session_inner(app, id).await {
+            log::warn!("[auto-close] destroy {} failed: {}", &id.to_string()[..8], e);
+        } else {
+            log::info!(
+                "[auto-close] terminated idle session {}",
+                &id.to_string()[..8]
+            );
+            if let Some(team) = id_to_team.get(&id) {
+                closed_teams.insert(team.clone());
+            }
         }
     }
 
@@ -182,76 +331,219 @@ mod tests {
         (id, team.to_string())
     }
 
+    fn ts(secs: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(1_700_000_000 + secs, 0).expect("valid timestamp")
+    }
+
+    // ---- member_post_repaint_silence (the E1 repaint-exclusion fix) ----
+
     #[test]
-    fn all_silent_team_returns_all_members() {
-        let a = Uuid::new_v4();
-        let b = Uuid::new_v4();
-        let members = vec![key(a, "proj:wg-1"), key(b, "proj:wg-1")];
-        let timeout = Duration::from_secs(60);
-        let out = teams_to_close(&members, timeout, &|_| Some(Duration::from_secs(120)));
-        assert_eq!(out.len(), 2);
-        assert!(out.contains(&a) && out.contains(&b));
+    fn post_repaint_none_when_untracked() {
+        let g = Duration::from_secs(10);
+        assert_eq!(
+            member_post_repaint_silence(None, Some(Duration::from_secs(5)), g),
+            None,
+            "missing alive_age (spawn race) -> excluded"
+        );
+        assert_eq!(
+            member_post_repaint_silence(Some(Duration::from_secs(60)), None, g),
+            None,
+            "missing silence_age (spawn race) -> excluded"
+        );
     }
 
     #[test]
-    fn one_fresh_member_protects_the_whole_team() {
+    fn post_repaint_none_when_inside_wake_window() {
+        let g = Duration::from_secs(10);
+        // alive < grace -> checked_sub None -> excluded.
+        assert_eq!(
+            member_post_repaint_silence(
+                Some(Duration::from_secs(5)),
+                Some(Duration::from_secs(0)),
+                g
+            ),
+            None
+        );
+        // alive == grace -> window 0 -> silence(0) < 0 is false -> excluded.
+        assert_eq!(
+            member_post_repaint_silence(
+                Some(Duration::from_secs(10)),
+                Some(Duration::from_secs(0)),
+                g
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn post_repaint_none_when_last_output_was_repaint_replay() {
+        // Case A (abandoned): alive 60, repaint burst ended at t=2 -> silence 58.
+        // window = 50; 58 >= 50 -> excluded, the persisted anchor stays frozen.
+        let g = Duration::from_secs(10);
+        assert_eq!(
+            member_post_repaint_silence(
+                Some(Duration::from_secs(60)),
+                Some(Duration::from_secs(58)),
+                g
+            ),
+            None,
+            "scrollback-only output must NOT advance the anchor"
+        );
+    }
+
+    #[test]
+    fn post_repaint_some_when_genuine_post_repaint_output() {
+        // Case B (genuine resume): alive 60, real work at ~t=25 -> silence 35.
+        // window = 50; 35 < 50 -> contributes Some(35).
+        let g = Duration::from_secs(10);
+        assert_eq!(
+            member_post_repaint_silence(
+                Some(Duration::from_secs(60)),
+                Some(Duration::from_secs(35)),
+                g
+            ),
+            Some(Duration::from_secs(35)),
+            "genuine post-repaint work must advance the anchor"
+        );
+    }
+
+    #[test]
+    fn post_repaint_boundary_is_excluded() {
+        // silence == alive - grace -> NOT strictly less -> excluded (strict <).
+        let g = Duration::from_secs(10);
+        assert_eq!(
+            member_post_repaint_silence(
+                Some(Duration::from_secs(60)),
+                Some(Duration::from_secs(50)),
+                g
+            ),
+            None,
+            "boundary silence == alive - grace is excluded"
+        );
+    }
+
+    // ---- team_min_silence (folds the per-member post-repaint filter) ----
+
+    #[test]
+    fn team_min_silence_takes_min_over_contributing_members() {
         let a = Uuid::new_v4();
         let b = Uuid::new_v4();
         let members = vec![key(a, "proj:wg-1"), key(b, "proj:wg-1")];
-        let timeout = Duration::from_secs(60);
-        // `a` is stale, `b` is fresh -> the team is NOT closed.
-        let out = teams_to_close(&members, timeout, &|id| {
+        let out = team_min_silence(&members, &|id| {
             if id == a {
-                Some(Duration::from_secs(120))
+                Some(Duration::from_secs(30))
             } else {
-                Some(Duration::from_secs(1))
+                Some(Duration::from_secs(10))
             }
         });
-        assert!(out.is_empty(), "a single active member must protect the team");
+        assert_eq!(out.get("proj:wg-1"), Some(&Duration::from_secs(10)));
     }
 
     #[test]
-    fn untracked_none_member_protects_the_team() {
+    fn team_min_silence_absent_when_no_member_contributes() {
         let a = Uuid::new_v4();
         let b = Uuid::new_v4();
         let members = vec![key(a, "proj:wg-1"), key(b, "proj:wg-1")];
-        let timeout = Duration::from_secs(60);
-        // `b` has no silence age (spawn race) -> treated as NOT silent.
-        let out = teams_to_close(&members, timeout, &|id| {
-            if id == a {
-                Some(Duration::from_secs(120))
-            } else {
-                None
-            }
-        });
-        assert!(out.is_empty(), "an untracked live member must protect the team");
+        // All members repaint-only / sub-grace / untracked -> None for each.
+        let out = team_min_silence(&members, &|_| None);
+        assert!(
+            !out.contains_key("proj:wg-1"),
+            "a team with no contributing member must be ABSENT (anchor frozen)"
+        );
+        assert!(out.is_empty());
     }
 
     #[test]
-    fn multiple_teams_are_isolated() {
-        let a = Uuid::new_v4(); // team 1, stale
-        let b = Uuid::new_v4(); // team 2, stale
-        let c = Uuid::new_v4(); // team 2, fresh
+    fn team_min_silence_isolates_teams() {
+        let a = Uuid::new_v4(); // team 1, contributes 40
+        let b = Uuid::new_v4(); // team 2, contributes 5
+        let c = Uuid::new_v4(); // team 2, untracked -> excluded
         let members = vec![
             key(a, "proj:wg-1"),
             key(b, "proj:wg-2"),
             key(c, "proj:wg-2"),
         ];
-        let timeout = Duration::from_secs(60);
-        let out = teams_to_close(&members, timeout, &|id| {
-            if id == c {
-                Some(Duration::from_secs(1))
+        let out = team_min_silence(&members, &|id| {
+            if id == a {
+                Some(Duration::from_secs(40))
+            } else if id == b {
+                Some(Duration::from_secs(5))
             } else {
-                Some(Duration::from_secs(120))
+                None
             }
         });
-        // team 1 (only `a`, stale) closes; team 2 protected by fresh `c`.
-        assert_eq!(out, vec![a]);
+        assert_eq!(out.get("proj:wg-1"), Some(&Duration::from_secs(40)));
+        assert_eq!(out.get("proj:wg-2"), Some(&Duration::from_secs(5)));
+    }
+
+    // ---- team_idle_since_secs (unified max(user, activity) anchor) ----
+
+    #[test]
+    fn idle_since_secs_picks_max_present_component() {
+        assert_eq!(team_idle_since_secs(Some(ts(100)), None), ts(100).timestamp());
+        assert_eq!(team_idle_since_secs(None, Some(ts(200))), ts(200).timestamp());
+        assert_eq!(
+            team_idle_since_secs(Some(ts(100)), Some(ts(200))),
+            ts(200).timestamp(),
+            "max of the two present components"
+        );
+        assert_eq!(
+            team_idle_since_secs(None, None),
+            i64::MIN,
+            "both absent -> MIN (no badge)"
+        );
+    }
+
+    // ---- team_is_closeable (the KILL predicate; replaces the teams_to_close tests) ----
+
+    #[test]
+    fn closeable_when_established_and_idle_past_timeout() {
+        let now = ts(10_000).timestamp();
+        let timeout = 3600; // 60 min
+        // 3700s idle > 3600s timeout.
+        let anchor = team_idle_since_secs(Some(ts(10_000 - 3700)), None);
+        assert!(team_is_closeable(true, anchor, now, timeout));
     }
 
     #[test]
-    fn empty_input_returns_empty() {
-        let out = teams_to_close(&[], Duration::from_secs(60), &|_| Some(Duration::from_secs(120)));
-        assert!(out.is_empty());
+    fn not_closeable_without_established_member() {
+        // wake grace: no member alive past WAKE_GRACE -> not established -> never closes.
+        let now = ts(10_000).timestamp();
+        let anchor = team_idle_since_secs(Some(ts(10_000 - 3700)), None);
+        assert!(
+            !team_is_closeable(false, anchor, now, 3600),
+            "no established member must protect the team (wake grace)"
+        );
+    }
+
+    #[test]
+    fn not_closeable_when_user_message_keeps_anchor_fresh() {
+        let now = ts(10_000).timestamp();
+        // Recent user message (60s ago) keeps the anchor fresh even though activity is old.
+        let anchor = team_idle_since_secs(Some(ts(10_000 - 60)), Some(ts(10_000 - 9000)));
+        assert!(
+            !team_is_closeable(true, anchor, now, 3600),
+            "a recent last_user_message_at must keep the team open"
+        );
+    }
+
+    #[test]
+    fn not_closeable_when_activity_recent() {
+        let now = ts(10_000).timestamp();
+        // Recent activity (120s ago) keeps the anchor fresh even though the user message is old.
+        let anchor = team_idle_since_secs(Some(ts(10_000 - 9000)), Some(ts(10_000 - 120)));
+        assert!(
+            !team_is_closeable(true, anchor, now, 3600),
+            "a recent last_activity_at must keep the team open"
+        );
+    }
+
+    #[test]
+    fn not_closeable_when_anchor_absent() {
+        let now = ts(10_000).timestamp();
+        assert!(
+            !team_is_closeable(true, i64::MIN, now, 3600),
+            "a team with no anchor (i64::MIN) is never closeable"
+        );
     }
 }

--- a/src/shared/coordinator-badge.ts
+++ b/src/shared/coordinator-badge.ts
@@ -10,15 +10,18 @@ export interface CoordinatorBadge {
 }
 
 /**
- * #552 Pure, timer-free badge derivation so it unit-tests cleanly. Minutes-only,
- * raw integer, NO h/d rollover (spec): 45m, 135m, 4320m. Color comes from the
- * global thresholds: `minutes >= red -> red`, else `>= yellow -> yellow`, else
- * green (red is tested first, so an inverted yellow>=red pair just collapses the
- * yellow band rather than misbehaving). The `Math.max(0, ...)` floor means clock
- * skew / a future-dated timestamp shows `0m`, never a negative value.
+ * #552/#580 Pure, timer-free badge derivation so it unit-tests cleanly. The
+ * input timestamp is the unified team-idle anchor (#580): minutes since the team
+ * was last truly active, not merely the user's last message (the param name is
+ * retained — rename deferred). Minutes-only, raw integer, NO h/d rollover (spec):
+ * 45m, 135m, 4320m. Color comes from the global thresholds: `minutes >= red ->
+ * red`, else `>= yellow -> yellow`, else green (red is tested first, so an
+ * inverted yellow>=red pair just collapses the yellow band rather than
+ * misbehaving). The `Math.max(0, ...)` floor means clock skew / a future-dated
+ * timestamp shows `0m`, never a negative value.
  *
  * Returns `null` when there is no usable timestamp (absent or unparseable), so
- * callers render nothing for a coordinator that has never been messaged.
+ * callers render nothing for a coordinator with no idle anchor yet.
  */
 export function coordinatorIdleBadge(
   lastUserMessageAtIso: string | undefined,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -526,8 +526,10 @@ export function onDiscoveryBranchUpdated(
   );
 }
 
-// #552 coordinator idle badge: a real user message to a coordinator resets its
-// badge clock; the backend emits this with the new RFC3339 timestamp. Mirrors
+// #552/#580 coordinator idle badge clock event. The backend emits the unified
+// team-idle anchor (#580: `max(last_user_message_at, last_activity_at)`) in the
+// `lastUserMessageAt` field — the field name is retained (rename deferred) but
+// it now means "team idle since", not just the user's last message. Mirrors
 // `ac_discovery_branch_updated` so ProjectPanel can patch the replica in place
 // without waiting for a full discovery reload.
 export function onCoordinatorClockUpdated(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -543,9 +543,13 @@ export interface AcAgentReplica {
   currentCodingAgentId?: string;
   /** #384: per-replica profile letter (`tooling.profile`, then legacy override). */
   currentProfile?: string;
-  /** #552 RFC3339 time of the user's last message to this coordinator, or
-   *  undefined. Only meaningful when `isCoordinator`. Drives the idle badge;
-   *  read from the persisted CoordinatorClocks store (survives restart + dormant). */
+  /** #552/#580 RFC3339 timestamp of the unified team-idle anchor, i.e. the
+   *  backend's `max(last_user_message_at, last_activity_at)` — the field now
+   *  means "team idle since" (reset when you message the coordinator, any member
+   *  is active, or the coordinator is active), NOT just the user's last message
+   *  (#580; rename to idleSinceAt deferred). `undefined` when none. Only
+   *  meaningful when `isCoordinator`. Drives the idle badge; read from the
+   *  persisted CoordinatorClocks store (survives restart + dormant). */
   lastUserMessageAt?: string;
   /** #552 RFC3339 time this coordinator's team was auto-closed for inactivity,
    *  or undefined. Only meaningful when `isCoordinator`. Drives the neutral

--- a/src/sidebar/components/ProjectPanel.idle-badge.test.tsx
+++ b/src/sidebar/components/ProjectPanel.idle-badge.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { settingsStore } from "../../shared/stores/settings";
+import { clockStore } from "../stores/clock";
+import type { AcAgentReplica } from "../../shared/types";
+
+// #580 — the coordinator idle counter and the AUTO-CLOSED pill are mutually
+// exclusive (the XOR gate, Section 7.1), and the tooltip's auto-close clause is
+// conditional on the setting (Section 7.2). These render the real ProjectPanel
+// through the FakeTransport harness and assert the DOM, per the
+// frontend-visual-verification discipline.
+
+const projectPath = "C:\\Project";
+const workgroupPath = `${projectPath}\\.ac\\wg-2-dev-team`;
+const coordPath = `${workgroupPath}\\__agent_dev-webpage-ui`;
+
+const IDLE_TOOLTIP_BASE =
+  "Time this team has been idle. Resets when you message the coordinator or any member is active (persists across restarts).";
+const IDLE_TOOLTIP_AUTOCLOSE = "The team auto-closes at the configured limit.";
+
+/** An RFC3339 anchor `minutes` before the badge clock's "now". Anchored to
+ *  `clockStore.nowMs` (the exact value the badge memo reads) so the rendered
+ *  minutes label is deterministic regardless of wall-clock at test time. */
+function isoMinutesAgo(minutes: number): string {
+  return new Date(clockStore.nowMs - minutes * 60_000).toISOString();
+}
+
+/** Discovery with a single coordinator replica carrying the given idle fields. */
+function coordDiscovery(coord: Partial<AcAgentReplica>) {
+  return discovery({
+    workgroups: [
+      {
+        name: "wg-2-dev-team",
+        path: workgroupPath,
+        task: null,
+        taskTitle: "Idle badge",
+        agents: [
+          {
+            name: "dev-webpage-ui",
+            path: coordPath,
+            repoPaths: [],
+            isCoordinator: true,
+            ...coord,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+describe("ProjectPanel coordinator idle badge (#580 XOR gate + conditional tooltip)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("shows only the AUTO-CLOSED pill when auto-closed, then restores the red 90m counter on reopen", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("get_settings", baseSettings({ coordinatorAutoCloseEnabled: true }));
+    // The coordinator has BOTH a 90-min idle anchor AND an auto-closed marker:
+    // the XOR gate must suppress the counter while the marker is present.
+    fake.resolve(
+      "discover_project",
+      coordDiscovery({ lastUserMessageAt: isoMinutesAgo(90), autoClosedAt: isoMinutesAgo(5) })
+    );
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      // Auto-closed → the gray pill renders and the minutes counter is gated off.
+      await waitFor(() => {
+        expect(rendered.root.querySelector(".coord-autoclosed")).not.toBeNull();
+        expect(rendered.root.querySelector(".coord-idle")).toBeNull();
+      });
+      expect(rendered.root.querySelector(".coord-autoclosed")?.textContent).toBe("AUTO-CLOSED");
+      expect(rendered.root.textContent).not.toContain("90m");
+
+      // Reopen (clear the marker, as the auto-close event does) → the pill
+      // disappears and the red 90m counter returns from the same anchor.
+      projectStore.updateCoordinatorAutoClosed(coordPath, null);
+      await waitFor(() => {
+        expect(rendered.root.querySelector(".coord-autoclosed")).toBeNull();
+        const counter = rendered.root.querySelector(".coord-idle");
+        expect(counter).not.toBeNull();
+        expect(counter?.classList.contains("red")).toBe(true);
+        expect(counter?.textContent).toBe("90m");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("appends the auto-close clause to the idle tooltip when coordinatorAutoCloseEnabled is true", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("get_settings", baseSettings({ coordinatorAutoCloseEnabled: true }));
+    fake.resolve("discover_project", coordDiscovery({ lastUserMessageAt: isoMinutesAgo(90) }));
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.querySelector(".coord-idle")).not.toBeNull());
+
+      const title = rendered.root.querySelector(".coord-idle")?.getAttribute("title") ?? "";
+      expect(title).toContain(IDLE_TOOLTIP_BASE);
+      expect(title).toContain(IDLE_TOOLTIP_AUTOCLOSE);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("omits the auto-close clause from the idle tooltip when coordinatorAutoCloseEnabled is false (badge still shown)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    // Decision 3: the badge stays visible when auto-close is OFF, but it will NOT
+    // close, so the tooltip must not assert that it auto-closes.
+    fake.resolve("get_settings", baseSettings({ coordinatorAutoCloseEnabled: false }));
+    fake.resolve("discover_project", coordDiscovery({ lastUserMessageAt: isoMinutesAgo(90) }));
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.querySelector(".coord-idle")).not.toBeNull());
+
+      const title = rendered.root.querySelector(".coord-idle")?.getAttribute("title") ?? "";
+      expect(title).toContain(IDLE_TOOLTIP_BASE);
+      expect(title).not.toContain("auto-closes");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1185,7 +1185,12 @@ const ProjectPanel: Component = () => {
               ? s.gitRepos
               : configuredReplicaRepoBadges(replica, wg);
           });
-          // #552 coordinator idle badge. A createMemo (NOT an IIFE — the IIFE
+          // #552/#580 coordinator idle badge. The value is now the unified
+          // team-idle anchor (#580): minutes since the whole team was last truly
+          // active — it pins to 0 when you message the coordinator, any member is
+          // active, or the coordinator is active. The backend carries that anchor
+          // in the EXISTING `lastUserMessageAt` field/event (rename deferred), so
+          // the FE derivation is unchanged. A createMemo (NOT an IIFE — the IIFE
           // froze; confirmed blocker) so it subscribes to clockStore.nowMs (the
           // live 30s tick) and settingsStore.current (threshold edits apply
           // instantly). replica.lastUserMessageAt is a plain prop read; a reset
@@ -1199,9 +1204,21 @@ const ProjectPanel: Component = () => {
                 )
               : null
           );
-          // #552 auto-closed pill: coexists with the minutes badge on a dormant
-          // row. Driven by the persisted autoClosedAt marker, patched in place.
+          // #552 auto-closed pill. Driven by the persisted autoClosedAt marker,
+          // patched in place. #580: MUTUALLY EXCLUSIVE with the minutes badge —
+          // when autoClosed() is true the counter is gated off (XOR below), so a
+          // closed team shows ONLY the gray AUTO-CLOSED pill; clearing the marker
+          // on reopen makes autoClosed() false and the counter returns.
           const autoClosed = createMemo(() => isCoord() && !!replica.autoClosedAt);
+          // #580 idle-badge tooltip. The auto-close clause is appended ONLY when
+          // the setting is enabled: Decision 3 keeps the badge (and its red >=60
+          // color) visible even when auto-close is OFF, where the team will NOT
+          // close — so an unconditional "auto-closes" claim would be wrong.
+          const idleBadgeTitle = () =>
+            "Time this team has been idle. Resets when you message the coordinator or any member is active (persists across restarts)." +
+            (settingsStore.current?.coordinatorAutoCloseEnabled
+              ? " The team auto-closes at the configured limit."
+              : "");
           const rowTestId = () =>
             `replica.row.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}`;
           const badgesTestId = () =>
@@ -1314,14 +1331,15 @@ const ProjectPanel: Component = () => {
                 </Show>
                 <span class="replica-item-name">{replica.originProject ? `${replica.name}@${replica.originProject}` : replica.name}</span>
                 <div class="ac-discovery-badges" data-ac-testid={badgesTestId()}>
-                  {/* #552: the coordinator idle (minutes) badge leads the row,
-                      with the neutral auto-closed pill immediately after it, so
-                      the two #552 badges render first before all other badges. */}
-                  <Show when={idleBadge()}>
+                  {/* #552/#580: the coordinator idle (minutes) badge leads the
+                      row; the neutral AUTO-CLOSED pill REPLACES it when the team
+                      is auto-closed (mutually exclusive — the #580 XOR gate), so
+                      exactly one of the two renders first, before all others. */}
+                  <Show when={!autoClosed() && idleBadge()}>
                     {(b) => (
                       <span
                         class={`ac-discovery-badge coord-idle ${b().colorClass}`}
-                        title="Time since your last message to this coordinator"
+                        title={idleBadgeTitle()}
                       >
                         {b().label}
                       </span>
@@ -1332,7 +1350,7 @@ const ProjectPanel: Component = () => {
                       class="ac-discovery-badge coord-autoclosed"
                       title="This team was auto-closed after inactivity. Reopen it to clear."
                     >
-                      auto-closed
+                      AUTO-CLOSED
                     </span>
                   </Show>
                   <Show when={runningPeers && runningPeers()!.length > 0}>

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -198,10 +198,12 @@ export const projectStore = {
     );
   },
 
-  /** #552 patch a coordinator replica's lastUserMessageAt from the clock event.
-   *  Match by NORMALIZED path (required, not a deviation: the event path is the
-   *  session working_directory, which can differ in slash/case from the
-   *  discovery path on Windows). Discovery reload self-heals on any miss. */
+  /** #552/#580 patch a coordinator replica's lastUserMessageAt (which now carries
+   *  the unified team-idle anchor, #580 — "team idle since", not just the user's
+   *  last message) from the clock event. Match by NORMALIZED path (required, not
+   *  a deviation: the event path is the session working_directory, which can
+   *  differ in slash/case from the discovery path on Windows). Discovery reload
+   *  self-heals on any miss. */
   updateCoordinatorClock(replicaPath: string, lastUserMessageAt: string) {
     const target = normalizePath(replicaPath);
     setProjects((prev) =>

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -4189,9 +4189,10 @@ html.light-theme .ac-discovery-badge.running-peer {
 }
 
 /* #552 auto-closed pill — NEUTRAL/muted on purpose so it reads as a state label
-   and stays distinct from the red idle badge (a dormant row can show BOTH).
-   Mirrors the muted `.disabled` badge; no border, per the industrial-dark
-   "separation by opacity, not borders" aesthetic. */
+   and stays distinct from the red idle badge. #580: the pill and the idle
+   counter are mutually exclusive (XOR gate), so a row shows one or the other,
+   never both. Mirrors the muted `.disabled` badge; no border, per the
+   industrial-dark "separation by opacity, not borders" aesthetic. */
 .ac-discovery-badge.coord-autoclosed {
   background: rgba(148, 163, 184, 0.14);
   color: #94a3b8;


### PR DESCRIPTION
Unifies the coordinator idle badge and team auto-close onto a single "team fully idle" counter.

## What changed
- The idle counter now resets to 0 (and stays at 0 while active) on ANY of: the user messages the coordinator, any team member is active (RUNNING), or the coordinator itself is active. It only climbs when the whole team is idle and the user isn't messaging.
- The badge displays this unified counter; auto-close fires on the SAME number (60-min default unchanged). An actively-working team never auto-closes.
- The counter persists across app restarts (wall-clock from a persisted anchor; closed time counts).
- An AUTO-CLOSED team hides the counter and shows only the gray AUTO-CLOSED pill (mutually exclusive); reopening restores the counter.

## Implementation
- **Backend** (`81a03a1`): `coordinator_clocks.rs` (persisted `last_activity_at` + `idle_anchor()`), `idle_detector.rs` (`registered_at` / `alive_age`), `auto_close.rs` (`REPAINT_GRACE=10s` / `WAKE_GRACE=30s`, two-filter advance/kill model, restructured tick, `team_is_closeable`), `ac_discovery.rs` (unified anchor at both emit sites). +19 backend unit tests.
- **Frontend** (`9c60923`): `ProjectPanel.tsx` XOR gate (AUTO-CLOSED replaces counter) + conditional tooltip; doc-comment-only updates elsewhere (no IPC/type shape change). +3 vitest tests.
- Re-synced onto latest `origin/main` (merge `fc609ac`, clean; coexists with #576/#581).

## Testing / review
- Designed via the full architect plan + dev/grinch consensus path (plan REV 3, `_plans/issue-580-unify-coordinator-idle-counter.md`).
- grinch adversarial review: **PASS** (4-case design verified against code, lock discipline, persistence, XOR gate; no #552 regression; G3 fast-resume residual documented + accepted).
- Gates green: `cargo build` / `cargo clippy -D warnings` clean, **1406 backend tests**, `tsc --noEmit` clean, **vitest 402**.
- shipper built + deployed `agentscommander_standalone_wg-1.exe` to `0_AC`; user authorized landing.
- Re-sync onto latest `main`: clean merge + focused grinch re-review **PASS**.

Follow-up: #582 (member spared by the `REPAINT_GRACE` skip can be briefly orphaned on a half-teardown — non-blocking, recoverable).

Closes #580
