### PR TITLE
docs: document the Coding Agent Profiles matrix (#622, #623, #625)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ These are not accidents.
 - [Quickstart](docs/quickstart.md): 60-second install to first running agent
 - [Concepts](docs/concepts.md): agent, team, workgroup, coordinator, brief
 - [Teams and workgroups](docs/agents/teams-and-workgroups.md): coordinators, members, briefs, messaging
-- [Features](docs/features/): Telegram bridge with image and screenshot sends, voice-to-text, portable instances, RTK integration
+- [Features](docs/features/): Coding Agent Profiles, Telegram bridge with image and screenshot sends, voice-to-text, portable instances, RTK integration
 - [Reference](docs/reference/): full CLI, `settings.json` schema, architecture, log filtering
 - [Roadmap](ROADMAP.md) · [Changelog](CHANGELOG.md) · [Docs style guide](docs/style-guide.md)
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ These are not accidents.
 - [Quickstart](docs/quickstart.md): 60-second install to first running agent
 - [Concepts](docs/concepts.md): agent, team, workgroup, coordinator, brief
 - [Teams and workgroups](docs/agents/teams-and-workgroups.md): coordinators, members, briefs, messaging
-- [Features](docs/features/): Coding Agent Profiles, Telegram bridge with image and screenshot sends, voice-to-text, portable instances, RTK integration
+- [Features](docs/features/): [Coding Agent Profiles](docs/features/coding-agent-profiles.md), Telegram bridge with image and screenshot sends, voice-to-text, portable instances, RTK integration
 - [Reference](docs/reference/): full CLI, `settings.json` schema, architecture, log filtering
 - [Roadmap](ROADMAP.md) · [Changelog](CHANGELOG.md) · [Docs style guide](docs/style-guide.md)
 

--- a/docs/agent-matrix-conventions.md
+++ b/docs/agent-matrix-conventions.md
@@ -311,7 +311,9 @@ Located at `.ac/project-settings.json`. Defines the coding agent configurations 
 
 ## 5. Profile Path Placeholders
 
-Coding-agent **profile** command strings and `env` values may use a small set of `%...%` path placeholders that AgentsCommander expands to absolute paths **at launch**. Only the three tokens below are recognized. There is no shell to evaluate values, so `$`-style forms such as `$(pwd)` and `${VAR}` are **not** expanded — they pass through to the child process **verbatim**. Any other `%WORD%` marker (one that is not one of the three AC tokens) is **not** taken literally: it is **rejected** at launch as an unknown placeholder (fail-closed), and for `CODEX_HOME` it also fails at settings save-time.
+> These tokens are used **inside** a profile cell's command or env. For the profile matrix itself (the lettered A/B/C launch variants per coding agent), see [Coding Agent Profiles](features/coding-agent-profiles.md).
+
+Coding-agent profile command strings and `env` values may use a small set of `%...%` path placeholders that AgentsCommander expands to absolute paths **at launch**. Only the three tokens below are recognized. There is no shell to evaluate values, so `$`-style forms such as `$(pwd)` and `${VAR}` are **not** expanded — they pass through to the child process **verbatim**. Any other `%WORD%` marker (one that is not one of the three AC tokens) is **not** taken literally: it is **rejected** at launch as an unknown placeholder (fail-closed), and for `CODEX_HOME` it also fails at settings save-time.
 
 The tokens map onto the matrix layout from the sections above: a replica is a `__agent_<name>` dir under a `wg-*` workgroup, the workspace is the project's `.ac` root, and the matrix is the canonical `_agent_<name>` dir.
 

--- a/docs/agent-matrix-conventions.md
+++ b/docs/agent-matrix-conventions.md
@@ -313,7 +313,7 @@ Located at `.ac/project-settings.json`. Defines the coding agent configurations 
 
 > These tokens are used **inside** a profile cell's command or env. For the profile matrix itself (the lettered A/B/C launch variants per coding agent), see [Coding Agent Profiles](features/coding-agent-profiles.md).
 
-Coding-agent profile command strings and `env` values may use a small set of `%...%` path placeholders that AgentsCommander expands to absolute paths **at launch**. Only the three tokens below are recognized. There is no shell to evaluate values, so `$`-style forms such as `$(pwd)` and `${VAR}` are **not** expanded — they pass through to the child process **verbatim**. Any other `%WORD%` marker (one that is not one of the three AC tokens) is **not** taken literally: it is **rejected** at launch as an unknown placeholder (fail-closed), and for `CODEX_HOME` it also fails at settings save-time.
+Coding-agent profile command strings and `env` values may use a small set of `%...%` path placeholders that AgentsCommander expands to absolute paths **at launch**. Only the three tokens below are recognized. There is no shell to evaluate values, so `$`-style forms such as `$(pwd)` and `${VAR}` are **not** expanded; they pass through to the child process **verbatim**. Any other `%WORD%` marker (one that is not one of the three AC tokens) is **not** taken literally: it is **rejected** at launch as an unknown placeholder (fail-closed), and for `CODEX_HOME` it also fails at settings save-time.
 
 The tokens map onto the matrix layout from the sections above: a replica is a `__agent_<name>` dir under a `wg-*` workgroup, the workspace is the project's `.ac` root, and the matrix is the canonical `_agent_<name>` dir.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,6 +1,6 @@
 # Concepts
 
-For developers reading the docs for the first time. Eight terms — once these click, the rest of the docs make sense.
+For developers reading the docs for the first time. Nine terms. Once these click, the rest of the docs make sense.
 
 ## Agent
 
@@ -15,6 +15,12 @@ An agent does not run by itself. It comes alive when you launch a session with a
 The CLI process that does the actual LLM work: Claude Code, Codex, or Gemini. AgentsCommander is **not** a coding agent. It spawns coding agent processes and lets you watch and coordinate them.
 
 You pick the coding agent **per session**. The same agent directory can be launched with Claude one day and Codex the next.
+
+## Profile
+
+A named launch variant (`A`, `B`, `C`, ...) of a coding agent: extra command parameters plus environment variables, layered on top of the agent's base command. You set a default profile per agent and override it per session, so one `claude` entry can launch as "max effort" in one session and "cheap" in another.
+
+See [Coding Agent Profiles](features/coding-agent-profiles.md).
 
 ## Session
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -18,7 +18,7 @@ You pick the coding agent **per session**. The same agent directory can be launc
 
 ## Profile
 
-A named launch variant (`A`, `B`, `C`, ...) of a coding agent: extra command parameters plus environment variables, layered on top of the agent's base command. You set a default profile per agent and override it per session, so one `claude` entry can launch as "max effort" in one session and "cheap" in another.
+A lettered launch variant (`A`, `B`, `C`, ...) of a coding agent: extra command parameters plus environment variables, layered on top of the agent's base command. You set a default profile per agent and override it per session, so one `claude` entry can launch as "max effort" in one session and "cheap" in another.
 
 See [Coding Agent Profiles](features/coding-agent-profiles.md).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,11 +8,11 @@ No. AC does not include an LLM. It spawns and coordinates the coding-agent CLIs 
 
 ## Which coding agents are supported?
 
-Claude Code, Codex, and Gemini have first-class tuned profiles (resume tokens, idle tuning). OpenCode works today too, through the custom coding-agent path: because OpenCode is provider-agnostic you can point it at any provider or model. A first-class OpenCode profile and an Nvidia agent are on the [roadmap](../ROADMAP.md).
+Claude Code, Codex, and Gemini have first-class tuned integrations (resume tokens, idle tuning). OpenCode works today too, through the custom coding-agent path: because OpenCode is provider-agnostic you can point it at any provider or model. A first-class OpenCode integration and an Nvidia agent are on the [roadmap](../ROADMAP.md).
 
 ## What about OpenCode?
 
-Usable today. OpenCode is provider-agnostic, so you add it as a custom coding agent (Settings, Coding Agents, Add agent) and point it at any provider or model. That is what lets AC drive any model through it, including OpenRouter Fusion. What is still planned is a first-class tuned profile: its own `CodingAgentKind` variant with resume tokens and idle tuning. The current enum is in `session/profile.rs::CodingAgentKind`. Track the tuned profile on the [roadmap](../ROADMAP.md).
+Usable today. OpenCode is provider-agnostic, so you add it as a custom coding agent (Settings, Coding Agents, Add agent) and point it at any provider or model. That is what lets AC drive any model through it, including OpenRouter Fusion. What is still planned is a first-class tuned integration: its own `CodingAgentKind` variant with resume tokens and idle tuning. The current enum is in `session/profile.rs::CodingAgentKind`. Track the tuned integration on the [roadmap](../ROADMAP.md).
 
 ## Do I need Python or LangChain?
 

--- a/docs/features/coding-agent-profiles.md
+++ b/docs/features/coding-agent-profiles.md
@@ -4,6 +4,8 @@ For developers who want more than one way to launch the same coding agent: a che
 
 After this page you can define a `claude` "max effort" variant and a "cheap" variant, set one agent to default to one of them, and switch a single session to the other without editing any command by hand.
 
+> **Upgrading from a pre-#597 config?** See [the breaking change](#the-effective-launch-command) before you launch: a profile cell now holds parameters, not a full command.
+
 ## What a profile is
 
 A **profile** is a lettered launch variant (`A`, `B`, `C`, ...) of a coding agent. Each profile holds extra command parameters plus environment variables. You assign a profile to an agent or to a single session; at launch AC composes the agent's base command with the profile's parameters and starts the session with the result.
@@ -43,7 +45,17 @@ A cell holds four fields:
 The matrix is keyed by **coding-agent id** (the row). Which *letter* a given agent or session uses is a separate assignment, resolved by the ranking below.
 
 > **Out of the box only `A` exists.** You add `B`, `C`, and so on in **Settings -> Coding Agents**. Letters are single characters `A` through `Z`. The `A`/`B`/`C` examples on this page are illustrative, not a fixed set.
-<!-- VERIFY-FE: "Settings -> Coding Agents" navigation and the per-cell editor (params input, env rows, notes, enabled toggle) per SettingsModal.tsx renderProfileCard (~line 1690-1790). The cell editor shows the hint "Runs <base command> then your params:" (SettingsModal.tsx:1778-1780, class settings-profile-command-base). Confirm against the build. -->
+
+## Quick walkthrough
+
+This runs the scenario from the top of the page end to end. It assumes a `claude` Coding Agent is already configured.
+
+1. Open **Settings -> Coding Agents** and find the `claude` row.
+2. Add profile **B** and set its params to `--effort max` (your "max effort" variant).
+3. Add profile **C** and set its params to a cheaper variant, for example `--model <small-model-id>`.
+4. On an agent, use **Set default** and pick **B**. New sessions for that agent now start on B.
+5. Launch a session for that agent. It runs `claude --effort max`.
+6. To switch only that session to C, open the launch picker, pick profile **C**, and assign it to the replica. The session relaunches as the cheaper variant. You never edited a command by hand.
 
 ## How a profile is chosen
 
@@ -55,11 +67,13 @@ AC picks the requested letter from the first source that has one, highest priori
 
 | Tier | Source | Set by |
 |---|---|---|
-| 1. Instance override | The replica's `tooling.profile` in its own `config.json` | A per-session assignment (highest, wins over everything) |
+| 1. Instance override | The replica's `tooling.profile` in its own `config.json` | Assigned to the replica; persists across future launches |
 | 2. Explicit request | The letter you pick for this one launch | The launch picker, for this launch only |
 | 3. Origin default | The agent matrix's `tooling.defaultProfile` | The "Set default" action (per agent) |
 | 4. Agent default | `codingAgentProfiles.defaultProfileByAgent[<agent>]` in `settings.json` | Rarely set by hand; see note below |
 | Floor | `A` | Always available when nothing else resolves |
+
+Tier 1 outranks tier 2 on purpose: a profile you deliberately assigned to a replica should survive future launches, so it beats an ephemeral letter picked for a single launch.
 
 > **Naming trap:** the "Set default" action writes the **origin default** (tier 3), the per-agent-matrix `tooling.defaultProfile`. It does **not** write tier 4. Tier 4 (`defaultProfileByAgent`) has no dedicated button; in practice it is populated only by an inherited/migrated config or by hand-editing `settings.json`.
 
@@ -77,13 +91,9 @@ When the cell that wins is not the letter that was requested, AC marks the resul
 
 ## Assigning and defaulting a profile
 
-<!-- VERIFY-FE: this entire section's UI labels and navigation are dev-webpage-ui's authority. Confirm each step against the build. Anchors below are best-effort from source. -->
-
 **Set a default profile for an agent (tier 3).** Use the "Set default" action on the agent. This writes the origin matrix's `tooling.defaultProfile`, so every new session for that agent starts on that letter unless a higher tier overrides it.
-<!-- VERIFY-FE: "Set default" action label/location; backed by the set_agent_default_profile command (commands/config.rs) which writes tooling.defaultProfile. -->
 
 **Override the profile for one replica/session (tier 1).** In the launch picker, pick the Coding Agent and Profile, then assign it to the replica. This writes the replica's `tooling.profile` (the instance override), which beats the agent default. The picker previews the exact composed command before you launch.
-<!-- VERIFY-FE: launch picker = AgentPickerModal.tsx. It shows a Coding Agent + Profile selector, a composed-command preview (composeEffectiveCommand), an "Assign to this replica" action, and a MATCH pill when the selection equals the current one. Confirm labels against the build. -->
 
 **Pick a profile for a single launch (tier 2).** Choosing a different letter at launch time, without assigning it to the replica, applies only to that launch.
 
@@ -97,10 +107,10 @@ effective = "<agent base command> <profile cell params>"
 
 The base command (the binary, plus any fixed args) comes from the Coding Agent entry in `settings.json`. The cell holds only the extra params. An empty side contributes nothing, and if both are empty the launch fails with `agent command is empty`.
 
-**Example.** Base command `claude-amp`, profile `B` params `--effort max --model some-model`:
+**Example.** Base command `claude-amp`, profile `B` params `--effort max --model <model-id>`:
 
 ```
-claude-amp --effort max --model some-model
+claude-amp --effort max --model <model-id>
 ```
 
 Environment variables merge in layers: the agent's base env first, then the profile cell's env on top (profile wins on a clashing key), then any AC-generated env (such as an isolated `CODEX_HOME`). Path placeholders like `%AC_REPLICA_ROOT%` are allowed in either the base command or the cell and expand at launch; see [Agent Matrix conventions §5](../agent-matrix-conventions.md#5-profile-path-placeholders).
@@ -117,9 +127,7 @@ When the configuration drifts from what a session launched with, that session sh
 - **Tooltip:** "Loaded profile no longer matches its configuration. Reload to relaunch with the current profile."
 - **Click it** to relaunch the session with the current configuration. The relaunch clears the badge.
 
-<!-- VERIFY-FE: badge label "⟳ outdated" and tooltip are source-verified at ProfileOutdatedBadge.tsx:23,30. The badge is shared by SessionItem, the ProjectPanel replica rows, and RootAgentBanner (the Root Agent). Confirm placement/behavior against the build. -->
-
-Drift is **manual**: AC never auto-reloads. The check covers an edit to the base command, the cell params, the base env, or the cell env. It survives an AC restart (the fingerprint is persisted per replica). Plain-shell sessions and sessions in a non-replica directory never drift, because they have no resolved profile.
+Drift is **manual**: AC never auto-reloads. The check covers an edit to the base command, the cell params, the base env, or the cell env. It survives an AC restart (the fingerprint is persisted per replica). Plain-shell sessions (sessions with no coding agent) never drift. In a directory that is not an agent replica the fingerprint is not persisted, so any drift is not retained across an AC restart.
 
 ## Where profiles are stored
 
@@ -134,8 +142,7 @@ Profiles live in two places: the global `settings.json` (the matrix and defaults
 | Instance override (tier 1) | replica `__agent_<name>/config.json` | `tooling.profile` (legacy `tooling.instanceProfileOverride`) |
 | Drift fingerprint | replica/matrix `config.json` | `tooling.profileContentHash` |
 
-The full `codingAgentProfiles` schema (including `schemaVersion`) is in the [settings reference](../reference/settings.md). The matrix uses schema version 2; an older version-1 config is migrated on load.
-<!-- VERIFY: the v1 -> v2 migration is automatic on settings load (migrate_profiles_object_to_v2, config/settings.rs). Confirm the user-visible effect (silent on-load upgrade, rewritten on next save) before publishing. -->
+The full `codingAgentProfiles` schema (including `schemaVersion`) is in the [settings reference](../reference/settings.md#coding-agent-profiles). The matrix uses schema version 2; a version-1 config is upgraded and persisted on load, after a one-time v1 backup.
 
 ## There is no CLI for profiles
 
@@ -153,7 +160,7 @@ You configure profiles in **Settings** or by editing `settings.json` and the per
 
 ## See also
 
-- [Settings reference](../reference/settings.md) - the full `codingAgentProfiles` schema
+- [Settings reference](../reference/settings.md#coding-agent-profiles) - the full `codingAgentProfiles` schema
 - [Coding agents](../integrations/coding-agents.md) - the coding-agent catalog and tuned `CodingAgentKind` integrations
 - [Agent Matrix conventions §5](../agent-matrix-conventions.md#5-profile-path-placeholders) - path placeholders usable inside a profile cell
 - [Glossary](../glossary.md) - profile, profile matrix, profile cell

--- a/docs/features/coding-agent-profiles.md
+++ b/docs/features/coding-agent-profiles.md
@@ -1,0 +1,159 @@
+# Coding Agent Profiles
+
+For developers who want more than one way to launch the same coding agent: a cheap variant, a max-effort variant, an isolated-config variant, switchable per agent and per session.
+
+After this page you can define a `claude` "max effort" variant and a "cheap" variant, set one agent to default to one of them, and switch a single session to the other without editing any command by hand.
+
+## What a profile is
+
+A **profile** is a lettered launch variant (`A`, `B`, `C`, ...) of a coding agent. Each profile holds extra command parameters plus environment variables. You assign a profile to an agent or to a single session; at launch AC composes the agent's base command with the profile's parameters and starts the session with the result.
+
+The whole feature is the **profile matrix**: a grid of these variants, one row per coding agent, one column per letter.
+
+## Three things called "profile"
+
+The word "profile" appears in three unrelated places in AgentsCommander. This page owns the third one. Keep them separate:
+
+| Term | What it means | Where it lives |
+|---|---|---|
+| **Path placeholder** | A `%AC_REPLICA_ROOT%`-style token you can use *inside* a profile cell's command or env. Not a kind of profile. | [Agent Matrix conventions §5](../agent-matrix-conventions.md#5-profile-path-placeholders) |
+| **Tuned coding-agent integration** | A first-class `CodingAgentKind` (resume tokens, idle tuning) for one CLI. Independent of A/B/C. | [Coding agents](../integrations/coding-agents.md), `session/profile.rs::CodingAgentKind` |
+| **Profile (this page)** | A lettered launch variant of a coding agent, resolved from the profile matrix. | This page |
+
+When this page says "profile" with no qualifier, it always means the third one.
+
+## The profile matrix
+
+The matrix is a grid. Each **row** is a coding agent (`claude`, `codex`, `gemini`, or a custom one). Each **column** is a profile letter. Each **cell** is one launch variant for that coding agent and letter:
+
+| | A | B | C |
+|---|---|---|---|
+| **claude** | (params, env) | (params, env) | (params, env) |
+| **codex** | (params, env) | (params, env) | (params, env) |
+
+A cell holds four fields:
+
+| Field | Meaning |
+|---|---|
+| `enabled` | Whether this cell participates in resolution. A disabled cell is skipped (except `A`, which is always available). |
+| `command` | The extra parameters appended to the agent's base command. Params only, not the binary. See [The effective launch command](#the-effective-launch-command). |
+| `env` | Environment variables for this variant. Overlaid on the agent's base env, profile wins on a key clash. |
+| `notes` | Free text for your own reference. |
+
+The matrix is keyed by **coding-agent id** (the row). Which *letter* a given agent or session uses is a separate assignment, resolved by the ranking below.
+
+> **Out of the box only `A` exists.** You add `B`, `C`, and so on in **Settings -> Coding Agents**. Letters are single characters `A` through `Z`. The `A`/`B`/`C` examples on this page are illustrative, not a fixed set.
+<!-- VERIFY-FE: "Settings -> Coding Agents" navigation and the per-cell editor (params input, env rows, notes, enabled toggle) per SettingsModal.tsx renderProfileCard (~line 1690-1790). The cell editor shows the hint "Runs <base command> then your params:" (SettingsModal.tsx:1778-1780, class settings-profile-command-base). Confirm against the build. -->
+
+## How a profile is chosen
+
+Resolution runs in two distinct steps.
+
+### Step 1: pick the requested letter (4-tier ranking)
+
+AC picks the requested letter from the first source that has one, highest priority first:
+
+| Tier | Source | Set by |
+|---|---|---|
+| 1. Instance override | The replica's `tooling.profile` in its own `config.json` | A per-session assignment (highest, wins over everything) |
+| 2. Explicit request | The letter you pick for this one launch | The launch picker, for this launch only |
+| 3. Origin default | The agent matrix's `tooling.defaultProfile` | The "Set default" action (per agent) |
+| 4. Agent default | `codingAgentProfiles.defaultProfileByAgent[<agent>]` in `settings.json` | Rarely set by hand; see note below |
+| Floor | `A` | Always available when nothing else resolves |
+
+> **Naming trap:** the "Set default" action writes the **origin default** (tier 3), the per-agent-matrix `tooling.defaultProfile`. It does **not** write tier 4. Tier 4 (`defaultProfileByAgent`) has no dedicated button; in practice it is populated only by an inherited/migrated config or by hand-editing `settings.json`.
+
+### Step 2: walk down to the nearest enabled cell
+
+Once Step 1 picks a letter, AC looks up the cell for that coding agent and letter. If the cell is missing or disabled, AC walks **down** the alphabet toward `A` and uses the first enabled cell it finds (`D` -> `C` -> `B` -> `A`). `A` is always materialized, as an empty cell if you never defined one, so resolution always terminates.
+
+When the cell that wins is not the letter that was requested, AC marks the result `fallbackApplied`. That is the signal behind "I asked for D but it launched with C."
+
+**Worked example.** You request `D` for `codex`, but only `codex` cells `A` and `C` are enabled:
+
+1. Step 1 picks `D` (say, from an explicit request).
+2. Step 2 walks `D` -> `C`. `C` is enabled, so the effective profile is `C`.
+3. The session launches with `codex`'s `C` params, and `fallbackApplied` is true.
+
+## Assigning and defaulting a profile
+
+<!-- VERIFY-FE: this entire section's UI labels and navigation are dev-webpage-ui's authority. Confirm each step against the build. Anchors below are best-effort from source. -->
+
+**Set a default profile for an agent (tier 3).** Use the "Set default" action on the agent. This writes the origin matrix's `tooling.defaultProfile`, so every new session for that agent starts on that letter unless a higher tier overrides it.
+<!-- VERIFY-FE: "Set default" action label/location; backed by the set_agent_default_profile command (commands/config.rs) which writes tooling.defaultProfile. -->
+
+**Override the profile for one replica/session (tier 1).** In the launch picker, pick the Coding Agent and Profile, then assign it to the replica. This writes the replica's `tooling.profile` (the instance override), which beats the agent default. The picker previews the exact composed command before you launch.
+<!-- VERIFY-FE: launch picker = AgentPickerModal.tsx. It shows a Coding Agent + Profile selector, a composed-command preview (composeEffectiveCommand), an "Assign to this replica" action, and a MATCH pill when the selection equals the current one. Confirm labels against the build. -->
+
+**Pick a profile for a single launch (tier 2).** Choosing a different letter at launch time, without assigning it to the replica, applies only to that launch.
+
+## The effective launch command
+
+The command that actually starts is the agent's base command followed by the profile cell's parameters, joined with a single space:
+
+```
+effective = "<agent base command> <profile cell params>"
+```
+
+The base command (the binary, plus any fixed args) comes from the Coding Agent entry in `settings.json`. The cell holds only the extra params. An empty side contributes nothing, and if both are empty the launch fails with `agent command is empty`.
+
+**Example.** Base command `claude-amp`, profile `B` params `--effort max --model some-model`:
+
+```
+claude-amp --effort max --model some-model
+```
+
+Environment variables merge in layers: the agent's base env first, then the profile cell's env on top (profile wins on a clashing key), then any AC-generated env (such as an isolated `CODEX_HOME`). Path placeholders like `%AC_REPLICA_ROOT%` are allowed in either the base command or the cell and expand at launch; see [Agent Matrix conventions §5](../agent-matrix-conventions.md#5-profile-path-placeholders).
+
+> **Breaking change: a profile cell holds parameters, not a full command.** AC composes the cell after the base command. If a cell still contains the whole command (for example `claude --foo` on a `claude` base), it composes to `claude claude --foo`, which launches wrong or fails. There is **no automatic migration**. Move the binary into the Coding Agent command and keep only parameters in each cell. Re-check every existing profile cell after upgrading.
+
+## Drift: the "outdated" badge
+
+A profile's identity is positional (coding-agent id plus letter), so editing a cell's command or env does not, by itself, change which cell a running session is on. To catch the case where a running session's profile no longer matches its configuration, AC fingerprints the effective command and merged env at launch and compares it on demand.
+
+When the configuration drifts from what a session launched with, that session shows a clickable badge in the sidebar:
+
+- **Badge:** `⟳ outdated`
+- **Tooltip:** "Loaded profile no longer matches its configuration. Reload to relaunch with the current profile."
+- **Click it** to relaunch the session with the current configuration. The relaunch clears the badge.
+
+<!-- VERIFY-FE: badge label "⟳ outdated" and tooltip are source-verified at ProfileOutdatedBadge.tsx:23,30. The badge is shared by SessionItem, the ProjectPanel replica rows, and RootAgentBanner (the Root Agent). Confirm placement/behavior against the build. -->
+
+Drift is **manual**: AC never auto-reloads. The check covers an edit to the base command, the cell params, the base env, or the cell env. It survives an AC restart (the fingerprint is persisted per replica). Plain-shell sessions and sessions in a non-replica directory never drift, because they have no resolved profile.
+
+## Where profiles are stored
+
+Profiles live in two places: the global `settings.json` (the matrix and defaults) and per-agent `config.json` files (the per-agent and per-replica assignments).
+
+| Datum | Location | Key |
+|---|---|---|
+| Matrix cells (params, env, notes) | `settings.json` | `codingAgentProfiles.profilesByAgent[<coding-agent-id>][<letter>]` |
+| Profile letters and labels | `settings.json` | `codingAgentProfiles.profileSlots`, `codingAgentProfiles.profileLabelsByAgent` |
+| Agent default letter (tier 4) | `settings.json` | `codingAgentProfiles.defaultProfileByAgent[<agent>]` |
+| Origin default (tier 3) | agent matrix `_agent_<name>/config.json` | `tooling.defaultProfile` |
+| Instance override (tier 1) | replica `__agent_<name>/config.json` | `tooling.profile` (legacy `tooling.instanceProfileOverride`) |
+| Drift fingerprint | replica/matrix `config.json` | `tooling.profileContentHash` |
+
+The full `codingAgentProfiles` schema (including `schemaVersion`) is in the [settings reference](../reference/settings.md). The matrix uses schema version 2; an older version-1 config is migrated on load.
+<!-- VERIFY: the v1 -> v2 migration is automatic on settings load (migrate_profiles_object_to_v2, config/settings.rs). Confirm the user-visible effect (silent on-load upgrade, rewritten on next save) before publishing. -->
+
+## There is no CLI for profiles
+
+You configure profiles in **Settings** or by editing `settings.json` and the per-agent `config.json` files. The `agentscommander` CLI has no `profile` subcommand. Resolution happens internally when a session spawns.
+
+## Troubleshooting
+
+**"My session launched with A even though I asked for D."** Letter fallback (Step 2). There is no enabled `D`, `C`, or `B` cell for that coding agent, so resolution walked down to `A`. Enable the cell you want, or define its params.
+
+**"Ignoring invalid profile letter '...'."** A profile letter must be a single character `A` through `Z`. AC logs this and ignores the bad value rather than failing the launch.
+
+**"I edited a profile and the running session did not change."** Drift is manual. Click the `⟳ outdated` badge on the session (or restart it) to relaunch with the new configuration.
+
+**"After upgrading, my agent launches the binary twice, or fails with `agent command is empty`."** The profile cell still holds a full command. Move the binary into the Coding Agent command and keep only parameters in the cell. See [the breaking-change note](#the-effective-launch-command).
+
+## See also
+
+- [Settings reference](../reference/settings.md) - the full `codingAgentProfiles` schema
+- [Coding agents](../integrations/coding-agents.md) - the coding-agent catalog and tuned `CodingAgentKind` integrations
+- [Agent Matrix conventions §5](../agent-matrix-conventions.md#5-profile-path-placeholders) - path placeholders usable inside a profile cell
+- [Glossary](../glossary.md) - profile, profile matrix, profile cell

--- a/docs/features/coding-agent-profiles.md
+++ b/docs/features/coding-agent-profiles.md
@@ -53,9 +53,9 @@ This runs the scenario from the top of the page end to end. It assumes a `claude
 1. Open **Settings -> Coding Agents** and find the `claude` row.
 2. Add profile **B** and set its params to `--effort max` (your "max effort" variant).
 3. Add profile **C** and set its params to a cheaper variant, for example `--model <small-model-id>`.
-4. On an agent, use **Set default** and pick **B**. New sessions for that agent now start on B.
+4. Open the launch picker for that agent, pick profile **B**, and choose **Assign to this replica**. New sessions for that replica now start on B.
 5. Launch a session for that agent. It runs `claude --effort max`.
-6. To switch only that session to C, open the launch picker, pick profile **C**, and assign it to the replica. The session relaunches as the cheaper variant. You never edited a command by hand.
+6. To switch only that session to C, open the launch picker, pick profile **C**, and launch it without assigning to the replica. That choice applies to this launch only (tier 2), so the replica keeps B. You never edited a command by hand.
 
 ## How a profile is chosen
 
@@ -69,13 +69,13 @@ AC picks the requested letter from the first source that has one, highest priori
 |---|---|---|
 | 1. Instance override | The replica's `tooling.profile` in its own `config.json` | Assigned to the replica; persists across future launches |
 | 2. Explicit request | The letter you pick for this one launch | The launch picker, for this launch only |
-| 3. Origin default | The agent matrix's `tooling.defaultProfile` | The "Set default" action (per agent) |
+| 3. Origin default | The agent matrix's `tooling.defaultProfile` | Hand-edited in the matrix `config.json`, or inherited (no UI control) |
 | 4. Agent default | `codingAgentProfiles.defaultProfileByAgent[<agent>]` in `settings.json` | Rarely set by hand; see note below |
 | Floor | `A` | Always available when nothing else resolves |
 
 Tier 1 outranks tier 2 on purpose: a profile you deliberately assigned to a replica should survive future launches, so it beats an ephemeral letter picked for a single launch.
 
-> **Naming trap:** the "Set default" action writes the **origin default** (tier 3), the per-agent-matrix `tooling.defaultProfile`. It does **not** write tier 4. Tier 4 (`defaultProfileByAgent`) has no dedicated button; in practice it is populated only by an inherited/migrated config or by hand-editing `settings.json`.
+> **No per-agent "default" button.** Neither the origin default (tier 3, the per-agent-matrix `tooling.defaultProfile`) nor tier 4 (`defaultProfileByAgent` in `settings.json`) has a UI control. Tier 3 is set only by hand-editing the matrix `config.json` or by inheritance; tier 4 only by an inherited or migrated config or by hand-editing `settings.json`. The closest thing to a default in the UI is an instance override (tier 1), assigned through the launch picker as described below.
 
 ### Step 2: walk down to the nearest enabled cell
 
@@ -91,11 +91,11 @@ When the cell that wins is not the letter that was requested, AC marks the resul
 
 ## Assigning and defaulting a profile
 
-**Set a default profile for an agent (tier 3).** Use the "Set default" action on the agent. This writes the origin matrix's `tooling.defaultProfile`, so every new session for that agent starts on that letter unless a higher tier overrides it.
-
-**Override the profile for one replica/session (tier 1).** In the launch picker, pick the Coding Agent and Profile, then assign it to the replica. This writes the replica's `tooling.profile` (the instance override), which beats the agent default. The picker previews the exact composed command before you launch.
+**Make a profile the one new sessions start on (tier 1 — the practical default).** In the launch picker, pick the Coding Agent and Profile, then choose **Assign to this replica**. This writes the replica's `tooling.profile` (the instance override), which beats the lower default tiers, so new sessions on that replica start on that letter until you change it. The picker previews the exact composed command before you launch. From a workgroup replica, the picker's **Apply to** control widens the same write to more replicas: **This replica**, **All replicas of this kind**, or **Entire workgroup** (each target replica gets its own instance override).
 
 **Pick a profile for a single launch (tier 2).** Choosing a different letter at launch time, without assigning it to the replica, applies only to that launch.
+
+**The per-agent origin default (tier 3) has no UI control.** To set the agent matrix's `tooling.defaultProfile`, hand-edit that matrix's `config.json` (or let it be inherited). Any instance override you assign (tier 1) outranks it.
 
 ## The effective launch command
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -46,6 +46,14 @@ Per-replica directories where an agent receives (`inbox/`) and stages outbound (
 
 A renamed copy of `agentscommander.exe` (with an `_<suffix>` like `agentscommander_team-a.exe`) that runs fully isolated: its own config directory, its own mutex, its own web port.
 
+## Profile
+
+A lettered launch variant (`A`, `B`, `C`, ...) of a coding agent: extra command parameters and environment variables layered on its base command. Resolved per agent and per session. See [Coding Agent Profiles](features/coding-agent-profiles.md). Distinct from a tuned `CodingAgentKind` integration and from path placeholders, which also use the word "profile".
+
+## Profile matrix
+
+The grid of profiles: one row per coding agent, one column per letter, each cell holding that variant's params, env, and notes. Stored in `settings.json` under `codingAgentProfiles`.
+
 ## Project (AC project)
 
 A folder containing a Project AC Root (`.ac/`). AC manages all agents, teams, and workgroups under that root.

--- a/docs/integrations/coding-agents.md
+++ b/docs/integrations/coding-agents.md
@@ -12,7 +12,7 @@ AgentsCommander is **not** a coding agent. It spawns coding-agent processes and 
 | **Codex** | `codex` | `resume --last` | OpenAI's coding agent CLI. |
 | **Gemini** | `gemini` | `--resume latest` | Google's CLI. |
 
-> **OpenCode** runs today through the custom coding-agent path (see [Adding a custom coding-agent profile](#adding-a-custom-coding-agent-profile)). OpenCode is provider-agnostic, so you can point it at any provider or model, including OpenRouter Fusion. It does not yet have a first-class tuned profile (resume tokens, idle tuning); that work is tracked as [#315](https://github.com/mblua/AgentsCommander/issues/315).
+> **OpenCode** runs today through the custom coding-agent path (see [Adding a custom coding agent](#adding-a-custom-coding-agent)). OpenCode is provider-agnostic, so you can point it at any provider or model, including OpenRouter Fusion. It does not yet have a first-class tuned integration (resume tokens, idle tuning); that work is tracked as [#315](https://github.com/mblua/AgentsCommander/issues/315).
 
 Detection rule: AC inspects the shell command + args, takes each token's executable basename (lowercased, `.exe` stripped), and matches by **prefix** with precedence Claude > Codex > Gemini. Wrappers named `claude-foo` or `codex-bar` match automatically. Anything else falls through to the plain-shell behavior (no resume tokens, generic idle tuning).
 
@@ -56,6 +56,10 @@ When you launch a session AC shows a dropdown listing every entry in `agents[]`.
 
 You can change the choice for a session later: right-click → **Launch with…** → pick a different agent.
 
+## Profiles: launch variants per coding agent
+
+Each coding agent can have several **profiles** (lettered launch variants: a cheap one, a max-effort one, an isolated-config one). A profile adds parameters and env vars on top of the agent's base command, and you assign one per agent or per session. This is a separate feature from the tuned `CodingAgentKind` integration above. See [Coding Agent Profiles](../features/coding-agent-profiles.md).
+
 ## Role-template picker
 
 When you create a new agent through the UI you can pick a role template. The picker shows two sources:
@@ -67,7 +71,7 @@ Each template provides metadata (name, description, category, accent color) and 
 
 > AC's role-template picker can use a downloaded cache of [@msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents). If you author a new role and want it discoverable in AC by default, submit it upstream to the agency-agents catalog, then refresh the cache with `agency-templates update`.
 
-## Adding a custom coding-agent profile
+## Adding a custom coding agent
 
 To make AC recognise a new CLI (e.g. a custom wrapper) under the **Coding Agents** dropdown:
 
@@ -77,7 +81,9 @@ To make AC recognise a new CLI (e.g. a custom wrapper) under the **Coding Agents
 
 The new entry appears in the launcher dropdown immediately. AC will spawn the binary as-is — no resume tokens are injected unless the binary's basename starts with `claude`, `codex`, or `gemini`.
 
-For deeper integration (a new `CodingAgentKind` with its own resume tokens and idle tuning), you need to add a profile to `src-tauri/src/session/profile.rs` and rebuild. OpenCode already runs through the custom-agent steps above; its first-class tuned profile is tracked on the [roadmap](../../ROADMAP.md) ([#315](https://github.com/mblua/AgentsCommander/issues/315)) as the canonical example of how a new `CodingAgentKind` is added.
+For deeper integration (a new `CodingAgentKind` with its own resume tokens and idle tuning), you need to add a variant to `src-tauri/src/session/profile.rs` and rebuild. OpenCode already runs through the custom-agent steps above; its first-class tuned integration is tracked on the [roadmap](../../ROADMAP.md) ([#315](https://github.com/mblua/AgentsCommander/issues/315)) as the canonical example of how a new `CodingAgentKind` is added.
+
+> **"Profile" here does not mean the profile matrix.** A tuned `CodingAgentKind` is how AC drives one CLI (resume tokens, idle tuning). The lettered launch variants (A/B/C) are a separate feature: see [Coding Agent Profiles](../features/coding-agent-profiles.md).
 
 ## Authentication and secrets
 
@@ -93,7 +99,8 @@ If you use the AC-managed agent directories, AC may write minimal `.claude/setti
 
 ## See also
 
+- [Coding Agent Profiles](../features/coding-agent-profiles.md): lettered launch variants (A/B/C) per coding agent
 - [Creating agents](../agents/creating-agents.md) — make a new agent dir
 - [Settings reference](../reference/settings.md) — full schema for `agents[]`
 - [RTK integration](../features/rtk-integration.md) — Claude Code Bash-tool compression
-- [Roadmap: coding agents](../../ROADMAP.md): OpenCode first-class profile, Nvidia agent, more
+- [Roadmap: coding agents](../../ROADMAP.md): OpenCode first-class integration, Nvidia agent, more

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,7 +49,7 @@ agentscommander agency-templates update --ref main
 agentscommander agency-templates list --pretty
 ```
 
-`update` resolves the ref to a commit and publishes `<config-dir>/agency-agents_templates` under a single-writer lock. The updater uses `git`, so `git` must be installed and available on `PATH`. `list`, `status`, and `create-agent-matrix --role-template agency:<id>` operate offline on the validated cache.
+`update` resolves the ref to a commit and publishes `<config-dir>/agency-agents_templates` under a single-writer lock. The updater uses `git`, so `git` must be installed and available on `PATH`. `list`, `status`, and [`create-agent-matrix`](#create-agent-matrix) `--role-template agency:<id>` operate offline on the validated cache.
 
 Status reasons include `missing`, `locked`, `manifestMissing`, `manifestMalformed`, `invalidCommit`, `templateCountMismatch`, and `cacheInvalid`.
 
@@ -334,30 +334,61 @@ The command refuses to remove the current coordinator and refuses live sessions 
 
 ## `create-agent`
 
-Create an agent directory with a `CLAUDE.md` role prompt; optionally launch it.
+Create a full Agent Matrix (`_agent_<id>/` with a `Role.md`) in a registered AC project; optionally launch it. A near-alias of [`create-agent-matrix`](#create-agent-matrix): identical flags and JSON output, differing only in that `create-agent` trims `--description` and rejects it when empty.
 
 ```bash
-agentscommander create-agent --parent "C:\path\to\folder" --name " MyAgent "
-agentscommander create-agent --parent "C:\path\to\folder" --name " MyAgent " --launch claude
+agentscommander create-agent --project MyProject --name "QA Bot" --description "Runs the integration suite and reports failures."
+agentscommander create-agent --project MyProject --name "QA Bot" --description "Runs the integration suite." --role-template agency:dev-rust --launch claude
 ```
 
 | Flag | Required | Description |
 |---|---|---|
-| `--parent` | Yes | Existing parent directory; the agent folder is created inside it. |
-| `--name` | Yes | Agent name (trimmed). Cannot contain `/`, `\`, or NUL. |
-| `--launch` | No | Coding agent id to launch (`claude`, `codex`, `gemini`). Must match an entry in `settings.json → agents[]`. |
-| `--root` | No | Caller's root directory (logging context). |
-| `--token` | No | Session token (auth context). |
+| `--project` | Yes | Registered AC project folder name from `settings.projectPaths`. Paths are not accepted; the project must contain `.ac`. |
+| `--name` | Yes | Display/input name, sanitized into a lower-case `_agent_<id>` folder id (the same backend as the New Agent UI). |
+| `--description` | Yes | Written into the `Role.md` frontmatter and body. Trimmed; rejected when empty after trim. |
+| `--role-template` | No | Role template id from the New Agent picker source, e.g. `agency:dev-rust` or `local:my-template`. An invalid id fails before any directory is created. |
+| `--launch` | No | Coding agent to launch after creation. Matches an `id`, `label`, or command prefix in `settings.json → agents[]`. |
+| `--root` | No | Accepted for parity with `create-agent-matrix`; ignored by the handler. |
+| `--token` | No | Accepted for parity with `create-agent-matrix`; ignored by the handler. |
 
 Behaviour:
 
-1. Creates `<parent>/<trimmed-name>/`.
-2. Writes `CLAUDE.md` with `You are the agent <parentFolder>/<trimmed-name>`.
-3. If `--launch` is set, writes a session request that the running AC app picks up within ~3s.
+1. Resolves `--project` to a registered project path (paths are rejected).
+2. Creates `<project>/.ac/_agent_<id>/` with the matrix layout (`memory/`, `plans/`, `skills/`, `inbox/`, `outbox/`) and writes `Role.md`. A picked role template's body becomes a `## Role Profile` section, and its `skills/` are copied in.
+3. Applies the RTK `PreToolUse` hook when the global `injectRtkHook` setting is on.
+4. Requests a sidebar refresh in the running AC app.
+5. If `--launch` is set, writes a session request the running AC app picks up within ~3s.
 
-Output (stdout, JSON): `{ agentPath, agentName, claudeMd, launched, launchAgent }`.
+Output (stdout, JSON): `{ agentPath, agentName, rolePath, launched, launchAgent }`.
 
 See [Creating agents](../agents/creating-agents.md) for richer agent layouts.
+
+---
+
+## `create-agent-matrix`
+
+Create a full Agent Matrix in a registered AC project from a role template; optionally launch it. The sibling of [`create-agent`](#create-agent): same on-disk result, same JSON output, same flags. The only behavioral difference is that `create-agent` trims and rejects an empty `--description`, while `create-agent-matrix` passes `--description` through as given.
+
+```bash
+agentscommander create-agent-matrix --project MyProject --name "dev-rust" --description "Implements the Rust backend."
+agentscommander create-agent-matrix --project MyProject --name "dev-rust" --description "Implements the Rust backend." --role-template agency:dev-rust --launch claude
+```
+
+| Flag | Required | Description |
+|---|---|---|
+| `--project` | Yes | Registered AC project folder name from `settings.projectPaths`. Paths are not accepted; the project must contain `.ac`. |
+| `--name` | Yes | Display/input name, sanitized into a lower-case `_agent_<id>` folder id (the same backend as the New Agent UI). |
+| `--description` | Yes | Written into the `Role.md` frontmatter and body. Passed through as given (no trim, no empty check in the handler). |
+| `--role-template` | No | Role template id from the New Agent picker source, e.g. `agency:dev-rust` or `local:my-template`. An invalid id fails before any directory is created. |
+| `--launch` | No | Coding agent to launch after creation. Matches an `id`, `label`, or command prefix in `settings.json → agents[]`. |
+| `--root` | No | Accepted for parity with `create-agent`; ignored by the handler. |
+| `--token` | No | Accepted for parity with `create-agent`; ignored by the handler. |
+
+Behaviour is identical to [`create-agent`](#create-agent) above, minus the `--description` trim and empty-check.
+
+Output (stdout, JSON): `{ agentPath, agentName, rolePath, launched, launchAgent }`.
+
+> The CLI verb `create-agent-matrix` is distinct from the in-app New Agent command of the same name. The GUI command shares the same on-disk core but never launches a session and returns only `{ path }`.
 
 ---
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -85,6 +85,35 @@ A minimal `settings.json`:
 | `command` | string | — | Binary to spawn. Resolved against PATH unless absolute. |
 | `color` | string | — | CSS hex color for sidebar accent. |
 
+### Coding agent profiles
+
+Lettered launch variants (`A`, `B`, `C`, ...) per coding agent. See [Coding Agent Profiles](../features/coding-agent-profiles.md) for the feature; this is the `settings.json` schema.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `codingAgentProfiles` | `CodingAgentProfilesConfig` | See below | The profile matrix and its defaults. |
+
+`CodingAgentProfilesConfig`:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `schemaVersion` | number | `2` | Schema version. A version-1 object is upgraded and persisted on load, after a one-time v1 backup. |
+| `profileSlots` | `{ <LETTER>: { label: string } }` | `{ "A": { "label": "" } }` | The defined profile letters. Alias: `letters`. |
+| `defaultProfileByAgent` | `{ <agent>: <LETTER> }` | `{}` | Tier-4 fallback letter per agent matrix. Alias: `agentDefaults`. Rarely set by hand. |
+| `profilesByAgent` | `{ <coding-agent-id>: { <LETTER>: ProfileCellConfig } }` | `{}` | The matrix: per coding agent, the cell for each letter. Alias: `matrix`. |
+| `profileLabelsByAgent` | `{ <coding-agent-id>: { <LETTER>: string } }` | `{}` | Optional per-(agent, letter) label override. Empty inherits. |
+
+`ProfileCellConfig` (one cell of `profilesByAgent`):
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `true` | Whether the cell participates in resolution. |
+| `command` | string | `""` | Parameters appended to the agent's base command (not the binary). |
+| `env` | `{ string: string }` | `{}` | Per-cell env, overlaid on the agent env (profile wins on a key clash). |
+| `notes` | string | `""` | Free text. |
+
+The per-agent and per-replica assignments do **not** live here. They are stored in each agent's `config.json` under `tooling`: the origin default (`tooling.defaultProfile`), the instance override (`tooling.profile`, legacy `tooling.instanceProfileOverride`), and the drift fingerprint (`tooling.profileContentHash`).
+
 ### Projects
 
 | Field | Type | Default | Description |


### PR DESCRIPTION
Closes #622
Closes #623
Closes #625

## What

Documents the **Coding Agent Profiles** matrix: the flagship feature doc (`docs/features/coding-agent-profiles.md`), the `create-agent-matrix` CLI reference section (`docs/reference/cli.md`), and the `codingAgentProfiles` settings reference (`docs/reference/settings.md`). Authored and reviewed by **wg-12-community**; the final frontend gap was closed by **wg-1-dev-team**.

## Frontend gap closed (wg-1)

The flagship doc described a **"Set default"** UI control that does not exist in the current frontend: `set_agent_default_profile` lost its FE caller when the V2 agent picker scope model (`src/shared/types.ts:715`, `replica | kind | workgroup`) replaced the old per-agent default — all three scopes write the **tier-1 instance override** instead. Verified by FE source-trace (`dev-webpage-ui`):

- `setAgentDefaultProfile` (`src/shared/ipc.ts`) has **zero component callers**; no "Set default" control exists in `src/`.
- All three picker scopes write tier-1 (`tooling.profile`) via `set_replica_coding_agent_selection`; none writes tier-3 (`tooling.defaultProfile`) or tier-4.

The Quick walkthrough, ranking table, "naming trap" callout, and how-to were rewritten to the real mechanism: launch picker → **Assign to this replica**, with the **Apply to** scope widening to *This replica* / *All replicas of this kind* / *Entire workgroup*. The walkthrough's step 6 was also corrected from a contradictory tier-1 example ("switch only that session" while using the persistent tier-1 action) to the intended **tier-2 ephemeral** one. Docs-only — no code touched.

## Follow-up (separate)

The orphaned `set_agent_default_profile` command is tracked for a later **rewire-vs-deprecate** decision in #641 (intentionally left undecided).

## Review

- **wg-12:** backend accuracy review (`dev-rust`) PASS; clarity / onboarding (`developer-advocate`) PASS.
- **wg-1:** FE source verification + rewrite (`dev-webpage-ui`); diff verified by tech-lead. Clean merge — no docs file changed on `main` since the branch base.
