### PR TITLE
fix(coordinator): clear stale/wrong AUTO-CLOSED pill on a live coordinator (#589)

### DIFF
--- a/src-tauri/src/session/auto_close.rs
+++ b/src-tauri/src/session/auto_close.rs
@@ -111,6 +111,17 @@ fn team_is_closeable(established: bool, anchor_secs: i64, now_secs: i64, timeout
     established && anchor_secs != i64::MIN && (now_secs - anchor_secs) > timeout_secs
 }
 
+/// (#589) Should a successful destroy stamp its team's coordinator row
+/// AUTO-CLOSED? True IFF the destroyed session IS that team's coordinator
+/// (`coord_id_of_team == Some(destroyed_id)`). A reaped sibling member while the
+/// coordinator survives (spared by the TOCTOU/repaint guards) returns false, so
+/// the LIVE coordinator keeps its idle counter instead of a stale pill. `None`
+/// (no coordinator record for the team) is never a coordinator close. Pure; this
+/// is the #589 gate and gets its own unit test.
+fn destroyed_is_team_coordinator(destroyed_id: Uuid, coord_id_of_team: Option<Uuid>) -> bool {
+    coord_id_of_team == Some(destroyed_id)
+}
+
 async fn tick(app: &AppHandle, last_emitted: &mut HashMap<String, i64>) {
     let settings = app.state::<SettingsState>();
     let (enabled, timeout_min) = {
@@ -153,6 +164,13 @@ async fn tick(app: &AppHandle, last_emitted: &mut HashMap<String, i64>) {
     let id_to_team: HashMap<Uuid, String> =
         members.iter().map(|(id, k)| (*id, k.clone())).collect();
     let coord_refs = session_mgr.read().await.coordinator_refs_by_team().await;
+    // (#589) team -> coordinator session id, over the same coordinator records as
+    // coord_refs. Gates the AUTO-CLOSED mark on the coordinator's OWN destruction
+    // (not "any member destroyed"): a surviving coordinator whose sibling was
+    // reaped keeps its idle counter instead of getting a stale pill. A separate
+    // read lock from coord_refs, but a transient disagreement is benign (a team in
+    // one map but not the other simply yields no spurious mark).
+    let coord_ids = session_mgr.read().await.coordinator_ids_by_team().await;
 
     let now_secs = Utc::now().timestamp();
     let Some(clocks) = app.try_state::<CoordinatorClocksState>() else {
@@ -232,7 +250,10 @@ async fn tick(app: &AppHandle, last_emitted: &mut HashMap<String, i64>) {
         .map(|(id, _)| *id)
         .collect();
 
-    let mut closed_teams: HashSet<String> = HashSet::new();
+    // (#589) Teams whose COORDINATOR'S OWN session was auto-closed this tick. A
+    // team where only a non-coordinator member was reaped is deliberately absent,
+    // so the surviving coordinator row is never stamped AUTO-CLOSED.
+    let mut coord_closed_teams: HashSet<String> = HashSet::new();
     for id in to_close {
         // TOCTOU re-check (G2): skip if a user message advanced the anchor since
         // the snapshot, OR this member emitted within REPAINT_GRACE. The second
@@ -265,8 +286,14 @@ async fn tick(app: &AppHandle, last_emitted: &mut HashMap<String, i64>) {
                 "[auto-close] terminated idle session {}",
                 &id.to_string()[..8]
             );
+            // (#589) Record the team for the AUTO-CLOSED mark ONLY when the
+            // destroyed session IS this team's coordinator. A sibling member
+            // reaped while the coordinator survives must NOT stamp the live
+            // coordinator row; it keeps its idle counter.
             if let Some(team) = id_to_team.get(&id) {
-                closed_teams.insert(team.clone());
+                if destroyed_is_team_coordinator(id, coord_ids.get(team).copied()) {
+                    coord_closed_teams.insert(team.clone());
+                }
             }
         }
     }
@@ -275,12 +302,12 @@ async fn tick(app: &AppHandle, last_emitted: &mut HashMap<String, i64>) {
     // emit so the sidebar shows the pill live (discovery reload self-heals from
     // the persisted marker). mark_auto_closed is idempotent (emits once). The
     // dirty flag set here is persisted by flush_clocks at the end of this tick.
-    if !closed_teams.is_empty() {
+    if !coord_closed_teams.is_empty() {
         if let Some(clocks) =
             app.try_state::<crate::config::coordinator_clocks::CoordinatorClocksState>()
         {
             let now = chrono::Utc::now();
-            for team in &closed_teams {
+            for team in &coord_closed_teams {
                 // No live coordinator record for this team at close time (already
                 // torn down) -> nothing to badge; sessions were still terminated.
                 // Rare; documented in plan §7.
@@ -544,6 +571,33 @@ mod tests {
         assert!(
             !team_is_closeable(true, i64::MIN, now, 3600),
             "a team with no anchor (i64::MIN) is never closeable"
+        );
+    }
+
+    // ---- destroyed_is_team_coordinator (#589 gated AUTO-CLOSED mark) ----
+
+    #[test]
+    fn mark_gate_true_only_when_destroyed_is_the_coordinator() {
+        let coord = Uuid::new_v4();
+        let member = Uuid::new_v4();
+
+        // The destroyed session IS the team's coordinator -> the row may be marked.
+        assert!(
+            destroyed_is_team_coordinator(coord, Some(coord)),
+            "destroying the coordinator's own session marks the row"
+        );
+
+        // A sibling member was reaped while the coordinator (coord) survives ->
+        // the live coordinator row must NOT be stamped. This is the #589 bug.
+        assert!(
+            !destroyed_is_team_coordinator(member, Some(coord)),
+            "a surviving coordinator must NOT be stamped when only a member is reaped"
+        );
+
+        // No coordinator record for the team -> never a coordinator close.
+        assert!(
+            !destroyed_is_team_coordinator(member, None),
+            "absent coordinator id must not mark the row"
         );
     }
 }

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -318,6 +318,27 @@ impl SessionManager {
         out
     }
 
+    /// (#589) team key `<project>:<wg>` -> the coordinator session's `Uuid`, over
+    /// the SAME coordinator records that `coordinator_refs_by_team` keys. The
+    /// auto-close task uses this to mark a coordinator row AUTO-CLOSED only when
+    /// the coordinator's OWN session was the one destroyed, not when any sibling
+    /// member was reaped while the coordinator survived. One coordinator per team;
+    /// on the unlikely duplicate, last writer wins (mirrors `coordinator_refs_by_team`).
+    pub async fn coordinator_ids_by_team(&self) -> std::collections::HashMap<String, Uuid> {
+        let sessions = self.sessions.read().await;
+        let mut out: std::collections::HashMap<String, Uuid> = std::collections::HashMap::new();
+        for s in sessions.values() {
+            if !s.is_coordinator {
+                continue;
+            }
+            let fqn = crate::config::teams::agent_fqn_from_path(&s.working_directory);
+            if let Some((team, _agent)) = fqn.rsplit_once('/') {
+                out.insert(team.to_string(), s.id);
+            }
+        }
+        out
+    }
+
     pub async fn mark_exited(&self, id: Uuid, code: i32) {
         let mut sessions = self.sessions.write().await;
         if let Some(s) = sessions.get_mut(&id) {
@@ -1045,5 +1066,35 @@ mod tests {
         assert_eq!(fqn, "myproj:wg-1-team/lead");
         assert_eq!(cwd, COORD_CWD);
         let _ = coord;
+    }
+
+    #[tokio::test]
+    async fn coordinator_ids_by_team_maps_team_to_coordinator_id() {
+        let mgr = SessionManager::new();
+        let coord = mgr
+            .create_session("claude".into(), vec![], COORD_CWD.into(), None, None, vec![], true)
+            .await
+            .unwrap();
+        // A non-coordinator agent on the same team must NOT appear (only the coordinator).
+        let _rust = mgr
+            .create_session(
+                "codex".into(),
+                vec![],
+                RUST_CWD.into(),
+                Some("codex".into()),
+                None,
+                vec![],
+                false,
+            )
+            .await
+            .unwrap();
+
+        let ids = mgr.coordinator_ids_by_team().await;
+        assert_eq!(ids.len(), 1, "exactly one coordinator team");
+        assert_eq!(
+            ids.get(TEAM_KEY),
+            Some(&coord.id),
+            "team key maps to the coordinator session id, not a member"
+        );
     }
 }

--- a/src/sidebar/components/ProjectPanel.idle-badge.test.tsx
+++ b/src/sidebar/components/ProjectPanel.idle-badge.test.tsx
@@ -8,9 +8,11 @@ import {
   installBrowserDomStubs,
   renderWithFakeTransport,
   resetUiStoresForTests,
+  session,
   waitFor,
 } from "../../shared/testing/ui-harness";
 import { projectStore } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
 import { settingsStore } from "../../shared/stores/settings";
 import { clockStore } from "../stores/clock";
 import type { AcAgentReplica } from "../../shared/types";
@@ -109,6 +111,62 @@ describe("ProjectPanel coordinator idle badge (#580 XOR gate + conditional toolt
         expect(counter?.classList.contains("red")).toBe(true);
         expect(counter?.textContent).toBe("90m");
       });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("#589: hides the AUTO-CLOSED pill once the coordinator has a live session, restoring the counter — even with a stale autoClosedAt", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("get_settings", baseSettings({ coordinatorAutoCloseEnabled: true }));
+    // Auto-closed marker set AND a 90-min idle anchor. Critically, the marker is
+    // NEVER cleared in this test (it simulates a discovery reload clobbering the
+    // event clear, the #589 root cause): the liveness gate alone must drive the
+    // pill, proving the fix self-heals without the projectStore marker changing.
+    fake.resolve(
+      "discover_project",
+      coordDiscovery({ lastUserMessageAt: isoMinutesAgo(90), autoClosedAt: isoMinutesAgo(5) })
+    );
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      // (b) autoClosedAt set AND no live session → the gray pill shows, counter gated off.
+      await waitFor(() => {
+        expect(rendered.root.querySelector(".coord-autoclosed")).not.toBeNull();
+        expect(rendered.root.querySelector(".coord-idle")).toBeNull();
+      });
+
+      // Raise: a live session lands in the sessionsStore — the SAME signal the
+      // status dot reads — while the projectStore autoClosedAt stays stale.
+      sessionsStore.setSessions([
+        session({
+          id: "coord-live",
+          name: "wg-2-dev-team/dev-webpage-ui",
+          workingDirectory: coordPath,
+          isCoordinator: true,
+          status: "running",
+        }),
+      ]);
+
+      // (a) autoClosedAt still set BUT the session is live → pill ABSENT, the red
+      // 90m counter returns automatically via the XOR gate.
+      await waitFor(() => {
+        expect(rendered.root.querySelector(".coord-autoclosed")).toBeNull();
+        const counter = rendered.root.querySelector(".coord-idle");
+        expect(counter).not.toBeNull();
+        expect(counter?.classList.contains("red")).toBe(true);
+        expect(counter?.textContent).toBe("90m");
+      });
+
+      // The marker was never cleared — the liveness gate, not the marker, hid the
+      // pill. This is the self-heal that survives a discovery clobber.
+      const coord = projectStore.projects[0]?.workgroups[0]?.agents[0];
+      expect(coord?.autoClosedAt).toBeTruthy();
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1233,7 +1233,21 @@ const ProjectPanel: Component = () => {
           // when autoClosed() is true the counter is gated off (XOR below), so a
           // closed team shows ONLY the gray AUTO-CLOSED pill; clearing the marker
           // on reopen makes autoClosed() false and the counter returns.
-          const autoClosed = createMemo(() => isCoord() && !!replica.autoClosedAt);
+          // #589: ALSO gate on liveness. On raise the dot turns green from the
+          // sessionsStore (live session), but a discovery reload can clobber the
+          // event-cleared autoClosedAt back to its stale value (reloadProject's
+          // wholesale `workgroups` replace, project.ts:311-323), leaving the pill
+          // stuck while the dot is green. An auto-closed team is DESTROYED, so it is
+          // never live — there is no legitimate "live + auto-closed" state. Gating
+          // on `!live` hides the pill the moment the session goes live, reusing the
+          // exact signal the status dot reads, so it self-heals regardless of the
+          // stale marker; the XOR'd idle counter returns automatically. Inlined
+          // isSessionLive(session()) (=== isLive() below) because createMemo runs
+          // EAGERLY and `isLive` is declared further down — calling it here would
+          // hit its temporal dead zone for a coordinator already auto-closed at mount.
+          const autoClosed = createMemo(
+            () => isCoord() && !!replica.autoClosedAt && !isSessionLive(session())
+          );
           // #580 idle-badge tooltip. The auto-close clause is appended ONLY when
           // the setting is enabled: Decision 3 keeps the badge (and its red >=60
           // color) visible even when auto-close is OFF, where the team will NOT


### PR DESCRIPTION
Fixes a LIVE (green-dot) coordinator still showing the gray AUTO-CLOSED pill. Observed: after relaunching the app and raising a coordinator that was auto-closed beforehand, the pill did not clear immediately.

## Root causes (two)
1. **FE discovery clobber** — on raise, the backend clears `autoClosedAt` and emits `coordinator_auto_close_changed {null}`, the FE applies it (pill clears), but a racing in-flight discovery refresh does a wholesale `workgroups` array replace (`src/sidebar/stores/project.ts`) that clobbers the event clear and re-sets the stale value. The status dot updates because it reads `sessionsStore` (session liveness), a different store than `projectStore` (which carries `autoClosedAt`) — so dot and pill diverged.
2. **BE mis-mark** — `session/auto_close.rs` stamped a team's coordinator AUTO-CLOSED whenever ANY member of a closeable team was destroyed, even if the coordinator's own session survived (spared by the per-member guards).

## Fixes (defense in depth)
- **Frontend** (`b04f59b`): gate the pill on liveness — `autoClosed = isCoord() && !!replica.autoClosedAt && !isSessionLive(session())` (`ProjectPanel.tsx`), reusing the `sessionsStore` liveness the dot already uses. A live coordinator never shows AUTO-CLOSED; the pill clears immediately on raise regardless of a stale `projectStore.autoClosedAt`. Inlined `isSessionLive(session())` (not `isLive()`) to avoid an eager-`createMemo` TDZ ReferenceError. + test.
- **Backend** (`2872d3a`): mark a coordinator AUTO-CLOSED only when its OWN session was destroyed — new `SessionManager::coordinator_ids_by_team()`, pure `destroyed_is_team_coordinator` predicate, `closed_teams` → `coord_closed_teams`. A member-only reap no longer mis-marks a surviving coordinator. + unit tests.
- Re-synced onto latest `origin/main` (merge `809fb83`, clean; coexists with #548 / #591, v0.9.16).

## Testing / review
- grinch adversarial review: **PASS** (FE reactive-hide + no-false-negative + TDZ-avoidance verified; BE mark-only-on-own-reap + benign second-read-lock verified; re-sync integrity byte-identical #589 footprint, disjoint from #548, zero conflict markers).
- Gates green: `cargo build` / `cargo clippy -D warnings` clean; **1420 backend tests**; `tsc --noEmit` clean; **vitest 434**.
- shipper built + deployed `agentscommander_standalone_wg-1.exe` to `0_AC`; **user manually tested** (raised an auto-closed coordinator → pill cleared immediately, idle counter returned) and confirmed it works.

## Follow-ups (not in this PR)
- #582 — orphaned member on a half-teardown.
- FE Option B — make `reloadProject` preserve in-flight event patches (hardens the general "discovery clobbers event patch" class; also protects clock/branch patches).
- Optional BE hardening — ensure discovery cannot return a snapshot whose `autoClosedAt` predates the last emitted clear.

Closes #589
