### PR TITLE
feat: logging cleanup + live log-level selector (#612)

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -110,6 +110,13 @@ pub async fn save_settings_draft(
     let (saved, events) = persist_settings_draft_update(settings.inner(), draft).await?;
     purge_sessions_after_settings_update(&saved);
     emit_settings_draft_update_events(&app, &events);
+    // #612 apply the (possibly changed) log level live + broadcast so every
+    // webview re-applies its console gate. Idempotent and cheap; runs only on an
+    // explicit Settings Save. `saved` is the binding already destructured from
+    // the persist call above, so this does NOT re-persist.
+    let level = crate::logging::normalize_log_level(saved.log_level.as_deref().unwrap_or("info"))
+        .unwrap_or("info");
+    apply_and_broadcast_log_level(&app, level);
     Ok(())
 }
 
@@ -1199,6 +1206,41 @@ pub async fn set_main_resource_monitor_attached(
         candidate.main_resource_monitor_attached = value;
     })
     .await
+}
+
+/// #612 apply the runtime log level (no-op under RUST_LOG) and broadcast so
+/// every webview re-applies its own console gate. Single point that both the
+/// dedicated `set_log_level` command and the SettingsModal Save path reuse.
+fn apply_and_broadcast_log_level(app: &AppHandle, level: &str) {
+    // set_runtime_log_level returns false when the gate is not installed
+    // (RUST_LOG dev-override active): the backend stays frozen and only the
+    // frontend console gate moves. Emit one debug line so an operator reading
+    // app.log isn't confused why the backend verbosity didn't change.
+    if !crate::logging::set_runtime_log_level(level) {
+        log::debug!(
+            "[log-level] RUST_LOG override active; backend frozen, applying '{level}' to frontend only"
+        );
+    }
+    let _ = app.emit("log_level_changed", serde_json::json!({ "level": level }));
+}
+
+/// #612 canonical command to change ONLY the log level: validates, persists
+/// `logLevel`, applies live, broadcasts. Used by programmatic callers / future
+/// quick-switch; the SettingsModal uses the form Save path (`save_settings_draft`).
+#[tauri::command]
+pub async fn set_log_level(
+    app: AppHandle,
+    settings: State<'_, SettingsState>,
+    level: String,
+) -> Result<(), String> {
+    let normalized = crate::logging::normalize_log_level(&level)
+        .ok_or_else(|| format!("Invalid log level: {level}"))?;
+    persist_narrow_settings_update(settings.inner(), |candidate| {
+        candidate.log_level = Some(normalized.to_string());
+    })
+    .await?;
+    apply_and_broadcast_log_level(&app, normalized);
+    Ok(())
 }
 
 /// Sweep every AC-managed agent directory and apply

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1460,7 +1460,7 @@ fn load_settings_from_path(path: &Path) -> AppSettings {
         match std::fs::read_to_string(path) {
             Ok(contents) => match parse_settings_json(&contents, &path.to_string_lossy()) {
                 Ok((s, migrated)) => {
-                    log::info!("Loaded settings from {:?}", path);
+                    log::debug!("Loaded settings from {:?}", path);
                     if migrated {
                         profile_migrated_to_v2 = true;
                         pre_migration_contents = Some(contents);
@@ -1603,7 +1603,7 @@ pub fn load_settings_for_cli() -> AppSettings {
         match std::fs::read_to_string(&path) {
             Ok(contents) => match parse_settings_json(&contents, &path.to_string_lossy()) {
                 Ok((s, _migrated)) => {
-                    log::info!("[cli] Loaded settings from {:?}", path);
+                    log::debug!("[cli] Loaded settings from {:?}", path);
                     s
                 }
                 Err(e) => {
@@ -1722,7 +1722,7 @@ fn save_settings_to_path(settings: &AppSettings, path: &Path) -> Result<(), Stri
     std::fs::rename(&tmp_path, path)
         .map_err(|e| format!("Failed to rename settings file: {}", e))?;
 
-    log::info!("Saved settings to {:?}", path);
+    log::debug!("Saved settings to {:?}", path);
     Ok(())
 }
 

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -896,7 +896,7 @@ pub fn discover_teams() -> Vec<DiscoveredTeam> {
         }
     }
 
-    log::info!(
+    log::debug!(
         "[teams] discovered {} team(s) across {} project path(s)",
         teams.len(),
         settings.project_paths.len()
@@ -946,16 +946,16 @@ fn discover_teams_in_project(project_dir: &Path, teams: &mut Vec<DiscoveredTeam>
         let raw = match std::fs::read_to_string(&config_path) {
             Ok(s) => s,
             Err(e) => {
-                // #280 §3.4 — NotFound is an expected state for half-installed
+                // #280 §3.4: NotFound is an expected state for half-installed
                 // team dirs (`_team_foo/` created but no `config.json` yet).
-                // Logging WARN at every discovery sweep spams app.log; downgrade
-                // NotFound to DEBUG and emit a one-shot INFO per (project,
-                // team_dir) per process so the operator still sees the visit.
-                // Unexpected IO errors stay at WARN.
+                // Logging WARN at every discovery sweep spams app.log, so both
+                // the one-shot per-(project, team_dir) visit record and the
+                // per-drop record below are DEBUG (#612 downgraded the prior
+                // one-shot INFO). Unexpected IO errors stay at WARN.
                 match e.kind() {
                     std::io::ErrorKind::NotFound => {
                         if note_missing_team_config(&project_folder, dir_name) {
-                            log::info!(
+                            log::debug!(
                                 "[teams] team config missing (logged once per startup) — project='{}' team_dir='{}' path='{}'",
                                 project_folder,
                                 dir_name,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -241,7 +241,7 @@ pub fn run(
     let handle_for_busy = Arc::clone(&app_handle_lock);
     let idle_detector = IdleDetector::new(
         move |id| {
-            log::info!("[idle] >>> EMIT session_idle for {}", &id.to_string()[..8]);
+            log::debug!("[idle] >>> EMIT session_idle for {}", &id.to_string()[..8]);
             if let Some(app) = handle_for_idle.get() {
                 let _ = tauri::Emitter::emit(
                     app,
@@ -267,7 +267,7 @@ pub fn run(
             }
         },
         move |id| {
-            log::info!("[idle] >>> EMIT session_busy for {}", &id.to_string()[..8]);
+            log::debug!("[idle] >>> EMIT session_busy for {}", &id.to_string()[..8]);
             if let Some(app) = handle_for_busy.get() {
                 let _ = tauri::Emitter::emit(
                     app,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1736,6 +1736,7 @@ pub fn run(
             commands::config::set_sounds_enabled,
             commands::config::set_theme_light,
             commands::config::set_main_resource_monitor_attached,
+            commands::config::set_log_level,
             commands::config::sweep_rtk_hook,
             commands::config::get_rtk_startup_status,
             commands::config::get_update_status,

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -15,10 +15,106 @@
 use std::collections::VecDeque;
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 static INIT: OnceLock<()> = OnceLock::new();
+
+/// #612 runtime-adjustable verbosity for our own targets (`agentscommander*`),
+/// stored as `log::Level as u8` (Error=1 .. Trace=5). Installed ONLY on the
+/// no-RUST_LOG path (see `init_logger_inner`); the RUST_LOG dev-override path
+/// keeps env_logger frozen and leaves this unset.
+static RUNTIME_LEVEL: OnceLock<Arc<AtomicU8>> = OnceLock::new();
+
+/// #612 fixed inner filter for the gated path: third-party crates pinned at
+/// `warn`; our own targets opened to `trace` so the runtime atomic (not
+/// env_logger) is the sole gate for `agentscommander*`.
+const GATE_INNER_FILTER: &str = "warn,agentscommander=trace";
+
+/// #612 lenient string -> Level for the runtime gate. None / legacy full-filter
+/// string / typo all fall back to Info (the historical default).
+fn level_from_str(s: &str) -> log::Level {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "error" => log::Level::Error,
+        "warn" => log::Level::Warn,
+        "info" => log::Level::Info,
+        "debug" => log::Level::Debug,
+        "trace" => log::Level::Trace,
+        _ => log::Level::Info,
+    }
+}
+
+/// #612 strict normalize for the command boundary: returns the canonical
+/// lowercase string for a valid level, else None (so `set_log_level` rejects
+/// junk instead of silently persisting it).
+pub fn normalize_log_level(s: &str) -> Option<&'static str> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "error" => Some("error"),
+        "warn" => Some("warn"),
+        "info" => Some("info"),
+        "debug" => Some("debug"),
+        "trace" => Some("trace"),
+        _ => None,
+    }
+}
+
+/// #612 global `max_level` for the gated path. Clamped to at least Warn so
+/// third-party `warn!` stays visible even when the user picks Error for our own
+/// targets; raising it to the selected level lets the `log!` macro short-circuit
+/// suppressed debug!/trace! on hot paths BEFORE they reach the gate (the PTY
+/// read-loop trace! is the motivating case).
+fn max_filter_for(level: log::Level) -> log::LevelFilter {
+    std::cmp::max(level.to_level_filter(), log::LevelFilter::Warn)
+}
+
+/// #612 thin `log::Log` wrapper: consults the runtime atomic for
+/// `agentscommander*` targets and delegates everything else to a fixed inner
+/// `env_logger::Logger` (third-party crates pinned by `GATE_INNER_FILTER`).
+/// Lets the level change with no restart while reusing the inner logger's
+/// format closure (timestamp + secret scrub + #264 sink + rotation) unchanged.
+struct LevelGateLogger {
+    inner: env_logger::Logger,
+    level: Arc<AtomicU8>,
+}
+
+impl log::Log for LevelGateLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        if metadata.target().starts_with("agentscommander") {
+            (metadata.level() as u8) <= self.level.load(Ordering::Relaxed)
+        } else {
+            // Third-party: defer to the inner env_logger's fixed warn filter.
+            self.inner.enabled(metadata)
+        }
+    }
+
+    fn log(&self, record: &log::Record) {
+        // Re-check per the log::Log contract: the global max_level may admit
+        // records this gate rejects. Delegating to inner reuses the existing
+        // format closure unchanged (scrub + #264 sink + rotation).
+        if self.enabled(record.metadata()) {
+            self.inner.log(record);
+        }
+    }
+
+    fn flush(&self) {
+        self.inner.flush();
+    }
+}
+
+/// #612 update runtime verbosity for `agentscommander*`. Returns false (no-op)
+/// when the gate is not installed (RUST_LOG override active, or called before
+/// `init_logger`), so callers can tell whether the backend stayed frozen.
+pub fn set_runtime_log_level(level: &str) -> bool {
+    let lvl = level_from_str(level);
+    match RUNTIME_LEVEL.get() {
+        Some(atomic) => {
+            atomic.store(lvl as u8, Ordering::Relaxed);
+            log::set_max_level(max_filter_for(lvl));
+            true
+        }
+        None => false,
+    }
+}
 
 /// #280 §2 — size cap per `app.log` file. Above this, the file is rotated.
 /// 50 MB chosen so a single file is still grep-able in a text editor while
@@ -215,6 +311,54 @@ pub fn init_logger() {
     INIT.get_or_init(init_logger_inner);
 }
 
+/// #612 apply the shared format closure (timestamp + universal secret scrub +
+/// #264 error-sink tee + 50MB rotation) to `builder`. The body is the EXACT
+/// closure that was inline in `init_logger_inner`; only the captured `log_state`
+/// moves to this parameter, so both the RUST_LOG path and the runtime-gated
+/// path build on one definition. Do NOT reorder: the #264 capture stays BEFORE
+/// the buf/file writes (M1) so a failing write cannot skip error capture.
+fn install_format(builder: &mut env_logger::Builder, log_state: Arc<Option<Arc<AppLogFile>>>) {
+    builder.format(move |buf, record| {
+        let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+        let line = format!(
+            "{} [{}] {} — {}\n",
+            ts,
+            record.level(),
+            record.target(),
+            record.args()
+        );
+        // #280 — universal secret scrub before the line reaches
+        // stderr or app.log. Defends against new call sites and
+        // third-party crate errors that may have bypassed api.rs's
+        // and voice.rs's redaction. Near-zero cost when the line
+        // contains no "/bot" or "key=" substring (early-return
+        // inside redact()).
+        let line = crate::telegram::redact::redact(&line);
+        // #264 — tee ERROR-level entries from AgentsCommander's own
+        // targets into the process-wide sink for the UI error modal.
+        // Placed BEFORE the `?` writes below so a failing stderr/app.log
+        // write cannot skip capture (M1). MUST NOT call any log::* macro
+        // — this runs inside the logger and would recurse.
+        if should_capture(record) {
+            error_sink().capture(ErrorLogEntry::from_record(ts.to_string(), record));
+        }
+        if !machine_output_enabled() {
+            buf.write_all(line.as_bytes())?;
+        }
+        if let Some(ref state) = *log_state {
+            if let Ok(mut f) = state.file.lock() {
+                let _ = f.write_all(line.as_bytes());
+            }
+            let new_total = state.bytes.fetch_add(line.len() as u64, Ordering::Relaxed)
+                + line.len() as u64;
+            if new_total >= APP_LOG_MAX_BYTES {
+                rotate(state);
+            }
+        }
+        Ok(())
+    });
+}
+
 fn init_logger_inner() {
     let log_state: Option<Arc<AppLogFile>> = crate::config::config_dir().and_then(|dir| {
         let _ = std::fs::create_dir_all(&dir);
@@ -247,66 +391,50 @@ fn init_logger_inner() {
     }
     let log_state = Arc::new(log_state);
 
-    // #93 precedence: RUST_LOG env > settings.logLevel > "agentscommander=info" default.
-    // - read_log_level_only is read-only and side-effect-free: does NOT trigger
-    //   migrations, auto-token-gen, or save_settings, so all log calls inside the
-    //   full load_settings() flow re-fire on the post-init SettingsState construction
-    //   call and are captured.
-    // - from_env(Env::default()) preserves RUST_LOG_STYLE handling (color output).
-    // - No floor is applied: if `resolved_filter` is malformed (e.g. user typo in
-    //   settings.json::logLevel), parse_filters produces no matching directives for
-    //   agentscommander* targets, and all logs from those targets are suppressed.
-    //   The user-facing recovery is to fix the typo.
-    let resolved_filter = std::env::var("RUST_LOG")
-        .ok()
-        .or_else(crate::config::settings::read_log_level_only)
-        .unwrap_or_else(|| "agentscommander=info".to_string());
+    // #612 precedence (was #93): RUST_LOG env > settings.logLevel > Info default.
+    //
+    // RUST_LOG is the dev override and wins. When set, keep the original frozen
+    // env_logger path with NO runtime gate: a dev who exports RUST_LOG wants
+    // exactly that filter (including third-party verbosity) for the whole
+    // session, so the UI selector cannot change the backend level until a
+    // restart without RUST_LOG. read_log_level_only is read-only and
+    // side-effect-free (no migration / token-gen / save), so log calls inside
+    // the later full load_settings() flow still reach this sink.
+    if let Ok(rust_log) = std::env::var("RUST_LOG") {
+        let mut builder = env_logger::Builder::from_env(env_logger::Env::default());
+        builder.parse_filters(&rust_log);
+        install_format(&mut builder, Arc::clone(&log_state));
+        builder.init();
+        return;
+    }
 
-    env_logger::Builder::from_env(env_logger::Env::default())
-        .parse_filters(&resolved_filter)
-        .format({
-            let log_state = Arc::clone(&log_state);
-            move |buf, record| {
-                let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
-                let line = format!(
-                    "{} [{}] {} — {}\n",
-                    ts,
-                    record.level(),
-                    record.target(),
-                    record.args()
-                );
-                // #280 — universal secret scrub before the line reaches
-                // stderr or app.log. Defends against new call sites and
-                // third-party crate errors that may have bypassed api.rs's
-                // and voice.rs's redaction. Near-zero cost when the line
-                // contains no "/bot" or "key=" substring (early-return
-                // inside redact()).
-                let line = crate::telegram::redact::redact(&line);
-                // #264 — tee ERROR-level entries from AgentsCommander's own
-                // targets into the process-wide sink for the UI error modal.
-                // Placed BEFORE the `?` writes below so a failing stderr/app.log
-                // write cannot skip capture (M1). MUST NOT call any log::* macro
-                // — this runs inside the logger and would recurse.
-                if should_capture(record) {
-                    error_sink().capture(ErrorLogEntry::from_record(ts.to_string(), record));
-                }
-                if !machine_output_enabled() {
-                    buf.write_all(line.as_bytes())?;
-                }
-                if let Some(ref state) = *log_state {
-                    if let Ok(mut f) = state.file.lock() {
-                        let _ = f.write_all(line.as_bytes());
-                    }
-                    let new_total = state.bytes.fetch_add(line.len() as u64, Ordering::Relaxed)
-                        + line.len() as u64;
-                    if new_total >= APP_LOG_MAX_BYTES {
-                        rotate(state);
-                    }
-                }
-                Ok(())
-            }
-        })
-        .init();
+    // No RUST_LOG: install the runtime-gated logger. The initial level comes
+    // from settings.logLevel (canonical 5-value string; None / legacy filter /
+    // typo all fall back to Info via level_from_str). from_env(Env::default())
+    // contributes nothing to the filter here (RUST_LOG is unset) but preserves
+    // RUST_LOG_STYLE color handling, matching the prior behavior; the fixed
+    // GATE_INNER_FILTER then pins third-party crates at warn and opens our own
+    // targets to trace so the runtime atomic is the sole gate for them.
+    let initial = level_from_str(
+        crate::config::settings::read_log_level_only()
+            .as_deref()
+            .unwrap_or("info"),
+    );
+    let atomic = Arc::new(AtomicU8::new(initial as u8));
+    let _ = RUNTIME_LEVEL.set(Arc::clone(&atomic));
+
+    let mut builder = env_logger::Builder::from_env(env_logger::Env::default());
+    builder.parse_filters(GATE_INNER_FILTER);
+    install_format(&mut builder, Arc::clone(&log_state));
+    let inner = builder.build(); // build(), NOT init(): we wrap it below
+
+    let gate = LevelGateLogger {
+        inner,
+        level: atomic,
+    };
+    if log::set_boxed_logger(Box::new(gate)).is_ok() {
+        log::set_max_level(max_filter_for(initial));
+    }
 }
 
 // ===========================================================================
@@ -447,6 +575,9 @@ pub fn spawn_error_emit_task(app: tauri::AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // #612 the gate's enabled()/log() are `log::Log` trait methods; bring the
+    // trait into scope so the tests can call them on a `LevelGateLogger` value.
+    use log::Log;
 
     /// Build an `ErrorLogEntry` carrying `message`; the other fields are fixed.
     fn entry(message: &str) -> ErrorLogEntry {
@@ -766,6 +897,176 @@ mod tests {
         assert!(
             read_marker(tmp.path(), "app.log.2").is_none(),
             "no second-slot file should exist after idempotent second rotation"
+        );
+    }
+
+    // ── #612 runtime log-level gate tests ───────────────────────────
+
+    /// Build the fixed inner `env_logger::Logger` for the gate WITHOUT reading
+    /// RUST_LOG (hermetic): `Builder::new()` + the exact production filter, so a
+    /// dev with RUST_LOG exported in their shell cannot perturb these tests.
+    fn gate_inner() -> env_logger::Logger {
+        let mut builder = env_logger::Builder::new();
+        builder.parse_filters(GATE_INNER_FILTER);
+        builder.build()
+    }
+
+    /// A gate at `level` over a fresh hermetic inner logger.
+    fn gate_at(level: log::Level) -> LevelGateLogger {
+        LevelGateLogger {
+            inner: gate_inner(),
+            level: Arc::new(AtomicU8::new(level as u8)),
+        }
+    }
+
+    fn admits(gate: &LevelGateLogger, level: log::Level, target: &str) -> bool {
+        gate.enabled(&log::Metadata::builder().level(level).target(target).build())
+    }
+
+    #[test]
+    fn level_from_str_maps_five_levels_and_falls_back_to_info() {
+        assert_eq!(level_from_str("error"), log::Level::Error);
+        assert_eq!(level_from_str("warn"), log::Level::Warn);
+        assert_eq!(level_from_str("info"), log::Level::Info);
+        assert_eq!(level_from_str("debug"), log::Level::Debug);
+        assert_eq!(level_from_str("trace"), log::Level::Trace);
+        // Case-insensitive + trimmed.
+        assert_eq!(level_from_str("  INFO  "), log::Level::Info);
+        assert_eq!(level_from_str("Debug"), log::Level::Debug);
+        // None-equivalent / empty / legacy full-filter string / typo -> Info.
+        assert_eq!(level_from_str(""), log::Level::Info);
+        assert_eq!(
+            level_from_str("info,agentscommander_lib::config::teams=debug"),
+            log::Level::Info
+        );
+        assert_eq!(level_from_str("verbose"), log::Level::Info);
+    }
+
+    #[test]
+    fn normalize_log_level_accepts_valid_rejects_junk() {
+        assert_eq!(normalize_log_level("error"), Some("error"));
+        assert_eq!(normalize_log_level("WARN"), Some("warn"));
+        assert_eq!(normalize_log_level(" info "), Some("info"));
+        assert_eq!(normalize_log_level("debug"), Some("debug"));
+        assert_eq!(normalize_log_level("trace"), Some("trace"));
+        // Junk / empty / legacy full-filter string -> None (command rejects it).
+        assert_eq!(normalize_log_level(""), None);
+        assert_eq!(normalize_log_level("verbose"), None);
+        assert_eq!(
+            normalize_log_level("info,agentscommander_lib::config::teams=debug"),
+            None
+        );
+    }
+
+    #[test]
+    fn max_filter_for_clamps_to_at_least_warn() {
+        // Error/Warn both floor at Warn so third-party warn! stays visible even
+        // when the user selects Error for our own targets.
+        assert_eq!(max_filter_for(log::Level::Error), log::LevelFilter::Warn);
+        assert_eq!(max_filter_for(log::Level::Warn), log::LevelFilter::Warn);
+        // Info/Debug/Trace map through unchanged.
+        assert_eq!(max_filter_for(log::Level::Info), log::LevelFilter::Info);
+        assert_eq!(max_filter_for(log::Level::Debug), log::LevelFilter::Debug);
+        assert_eq!(max_filter_for(log::Level::Trace), log::LevelFilter::Trace);
+    }
+
+    #[test]
+    fn level_gate_at_info_suppresses_our_debug_keeps_thirdparty_warn() {
+        let gate = gate_at(log::Level::Info);
+        // Our own targets: trace/debug suppressed; info/warn/error admitted.
+        assert!(!admits(&gate, log::Level::Trace, "agentscommander_lib::x"));
+        assert!(!admits(&gate, log::Level::Debug, "agentscommander_lib::x"));
+        assert!(admits(&gate, log::Level::Info, "agentscommander_lib::x"));
+        assert!(admits(&gate, log::Level::Warn, "agentscommander_lib::x"));
+        assert!(admits(&gate, log::Level::Error, "agentscommander_lib::x"));
+        // Third-party: info suppressed, warn admitted (fixed warn filter).
+        assert!(!admits(&gate, log::Level::Info, "hyper::client"));
+        assert!(admits(&gate, log::Level::Warn, "hyper::client"));
+    }
+
+    #[test]
+    fn level_gate_at_error_admits_only_error_for_our_targets() {
+        let gate = gate_at(log::Level::Error);
+        assert!(admits(&gate, log::Level::Error, "agentscommander_lib::foo"));
+        assert!(!admits(&gate, log::Level::Warn, "agentscommander_lib::foo"));
+        assert!(!admits(&gate, log::Level::Info, "agentscommander_lib::foo"));
+        // Third-party warn is independent of the atomic: still admitted at Error.
+        assert!(admits(&gate, log::Level::Warn, "hyper::client"));
+    }
+
+    #[test]
+    fn level_gate_at_trace_admits_all_ours_but_not_thirdparty_trace() {
+        let gate = gate_at(log::Level::Trace);
+        for lvl in [
+            log::Level::Error,
+            log::Level::Warn,
+            log::Level::Info,
+            log::Level::Debug,
+            log::Level::Trace,
+        ] {
+            assert!(
+                admits(&gate, lvl, "agentscommander_lib::x"),
+                "{lvl} should be admitted for our targets at Trace"
+            );
+        }
+        // Third-party stays pinned at warn even when WE are at Trace.
+        assert!(!admits(&gate, log::Level::Trace, "hyper::client"));
+        assert!(!admits(&gate, log::Level::Debug, "hyper::client"));
+        assert!(admits(&gate, log::Level::Warn, "hyper::client"));
+    }
+
+    #[test]
+    fn level_gate_atomic_flip_changes_verdict_at_runtime() {
+        let atomic = Arc::new(AtomicU8::new(log::Level::Info as u8));
+        let gate = LevelGateLogger {
+            inner: gate_inner(),
+            level: Arc::clone(&atomic),
+        };
+        // At Info, our debug is suppressed.
+        assert!(!admits(&gate, log::Level::Debug, "agentscommander_lib::x"));
+        // Flip the atomic (what set_runtime_log_level does) -> now admitted.
+        atomic.store(log::Level::Debug as u8, Ordering::Relaxed);
+        assert!(admits(&gate, log::Level::Debug, "agentscommander_lib::x"));
+        // Flip back down to Error -> debug suppressed again.
+        atomic.store(log::Level::Error as u8, Ordering::Relaxed);
+        assert!(!admits(&gate, log::Level::Debug, "agentscommander_lib::x"));
+    }
+
+    /// R2 (grinch): the #264 error-sink now sits BEHIND the new gate plumbing.
+    /// Prove an ERROR record is NOT dropped by the gate at the STRICTEST
+    /// selectable level (Error) and still reaches `error_sink()` through the
+    /// reused format closure (`install_format`'s #264 tee). `error_sink()` is a
+    /// process-wide global, so assert our unique message was captured (a delta
+    /// check) rather than an absolute count, to stay robust under the parallel
+    /// test runner. This crate's only unit-test global-sink drainer is this
+    /// test, so the entry cannot be stolen between log() and drain().
+    #[test]
+    fn error_record_survives_gate_at_strictest_level_and_reaches_264_sink() {
+        let mut builder = env_logger::Builder::new();
+        builder.parse_filters(GATE_INNER_FILTER);
+        // No app.log file: an empty log_state makes the closure's file branch a
+        // no-op; the #264 tee path is independent of the file sink.
+        install_format(&mut builder, Arc::new(None::<Arc<AppLogFile>>));
+        let gate = LevelGateLogger {
+            inner: builder.build(),
+            level: Arc::new(AtomicU8::new(log::Level::Error as u8)),
+        };
+
+        // Clear pre-existing entries so the delta is clean, then push an ERROR
+        // for one of our own targets through the gate at the strictest level.
+        let _ = error_sink().drain();
+        let needle = "synthetic #612 gate-264 probe";
+        gate.log(
+            &log::Record::builder()
+                .level(log::Level::Error)
+                .target("agentscommander_lib::commands::probe_612")
+                .args(format_args!("{needle}"))
+                .build(),
+        );
+        let captured = error_sink().drain();
+        assert!(
+            captured.iter().any(|e| e.message.contains(needle)),
+            "ERROR did not reach the #264 sink through the gate at Error; captured={captured:?}"
         );
     }
 }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -589,7 +589,7 @@ fn resolve_wg_path_from_session_dirs(dirs: &[(Uuid, String)], agent_name: &str) 
                 }
             }
 
-            log::info!(
+            log::debug!(
                 "[mailbox] wake: resolved WG agent path from sibling session: {}",
                 candidate
             );
@@ -1001,7 +1001,7 @@ impl MailboxPoller {
         // for response-dir lookup now sees a canonical input).
         let original_from_for_log = msg.from.clone();
         if canonicalize_msg_from_in_place(&mut msg.from, expected_from.as_deref()) {
-            log::info!(
+            log::debug!(
                 "[mailbox] canonicalized legacy msg.from '{}' → '{}'",
                 original_from_for_log,
                 msg.from
@@ -1040,7 +1040,7 @@ impl MailboxPoller {
             match crate::config::teams::resolve_agent_target(&msg.to, &paths) {
                 Ok(fqn) => {
                     if fqn != msg.to {
-                        log::info!("[mailbox] canonicalized msg.to '{}' → '{}'", msg.to, fqn);
+                        log::debug!("[mailbox] canonicalized msg.to '{}' → '{}'", msg.to, fqn);
                         msg.to = fqn;
                     }
                 }
@@ -1182,7 +1182,7 @@ impl MailboxPoller {
             if let Err(reason) = validate_root_sender_payload(&msg) {
                 return self.reject_message(path, &msg, &reason).await;
             }
-            log::info!(
+            log::debug!(
                 "[mailbox] Root Agent routing check passed: '{}' -> '{}'",
                 msg.from,
                 msg.to
@@ -1218,13 +1218,13 @@ impl MailboxPoller {
             if let Err(reason) = validate_coordinator_to_root_route(&msg.from, &paths) {
                 return self.reject_message(path, &msg, reason).await;
             }
-            log::info!(
+            log::debug!(
                 "[mailbox] Coordinator→Root routing check passed: '{}' -> '{}'",
                 msg.from,
                 msg.to
             );
         } else if is_master {
-            log::info!(
+            log::debug!(
                 "[mailbox] Master token used — bypassing team validation for {} -> {}",
                 msg.from,
                 msg.to
@@ -1241,7 +1241,7 @@ impl MailboxPoller {
                     .reject_message(path, &msg, "Sender cannot reach destination")
                     .await;
             }
-            log::info!(
+            log::debug!(
                 "[mailbox] Routing check passed: '{}' -> '{}'",
                 msg.from,
                 msg.to
@@ -1348,7 +1348,7 @@ impl MailboxPoller {
             };
 
         for &(session_id, ref status) in &candidates {
-            log::info!(
+            log::debug!(
                 "[mailbox] wake: candidate {} captured-status={:?}",
                 session_id,
                 status
@@ -1395,7 +1395,7 @@ impl MailboxPoller {
                                 .and_then(|s| s.telegram_bot_id.clone())
                         };
                         spawn_with_resume = true;
-                        log::info!(
+                        log::debug!(
                             "[mailbox] wake: deferring Exited destroy for {} (status={:?}) pending later Inject success",
                             session_id,
                             status
@@ -1421,14 +1421,14 @@ impl MailboxPoller {
             && (candidates.is_empty() && had_any_match || lost_inject_to_race)
         {
             spawn_with_resume = true;
-            log::info!(
+            log::debug!(
                 "[mailbox] wake: all CWD candidates for '{}' are phantoms or lost to race; enabling auto-resume on spawn-persistent",
                 msg.to
             );
         }
 
         if let Some(exited_id) = pending_exited_destroy {
-            log::info!(
+            log::debug!(
                 "[mailbox] wake: executing deferred destroy for Exited candidate {}",
                 exited_id
             );
@@ -2122,7 +2122,7 @@ impl MailboxPoller {
         let mgr = session_mgr.read().await;
         let sessions = mgr.list_sessions().await;
 
-        log::info!(
+        log::debug!(
             "[mailbox] find_active_session for '{}' — {} sessions: {:?}",
             agent_name,
             sessions.len(),
@@ -2146,7 +2146,7 @@ impl MailboxPoller {
             return None;
         }
 
-        log::info!(
+        log::debug!(
             "[mailbox] {} CWD matches for '{}': {:?}",
             matches.len(),
             agent_name,
@@ -2170,7 +2170,7 @@ impl MailboxPoller {
         });
 
         let best = &matches[0];
-        log::info!(
+        log::debug!(
             "[mailbox] Best match for '{}': session {} (name='{}', status={:?})",
             agent_name,
             best.id,
@@ -2258,7 +2258,7 @@ impl MailboxPoller {
             }
         }
 
-        log::info!(
+        log::debug!(
             "[mailbox] {} viable wake candidate(s) for '{}' (had_any_match={}): {:?}",
             viable.len(),
             agent_name,

--- a/src-tauri/src/pty/idle_detector.rs
+++ b/src-tauri/src/pty/idle_detector.rs
@@ -99,7 +99,7 @@ impl IdleDetector {
                 .lock()
                 .unwrap()
                 .insert(session_id, Instant::now());
-            log::info!(
+            log::debug!(
                 "[idle] SEEDED activity for {} at spawn (idle_threshold={}ms)",
                 &session_id.to_string()[..8],
                 tuning.idle_threshold.as_millis()
@@ -124,7 +124,7 @@ impl IdleDetector {
     /// Mark that a resize just happened for this session.
     /// PTY output within RESIZE_GRACE will be ignored (prompt repaint noise).
     pub fn record_resize(&self, session_id: Uuid) {
-        log::info!(
+        log::debug!(
             "[idle] RESIZE recorded for {}",
             &session_id.to_string()[..8]
         );
@@ -150,7 +150,7 @@ impl IdleDetector {
         if let Some(&last_resize) = self.resize_grace.lock().unwrap().get(&session_id) {
             let elapsed = last_resize.elapsed();
             if elapsed < resize_grace {
-                log::info!(
+                log::trace!(
                     "[idle] SUPPRESSED {} ({} bytes, {}ms after resize)",
                     sid,
                     byte_count,
@@ -168,7 +168,7 @@ impl IdleDetector {
             idle_set.remove(&session_id)
         };
         if was_idle {
-            log::info!(
+            log::debug!(
                 "[idle] BUSY {} ({} bytes, was idle → now busy)",
                 sid,
                 byte_count
@@ -255,7 +255,7 @@ impl IdleDetector {
                 let crossing = sessions_crossing_idle_threshold(now, &activity, &idle_set, &tuning);
                 for (session_id, elapsed) in crossing {
                     idle_set.insert(session_id);
-                    log::info!(
+                    log::debug!(
                         "[idle] IDLE {} ({}ms since last activity)",
                         &session_id.to_string()[..8],
                         elapsed.as_millis()

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -494,7 +494,7 @@ impl PtyManager {
                         if has_printable {
                             idle_detector.record_activity_with_bytes(id, n);
                         } else {
-                            log::info!(
+                            log::trace!(
                                 "[idle] SKIPPED activity for {} ({} bytes, escape-only output)",
                                 &id.to_string()[..8],
                                 n

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import SpecBoardApp from "./spec-board/App";
 import ResourceMonitorApp from "./resource-monitor/App";
 import MainApp from "./main/App";
 import { initAutomationBridge } from "./shared/automation-bridge";
+import { initLogLevelForWindow } from "./shared/log-level";
 
 const params = new URLSearchParams(window.location.search);
 const windowType = params.get("window");
@@ -24,6 +25,13 @@ if (!root) throw new Error("Root element not found");
 if (isTauri) {
   void initAutomationBridge();
 }
+
+// #612 Install the console log-level gate for THIS window (all 6 window roots
+// route through here). Ungated on purpose: the function's internal try/catch
+// falls back to a static Info level in non-Tauri/browser contexts where the
+// event bus is absent. Runs after the `console-capture` side-effect import (the
+// first import above) has installed the console monkey-patch this gate flips.
+void initLogLevelForWindow();
 
 // Browser mode (no Tauri): BrowserApp regardless of ?window param.
 // Remote web clients load ?window=main but still need the split-browser UX.

--- a/src/shared/console-capture.test.ts
+++ b/src/shared/console-capture.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { afterAll, describe, expect, it } from "vitest";
+import { setLogLevel, getConsoleLogs } from "./console-capture";
+import type { LogLevel } from "./types";
+
+// The module monkey-patches the global console + keeps ONE shared ring buffer,
+// so assertions probe `getConsoleLogs()` with a unique marker per call rather
+// than depending on cross-test ordering / accumulation.
+let seq = 0;
+function marker(tag: string): string {
+  seq += 1;
+  return `__cc_test_${tag}_${seq}__`;
+}
+function buffered(m: string): boolean {
+  return getConsoleLogs().some((e) => e.args.includes(m));
+}
+
+afterAll(() => {
+  setLogLevel("info"); // restore the module default for any later consumer
+});
+
+describe("console-capture severity gate (#612)", () => {
+  it("Info: suppresses debug, keeps warn + error", () => {
+    setLogLevel("info");
+    const d = marker("debug");
+    const w = marker("warn");
+    const e = marker("error");
+    console.debug(d);
+    console.warn(w);
+    console.error(e);
+    expect(buffered(d)).toBe(false);
+    expect(buffered(w)).toBe(true);
+    expect(buffered(e)).toBe(true);
+  });
+
+  it("Info: keeps info + log (log is treated as info severity)", () => {
+    setLogLevel("info");
+    const i = marker("info");
+    const lg = marker("log");
+    console.info(i);
+    console.log(lg);
+    expect(buffered(i)).toBe(true);
+    expect(buffered(lg)).toBe(true);
+  });
+
+  it("Trace: buffers debug (the widest gate admits everything below)", () => {
+    setLogLevel("trace");
+    const d = marker("debug");
+    console.debug(d);
+    expect(buffered(d)).toBe(true);
+  });
+
+  it("Error: drops warn + info + log, keeps error", () => {
+    setLogLevel("error");
+    const w = marker("warn");
+    const i = marker("info");
+    const lg = marker("log");
+    const e = marker("error");
+    console.warn(w);
+    console.info(i);
+    console.log(lg);
+    console.error(e);
+    expect(buffered(w)).toBe(false);
+    expect(buffered(i)).toBe(false);
+    expect(buffered(lg)).toBe(false);
+    expect(buffered(e)).toBe(true);
+  });
+
+  it("flipping the level changes the verdict for the same method (runtime adjustability)", () => {
+    setLogLevel("info");
+    const suppressed = marker("debug_suppressed");
+    console.debug(suppressed);
+    expect(buffered(suppressed)).toBe(false);
+
+    setLogLevel("debug");
+    const admitted = marker("debug_admitted");
+    console.debug(admitted);
+    expect(buffered(admitted)).toBe(true);
+  });
+
+  it("an unknown level falls back to Info", () => {
+    setLogLevel("totally-bogus" as LogLevel);
+    const d = marker("debug");
+    const i = marker("info");
+    console.debug(d);
+    console.info(i);
+    expect(buffered(d)).toBe(false); // Info gate suppresses debug
+    expect(buffered(i)).toBe(true);
+  });
+});

--- a/src/shared/console-capture.ts
+++ b/src/shared/console-capture.ts
@@ -1,12 +1,36 @@
+import type { LogLevel } from "./types";
+
 const MAX_ENTRIES = 500;
 
 interface LogEntry {
   ts: string;
-  level: "log" | "warn" | "error" | "info";
+  level: "log" | "warn" | "error" | "info" | "debug" | "trace";
   args: string;
 }
 
 const captured: LogEntry[] = [];
+
+// #612 Severity ranking for the runtime log-level gate. NOTE: these integers are
+// a FRONTEND-LOCAL ordering (error=0 .. trace=4) and are intentionally NOT the
+// backend's `log::Level` u8 (Error=1 .. Trace=5). A console.* call is suppressed
+// (neither buffered nor forwarded to the real console) when its severity is
+// greater than the current level. console.log is treated as `info`.
+const SEVERITY: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+  trace: 4,
+};
+
+let currentLevel = SEVERITY.info; // default Info
+
+/** #612 Set the active console verbosity. Called by `initLogLevelForWindow`
+ *  from the persisted setting and the live `log_level_changed` event. An
+ *  unknown value falls back to Info. */
+export function setLogLevel(level: LogLevel): void {
+  currentLevel = SEVERITY[level] ?? SEVERITY.info;
+}
 
 function timestamp(): string {
   const d = new Date();
@@ -26,7 +50,18 @@ function serialize(args: unknown[]): string {
     .join(" ");
 }
 
-function capture(level: LogEntry["level"], origFn: (...args: unknown[]) => void, args: unknown[]) {
+function capture(
+  level: LogEntry["level"],
+  severity: number,
+  origFn: (...args: unknown[]) => void,
+  args: unknown[]
+) {
+  // #612 Gate BOTH the ring buffer AND the real-console passthrough. At the
+  // default Info level the downgraded [idle-fe] debug chatter is dropped, so it
+  // neither floods the 500-entry buffer nor evicts real errors from "copy logs".
+  // Errors (severity 0) survive every selectable level. To capture debug/trace,
+  // raise the level and reproduce (consistent with the backend gate).
+  if (severity > currentLevel) return;
   const entry: LogEntry = { ts: timestamp(), level, args: serialize(args) };
   captured.push(entry);
   if (captured.length > MAX_ENTRIES) captured.shift();
@@ -37,13 +72,18 @@ const origLog = console.log;
 const origWarn = console.warn;
 const origError = console.error;
 const origInfo = console.info;
+const origDebug = console.debug;
+const origTrace = console.trace;
 
-console.log = (...args: unknown[]) => capture("log", origLog, args);
-console.warn = (...args: unknown[]) => capture("warn", origWarn, args);
-console.error = (...args: unknown[]) => capture("error", origError, args);
-console.info = (...args: unknown[]) => capture("info", origInfo, args);
+console.log = (...args: unknown[]) => capture("log", SEVERITY.info, origLog, args);
+console.info = (...args: unknown[]) => capture("info", SEVERITY.info, origInfo, args);
+console.warn = (...args: unknown[]) => capture("warn", SEVERITY.warn, origWarn, args);
+console.error = (...args: unknown[]) => capture("error", SEVERITY.error, origError, args);
+console.debug = (...args: unknown[]) => capture("debug", SEVERITY.debug, origDebug, args);
+console.trace = (...args: unknown[]) => capture("trace", SEVERITY.trace, origTrace, args);
 
-// Also capture unhandled errors and promise rejections
+// Also capture unhandled errors and promise rejections. These are ERROR-level
+// signals and bypass the #612 severity gate entirely (always captured).
 window.addEventListener("error", (e) => {
   const msg = `${e.message} at ${e.filename}:${e.lineno}:${e.colno}`;
   captured.push({ ts: timestamp(), level: "error", args: msg });

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -7,6 +7,7 @@ import type {
   SessionRepo,
   PtyOutputEvent,
   AppSettings,
+  LogLevel,
   UpdateInfo,
   CodingAgentEnv,
   CodingAgentProfilesConfig,
@@ -254,6 +255,12 @@ export const SettingsAPI = {
   // round-trip racing SettingsModal.
   setMainResourceMonitorAttached: (value: boolean) =>
     transport.invoke<void>("set_main_resource_monitor_attached", { value }),
+  // #612 — canonical command to change ONLY the log level: validates, persists
+  // logLevel, applies live + broadcasts `log_level_changed`. The SettingsModal
+  // uses the form Save path (save_settings_draft) instead; this is for
+  // programmatic / future quick-switch callers.
+  setLogLevel: (level: LogLevel) =>
+    transport.invoke<void>("set_log_level", { level }),
   updateCodingAgentProfiles: (profiles: CodingAgentProfilesConfig) =>
     transport.invoke<void>("update_coding_agent_profiles", { profiles }),
   updateCodingAgentEnvSettings: (

--- a/src/shared/log-level.test.ts
+++ b/src/shared/log-level.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stable mock fns shared across module re-evaluations (vi.resetModules clears
+// the module cache so each test gets a fresh `wired` guard, but these closures
+// — and the vi.mock registrations — persist).
+const listenMock = vi.fn();
+const getMock = vi.fn();
+const setLogLevelMock = vi.fn();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (...args: unknown[]) => listenMock(...args),
+}));
+vi.mock("./ipc", () => ({
+  SettingsAPI: { get: (...args: unknown[]) => getMock(...args) },
+}));
+vi.mock("./console-capture", () => ({
+  setLogLevel: (...args: unknown[]) => setLogLevelMock(...args),
+}));
+
+type LevelEvent = { payload?: { level?: string } };
+
+beforeEach(() => {
+  vi.resetModules(); // fresh `wired` guard per test
+  listenMock.mockReset();
+  getMock.mockReset();
+  setLogLevelMock.mockReset();
+  listenMock.mockResolvedValue(() => {});
+  getMock.mockResolvedValue({ logLevel: "debug" });
+});
+
+async function load(): Promise<() => Promise<void>> {
+  return (await import("./log-level")).initLogLevelForWindow;
+}
+
+describe("initLogLevelForWindow (#612)", () => {
+  it("applies the fetched level and registers the live listener", async () => {
+    getMock.mockResolvedValue({ logLevel: "trace" });
+    const init = await load();
+    await init();
+    expect(setLogLevelMock).toHaveBeenCalledWith("trace");
+    expect(listenMock).toHaveBeenCalledWith(
+      "log_level_changed",
+      expect.any(Function)
+    );
+  });
+
+  it("coerces a null persisted level to info", async () => {
+    getMock.mockResolvedValue({ logLevel: null });
+    const init = await load();
+    await init();
+    expect(setLogLevelMock).toHaveBeenCalledWith("info");
+  });
+
+  it("is idempotent — a second call does not re-fetch or re-register", async () => {
+    const init = await load();
+    await init();
+    await init();
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(listenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates SettingsAPI.get() rejection and still registers the listener", async () => {
+    getMock.mockRejectedValue(new Error("no backend"));
+    const init = await load();
+    await expect(init()).resolves.toBeUndefined();
+    expect(setLogLevelMock).not.toHaveBeenCalled();
+    expect(listenMock).toHaveBeenCalledWith(
+      "log_level_changed",
+      expect.any(Function)
+    );
+  });
+
+  it("tolerates listen() rejection without throwing", async () => {
+    listenMock.mockRejectedValue(new Error("no event bus"));
+    const init = await load();
+    await expect(init()).resolves.toBeUndefined();
+  });
+
+  it("re-applies the level when a log_level_changed event arrives", async () => {
+    let handler: ((e: LevelEvent) => void) | undefined;
+    listenMock.mockImplementation(
+      (_event: string, cb: (e: LevelEvent) => void) => {
+        handler = cb;
+        return Promise.resolve(() => {});
+      }
+    );
+    const init = await load();
+    await init();
+    setLogLevelMock.mockClear();
+    handler?.({ payload: { level: "warn" } });
+    expect(setLogLevelMock).toHaveBeenCalledWith("warn");
+  });
+
+  it("coerces a missing event payload level to info", async () => {
+    let handler: ((e: LevelEvent) => void) | undefined;
+    listenMock.mockImplementation(
+      (_event: string, cb: (e: LevelEvent) => void) => {
+        handler = cb;
+        return Promise.resolve(() => {});
+      }
+    );
+    const init = await load();
+    await init();
+    setLogLevelMock.mockClear();
+    handler?.({ payload: undefined });
+    expect(setLogLevelMock).toHaveBeenCalledWith("info");
+  });
+});

--- a/src/shared/log-level.ts
+++ b/src/shared/log-level.ts
@@ -1,0 +1,36 @@
+import { listen } from "@tauri-apps/api/event";
+import { SettingsAPI } from "./ipc";
+import { setLogLevel } from "./console-capture";
+import type { LogLevel } from "./types";
+
+let wired = false;
+
+/**
+ * #612 Initialize THIS window's console log-level gate from the persisted
+ * setting and keep it live via the backend `log_level_changed` event.
+ *
+ * Called ONCE from `src/main.tsx` for every window root (main/terminal/guide/
+ * browser/spec-board/resource-monitor). It does NOT depend on `settingsStore`:
+ * it reads the level via `SettingsAPI.get()` directly, so it works for windows
+ * (guide, spec-board) that never hydrate the store. The `wired` guard makes it
+ * idempotent, and both async calls are wrapped in try/catch so a non-Tauri /
+ * pure-web context (where `listen` may be unavailable) falls back to a static
+ * Info level without throwing.
+ */
+export async function initLogLevelForWindow(): Promise<void> {
+  if (wired) return;
+  wired = true;
+  try {
+    const s = await SettingsAPI.get();
+    setLogLevel((s.logLevel as LogLevel | null) ?? "info");
+  } catch {
+    /* keep default Info */
+  }
+  try {
+    await listen<{ level: LogLevel }>("log_level_changed", (e) => {
+      setLogLevel((e.payload?.level as LogLevel) ?? "info");
+    });
+  } catch {
+    /* event bus unavailable (e.g. pure web-remote) -> static level, fine */
+  }
+}

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -160,6 +160,7 @@ export function baseSettings(overrides: Partial<AppSettings> = {}): AppSettings 
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
+    logLevel: null,
     ...overrides,
     codingAgentProfiles: overrides.codingAgentProfiles ?? defaultCodingAgentProfiles(),
   };

--- a/src/shared/transport-ws.ts
+++ b/src/shared/transport-ws.ts
@@ -42,7 +42,7 @@ export class WsTransport implements Transport {
         }
         this.connected = true;
         this.reconnectDelay = 1000;
-        console.log("[ws-transport] Connected");
+        console.debug("[ws-transport] Connected");
       };
 
       socket.onmessage = (event) => {
@@ -86,7 +86,7 @@ export class WsTransport implements Transport {
       ) {
         return;
       }
-      console.log(
+      console.debug(
         `[ws-transport] Reconnecting after ${delay}ms...`
       );
       this.connect();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -239,6 +239,12 @@ export interface WindowGeometry {
 
 export type MainSidebarSide = "left" | "right";
 
+/** #612 LIVE log verbosity for `agentscommander*` targets. The 5 canonical
+ *  lowercase wire values shared with the Rust side (`log_level: Option<String>`)
+ *  and the `log_level_changed` event payload. Defined once here and imported by
+ *  `console-capture.ts` / `ipc.ts` / `SettingsModal.tsx`. */
+export type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
+
 export interface AppSettings {
   defaultShell: string;
   defaultShellArgs: string[];
@@ -307,6 +313,8 @@ export interface AppSettings {
   /** #609 Check npm on startup (<=1x/24h) and notify when a newer published
    *  version of @mblua/agentscommander is available. Default true. */
   npmUpdateNotificationsEnabled: boolean;
+  /** #612 LIVE log level for agentscommander targets. null (legacy/unset) => "info". */
+  logLevel: LogLevel | null;
 }
 
 /** #609 "npm update available" payload. Mirrors the Rust `UpdateInfo` struct

--- a/src/sidebar/components/AcDiscoveryPanel.tsx
+++ b/src/sidebar/components/AcDiscoveryPanel.tsx
@@ -181,7 +181,7 @@ const AcDiscoveryPanel: Component = () => {
 
     // Listen for replica branch updates from the backend poller
     unlistenBranch = await onDiscoveryBranchUpdated((data) => {
-      console.log("[DiscoveryBranchWatcher] event received:", data.replicaPath, "->", data.branch);
+      console.debug("[DiscoveryBranchWatcher] event received:", data.replicaPath, "->", data.branch);
       setWorkgroups((wgs) =>
         wgs.map((wg) => ({
           ...wg,

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -176,6 +176,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
+    logLevel: null,
     ...overrides,
   };
 }

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -90,6 +90,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
+    logLevel: null,
     ...overrides,
   };
 }

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -133,6 +133,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
+    logLevel: null,
     ...overrides,
   };
 }

--- a/src/sidebar/components/SettingsModal.test.ts
+++ b/src/sidebar/components/SettingsModal.test.ts
@@ -74,6 +74,7 @@ function settings(overrides: Partial<AppSettings>): AppSettings {
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
+    logLevel: null,
     ...overrides,
   };
 }

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -5,6 +5,7 @@ import type {
   AppSettings,
   AgentConfig,
   CodingAgentEnv,
+  LogLevel,
   TelegramBotConfig,
   ProfileCellConfig,
 } from "../../shared/types";
@@ -1074,6 +1075,33 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           />
           <span>Beep when a team finishes working (all agents idle)</span>
         </label>
+      </div>
+
+      <div class="settings-section">
+        <div class="settings-section-title">Logging</div>
+        <label class="settings-field">
+          <span class="settings-label">Log level</span>
+          <select
+            class="settings-input"
+            value={settings.data!.logLevel ?? "info"}
+            onChange={(e) =>
+              updateField("logLevel", e.currentTarget.value as LogLevel)
+            }
+            data-ac-testid="settings.general.logLevel"
+            data-ac-role="combobox"
+          >
+            <option value="error">Error</option>
+            <option value="warn">Warn</option>
+            <option value="info">Info</option>
+            <option value="debug">Debug</option>
+            <option value="trace">Trace</option>
+          </select>
+        </label>
+        <div class="settings-hint">
+          Controls AgentsCommander log verbosity (applies immediately, no
+          restart). Higher levels are noisier. The RUST_LOG env var, if set,
+          overrides this until restart.
+        </div>
       </div>
 
     </>

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -90,6 +90,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorAutoCloseMinutes: 60,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
+    logLevel: null,
     ...overrides,
   };
 }

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -309,7 +309,7 @@ export const sessionsStore = {
 
   setActiveId(id: string | null) {
     const prev = state.activeId;
-    console.log(`[idle-fe] setActiveId: ${id?.slice(0,8)} (prev: ${prev?.slice(0,8)})`);
+    console.debug(`[idle-fe] setActiveId: ${id?.slice(0,8)} (prev: ${prev?.slice(0,8)})`);
     setState("activeId", id);
     // Promote selected session to "active" only when its status is a runtime
     // string. Exited({ exited: N }) is preserved so dormant roots keep the
@@ -338,11 +338,11 @@ export const sessionsStore = {
     const session = state.sessions.find((s) => s.id === id);
     const wasAlreadyWaiting = session?.waitingForInput ?? false;
     const isActive = id === state.activeId;
-    console.log(`[idle-fe] setSessionWaiting: ${id.slice(0,8)} waiting=${waiting} wasAlreadyWaiting=${wasAlreadyWaiting} isActive=${isActive} pendingReview=${session?.pendingReview}`);
+    console.debug(`[idle-fe] setSessionWaiting: ${id.slice(0,8)} waiting=${waiting} wasAlreadyWaiting=${wasAlreadyWaiting} isActive=${isActive} pendingReview=${session?.pendingReview}`);
     setState("sessions", (s) => s.id === id, "waitingForInput", waiting);
     // Only set pendingReview on a real busy→idle transition, not re-detection
     if (waiting && !wasAlreadyWaiting && !isActive) {
-      console.log(`[idle-fe] >>> SETTING pendingReview=true for ${id.slice(0,8)}`);
+      console.debug(`[idle-fe] >>> SETTING pendingReview=true for ${id.slice(0,8)}`);
       setState("sessions", (s) => s.id === id, "pendingReview", true);
     }
     if (!waiting) {


### PR DESCRIPTION
## Summary

Two-part logging change for #612:

1. **Cleanup (downgrade-not-delete):** 28 backend + 6 frontend non-actionable INFO log sites downgraded to debug/trace, so the default (Info) level is much quieter. Nothing deleted — everything is reachable again by lowering the level.
2. **Live log-level selector:** new **Settings → Logging → "Log level"** (5 standard levels `error/warn/info/debug/trace`, default Info) that applies **live, no restart**, on both the backend log gate and the frontend console capture.

## Implementation

- **Backend (`src-tauri/`):** a `log::Log` wrapper (`LevelGateLogger`) over `Arc<AtomicU8>` wrapping the existing `env_logger::Logger`, reusing the format closure / 50 MB rotation / secret-scrub / #264 error-sink (extracted byte-identical via `install_format`). New `set_log_level` command + `save_settings_draft` apply-hook; `RUST_LOG` stays a frozen dev override that wins. Commits `d89d6c9` (cleanup) + `62ae060` (feature).
- **Frontend (`src/`):** severity gate in `console-capture.ts` (wraps `debug`/`trace`, gates ring buffer + console); one `initLogLevelForWindow()` call in `main.tsx` covering all 6 window roots; `<select>` in SettingsModal; `logLevel` added to `AppSettings`. Commit `bc61127`.

## Review & verification

- **Plan:** architect plan + dev-rust / dev-webpage-ui / grinch enrichment + consensus (`READY_FOR_IMPLEMENTATION`).
- **Grinch Step-7 PASS** on `62ae060`: BE `cargo test` 1507/0/12, FE tsc 0 / vitest 493 / build OK; §2.1.2 byte-identical closure move verified; #264 error-sink reaches the modal at every level; 8 new BE + 13 new FE tests.
- **Re-sync** with `origin/main` (#611 wake-spawn fix) → merge `f02cb8d`, clean auto-merge (zero conflicts). **Grinch Step-7.5 re-review PASS**: both features coexist, gates green on the merged tree (BE 1514/0/12, FE tsc 0 / vitest 493 / build OK).
- **Shipper:** built + deployed `agentscommander_standalone_wg-1.exe` to 0_AC; user manually tested and approved.

Closes #612
