### PR TITLE
feat(#609): notify in-app when a newer npm version is available

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1287,6 +1287,18 @@ pub async fn get_rtk_startup_status(
         .unwrap_or_else(|| "silent".to_string()))
 }
 
+/// Issue #609 - return the pending "npm update available" info, or null if the
+/// running build is current / the check has not finished / it is disabled.
+/// Pure read of the cached `UpdateCheckState` (set by the startup task in
+/// `update_check::run_startup_check`). The sidebar queries this on mount to
+/// cover the case where the startup emit fired before its listener registered.
+#[tauri::command]
+pub async fn get_update_status(
+    cache: State<'_, crate::UpdateCheckState>,
+) -> Result<Option<crate::update_check::UpdateInfo>, String> {
+    Ok(cache.get().cloned())
+}
+
 /// Fetch the Home screen Markdown source from the public docs URL.
 /// Returns the raw Markdown body as a String.
 /// Errors are returned as user-facing strings; the frontend renders them in

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -438,6 +438,10 @@ pub struct AppSettings {
     /// agents (cascade). When false, only the coordinator closes. Default true.
     #[serde(default = "default_true")]
     pub coordinator_cascade_close_enabled: bool,
+    /// #609 When true, check npm on startup (<=1x/24h) and notify in-app when
+    /// a newer published version is available. Default true.
+    #[serde(default = "default_true")]
+    pub npm_update_notifications_enabled: bool,
 }
 
 fn default_true() -> bool {
@@ -622,6 +626,7 @@ impl Default for AppSettings {
             coordinator_auto_close_enabled: true,
             coordinator_auto_close_minutes: default_coord_auto_close_minutes(),
             coordinator_cascade_close_enabled: true,
+            npm_update_notifications_enabled: true,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ pub mod session;
 pub mod shutdown;
 pub mod telegram;
 pub mod testability;
+pub mod update_check;
 pub mod voice;
 pub mod web;
 
@@ -56,6 +57,11 @@ pub type RtkSweepLockState = Arc<tokio::sync::Mutex<()>>;
 /// boot decision instead of recomputing from post-side-effect state
 /// (which would mismatch the listener for the `auto-disabled` mode).
 pub type RtkStartupModeState = Arc<std::sync::OnceLock<String>>;
+
+// Issue #609 - cached "npm update available" result. Set ONCE by the startup
+// check task; read by `get_update_status` so a late-mounting sidebar still
+// sees a pending update (mirrors RtkStartupModeState).
+pub type UpdateCheckState = Arc<std::sync::OnceLock<update_check::UpdateInfo>>;
 
 /// Floating spec/Mermaid board document state.
 pub type SpecBoardState = Arc<tokio::sync::RwLock<commands::spec_board::SpecBoardManager>>;
@@ -326,6 +332,11 @@ pub fn run(
     let rtk_startup_mode: RtkStartupModeState = Arc::new(std::sync::OnceLock::new());
     let rtk_startup_mode_for_setup = Arc::clone(&rtk_startup_mode);
 
+    // Issue #609 - cached "npm update available" result, set ONCE by the
+    // detached startup check below and read by `get_update_status`.
+    let update_check_state: UpdateCheckState = Arc::new(std::sync::OnceLock::new());
+    let update_check_state_for_setup = Arc::clone(&update_check_state);
+
     let shutdown_for_setup = shutdown_signal.clone();
     let shutdown_for_exit = shutdown_signal.clone();
     let tg_mgr_for_exit = tg_mgr.clone();
@@ -354,6 +365,7 @@ pub fn run(
         .manage(WebServerHandle::default())
         .manage(rtk_sweep_lock)
         .manage(rtk_startup_mode)
+        .manage(update_check_state)
         .manage(ui_automation_state)
         .manage(shutdown_signal)
         .manage(Arc::new(RestoreInProgress(AtomicBool::new(false))))
@@ -541,6 +553,16 @@ pub fn run(
                         prompt_dismissed,
                         inform_when_installed
                     );
+                });
+            }
+
+            // Issue #609 - detached "npm update available" check. Fully fail-silent;
+            // detached so startup is never blocked or delayed (acceptance criterion).
+            {
+                let app_handle_for_update = app.handle().clone();
+                let update_cache = Arc::clone(&update_check_state_for_setup);
+                tauri::async_runtime::spawn(async move {
+                    crate::update_check::run_startup_check(app_handle_for_update, update_cache).await;
                 });
             }
 
@@ -1716,6 +1738,7 @@ pub fn run(
             commands::config::set_main_resource_monitor_attached,
             commands::config::sweep_rtk_hook,
             commands::config::get_rtk_startup_status,
+            commands::config::get_update_status,
             commands::repos::search_repos,
             commands::telegram::telegram_attach,
             commands::telegram::telegram_detach,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -52,6 +52,28 @@ fn main() {
                         // GATED on `cli.command.is_some()` so the GUI branch
                         // below initializes via `lib::run()` exactly once.
                         agentscommander_lib::logging::init_logger();
+
+                        // Issue #609 Phase 2 - one-line "update available" notice for
+                        // terminal runs. Cache-only (no network, no blocking). M1: gate
+                        // on an INTERACTIVE stderr, not the AC_MACHINE_OUTPUT allowlist -
+                        // that allowlist (above) covers only ListPeers/ListPeersLean/
+                        // ListSessions/AgencyTemplates/Ui*, so `send`, `task`,
+                        // `window-info`, and any future machine verb would get stderr
+                        // spam for up to 24h while an update is pending. `is_terminal()`
+                        // is the future-proof gate: a human at a terminal sees the
+                        // notice; agents, scripts, and piped/redirected runs (stderr is
+                        // not a tty) stay silent.
+                        {
+                            use std::io::IsTerminal;
+                            if std::io::stderr().is_terminal() {
+                                if let Some(notice) =
+                                    agentscommander_lib::update_check::read_cached_notice()
+                                {
+                                    eprintln!("{}", notice);
+                                }
+                            }
+                        }
+
                         let code = agentscommander_lib::cli::handle_cli(cmd);
                         std::process::exit(code);
                     }

--- a/src-tauri/src/update_check.rs
+++ b/src-tauri/src/update_check.rs
@@ -1,0 +1,427 @@
+//! Issue #609 - "npm update available" detection.
+//!
+//! On startup a detached task (see `lib.rs` setup) reads the baked-in version,
+//! optionally queries the npm registry for the latest published version of
+//! `@mblua/agentscommander` (throttled to <=1x/24h via an on-disk cache),
+//! compares, and on a newer version caches an `UpdateInfo` + emits
+//! `npm_update_available`. Everything is fail-silent: any error logs at debug
+//! and produces no notification. The task is detached, so startup never blocks.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager};
+
+/// The published package. Used verbatim in the upgrade command shown to the
+/// user (literal `/`, because that is exactly what they type into a shell).
+const PACKAGE_NAME: &str = "@mblua/agentscommander";
+/// npm registry dist-tags endpoint. The scope separator MUST be `%2F`-encoded:
+/// reqwest sends a literal `/` as a path segment, and the `%2F` form is the
+/// unambiguous, npm-CLI-proven shape. Verified live by tech-lead (H1): this URL
+/// returns `{"latest":"..."}`. Do NOT switch back to a literal `/`.
+const DIST_TAGS_URL: &str =
+    "https://registry.npmjs.org/-/package/@mblua%2Fagentscommander/dist-tags";
+const CHECK_INTERVAL_HOURS: i64 = 24;
+const REQUEST_TIMEOUT_SECS: u64 = 10;
+/// Hard cap on the dist-tags response body, mirroring fetch_home_markdown's
+/// length-check (L1). The JSON is tiny; 64 KB is a generous bound.
+const DIST_TAGS_MAX_BYTES: usize = 64 * 1024;
+const CACHE_FILE_NAME: &str = "update-check.json";
+
+/// Cached result of an "update available" computation. Sent to the frontend
+/// (serialized camelCase) and stored in `UpdateCheckState`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInfo {
+    pub current_version: String,
+    pub latest_version: String,
+    pub upgrade_command: String,
+}
+
+/// On-disk throttle cache. `last_checked_at` gates the next network call;
+/// `latest_version` lets us still notify on every boot inside the 24h window
+/// without re-hitting the registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateCache {
+    last_checked_at: DateTime<Utc>,
+    latest_version: String,
+}
+
+fn cache_path() -> Option<PathBuf> {
+    crate::config::config_dir().map(|d| d.join(CACHE_FILE_NAME))
+}
+
+fn read_cache() -> Option<UpdateCache> {
+    let path = cache_path()?;
+    let bytes = std::fs::read(&path).ok()?;
+    serde_json::from_slice::<UpdateCache>(&bytes).ok()
+}
+
+fn write_cache(cache: &UpdateCache) {
+    let Some(path) = cache_path() else { return };
+    let Ok(json) = serde_json::to_string_pretty(cache) else { return };
+    // Atomic write (L3/E1): write a sibling temp file, then rename over the
+    // target so a concurrent reader (the Phase-2 CLI) never observes a
+    // half-written file. On Windows, std::fs::rename maps to MoveFileExW with
+    // MOVEFILE_REPLACE_EXISTING, so it atomically replaces the existing cache.
+    // Best-effort throughout; a failed write/rename only means we re-check
+    // sooner.
+    let tmp = path.with_extension("json.tmp"); // -> update-check.json.tmp (same dir)
+    if std::fs::write(&tmp, json).is_ok() {
+        let _ = std::fs::rename(&tmp, &path);
+    }
+}
+
+/// True when we should hit the network now: no cache, stale cache (older than
+/// the interval), or a cache timestamp in the future (clock moved backwards).
+fn should_check(cache: &Option<UpdateCache>, now: DateTime<Utc>) -> bool {
+    match cache {
+        None => true,
+        Some(c) => {
+            let age = now.signed_duration_since(c.last_checked_at);
+            age >= chrono::Duration::hours(CHECK_INTERVAL_HOURS) || age.num_seconds() < 0
+        }
+    }
+}
+
+// ---- Pure decision logic (T1) ---------------------------------------------
+// Extracted so toggle-off / throttle-hit / fetch-fail-fallback /
+// write-only-on-success are unit-testable with zero Tauri and zero network.
+// `run_startup_check` is the thin async shell that performs the I/O these
+// functions decide on.
+
+/// What the startup check should do this run, decided with no I/O.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CheckPlan {
+    /// Toggle off: do nothing at all.
+    Skip,
+    /// Inside the 24h window: reuse the cached latest, no network.
+    UseCached,
+    /// No cache, or stale/clock-skewed cache: hit the registry.
+    Fetch,
+}
+
+/// Pure: settings toggle + current cache + now -> plan.
+fn plan_check(enabled: bool, cache: &Option<UpdateCache>, now: DateTime<Utc>) -> CheckPlan {
+    if !enabled {
+        CheckPlan::Skip
+    } else if should_check(cache, now) {
+        CheckPlan::Fetch
+    } else {
+        CheckPlan::UseCached
+    }
+}
+
+/// Pure: plan + fetch outcome + existing cache -> (latest to compare against,
+/// write_back?). `fetched` is `Some` only on a successful network call.
+/// `write_back` is true ONLY on a fresh successful fetch (write-only-on-success);
+/// the caller stamps `now` and writes when it is true.
+fn resolve_latest(
+    plan: CheckPlan,
+    fetched: Option<String>,
+    cache: &Option<UpdateCache>,
+) -> (Option<String>, bool) {
+    match plan {
+        CheckPlan::Skip => (None, false),
+        CheckPlan::UseCached => (cache.as_ref().map(|c| c.latest_version.clone()), false),
+        CheckPlan::Fetch => match fetched {
+            // Fresh value: compare against it AND signal a cache write.
+            Some(v) => (Some(v), true),
+            // Fetch failed: fall back to any cached value, no write.
+            None => (cache.as_ref().map(|c| c.latest_version.clone()), false),
+        },
+    }
+}
+
+/// Parse a version string into a (major, minor, patch) tuple, ignoring any
+/// pre-release/build suffix (everything from the first `-` or `+`). Missing
+/// components default to 0. Non-numeric components make the parse fail.
+fn parse_version(v: &str) -> Option<(u64, u64, u64)> {
+    let core = v.trim().split(['-', '+']).next().unwrap_or("");
+    let mut it = core.split('.');
+    let major = it.next()?.parse::<u64>().ok()?;
+    let minor = it.next().unwrap_or("0").parse::<u64>().ok()?;
+    let patch = it.next().unwrap_or("0").parse::<u64>().ok()?;
+    Some((major, minor, patch))
+}
+
+/// True when `latest` is strictly newer than `current`. Fail-closed: if either
+/// side fails to parse, returns false (no false-positive notification).
+pub fn is_newer(latest: &str, current: &str) -> bool {
+    match (parse_version(latest), parse_version(current)) {
+        (Some(l), Some(c)) => l > c,
+        _ => false,
+    }
+}
+
+/// Pull `dist-tags.latest` out of the registry JSON body. Fail-silent.
+fn parse_latest(body: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    v.get("latest")?.as_str().map(|s| s.to_string())
+}
+
+fn upgrade_command() -> String {
+    format!("npm i -g {}", PACKAGE_NAME)
+}
+
+/// Detached startup task. Reads the toggle, applies the 24h throttle, queries
+/// the registry only when due, compares, and on a newer version caches the
+/// `UpdateInfo` and emits `npm_update_available`. Never returns an error to the
+/// caller: own no-ops log at debug; a registry that responds with a bad/
+/// unparseable body logs at warn (see `fetch_latest`, H1); everything is
+/// swallowed so startup is never affected.
+pub async fn run_startup_check(app: AppHandle, cache_state: Arc<OnceLock<UpdateInfo>>) {
+    // 1. Read the settings toggle (default ON) once.
+    let enabled = {
+        let settings_state = app.state::<crate::config::settings::SettingsState>();
+        let s = settings_state.read().await;
+        s.npm_update_notifications_enabled
+    };
+
+    let current = env!("CARGO_PKG_VERSION").to_string();
+    let now = Utc::now();
+    let cache = read_cache();
+
+    // 2. Pure decision: skip / use-cached / fetch (T1, unit-tested).
+    let plan = plan_check(enabled, &cache, now);
+    if plan == CheckPlan::Skip {
+        log::debug!("[update-check] disabled by settings; skipping");
+        return;
+    }
+
+    // 3. Hit the network only when the plan says to. Inside the 24h window we
+    //    reuse the cached latest version so the toast still appears without
+    //    re-hitting the registry.
+    let fetched = if plan == CheckPlan::Fetch {
+        fetch_latest(&app).await
+    } else {
+        None
+    };
+
+    // 4. Pure resolution + write-only-on-success (T1, unit-tested). On a fresh
+    //    successful fetch we stamp `now` and write the cache; on a throttle hit
+    //    or a failed fetch we fall back to the cached value and write nothing.
+    let (latest, write_back) = resolve_latest(plan, fetched, &cache);
+    if write_back {
+        if let Some(ref v) = latest {
+            write_cache(&UpdateCache {
+                last_checked_at: now,
+                latest_version: v.clone(),
+            });
+        }
+    }
+
+    let Some(latest) = latest else {
+        log::debug!("[update-check] no latest version available; no-op");
+        return;
+    };
+
+    // 5. Compare + notify.
+    if is_newer(&latest, &current) {
+        let info = UpdateInfo {
+            current_version: current,
+            latest_version: latest,
+            upgrade_command: upgrade_command(),
+        };
+        let _ = cache_state.set(info.clone());
+        let _ = app.emit("npm_update_available", &info);
+        log::info!(
+            "[update-check] update available: {} -> {}",
+            info.current_version,
+            info.latest_version
+        );
+    } else {
+        log::debug!("[update-check] up to date (current {}, latest {})", current, latest);
+    }
+}
+
+/// GET the dist-tags and return `latest`. Fail-silent on offline/timeout
+/// (returns None quietly). Logs at WARN (H1) when the registry *responds* but
+/// the response is unusable (non-2xx, empty/oversized, or unparseable) so a
+/// wrong URL or a future registry-shape change leaves a breadcrumb in app.log.
+/// This warn-on-bad-response posture is the safety net for the no-test-gate
+/// path: plain offline stays silent, a broken contract is loud.
+async fn fetch_latest(app: &AppHandle) -> Option<String> {
+    let network = app.state::<crate::network::OutboundNetwork>();
+    let _permit = network.acquire("update_check.dist_tags").await.ok()?;
+    let resp = tokio::time::timeout(
+        Duration::from_secs(REQUEST_TIMEOUT_SECS),
+        network
+            .general()
+            .get(DIST_TAGS_URL)
+            .header(
+                reqwest::header::USER_AGENT,
+                concat!("agentscommander/", env!("CARGO_PKG_VERSION")),
+            )
+            .send(),
+    )
+    .await
+    .ok()? // timeout: fail-silent (treat as offline)
+    .ok()?; // transport error: fail-silent (treat as offline)
+
+    if !resp.status().is_success() {
+        log::warn!(
+            "[update-check] registry returned status {}",
+            resp.status().as_u16()
+        );
+        return None;
+    }
+
+    // L1: mirror fetch_home_markdown exactly - read bytes and length-check
+    // before allocating/decoding a String.
+    let bytes = resp.bytes().await.ok()?;
+    if bytes.is_empty() || bytes.len() > DIST_TAGS_MAX_BYTES {
+        log::warn!(
+            "[update-check] registry body empty or too large ({} bytes)",
+            bytes.len()
+        );
+        return None;
+    }
+    // Registry returns clean UTF-8 JSON (no BOM); add a strip_prefix for the BOM
+    // only if one is ever observed.
+    let body = String::from_utf8(bytes.to_vec()).ok()?;
+    match parse_latest(&body) {
+        Some(v) => Some(v),
+        None => {
+            log::warn!("[update-check] could not parse 'latest' from dist-tags response");
+            None
+        }
+    }
+}
+
+// ---- Phase 2 (in this PR per O1): CLI cache-only notice -------------------
+
+/// Cache-only check for the CLI startup line. No network, no settings read.
+/// Returns a one-line notice if the cached latest is newer than the running
+/// build, else None. Safe to call synchronously from `main.rs`.
+pub fn read_cached_notice() -> Option<String> {
+    let cache = read_cache()?;
+    let current = env!("CARGO_PKG_VERSION");
+    if is_newer(&cache.latest_version, current) {
+        Some(format!(
+            "Update available: v{} (you have v{}). Run: {}",
+            cache.latest_version,
+            current,
+            upgrade_command()
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_newer_basic() {
+        assert!(is_newer("0.9.17", "0.9.16"));
+        assert!(is_newer("1.0.0", "0.9.16"));
+        assert!(is_newer("0.10.0", "0.9.16"));
+        assert!(!is_newer("0.9.16", "0.9.16"));
+        assert!(!is_newer("0.9.15", "0.9.16"));
+    }
+
+    #[test]
+    fn is_newer_ignores_prerelease_and_build() {
+        assert!(is_newer("1.0.0-rc.1", "0.9.16")); // numeric core wins
+        assert!(!is_newer("0.9.16+build.5", "0.9.16"));
+    }
+
+    #[test]
+    fn is_newer_fails_closed_on_garbage() {
+        assert!(!is_newer("not-a-version", "0.9.16"));
+        assert!(!is_newer("0.9.17", "garbage"));
+        assert!(!is_newer("", ""));
+    }
+
+    #[test]
+    fn parse_latest_extracts_tag() {
+        assert_eq!(
+            parse_latest(r#"{"latest":"1.2.3","beta":"2.0.0-rc.1"}"#),
+            Some("1.2.3".to_string())
+        );
+        assert_eq!(parse_latest(r#"{"no-latest":"x"}"#), None);
+        assert_eq!(parse_latest("not json"), None);
+    }
+
+    #[test]
+    fn should_check_gates_on_age() {
+        let now = "2026-06-23T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        assert!(should_check(&None, now));
+        let fresh = UpdateCache {
+            last_checked_at: "2026-06-23T06:00:00Z".parse().unwrap(), // 6h ago
+            latest_version: "0.9.16".into(),
+        };
+        assert!(!should_check(&Some(fresh), now));
+        let stale = UpdateCache {
+            last_checked_at: "2026-06-22T06:00:00Z".parse().unwrap(), // 30h ago
+            latest_version: "0.9.16".into(),
+        };
+        assert!(should_check(&Some(stale), now));
+        let future = UpdateCache {
+            last_checked_at: "2026-06-24T06:00:00Z".parse().unwrap(), // clock skew
+            latest_version: "0.9.16".into(),
+        };
+        assert!(should_check(&Some(future), now));
+    }
+
+    // ---- T1: pure decision-logic tests (zero Tauri, zero network) ----------
+
+    #[test]
+    fn plan_check_skip_use_fetch() {
+        let now = "2026-06-23T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let fresh = UpdateCache {
+            last_checked_at: "2026-06-23T06:00:00Z".parse().unwrap(), // 6h ago
+            latest_version: "0.9.16".into(),
+        };
+        // Toggle off -> Skip, even with a fresh cache.
+        assert_eq!(plan_check(false, &Some(fresh.clone()), now), CheckPlan::Skip);
+        // Enabled + no cache -> Fetch.
+        assert_eq!(plan_check(true, &None, now), CheckPlan::Fetch);
+        // Enabled + fresh cache (throttle hit) -> UseCached.
+        assert_eq!(plan_check(true, &Some(fresh), now), CheckPlan::UseCached);
+        // Enabled + stale cache (30h) -> Fetch.
+        let stale = UpdateCache {
+            last_checked_at: "2026-06-22T06:00:00Z".parse().unwrap(),
+            latest_version: "0.9.16".into(),
+        };
+        assert_eq!(plan_check(true, &Some(stale), now), CheckPlan::Fetch);
+    }
+
+    #[test]
+    fn resolve_latest_all_paths() {
+        let cache = Some(UpdateCache {
+            last_checked_at: "2026-06-23T06:00:00Z".parse().unwrap(),
+            latest_version: "0.9.10".into(),
+        });
+        // Skip: nothing known, no write.
+        assert_eq!(resolve_latest(CheckPlan::Skip, None, &cache), (None, false));
+        // UseCached: cached value, no write (throttle hit).
+        assert_eq!(
+            resolve_latest(CheckPlan::UseCached, None, &cache),
+            (Some("0.9.10".into()), false)
+        );
+        // Fetch success: fresh value, write-back true (write-only-on-success).
+        assert_eq!(
+            resolve_latest(CheckPlan::Fetch, Some("0.9.20".into()), &cache),
+            (Some("0.9.20".into()), true)
+        );
+        // Fetch fail: fall back to cache, no write.
+        assert_eq!(
+            resolve_latest(CheckPlan::Fetch, None, &cache),
+            (Some("0.9.10".into()), false)
+        );
+    }
+
+    #[test]
+    fn resolve_latest_fetch_fail_no_cache() {
+        // Fetch fail with no cache -> nothing known, no write (no false toast).
+        assert_eq!(resolve_latest(CheckPlan::Fetch, None, &None), (None, false));
+    }
+}

--- a/src-tauri/src/update_check.rs
+++ b/src-tauri/src/update_check.rs
@@ -160,9 +160,15 @@ pub fn is_newer(latest: &str, current: &str) -> bool {
 }
 
 /// Pull `dist-tags.latest` out of the registry JSON body. Fail-silent.
+/// An empty `latest` (e.g. a malformed `{"latest":""}`) is treated as no result
+/// (FIX-2) so we re-check next boot instead of caching `""` and anchoring the
+/// 24h throttle on junk.
 fn parse_latest(body: &str) -> Option<String> {
     let v: serde_json::Value = serde_json::from_str(body).ok()?;
-    v.get("latest")?.as_str().map(|s| s.to_string())
+    v.get("latest")?
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
 }
 
 fn upgrade_command() -> String {
@@ -296,22 +302,49 @@ async fn fetch_latest(app: &AppHandle) -> Option<String> {
 
 // ---- Phase 2 (in this PR per O1): CLI cache-only notice -------------------
 
-/// Cache-only check for the CLI startup line. No network, no settings read.
-/// Returns a one-line notice if the cached latest is newer than the running
-/// build, else None. Safe to call synchronously from `main.rs`.
+/// Pure: format the CLI notice from the loaded cache + running version + toggle.
+/// Returns the one-line string ONLY when notifications are enabled AND a newer
+/// version is cached. Kept I/O-free so the toggle-OFF and not-newer paths are
+/// unit-testable (mirrors the `plan_check`/`resolve_latest` split);
+/// `read_cached_notice` is the thin shell that loads the cache + setting.
+fn cli_notice(cache: &UpdateCache, current: &str, enabled: bool) -> Option<String> {
+    if !enabled {
+        return None;
+    }
+    if !is_newer(&cache.latest_version, current) {
+        return None;
+    }
+    Some(format!(
+        "Update available: v{} (you have v{}). Run: {}",
+        cache.latest_version,
+        current,
+        upgrade_command()
+    ))
+}
+
+/// Cache-first check for the CLI startup line. No network. Returns a one-line
+/// notice when the cached latest is newer than the running build AND the user
+/// has not disabled `npm_update_notifications_enabled`. Safe to call
+/// synchronously from `main.rs`.
+///
+/// FIX-1 (tech-lead): the single opt-out must silence BOTH the GUI toast and
+/// this CLI line. This intentionally OVERRIDES plan §5's "no settings read":
+/// opt-out consistency wins. To keep the read off every other CLI verb, we load
+/// the setting ONLY after confirming a newer version is actually cached (the
+/// caller in `main.rs` has already confirmed an interactive stderr). We use the
+/// read-only `load_settings_for_cli` loader so the CLI never writes settings.json
+/// (the GUI `load_settings` would auto-gen root_token + save, violating the
+/// read-only-CLI contract).
 pub fn read_cached_notice() -> Option<String> {
     let cache = read_cache()?;
     let current = env!("CARGO_PKG_VERSION");
-    if is_newer(&cache.latest_version, current) {
-        Some(format!(
-            "Update available: v{} (you have v{}). Run: {}",
-            cache.latest_version,
-            current,
-            upgrade_command()
-        ))
-    } else {
-        None
+    // Cheap path: bail before any settings read when nothing newer is cached.
+    if !is_newer(&cache.latest_version, current) {
+        return None;
     }
+    let enabled =
+        crate::config::settings::load_settings_for_cli().npm_update_notifications_enabled;
+    cli_notice(&cache, current, enabled)
 }
 
 #[cfg(test)]
@@ -348,6 +381,28 @@ mod tests {
         );
         assert_eq!(parse_latest(r#"{"no-latest":"x"}"#), None);
         assert_eq!(parse_latest("not json"), None);
+        // FIX-2: an empty `latest` is treated as no-result, not cached as "".
+        assert_eq!(parse_latest(r#"{"latest":""}"#), None);
+    }
+
+    #[test]
+    fn cli_notice_honors_toggle_and_version() {
+        let newer = UpdateCache {
+            last_checked_at: "2026-06-23T06:00:00Z".parse().unwrap(),
+            latest_version: "0.9.20".into(),
+        };
+        let same = UpdateCache {
+            last_checked_at: "2026-06-23T06:00:00Z".parse().unwrap(),
+            latest_version: "0.9.16".into(),
+        };
+        // Enabled + newer -> notice carrying the version + upgrade command.
+        let notice = cli_notice(&newer, "0.9.16", true).expect("expected a notice");
+        assert!(notice.contains("0.9.20"));
+        assert!(notice.contains("npm i -g @mblua/agentscommander"));
+        // FIX-1: toggle OFF -> silent even with a newer cache.
+        assert_eq!(cli_notice(&newer, "0.9.16", false), None);
+        // Enabled but not newer -> silent.
+        assert_eq!(cli_notice(&same, "0.9.16", true), None);
     }
 
     #[test]

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -7,6 +7,7 @@ import type {
   SessionRepo,
   PtyOutputEvent,
   AppSettings,
+  UpdateInfo,
   CodingAgentEnv,
   CodingAgentProfilesConfig,
   RepoMatch,
@@ -301,6 +302,8 @@ export const SettingsAPI = {
     transport.invoke<RtkSweepResult>("sweep_rtk_hook", { enabled }),
   getRtkStartupStatus: () =>
     transport.invoke<RtkStartupMode>("get_rtk_startup_status"),
+  getUpdateStatus: () =>
+    transport.invoke<UpdateInfo | null>("get_update_status"),
 };
 
 export const ReposAPI = {
@@ -865,6 +868,14 @@ export function onRtkStartupStatus(
   return transport.listen<{ mode: RtkStartupMode }>(
     "rtk_startup_status",
     (data) => callback(data.mode)
+  );
+}
+
+export function onNpmUpdateAvailable(
+  callback: (info: UpdateInfo) => void
+): Promise<UnlistenFn> {
+  return transport.listen<UpdateInfo>("npm_update_available", (info) =>
+    callback(info)
   );
 }
 

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -159,6 +159,7 @@ export function baseSettings(overrides: Partial<AppSettings> = {}): AppSettings 
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
+    npmUpdateNotificationsEnabled: true,
     ...overrides,
     codingAgentProfiles: overrides.codingAgentProfiles ?? defaultCodingAgentProfiles(),
   };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -304,6 +304,18 @@ export interface AppSettings {
   coordinatorAutoCloseMinutes: number;
   /** #588 When true, manually closing a coordinator also closes its team. */
   coordinatorCascadeCloseEnabled: boolean;
+  /** #609 Check npm on startup (<=1x/24h) and notify when a newer published
+   *  version of @mblua/agentscommander is available. Default true. */
+  npmUpdateNotificationsEnabled: boolean;
+}
+
+/** #609 "npm update available" payload. Mirrors the Rust `UpdateInfo` struct
+ *  (serde camelCase): carried by the `npm_update_available` event and returned
+ *  by `get_update_status` (null when up-to-date / not yet checked / disabled). */
+export interface UpdateInfo {
+  currentVersion: string;
+  latestVersion: string;
+  upgradeCommand: string;
 }
 
 export type ResourceWatchdogAction = "warn" | "killGroup";

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -27,6 +27,7 @@ import {
   onCodingAgentEnvSettingsUpdated,
   onCodingAgentProfileSelectionUpdated,
   onLoopEvent,
+  onNpmUpdateAvailable,
 } from "../shared/ipc";
 import { taskFirstLine } from "../shared/markdown";
 import { registerShortcuts, unregisterShortcuts } from "../shared/shortcuts";
@@ -47,6 +48,7 @@ import OnboardingModal from "./components/OnboardingModal";
 import ToastHost from "../shared/components/ToastHost";
 import { handleProjectRefreshRequested } from "./project-refresh-handler";
 import { loopToastFromEvent, type LoopToast } from "./loop-event-toast";
+import { createUpdateToaster } from "./update-toast";
 import "./styles/sidebar.css";
 import "../shared/styles/toast.css";
 
@@ -107,6 +109,10 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     }, 3000);
   };
 
+  // #609 — sticky "npm update available" toaster. Per-mount dedup state so the
+  // startup event + the getUpdateStatus snapshot never double-toast a version.
+  const showUpdateToast = createUpdateToaster();
+
   // #592 - pull the backend-computed drift flag and surgically patch each
   // session. Uses setProfileOutdated (never setSessions) so the frontend-only
   // pendingReview field is preserved. list_sessions recomputes profileOutdated
@@ -163,6 +169,21 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
         void refreshProfileOutdated();
       })
     );
+    // #609 npm update notification. Subscribe BEFORE snapshotting so a startup
+    // emit fired during mount is never dropped; showUpdateToast dedups on
+    // version (mirrors RtkBanner's subscribe-then-snapshot order). The snapshot
+    // is fire-and-forget so its IPC round-trip never delays the listener
+    // registrations that follow in this onMount.
+    unlisteners.push(
+      await onNpmUpdateAvailable((info) => showUpdateToast(info))
+    );
+    void SettingsAPI.getUpdateStatus()
+      .then((pending) => {
+        if (pending) showUpdateToast(pending);
+      })
+      .catch((err) => {
+        console.error("[update-check] getUpdateStatus failed:", err);
+      });
     unlisteners.push(
       await onCodingAgentEnvSettingsUpdated(() => {
         settingsStore.refresh();

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -175,6 +175,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
+    npmUpdateNotificationsEnabled: true,
     ...overrides,
   };
 }

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -89,6 +89,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
+    npmUpdateNotificationsEnabled: true,
     ...overrides,
   };
 }

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -132,6 +132,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
+    npmUpdateNotificationsEnabled: true,
     ...overrides,
   };
 }
@@ -1143,6 +1144,37 @@ describe("SettingsModal automation hooks", () => {
 
     const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
     expect(saved?.coordinatorCascadeCloseEnabled).toBe(false);
+
+    dispose();
+  });
+
+  it("round-trips npmUpdateNotificationsEnabled through the General update-notify checkbox (#609)", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {} }),
+      root,
+    );
+    await settle();
+
+    const checkbox = byTestId<HTMLInputElement>("settings.general.npmUpdateNotificationsEnabled");
+    expect(checkbox.closest("label")?.textContent).toContain(
+      "Notify me when a new version is available",
+    );
+    // Loaded default is true (the seeded settings have it on).
+    expect(checkbox.checked).toBe(true);
+
+    // Toggle OFF and save -> the persisted draft carries the new value, proving
+    // updateField accepts the new AppSettings key end to end.
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.npmUpdateNotificationsEnabled).toBe(false);
 
     dispose();
   });

--- a/src/sidebar/components/SettingsModal.test.ts
+++ b/src/sidebar/components/SettingsModal.test.ts
@@ -73,6 +73,7 @@ function settings(overrides: Partial<AppSettings>): AppSettings {
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
+    npmUpdateNotificationsEnabled: true,
     ...overrides,
   };
 }

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -951,6 +951,18 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           />
           <span>Always close team members when manually closing Coordinator</span>
         </label>
+        <label class="settings-checkbox-field">
+          <input
+            type="checkbox"
+            class="settings-checkbox"
+            checked={settings.data!.npmUpdateNotificationsEnabled}
+            onChange={(e) =>
+              updateField("npmUpdateNotificationsEnabled", e.currentTarget.checked)
+            }
+            data-ac-testid="settings.general.npmUpdateNotificationsEnabled"
+          />
+          <span>Notify me when a new version is available</span>
+        </label>
       </div>
 
       <div class="settings-section">

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -89,6 +89,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
+    npmUpdateNotificationsEnabled: true,
     ...overrides,
   };
 }

--- a/src/sidebar/update-toast.test.ts
+++ b/src/sidebar/update-toast.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createUpdateToaster } from "./update-toast";
+import { toastStore } from "../shared/stores/toasts";
+import type { UpdateInfo } from "../shared/types";
+
+function info(latestVersion: string): UpdateInfo {
+  return {
+    currentVersion: "0.9.16",
+    latestVersion,
+    upgradeCommand: "npm i -g @mblua/agentscommander",
+  };
+}
+
+describe("createUpdateToaster (#609)", () => {
+  beforeEach(() => toastStore.clear());
+
+  it("shows one sticky info toast carrying the version + upgrade command", () => {
+    const show = createUpdateToaster();
+    show(info("0.9.17"));
+
+    expect(toastStore.items).toHaveLength(1);
+    expect(toastStore.items[0].kind).toBe("info");
+    expect(toastStore.items[0].message).toContain("0.9.17");
+    expect(toastStore.items[0].message).toContain(
+      "npm i -g @mblua/agentscommander",
+    );
+  });
+
+  it("dedups the same latestVersion (event + snapshot race) to one toast", () => {
+    const show = createUpdateToaster();
+    show(info("0.9.17"));
+    show(info("0.9.17"));
+
+    expect(toastStore.items).toHaveLength(1);
+  });
+
+  it("shows a second toast when latestVersion changes", () => {
+    const show = createUpdateToaster();
+    show(info("0.9.17"));
+    show(info("0.9.18"));
+
+    expect(toastStore.items).toHaveLength(2);
+  });
+
+  it("gives each toaster instance independent dedup state", () => {
+    const a = createUpdateToaster();
+    const b = createUpdateToaster();
+    a(info("0.9.17"));
+    b(info("0.9.17"));
+
+    expect(toastStore.items).toHaveLength(2);
+  });
+});

--- a/src/sidebar/update-toast.ts
+++ b/src/sidebar/update-toast.ts
@@ -1,0 +1,26 @@
+import { toastStore } from "../shared/stores/toasts";
+import type { UpdateInfo } from "../shared/types";
+
+/**
+ * #609 — build a sticky "npm update available" toaster with per-version dedup.
+ *
+ * The sidebar subscribes to the `npm_update_available` event BEFORE it snapshots
+ * `get_update_status`, so a startup emit fired during mount is never dropped.
+ * That means the same `UpdateInfo` can arrive twice (event + snapshot). The
+ * returned closure shows the info toast at most once per `latestVersion`, so the
+ * race never double-toasts. Each factory call owns its own dedup state, so a
+ * fresh mount starts clean (and unit tests stay isolated).
+ */
+export function createUpdateToaster(): (info: UpdateInfo) => void {
+  let lastVersion: string | null = null;
+  return (info: UpdateInfo): void => {
+    if (lastVersion === info.latestVersion) return;
+    lastVersion = info.latestVersion;
+    // O2: English, sticky (durationMs: null) so the upgrade command stays
+    // readable until the user dismisses it.
+    toastStore.info(
+      `Update available: v${info.latestVersion} (you have v${info.currentVersion}). Run: ${info.upgradeCommand}`,
+      { durationMs: null },
+    );
+  };
+}


### PR DESCRIPTION
## Summary

Adds an in-app notification when a newer version of the published npm package `@mblua/agentscommander` is available, so users know to update via `npm i -g @mblua/agentscommander`.

- **Detection:** a detached startup check reads the baked-in version (`CARGO_PKG_VERSION`) and queries the npm registry dist-tags for `@mblua/agentscommander` (`%2F`-encoded URL), semver-compares, and on a newer version caches the result + emits `npm_update_available`. Reuses the managed `OutboundNetwork` (no new HTTP code / no new crates); 10s timeout, fail-silent offline, `warn`-level logging on a broken response (the breadcrumb).
- **Throttle:** once / 24h, persisted atomically (temp + rename) in `update-check.json` (separate from `settings.json`); the cached toast still shows within the window.
- **Surfaces:** Phase 1 — sidebar sticky info toast (English) with the upgrade command; Phase 2 — a one-line CLI notice on interactive terminals only (gated on `std::io::stderr().is_terminal()`, never on agent/script/piped runs).
- **Control:** Settings toggle `npmUpdateNotificationsEnabled` (default ON) that silences BOTH the GUI toast and the CLI line. Notify-only — no auto-update.

## Review & validation

- Full path: architect plan → dev-rust + grinch plan enrichment → architect consensus (READY) → BE (dev-rust) + FE (dev-webpage-ui) implementation → grinch Step-7 on the real code.
- **Grinch Step-7: PASS** — no HIGH/MEDIUM/LOW. Grinch re-ran every gate itself: BE `cargo build`/`clippy` clean, `cargo test` lib **1358/0/8** (9 new #609 tests pass by name); FE `tsc` clean, **vitest 480/480**, `vite build` OK.
- Adversarial catch during planning: the registry URL needed `%2F`-encoding (a literal slash would 404 → silent never-notify); fixed and **live-verified**, plus `warn`-level logging as a safety breadcrumb.
- Production build validated by shipper (clean `tauri build`, 0.9.16) and deployed to 0_AC for the workgroup.
- Note: live npm `latest`=`0.8.50` < repo `0.9.16`, so the positive toast path is covered by unit tests with forced versions; it surfaces in the wild once a newer version is published to npm.

## Notes

- **No version bump** (per policy — the bump happens when cutting the GitHub/npm release).
- Pre-existing `cli_close_session` integration failures are environmental (a broken PowerShell test fixture), proven identical on the clean base `3d96cef` — not introduced by this PR.

Closes #609
