### PR TITLE
feat: MANUALLY-CLOSED coordinator badge + Settings-gated cascade close (#588)

### DIFF
--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -121,6 +121,10 @@ pub struct AcAgentReplica {
     /// inactivity, or None. Only meaningful when `is_coordinator`. Drives the
     /// "auto-closed" pill; cleared on reopen. Read from the same store entry.
     pub auto_closed_at: Option<String>,
+    /// #588 RFC3339 time this coordinator was manually closed, or None. Only
+    /// meaningful when `is_coordinator`. Drives the MANUALLY-CLOSED pill;
+    /// cleared on reopen. Read from the same persisted store entry.
+    pub manually_closed_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1146,6 +1150,9 @@ pub async fn discover_ac_agents(
                                 let auto_closed_at = clock_entry
                                     .and_then(|e| e.auto_closed_at)
                                     .map(|dt| dt.to_rfc3339());
+                                let manually_closed_at = clock_entry
+                                    .and_then(|e| e.manually_closed_at)
+                                    .map(|dt| dt.to_rfc3339());
 
                                 wg_agents.push(AcAgentReplica {
                                     name: replica_name,
@@ -1160,6 +1167,7 @@ pub async fn discover_ac_agents(
                                     is_coordinator,
                                     last_user_message_at,
                                     auto_closed_at,
+                                    manually_closed_at,
                                 });
                             }
                         }
@@ -1639,6 +1647,9 @@ pub async fn discover_project(
                         let auto_closed_at = clock_entry
                             .and_then(|e| e.auto_closed_at)
                             .map(|dt| dt.to_rfc3339());
+                        let manually_closed_at = clock_entry
+                            .and_then(|e| e.manually_closed_at)
+                            .map(|dt| dt.to_rfc3339());
 
                         wg_agents.push(AcAgentReplica {
                             name: replica_name,
@@ -1653,6 +1664,7 @@ pub async fn discover_project(
                             is_coordinator,
                             last_user_message_at,
                             auto_closed_at,
+                            manually_closed_at,
                         });
                     }
                 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use crate::config::agent_command::AgentSpawnCommand;
 use crate::config::agent_config::{self, AgentLocalConfig};
+use crate::config::coordinator_clocks::CoordinatorClocksState;
 use crate::config::sessions_persistence::persist_current_state;
 use crate::config::settings::{AppSettings, SettingsState};
 use crate::pty::manager::PtyManager;
@@ -756,9 +757,13 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             // agent_fqn_from_path returns String (teams.rs:80), not Option.
             let fqn = crate::config::teams::agent_fqn_from_path(&cwd);
             let now = chrono::Utc::now();
-            let (seeded, cleared) = {
+            let (seeded, cleared_auto, cleared_manual) = {
                 let mut g = clocks.lock().unwrap_or_else(|e| e.into_inner());
-                (g.seed_if_absent(&fqn, now), g.clear_auto_closed(&fqn))
+                (
+                    g.seed_if_absent(&fqn, now),
+                    g.clear_auto_closed(&fqn),
+                    g.clear_manually_closed(&fqn),
+                )
             };
             if seeded {
                 let _ = app.emit(
@@ -766,10 +771,16 @@ pub async fn create_session_inner<R: tauri::Runtime>(
                     serde_json::json!({ "replicaPath": cwd, "lastUserMessageAt": now.to_rfc3339() }),
                 );
             }
-            if cleared {
+            if cleared_auto {
                 let _ = app.emit(
                     "coordinator_auto_close_changed",
                     serde_json::json!({ "replicaPath": cwd, "autoClosedAt": null }),
+                );
+            }
+            if cleared_manual {
+                let _ = app.emit(
+                    "coordinator_manual_close_changed",
+                    serde_json::json!({ "replicaPath": cwd, "manuallyClosedAt": null }),
                 );
             }
         }
@@ -1694,6 +1705,164 @@ pub async fn destroy_session(
     destroy_session_inner(&app, uuid).await
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoordinatorCloseOutcome {
+    /// true if the close was performed; false if confirmation is required first.
+    pub closed: bool,
+    /// number of live, working (not waiting_for_input) team members; only
+    /// meaningful when `closed == false`.
+    pub working_count: usize,
+}
+
+/// #588 Count LIVE team members that are working (not waiting_for_input). Pure so
+/// the working-gate rule is unit-testable without a live app, mirroring how
+/// `auto_close.rs` extracts `team_is_closeable`. A member counts only when it is
+/// both live (PTY-backed) and not waiting for input.
+fn count_working_members(members: &[(bool /*live*/, bool /*waiting_for_input*/)]) -> usize {
+    members
+        .iter()
+        .filter(|(live, waiting)| *live && !*waiting)
+        .count()
+}
+
+/// #588 Manually close a coordinator (and, when the cascade setting is on, its
+/// team). Sets the MANUALLY-CLOSED marker on the coordinator regardless of the
+/// cascade setting. When cascade is on and confirmation has not been given and at
+/// least one team member is working, closes NOTHING and reports `closed:false` so
+/// the FE can show the confirmation modal.
+#[tauri::command]
+pub async fn close_coordinator(
+    app: AppHandle,
+    id: String,
+    confirmed: bool,
+) -> Result<CoordinatorCloseOutcome, String> {
+    let uuid = Uuid::parse_str(&id).map_err(|e| e.to_string())?;
+    let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+
+    // Snapshot coordinator facts BEFORE destroying (destroy removes the record).
+    let (is_coordinator, cwd) = {
+        let mgr = session_mgr.read().await;
+        let s = mgr
+            .get_session(uuid)
+            .await
+            .ok_or_else(|| "Session not found".to_string())?;
+        (s.is_coordinator, s.working_directory.clone())
+    };
+
+    // Defensive: a non-coordinator target is a plain destroy (no marker/cascade).
+    if !is_coordinator {
+        destroy_session_inner(&app, uuid).await?;
+        return Ok(CoordinatorCloseOutcome {
+            closed: true,
+            working_count: 0,
+        });
+    }
+
+    let fqn = crate::config::teams::agent_fqn_from_path(&cwd);
+    let team_key = match fqn.rsplit_once('/') {
+        Some((team, _agent)) => team.to_string(),
+        None => String::new(),
+    };
+
+    // E0716: bind the State to a local FIRST (matches auto_close.rs:115). The
+    // guard-bound-then-used-next-line form does NOT compile (the temporary State is
+    // dropped at the `;`, so the read guard dangles). `bool` is Copy.
+    let settings = app.state::<SettingsState>();
+    let cascade = settings.read().await.coordinator_cascade_close_enabled;
+    let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
+
+    // LIVE-PTY members of THIS team, excluding the coordinator (decision 1; mirrors
+    // auto_close.rs:136-142). agent_team_members() includes EXITED/dormant records
+    // (exited sessions persist until destroy), so we filter on has_session to a live
+    // set ONCE and share it between the working-count gate and the destroy loop;
+    // dormant rows are never reaped. The std Mutex guard is taken AFTER the tokio
+    // read await and dropped at the block end, so no lock is held across an await.
+    let live_ids: Vec<Uuid> = {
+        let mgr = session_mgr.read().await;
+        let members = mgr.agent_team_members().await;
+        let pm = pty_mgr.lock().unwrap_or_else(|e| e.into_inner());
+        members
+            .into_iter()
+            .filter(|(mid, tk)| {
+                *mid != uuid && !team_key.is_empty() && *tk == team_key && pm.has_session(*mid)
+            })
+            .map(|(mid, _)| mid)
+            .collect()
+    };
+
+    // Confirmation gate: cascade ON, not yet confirmed, >=1 LIVE member working.
+    // Only the tokio read guard is held across the get_session awaits.
+    if cascade && !confirmed {
+        let mgr = session_mgr.read().await;
+        let mut member_states: Vec<(bool, bool)> = Vec::with_capacity(live_ids.len());
+        for mid in &live_ids {
+            // live_ids is pre-filtered to live PTYs, so `live` is true; the waiting
+            // flag is the authoritative session record (absent -> treat as idle so a
+            // vanished member never forces a modal).
+            let waiting = mgr
+                .get_session(*mid)
+                .await
+                .map(|s| s.waiting_for_input)
+                .unwrap_or(true);
+            member_states.push((true, waiting));
+        }
+        let working_count = count_working_members(&member_states);
+        if working_count > 0 {
+            return Ok(CoordinatorCloseOutcome {
+                closed: false,
+                working_count,
+            });
+        }
+    }
+
+    // Perform the close. Live members first (avoids intermediate auto-activation
+    // churn), coordinator last. Mirrors the auto-close destroy loop.
+    if cascade {
+        for mid in live_ids {
+            if let Err(e) = destroy_session_inner(&app, mid).await {
+                log::warn!(
+                    "[manual-close] member destroy {} failed: {}",
+                    &mid.to_string()[..8],
+                    e
+                );
+            }
+        }
+    }
+    destroy_session_inner(&app, uuid).await?;
+
+    // Set the manual marker on the coordinator FQN and persist immediately (this
+    // command is not on the auto-close tick, so flush_clocks won't run).
+    if let Some(clocks) = app.try_state::<CoordinatorClocksState>() {
+        let now = chrono::Utc::now();
+        let newly = clocks
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .mark_manually_closed(&fqn, now);
+        if newly {
+            let _ = app.emit(
+                "coordinator_manual_close_changed",
+                serde_json::json!({ "replicaPath": cwd, "manuallyClosedAt": now.to_rfc3339() }),
+            );
+            // also clear any stale auto-closed pill on the FE (mark_* cleared it
+            // server-side via the mutual-exclusion transition).
+            let _ = app.emit(
+                "coordinator_auto_close_changed",
+                serde_json::json!({ "replicaPath": cwd, "autoClosedAt": null }),
+            );
+        }
+        let snapshot = { clocks.lock().unwrap_or_else(|e| e.into_inner()).snapshot() };
+        if let Err(e) = crate::config::coordinator_clocks::save_map(&snapshot) {
+            log::warn!("[manual-close] clocks save failed: {}", e);
+        }
+    }
+
+    Ok(CoordinatorCloseOutcome {
+        closed: true,
+        working_count: 0,
+    })
+}
+
 /// Resolves the effective `skip_auto_resume` flag for `restart_session`.
 /// Defaults to `true` (fresh conversation) to preserve existing restart-button semantics.
 /// `Some(false)` is used by the deferred-wake path (ProjectPanel.handleReplicaClick)
@@ -2474,16 +2643,47 @@ pub async fn create_root_agent_session(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_existing_root, effective_restart_requested_profile, inject_codex_resume,
-        resolve_actual_agent, resolve_agent_command, resolve_agent_from_shell,
-        resolve_restart_selected_agent_id, resolve_root_agent_command, should_inject_continue,
-        ExistingRootAction,
+        classify_existing_root, count_working_members, effective_restart_requested_profile,
+        inject_codex_resume, resolve_actual_agent, resolve_agent_command,
+        resolve_agent_from_shell, resolve_restart_selected_agent_id, resolve_root_agent_command,
+        should_inject_continue, ExistingRootAction,
     };
     use crate::config::settings::{AgentConfig, AppSettings, ProfileCellConfig};
     use crate::session::manager::SessionManager;
     use crate::session::session::SessionStatus;
     use std::collections::BTreeMap;
     use std::path::PathBuf;
+
+    #[test]
+    fn count_working_members_counts_live_and_busy_only() {
+        // tuples are (live /*PTY-backed*/, waiting_for_input)
+        assert_eq!(count_working_members(&[]), 0, "empty -> 0");
+        assert_eq!(
+            count_working_members(&[(true, true), (true, true)]),
+            0,
+            "all live but idle (waiting) -> 0"
+        );
+        assert_eq!(
+            count_working_members(&[(true, false), (true, false), (true, false)]),
+            3,
+            "all live and busy -> N"
+        );
+        assert_eq!(
+            count_working_members(&[(true, true), (true, false)]),
+            1,
+            "only the live+busy member counts"
+        );
+        assert_eq!(
+            count_working_members(&[(false, false), (false, false)]),
+            0,
+            "busy but dead (no live PTY) -> 0"
+        );
+        assert_eq!(
+            count_working_members(&[(true, false), (false, false), (true, true)]),
+            1,
+            "mixed: one live+busy, one dead+busy, one live+idle -> 1"
+        );
+    }
 
     fn test_settings() -> AppSettings {
         AppSettings {

--- a/src-tauri/src/config/coordinator_clocks.rs
+++ b/src-tauri/src/config/coordinator_clocks.rs
@@ -39,6 +39,12 @@ pub struct ClockEntry {
     /// error exit.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_closed_at: Option<DateTime<Utc>>,
+    /// #588 Manual-close marker: set when this coordinator was closed manually
+    /// by the user; cleared on reopen. `Some` => show the "manually-closed" pill.
+    /// Mutually exclusive with `auto_closed_at` (hardened in `mark_*`), but the
+    /// renderer treats manual as the winner if both were ever set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manually_closed_at: Option<DateTime<Utc>>,
 }
 
 impl ClockEntry {
@@ -96,6 +102,7 @@ impl CoordinatorClocks {
                 last_user_message_at: Some(now),
                 last_activity_at: None,
                 auto_closed_at: None,
+                manually_closed_at: None,
             },
         );
         self.dirty = true;
@@ -137,6 +144,12 @@ impl CoordinatorClocks {
     /// counting on the dormant row).
     pub fn mark_auto_closed(&mut self, fqn: &str, now: DateTime<Utc>) -> bool {
         let entry = self.map.entry(fqn.to_string()).or_default();
+        // #588 manual close wins: never auto-mark a coordinator the user closed by
+        // hand (stops a concurrent tick re-setting auto_closed_at + emitting a stray
+        // coordinator_auto_close_changed).
+        if entry.manually_closed_at.is_some() {
+            return false;
+        }
         if entry.auto_closed_at.is_some() {
             return false;
         }
@@ -152,6 +165,41 @@ impl CoordinatorClocks {
         if let Some(entry) = self.map.get_mut(fqn) {
             if entry.auto_closed_at.is_some() {
                 entry.auto_closed_at = None;
+                self.dirty = true;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// #588 Manual-close marker accessor.
+    pub fn manually_closed_at(&self, fqn: &str) -> Option<DateTime<Utc>> {
+        self.map.get(fqn).and_then(|e| e.manually_closed_at)
+    }
+
+    /// #588 Mark this coordinator manually-closed at `now`. Idempotent: returns
+    /// `true` only on the None -> Some transition so the caller emits once. Clears
+    /// `auto_closed_at` ON THE TRANSITION (mutual-exclusion that also keeps the
+    /// dirty flag honest; manual is the deliberate action). Preserves
+    /// last_user_message_at / last_activity_at.
+    pub fn mark_manually_closed(&mut self, fqn: &str, now: DateTime<Utc>) -> bool {
+        let entry = self.map.entry(fqn.to_string()).or_default();
+        if entry.manually_closed_at.is_some() {
+            return false;
+        }
+        entry.auto_closed_at = None; // mutual-exclusion, on the real transition
+        entry.manually_closed_at = Some(now);
+        self.dirty = true;
+        true
+    }
+
+    /// #588 Clear the manual-close marker on reopen. Returns `true` only on the
+    /// Some -> None transition so the caller emits the clear once. Preserves
+    /// last_user_message_at.
+    pub fn clear_manually_closed(&mut self, fqn: &str) -> bool {
+        if let Some(entry) = self.map.get_mut(fqn) {
+            if entry.manually_closed_at.is_some() {
+                entry.manually_closed_at = None;
                 self.dirty = true;
                 return true;
             }
@@ -314,6 +362,82 @@ mod tests {
     }
 
     #[test]
+    fn mark_manually_closed_is_idempotent() {
+        let mut clocks = CoordinatorClocks::default();
+        let fqn = "proj:wg-1-team/coord";
+
+        assert!(
+            clocks.mark_manually_closed(fqn, ts(0)),
+            "first mark transitions None -> Some"
+        );
+        assert_eq!(clocks.manually_closed_at(fqn), Some(ts(0)));
+        assert!(
+            !clocks.mark_manually_closed(fqn, ts(50)),
+            "second mark is a no-op (already Some)"
+        );
+        // The original marker time is preserved on the idempotent call.
+        assert_eq!(clocks.manually_closed_at(fqn), Some(ts(0)));
+    }
+
+    #[test]
+    fn clear_manually_closed_only_on_some_to_none_and_preserves_badge() {
+        let mut clocks = CoordinatorClocks::default();
+        let fqn = "proj:wg-1-team/coord";
+
+        // No entry -> nothing to clear.
+        assert!(!clocks.clear_manually_closed(fqn));
+
+        clocks.note_user_message(fqn, ts(0));
+        clocks.mark_manually_closed(fqn, ts(1));
+        assert!(clocks.clear_manually_closed(fqn), "Some -> None returns true");
+        assert_eq!(clocks.manually_closed_at(fqn), None);
+        // The badge clock survives the clear.
+        assert_eq!(clocks.last_user_message_at(fqn), Some(ts(0)));
+        // Clearing again is a no-op.
+        assert!(!clocks.clear_manually_closed(fqn));
+    }
+
+    #[test]
+    fn mark_manually_closed_clears_preset_auto_closed_on_transition() {
+        let mut clocks = CoordinatorClocks::default();
+        let fqn = "proj:wg-1-team/coord";
+
+        clocks.note_user_message(fqn, ts(0));
+        clocks.mark_auto_closed(fqn, ts(1));
+        assert_eq!(clocks.auto_closed_at(fqn), Some(ts(1)));
+
+        // Marking manual clears the auto marker on the real transition.
+        assert!(clocks.mark_manually_closed(fqn, ts(2)));
+        assert_eq!(
+            clocks.auto_closed_at(fqn),
+            None,
+            "mark_manually_closed must clear a pre-set auto_closed_at"
+        );
+        assert_eq!(clocks.manually_closed_at(fqn), Some(ts(2)));
+        // The badge clock is untouched.
+        assert_eq!(clocks.last_user_message_at(fqn), Some(ts(0)));
+    }
+
+    #[test]
+    fn mark_auto_closed_skips_when_manually_closed() {
+        let mut clocks = CoordinatorClocks::default();
+        let fqn = "proj:wg-1-team/coord";
+
+        clocks.mark_manually_closed(fqn, ts(0));
+        // A concurrent auto-close tick must NOT re-mark a manually-closed coordinator.
+        assert!(
+            !clocks.mark_auto_closed(fqn, ts(5)),
+            "mark_auto_closed must skip when manually_closed_at is set"
+        );
+        assert_eq!(
+            clocks.auto_closed_at(fqn),
+            None,
+            "auto_closed_at must stay None when manual close already won"
+        );
+        assert_eq!(clocks.manually_closed_at(fqn), Some(ts(0)));
+    }
+
+    #[test]
     fn note_user_message_preserves_auto_closed_marker() {
         let mut clocks = CoordinatorClocks::default();
         let fqn = "proj:wg-1-team/coord";
@@ -420,6 +544,7 @@ mod tests {
                 last_user_message_at: Some(ts(0) + Duration::minutes(45)),
                 last_activity_at: Some(ts(0) + Duration::minutes(50)),
                 auto_closed_at: Some(ts(0) + Duration::minutes(60)),
+                manually_closed_at: Some(ts(0) + Duration::minutes(70)),
             },
         );
         // A second entry exercising the skip_serializing_if absence of two fields.
@@ -429,6 +554,7 @@ mod tests {
                 last_user_message_at: Some(ts(0)),
                 last_activity_at: None,
                 auto_closed_at: None,
+                manually_closed_at: None,
             },
         );
 
@@ -454,7 +580,13 @@ mod tests {
             loaded.auto_closed_at("proj:wg-1-team/coord"),
             Some(ts(0) + Duration::minutes(60))
         );
+        assert_eq!(
+            loaded.manually_closed_at("proj:wg-1-team/coord"),
+            Some(ts(0) + Duration::minutes(70)),
+            "manually_closed_at must survive save/load (#588)"
+        );
         assert_eq!(loaded.last_activity_at("proj:wg-2-team/coord"), None);
         assert_eq!(loaded.auto_closed_at("proj:wg-2-team/coord"), None);
+        assert_eq!(loaded.manually_closed_at("proj:wg-2-team/coord"), None);
     }
 }

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -398,6 +398,10 @@ pub struct AppSettings {
     pub coordinator_auto_close_enabled: bool,
     #[serde(default = "default_coord_auto_close_minutes")]
     pub coordinator_auto_close_minutes: u32,
+    /// #588 When true, manually closing a coordinator also closes its team
+    /// agents (cascade). When false, only the coordinator closes. Default true.
+    #[serde(default = "default_true")]
+    pub coordinator_cascade_close_enabled: bool,
 }
 
 fn default_true() -> bool {
@@ -580,6 +584,7 @@ impl Default for AppSettings {
             coordinator_idle_badge_red_minutes: default_coord_badge_red_minutes(),
             coordinator_auto_close_enabled: true,
             coordinator_auto_close_minutes: default_coord_auto_close_minutes(),
+            coordinator_cascade_close_enabled: true,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1683,6 +1683,7 @@ pub fn run(
         .invoke_handler(tauri::generate_handler![
             commands::session::create_session,
             commands::session::destroy_session,
+            commands::session::close_coordinator,
             commands::session::restart_session,
             commands::session::switch_session,
             commands::session::rename_session,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -43,7 +43,8 @@ import type {
   UiAutomationResponse,
   ResourceKillRequest,
   ResourceKillResult,
-  ResourceSnapshot
+  ResourceSnapshot,
+  CoordinatorCloseOutcome
 } from "./types";
 
 export interface SessionRepoInput {
@@ -163,6 +164,12 @@ export const SessionAPI = {
     }),
 
   destroy: (id: string) => transport.invoke<void>("destroy_session", { id }),
+
+  /** #588 Manually close a coordinator. When the cascade setting is on and the
+   *  team has working members, the backend returns `{ closed: false, workingCount }`
+   *  so the caller can confirm; calling again with `confirmed: true` forces it. */
+  closeCoordinator: (id: string, confirmed: boolean) =>
+    transport.invoke<CoordinatorCloseOutcome>("close_coordinator", { id, confirmed }),
 
   restart: (id: string, opts?: RestartSessionOptions): Promise<Session> =>
     transport.invoke<Session>("restart_session", {
@@ -548,6 +555,17 @@ export function onCoordinatorAutoCloseChanged(
 ): Promise<UnlistenFn> {
   return transport.listen<{ replicaPath: string; autoClosedAt: string | null }>(
     "coordinator_auto_close_changed",
+    callback
+  );
+}
+
+// #588 manually-closed pill: close_coordinator sets the marker (string
+// timestamp) when the user manually closes a coordinator; reopen clears it.
+export function onCoordinatorManualCloseChanged(
+  callback: (data: { replicaPath: string; manuallyClosedAt: string | null }) => void
+): Promise<UnlistenFn> {
+  return transport.listen<{ replicaPath: string; manuallyClosedAt: string | null }>(
+    "coordinator_manual_close_changed",
     callback
   );
 }

--- a/src/shared/shortcuts.ts
+++ b/src/shared/shortcuts.ts
@@ -1,5 +1,6 @@
 import { SessionAPI } from "./ipc";
 import { voiceRecorder } from "./voice-recorder";
+import { requestCoordinatorCloseById } from "../sidebar/stores/coordinator-close";
 
 type ShortcutHandler = (e: KeyboardEvent) => void;
 
@@ -15,7 +16,11 @@ const shortcuts: Array<{
     key: "w",
     handler: async () => {
       const activeId = await SessionAPI.getActive();
-      if (activeId) SessionAPI.destroy(activeId);
+      // #588 route the active session close through the shared helper so the
+      // keyboard shortcut marks + (settings-gated) cascades + confirms a
+      // coordinator close exactly like the row "X". The helper resolves the id to
+      // a Session internally; a non-coordinator is an unchanged plain destroy.
+      if (activeId) void requestCoordinatorCloseById(activeId);
     },
   },
   {

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -156,6 +156,7 @@ export function baseSettings(overrides: Partial<AppSettings> = {}): AppSettings 
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorCascadeCloseEnabled: true,
     ...overrides,
     codingAgentProfiles: overrides.codingAgentProfiles ?? defaultCodingAgentProfiles(),
   };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -273,6 +273,8 @@ export interface AppSettings {
    *  fully silent for `coordinatorAutoCloseMinutes` is terminated. */
   coordinatorAutoCloseEnabled: boolean;
   coordinatorAutoCloseMinutes: number;
+  /** #588 When true, manually closing a coordinator also closes its team. */
+  coordinatorCascadeCloseEnabled: boolean;
 }
 
 export type ResourceWatchdogAction = "warn" | "killGroup";
@@ -558,6 +560,18 @@ export interface AcAgentReplica {
    *  or undefined. Only meaningful when `isCoordinator`. Drives the neutral
    *  "auto-closed" pill; cleared on reopen. */
   autoClosedAt?: string;
+  /** #588 RFC3339 time this coordinator was manually closed, or undefined. Only
+   *  meaningful when `isCoordinator`. Drives the MANUALLY-CLOSED pill; cleared
+   *  on reopen. Visually identical to the auto-closed pill, different label. */
+  manuallyClosedAt?: string;
+}
+
+/** #588 Result of the `close_coordinator` command. When `closed` is false the
+ *  backend refused to cascade-close a coordinator whose team has working members
+ *  without confirmation; `workingCount` is how many are still working. */
+export interface CoordinatorCloseOutcome {
+  closed: boolean;
+  workingCount: number;
 }
 
 export interface AcWorkgroup {

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -172,6 +172,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorCascadeCloseEnabled: true,
     ...overrides,
   };
 }

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -86,6 +86,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorCascadeCloseEnabled: true,
     ...overrides,
   };
 }

--- a/src/sidebar/components/ProjectPanel.manually-closed-badge.test.tsx
+++ b/src/sidebar/components/ProjectPanel.manually-closed-badge.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
+import { settingsStore } from "../../shared/stores/settings";
+import { clockStore } from "../stores/clock";
+import type { AcAgentReplica } from "../../shared/types";
+
+// #588 — the MANUALLY-CLOSED pill mirrors AUTO-CLOSED (same `coord-autoclosed`
+// class, only the label differs), shows ONLY on a manually-closed *dormant*
+// coordinator, wins the XOR over both the idle badge and AUTO-CLOSED, and — like
+// #589's AUTO-CLOSED gate — hides the instant the coordinator has a live session
+// again (the `!isSessionLive(session())` gate, the stale-on-raise guard).
+
+const projectPath = "C:\\Project";
+const workgroupPath = `${projectPath}\\.ac\\wg-2-dev-team`;
+const coordPath = `${workgroupPath}\\__agent_dev-webpage-ui`;
+const coordSessionName = "wg-2-dev-team/dev-webpage-ui";
+
+/** RFC3339 anchor `minutes` before the badge clock's "now" (deterministic). */
+function isoMinutesAgo(minutes: number): string {
+  return new Date(clockStore.nowMs - minutes * 60_000).toISOString();
+}
+
+/** Discovery with a single coordinator replica carrying the given fields. */
+function coordDiscovery(coord: Partial<AcAgentReplica>) {
+  return discovery({
+    workgroups: [
+      {
+        name: "wg-2-dev-team",
+        path: workgroupPath,
+        task: null,
+        taskTitle: "Manual close",
+        agents: [
+          {
+            name: "dev-webpage-ui",
+            path: coordPath,
+            repoPaths: [],
+            isCoordinator: true,
+            ...coord,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+/** All pills that reuse the shared coord-autoclosed style (AUTO/MANUALLY). */
+function closedPills(root: HTMLElement): Element[] {
+  return Array.from(root.querySelectorAll(".coord-autoclosed"));
+}
+
+describe("ProjectPanel MANUALLY-CLOSED pill (#588)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("renders the MANUALLY-CLOSED pill and suppresses the idle counter (XOR) for a dormant coordinator", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("get_settings", baseSettings({ coordinatorAutoCloseEnabled: true }));
+    // 90-min idle anchor AND a manual-close marker, NO live session: the manual
+    // pill must show and the minutes counter must be gated off.
+    fake.resolve(
+      "discover_project",
+      coordDiscovery({ lastUserMessageAt: isoMinutesAgo(90), manuallyClosedAt: isoMinutesAgo(2) })
+    );
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      // The coordinator is rendered in both the pinned coordinators overview and
+      // the workgroup replica list, so the pill legitimately appears more than
+      // once; assert EVERY closed-pill is the manual one (the AUTO-CLOSED label
+      // never leaks through).
+      await waitFor(() => {
+        const pills = closedPills(rendered.root);
+        expect(pills.length).toBeGreaterThan(0);
+        expect(pills.every((p) => p.textContent === "MANUALLY-CLOSED")).toBe(true);
+      });
+      // XOR: the idle minutes counter is suppressed while the manual marker is set.
+      expect(rendered.root.querySelector(".coord-idle")).toBeNull();
+      expect(rendered.root.textContent).not.toContain("90m");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("lets MANUALLY-CLOSED win when both markers are set (no AUTO-CLOSED, no double pill)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("get_settings", baseSettings({ coordinatorAutoCloseEnabled: true }));
+    fake.resolve(
+      "discover_project",
+      coordDiscovery({ autoClosedAt: isoMinutesAgo(5), manuallyClosedAt: isoMinutesAgo(2) })
+    );
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await waitFor(() => {
+        const pills = closedPills(rendered.root);
+        expect(pills.length).toBeGreaterThan(0);
+        expect(pills.every((p) => p.textContent === "MANUALLY-CLOSED")).toBe(true);
+      });
+      // Manual wins the XOR: the AUTO-CLOSED label is suppressed everywhere.
+      expect(rendered.root.textContent).not.toContain("AUTO-CLOSED");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("suppresses the pill the moment the coordinator has a live session again (#589-parity !isSessionLive gate)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("get_settings", baseSettings({ coordinatorAutoCloseEnabled: true }));
+    fake.resolve("discover_project", coordDiscovery({ manuallyClosedAt: isoMinutesAgo(2) }));
+
+    // A live (running) session matching the replica name -> isSessionLive() true,
+    // so the manual pill must NOT render even though the marker is present. This
+    // is the exact stale-on-raise trap #589 fixes for AUTO-CLOSED.
+    sessionsStore.setSessions([
+      session({ id: "live-coord", name: coordSessionName, isCoordinator: true, status: "running" }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      // Give any async badge patching a beat, then assert the pill stayed hidden.
+      await waitFor(() => expect(rendered.root.textContent).not.toContain("MANUALLY-CLOSED"));
+      expect(closedPills(rendered.root)).toHaveLength(0);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1,8 +1,14 @@
 import { Component, For, Show, createEffect, createMemo, createSignal, onMount, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
 import type { AcWorkgroup, AcAgentReplica, AcTeam, AcLoopSummary, Session, TelegramBotConfig, BlockerReport } from "../../shared/types";
-import { SessionAPI, WindowAPI, EntityAPI, LoopAPI, TelegramAPI, SettingsAPI, TaskAPI, onDiscoveryBranchUpdated, onCoordinatorClockUpdated, onCoordinatorAutoCloseChanged, emitOpenSettings } from "../../shared/ipc";
+import { SessionAPI, WindowAPI, EntityAPI, LoopAPI, TelegramAPI, SettingsAPI, TaskAPI, onDiscoveryBranchUpdated, onCoordinatorClockUpdated, onCoordinatorAutoCloseChanged, onCoordinatorManualCloseChanged, emitOpenSettings } from "../../shared/ipc";
 import type { SessionRepoInput } from "../../shared/ipc";
+import {
+  pendingCoordinatorClose,
+  setPendingCoordinatorClose,
+  confirmPendingCoordinatorClose,
+  requestCoordinatorClose,
+} from "../stores/coordinator-close";
 import { isTauri } from "../../shared/platform";
 import { stripFrontmatter } from "../../shared/markdown";
 import { launchErrorMessage } from "../../shared/launch-errors";
@@ -194,6 +200,7 @@ const ProjectPanel: Component = () => {
   let unlistenBranch: (() => void) | null = null;
   let unlistenClock: (() => void) | null = null;
   let unlistenAutoClose: (() => void) | null = null;
+  let unlistenManualClose: (() => void) | null = null;
   onMount(async () => {
     unlistenBranch = await onDiscoveryBranchUpdated((data) => {
       projectStore.updateReplicaBranch(data.replicaPath, data.branch);
@@ -206,11 +213,16 @@ const ProjectPanel: Component = () => {
     unlistenAutoClose = await onCoordinatorAutoCloseChanged((data) => {
       projectStore.updateCoordinatorAutoClosed(data.replicaPath, data.autoClosedAt);
     });
+    // #588 manually-closed pill: patch in place, same as the auto-close marker.
+    unlistenManualClose = await onCoordinatorManualCloseChanged((data) => {
+      projectStore.updateCoordinatorManuallyClosed(data.replicaPath, data.manuallyClosedAt);
+    });
   });
   onCleanup(() => {
     unlistenBranch?.();
     unlistenClock?.();
     unlistenAutoClose?.();
+    unlistenManualClose?.();
   });
 
   const [pendingLaunch, setPendingLaunch] = createSignal<PendingLaunch | null>(null);
@@ -1234,6 +1246,16 @@ const ProjectPanel: Component = () => {
           // closed team shows ONLY the gray AUTO-CLOSED pill; clearing the marker
           // on reopen makes autoClosed() false and the counter returns.
           const autoClosed = createMemo(() => isCoord() && !!replica.autoClosedAt);
+          // #588 manually-closed pill. Mirrors autoClosed, but ALSO gated on
+          // !isSessionLive(session()): a dormant coordinator has no live session
+          // so the pill shows; a reopened/raised coordinator is live so the pill
+          // hides immediately, independent of marker-clear event timing (the same
+          // stale-on-raise trap #589 fixes for AUTO-CLOSED). Use INLINE
+          // isSessionLive(session()), NOT isLive() — isLive is declared later and
+          // this memo is eager (TDZ).
+          const manuallyClosed = createMemo(
+            () => isCoord() && !!replica.manuallyClosedAt && !isSessionLive(session())
+          );
           // #580 idle-badge tooltip. The auto-close clause is appended ONLY when
           // the setting is enabled: Decision 3 keeps the badge (and its red >=60
           // color) visible even when auto-close is OFF, where the team will NOT
@@ -1326,7 +1348,10 @@ const ProjectPanel: Component = () => {
           const handleClose = (e: MouseEvent) => {
             e.stopPropagation();
             const s = session();
-            if (s) SessionAPI.destroy(s.id);
+            // #588 route through the shared helper: a coordinator close marks +
+            // (settings-gated) cascades + confirms when busy; a non-coordinator
+            // is a plain destroy inside the helper (unchanged behavior).
+            if (s) void requestCoordinatorClose(s);
           };
 
           return (
@@ -1359,7 +1384,7 @@ const ProjectPanel: Component = () => {
                       row; the neutral AUTO-CLOSED pill REPLACES it when the team
                       is auto-closed (mutually exclusive — the #580 XOR gate), so
                       exactly one of the two renders first, before all others. */}
-                  <Show when={!autoClosed() && idleBadge()}>
+                  <Show when={!autoClosed() && !manuallyClosed() && idleBadge()}>
                     {(b) => (
                       <span
                         class={`ac-discovery-badge coord-idle ${b().colorClass}`}
@@ -1369,12 +1394,23 @@ const ProjectPanel: Component = () => {
                       </span>
                     )}
                   </Show>
-                  <Show when={autoClosed()}>
+                  <Show when={autoClosed() && !manuallyClosed()}>
                     <span
                       class="ac-discovery-badge coord-autoclosed"
                       title="This team was auto-closed after inactivity. Reopen it to clear."
                     >
                       AUTO-CLOSED
+                    </span>
+                  </Show>
+                  {/* #588 MANUALLY-CLOSED pill: same coord-autoclosed style as
+                      AUTO-CLOSED (pixel-identical, only the label differs). Manual
+                      wins the XOR — the AUTO-CLOSED gate above is `&& !manuallyClosed()`. */}
+                  <Show when={manuallyClosed()}>
+                    <span
+                      class="ac-discovery-badge coord-autoclosed"
+                      title="This team's coordinator was closed manually. Reopen it to clear."
+                    >
+                      MANUALLY-CLOSED
                     </span>
                   </Show>
                   <Show when={runningPeers && runningPeers()!.length > 0}>
@@ -2914,6 +2950,47 @@ const ProjectPanel: Component = () => {
         );
       }}
     </For>
+
+    {/* #588 Coordinator manual-close confirmation. Hoisted to the stable
+        ProjectPanel root (outside the projects <For>, like pendingLaunch) so a
+        background discovery refresh that re-creates each <For> row cannot tear it
+        down mid-decision. Driven by the module-level pendingCoordinatorClose
+        signal set by requestCoordinatorClose(ById) when the team is busy. */}
+    {pendingCoordinatorClose() && (
+      <Portal>
+        <div class="modal-overlay" data-ac-testid="coordinatorClose.modal">
+          <div class="agent-modal" style={{ "max-width": "380px" }}>
+            <div class="agent-modal-header">
+              <span class="agent-modal-title">Close coordinator?</span>
+            </div>
+            <div class="new-agent-form">
+              <p style={{ margin: "0", "line-height": "1.5", opacity: 0.85 }}>
+                <strong>{pendingCoordinatorClose()!.workingCount}</strong> team agent
+                {pendingCoordinatorClose()!.workingCount === 1 ? " is" : "s are"} still working.
+                Closing <strong>{pendingCoordinatorClose()!.name}</strong> will also close the team.
+              </p>
+            </div>
+            <div class="new-agent-footer">
+              <button
+                class="new-agent-cancel-btn"
+                data-ac-testid="coordinatorClose.cancel"
+                onClick={() => setPendingCoordinatorClose(null)}
+              >
+                Cancel
+              </button>
+              <button
+                class="new-agent-create-btn"
+                style={{ "background": "var(--danger, #c0392b)" }}
+                data-ac-testid="coordinatorClose.confirm"
+                onClick={() => void confirmPendingCoordinatorClose()}
+              >
+                Close team
+              </button>
+            </div>
+          </div>
+        </div>
+      </Portal>
+    )}
 
     {/* Agent picker for agents/replicas without a preferredAgentId */}
     {pendingLaunch() && (

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -8,6 +8,7 @@ import {
   setPendingCoordinatorClose,
   confirmPendingCoordinatorClose,
   requestCoordinatorClose,
+  registerCoordinatorCloseModalHost,
 } from "../stores/coordinator-close";
 import { isTauri } from "../../shared/platform";
 import { stripFrontmatter } from "../../shared/markdown";
@@ -201,6 +202,10 @@ const ProjectPanel: Component = () => {
   let unlistenClock: (() => void) | null = null;
   let unlistenAutoClose: (() => void) | null = null;
   let unlistenManualClose: (() => void) | null = null;
+  // #588 register this ProjectPanel as the confirm-modal host for THIS window, so
+  // the shared close helper opens the modal here (sidebar / web) but falls back to
+  // a plain destroy in a window with no host (the detached terminal webview).
+  onCleanup(registerCoordinatorCloseModalHost());
   onMount(async () => {
     unlistenBranch = await onDiscoveryBranchUpdated((data) => {
       projectStore.updateReplicaBranch(data.replicaPath, data.branch);

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -6,6 +6,7 @@ import { extractProjectName } from "../../shared/path-extractors";
 import { isTauri } from "../../shared/platform";
 import { bridgesStore } from "../stores/bridges";
 import { sessionsStore } from "../stores/sessions";
+import { requestCoordinatorClose } from "../stores/coordinator-close";
 import { settingsStore } from "../../shared/stores/settings";
 import { voiceRecorder, formatRecordingTime } from "../../shared/voice-recorder";
 import OpenAgentModal from "./OpenAgentModal";
@@ -152,7 +153,10 @@ const SessionItem: Component<{
 
   const handleClose = (e: MouseEvent) => {
     e.stopPropagation();
-    SessionAPI.destroy(props.session.id);
+    // #588 route through the shared helper: closing a coordinator from the
+    // session list marks + (settings-gated) cascades + confirms when busy. For a
+    // non-coordinator this is identical to the previous SessionAPI.destroy.
+    void requestCoordinatorClose(props.session);
   };
 
   /** True if any configured coding agent is Claude-based */

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -129,6 +129,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorCascadeCloseEnabled: true,
     ...overrides,
   };
 }
@@ -1005,6 +1006,38 @@ describe("SettingsModal automation hooks", () => {
 
     const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
     expect(saved?.agents[0]).not.toHaveProperty("instructionsFilename");
+
+    dispose();
+  });
+
+  it("round-trips coordinatorCascadeCloseEnabled through the General cascade checkbox (#588)", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {} }),
+      root,
+    );
+    await settle();
+
+    const checkbox = byTestId<HTMLInputElement>("settings.general.coordinatorCascadeCloseEnabled");
+    // The label is the issue's verbatim wording.
+    expect(checkbox.closest("label")?.textContent).toContain(
+      "Always close team members when manually closing Coordinator",
+    );
+    // Loaded default is true (the seeded settings have it on).
+    expect(checkbox.checked).toBe(true);
+
+    // Toggle OFF and save -> the persisted draft carries the new value, proving
+    // updateField accepts the new AppSettings key end to end.
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.coordinatorCascadeCloseEnabled).toBe(false);
 
     dispose();
   });

--- a/src/sidebar/components/SettingsModal.test.ts
+++ b/src/sidebar/components/SettingsModal.test.ts
@@ -70,6 +70,7 @@ function settings(overrides: Partial<AppSettings>): AppSettings {
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorCascadeCloseEnabled: true,
     ...overrides,
   };
 }

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -904,6 +904,18 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           configured minutes; the coordinator stays as a dormant row you can
           reopen by messaging it.
         </div>
+        <label class="settings-checkbox-field">
+          <input
+            type="checkbox"
+            class="settings-checkbox"
+            checked={settings.data!.coordinatorCascadeCloseEnabled}
+            onChange={(e) =>
+              updateField("coordinatorCascadeCloseEnabled", e.currentTarget.checked)
+            }
+            data-ac-testid="settings.general.coordinatorCascadeCloseEnabled"
+          />
+          <span>Always close team members when manually closing Coordinator</span>
+        </label>
       </div>
 
       <div class="settings-section">

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -86,6 +86,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorCascadeCloseEnabled: true,
     ...overrides,
   };
 }

--- a/src/sidebar/stores/coordinator-close.test.ts
+++ b/src/sidebar/stores/coordinator-close.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __setTransportForTests } from "../../shared/ipc";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import { session } from "../../shared/testing/ui-harness";
+import { sessionsStore } from "./sessions";
+import {
+  requestCoordinatorClose,
+  requestCoordinatorCloseById,
+  confirmPendingCoordinatorClose,
+  pendingCoordinatorClose,
+  setPendingCoordinatorClose,
+} from "./coordinator-close";
+
+// #588 — the single by-id helper funnels all three close paths (ProjectPanel
+// "X", SessionItem, keyboard shortcut). A non-coordinator is a plain destroy; a
+// coordinator goes through close_coordinator and opens the busy-confirm modal
+// (the module-level pendingCoordinatorClose signal) when the backend refuses.
+
+const COORD_NAME = "wg-2-dev-team/dev-webpage-ui";
+
+describe("coordinator-close helper (#588)", () => {
+  let fake: FakeTransport;
+  let restoreTransport: () => void;
+
+  beforeEach(() => {
+    fake = new FakeTransport();
+    restoreTransport = __setTransportForTests(fake);
+    sessionsStore.setSessions([]);
+    setPendingCoordinatorClose(null);
+  });
+
+  afterEach(() => {
+    restoreTransport();
+    sessionsStore.setSessions([]);
+    setPendingCoordinatorClose(null);
+  });
+
+  it("routes a non-coordinator close straight to destroy_session (no close_coordinator, no modal)", async () => {
+    const s = session({ id: "s-plain", isCoordinator: false });
+    sessionsStore.setSessions([s]);
+    fake.resolve("destroy_session", undefined);
+
+    await requestCoordinatorClose(s);
+
+    expect(fake.callsFor("destroy_session").map((c) => c.args)).toEqual([{ id: "s-plain" }]);
+    expect(fake.callsFor("close_coordinator")).toHaveLength(0);
+    expect(pendingCoordinatorClose()).toBeNull();
+  });
+
+  it("closes an idle coordinator directly (close_coordinator confirmed:false -> closed:true, no modal)", async () => {
+    const s = session({ id: "s-coord", name: COORD_NAME, isCoordinator: true });
+    sessionsStore.setSessions([s]);
+    fake.resolve("close_coordinator", { closed: true, workingCount: 0 });
+
+    await requestCoordinatorClose(s);
+
+    const calls = fake.callsFor("close_coordinator");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual({ id: "s-coord", confirmed: false });
+    expect(fake.callsFor("destroy_session")).toHaveLength(0);
+    expect(pendingCoordinatorClose()).toBeNull();
+  });
+
+  it("opens the confirmation modal (named from the session) when the backend reports working members", async () => {
+    const s = session({ id: "s-coord", name: COORD_NAME, isCoordinator: true });
+    sessionsStore.setSessions([s]);
+    fake.resolve("close_coordinator", { closed: false, workingCount: 3 });
+
+    await requestCoordinatorClose(s);
+
+    const pending = pendingCoordinatorClose();
+    expect(pending).not.toBeNull();
+    expect(pending!.sessionId).toBe("s-coord");
+    expect(pending!.name).toBe(COORD_NAME);
+    expect(pending!.workingCount).toBe(3);
+  });
+
+  it("confirm calls close_coordinator(confirmed:true) and clears the modal", async () => {
+    setPendingCoordinatorClose({ sessionId: "s-coord", name: "x", workingCount: 2 });
+    fake.resolve("close_coordinator", { closed: true, workingCount: 0 });
+
+    await confirmPendingCoordinatorClose();
+
+    const calls = fake.callsFor("close_coordinator");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual({ id: "s-coord", confirmed: true });
+    expect(pendingCoordinatorClose()).toBeNull();
+  });
+
+  it("cancel (clearing the pending signal) destroys nothing and invokes no command", async () => {
+    setPendingCoordinatorClose({ sessionId: "s-coord", name: "x", workingCount: 2 });
+    setPendingCoordinatorClose(null);
+
+    expect(pendingCoordinatorClose()).toBeNull();
+    expect(fake.callsFor("close_coordinator")).toHaveLength(0);
+    expect(fake.callsFor("destroy_session")).toHaveLength(0);
+  });
+
+  it("by-id with an unknown id still routes through close_coordinator and falls back to 'this coordinator'", async () => {
+    // No session in the store for this id -> the helper cannot short-circuit to a
+    // plain destroy; it lets the backend self-route. The modal name falls back to
+    // the generic label (the id-only keyboard-shortcut path).
+    fake.resolve("close_coordinator", { closed: false, workingCount: 1 });
+
+    await requestCoordinatorCloseById("ghost-id");
+
+    const calls = fake.callsFor("close_coordinator");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual({ id: "ghost-id", confirmed: false });
+    expect(pendingCoordinatorClose()?.name).toBe("this coordinator");
+  });
+});

--- a/src/sidebar/stores/coordinator-close.test.ts
+++ b/src/sidebar/stores/coordinator-close.test.ts
@@ -10,6 +10,8 @@ import {
   confirmPendingCoordinatorClose,
   pendingCoordinatorClose,
   setPendingCoordinatorClose,
+  registerCoordinatorCloseModalHost,
+  __resetCoordinatorCloseModalHostForTests,
 } from "./coordinator-close";
 
 // #588 — the single by-id helper funnels all three close paths (ProjectPanel
@@ -22,15 +24,23 @@ const COORD_NAME = "wg-2-dev-team/dev-webpage-ui";
 describe("coordinator-close helper (#588)", () => {
   let fake: FakeTransport;
   let restoreTransport: () => void;
+  // Tests that expect the confirm modal must register a host (a window with a
+  // mounted ProjectPanel); dispose it in afterEach so the ref-count resets.
+  let disposeModalHost: (() => void) | null = null;
 
   beforeEach(() => {
     fake = new FakeTransport();
     restoreTransport = __setTransportForTests(fake);
     sessionsStore.setSessions([]);
     setPendingCoordinatorClose(null);
+    disposeModalHost = null;
+    // Deterministic host==0 precondition regardless of test order/shuffle.
+    __resetCoordinatorCloseModalHostForTests();
   });
 
   afterEach(() => {
+    disposeModalHost?.();
+    disposeModalHost = null;
     restoreTransport();
     sessionsStore.setSessions([]);
     setPendingCoordinatorClose(null);
@@ -63,6 +73,7 @@ describe("coordinator-close helper (#588)", () => {
   });
 
   it("opens the confirmation modal (named from the session) when the backend reports working members", async () => {
+    disposeModalHost = registerCoordinatorCloseModalHost(); // a window with the modal host
     const s = session({ id: "s-coord", name: COORD_NAME, isCoordinator: true });
     sessionsStore.setSessions([s]);
     fake.resolve("close_coordinator", { closed: false, workingCount: 3 });
@@ -98,6 +109,7 @@ describe("coordinator-close helper (#588)", () => {
   });
 
   it("by-id with an unknown id still routes through close_coordinator and falls back to 'this coordinator'", async () => {
+    disposeModalHost = registerCoordinatorCloseModalHost(); // sidebar/web window
     // No session in the store for this id -> the helper cannot short-circuit to a
     // plain destroy; it lets the backend self-route. The modal name falls back to
     // the generic label (the id-only keyboard-shortcut path).
@@ -109,5 +121,25 @@ describe("coordinator-close helper (#588)", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].args).toEqual({ id: "ghost-id", confirmed: false });
     expect(pendingCoordinatorClose()?.name).toBe("this coordinator");
+  });
+
+  it("falls back to a plain destroy (no modal, no cascade) on closed:false when NO modal host is mounted", async () => {
+    // The detached terminal webview: registerShortcuts runs but no ProjectPanel
+    // hosts the confirm modal. A busy coordinator close must NOT silently no-op —
+    // it falls back to destroying JUST the coordinator.
+    const s = session({ id: "s-coord", name: COORD_NAME, isCoordinator: true });
+    sessionsStore.setSessions([s]);
+    fake.resolve("close_coordinator", { closed: false, workingCount: 2 });
+    fake.resolve("destroy_session", undefined);
+
+    await requestCoordinatorCloseById("s-coord");
+
+    // close_coordinator(confirmed:false) was attempted, came back closed:false,
+    // then the helper fell back to destroy_session(id) — no pending modal.
+    expect(fake.callsFor("close_coordinator")).toEqual([
+      { cmd: "close_coordinator", args: { id: "s-coord", confirmed: false } },
+    ]);
+    expect(fake.callsFor("destroy_session").map((c) => c.args)).toEqual([{ id: "s-coord" }]);
+    expect(pendingCoordinatorClose()).toBeNull();
   });
 });

--- a/src/sidebar/stores/coordinator-close.ts
+++ b/src/sidebar/stores/coordinator-close.ts
@@ -13,6 +13,34 @@ const [pendingCoordinatorClose, setPendingCoordinatorClose] =
   createSignal<PendingCoordinatorClose | null>(null);
 export { pendingCoordinatorClose, setPendingCoordinatorClose };
 
+// #588 confirm-modal host presence (ref-counted). ProjectPanel — the ONLY
+// renderer of the pendingCoordinatorClose modal — registers itself on mount so
+// the by-id helper knows whether a confirmation modal can actually be shown in
+// THIS window. In a detached terminal webview no host registers (separate JS
+// context, no ProjectPanel), so a busy-coordinator keyboard close falls back to
+// a plain destroy instead of setting a signal nothing renders (a silent no-op).
+let modalHostRefs = 0;
+
+/** #588 Register the confirm-modal host (ProjectPanel) for the current window.
+ *  Returns a disposer to call on cleanup. */
+export function registerCoordinatorCloseModalHost(): () => void {
+  modalHostRefs += 1;
+  return () => {
+    modalHostRefs = Math.max(0, modalHostRefs - 1);
+  };
+}
+
+/** #588 True iff a confirm-modal host is mounted in this window. */
+function coordinatorCloseModalHostAvailable(): boolean {
+  return modalHostRefs > 0;
+}
+
+/** Test-only: reset the modal-host ref-count so each test starts from a known
+ *  state regardless of order (mirrors the `__*ForTests` hooks elsewhere). */
+export function __resetCoordinatorCloseModalHostForTests(): void {
+  modalHostRefs = 0;
+}
+
 /** #588 by-id entry point: the single implementation. Resolves the live session
  *  ONLY to give the modal a friendly name; the backend self-routes a
  *  non-coordinator id to a plain destroy, so id-only callers (the keyboard
@@ -28,11 +56,20 @@ export async function requestCoordinatorCloseById(id: string): Promise<void> {
   try {
     const outcome = await SessionAPI.closeCoordinator(id, false);
     if (!outcome.closed) {
-      setPendingCoordinatorClose({
-        sessionId: id,
-        name: s?.name ?? "this coordinator",
-        workingCount: outcome.workingCount,
-      });
+      if (coordinatorCloseModalHostAvailable()) {
+        setPendingCoordinatorClose({
+          sessionId: id,
+          name: s?.name ?? "this coordinator",
+          workingCount: outcome.workingCount,
+        });
+      } else {
+        // #588 No confirm-modal host in this window (e.g. the detached terminal
+        // webview's keyboard shortcut): fall back to closing JUST the coordinator
+        // (plain destroy, no cascade) so the user is never left with a silent
+        // no-op. The backend refused to cascade busy members without confirmation;
+        // destroying only the coordinator restores the pre-#588 behavior here.
+        await SessionAPI.destroy(id);
+      }
     }
   } catch (err) {
     console.error("close_coordinator failed:", err);

--- a/src/sidebar/stores/coordinator-close.ts
+++ b/src/sidebar/stores/coordinator-close.ts
@@ -1,0 +1,65 @@
+import { createSignal } from "solid-js";
+import type { Session } from "../../shared/types";
+import { SessionAPI } from "../../shared/ipc";
+import { sessionsStore } from "./sessions"; // sidebar->sidebar, mirrors team-idle-watcher.ts
+
+export interface PendingCoordinatorClose {
+  sessionId: string;
+  name: string;
+  workingCount: number;
+}
+
+const [pendingCoordinatorClose, setPendingCoordinatorClose] =
+  createSignal<PendingCoordinatorClose | null>(null);
+export { pendingCoordinatorClose, setPendingCoordinatorClose };
+
+/** #588 by-id entry point: the single implementation. Resolves the live session
+ *  ONLY to give the modal a friendly name; the backend self-routes a
+ *  non-coordinator id to a plain destroy, so id-only callers (the keyboard
+ *  shortcut) need no `Session`. On needs-confirmation it opens the modal (host
+ *  lives in ProjectPanel). */
+export async function requestCoordinatorCloseById(id: string): Promise<void> {
+  const s = sessionsStore.sessions.find((x) => x.id === id);
+  // Known non-coordinator -> identical net effect to destroy_session.
+  if (s && !s.isCoordinator) {
+    await SessionAPI.destroy(id);
+    return;
+  }
+  try {
+    const outcome = await SessionAPI.closeCoordinator(id, false);
+    if (!outcome.closed) {
+      setPendingCoordinatorClose({
+        sessionId: id,
+        name: s?.name ?? "this coordinator",
+        workingCount: outcome.workingCount,
+      });
+    }
+  } catch (err) {
+    console.error("close_coordinator failed:", err);
+  }
+}
+
+/** #588 entry point for callers that already hold the `Session` (ProjectPanel
+ *  "X", SessionItem). Non-coordinator -> plain destroy (unchanged behavior);
+ *  coordinator -> delegate to the by-id helper (one implementation). */
+export async function requestCoordinatorClose(session: Session): Promise<void> {
+  if (!session.isCoordinator) {
+    await SessionAPI.destroy(session.id);
+    return;
+  }
+  await requestCoordinatorCloseById(session.id);
+}
+
+/** Confirm the pending cascade close (called from the modal). Consume-and-clear:
+ *  the modal closes before the confirmed call awaits. Accepted (grinch F6, §7):
+ *  a failed close leaves the team visibly running, so there is no false success. */
+export async function confirmPendingCoordinatorClose(): Promise<void> {
+  const pending = pendingCoordinatorClose();
+  if (!pending) return;
+  setPendingCoordinatorClose(null);
+  try {
+    await SessionAPI.closeCoordinator(pending.sessionId, true);
+  } catch (err) {
+    console.error("close_coordinator (confirmed) failed:", err);
+  }
+}

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -239,6 +239,26 @@ export const projectStore = {
     );
   },
 
+  /** #588 patch a coordinator replica's manuallyClosedAt from the event.
+   *  A string sets the marker; `null` clears it (reopen). Matched by normalized
+   *  path, same as updateCoordinatorAutoClosed. */
+  updateCoordinatorManuallyClosed(replicaPath: string, manuallyClosedAt: string | null) {
+    const target = normalizePath(replicaPath);
+    setProjects((prev) =>
+      prev.map((proj) => ({
+        ...proj,
+        workgroups: proj.workgroups.map((wg) => ({
+          ...wg,
+          agents: wg.agents.map((a) =>
+            normalizePath(a.path) === target
+              ? { ...a, manuallyClosedAt: manuallyClosedAt ?? undefined }
+              : a
+          ),
+        })),
+      }))
+    );
+  },
+
   /** Update a workgroup's TASK.md fields from the discovery watcher. */
   updateWorkgroupTask(
     workgroupPath: string,


### PR DESCRIPTION
## Summary
Adds a `MANUALLY-CLOSED` badge for coordinators closed manually (mirrors the existing `AUTO-CLOSED` badge, coordinator-only), and makes a manual coordinator close optionally cascade to closing its team agents.

## What changed
- **MANUALLY-CLOSED badge** — new pill reusing the `coord-autoclosed` CSS class (pixel-identical, only the text differs), shown only on the coordinator. Tracked via a persisted `manually_closed_at` marker on `ClockEntry` mirroring `auto_closed_at`. XOR with idle / AUTO-CLOSED (manual wins), each gated on `!isSessionLive` so neither goes stale on raise.
- **Settings-gated cascade** — new setting `coordinator_cascade_close_enabled` (default `true`), label "Always close team members when manually closing Coordinator". When on, manually closing a coordinator also closes its live team agents; when off, only the coordinator closes and the team keeps running.
- **Busy-confirm modal** — one backend command `close_coordinator(id, confirmed)` owns the cascade + working-count gate + marker, using a live-PTY-filtered member set. If the cascade is on and at least one team agent is working, it returns `closed:false` so the FE shows a confirmation modal; on confirm it recalls with `confirmed:true`. If all team agents are idle, it closes directly with no modal.
- **Unified close paths** — all coordinator-close entry points (ProjectPanel "X", SessionItem, keyboard shortcut) route through one `requestCoordinatorCloseById` helper. The detached terminal window (which has no modal host) falls back to a plain coordinator-only destroy on a busy coordinator instead of a silent no-op.

## Testing
- Implemented per a consolidated architect plan (dev-rust backend + dev-webpage-ui frontend), with dev-side `/code-review` at high effort on each half (no HIGH findings).
- Adversarial implementation review (grinch) PASS — gates: `cargo test --lib --bins --tests` 1426 passed / 0 failed / 12 ignored, `cargo clippy` clean, `tsc` clean, `vitest` 461 passed, `npm run build` OK.
- Re-synced onto latest `origin/main` twice (first onto #589 + #548/0.9.16, then onto #587 resource-monitor); each re-sync was re-reviewed by grinch (PASS) with all gates re-run on the merged tree. The only conflict was the ProjectPanel badge block, resolved keeping both #589's and #588's liveness gates.
- Shipper built the workgroup standalone exe and deployed it to 0_AC; the user manually tested it and gave the go-ahead to land.

Closes #588
