### PR TITLE
fix(#630,#631): persist app-restart resume intent (resume unless explicit Restart Session)

### DIFF
--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -57,6 +57,26 @@ pub(crate) async fn note_user_message_to_session<R: tauri::Runtime>(
         idle.touch_silence(session_id);
     }
 
+    // (#630/#631) Re-arm resume intent on the FIRST real user message. This is
+    // the unified user-input choke point (xterm/Telegram/web); injection and
+    // auto-resume never call it, so a restarted-fresh session stays fresh until
+    // the user actually engages. One-shot: persist only on the true->false flip.
+    // MUST run before the coordinator-only early return below so non-coordinator
+    // members re-arm too.
+    {
+        let mgr =
+            app.state::<Arc<tokio::sync::RwLock<crate::session::manager::SessionManager>>>();
+        let cleared = mgr
+            .read()
+            .await
+            .clear_start_fresh_on_restore_if_set(session_id)
+            .await;
+        if cleared {
+            let m = mgr.read().await;
+            crate::config::sessions_persistence::persist_current_state(&m).await;
+        }
+    }
+
     // (b) badge: reset only when the typed-to session is a coordinator.
     let cwd = {
         let mgr = app

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -915,18 +915,33 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             .find(|(k, _)| k.eq_ignore_ascii_case("CLAUDE_CONFIG_DIR"))
             .map(|(_, v)| v.clone())
     });
-    let claude_project_exists = match claude_config_dir_override {
-        Some(ref dir) => claude_projects_dir_for_config_dir(dir, &cwd).is_dir(),
-        None => resolve_claude_projects_dir(&shell, &shell_args, &cwd)
-            .map(|p| p.is_dir())
-            .unwrap_or(false),
+    let resolved_claude_projects_dir = match claude_config_dir_override {
+        Some(ref dir) => Some(claude_projects_dir_for_config_dir(dir, &cwd)),
+        None => resolve_claude_projects_dir(&shell, &shell_args, &cwd),
     };
-    if should_inject_continue(
-        agent_kind == Some(CodingAgentKind::Claude),
-        skip_auto_resume,
-        claude_project_exists,
-        &full_cmd,
-    ) {
+    let claude_project_exists = resolved_claude_projects_dir
+        .as_ref()
+        .map(|p| p.is_dir())
+        .unwrap_or(false);
+    let is_claude = agent_kind == Some(CodingAgentKind::Claude);
+    let will_inject_continue =
+        should_inject_continue(is_claude, skip_auto_resume, claude_project_exists, &full_cmd);
+    // (#630/#631) Resume-decision trace. Widened beyond Claude: codex/gemini ride
+    // the same `skip_auto_resume` axis (below) and were equally invisible. INFO
+    // during the stabilization window; demote later.
+    if agent_kind.is_some() {
+        log::info!(
+            "[session] resume-decision {} agent={:?} cwd={:?} projects_dir={:?} exists={} skip_auto_resume={} -> inject_continue={}",
+            &id.to_string()[..8],
+            agent_kind,
+            cwd,
+            resolved_claude_projects_dir,
+            claude_project_exists,
+            skip_auto_resume,
+            will_inject_continue
+        );
+    }
+    if will_inject_continue {
         // #260 — Claude's resume flag from the CodingAgentProfile. resume_tokens
         // is a 1-element const for Claude, so [0] is provably in bounds.
         let continue_flag = CodingAgentKind::Claude.profile().resume_tokens[0];
@@ -2022,6 +2037,17 @@ fn effective_restart_skip_auto_resume(requested: Option<bool>) -> bool {
     requested.unwrap_or(true)
 }
 
+/// (#630/#631) Compose the restart path's effective fresh intent: fresh on an
+/// explicit "Restart Session" (`requested` defaults to `true`), OR if the session
+/// still carries an unconsumed durable fresh intent (`stored_start_fresh`). A
+/// deferred member reopened via Branch A passes `Some(false)`, but its persisted
+/// intent wins, so it stays fresh; a normal member (`false || false`) resumes,
+/// unchanged. Named so the call-site composition is unit-tested and cannot be
+/// silently reverted (mirrors `lib::skip_auto_resume_for_restore`).
+fn restart_skip_auto_resume_with_intent(stored_start_fresh: bool, requested: Option<bool>) -> bool {
+    stored_start_fresh || effective_restart_skip_auto_resume(requested)
+}
+
 /// (#599) Resolves the effective `skip_auto_resume` for the `create_session`
 /// command. Defaults to `true` (fresh conversation) so every existing
 /// create-in-place / new-agent / open-agent / CLI / web call site keeps its
@@ -2141,6 +2167,7 @@ pub async fn restart_session_inner_with_activation<R: tauri::Runtime>(
         is_root_agent,
         telegram_bot_id,
         stored_requested_profile,
+        stored_start_fresh,
     ) = {
         let mgr = session_mgr.read().await;
         let session = mgr.get_session(uuid).await.ok_or("Session not found")?;
@@ -2156,6 +2183,7 @@ pub async fn restart_session_inner_with_activation<R: tauri::Runtime>(
                 || crate::config::root_agent::is_root_agent_path(&session.working_directory),
             session.telegram_bot_id.clone(),
             session.requested_profile.clone(),
+            session.start_fresh_on_restore, // (#630/#631) honor an unconsumed durable fresh intent
         )
     };
 
@@ -2217,6 +2245,14 @@ pub async fn restart_session_inner_with_activation<R: tauri::Runtime>(
         destroy_session_inner(app, uuid).await?;
     }
 
+    // (#630/#631) Fresh on an explicit "Restart Session" (None -> true), OR if the
+    // session still carries an unconsumed durable fresh intent. Root agents are
+    // scoped out (separate restore path ignores the marker, §8): they are never
+    // stamped below, so `stored_start_fresh` is false for root and this reduces to
+    // today's `effective_restart_skip_auto_resume`.
+    let restart_start_fresh =
+        restart_skip_auto_resume_with_intent(stored_start_fresh, skip_auto_resume);
+
     // 4. Create new session with same config, or switch to the selected coding agent.
     let session_info = create_session_inner(
         app,
@@ -2230,12 +2266,22 @@ pub async fn restart_session_inner_with_activation<R: tauri::Runtime>(
         agent_label,
         false, // skip_tooling_save
         git_repos,
-        effective_restart_skip_auto_resume(skip_auto_resume),
+        restart_start_fresh,
         resolved_spawn,
     )
     .await?;
 
     let new_uuid = Uuid::parse_str(&session_info.id).map_err(|e| e.to_string())?;
+
+    // (#630/#631) Stamp the honored fresh intent onto the recreated session so it
+    // survives the next app restart. Skipped for root agents (scoped out, §8): the
+    // root restore path ignores the marker, so we do not persist a field we ignore.
+    // The `persist_current_state` in step 7 below writes it durably.
+    if !is_root_agent {
+        let mgr = session_mgr.read().await;
+        mgr.set_start_fresh_on_restore(new_uuid, restart_start_fresh).await;
+    }
+
     if activate_after {
         // 5. Explicitly activate the new session.
         //    destroy_session_inner may have auto-activated a sibling.
@@ -3093,6 +3139,7 @@ mod tests {
             telegram_bot_id: None,
             was_detached: false,
             detached_geometry: None,
+            start_fresh_on_restore: false,
         }
     }
 
@@ -3665,6 +3712,35 @@ mod tests {
         // Explicit true still works (future-proof against a caller that
         // wants to be explicit rather than rely on the default).
         assert!(super::effective_restart_skip_auto_resume(Some(true)));
+    }
+
+    // ── (#630/#631) restart_skip_auto_resume_with_intent: the call site uses this
+    //    exact composition to decide resume-vs-fresh on a restart. ──
+
+    #[test]
+    fn restart_intent_explicit_restart_button_is_fresh() {
+        // "Restart Session" (None) on a session with no stored intent => fresh.
+        assert!(super::restart_skip_auto_resume_with_intent(false, None));
+    }
+
+    #[test]
+    fn restart_intent_normal_member_reopen_resumes() {
+        // Branch A reopen of a NORMAL member (no stored intent, Some(false))
+        // => resume, unchanged from today.
+        assert!(!super::restart_skip_auto_resume_with_intent(false, Some(false)));
+    }
+
+    #[test]
+    fn restart_intent_deferred_fresh_member_reopen_stays_fresh() {
+        // #631 closure: a "Restart Session"-then-app-restart member defers, then
+        // reopens via Branch A (Some(false)), but its persisted fresh intent wins.
+        assert!(super::restart_skip_auto_resume_with_intent(true, Some(false)));
+    }
+
+    #[test]
+    fn restart_intent_stored_fresh_with_restart_button_is_fresh() {
+        // Stored fresh AND an explicit restart => still fresh (no regression).
+        assert!(super::restart_skip_auto_resume_with_intent(true, None));
     }
 
     // ── #599 R1 effective_create_skip_auto_resume tests ──

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -2042,8 +2042,11 @@ fn effective_restart_skip_auto_resume(requested: Option<bool>) -> bool {
 /// still carries an unconsumed durable fresh intent (`stored_start_fresh`). A
 /// deferred member reopened via Branch A passes `Some(false)`, but its persisted
 /// intent wins, so it stays fresh; a normal member (`false || false`) resumes,
-/// unchanged. Named so the call-site composition is unit-tested and cannot be
-/// silently reverted (mirrors `lib::skip_auto_resume_for_restore`).
+/// unchanged. Named so the composition is unit-tested; the call site is guarded
+/// against a silent revert by the `dead_code` lint under `-D warnings` (CI runs
+/// `cargo clippy --all-targets -- -D warnings`), which fails the build if
+/// reverting to the inline expression leaves this function unused. Mirrors
+/// `lib::skip_auto_resume_for_restore`.
 fn restart_skip_auto_resume_with_intent(stored_start_fresh: bool, requested: Option<bool>) -> bool {
     stored_start_fresh || effective_restart_skip_auto_resume(requested)
 }

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -217,6 +217,14 @@ pub struct PersistedSession {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub detached_geometry: Option<WindowGeometry>,
 
+    /// (#630/#631) Durable resume intent. `true` => start fresh on restore
+    /// ("Restart Session"); `false` => resume. `#[serde(default)]` so pre-existing
+    /// records deserialize to `false` = resume (polarity is deliberate: the safe
+    /// serde/Default value must mean "resume"). No `skip_serializing_if`: always
+    /// written so the on-disk record is explicit after the first save.
+    #[serde(default)]
+    pub start_fresh_on_restore: bool,
+
     // ── Legacy fields — read-only, consumed by the upgrade pass in load_sessions. ──
     // `skip_serializing_if = "Option::is_none"` means snapshot_sessions never writes them
     // back, and the first save after upgrade retires them from disk.
@@ -786,6 +794,7 @@ pub async fn snapshot_sessions(mgr: &SessionManager) -> Vec<PersistedSession> {
             was_detached: s.was_detached,
             last_prompt: s.last_prompt.clone(),
             detached_geometry: s.detached_geometry.clone(),
+            start_fresh_on_restore: s.start_fresh_on_restore,
             // Legacy fields are always None on new saves; skip_serializing_if elides them.
             git_branch_source: None,
             git_branch_prefix: None,
@@ -1206,6 +1215,7 @@ mod tests {
             status: Some(SessionStatus::Idle),
             waiting_for_input: Some(true),
             created_at: Some("2026-05-15T00:00:00Z".into()),
+            ..Default::default()
         };
 
         let clean = sanitize_failed_recoverable(&ps);
@@ -1257,6 +1267,7 @@ mod tests {
             status: None,
             waiting_for_input: None,
             created_at: None,
+            ..Default::default()
         };
         let once = sanitize_failed_recoverable(&ps);
         let twice = sanitize_failed_recoverable(&once);
@@ -1298,6 +1309,43 @@ mod tests {
         assert_eq!(back.telegram_bot_id.as_deref(), Some("bot-1"));
     }
 
+    // (#630 fleet-safety) A pre-existing sessions.json record that predates this
+    // field must deserialize to `false` = resume, so no existing user is silently
+    // flipped to "start fresh" on upgrade. Polarity guard for §3.1.
+    #[test]
+    fn start_fresh_on_restore_defaults_false_for_legacy_json() {
+        let json = r#"{
+            "name": "legacy",
+            "shell": "cmd",
+            "shellArgs": [],
+            "workingDirectory": "C:/x"
+        }"#;
+
+        let back: PersistedSession = serde_json::from_str(json).expect("deserialize");
+        assert!(!back.start_fresh_on_restore);
+    }
+
+    // (#631) The durable fresh intent survives a serialize -> deserialize round-trip
+    // in both polarities, so "Restart Session" persists across an app restart. The
+    // field has no `skip_serializing_if`, so it is always written explicitly.
+    #[test]
+    fn start_fresh_on_restore_round_trips() {
+        for fresh in [true, false] {
+            let ps = PersistedSession {
+                name: "round-trip".into(),
+                shell: "claude".into(),
+                shell_args: vec![],
+                working_directory: "C:/x".into(),
+                start_fresh_on_restore: fresh,
+                ..Default::default()
+            };
+            let json = serde_json::to_value(&ps).expect("serialize");
+            assert_eq!(json["startFreshOnRestore"], fresh);
+            let back: PersistedSession = serde_json::from_value(json).expect("deserialize");
+            assert_eq!(back.start_fresh_on_restore, fresh);
+        }
+    }
+
     #[tokio::test]
     async fn snapshot_sessions_preserves_telegram_bot_id() {
         let mgr = SessionManager::new();
@@ -1321,6 +1369,37 @@ mod tests {
 
         assert_eq!(snapshot.len(), 1);
         assert_eq!(snapshot[0].telegram_bot_id.as_deref(), Some("bot-1"));
+    }
+
+    // (#630/#631) The durable fresh intent flows Session -> SessionInfo carrier ->
+    // PersistedSession through the real snapshot path, so a restart-fresh session's
+    // intent reaches disk (and is not lost at the SessionInfo boundary).
+    #[tokio::test]
+    async fn snapshot_sessions_preserves_start_fresh_on_restore() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude-mb".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+            )
+            .await
+            .expect("create_session should succeed");
+
+        // Default snapshots as resume (false).
+        let before = snapshot_sessions(&mgr).await;
+        assert_eq!(before.len(), 1);
+        assert!(!before[0].start_fresh_on_restore);
+
+        mgr.set_start_fresh_on_restore(session.id, true).await;
+
+        let after = snapshot_sessions(&mgr).await;
+        assert_eq!(after.len(), 1);
+        assert!(after[0].start_fresh_on_restore);
     }
 
     #[tokio::test]
@@ -1751,6 +1830,7 @@ mod tests {
             status: None,
             waiting_for_input: None,
             created_at: None,
+            ..Default::default()
         };
 
         // Mimic the upgrade pass in load_sessions (single-repo branch).
@@ -1804,6 +1884,7 @@ mod tests {
                 status: Some(status.clone()),
                 waiting_for_input: Some(false),
                 created_at: Some("2026-05-17T00:00:00Z".into()),
+                ..Default::default()
             };
             let json = serde_json::to_string(&ps).expect("serialize");
             let back: PersistedSession = serde_json::from_str(&json).expect("deserialize");
@@ -1868,6 +1949,7 @@ mod tests {
             status: None,
             waiting_for_input: None,
             created_at: None,
+            ..Default::default()
         };
 
         if ps.git_repos.is_empty() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -159,6 +159,31 @@ pub(crate) fn should_wake_on_restore(
     }
 }
 
+/// (#630) Resolve coordinator status for a restore decision, backstopping a
+/// transient empty `discover_teams()` with the snapshot's persisted
+/// `is_coordinator`. When live discovery returned teams we trust it. Only when
+/// discovery came back EMPTY do we fall back, so a real coordinator is not
+/// silently downgraded to "deferred" because project paths were not ready at
+/// cold start. The woken session's `is_coordinator` is recomputed in
+/// `create_session_inner`, so a stale backstop cannot poison identity.
+pub(crate) fn resolve_is_coord_for_restore(
+    live_is_coord: bool,
+    teams_empty: bool,
+    persisted_is_coord: bool,
+) -> bool {
+    live_is_coord || (teams_empty && persisted_is_coord)
+}
+
+/// (#630/#631) Bridge the persisted `start_fresh_on_restore` intent into the
+/// restore wake path's `skip_auto_resume` argument. The two are value-identical
+/// (both `true` => start fresh / suppress `--continue`); this is the single
+/// named seam the wake path reads, so the read is unit-tested and a future
+/// refactor cannot silently revert it to a hardcoded value without breaking
+/// `wake_path_passes_persisted_fresh_intent` (which references this function).
+pub(crate) fn skip_auto_resume_for_restore(start_fresh_on_restore: bool) -> bool {
+    start_fresh_on_restore
+}
+
 pub(crate) fn should_wake_root_agent_on_restore(
     persisted_status: Option<&crate::session::session::SessionStatus>,
 ) -> bool {
@@ -1405,7 +1430,15 @@ pub fn run(
                         // team membership and coordinator checks. Strict `is_coordinator`
                         // (§AR2-strict) requires the FQN to avoid cross-project flag leaks.
                         let agent_name = crate::config::teams::agent_fqn_from_path(&ps.working_directory);
-                        let is_coord = crate::config::teams::is_any_coordinator(&agent_name, &teams);
+                        let live_is_coord = crate::config::teams::is_any_coordinator(&agent_name, &teams);
+                        // (#630) Backstop a transient empty discover_teams() with the snapshot's
+                        // persisted is_coordinator so a real coordinator is not silently downgraded
+                        // to "deferred" when project paths were not ready at cold start.
+                        let is_coord = resolve_is_coord_for_restore(
+                            live_is_coord,
+                            teams.is_empty(),
+                            ps.is_coordinator,
+                        );
                         let wake = should_wake_on_restore(setting_on, is_coord, ps.status.as_ref());
 
                         if !wake {
@@ -1437,6 +1470,13 @@ pub fn run(
                                     }
                                     if let Some(ref prompt) = ps.last_prompt {
                                         mgr.set_last_prompt(session.id, prompt.clone()).await;
+                                    }
+                                    // (#630/#631) Carry the durable fresh intent onto the dormant
+                                    // record so a "Restart Session"-then-app-restart member keeps it
+                                    // while deferred, and the Branch-A reopen (restart path) honors
+                                    // it. Order vs mark_exited is irrelevant (different field).
+                                    if ps.start_fresh_on_restore {
+                                        mgr.set_start_fresh_on_restore(session.id, true).await;
                                     }
                                     commands::session::preserve_deferred_telegram_intent_if_valid(
                                         &mgr,
@@ -1532,7 +1572,7 @@ pub fn run(
                             agent_label,
                             false, // Persist tooling on restore
                             ps.git_repos.clone(),
-                            false, // skip_auto_resume = false → restore path; allow `--continue`
+                            skip_auto_resume_for_restore(ps.start_fresh_on_restore), // (#630/#631) resume unless restarted fresh
                             resolved_spawn,
                         ).await {
                             Ok(info) => {
@@ -1540,6 +1580,22 @@ pub fn run(
                                     active_id = Some(info.id.clone());
                                 }
                                 n_woken += 1;
+                                // (#630/#631) Re-inherit the durable fresh intent onto the woken
+                                // live session so it persists again across further restarts until
+                                // the user engages (note_user_message_to_session re-arms it). The
+                                // create_session_inner above does not persist, so this lands before
+                                // any write (no false-then-true crash window).
+                                if ps.start_fresh_on_restore {
+                                    if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
+                                        let mgr = session_mgr_clone.read().await;
+                                        mgr.set_start_fresh_on_restore(uuid, true).await;
+                                    }
+                                }
+                                // (#630/#631) Restore-decision trace (INFO during stabilization).
+                                log::info!(
+                                    "[restore] woke '{}' (is_coord={}, live_is_coord={}, start_fresh_on_restore={})",
+                                    ps.name, is_coord, live_is_coord, ps.start_fresh_on_restore
+                                );
                                 if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
                                     commands::session::attach_persisted_telegram_if_configured(
                                         &app_handle,
@@ -1964,8 +2020,8 @@ pub fn run(
 #[cfg(test)]
 mod tests {
     use super::{
-        should_auto_create_root_agent_on_first_restore, should_wake_on_restore,
-        should_wake_root_agent_on_restore,
+        resolve_is_coord_for_restore, should_auto_create_root_agent_on_first_restore,
+        should_wake_on_restore, should_wake_root_agent_on_restore, skip_auto_resume_for_restore,
     };
     use crate::config::settings::{AgentConfig, AppSettings};
     use crate::session::session::SessionStatus;
@@ -2074,6 +2130,30 @@ mod tests {
         assert!(!should_auto_create_root_agent_on_first_restore(
             &settings, None
         ));
+    }
+
+    // (#630) Backstop truth table: a real coordinator survives a transient empty
+    // discover_teams(); a healthy non-empty discovery is trusted as-is.
+    #[test]
+    fn resolve_is_coord_for_restore_truth_table() {
+        // Empty discovery + persisted coord => backstop wakes the real coord.
+        assert!(resolve_is_coord_for_restore(false, true, true));
+        // Healthy discovery (non-empty) that no longer lists this agent => trust it.
+        assert!(!resolve_is_coord_for_restore(false, false, true));
+        // Live discovery already says coord => trust it regardless of the rest.
+        assert!(resolve_is_coord_for_restore(true, false, false));
+        assert!(resolve_is_coord_for_restore(true, true, false));
+        // Empty discovery + not a persisted coord => stays deferred.
+        assert!(!resolve_is_coord_for_restore(false, true, false));
+    }
+
+    // (#630/#631) The wake path passes the persisted fresh intent straight through
+    // as create_session_inner's skip_auto_resume. Guards the lib.rs read seam: if
+    // this identity is ever broken, restore stops honoring "Restart Session".
+    #[test]
+    fn wake_path_passes_persisted_fresh_intent() {
+        assert!(skip_auto_resume_for_restore(true)); // restarted fresh => suppress --continue
+        assert!(!skip_auto_resume_for_restore(false)); // default => resume
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -177,9 +177,11 @@ pub(crate) fn resolve_is_coord_for_restore(
 /// (#630/#631) Bridge the persisted `start_fresh_on_restore` intent into the
 /// restore wake path's `skip_auto_resume` argument. The two are value-identical
 /// (both `true` => start fresh / suppress `--continue`); this is the single
-/// named seam the wake path reads, so the read is unit-tested and a future
-/// refactor cannot silently revert it to a hardcoded value without breaking
-/// `wake_path_passes_persisted_fresh_intent` (which references this function).
+/// named seam the wake path reads. Anti-revert guard: CI runs
+/// `cargo clippy --all-targets -- -D warnings`, so reverting the call site to a
+/// hardcoded value leaves this function unused and the `dead_code` lint fails the
+/// build. The unit test `wake_path_passes_persisted_fresh_intent` pins this
+/// bridge's own behavior but would not, by itself, catch a reverted call site.
 pub(crate) fn skip_auto_resume_for_restore(start_fresh_on_restore: bool) -> bool {
     start_fresh_on_restore
 }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -3904,6 +3904,7 @@ mod tests {
             telegram_bot_id: None,
             was_detached: false,
             detached_geometry: None,
+            start_fresh_on_restore: false,
         }
     }
 

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -80,6 +80,7 @@ impl SessionManager {
             telegram_bot_id: None,
             was_detached: false,
             detached_geometry: None,
+            start_fresh_on_restore: false,
         };
 
         self.sessions.write().await.insert(id, session.clone());
@@ -415,6 +416,34 @@ impl SessionManager {
         }
     }
 
+    /// (#630/#631) Stamp the durable resume intent. Used by the restart path and
+    /// the restore wake/defer paths.
+    pub async fn set_start_fresh_on_restore(&self, id: Uuid, value: bool) {
+        let mut sessions = self.sessions.write().await;
+        if let Some(s) = sessions.get_mut(&id) {
+            s.start_fresh_on_restore = value;
+        }
+    }
+
+    /// (#630/#631) Re-arm on first real user message: clear the fresh intent.
+    /// Returns true ONLY on the `true -> false` transition, so the caller persists
+    /// exactly once (not on every subsequent keystroke).
+    pub async fn clear_start_fresh_on_restore_if_set(&self, id: Uuid) -> bool {
+        let mut sessions = self.sessions.write().await;
+        if let Some(s) = sessions.get_mut(&id) {
+            if s.start_fresh_on_restore {
+                log::info!(
+                    "[session-state] {} '{}': start_fresh_on_restore true -> false (user message, re-armed)",
+                    &id.to_string()[..8],
+                    s.name
+                );
+                s.start_fresh_on_restore = false;
+                return true;
+            }
+        }
+        false
+    }
+
     /// Set the resolved coding-agent identity. Called once by
     /// `create_session_inner` immediately after `CodingAgentKind::detect`.
     pub async fn set_agent_kind(&self, id: Uuid, kind: Option<CodingAgentKind>) {
@@ -658,6 +687,62 @@ mod tests {
         mgr.set_effective_shell_args(missing, vec!["--continue".to_string()])
             .await;
         assert!(mgr.get_session(missing).await.is_none());
+    }
+
+    // (#630/#631) Re-arm on first user message: a fresh session clears its intent
+    // exactly once (true -> false), and a second call is a no-op (one-shot gate).
+    #[tokio::test]
+    async fn clear_start_fresh_on_restore_is_one_shot() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude-mb".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+            )
+            .await
+            .expect("create_session should succeed");
+
+        // Constructor default is the resume intent (false).
+        assert!(!session.start_fresh_on_restore);
+
+        // Stamp the durable fresh intent (as the restart path would).
+        mgr.set_start_fresh_on_restore(session.id, true).await;
+        let stamped = mgr
+            .get_session(session.id)
+            .await
+            .expect("session should still exist");
+        assert!(stamped.start_fresh_on_restore);
+
+        // First user message clears it and reports the true -> false transition.
+        assert!(
+            mgr.clear_start_fresh_on_restore_if_set(session.id).await,
+            "first clear must report the transition so the caller persists once"
+        );
+        let cleared = mgr
+            .get_session(session.id)
+            .await
+            .expect("session should still exist");
+        assert!(!cleared.start_fresh_on_restore);
+
+        // Second message is a no-op: no transition, so the caller does not re-persist.
+        assert!(
+            !mgr.clear_start_fresh_on_restore_if_set(session.id).await,
+            "second clear must be a no-op (one-shot)"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_start_fresh_on_restore_no_op_on_missing_session() {
+        let mgr = SessionManager::new();
+        assert!(
+            !mgr.clear_start_fresh_on_restore_if_set(Uuid::new_v4())
+                .await
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -134,6 +134,16 @@ pub struct Session {
     /// (including the Phase 3 restore path).
     #[serde(default)]
     pub detached_geometry: Option<WindowGeometry>,
+    /// (#630/#631) Durable per-session resume intent for the next app restart.
+    /// `true` => the user explicitly started this session fresh ("Restart Session")
+    /// and that intent must survive the restart, so the restore path passes
+    /// `skip_auto_resume = true` and injects no `--continue`. `false` (default)
+    /// => resume the prior conversation. Re-armed to `false` on the first real
+    /// user message (`note_user_message_to_session`) so a fresh-then-used session
+    /// resumes its NEW conversation next time. Durable copy lives in
+    /// `PersistedSession`; carried (off the wire) through `SessionInfo`.
+    #[serde(default)]
+    pub start_fresh_on_restore: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -240,6 +250,12 @@ pub struct SessionInfo {
     /// second lock round-trip through `SessionManager::get_session`.
     #[serde(skip)]
     pub detached_geometry: Option<WindowGeometry>,
+    /// (#630/#631) Not serialized to the frontend: internal carrier for
+    /// `snapshot_sessions` so persistence can read the durable resume intent
+    /// without a second lock round-trip. Mirrors `detached_geometry`: `#[serde(skip)]`
+    /// keeps it off the IPC wire, so the frontend contract is unchanged.
+    #[serde(skip)]
+    pub start_fresh_on_restore: bool,
 }
 
 impl From<&Session> for SessionInfo {
@@ -274,6 +290,7 @@ impl From<&Session> for SessionInfo {
             telegram_bot_id: s.telegram_bot_id.clone(),
             was_detached: s.was_detached,
             detached_geometry: s.detached_geometry.clone(),
+            start_fresh_on_restore: s.start_fresh_on_restore,
         }
     }
 }
@@ -312,6 +329,7 @@ mod tests {
             telegram_bot_id: None,
             was_detached: false,
             detached_geometry: None,
+            start_fresh_on_restore: false,
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes two opposite, intermittent app-restart resume bugs that are one defect: the resume-vs-fresh decision on full app restart was re-derived from coarse signals and never read from a persisted intent.

- **#630** an existing session sometimes came back WITHOUT `--continue` (fresh) instead of resuming.
- **#631** a "Restart Session"-cleared agent wrongly RESUMED the old conversation after an app restart.

## Root cause

`PersistedSession` had no resume-intent field; the restore wake path hardcoded `skip_auto_resume = false`; and a live session never auto-marks Exited when Claude dies, so an in-use coordinator persisted "awake" and resumed by default. The "Restart Session" fresh intent only lived for one spawn and evaporated across a restart (#631); the wake decision could also misfire when cold-start team discovery transiently returned empty, deferring a real coordinator instead of waking it (#630).

## What changed (backend-only, 7 files)

- **Persist intent:** new `start_fresh_on_restore: bool` on `Session` + `PersistedSession` with `#[serde(default)]` (default `false` = resume, so legacy `sessions.json` records keep resuming; no migration, no version bump). The restore wake path now reads this instead of the hardcoded `false`.
- **Re-arm on real user input:** the fresh intent clears on the first genuine user message via `note_user_message_to_session` (xterm + Telegram + web), never on PTY/boot/MCP/statusline output or injection. Runs before the coordinator early-return so non-coordinator members re-arm too.
- **Stamp per command path:** genuine `create_session` stays resume; "Restart Session" stamps fresh, gated `!is_root_agent` (root scoped out).
- **Non-coordinator #631 (backend-only):** the defer arm carries the persisted intent onto the dormant record and the restart path honors `stored || effective_restart_skip_auto_resume(...)`, so members close #631 too with no frontend change.
- **Cold-start hardening for #630:** `resolve_is_coord_for_restore` backstop uses the persisted `is_coordinator` when live `discover_teams()` is empty, so a real coordinator is not deferred. (The speculative discovery-retry was dropped as it blocked the main thread.)
- **Diagnostics:** a resume-decision INFO log (widened beyond Claude to codex/gemini) makes the previously-invisible decision traceable.

## Review trail

- Architect plan + consensus (re-arm trigger, non-coord closure, retry-drop, root scope-out all resolved by the design authority).
- dev-rust implementation; **grinch Step-7 PASS** (no HIGH/MED), gates re-run independently.
- Step-7.5 re-synced onto current `origin/main` (`d7cee97`, carries #621/#629) with a **focused grinch merge re-review PASS** (lossless both ways; #621 and #630/#631 verified behaviorally independent: coordinator_clocks.json + context-cache vs sessions.json + discover_teams).
- shipper built `agentscommander_standalone_wg-1.exe` to 0_AC from the synced head.

## Gates (merged tree `c8d7dce`)

- `cargo build` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --lib --bins --tests`: **1583 passed / 0 failed / 12 ignored** (+11 new tests pinning both bug directions and the genuine-fresh case)

No version bump (normal landing).

Closes #630
Closes #631
