### PR TITLE
feat(resource-monitor): activity filters + rename Groups to Agents + close-on-exit (#566)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1001,6 +1001,9 @@ pub async fn create_session_inner<R: tauri::Runtime>(
                 (None, None)
             }
         };
+        // #566 - project folder name for the Resource Monitor row, derived from
+        // the same deterministic spawn cwd as the (workgroup, agent) pair above.
+        let project = crate::config::teams::project_from_path(&cwd);
         ResourceLaunchRegistration::new(
             resource_monitor.as_ref().clone(),
             permit,
@@ -1011,6 +1014,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
                 agent_label: agent_label.clone(),
                 workgroup,
                 agent,
+                project,
             },
         )
     });

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -128,6 +128,23 @@ pub fn workgroup_and_agent_from_path(path: &str) -> (Option<String>, Option<Stri
     (None, None)
 }
 
+/// Derive the project folder name from a CWD: the directory immediately
+/// preceding the `.ac` workspace segment. Mirrors the project anchor used by
+/// `agent_fqn_from_path` (#566). Returns `None` when there is no workspace
+/// segment (origin agents, ad-hoc shells) or `.ac` is the first segment.
+///
+/// Deliberately more permissive than `workgroup_and_agent_from_path`: it
+/// returns `Some(project)` for ANY cwd with a `.ac` segment that has a parent,
+/// so root agents (`<proj>/.ac/ac-root-agent`) and origin/matrix agents
+/// (`<proj>/.ac/_agent_x`) also carry a project even when their wg/agent are
+/// `None`. Only a cwd with no `.ac` segment at all yields `None`.
+pub fn project_from_path(path: &str) -> Option<String> {
+    let normalized = path.replace('\\', "/");
+    let parts: Vec<&str> = normalized.split('/').filter(|s| !s.is_empty()).collect();
+    let ac_idx = find_workspace_segment(&parts)?;
+    (ac_idx > 0).then(|| parts[ac_idx - 1].to_string())
+}
+
 // ── FQN resolution (shared between CLI and mailbox — §AR2-shared) ──
 
 /// Error type for `resolve_agent_target`. Each variant carries the data needed to
@@ -1120,6 +1137,56 @@ mod tests {
             workgroup_and_agent_from_path("C:/repos/proj-a/.ac/ac-root-agent"),
             (None, None)
         );
+    }
+
+    // ── #566 project_from_path ──
+
+    #[test]
+    fn project_from_path_wg_replica() {
+        let cwd = "C:/repos/AgentsCommander_ac/.ac/wg-5-dev-team/__agent_dev-rust";
+        assert_eq!(
+            project_from_path(cwd),
+            Some("AgentsCommander_ac".to_string())
+        );
+    }
+
+    /// Deep subdir inside a replica (and Windows backslashes) still anchors on
+    /// the right-most `.ac` and returns the owning project.
+    #[test]
+    fn project_from_path_deeper_cwd_windows_style() {
+        let cwd = r"C:\repos\proj-a\.ac\wg-1-devs\__agent_alice\repo-x\src";
+        assert_eq!(project_from_path(cwd), Some("proj-a".to_string()));
+    }
+
+    /// Permissive by design: root agents carry a project even though their
+    /// wg/agent resolve to `(None, None)` / the "Root agent" label fallback.
+    #[test]
+    fn project_from_path_root_agent() {
+        assert_eq!(
+            project_from_path("C:/repos/proj-a/.ac/ac-root-agent"),
+            Some("proj-a".to_string())
+        );
+    }
+
+    /// Origin / matrix agents also carry a project (the parent of `.ac`).
+    #[test]
+    fn project_from_path_origin_agent() {
+        assert_eq!(
+            project_from_path("C:/repos/proj-a/.ac/_agent_architect"),
+            Some("proj-a".to_string())
+        );
+    }
+
+    /// No `.ac` segment at all (ad-hoc / non-AC shell) -> `None`.
+    #[test]
+    fn project_from_path_no_workspace_segment_returns_none() {
+        assert_eq!(project_from_path("C:/repos/my-project/tech-lead"), None);
+    }
+
+    /// `.ac` as the first segment has no parent project dir -> `None`.
+    #[test]
+    fn project_from_path_ac_first_segment_returns_none() {
+        assert_eq!(project_from_path("/.ac/wg-1-devs/__agent_alice"), None);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1795,6 +1795,20 @@ pub fn run(
                             commands::spec_board::spec_board_close_all(state).await;
                         });
                     }
+                    // #566 - when the main window is destroyed (any close path:
+                    // X, Alt+F4, programmatic, silent- or confirm-quit), close the
+                    // Resource Monitor window so it cannot orphan and keep the app
+                    // alive. No-op if it was never opened or already closed.
+                    if label == "main" {
+                        if let Some(rm) = app_handle.get_webview_window("resource-monitor") {
+                            // G4: log on failure rather than swallow. A swallowed
+                            // error would hide the exact orphan bug this fixes;
+                            // mirrors the FE quit path's console.warn.
+                            if let Err(e) = rm.destroy() {
+                                log::warn!("[shutdown] RM window destroy failed: {e}");
+                            }
+                        }
+                    }
                     // Detached-window destroyed (by any mechanism — X, Alt+F4, programmatic).
                     // Two jobs:
                     //   1) Clear from `DetachedSessionsState` — switch_session needs an

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -61,6 +61,7 @@ struct ResourceAgentGroup {
     agent_label: Option<String>,
     workgroup: Option<String>,
     agent: Option<String>,
+    project: Option<String>,
     root_identity: ProcessIdentity,
     state: ResourceGroupState,
     descendants_observed: bool,
@@ -130,6 +131,7 @@ impl ResourceLaunchRegistration {
             self.metadata.agent_label.clone(),
             self.metadata.workgroup.clone(),
             self.metadata.agent.clone(),
+            self.metadata.project.clone(),
             identity,
         )?;
         self.registered = true;
@@ -202,6 +204,7 @@ impl ResourceMonitorState {
         agent_label: Option<String>,
         workgroup: Option<String>,
         agent: Option<String>,
+        project: Option<String>,
         root_identity: ProcessIdentity,
     ) -> Result<(), String> {
         let observed = self.backend.observe_tree(root_identity);
@@ -233,7 +236,12 @@ impl ResourceMonitorState {
             inner.groups.retain(|_, g| {
                 !(matches!(g.state, ResourceGroupState::Terminated)
                     && g.workgroup == workgroup
-                    && g.agent == agent)
+                    && g.agent == agent
+                    // #566 - also match project so two different projects running
+                    // the same wg/role never dedup against each other's Terminated
+                    // row. PREDICATE only; the gate above stays (wg|agent) so
+                    // unrelated non-WG launches are never merged (preserves #559).
+                    && g.project == project)
             });
         }
         inner.groups.insert(
@@ -245,6 +253,7 @@ impl ResourceMonitorState {
                 agent_label,
                 workgroup,
                 agent,
+                project,
                 root_identity,
                 state: ResourceGroupState::Running,
                 descendants_observed,
@@ -816,7 +825,10 @@ struct SampleOutcome {
 /// confirm (see snapshot()), so this threshold never authorizes a reap on its own.
 const REAP_STRIKES: u8 = 2;
 
-/// #559 - upper bound on retained Terminated rows (matches the slot cap).
+/// #559 - upper bound on retained Terminated (released-permit) rows kept for
+/// recent-history display. Deliberately a fixed bound, independent of the
+/// active-slot cap `max_concurrent_agent_processes` (#565): eviction here never
+/// affects active_count, so it does not need to track the configurable cap.
 const MAX_TERMINATED_RETAINED: usize = 16;
 
 /// #559 - minimum interval between cleanup retries for a single quarantine.
@@ -951,6 +963,7 @@ fn group_snapshot(group: &ResourceAgentGroup) -> ResourceAgentGroupSnapshot {
             .unwrap_or_else(|| group.name.clone()),
         workgroup: group.workgroup.clone(),
         agent: group.agent.clone(),
+        project: group.project.clone(),
         root_pid: group.root_identity.pid,
         root_identity: group.root_identity,
         state: group.state,
@@ -1258,7 +1271,7 @@ mod tests {
         );
         let permit = state.try_reserve_agent_slot(limits(3)).unwrap().unwrap();
         state
-            .register_group(permit, Uuid::new_v4(), "agent".into(), None, None, None, None, root)
+            .register_group(permit, Uuid::new_v4(), "agent".into(), None, None, None, None, None, root)
             .unwrap();
         let snapshot = state.snapshot(limits(3));
         assert_eq!(snapshot.groups[0].process_count, 2);
@@ -1282,7 +1295,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(3)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
         let result = state.kill_group(id, ResourceKillReason::User).unwrap();
         assert!(!result.quarantined);
@@ -1306,7 +1319,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
         let result = state.kill_group(id, ResourceKillReason::User).unwrap();
         assert!(!result.quarantined);
@@ -1329,7 +1342,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
         let result = state.kill_group(id, ResourceKillReason::User).unwrap();
         assert!(result.quarantined);
@@ -1346,7 +1359,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         backend.mark_gone(root);
@@ -1379,7 +1392,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         backend.replace_tree(
@@ -1416,7 +1429,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         let result = state.kill_group(id, ResourceKillReason::User).unwrap();
@@ -1441,7 +1454,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         backend.replace_tree(
@@ -1484,7 +1497,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         backend.replace_tree(
@@ -1515,7 +1528,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         backend.replace_tree(
@@ -1547,7 +1560,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         backend.replace_tree(
@@ -1585,7 +1598,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         backend.replace_tree(
@@ -1622,7 +1635,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         backend.mark_unverifiable(root.pid);
@@ -1647,7 +1660,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         backend.mark_exit_during_terminate(root);
@@ -1668,7 +1681,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
         let first = state.kill_group(id, ResourceKillReason::User).unwrap();
         let second = state.kill_group(id, ResourceKillReason::Watchdog).unwrap();
@@ -1727,7 +1740,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         // Live root: no strike.
@@ -1761,7 +1774,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         // One missing-root strike.
@@ -1791,7 +1804,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         // A failed enumeration routes through set_group_error (the Err arm), which never
@@ -1815,7 +1828,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         // Tree reports missing-root (the creation-time-mismatch path) and the confirm
@@ -1840,7 +1853,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         // Root stays in the identities map, so observe_identity returns Ok(Some(root)).
@@ -1861,7 +1874,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         // Missing-root signal fires, but observe_identity returns Err (pid still exists,
@@ -1889,7 +1902,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         let result = state.kill_group(id, ResourceKillReason::User).unwrap();
@@ -1923,6 +1936,7 @@ mod tests {
                 None,
                 Some("wg-1".into()),
                 Some("tech-lead".into()),
+                None,
                 root_a,
             )
             .unwrap();
@@ -1943,6 +1957,7 @@ mod tests {
                 None,
                 Some("wg-1".into()),
                 Some("tech-lead".into()),
+                None,
                 root_b,
             )
             .unwrap();
@@ -1951,6 +1966,61 @@ mod tests {
         assert_eq!(snap.groups.len(), 1);
         assert_eq!(snap.groups[0].session_id, id_b.to_string());
         assert_eq!(snap.groups[0].state, ResourceGroupState::Running);
+    }
+
+    // (c2) #566 - two different projects running the same wg/role must NOT dedup
+    // against each other's Terminated row (the dedup predicate gained `project`).
+    // Regression guard: reverting the `g.project == project` clause makes this
+    // assert len == 1 instead of 2.
+    #[test]
+    fn cross_project_same_role_terminated_rows_are_not_deduped() {
+        let (state, backend) = state_with_fake();
+
+        // Project A: register the (wg-1, tech-lead) group, then kill it so its
+        // row is Terminated.
+        let root_a = identity(80, 80);
+        backend.add_tree(root_a, vec![observed(80, 80, None, 0)]);
+        let permit = state.try_reserve_agent_slot(limits(3)).unwrap().unwrap();
+        let id_a = Uuid::new_v4();
+        state
+            .register_group(
+                permit,
+                id_a,
+                "agent".into(),
+                None,
+                None,
+                Some("wg-1".into()),
+                Some("tech-lead".into()),
+                Some("proj-a".into()),
+                root_a,
+            )
+            .unwrap();
+        let killed = state.kill_group(id_a, ResourceKillReason::User).unwrap();
+        assert_eq!(killed.state, ResourceGroupState::Terminated);
+
+        // Project B: same wg/role, different project. The predicate's
+        // `g.project == project` clause means A's Terminated row is NOT dropped.
+        let root_b = identity(81, 81);
+        backend.add_tree(root_b, vec![observed(81, 81, None, 0)]);
+        let permit = state.try_reserve_agent_slot(limits(3)).unwrap().unwrap();
+        let id_b = Uuid::new_v4();
+        state
+            .register_group(
+                permit,
+                id_b,
+                "agent".into(),
+                None,
+                None,
+                Some("wg-1".into()),
+                Some("tech-lead".into()),
+                Some("proj-b".into()),
+                root_b,
+            )
+            .unwrap();
+
+        // Both rows survive: A (Terminated, proj-a) + B (Running, proj-b).
+        let snap = state.snapshot(limits(3));
+        assert_eq!(snap.groups.len(), 2);
     }
 
     // (T2) H1 - the reaping sample stamps the friendly message and suppresses the raw
@@ -1963,7 +2033,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
 
         backend.replace_tree(root, Vec::new(), missing_root_error(root));
@@ -2008,7 +2078,7 @@ mod tests {
         let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
         let id = Uuid::new_v4();
         state
-            .register_group(permit, id, "agent".into(), None, None, None, None, root)
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
             .unwrap();
         let result = state.kill_group(id, ResourceKillReason::User).unwrap();
         assert!(result.quarantined);
@@ -2035,7 +2105,7 @@ mod tests {
             let permit = state.try_reserve_agent_slot(limits(100)).unwrap().unwrap();
             let id = Uuid::new_v4();
             state
-                .register_group(permit, id, "agent".into(), None, None, None, None, root)
+                .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
                 .unwrap();
             let killed = state.kill_group(id, ResourceKillReason::User).unwrap();
             assert_eq!(killed.state, ResourceGroupState::Terminated);

--- a/src-tauri/src/resource_monitor/types.rs
+++ b/src-tauri/src/resource_monitor/types.rs
@@ -134,6 +134,11 @@ pub struct ResourceAgentGroupSnapshot {
     /// #516 - human-readable agent name (e.g. "dev-rust"), or `None` when the
     /// launch cwd carries no replica identity.
     pub agent: Option<String>,
+    /// #566 - project folder name (e.g. "AgentsCommander_ac"), or `None` for
+    /// origin / ad-hoc / unparseable launches. Always serialized (no
+    /// `skip_serializing_if`) for parity with `workgroup`/`agent`, so the
+    /// frontend sees `null` rather than `undefined`.
+    pub project: Option<String>,
     pub root_pid: u32,
     pub root_identity: ProcessIdentity,
     pub state: ResourceGroupState,
@@ -214,4 +219,6 @@ pub struct ResourceLaunchMetadata {
     pub workgroup: Option<String>,
     /// #516 - agent name derived from the spawn cwd (e.g. "dev-rust"), or `None`.
     pub agent: Option<String>,
+    /// #566 - project folder name derived from the spawn cwd, or `None`.
+    pub project: Option<String>,
 }

--- a/src-tauri/src/resource_monitor/watchdog.rs
+++ b/src-tauri/src/resource_monitor/watchdog.rs
@@ -181,6 +181,7 @@ mod tests {
             name: "agent".to_string(),
             workgroup: None,
             agent: None,
+            project: None,
             root_pid: 1,
             root_identity: identity(1),
             state: ResourceGroupState::Running,

--- a/src/resource-monitor/App.automation.test.tsx
+++ b/src/resource-monitor/App.automation.test.tsx
@@ -423,4 +423,88 @@ describe("ResourceMonitorApp automation hooks", () => {
       rendered.cleanup();
     }
   });
+
+  // #566 N1 - regression guard: with a snapshot already loaded but the active
+  // filter matching zero rows, an in-flight poll (loading=true, kept snapshot)
+  // must NOT flash the "loading" empty-state over the stable filtered-empty one.
+  it("keeps the filtered-empty state during an in-flight poll instead of flashing loading (N1)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", baseSettings());
+    fake.resolve("kill_resource_group", {
+      sessionId: "session-1",
+      state: "terminating",
+      quarantined: false,
+      message: "terminating",
+    });
+    // A controllable snapshot handler: returns rows normally, but once `hang` is
+    // set the next call stays pending so the store's `loading` flag stays true.
+    let hang = false;
+    const pending: { resolve: (snapshot: ResourceSnapshot) => void } = {
+      resolve: () => {},
+    };
+    fake.onInvoke("get_resource_snapshot", () => {
+      if (!hang) return multiGroupSnapshot();
+      return new Promise<ResourceSnapshot>((resolve) => {
+        pending.resolve = resolve;
+      });
+    });
+
+    const rendered = renderWithFakeTransport(() => <ResourceMonitorApp />, fake);
+    try {
+      await waitFor(() => {
+        expect(groupRowCount(rendered.root)).toBe(3);
+      });
+
+      // Exclude every row: Inactive + a workgroup that has no terminated row.
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.filter.status.inactive"]'
+        )!
+      );
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.filter.workgroup.wg-9-other-team"]'
+        )!
+      );
+      await waitFor(() => {
+        expect(
+          rendered.root
+            .querySelector('[data-ac-testid="resourceMonitor.empty"]')
+            ?.getAttribute("data-ac-state")
+        ).toBe("filtered-empty");
+      });
+
+      // Drive a poll in-flight while filtered-empty. Settle any prior poll first,
+      // stop the timer so only our hanging refresh flips `loading`, then make the
+      // next snapshot call hang so `loading` stays true deterministically.
+      await waitFor(() => {
+        expect(resourceMonitorStore.loading).toBe(false);
+      });
+      resourceMonitorStore.stopPolling();
+      hang = true;
+      void resourceMonitorStore.refresh();
+
+      await waitFor(() => {
+        expect(resourceMonitorStore.loading).toBe(true);
+        const empty = rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.empty"]'
+        );
+        // The N1 assertion: still filtered-empty, NOT "loading".
+        expect(empty?.getAttribute("data-ac-state")).toBe("filtered-empty");
+        expect(empty?.textContent).toContain("No agents match the filters");
+      });
+    } finally {
+      // Release the pending snapshot so the store settles back to loading=false
+      // and does not leak an in-flight promise into later tests. cleanup() must
+      // run even if the settle wait throws, so guard it in its own finally.
+      pending.resolve(emptySnapshot());
+      try {
+        await waitFor(() => {
+          expect(resourceMonitorStore.loading).toBe(false);
+        });
+      } finally {
+        rendered.cleanup();
+      }
+    }
+  });
 });

--- a/src/resource-monitor/App.automation.test.tsx
+++ b/src/resource-monitor/App.automation.test.tsx
@@ -29,6 +29,7 @@ const activeSnapshot = (): ResourceSnapshot => ({
       name: "cap-one",
       workgroup: "wg-5-dev-team",
       agent: "dev-rust",
+      project: "AgentsCommander_ac",
       rootPid: 100,
       state: "running",
       descendantsObserved: true,
@@ -71,8 +72,50 @@ const nullIdentitySnapshot = (): ResourceSnapshot => {
   const snapshot = activeSnapshot();
   snapshot.groups[0].workgroup = null;
   snapshot.groups[0].agent = null;
+  snapshot.groups[0].project = null;
   return snapshot;
 };
+
+// #566 - multiple groups spanning projects / workgroups / roles / states so the
+// filter dimensions visibly change the rendered row count.
+const multiGroupSnapshot = (): ResourceSnapshot => {
+  const snapshot = activeSnapshot();
+  snapshot.activeAgentGroups = 2;
+  snapshot.maxConcurrentAgentGroups = 3;
+  snapshot.groups = [
+    {
+      ...snapshot.groups[0],
+      sessionId: "session-1",
+      name: "cap-one",
+      workgroup: "wg-5-dev-team",
+      agent: "dev-rust",
+      project: "AgentsCommander_ac",
+      state: "running",
+    },
+    {
+      ...snapshot.groups[0],
+      sessionId: "session-2",
+      name: "cap-two",
+      workgroup: "wg-9-other-team",
+      agent: "tech-lead",
+      project: "OtherProject_ac",
+      state: "running",
+    },
+    {
+      ...snapshot.groups[0],
+      sessionId: "session-3",
+      name: "cap-dead",
+      workgroup: "wg-5-dev-team",
+      agent: "shipper",
+      project: "AgentsCommander_ac",
+      state: "terminated",
+    },
+  ];
+  return snapshot;
+};
+
+const groupRowCount = (root: ParentNode): number =>
+  root.querySelectorAll(".rm-group-row").length;
 
 function setupResourceMonitor(fake: FakeTransport, snapshot: ResourceSnapshot): void {
   fake.resolve("get_settings", baseSettings());
@@ -197,7 +240,7 @@ describe("ResourceMonitorApp automation hooks", () => {
     }
   });
 
-  it("exposes a stable empty-state selector when no agent groups are active", async () => {
+  it("exposes a stable empty-state selector when no agents are active", async () => {
     const fake = new FakeTransport();
     setupResourceMonitor(fake, emptySnapshot());
 
@@ -206,7 +249,7 @@ describe("ResourceMonitorApp automation hooks", () => {
       await waitFor(() => {
         const empty = rendered.root.querySelector('[data-ac-testid="resourceMonitor.empty"]');
         expect(empty?.getAttribute("data-ac-state")).toBe("empty");
-        expect(empty?.textContent).toContain("No active agent groups");
+        expect(empty?.textContent).toContain("No active agents");
       });
     } finally {
       rendered.cleanup();
@@ -234,6 +277,148 @@ describe("ResourceMonitorApp automation hooks", () => {
             ?.textContent
         ).toBe("- / cap-one");
       });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("filters rows by status, workgroup, and project, and re-runs when a chip is toggled off (G3)", async () => {
+    const fake = new FakeTransport();
+    setupResourceMonitor(fake, multiGroupSnapshot());
+
+    const rendered = renderWithFakeTransport(() => <ResourceMonitorApp />, fake);
+    try {
+      // All three rows visible once the snapshot loads.
+      await waitFor(() => {
+        expect(groupRowCount(rendered.root)).toBe(3);
+      });
+
+      // Status: Active hides the single terminated row.
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.filter.status.active"]'
+        )!
+      );
+      await waitFor(() => {
+        expect(groupRowCount(rendered.root)).toBe(2);
+      });
+      expect(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.group.session-3"]')
+      ).toBeNull();
+
+      // Status: Inactive shows only the terminated row.
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.filter.status.inactive"]'
+        )!
+      );
+      await waitFor(() => {
+        expect(groupRowCount(rendered.root)).toBe(1);
+      });
+      expect(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.group.session-3"]')
+      ).not.toBeNull();
+
+      // Reset status back to All.
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.filter.status.all"]'
+        )!
+      );
+      await waitFor(() => {
+        expect(groupRowCount(rendered.root)).toBe(3);
+      });
+
+      // Workgroup chip (multi-select Set) narrows to its single row. This is the
+      // G3 assertion: in-place Set mutation would leave the count unchanged here.
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.filter.workgroup.wg-9-other-team"]'
+        )!
+      );
+      await waitFor(() => {
+        expect(groupRowCount(rendered.root)).toBe(1);
+      });
+      expect(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.group.session-2"]')
+      ).not.toBeNull();
+
+      // "Showing X of Y" indicator appears only while a filter is active.
+      expect(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.filter.count"]')
+          ?.textContent
+      ).toContain("Showing 1 of 3");
+
+      // Toggling the SAME chip off restores every row — proves the toggle yields
+      // a fresh Set in both directions (the core G3 regression guard).
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.filter.workgroup.wg-9-other-team"]'
+        )!
+      );
+      await waitFor(() => {
+        expect(groupRowCount(rendered.root)).toBe(3);
+      });
+
+      // Project chip narrows to the matching project (new #566 dimension).
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.filter.project.OtherProject_ac"]'
+        )!
+      );
+      await waitFor(() => {
+        expect(groupRowCount(rendered.root)).toBe(1);
+      });
+      expect(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.group.session-2"]')
+      ).not.toBeNull();
+
+      // Clear filters resets everything and hides the indicator.
+      click(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.filter.clear"]')!
+      );
+      await waitFor(() => {
+        expect(groupRowCount(rendered.root)).toBe(3);
+      });
+      expect(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.filter.count"]')
+      ).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows a distinct filtered-empty state when filters exclude every row", async () => {
+    const fake = new FakeTransport();
+    setupResourceMonitor(fake, multiGroupSnapshot());
+
+    const rendered = renderWithFakeTransport(() => <ResourceMonitorApp />, fake);
+    try {
+      await waitFor(() => {
+        expect(groupRowCount(rendered.root)).toBe(3);
+      });
+
+      // Inactive + a workgroup with no terminated row => zero matches, but the
+      // snapshot still has rows, so this is filtered-empty, not truly-empty.
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.filter.status.inactive"]'
+        )!
+      );
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.filter.workgroup.wg-9-other-team"]'
+        )!
+      );
+
+      await waitFor(() => {
+        const empty = rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.empty"]'
+        );
+        expect(empty?.getAttribute("data-ac-state")).toBe("filtered-empty");
+        expect(empty?.textContent).toContain("No agents match the filters");
+      });
+      expect(groupRowCount(rendered.root)).toBe(0);
     } finally {
       rendered.cleanup();
     }

--- a/src/resource-monitor/App.tsx
+++ b/src/resource-monitor/App.tsx
@@ -632,14 +632,20 @@ const ResourceMonitorApp: Component = () => {
                 data-ac-testid="resourceMonitor.empty"
                 data-ac-role="status"
                 data-ac-state={
-                  resourceMonitorStore.loading
+                  // #566 N1 - loading only wins when there is genuinely no data
+                  // yet (groups().length === 0). With keepLastSnapshot, every
+                  // poll's setLoading(true) would otherwise flash "loading" over
+                  // an already-populated-but-filtered view each cycle. Once rows
+                  // exist but the active filter matches none, stay on the stable
+                  // filtered-empty state; initial load (no data) still shows it.
+                  resourceMonitorStore.loading && groups().length === 0
                     ? "loading"
                     : groups().length === 0
                       ? "empty"
                       : "filtered-empty"
                 }
               >
-                {resourceMonitorStore.loading
+                {resourceMonitorStore.loading && groups().length === 0
                   ? "Loading snapshot..."
                   : groups().length === 0
                     ? "No active agents"

--- a/src/resource-monitor/App.tsx
+++ b/src/resource-monitor/App.tsx
@@ -98,6 +98,45 @@ const groupSeverity = (group: ResourceAgentGroupSnapshot): string => {
   return "ok";
 };
 
+// #566 - active = the agent still holds (or is releasing) live OS processes /
+// a concurrency slot: every state except `terminated` (matches the backend's
+// active_count semantics). Single source of truth for the status filter (A.1).
+const isActiveGroup = (group: ResourceAgentGroupSnapshot): boolean =>
+  group.state !== "terminated";
+
+// #566 - status filter is component-local view state, not part of the IPC data
+// contract (deliberately kept out of shared/types.ts).
+type RmStatusFilter = "all" | "active" | "inactive";
+
+const STATUS_FILTERS: ReadonlyArray<{ value: RmStatusFilter; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "inactive", label: "Inactive" },
+];
+
+// #566 - distinct, sorted, non-empty values for a filter dimension. Derives from
+// the full snapshot set so a value stays selectable even while filtered out.
+const distinct = (values: (string | null | undefined)[]): string[] =>
+  [...new Set(values.filter((v): v is string => !!v))].sort();
+
+// #566 - G3 reactivity contract: a multi-select toggle MUST replace the Set with
+// a fresh copy. Mutating in place returns the same reference, so SolidJS's
+// Object.is equality treats it as unchanged and the dependent memos silently
+// never re-run (the filters render, clicks register, nothing filters).
+const toggleFilter = (
+  get: () => Set<string>,
+  set: (next: Set<string>) => void,
+  value: string,
+): void => {
+  const next = new Set(get());
+  if (next.has(value)) {
+    next.delete(value);
+  } else {
+    next.add(value);
+  }
+  set(next);
+};
+
 const Titlebar: Component = () => {
   const handleDock = async () => {
     try {
@@ -219,6 +258,57 @@ const ResourceMonitorApp: Component = () => {
 
   const snapshot = () => resourceMonitorStore.snapshot;
   const groups = createMemo(() => snapshot()?.groups ?? []);
+
+  // #566 - filter view-state (ephemeral, not persisted). The three multi-selects
+  // are Set<string>; every toggle goes through toggleFilter (fresh-Set copy) so
+  // the dependent memos actually re-run (see the G3 contract above).
+  const [statusFilter, setStatusFilter] = createSignal<RmStatusFilter>("all");
+  const [projectFilter, setProjectFilter] = createSignal<Set<string>>(new Set());
+  const [workgroupFilter, setWorkgroupFilter] = createSignal<Set<string>>(
+    new Set()
+  );
+  const [roleFilter, setRoleFilter] = createSignal<Set<string>>(new Set());
+
+  // Option lists derive from the FULL snapshot set, not the filtered one, so a
+  // value stays selectable even while it is filtered out (A.4.2).
+  const projectOptions = createMemo(() =>
+    distinct(groups().map((g) => g.project))
+  );
+  const workgroupOptions = createMemo(() =>
+    distinct(groups().map((g) => g.workgroup))
+  );
+  const roleOptions = createMemo(() => distinct(groups().map((g) => g.agent)));
+
+  // AND across dimensions, OR within a dimension; an empty Set = no constraint.
+  const filteredGroups = createMemo(() => {
+    const status = statusFilter();
+    const projects = projectFilter();
+    const wgs = workgroupFilter();
+    const roles = roleFilter();
+    return groups().filter((g) => {
+      if (status === "active" && !isActiveGroup(g)) return false;
+      if (status === "inactive" && isActiveGroup(g)) return false;
+      if (projects.size > 0 && !(g.project && projects.has(g.project)))
+        return false;
+      if (wgs.size > 0 && !(g.workgroup && wgs.has(g.workgroup))) return false;
+      if (roles.size > 0 && !(g.agent && roles.has(g.agent))) return false;
+      return true;
+    });
+  });
+  const filtersActive = createMemo(
+    () =>
+      statusFilter() !== "all" ||
+      projectFilter().size > 0 ||
+      workgroupFilter().size > 0 ||
+      roleFilter().size > 0
+  );
+  const clearFilters = () => {
+    setStatusFilter("all");
+    setProjectFilter(new Set<string>());
+    setWorkgroupFilter(new Set<string>());
+    setRoleFilter(new Set<string>());
+  };
+
   const statusClass = createMemo(() => {
     const s = snapshot();
     if (!s || s.overallState === "unknown") return "unknown";
@@ -312,7 +402,7 @@ const ResourceMonitorApp: Component = () => {
             data-ac-testid="resourceMonitor.summary.activeGroups"
             data-ac-role="metric"
           >
-            <span class="rm-tile-label">Active Groups</span>
+            <span class="rm-tile-label">Active Agents</span>
             <strong>
               <span
                 data-ac-testid="resourceMonitor.summary.activeGroups.count"
@@ -373,30 +463,192 @@ const ResourceMonitorApp: Component = () => {
 
         <section class="rm-groups">
           <div class="rm-section-header">
-            <h2>Agent Groups</h2>
-            <span
-              data-ac-testid="resourceMonitor.summary.timestamp"
-              data-ac-role="text"
+            <h2>Agents</h2>
+            <div class="rm-section-header-meta">
+              <Show when={filtersActive()}>
+                <span
+                  class="rm-filter-count"
+                  data-ac-testid="resourceMonitor.filter.count"
+                  data-ac-role="text"
+                >
+                  Showing {filteredGroups().length} of {groups().length}
+                </span>
+              </Show>
+              <span
+                data-ac-testid="resourceMonitor.summary.timestamp"
+                data-ac-role="text"
+              >
+                Last update {formatTimestamp(snapshot()?.capturedAt)}
+              </span>
+            </div>
+          </div>
+
+          <div
+            class="rm-filter-bar"
+            data-ac-testid="resourceMonitor.filter"
+            data-ac-role="toolbar"
+          >
+            <div
+              class="rm-filter-segment"
+              role="group"
+              aria-label="Filter by status"
+              data-ac-testid="resourceMonitor.filter.status"
+              data-ac-role="group"
             >
-              Last update {formatTimestamp(snapshot()?.capturedAt)}
-            </span>
+              <For each={STATUS_FILTERS}>
+                {(option) => (
+                  <button
+                    type="button"
+                    class="rm-filter-seg-btn"
+                    classList={{ "is-active": statusFilter() === option.value }}
+                    onClick={() => setStatusFilter(option.value)}
+                    aria-pressed={statusFilter() === option.value}
+                    data-ac-testid={`resourceMonitor.filter.status.${option.value}`}
+                    data-ac-role="button"
+                    data-ac-state={
+                      statusFilter() === option.value ? "active" : "inactive"
+                    }
+                  >
+                    {option.label}
+                  </button>
+                )}
+              </For>
+            </div>
+
+            <Show when={projectOptions().length > 0}>
+              <div
+                class="rm-filter-group"
+                role="group"
+                aria-label="Filter by project"
+                data-ac-testid="resourceMonitor.filter.project"
+                data-ac-role="group"
+              >
+                <span class="rm-filter-label">Project</span>
+                <For each={projectOptions()}>
+                  {(value) => (
+                    <button
+                      type="button"
+                      class="rm-filter-chip"
+                      classList={{ "is-active": projectFilter().has(value) }}
+                      onClick={() =>
+                        toggleFilter(projectFilter, setProjectFilter, value)
+                      }
+                      aria-pressed={projectFilter().has(value)}
+                      data-ac-testid={`resourceMonitor.filter.project.${value}`}
+                      data-ac-role="button"
+                      data-ac-state={
+                        projectFilter().has(value) ? "active" : "inactive"
+                      }
+                    >
+                      {value}
+                    </button>
+                  )}
+                </For>
+              </div>
+            </Show>
+
+            <Show when={workgroupOptions().length > 0}>
+              <div
+                class="rm-filter-group"
+                role="group"
+                aria-label="Filter by workgroup"
+                data-ac-testid="resourceMonitor.filter.workgroup"
+                data-ac-role="group"
+              >
+                <span class="rm-filter-label">Workgroup</span>
+                <For each={workgroupOptions()}>
+                  {(value) => (
+                    <button
+                      type="button"
+                      class="rm-filter-chip"
+                      classList={{ "is-active": workgroupFilter().has(value) }}
+                      onClick={() =>
+                        toggleFilter(workgroupFilter, setWorkgroupFilter, value)
+                      }
+                      aria-pressed={workgroupFilter().has(value)}
+                      data-ac-testid={`resourceMonitor.filter.workgroup.${value}`}
+                      data-ac-role="button"
+                      data-ac-state={
+                        workgroupFilter().has(value) ? "active" : "inactive"
+                      }
+                    >
+                      {value}
+                    </button>
+                  )}
+                </For>
+              </div>
+            </Show>
+
+            <Show when={roleOptions().length > 0}>
+              <div
+                class="rm-filter-group"
+                role="group"
+                aria-label="Filter by role"
+                data-ac-testid="resourceMonitor.filter.role"
+                data-ac-role="group"
+              >
+                <span class="rm-filter-label">Role</span>
+                <For each={roleOptions()}>
+                  {(value) => (
+                    <button
+                      type="button"
+                      class="rm-filter-chip"
+                      classList={{ "is-active": roleFilter().has(value) }}
+                      onClick={() =>
+                        toggleFilter(roleFilter, setRoleFilter, value)
+                      }
+                      aria-pressed={roleFilter().has(value)}
+                      data-ac-testid={`resourceMonitor.filter.role.${value}`}
+                      data-ac-role="button"
+                      data-ac-state={
+                        roleFilter().has(value) ? "active" : "inactive"
+                      }
+                    >
+                      {value}
+                    </button>
+                  )}
+                </For>
+              </div>
+            </Show>
+
+            <Show when={filtersActive()}>
+              <button
+                type="button"
+                class="rm-filter-clear"
+                onClick={clearFilters}
+                data-ac-testid="resourceMonitor.filter.clear"
+                data-ac-role="button"
+              >
+                Clear filters
+              </button>
+            </Show>
           </div>
 
           <Show
-            when={groups().length > 0}
+            when={filteredGroups().length > 0}
             fallback={
               <div
                 class="rm-empty"
                 data-ac-testid="resourceMonitor.empty"
                 data-ac-role="status"
-                data-ac-state={resourceMonitorStore.loading ? "loading" : "empty"}
+                data-ac-state={
+                  resourceMonitorStore.loading
+                    ? "loading"
+                    : groups().length === 0
+                      ? "empty"
+                      : "filtered-empty"
+                }
               >
-                {resourceMonitorStore.loading ? "Loading snapshot..." : "No active agent groups"}
+                {resourceMonitorStore.loading
+                  ? "Loading snapshot..."
+                  : groups().length === 0
+                    ? "No active agents"
+                    : "No agents match the filters"}
               </div>
             }
           >
             <div class="rm-group-list">
-              <For each={groups()}>
+              <For each={filteredGroups()}>
                 {(group) => (
                   <div
                     class={`rm-group-row state-${groupSeverity(group)}`}
@@ -602,7 +854,7 @@ const ResourceMonitorApp: Component = () => {
         {(target) => (
           <div class="rm-modal-backdrop" data-ac-testid="resourceMonitor.killConfirm">
             <div class="rm-modal" role="dialog" aria-modal="true">
-              <h2>Kill agent group</h2>
+              <h2>Kill agent</h2>
               <p
                 class="rm-modal-target"
                 title={groupOrigin(target)}
@@ -641,7 +893,7 @@ const ResourceMonitorApp: Component = () => {
                   data-ac-testid="resourceMonitor.killConfirm.confirm"
                   data-ac-role="button"
                 >
-                  {killInFlight() ? "Killing..." : "Kill Group"}
+                  {killInFlight() ? "Killing..." : "Kill Agent"}
                 </button>
               </div>
             </div>

--- a/src/resource-monitor/styles/resource-monitor.css
+++ b/src/resource-monitor/styles/resource-monitor.css
@@ -279,6 +279,119 @@ button {
   font-size: var(--font-size-sm);
 }
 
+/* #566 - right-aligned meta group so <h2> stays left and the "Showing X of Y"
+   indicator + timestamp stay right (space-between with one grouped child). */
+.rm-section-header-meta {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-md);
+  min-width: 0;
+}
+
+.rm-filter-count {
+  color: var(--sidebar-accent) !important;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+/* #566 - filter toolbar */
+.rm-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  border-radius: var(--radius-md);
+  background: var(--sidebar-surface);
+  box-shadow: inset 0 0 0 1px var(--sidebar-border);
+}
+
+.rm-filter-segment {
+  display: inline-flex;
+  padding: 2px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.rm-filter-seg-btn {
+  min-height: 26px;
+  padding: 0 12px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--sidebar-fg-dim);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.rm-filter-seg-btn:hover {
+  color: var(--sidebar-fg);
+}
+
+.rm-filter-seg-btn.is-active {
+  background: rgba(0, 212, 255, 0.13);
+  color: var(--sidebar-accent);
+}
+
+.rm-filter-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+}
+
+.rm-filter-label {
+  color: var(--sidebar-fg-dim);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.rm-filter-chip {
+  min-height: 24px;
+  padding: 0 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--sidebar-fg-dim);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.rm-filter-chip:hover {
+  background: rgba(255, 255, 255, 0.09);
+  color: var(--sidebar-fg);
+}
+
+.rm-filter-chip.is-active {
+  background: rgba(0, 212, 255, 0.13);
+  color: var(--sidebar-accent);
+  box-shadow: inset 0 0 0 1px rgba(0, 212, 255, 0.3);
+}
+
+.rm-filter-clear {
+  min-height: 24px;
+  margin-left: auto;
+  padding: 0 10px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--sidebar-fg-dim);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.rm-filter-clear:hover {
+  background: rgba(255, 59, 92, 0.12);
+  color: var(--status-exited);
+}
+
 .rm-group-list {
   display: flex;
   flex-direction: column;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -319,6 +319,9 @@ export interface ResourceAgentGroupSnapshot {
   /** #516 - bare agent name (e.g. "dev-rust"), or `null` when the launch cwd
    * carries no replica identity. Always present. */
   agent: string | null;
+  /** #566 - project folder name (e.g. "AgentsCommander_ac"), or `null` for
+   * origin / ad-hoc / unparseable launches. Always present. */
+  project: string | null;
   rootPid?: number | null;
   rootIdentity?: ResourceProcessIdentity | null;
   state: ResourceGroupState;

--- a/src/sidebar/components/ActionBar.tsx
+++ b/src/sidebar/components/ActionBar.tsx
@@ -230,7 +230,7 @@ const ActionBar: Component = () => {
     const snapshot = resourceMonitorStore.snapshot;
     if (state === "disabled") return "Resource Monitor disabled";
     if (!snapshot) return "Resource Monitor status unknown";
-    return `Resource Monitor: ${snapshot.activeAgentGroups}/${snapshot.maxConcurrentAgentGroups} agent groups, ${state}`;
+    return `Resource Monitor: ${snapshot.activeAgentGroups}/${snapshot.maxConcurrentAgentGroups} agents, ${state}`;
   };
 
   const handleOpenResourceMonitor = () => {


### PR DESCRIPTION
## Summary

Resource Monitor window improvements (re-scoped #566):

- **A — Activity filters**: status segmented control (All/Active/Inactive; active = `state !== "terminated"`) + multi-select chips for **project**, **workgroup**, and **role**. Combinable (AND across dimensions, OR within). Header "Active Agents N/M" stays bound to global totals; a "Showing X of Y" indicator + Clear filters reflect the filtered view. New backend `project` field threaded through the resource-monitor snapshot (derived from the spawn cwd's `.ac` anchor); dedup `project` added to the retain predicate only (the #559 eviction gate is untouched).
- **B — Rename**: all user-facing "Group/Groups" wording → "Agent/Agents" across the Resource Monitor window (header, sections, empty states, kill modal) + the sidebar RM badge tooltip. Internal identifiers (`data-ac-role="group"`, testids, CSS classes, IPC field names) preserved.
- **C — Close-on-exit**: when the `main` window is destroyed, the `resource-monitor` window is destroyed too (no orphaned window), with log-on-failure. Covers both quit paths (X button + confirm modal).
- **D — (LOW)** reworded the stale `MAX_TERMINATED_RETAINED` doc comment (value kept at 16).
- **N1 polish**: the filtered-empty view no longer flashes "Loading…" on each poll (loading branch gated on `groups().length === 0`).

## Testing / review

- Full path: architect plan → dev-rust + dev-webpage-ui + grinch consensus (READY_FOR_IMPLEMENTATION) → implementation → grinch adversarial review (PASS) → N1 fix + focused grinch re-review (PASS).
- Gates green on the merged tree (`45402e9`): `cargo test --lib --bins --tests` 1413 passed, `vitest` 423 passed, `tsc --noEmit` clean.
- Re-synced with `origin/main` twice (first re-sync — resmon #559/#543/#564 overlap — got a full focused grinch PASS; second re-sync — additive `types.ts` only, #574/#580, no resmon interaction — verified by green gates + PR CI).
- The user authorized landing without a manual 0_AC test, accepting that the close-on-exit (G5) behavior was verified statically (not runtime).

Follow-up tracked separately: **#583** (pre-existing store-level per-poll `loading` flicker on the Refresh button).

Closes #566
