### PR TITLE
feat(config-seed): seed a default config folder into the coding-agent replica at spawn (#598)

### DIFF
--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -158,6 +158,7 @@ mod tests {
             envs: Vec::new(),
             isolated_home: false,
             instructions_filename: None,
+            config_seed: None,
         }
     }
 

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1330,6 +1330,7 @@ mod tests {
                 envs: Vec::new(),
                 isolated_home: false,
                 instructions_filename: None,
+                config_seed: None,
             }],
             ..AppSettings::default()
         }

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -2691,6 +2691,7 @@ mod tests {
                 envs: Vec::new(),
                 isolated_home: false,
                 instructions_filename: None,
+                config_seed: None,
             },
             crate::config::settings::AgentConfig {
                 id: "claude".to_string(),
@@ -2702,6 +2703,7 @@ mod tests {
                 envs: Vec::new(),
                 isolated_home: false,
                 instructions_filename: None,
+                config_seed: None,
             },
         ];
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1061,6 +1061,49 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         )
     });
 
+    // #598 - seed the config folder before the PTY starts so the agent sees the
+    // templated config. Best-effort: never aborts the spawn. This is the single
+    // execution chokepoint every real spawn funnels through (create / replica /
+    // other variants, delivery / mailbox / web wakes); prevalidation never hits
+    // it because it discards the spawn. For a `.claude` dest, hold the RTK sweep
+    // lock (M2) around the seed + re-apply, then re-stamp claudeMdExcludes (if
+    // opted in) and the rtk hook (M1), mirroring
+    // entity_creation::apply_agent_matrix_settings_files. Per Q2 this runs on
+    // EVERY spawn, including loop/scheduler resume-wakes (overwrite every spawn).
+    if let Some(seed) = resolved_spawn.as_ref().and_then(|s| s.seed.as_ref()) {
+        // M2: serialize against sweep_rtk_hook's read-modify-write of
+        // .claude/settings.local.json. Clone the Arc out of State first so the
+        // owned guard does not borrow a State temporary (E0716).
+        let _sweep_guard = if seed.claude_settings_reapply.is_some() {
+            let lock = app.state::<crate::RtkSweepLockState>().inner().clone();
+            Some(lock.lock_owned().await)
+        } else {
+            None
+        };
+
+        let report = crate::config::config_seed::perform_config_seed(seed, &id.to_string());
+
+        // M1: a `.claude` seed clean-replaces the dir, wiping the AC-managed
+        // settings.local.json. Re-stamp both claudeMdExcludes (if the agent opts
+        // in) and the rtk hook (per the global toggle). `cwd` is the replica
+        // root; the writers append `.claude`, so this lands in the seeded dir.
+        if matches!(report, crate::config::config_seed::ConfigSeedReport::Seeded) {
+            if let Some(re) = &seed.claude_settings_reapply {
+                let dir = std::path::Path::new(&cwd);
+                if re.apply_excludes {
+                    if let Err(e) = crate::config::claude_settings::ensure_claude_md_excludes(dir) {
+                        log::warn!("[config-seed] re-apply claudeMdExcludes failed: {}", e);
+                    }
+                }
+                if let Err(e) =
+                    crate::config::claude_settings::ensure_rtk_pretool_hook(dir, re.inject_rtk_hook)
+                {
+                    log::warn!("[config-seed] re-apply rtk hook failed: {}", e);
+                }
+            }
+        }
+    }
+
     let spawn_result = {
         pty_mgr.lock().unwrap().spawn(
             id,
@@ -2698,6 +2741,7 @@ mod tests {
                     envs: Vec::new(),
                     isolated_home: false,
                     instructions_filename: None,
+                    config_seed: None,
                 },
                 AgentConfig {
                     id: "codex".to_string(),
@@ -2709,6 +2753,7 @@ mod tests {
                     envs: Vec::new(),
                     isolated_home: false,
                     instructions_filename: None,
+                    config_seed: None,
                 },
             ],
             ..AppSettings::default()
@@ -3256,6 +3301,7 @@ mod tests {
             envs: Vec::new(),
             isolated_home: false,
             instructions_filename: None,
+            config_seed: None,
         });
 
         let resolved = resolve_actual_agent(
@@ -3334,6 +3380,7 @@ mod tests {
             envs: Vec::new(),
             isolated_home: false,
             instructions_filename: None,
+            config_seed: None,
         }];
 
         let resolved = resolve_agent_from_shell("codex", &[], &settings);

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1065,20 +1065,24 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     // templated config. Best-effort: never aborts the spawn. This is the single
     // execution chokepoint every real spawn funnels through (create / replica /
     // other variants, delivery / mailbox / web wakes); prevalidation never hits
-    // it because it discards the spawn. For a `.claude` dest, hold the RTK sweep
-    // lock (M2) around the seed + re-apply, then re-stamp claudeMdExcludes (if
-    // opted in) and the rtk hook (M1), mirroring
-    // entity_creation::apply_agent_matrix_settings_files. Per Q2 this runs on
-    // EVERY spawn, including loop/scheduler resume-wakes (overwrite every spawn).
+    // it because it discards the spawn. Per Q2 this runs on EVERY spawn,
+    // including loop/scheduler resume-wakes (overwrite every spawn).
     if let Some(seed) = resolved_spawn.as_ref().and_then(|s| s.seed.as_ref()) {
-        // M2: serialize against sweep_rtk_hook's read-modify-write of
-        // .claude/settings.local.json. Clone the Arc out of State first so the
-        // owned guard does not borrow a State temporary (E0716).
-        let _sweep_guard = if seed.claude_settings_reapply.is_some() {
+        // grinch HIGH-1: serialize the seed swap for ALL dests (not just
+        // `.claude`). Two same-replica spawns can run concurrently (e.g. a
+        // delivery tick + a mailbox wake) holding only `session_mgr.read()`,
+        // with no global spawn lock. Without serialization, spawn B's
+        // prefix-sweep of stale scratch (`clear_stale_seed_scratch`) could
+        // delete spawn A's in-flight temp/trash mid-swap and lose the config
+        // (breaking H1's "dest always fully-old or fully-new" + M3 isolation).
+        // Under this lock any other-id scratch is truly stale, so the
+        // leak-reclaim sweep stays safe. The same lock also gives the `.claude`
+        // re-apply its M2 serialization vs sweep_rtk_hook's settings.local.json
+        // read-modify-write. Clone the Arc out of State first so the owned guard
+        // does not borrow a State temporary (E0716).
+        let _seed_guard = {
             let lock = app.state::<crate::RtkSweepLockState>().inner().clone();
-            Some(lock.lock_owned().await)
-        } else {
-            None
+            lock.lock_owned().await
         };
 
         let report = crate::config::config_seed::perform_config_seed(seed, &id.to_string());

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -2004,15 +2004,24 @@ mod tests {
         let letter = spawn.profile_resolution.effective_profile.to_ascii_lowercase();
 
         use crate::config::config_seed::ConfigSeedTier;
+        // Workspace tiers outrank matrix tiers; profile beats base in each. The
+        // matrix's bare `.claude` (the agent's own live config) is never a source.
         assert_eq!(
             seed.candidates,
             vec![
                 (
-                    ConfigSeedTier::Profile,
+                    ConfigSeedTier::WorkspaceProfile,
                     workspace.join(format!("default_profile_{}.claude", letter))
                 ),
-                (ConfigSeedTier::Matrix, matrix.join(".claude")),
-                (ConfigSeedTier::Base, workspace.join("default.claude")),
+                (
+                    ConfigSeedTier::WorkspaceBase,
+                    workspace.join("default.claude")
+                ),
+                (
+                    ConfigSeedTier::MatrixProfile,
+                    matrix.join(format!("default_profile_{}.claude", letter))
+                ),
+                (ConfigSeedTier::MatrixBase, matrix.join("default.claude")),
             ]
         );
         assert_eq!(seed.dest, expected_replica.join(".claude"));

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -35,6 +35,10 @@ pub struct AgentSpawnCommand {
     pub profile_resolution: ProfileResolution,
     pub trusted_agent_id: String,
     pub trusted_agent_label: String,
+    /// #598 - resolved config-folder seed (pure path math; executed at the
+    /// session chokepoint, never here). `None` when the agent has no active seed
+    /// or the launch root is not an AC replica/root-agent.
+    pub seed: Option<crate::config::config_seed::ResolvedConfigSeed>,
 }
 
 pub fn normalize_legacy_agent_command(command: &str) -> Result<NormalizedAgentCommand, String> {
@@ -540,7 +544,8 @@ const OPENCODE_ARG_FORMS: [&str; 4] =
 /// the extension carries real signal here.
 ///
 /// Called BEFORE the `git_pull_before` wrap, so `shell` is the real command.
-fn command_runs_opencode(shell: &str, shell_args: &[String]) -> bool {
+/// `pub(crate)` so `config_seed::compute_config_dir_warning` can reuse it (#598).
+pub(crate) fn command_runs_opencode(shell: &str, shell_args: &[String]) -> bool {
     if executable_basename(shell) == "opencode" {
         return true;
     }
@@ -708,6 +713,10 @@ pub fn build_agent_spawn_command(
         log::warn!("[profiles] {}", warning);
     }
 
+    // #598 - active config-folder seed for this agent (resolved below, before the
+    // git_pull wrap). `is_active` = enabled AND non-empty dest.
+    let seed_choice = agent.config_seed.as_ref().filter(|c| c.is_active());
+
     let selected_command = if profile_resolution.cell.command.trim().is_empty() {
         agent.command.as_str()
     } else {
@@ -734,7 +743,12 @@ pub fn build_agent_spawn_command(
             .cell
             .env
             .values()
-            .any(|value| value_contains_ac_placeholder(value));
+            .any(|value| value_contains_ac_placeholder(value))
+        // #598: an active seed needs the placeholder context (for the dest, the
+        // tier candidates, and content substitution). The `launch_path.is_some()`
+        // guard keeps a configured seed from turning a no-path build (e.g.
+        // prevalidation) into a hard error at the `?` below.
+        || (seed_choice.is_some() && launch_path.is_some());
     let placeholder_context = if needs_placeholder_context {
         Some(
             launch_path
@@ -774,6 +788,45 @@ pub fn build_agent_spawn_command(
     let child_env =
         merge_env_layers(&[&agent_env, &profile_env, &computed_codex_home.generated_env]);
 
+    // #598 - resolve the config-folder seed BEFORE the git_pull wrap (L2) so the
+    // config-dir warning detects the real command (the wrap rewrites `shell` to
+    // `cmd.exe` and buries the real command in args). Pure path math plus a
+    // log-only warning string; NO filesystem is touched here. The destructive
+    // copy runs later at the single session chokepoint (create_session_inner).
+    let seed = match seed_choice {
+        Some(cfg) => {
+            let mut resolved = crate::config::config_seed::resolve_config_seed(
+                cfg,
+                &profile_resolution.effective_profile,
+                placeholder_context.as_ref(),
+            );
+            if let Some(r) = resolved.as_mut() {
+                r.config_dir_warning = crate::config::config_seed::compute_config_dir_warning(
+                    &r.dest,
+                    &shell,
+                    &shell_args,
+                    &agent_env,
+                    &profile_env,
+                    computed_codex_home.effective_codex_home.as_deref(),
+                );
+                // M1/M2: only a `.claude` dest can be re-stamped (the writers
+                // hardcode the `.claude` subdir); presence also holds the sweep
+                // lock around the seed + re-apply.
+                r.claude_settings_reapply =
+                    if r.dest.file_name().and_then(|n| n.to_str()) == Some(".claude") {
+                        Some(crate::config::config_seed::ClaudeSettingsReapply {
+                            apply_excludes: agent.exclude_global_claude_md,
+                            inject_rtk_hook: settings.inject_rtk_hook,
+                        })
+                    } else {
+                        None
+                    };
+            }
+            resolved
+        }
+        None => None,
+    };
+
     if agent.git_pull_before {
         let wrapped = wrap_git_pull_before(shell, shell_args)?;
         shell = wrapped.0;
@@ -792,6 +845,7 @@ pub fn build_agent_spawn_command(
         profile_resolution,
         trusted_agent_id: agent.id.clone(),
         trusted_agent_label: agent.label.clone(),
+        seed,
     })
 }
 
@@ -804,7 +858,8 @@ mod tests {
         resolve_target_filename, OpencodeConfigDirOutcome,
     };
     use crate::config::settings::{
-        AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ProfileCellConfig,
+        AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ConfigSeedConfig,
+        ProfileCellConfig,
     };
     use std::collections::BTreeMap;
 
@@ -923,6 +978,7 @@ mod tests {
             envs: Vec::new(),
             isolated_home: false,
             instructions_filename: None,
+            config_seed: None,
         }
     }
 
@@ -1790,5 +1846,173 @@ mod tests {
             std::path::Path::new(&expected_config).is_dir(),
             "build should have created the expanded OPENCODE_CONFIG_DIR at {expected_config}"
         );
+    }
+
+    // #598 - config-folder seed resolution wired into build_agent_spawn_command.
+
+    fn seed_replica(temp: &std::path::Path) -> std::path::PathBuf {
+        let replica = temp
+            .join(".ac")
+            .join("wg-7-dev-team")
+            .join("__agent_dev-rust");
+        std::fs::create_dir_all(&replica).unwrap();
+        replica
+    }
+
+    /// Mirror the builder's canonicalize + verbatim-prefix strip.
+    fn canonical_replica(replica: &std::path::Path) -> std::path::PathBuf {
+        let canonical = std::fs::canonicalize(replica).unwrap();
+        canonical
+            .to_string_lossy()
+            .strip_prefix(r"\\?\")
+            .map(std::path::PathBuf::from)
+            .unwrap_or(canonical)
+    }
+
+    #[test]
+    fn build_spawn_resolves_active_seed_for_replica_without_touching_fs() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = seed_replica(temp.path());
+
+        let mut claude = agent("claude", "claude");
+        claude.exclude_global_claude_md = true;
+        claude.config_seed = Some(ConfigSeedConfig {
+            enabled: true,
+            dest: ".claude".to_string(),
+        });
+        let mut settings = AppSettings {
+            agents: vec![claude],
+            ..AppSettings::default()
+        };
+        settings.inject_rtk_hook = true;
+
+        let spawn =
+            build_agent_spawn_command(&settings, "claude", Some(&replica), Some("A")).unwrap();
+        let seed = spawn.seed.expect("active seed resolves to Some");
+
+        let expected_replica = canonical_replica(&replica);
+        let workspace = expected_replica.parent().unwrap().parent().unwrap();
+        let matrix = workspace.join("_agent_dev-rust");
+        let letter = spawn.profile_resolution.effective_profile.to_ascii_lowercase();
+
+        use crate::config::config_seed::ConfigSeedTier;
+        assert_eq!(
+            seed.candidates,
+            vec![
+                (
+                    ConfigSeedTier::Profile,
+                    workspace.join(format!("default_profile_{}.claude", letter))
+                ),
+                (ConfigSeedTier::Matrix, matrix.join(".claude")),
+                (ConfigSeedTier::Base, workspace.join("default.claude")),
+            ]
+        );
+        assert_eq!(seed.dest, expected_replica.join(".claude"));
+        // Pure resolution: no template dirs were created.
+        assert!(!workspace.join("default.claude").exists());
+        // `.claude` dest -> reapply carries the agent + global flags.
+        let re = seed
+            .claude_settings_reapply
+            .expect("reapply present for .claude");
+        assert!(re.apply_excludes);
+        assert!(re.inject_rtk_hook);
+    }
+
+    #[test]
+    fn build_spawn_computes_seed_warning_before_git_pull_wrap() {
+        // L2 regression: on Windows the git_pull wrap rewrites shell -> cmd.exe,
+        // so a warning computed AFTER the wrap would misdetect to None. We compute
+        // it before, so a Claude agent with no CLAUDE_CONFIG_DIR gets the
+        // "not configured" warning even with git_pull_before on.
+        let temp = tempfile::tempdir().unwrap();
+        let replica = seed_replica(temp.path());
+
+        let mut claude = agent("claude", "claude");
+        claude.git_pull_before = true;
+        claude.config_seed = Some(ConfigSeedConfig {
+            enabled: true,
+            dest: ".claude".to_string(),
+        });
+        let settings = AppSettings {
+            agents: vec![claude],
+            ..AppSettings::default()
+        };
+
+        let spawn =
+            build_agent_spawn_command(&settings, "claude", Some(&replica), Some("A")).unwrap();
+        let warning = spawn
+            .seed
+            .expect("seed")
+            .config_dir_warning
+            .expect("warning computed on the unwrapped command");
+        assert!(warning.contains("CLAUDE_CONFIG_DIR"), "{warning}");
+    }
+
+    #[test]
+    fn build_spawn_seed_none_for_normal_cwd() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo-thing");
+        std::fs::create_dir_all(&repo).unwrap();
+
+        let mut claude = agent("claude", "claude");
+        claude.config_seed = Some(ConfigSeedConfig {
+            enabled: true,
+            dest: ".claude".to_string(),
+        });
+        let settings = AppSettings {
+            agents: vec![claude],
+            ..AppSettings::default()
+        };
+
+        let spawn = build_agent_spawn_command(&settings, "claude", Some(&repo), Some("A")).unwrap();
+        assert!(
+            spawn.seed.is_none(),
+            "a normal (non-replica) cwd must not seed"
+        );
+    }
+
+    #[test]
+    fn build_spawn_seed_reapply_none_for_non_claude_dest() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = seed_replica(temp.path());
+
+        let mut claude = agent("claude", "claude");
+        claude.config_seed = Some(ConfigSeedConfig {
+            enabled: true,
+            dest: ".claude-amp".to_string(),
+        });
+        let settings = AppSettings {
+            agents: vec![claude],
+            ..AppSettings::default()
+        };
+
+        let spawn =
+            build_agent_spawn_command(&settings, "claude", Some(&replica), Some("A")).unwrap();
+        let seed = spawn.seed.expect("seed");
+        assert_eq!(seed.dest.file_name().unwrap(), ".claude-amp");
+        assert!(
+            seed.claude_settings_reapply.is_none(),
+            "non-.claude dest must not trigger the .claude re-apply"
+        );
+    }
+
+    #[test]
+    fn build_spawn_seed_none_when_disabled() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = seed_replica(temp.path());
+
+        let mut claude = agent("claude", "claude");
+        claude.config_seed = Some(ConfigSeedConfig {
+            enabled: false,
+            dest: ".claude".to_string(),
+        });
+        let settings = AppSettings {
+            agents: vec![claude],
+            ..AppSettings::default()
+        };
+
+        let spawn =
+            build_agent_spawn_command(&settings, "claude", Some(&replica), Some("A")).unwrap();
+        assert!(spawn.seed.is_none(), "disabled seed must resolve to None");
     }
 }

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -809,18 +809,33 @@ pub fn build_agent_spawn_command(
                     &profile_env,
                     computed_codex_home.effective_codex_home.as_deref(),
                 );
-                // M1/M2: only a `.claude` dest can be re-stamped (the writers
-                // hardcode the `.claude` subdir); presence also holds the sweep
-                // lock around the seed + re-apply.
-                r.claude_settings_reapply =
-                    if r.dest.file_name().and_then(|n| n.to_str()) == Some(".claude") {
-                        Some(crate::config::config_seed::ClaudeSettingsReapply {
-                            apply_excludes: agent.exclude_global_claude_md,
-                            inject_rtk_hook: settings.inject_rtk_hook,
-                        })
-                    } else {
-                        None
-                    };
+                // M1: only a `.claude` dest can be re-stamped (the writers
+                // hardcode the `.claude` subdir). LOW-1 (grinch): on Windows a
+                // dest like `.Claude` clean-replaces the SAME physical `.claude`
+                // dir, so the re-apply must still fire or the rtk hook is
+                // silently dropped (Resource-Monitor child-tracking regression);
+                // Unix is case-sensitive, so `.Claude` is a different dir there
+                // and must NOT re-apply (the writers would target the wrong dir).
+                let dest_is_dot_claude = r
+                    .dest
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| {
+                        if cfg!(windows) {
+                            n.eq_ignore_ascii_case(".claude")
+                        } else {
+                            n == ".claude"
+                        }
+                    })
+                    .unwrap_or(false);
+                r.claude_settings_reapply = if dest_is_dot_claude {
+                    Some(crate::config::config_seed::ClaudeSettingsReapply {
+                        apply_excludes: agent.exclude_global_claude_md,
+                        inject_rtk_hook: settings.inject_rtk_hook,
+                    })
+                } else {
+                    None
+                };
             }
             resolved
         }
@@ -1994,6 +2009,40 @@ mod tests {
             seed.claude_settings_reapply.is_none(),
             "non-.claude dest must not trigger the .claude re-apply"
         );
+    }
+
+    #[test]
+    fn build_spawn_seed_reapply_is_case_insensitive_only_on_windows() {
+        // LOW-1 (grinch): a `.Claude` dest is the SAME physical dir as `.claude`
+        // on Windows (so re-apply must fire) but a DISTINCT dir on Unix (so it
+        // must not, or the writers would stamp the wrong directory).
+        let temp = tempfile::tempdir().unwrap();
+        let replica = seed_replica(temp.path());
+
+        let mut claude = agent("claude", "claude");
+        claude.config_seed = Some(ConfigSeedConfig {
+            enabled: true,
+            dest: ".Claude".to_string(),
+        });
+        let settings = AppSettings {
+            agents: vec![claude],
+            ..AppSettings::default()
+        };
+
+        let spawn =
+            build_agent_spawn_command(&settings, "claude", Some(&replica), Some("A")).unwrap();
+        let seed = spawn.seed.expect("seed");
+        if cfg!(windows) {
+            assert!(
+                seed.claude_settings_reapply.is_some(),
+                ".Claude must re-apply on Windows (same physical dir as .claude)"
+            );
+        } else {
+            assert!(
+                seed.claude_settings_reapply.is_none(),
+                ".Claude must NOT re-apply on Unix (distinct dir from .claude)"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/config/coding_agent_profiles.rs
+++ b/src-tauri/src/config/coding_agent_profiles.rs
@@ -757,6 +757,7 @@ mod tests {
             envs: Vec::new(),
             isolated_home: false,
             instructions_filename: None,
+            config_seed: None,
         }];
         settings
     }

--- a/src-tauri/src/config/config_seed.rs
+++ b/src-tauri/src/config/config_seed.rs
@@ -244,9 +244,29 @@ fn segments_eq(a: &str, b: &str) -> bool {
 pub fn perform_config_seed(seed: &ResolvedConfigSeed, unique_sfx: &str) -> ConfigSeedReport {
     // 1. Pick the winning tier by source-folder presence (highest precedence first).
     let Some((tier, src)) = seed.candidates.iter().find(|(_, src)| is_readable_dir(src)) else {
-        log::debug!(
-            "[config-seed] no template present for dest {}; skipping",
-            seed.dest.display()
+        // #598: seeding is active but no template exists at any tier. This is a
+        // benign no-op (nothing to copy), but a SILENT one confused users who
+        // enabled the feature, created no template, and saw nothing happen. Log
+        // it at info with the exact candidate paths so they know WHERE to create
+        // a template. Only fires here, at the real spawn chokepoint (callers gate
+        // on a resolved seed), never during prevalidation/delivery builds.
+        let replica_label = seed
+            .context
+            .replica_root
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?");
+        let looked_in = seed
+            .candidates
+            .iter()
+            .map(|(t, p)| format!("{:?}={}", t, p.display()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        log::info!(
+            "[config-seed] active for replica '{}' dest '{}' but no source template found at any tier; skipped (looked for: {})",
+            replica_label,
+            seed.dest.display(),
+            looked_in
         );
         return ConfigSeedReport::Skipped;
     };
@@ -328,10 +348,10 @@ pub fn perform_config_seed(seed: &ResolvedConfigSeed, unique_sfx: &str) -> Confi
         log::warn!("[config-seed] {}", w);
     }
     log::info!(
-        "[config-seed] seeded {} from {} (tier={:?})",
+        "[config-seed] seeded '{}' into replica from {:?} source '{}'",
         seed.dest.display(),
-        src.display(),
-        tier
+        tier,
+        src.display()
     );
     ConfigSeedReport::Seeded
 }

--- a/src-tauri/src/config/config_seed.rs
+++ b/src-tauri/src/config/config_seed.rs
@@ -1,0 +1,926 @@
+//! #598 - seed a template config folder (e.g. `.claude`) into a coding-agent
+//! replica at spawn time.
+//!
+//! Two phases:
+//! - [`resolve_config_seed`] is PURE path math (no filesystem) and fail-soft:
+//!   it never returns an error that aborts a launch (M7).
+//! - [`perform_config_seed`] is the side-effecting, best-effort, Windows-safe
+//!   rename-to-trash-first atomic swap (H1): the destination is always either
+//!   fully-old or fully-new, never half-written. It never aborts the spawn.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::config::placeholders::{
+    expand_placeholders_in_content, PlaceholderContext, PlaceholderRootKind,
+};
+use crate::config::settings::{validate_config_seed_dest, ConfigSeedConfig};
+use crate::session::profile::CodingAgentKind;
+
+/// Files at or below this size are read so the 3 AC tokens can be substituted in
+/// their CONTENT. Larger files are streamed via `std::fs::copy` (M4), never read
+/// whole into memory.
+const CONTENT_SUBSTITUTION_CAP: u64 = 5 * 1024 * 1024; // 5 MiB
+
+/// Recursion-depth bound for the template tree (M6). Defends against a
+/// pathological or cyclic-via-junction layout; junction/symlink entries are
+/// already skipped, so this is a belt-and-braces safety net.
+const MAX_SEED_DEPTH: u32 = 64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigSeedTier {
+    Profile,
+    Matrix,
+    Base,
+}
+
+/// After a successful seed of `.claude`, re-stamp the AC-managed
+/// `.claude/settings.local.json` (M1). Presence ALSO signals "hold the sweep
+/// lock around the seed + re-apply" (M2). `None` for any non-`.claude` dest,
+/// because `ensure_claude_md_excludes`/`ensure_rtk_pretool_hook` hardcode the
+/// `.claude` subdir (the `.claude-amp` limitation is documented in the plan §8.2,
+/// follow-up F4).
+#[derive(Debug, Clone)]
+pub struct ClaudeSettingsReapply {
+    /// `agent.exclude_global_claude_md`.
+    pub apply_excludes: bool,
+    /// Global `inject_rtk_hook` toggle, sampled at build time.
+    pub inject_rtk_hook: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedConfigSeed {
+    /// Candidate source folders, highest precedence first (Profile, Matrix,
+    /// Base). Pure path math; no filesystem touched at resolve time.
+    pub candidates: Vec<(ConfigSeedTier, PathBuf)>,
+    /// Absolute destination, under the replica root.
+    pub dest: PathBuf,
+    /// Carried for CONTENT substitution at copy time.
+    pub context: PlaceholderContext,
+    /// Heuristic, log-only warning about a dest vs config-dir-env mismatch
+    /// (computed before the git_pull wrap; emitted once at execution).
+    pub config_dir_warning: Option<String>,
+    /// Set only when dest is `.claude` (drives the M1 re-apply + M2 lock).
+    pub claude_settings_reapply: Option<ClaudeSettingsReapply>,
+}
+
+/// Outcome of [`perform_config_seed`]. Returned for testing and to gate the
+/// post-seed `.claude` re-apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigSeedReport {
+    Seeded,
+    Skipped,
+    Failed,
+}
+
+/// Resolve the seed candidates + destination. Returns `None` (and warns/debug-
+/// logs) on any problem; NEVER returns an error that aborts the launch (M7).
+pub fn resolve_config_seed(
+    cfg: &ConfigSeedConfig,
+    effective_letter: &str,
+    context: Option<&PlaceholderContext>,
+) -> Option<ResolvedConfigSeed> {
+    let context = context?;
+    if context.root_kind != PlaceholderRootKind::AcReplicaOrRootAgent {
+        log::debug!("[config-seed] launch root is not an AC replica/root-agent; skipping seed");
+        return None;
+    }
+    let dest_name = cfg.dest.trim();
+    if let Err(e) = validate_config_seed_dest(dest_name) {
+        // M7: a settings.json that bypassed save-time validation can still carry
+        // a bad dest. Fail soft rather than abort the launch.
+        log::warn!(
+            "[config-seed] invalid dest '{}', skipping seed: {}",
+            cfg.dest,
+            e
+        );
+        return None;
+    }
+    // The user's example uses a lowercase profile letter; effective_profile is UPPERCASE.
+    let letter = effective_letter.to_ascii_lowercase();
+
+    let mut candidates: Vec<(ConfigSeedTier, PathBuf)> = Vec::new();
+    if let Some(ws) = context.workspace_root.as_ref() {
+        candidates.push((
+            ConfigSeedTier::Profile,
+            ws.join(format!("default_profile_{}{}", letter, dest_name)),
+        ));
+    }
+    if let Some(mx) = context.matrix_root.as_ref() {
+        candidates.push((ConfigSeedTier::Matrix, mx.join(dest_name)));
+    }
+    if let Some(ws) = context.workspace_root.as_ref() {
+        candidates.push((
+            ConfigSeedTier::Base,
+            ws.join(format!("default{}", dest_name)),
+        ));
+    }
+    if candidates.is_empty() {
+        return None;
+    }
+
+    Some(ResolvedConfigSeed {
+        candidates,
+        dest: context.replica_root.join(dest_name),
+        context: context.clone(),
+        config_dir_warning: None,
+        claude_settings_reapply: None,
+    })
+}
+
+/// Heuristic, log-only warning when the seed dest does not line up with the
+/// coding agent's configured config-dir env (so the tool would read its config
+/// from elsewhere), OR when it EXACTLY matches it (L1: the seed overwrites the
+/// tool's ACTIVE config dir every spawn). Never blocks; may warn spuriously if a
+/// config-dir env is injected by a path this does not inspect.
+///
+/// Called BEFORE the `git_pull_before` wrap so `shell`/`shell_args` are still the
+/// real command (the wrap rewrites them to `cmd.exe /K ...`).
+pub fn compute_config_dir_warning(
+    dest: &Path,
+    shell: &str,
+    shell_args: &[String],
+    agent_env: &BTreeMap<String, String>,
+    profile_env: &BTreeMap<String, String>,
+    effective_codex_home: Option<&Path>,
+) -> Option<String> {
+    let key = match CodingAgentKind::detect(shell, shell_args) {
+        Some(CodingAgentKind::Claude) => "CLAUDE_CONFIG_DIR",
+        Some(CodingAgentKind::Codex) => "CODEX_HOME",
+        // Gemini has no AC-managed config-dir env to compare against.
+        Some(CodingAgentKind::Gemini) => return None,
+        None => {
+            if crate::config::agent_command::command_runs_opencode(shell, shell_args) {
+                "OPENCODE_CONFIG_DIR"
+            } else {
+                return None;
+            }
+        }
+    };
+
+    let dest_seg = dest.file_name().and_then(|s| s.to_str())?;
+
+    // CODEX_HOME already went through the full resolver (isolation/profile/agent/
+    // inherited); prefer its resolved value. Others: profile over agent layer.
+    let configured: Option<String> = if key == "CODEX_HOME" {
+        effective_codex_home
+            .map(|p| p.to_string_lossy().to_string())
+            .or_else(|| lookup_env_ci(profile_env, agent_env, key).cloned())
+    } else {
+        lookup_env_ci(profile_env, agent_env, key).cloned()
+    };
+
+    match configured {
+        Some(value) => {
+            let matches = final_segment(&value)
+                .as_deref()
+                .map(|seg| segments_eq(seg, dest_seg))
+                .unwrap_or(false);
+            if matches {
+                // L1 case 2: seed overwrites the tool's ACTIVE config dir.
+                Some(format!(
+                    "config seed destination '{}' is the tool's active {}='{}'; it is overwritten on every spawn, so any credentials or session state living there are reset each launch (ensure the template is self-sufficient)",
+                    dest_seg, key, value
+                ))
+            } else {
+                // Case 1: dest does not match the configured config-dir env.
+                Some(format!(
+                    "config seed destination '{}' does not match {}='{}'; the tool will read its config from there, not the seeded folder",
+                    dest_seg, key, value
+                ))
+            }
+        }
+        // Case 1 (unset but expected for this tool).
+        None => Some(format!(
+            "config seed destination '{}' is set but {} is not configured; the tool may ignore the seeded folder",
+            dest_seg, key
+        )),
+    }
+}
+
+/// Case-insensitive env lookup (Windows env keys are case-insensitive, and the
+/// stored key casing is user-controlled), profile layer over agent layer. The
+/// plan's illustrative `.get(key)` would miss a lowercase-keyed value; this
+/// mirrors `agent_command::find_env_value`.
+fn lookup_env_ci<'a>(
+    profile_env: &'a BTreeMap<String, String>,
+    agent_env: &'a BTreeMap<String, String>,
+    key: &str,
+) -> Option<&'a String> {
+    let want = key.to_ascii_uppercase();
+    profile_env
+        .iter()
+        .find(|(k, _)| k.to_ascii_uppercase() == want)
+        .or_else(|| agent_env.iter().find(|(k, _)| k.to_ascii_uppercase() == want))
+        .map(|(_, v)| v)
+}
+
+/// Final path segment of a configured value, trailing separators trimmed.
+fn final_segment(value: &str) -> Option<String> {
+    let trimmed = value.trim_end_matches(['/', '\\']);
+    Path::new(trimmed)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+}
+
+fn segments_eq(a: &str, b: &str) -> bool {
+    if cfg!(windows) {
+        a.eq_ignore_ascii_case(b)
+    } else {
+        a == b
+    }
+}
+
+/// Best-effort, Windows-safe seed execution (H1). NEVER aborts the spawn.
+/// `unique_sfx` (the session id) keeps the temp/trash leaves unique per spawn
+/// (M3) and short (I2/MAX_PATH).
+pub fn perform_config_seed(seed: &ResolvedConfigSeed, unique_sfx: &str) -> ConfigSeedReport {
+    // 1. Pick the winning tier by source-folder presence (highest precedence first).
+    let Some((tier, src)) = seed.candidates.iter().find(|(_, src)| is_readable_dir(src)) else {
+        log::debug!(
+            "[config-seed] no template present for dest {}; skipping",
+            seed.dest.display()
+        );
+        return ConfigSeedReport::Skipped;
+    };
+
+    let (Some(parent), Some(dest_name)) = (
+        seed.dest.parent(),
+        seed.dest.file_name().and_then(|s| s.to_str()),
+    ) else {
+        log::warn!(
+            "[config-seed] dest {} has no parent/name; skipping",
+            seed.dest.display()
+        );
+        return ConfigSeedReport::Skipped;
+    };
+
+    // M3: unique per spawn. Same-volume siblings of dest, so renames are atomic.
+    let temp = parent.join(format!("{}.acseed-tmp-{}", dest_name, unique_sfx));
+    let trash = parent.join(format!("{}.acseed-old-{}", dest_name, unique_sfx));
+
+    // 2. Reclaim ALL stale seed scratch for this dest (any session id), not just
+    //    this spawn's. A trash dir whose removal failed earlier (locked by a
+    //    lingering handle) carries a DIFFERENT session id, so a per-suffix
+    //    cleanup would leak it forever; sweep by prefix so it is reclaimed on the
+    //    first run after the lock releases.
+    clear_stale_seed_scratch(parent, dest_name);
+
+    // 3. Stage the template into temp. On any error the dest is untouched.
+    if let Err(e) = copy_tree(src, &temp, 0, &seed.context) {
+        log::warn!(
+            "[config-seed] failed to stage template {} -> {}: {}",
+            src.display(),
+            temp.display(),
+            e
+        );
+        let _ = std::fs::remove_dir_all(&temp);
+        return ConfigSeedReport::Failed;
+    }
+
+    // 4. Move the existing dest aside (atomic). If it is locked by a live
+    //    process, keep the existing config and SKIP (dest stays fully intact).
+    if seed.dest.exists() {
+        if let Err(e) = std::fs::rename(&seed.dest, &trash) {
+            log::warn!(
+                "[config-seed] dest {} is in use ({}); keeping existing config, skipping this seed",
+                seed.dest.display(),
+                e
+            );
+            let _ = std::fs::remove_dir_all(&temp);
+            return ConfigSeedReport::Skipped;
+        }
+    }
+
+    // 5. Install the freshly staged temp (atomic).
+    if let Err(e) = std::fs::rename(&temp, &seed.dest) {
+        log::warn!(
+            "[config-seed] failed to install seed at {}: {}",
+            seed.dest.display(),
+            e
+        );
+        // Restore the old config if we moved it aside and the dest is now gone.
+        if !seed.dest.exists() && trash.exists() {
+            if let Err(re) = std::fs::rename(&trash, &seed.dest) {
+                log::warn!(
+                    "[config-seed] failed to restore previous config at {}: {}",
+                    seed.dest.display(),
+                    re
+                );
+            }
+        }
+        let _ = std::fs::remove_dir_all(&temp);
+        return ConfigSeedReport::Failed;
+    }
+
+    // 6. Drop the old config (ignore if locked; it lingers, cleared next run).
+    let _ = std::fs::remove_dir_all(&trash);
+
+    // 7. Emit the deferred config-dir warning + the success line.
+    if let Some(w) = &seed.config_dir_warning {
+        log::warn!("[config-seed] {}", w);
+    }
+    log::info!(
+        "[config-seed] seeded {} from {} (tier={:?})",
+        seed.dest.display(),
+        src.display(),
+        tier
+    );
+    ConfigSeedReport::Seeded
+}
+
+/// True iff `path` is a readable directory. Follows symlinks on the ROOT (the
+/// template folder itself may be a real or symlinked dir); only ENTRIES are
+/// filtered for reparse points during the copy (see [`is_symlink_or_reparse`]).
+fn is_readable_dir(path: &Path) -> bool {
+    std::fs::metadata(path).map(|m| m.is_dir()).unwrap_or(false)
+}
+
+/// Remove every leftover seed-scratch sibling for `dest_name` (any session-id
+/// suffix), best-effort. Reclaims a temp/trash dir leaked by an earlier locked
+/// removal; the current spawn's `temp`/`trash` (same prefix) are cleared too.
+fn clear_stale_seed_scratch(parent: &Path, dest_name: &str) {
+    let tmp_prefix = format!("{}.acseed-tmp-", dest_name);
+    let old_prefix = format!("{}.acseed-old-", dest_name);
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if let Some(name) = entry.file_name().to_str() {
+            if name.starts_with(&tmp_prefix) || name.starts_with(&old_prefix) {
+                let _ = std::fs::remove_dir_all(entry.path());
+            }
+        }
+    }
+}
+
+fn copy_tree(
+    src_dir: &Path,
+    dst_dir: &Path,
+    depth: u32,
+    ctx: &PlaceholderContext,
+) -> Result<(), String> {
+    if depth > MAX_SEED_DEPTH {
+        log::warn!(
+            "[config-seed] template tree deeper than {} levels at {}; truncating",
+            MAX_SEED_DEPTH,
+            src_dir.display()
+        );
+        return Ok(());
+    }
+    std::fs::create_dir_all(dst_dir).map_err(|e| format!("create {}: {}", dst_dir.display(), e))?;
+    let entries =
+        std::fs::read_dir(src_dir).map_err(|e| format!("read {}: {}", src_dir.display(), e))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("read entry in {}: {}", src_dir.display(), e))?;
+        // M6/I3: skip symlinks AND Windows junctions/reparse points (warn, not debug).
+        if is_symlink_or_reparse(&entry) {
+            log::warn!(
+                "[config-seed] skipping symlink/reparse entry {}",
+                entry.path().display()
+            );
+            continue;
+        }
+        let ft = entry
+            .file_type()
+            .map_err(|e| format!("file type of {}: {}", entry.path().display(), e))?;
+        let dst = dst_dir.join(entry.file_name());
+        if ft.is_dir() {
+            copy_tree(&entry.path(), &dst, depth + 1, ctx)?;
+        } else if ft.is_file() {
+            copy_file_substituted(&entry.path(), &dst, ctx)?;
+        }
+        // Anything else (already-filtered symlinks/reparse) is ignored.
+    }
+    Ok(())
+}
+
+fn copy_file_substituted(src: &Path, dst: &Path, ctx: &PlaceholderContext) -> Result<(), String> {
+    let len = std::fs::metadata(src)
+        .map_err(|e| format!("stat {}: {}", src.display(), e))?
+        .len();
+    // M4: over-cap files are streamed, never read whole into memory.
+    if len > CONTENT_SUBSTITUTION_CAP {
+        std::fs::copy(src, dst)
+            .map_err(|e| format!("copy {} -> {}: {}", src.display(), dst.display(), e))?;
+        return Ok(());
+    }
+    let bytes = std::fs::read(src).map_err(|e| format!("read {}: {}", src.display(), e))?;
+    // Binary sniff: a NUL in the leading window means "copy verbatim".
+    let probe = bytes.len().min(8192);
+    if bytes[..probe].contains(&0u8) {
+        return std::fs::write(dst, &bytes).map_err(|e| format!("write {}: {}", dst.display(), e));
+    }
+    match std::str::from_utf8(&bytes) {
+        // CRLF and a UTF-8 BOM survive (only known token substrings are swapped).
+        Ok(text) => std::fs::write(dst, expand_placeholders_in_content(text, ctx).as_bytes())
+            .map_err(|e| format!("write {}: {}", dst.display(), e)),
+        // Non-UTF-8 (no NUL): copy verbatim.
+        Err(_) => std::fs::write(dst, &bytes).map_err(|e| format!("write {}: {}", dst.display(), e)),
+    }
+}
+
+/// True for a symlink OR a Windows junction/reparse point. `is_symlink()` alone
+/// is FALSE for junctions, so the reparse-attribute check is required (M6).
+/// `DirEntry::metadata` does NOT traverse, so the junction's own attributes are
+/// observed. An undeterminable file type is treated as skip-worthy.
+fn is_symlink_or_reparse(entry: &std::fs::DirEntry) -> bool {
+    match entry.file_type() {
+        Ok(ft) if ft.is_symlink() => return true,
+        Ok(_) => {}
+        Err(_) => return true,
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0400;
+        if let Ok(md) = entry.metadata() {
+            if md.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx_with(
+        replica: &Path,
+        workspace: Option<&Path>,
+        matrix: Option<&Path>,
+    ) -> PlaceholderContext {
+        PlaceholderContext {
+            replica_root: replica.to_path_buf(),
+            root_kind: PlaceholderRootKind::AcReplicaOrRootAgent,
+            workspace_root: workspace.map(|p| p.to_path_buf()),
+            matrix_root: matrix.map(|p| p.to_path_buf()),
+        }
+    }
+
+    fn seed_cfg(dest: &str) -> ConfigSeedConfig {
+        ConfigSeedConfig {
+            enabled: true,
+            dest: dest.to_string(),
+        }
+    }
+
+    fn write_file(path: &Path, content: &[u8]) {
+        if let Some(p) = path.parent() {
+            std::fs::create_dir_all(p).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn abs(win: &str, unix: &str) -> PathBuf {
+        PathBuf::from(if cfg!(windows) { win } else { unix })
+    }
+
+    // ---- resolve_config_seed (pure path math, fail-soft) -------------------
+
+    #[test]
+    fn resolve_orders_profile_matrix_base_with_lowercased_letter() {
+        let workspace = abs(r"C:\ws", "/ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        let matrix = workspace.join("_agent_x");
+        let ctx = ctx_with(&replica, Some(&workspace), Some(&matrix));
+
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "C", Some(&ctx)).expect("some");
+        assert_eq!(resolved.candidates.len(), 3);
+        assert_eq!(resolved.candidates[0].0, ConfigSeedTier::Profile);
+        assert_eq!(
+            resolved.candidates[0].1,
+            workspace.join("default_profile_c.claude")
+        );
+        assert_eq!(resolved.candidates[1].0, ConfigSeedTier::Matrix);
+        assert_eq!(resolved.candidates[1].1, matrix.join(".claude"));
+        assert_eq!(resolved.candidates[2].0, ConfigSeedTier::Base);
+        assert_eq!(resolved.candidates[2].1, workspace.join("default.claude"));
+        assert_eq!(resolved.dest, replica.join(".claude"));
+    }
+
+    #[test]
+    fn resolve_omits_matrix_when_absent() {
+        let workspace = abs(r"C:\ws", "/ws");
+        let replica = workspace.join("ac-root-agent");
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).expect("some");
+        let tiers: Vec<_> = resolved.candidates.iter().map(|(t, _)| *t).collect();
+        assert_eq!(tiers, vec![ConfigSeedTier::Profile, ConfigSeedTier::Base]);
+    }
+
+    #[test]
+    fn resolve_is_none_for_non_replica_root() {
+        let ctx = PlaceholderContext {
+            replica_root: abs(r"C:\cwd", "/cwd"),
+            root_kind: PlaceholderRootKind::NormalLaunchCwd,
+            workspace_root: Some(abs(r"C:\ws", "/ws")),
+            matrix_root: None,
+        };
+        assert!(resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).is_none());
+    }
+
+    #[test]
+    fn resolve_is_none_for_bad_dest_failsoft() {
+        let workspace = abs(r"C:\ws", "/ws");
+        let replica = workspace.join("wg-1").join("__agent_x");
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        // A dest that bypassed save validation must fail soft (None), not abort.
+        assert!(resolve_config_seed(&seed_cfg("../escape"), "A", Some(&ctx)).is_none());
+        assert!(resolve_config_seed(&seed_cfg("a/b"), "A", Some(&ctx)).is_none());
+    }
+
+    #[test]
+    fn resolve_is_none_without_context() {
+        assert!(resolve_config_seed(&seed_cfg(".claude"), "A", None).is_none());
+    }
+
+    // ---- perform_config_seed (trash-first atomic swap) ---------------------
+
+    #[test]
+    fn perform_seeds_from_highest_present_tier_and_clean_replaces_dest() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        // Base AND Profile templates both present; Profile must win.
+        write_file(&workspace.join("default.claude").join("f.txt"), b"BASE");
+        write_file(
+            &workspace.join("default_profile_c.claude").join("f.txt"),
+            b"PROFILE",
+        );
+        // Pre-existing dest content that must be cleanly replaced.
+        write_file(&replica.join(".claude").join("stale.txt"), b"OLD");
+
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "C", Some(&ctx)).unwrap();
+        assert_eq!(
+            perform_config_seed(&resolved, "sfx1"),
+            ConfigSeedReport::Seeded
+        );
+
+        assert_eq!(
+            std::fs::read(replica.join(".claude").join("f.txt")).unwrap(),
+            b"PROFILE"
+        );
+        // Clean replace: the prior file is gone.
+        assert!(!replica.join(".claude").join("stale.txt").exists());
+        // No temp/trash residue.
+        assert!(!replica.join(".claude.acseed-tmp-sfx1").exists());
+        assert!(!replica.join(".claude.acseed-old-sfx1").exists());
+    }
+
+    #[test]
+    fn perform_skips_and_preserves_dest_when_no_template_present() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        write_file(&replica.join(".claude").join("keep.txt"), b"KEEP");
+
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).unwrap();
+        assert_eq!(perform_config_seed(&resolved, "s"), ConfigSeedReport::Skipped);
+        // Dest fully intact.
+        assert_eq!(
+            std::fs::read(replica.join(".claude").join("keep.txt")).unwrap(),
+            b"KEEP"
+        );
+    }
+
+    #[test]
+    fn perform_failed_copy_leaves_dest_intact() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        write_file(&workspace.join("default.claude").join("f.txt"), b"NEW");
+        write_file(&replica.join(".claude").join("keep.txt"), b"OLD");
+        // Fault injection: a FILE where the temp DIR would be created makes
+        // copy_tree's create_dir_all fail, so the swap never touches dest.
+        write_file(&replica.join(".claude.acseed-tmp-sfx"), b"blocker");
+
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).unwrap();
+        assert_eq!(
+            perform_config_seed(&resolved, "sfx"),
+            ConfigSeedReport::Failed
+        );
+        // Dest fully intact (old content kept).
+        assert_eq!(
+            std::fs::read(replica.join(".claude").join("keep.txt")).unwrap(),
+            b"OLD"
+        );
+    }
+
+    /// H1 "dest in use" branch: when the existing dest is locked by a live
+    /// process, the dest->trash rename fails and the seed is SKIPPED with the
+    /// existing config kept fully intact. Windows-specific (Unix renames a
+    /// directory even with open handles inside it), which is the whole reason H1
+    /// exists: the prior process still holding handles in `.claude`.
+    #[cfg(windows)]
+    #[test]
+    fn perform_skips_and_preserves_dest_when_dest_is_locked() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        write_file(&workspace.join("default.claude").join("f.txt"), b"NEW");
+        write_file(&replica.join(".claude").join("keep.txt"), b"OLD");
+
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).unwrap();
+
+        // Hold an open handle to a file inside dest: Windows then refuses to
+        // rename the dest directory (File::open grants no FILE_SHARE_DELETE),
+        // forcing the dest->trash rename to fail -> skip, dest untouched.
+        let locked = std::fs::File::open(replica.join(".claude").join("keep.txt")).unwrap();
+        let report = perform_config_seed(&resolved, "sfx");
+        drop(locked);
+
+        assert_eq!(report, ConfigSeedReport::Skipped);
+        // Existing config fully intact.
+        assert_eq!(
+            std::fs::read(replica.join(".claude").join("keep.txt")).unwrap(),
+            b"OLD"
+        );
+        // Staged temp was cleaned up.
+        assert!(!replica.join(".claude.acseed-tmp-sfx").exists());
+    }
+
+    #[test]
+    fn perform_clears_stale_temp_and_trash_from_prior_run() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        write_file(&workspace.join("default.claude").join("f.txt"), b"NEW");
+        // Stale dirs from a crashed prior run.
+        write_file(
+            &replica.join(".claude.acseed-tmp-sfx").join("junk.txt"),
+            b"stale",
+        );
+        write_file(
+            &replica.join(".claude.acseed-old-sfx").join("junk.txt"),
+            b"stale",
+        );
+
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).unwrap();
+        assert_eq!(
+            perform_config_seed(&resolved, "sfx"),
+            ConfigSeedReport::Seeded
+        );
+        assert_eq!(
+            std::fs::read(replica.join(".claude").join("f.txt")).unwrap(),
+            b"NEW"
+        );
+        assert!(!replica.join(".claude.acseed-tmp-sfx").exists());
+        assert!(!replica.join(".claude.acseed-old-sfx").exists());
+    }
+
+    #[test]
+    fn perform_reclaims_leaked_scratch_from_other_session_ids() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        write_file(&workspace.join("default.claude").join("f.txt"), b"NEW");
+        // Scratch leaked by a prior run whose removal was locked — note the
+        // DIFFERENT session id. A per-suffix cleanup would never reclaim these.
+        write_file(
+            &replica.join(".claude.acseed-old-OLDID").join("junk.txt"),
+            b"stale",
+        );
+        write_file(
+            &replica.join(".claude.acseed-tmp-OLDID").join("junk.txt"),
+            b"stale",
+        );
+
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).unwrap();
+        assert_eq!(
+            perform_config_seed(&resolved, "NEWID"),
+            ConfigSeedReport::Seeded
+        );
+        assert!(!replica.join(".claude.acseed-old-OLDID").exists());
+        assert!(!replica.join(".claude.acseed-tmp-OLDID").exists());
+    }
+
+    // ---- copy_file_substituted (size-first, binary/UTF-8) ------------------
+
+    #[test]
+    fn copy_file_substitutes_utf8_tokens_forward_slashed() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = abs(r"C:\replica\root", "/replica/root");
+        let ctx = ctx_with(&replica, Some(&abs(r"C:\ws", "/ws")), None);
+
+        let src = temp.path().join("a.txt");
+        std::fs::write(&src, b"path=%AC_REPLICA_ROOT%/x").unwrap();
+        let dst = temp.path().join("a.out");
+        copy_file_substituted(&src, &dst, &ctx).unwrap();
+
+        let expected = replica.to_string_lossy().replace('\\', "/");
+        assert_eq!(
+            std::fs::read_to_string(&dst).unwrap(),
+            format!("path={}/x", expected)
+        );
+    }
+
+    #[test]
+    fn copy_file_preserves_binary_verbatim() {
+        let temp = tempfile::tempdir().unwrap();
+        let ctx = ctx_with(&abs(r"C:\r", "/r"), Some(&abs(r"C:\ws", "/ws")), None);
+
+        let src = temp.path().join("b.bin");
+        let raw: &[u8] = b"%AC_REPLICA_ROOT%\x00binary";
+        std::fs::write(&src, raw).unwrap();
+        let dst = temp.path().join("b.out");
+        copy_file_substituted(&src, &dst, &ctx).unwrap();
+        // NUL present -> verbatim, no token substitution.
+        assert_eq!(std::fs::read(&dst).unwrap(), raw);
+    }
+
+    #[test]
+    fn copy_file_preserves_non_utf8_without_nul_verbatim() {
+        let temp = tempfile::tempdir().unwrap();
+        let ctx = ctx_with(&abs(r"C:\r", "/r"), Some(&abs(r"C:\ws", "/ws")), None);
+
+        let src = temp.path().join("c.dat");
+        let raw: &[u8] = &[0xFF, 0xFE, b'h', b'i'];
+        std::fs::write(&src, raw).unwrap();
+        let dst = temp.path().join("c.out");
+        copy_file_substituted(&src, &dst, &ctx).unwrap();
+        assert_eq!(std::fs::read(&dst).unwrap(), raw);
+    }
+
+    #[test]
+    fn copy_file_over_cap_is_streamed_without_substitution() {
+        let temp = tempfile::tempdir().unwrap();
+        let ctx = ctx_with(&abs(r"C:\r", "/r"), Some(&abs(r"C:\ws", "/ws")), None);
+
+        let src = temp.path().join("big.txt");
+        let mut content = vec![b'a'; (CONTENT_SUBSTITUTION_CAP as usize) + 16];
+        content[..18].copy_from_slice(b"%AC_REPLICA_ROOT%\n");
+        std::fs::write(&src, &content).unwrap();
+        let dst = temp.path().join("big.out");
+        copy_file_substituted(&src, &dst, &ctx).unwrap();
+
+        let out = std::fs::read(&dst).unwrap();
+        assert_eq!(out.len(), content.len());
+        // Streamed verbatim: token NOT substituted.
+        assert!(out.starts_with(b"%AC_REPLICA_ROOT%"));
+    }
+
+    // ---- copy_tree (reparse skip + depth bound) ----------------------------
+
+    #[test]
+    fn copy_tree_truncates_beyond_max_depth() {
+        let temp = tempfile::tempdir().unwrap();
+        let src = temp.path().join("src");
+        write_file(&src.join("f.txt"), b"x");
+        let dst = temp.path().join("dst");
+        let ctx = ctx_with(&abs(r"C:\r", "/r"), Some(&abs(r"C:\ws", "/ws")), None);
+        // Start already over the bound -> immediate Ok, nothing created.
+        copy_tree(&src, &dst, MAX_SEED_DEPTH + 1, &ctx).unwrap();
+        assert!(!dst.exists(), "over-depth call must not create the dst tree");
+    }
+
+    #[test]
+    fn copy_tree_skips_symlink_and_junction_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let src = temp.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        write_file(&src.join("real.txt"), b"real");
+        let target = temp.path().join("target");
+        write_file(&target.join("inside.txt"), b"x");
+
+        let link = src.join("linked");
+        let created;
+        #[cfg(unix)]
+        {
+            created = std::os::unix::fs::symlink(&target, &link).is_ok();
+        }
+        #[cfg(windows)]
+        {
+            let mut cmd = std::process::Command::new("cmd");
+            crate::pty::credentials::scrub_credentials_from_std_command(&mut cmd);
+            let status = cmd
+                .args([
+                    "/C",
+                    "mklink",
+                    "/J",
+                    link.to_str().unwrap(),
+                    target.to_str().unwrap(),
+                ])
+                .status();
+            created = matches!(status, Ok(s) if s.success());
+        }
+        if !created {
+            return; // environment cannot create links — skip gracefully.
+        }
+
+        let dst = temp.path().join("dst");
+        let ctx = ctx_with(&abs(r"C:\r", "/r"), Some(&abs(r"C:\ws", "/ws")), None);
+        copy_tree(&src, &dst, 0, &ctx).unwrap();
+        assert!(dst.join("real.txt").exists(), "real file must be copied");
+        assert!(
+            !dst.join("linked").exists(),
+            "symlink/junction entry must be skipped"
+        );
+    }
+
+    // ---- compute_config_dir_warning (two cases) ----------------------------
+
+    #[test]
+    fn warning_mismatch_when_config_dir_env_differs() {
+        let dest = abs(r"C:\replica\.claude", "/replica/.claude");
+        let mut profile_env = BTreeMap::new();
+        profile_env.insert(
+            "CLAUDE_CONFIG_DIR".to_string(),
+            abs(r"C:\replica\.claude-amp", "/replica/.claude-amp")
+                .to_string_lossy()
+                .to_string(),
+        );
+        let w = compute_config_dir_warning(
+            &dest,
+            "claude",
+            &[],
+            &BTreeMap::new(),
+            &profile_env,
+            None,
+        )
+        .expect("warning");
+        assert!(w.contains("does not match"), "{w}");
+    }
+
+    #[test]
+    fn warning_overwrite_when_dest_equals_active_config_dir() {
+        let dest = abs(r"C:\replica\.claude", "/replica/.claude");
+        let mut env = BTreeMap::new();
+        // Different parent, same final segment -> "equal active dir" case.
+        env.insert(
+            "CLAUDE_CONFIG_DIR".to_string(),
+            abs(r"C:\other\.claude", "/other/.claude")
+                .to_string_lossy()
+                .to_string(),
+        );
+        let w = compute_config_dir_warning(&dest, "claude", &[], &BTreeMap::new(), &env, None)
+            .expect("warning");
+        assert!(w.contains("active") && w.contains("overwritten"), "{w}");
+    }
+
+    #[test]
+    fn warning_unset_when_no_config_dir_env() {
+        let dest = abs(r"C:\replica\.claude", "/replica/.claude");
+        let w = compute_config_dir_warning(
+            &dest,
+            "claude",
+            &[],
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            None,
+        )
+        .expect("warning");
+        assert!(w.contains("not configured"), "{w}");
+    }
+
+    #[test]
+    fn warning_uses_effective_codex_home_for_codex() {
+        let dest = abs(r"C:\replica\.codex", "/replica/.codex");
+        let eff = abs(r"C:\replica\.codex", "/replica/.codex");
+        let w = compute_config_dir_warning(
+            &dest,
+            "codex",
+            &[],
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            Some(&eff),
+        )
+        .expect("warning");
+        assert!(w.contains("active"), "{w}");
+    }
+
+    #[test]
+    fn warning_none_for_non_config_dir_agent() {
+        let dest = abs(r"C:\replica\.gemini", "/replica/.gemini");
+        // Gemini has no managed config-dir env; a custom command also yields None.
+        assert!(
+            compute_config_dir_warning(&dest, "gemini", &[], &BTreeMap::new(), &BTreeMap::new(), None)
+                .is_none()
+        );
+        assert!(compute_config_dir_warning(
+            &dest,
+            "my-custom-agent",
+            &[],
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            None
+        )
+        .is_none());
+    }
+}

--- a/src-tauri/src/config/config_seed.rs
+++ b/src-tauri/src/config/config_seed.rs
@@ -27,11 +27,18 @@ const CONTENT_SUBSTITUTION_CAP: u64 = 5 * 1024 * 1024; // 5 MiB
 /// already skipped, so this is a belt-and-braces safety net.
 const MAX_SEED_DEPTH: u32 = 64;
 
+/// Source tiers, highest precedence first. All workspace tiers outrank all
+/// matrix tiers; within a location the profile-lettered folder outranks the
+/// base folder. The matrix's bare `<dest>` (e.g. `_agent_<role>/.claude`) is
+/// deliberately NOT a tier: that is the agent's OWN live config (the matrix dir
+/// is itself a launch root), not a template, so seeding from it would copy real
+/// config and clobber it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigSeedTier {
-    Profile,
-    Matrix,
-    Base,
+    WorkspaceProfile,
+    WorkspaceBase,
+    MatrixProfile,
+    MatrixBase,
 }
 
 /// After a successful seed of `.claude`, re-stamp the AC-managed
@@ -50,8 +57,9 @@ pub struct ClaudeSettingsReapply {
 
 #[derive(Debug, Clone)]
 pub struct ResolvedConfigSeed {
-    /// Candidate source folders, highest precedence first (Profile, Matrix,
-    /// Base). Pure path math; no filesystem touched at resolve time.
+    /// Candidate source folders, highest precedence first: workspace profile,
+    /// workspace base, matrix profile, matrix base. Pure path math; no
+    /// filesystem touched at resolve time.
     pub candidates: Vec<(ConfigSeedTier, PathBuf)>,
     /// Absolute destination, under the replica root.
     pub dest: PathBuf,
@@ -99,20 +107,30 @@ pub fn resolve_config_seed(
     // The user's example uses a lowercase profile letter; effective_profile is UPPERCASE.
     let letter = effective_letter.to_ascii_lowercase();
 
+    // Precedence: all workspace candidates beat all matrix candidates; within a
+    // location, the profile-lettered folder beats the base folder. The matrix's
+    // bare `<dest>` is intentionally never a source (it is the agent's own live
+    // config; see ConfigSeedTier), so the matrix tiers mirror the workspace
+    // naming (`default_profile_<l><dest>` / `default<dest>`) instead.
     let mut candidates: Vec<(ConfigSeedTier, PathBuf)> = Vec::new();
     if let Some(ws) = context.workspace_root.as_ref() {
         candidates.push((
-            ConfigSeedTier::Profile,
+            ConfigSeedTier::WorkspaceProfile,
             ws.join(format!("default_profile_{}{}", letter, dest_name)),
+        ));
+        candidates.push((
+            ConfigSeedTier::WorkspaceBase,
+            ws.join(format!("default{}", dest_name)),
         ));
     }
     if let Some(mx) = context.matrix_root.as_ref() {
-        candidates.push((ConfigSeedTier::Matrix, mx.join(dest_name)));
-    }
-    if let Some(ws) = context.workspace_root.as_ref() {
         candidates.push((
-            ConfigSeedTier::Base,
-            ws.join(format!("default{}", dest_name)),
+            ConfigSeedTier::MatrixProfile,
+            mx.join(format!("default_profile_{}{}", letter, dest_name)),
+        ));
+        candidates.push((
+            ConfigSeedTier::MatrixBase,
+            mx.join(format!("default{}", dest_name)),
         ));
     }
     if candidates.is_empty() {
@@ -513,24 +531,39 @@ mod tests {
     // ---- resolve_config_seed (pure path math, fail-soft) -------------------
 
     #[test]
-    fn resolve_orders_profile_matrix_base_with_lowercased_letter() {
+    fn resolve_orders_workspace_then_matrix_each_profile_then_base_lowercased() {
         let workspace = abs(r"C:\ws", "/ws");
         let replica = workspace.join("wg-1-team").join("__agent_x");
         let matrix = workspace.join("_agent_x");
         let ctx = ctx_with(&replica, Some(&workspace), Some(&matrix));
 
         let resolved = resolve_config_seed(&seed_cfg(".claude"), "C", Some(&ctx)).expect("some");
-        assert_eq!(resolved.candidates.len(), 3);
-        assert_eq!(resolved.candidates[0].0, ConfigSeedTier::Profile);
+        // All workspace tiers outrank all matrix tiers; profile beats base in each.
+        assert_eq!(resolved.candidates.len(), 4);
+        assert_eq!(resolved.candidates[0].0, ConfigSeedTier::WorkspaceProfile);
         assert_eq!(
             resolved.candidates[0].1,
             workspace.join("default_profile_c.claude")
         );
-        assert_eq!(resolved.candidates[1].0, ConfigSeedTier::Matrix);
-        assert_eq!(resolved.candidates[1].1, matrix.join(".claude"));
-        assert_eq!(resolved.candidates[2].0, ConfigSeedTier::Base);
-        assert_eq!(resolved.candidates[2].1, workspace.join("default.claude"));
+        assert_eq!(resolved.candidates[1].0, ConfigSeedTier::WorkspaceBase);
+        assert_eq!(resolved.candidates[1].1, workspace.join("default.claude"));
+        assert_eq!(resolved.candidates[2].0, ConfigSeedTier::MatrixProfile);
+        assert_eq!(
+            resolved.candidates[2].1,
+            matrix.join("default_profile_c.claude")
+        );
+        assert_eq!(resolved.candidates[3].0, ConfigSeedTier::MatrixBase);
+        assert_eq!(resolved.candidates[3].1, matrix.join("default.claude"));
         assert_eq!(resolved.dest, replica.join(".claude"));
+        // Regression guard: the matrix's bare `.claude` (the agent's own live
+        // config) must NEVER be a source candidate.
+        assert!(
+            !resolved
+                .candidates
+                .iter()
+                .any(|(_, p)| *p == matrix.join(".claude")),
+            "bare matrix .claude must not be a seed source"
+        );
     }
 
     #[test]
@@ -540,8 +573,12 @@ mod tests {
         let ctx = ctx_with(&replica, Some(&workspace), None);
 
         let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).expect("some");
+        // Root-agent: matrix is None, so only the two workspace tiers remain.
         let tiers: Vec<_> = resolved.candidates.iter().map(|(t, _)| *t).collect();
-        assert_eq!(tiers, vec![ConfigSeedTier::Profile, ConfigSeedTier::Base]);
+        assert_eq!(
+            tiers,
+            vec![ConfigSeedTier::WorkspaceProfile, ConfigSeedTier::WorkspaceBase]
+        );
     }
 
     #[test]

--- a/src-tauri/src/config/config_seed.rs
+++ b/src-tauri/src/config/config_seed.rs
@@ -235,6 +235,12 @@ fn segments_eq(a: &str, b: &str) -> bool {
 /// Best-effort, Windows-safe seed execution (H1). NEVER aborts the spawn.
 /// `unique_sfx` (the session id) keeps the temp/trash leaves unique per spawn
 /// (M3) and short (I2/MAX_PATH).
+///
+/// CONCURRENCY CONTRACT (grinch HIGH-1): callers MUST serialize this for the
+/// same replica, because step 2 sweeps ALL `<dest>.acseed-*` scratch by prefix
+/// (see [`clear_stale_seed_scratch`]) and would otherwise delete a concurrent
+/// spawn's in-flight temp/trash mid-swap. The only caller, the session spawn
+/// chokepoint, holds `RtkSweepLockState` across this call for all dests.
 pub fn perform_config_seed(seed: &ResolvedConfigSeed, unique_sfx: &str) -> ConfigSeedReport {
     // 1. Pick the winning tier by source-folder presence (highest precedence first).
     let Some((tier, src)) = seed.candidates.iter().find(|(_, src)| is_readable_dir(src)) else {
@@ -340,6 +346,11 @@ fn is_readable_dir(path: &Path) -> bool {
 /// Remove every leftover seed-scratch sibling for `dest_name` (any session-id
 /// suffix), best-effort. Reclaims a temp/trash dir leaked by an earlier locked
 /// removal; the current spawn's `temp`/`trash` (same prefix) are cleared too.
+///
+/// Sweeps across ALL session ids, so it is SAFE only when the caller has
+/// serialized seeding for this replica (see [`perform_config_seed`]'s
+/// concurrency contract); otherwise it can delete a concurrent spawn's in-flight
+/// scratch (grinch HIGH-1).
 fn clear_stale_seed_scratch(parent: &Path, dest_name: &str) {
     let tmp_prefix = format!("{}.acseed-tmp-", dest_name);
     let old_prefix = format!("{}.acseed-old-", dest_name);
@@ -709,6 +720,41 @@ mod tests {
         );
         assert!(!replica.join(".claude.acseed-old-OLDID").exists());
         assert!(!replica.join(".claude.acseed-tmp-OLDID").exists());
+    }
+
+    /// grinch HIGH-1 characterization: proves WHY `perform_config_seed` must be
+    /// serialized for all dests. We reconstruct the exact mid-swap state of a
+    /// concurrent spawn A (dest already renamed to trash_A, staged temp_A
+    /// present) and run what spawn B's step-2 cleanup does for the SAME dest with
+    /// a DIFFERENT session id. The prefix-sweep deletes BOTH of A's in-flight
+    /// dirs, after which A can neither install (temp gone) nor restore (trash
+    /// gone) -> config lost. This is the data-loss the session chokepoint's
+    /// RtkSweepLockState serialization (held across the seed for ALL dests)
+    /// prevents; a regression that drops or narrows that lock re-opens it.
+    #[test]
+    fn unserialized_prefix_sweep_would_destroy_a_concurrent_inflight_swap() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = temp.path().join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+
+        // Spawn A is mid-swap on dest ".claude-amp" (the previously-unlocked path):
+        // dest has been renamed to trash_A (its ONLY surviving old copy) and
+        // temp_A holds the freshly staged new config.
+        let trash_a = replica.join(".claude-amp.acseed-old-idA");
+        let temp_a = replica.join(".claude-amp.acseed-tmp-idA");
+        write_file(&trash_a.join("keep.txt"), b"OLD");
+        write_file(&temp_a.join("f.txt"), b"NEW");
+        assert!(!replica.join(".claude-amp").exists(), "A moved dest aside");
+
+        // Spawn B (different session id) runs its step-2 prefix-sweep concurrently.
+        clear_stale_seed_scratch(&replica, ".claude-amp");
+
+        // Hazard: B deleted BOTH of A's in-flight dirs. A's later
+        // rename(temp_A->dest) and restore(trash_A->dest) would both fail,
+        // leaving the replica with NO .claude-amp -> the exact data loss the
+        // chokepoint lock serializes against.
+        assert!(!temp_a.exists(), "prefix-sweep deletes a concurrent spawn's staged temp");
+        assert!(!trash_a.exists(), "prefix-sweep deletes a concurrent spawn's only old copy");
     }
 
     // ---- copy_file_substituted (size-first, binary/UTF-8) ------------------

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -3,6 +3,7 @@ pub mod agent_config;
 pub mod agent_creation;
 pub mod claude_settings;
 pub mod coding_agent_profiles;
+pub mod config_seed;
 pub mod coordinator_clocks;
 pub mod daemon_pid;
 pub mod local_config_io;

--- a/src-tauri/src/config/placeholders.rs
+++ b/src-tauri/src/config/placeholders.rs
@@ -139,6 +139,26 @@ pub fn expand_placeholders_in_args(
         .collect()
 }
 
+/// Expand the 3 known AC tokens inside file CONTENT (#598 config-folder seed).
+/// Unlike [`expand_placeholders`] this does NOT fail-closed on unknown `%...%`:
+/// a seeded template may legitimately contain other `%VAR%` text the tool reads
+/// at runtime, so unknown markers are left literal. Substituted paths are
+/// forward-slash normalized (JSON/TOML safe; accepted by Node/Rust/Win32).
+pub fn expand_placeholders_in_content(value: &str, context: &PlaceholderContext) -> String {
+    let fwd = |p: &std::path::Path| p.to_string_lossy().replace('\\', "/");
+    let mut out = value.to_string();
+    if context.root_kind == PlaceholderRootKind::AcReplicaOrRootAgent {
+        out = out.replace(AC_REPLICA_ROOT_PLACEHOLDER, &fwd(&context.replica_root));
+    }
+    if let Some(ws) = &context.workspace_root {
+        out = out.replace(AC_WORKSPACE_ROOT_PLACEHOLDER, &fwd(ws));
+    }
+    if let Some(mx) = &context.matrix_root {
+        out = out.replace(AC_MATRIX_ROOT_PLACEHOLDER, &fwd(mx));
+    }
+    out
+}
+
 pub fn reject_unexpanded_markers(
     value: &str,
     context: &str,
@@ -340,6 +360,50 @@ mod tests {
         // No alias: a leftover %AC_ROOT% is no longer expanded and trips the backstop.
         let err = expand_placeholders(r"%AC_ROOT%\x", &ctx).unwrap_err();
         assert!(err.contains("unknown placeholder"), "{err}");
+    }
+
+    #[test]
+    fn expand_in_content_substitutes_known_tokens_forward_slashed() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = make_replica(temp.path());
+        let ctx = placeholder_context_for_launch_root(&replica).unwrap();
+
+        let expected_replica = canonical_stripped(&replica).to_string_lossy().replace('\\', "/");
+        let out = expand_placeholders_in_content(
+            "root=%AC_REPLICA_ROOT%/x and %AC_WORKSPACE_ROOT% and %AC_MATRIX_ROOT%",
+            &ctx,
+        );
+        assert!(out.contains(&format!("root={}/x", expected_replica)), "{out}");
+        // No backslashes from the substituted paths (forward-slash normalized).
+        assert!(!out.contains('\\'), "{out}");
+    }
+
+    #[test]
+    fn expand_in_content_leaves_unknown_markers_literal() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = make_replica(temp.path());
+        let ctx = placeholder_context_for_launch_root(&replica).unwrap();
+        // Unlike expand_placeholders, content expansion is lenient: unknown
+        // %...% markers survive verbatim (the template may use them at runtime).
+        let out = expand_placeholders_in_content("%UNKNOWN% and %AC_ROOT% stay", &ctx);
+        assert_eq!(out, "%UNKNOWN% and %AC_ROOT% stay");
+    }
+
+    #[test]
+    fn expand_in_content_skips_tokens_with_no_matching_root() {
+        // Normal cwd: replica token is NOT substituted (no replica root kind),
+        // and workspace/matrix are None, so all three are left literal.
+        let normal = PlaceholderContext {
+            replica_root: PathBuf::from(if cfg!(windows) { r"C:\cwd" } else { "/cwd" }),
+            root_kind: PlaceholderRootKind::NormalLaunchCwd,
+            workspace_root: None,
+            matrix_root: None,
+        };
+        let out = expand_placeholders_in_content(
+            "%AC_REPLICA_ROOT% %AC_WORKSPACE_ROOT% %AC_MATRIX_ROOT%",
+            &normal,
+        );
+        assert_eq!(out, "%AC_REPLICA_ROOT% %AC_WORKSPACE_ROOT% %AC_MATRIX_ROOT%");
     }
 
     #[test]

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -33,6 +33,11 @@ pub struct AgentConfig {
     /// `instructionsFilename`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions_filename: Option<String>,
+    /// #598 - optional config-folder seed (e.g. `.claude`) copied from a
+    /// convention-chosen template into the replica at spawn. `None`/inactive
+    /// means no seeding. Serialized as `configSeed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_seed: Option<ConfigSeedConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -104,6 +109,26 @@ pub struct ProfileCellConfig {
     pub env: BTreeMap<String, String>,
     #[serde(default)]
     pub notes: String,
+}
+
+/// Optional config-folder seed for a coding agent. When active, AC copies a
+/// template config folder (chosen by convention across profile > matrix >
+/// coding-agent-base; see `config_seed.rs`) into the replica at spawn. `dest` is
+/// the destination folder NAME under `%AC_REPLICA_ROOT%/` (e.g. ".claude"). No
+/// `source` field: the template locations are derived by naming convention.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigSeedConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub dest: String,
+}
+
+impl ConfigSeedConfig {
+    pub fn is_active(&self) -> bool {
+        self.enabled && !self.dest.trim().is_empty()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1213,6 +1238,53 @@ pub fn merge_protected_coding_agent_settings(
     incoming
 }
 
+/// A config-seed `dest` must be a single, relative folder NAME under the replica
+/// root. The convention prefixes (`default`, `default_profile_<letter>`) are
+/// concatenated onto this name for the workspace-root tiers, so it must be a
+/// single path segment and a legal Windows directory name.
+pub fn validate_config_seed_dest(dest: &str) -> Result<(), String> {
+    let d = dest.trim();
+    if d.is_empty() {
+        return Err("config seed destination must not be empty".to_string());
+    }
+    if d.contains('/') || d.contains('\\') {
+        return Err(
+            "config seed destination must be a single folder name (no path separators)".to_string(),
+        );
+    }
+    if d == "." || d == ".." || d.contains("..") {
+        return Err("config seed destination must not contain '..'".to_string());
+    }
+    if Path::new(d).is_absolute() {
+        return Err("config seed destination must be relative".to_string());
+    }
+    // M5: ':' makes "C:foo" drive-relative (is_absolute()==false) or "x:y" an ADS.
+    if d.contains(':') {
+        return Err("config seed destination must not contain ':'".to_string());
+    }
+    if d.contains('%') || d.contains('$') {
+        return Err("config seed destination must not contain placeholder markers".to_string());
+    }
+    // M5: reject a trailing dot (Windows strips it, causing target drift). A
+    // trailing space cannot reach here: `d` was trimmed above.
+    if d.ends_with('.') {
+        return Err("config seed destination must not end with a dot".to_string());
+    }
+    // M5: reject Windows reserved device names (case-insensitive, before any extension).
+    let stem = d.split('.').next().unwrap_or(d).to_ascii_uppercase();
+    const RESERVED: &[&str] = &[
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    ];
+    if RESERVED.contains(&stem.as_str()) {
+        return Err(format!(
+            "config seed destination '{}' is a reserved Windows device name",
+            d
+        ));
+    }
+    Ok(())
+}
+
 pub fn validate_agent_commands(settings: &AppSettings) -> Result<(), String> {
     for agent in &settings.agents {
         validate_agent_command_text(&format!("Agent \"{}\"", agent.label), &agent.command)?;
@@ -1232,6 +1304,17 @@ pub fn validate_agent_commands(settings: &AppSettings) -> Result<(), String> {
                     "Agent \"{}\" instructions filename is invalid: must be a bare .md filename with no path separators",
                     agent.label
                 ));
+            }
+        }
+
+        // #598: reject a bad config-seed dest at save so the user gets a clear
+        // IPC error here, not a silent fail-soft skip at launch. Inactive
+        // (disabled or empty dest) is allowed (means "no seeding").
+        if let Some(seed) = agent.config_seed.as_ref() {
+            if seed.is_active() {
+                validate_config_seed_dest(&seed.dest).map_err(|e| {
+                    format!("Agent \"{}\" config seed is invalid: {}", agent.label, e)
+                })?;
             }
         }
     }
@@ -1705,10 +1788,105 @@ mod tests {
                     envs: Vec::new(),
                     isolated_home: false,
                     instructions_filename: None,
+                    config_seed: None,
                 })
                 .collect(),
             ..AppSettings::default()
         }
+    }
+
+    #[test]
+    fn validate_config_seed_dest_accepts_dotfile_names() {
+        for ok in [".claude", ".claude-amp", ".codex", ".opencode", "config"] {
+            assert!(
+                super::validate_config_seed_dest(ok).is_ok(),
+                "should accept {ok:?}"
+            );
+        }
+        // Leading/trailing whitespace is trimmed before validation.
+        assert!(super::validate_config_seed_dest("  .claude  ").is_ok());
+    }
+
+    #[test]
+    fn validate_config_seed_dest_rejects_unsafe_names() {
+        let bad = [
+            "",                // empty
+            "   ",             // whitespace only
+            ".config/opencode", // forward separator (nested)
+            ".config\\x",      // backslash separator
+            "..",              // parent
+            "a..b",            // contains ..
+            "C:foo",           // drive-relative colon
+            "x:y",             // ADS colon
+            "%AC_REPLICA_ROOT%", // placeholder marker
+            "$HOME",           // shell marker
+            ".claude.",        // trailing dot (trim does NOT strip dots)
+            "CON",             // reserved device
+            "nul",             // reserved device (case-insensitive)
+            "COM1",            // reserved device
+            "lpt9.claude",     // reserved device before first dot
+        ];
+        for name in bad {
+            assert!(
+                super::validate_config_seed_dest(name).is_err(),
+                "should reject {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn config_seed_is_active_requires_enabled_and_nonempty_dest() {
+        use super::ConfigSeedConfig;
+        assert!(ConfigSeedConfig {
+            enabled: true,
+            dest: ".claude".to_string()
+        }
+        .is_active());
+        assert!(!ConfigSeedConfig {
+            enabled: false,
+            dest: ".claude".to_string()
+        }
+        .is_active());
+        assert!(!ConfigSeedConfig {
+            enabled: true,
+            dest: "   ".to_string()
+        }
+        .is_active());
+    }
+
+    #[test]
+    fn config_seed_serde_round_trips_camel_case_and_omits_when_absent() {
+        use super::AgentConfig;
+        // Present -> serializes as nested `configSeed { enabled, dest }`.
+        let mut agent = AgentConfig {
+            id: "claude".to_string(),
+            label: "Claude".to_string(),
+            command: "claude".to_string(),
+            color: "#fff".to_string(),
+            git_pull_before: false,
+            exclude_global_claude_md: false,
+            envs: Vec::new(),
+            isolated_home: false,
+            instructions_filename: None,
+            config_seed: Some(super::ConfigSeedConfig {
+                enabled: true,
+                dest: ".claude".to_string(),
+            }),
+        };
+        let json = serde_json::to_string(&agent).unwrap();
+        assert!(json.contains("\"configSeed\""), "{json}");
+        assert!(json.contains("\"dest\":\".claude\""), "{json}");
+        let back: AgentConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.config_seed.as_ref().map(|c| c.dest.as_str()), Some(".claude"));
+
+        // Absent -> key omitted (skip_serializing_if), and old files deserialize to None.
+        agent.config_seed = None;
+        let json = serde_json::to_string(&agent).unwrap();
+        assert!(!json.contains("configSeed"), "{json}");
+        let back: AgentConfig =
+            serde_json::from_str(r##"{"id":"x","label":"X","command":"claude","color":"#000"}"##)
+                .unwrap();
+        assert!(back.config_seed.is_none());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1946,6 +1946,7 @@ mod tests {
                 envs: Vec::new(),
                 isolated_home: false,
                 instructions_filename: None,
+                config_seed: None,
             }],
             ..AppSettings::default()
         }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -3444,6 +3444,7 @@ mod tests {
             envs: Vec::new(),
             isolated_home: false,
             instructions_filename: None,
+            config_seed: None,
         }
     }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -89,6 +89,17 @@ export interface PtyOutputEvent {
   data: number[];
 }
 
+/**
+ * #598 — per-agent config-folder seed. Mirrors the Rust `ConfigSeedConfig`
+ * (`#[serde(rename_all = "camelCase")]`): `enabled` (serde default true) and
+ * `dest` (serde default ""). Lives on `AgentConfig` ONLY — nothing on
+ * `ProfileCellConfig` / `CodingAgentProfilesConfig`.
+ */
+export interface ConfigSeedConfig {
+  enabled: boolean;
+  dest: string;
+}
+
 export interface AgentConfig {
   id: string;
   label: string;
@@ -109,6 +120,16 @@ export interface AgentConfig {
    * string is normalized to omitted before save, so it is never persisted.
    */
   instructionsFilename?: string;
+  /**
+   * #598 — optional config-folder seed. When `enabled` and `dest` is non-empty,
+   * AC copies a template config folder (chosen by convention, precedence
+   * profile > matrix > coding-agent base) into the replica at spawn,
+   * overwriting it every launch. `dest` is the destination folder NAME under
+   * the replica root (e.g. ".claude"). Dropped to omitted before save when
+   * disabled or `dest` is empty (mirrors `instructionsFilename`), so an
+   * inactive seed is never persisted as a sentinel.
+   */
+  configSeed?: ConfigSeedConfig;
 }
 
 /**

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -864,6 +864,19 @@ const AgentPickerModal: Component<{
                       Home isolation {selectedAgent()?.isolatedHome ? "enabled" : "disabled"}
                     </div>
                   </Show>
+                  {/* #598 — read-only hint that this agent reseeds a config
+                      folder each spawn. The winning template tier needs a live
+                      FS check the picker must not do, so we only name the dest. */}
+                  <Show
+                    when={
+                      !!selectedAgent()?.configSeed?.enabled &&
+                      !!selectedAgent()?.configSeed?.dest?.trim()
+                    }
+                  >
+                    <div class="agent-projection-note">
+                      Seeds {selectedAgent()?.configSeed?.dest?.trim()} on every spawn
+                    </div>
+                  </Show>
                   <Show when={projectedCell().notes}>
                     <div class="agent-projection-note">Note: {projectedCell().notes}</div>
                   </Show>

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -254,6 +254,47 @@ describe("SettingsModal automation hooks", () => {
     dispose();
   });
 
+  // #598 — the config-seed control renders for every agent (not Codex-only) and
+  // its dest field is gated behind the enable toggle.
+  it("exposes the config-seed toggle and reveals the dest field when enabled", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    // The seeded test agent has no configSeed, so the toggle starts unchecked
+    // and the dest field is hidden until the seed is enabled.
+    const toggle = byTestId<HTMLInputElement>("settings.agentRow.0.configSeedEnabled");
+    expect(toggle.checked).toBe(false);
+    expect(toggle.getAttribute("data-ac-state")).toBe("unchecked");
+    expect(
+      document.querySelector('[data-ac-testid="settings.agentRow.0.configSeedDest"]'),
+    ).toBeNull();
+
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+
+    expect(
+      byTestId("settings.agentRow.0.configSeedEnabled").getAttribute("data-ac-state"),
+    ).toBe("checked");
+    const dest = byTestId<HTMLInputElement>("settings.agentRow.0.configSeedDest");
+    expect(dest).toBeTruthy();
+
+    dest.value = ".claude";
+    dest.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+
+    expect(byTestId<HTMLInputElement>("settings.agentRow.0.configSeedDest").value).toBe(".claude");
+
+    dispose();
+  });
+
   it("keeps an early custom agent draft when the fresh load resolves late", async () => {
     let resolveLoadedSettings: (value: AppSettings) => void = () => {};
     vi.mocked(SettingsAPI.get).mockReturnValueOnce(

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -243,6 +243,30 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     setSettings("data", "agents", index, field as any, value as any);
   };
 
+  // #598 — config seed is a nested object on AgentConfig, so it cannot flow
+  // through updateAgent (scalar fields only). These setters merge the nested
+  // shape while editing; the disabled/empty case is normalized to omitted at
+  // the save choke point (settings-save.ts::normalizeAgentConfigSeed).
+  const setAgentConfigSeedEnabled = (index: number, enabled: boolean) => {
+    if (!settings.data) return;
+    setDraftDirty(true);
+    const current = settings.data.agents[index]?.configSeed;
+    setSettings("data", "agents", index, "configSeed", {
+      enabled,
+      dest: current?.dest ?? "",
+    });
+  };
+
+  const setAgentConfigSeedDest = (index: number, dest: string) => {
+    if (!settings.data) return;
+    setDraftDirty(true);
+    const current = settings.data.agents[index]?.configSeed;
+    setSettings("data", "agents", index, "configSeed", {
+      enabled: current?.enabled ?? true,
+      dest,
+    });
+  };
+
   const updateAgentEnv = (
     agentIndex: number,
     rowIndex: number,
@@ -1329,6 +1353,39 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
               Filename AC writes into the agent root at launch (its AC context +
               Role.md). Leave blank to use the default shown.
             </div>
+            <label class="settings-checkbox-field">
+              <input
+                type="checkbox"
+                class="settings-checkbox"
+                checked={!!agent.configSeed?.enabled}
+                onChange={(e) =>
+                  setAgentConfigSeedEnabled(i(), e.currentTarget.checked)
+                }
+                data-ac-testid={`settings.agentRow.${i()}.configSeedEnabled`}
+                data-ac-role="checkbox"
+                data-ac-state={agent.configSeed?.enabled ? "checked" : "unchecked"}
+              />
+              <span>Seed a config folder into the replica at spawn</span>
+            </label>
+            <Show when={agent.configSeed?.enabled}>
+              <label class="settings-field">
+                <span class="settings-label">Config folder</span>
+                <input
+                  class="settings-input"
+                  value={agent.configSeed?.dest ?? ""}
+                  onInput={(e) => setAgentConfigSeedDest(i(), e.currentTarget.value)}
+                  placeholder=".claude"
+                  data-ac-testid={`settings.agentRow.${i()}.configSeedDest`}
+                  data-ac-role="textbox"
+                />
+              </label>
+              <div class="settings-hint">
+                {"AC seeds this folder from the first template present: " +
+                  "<workspace>/default_profile_<letter><dest>, then " +
+                  "<matrix>/<dest>, then <workspace>/default<dest>. " +
+                  "It is overwritten on every spawn. Leave the folder blank to disable."}
+              </div>
+            </Show>
             <label class="settings-field">
               <span class="settings-label">Color</span>
               <div class="settings-color-row">

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -1381,8 +1381,10 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
               </label>
               <div class="settings-hint">
                 {"AC seeds this folder from the first template present: " +
-                  "<workspace>/default_profile_<letter><dest>, then " +
-                  "<matrix>/<dest>, then <workspace>/default<dest>. " +
+                  "<workspace>/default_profile_<letter><dest>, " +
+                  "<workspace>/default<dest>, " +
+                  "<matrix>/default_profile_<letter><dest>, then " +
+                  "<matrix>/default<dest>. " +
                   "It is overwritten on every spawn. Leave the folder blank to disable."}
               </div>
             </Show>

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -138,3 +138,46 @@ describe("mergeSettingsForSavePreservingProjects (#529 G3 normalization)", () =>
     expect(merged.projectPaths).toEqual(["C:/fresh", "C:/other"]);
   });
 });
+
+describe("mergeSettingsForSavePreservingProjects (#598 configSeed normalization)", () => {
+  it("drops an inactive configSeed so it never persists as a sentinel", () => {
+    const draft = settings({
+      agents: [
+        agent({ id: "absent", configSeed: undefined }),
+        agent({ id: "disabled", configSeed: { enabled: false, dest: ".claude" } }),
+        agent({ id: "emptyDest", configSeed: { enabled: true, dest: "" } }),
+        agent({ id: "spacesDest", configSeed: { enabled: true, dest: "   " } }),
+      ],
+    });
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    for (const a of merged.agents) {
+      expect("configSeed" in a).toBe(false);
+    }
+  });
+
+  it("keeps an active configSeed, trims dest, and forces enabled true", () => {
+    const draft = settings({
+      agents: [agent({ id: "set", configSeed: { enabled: true, dest: "  .claude  " } })],
+    });
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect(merged.agents[0]?.configSeed).toEqual({ enabled: true, dest: ".claude" });
+  });
+
+  it("normalizes configSeed and instructionsFilename together without cross-talk", () => {
+    const draft = settings({
+      agents: [
+        agent({
+          id: "both",
+          instructionsFilename: "  CLAUDE.md  ",
+          configSeed: { enabled: true, dest: ".claude" },
+        }),
+      ],
+    });
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect(merged.agents[0]?.instructionsFilename).toBe("CLAUDE.md");
+    expect(merged.agents[0]?.configSeed).toEqual({ enabled: true, dest: ".claude" });
+  });
+});

--- a/src/sidebar/components/settings-save.ts
+++ b/src/sidebar/components/settings-save.ts
@@ -19,13 +19,36 @@ function normalizeAgentInstructionsFilename(agent: AgentConfig): AgentConfig {
   return rest;
 }
 
+/**
+ * #598 — normalize the optional config-folder seed to an honest stored shape.
+ * The Coding Agents tab keeps `configSeed` as a live object while editing (so
+ * the dest input and the enable toggle stay bound), but the backend uses
+ * `#[serde(skip_serializing_if = "Option::is_none")]`: an inactive seed
+ * (disabled, or an empty/whitespace `dest`) must serialize as omitted, not as
+ * `{enabled:false}` or `{dest:""}`. Drop it unless it is genuinely active and
+ * trim the kept `dest`, mirroring normalizeAgentInstructionsFilename. The
+ * backend independently re-validates an active dest at save (rejecting
+ * separators, `..`, `:`, etc.) and fails soft at launch, so this only governs
+ * the persisted shape, never the validation.
+ */
+function normalizeAgentConfigSeed(agent: AgentConfig): AgentConfig {
+  const dest = agent.configSeed?.dest?.trim();
+  if (agent.configSeed?.enabled && dest) {
+    return { ...agent, configSeed: { enabled: true, dest } };
+  }
+  const { configSeed: _drop, ...rest } = agent;
+  return rest;
+}
+
 export function mergeSettingsForSavePreservingProjects(
   draft: AppSettings,
   fresh: AppSettings
 ): AppSettings {
   return {
     ...draft,
-    agents: draft.agents.map(normalizeAgentInstructionsFilename),
+    agents: draft.agents
+      .map(normalizeAgentInstructionsFilename)
+      .map(normalizeAgentConfigSeed),
     projectPaths: fresh.projectPaths ?? [],
     projectPath: fresh.projectPath ?? null,
   };


### PR DESCRIPTION
## Summary

Seeds a default config folder (e.g. `.claude`) into a coding agent's **replica at spawn**, copying from a template with AC-placeholder substitution. Opt-in per coding agent (`configSeed: { enabled, dest }`, default off).

## How it works

- **Source resolution** (pick-one, highest present on-disk wins), for dest `<dest>` and resolved profile letter `<l>`:
  1. `%AC_WORKSPACE_ROOT%/default_profile_<l><dest>`
  2. `%AC_WORKSPACE_ROOT%/default<dest>`
  3. `%AC_MATRIX_ROOT%/default_profile_<l><dest>`
  4. `%AC_MATRIX_ROOT%/default<dest>`
  The bare `%AC_MATRIX_ROOT%/<dest>` is intentionally **not** a source — that path is the agent's own live config.
- Copied to `%AC_REPLICA_ROOT%/<dest>`, **overwrite every spawn**, via an atomic rename-to-trash swap (dest is always fully-old or fully-new).
- **Content substitution**: expands the AC placeholder tokens inside text files (lenient — unknown `%...%` markers left literal; CRLF/BOM preserved; binaries/symlinks/reparse-points skipped).
- After a `.claude` seed, re-applies the rtk PreToolUse hook + CLAUDE.md excludes so the Resource Monitor keeps tracking. The seed is serialized under a global lock to prevent a concurrent-spawn data-loss race.
- Skip + seeded outcomes logged at info (`[config-seed]`), listing the candidate tiers.

## Review

- Architect plan + consensus; dev-rust enrichment + dev-rust-grinch adversarial review.
- Implemented by dev-rust (backend) + dev-webpage-ui (frontend: Settings → Coding Agents enable/dest field + hint).
- Grinch: PASS after fixing a **HIGH** (concurrent same-replica spawn data-loss race → unconditional serialization + atomic swap) and a **MEDIUM** (stale UI hint pointing at the removed path). Convention later corrected (matrix sources are `default`-prefixed) + re-synced onto latest main (clean, disjoint) — Step-7.5 PASS.
- Gates: `cargo test --lib` 1349/0/8, clippy clean, `tsc` 0, `vitest` 475/60, `vite build` OK.
- Built to 0_AC and tested by the owner; landing approved.

## Follow-ups

- **#605** — "Gen Default" buttons + UI hint to create source templates.
- F4 (deferred) — generalize the rtk/excludes re-apply beyond `.claude` (for `.claude-amp` etc.).

Closes #598
