### PR TITLE
feat(profiles): content-hash drift detection (#592) + command concatenation (#597)

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -195,7 +195,16 @@ fn settings_draft_update_events(
     }
 
     SettingsDraftUpdateEvents {
-        profiles_changed: before.coding_agent_profiles != after.coding_agent_profiles,
+        // #592/#597 - the drift content-hash fingerprints the EFFECTIVE command
+        // (agent base command + cell command, via compose_effective_command), so a
+        // bare agent-base-command edit (e.g. `claude` -> `claude-amp -c ...`) is real
+        // drift even when the profile cells are untouched. It is neither a
+        // coding_agent_profiles change nor an env change, so without folding it in
+        // here the SettingsModal save path emits NO refresh event and the outdated
+        // badge never updates. coding_agent_profiles_updated drives
+        // refreshProfileOutdated in the sidebar, so route base-command edits through it.
+        profiles_changed: before.coding_agent_profiles != after.coding_agent_profiles
+            || agent_commands_by_id(before) != agent_commands_by_id(after),
         env_agent_ids,
     }
 }
@@ -210,12 +219,35 @@ fn agent_env_settings_by_id(
         .collect()
 }
 
+/// #592/#597 - per-agent base command, the other half of the drift hash input
+/// (`compose_effective_command(agent.command, cell.command)`). A change here must
+/// trigger a drift refresh just like a profile-cell edit.
+fn agent_commands_by_id(settings: &AppSettings) -> BTreeMap<String, String> {
+    settings
+        .agents
+        .iter()
+        .map(|agent| (agent.id.clone(), agent.command.clone()))
+        .collect()
+}
+
 fn emit_settings_draft_update_events(app: &AppHandle, events: &SettingsDraftUpdateEvents) {
     if events.profiles_changed {
+        // #592/#597 diagnostic: the SettingsModal "Save" persists profile cells AND
+        // agent base commands through save_settings_draft (NOT
+        // update_coding_agent_profiles), so THIS is the emit point the user's normal
+        // edit flow actually reaches. Logged with the same [profile-hash] prefix so
+        // the drift trace shows the refresh event firing from the real save path.
+        log::info!(
+            "[profile-hash] profile-save (save_settings_draft): coding-agent config changed; emitting coding_agent_profiles_updated"
+        );
         let _ = app.emit("coding_agent_profiles_updated", serde_json::json!({}));
     }
 
     for agent_id in &events.env_agent_ids {
+        log::info!(
+            "[profile-hash] profile-save (save_settings_draft): agent env changed for {}; emitting coding_agent_env_settings_updated",
+            agent_id
+        );
         let _ = app.emit(
             "coding_agent_env_settings_updated",
             serde_json::json!({ "agentId": agent_id }),
@@ -1362,6 +1394,55 @@ mod tests {
         assert_ne!(ab_c, a_bc);
         assert_ne!(ab_c, restart);
         assert_ne!(ab_c, other_targets);
+    }
+
+    #[test]
+    fn settings_draft_events_flag_agent_base_command_edit() {
+        // #592/#597 - a bare agent base-command edit changes the effective-command
+        // drift hash, so save_settings_draft must emit coding_agent_profiles_updated
+        // even though the profile cells and envs are untouched. This is the bug the
+        // user hit editing `claude` -> `claude-amp -c ...` in Settings -> Coding Agents.
+        let before = settings_with_single_agent();
+        let mut after = settings_with_single_agent();
+        after.agents[0].command = "codex --resume".to_string();
+
+        let events = super::settings_draft_update_events(&before, &after);
+        assert!(
+            events.profiles_changed,
+            "an agent base-command edit must flag a profiles refresh"
+        );
+        assert!(events.env_agent_ids.is_empty(), "no env changed");
+    }
+
+    #[test]
+    fn settings_draft_events_quiet_for_non_drift_field_edit() {
+        // A non-drift field (label) changing must NOT emit a profiles refresh, so the
+        // fix does not over-fire on unrelated settings saves.
+        let before = settings_with_single_agent();
+        let mut after = settings_with_single_agent();
+        after.agents[0].label = "Renamed".to_string();
+
+        let events = super::settings_draft_update_events(&before, &after);
+        assert!(!events.profiles_changed, "a label edit is not drift");
+        assert!(events.env_agent_ids.is_empty());
+    }
+
+    #[test]
+    fn settings_draft_events_flag_agent_env_edit() {
+        // Regression guard: the pre-existing env path still flags the agent id (the
+        // base env is also a drift-hash input, surfaced via the env event).
+        let before = settings_with_single_agent();
+        let mut after = settings_with_single_agent();
+        after.agents[0].envs = vec![CodingAgentEnv {
+            key: "FOO".to_string(),
+            value: "bar".to_string(),
+            source: CodingAgentEnvSource::User,
+            enabled: true,
+        }];
+
+        let events = super::settings_draft_update_events(&before, &after);
+        assert_eq!(events.env_agent_ids, vec!["agent-0".to_string()]);
+        assert!(!events.profiles_changed, "env-only edit is not a profiles change");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -230,6 +230,12 @@ pub async fn update_coding_agent_profiles(
     profiles: CodingAgentProfilesConfig,
 ) -> Result<(), String> {
     persist_coding_agent_profiles_update(settings.inner(), profiles).await?;
+    // #592/#597 diagnostic: confirm the in-memory settings were updated and the
+    // refresh event is emitted, so a later `list_sessions` recomputes drift
+    // against the edited cell.
+    log::info!(
+        "[profile-hash] coding agent profiles saved (in-memory updated); emitting coding_agent_profiles_updated"
+    );
     let _ = app.emit("coding_agent_profiles_updated", serde_json::json!({}));
     Ok(())
 }

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -232,19 +232,18 @@ fn agent_commands_by_id(settings: &AppSettings) -> BTreeMap<String, String> {
 
 fn emit_settings_draft_update_events(app: &AppHandle, events: &SettingsDraftUpdateEvents) {
     if events.profiles_changed {
-        // #592/#597 diagnostic: the SettingsModal "Save" persists profile cells AND
-        // agent base commands through save_settings_draft (NOT
-        // update_coding_agent_profiles), so THIS is the emit point the user's normal
-        // edit flow actually reaches. Logged with the same [profile-hash] prefix so
-        // the drift trace shows the refresh event firing from the real save path.
-        log::info!(
+        // #592/#597: the SettingsModal "Save" persists profile cells AND agent base
+        // commands through save_settings_draft (NOT update_coding_agent_profiles), so
+        // THIS is the emit point the user's normal edit flow actually reaches. Kept at
+        // debug to confirm the refresh fired without spamming app.log.
+        log::debug!(
             "[profile-hash] profile-save (save_settings_draft): coding-agent config changed; emitting coding_agent_profiles_updated"
         );
         let _ = app.emit("coding_agent_profiles_updated", serde_json::json!({}));
     }
 
     for agent_id in &events.env_agent_ids {
-        log::info!(
+        log::debug!(
             "[profile-hash] profile-save (save_settings_draft): agent env changed for {}; emitting coding_agent_env_settings_updated",
             agent_id
         );
@@ -262,12 +261,6 @@ pub async fn update_coding_agent_profiles(
     profiles: CodingAgentProfilesConfig,
 ) -> Result<(), String> {
     persist_coding_agent_profiles_update(settings.inner(), profiles).await?;
-    // #592/#597 diagnostic: confirm the in-memory settings were updated and the
-    // refresh event is emitted, so a later `list_sessions` recomputes drift
-    // against the edited cell.
-    log::info!(
-        "[profile-hash] coding agent profiles saved (in-memory updated); emitting coding_agent_profiles_updated"
-    );
     let _ = app.emit("coding_agent_profiles_updated", serde_json::json!({}));
     Ok(())
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1214,6 +1214,13 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             // #592 - persist the loaded profile content-hash so drift survives an
             // AC restart. Best-effort; never aborts the spawn. No-op off-replica.
             if let Some(hash) = session.profile_content_hash.as_deref() {
+                log::info!(
+                    "[profile-hash] spawn-persist: session={} agent={} hash={} cwd={:?}",
+                    id,
+                    aid,
+                    hash,
+                    cwd,
+                );
                 if let Err(e) = crate::config::coding_agent_profiles::set_replica_profile_content_hash(
                     std::path::Path::new(&cwd),
                     hash,
@@ -1259,6 +1266,12 @@ fn compute_profile_outdated(settings: &AppSettings, info: &SessionInfo) -> bool 
     let Some(agent_id) =
         resolve_restart_selected_agent_id(settings, cwd, None, info.agent_id.as_deref())
     else {
+        log::info!(
+            "[profile-hash] drift-check: session={} no resolvable reload agent (cwd={:?}, stored={:?}); outdated=false",
+            info.id,
+            cwd,
+            info.agent_id,
+        );
         return false;
     };
     let requested = effective_restart_requested_profile(None, info.requested_profile.clone());
@@ -1275,26 +1288,59 @@ fn compute_profile_outdated(settings: &AppSettings, info: &SessionInfo) -> bool 
     // (agent base + cell params) and the raw merged env (agent + cell). Look up the
     // agent a Reload would launch; if it vanished from settings, do not false-flag.
     let Some(agent) = settings.agents.iter().find(|a| a.id == agent_id) else {
+        log::info!(
+            "[profile-hash] drift-check: session={} reload agent {} not in settings; outdated=false",
+            info.id,
+            agent_id,
+        );
         return false;
     };
-    let configured = crate::config::agent_command::profile_content_hash(
-        &crate::config::agent_command::compose_effective_command(
-            &agent.command,
-            &resolution.cell.command,
-        ),
-        &crate::config::agent_command::raw_merged_profile_env(agent, &resolution.cell.env),
+    let configured_command = crate::config::agent_command::compose_effective_command(
+        &agent.command,
+        &resolution.cell.command,
     );
+    let configured_env =
+        crate::config::agent_command::raw_merged_profile_env(agent, &resolution.cell.env);
+    let configured =
+        crate::config::agent_command::profile_content_hash(&configured_command, &configured_env);
     // Loaded hash: in-memory stamp, else the persisted replica copy (survives an
     // AC restart that cleared the in-memory stamp).
+    let loaded_source = if info.profile_content_hash.is_some() {
+        "in-memory"
+    } else {
+        "replica-config"
+    };
     let loaded = info.profile_content_hash.clone().or_else(|| {
         crate::config::coding_agent_profiles::read_replica_profile_content_hash(
             std::path::Path::new(cwd),
         )
     });
-    match loaded {
-        Some(loaded) => loaded != configured,
+    let outdated = match &loaded {
+        Some(loaded) => *loaded != configured,
         None => false,
-    }
+    };
+    // #592/#597 diagnostic: per-session drift decision. `loaded` is the hash
+    // stamped at the session's spawn (from memory or the replica config.json);
+    // `configured` is recomputed from CURRENT settings. They diverge when the
+    // profile cell/base command/env was edited after spawn.
+    log::info!(
+        "[profile-hash] drift-check: session={} agent={} profile={} loaded={:?} (via {}) configured={} outdated={} configured_command={:?} env_keys=[{}] ({} entries)",
+        info.id,
+        agent_id,
+        resolution.effective_profile,
+        loaded,
+        loaded_source,
+        configured,
+        outdated,
+        configured_command,
+        configured_env
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", "),
+        configured_env.len(),
+    );
+    outdated
 }
 
 /// Create a new session. Optionally override shell/args/cwd/name (for action buttons).

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1271,9 +1271,18 @@ fn compute_profile_outdated(settings: &AppSettings, info: &SessionInfo) -> bool 
             requested_profile: requested.as_deref(),
         },
     );
+    // #597 - mirror the spawn-time composition exactly: hash the effective command
+    // (agent base + cell params) and the raw merged env (agent + cell). Look up the
+    // agent a Reload would launch; if it vanished from settings, do not false-flag.
+    let Some(agent) = settings.agents.iter().find(|a| a.id == agent_id) else {
+        return false;
+    };
     let configured = crate::config::agent_command::profile_content_hash(
-        &resolution.cell.command,
-        &resolution.cell.env,
+        &crate::config::agent_command::compose_effective_command(
+            &agent.command,
+            &resolution.cell.command,
+        ),
+        &crate::config::agent_command::raw_merged_profile_env(agent, &resolution.cell.env),
     );
     // Loaded hash: in-memory stamp, else the persisted replica copy (survives an
     // AC restart that cleared the in-memory stamp).
@@ -2731,7 +2740,9 @@ mod tests {
                 "C".to_string(),
                 ProfileCellConfig {
                     enabled: true,
-                    command: "codex --profile-c".to_string(),
+                    // #597 - the cell holds params only; they append to the agent
+                    // base command (`codex`) to launch `codex --profile-c`.
+                    command: "--profile-c".to_string(),
                     env: BTreeMap::new(),
                     notes: String::new(),
                 },
@@ -2803,21 +2814,28 @@ mod tests {
                 "A".to_string(),
                 ProfileCellConfig {
                     enabled: true,
-                    command: "codex --v1".to_string(),
+                    command: "--v1".to_string(),
                     env: BTreeMap::new(),
                     notes: String::new(),
                 },
             );
 
-        // The hash the session was launched ("loaded") with: cell A v1.
-        let loaded =
-            crate::config::agent_command::profile_content_hash("codex --v1", &BTreeMap::new());
+        // #597 - the hash the session launched with: agent base + cell A params,
+        // composed via the SAME helpers the spawn path uses. The codex borrow ends
+        // with this block, before the get_mut mutation below.
+        let loaded = {
+            let codex = settings.agents.iter().find(|a| a.id == "codex").unwrap();
+            crate::config::agent_command::profile_content_hash(
+                &crate::config::agent_command::compose_effective_command(&codex.command, "--v1"),
+                &crate::config::agent_command::raw_merged_profile_env(codex, &BTreeMap::new()),
+            )
+        };
         let mut info = make_info(&cwd, Some("codex"), Some("A"), Some(loaded));
 
         // Config unchanged -> not outdated.
         assert!(!compute_profile_outdated(&settings, &info));
 
-        // Edit the effective cell -> outdated.
+        // Edit the effective cell params -> outdated.
         settings
             .coding_agent_profiles
             .profiles_by_agent
@@ -2825,12 +2843,56 @@ mod tests {
             .unwrap()
             .get_mut("A")
             .unwrap()
-            .command = "codex --v2".to_string();
+            .command = "--v2".to_string();
         assert!(compute_profile_outdated(&settings, &info));
 
         // A plain-shell session (no agent) never drifts.
         info.agent_id = None;
         assert!(!compute_profile_outdated(&settings, &info));
+    }
+
+    #[test]
+    fn compute_profile_outdated_flips_on_agent_base_command_edit() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().to_string_lossy().to_string();
+
+        let mut settings = test_settings();
+        settings
+            .coding_agent_profiles
+            .profiles_by_agent
+            .entry("codex".to_string())
+            .or_default()
+            .insert(
+                "A".to_string(),
+                ProfileCellConfig {
+                    enabled: true,
+                    command: "--v1".to_string(),
+                    env: BTreeMap::new(),
+                    notes: String::new(),
+                },
+            );
+
+        // #597 - stamp loaded from agent base `codex` + cell `--v1`.
+        let loaded = {
+            let codex = settings.agents.iter().find(|a| a.id == "codex").unwrap();
+            crate::config::agent_command::profile_content_hash(
+                &crate::config::agent_command::compose_effective_command(&codex.command, "--v1"),
+                &crate::config::agent_command::raw_merged_profile_env(codex, &BTreeMap::new()),
+            )
+        };
+        let info = make_info(&cwd, Some("codex"), Some("A"), Some(loaded));
+
+        // Base unchanged -> not outdated.
+        assert!(!compute_profile_outdated(&settings, &info));
+
+        // Edit the agent base command -> outdated (the base is now in the hash).
+        settings
+            .agents
+            .iter_mut()
+            .find(|a| a.id == "codex")
+            .unwrap()
+            .command = "codex-next".into();
+        assert!(compute_profile_outdated(&settings, &info));
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -834,6 +834,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             spawn.profile_resolution.fallback_chain.clone(),
             spawn.profile_resolution.fallback_applied,
             effective_codex_home.clone(),
+            Some(spawn.profile_content_hash.clone()),
         )
         .await;
         session.requested_profile = Some(spawn.profile_resolution.requested_profile.clone());
@@ -841,6 +842,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         session.profile_fallback_chain = spawn.profile_resolution.fallback_chain.clone();
         session.profile_fallback_applied = spawn.profile_resolution.fallback_applied;
         session.effective_codex_home = effective_codex_home;
+        session.profile_content_hash = Some(spawn.profile_content_hash.clone());
     }
 
     let mut shell_args = shell_args;
@@ -1209,6 +1211,16 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             ) {
                 log::warn!("Failed to save lastCodingAgent: {}", e);
             }
+            // #592 - persist the loaded profile content-hash so drift survives an
+            // AC restart. Best-effort; never aborts the spawn. No-op off-replica.
+            if let Some(hash) = session.profile_content_hash.as_deref() {
+                if let Err(e) = crate::config::coding_agent_profiles::set_replica_profile_content_hash(
+                    std::path::Path::new(&cwd),
+                    hash,
+                ) {
+                    log::warn!("Failed to persist profileContentHash: {}", e);
+                }
+            }
         }
     }
 
@@ -1231,6 +1243,49 @@ pub(crate) fn build_configured_agent_spawn_for_cwd(
         requested_profile,
     )
     .map(Some)
+}
+
+/// #592 - true when a session's loaded profile cell no longer matches what a
+/// Reload would load right now. Mirrors the restart-time resolution so the
+/// "configured" side equals `restart_session`'s effective cell. Hashes RAW
+/// cells (cell-only); swallows all "cannot determine" cases to false (never
+/// false-alarms). Plain-shell sessions (no agent) never drift.
+fn compute_profile_outdated(settings: &AppSettings, info: &SessionInfo) -> bool {
+    if info.agent_id.is_none() {
+        return false;
+    }
+    let cwd = info.working_directory.as_str();
+    // Which coding agent + letter a Reload would launch (honors currentCodingAgent).
+    let Some(agent_id) =
+        resolve_restart_selected_agent_id(settings, cwd, None, info.agent_id.as_deref())
+    else {
+        return false;
+    };
+    let requested = effective_restart_requested_profile(None, info.requested_profile.clone());
+    let resolution = crate::config::coding_agent_profiles::resolve_profile(
+        settings,
+        crate::config::coding_agent_profiles::ProfileResolutionRequest {
+            coding_agent_id: &agent_id,
+            launch_path: Some(std::path::Path::new(cwd)),
+            agent_matrix_name: None,
+            requested_profile: requested.as_deref(),
+        },
+    );
+    let configured = crate::config::agent_command::profile_content_hash(
+        &resolution.cell.command,
+        &resolution.cell.env,
+    );
+    // Loaded hash: in-memory stamp, else the persisted replica copy (survives an
+    // AC restart that cleared the in-memory stamp).
+    let loaded = info.profile_content_hash.clone().or_else(|| {
+        crate::config::coding_agent_profiles::read_replica_profile_content_hash(
+            std::path::Path::new(cwd),
+        )
+    });
+    match loaded {
+        Some(loaded) => loaded != configured,
+        None => false,
+    }
 }
 
 /// Create a new session. Optionally override shell/args/cwd/name (for action buttons).
@@ -2029,9 +2084,16 @@ pub async fn rename_session(
 #[tauri::command]
 pub async fn list_sessions(
     session_mgr: State<'_, Arc<tokio::sync::RwLock<SessionManager>>>,
+    settings: State<'_, SettingsState>,
 ) -> Result<Vec<SessionInfo>, String> {
-    let mgr = session_mgr.read().await;
-    Ok(mgr.list_sessions().await)
+    let mut infos = { session_mgr.read().await.list_sessions().await };
+    // #592 - recompute drift per session against current settings (settings-aware,
+    // unlike the `From<&Session>` path which always emits `profile_outdated=false`).
+    let cfg = settings.read().await;
+    for info in infos.iter_mut() {
+        info.profile_outdated = compute_profile_outdated(&cfg, info);
+    }
+    Ok(infos)
 }
 
 #[tauri::command]
@@ -2474,14 +2536,14 @@ pub async fn create_root_agent_session(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_existing_root, effective_restart_requested_profile, inject_codex_resume,
-        resolve_actual_agent, resolve_agent_command, resolve_agent_from_shell,
+        classify_existing_root, compute_profile_outdated, effective_restart_requested_profile,
+        inject_codex_resume, resolve_actual_agent, resolve_agent_command, resolve_agent_from_shell,
         resolve_restart_selected_agent_id, resolve_root_agent_command, should_inject_continue,
         ExistingRootAction,
     };
     use crate::config::settings::{AgentConfig, AppSettings, ProfileCellConfig};
     use crate::session::manager::SessionManager;
-    use crate::session::session::SessionStatus;
+    use crate::session::session::{SessionInfo, SessionStatus};
     use std::collections::BTreeMap;
     use std::path::PathBuf;
 
@@ -2684,6 +2746,91 @@ mod tests {
         assert_eq!(spawn.profile_resolution.requested_profile, "C");
         assert_eq!(spawn.profile_resolution.effective_profile, "C");
         assert_eq!(spawn.shell_args, vec!["--profile-c".to_string()]);
+    }
+
+    // #592 - compute_profile_outdated integration: loaded hash vs current config.
+    fn make_info(
+        cwd: &str,
+        agent_id: Option<&str>,
+        requested_profile: Option<&str>,
+        loaded_hash: Option<String>,
+    ) -> SessionInfo {
+        SessionInfo {
+            id: "00000000-0000-0000-0000-000000000000".to_string(),
+            name: "s".to_string(),
+            shell: "codex".to_string(),
+            shell_args: Vec::new(),
+            effective_shell_args: None,
+            created_at: "2026-06-21T00:00:00Z".to_string(),
+            working_directory: cwd.to_string(),
+            status: SessionStatus::Running,
+            waiting_for_input: false,
+            pending_review: false,
+            last_prompt: None,
+            agent_id: agent_id.map(str::to_string),
+            agent_label: None,
+            git_repos: Vec::new(),
+            workgroup_task: None,
+            is_coordinator: false,
+            is_root_agent: false,
+            token: "t".to_string(),
+            agent_kind: None,
+            requested_profile: requested_profile.map(str::to_string),
+            effective_profile: None,
+            profile_fallback_chain: Vec::new(),
+            profile_fallback_applied: false,
+            effective_codex_home: None,
+            profile_content_hash: loaded_hash,
+            profile_outdated: false,
+            telegram_bot_id: None,
+            was_detached: false,
+            detached_geometry: None,
+        }
+    }
+
+    #[test]
+    fn compute_profile_outdated_flips_when_effective_cell_changes() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().to_string_lossy().to_string();
+
+        let mut settings = test_settings();
+        settings
+            .coding_agent_profiles
+            .profiles_by_agent
+            .entry("codex".to_string())
+            .or_default()
+            .insert(
+                "A".to_string(),
+                ProfileCellConfig {
+                    enabled: true,
+                    command: "codex --v1".to_string(),
+                    env: BTreeMap::new(),
+                    notes: String::new(),
+                },
+            );
+
+        // The hash the session was launched ("loaded") with: cell A v1.
+        let loaded =
+            crate::config::agent_command::profile_content_hash("codex --v1", &BTreeMap::new());
+        let mut info = make_info(&cwd, Some("codex"), Some("A"), Some(loaded));
+
+        // Config unchanged -> not outdated.
+        assert!(!compute_profile_outdated(&settings, &info));
+
+        // Edit the effective cell -> outdated.
+        settings
+            .coding_agent_profiles
+            .profiles_by_agent
+            .get_mut("codex")
+            .unwrap()
+            .get_mut("A")
+            .unwrap()
+            .command = "codex --v2".to_string();
+        assert!(compute_profile_outdated(&settings, &info));
+
+        // A plain-shell session (no agent) never drifts.
+        info.agent_id = None;
+        assert!(!compute_profile_outdated(&settings, &info));
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1225,7 +1225,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             // #592 - persist the loaded profile content-hash so drift survives an
             // AC restart. Best-effort; never aborts the spawn. No-op off-replica.
             if let Some(hash) = session.profile_content_hash.as_deref() {
-                log::info!(
+                log::debug!(
                     "[profile-hash] spawn-persist: session={} agent={} hash={} cwd={:?}",
                     id,
                     aid,
@@ -1277,12 +1277,6 @@ fn compute_profile_outdated(settings: &AppSettings, info: &SessionInfo) -> bool 
     let Some(agent_id) =
         resolve_restart_selected_agent_id(settings, cwd, None, info.agent_id.as_deref())
     else {
-        log::info!(
-            "[profile-hash] drift-check: session={} no resolvable reload agent (cwd={:?}, stored={:?}); outdated=false",
-            info.id,
-            cwd,
-            info.agent_id,
-        );
         return false;
     };
     let requested = effective_restart_requested_profile(None, info.requested_profile.clone());
@@ -1299,11 +1293,6 @@ fn compute_profile_outdated(settings: &AppSettings, info: &SessionInfo) -> bool 
     // (agent base + cell params) and the raw merged env (agent + cell). Look up the
     // agent a Reload would launch; if it vanished from settings, do not false-flag.
     let Some(agent) = settings.agents.iter().find(|a| a.id == agent_id) else {
-        log::info!(
-            "[profile-hash] drift-check: session={} reload agent {} not in settings; outdated=false",
-            info.id,
-            agent_id,
-        );
         return false;
     };
     let configured_command = crate::config::agent_command::compose_effective_command(
@@ -1316,42 +1305,15 @@ fn compute_profile_outdated(settings: &AppSettings, info: &SessionInfo) -> bool 
         crate::config::agent_command::profile_content_hash(&configured_command, &configured_env);
     // Loaded hash: in-memory stamp, else the persisted replica copy (survives an
     // AC restart that cleared the in-memory stamp).
-    let loaded_source = if info.profile_content_hash.is_some() {
-        "in-memory"
-    } else {
-        "replica-config"
-    };
     let loaded = info.profile_content_hash.clone().or_else(|| {
         crate::config::coding_agent_profiles::read_replica_profile_content_hash(
             std::path::Path::new(cwd),
         )
     });
-    let outdated = match &loaded {
-        Some(loaded) => *loaded != configured,
+    match loaded {
+        Some(loaded) => loaded != configured,
         None => false,
-    };
-    // #592/#597 diagnostic: per-session drift decision. `loaded` is the hash
-    // stamped at the session's spawn (from memory or the replica config.json);
-    // `configured` is recomputed from CURRENT settings. They diverge when the
-    // profile cell/base command/env was edited after spawn.
-    log::info!(
-        "[profile-hash] drift-check: session={} agent={} profile={} loaded={:?} (via {}) configured={} outdated={} configured_command={:?} env_keys=[{}] ({} entries)",
-        info.id,
-        agent_id,
-        resolution.effective_profile,
-        loaded,
-        loaded_source,
-        configured,
-        outdated,
-        configured_command,
-        configured_env
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>()
-            .join(", "),
-        configured_env.len(),
-    );
-    outdated
+    }
 }
 
 /// Create a new session. Optionally override shell/args/cwd/name (for action buttons).

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -797,11 +797,12 @@ pub fn build_agent_spawn_command(
     // drift. SUPERSEDES the #592 cell-only hash input.
     let merged_profile_env = raw_merged_profile_env(agent, &profile_resolution.cell.env);
     let profile_hash = profile_content_hash(&effective_command, &merged_profile_env);
-    // #592/#597 diagnostic: surface exactly what gets hashed at spawn so a later
-    // drift mismatch can be traced. Env VALUES are intentionally omitted (they may
-    // hold secrets); the hash already fingerprints them, and the key set + count
+    // #592/#597 - surface exactly what gets hashed at spawn so a later drift
+    // mismatch can be traced. Kept at debug for support; off the hot path (fires
+    // once per spawn). Env VALUES are intentionally omitted (they may hold
+    // secrets); the hash already fingerprints them, and the key set + count
     // reveal whether an env row participated.
-    log::info!(
+    log::debug!(
         "[profile-hash] spawn-stamp: agent={} profile={} hash={} effective_command={:?} env_keys=[{}] ({} entries)",
         agent.id,
         profile_resolution.effective_profile,

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -795,9 +795,24 @@ pub fn build_agent_spawn_command(
     // the RAW merged env (agent enabled rows + cell, profile-wins) so an edit to
     // the base command, cell command, base env, or cell env is detectable as
     // drift. SUPERSEDES the #592 cell-only hash input.
-    let profile_hash = profile_content_hash(
-        &effective_command,
-        &raw_merged_profile_env(agent, &profile_resolution.cell.env),
+    let merged_profile_env = raw_merged_profile_env(agent, &profile_resolution.cell.env);
+    let profile_hash = profile_content_hash(&effective_command, &merged_profile_env);
+    // #592/#597 diagnostic: surface exactly what gets hashed at spawn so a later
+    // drift mismatch can be traced. Env VALUES are intentionally omitted (they may
+    // hold secrets); the hash already fingerprints them, and the key set + count
+    // reveal whether an env row participated.
+    log::info!(
+        "[profile-hash] spawn-stamp: agent={} profile={} hash={} effective_command={:?} env_keys=[{}] ({} entries)",
+        agent.id,
+        profile_resolution.effective_profile,
+        profile_hash,
+        effective_command,
+        merged_profile_env
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", "),
+        merged_profile_env.len(),
     );
 
     let normalized = normalize_legacy_agent_command(&effective_command).map_err(|e| {

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -688,14 +688,57 @@ fn wrap_git_pull_before(
     Ok((shell, shell_args))
 }
 
-/// #592 - stable 16-hex content fingerprint of a profile CELL, for drift
-/// detection ("loaded != configured"). Hashes the RAW `command` + `env`
-/// (placeholders un-expanded) of the EFFECTIVE resolved cell only; never the
-/// agent base layer. Env keys are normalized with the same platform rule
-/// `merge_env_layers` uses (Windows case-fold), then ordered via `BTreeMap`,
-/// so a case-only key edit on Windows does not false-flag and iteration order
-/// is irrelevant. SHA-256 (stable across Rust versions, unlike DefaultHasher),
-/// truncated to the first 16 hex chars (matches the existing
+/// #597 - the effective launch command: the agent base command (the binary,
+/// possibly with its own fixed args) followed by the profile cell command (extra
+/// params), joined as `<base> <cell>`. Each side is trimmed; a single ASCII space
+/// joins them when both are non-empty; an empty side contributes nothing (no
+/// stray space). Both empty yields `""`, which `normalize_legacy_agent_command`
+/// then rejects as "agent command is empty", the same failure a blank command has
+/// always produced. This is the single source of truth for the concatenation rule
+/// (build, drift recompute, and settings validation all call it).
+pub fn compose_effective_command(agent_command: &str, cell_command: &str) -> String {
+    let base = agent_command.trim();
+    let cell = cell_command.trim();
+    match (base.is_empty(), cell.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => base.to_string(),
+        (true, false) => cell.to_string(),
+        (false, false) => format!("{base} {cell}"),
+    }
+}
+
+/// #597 - RAW (pre-expansion) merged env used for the content hash: the agent's
+/// ENABLED env rows overlaid by the cell env (profile-wins), keys normalized for
+/// the platform so a case-only difference does not double-count. Values verbatim.
+/// Mirrors `merge_env_layers`' agent-then-profile precedence but stays raw and
+/// excludes the generated layer (CODEX_HOME isolation etc.), which is derived
+/// state, not user config (decision §0.2; see Notes for the accepted limitation).
+pub fn raw_merged_profile_env(
+    agent: &AgentConfig,
+    cell_env: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut merged: BTreeMap<String, String> = BTreeMap::new();
+    for row in agent.envs.iter().filter(|row| row.enabled) {
+        merged.insert(normalize_env_key_for_platform(&row.key), row.value.clone());
+    }
+    for (key, value) in cell_env {
+        merged.insert(normalize_env_key_for_platform(key), value.clone());
+    }
+    merged
+}
+
+/// #592 - stable 16-hex content fingerprint for profile drift detection
+/// ("loaded != configured"). Hashes the RAW `command` + `env` it is given
+/// (placeholders un-expanded); the primitive is agnostic to how those are built.
+/// #597 - callers now pass the COMPOSED effective command (agent base + cell
+/// params) via `compose_effective_command` and the merged env (agent enabled rows
+/// overlaid by the cell, profile-wins) via `raw_merged_profile_env`, so an edit to
+/// the base command, cell command, base env, or cell env all flip the hash
+/// (SUPERSEDES the original #592 cell-only input). Env keys are normalized with
+/// the same platform rule `merge_env_layers` uses (Windows case-fold), then
+/// ordered via `BTreeMap`, so a case-only key edit on Windows does not false-flag
+/// and iteration order is irrelevant. SHA-256 (stable across Rust versions, unlike
+/// DefaultHasher), truncated to the first 16 hex chars (matches the existing
 /// `profile_assignment_fingerprint` 16-hex shape).
 pub fn profile_content_hash(command: &str, env: &BTreeMap<String, String>) -> String {
     use std::fmt::Write as _;
@@ -740,22 +783,27 @@ pub fn build_agent_spawn_command(
         log::warn!("[profiles] {}", warning);
     }
 
-    // #592 - fingerprint the RAW effective cell (pre-expansion, cell-only) so a
-    // later edit to this cell's command/env is detectable as drift.
+    // #597 - the effective command CONCATENATES the agent base command (the
+    // binary, possibly with its own fixed args) with the profile cell command
+    // (extra params): `<base> <cell>`. An empty side drops cleanly; both empty
+    // yields an empty string that the tokenizer rejects, same as a blank command
+    // has always been rejected.
+    let effective_command =
+        compose_effective_command(&agent.command, &profile_resolution.cell.command);
+
+    // #597 - fingerprint the RAW effective command (base+cell, pre-expansion) and
+    // the RAW merged env (agent enabled rows + cell, profile-wins) so an edit to
+    // the base command, cell command, base env, or cell env is detectable as
+    // drift. SUPERSEDES the #592 cell-only hash input.
     let profile_hash = profile_content_hash(
-        &profile_resolution.cell.command,
-        &profile_resolution.cell.env,
+        &effective_command,
+        &raw_merged_profile_env(agent, &profile_resolution.cell.env),
     );
 
-    let selected_command = if profile_resolution.cell.command.trim().is_empty() {
-        agent.command.as_str()
-    } else {
-        profile_resolution.cell.command.as_str()
-    };
-    let normalized = normalize_legacy_agent_command(selected_command).map_err(|e| {
+    let normalized = normalize_legacy_agent_command(&effective_command).map_err(|e| {
         format!(
             "Invalid profile command for '{}:{}': {}. command={:?}",
-            agent.id, profile_resolution.effective_profile, e, selected_command
+            agent.id, profile_resolution.effective_profile, e, effective_command
         )
     })?;
     let mut command_tokens = Vec::with_capacity(normalized.shell_args.len() + 1);
@@ -967,25 +1015,10 @@ mod tests {
     }
 
     #[test]
-    fn build_spawn_uses_profile_command_as_complete_invocation() {
-        let mut settings = AppSettings {
-            agents: vec![agent("codex", "codex --base")],
-            ..AppSettings::default()
-        };
-        settings
-            .coding_agent_profiles
-            .profiles_by_agent
-            .entry("codex".to_string())
-            .or_default()
-            .insert(
-                "B".to_string(),
-                ProfileCellConfig {
-                    enabled: true,
-                    command: "codex --profile fast".to_string(),
-                    env: BTreeMap::new(),
-                    notes: String::new(),
-                },
-            );
+    fn build_spawn_concatenates_agent_base_and_cell_params() {
+        // #597 - the cell holds params only; they append to the agent base command,
+        // so base `codex` + cell `--profile fast` launches `codex --profile fast`.
+        let settings = settings_with_cell("codex", "B", cell("--profile fast", BTreeMap::new()));
 
         let spawn = build_agent_spawn_command(&settings, "codex", None, Some("B")).unwrap();
 
@@ -1125,8 +1158,12 @@ mod tests {
             .join("wg-7-dev-team")
             .join("__agent_dev-rust");
         std::fs::create_dir_all(&replica).unwrap();
+        // #597 - under concatenation the binary (placeholder included) lives in the
+        // agent base command and the cell holds the param. The placeholder must
+        // still expand on the composed token list so the launched shell is the
+        // expanded binary path.
         let mut settings = AppSettings {
-            agents: vec![agent("codex", "codex")],
+            agents: vec![agent("codex", "%AC_REPLICA_ROOT%\\bin\\codex.exe")],
             ..AppSettings::default()
         };
         settings
@@ -1138,7 +1175,7 @@ mod tests {
                 "A".to_string(),
                 ProfileCellConfig {
                     enabled: true,
-                    command: "%AC_REPLICA_ROOT%\\bin\\codex.exe --flag".to_string(),
+                    command: "--flag".to_string(),
                     env: BTreeMap::new(),
                     notes: String::new(),
                 },
@@ -1883,18 +1920,18 @@ mod tests {
     }
 
     #[test]
-    fn profile_content_hash_is_cell_only_ignoring_agent_base_command() {
-        // Two settings differing ONLY in agent.command, both with an EMPTY cell
-        // command for letter A. The cell hash must be identical (§0.1/§0.6).
-        let s1 = settings_with_cell("codex --one", "A", cell("", BTreeMap::new()));
-        let s2 = settings_with_cell("codex --two", "A", cell("", BTreeMap::new()));
+    fn profile_content_hash_changes_on_agent_base_command_edit() {
+        // #597 - the hash now fingerprints the EFFECTIVE command (base + cell), so
+        // an edit to the agent base command flips it even with the cell unchanged.
+        let s1 = settings_with_cell("codex --one", "A", cell("--p", BTreeMap::new()));
+        let s2 = settings_with_cell("codex --two", "A", cell("--p", BTreeMap::new()));
         let h1 = build_agent_spawn_command(&s1, "codex", None, Some("A"))
             .unwrap()
             .profile_content_hash;
         let h2 = build_agent_spawn_command(&s2, "codex", None, Some("A"))
             .unwrap()
             .profile_content_hash;
-        assert_eq!(h1, h2, "an agent-base edit must not change the cell hash");
+        assert_ne!(h1, h2, "an agent-base edit must flip the effective-command hash");
     }
 
     #[test]
@@ -1930,12 +1967,134 @@ mod tests {
         let spawn = build_agent_spawn_command(&settings, "codex", None, Some("D")).unwrap();
         assert_eq!(spawn.profile_resolution.effective_profile, "C");
         assert_eq!(spawn.profile_resolution.cell.command, "codex --c");
-        // The stamped hash is the EFFECTIVE (post-fallback C) cell, not D.
+        // The stamped hash is the EFFECTIVE (post-fallback C) cell composed with
+        // the agent base command, not D. (#597)
+        let agent_cfg = settings.agents.iter().find(|a| a.id == "codex").unwrap();
         let expected = profile_content_hash(
-            &spawn.profile_resolution.cell.command,
-            &spawn.profile_resolution.cell.env,
+            &super::compose_effective_command(
+                &agent_cfg.command,
+                &spawn.profile_resolution.cell.command,
+            ),
+            &super::raw_merged_profile_env(agent_cfg, &spawn.profile_resolution.cell.env),
         );
         assert_eq!(spawn.profile_content_hash, expected);
+    }
+
+    #[test]
+    fn compose_effective_command_joins_and_drops_empty_sides() {
+        assert_eq!(super::compose_effective_command("claude", "--x"), "claude --x");
+        assert_eq!(super::compose_effective_command("claude", ""), "claude");
+        assert_eq!(super::compose_effective_command("", "--x"), "--x");
+        assert_eq!(super::compose_effective_command("", ""), "");
+        // Each side is trimmed; no double space at the seam.
+        assert_eq!(
+            super::compose_effective_command("  claude  ", "  --x  "),
+            "claude --x"
+        );
+    }
+
+    #[test]
+    fn build_spawn_empty_cell_uses_base_command_only() {
+        let settings = settings_with_cell("codex --yolo", "A", cell("", BTreeMap::new()));
+        let spawn = build_agent_spawn_command(&settings, "codex", None, Some("A")).unwrap();
+        assert_eq!(spawn.shell, "codex");
+        assert_eq!(spawn.shell_args, vec!["--yolo"]);
+    }
+
+    #[test]
+    fn build_spawn_concatenation_handles_base_with_args_and_quoted_params() {
+        // The whole `<base> <cell>` line tokenizes once; quotes/embedded spaces survive.
+        let settings = settings_with_cell(
+            "cmd.exe /c claude",
+            "A",
+            cell("--model \"gpt 5\"", BTreeMap::new()),
+        );
+        let spawn = build_agent_spawn_command(&settings, "codex", None, Some("A")).unwrap();
+        assert_eq!(spawn.shell, "cmd.exe");
+        assert_eq!(spawn.shell_args, vec!["/c", "claude", "--model", "gpt 5"]);
+    }
+
+    #[test]
+    fn build_spawn_errors_when_base_and_cell_both_empty() {
+        let settings = settings_with_cell("", "A", cell("", BTreeMap::new()));
+        let err = build_agent_spawn_command(&settings, "codex", None, Some("A")).unwrap_err();
+        assert!(
+            err.contains("agent command is empty"),
+            "both-empty must report an empty command: {err}"
+        );
+    }
+
+    #[test]
+    fn profile_content_hash_changes_on_agent_base_env_edit() {
+        // The base env is now in the hash; a value edit on an enabled row flips it.
+        // LOWERCASE key so the Windows case-fold in raw_merged_profile_env does not
+        // skew the assertion.
+        fn settings_with_env_value(value: &str) -> AppSettings {
+            let mut ag = agent("codex", "codex");
+            ag.envs = vec![CodingAgentEnv {
+                key: "kk".to_string(),
+                value: value.to_string(),
+                source: CodingAgentEnvSource::User,
+                enabled: true,
+            }];
+            let mut settings = AppSettings {
+                agents: vec![ag],
+                ..AppSettings::default()
+            };
+            settings
+                .coding_agent_profiles
+                .profiles_by_agent
+                .entry("codex".to_string())
+                .or_default()
+                .insert("A".to_string(), cell("", BTreeMap::new()));
+            settings
+        }
+        let h1 =
+            build_agent_spawn_command(&settings_with_env_value("one"), "codex", None, Some("A"))
+                .unwrap()
+                .profile_content_hash;
+        let h2 =
+            build_agent_spawn_command(&settings_with_env_value("two"), "codex", None, Some("A"))
+                .unwrap()
+                .profile_content_hash;
+        assert_ne!(h1, h2, "an agent base env edit must flip the hash");
+    }
+
+    #[test]
+    fn raw_merged_profile_env_overlays_cell_over_agent_raw() {
+        let mut ag = agent("codex", "codex");
+        ag.envs = vec![
+            CodingAgentEnv {
+                key: "ka".to_string(),
+                value: "agent".to_string(),
+                source: CodingAgentEnvSource::User,
+                enabled: true,
+            },
+            CodingAgentEnv {
+                key: "kb".to_string(),
+                value: "agent".to_string(),
+                source: CodingAgentEnvSource::User,
+                enabled: true,
+            },
+            CodingAgentEnv {
+                key: "koff".to_string(),
+                value: "agent".to_string(),
+                source: CodingAgentEnvSource::User,
+                enabled: false,
+            },
+        ];
+        let cell_env = BTreeMap::from([
+            ("kb".to_string(), "cell".to_string()),
+            ("kc".to_string(), "cell".to_string()),
+        ]);
+        let merged = super::raw_merged_profile_env(&ag, &cell_env);
+        // Keys come back platform-normalized (uppercased on Windows), so look them
+        // up through the same normalizer to stay cross-platform.
+        let key = |k: &str| crate::config::settings::normalize_env_key_for_platform(k);
+        assert_eq!(merged.get(&key("ka")).map(String::as_str), Some("agent"));
+        assert_eq!(merged.get(&key("kb")).map(String::as_str), Some("cell")); // profile wins
+        assert_eq!(merged.get(&key("kc")).map(String::as_str), Some("cell"));
+        assert!(!merged.contains_key(&key("koff")), "disabled rows are excluded");
     }
 
     #[cfg(windows)]

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -15,6 +15,7 @@ use crate::config::settings::{
     validate_expanded_codex_home_value, validate_user_env_key, AgentConfig, AppSettings,
 };
 use crate::session::profile::CodingAgentKind;
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedAgentCommand {
@@ -33,6 +34,9 @@ pub struct AgentSpawnCommand {
     pub env_remove_keys: Vec<String>,
     pub effective_codex_home: Option<PathBuf>,
     pub profile_resolution: ProfileResolution,
+    /// 16-hex SHA-256 of the effective resolved cell's RAW command + env
+    /// (#592). Drift detector only; positional identity stays the locator.
+    pub profile_content_hash: String,
     pub trusted_agent_id: String,
     pub trusted_agent_label: String,
 }
@@ -684,6 +688,34 @@ fn wrap_git_pull_before(
     Ok((shell, shell_args))
 }
 
+/// #592 - stable 16-hex content fingerprint of a profile CELL, for drift
+/// detection ("loaded != configured"). Hashes the RAW `command` + `env`
+/// (placeholders un-expanded) of the EFFECTIVE resolved cell only; never the
+/// agent base layer. Env keys are normalized with the same platform rule
+/// `merge_env_layers` uses (Windows case-fold), then ordered via `BTreeMap`,
+/// so a case-only key edit on Windows does not false-flag and iteration order
+/// is irrelevant. SHA-256 (stable across Rust versions, unlike DefaultHasher),
+/// truncated to the first 16 hex chars (matches the existing
+/// `profile_assignment_fingerprint` 16-hex shape).
+pub fn profile_content_hash(command: &str, env: &BTreeMap<String, String>) -> String {
+    use std::fmt::Write as _;
+    // Normalize keys for dedup/compare; value stays verbatim (raw).
+    let mut normalized: BTreeMap<String, &str> = BTreeMap::new();
+    for (key, value) in env {
+        normalized.insert(normalize_env_key_for_platform(key), value.as_str());
+    }
+    // Versioned, NUL-tagged serialization. NUL cannot appear in commands/env we
+    // accept, and the field tags stop a value from forging a record boundary.
+    let mut buf = String::new();
+    let _ = write!(buf, "v1\u{0}cmd\u{0}{}\u{0}envc\u{0}{}\u{0}", command, normalized.len());
+    for (key, value) in &normalized {
+        let _ = write!(buf, "k\u{0}{}\u{0}v\u{0}{}\u{0}", key, value);
+    }
+    let digest = format!("{:x}", Sha256::digest(buf.as_bytes()));
+    // Hex is ASCII single-byte; slicing the first 16 chars is char-boundary safe.
+    digest[..16].to_string()
+}
+
 pub fn build_agent_spawn_command(
     settings: &AppSettings,
     agent_id: &str,
@@ -707,6 +739,13 @@ pub fn build_agent_spawn_command(
     for warning in &profile_resolution.warnings {
         log::warn!("[profiles] {}", warning);
     }
+
+    // #592 - fingerprint the RAW effective cell (pre-expansion, cell-only) so a
+    // later edit to this cell's command/env is detectable as drift.
+    let profile_hash = profile_content_hash(
+        &profile_resolution.cell.command,
+        &profile_resolution.cell.env,
+    );
 
     let selected_command = if profile_resolution.cell.command.trim().is_empty() {
         agent.command.as_str()
@@ -790,6 +829,7 @@ pub fn build_agent_spawn_command(
         env_remove_keys: computed_codex_home.env_remove_keys,
         effective_codex_home: computed_codex_home.effective_codex_home,
         profile_resolution,
+        profile_content_hash: profile_hash,
         trusted_agent_id: agent.id.clone(),
         trusted_agent_label: agent.label.clone(),
     })
@@ -800,8 +840,8 @@ mod tests {
     use super::{
         build_agent_spawn_command, command_runs_opencode, default_instructions_filename_for_command,
         ensure_opencode_config_dir, find_opencode_config_dir, is_safe_instructions_filename,
-        managed_instructions_filenames, normalize_legacy_agent_command, resolve_instructions_filename,
-        resolve_target_filename, OpencodeConfigDirOutcome,
+        managed_instructions_filenames, normalize_legacy_agent_command, profile_content_hash,
+        resolve_instructions_filename, resolve_target_filename, OpencodeConfigDirOutcome,
     };
     use crate::config::settings::{
         AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ProfileCellConfig,
@@ -1789,6 +1829,126 @@ mod tests {
         assert!(
             std::path::Path::new(&expected_config).is_dir(),
             "build should have created the expanded OPENCODE_CONFIG_DIR at {expected_config}"
+        );
+    }
+
+    // #592 - profile content-hash (drift detector) tests.
+
+    fn cell(command: &str, env: BTreeMap<String, String>) -> ProfileCellConfig {
+        ProfileCellConfig {
+            enabled: true,
+            command: command.to_string(),
+            env,
+            notes: String::new(),
+        }
+    }
+
+    fn settings_with_cell(agent_command: &str, letter: &str, cell: ProfileCellConfig) -> AppSettings {
+        let mut settings = AppSettings {
+            agents: vec![agent("codex", agent_command)],
+            ..AppSettings::default()
+        };
+        settings
+            .coding_agent_profiles
+            .profiles_by_agent
+            .entry("codex".to_string())
+            .or_default()
+            .insert(letter.to_string(), cell);
+        settings
+    }
+
+    #[test]
+    fn profile_content_hash_is_deterministic_and_16_lowercase_hex() {
+        let mut env = BTreeMap::new();
+        env.insert("FOO".to_string(), "bar".to_string());
+        let a = profile_content_hash("claude --x", &env);
+        let b = profile_content_hash("claude --x", &env);
+        assert_eq!(a, b, "same inputs must hash identically");
+        assert_eq!(a.len(), 16, "hash must be 16 chars");
+        assert!(
+            a.chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            "hash must be lowercase hex: {a}"
+        );
+    }
+
+    #[test]
+    fn profile_content_hash_is_raw_not_expanded() {
+        let env = BTreeMap::new();
+        let raw = profile_content_hash("%AC_REPLICA_ROOT%\\bin\\claude", &env);
+        let expanded = profile_content_hash("C:\\replica\\bin\\claude", &env);
+        assert_ne!(
+            raw, expanded,
+            "the function must hash the raw placeholder text, never an expansion"
+        );
+    }
+
+    #[test]
+    fn profile_content_hash_is_cell_only_ignoring_agent_base_command() {
+        // Two settings differing ONLY in agent.command, both with an EMPTY cell
+        // command for letter A. The cell hash must be identical (§0.1/§0.6).
+        let s1 = settings_with_cell("codex --one", "A", cell("", BTreeMap::new()));
+        let s2 = settings_with_cell("codex --two", "A", cell("", BTreeMap::new()));
+        let h1 = build_agent_spawn_command(&s1, "codex", None, Some("A"))
+            .unwrap()
+            .profile_content_hash;
+        let h2 = build_agent_spawn_command(&s2, "codex", None, Some("A"))
+            .unwrap()
+            .profile_content_hash;
+        assert_eq!(h1, h2, "an agent-base edit must not change the cell hash");
+    }
+
+    #[test]
+    fn profile_content_hash_flips_on_cell_command_edit() {
+        let s1 = settings_with_cell("codex", "A", cell("claude", BTreeMap::new()));
+        let s2 = settings_with_cell("codex", "A", cell("claude --foo", BTreeMap::new()));
+        let h1 = build_agent_spawn_command(&s1, "codex", None, Some("A"))
+            .unwrap()
+            .profile_content_hash;
+        let h2 = build_agent_spawn_command(&s2, "codex", None, Some("A"))
+            .unwrap()
+            .profile_content_hash;
+        assert_ne!(h1, h2, "a cell command edit must flip the hash (drift)");
+    }
+
+    #[test]
+    fn profile_content_hash_uses_effective_cell_after_fallback() {
+        let mut settings = AppSettings {
+            agents: vec![agent("codex", "codex")],
+            ..AppSettings::default()
+        };
+        {
+            let cells = settings
+                .coding_agent_profiles
+                .profiles_by_agent
+                .entry("codex".to_string())
+                .or_default();
+            cells.insert("A".to_string(), cell("codex --a", BTreeMap::new()));
+            cells.insert("C".to_string(), cell("codex --c", BTreeMap::new()));
+        }
+
+        // Request D with only A/C present -> falls back to C.
+        let spawn = build_agent_spawn_command(&settings, "codex", None, Some("D")).unwrap();
+        assert_eq!(spawn.profile_resolution.effective_profile, "C");
+        assert_eq!(spawn.profile_resolution.cell.command, "codex --c");
+        // The stamped hash is the EFFECTIVE (post-fallback C) cell, not D.
+        let expected = profile_content_hash(
+            &spawn.profile_resolution.cell.command,
+            &spawn.profile_resolution.cell.env,
+        );
+        assert_eq!(spawn.profile_content_hash, expected);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn profile_content_hash_normalizes_env_keys_case_insensitively_on_windows() {
+        let mut lower = BTreeMap::new();
+        lower.insert("Path".to_string(), "x".to_string());
+        let mut upper = BTreeMap::new();
+        upper.insert("PATH".to_string(), "x".to_string());
+        assert_eq!(
+            profile_content_hash("claude", &lower),
+            profile_content_hash("claude", &upper),
+            "a case-only env-key edit must not false-flag drift on Windows"
         );
     }
 }

--- a/src-tauri/src/config/coding_agent_profiles.rs
+++ b/src-tauri/src/config/coding_agent_profiles.rs
@@ -393,15 +393,28 @@ pub fn read_replica_profile_content_hash(launch_path: &Path) -> Option<String> {
 }
 
 /// #592 - persist the loaded profile content-hash. No-op for non-replica /
-/// non-matrix launch roots (a normal repo has no per-agent config.json and must
-/// not be littered with one). Best-effort: callers log + ignore errors.
+/// non-matrix / non-root-agent launch roots (a normal repo has no per-agent
+/// config.json and must not be littered with one). Best-effort: callers log +
+/// ignore errors.
 pub fn set_replica_profile_content_hash(launch_path: &Path, hash: &str) -> Result<(), String> {
     let is_agent_dir = launch_path
         .file_name()
         .and_then(|name| name.to_str())
         .map(|name| name.starts_with("__agent_") || name.starts_with("_agent_"))
         .unwrap_or(false);
-    if !is_agent_dir {
+    // #592 - the Root Agent (`ac-root-agent`) is a legitimate replica that runs a
+    // coding agent and must support drift like any other; its dir name does not
+    // match the `__agent_`/`_agent_` prefix, so accept it explicitly. Name-only
+    // (vs path-validated `is_root_agent_path`) is sufficient here: the sole caller
+    // `create_session_inner` already writes this dir's `config.json`
+    // unconditionally via `set_last_coding_agent` right before this call, so the
+    // gate only governs whether the hash field is added, never whether a stray
+    // config.json is created. The read side is ungated, so it round-trips.
+    let is_root_agent = launch_path
+        .to_str()
+        .map(crate::config::root_agent::is_root_agent_dir_name)
+        .unwrap_or(false);
+    if !is_agent_dir && !is_root_agent {
         return Ok(());
     }
     write_tooling_string(launch_path, "profileContentHash", Some(hash))
@@ -1033,5 +1046,26 @@ mod tests {
         assert!(set_replica_profile_content_hash(&repo, "x").is_ok());
         assert!(!repo.join("config.json").exists());
         assert_eq!(read_replica_profile_content_hash(&repo), None);
+    }
+
+    #[test]
+    fn profile_content_hash_write_persists_for_root_agent_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        // The Root Agent dir name does NOT start with `__agent_`/`_agent_`, but it
+        // is a legitimate replica running a coding agent: the hash must persist
+        // and round-trip so drift survives an AC restart (#592 Root Agent fix).
+        let root_agent = temp.path().join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
+        std::fs::create_dir_all(&root_agent).unwrap();
+
+        set_replica_profile_content_hash(&root_agent, "cafef00dcafef00d").unwrap();
+
+        assert_eq!(
+            read_replica_profile_content_hash(&root_agent).as_deref(),
+            Some("cafef00dcafef00d")
+        );
+        let saved: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(root_agent.join("config.json")).unwrap())
+                .unwrap();
+        assert_eq!(saved["tooling"]["profileContentHash"], "cafef00dcafef00d");
     }
 }

--- a/src-tauri/src/config/coding_agent_profiles.rs
+++ b/src-tauri/src/config/coding_agent_profiles.rs
@@ -387,6 +387,26 @@ pub fn read_replica_current_coding_agent(launch_path: &Path) -> Option<String> {
     read_tooling_string(launch_path, "currentCodingAgent")
 }
 
+/// #592 - read the loaded profile content-hash persisted at last spawn.
+pub fn read_replica_profile_content_hash(launch_path: &Path) -> Option<String> {
+    read_tooling_string(launch_path, "profileContentHash")
+}
+
+/// #592 - persist the loaded profile content-hash. No-op for non-replica /
+/// non-matrix launch roots (a normal repo has no per-agent config.json and must
+/// not be littered with one). Best-effort: callers log + ignore errors.
+pub fn set_replica_profile_content_hash(launch_path: &Path, hash: &str) -> Result<(), String> {
+    let is_agent_dir = launch_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.starts_with("__agent_") || name.starts_with("_agent_"))
+        .unwrap_or(false);
+    if !is_agent_dir {
+        return Ok(());
+    }
+    write_tooling_string(launch_path, "profileContentHash", Some(hash))
+}
+
 pub fn read_origin_default_profile(launch_path: &Path) -> Result<Option<String>, String> {
     let Some(origin) = origin_matrix_dir_for_launch_path(launch_path)? else {
         return Ok(None);
@@ -964,5 +984,54 @@ mod tests {
 
         assert!(err.contains("configured AC project roots"), "{err}");
         assert!(!fake.join("config.json").exists());
+    }
+
+    // #592 - profile content-hash replica persistence.
+
+    #[test]
+    fn profile_content_hash_round_trips_and_preserves_profile() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        let workspace = project.join(".ac");
+        let matrix = workspace.join("_agent_dev-rust");
+        let replica = workspace.join("wg-7-dev-team").join("__agent_dev-rust");
+        std::fs::create_dir_all(&matrix).unwrap();
+        std::fs::create_dir_all(&replica).unwrap();
+        std::fs::write(
+            replica.join("config.json"),
+            r#"{"identity":"../../_agent_dev-rust","tooling":{"lastCodingAgent":"claude"}}"#,
+        )
+        .unwrap();
+        let settings = settings_with_project(&project);
+
+        // Assign a profile first (writes tooling.profile = "B").
+        set_replica_coding_agent_selection(&settings, &replica, "codex", "b").unwrap();
+        // Persist a content-hash.
+        set_replica_profile_content_hash(&replica, "deadbeefdeadbeef").unwrap();
+
+        assert_eq!(
+            read_replica_profile_content_hash(&replica).as_deref(),
+            Some("deadbeefdeadbeef")
+        );
+        // The profile assignment is untouched by the hash write.
+        let saved: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(replica.join("config.json")).unwrap())
+                .unwrap();
+        assert_eq!(saved["tooling"]["profile"], "B");
+        assert_eq!(saved["tooling"]["currentCodingAgent"], "codex");
+        assert_eq!(saved["tooling"]["profileContentHash"], "deadbeefdeadbeef");
+    }
+
+    #[test]
+    fn profile_content_hash_write_is_noop_off_replica() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo-thing");
+        std::fs::create_dir_all(&repo).unwrap();
+
+        // A normal repo dir is not a replica/matrix: the write is a silent no-op
+        // and must NOT create a config.json.
+        assert!(set_replica_profile_content_hash(&repo, "x").is_ok());
+        assert!(!repo.join("config.json").exists());
+        assert_eq!(read_replica_profile_content_hash(&repo), None);
     }
 }

--- a/src-tauri/src/config/coding_agent_profiles.rs
+++ b/src-tauri/src/config/coding_agent_profiles.rs
@@ -415,8 +415,18 @@ pub fn set_replica_profile_content_hash(launch_path: &Path, hash: &str) -> Resul
         .map(crate::config::root_agent::is_root_agent_dir_name)
         .unwrap_or(false);
     if !is_agent_dir && !is_root_agent {
+        log::info!(
+            "[profile-hash] persist skipped (not a replica/matrix/root-agent dir): {} hash={}",
+            launch_path.display(),
+            hash,
+        );
         return Ok(());
     }
+    log::info!(
+        "[profile-hash] persist: writing profileContentHash={} to {}",
+        hash,
+        launch_path.display(),
+    );
     write_tooling_string(launch_path, "profileContentHash", Some(hash))
 }
 

--- a/src-tauri/src/config/coding_agent_profiles.rs
+++ b/src-tauri/src/config/coding_agent_profiles.rs
@@ -415,14 +415,9 @@ pub fn set_replica_profile_content_hash(launch_path: &Path, hash: &str) -> Resul
         .map(crate::config::root_agent::is_root_agent_dir_name)
         .unwrap_or(false);
     if !is_agent_dir && !is_root_agent {
-        log::info!(
-            "[profile-hash] persist skipped (not a replica/matrix/root-agent dir): {} hash={}",
-            launch_path.display(),
-            hash,
-        );
         return Ok(());
     }
-    log::info!(
+    log::debug!(
         "[profile-hash] persist: writing profileContentHash={} to {}",
         hash,
         launch_path.display(),

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1242,9 +1242,23 @@ pub fn validate_agent_commands(settings: &AppSettings) -> Result<(), String> {
                 ),
             )?;
             if cell.enabled && !cell.command.trim().is_empty() {
+                // #597 - the cell holds params appended to the agent base command,
+                // so validate the COMPOSED effective command. Otherwise a banned
+                // provider flag (claude --continue/-c, codex/gemini manual resume)
+                // placed in the cell params escapes the check: the provider token
+                // lives in the base, not the cell. Falls back to the cell text when
+                // the cell references an agent id that has no configured agent.
+                let base = settings
+                    .agents
+                    .iter()
+                    .find(|a| a.id == *agent_id)
+                    .map(|a| a.command.as_str())
+                    .unwrap_or("");
+                let effective =
+                    crate::config::agent_command::compose_effective_command(base, &cell.command);
                 validate_agent_command_text(
                     &format!("Coding agent profile '{}:{}'", agent_id, letter),
-                    &cell.command,
+                    &effective,
                 )?;
             }
         }
@@ -1971,6 +1985,56 @@ mod tests {
         let settings = settings_with_agents(&[("Claude", "claude --continue")]);
         let err = validate_agent_commands(&settings).unwrap_err();
         assert!(err.contains("Claude commands must not include --continue or -c"));
+    }
+
+    #[test]
+    fn validate_rejects_banned_continue_flag_in_cell_params() {
+        // #597 - the cell holds params only; the provider token (claude) lives in
+        // the base. The ban must still catch `--continue` typed in the cell, which
+        // only works if validation runs on the COMPOSED command.
+        let mut settings = settings_with_agents(&[("Claude", "claude")]);
+        settings
+            .coding_agent_profiles
+            .profiles_by_agent
+            .entry("agent-0".to_string())
+            .or_default()
+            .insert(
+                "A".to_string(),
+                ProfileCellConfig {
+                    enabled: true,
+                    command: "--continue".to_string(),
+                    env: BTreeMap::new(),
+                    notes: String::new(),
+                },
+            );
+        let err = validate_agent_commands(&settings).unwrap_err();
+        assert!(
+            err.contains("must not include --continue"),
+            "composed claude + --continue cell must be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_allows_continue_flag_when_base_is_not_claude() {
+        // #597 - the --continue ban is claude-specific. With a codex base the
+        // composed `codex --continue` is allowed, proving validation keys off the
+        // composed provider token, not the raw cell text.
+        let mut settings = settings_with_agents(&[("Codex", "codex")]);
+        settings
+            .coding_agent_profiles
+            .profiles_by_agent
+            .entry("agent-0".to_string())
+            .or_default()
+            .insert(
+                "A".to_string(),
+                ProfileCellConfig {
+                    enabled: true,
+                    command: "--continue".to_string(),
+                    env: BTreeMap::new(),
+                    notes: String::new(),
+                },
+            );
+        assert!(validate_agent_commands(&settings).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -3353,6 +3353,8 @@ mod tests {
             profile_fallback_chain: Vec::new(),
             profile_fallback_applied: false,
             effective_codex_home: None,
+            profile_content_hash: None,
+            profile_outdated: false,
             telegram_bot_id: None,
             was_detached: false,
             detached_geometry: None,

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -76,6 +76,7 @@ impl SessionManager {
             profile_fallback_chain: Vec::new(),
             profile_fallback_applied: false,
             effective_codex_home: None,
+            profile_content_hash: None,
             telegram_bot_id: None,
             was_detached: false,
             detached_geometry: None,
@@ -402,6 +403,7 @@ impl SessionManager {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn set_profile_metadata(
         &self,
         id: Uuid,
@@ -410,6 +412,7 @@ impl SessionManager {
         profile_fallback_chain: Vec<String>,
         profile_fallback_applied: bool,
         effective_codex_home: Option<String>,
+        profile_content_hash: Option<String>,
     ) {
         let mut sessions = self.sessions.write().await;
         if let Some(s) = sessions.get_mut(&id) {
@@ -418,6 +421,7 @@ impl SessionManager {
             s.profile_fallback_chain = profile_fallback_chain;
             s.profile_fallback_applied = profile_fallback_applied;
             s.effective_codex_home = effective_codex_home;
+            s.profile_content_hash = profile_content_hash;
         }
     }
 

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -107,6 +107,11 @@ pub struct Session {
     pub profile_fallback_applied: bool,
     #[serde(skip)]
     pub effective_codex_home: Option<String>,
+    /// #592 - 16-hex content-hash of the profile cell this session launched
+    /// with. In-memory; the durable copy is `tooling.profileContentHash` in the
+    /// replica config. `None` for plain-shell sessions (no resolved profile).
+    #[serde(skip)]
+    pub profile_content_hash: Option<String>,
     /// Telegram bot id that should be attached whenever this session has a live PTY.
     /// None means the Telegram toggle is OFF for this session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -215,6 +220,15 @@ pub struct SessionInfo {
     pub profile_fallback_applied: bool,
     #[serde(skip)]
     pub effective_codex_home: Option<String>,
+    /// #592 - internal carrier (NOT on the wire) of the session's loaded hash,
+    /// read by the `list_sessions` command to compute `profile_outdated`.
+    #[serde(skip)]
+    pub profile_content_hash: Option<String>,
+    /// #592 - true when the loaded profile cell no longer matches the current
+    /// configuration. Computed by the `list_sessions` command (settings-aware);
+    /// `From<&Session>` cannot compute it (no settings) so it defaults false.
+    #[serde(default)]
+    pub profile_outdated: bool,
     /// Internal carrier for sessions persistence. Not part of the frontend contract;
     /// the UI uses BridgeInfo events/listing for live bridge state.
     #[serde(skip)]
@@ -255,6 +269,8 @@ impl From<&Session> for SessionInfo {
             profile_fallback_chain: s.profile_fallback_chain.clone(),
             profile_fallback_applied: s.profile_fallback_applied,
             effective_codex_home: s.effective_codex_home.clone(),
+            profile_content_hash: s.profile_content_hash.clone(),
+            profile_outdated: false,
             telegram_bot_id: s.telegram_bot_id.clone(),
             was_detached: s.was_detached,
             detached_geometry: s.detached_geometry.clone(),
@@ -292,6 +308,7 @@ mod tests {
             profile_fallback_chain: Vec::new(),
             profile_fallback_applied: false,
             effective_codex_home: None,
+            profile_content_hash: None,
             telegram_bot_id: None,
             was_detached: false,
             detached_geometry: None,

--- a/src/shared/profile-utils.test.ts
+++ b/src/shared/profile-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentConfig, CodingAgentProfilesConfig } from "./types";
 import {
   commandExecutableBasename,
+  composeEffectiveCommand,
   defaultInstructionsFilename,
   effectiveEnvProjection,
   executableBasename,
@@ -145,6 +146,16 @@ describe("profile utils", () => {
     expect(profileCellCommandText(profiles().profilesByAgent.codex.C)).toBe("codex --model gpt-5");
     expect(profileCellCommandText(null)).toBe("");
     expect(profileCellCommandText(undefined)).toBe("");
+  });
+
+  it("composes the effective command from agent base + cell params (#597)", () => {
+    // Mirrors the Rust compose_effective_command edge cases.
+    expect(composeEffectiveCommand("claude", "--x")).toBe("claude --x");
+    expect(composeEffectiveCommand("claude", "")).toBe("claude");
+    expect(composeEffectiveCommand("", "--x")).toBe("--x");
+    expect(composeEffectiveCommand("", "")).toBe("");
+    // Each side is trimmed; no double space at the seam.
+    expect(composeEffectiveCommand("  claude  ", "  --x  ")).toBe("claude --x");
   });
 
   it("derives the binary basename from a full command string", () => {

--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -119,9 +119,24 @@ export function profileCellOrDefault(
   return profiles.profilesByAgent[agentId]?.[letter] ?? EMPTY_CELL;
 }
 
-/** v2 (#384): the full invocation string stored on a profile cell. */
+/** v2 (#384): the params string stored on a profile cell (#597: appended to the agent base command at launch). */
 export function profileCellCommandText(cell: ProfileCellConfig | null | undefined): string {
   return cell?.command ?? "";
+}
+
+/**
+ * #597 - the effective launch command: the agent base command (the binary,
+ * possibly with its own fixed args) followed by the profile cell command (extra
+ * params). Each side is trimmed; a single space joins them when both are
+ * non-empty; an empty side contributes nothing (no stray space). Mirrors the Rust
+ * `compose_effective_command` so the UI preview matches what actually launches.
+ */
+export function composeEffectiveCommand(base: string, cell: string): string {
+  const b = base.trim();
+  const c = cell.trim();
+  if (!b) return c;
+  if (!c) return b;
+  return `${b} ${c}`;
 }
 
 /** True when a value contains any AC path placeholder (display check). */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -28,6 +28,8 @@ export interface Session {
   effectiveProfile: string | null;
   profileFallbackChain: string[];
   profileFallbackApplied: boolean;
+  /** #592 - backend-computed: loaded profile cell != current config. */
+  profileOutdated?: boolean;
 }
 
 export type SessionStatus = "active" | "running" | "idle" | { exited: number };

--- a/src/sidebar/App.profile-drift.test.tsx
+++ b/src/sidebar/App.profile-drift.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SidebarApp from "./App";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../shared/testing/ui-harness";
+
+// #592: the profile-drift badge must surface from the NORMAL list_sessions load
+// path, not only from a coding_agent_profiles_updated event. The canonical failure
+// the user hit: a profile cell edited OUTSIDE the app (a hand edit to settings.json)
+// emits no event, so the surgical event refresh never runs and the badge stays dark.
+// This mounts the real SidebarApp and proves a window focus re-list lights the badge
+// with NO event emitted.
+
+const projectPath = "C:\\Project";
+const agentPath = `${projectPath}\\.ac\\_agent_General`;
+
+function setupTransport(fake: FakeTransport, isOutdated: () => boolean): void {
+  fake.resolve(
+    "get_settings",
+    baseSettings({ projectPaths: [projectPath], projectPath }),
+  );
+  fake.resolve("open_project", { path: projectPath, registered: true, created: false });
+  fake.resolve(
+    "discover_project",
+    discovery({
+      agents: [{ name: "General", path: agentPath, roleExists: true }],
+      teams: [],
+      workgroups: [],
+    }),
+  );
+  fake.resolve("search_repos", []);
+  // Dynamic: the drift flag the backend would compute in list_sessions flips
+  // between calls without any event being emitted.
+  fake.onInvoke("list_sessions", () => [
+    session({
+      id: "session-1",
+      name: "General",
+      workingDirectory: agentPath,
+      status: "active",
+      agentId: "codex",
+      agentLabel: "Codex",
+      profileOutdated: isOutdated(),
+    }),
+  ]);
+  fake.resolve("get_active_session", "session-1");
+  fake.resolve("list_detached_sessions", []);
+  fake.resolve("telegram_list_bridges", []);
+}
+
+describe("SidebarApp profile-drift surfacing (#592)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+  });
+
+  it("lights the outdated badge on window focus when list_sessions reports drift, with no event", async () => {
+    let outdated = false;
+    const fake = new FakeTransport();
+    setupTransport(fake, () => outdated);
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      // Initial load: the agent renders, no drift yet → no badge.
+      await waitFor(() => expect(rendered.root.textContent).toContain("General"));
+      expect(rendered.root.querySelector(".profile-outdated-badge")).toBeNull();
+
+      // Backend now reports drift (e.g. settings.json hand-edited). NO
+      // coding_agent_profiles_updated event is emitted; the only trigger is the
+      // user returning to the window.
+      outdated = true;
+      window.dispatchEvent(new Event("focus"));
+
+      // The debounced re-list (250ms) pulls the fresh profileOutdated and
+      // surgically applies it; the badge appears without any event. Generous
+      // timeout so the debounce + async list_sessions never flakes on slow CI.
+      await waitFor(
+        () => expect(rendered.root.querySelector(".profile-outdated-badge")).not.toBeNull(),
+        2000,
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -115,6 +115,20 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     if (!props.embedded) {
       document.documentElement.classList.add("light-theme");
     }
+    // #592 - re-fetch sessions and surgically patch each session's drift flag.
+    // Profile/env/selection edits change the "configured" cell; the backend
+    // recomputes profileOutdated in list_sessions, so we pull and apply it
+    // without setSessions (which would clobber frontend-only pendingReview).
+    const refreshProfileOutdated = async () => {
+      try {
+        const list = await SessionAPI.list();
+        for (const s of list) {
+          sessionsStore.setProfileOutdated(s.id, s.profileOutdated ?? false);
+        }
+      } catch (e) {
+        console.error("Failed to refresh profile drift:", e);
+      }
+    };
     unlisteners.push(
       await onAcProjectRefreshRequested((data) => {
         handleProjectRefreshRequested(data);
@@ -123,16 +137,19 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     unlisteners.push(
       await onCodingAgentProfilesUpdated(() => {
         settingsStore.refresh();
+        void refreshProfileOutdated();
       })
     );
     unlisteners.push(
       await onCodingAgentEnvSettingsUpdated(() => {
         settingsStore.refresh();
+        void refreshProfileOutdated();
       })
     );
     unlisteners.push(
       await onCodingAgentProfileSelectionUpdated((data) => {
         settingsStore.refresh();
+        void refreshProfileOutdated();
         if (data.agentPath) {
           void projectStore.reloadProjectIfLoaded(data.agentPath);
         } else {

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -73,6 +73,8 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
   let loopToastTimer: ReturnType<typeof setTimeout> | null = null;
   let raiseTerminalEnabled = true;
   let lastRaiseTime = 0;
+  // #592 - debounce handle for the profile-drift re-list (collapses bursts).
+  let profileDriftRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   const blockContextMenu = (e: Event) => {
     // Allow the WebView2 native menu over the embedded terminal so users get
     // Copy/Paste. Custom menus elsewhere (SessionItem, ProjectPanel, etc.)
@@ -105,6 +107,41 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     }, 3000);
   };
 
+  // #592 - pull the backend-computed drift flag and surgically patch each
+  // session. Uses setProfileOutdated (never setSessions) so the frontend-only
+  // pendingReview field is preserved. list_sessions recomputes profileOutdated
+  // from the persisted replica hash vs the current config, so this surfaces drift
+  // from ANY source: a profile event, an external settings.json edit, or
+  // pre-existing drift restored at boot.
+  const refreshProfileOutdated = async () => {
+    try {
+      const list = await SessionAPI.list();
+      for (const s of list) {
+        sessionsStore.setProfileOutdated(s.id, s.profileOutdated ?? false);
+      }
+    } catch (e) {
+      console.error("Failed to refresh profile drift:", e);
+    }
+  };
+  // Debounce so a burst (a workgroup spawn emitting many session_created, or a
+  // broad-scope profile apply touching many replicas) collapses into a single
+  // list_sessions round-trip.
+  const scheduleProfileOutdatedRefresh = () => {
+    if (profileDriftRefreshTimer) clearTimeout(profileDriftRefreshTimer);
+    profileDriftRefreshTimer = setTimeout(() => {
+      profileDriftRefreshTimer = null;
+      void refreshProfileOutdated();
+    }, 250);
+  };
+  // Re-check drift when the window regains focus / becomes visible. The robust
+  // catch-all for a cell edited OUTSIDE the app (a hand edit to settings.json,
+  // or any path that does not emit coding_agent_profiles_updated): the badge
+  // lights up as soon as the user returns to AC.
+  const handleWindowFocusDriftRefresh = () => {
+    if (document.visibilityState === "hidden") return;
+    scheduleProfileOutdatedRefresh();
+  };
+
   onMount(async () => {
     // #289 — optimistically paint in light mode (the historic default and the
     // AppSettings default) to keep first paint flash-free for the common case.
@@ -115,20 +152,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     if (!props.embedded) {
       document.documentElement.classList.add("light-theme");
     }
-    // #592 - re-fetch sessions and surgically patch each session's drift flag.
-    // Profile/env/selection edits change the "configured" cell; the backend
-    // recomputes profileOutdated in list_sessions, so we pull and apply it
-    // without setSessions (which would clobber frontend-only pendingReview).
-    const refreshProfileOutdated = async () => {
-      try {
-        const list = await SessionAPI.list();
-        for (const s of list) {
-          sessionsStore.setProfileOutdated(s.id, s.profileOutdated ?? false);
-        }
-      } catch (e) {
-        console.error("Failed to refresh profile drift:", e);
-      }
-    };
     unlisteners.push(
       await onAcProjectRefreshRequested((data) => {
         handleProjectRefreshRequested(data);
@@ -249,6 +272,13 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     const activeId = await SessionAPI.getActive();
     sessionsStore.setActiveId(activeId);
 
+    // #592 - surface profile drift edited OUTSIDE the app (a hand edit to
+    // settings.json, or any path that does not emit coding_agent_profiles_updated)
+    // the moment the user returns to AC. The in-app edit events still refresh
+    // immediately; this is the robust catch-all for everything else.
+    window.addEventListener("focus", handleWindowFocusDriftRefresh);
+    document.addEventListener("visibilitychange", handleWindowFocusDriftRefresh);
+
     // Listen for events
     unlisteners.push(
       await onSessionCreated((session) => {
@@ -260,6 +290,12 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
         ) {
           sessionsStore.setActiveId(session.id);
         }
+        // #592 - session_created carries profileOutdated=false (From<&Session>
+        // cannot compute drift). A session restored at boot with pre-existing
+        // drift must re-derive it from list_sessions, which would otherwise be
+        // clobbered to false by the addSession upsert. Debounced so a workgroup
+        // spawn burst collapses into one re-list.
+        scheduleProfileOutdatedRefresh();
       })
     );
 
@@ -373,9 +409,12 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     if (cleanupGeometry) cleanupGeometry();
     if (stopTeamIdleWatcher) stopTeamIdleWatcher();
     if (loopToastTimer) clearTimeout(loopToastTimer);
+    if (profileDriftRefreshTimer) clearTimeout(profileDriftRefreshTimer);
     sessionsStore.setSidebarPointerInside(false);
     document.removeEventListener("mousedown", handleRaiseTerminal);
     document.removeEventListener("contextmenu", blockContextMenu);
+    window.removeEventListener("focus", handleWindowFocusDriftRefresh);
+    document.removeEventListener("visibilitychange", handleWindowFocusDriftRefresh);
   });
 
   return (

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -330,6 +330,7 @@ function renderPicker(
     currentRequestedProfile: string | null;
     scopeContext: AgentPickerScopeContext | undefined;
     disableRedundantReplicaAssign: boolean;
+    targetProfileOutdated: boolean;
     onSelect: (selection: AgentPickerSelection) => void | Promise<void>;
     onClose: () => void;
   }> = {},
@@ -354,6 +355,7 @@ function renderPicker(
         currentRequestedProfile={overrides.currentRequestedProfile}
         scopeContext={overrides.scopeContext}
         disableRedundantReplicaAssign={overrides.disableRedundantReplicaAssign}
+        targetProfileOutdated={overrides.targetProfileOutdated}
         onSelect={overrides.onSelect ?? onSelect}
         onClose={overrides.onClose ?? onClose}
       />
@@ -964,6 +966,29 @@ describe("AgentPickerModal", () => {
       await settle();
 
       const apply = target<HTMLButtonElement>("agentPicker.apply");
+      expect(apply.disabled).toBe(false);
+      expect(apply.getAttribute("title")).toBeNull();
+
+      dispose();
+    });
+
+    // #592: drift overrides the #551 redundancy disable. When the target session's
+    // loaded profile no longer matches its configuration (profileOutdated), the
+    // same-pair re-assign is meaningful (re-stamp the cell content + relaunch), so
+    // "Assign to this replica" must stay ENABLED even on the otherwise-redundant pair.
+    it("re-enables apply for a redundant pair when the target session has drifted (#592)", async () => {
+      const { dispose } = renderPicker({
+        currentAgentId: "codex",
+        currentRequestedProfile: "B",
+        disableRedundantReplicaAssign: true,
+        targetProfileOutdated: true,
+      });
+      await settle();
+
+      const apply = target<HTMLButtonElement>("agentPicker.apply");
+      expect(text("agentPicker.apply")).toContain("Assign to this replica");
+      // Without drift this exact pair would be disabled with the redundant tooltip
+      // (see the first test in this block); drift flips it back on.
       expect(apply.disabled).toBe(false);
       expect(apply.getAttribute("title")).toBeNull();
 

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -13,6 +13,7 @@ import { launchErrorMessage } from "../../shared/launch-errors";
 import { automationAttrs } from "../../shared/automation-hooks";
 import {
   agentNameFromPathOrSession,
+  composeEffectiveCommand,
   effectiveEnvProjection,
   expandAcPlaceholdersPreview,
   hasAcPlaceholder,
@@ -235,10 +236,13 @@ const AgentPickerModal: Component<{
     if (!agent) return EMPTY_DISPLAY_CELL;
     return enabledLaunchCellFor(agent, effectivePreview().effectiveProfile);
   });
-  // The cell command is the full invocation; an empty cell command falls back to
-  // the agent's base command. Display-only AC placeholder expansion uses the replica root.
+  // #597: the effective command is the agent base command followed by the cell params.
+  // Display-only AC placeholder expansion uses the replica root.
   const projectedCommand = createMemo(() => {
-    const cmd = profileCellCommandText(projectedCell()) || selectedAgent()?.command || "";
+    const cmd = composeEffectiveCommand(
+      selectedAgent()?.command ?? "",
+      profileCellCommandText(projectedCell()),
+    );
     return expandAcPlaceholdersPreview(cmd, acRoot());
   });
   // #527 Effective Projection: merged effective env (agent env + profile env) with
@@ -256,7 +260,12 @@ const AgentPickerModal: Component<{
       : "Direct match",
   );
   const commandUsesAcPlaceholder = createMemo(() =>
-    hasAcPlaceholder(profileCellCommandText(projectedCell()) || selectedAgent()?.command || ""),
+    hasAcPlaceholder(
+      composeEffectiveCommand(
+        selectedAgent()?.command ?? "",
+        profileCellCommandText(projectedCell()),
+      ),
+    ),
   );
   const providerDefaultPreview = (agent: AgentConfig) => {
     const current = settings();
@@ -777,7 +786,7 @@ const AgentPickerModal: Component<{
                         <span class="agent-profile-param-list">
                           <span class="agent-profile-param">
                             <span>Command </span>
-                            <span>{profileCellCommandText(cell()) || selectedAgent()?.command || "none"}</span>
+                            <span>{composeEffectiveCommand(selectedAgent()?.command ?? "", profileCellCommandText(cell())) || "none"}</span>
                           </span>
                           <Show when={!configured()}>
                             <span class="agent-profile-token warn">

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -96,6 +96,13 @@ const AgentPickerModal: Component<{
   // The launch flow leaves this off so a replica can always be started with its
   // configured agent.
   disableRedundantReplicaAssign?: boolean;
+  // #592: when the target session's loaded profile has DRIFTED from its current
+  // configuration (profileOutdated), re-assigning the same Coding Agent + Profile
+  // is no longer a no-op: it re-stamps the cell content and relaunches. So drift
+  // overrides the redundancy disable above and keeps "Assign to this replica"
+  // enabled: a sibling "manual reload" affordance to the outdated badge. Read
+  // from the SAME backend-computed profileOutdated the badge uses (no FE hash).
+  targetProfileOutdated?: boolean;
   onSelect: (selection: AgentPickerSelection) => void | Promise<void>;
   onClose: () => void;
 }> = (props) => {
@@ -492,6 +499,9 @@ const AgentPickerModal: Component<{
   const isRedundantReplicaSelection = createMemo(() => {
     if (!props.disableRedundantReplicaAssign) return false;
     if (selectedScope() !== "replica") return false;
+    // #592 - drift makes a same-pair re-assign meaningful (re-stamp + relaunch
+    // with the current cell content), so it is never redundant while outdated.
+    if (props.targetProfileOutdated) return false;
     const agent = selectedAgent();
     const baselineAgentId = props.explicitCurrentAgentId;
     if (!agent || !baselineAgentId) return false;

--- a/src/sidebar/components/ProfileOutdatedBadge.tsx
+++ b/src/sidebar/components/ProfileOutdatedBadge.tsx
@@ -1,0 +1,35 @@
+import { Component } from "solid-js";
+
+/**
+ * #592 - the drift "Reload" affordance, shown when a session's loaded profile
+ * cell no longer matches its current configuration (the backend-computed
+ * profileOutdated flag). Clicking relaunches the session with the current
+ * config, which re-stamps the content hash and clears the flag.
+ *
+ * Shared by SessionItem, the ProjectPanel replica rows, and RootAgentBanner so
+ * the badge looks and behaves identically everywhere a coding-agent session can
+ * drift. The caller supplies the reload action because each surface restarts
+ * through a different path (sidebar restart vs replica restart vs root wake);
+ * stopPropagation is handled here so a badge click never selects the row.
+ */
+const ProfileOutdatedBadge: Component<{
+  onReload: () => void;
+  testId?: string;
+}> = (props) => {
+  return (
+    <button
+      type="button"
+      class="profile-outdated-badge"
+      title="Loaded profile no longer matches its configuration. Reload to relaunch with the current profile."
+      data-ac-testid={props.testId}
+      onClick={(e) => {
+        e.stopPropagation();
+        props.onReload();
+      }}
+    >
+      &#x27F3; outdated
+    </button>
+  );
+};
+
+export default ProfileOutdatedBadge;

--- a/src/sidebar/components/ProjectPanel.profile-outdated.test.tsx
+++ b/src/sidebar/components/ProjectPanel.profile-outdated.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
+import { settingsStore } from "../../shared/stores/settings";
+
+// #592: the profile-drift "outdated" badge must surface on a WG replica row, not
+// only on the sidebar SessionItem. The backend marks profileOutdated in
+// list_sessions (loaded cell hash != current config); the row reads the SAME store
+// value the status dot reads. Rendered through the real ProjectPanel + FakeTransport
+// per the frontend-visual-verification discipline.
+
+const projectPath = "C:\\Project";
+const workgroupPath = `${projectPath}\\.ac\\wg-2-dev-team`;
+const replicaPath = `${workgroupPath}\\__agent_dev-webpage-ui`;
+const replicaName = "dev-webpage-ui";
+const sessionName = `wg-2-dev-team/${replicaName}`;
+
+function replicaDiscovery() {
+  return discovery({
+    workgroups: [
+      {
+        name: "wg-2-dev-team",
+        path: workgroupPath,
+        task: null,
+        taskTitle: "Drift badge",
+        agents: [
+          {
+            name: replicaName,
+            path: replicaPath,
+            repoPaths: [],
+            isCoordinator: true,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+/** A live session bound to the replica row (matched by name, like the status dot). */
+function replicaSession(profileOutdated: boolean | undefined) {
+  return session({
+    id: "replica-live",
+    name: sessionName,
+    workingDirectory: replicaPath,
+    isCoordinator: true,
+    status: "running",
+    agentId: "codex",
+    agentLabel: "Codex",
+    profileOutdated,
+  });
+}
+
+async function mount() {
+  const fake = new FakeTransport();
+  fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+  fake.resolve("get_settings", baseSettings());
+  fake.resolve("discover_project", replicaDiscovery());
+  const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+  await settingsStore.load();
+  await projectStore.createAndLoad(projectPath);
+  await waitFor(() => expect(rendered.root.textContent).toContain(replicaName));
+  return rendered;
+}
+
+describe("ProjectPanel replica profile-outdated badge (#592)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("renders the reload badge on a replica row whose session is profileOutdated", async () => {
+    const rendered = await mount();
+    try {
+      // No drift yet → no badge even though the live session renders.
+      sessionsStore.setSessions([replicaSession(false)]);
+      await waitFor(() => expect(rendered.root.querySelector(".replica-item")).not.toBeNull());
+      expect(rendered.root.querySelector(".profile-outdated-badge")).toBeNull();
+
+      // Backend marks drift (surgical setProfileOutdated, the same path App.tsx uses
+      // on load / focus / events) → the badge appears with no full re-list.
+      sessionsStore.setProfileOutdated("replica-live", true);
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".profile-outdated-badge")).not.toBeNull(),
+      );
+
+      // Clearing the drift (e.g. after a reload re-stamps the hash) hides it again.
+      sessionsStore.setProfileOutdated("replica-live", false);
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".profile-outdated-badge")).toBeNull(),
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -16,6 +16,7 @@ import { isWgReplicaPath, profileDisplayLabel, sessionProfileBadge, shouldOfferR
 import { clockStore } from "../stores/clock";
 import { coordinatorIdleBadge } from "../../shared/coordinator-badge";
 import SessionItem from "./SessionItem";
+import ProfileOutdatedBadge from "./ProfileOutdatedBadge";
 import NewEntityAgentModal from "./NewEntityAgentModal";
 import NewTeamModal from "./NewTeamModal";
 import NewWorkgroupModal from "./NewWorkgroupModal";
@@ -1433,6 +1434,21 @@ const ProjectPanel: Component = () => {
                   <Show when={profileBadge()}>
                     {(badge) => <span class="profile-badge" title={profileBadgeTitle()}>{badge()}</span>}
                   </Show>
+                  {/* #592 - drift indicator for a WG replica session. Mirrors the
+                      SessionItem badge: the backend marks profileOutdated in
+                      list_sessions when the loaded cell != current config; clicking
+                      relaunches via the existing replica restart (re-stamps the hash
+                      and clears the flag). stopPropagation keeps the row from
+                      selecting the session under the click. */}
+                  <Show when={session()?.profileOutdated}>
+                    <ProfileOutdatedBadge
+                      testId={`replica.outdated.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}`}
+                      onReload={() => {
+                        const s = session();
+                        if (s) void restartReplicaSession(s.id);
+                      }}
+                    />
+                  </Show>
                   <Show when={isCoord()}>
                     <span class="ac-discovery-badge coord">coordinator</span>
                   </Show>
@@ -2578,6 +2594,10 @@ const ProjectPanel: Component = () => {
                   // #551: re-assigning the running agent+profile is a no-op and
                   // pops a needless restart prompt — disable it with a tooltip.
                   disableRedundantReplicaAssign
+                  // #592: but DRIFT (loaded cell != current config) makes a same-pair
+                  // re-assign meaningful (re-stamp + relaunch), so it overrides the
+                  // disable. Same backend profileOutdated the badge reads.
+                  targetProfileOutdated={sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId)?.profileOutdated}
                   onSelect={async (selection) => {
                     // The picker already persisted the selection through the backend
                     // (config write) for WG replicas. For a non-WG agent session there

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -16,6 +16,7 @@ import { voiceRecorder, formatRecordingTime } from "../../shared/voice-recorder"
 import type { Session, SessionStatus, TelegramBotConfig } from "../../shared/types";
 import { sessionProfileBadge } from "../../shared/profile-utils";
 import AgentPickerModal, { type AgentPickerSelection } from "./AgentPickerModal";
+import ProfileOutdatedBadge from "./ProfileOutdatedBadge";
 import { rootAgentCodingAgentAction } from "./root-agent-action";
 import { TelegramIcon } from "./TelegramIcon";
 
@@ -419,6 +420,12 @@ const RootAgentBanner: Component = () => {
               {subtitle()}
               <Show when={profileBadge()}>
                 {(badge) => <span class="profile-badge root-profile-badge">{badge()}</span>}
+              </Show>
+              {/* #592 - drift reload for the Root Agent (loaded profile cell no
+                  longer matches its current config). Reuses the restart path, which
+                  re-stamps the content hash and clears the flag. */}
+              <Show when={rootSession()?.profileOutdated}>
+                <ProfileOutdatedBadge onReload={() => void handleRestart()} />
               </Show>
             </span>
           </Show>

--- a/src/sidebar/components/SessionAutomation.test.tsx
+++ b/src/sidebar/components/SessionAutomation.test.tsx
@@ -141,4 +141,60 @@ describe("session workflow automation hooks", () => {
       rendered.cleanup();
     }
   });
+
+  it("#592: surfaces the Root Agent drift reload badge and relaunches on click", async () => {
+    // The Root Agent can drift too (its loaded profile cell vs current config), and
+    // its hash is persisted (a80a1a7). The banner must show the same reload badge as
+    // SessionItem / replica rows, wired to the root restart path.
+    const root = session({
+      id: "root-1",
+      name: "Agent's Commander",
+      isRootAgent: true,
+      status: "running",
+      profileOutdated: true,
+    });
+    sessionsStore.setSessions([root]);
+
+    const fake = new FakeTransport();
+    fake.resolve("restart_session", root);
+    fake.resolve("switch_session", undefined);
+
+    const rendered = renderWithFakeTransport(() => <RootAgentBanner />, fake);
+    try {
+      const badge = rendered.root.querySelector(".profile-outdated-badge");
+      expect(badge).not.toBeNull();
+
+      click(badge!);
+      await waitFor(() =>
+        expect(fake.lastCall("restart_session")?.args).toEqual({
+          id: "root-1",
+          agentId: null,
+          requestedProfile: null,
+          skipAutoResume: null,
+        })
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("#592: hides the Root Agent drift badge when the profile is current", async () => {
+    const root = session({
+      id: "root-1",
+      name: "Agent's Commander",
+      isRootAgent: true,
+      status: "running",
+      profileOutdated: false,
+    });
+    sessionsStore.setSessions([root]);
+
+    const fake = new FakeTransport();
+    const rendered = renderWithFakeTransport(() => <RootAgentBanner />, fake);
+    try {
+      expect(rendered.root.querySelector('[data-ac-testid="rootAgent.banner"]')).not.toBeNull();
+      expect(rendered.root.querySelector(".profile-outdated-badge")).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
 });

--- a/src/sidebar/components/SessionItem.test.tsx
+++ b/src/sidebar/components/SessionItem.test.tsx
@@ -213,3 +213,50 @@ describe("SessionItem profile badge tooltip (#548)", () => {
     }
   });
 });
+
+describe("SessionItem profile-outdated badge (#592)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("shows the Reload badge when profileOutdated is true", async () => {
+    const settings = baseSettings({ agents: TWO_AGENTS, codingAgentProfiles: profiles({}) });
+    const rendered = await renderRow(
+      { agentId: "codex", agentLabel: "Codex", profileOutdated: true },
+      settings,
+    );
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".profile-outdated-badge")).not.toBeNull(),
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("hides the Reload badge when profileOutdated is falsy", async () => {
+    const settings = baseSettings({ agents: TWO_AGENTS, codingAgentProfiles: profiles({}) });
+    const rendered = await renderRow(
+      { agentId: "codex", agentLabel: "Codex", profileOutdated: false },
+      settings,
+    );
+    try {
+      // The agent badge renders, so the meta container is present; the outdated
+      // badge specifically must not be.
+      await waitFor(() => expect(rendered.root.querySelector(".agent-badge")).not.toBeNull());
+      expect(rendered.root.querySelector(".profile-outdated-badge")).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -11,6 +11,7 @@ import { centralViewStore } from "../../main/stores/centralView";
 import { voiceRecorder, formatRecordingTime } from "../../shared/voice-recorder";
 import OpenAgentModal from "./OpenAgentModal";
 import AgentPickerModal from "./AgentPickerModal";
+import ProfileOutdatedBadge from "./ProfileOutdatedBadge";
 import { TelegramIcon } from "./TelegramIcon";
 import { profileDisplayLabel, sessionProfileBadge } from "../../shared/profile-utils";
 
@@ -379,17 +380,7 @@ const SessionItem: Component<{
                 )}
               </Show>
               <Show when={props.session.profileOutdated}>
-                <button
-                  type="button"
-                  class="profile-outdated-badge"
-                  title="Loaded profile no longer matches its configuration. Reload to relaunch with the current profile."
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void restartSession();
-                  }}
-                >
-                  ⟳ outdated
-                </button>
+                <ProfileOutdatedBadge onReload={() => void restartSession()} />
               </Show>
               <Show when={props.session.isCoordinator && !isInactive() && props.session.gitRepos.length > 0}>
                 <div class="session-item-branches">

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -374,6 +374,19 @@ const SessionItem: Component<{
                   </span>
                 )}
               </Show>
+              <Show when={props.session.profileOutdated}>
+                <button
+                  type="button"
+                  class="profile-outdated-badge"
+                  title="Loaded profile no longer matches its configuration. Reload to relaunch with the current profile."
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void restartSession();
+                  }}
+                >
+                  ⟳ outdated
+                </button>
+              </Show>
               <Show when={props.session.isCoordinator && !isInactive() && props.session.gitRepos.length > 0}>
                 <div class="session-item-branches">
                   <For each={props.session.gitRepos}>

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -430,11 +430,12 @@ describe("SettingsModal automation hooks", () => {
     // base command until a command is typed).
     expect(byTestId("settings.profileCard.0.B").getAttribute("data-ac-state")).toBe("missing");
     expect(byTestId("settings.profileCard.0.B.badge").textContent).toContain("MISSING");
-    // #538: the sub-line states what the cell launches via fallback (consistent
-    // with the MISSING badge) instead of a contradictory bare "Configured".
+    // #597: the sub-line shows the agent base binary the cell params append to
+    // (here `codex`), consistent with the MISSING badge (B has no params of its
+    // own yet) instead of a contradictory bare "Configured".
     expect(
       byTestId("settings.profileCard.0.B").querySelector(".settings-profile-card-sub")?.textContent,
-    ).toBe("Launches A");
+    ).toBe("codex");
     expect(document.querySelector('[data-ac-testid="settings.profileCard.0.B.missing"]')).toBeNull();
     expect(document.querySelector('[data-ac-testid="settings.profileCard.0.B.add"]')).toBeNull();
     // Instead it exposes the same expand/edit affordance as every cell: a chevron

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -376,7 +376,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     }));
   };
 
-  // ── Profile cell command string (one full invocation per cell) ──
+  // ── Profile cell command string (params appended to the agent base command, #597) ──
   const updateProfileCellCommand = (agentId: string, letter: string, text: string) => {
     const key = profileCellKey(agentId, letter);
     setDraftDirty(true);
@@ -1592,9 +1592,10 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     invalid: "invalid",
   };
 
-  // One full invocation string per profile cell — model/effort/sandbox are NOT
-  // split into separate fields (#384). The two comparison rails render the slots
-  // A..Z of two coding agents side by side; cards are addressed by rail index.
+  // The cell command holds the params appended to the agent base command (#597);
+  // model/effort/sandbox are not split into separate fields (#384). The two
+  // comparison rails render the slots A..Z of two coding agents side by side;
+  // cards are addressed by rail index.
   const renderProfileCard = (agent: AgentConfig, railIndex: number, letter: string) => {
     const badge = () => profileCellBadge(agent.id, letter);
     const command = () => displayedProfileCellCommand(agent.id, letter);
@@ -1605,13 +1606,15 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       resolveProfilePreview(settings.data!.codingAgentProfiles, agent.id, letter);
     // #538: every cell always exposes its command editor (no "Add cell" / missing
     // box). The badge reports the real match/configured/fallback/missing state; the
-    // sub-line shows the cell's own executable, or — when it has no command of its
-    // own — what it launches via fallback, so it never contradicts a MISSING or
-    // FALLBACK badge by claiming "Configured".
+    // sub-line shows the agent base binary the cell params append to (#597), or,
+    // when no base command is set yet, the fallback/configured text, so it never
+    // contradicts a MISSING or FALLBACK badge by claiming "Configured".
     const subLine = () => {
       if (cellError()) return "Command syntax error";
-      const ownCommand = commandExecutableBasename(command());
-      if (ownCommand) return ownCommand;
+      // #597 - the binary comes from the agent base command; the cell holds only
+      // params. Show the effective binary basename, not the params text.
+      const baseExe = commandExecutableBasename(agent.command);
+      if (baseExe) return baseExe;
       const resolved = preview();
       return resolved.fallbackApplied ? `Launches ${resolved.effectiveProfile}` : "Configured";
     };
@@ -1687,12 +1690,15 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
               ?
             </button>
           </div>
+          <div class="settings-profile-command-base" data-ac-testid={`${cardId}.commandBase`}>
+            Runs <code>{agent.command || "(set the Coding Agent command first)"}</code> then your params:
+          </div>
           <input
             class="settings-input settings-profile-command"
             classList={{ invalid: Boolean(cellError()) }}
             value={command()}
             onInput={(e) => updateProfileCellCommand(agent.id, letter, e.currentTarget.value)}
-            placeholder="codex --sandbox workspace-write --model gpt-5-codex"
+            placeholder="--sandbox workspace-write --model gpt-5-codex"
             data-ac-testid={`${cardId}.command`}
             data-ac-role="textbox"
             data-ac-state={cellError() ? "invalid" : "valid"}

--- a/src/sidebar/stores/sessions.test.ts
+++ b/src/sidebar/stores/sessions.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sessionsStore } from "./sessions";
+import { session } from "../../shared/testing/ui-harness";
+
+describe("sessionsStore.setProfileOutdated (#592)", () => {
+  beforeEach(() => {
+    sessionsStore.setSessions([]);
+  });
+  afterEach(() => {
+    sessionsStore.setSessions([]);
+  });
+
+  it("patches only profileOutdated and leaves pendingReview untouched", () => {
+    sessionsStore.setSessions([
+      session({ id: "s1", pendingReview: true, profileOutdated: false }),
+    ]);
+
+    sessionsStore.setProfileOutdated("s1", true);
+
+    const updated = sessionsStore.sessions.find((s) => s.id === "s1");
+    expect(updated?.profileOutdated).toBe(true);
+    // The frontend-only review flag must survive a surgical drift update.
+    expect(updated?.pendingReview).toBe(true);
+  });
+
+  it("only touches the targeted session", () => {
+    sessionsStore.setSessions([
+      session({ id: "s1", profileOutdated: false }),
+      session({ id: "s2", profileOutdated: false }),
+    ]);
+
+    sessionsStore.setProfileOutdated("s2", true);
+
+    expect(sessionsStore.sessions.find((s) => s.id === "s1")?.profileOutdated).toBe(false);
+    expect(sessionsStore.sessions.find((s) => s.id === "s2")?.profileOutdated).toBe(true);
+  });
+});

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -358,6 +358,13 @@ export const sessionsStore = {
     setState("sessions", (s) => s.id === sessionId, "isCoordinator", value);
   },
 
+  // #592 - surgical per-session drift flag update. Mirrors setIsCoordinator;
+  // never use setSessions for this (a wholesale replace would reset the
+  // frontend-only pendingReview field).
+  setProfileOutdated(id: string, outdated: boolean) {
+    setState("sessions", (s) => s.id === id, "profileOutdated", outdated);
+  },
+
   setTeams(teams: Team[]) {
     setState("teams", teams);
     if (

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -1538,6 +1538,20 @@ html.light-theme .root-agent-avatar {
   line-height: 1.4;
 }
 
+/* #597 - hint above a profile cell editor showing the agent base command the
+   cell params append to. */
+.settings-profile-command-base {
+  font-size: 11px;
+  color: var(--sidebar-fg-dim);
+  margin: 2px 0 4px;
+}
+.settings-profile-command-base code {
+  padding: 0 4px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--sidebar-fg);
+}
+
 .settings-profile-ph-token {
   font-family: "Cascadia Code", "JetBrains Mono", monospace;
   color: var(--sidebar-accent);

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -564,6 +564,24 @@ html, body, #root {
   white-space: nowrap;
 }
 
+/* #592 - drift indicator: amber, clickable (Reload). */
+.profile-outdated-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 9px;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: none;
+  cursor: pointer;
+  background: rgba(234, 179, 8, 0.15);
+  color: #eab308;
+}
+.profile-outdated-badge:hover {
+  background: rgba(234, 179, 8, 0.28);
+}
+
 .root-profile-badge {
   margin-left: 6px;
   vertical-align: middle;


### PR DESCRIPTION
## Summary

Two stacked features for coding-agent profiles, delivered together:

- **#592 - Profile content-hash drift detection.** Each profile gets a 16-hex content-hash (SHA-256 truncated) of its effective command + env. When a running agent's loaded profile no longer matches the configured one, it surfaces as "outdated" with a manual Reload. Persisted per replica (survives restart); drift is recomputed in `list_sessions`.
- **#597 - Command concatenation (BREAKING).** The effective launch command is now `agent.command` (base binary) + `cell.command` (params), instead of the cell replacing the base. The content-hash covers the full effective command + env (base + cell).

## ⚠️ BREAKING change (no migration)

Profile cells that hold the full command must be reconfigured: put the binary in the Coding Agent and only the params in each profile cell. Otherwise an existing cell with a full command duplicates the binary (`claude` + `claude --foo` -> `claude claude --foo`). The cell editor now shows a `Command: <base>` label to make this visible. No automatic migration (owner decision).

## What's included
- **Backend:** `profile_content_hash` (SHA-256 / 16-hex), `compose_effective_command` + `raw_merged_profile_env` helpers, stamp at spawn, replica persistence (`tooling.profileContentHash`), drift recompute, `profileOutdated` on `SessionInfo`. §A4 validates the composed command (closes the banned-flag bypass).
- **Root Agent baseline fix:** the persistence gate excluded `ac-root-agent`; widened via `is_root_agent_dir_name`.
- **Frontend:** shared `ProfileOutdatedBadge` on standalone agents + replica/coordinator rows + Root Agent banner; robust surfacing (focus/visibility/boot, debounced, surgical so it never clobbers `pendingReview`); "Assign to this replica" enabled under drift.
- Diagnostic `[profile-hash]` logs quieted for production (5 removed from hot paths, 5 downgraded to `debug!`).

## Testing
- Gates green: `cargo clippy --all-targets` clean, `cargo test --lib` **1313/0/8**, `tsc --noEmit` clean, `vitest` **471/60**. (The `cli::task_ops::concurrent_writes` failure is a pre-existing concurrency bin-test flake, passes in isolation; unrelated.)
- `/code-review` high effort (no grinch agent in this workgroup): all findings resolved.
- Shipper-built `agentscommander_standalone_wg-12.exe` deployed to 0_AC; **user-tested OK** (badge surfaces on coordinators/replicas/Root Agent + base-command edit + boot + the Assign button).
- Re-synced cleanly onto `main` across #589, #587, #588/#582, and #602 (all disjoint or auto-merged, verified).

Closes #592
Closes #597
