### PR TITLE
fix: prevent orphaned agent process trees on app shutdown (Job Objects + bounded reaper)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_ProcessStatus",
+    "Win32_System_JobObjects",
     "Win32_Graphics_Dwm",
     "Win32_Graphics_Gdi",
     "Win32_UI_WindowsAndMessaging",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -66,6 +66,13 @@ pub type UpdateCheckState = Arc<std::sync::OnceLock<update_check::UpdateInfo>>;
 /// Floating spec/Mermaid board document state.
 pub type SpecBoardState = Arc<tokio::sync::RwLock<commands::spec_board::SpecBoardManager>>;
 
+/// #632 - hard ceiling on the shutdown reaper cleanup. For jobbed sessions the Job
+/// Object kill already prevented orphans, so exceeding this just stops the
+/// best-effort accounting reaper. For a job-less session (assign failed) this bound
+/// CAN abandon a still-dying tree, so the Exit handler warns when that is possible
+/// (MED-2).
+const SHUTDOWN_CLEANUP_BUDGET_SECS: u64 = 5;
+
 /// Master token generated at app startup. Allows bypassing team validation (can_reach).
 /// Persisted to `master-token.txt` in config_dir for CLI use. Regenerated on each app startup. See #34.
 /// Field is private — use `matches()` for constant-time comparison.
@@ -1985,20 +1992,66 @@ pub fn run(
                         shutdown.abort_now();
                     }
 
-                    for result in resource_monitor_for_exit
-                        .kill_all_owned_groups(resource_monitor::ResourceKillReason::AppShutdown)
-                    {
-                        if result.quarantined {
-                            log::warn!(
-                                "[shutdown] resource group {} quarantined during cleanup: {}",
-                                result.session_id,
-                                result.message
-                            );
-                        }
-                    }
-
+                    // #632 B1 - trigger background-task shutdown FIRST so the resource
+                    // watchdog stops dispatching NEW ticks and the idle detectors stop.
+                    // (An already-dispatched spawn_blocking kill_group still runs;
+                    // safety there rests on B2b's bounded set + kill_group's
+                    // Terminating/Terminated idempotency guard, not on trigger().)
                     log::info!("[shutdown] Triggering background task shutdown (async, not awaited)...");
                     shutdown_for_exit.trigger();
+
+                    // #632 A - kill every agent's Job Object: atomically terminates
+                    // each jobbed session's whole descendant tree via the job handle.
+                    // This is the durable, orphan-free guarantee for jobbed sessions.
+                    let (jobs_killed, jobless_sessions) = {
+                        let pty_mgr = app_handle.state::<Arc<Mutex<PtyManager>>>();
+                        let guard = pty_mgr.lock().unwrap_or_else(|e| e.into_inner());
+                        guard.kill_all_jobs()
+                    };
+                    log::info!(
+                        "[shutdown] terminated {jobs_killed} agent job object(s); {jobless_sessions} session(s) had no job"
+                    );
+
+                    // #632 B2+B4 - run the identity reaper for accounting and as the
+                    // backstop for job-less sessions, TIME-BOXED. Fresh-only targets
+                    // (B2a) make it near-instant for jobbed sessions (their live tree is
+                    // already dead). Abandoning it on timeout is safe for jobbed
+                    // sessions; the job-less warning below covers the MED-2 residual.
+                    let rm_for_cleanup = resource_monitor_for_exit.clone();
+                    let cleanup = crate::shutdown::run_time_boxed(
+                        std::time::Duration::from_secs(SHUTDOWN_CLEANUP_BUDGET_SECS),
+                        move || {
+                            rm_for_cleanup.kill_all_owned_groups(
+                                resource_monitor::ResourceKillReason::AppShutdown,
+                            )
+                        },
+                    );
+                    match &cleanup {
+                        Ok(results) => {
+                            for result in results {
+                                if result.quarantined {
+                                    log::warn!(
+                                        "[shutdown] resource group {} quarantined during cleanup: {}",
+                                        result.session_id,
+                                        result.message
+                                    );
+                                }
+                            }
+                        }
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => log::warn!(
+                            "[shutdown] resource cleanup exceeded {SHUTDOWN_CLEANUP_BUDGET_SECS}s budget; proceeding to exit (job objects already terminated jobbed trees)"
+                        ),
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => log::error!(
+                            "[shutdown] resource cleanup thread panicked before completing; jobbed trees were still terminated by the job kill"
+                        ),
+                    }
+                    // #632 MED-2 - job-less sessions are reaper-only; if the reaper did
+                    // not finish, their trees may be orphaned. Make it visible.
+                    if cleanup.is_err() && jobless_sessions > 0 {
+                        log::warn!(
+                            "[shutdown] {jobless_sessions} session(s) had no Job Object and the reaper did not finish in budget; their process trees may be orphaned"
+                        );
+                    }
 
                     log::info!("[shutdown] Persisting session state...");
                     let mgr_clone = session_mgr_for_exit.clone();

--- a/src-tauri/src/pty/job.rs
+++ b/src-tauri/src/pty/job.rs
@@ -1,0 +1,282 @@
+//! #632 - per-agent Windows Job Object for reliable process-tree teardown.
+//!
+//! Each spawned agent's ConPTY child is assigned to its own Job Object created
+//! with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Terminating the job (explicitly via
+//! `TerminateJobObject`, or implicitly when the last handle closes on a hard
+//! process exit / panic) kills the entire descendant tree atomically. This is
+//! immune to PID reuse and per-PID ACCESS_DENIED, and needs no process-snapshot
+//! walking or per-process waits, so it closes the orphan failure mode in #632.
+//!
+//! The resource-monitor identity reaper stays as the ACCOUNTING / slot-cap
+//! mechanism (and the fallback when a job cannot be created or assigned). The job
+//! is purely the KILL mechanism layered under it.
+//!
+//! INVARIANT (do not break): the job handle is created NON-INHERITABLE
+//! (`CreateJobObjectW(null, null)` - no inheritable SECURITY_ATTRIBUTES) and is
+//! owned solely by one `PtyInstance`. portable_pty spawns ConPTY children with
+//! handle inheritance ON, so an inheritable job handle would leak into the child
+//! and defeat KILL_ON_JOB_CLOSE (the job would not be the last handle holder).
+//! A non-inheritable, singly-owned handle makes KILL_ON_JOB_CLOSE fire exactly
+//! once, when AC's only handle closes (terminate / drop / process-exit).
+//!
+//! Non-Windows builds use a zero-sized stub so PtyManager stays platform-agnostic.
+
+#[cfg(windows)]
+pub use windows_impl::JobObject;
+
+#[cfg(not(windows))]
+pub use stub_impl::JobObject;
+
+#[cfg(windows)]
+mod windows_impl {
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject, TerminateJobObject,
+        JobObjectExtendedLimitInformation, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE};
+
+    /// Owns a Job Object handle. Dropping it closes the handle; because the job is
+    /// created with KILL_ON_JOB_CLOSE and we hold the only handle, the OS kills the
+    /// whole assigned tree on drop too (the hard-exit / panic safety net).
+    pub struct JobObject {
+        handle: HANDLE,
+    }
+
+    // A HANDLE is an opaque kernel handle, safe to use and close from any thread;
+    // the value is only moved into PtyInstance and read back out under a Mutex.
+    unsafe impl Send for JobObject {}
+    unsafe impl Sync for JobObject {}
+
+    impl JobObject {
+        /// Create a job, set KILL_ON_JOB_CLOSE, and assign process `pid` to it.
+        /// Returns `None` (after a warn log) on ANY failure, so a job problem never
+        /// blocks a spawn; the identity reaper remains the cleanup fallback.
+        ///
+        /// `pid` is the process portable_pty spawned. For a non-`.exe` command the
+        /// non-direct-exe branch of `PtyManager::spawn` wraps it as `cmd.exe /C <cmd>`,
+        /// so `pid` is usually the cmd.exe wrapper and the real agent is a grandchild
+        /// cmd spawns AFTER assignment - that is ideal: KILL_ON_JOB_CLOSE plus
+        /// child-inheritance captures the whole wrapper -> agent -> descendants subtree.
+        ///
+        /// portable_pty cannot spawn CREATE_SUSPENDED, so `pid` is already running.
+        /// A grandchild spawned in the sub-ms window before assignment can escape
+        /// the job; neither cmd.exe nor an agent CLI forks that fast. See the plan
+        /// section 5 for the (accepted, race-bound) shutdown residual this leaves.
+        pub fn for_child(pid: u32) -> Option<Self> {
+            // SAFETY: every returned handle is null-checked before use; the limit
+            // info struct is zero-initialized then fully written.
+            unsafe {
+                // NON-INHERITABLE handle: null SECURITY_ATTRIBUTES. See module invariant.
+                let handle = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+                if handle.is_null() {
+                    log::warn!("[pty] CreateJobObjectW failed for pid {pid}; reaper-only cleanup");
+                    return None;
+                }
+                let job = JobObject { handle };
+
+                let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+                info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+                let set_ok = SetInformationJobObject(
+                    handle,
+                    JobObjectExtendedLimitInformation,
+                    &info as *const _ as *const core::ffi::c_void,
+                    std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+                );
+                if set_ok == 0 {
+                    log::warn!(
+                        "[pty] SetInformationJobObject failed for pid {pid}; reaper-only cleanup"
+                    );
+                    return None; // `job` drops here -> handle closed
+                }
+
+                let process = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
+                if process.is_null() {
+                    log::warn!(
+                        "[pty] OpenProcess(SET_QUOTA|TERMINATE) failed for pid {pid}; reaper-only cleanup"
+                    );
+                    return None;
+                }
+                let assigned = AssignProcessToJobObject(handle, process);
+                let _ = CloseHandle(process);
+                if assigned == 0 {
+                    // Most likely the process is in a non-nestable job on a pre-Win8
+                    // kernel; on Win8+ nested jobs make this succeed. Either way the
+                    // reaper is the fallback (and the MED-2 residual applies).
+                    log::warn!(
+                        "[pty] AssignProcessToJobObject failed for pid {pid}; reaper-only cleanup"
+                    );
+                    return None;
+                }
+                log::info!("[pty] assigned pid {pid} to job object for tree-kill");
+                Some(job)
+            }
+        }
+
+        /// Terminate every process in the job. Idempotent; safe on an already-dead
+        /// tree (TerminateJobObject just reports failure, which we log at debug).
+        pub fn terminate(&self) {
+            // SAFETY: `self.handle` is a valid job handle owned by `self`.
+            let ok = unsafe { TerminateJobObject(self.handle, 1) };
+            if ok == 0 {
+                log::debug!("[pty] TerminateJobObject failed (tree likely already gone)");
+            }
+        }
+    }
+
+    impl Drop for JobObject {
+        fn drop(&mut self) {
+            // SAFETY: `self.handle` is a valid job handle owned by `self`. Closing
+            // the last handle to a KILL_ON_JOB_CLOSE job terminates the remaining
+            // tree, so this doubles as the hard-exit safety net.
+            unsafe {
+                let _ = CloseHandle(self.handle);
+            }
+        }
+    }
+}
+
+#[cfg(not(windows))]
+mod stub_impl {
+    /// No-op Job Object for non-Windows builds. The Win32 tree-kill primitive does
+    /// not exist here, so PtyManager simply never holds one (`for_child` -> None).
+    /// `#[allow(dead_code)]` because the unit struct is never constructed on this
+    /// platform (for_child always returns None).
+    #[allow(dead_code)]
+    pub struct JobObject;
+
+    impl JobObject {
+        pub fn for_child(_pid: u32) -> Option<Self> {
+            None
+        }
+        pub fn terminate(&self) {}
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::JobObject;
+
+        #[test]
+        fn stub_for_child_is_none() {
+            assert!(JobObject::for_child(1234).is_none());
+        }
+    }
+}
+
+// #632 LOW-2 - the ONE automated proof that the job kills the whole tree (child AND
+// grandchild). Deliberately NOT #[ignore] and gated #[cfg(windows)] so it runs by
+// default in the `rust-regression` CI lane (runs-on: windows-latest, executes
+// `cargo test --lib --bins --tests`). Real processes; written defensively (generous
+// polls) to avoid flake. Do NOT add #[ignore] - that removes all executed coverage
+// of Part A.
+#[cfg(all(test, windows))]
+mod win_tests {
+    use super::JobObject;
+    use std::collections::HashMap;
+    use std::os::windows::process::CommandExt;
+    use std::process::Command;
+    use std::time::{Duration, Instant};
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    /// Mirror of `windows.rs::process_entries`: one `CreateToolhelp32Snapshot` pass
+    /// returning `pid -> parent_pid`. Used to collect the full descendant set of a
+    /// root pid so the assertion does not depend on process names.
+    fn parent_map() -> HashMap<u32, u32> {
+        use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+        use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+            TH32CS_SNAPPROCESS,
+        };
+
+        let mut map = HashMap::new();
+        // SAFETY: standard toolhelp enumeration; the snapshot handle is closed
+        // before returning and the entry struct is zero-initialized with dwSize set.
+        unsafe {
+            let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+            if snapshot == INVALID_HANDLE_VALUE {
+                return map;
+            }
+            let mut entry: PROCESSENTRY32W = std::mem::zeroed();
+            entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+            if Process32FirstW(snapshot, &mut entry) != 0 {
+                loop {
+                    map.insert(entry.th32ProcessID, entry.th32ParentProcessID);
+                    if Process32NextW(snapshot, &mut entry) == 0 {
+                        break;
+                    }
+                }
+            }
+            let _ = CloseHandle(snapshot);
+        }
+        map
+    }
+
+    fn descendants_of(root: u32, map: &HashMap<u32, u32>) -> Vec<u32> {
+        let mut out = Vec::new();
+        let mut frontier = vec![root];
+        while let Some(p) = frontier.pop() {
+            for (&pid, &ppid) in map {
+                if ppid == p && pid != root && !out.contains(&pid) {
+                    out.push(pid);
+                    frontier.push(pid);
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn job_terminate_kills_child_and_grandchild() {
+        // Assigned pid = outer cmd; it spawns an inner cmd (child) that spawns ping
+        // (grandchild of the assigned pid). Proves tree-kill to depth 2 and that
+        // descendants spawned AFTER assignment are captured.
+        let mut child = Command::new("cmd.exe")
+            .args(["/C", "cmd /C ping -n 30 127.0.0.1 >NUL"])
+            .creation_flags(CREATE_NO_WINDOW)
+            .spawn()
+            .expect("spawn outer cmd");
+        let root = child.id();
+
+        let job = JobObject::for_child(root).expect("job created + assigned");
+
+        // Wait (generously, to avoid flake on a loaded CI runner) for the grandchild
+        // tree to materialize. The loop exits as soon as any descendant appears, so the
+        // ceiling only matters under heavy load.
+        let mut tree = Vec::new();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            tree = descendants_of(root, &parent_map());
+            if !tree.is_empty() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        assert!(
+            !tree.is_empty(),
+            "expected at least one descendant before terminate"
+        );
+
+        job.terminate();
+
+        // Every member of the subtree (root + descendants) is gone shortly after the
+        // job kill. The ceiling is generous (CI load) but far under the ping's ~30s
+        // lifetime, so a broken job that leaves survivors still fails this loop.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let map = parent_map();
+            let alive_root = map.contains_key(&root);
+            let alive_tree = descendants_of(root, &map);
+            if !alive_root && alive_tree.is_empty() {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "job did not kill the whole tree in time (root_alive={alive_root}, survivors={alive_tree:?})"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        let _ = child.wait();
+    }
+}

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -17,6 +17,9 @@ struct PtyInstance {
     master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     child: Option<Box<dyn portable_pty::Child + Send + Sync>>,
+    /// #632 - Job Object the child (and its descendant tree) is assigned to, when
+    /// the OS allowed it. `None` falls back to the identity reaper for cleanup.
+    job: Option<crate::pty::job::JobObject>,
 }
 
 /// Tracks active response marker watchers per session.
@@ -385,6 +388,14 @@ impl PtyManager {
             id,
             child.process_id()
         );
+
+        // #632 - assign the child (and the descendant tree it spawns after this
+        // point) to a Job Object with KILL_ON_JOB_CLOSE, so session-destroy and
+        // app-exit can kill the whole tree atomically via the job handle. Created
+        // before the resource registration so the early-return error paths below
+        // drop `job` and let KILL_ON_JOB_CLOSE reap the child too.
+        let job = child.process_id().and_then(crate::pty::job::JobObject::for_child);
+
         if let Some(registration) = resource_registration.as_mut() {
             let Some(pid) = child.process_id() else {
                 let _ = child.kill();
@@ -425,6 +436,7 @@ impl PtyManager {
             master: Arc::new(Mutex::new(pair.master)),
             writer: Arc::new(Mutex::new(writer)),
             child: Some(child),
+            job,
         };
 
         self.ptys.lock().unwrap().insert(id, instance);
@@ -613,6 +625,15 @@ impl PtyManager {
         };
 
         if let Some(mut instance) = instance {
+            // #632 - kill the whole descendant tree via the Job Object first. This
+            // catches descendants the identity reaper's #543 gate refuses to
+            // terminate (recycled / elevated PIDs) and any spawn-race escapee, with
+            // no snapshot walk and no 2s waits. The child handling below then reaps
+            // the (now-dead) direct child's exit status as before.
+            if let Some(job) = instance.job.take() {
+                job.terminate();
+                // job drops here -> handle closed (KILL_ON_JOB_CLOSE backstop)
+            }
             if let Some(mut child) = instance.child.take() {
                 let pid = child.process_id();
                 match child.try_wait() {
@@ -670,6 +691,31 @@ impl PtyManager {
         }
 
         Ok(())
+    }
+
+    /// #632 - terminate every live agent's Job Object at app shutdown. Atomically
+    /// kills each session's whole descendant tree via the job handle (immune to PID
+    /// reuse / ACCESS_DENIED, no snapshot walking, no per-process waits). Returns
+    /// `(jobs_terminated, jobless_sessions)` so the caller can detect the MED-2
+    /// case: a session with no Job Object is reaper-only and can orphan if the
+    /// time-boxed reaper does not finish. Does NOT remove the PtyInstances; the
+    /// process is exiting and the OS reclaims the rest. No-op on non-Windows (jobs
+    /// are always `None`, so it returns `(0, live_session_count)`).
+    pub fn kill_all_jobs(&self) -> (usize, usize) {
+        let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
+        let mut terminated = 0;
+        let mut jobless = 0;
+        for (id, instance) in ptys.iter() {
+            match instance.job.as_ref() {
+                Some(job) => {
+                    job.terminate();
+                    terminated += 1;
+                    log::info!("[pty] terminated job object for session {id} at shutdown");
+                }
+                None => jobless += 1,
+            }
+        }
+        (terminated, jobless)
     }
 
     /// Get a screen snapshot for replay to late-joining WS clients.

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -2,4 +2,5 @@ pub mod credentials;
 pub mod git_watcher;
 pub mod idle_detector;
 pub mod inject;
+pub mod job; // #632 - per-agent Job Object for tree-kill
 pub mod manager;

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -744,6 +744,12 @@ impl ResourceMonitorState {
         // live child a racy snapshot momentarily missed (which would weaken the no-job
         // reaper fallback). A clean tree always contains the root, so the root is
         // retained.
+        //
+        // KNOWN RESIDUAL (#637): a still-alive grandchild whose intermediate parent
+        // exited is unreachable from the root in this BFS (Windows does not reparent)
+        // yet the sample still looks clean, so it is pruned here. Harmless for jobbed
+        // sessions (the Job Object kills the whole tree regardless of reachability);
+        // for a job-less session it extends the MED-2 reaper-only orphan residual.
         if root_alive && sample_clean {
             group
                 .observed_processes

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -377,6 +377,21 @@ impl ResourceMonitorState {
         session_id: Uuid,
         reason: ResourceKillReason,
     ) -> Result<ResourceKillResult, String> {
+        self.kill_group_inner(session_id, reason, false)
+    }
+
+    /// #632 B2a - shared kill implementation. `fresh_targets_only` controls only the
+    /// target SEED, never the verification: when true (app-shutdown bulk cleanup) the
+    /// accumulated `observed_processes` set is skipped and only the fresh `observe_tree`
+    /// is targeted, so the reaper does not walk hundreds of stale-dead PIDs (each of
+    /// which would force a full toolhelp snapshot). The Job Object kill already
+    /// terminated the live tree at shutdown, so the fresh set is normally empty.
+    fn kill_group_inner(
+        &self,
+        session_id: Uuid,
+        reason: ResourceKillReason,
+        fresh_targets_only: bool,
+    ) -> Result<ResourceKillResult, String> {
         let kill_started = Instant::now();
         let (root_identity, previous_targets) = {
             let mut inner = self
@@ -417,11 +432,18 @@ impl ResourceMonitorState {
             group.kill_started_at = Some(Instant::now());
             (
                 group.root_identity,
-                group
-                    .observed_processes
-                    .values()
-                    .cloned()
-                    .collect::<Vec<_>>(),
+                if fresh_targets_only {
+                    // #632 B2a - at shutdown, ignore the accumulated set entirely;
+                    // target only the fresh live tree captured below. The Job Object
+                    // kill already terminated the tree, so this is normally empty.
+                    Vec::new()
+                } else {
+                    group
+                        .observed_processes
+                        .values()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                },
             )
         };
 
@@ -606,6 +628,12 @@ impl ResourceMonitorState {
         })
     }
 
+    /// #632 - app-shutdown bulk cleanup. Uses fresh-tree-only targets
+    /// (`kill_group_inner` with `fresh_targets_only = true`). Its only caller is the
+    /// app-exit handler. Fresh-only avoids re-introducing the #632 hang: after the
+    /// Job Object kill the live tree is empty, and walking the accumulated stale set
+    /// here would pay one full toolhelp snapshot per dead PID. Per-session kills keep
+    /// the union behavior, which stays bounded via the B2b sampling prune.
     pub fn kill_all_owned_groups(&self, reason: ResourceKillReason) -> Vec<ResourceKillResult> {
         let ids = self
             .inner
@@ -613,7 +641,7 @@ impl ResourceMonitorState {
             .map(|inner| inner.groups.keys().copied().collect::<Vec<_>>())
             .unwrap_or_default();
         ids.into_iter()
-            .filter_map(|id| self.kill_group(id, reason).ok())
+            .filter_map(|id| self.kill_group_inner(id, reason, true).ok())
             .collect()
     }
 
@@ -697,8 +725,30 @@ impl ResourceMonitorState {
             .iter()
             .any(|p| p.identity == group.root_identity);
 
+        // #632 B2b - capture the live identity set and whether the sample is CLEAN
+        // before merge_observed consumes the tree. "Clean" = no enumeration errors at
+        // all (no missing root, no per-pid "identity unavailable" placeholder), so a
+        // partial/racy toolhelp snapshot can never drop a live descendant.
+        let live_identities: BTreeSet<ProcessIdentity> =
+            tree.processes.iter().map(|p| p.identity).collect();
+        let sample_clean = tree.errors.is_empty();
+
         group.descendants_observed |= tree.processes.len() > 1;
         merge_observed(&mut group.observed_processes, tree.processes);
+
+        // #632 B2b - on a CLEAN sample with the root observed alive, the fresh tree is
+        // the authoritative live set, so drop entries no longer present. Gated on
+        // `root_alive && sample_clean` (MED-3): a missing-root, partial, or
+        // ACCESS_DENIED-placeholder sample keeps the last-known set - that case is
+        // owned by the #559 strike/reap logic below, and keeping it avoids dropping a
+        // live child a racy snapshot momentarily missed (which would weaken the no-job
+        // reaper fallback). A clean tree always contains the root, so the root is
+        // retained.
+        if root_alive && sample_clean {
+            group
+                .observed_processes
+                .retain(|identity, _| live_identities.contains(identity));
+        }
         let joined = join_errors(tree.errors);
         if joined.is_some() {
             group.last_error = joined.clone();
@@ -2130,5 +2180,162 @@ mod tests {
         let snap = state.snapshot(limits(100));
         assert_eq!(snap.groups.len(), MAX_TERMINATED_RETAINED);
         assert_eq!(state.active_agent_groups(), 0);
+    }
+
+    // #632 B2a - the app-shutdown bulk path (kill_all_owned_groups -> fresh_targets_only)
+    // targets only the fresh live tree, NOT the accumulated observed_processes. A child
+    // that left the live tree but is still alive must therefore NOT be killed here.
+    #[test]
+    fn kill_all_owned_groups_uses_fresh_tree_only() {
+        let (state, backend) = state_with_fake();
+        let root = identity(90, 90);
+        let child = identity(91, 91);
+        backend.add_tree(
+            root,
+            vec![observed(90, 90, None, 0), observed(91, 91, Some(90), 1)],
+        );
+        let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
+        let id = Uuid::new_v4();
+        state
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
+            .unwrap();
+
+        // register seeded observed_processes with {root, child}. The child now leaves
+        // the live tree (fresh observe_tree is root-only) but stays alive.
+        backend.replace_tree(root, vec![observed(90, 90, None, 0)], Vec::new());
+        backend.mark_present(child);
+
+        let results = state.kill_all_owned_groups(ResourceKillReason::AppShutdown);
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].quarantined);
+        assert!(backend.terminated().contains(&root));
+        assert!(
+            !backend.terminated().contains(&child),
+            "fresh-only shutdown kill must not target the accumulated child"
+        );
+    }
+
+    // #632 B2a contrast - the per-session union path (kill_group, fresh_targets_only =
+    // false) DOES target the accumulated child. Same setup as the fresh-only test;
+    // proves the flag is the only difference.
+    #[test]
+    fn kill_group_union_still_targets_accumulated_child() {
+        let (state, backend) = state_with_fake();
+        let root = identity(92, 92);
+        let child = identity(93, 93);
+        backend.add_tree(
+            root,
+            vec![observed(92, 92, None, 0), observed(93, 93, Some(92), 1)],
+        );
+        let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
+        let id = Uuid::new_v4();
+        state
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
+            .unwrap();
+
+        backend.replace_tree(root, vec![observed(92, 92, None, 0)], Vec::new());
+        backend.mark_present(child);
+
+        let result = state
+            .kill_group(id, ResourceKillReason::SessionDestroy)
+            .unwrap();
+        assert!(!result.quarantined);
+        assert!(backend.terminated().contains(&root));
+        assert!(
+            backend.terminated().contains(&child),
+            "union kill must still target the accumulated child"
+        );
+    }
+
+    // #632 B2b - a CLEAN sample (root alive, no errors) prunes a descendant that has
+    // exited, so observed_processes tracks the live set instead of accumulating.
+    #[test]
+    fn clean_sample_prunes_exited_descendant() {
+        let (state, backend) = state_with_fake();
+        let root = identity(94, 94);
+        let child = identity(95, 95);
+        backend.add_tree(
+            root,
+            vec![observed(94, 94, None, 0), observed(95, 95, Some(94), 1)],
+        );
+        let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
+        let id = Uuid::new_v4();
+        state
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
+            .unwrap();
+        let snap = state.snapshot(limits(1));
+        assert_eq!(snap.groups[0].process_count, 2);
+
+        // Child exits; a clean root-only sample prunes it.
+        backend.replace_tree(root, vec![observed(94, 94, None, 0)], Vec::new());
+        backend.mark_gone(child);
+        let snap = state.snapshot(limits(1));
+        assert_eq!(snap.groups[0].process_count, 1);
+    }
+
+    // #632 B2b guard - a missing-root sample (empty tree + missing-root error) must NOT
+    // prune; the last-known set is owned by the #559 strike/reap path.
+    #[test]
+    fn missing_root_sample_retains_last_known_set() {
+        let (state, backend) = state_with_fake();
+        let root = identity(96, 96);
+        backend.add_tree(
+            root,
+            vec![observed(96, 96, None, 0), observed(97, 97, Some(96), 1)],
+        );
+        let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
+        let id = Uuid::new_v4();
+        state
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
+            .unwrap();
+        let snap = state.snapshot(limits(1));
+        assert_eq!(snap.groups[0].process_count, 2);
+
+        backend.replace_tree(
+            root,
+            Vec::new(),
+            vec![format!("root pid {} was not in process snapshot", root.pid)],
+        );
+        backend.mark_gone(root);
+        let snap = state.snapshot(limits(1));
+        assert_eq!(
+            snap.groups[0].process_count, 2,
+            "missing-root sample must retain the last-known set"
+        );
+    }
+
+    // #632 B2b guard (MED-3) - a root-alive but ERRORED sample (e.g. a transient
+    // "identity unavailable" for a child) must NOT prune, so a racy/partial snapshot
+    // can never drop a still-live descendant.
+    #[test]
+    fn errored_sample_does_not_prune() {
+        let (state, backend) = state_with_fake();
+        let root = identity(98, 98);
+        let child = identity(99, 99);
+        backend.add_tree(
+            root,
+            vec![observed(98, 98, None, 0), observed(99, 99, Some(98), 1)],
+        );
+        let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
+        let id = Uuid::new_v4();
+        state
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
+            .unwrap();
+        let snap = state.snapshot(limits(1));
+        assert_eq!(snap.groups[0].process_count, 2);
+
+        // Root-only fresh tree, but the sample carries an enumeration error: root_alive
+        // is true yet sample_clean is false, so MED-3 keeps the live child.
+        backend.replace_tree(
+            root,
+            vec![observed(98, 98, None, 0)],
+            vec![format!("identity unavailable for pid {}", child.pid)],
+        );
+        backend.mark_present(child);
+        let snap = state.snapshot(limits(1));
+        assert_eq!(
+            snap.groups[0].process_count, 2,
+            "errored sample must not prune the live child"
+        );
     }
 }

--- a/src-tauri/src/shutdown.rs
+++ b/src-tauri/src/shutdown.rs
@@ -52,3 +52,54 @@ impl ShutdownSignal {
         self.flag.load(Ordering::SeqCst)
     }
 }
+
+/// #632 - run `f` on a scratch thread and wait up to `budget`. Returns `Ok(result)`
+/// if it finished in time, `Err(Timeout)` if the budget elapsed (the thread is
+/// abandoned and the OS reclaims it at process exit), or `Err(Disconnected)` if the
+/// closure PANICKED (the worker dropped the sender without sending).
+///
+/// Distinguishing timeout from panic lets the caller log a slow reaper differently
+/// from a crashed one (LOW-3). Bounds shutdown cleanup so the UI thread cannot block
+/// for minutes. Abandoning the work is safe ONLY for sessions that got a Job Object;
+/// see the caller's job-less warning (MED-2).
+pub fn run_time_boxed<T, F>(
+    budget: std::time::Duration,
+    f: F,
+) -> Result<T, std::sync::mpsc::RecvTimeoutError>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(f());
+    });
+    rx.recv_timeout(budget)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_time_boxed;
+    use std::sync::mpsc::RecvTimeoutError;
+    use std::time::Duration;
+
+    #[test]
+    fn ok_when_work_finishes_in_budget() {
+        assert_eq!(run_time_boxed(Duration::from_secs(5), || 42), Ok(42));
+    }
+
+    #[test]
+    fn timeout_when_work_exceeds_budget() {
+        let r = run_time_boxed(Duration::from_millis(50), || {
+            std::thread::sleep(Duration::from_millis(500));
+            42
+        });
+        assert_eq!(r, Err(RecvTimeoutError::Timeout));
+    }
+
+    #[test]
+    fn disconnected_when_closure_panics() {
+        let r: Result<i32, _> = run_time_boxed(Duration::from_secs(5), || panic!("boom"));
+        assert_eq!(r, Err(RecvTimeoutError::Disconnected));
+    }
+}


### PR DESCRIPTION
Closes #632.

## Problem

Closing the app orphaned agent process trees. On shutdown every `kill_group reason=app-shutdown` reported `killed=0 / quarantined` (win32 err 5 ACCESS_DENIED, "still alive after termination"); the watchdog retried for minutes (one instance churned 13:24:09→13:27:42, high CPU) and the process then exited leaving children alive. Root cause = three stacked defects:

1. Insert-only, never-pruned `observed_processes` → `kill_group` did O(stale-PIDs) full-system snapshots (the multi-minute hang).
2. `shutdown.trigger()` ordered after a synchronous, sequential cleanup on the UI thread (watchdog + PTY read loops still live → compounding + CPU burn).
3. No reliable tree-kill primitive — ConPTY spawn with no Job Object; a per-process 2s verified kill that quarantines on any failure and never escalates (the orphans).

## Fix

- **A — Windows Job Object** per agent (`pty/job.rs`, new): the ConPTY child is assigned to a **non-inheritable, singly-owned** job with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`; `kill()` terminates the job, `kill_all_jobs()` fires at app exit → atomic tree teardown immune to PID-reuse / integrity / ACCESS_DENIED. Job create/assign is **non-fatal** (any failure → `None` + warn → reaper fallback, no spawn regression).
- **B1** — `shutdown.trigger()` runs before cleanup (stops the watchdog + idle detectors first).
- **B2a** — the shutdown reaper targets only the fresh live tree (skips the accumulated set).
- **B2b** — `merge_sample` prunes `observed_processes` to the live set on a **clean** sample only (`root_alive && tree.errors.is_empty()`), bounding the map and fixing the inflated RM `process_count`.
- **B4** — shutdown cleanup is time-boxed (5s); safe for jobbed sessions because the job kill is the durable guarantee, with a loud warn when the reaper times out and any job-less session exists.

Consolidated `RunEvent::Exit`: trigger → kill_all_jobs → time-boxed fresh-only reaper → jobless warn → persist (persist is never skipped on timeout).

Non-regression: the #543 / #559 / #564 identity-verification logic is untouched (only the target seed + an additive prune changed). The identity reaper stays for accounting + the job-less fallback.

## Review & validation

- **architect** plan + consensus: grinch's plan-review (3 MED + 3 LOW) folded; design-authority verdict `READY_FOR_IMPLEMENTATION`. A new MED-4 (reparented-but-alive descendant on job-less sessions) ruled an accepted residual.
- **dev-rust** implemented; `/code-review` high → no HIGH.
- **grinch Step-7 PASS** — re-ran the gates itself: `cargo test --lib --bins --tests` **1592 passed / 0 failed / 12 ignored**, `cargo clippy --all-targets -- -D warnings` clean, and the `#[cfg(windows)]` real tree-kill test (`cmd→cmd→ping`, fails-closed, **not** `#[ignore]`, runs in-suite) passed. Handle lifecycle audited (closed exactly once, no leak/double-close); non-inheritable-handle invariant held.
- **shipper** built + deployed `agentscommander_standalone_wg-11.exe` to 0_AC.

## Follow-up

- #637 — narrow job-less-only residual (reparented-but-alive descendant); ruled accepted, low priority (the jobbed path already covers it).

No version bump (not a release). Landed at the user's direction.
