### PR TITLE
fix(#624): show coding-agent badge on Root Agent row

### DIFF
--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -71,6 +71,16 @@ const RootAgentBanner: Component = () => {
     const r = rootSession();
     return r ? sessionProfileBadge(r) : null;
   });
+  // #624 - mirror SessionItem's coding-agent resolver so the Root Agent row
+  // shows the same `[Coding Agent]` badge: prefer the session's own label, else
+  // resolve the configured agent's label from settings by id.
+  const agentLabel = createMemo(() => {
+    const r = rootSession();
+    if (!r) return null;
+    if (r.agentLabel) return r.agentLabel;
+    if (!r.agentId) return null;
+    return settingsStore.current?.agents?.find((a) => a.id === r.agentId)?.label ?? null;
+  });
 
   const bridge = () => {
     const r = rootSession();
@@ -399,6 +409,21 @@ const RootAgentBanner: Component = () => {
           <Show when={!isRecording() && !isProcessing() && !isAutoExecuting() && !isTypingWarning() && !voiceRecorder.micError()}>
             <span class="root-agent-subtitle">
               {subtitle()}
+              {/* #624 - coding-agent badge, mirroring SessionItem. Non-running
+                  styling falls out of hasLivePty() so a dormant/exited root still
+                  shows the badge (no `running` class). data-agent drives the same
+                  per-agent coloring as the session rows; custom labels fall back
+                  to the base .agent-badge. */}
+              <Show when={agentLabel()}>
+                {(label) => (
+                  <span
+                    class={`agent-badge root-agent-badge ${hasLivePty() ? "running" : ""}`}
+                    data-agent={label()}
+                  >
+                    {label()}
+                  </span>
+                )}
+              </Show>
               <Show when={profileBadge()}>
                 {(badge) => <span class="profile-badge root-profile-badge">{badge()}</span>}
               </Show>

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -588,10 +588,14 @@ html, body, #root {
 }
 
 /* #624 - spacing for the coding-agent badge inside the inline root subtitle
-   (the badge itself only carries color/size via .agent-badge). */
+   (the badge itself only carries color/size via .agent-badge).
+   text-transform:none overrides the uppercase inherited from
+   .root-agent-subtitle so the badge reads mixed-case (e.g. "Claude Code AMP"),
+   matching the session/coordinator rows. */
 .root-agent-badge {
   margin-left: 6px;
   vertical-align: middle;
+  text-transform: none;
 }
 
 /* Show inactive toggle */

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -587,6 +587,13 @@ html, body, #root {
   vertical-align: middle;
 }
 
+/* #624 - spacing for the coding-agent badge inside the inline root subtitle
+   (the badge itself only carries color/size via .agent-badge). */
+.root-agent-badge {
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
 /* Show inactive toggle */
 .show-categories-btn {
   font-size: 14px;


### PR DESCRIPTION
## Summary
Fixes #624 — the Root Agent sidebar row showed only the profile letter ("A"), not the assigned Coding Agent badge that normal/coordinator rows display.

**Root cause:** the Root Agent row is rendered by a special-cased component `RootAgentBanner.tsx` that never rendered the coding-agent badge; normal rows use `SessionItem.tsx`, which does. The data (`agentId`/`agentLabel`) was already present on the root session — a pure frontend rendering omission, no backend gap.

**Fix (FE-only, no backend):**
- `src/sidebar/components/RootAgentBanner.tsx`: added an `agentLabel` resolver memo mirroring SessionItem's `sessionAgentLabel`, and render the `agent-badge` in the subtitle before the profile letter.
- `src/sidebar/styles/sidebar.css`: `.root-agent-badge` spacing class + `text-transform: none` so the badge reads mixed-case (`Claude Code AMP`), matching the session/coordinator rows.

**Result:** the Root Agent row now shows `Root Agent [Claude Code AMP] [A]`. The badge is also shown when the root is dormant/exited (dimmed, non-running style), and is a graceful no-op when the root has no coding agent assigned.

## Review & verification
- **dev-webpage-ui** implemented; `tsc --noEmit` clean, `vitest` 498/64; headless screenshots (running + dormant) Read and confirmed; `/code-review` high = 0 HIGH / 0 MED.
- **dev-rust-grinch** PASS ×2 (original change `b5cac95` + mixed-case delta `5c2d445`); re-ran gates itself (tsc clean, vitest 498/64); reactivity/correctness candidates refuted against Solid semantics.
- **shipper** built the wg-11 standalone exe (v0.9.16, no bump) and deployed to 0_AC; `--help` identity verified.
- **User** tested the 0_AC build and approved landing.

No version bump (not a release).

Closes #624
