### PR TITLE
feat(resource-monitor): maximize detached window + central-pane view (#587)

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1156,6 +1156,20 @@ pub async fn set_theme_light(
     .await
 }
 
+/// Narrow setter for `main_resource_monitor_attached` (#587). Same
+/// candidate-save-publish pattern as `set_theme_light`; lets the central-view
+/// toggle persist without a get+update round-trip racing SettingsModal.
+#[tauri::command]
+pub async fn set_main_resource_monitor_attached(
+    settings: State<'_, SettingsState>,
+    value: bool,
+) -> Result<(), String> {
+    persist_narrow_settings_update(settings.inner(), |candidate| {
+        candidate.main_resource_monitor_attached = value;
+    })
+    .await
+}
+
 /// Sweep every AC-managed agent directory and apply
 /// `ensure_rtk_pretool_hook(dir, enabled)`. Best-effort per directory:
 /// per-dir failures are logged + appended to `errors` and the sweep

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -297,6 +297,10 @@ pub struct AppSettings {
     /// Keep the unified main window always on top.
     #[serde(default)]
     pub main_always_on_top: bool,
+    /// #587 - whether the Resource Monitor occupies the main central pane (vs the
+    /// terminal). Restored on startup; default false (terminal).
+    #[serde(default)]
+    pub main_resource_monitor_attached: bool,
     /// Enable the embedded web server for remote browser access
     #[serde(default)]
     pub web_server_enabled: bool,
@@ -550,6 +554,7 @@ impl Default for AppSettings {
             main_sidebar_width: default_main_sidebar_width(),
             main_sidebar_side: MainSidebarSide::default(),
             main_always_on_top: false,
+            main_resource_monitor_attached: false,
             web_server_enabled: false,
             web_server_port: default_web_port(),
             web_server_bind: default_web_bind(),
@@ -2623,6 +2628,55 @@ mod tests {
         assert!(json.contains("\"injectRtkHook\":true"));
         let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
         assert!(back.inject_rtk_hook);
+    }
+
+    #[test]
+    fn main_resource_monitor_attached_round_trips_and_defaults_false() {
+        // #587 - round-trips through serde as camelCase.
+        let mut s = AppSettings::default();
+        assert!(!s.main_resource_monitor_attached);
+        s.main_resource_monitor_attached = true;
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert!(json.contains("\"mainResourceMonitorAttached\":true"));
+        let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.main_resource_monitor_attached);
+
+        // Absent from an older settings.json => serde default false.
+        let json_without = r#"{
+            "defaultShell": "bash",
+            "defaultShellArgs": [],
+            "agents": [],
+            "telegramBots": [],
+            "startOnlyCoordinators": true,
+            "sidebarAlwaysOnTop": false,
+            "raiseTerminalOnClick": true,
+            "voiceToTextEnabled": false,
+            "geminiApiKey": "",
+            "geminiModel": "gemini-2.5-flash",
+            "voiceAutoExecute": true,
+            "voiceAutoExecuteDelay": 15,
+            "sidebarZoom": 1.0,
+            "terminalZoom": 1.0,
+            "mainZoom": 1.0,
+            "guideZoom": 1.0,
+            "darkfactoryZoom": 1.0,
+            "sidebarGeometry": null,
+            "terminalGeometry": null,
+            "mainGeometry": null,
+            "mainSidebarWidth": 280.0,
+            "mainAlwaysOnTop": false,
+            "webServerEnabled": false,
+            "webServerPort": 7777,
+            "webServerBind": "127.0.0.1",
+            "projectPath": null,
+            "projectPaths": [],
+            "sidebarStyle": "noir-minimal",
+            "onboardingDismissed": false,
+            "coordSortByActivity": false
+        }"#;
+        let from_old: AppSettings =
+            serde_json::from_str(json_without).expect("deserialize old json");
+        assert!(!from_old.main_resource_monitor_attached);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1712,6 +1712,7 @@ pub fn run(
             commands::config::set_rtk_prompt_dismissed,
             commands::config::set_sounds_enabled,
             commands::config::set_theme_light,
+            commands::config::set_main_resource_monitor_attached,
             commands::config::sweep_rtk_hook,
             commands::config::get_rtk_startup_status,
             commands::repos::search_repos,

--- a/src/main/App.tsx
+++ b/src/main/App.tsx
@@ -1,7 +1,7 @@
 import { Component, createSignal, onMount, onCleanup, Show } from "solid-js";
 import type { UnlistenFn } from "../shared/transport";
 import type { MainSidebarSide } from "../shared/types";
-import { SettingsAPI, onResourceMonitorAttach, onSessionSwitched } from "../shared/ipc";
+import { SettingsAPI } from "../shared/ipc";
 import { isTauri } from "../shared/platform";
 import { initZoom } from "../shared/zoom";
 import { initWindowGeometry } from "../shared/window-geometry";
@@ -9,6 +9,7 @@ import SidebarApp from "../sidebar/App";
 import TerminalApp from "../terminal/App";
 import ResourceMonitorApp from "../resource-monitor/App";
 import { centralViewStore } from "./stores/centralView";
+import { wireCentralViewListeners } from "./listeners-central-view";
 import Titlebar from "../sidebar/components/Titlebar";
 import QuitConfirmModal from "./components/QuitConfirmModal";
 import RtkBanner from "./components/RtkBanner";
@@ -185,16 +186,10 @@ const MainApp: Component = () => {
     // discriminator on session_switched — is unit-testable in isolation.
     unlisteners.push(...(await wireHomeListeners()));
 
-    // #587 — selecting any session reveals the terminal (covers an embedded
-    // RM); the detached RM window's Attach button pulls RM back in-pane. Both
-    // calls are guarded idempotent in centralViewStore, so double-firing
-    // alongside SessionItem's direct showTerminal() is harmless.
-    unlisteners.push(
-      await onSessionSwitched(() => centralViewStore.showTerminal())
-    );
-    unlisteners.push(
-      await onResourceMonitorAttach(() => centralViewStore.showResourceMonitor())
-    );
+    // #587 — central-view event contract (gated session_switched + RM attach).
+    // Extracted to a helper that mirrors wireHomeListeners so the userInitiated
+    // discriminator is unit-testable in isolation (see listeners-central-view.ts).
+    unlisteners.push(...(await wireCentralViewListeners()));
 
     window.addEventListener("resize", onWindowResize);
     window.addEventListener("main-sidebar-width-change", onSidebarWidthChange);

--- a/src/main/App.tsx
+++ b/src/main/App.tsx
@@ -1,12 +1,14 @@
 import { Component, createSignal, onMount, onCleanup, Show } from "solid-js";
 import type { UnlistenFn } from "../shared/transport";
 import type { MainSidebarSide } from "../shared/types";
-import { SettingsAPI } from "../shared/ipc";
+import { SettingsAPI, onResourceMonitorAttach, onSessionSwitched } from "../shared/ipc";
 import { isTauri } from "../shared/platform";
 import { initZoom } from "../shared/zoom";
 import { initWindowGeometry } from "../shared/window-geometry";
 import SidebarApp from "../sidebar/App";
 import TerminalApp from "../terminal/App";
+import ResourceMonitorApp from "../resource-monitor/App";
+import { centralViewStore } from "./stores/centralView";
 import Titlebar from "../sidebar/components/Titlebar";
 import QuitConfirmModal from "./components/QuitConfirmModal";
 import RtkBanner from "./components/RtkBanner";
@@ -165,6 +167,11 @@ const MainApp: Component = () => {
       const saved = settings.mainSidebarWidth ?? DEFAULT_MAIN_SIDEBAR_WIDTH;
       setSidebarWidth(clampMainSidebarWidth(saved, window.innerWidth));
       setSidebarSide(settings.mainSidebarSide === "left" ? "left" : DEFAULT_SIDEBAR_SIDE);
+      // #587 — restore the persisted central-view choice (RM attached vs
+      // terminal). setInitialView only sets the signal; it does not persist.
+      centralViewStore.setInitialView(
+        settings.mainResourceMonitorAttached ? "resourceMonitor" : "terminal"
+      );
       if (isTauri && settings.mainAlwaysOnTop) {
         const { getCurrentWindow } = await import("@tauri-apps/api/window");
         await getCurrentWindow().setAlwaysOnTop(true);
@@ -177,6 +184,17 @@ const MainApp: Component = () => {
     // dedicated helper so the gating logic — especially the userInitiated
     // discriminator on session_switched — is unit-testable in isolation.
     unlisteners.push(...(await wireHomeListeners()));
+
+    // #587 — selecting any session reveals the terminal (covers an embedded
+    // RM); the detached RM window's Attach button pulls RM back in-pane. Both
+    // calls are guarded idempotent in centralViewStore, so double-firing
+    // alongside SessionItem's direct showTerminal() is harmless.
+    unlisteners.push(
+      await onSessionSwitched(() => centralViewStore.showTerminal())
+    );
+    unlisteners.push(
+      await onResourceMonitorAttach(() => centralViewStore.showResourceMonitor())
+    );
 
     window.addEventListener("resize", onWindowResize);
     window.addEventListener("main-sidebar-width-change", onSidebarWidthChange);
@@ -249,6 +267,15 @@ const MainApp: Component = () => {
         />
         <div class="main-terminal-pane">
           <TerminalApp embedded />
+          <Show when={centralViewStore.isResourceMonitor}>
+            <div
+              class="main-rm-pane"
+              data-ac-testid="main.resourceMonitorPane"
+              data-ac-role="surface"
+            >
+              <ResourceMonitorApp embedded />
+            </div>
+          </Show>
         </div>
       </div>
       <Show when={quitModalCount() !== null}>

--- a/src/main/listeners-central-view.test.ts
+++ b/src/main/listeners-central-view.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type SwitchedPayload = { id: string | null; userInitiated?: boolean };
+
+// Capture the listener callbacks so cases can fire crafted payloads through the
+// same code path the backend would use (mirrors listeners-home.test.ts).
+const m = vi.hoisted(() => ({
+  switchedCb: null as ((data: SwitchedPayload) => void) | null,
+  attachCb: null as (() => void) | null,
+  setAttached: vi.fn(() => Promise.resolve()),
+}));
+
+// isTauri=false so centralViewStore.closeDetachedResourceMonitor() is a no-op.
+vi.mock("../shared/platform", () => ({ isTauri: false }));
+
+vi.mock("../shared/ipc", () => ({
+  onSessionSwitched: vi.fn((cb: (data: SwitchedPayload) => void) => {
+    m.switchedCb = cb;
+    return Promise.resolve(() => {});
+  }),
+  onResourceMonitorAttach: vi.fn((cb: () => void) => {
+    m.attachCb = cb;
+    return Promise.resolve(() => {});
+  }),
+  // centralViewStore imports SettingsAPI; stub the narrow setter it persists with
+  // so we can assert (no) persistence.
+  SettingsAPI: { setMainResourceMonitorAttached: m.setAttached },
+}));
+
+import { wireCentralViewListeners } from "./listeners-central-view";
+import {
+  centralViewStore,
+  __resetCentralViewStoreForTests,
+} from "./stores/centralView";
+
+describe("wireCentralViewListeners (issue #587)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetCentralViewStoreForTests();
+    m.switchedCb = null;
+    m.attachCb = null;
+  });
+
+  it("session_switched with userInitiated=true and a real id reveals the terminal", async () => {
+    centralViewStore.setInitialView("resourceMonitor");
+    await wireCentralViewListeners();
+    m.switchedCb!({ id: "abc", userInitiated: true });
+    expect(centralViewStore.isResourceMonitor).toBe(false);
+    expect(m.setAttached).toHaveBeenCalledWith(false);
+  });
+
+  // HIGH-1 regression guard: a NON-user switch must NOT flip away from RM — it
+  // would persist `false` and corrupt the restored mainResourceMonitorAttached
+  // choice (and yank the RM view away mid-use).
+  it("session_switched WITHOUT userInitiated leaves RM in place (restore / auto-promote)", async () => {
+    centralViewStore.setInitialView("resourceMonitor");
+    await wireCentralViewListeners();
+    m.switchedCb!({ id: "abc" });
+    expect(centralViewStore.isResourceMonitor).toBe(true);
+    expect(m.setAttached).not.toHaveBeenCalled();
+  });
+
+  it("session_switched with userInitiated=false leaves RM in place", async () => {
+    centralViewStore.setInitialView("resourceMonitor");
+    await wireCentralViewListeners();
+    m.switchedCb!({ id: "abc", userInitiated: false });
+    expect(centralViewStore.isResourceMonitor).toBe(true);
+    expect(m.setAttached).not.toHaveBeenCalled();
+  });
+
+  it("session_switched with id=null leaves RM in place even when userInitiated=true", async () => {
+    centralViewStore.setInitialView("resourceMonitor");
+    await wireCentralViewListeners();
+    m.switchedCb!({ id: null, userInitiated: true });
+    expect(centralViewStore.isResourceMonitor).toBe(true);
+    expect(m.setAttached).not.toHaveBeenCalled();
+  });
+
+  it("resource_monitor_attach pulls RM back into the central pane", async () => {
+    centralViewStore.setInitialView("terminal");
+    await wireCentralViewListeners();
+    m.attachCb!();
+    expect(centralViewStore.isResourceMonitor).toBe(true);
+    expect(m.setAttached).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/main/listeners-central-view.ts
+++ b/src/main/listeners-central-view.ts
@@ -1,0 +1,40 @@
+import { onResourceMonitorAttach, onSessionSwitched } from "../shared/ipc";
+import type { UnlistenFn } from "../shared/transport";
+import { centralViewStore } from "./stores/centralView";
+
+/**
+ * Wires the #587 central-view event contract for the main window. Extracted
+ * into a helper (mirrors `wireHomeListeners`) so the `userInitiated`
+ * discriminator on `session_switched` is unit-testable in isolation.
+ *
+ * Listeners installed:
+ * - `session_switched`: reveal the terminal (cover an embedded RM) ONLY when
+ *   the backend marks the switch user-initiated (`userInitiated === true`) and
+ *   it carries a real id. A non-user switch — boot restore, destroy
+ *   auto-promote, detach sibling-switch, mailbox/coordinator switch — must NOT
+ *   flip away from RM: `centralViewStore.showTerminal()` persists `false`, which
+ *   would defeat the restored `mainResourceMonitorAttached` choice (plan §6) and
+ *   yank the RM view away mid-use. This mirrors the Home listener's discriminator
+ *   (`listeners-home.ts`). Explicit user clicks are additionally covered by
+ *   `SessionItem.handleClick`, which calls `showTerminal()` directly (so an
+ *   already-active click, which emits no `session_switched`, still covers RM).
+ * - `resource_monitor_attach`: the detached RM window asks the main window to
+ *   pull RM back into the central pane.
+ *
+ * Returns the unlisten functions so the caller can clean up on unmount.
+ */
+export async function wireCentralViewListeners(): Promise<UnlistenFn[]> {
+  const unlisteners: UnlistenFn[] = [];
+
+  unlisteners.push(
+    await onSessionSwitched(({ id, userInitiated }) => {
+      if (id && userInitiated === true) centralViewStore.showTerminal();
+    })
+  );
+
+  unlisteners.push(
+    await onResourceMonitorAttach(() => centralViewStore.showResourceMonitor())
+  );
+
+  return unlisteners;
+}

--- a/src/main/stores/centralView.test.ts
+++ b/src/main/stores/centralView.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// isTauri=false so closeDetachedResourceMonitor() is a no-op and we never reach
+// the @tauri-apps/api/webviewWindow dynamic import.
+vi.mock("../../shared/platform", () => ({ isTauri: false }));
+vi.mock("../../shared/ipc", () => ({
+  SettingsAPI: {
+    setMainResourceMonitorAttached: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+import { centralViewStore, __resetCentralViewStoreForTests } from "./centralView";
+import { SettingsAPI } from "../../shared/ipc";
+
+const setAttached = () =>
+  SettingsAPI.setMainResourceMonitorAttached as ReturnType<typeof vi.fn>;
+
+describe("centralViewStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetCentralViewStoreForTests();
+  });
+
+  it("defaults to the terminal view", () => {
+    expect(centralViewStore.view).toBe("terminal");
+    expect(centralViewStore.isResourceMonitor).toBe(false);
+  });
+
+  it("showResourceMonitor flips to RM and persists true", () => {
+    centralViewStore.showResourceMonitor();
+    expect(centralViewStore.isResourceMonitor).toBe(true);
+    expect(setAttached()).toHaveBeenCalledTimes(1);
+    expect(setAttached()).toHaveBeenCalledWith(true);
+  });
+
+  it("showTerminal from RM flips back and persists false", () => {
+    centralViewStore.showResourceMonitor();
+    setAttached().mockClear();
+    centralViewStore.showTerminal();
+    expect(centralViewStore.view).toBe("terminal");
+    expect(setAttached()).toHaveBeenCalledTimes(1);
+    expect(setAttached()).toHaveBeenCalledWith(false);
+  });
+
+  it("showTerminal early-returns when already terminal (no persist storm)", () => {
+    // session_switched fires often; the guard must avoid re-persisting false.
+    centralViewStore.showTerminal();
+    expect(setAttached()).not.toHaveBeenCalled();
+  });
+
+  it("showResourceMonitor early-returns when already RM (idempotent)", () => {
+    centralViewStore.showResourceMonitor();
+    setAttached().mockClear();
+    centralViewStore.showResourceMonitor();
+    expect(setAttached()).not.toHaveBeenCalled();
+  });
+
+  it("toggleResourceMonitor alternates between the two views", () => {
+    centralViewStore.toggleResourceMonitor();
+    expect(centralViewStore.isResourceMonitor).toBe(true);
+    centralViewStore.toggleResourceMonitor();
+    expect(centralViewStore.isResourceMonitor).toBe(false);
+  });
+
+  it("setInitialView sets the signal WITHOUT persisting (restore-only)", () => {
+    centralViewStore.setInitialView("resourceMonitor");
+    expect(centralViewStore.isResourceMonitor).toBe(true);
+    expect(setAttached()).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/stores/centralView.ts
+++ b/src/main/stores/centralView.ts
@@ -1,0 +1,74 @@
+import { createSignal } from "solid-js";
+import { isTauri } from "../../shared/platform";
+import { SettingsAPI } from "../../shared/ipc";
+
+// Issue #587 — the main central pane shows one of two views at a time: the
+// always-mounted terminal, or the Resource Monitor overlaid on top of it (same
+// shape as the Home overlay, see home.ts). This tiny store owns that choice.
+export type CentralView = "terminal" | "resourceMonitor";
+
+const [view, setView] = createSignal<CentralView>("terminal");
+
+// Best-effort persist of the attached-view choice (optimistic; errors are
+// logged, never surfaced — mirrors ActionBar's other optimistic persists).
+function persist(attached: boolean) {
+  SettingsAPI.setMainResourceMonitorAttached(attached).catch((e) =>
+    console.error("Failed to persist central-view choice:", e)
+  );
+}
+
+// Close a detached Resource Monitor window if one exists (enforces the
+// embedded-XOR-detached invariant). Best-effort, Tauri-only. The label literal
+// must match the backend RESOURCE_MONITOR_WINDOW_LABEL (window.rs).
+async function closeDetachedResourceMonitor() {
+  if (!isTauri) return;
+  try {
+    const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
+    const win = await WebviewWindow.getByLabel("resource-monitor");
+    if (win) await win.destroy();
+  } catch (e) {
+    console.warn("[centralView] closing detached RM window failed:", e);
+  }
+}
+
+export const centralViewStore = {
+  get view() {
+    return view();
+  },
+  get isResourceMonitor() {
+    return view() === "resourceMonitor";
+  },
+
+  // Restore-only: set the signal without persisting or touching windows.
+  // Called once from MainApp.onMount after settings load.
+  setInitialView(next: CentralView) {
+    setView(next);
+  },
+
+  showResourceMonitor() {
+    if (view() === "resourceMonitor") return;
+    void closeDetachedResourceMonitor();
+    setView("resourceMonitor");
+    persist(true);
+  },
+
+  showTerminal() {
+    // Guard against write storms: session_switched fires often, and without
+    // this early return every switch would re-persist `false`.
+    if (view() === "terminal") return;
+    setView("terminal");
+    persist(false);
+  },
+
+  toggleResourceMonitor() {
+    if (view() === "resourceMonitor") this.showTerminal();
+    else this.showResourceMonitor();
+  },
+};
+
+// Test-only reset (mirror __resetHomeStoreForTests). Gated to Vite MODE ===
+// "test" so production never resets the signal.
+export function __resetCentralViewStoreForTests() {
+  if (import.meta.env.MODE !== "test") return;
+  setView("terminal");
+}

--- a/src/main/styles/main.css
+++ b/src/main/styles/main.css
@@ -74,6 +74,26 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  /* #587 — containing block for the Resource Monitor overlay (.main-rm-pane). */
+  position: relative;
+}
+
+/* #587 — Resource Monitor as a central-pane view. The RM overlay covers the
+ * always-mounted terminal while RM is the selected central view (same pattern
+ * as the Home overlay). z-index MUST exceed .home-view's z-index:10 (above) so
+ * RM reliably covers Home too; .terminal-layout does not establish its own
+ * stacking context (position:relative + z-index:auto), so Home's z-10 lives in
+ * this pane's stacking context. */
+.main-rm-pane {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  background: var(--sidebar-bg, #0a0e14);
+}
+.main-rm-pane > .rm-root {
+  width: 100%;
+  height: 100%;
 }
 
 .main-root.main-sidebar-right .main-terminal-pane {

--- a/src/resource-monitor/App.automation.test.tsx
+++ b/src/resource-monitor/App.automation.test.tsx
@@ -240,6 +240,64 @@ describe("ResourceMonitorApp automation hooks", () => {
     }
   });
 
+  // #587 — embedded mode (mounted in MainApp's central pane) drops the window
+  // titlebar and exposes a Detach control instead.
+  it("in embedded mode hides the window titlebar and shows a Detach button", async () => {
+    const fake = new FakeTransport();
+    setupResourceMonitor(fake, activeSnapshot());
+
+    const rendered = renderWithFakeTransport(
+      () => <ResourceMonitorApp embedded />,
+      fake
+    );
+    try {
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector('[data-ac-testid="resourceMonitor.window"]')
+        ).not.toBeNull();
+      });
+
+      // No window titlebar (main owns the window chrome).
+      expect(rendered.root.querySelector(".rm-titlebar")).toBeNull();
+      expect(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.titlebar.attach"]')
+      ).toBeNull();
+      // Detach button present; the body + root still render.
+      expect(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.detach"]')
+      ).not.toBeNull();
+      expect(rendered.root.querySelector(".rm-root")).not.toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // #587 — windowed (default) mode keeps the window titlebar and shows no
+  // Detach button. (The titlebar's controls — including the renamed Attach
+  // button — are gated behind isTauri, which is false under jsdom, so only the
+  // titlebar shell is observable here; the Detach-vs-titlebar split is the
+  // meaningful embedded/windowed distinction.)
+  it("in windowed mode keeps the titlebar and shows no Detach button", async () => {
+    const fake = new FakeTransport();
+    setupResourceMonitor(fake, activeSnapshot());
+
+    const rendered = renderWithFakeTransport(() => <ResourceMonitorApp />, fake);
+    try {
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector('[data-ac-testid="resourceMonitor.window"]')
+        ).not.toBeNull();
+      });
+
+      expect(rendered.root.querySelector(".rm-titlebar")).not.toBeNull();
+      expect(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.detach"]')
+      ).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
   it("exposes a stable empty-state selector when no agents are active", async () => {
     const fake = new FakeTransport();
     setupResourceMonitor(fake, emptySnapshot());

--- a/src/resource-monitor/App.tsx
+++ b/src/resource-monitor/App.tsx
@@ -138,6 +138,13 @@ const toggleFilter = (
 };
 
 const Titlebar: Component = () => {
+  // #587 - tracks the real OS maximize state so the button glyph (maximize vs
+  // restore) and its labels stay correct. Not all maximize paths route through
+  // handleMaximize: Tauri v2 also maximizes natively on data-tauri-drag-region
+  // double-click, and the OS does it on Win+Up / edge-snap. onResized below
+  // re-reads the truth after every such change.
+  const [maximized, setMaximized] = createSignal(false);
+
   const handleDock = async () => {
     try {
       await WindowAPI.dockResourceMonitor();
@@ -152,11 +159,49 @@ const Titlebar: Component = () => {
     await getCurrentWindow().minimize();
   };
 
+  const handleMaximize = async () => {
+    if (!isTauri) return;
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    const win = getCurrentWindow();
+    await win.toggleMaximize();
+    // Reflect immediately so the icon swaps without waiting for the resize event.
+    setMaximized(await win.isMaximized());
+  };
+
   const handleClose = async () => {
     if (!isTauri) return;
     const { getCurrentWindow } = await import("@tauri-apps/api/window");
     await getCurrentWindow().close();
   };
+
+  onMount(() => {
+    if (!isTauri) return;
+    let unlisten: (() => void) | undefined;
+    let disposed = false;
+    // Register cleanup synchronously so it binds to this component's owner; the
+    // async listener registration below fills in `unlisten` once it resolves.
+    onCleanup(() => {
+      disposed = true;
+      unlisten?.();
+    });
+    void (async () => {
+      try {
+        const { getCurrentWindow } = await import("@tauri-apps/api/window");
+        const win = getCurrentWindow();
+        setMaximized(await win.isMaximized());
+        const stop = await win.onResized(() => {
+          void win.isMaximized().then(setMaximized).catch(() => {});
+        });
+        if (disposed) {
+          stop();
+          return;
+        }
+        unlisten = stop;
+      } catch (err) {
+        console.error("Resource monitor maximize-state tracking failed:", err);
+      }
+    })();
+  });
 
   return (
     <div class="rm-titlebar" data-tauri-drag-region>
@@ -198,6 +243,28 @@ const Titlebar: Component = () => {
               data-ac-role="button"
             >
               &#x2014;
+            </span>
+          </button>
+          <button
+            class="rm-titlebar-btn"
+            onClick={handleMaximize}
+            title={maximized() ? "Restore" : "Maximize"}
+            aria-label={
+              maximized() ? "Restore Resource Monitor" : "Maximize Resource Monitor"
+            }
+            data-ac-testid="resourceMonitor.titlebar.maximize"
+            data-ac-role="button"
+            data-ac-state={maximized() ? "maximized" : "normal"}
+          >
+            <span
+              class="rm-titlebar-btn-alias"
+              data-ac-testid="resourceMonitor.maximize"
+              data-ac-role="button"
+            >
+              {/* restore (when maximized) vs maximize glyph; built from char codes
+                  to keep the source ASCII-only, matching the sibling buttons
+                  which render &#x25A1; / &#x2750; HTML entities. */}
+              {maximized() ? String.fromCharCode(0x2750) : String.fromCharCode(0x25A1)}
             </span>
           </button>
           <button

--- a/src/resource-monitor/App.tsx
+++ b/src/resource-monitor/App.tsx
@@ -8,8 +8,15 @@ import {
   onMount,
 } from "solid-js";
 import iconUrl from "../assets/icon-16.png";
-import { ResourceMonitorAPI, SettingsAPI, WindowAPI, emitOpenSettings } from "../shared/ipc";
+import {
+  ResourceMonitorAPI,
+  SettingsAPI,
+  WindowAPI,
+  emitOpenSettings,
+  emitResourceMonitorAttach,
+} from "../shared/ipc";
 import { isTauri } from "../shared/platform";
+import { centralViewStore } from "../main/stores/centralView";
 import { resourceMonitorStore } from "../shared/stores/resourceMonitor";
 import type {
   ResourceAgentGroupSnapshot,
@@ -145,11 +152,18 @@ const Titlebar: Component = () => {
   // re-reads the truth after every such change.
   const [maximized, setMaximized] = createSignal(false);
 
-  const handleDock = async () => {
+  // #587 — "Attach" pulls RM back into the main window's central pane (replaces
+  // the old window-snapping "Dock"). Emit BEFORE closing so the event is queued
+  // before this webview tears down; main's listener runs showResourceMonitor().
+  const handleAttach = async () => {
     try {
-      await WindowAPI.dockResourceMonitor();
+      await emitResourceMonitorAttach();
+      if (isTauri) {
+        const { getCurrentWindow } = await import("@tauri-apps/api/window");
+        await getCurrentWindow().close();
+      }
     } catch (err) {
-      console.error("Dock resource monitor failed:", err);
+      console.error("Attach resource monitor failed:", err);
     }
   };
 
@@ -234,15 +248,15 @@ const Titlebar: Component = () => {
         <div class="rm-titlebar-controls">
           <button
             class="rm-titlebar-btn"
-            onClick={handleDock}
-            title="Dock"
-            aria-label="Dock Resource Monitor"
-            data-ac-testid="resourceMonitor.titlebar.dock"
+            onClick={handleAttach}
+            title="Attach"
+            aria-label="Attach Resource Monitor to main window"
+            data-ac-testid="resourceMonitor.titlebar.attach"
             data-ac-role="button"
           >
             <span
               class="rm-titlebar-btn-alias"
-              data-ac-testid="resourceMonitor.dock"
+              data-ac-testid="resourceMonitor.attach"
               data-ac-role="button"
             >
               &#x21B2;
@@ -308,23 +322,44 @@ const Titlebar: Component = () => {
   );
 };
 
-const ResourceMonitorApp: Component = () => {
+interface ResourceMonitorAppProps {
+  /** True when mounted inside MainApp's central pane. Suppresses the window
+   *  titlebar and skips documentElement theme init (main owns it), and shows a
+   *  "Detach" button that pops RM out into its own window (#587). */
+  embedded?: boolean;
+}
+
+const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
   const [expandedGroupId, setExpandedGroupId] = createSignal<string | null>(null);
   const [killTarget, setKillTarget] =
     createSignal<ResourceAgentGroupSnapshot | null>(null);
   const [killError, setKillError] = createSignal("");
   const [killInFlight, setKillInFlight] = createSignal(false);
 
+  // #587 — pop the embedded RM out into its own OS window, then reveal the
+  // terminal in the pane (preserves the embedded-XOR-detached invariant).
+  const handleDetach = async () => {
+    try {
+      await WindowAPI.openResourceMonitor();
+      centralViewStore.showTerminal();
+    } catch (err) {
+      console.error("Detach resource monitor failed:", err);
+    }
+  };
+
   onMount(async () => {
     let resourcePreferences = DEFAULT_RESOURCE_PREFERENCES;
-    document.documentElement.classList.add("light-theme");
+    // #587 — embedded RM inherits the theme MainApp owns on documentElement; it
+    // must not add/remove the class itself (would fight main). Windowed RM still
+    // does its own optimistic light-first paint + corrective read.
+    if (!props.embedded) document.documentElement.classList.add("light-theme");
     try {
       const settings = await SettingsAPI.get();
       resourcePreferences = {
         resourceBackoffPolling: settings.resourceBackoffPolling,
         resourceKeepLastSnapshot: settings.resourceKeepLastSnapshot,
       };
-      if (!settings.themeLight) {
+      if (!props.embedded && !settings.themeLight) {
         document.documentElement.classList.remove("light-theme");
       }
     } catch (err) {
@@ -440,7 +475,9 @@ const ResourceMonitorApp: Component = () => {
       data-ac-testid="resourceMonitor.window"
       data-ac-role="surface"
     >
-      <Titlebar />
+      <Show when={!props.embedded}>
+        <Titlebar />
+      </Show>
       <main class="rm-body">
         <header class="rm-header">
           <div>
@@ -448,6 +485,17 @@ const ResourceMonitorApp: Component = () => {
             <h1>Resource Monitor</h1>
           </div>
           <div class="rm-header-actions">
+            <Show when={props.embedded}>
+              <button
+                class="rm-action-btn"
+                onClick={handleDetach}
+                title="Detach to a separate window"
+                data-ac-testid="resourceMonitor.detach"
+                data-ac-role="button"
+              >
+                Detach
+              </button>
+            </Show>
             <button
               class="rm-action-btn"
               onClick={() => resourceMonitorStore.refresh()}

--- a/src/resource-monitor/App.tsx
+++ b/src/resource-monitor/App.tsx
@@ -164,7 +164,20 @@ const Titlebar: Component = () => {
     try {
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
       const win = getCurrentWindow();
-      await win.toggleMaximize();
+      // Use explicit maximize()/unmaximize() rather than toggleMaximize().
+      // The app capability set (src-tauri/capabilities/default.json) grants
+      // core:window:allow-maximize, allow-unmaximize and allow-is-maximized,
+      // but NOT allow-toggle-maximize. toggleMaximize() therefore gets rejected
+      // at the Tauri v2 ACL layer at runtime, which is why the button "did
+      // nothing" in the real build (the rejection was only logged below). The
+      // drag-region double-click still maximizes because that path uses the
+      // separate allow-internal-toggle-maximize permission, which IS in
+      // core:window:default.
+      if (await win.isMaximized()) {
+        await win.unmaximize();
+      } else {
+        await win.maximize();
+      }
       // Reflect immediately so the icon swaps without waiting for the resize
       // event. On failure leave the glyph as-is; the onResized mirror reconciles
       // it once the window settles.

--- a/src/resource-monitor/App.tsx
+++ b/src/resource-monitor/App.tsx
@@ -161,11 +161,17 @@ const Titlebar: Component = () => {
 
   const handleMaximize = async () => {
     if (!isTauri) return;
-    const { getCurrentWindow } = await import("@tauri-apps/api/window");
-    const win = getCurrentWindow();
-    await win.toggleMaximize();
-    // Reflect immediately so the icon swaps without waiting for the resize event.
-    setMaximized(await win.isMaximized());
+    try {
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      const win = getCurrentWindow();
+      await win.toggleMaximize();
+      // Reflect immediately so the icon swaps without waiting for the resize
+      // event. On failure leave the glyph as-is; the onResized mirror reconciles
+      // it once the window settles.
+      setMaximized(await win.isMaximized());
+    } catch (err) {
+      console.error("Resource monitor toggle maximize failed:", err);
+    }
   };
 
   const handleClose = async () => {
@@ -261,9 +267,9 @@ const Titlebar: Component = () => {
               data-ac-testid="resourceMonitor.maximize"
               data-ac-role="button"
             >
-              {/* restore (when maximized) vs maximize glyph; built from char codes
-                  to keep the source ASCII-only, matching the sibling buttons
-                  which render &#x25A1; / &#x2750; HTML entities. */}
+              {/* U+2750 = restore glyph (shown when maximized), U+25A1 = maximize
+                  glyph. Built from char codes so the source stays ASCII-only,
+                  avoiding a literal glyph or \u escape that tooling can mangle. */}
               {maximized() ? String.fromCharCode(0x2750) : String.fromCharCode(0x25A1)}
             </span>
           </button>

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -241,6 +241,11 @@ export const SettingsAPI = {
     transport.invoke<void>("set_sounds_enabled", { value }),
   setThemeLight: (value: boolean) =>
     transport.invoke<void>("set_theme_light", { value }),
+  // #587 — narrow setter for the central-view toggle (RM attached vs terminal).
+  // Same write-lock pattern as the other narrow setters; avoids a get+update
+  // round-trip racing SettingsModal.
+  setMainResourceMonitorAttached: (value: boolean) =>
+    transport.invoke<void>("set_main_resource_monitor_attached", { value }),
   updateCodingAgentProfiles: (profiles: CodingAgentProfilesConfig) =>
     transport.invoke<void>("update_coding_agent_profiles", { profiles }),
   updateCodingAgentEnvSettings: (
@@ -802,6 +807,19 @@ export function onThemeChanged(
   callback: (data: { light: boolean }) => void
 ): Promise<UnlistenFn> {
   return transport.listen<{ light: boolean }>("theme_changed", callback);
+}
+
+// #587 — the detached Resource Monitor window asks the main window to pull RM
+// back into the central pane. Fire-and-forget; main's listener sets the central
+// view. Mirrors the theme_changed emit/listen pair.
+export function emitResourceMonitorAttach(): Promise<void> {
+  return transport.emit("resource_monitor_attach", {});
+}
+
+export function onResourceMonitorAttach(
+  callback: () => void
+): Promise<UnlistenFn> {
+  return transport.listen<unknown>("resource_monitor_attach", () => callback());
 }
 
 // Open the Settings modal (handled by sidebar ActionBar). Emitted from any

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -128,6 +128,7 @@ export function baseSettings(overrides: Partial<AppSettings> = {}): AppSettings 
     mainSidebarWidth: 360,
     mainSidebarSide: "right",
     mainAlwaysOnTop: false,
+    mainResourceMonitorAttached: false,
     webServerEnabled: false,
     webServerPort: 8765,
     webServerBind: "127.0.0.1",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -240,6 +240,9 @@ export interface AppSettings {
   mainSidebarWidth: number;
   mainSidebarSide: MainSidebarSide;
   mainAlwaysOnTop: boolean;
+  // #587 — whether the Resource Monitor occupies the main central pane (vs the
+  // terminal). Restored on startup; default false (terminal).
+  mainResourceMonitorAttached: boolean;
   webServerEnabled: boolean;
   webServerPort: number;
   webServerBind: string;

--- a/src/sidebar/components/ActionBar.test.ts
+++ b/src/sidebar/components/ActionBar.test.ts
@@ -65,6 +65,7 @@ vi.mock("../../shared/ipc", () => ({
   SettingsAPI: {
     setSoundsEnabled: vi.fn(() => Promise.resolve()),
     setThemeLight: vi.fn(() => Promise.resolve()),
+    setMainResourceMonitorAttached: vi.fn(() => Promise.resolve()),
   },
   SpecBoardAPI: {
     open: vi.fn(),
@@ -98,6 +99,10 @@ vi.mock("./SettingsModal", () => ({
 }));
 
 import ActionBar from "./ActionBar";
+import {
+  centralViewStore,
+  __resetCentralViewStoreForTests,
+} from "../../main/stores/centralView";
 
 function renderActionBar() {
   const root = document.createElement("div");
@@ -118,6 +123,7 @@ describe("ActionBar selected workgroup visibility toggle", () => {
     mockState.sessions.hydrated = true;
     mockState.sessions.toggleInFlight = false;
     mockState.sessions.coordSortByActivity = false;
+    __resetCentralViewStoreForTests();
     vi.clearAllMocks();
   });
 
@@ -143,6 +149,36 @@ describe("ActionBar selected workgroup visibility toggle", () => {
     expect(pinButton.getAttribute("aria-pressed")).toBe("false");
     expect(pinButton.getAttribute("data-ac-state")).toBe("default");
     expect(pinButton.title).not.toContain("Don't force");
+
+    dispose();
+  });
+
+  // #587 — the ▦ Resource Monitor button reflects whether RM occupies the
+  // central pane (mirrors the 🏠 Home toggle's active state).
+  it("marks the Resource Monitor button active when RM is the central view", () => {
+    centralViewStore.setInitialView("resourceMonitor");
+    const { dispose } = renderActionBar();
+    const rmButton = document.body.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="actionBar.resourceMonitor"]'
+    );
+    if (!rmButton) throw new Error("resource monitor button not rendered");
+
+    expect(rmButton.className).toContain("active");
+    expect(rmButton.getAttribute("aria-pressed")).toBe("true");
+
+    dispose();
+  });
+
+  it("does not mark the Resource Monitor button active when the terminal is shown", () => {
+    centralViewStore.setInitialView("terminal");
+    const { dispose } = renderActionBar();
+    const rmButton = document.body.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="actionBar.resourceMonitor"]'
+    );
+    if (!rmButton) throw new Error("resource monitor button not rendered");
+
+    expect(rmButton.className).not.toContain("active");
+    expect(rmButton.getAttribute("aria-pressed")).toBe("false");
 
     dispose();
   });

--- a/src/sidebar/components/ActionBar.tsx
+++ b/src/sidebar/components/ActionBar.tsx
@@ -3,11 +3,12 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { projectStore } from "../stores/project";
 import { sessionsStore } from "../stores/sessions";
 import type { UnlistenFn } from "../../shared/transport";
-import { ProjectAPI, GuideAPI, SettingsAPI, SpecBoardAPI, WindowAPI, emitThemeChanged, onOpenSettings } from "../../shared/ipc";
+import { ProjectAPI, GuideAPI, SettingsAPI, SpecBoardAPI, emitThemeChanged, onOpenSettings } from "../../shared/ipc";
 import { settingsStore } from "../../shared/stores/settings";
 import { resourceMonitorStore } from "../../shared/stores/resourceMonitor";
 import { setSoundsEnabled } from "../../shared/sound";
 import { homeStore } from "../../main/stores/home";
+import { centralViewStore } from "../../main/stores/centralView";
 import SettingsModal from "./SettingsModal";
 
 const SELECTED_WORKGROUP_VISIBILITY_LABEL = "Always keep selected workgroup visible";
@@ -233,11 +234,11 @@ const ActionBar: Component = () => {
     return `Resource Monitor: ${snapshot.activeAgentGroups}/${snapshot.maxConcurrentAgentGroups} agents, ${state}`;
   };
 
-  const handleOpenResourceMonitor = () => {
-    WindowAPI.openResourceMonitor().catch((err) => {
-      const msg = err instanceof Error ? err.message : String(err);
-      showToast(`Failed to open Resource Monitor: ${msg}`);
-    });
+  // #587 — the ▦ button now toggles the central-pane RM view (mirrors the 🏠
+  // Home toggle two slots away). Opening RM in a separate OS window is reachable
+  // from the embedded RM's "Detach" button.
+  const handleToggleResourceMonitor = () => {
+    centralViewStore.toggleResourceMonitor();
   };
 
   return (
@@ -374,10 +375,11 @@ const ActionBar: Component = () => {
             &#x1F4A1;
           </button>
           <button
-            class={`toolbar-gear-btn resource-monitor-btn state-${resourceBadgeState()}`}
-            onClick={handleOpenResourceMonitor}
+            class={`toolbar-gear-btn resource-monitor-btn state-${resourceBadgeState()} ${centralViewStore.isResourceMonitor ? "active" : ""}`}
+            onClick={handleToggleResourceMonitor}
             title={resourceBadgeTitle()}
             aria-label={resourceBadgeTitle()}
+            aria-pressed={centralViewStore.isResourceMonitor}
             data-ac-testid="actionBar.resourceMonitor"
             data-ac-role="button"
             data-ac-state={resourceBadgeState()}

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -101,6 +101,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     mainSidebarWidth: 360,
     mainSidebarSide: "right",
     mainAlwaysOnTop: false,
+    mainResourceMonitorAttached: false,
     agents: [
       agent({
         id: "codex",

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -59,6 +59,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     mainSidebarWidth: 360,
     mainSidebarSide: "right",
     mainAlwaysOnTop: false,
+    mainResourceMonitorAttached: false,
     agents: [],
     codingAgentProfiles: {
       schemaVersion: 2,

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -7,6 +7,7 @@ import { isTauri } from "../../shared/platform";
 import { bridgesStore } from "../stores/bridges";
 import { sessionsStore } from "../stores/sessions";
 import { settingsStore } from "../../shared/stores/settings";
+import { centralViewStore } from "../../main/stores/centralView";
 import { voiceRecorder, formatRecordingTime } from "../../shared/voice-recorder";
 import OpenAgentModal from "./OpenAgentModal";
 import AgentPickerModal from "./AgentPickerModal";
@@ -88,6 +89,9 @@ const SessionItem: Component<{
   };
 
   const handleClick = async () => {
+    // #587 — cover an embedded RM with the terminal even when switch_session
+    // no-ops on the already-active session (which emits no session_switched).
+    centralViewStore.showTerminal();
     await SessionAPI.switch(props.session.id);
     if (isTauri) {
       const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -91,6 +91,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     mainSidebarWidth: 360,
     mainSidebarSide: "right",
     mainAlwaysOnTop: false,
+    mainResourceMonitorAttached: false,
     agents: [
       {
         id: "codex",

--- a/src/sidebar/components/SettingsModal.test.ts
+++ b/src/sidebar/components/SettingsModal.test.ts
@@ -43,6 +43,7 @@ function settings(overrides: Partial<AppSettings>): AppSettings {
     mainSidebarWidth: 360,
     mainSidebarSide: "right",
     mainAlwaysOnTop: false,
+    mainResourceMonitorAttached: false,
     agents: [],
     codingAgentProfiles: {
       schemaVersion: 2,

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -59,6 +59,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     mainSidebarWidth: 360,
     mainSidebarSide: "right",
     mainAlwaysOnTop: false,
+    mainResourceMonitorAttached: false,
     agents: [],
     codingAgentProfiles: {
       schemaVersion: 2,


### PR DESCRIPTION
## Summary

Two UX improvements to the Resource Monitor window (#587):

1. **Maximize when detached** — the detached Resource Monitor window now has a maximize/restore button in its custom titlebar (double-click the titlebar also maximizes). Root cause of the initial no-op was a missing Tauri v2 ACL permission (`core:window:allow-toggle-maximize`); fixed by using the already-granted `maximize()`/`unmaximize()` instead of `toggleMaximize()` — frontend-only, no capability change.
2. **Attached = central-pane view** — when attached, the Resource Monitor shows as an overlay inside the central terminal pane (the terminal stays mounted underneath, mirroring the Home view pattern). Toggled from the existing toolbar Resource Monitor button. Selecting a terminal covers the RM; toggling RM brings it back. Detach pops it to its own window; Attach pulls it back in. The attached/detached choice persists across restarts (`mainResourceMonitorAttached`).

## Implementation
- Frontend (`src/`): dev-webpage-ui — `centralViewStore`, central-pane overlay in `MainApp`, `embedded` mode for `ResourceMonitorApp` (Detach button, Dock→Attach), ActionBar toolbar-button repoint, cross-window attach event, persistence wiring, listener extraction (`listeners-central-view.ts`).
- Backend (`src-tauri/`): dev-rust — `main_resource_monitor_attached` setting (serde default false, no migration) + `set_main_resource_monitor_attached` setter + registration.

## Review & verification
- grinch Step-7 adversarial review PASS on part 1 (maximize) and part 2 (central-view).
- A HIGH (unconditional `session_switched` → `showTerminal()` defeated restore + corrupted the persisted setting) was found, fixed (gated on `userInitiated`, mirroring the Home listener), and re-verified PASS with a new regression test.
- Built by shipper and **user-tested in 0_AC** (maximize, central-view toggle, detach/attach, restart-restore) — approved.
- Re-synced onto current `origin/main` (0.9.16); grinch re-sync verify PASS — coexists with #548 (profile labels) and #589 (stale AUTO-CLOSED pill), all gates green on the merged tree (tsc 0, vitest 450, cargo test 1421, clippy clean).

## Non-blocking follow-ups
- #594 — spec-board has the same `toggleMaximize()` ACL no-op (+ unhandled rejection); filed separately.
- Orphaned `dock_resource_monitor_window` / `WindowAPI.dockResourceMonitor` left in place (cleanup deferred per plan).

Closes #587
