### PR TITLE
fix(window): shorten taskbar window-title prefix to "AC" (#606)

### DIFF
--- a/docs/testing/01-project-lifecycle.md
+++ b/docs/testing/01-project-lifecycle.md
@@ -31,7 +31,7 @@ Tester: ac-cli-tester
 
 App under test: `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe --app`
 
-Target window: `Agents Commander [STANDALONE_WG-1]`
+Target window: `AC [STANDALONE_WG-1]`
 
 Evidence root: `C:\Users\maria\0_repos\AgentsCommander_ac\.ac\wg-1-dev-team\__agent_ac-cli-tester\evidence\testing-phase-1`
 
@@ -70,7 +70,7 @@ Verify that the workgroup-specific app instance is running, visually identifiabl
 Preconditions:
 
 - App wg-1 is open or launchable with `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe --app`.
-- Window title `Agents Commander [STANDALONE_WG-1]` is detectable.
+- Window title `AC [STANDALONE_WG-1]` is detectable.
 - Window is maximized on the monitor designated by the user for visual validation.
 - Initial capture is saved as evidence.
 - If the window is not maximized or is on a different monitor, the case must report `BLOCKED`/`PARTIAL` or move/maximize the window if the test plan permits, leaving evidence.
@@ -78,7 +78,7 @@ Preconditions:
 Steps:
 
 1. Start the app if it is not already running.
-2. Enumerate visible AgentsCommander windows and select only the one whose title is `Agents Commander [STANDALONE_WG-1]`.
+2. Enumerate visible AgentsCommander windows and select only the one whose title is `AC [STANDALONE_WG-1]`.
 3. Record PID, HWND, executable path, window rectangle, maximized state, and capture method.
 4. Save a screenshot of the target window.
 5. Confirm the header shows the `STANDALONE_WG-1` badge and the main/sidebar UI is readable.
@@ -175,7 +175,7 @@ Preconditions:
 Steps:
 
 1. Capture the sidebar state with the disposable project visible.
-2. Close the target `Agents Commander [STANDALONE_WG-1]` window normally.
+2. Close the target `AC [STANDALONE_WG-1]` window normally.
 3. Relaunch `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe --app`.
 4. Detect and maximize the target window again.
 5. Capture the sidebar state after relaunch.

--- a/docs/testing/04-team-and-workgroup-lifecycle.md
+++ b/docs/testing/04-team-and-workgroup-lifecycle.md
@@ -273,7 +273,7 @@ Preconditions:
 Steps:
 
 1. Capture the pre-restart workgroup list, selected workgroup, participants, sessions, and peer JSON.
-2. Close `Agents Commander [TESTEABLE]` normally.
+2. Close `AC [TESTEABLE]` normally.
 3. Relaunch `agentscommander_testeable.exe --app` with deterministic placement.
 4. Run `agentscommander_testeable.exe window-info` and capture the relaunched target.
 5. Capture the post-restart workgroup list and selected/active workgroup.

--- a/docs/testing/06-agent-templates-agency.md
+++ b/docs/testing/06-agent-templates-agency.md
@@ -233,7 +233,7 @@ Preconditions:
 
 - Depends on TPL-001 and TPL-002.
 - The current testable identity has known local template or agency status evidence.
-- The tester can close and relaunch only `Agents Commander [TESTEABLE]`.
+- The tester can close and relaunch only `AC [TESTEABLE]`.
 
 Steps:
 

--- a/docs/testing/09-settings-and-persistence.md
+++ b/docs/testing/09-settings-and-persistence.md
@@ -66,7 +66,7 @@ Steps:
 
 Expected Result:
 
-The settings surface opens from `Agents Commander [TESTEABLE]`, is visually readable, and can be closed without mutating settings.
+The settings surface opens from `AC [TESTEABLE]`, is visually readable, and can be closed without mutating settings.
 
 Evidence Required:
 
@@ -133,7 +133,7 @@ Steps:
 
 1. Capture the project/workgroup list before restart.
 2. Save any available settings or project registration snapshot for the testable identity.
-3. Close `Agents Commander [TESTEABLE]` normally.
+3. Close `AC [TESTEABLE]` normally.
 4. Relaunch `agentscommander_testeable.exe --app` with deterministic placement.
 5. Run `agentscommander_testeable.exe window-info` and save the output.
 6. Capture the project/workgroup list after restart.
@@ -203,7 +203,7 @@ Verify that `test-reset --confirm-testeable` is used only while the GUI is close
 Preconditions:
 
 - The testable GUI is closed.
-- The tester can prove no `Agents Commander [TESTEABLE]` window is active.
+- The tester can prove no `AC [TESTEABLE]` window is active.
 - Disposable testable identity directories exist or their absence can be recorded.
 - The tester will not manually delete or edit settings outside `.agentscommander_testeable` and `agentscommander_testeable`.
 

--- a/docs/testing/10-windowing-and-multimonitor.md
+++ b/docs/testing/10-windowing-and-multimonitor.md
@@ -66,7 +66,7 @@ Steps:
 
 Expected Result:
 
-The testable app launches as `Agents Commander [TESTEABLE]`, `window-info` reports the testable executable path, and the rectangle/maximized state matches the requested monitor placement within expected DPI variance.
+The testable app launches as `AC [TESTEABLE]`, `window-info` reports the testable executable path, and the rectangle/maximized state matches the requested monitor placement within expected DPI variance.
 
 Evidence Required:
 
@@ -206,7 +206,7 @@ Steps:
 
 1. Capture pre-restart `window-info` and target screenshot.
 2. If testing manual persistence, move or resize the testable window and capture changed `window-info`.
-3. Close `Agents Commander [TESTEABLE]` normally.
+3. Close `AC [TESTEABLE]` normally.
 4. Relaunch `agentscommander_testeable.exe --app` with the same placement method or documented no-placement condition.
 5. Run `window-info` immediately after relaunch.
 6. Capture the relaunched window.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -12,7 +12,7 @@ This directory is the product regression map for acceptance testing. Every user-
 
 - The app under test should be `agentscommander_testeable.exe` for deterministic GUI regression runs.
 - The testable app uses a disposable config directory next to the binary: `.agentscommander_testeable`.
-- The target window title for the testable app is `Agents Commander [TESTEABLE]`.
+- The target window title for the testable app is `AC [TESTEABLE]`.
 - If multiple AgentsCommander windows are open, never assume the active window is the target. Select the window whose title matches the workgroup under test.
 - For GUI and human-style checks, launch the app at the monitor rectangle designated by the user for visual validation.
 - Current visual-test baseline:

--- a/src-tauri/src/config/profile.rs
+++ b/src-tauri/src/config/profile.rs
@@ -56,16 +56,18 @@ pub fn config_dir_name() -> &'static str {
 }
 
 /// Application title for the sidebar window.
-/// Runtime suffix: "Agents Commander [SUFFIX]" (uppercased).
+/// Runtime suffix: "AC [SUFFIX]" (uppercased).
 /// No suffix: falls back to BUILD_PROFILE behaviour.
+/// The short "AC" prefix keeps the OS taskbar tooltip compact (issue #606);
+/// only this literal prefix changed, the suffix-derivation logic is unchanged.
 pub fn app_title() -> &'static str {
     static TITLE: OnceLock<String> = OnceLock::new();
     TITLE.get_or_init(|| match binary_suffix() {
-        Some(suffix) => format!("Agents Commander [{}]", suffix.to_uppercase()),
+        Some(suffix) => format!("AC [{}]", suffix.to_uppercase()),
         None => match BUILD_PROFILE {
-            "dev" => "Agents Commander".to_string(),
-            "stage" => "Agents Commander [STAGE]".to_string(),
-            _ => "Agents Commander".to_string(),
+            "dev" => "AC".to_string(),
+            "stage" => "AC [STAGE]".to_string(),
+            _ => "AC".to_string(),
         },
     })
 }


### PR DESCRIPTION
## What & why

The Windows taskbar tooltip (the OS window title) read `AGENTS COMMANDER [PERSONAL]` (suffix derived from the build/exe variant, e.g. `agentscommander_personal.exe`). `AGENTS COMMANDER` wastes horizontal space without adding value, so the prefix is shortened to `AC`:

```
AGENTS COMMANDER [PERSONAL]   →   AC [PERSONAL]
```

Closes #606.

## Change

- **Single source:** `config::profile::app_title()` (`src-tauri/src/config/profile.rs`) — only the literal prefix changed across all four arms (runtime-suffix, dev/no-suffix, stage, prod). Suffix-derivation logic (`binary_suffix()` + `to_uppercase()`) is untouched; the no-suffix case now yields exactly `AC`.
- All windows (main/taskbar `lib.rs:922`, recreate path `commands/window.rs:472`, Guide/Spec Board/Resource Monitor via `app_title_suffix()`, and the test harness `window_info.rs`) route through `app_title()`, so no window-builder edits were needed and all stay consistent.
- **Out of scope, deliberately untouched:** `product_name()` / `productName` / LOCALAPPDATA data-dir (install identity), and the in-app custom titlebar branding (`Titlebar.tsx` / `instance_label()`).
- **Docs:** synced 12 OS-window-title literals in `docs/testing/*.md` (`Agents Commander [...]` → `AC [...]`). `docs/features/portable-instances.md` "Titlebar" column left alone on purpose — it documents the in-app titlebar badge, not the OS window title.

Commits: `02b7675` (source) + `5b616f3` (docs).

## Review & verification

- **dev-rust:** `cargo build` clean, `cargo clippy --all-targets` 0 warnings, `cargo test --lib --bins --tests` (serial, authoritative) **1454 passed / 0 failed / 12 ignored**, `/code-review` high — no findings.
- **dev-rust-grinch (Step-7):** **PASS**, no HIGH/MEDIUM. Re-ran all gates independently; verified single-source, suffix logic intact, no consumer parses the old literal, install-identity untouched, doc sweep complete (0 stragglers). The one parallel-run test failure is the known orthogonal `cli::task_ops` lock-contention flake (passes serially).
- **shipper:** built `feature/606-window-title-ac-prefix` @ `5b616f3`, deployed `agentscommander_standalone_wg-9.exe` (v0.9.16) to `0_AC`; smoke test (`--help`) passed.
- **User:** approved landing after the 0_AC test build.

No version bump (per policy: bump only when cutting a release).
