### PR TITLE
feat(#574): reusable toast surfaces silent restart failures

### DIFF
--- a/src/shared/components/ToastHost.test.tsx
+++ b/src/shared/components/ToastHost.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "solid-js/web";
+import ToastHost from "./ToastHost";
+import { toastStore } from "../stores/toasts";
+
+function q<T extends HTMLElement = HTMLElement>(testId: string): T | null {
+  return document.body.querySelector<T>(`[data-ac-testid="${testId}"]`);
+}
+
+function qa(testId: string): HTMLElement[] {
+  return Array.from(
+    document.body.querySelectorAll<HTMLElement>(`[data-ac-testid="${testId}"]`),
+  );
+}
+
+function renderHost(): () => void {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  const dispose = render(() => <ToastHost />, root);
+  return () => {
+    dispose();
+    root.remove();
+  };
+}
+
+describe("ToastHost (#574)", () => {
+  let dispose: (() => void) | null = null;
+
+  afterEach(() => {
+    dispose?.();
+    dispose = null;
+    toastStore.clear();
+    document.body.replaceChildren();
+  });
+
+  it("renders an error toast with kind, role=alert, and the message text", () => {
+    dispose = renderHost();
+    toastStore.error("boom");
+    const item = q("toast.item");
+    expect(item).toBeTruthy();
+    expect(item?.getAttribute("data-ac-kind")).toBe("error");
+    expect(item?.getAttribute("role")).toBe("alert");
+    expect(item?.textContent ?? "").toContain("boom");
+  });
+
+  it("clicking the dismiss button removes the item", () => {
+    dispose = renderHost();
+    toastStore.error("boom");
+    expect(q("toast.item")).toBeTruthy();
+    q("toast.item.dismiss")!.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    expect(q("toast.item")).toBeNull();
+  });
+
+  it("renders one node per toast", () => {
+    dispose = renderHost();
+    toastStore.error("a");
+    toastStore.error("b");
+    expect(qa("toast.item")).toHaveLength(2);
+  });
+
+  it("data-ac-kind reflects each kind", () => {
+    dispose = renderHost();
+    toastStore.error("e");
+    toastStore.info("i");
+    toastStore.success("s");
+    const kinds = qa("toast.item").map((n) => n.getAttribute("data-ac-kind"));
+    expect(kinds).toEqual(["error", "info", "success"]);
+  });
+
+  it("exposes data-ac-toast-id matching the returned id (§15.8/Q5)", () => {
+    dispose = renderHost();
+    const id = toastStore.error("x");
+    expect(q("toast.item")?.getAttribute("data-ac-toast-id")).toBe(String(id));
+  });
+
+  it("a mousedown on the toast body does not reach a document listener (§15.6)", () => {
+    dispose = renderHost();
+    toastStore.error("boom");
+    const message = document.body.querySelector<HTMLElement>(".toast-item__message");
+    expect(message).toBeTruthy();
+
+    // Mirrors App.tsx's native document `mousedown` listener (handleRaiseTerminal).
+    const spy = vi.fn();
+    document.addEventListener("mousedown", spy);
+    try {
+      message!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+      // The item's native on:mousedown stopPropagation keeps the event below
+      // document, so the terminal-raise listener never fires.
+      expect(spy).not.toHaveBeenCalled();
+
+      // Control: a mousedown elsewhere DOES bubble to the document listener.
+      document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      document.removeEventListener("mousedown", spy);
+    }
+  });
+});

--- a/src/shared/components/ToastHost.tsx
+++ b/src/shared/components/ToastHost.tsx
@@ -1,0 +1,60 @@
+import { Component, For } from "solid-js";
+import { Portal } from "solid-js/web";
+import { toastStore, type ToastKind } from "../stores/toasts";
+
+const ROLE_BY_KIND: Record<ToastKind, "alert" | "status"> = {
+  error: "alert",
+  success: "status",
+  info: "status",
+};
+const ARIA_LIVE_BY_KIND: Record<ToastKind, "assertive" | "polite"> = {
+  error: "assertive",
+  success: "polite",
+  info: "polite",
+};
+
+const ToastHost: Component = () => {
+  // §15.6: clicking the toast body must NOT raise the terminal. The App's
+  // handleRaiseTerminal (App.tsx:82-95) is a NATIVE document `mousedown` listener
+  // that only excludes BUTTON, so the message span / item div would otherwise
+  // raise + focus the terminal on the standalone desktop sidebar. We use Solid's
+  // `on:mousedown` (a native listener attached directly to .toast-item) rather
+  // than the delegated `onMouseDown`: Solid delegates `mousedown` to `document`
+  // (web.cjs delegateEvents -> document.addEventListener), the SAME target as
+  // handleRaiseTerminal, and stopPropagation() does NOT stop sibling listeners on
+  // the same target. A native element-level listener stops the event below
+  // document, so neither Solid's delegation nor handleRaiseTerminal sees it. The
+  // dismiss button's separate `click` event is unaffected.
+  return (
+    <Portal>
+      <div class="toast-host" data-ac-testid="toast.host" data-ac-role="surface">
+        <For each={toastStore.items}>
+          {(toast) => (
+            <div
+              class={`toast-item toast-item--${toast.kind}`}
+              data-ac-testid="toast.item"
+              data-ac-kind={toast.kind}
+              data-ac-toast-id={toast.id}
+              role={ROLE_BY_KIND[toast.kind]}
+              aria-live={ARIA_LIVE_BY_KIND[toast.kind]}
+              on:mousedown={(e) => e.stopPropagation()}
+            >
+              <span class="toast-item__message">{toast.message}</span>
+              <button
+                class="toast-item__dismiss"
+                type="button"
+                aria-label="Dismiss notification"
+                data-ac-testid="toast.item.dismiss"
+                onClick={() => toastStore.dismiss(toast.id)}
+              >
+                &#xD7;
+              </button>
+            </div>
+          )}
+        </For>
+      </div>
+    </Portal>
+  );
+};
+
+export default ToastHost;

--- a/src/shared/stores/toasts.test.ts
+++ b/src/shared/stores/toasts.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { toastStore } from "./toasts";
+
+// The store is a module singleton, so every test must reset it. vi.useRealTimers()
+// is defensive: the timed cases install fake timers and a throw inside that window
+// could otherwise leak frozen timers into the next test.
+afterEach(() => {
+  vi.useRealTimers();
+  toastStore.clear();
+});
+
+describe("toastStore (#574)", () => {
+  it("push returns an id, items contains the toast, and kind defaults to info", () => {
+    const id = toastStore.push({ message: "hello" });
+    expect(typeof id).toBe("number");
+    expect(toastStore.items).toHaveLength(1);
+    expect(toastStore.items[0]).toMatchObject({ id, kind: "info", message: "hello" });
+  });
+
+  it("error toasts are sticky (no auto-dismiss past the non-error default)", async () => {
+    vi.useFakeTimers();
+    try {
+      toastStore.error("boom");
+      expect(toastStore.items).toHaveLength(1);
+      // Well past the 4000ms info/success default; the error must remain.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(toastStore.items).toHaveLength(1);
+      expect(toastStore.items[0].kind).toBe("error");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("info and success auto-dismiss after 4000ms", async () => {
+    vi.useFakeTimers();
+    try {
+      toastStore.info("note");
+      toastStore.success("done");
+      expect(toastStore.items).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(toastStore.items).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("honors a durationMs override in both directions", async () => {
+    vi.useFakeTimers();
+    try {
+      // An error opted into auto-dismiss at 1000ms.
+      toastStore.push({ kind: "error", durationMs: 1000, message: "transient error" });
+      // An info opted into sticky.
+      toastStore.push({ kind: "info", durationMs: null, message: "sticky info" });
+      expect(toastStore.items).toHaveLength(2);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      // The error auto-dismissed; the sticky info remains.
+      expect(toastStore.items).toHaveLength(1);
+      expect(toastStore.items[0].message).toBe("sticky info");
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      // The sticky info never auto-dismisses.
+      expect(toastStore.items).toHaveLength(1);
+      expect(toastStore.items[0].message).toBe("sticky info");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dismiss(id) removes only that toast", () => {
+    const a = toastStore.error("a");
+    const b = toastStore.error("b");
+    toastStore.dismiss(a);
+    expect(toastStore.items).toHaveLength(1);
+    expect(toastStore.items[0].id).toBe(b);
+  });
+
+  it("clear() empties items and cancels pending timers", async () => {
+    vi.useFakeTimers();
+    try {
+      toastStore.info("note");
+      expect(toastStore.items).toHaveLength(1);
+      toastStore.clear();
+      expect(toastStore.items).toHaveLength(0);
+      // The cancelled timer must not fire (no throw, items stays empty).
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(toastStore.items).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  describe("kind-aware eviction (§15.3)", () => {
+    it("(a) same-kind FIFO: the oldest is evicted and its timer is cancelled", async () => {
+      vi.useFakeTimers();
+      try {
+        for (let i = 0; i < 5; i++) toastStore.info(`info-${i}`);
+        // MAX_VISIBLE = 4; the oldest (info-0) is evicted FIFO.
+        expect(toastStore.items).toHaveLength(4);
+        expect(toastStore.items.map((t) => t.message)).toEqual([
+          "info-1",
+          "info-2",
+          "info-3",
+          "info-4",
+        ]);
+
+        // If info-0's timer had survived eviction, advancing 4000ms would fire a
+        // 5th (no-op) dismiss; exactly 4 proves the evicted timer was cancelled.
+        const dismissSpy = vi.spyOn(toastStore, "dismiss");
+        await vi.advanceTimersByTimeAsync(4000);
+        expect(dismissSpy).toHaveBeenCalledTimes(4);
+        expect(toastStore.items).toHaveLength(0);
+        dismissSpy.mockRestore();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("(b) sticky errors are protected: a transient info is the victim", () => {
+      for (let i = 0; i < 4; i++) toastStore.error(`error-${i}`);
+      toastStore.info("transient");
+      // The info (the only non-error) is evicted; all 4 errors survive.
+      expect(toastStore.items).toHaveLength(4);
+      expect(toastStore.items.every((t) => t.kind === "error")).toBe(true);
+      expect(toastStore.items.map((t) => t.message)).toEqual([
+        "error-0",
+        "error-1",
+        "error-2",
+        "error-3",
+      ]);
+    });
+
+    it("(c) all-errors fallback: the oldest error is evicted to keep the cap honest", () => {
+      for (let i = 0; i < 5; i++) toastStore.error(`error-${i}`);
+      // No non-error victim exists, so the oldest overall (error-0) is evicted.
+      expect(toastStore.items).toHaveLength(4);
+      expect(toastStore.items.map((t) => t.message)).toEqual([
+        "error-1",
+        "error-2",
+        "error-3",
+        "error-4",
+      ]);
+    });
+  });
+});

--- a/src/shared/stores/toasts.ts
+++ b/src/shared/stores/toasts.ts
@@ -1,0 +1,103 @@
+import { createSignal } from "solid-js";
+
+export type ToastKind = "error" | "success" | "info";
+
+export interface PushToastOptions {
+  message: string;
+  kind?: ToastKind;            // default "info"
+  /** Auto-dismiss delay. `null` = sticky (stays until dismissed). Omit to use
+   *  the per-kind default below. */
+  durationMs?: number | null;
+}
+
+export interface Toast {
+  id: number;
+  kind: ToastKind;
+  message: string;
+}
+
+// Errors stay until dismissed (the #574 failure MUST be noticed); info/success
+// auto-dismiss. Matches the existing loop toast's ~3s feel for non-errors.
+const DEFAULT_DURATION_MS: Record<ToastKind, number | null> = {
+  error: null,
+  success: 4000,
+  info: 4000,
+};
+
+// Cap on visible toasts. Past this, eviction is KIND-AWARE (#574 §15.3): the
+// oldest NON-error (auto-dismissing) toast is evicted first, so a transient
+// info/success can never silently bury an unread sticky error; only when every
+// visible toast is an error do we fall back to evicting the oldest error.
+const MAX_VISIBLE = 4;
+
+const [toasts, setToasts] = createSignal<Toast[]>([]);
+let nextId = 1;
+const timers = new Map<number, ReturnType<typeof setTimeout>>();
+
+function clearTimer(id: number): void {
+  const t = timers.get(id);
+  if (t !== undefined) {
+    clearTimeout(t);
+    timers.delete(id);
+  }
+}
+
+export const toastStore = {
+  /** Reactive accessor (read inside JSX / effects to subscribe). */
+  get items(): Toast[] {
+    return toasts();
+  },
+
+  push(opts: PushToastOptions): number {
+    const id = nextId++;
+    const kind = opts.kind ?? "info";
+    const toast: Toast = { id, kind, message: opts.message };
+
+    const evicted: number[] = [];
+    setToasts((prev) => {
+      const next = [...prev, toast];
+      // Kind-aware eviction (§15.3): evict the oldest NON-error first so an
+      // unread sticky error is never silently dropped by a transient toast.
+      // Fall back to the oldest overall only when all visible toasts are errors
+      // (keeps MAX_VISIBLE an honest hard cap). Pure: only mutates the local
+      // `next` copy; timer cleanup happens after via `evicted`.
+      while (next.length > MAX_VISIBLE) {
+        let victim = next.findIndex((t) => t.kind !== "error");
+        if (victim === -1) victim = 0;
+        evicted.push(next.splice(victim, 1)[0].id);
+      }
+      return next;
+    });
+    evicted.forEach(clearTimer);
+
+    const duration =
+      opts.durationMs === undefined ? DEFAULT_DURATION_MS[kind] : opts.durationMs;
+    if (duration !== null) {
+      timers.set(id, setTimeout(() => toastStore.dismiss(id), duration));
+    }
+    return id;
+  },
+
+  dismiss(id: number): void {
+    clearTimer(id);
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  },
+
+  /** Remove all toasts + cancel all timers (onCleanup + test reset). */
+  clear(): void {
+    timers.forEach((t) => clearTimeout(t));
+    timers.clear();
+    setToasts([]);
+  },
+
+  // Convenience wrappers.
+  error(message: string, opts?: Omit<PushToastOptions, "message" | "kind">): number {
+    return toastStore.push({ ...opts, message, kind: "error" });
+  },
+  info(message: string, opts?: Omit<PushToastOptions, "message" | "kind">): number {
+    return toastStore.push({ ...opts, message, kind: "info" });
+  },
+  success(message: string, opts?: Omit<PushToastOptions, "message" | "kind">): number {
+    return toastStore.push({ ...opts, message, kind: "success" });
+  },
+};

--- a/src/shared/styles/toast.css
+++ b/src/shared/styles/toast.css
@@ -1,0 +1,62 @@
+/* Reusable toast host + items (#574). Imported at the App level (see ExternalLink
+   precedent), not self-imported by the component. */
+.toast-host {
+  position: fixed;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  z-index: 2000;             /* parity with the existing toasts */
+  pointer-events: none;      /* container ignores clicks; items opt back in */
+}
+
+.toast-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: 420px;
+  padding: 8px 12px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-ui);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  pointer-events: auto;      /* dismissible */
+}
+
+.toast-item--error {
+  background: rgba(220, 50, 50, 0.92);
+  color: #fff;
+}
+.toast-item--info {
+  background: rgba(31, 41, 55, 0.94);
+  border: 1px solid var(--sidebar-border);
+  color: var(--sidebar-fg);
+}
+.toast-item--success {
+  background: rgba(34, 139, 78, 0.94);
+  color: #fff;
+}
+
+.toast-item__message {
+  flex: 1 1 auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.toast-item__dismiss {
+  flex: 0 0 auto;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+  opacity: 0.8;
+}
+.toast-item__dismiss:hover {
+  opacity: 1;
+}

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -9,6 +9,7 @@ import type {
   Session,
 } from "../types";
 import { FakeTransport } from "./fake-transport";
+import { toastStore } from "../stores/toasts";
 import { projectStore } from "../../sidebar/stores/project";
 import { sessionsStore } from "../../sidebar/stores/sessions";
 import { bridgesStore } from "../../sidebar/stores/bridges";
@@ -224,6 +225,7 @@ export function resetUiStoresForTests(): void {
   bridgesStore.setBridges([]);
   terminalStore.setActiveSession(null, "", "", null, "", null);
   terminalStore.setActiveWorkgroupTask(null);
+  toastStore.clear();
   __resetHomeStoreForTests();
 }
 

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -44,9 +44,11 @@ import ActionBar from "./components/ActionBar";
 import RootAgentBanner from "./components/RootAgentBanner";
 import ProjectPanel from "./components/ProjectPanel";
 import OnboardingModal from "./components/OnboardingModal";
+import ToastHost from "../shared/components/ToastHost";
 import { handleProjectRefreshRequested } from "./project-refresh-handler";
 import { loopToastFromEvent, type LoopToast } from "./loop-event-toast";
 import "./styles/sidebar.css";
+import "../shared/styles/toast.css";
 
 interface SidebarAppProps {
   /**
@@ -387,6 +389,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
           </div>
         )}
       </Show>
+      <ToastHost />
     </>
   );
 };

--- a/src/sidebar/components/ProjectPanel.restart-toast.test.tsx
+++ b/src/sidebar/components/ProjectPanel.restart-toast.test.tsx
@@ -154,7 +154,14 @@ describe("ProjectPanel restart-failure toast (#574)", () => {
 
       await waitFor(() => expect(q("toast.item")).toBeTruthy());
       expect(q("toast.item")?.getAttribute("data-ac-kind")).toBe("error");
-      expect(q("toast.item")?.textContent ?? "").toContain("Resource Monitor cap reached");
+      // Assert on normalization-only fragments. The parenthesized "(16/16)" ratio
+      // and the actionable tail exist ONLY in launchErrorMessage's output, never in
+      // the raw "...: 16/16 agent groups are active" reject. A regression swapping
+      // launchErrorMessage(e) for String(e) would fail here, so this genuinely
+      // guards that the catch funnels through normalization (#573's path).
+      const toastText = q("toast.item")?.textContent ?? "";
+      expect(toastText).toContain("Resource Monitor cap reached (16/16).");
+      expect(toastText).toContain("Close an agent or raise the limit in Settings > Resources.");
       expect(fake.callsFor("restart_session")).toHaveLength(1);
     } finally {
       rendered.cleanup();

--- a/src/sidebar/components/ProjectPanel.restart-toast.test.tsx
+++ b/src/sidebar/components/ProjectPanel.restart-toast.test.tsx
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ProjectPanel, { RESTART_TIMEOUT_MS } from "./ProjectPanel";
+import ToastHost from "../../shared/components/ToastHost";
+import type { AgentConfig, AppSettings } from "../../shared/types";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  click,
+  contextMenu,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
+import { automationIdPart } from "./replica-repo-badges";
+
+const projectPath = "C:\\Project";
+const workgroupName = "wg-1-dev-team";
+const workgroupPath = `${projectPath}\\.ac\\${workgroupName}`;
+const replicaName = "dev-webpage-ui";
+const replicaPath = `${workgroupPath}\\__agent_${replicaName}`;
+const sessionId = "sess-1";
+const sessionName = `${workgroupName}/${replicaName}`;
+
+const rowSelector = `[data-ac-testid="replica.row.quick.${automationIdPart(workgroupName)}.${automationIdPart(replicaName)}"]`;
+
+function q<T extends HTMLElement = HTMLElement>(testId: string): T | null {
+  return document.body.querySelector<T>(`[data-ac-testid="${testId}"]`);
+}
+
+function codexAgent(): AgentConfig {
+  return {
+    id: "codex",
+    label: "Codex",
+    command: "codex",
+    color: "#10b981",
+    gitPullBefore: false,
+    excludeGlobalClaudeMd: true,
+    envs: [],
+    isolatedHome: false,
+  };
+}
+
+function discoveryResult() {
+  return discovery({
+    teams: [{ name: "dev-team", agents: [replicaName], coordinator: replicaName }],
+    workgroups: [
+      {
+        name: workgroupName,
+        path: workgroupPath,
+        task: null,
+        taskTitle: "Restart toast",
+        teamName: "dev-team",
+        agents: [
+          {
+            name: replicaName,
+            path: replicaPath,
+            repoPaths: [],
+            isCoordinator: true,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function setupTransport(fake: FakeTransport): void {
+  fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+  fake.resolve("discover_project", discoveryResult());
+  fake.resolve("get_settings", baseSettings({ agents: [codexAgent()] }) satisfies AppSettings);
+}
+
+function seedLiveSession(): void {
+  sessionsStore.setSessions([
+    session({
+      id: sessionId,
+      name: sessionName,
+      workingDirectory: replicaPath,
+      status: "running",
+      agentId: "codex",
+      agentLabel: "Codex",
+      isCoordinator: true,
+    }),
+  ]);
+}
+
+function findButtonByText(label: string): HTMLButtonElement {
+  const match = Array.from(document.body.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  if (!(match instanceof HTMLButtonElement)) throw new Error(`Button not found: ${label}`);
+  return match;
+}
+
+/** Load the project, right-click the live replica row, and wait for its active
+ *  context menu's "Restart Session" button. Leaves the menu open. */
+async function driveToReplicaContextMenu(root: HTMLElement): Promise<void> {
+  seedLiveSession();
+  await projectStore.createAndLoad(projectPath);
+
+  await waitFor(() => expect(root.querySelector(rowSelector)).toBeTruthy());
+  const row = root.querySelector(rowSelector);
+  if (!(row instanceof HTMLElement)) throw new Error("Replica row not found");
+
+  contextMenu(row);
+  await waitFor(() => expect(findButtonByText("Restart Session")).toBeTruthy());
+}
+
+describe("ProjectPanel restart-failure toast (#574)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    // Defensive: the wedge test installs fake timers. Restore real timers here
+    // too (no-op otherwise) so a throw inside that window can't leak frozen
+    // timers into the next test.
+    vi.useRealTimers();
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("surfaces a friendly error toast when the context-menu restart rejects", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    // The Resource Monitor cap is the most likely relaunch failure; the toast
+    // must show the launchErrorMessage-normalized copy, proving the catch funnels
+    // through the same normalization #573 uses.
+    fake.reject("restart_session", "Resource Monitor cap reached: 16/16 agent groups are active");
+
+    const rendered = renderWithFakeTransport(
+      () => (
+        <>
+          <ProjectPanel />
+          <ToastHost />
+        </>
+      ),
+      fake,
+    );
+    try {
+      await driveToReplicaContextMenu(rendered.root);
+
+      click(findButtonByText("Restart Session"));
+
+      await waitFor(() => expect(q("toast.item")).toBeTruthy());
+      expect(q("toast.item")?.getAttribute("data-ac-kind")).toBe("error");
+      expect(q("toast.item")?.textContent ?? "").toContain("Resource Monitor cap reached");
+      expect(fake.callsFor("restart_session")).toHaveLength(1);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows no toast when the restart succeeds", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    fake.resolve(
+      "restart_session",
+      session({ id: sessionId, name: sessionName, workingDirectory: replicaPath }),
+    );
+
+    const rendered = renderWithFakeTransport(
+      () => (
+        <>
+          <ProjectPanel />
+          <ToastHost />
+        </>
+      ),
+      fake,
+    );
+    try {
+      await driveToReplicaContextMenu(rendered.root);
+
+      click(findButtonByText("Restart Session"));
+
+      await waitFor(() => expect(fake.callsFor("restart_session")).toHaveLength(1));
+      // The success path has no toast code path, so none must appear.
+      expect(q("toast.item")).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // §15.1 REQUIRED regression guard: a wedged desktop backend (restart_session
+  // never settles) must still toast after RESTART_TIMEOUT_MS. Without the
+  // Promise.race timeout the Tauri IPC await would hang forever, the catch would
+  // never run, and no toast would fire - the exact #574 silent-failure class.
+  it("toasts a timeout error when a desktop restart never settles (§15.1)", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    // Never settles - emulates a wedged backend / dropped IPC reply on desktop.
+    fake.onInvoke("restart_session", () => new Promise(() => {}));
+
+    const rendered = renderWithFakeTransport(
+      () => (
+        <>
+          <ProjectPanel />
+          <ToastHost />
+        </>
+      ),
+      fake,
+    );
+    try {
+      await driveToReplicaContextMenu(rendered.root);
+
+      // Fake timers must own the production window.setTimeout BEFORE the restart
+      // fires, so advanceTimers controls the RESTART_TIMEOUT_MS bound. Setup above
+      // ran on real timers (waitFor polls real time); the synchronous click +
+      // advance below need no waitFor, so the switch is safe from here on.
+      vi.useFakeTimers();
+      try {
+        click(findButtonByText("Restart Session"));
+
+        // The invoke fired and the timeout is armed; no toast yet.
+        expect(fake.callsFor("restart_session")).toHaveLength(1);
+        expect(q("toast.item")).toBeNull();
+
+        // Advance past the bound: the timeout wins the race and rejects.
+        await vi.advanceTimersByTimeAsync(RESTART_TIMEOUT_MS);
+
+        expect(q("toast.item")).toBeTruthy();
+        expect(q("toast.item")?.getAttribute("data-ac-kind")).toBe("error");
+        // launchErrorMessage passes the bare timeout string through verbatim.
+        expect(q("toast.item")?.textContent ?? "").toContain("Command timeout: restart_session");
+      } finally {
+        vi.useRealTimers();
+      }
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -10,6 +10,7 @@ import { projectStore } from "../stores/project";
 import { sessionsStore } from "../stores/sessions";
 import { bridgesStore } from "../stores/bridges";
 import { settingsStore } from "../../shared/stores/settings";
+import { toastStore } from "../../shared/stores/toasts";
 import { voiceRecorder } from "../../shared/voice-recorder";
 import { isWgReplicaPath, sessionProfileBadge, shouldOfferRestartAfterAssign } from "../../shared/profile-utils";
 import { clockStore } from "../stores/clock";
@@ -807,13 +808,36 @@ const ProjectPanel: Component = () => {
         ) => {
           setReplicaCtxMenu(null);
           cleanupCtx();
+          // #574 §15.1: bound the await with RESTART_TIMEOUT_MS, mirroring
+          // applyRestartPrompt (:244-279). The Tauri IPC transport has no
+          // client-side timeout (transport-tauri.ts:23-26), so a wedged backend
+          // would never settle this await, the catch would never run, and NO toast
+          // would fire on desktop - the exact #574 silent-failure class. WsTransport
+          // self-heals after 30s; this gives desktop the same guarantee. The bare
+          // "Command timeout: restart_session" reject string passes through
+          // launchErrorMessage verbatim (launch-errors.ts:17-28), so desktop and WS
+          // get identical copy.
+          let timeoutTimer: number | undefined;
           try {
-            await SessionAPI.restart(
-              sessionId,
-              agentId ? { agentId, requestedProfile } : undefined,
-            );
+            await Promise.race([
+              SessionAPI.restart(
+                sessionId,
+                agentId ? { agentId, requestedProfile } : undefined,
+              ),
+              new Promise<never>((_, reject) => {
+                timeoutTimer = window.setTimeout(
+                  () => reject("Command timeout: restart_session"),
+                  RESTART_TIMEOUT_MS,
+                );
+              }),
+            ]);
           } catch (e) {
-            console.error("Failed to restart session:", e);
+            console.error("Failed to restart session:", e); // keep for logs
+            toastStore.error(launchErrorMessage(e));
+          } finally {
+            // Cancel the pending timeout when the restart settles first, so a
+            // successful restart can't leave a dangling timer / late rejection.
+            window.clearTimeout(timeoutTimer);
           }
         };
 


### PR DESCRIPTION
Closes #574

## What
Adds a reusable toast/notification mechanism and wires `restartReplicaSession` to surface previously-silent restart failures.

Before, restart failures on the two no-modal surfaces — per-row context-menu "Restart Session" and non-WG-replica code-assign restart — were swallowed by `catch (e) { console.error(...) }`, invisible in the testable build. The user believed the restart applied when it had not.

## Changes (frontend-only, `src/`)
- **New reusable toast store** `src/shared/stores/toasts.ts` (module singleton): `push/dismiss/clear/error/info/success`, reactive `.items`. Errors sticky + manual ×; info/success auto-dismiss 4s. `MAX_VISIBLE=4` with **kind-aware eviction** (never evicts an unread sticky error — evicts the oldest non-error first).
- **New host** `src/shared/components/ToastHost.tsx` via `<Portal>`, mounted at `SidebarApp` top-level (survives discovery-refresh `<For>` disposal; works embedded-in-main). Per-item `role="alert"`. Automation hooks: `data-ac-testid="toast.host"/"toast.item"/"toast.item.dismiss"` + `data-ac-kind` + `data-ac-toast-id`. `on:mousedown` stopPropagation on the item (Solid-delegation fix so clicking the body doesn't raise the terminal).
- **New CSS** `src/shared/styles/toast.css` (bottom-center, z-index 2000).
- **Wiring** in `src/sidebar/components/ProjectPanel.tsx`: catch → `toastStore.error(launchErrorMessage(e))` (keeps `console.error`); both no-modal surfaces funnel through the one function; #573 modal path untouched (no double-fire). **Desktop timeout fix:** wraps the restart in a `Promise.race` against `RESTART_TIMEOUT_MS` so a wedged `restart_session` (no client-side timeout on Tauri) actually toasts instead of hanging silently.
- `src/sidebar/App.tsx` mounts `<ToastHost/>` + imports the css; `src/shared/testing/ui-harness.tsx` resets the store between tests.

## Testing & review
- Full path: architect plan → dev-webpage-ui + dev-rust-grinch enrichment → architect `READY_FOR_IMPLEMENTATION` → implementation → grinch adversarial review **PASS** → shipper → **user manual test of the 0_AC exe** → go-ahead to land.
- Full frontend suite green (**420 passed / 52 files**), `tsc --noEmit` clean. `/code-review` (high): **0 HIGH**.
- grinch independently verified the `Promise.race` timeout, kind-aware eviction, singleton lifecycle, single-catch coverage of both surfaces, the `on:mousedown` deviation, and test validity.
- Branch re-synced twice onto latest `origin/main` (#576, then #584/#580); grinch focused re-reviews **PASS**, #574/#580 coexistence in `ProjectPanel.tsx` confirmed.
- shipper built **v0.9.15** and deployed `agentscommander_standalone_wg-2.exe` to `0_AC`; user manually tested it.

No Rust / IPC / new dependencies.
