### PR TITLE
fix(#621): clean up orphaned coordinator_clocks key + context-cache on workgroup removal

### DIFF
--- a/src-tauri/src/cli/workgroup.rs
+++ b/src-tauri/src/cli/workgroup.rs
@@ -269,6 +269,21 @@ fn remove(args: WorkgroupRemoveArgs) -> Result<(), String> {
     ))? {
         RemoveRefreshDecision::EmitWorkgroupRemoved => {}
     }
+    // (#621) Drop the workgroup's coordinator_clocks keys. CLI is its own process,
+    // so load+save the on-disk map directly (the startup prune backstops the
+    // GUI-running-concurrently race).
+    if let Some(project_name) = project_path.file_name().and_then(|n| n.to_str()) {
+        match crate::config::coordinator_clocks::remove_workgroup_on_disk(
+            project_name,
+            &args.workgroup,
+        ) {
+            Ok(n) if n > 0 => {
+                log::info!("[workgroup-remove] dropped {} clock key(s) for {}", n, args.workgroup)
+            }
+            Ok(_) => {}
+            Err(e) => log::warn!("[workgroup-remove] clock cleanup failed: {}", e),
+        }
+    }
     write_refresh(&project_path, &wg_dir, &args.workgroup, "workgroupRemoved");
     if std::env::var_os("AC_MACHINE_OUTPUT").is_some() {
         print_json(&serde_json::json!({

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::commands::ac_discovery::DiscoveryBranchWatcher;
 use crate::config::replica_identity::{
@@ -1399,6 +1399,8 @@ pub async fn delete_team(
         .map_err(|e| format!("Failed to delete team directory: {}", e))?;
     log::info!("[entity_creation] Deleted team: {}", team_name);
 
+    // (#621) Count clock keys removed across the cascade; persist once after the loop.
+    let mut team_clock_removed = 0usize;
     // Then delete workgroups
     for wg_dir in &wg_dirs {
         let wg_name = wg_dir.file_name().unwrap_or_default().to_string_lossy();
@@ -1410,6 +1412,30 @@ pub async fn delete_team(
             );
         } else {
             log::info!("[entity_creation] Deleted workgroup: {}", wg_name);
+            // (#621) Drop this workgroup's coordinator_clocks keys (in-memory only;
+            // one persist after the loop, see below).
+            if let Some(project_name) = Path::new(&project_path).file_name().and_then(|n| n.to_str())
+            {
+                if let Some(clocks) =
+                    app.try_state::<crate::config::coordinator_clocks::CoordinatorClocksState>()
+                {
+                    team_clock_removed += clocks
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .remove_workgroup(project_name, wg_name.as_ref());
+                }
+            }
+        }
+    }
+    // (#621 MED-2) Single persist for the whole cascade (avoids N concurrent saves).
+    if team_clock_removed > 0 {
+        if let Some(clocks) =
+            app.try_state::<crate::config::coordinator_clocks::CoordinatorClocksState>()
+        {
+            let snapshot = { clocks.lock().unwrap_or_else(|e| e.into_inner()).snapshot() };
+            if let Err(e) = crate::config::coordinator_clocks::save_map(&snapshot) {
+                log::warn!("[delete-team] clocks save failed: {}", e);
+            }
         }
     }
     emit_coordinator_refresh(&app, session_mgr.inner()).await;
@@ -1461,6 +1487,19 @@ pub async fn delete_workgroup(
     // and we run the diagnostic on the still-intact tree. On success the dir is
     // re-parented to a sentinel name and removed; the user-visible WG is gone.
     delete_workgroup_dir_backend(&wg_dir, &workgroup_name, session_mgr.inner()).await?;
+    // (#621) Drop the workgroup's coordinator_clocks keys from the in-memory store
+    // and persist immediately (this command is not on the auto-close flush tick).
+    if let Some(project_name) = Path::new(&project_path).file_name().and_then(|n| n.to_str()) {
+        if let Some(clocks) =
+            app.try_state::<crate::config::coordinator_clocks::CoordinatorClocksState>()
+        {
+            crate::config::coordinator_clocks::remove_workgroup_in_state(
+                clocks.inner(),
+                project_name,
+                &workgroup_name,
+            );
+        }
+    }
     log::info!(
         "[entity_creation] Deleted workgroup: {} (force={})",
         workgroup_name,
@@ -3813,5 +3852,124 @@ mod tests {
 
         assert!(err.contains("lowercase slug"), "unexpected error: {}", err);
         assert!(!workspace.join("_agent_Tech Lead").exists());
+    }
+
+    // ── #621 workgroup-delete clock + cache cleanup (integration) ─────────────
+
+    #[test]
+    fn workgroup_removal_clears_clock_key_and_cache_sibling_intact() {
+        use crate::config::coordinator_clocks::CoordinatorClocks;
+        use crate::config::session_context::sweep_context_cache_dir;
+        use std::time::{Duration, SystemTime};
+
+        // (#621 E4) inline timestamp; no helper exists in this module.
+        let ts = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let proj = tmp.path().join("Proj");
+        let ac = proj.join(".ac");
+        let wg1 = ac.join("wg-1-team");
+        let wg2 = ac.join("wg-2-team");
+        std::fs::create_dir_all(&wg1).unwrap();
+        std::fs::create_dir_all(&wg2).unwrap();
+
+        // Seed clocks: target wg, sibling wg, origin agent.
+        let mut clocks = CoordinatorClocks::default();
+        clocks.note_user_message("Proj:wg-1-team/coord", ts);
+        clocks.note_user_message("Proj:wg-2-team/coord", ts);
+        clocks.seed_if_absent("Proj/architect", ts);
+
+        // Seed cache: a stale file for the removed wg's replica + a fresh sibling.
+        let cache = tmp.path().join("context-cache");
+        std::fs::create_dir_all(&cache).unwrap();
+        let old = SystemTime::now() - Duration::from_secs(40 * 24 * 60 * 60);
+        let stale = cache.join("replica-context-aaa.md");
+        std::fs::write(&stale, "x").unwrap();
+        std::fs::File::options().write(true).open(&stale).unwrap().set_modified(old).unwrap();
+        let fresh = cache.join("replica-context-bbb.md");
+        std::fs::write(&fresh, "x").unwrap();
+
+        // Remove wg-1: dir + clock key (cache via the age sweep).
+        assert!(matches!(try_atomic_delete_wg(&wg1), WgDeleteOutcome::Deleted));
+        assert_eq!(clocks.remove_workgroup("Proj", "wg-1-team"), 1);
+        let swept =
+            sweep_context_cache_dir(&cache, SystemTime::now(), Duration::from_secs(30 * 24 * 60 * 60));
+
+        assert!(!wg1.exists() && wg2.exists(), "only wg-1 dir removed");
+        assert_eq!(clocks.last_user_message_at("Proj:wg-1-team/coord"), None);
+        assert!(
+            clocks.last_user_message_at("Proj:wg-2-team/coord").is_some(),
+            "sibling clock intact"
+        );
+        assert!(clocks.last_user_message_at("Proj/architect").is_some(), "origin clock intact");
+        assert_eq!(swept, 1);
+        assert!(!stale.exists() && fresh.exists(), "stale cache gone, fresh kept");
+    }
+
+    #[test]
+    fn team_cascade_clears_each_wg_clock_keeps_others() {
+        // (#621 LOW-3b) delete_team loops its wg-N-<team> dirs; each removal drops that
+        // wg's keys. A non-team wg and an origin agent survive. Mirrors the §3.3 loop's
+        // per-wg `remove_workgroup` over multiple wgs (accumulator semantics).
+        use crate::config::coordinator_clocks::CoordinatorClocks;
+        let ts = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+
+        let mut clocks = CoordinatorClocks::default();
+        for k in [
+            "Proj:wg-1-squad/coord",
+            "Proj:wg-2-squad/coord",
+            "Proj:wg-2-squad/dev",   // second agent in a team wg
+            "Proj:wg-9-other/coord", // a DIFFERENT team's wg, must survive
+        ] {
+            clocks.note_user_message(k, ts);
+        }
+        clocks.seed_if_absent("Proj/architect", ts); // origin, survives
+
+        // Simulate the cascade over the "squad" team's wgs.
+        let mut total = 0usize;
+        for wg in ["wg-1-squad", "wg-2-squad"] {
+            total += clocks.remove_workgroup("Proj", wg);
+        }
+        assert_eq!(total, 3, "wg-1 (1) + wg-2 (2 agents) keys removed");
+        assert_eq!(clocks.last_user_message_at("Proj:wg-1-squad/coord"), None);
+        assert_eq!(clocks.last_user_message_at("Proj:wg-2-squad/coord"), None);
+        assert_eq!(clocks.last_user_message_at("Proj:wg-2-squad/dev"), None);
+        assert!(
+            clocks.last_user_message_at("Proj:wg-9-other/coord").is_some(),
+            "other team wg intact"
+        );
+        assert!(clocks.last_user_message_at("Proj/architect").is_some(), "origin intact");
+    }
+
+    #[test]
+    fn failed_wg_delete_keeps_clock_key() {
+        // (#621 LOW-3c) the clock cleanup is gated on a SUCCESSFUL dir delete (delete_workgroup
+        // via `?` early-return; delete_team via the `else` success branch). Force a failed
+        // remove and assert, applying that exact gate, that the key survives.
+        use crate::config::coordinator_clocks::CoordinatorClocks;
+        let ts = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let wg = tmp.path().join("wg-1-team");
+        std::fs::create_dir_all(&wg).unwrap();
+        let mut clocks = CoordinatorClocks::default();
+        clocks.note_user_message("Proj:wg-1-team/coord", ts);
+
+        // Force the remove step to fail (rename succeeds, remove_dir_all errors -> Partial).
+        let outcome = try_atomic_delete_wg_with_remove(&wg, |_p| {
+            Err(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "blocked"))
+        });
+        // The production gate: clean the clock ONLY on Deleted.
+        if matches!(outcome, WgDeleteOutcome::Deleted) {
+            clocks.remove_workgroup("Proj", "wg-1-team");
+        }
+        assert!(
+            !matches!(outcome, WgDeleteOutcome::Deleted),
+            "forced failure is not a Deleted outcome"
+        );
+        assert!(
+            clocks.last_user_message_at("Proj:wg-1-team/coord").is_some(),
+            "a failed delete must keep the clock key"
+        );
     }
 }

--- a/src-tauri/src/config/coordinator_clocks.rs
+++ b/src-tauri/src/config/coordinator_clocks.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use chrono::{DateTime, Utc};
@@ -9,6 +10,10 @@ use serde::{Deserialize, Serialize};
 /// coordinator. Keystroke bursts inside this window are coalesced to one
 /// update so we do not emit/persist per keystroke.
 const COALESCE_SECS: i64 = 10;
+
+/// (#621 MED-2) Monotonic suffix so concurrent `save_map_to` calls in one process
+/// (auto-close tick + off-tick workgroup-remove saves) never share a temp path.
+static SAVE_TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// Persisted per-coordinator state, keyed by the coordinator FQN
 /// (`<project>:<wg>/<agent>`). One entry holds the persisted facts behind the
@@ -214,6 +219,45 @@ impl CoordinatorClocks {
     pub fn take_dirty(&mut self) -> bool {
         std::mem::take(&mut self.dirty)
     }
+
+    /// (#621) Remove every key for one workgroup: all FQNs prefixed
+    /// `"<project>:<wg>/"`. Returns the number of keys removed; dirties the store
+    /// iff any were removed. The prefix is reconstructed exactly from the on-disk
+    /// project folder name + workgroup dir name (no hashing), so it is precise and
+    /// can never touch another workgroup. The trailing '/' stops a short wg name
+    /// from matching a longer sibling (`wg-1/` must not match `wg-12/coord`).
+    /// (#621 LOW-1) The compare is case-INSENSITIVE: the key carries the spawn
+    /// `working_directory` case while the caller passes `project_path.file_name()`,
+    /// and the prune + Windows FS are case-insensitive; an exact match would
+    /// `Ok(0)`-silently miss a case-drifted project. Case-insensitive project+wg
+    /// identity IS the FS identity, so this still cannot touch another workgroup.
+    pub fn remove_workgroup(&mut self, project: &str, wg: &str) -> usize {
+        let prefix = format!("{}:{}/", project, wg);
+        self.retain_keys(|k| !key_has_prefix_ignore_ascii_case(k, &prefix))
+    }
+
+    /// (#621) Retain only keys for which `keep` returns true. Returns the number
+    /// removed; dirties the store iff any were removed. Backbone for
+    /// `remove_workgroup` and the startup prune.
+    pub fn retain_keys<F: FnMut(&str) -> bool>(&mut self, mut keep: F) -> usize {
+        let before = self.map.len();
+        self.map.retain(|k, _| keep(k));
+        let removed = before - self.map.len();
+        if removed > 0 {
+            self.dirty = true;
+        }
+        removed
+    }
+}
+
+/// (#621 LOW-1) ASCII-case-insensitive prefix test that never panics on a non-char
+/// boundary (`get(..n)` returns None) and never allocates. `eq_ignore_ascii_case`
+/// matches Windows FS / project-resolution case-insensitivity; project + wg names
+/// are ASCII in practice, and a non-ASCII boundary simply yields "no match" (keep),
+/// which the case-insensitive startup prune still backstops.
+fn key_has_prefix_ignore_ascii_case(key: &str, prefix: &str) -> bool {
+    key.get(..prefix.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
 }
 
 pub type CoordinatorClocksState = std::sync::Arc<Mutex<CoordinatorClocks>>;
@@ -264,13 +308,147 @@ pub fn save_map_to(path: &Path, map: &HashMap<String, ClockEntry>) -> Result<(),
         std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
     }
     let json = serde_json::to_string_pretty(map).map_err(|e| e.to_string())?;
-    let tmp = path.with_extension(format!("json.{}.tmp", std::process::id()));
+    // (#621 MED-2) Unique temp per write: two concurrent saves in one process
+    // (auto-close tick + off-tick workgroup-remove) must not share a temp path,
+    // or interleaved writes produce a corrupt file that the next load() wipes.
+    let tmp = path.with_extension(format!(
+        "json.{}.{}.tmp",
+        std::process::id(),
+        SAVE_TMP_SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
     std::fs::write(&tmp, json).map_err(|e| e.to_string())?;
     // Reuse sessions_persistence::rename_with_retry for the Windows AV/indexer
     // hold retry (#280/#291). Discard the rich diagnostics on error.
     crate::config::sessions_persistence::rename_with_retry(&tmp, path)
         .map_err(|(msg, _diag)| msg)?;
     Ok(())
+}
+
+/// (#621) GUI-path helper: remove a workgroup's keys from the in-memory store
+/// (authoritative for the running app) and persist iff something changed. Returns
+/// keys removed. Used by `delete_workgroup` and `delete_team`.
+pub fn remove_workgroup_in_state(state: &CoordinatorClocksState, project: &str, wg: &str) -> usize {
+    let removed = {
+        let mut g = state.lock().unwrap_or_else(|e| e.into_inner());
+        g.remove_workgroup(project, wg)
+    };
+    if removed > 0 {
+        let snap = { state.lock().unwrap_or_else(|e| e.into_inner()).snapshot() };
+        if let Err(e) = save_map(&snap) {
+            log::warn!("[coordinator-clocks] workgroup-remove save failed: {}", e);
+        }
+    }
+    removed
+}
+
+/// (#621) CLI-path helper: the CLI runs in its own process with no in-memory
+/// store, so load -> remove -> save the on-disk map directly. Best-effort; returns
+/// Ok(0) when no config dir resolves. NOTE: if the GUI is running concurrently it
+/// owns the in-memory map and may re-persist the key on its next flush; the
+/// startup prune is the backstop for that race (see `prune_orphaned_workgroups_and_persist`).
+pub fn remove_workgroup_on_disk(project: &str, wg: &str) -> Result<usize, String> {
+    let mut clocks = load();
+    let removed = clocks.remove_workgroup(project, wg);
+    if removed > 0 {
+        save_map(&clocks.snapshot())?;
+    }
+    Ok(removed)
+}
+
+/// (#621) Conservative startup backstop: drop clock keys whose workgroup dir is
+/// CONFIRMED gone on disk, EXCEPT any key that belongs to a persisted session.
+/// Locks `state`, prunes, persists iff anything changed. Never fails startup
+/// (logs on save error). Cleans historical orphans + anything a concurrent/
+/// standalone CLI remove left behind.
+///
+/// (#621 MED-1) The `live_fqns` keep-set is built from `sessions.json` BEFORE the
+/// lock and makes the prune immune to FQN homonyms + temporarily-unregistered
+/// projects: a clock key is NEVER pruned while a session with that FQN is
+/// persisted. This literally enforces the issue's "never delete state of a live
+/// workgroup" constraint. The prune runs in `lib.rs` before the restore, but
+/// `load_sessions_raw()` is a read-only snapshot, safe to read here.
+///
+/// (#621 I4) The std `Mutex` is held across the per-key `is_dir` fs-IO inside
+/// `prune_with`/`should_keep_clock_key`. Benign: this runs single-threaded in
+/// `run()` BEFORE `.manage(coordinator_clocks)` and `.setup()`, so nothing else
+/// touches the store yet. Do NOT relocate this onto a hot path / shared-state tick
+/// without moving the fs work out from under the lock.
+pub fn prune_orphaned_workgroups_and_persist(
+    state: &CoordinatorClocksState,
+    project_paths: &[String],
+) {
+    let candidates =
+        crate::config::projects::enumerate_registered_project_candidates(project_paths);
+    let live_fqns = persisted_session_fqns();
+    let removed = {
+        let mut guard = state.lock().unwrap_or_else(|e| e.into_inner());
+        prune_with(&mut guard, &candidates, &live_fqns)
+    };
+    if removed > 0 {
+        let snap = { state.lock().unwrap_or_else(|e| e.into_inner()).snapshot() };
+        if let Err(e) = save_map(&snap) {
+            log::warn!("[coordinator-clocks] startup prune save failed: {}", e);
+        }
+        log::info!(
+            "[coordinator-clocks] startup prune removed {} orphaned workgroup key(s)",
+            removed
+        );
+    }
+}
+
+/// (#621) FQN keep-set from the persisted session snapshot (read-only). Same
+/// function (`agent_fqn_from_path`) + same input (`working_directory`) that seeds
+/// the clock keys, so a live coordinator's session maps to exactly its clock key.
+/// Member sessions add harmless extra entries (their FQNs never equal a clock key).
+fn persisted_session_fqns() -> HashSet<String> {
+    crate::config::sessions_persistence::load_sessions_raw()
+        .iter()
+        .map(|s| crate::config::teams::agent_fqn_from_path(&s.working_directory))
+        .collect()
+}
+
+/// (#621) Testable prune core: returns keys removed. A key is KEPT iff it belongs
+/// to a persisted session (MED-1) OR `should_keep_clock_key` keeps it. Split out so
+/// tests can inject `candidates` + `live_fqns` without touching real sessions.json.
+pub fn prune_with(
+    clocks: &mut CoordinatorClocks,
+    candidates: &[crate::config::projects::ProjectResolution],
+    live_fqns: &HashSet<String>,
+) -> usize {
+    clocks.retain_keys(|key| live_fqns.contains(key) || should_keep_clock_key(key, candidates))
+}
+
+/// (#621) Keep-decision for one clock key during the startup prune. CONSERVATIVE:
+/// returns true (KEEP) on ANY uncertainty. Returns false (PRUNE) only when the key
+/// is a WG-replica FQN whose project resolves to EXACTLY ONE registered project,
+/// that project's workspace dir exists, and the specific `<wg>` dir under it is
+/// confirmed absent.
+fn should_keep_clock_key(
+    key: &str,
+    candidates: &[crate::config::projects::ProjectResolution],
+) -> bool {
+    // Origin-agent keys ("<project>/<agent>", no ':') are never workgroup-scoped.
+    let Some((project, rest)) = key.split_once(':') else {
+        return true;
+    };
+    // Malformed (no "<wg>/<agent>") -> keep.
+    let Some((wg, _agent)) = rest.split_once('/') else {
+        return true;
+    };
+    // Resolve the project folder name to EXACTLY ONE registered candidate
+    // (case-insensitive, matching resolve_project_reference). 0 or >1 -> keep.
+    let mut matches = candidates
+        .iter()
+        .filter(|c| c.folder_name.eq_ignore_ascii_case(project));
+    let (Some(resolved), None) = (matches.next(), matches.next()) else {
+        return true;
+    };
+    // Workspace dir missing/unreadable -> cannot confirm absence -> keep.
+    let Some(workspace) = crate::config::workspace::existing_workspace_dir(&resolved.path) else {
+        return true;
+    };
+    // Keep iff the workgroup dir still exists; prune only on CONFIRMED absence.
+    workspace.join(wg).is_dir()
 }
 
 /// Path-explicit load for unit tests, symmetric with `save_map_to`.
@@ -285,6 +463,7 @@ pub fn load_from(path: &Path) -> CoordinatorClocks {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::projects::enumerate_registered_project_candidates;
     use chrono::Duration;
 
     fn ts(secs: i64) -> DateTime<Utc> {
@@ -588,5 +767,140 @@ mod tests {
         assert_eq!(loaded.last_activity_at("proj:wg-2-team/coord"), None);
         assert_eq!(loaded.auto_closed_at("proj:wg-2-team/coord"), None);
         assert_eq!(loaded.manually_closed_at("proj:wg-2-team/coord"), None);
+    }
+
+    // ── #621 targeted-removal + startup-prune tests ──────────────────────────
+
+    #[test]
+    fn remove_workgroup_drops_only_target_prefix() {
+        let mut clocks = CoordinatorClocks::default();
+        for k in [
+            "proj:wg-1-team/coord",
+            "proj:wg-1-team/dev",    // same wg, second agent
+            "proj:wg-2-team/coord",  // sibling wg
+            "other:wg-1-team/coord", // different project, same wg name
+        ] {
+            clocks.note_user_message(k, ts(0));
+        }
+        clocks.seed_if_absent("proj/architect", ts(0)); // origin agent, no ':'
+        let _ = clocks.take_dirty();
+
+        let removed = clocks.remove_workgroup("proj", "wg-1-team");
+        assert_eq!(removed, 2, "only the two proj:wg-1-team/ keys are dropped");
+        assert!(clocks.take_dirty(), "a real removal dirties the store");
+        assert_eq!(clocks.last_user_message_at("proj:wg-1-team/coord"), None);
+        assert_eq!(clocks.last_user_message_at("proj:wg-1-team/dev"), None);
+        assert!(clocks.last_user_message_at("proj:wg-2-team/coord").is_some());
+        assert!(clocks.last_user_message_at("other:wg-1-team/coord").is_some());
+        assert!(clocks.last_user_message_at("proj/architect").is_some());
+    }
+
+    #[test]
+    fn remove_workgroup_trailing_slash_guards_sibling_prefix() {
+        let mut clocks = CoordinatorClocks::default();
+        clocks.note_user_message("proj:wg-1/coord", ts(0));
+        clocks.note_user_message("proj:wg-12/coord", ts(0)); // wg-1 is a string prefix of wg-12
+        assert_eq!(clocks.remove_workgroup("proj", "wg-1"), 1);
+        assert_eq!(clocks.last_user_message_at("proj:wg-1/coord"), None);
+        assert!(
+            clocks.last_user_message_at("proj:wg-12/coord").is_some(),
+            "trailing '/' must stop wg-1 from matching wg-12"
+        );
+    }
+
+    #[test]
+    fn remove_workgroup_absent_is_noop_and_clean() {
+        let mut clocks = CoordinatorClocks::default();
+        clocks.note_user_message("proj:wg-2-team/coord", ts(0));
+        let _ = clocks.take_dirty();
+        assert_eq!(clocks.remove_workgroup("proj", "wg-1-team"), 0);
+        assert!(!clocks.take_dirty(), "removing nothing must not dirty the store");
+    }
+
+    #[test]
+    fn remove_workgroup_is_case_insensitive() {
+        let mut clocks = CoordinatorClocks::default();
+        clocks.note_user_message("MyProj:WG-1-Team/coord", ts(0)); // key carries spawn case
+        // Caller passes a different case (e.g. project resolved as a read_dir child).
+        assert_eq!(clocks.remove_workgroup("myproj", "wg-1-team"), 1);
+        assert_eq!(clocks.last_user_message_at("MyProj:WG-1-Team/coord"), None);
+    }
+
+    #[test]
+    fn should_keep_clock_key_policy() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let proj = tmp.path().join("MyProj");
+        std::fs::create_dir_all(proj.join(".ac").join("wg-1-live")).unwrap();
+        // wg-2-gone deliberately not created.
+        let project_paths = vec![proj.to_string_lossy().to_string()];
+        let candidates = enumerate_registered_project_candidates(&project_paths);
+
+        // Live wg dir present -> KEEP.
+        assert!(should_keep_clock_key("MyProj:wg-1-live/coord", &candidates));
+        // Wg dir confirmed absent -> PRUNE.
+        assert!(!should_keep_clock_key("MyProj:wg-2-gone/coord", &candidates));
+        // Origin agent (no ':') -> KEEP.
+        assert!(should_keep_clock_key("MyProj/architect", &candidates));
+        // Unknown/unregistered project -> KEEP (cannot confirm).
+        assert!(should_keep_clock_key("Unregistered:wg-1/coord", &candidates));
+        // Project name resolves case-insensitively (matches resolve_project_reference).
+        assert!(!should_keep_clock_key("myproj:wg-2-gone/coord", &candidates));
+    }
+
+    #[test]
+    fn should_keep_clock_key_keeps_when_project_unenumerable() {
+        // (#621 E1) A project whose `.ac` does not exist yields ZERO candidates
+        // (enumerate requires `.ac`), so the key is kept by the 0-match branch, NOT
+        // by the `existing_workspace_dir` guard (which is only a TOCTOU belt).
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let proj = tmp.path().join("NoAc");
+        std::fs::create_dir_all(&proj).unwrap(); // project exists, but no .ac/
+        let candidates =
+            enumerate_registered_project_candidates(&[proj.to_string_lossy().to_string()]);
+        assert!(candidates.is_empty(), "no .ac -> not a candidate");
+        assert!(should_keep_clock_key("NoAc:wg-1/coord", &candidates));
+    }
+
+    #[test]
+    fn should_keep_clock_key_keeps_ambiguous_homonym_project() {
+        // (#621 E3 / LOW-3a) Two registered projects share a folder_name; one lacks
+        // the wg. >1 match -> cannot confirm -> KEEP (mirrors resolve_project_reference
+        // Ambiguous). This is the conservative guard that backs MED-1.
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let a = tmp.path().join("a").join("app");
+        let b = tmp.path().join("b").join("app"); // same folder_name "app", different parent
+        std::fs::create_dir_all(a.join(".ac").join("wg-1-team")).unwrap(); // a HAS the wg
+        std::fs::create_dir_all(b.join(".ac")).unwrap(); // b lacks wg-1-team
+        let candidates = enumerate_registered_project_candidates(&[
+            a.to_string_lossy().to_string(),
+            b.to_string_lossy().to_string(),
+        ]);
+        // Even though `b` lacks wg-1-team, the homonym makes "app" ambiguous -> KEEP.
+        assert!(should_keep_clock_key("app:wg-1-team/coord", &candidates));
+    }
+
+    #[test]
+    fn prune_with_never_drops_a_persisted_session_key() {
+        // (#621 MED-1) The cardinal-sin guard: a live coordinator of a temporarily
+        // UNREGISTERED homonym project must keep its clock even though the prune would
+        // otherwise resolve the name to the registered homonym and find the wg absent.
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let registered = tmp.path().join("work").join("app"); // registered, lacks wg-5
+        std::fs::create_dir_all(registered.join(".ac")).unwrap();
+        let candidates =
+            enumerate_registered_project_candidates(&[registered.to_string_lossy().to_string()]);
+
+        // Control: with NO keep-set the key WOULD be pruned (one match, wg-5 absent).
+        let empty: HashSet<String> = HashSet::new();
+        let mut probe = CoordinatorClocks::default();
+        probe.note_user_message("app:wg-5-team/coord", ts(0));
+        assert_eq!(prune_with(&mut probe, &candidates, &empty), 1, "unprotected -> pruned");
+
+        // With the persisted-session keep-set the live key survives.
+        let mut clocks = CoordinatorClocks::default();
+        clocks.note_user_message("app:wg-5-team/coord", ts(0)); // live coord of the OTHER "app"
+        let live: HashSet<String> = HashSet::from(["app:wg-5-team/coord".to_string()]);
+        assert_eq!(prune_with(&mut clocks, &candidates, &live), 0, "live key protected");
+        assert!(clocks.last_user_message_at("app:wg-5-team/coord").is_some());
     }
 }

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -3,6 +3,7 @@ use std::ffi::OsStr;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime};
 
 pub const GLOBAL_CONTEXT_TEMPLATE_FILENAME: &str = "Context.AgentsCommander.md";
 const LEGACY_AGENT_CONTEXT_TEMPLATE_FILENAME: &str = "Context.agent.md";
@@ -1768,6 +1769,79 @@ pub fn materialize_agent_context_file(
     is_coordinator: bool,
 ) -> Result<Option<String>, String> {
     materialize_agent_context_file_with_filename(cwd, target.filename(), &[], is_coordinator)
+}
+
+// ── Context-cache GC (#621) ───────────────────────────────────────────────
+
+/// (#621) Retention window for generated context-cache files. A live agent
+/// re-writes its cache on every launch (fresh mtime), so anything untouched this
+/// long is an orphan (removed workgroup / renamed replica dir). 30 days is
+/// generous enough never to drop the cache of an agent the user simply has not
+/// launched recently, while still capping the directory. Internal GC knob,
+/// intentionally a const (not a user setting); promote to settings later if needed.
+const CONTEXT_CACHE_RETENTION: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+/// (#621) Startup entry point: GC the context-cache dir with the default
+/// retention. No-op (logs) when no config dir resolves. Never returns an error;
+/// housekeeping must not break startup. This pass is BOTH the orphan cleanup for
+/// removed workgroups (their cache ages out) AND the cap for the unbounded-growth
+/// secondary finding.
+pub fn sweep_context_cache_at_startup() {
+    let Some(context_dir) = super::config_dir().map(|d| d.join("context-cache")) else {
+        log::warn!("[context-cache] no config dir; skipping startup sweep");
+        return;
+    };
+    let removed = sweep_context_cache_dir(&context_dir, SystemTime::now(), CONTEXT_CACHE_RETENTION);
+    if removed > 0 {
+        log::info!("[context-cache] startup sweep removed {} stale cache file(s)", removed);
+    }
+}
+
+/// (#621) Testable core: unlink every generated context file in `context_dir`
+/// whose mtime is older than `retention` relative to `now`. Returns the count
+/// removed. Only touches the three known generated prefixes ending in `.md`, so an
+/// unrelated file dropped in the dir is never deleted. A file whose mtime cannot be
+/// read (or is in the future) is KEPT (conservative). A missing dir is a no-op.
+pub fn sweep_context_cache_dir(context_dir: &Path, now: SystemTime, retention: Duration) -> usize {
+    let entries = match std::fs::read_dir(context_dir) {
+        Ok(e) => e,
+        Err(_) => return 0, // first run / missing dir
+    };
+    let mut removed = 0usize;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !is_generated_context_filename(name) {
+            continue;
+        }
+        // Keep on any uncertainty (no metadata / no mtime / clock skew).
+        let Ok(meta) = entry.metadata() else { continue };
+        let Ok(mtime) = meta.modified() else { continue };
+        let Ok(age) = now.duration_since(mtime) else { continue }; // mtime in the future -> keep
+        if age > retention {
+            match std::fs::remove_file(&path) {
+                Ok(()) => removed += 1,
+                Err(e) => {
+                    log::warn!("[context-cache] failed to remove stale {}: {}", path.display(), e)
+                }
+            }
+        }
+    }
+    removed
+}
+
+/// (#621) True for the three generated context-cache filename shapes
+/// (`ac-context-*.md`, `replica-context-*.md`, `matrix-context-*.md`).
+fn is_generated_context_filename(name: &str) -> bool {
+    name.ends_with(".md")
+        && (name.starts_with("ac-context-")
+            || name.starts_with("replica-context-")
+            || name.starts_with("matrix-context-"))
 }
 
 /// Simple deterministic hash for a string (for temp file naming).
@@ -5442,5 +5516,76 @@ mod tests {
                 .expect("read existing prompt"),
             existing_context
         );
+    }
+
+    // ── #621 context-cache GC sweep tests ────────────────────────────────────
+
+    #[test]
+    fn sweep_removes_stale_keeps_fresh_and_non_cache() {
+        use std::time::{Duration, SystemTime};
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let dir = tmp.path();
+
+        let old = SystemTime::now() - Duration::from_secs(40 * 24 * 60 * 60); // 40d
+        let mk = |name: &str, backdate: bool| {
+            let p = dir.join(name);
+            std::fs::write(&p, "x").unwrap();
+            if backdate {
+                let f = std::fs::File::options().write(true).open(&p).unwrap();
+                f.set_modified(old).unwrap();
+            }
+            p
+        };
+
+        let stale_replica = mk("replica-context-111.md", true);
+        let stale_matrix = mk("matrix-context-222.md", true);
+        let stale_global = mk("ac-context-333.md", true);
+        let fresh_replica = mk("replica-context-444.md", false); // live agent, just launched
+        let other_md = mk("notes.md", true); // not a context prefix
+        let other_txt = mk("replica-context-555.txt", true); // wrong extension
+
+        let removed =
+            sweep_context_cache_dir(dir, SystemTime::now(), Duration::from_secs(30 * 24 * 60 * 60));
+
+        assert_eq!(removed, 3, "the three stale generated files are removed");
+        assert!(!stale_replica.exists());
+        assert!(!stale_matrix.exists());
+        assert!(!stale_global.exists());
+        assert!(fresh_replica.exists(), "a freshly-written cache survives");
+        assert!(other_md.exists(), "non-context .md is never touched");
+        assert!(other_txt.exists(), "non-.md is never touched");
+    }
+
+    #[test]
+    fn sweep_missing_dir_is_noop() {
+        use std::time::{Duration, SystemTime};
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let missing = tmp.path().join("does-not-exist");
+        assert_eq!(sweep_context_cache_dir(&missing, SystemTime::now(), Duration::ZERO), 0);
+    }
+
+    #[test]
+    fn sweep_keeps_file_with_future_mtime() {
+        // (#621 LOW-3d) clock skew: a file whose mtime is AHEAD of `now` makes
+        // `now.duration_since(mtime)` return Err -> KEEP (never delete on skew).
+        use std::time::{Duration, SystemTime};
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let p = tmp.path().join("replica-context-future.md");
+        std::fs::write(&p, "x").unwrap();
+        let future = SystemTime::now() + Duration::from_secs(10 * 24 * 60 * 60);
+        std::fs::File::options().write(true).open(&p).unwrap().set_modified(future).unwrap();
+        // Even with a zero retention, a future mtime must not be deleted.
+        assert_eq!(sweep_context_cache_dir(tmp.path(), SystemTime::now(), Duration::ZERO), 0);
+        assert!(p.exists(), "future-mtime file kept");
+    }
+
+    #[test]
+    fn is_generated_context_filename_matches_three_prefixes_only() {
+        assert!(is_generated_context_filename("ac-context-1.md"));
+        assert!(is_generated_context_filename("replica-context-1.md"));
+        assert!(is_generated_context_filename("matrix-context-1.md"));
+        assert!(!is_generated_context_filename("ac-context-1.txt"));
+        assert!(!is_generated_context_filename("random.md"));
+        assert!(!is_generated_context_filename("context-1.md"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -303,12 +303,21 @@ pub fn run(
         TelegramBridgeManager::new(output_senders),
     ));
 
-    let settings: SettingsState =
-        Arc::new(tokio::sync::RwLock::new(config::settings::load_settings()));
+    let loaded_settings = config::settings::load_settings();
+    // (#621) Snapshot registered project paths for the startup orphan-clock prune
+    // below (taken before the value is moved into the RwLock).
+    let startup_project_paths = loaded_settings.project_paths.clone();
+    let settings: SettingsState = Arc::new(tokio::sync::RwLock::new(loaded_settings));
     // #552 persisted coordinator badge clock + auto-closed marker store (loaded
     // once at startup; flushed by the auto-close tick and on app exit).
     let coordinator_clocks: crate::config::coordinator_clocks::CoordinatorClocksState =
         Arc::new(Mutex::new(crate::config::coordinator_clocks::load()));
+    // (#621) Conservative backstop: drop clock keys for workgroups confirmed gone
+    // on disk (historical orphans + CLI-removed wgs). Keep-on-any-doubt.
+    crate::config::coordinator_clocks::prune_orphaned_workgroups_and_persist(
+        &coordinator_clocks,
+        &startup_project_paths,
+    );
     let coordinator_clocks_for_exit = Arc::clone(&coordinator_clocks);
     let resource_monitor_state = Arc::new(resource_monitor::ResourceMonitorState::new());
     let settings_for_web = Arc::clone(&settings);
@@ -391,6 +400,12 @@ pub fn run(
 
             // #271 — seed `<config_dir>/agent-templates/` + README on startup.
             crate::commands::role_templates::ensure_default_templates_dir_at_config();
+
+            // (#621) GC the context-cache: unlink generated *-context-*.md files
+            // older than the retention window. Cleans orphans from removed
+            // workgroups AND caps the unbounded-growth secondary finding. Robust +
+            // self-healing: live agents re-write their cache every launch.
+            crate::config::session_context::sweep_context_cache_at_startup();
 
             // Git branch watcher: polls git branch for each session every 5s
             let git_watcher = GitWatcher::new(session_mgr_for_git, app.handle().clone());


### PR DESCRIPTION
## Summary

Fixes orphaned per-workgroup state after workgroup removal (#621). When a workgroup was removed, its `coordinator_clocks.json` key and `context-cache\` files were never cleaned up and became orphaned; the context-cache also grew unbounded (never garbage-collected). The workgroup directory and `sessions.json` were already cleaned — only these two side stores leaked.

## What changed

- **coordinator_clocks**: new `remove_workgroup` (case-insensitive prefix retain, trailing-`/` sibling guard) called from all **three** removal paths — CLI `workgroup remove`, GUI `delete_workgroup`, and the `delete_team` cascade. Plus a conservative **startup prune** of keys whose workgroup dir is gone, guarded by a keep-set of FQNs built from persisted `sessions.json` so a **live** coordinator's key is never dropped (MED-1 — "never delete live state").
- **context-cache**: a startup **mtime-based sweep** (`CONTEXT_CACHE_RETENTION` = 30 days) that GCs stale generated context files (`ac-context-`/`replica-context-`/`matrix-context-` prefixes). This also fixes the unbounded growth: live agents rewrite their cache each launch (fresh mtime) and survive; orphans age out.
- **Concurrency hardening (MED-2)**: unique per-write temp filename in `save_map_to` (atomic counter) to prevent concurrent-save corruption of `coordinator_clocks.json`; `delete_team` accumulates removals and persists **once** after the loop.
- `close_coordinator` is intentionally **not** touched (the `manuallyClosedAt` marker is valid while the workgroup still exists and can reopen; removal belongs to the wg-remove path).

## Tests

15 new regression tests across `coordinator_clocks`, `session_context`, and `entity_creation`:
- prefix isolation + case-insensitivity + trailing-`/` sibling guard (`wg-1` vs `wg-12`)
- ambiguous/homonym project → KEEP; `never_drops_a_persisted_session_key` (MED-1)
- mtime-future/skew → KEEP; cache sweep stale/fresh/non-cache/missing-dir
- `delete_team` cascade clears each wg key (siblings + origin intact)
- failed wg delete keeps the key
- end-to-end create→remove asserting no orphan key/cache remains and a sibling wg stays intact

## Review & validation

- **Design**: architect plan + Step-5 consensus (folded MED-1 / MED-2 / LOW-1).
- **Adversarial review (Grinch)**: PASS on the implementation and PASS on both re-syncs — no HIGH/MED findings.
- **Gates on the merged tree** (`a2178da`): `cargo build` clean, `cargo clippy --all-targets` clean, full-suite `cargo test --lib --bins --tests` = ~**1572 passed / 0 failed / 12 ignored**; the 15 new tests pass by name.
- **Shipper** built the wg-2 standalone exe to 0_AC.
- **Re-synced twice** onto a moving `main` (final: `a2178da` = `72e983c` ⨉ `56ac0ec`, carrying #617/#626/#624/#629), verified lossless against both parents and orthogonal to #621 (the self-clear change to `session_context.rs` is prompt-template text only).
- User authorized landing; the optional manual binary-swap test on live data was deferred.

Backend-only; no version bump.

Closes #621
