### PR TITLE
fix(#614): profile env-var fields keep focus while typing (For→Index)

### DIFF
--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -717,6 +717,82 @@ describe("SettingsModal automation hooks", () => {
     dispose();
   });
 
+  it("#614: typing in a profile env value keeps the same input focused (no <For> recreate)", async () => {
+    vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
+      codingAgentProfiles: {
+        schemaVersion: 2,
+        profileSlots: { A: { label: "" } },
+        defaultProfileByAgent: {},
+        profileLabelsByAgent: {},
+        profilesByAgent: {
+          codex: {
+            A: { enabled: true, command: "codex", env: { OPENAI_ORG: "ac" }, notes: "" },
+          },
+        },
+      },
+    }));
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "profiles" }),
+      root,
+    );
+    await settle();
+
+    const valueInput = byTestId<HTMLInputElement>("settings.profileCard.0.A.envRow.0.value");
+    expect(valueInput.value).toBe("ac");
+    valueInput.focus();
+    expect(document.activeElement).toBe(valueInput);
+
+    // Two keystrokes. Pre-#614 (reference-keyed <For>), updateCellEnvRow replaced
+    // the row object on each input, disposing this <input> and mounting a new
+    // node — so focus reverted to <body> and a re-query returned a DIFFERENT
+    // element. With <Index> the node is stable, so identity + focus survive.
+    valueInput.value = "acX";
+    valueInput.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+    valueInput.value = "acXY";
+    valueInput.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+
+    const afterTyping = byTestId<HTMLInputElement>("settings.profileCard.0.A.envRow.0.value");
+    expect(afterTyping).toBe(valueInput); // same DOM node — not recreated
+    expect(document.activeElement).toBe(valueInput); // focus retained
+    expect(afterTyping.value).toBe("acXY"); // edit applied
+
+    dispose();
+  });
+
+  it("#614: typing in an agent-level env value also keeps focus (in-place store update)", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    byTestId<HTMLButtonElement>("settings.agentRow.0.env.add").click();
+    await settle();
+
+    const valueInput = byTestId<HTMLInputElement>("settings.agentRow.0.envRow.0.value");
+    valueInput.focus();
+    expect(document.activeElement).toBe(valueInput);
+
+    valueInput.value = "v1";
+    valueInput.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+
+    const afterTyping = byTestId<HTMLInputElement>("settings.agentRow.0.envRow.0.value");
+    expect(afterTyping).toBe(valueInput);
+    expect(document.activeElement).toBe(valueInput);
+    expect(afterTyping.value).toBe("v1");
+
+    dispose();
+  });
+
   it("keeps early profile cell edits when the fresh load resolves late", async () => {
     let resolveLoadedSettings: (value: AppSettings) => void = () => {};
     vi.mocked(SettingsAPI.get).mockReturnValueOnce(

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, createEffect, For, Show, onMount, onCleanup } from "solid-js";
+import { Component, createSignal, createEffect, For, Index, Show, onMount, onCleanup } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import { isTauri } from "../../shared/platform";
 import type {
@@ -1809,56 +1809,64 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             data-ac-testid={`${cardId}.env`}
             data-ac-role="surface"
           >
-            <For each={cellEnvRows(agent.id, letter)}>
+            {/* #614 — <Index> (keyed by position) not <For> (keyed by row-object
+                reference): updateCellEnvRow replaces the row object on every
+                keystroke, so a reference-keyed <For> would dispose+recreate the
+                edited <input> and drop focus after one character. <Index> keeps a
+                stable DOM node per index and only updates the row signal. */}
+            <Index each={cellEnvRows(agent.id, letter)}>
               {(row, rowIndex) => (
                 <div
                   class="settings-profile-env-row"
-                  data-ac-testid={`${cardId}.envRow.${rowIndex()}`}
+                  data-ac-testid={`${cardId}.envRow.${rowIndex}`}
                   data-ac-role="row"
                 >
                   <input
                     class="settings-input settings-env-key"
-                    value={row.key}
-                    onInput={(e) => updateCellEnvRow(agent.id, letter, rowIndex(), "key", e.currentTarget.value)}
+                    value={row().key}
+                    onInput={(e) => updateCellEnvRow(agent.id, letter, rowIndex, "key", e.currentTarget.value)}
                     placeholder="KEY"
-                    data-ac-testid={`${cardId}.envRow.${rowIndex()}.key`}
+                    data-ac-testid={`${cardId}.envRow.${rowIndex}.key`}
                     data-ac-role="textbox"
                   />
                   <input
                     class="settings-input settings-env-value"
-                    value={row.value}
-                    onInput={(e) => updateCellEnvRow(agent.id, letter, rowIndex(), "value", e.currentTarget.value)}
+                    value={row().value}
+                    onInput={(e) => updateCellEnvRow(agent.id, letter, rowIndex, "value", e.currentTarget.value)}
                     placeholder="value"
-                    data-ac-testid={`${cardId}.envRow.${rowIndex()}.value`}
+                    data-ac-testid={`${cardId}.envRow.${rowIndex}.value`}
                     data-ac-role="textbox"
                   />
                   {(() => {
-                    const origin = profileEnvOrigin(row.key, row.value);
+                    // Accessor (not a once-computed const): <Index> keeps the row
+                    // scope alive across edits, so the origin label must re-read
+                    // row() to stay live as the user types.
+                    const origin = () => profileEnvOrigin(row().key, row().value);
                     return (
                       <span
-                        class={`settings-env-origin ${origin}`}
-                        data-ac-testid={`${cardId}.envRow.${rowIndex()}.origin`}
+                        class={`settings-env-origin ${origin()}`}
+                        data-ac-testid={`${cardId}.envRow.${rowIndex}.origin`}
                         data-ac-role="status"
-                        data-ac-env-origin={origin}
-                        title={`Env value origin: ${ENV_ORIGIN_LABEL[origin]}`}
+                        data-ac-env-origin={origin()}
+                        title={`Env value origin: ${ENV_ORIGIN_LABEL[origin()]}`}
                       >
-                        {ENV_ORIGIN_LABEL[origin]}
+                        {ENV_ORIGIN_LABEL[origin()]}
                       </span>
                     );
                   })()}
                   <button
                     class="settings-env-delete"
-                    onClick={() => removeCellEnvRow(agent.id, letter, rowIndex())}
+                    onClick={() => removeCellEnvRow(agent.id, letter, rowIndex)}
                     title="Delete environment row"
-                    data-ac-testid={`${cardId}.envRow.${rowIndex()}.delete`}
+                    data-ac-testid={`${cardId}.envRow.${rowIndex}.delete`}
                     data-ac-role="button"
                   >
                     &#x2715;
                   </button>
-                  <Show when={hasAcPlaceholder(row.value)}>
+                  <Show when={hasAcPlaceholder(row().value)}>
                     <div
                       class="settings-profile-ph-preview"
-                      data-ac-testid={`${cardId}.envRow.${rowIndex()}.placeholder`}
+                      data-ac-testid={`${cardId}.envRow.${rowIndex}.placeholder`}
                       data-ac-role="status"
                     >
                       <span class="arrow">&rarr;</span>
@@ -1867,7 +1875,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                   </Show>
                 </div>
               )}
-            </For>
+            </Index>
             <Show when={cellEnvError(agent.id, letter)}>
               <div
                 class="settings-profile-cell-error"


### PR DESCRIPTION
## What
Fixes the profile **Environment variables** fields in Settings → Coding Agents losing focus after a single keystroke.

Closes #614

## Root cause
`src/sidebar/components/SettingsModal.tsx` rendered the profile-cell env rows with SolidJS `<For>` (referentially keyed). `updateCellEnvRow` rebuilds the array on every keystroke and makes the edited row a **new object reference**, so `<For>` disposed that row's `<input>` and mounted a fresh one — dropping focus after the first character. Only the field being typed in lost focus (other rows kept their references), matching the symptom exactly. The agent-level env editor was unaffected because it mutates the store in place (`updateAgentEnv`), preserving row identity.

## Fix (Option A)
- Render the profile-cell env rows with **`<Index>`** instead of `<For>`. `<Index>` keys by **position**, so each row owns a stable DOM node and a value change updates in place → focus preserved. Store/update/sync/validation logic untouched.
- Made the env "origin" badge an accessor (`() => profileEnvOrigin(row().key, row().value)`) so it stays live while typing under `<Index>`.
- Added 2 regression tests: typing 2+ chars into a profile env value keeps the same `<input>` node + focus (genuinely red on old `<For>`, green on `<Index>`); plus a contrast test for the agent-level editor.

Frontend-only: `src/sidebar/components/SettingsModal.tsx` + `src/sidebar/components/SettingsModal.automation.test.ts`.

## Review & verification
- **dev-webpage-ui:** implemented Option A; `/code-review` high = no HIGH (red/green proof verified).
- **Grinch Step-7 (PASS):** ran gates itself — tsc 0, vitest 482/61, vite build OK; verified the `<Index>` conversion is complete, add/remove works, the regression test is genuine. No HIGH/MED/LOW (3 non-blocking INFO).
- **Re-sync (Step 7.5):** `main` advanced and #612 (`bc61127`, FE logging) touched the same file. Re-synced onto `origin/main` `1158141` → **clean auto-merge, zero conflicts** (merge `960e125`); #612 and #614 changes are in disjoint regions.
- **Grinch Step-7.5 re-sync re-review (PASS):** verified true 2-parent clean merge via diff-vs-both-parents (0 deletions on the #614 side, no scope-creep); gates on merged tree — tsc 0, **vitest 495/63**, vite build OK, both `#614` tests pass by name.
- **Shipper:** built `agentscommander_standalone_wg-10.exe` (v0.9.16, no bump) and deployed to `0_AC`; `--help` smoke test green.
- **User:** manually tested via the 0_AC build and approved landing.

## Notes
- No version bump (normal landing, not a release).
