### PR TITLE
fix(#647): RM Kill button terminates the agent tree via the Job Object

### DIFF
--- a/src-tauri/src/commands/resource_monitor.rs
+++ b/src-tauri/src/commands/resource_monitor.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use tauri::State;
+use tauri::{AppHandle, State};
 use uuid::Uuid;
 
 use crate::config::settings::SettingsState;
 use crate::resource_monitor::types::{
-    ResourceKillRequest, ResourceKillResult, ResourceLimits, ResourceSnapshot,
+    ResourceGroupState, ResourceKillRequest, ResourceKillResult, ResourceLimits, ResourceSnapshot,
 };
 use crate::resource_monitor::ResourceMonitorState;
 
@@ -22,14 +22,99 @@ pub async fn get_resource_snapshot(
         .map_err(|e| e.to_string())
 }
 
+/// #647 A: route the manual RM Kill through the per-agent Job Object (the only
+/// mechanism that bypasses per-handle `PROCESS_TERMINATE` stripping by an AV/EDR),
+/// then VERIFY the kill via the reaper before tearing the session down.
+///
+/// Fire-then-verify (grinch HIGH-1): the job is fired by the pure
+/// `terminate_job_for_session` (which keeps the instance/job), and only a result whose
+/// state is the verified `Terminated` runs the full `kill` cleanup + flips the tile to
+/// `Exited`. A `Quarantined` result (or an unverified `Terminating` early-return from a
+/// concurrent kill) leaves the instance/job intact so a Force/Retry can re-fire the
+/// durable kill, and never marks a possibly-alive agent `Exited`.
 #[tauri::command]
 pub async fn kill_resource_group(
+    app: AppHandle,
     request: ResourceKillRequest,
     monitor: State<'_, Arc<ResourceMonitorState>>,
+    pty_mgr: State<'_, Arc<std::sync::Mutex<crate::pty::manager::PtyManager>>>,
+    session_mgr: State<'_, Arc<tokio::sync::RwLock<crate::session::manager::SessionManager>>>,
 ) -> Result<ResourceKillResult, String> {
     let session_id = Uuid::parse_str(&request.session_id).map_err(|e| e.to_string())?;
-    let monitor = Arc::clone(&monitor);
-    tokio::task::spawn_blocking(move || monitor.kill_group(session_id, request.reason))
+    let reason = request.reason;
+
+    // Fire the Job Object FIRST (pure: keeps the instance/job for a Retry). The
+    // std-Mutex guard is dropped before any await.
+    let job_fired = { pty_mgr.lock().unwrap().terminate_job_for_session(session_id) };
+    log::info!(
+        "[resource-monitor] job-fire session={} job_present={}",
+        session_id,
+        job_fired
+    );
+
+    // Verify + account on the blocking pool. After the job kill the reaper observes
+    // the dead tree as AlreadyGone -> quarantined=false -> Terminated (slot released).
+    let monitor_c = Arc::clone(&monitor);
+    let result = tokio::task::spawn_blocking(move || monitor_c.kill_group(session_id, reason))
         .await
-        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())??;
+
+    if should_finalize_kill(result.state) {
+        // Verified dead: full PTY cleanup (drops the job handle = KILL_ON_JOB_CLOSE
+        // backstop, reaps the child, tears down idle/git/watchers/parser), then flip
+        // the tile to Exited. This is the only path that consumes the job.
+        {
+            let _ = pty_mgr.lock().unwrap().kill(session_id);
+        }
+        let mgr = session_mgr.read().await;
+        mgr.mark_exited(session_id, 0).await;
+        mgr.clear_active_if(session_id).await;
+        if let Some(updated) = mgr.get_session(session_id).await {
+            let info = crate::session::session::SessionInfo::from(&updated);
+            let _ = tauri::Emitter::emit(&app, "session_created", info);
+        }
+        crate::config::sessions_persistence::persist_current_state(&mgr).await;
+    } else {
+        // NOT verified dead (kernel-AV residual, no job, or a sub-ms async-reap race).
+        // Keep the instance/job so Force/Retry re-fires the durable kill; do NOT mark
+        // Exited. The result carries the per-PID errors + blocked_by_security.
+        log::warn!(
+            "[resource-monitor] kill session={} quarantined (job_fired={}): {}",
+            session_id,
+            job_fired,
+            result.message
+        );
+    }
+
+    Ok(result)
+}
+
+/// #647 A (grinch HIGH-1 invariant): finalize the kill (full PTY teardown + flip the
+/// tile to `Exited`) ONLY on a result whose state is the verified `Terminated`. This is
+/// STRICTER than `!quarantined`: `kill_group`'s early return for an already-`Terminating`
+/// group (a concurrent kill, e.g. a watchdog tick still mid observe/verify) also reports
+/// `quarantined == false`, but that kill is NOT yet verified, so finalizing on it could
+/// tear down the job and mark a possibly-alive agent `Exited`. Gating on `Terminated`
+/// lets the in-flight kill own the outcome; `Quarantined`/`Terminating`/`Running` never
+/// finalize.
+fn should_finalize_kill(state: ResourceGroupState) -> bool {
+    matches!(state, ResourceGroupState::Terminated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_finalize_kill;
+    use crate::resource_monitor::types::ResourceGroupState;
+
+    #[test]
+    fn finalizes_only_on_verified_terminated() {
+        // Verified dead -> tear down + mark Exited.
+        assert!(should_finalize_kill(ResourceGroupState::Terminated));
+        // Quarantined (possibly alive) -> keep instance/job, never mark Exited.
+        assert!(!should_finalize_kill(ResourceGroupState::Quarantined));
+        // A concurrent kill still in flight (early return) -> let it own the outcome,
+        // do NOT finalize here (the bug grinch HIGH-1 would otherwise reintroduce).
+        assert!(!should_finalize_kill(ResourceGroupState::Terminating));
+        assert!(!should_finalize_kill(ResourceGroupState::Running));
+    }
 }

--- a/src-tauri/src/commands/resource_monitor.rs
+++ b/src-tauri/src/commands/resource_monitor.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, State};
 use uuid::Uuid;
 
 use crate::config::settings::SettingsState;
 use crate::resource_monitor::types::{
-    ResourceGroupState, ResourceKillRequest, ResourceKillResult, ResourceLimits, ResourceSnapshot,
+    ResourceGroupState, ResourceKillReason, ResourceKillRequest, ResourceKillResult, ResourceLimits,
+    ResourceSnapshot,
 };
 use crate::resource_monitor::ResourceMonitorState;
 
@@ -26,12 +28,14 @@ pub async fn get_resource_snapshot(
 /// mechanism that bypasses per-handle `PROCESS_TERMINATE` stripping by an AV/EDR),
 /// then VERIFY the kill via the reaper before tearing the session down.
 ///
-/// Fire-then-verify (grinch HIGH-1): the job is fired by the pure
-/// `terminate_job_for_session` (which keeps the instance/job), and only a result whose
-/// state is the verified `Terminated` runs the full `kill` cleanup + flips the tile to
-/// `Exited`. A `Quarantined` result (or an unverified `Terminating` early-return from a
-/// concurrent kill) leaves the instance/job intact so a Force/Retry can re-fire the
-/// durable kill, and never marks a possibly-alive agent `Exited`.
+/// Fire-then-verify-then-settle (grinch HIGH): the job is fired by the pure
+/// `terminate_job_for_session` (which keeps the instance/job). Verification re-runs
+/// `kill_group` until the group leaves the transient `Terminating` a concurrent kill
+/// (e.g. a watchdog retry) may briefly own, so an in-flight kill is not mistaken for a
+/// verified one. Only a settled, verified `Terminated` runs the full `kill` cleanup,
+/// flips the tile to `Exited`, and sets `finalized = true`. A `Quarantined` (or a
+/// budget-exhausted `Terminating`) result leaves the instance/job intact for a
+/// Force/Retry and never marks a possibly-alive agent `Exited`.
 #[tauri::command]
 pub async fn kill_resource_group(
     app: AppHandle,
@@ -52,12 +56,10 @@ pub async fn kill_resource_group(
         job_fired
     );
 
-    // Verify + account on the blocking pool. After the job kill the reaper observes
-    // the dead tree as AlreadyGone -> quarantined=false -> Terminated (slot released).
-    let monitor_c = Arc::clone(&monitor);
-    let result = tokio::task::spawn_blocking(move || monitor_c.kill_group(session_id, reason))
-        .await
-        .map_err(|e| e.to_string())??;
+    // Verify + account, settling past a concurrent kill's transient `Terminating`.
+    let mut result =
+        verify_kill_settled(Arc::clone(&monitor), session_id, reason, SETTLE_BUDGET, SETTLE_POLL)
+            .await?;
 
     if should_finalize_kill(result.state) {
         // Verified dead: full PTY cleanup (drops the job handle = KILL_ON_JOB_CLOSE
@@ -74,19 +76,60 @@ pub async fn kill_resource_group(
             let _ = tauri::Emitter::emit(&app, "session_created", info);
         }
         crate::config::sessions_persistence::persist_current_state(&mgr).await;
+        result.finalized = true;
     } else {
-        // NOT verified dead (kernel-AV residual, no job, or a sub-ms async-reap race).
-        // Keep the instance/job so Force/Retry re-fires the durable kill; do NOT mark
-        // Exited. The result carries the per-PID errors + blocked_by_security.
+        // NOT verified dead (kernel-AV residual, no job, or a concurrent kill that did
+        // not settle within the budget). Keep the instance/job so Force/Retry re-fires
+        // the durable kill; do NOT mark Exited. result.finalized stays false so the FE
+        // keeps the modal open with the per-PID errors + blocked_by_security.
         log::warn!(
-            "[resource-monitor] kill session={} quarantined (job_fired={}): {}",
+            "[resource-monitor] kill session={} not finalized (state={:?} job_fired={}): {}",
             session_id,
+            result.state,
             job_fired,
             result.message
         );
     }
 
     Ok(result)
+}
+
+/// Upper bound on how long `verify_kill_settled` waits for a concurrent kill to leave
+/// `Terminating`. After the job fire the concurrent reaper sees an AlreadyGone tree, so
+/// the common case settles in one or two ~75ms polls. The budget sits ABOVE the
+/// worst-case single `kill_group` latency (a ~2s `WaitForSingleObject` in
+/// `terminate_verified`), so a genuinely in-flight kill is awaited to completion rather
+/// than misreported as not-finalized; the cap only trips on a pathologically stuck
+/// verify, after which we return a not-finalized result the FE surfaces for a retry.
+const SETTLE_BUDGET: Duration = Duration::from_millis(2500);
+/// Re-poll interval while a concurrent kill owns the `Terminating` state.
+const SETTLE_POLL: Duration = Duration::from_millis(75);
+
+/// #647 (Step 7): re-run `kill_group` until the group leaves `Terminating` or the
+/// budget elapses. `kill_group` is idempotent under concurrency: while another call
+/// owns `Terminating` it early-returns that state with no side effects; once the owner
+/// settles to `Terminated` it early-returns `Terminated`; a settled `Quarantined`
+/// re-runs the reaper (now seeing the job-killed tree as AlreadyGone -> `Terminated`).
+/// So a single Force-kill click reliably reaches a verified outcome instead of bailing
+/// on the transient `Terminating` and silently leaving a dead tree with a Running tile.
+async fn verify_kill_settled(
+    monitor: Arc<ResourceMonitorState>,
+    session_id: Uuid,
+    reason: ResourceKillReason,
+    budget: Duration,
+    poll: Duration,
+) -> Result<ResourceKillResult, String> {
+    let deadline = Instant::now() + budget;
+    loop {
+        let monitor_c = Arc::clone(&monitor);
+        let result = tokio::task::spawn_blocking(move || monitor_c.kill_group(session_id, reason))
+            .await
+            .map_err(|e| e.to_string())??;
+        if result.state != ResourceGroupState::Terminating || Instant::now() >= deadline {
+            return Ok(result);
+        }
+        tokio::time::sleep(poll).await;
+    }
 }
 
 /// #647 A (grinch HIGH-1 invariant): finalize the kill (full PTY teardown + flip the
@@ -103,8 +146,19 @@ fn should_finalize_kill(state: ResourceGroupState) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::should_finalize_kill;
-    use crate::resource_monitor::types::ResourceGroupState;
+    use super::{should_finalize_kill, verify_kill_settled};
+    use crate::resource_monitor::registry::{
+        ProcessTreeBackend, ResourceError, ResourceLaunchRegistration,
+    };
+    use crate::resource_monitor::types::{
+        ObservedProcess, ObservedProcessTree, ProcessIdentity, ProcessMemory, ResourceGroupState,
+        ResourceKillReason, ResourceLaunchMetadata, ResourceLimits, TerminateOutcome,
+    };
+    use crate::resource_monitor::ResourceMonitorState;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Condvar, Mutex};
+    use std::time::Duration;
+    use uuid::Uuid;
 
     #[test]
     fn finalizes_only_on_verified_terminated() {
@@ -116,5 +170,195 @@ mod tests {
         // do NOT finalize here (the bug grinch HIGH-1 would otherwise reintroduce).
         assert!(!should_finalize_kill(ResourceGroupState::Terminating));
         assert!(!should_finalize_kill(ResourceGroupState::Running));
+    }
+
+    /// A backend whose `observe_tree` BLOCKS (once armed) until the test releases it, so
+    /// a `kill_group` call parks the group in `Terminating`. Registration runs before
+    /// arming, so it observes the live root; after release the root reads as gone, so the
+    /// blocked kill settles cleanly to `Terminated`.
+    struct GatedBackend {
+        root: ProcessIdentity,
+        armed: AtomicBool,
+        entered: AtomicBool,
+        gate: (Mutex<bool>, Condvar),
+    }
+
+    impl GatedBackend {
+        fn new(root: ProcessIdentity) -> Self {
+            Self {
+                root,
+                armed: AtomicBool::new(false),
+                entered: AtomicBool::new(false),
+                gate: (Mutex::new(false), Condvar::new()),
+            }
+        }
+        fn released(&self) -> bool {
+            *self.gate.0.lock().unwrap()
+        }
+        fn release(&self) {
+            *self.gate.0.lock().unwrap() = true;
+            self.gate.1.notify_all();
+        }
+    }
+
+    impl ProcessTreeBackend for GatedBackend {
+        fn observe_tree(
+            &self,
+            _root: ProcessIdentity,
+        ) -> Result<ObservedProcessTree, ResourceError> {
+            if self.armed.load(Ordering::SeqCst) {
+                self.entered.store(true, Ordering::SeqCst);
+                let mut released = self.gate.0.lock().unwrap();
+                while !*released {
+                    released = self.gate.1.wait(released).unwrap();
+                }
+                // Released: tree is gone -> the reaper sees AlreadyGone -> Terminated.
+                Ok(ObservedProcessTree {
+                    processes: Vec::new(),
+                    errors: vec![format!(
+                        "root pid {} was not in process snapshot",
+                        self.root.pid
+                    )],
+                })
+            } else {
+                Ok(ObservedProcessTree {
+                    processes: vec![ObservedProcess {
+                        identity: self.root,
+                        parent_pid: None,
+                        parent_identity: None,
+                        exe_name: "root".to_string(),
+                        depth: 0,
+                        private_bytes: None,
+                        working_set_bytes: None,
+                        cpu_percent: None,
+                        kill_allowed: true,
+                    }],
+                    errors: Vec::new(),
+                })
+            }
+        }
+        fn observe_identity(&self, pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+            if pid == self.root.pid && !self.released() {
+                Ok(Some(self.root))
+            } else {
+                Ok(None)
+            }
+        }
+        fn terminate_verified(
+            &self,
+            _process: &ObservedProcess,
+        ) -> Result<TerminateOutcome, ResourceError> {
+            Ok(TerminateOutcome::AlreadyGone)
+        }
+        fn current_process_memory(&self) -> Result<ProcessMemory, ResourceError> {
+            Ok(ProcessMemory::default())
+        }
+    }
+
+    fn test_limits() -> ResourceLimits {
+        ResourceLimits {
+            monitor_enabled: true,
+            max_concurrent_agent_processes: 4,
+            group_warn_private_bytes: 100,
+            group_kill_private_bytes: 200,
+            process_kill_private_bytes: 200,
+        }
+    }
+
+    fn register_running(state: &ResourceMonitorState, id: Uuid, root: ProcessIdentity) {
+        let permit = state.try_reserve_agent_slot(test_limits()).unwrap().unwrap();
+        let mut reg = ResourceLaunchRegistration::new(
+            state.clone(),
+            permit,
+            ResourceLaunchMetadata {
+                session_id: id,
+                name: "agent".to_string(),
+                agent_id: None,
+                agent_label: None,
+                workgroup: None,
+                agent: None,
+                project: None,
+            },
+        );
+        reg.register_root_pid(root.pid).unwrap();
+    }
+
+    // Grinch HIGH (Step 7): a manual kill that races a concurrent watchdog kill must not
+    // mistake the transient `Terminating` for a verified success, and must settle to the
+    // real outcome. Proves both halves: (1) while a watchdog kill owns `Terminating`, a
+    // direct kill_group returns `Terminating` (NOT finalizable); (2) verify_kill_settled
+    // waits it out and returns the settled `Terminated` (finalizable).
+    #[tokio::test]
+    async fn force_kill_settles_past_concurrent_terminating() {
+        let root = ProcessIdentity {
+            pid: 4321,
+            creation_time_100ns: 99,
+        };
+        let backend = Arc::new(GatedBackend::new(root));
+        let state =
+            ResourceMonitorState::with_backend(backend.clone() as Arc<dyn ProcessTreeBackend>);
+        let id = Uuid::new_v4();
+        register_running(&state, id, root);
+
+        // Safety net: release the gate on scope exit so a panicking assertion below can
+        // never leave the blocked watchdog thread parked on the Condvar. `release` is
+        // idempotent, so the timed releaser on the happy path is unaffected.
+        struct ReleaseOnDrop(Arc<GatedBackend>);
+        impl Drop for ReleaseOnDrop {
+            fn drop(&mut self) {
+                self.0.release();
+            }
+        }
+        let _release_guard = ReleaseOnDrop(backend.clone());
+
+        // Arm so the next observe_tree (the watchdog kill) blocks in `Terminating`.
+        backend.armed.store(true, Ordering::SeqCst);
+        let watchdog = {
+            let s = state.clone();
+            std::thread::spawn(move || s.kill_group(id, ResourceKillReason::Watchdog))
+        };
+        // Wait until the watchdog kill has parked the group in `Terminating`.
+        let mut waited_ms = 0;
+        while !backend.entered.load(Ordering::SeqCst) {
+            std::thread::sleep(Duration::from_millis(5));
+            waited_ms += 5;
+            assert!(waited_ms < 2000, "watchdog kill never entered Terminating");
+        }
+
+        // (1) A direct kill now hits the `Terminating` early-return: not finalizable.
+        let racing = {
+            let s = state.clone();
+            tokio::task::spawn_blocking(move || s.kill_group(id, ResourceKillReason::User))
+                .await
+                .unwrap()
+                .unwrap()
+        };
+        assert_eq!(racing.state, ResourceGroupState::Terminating);
+        assert!(!racing.finalized);
+        assert!(!should_finalize_kill(racing.state));
+
+        // (2) Release the watchdog kill shortly, then verify_kill_settled must wait out
+        // `Terminating` and return the settled `Terminated`.
+        let releaser = {
+            let b = backend.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(100));
+                b.release();
+            })
+        };
+        let settled = verify_kill_settled(
+            Arc::new(state.clone()),
+            id,
+            ResourceKillReason::User,
+            Duration::from_millis(2000),
+            Duration::from_millis(25),
+        )
+        .await
+        .unwrap();
+        assert_eq!(settled.state, ResourceGroupState::Terminated);
+        assert!(should_finalize_kill(settled.state));
+
+        watchdog.join().unwrap().unwrap();
+        releaser.join().unwrap();
     }
 }

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -693,6 +693,24 @@ impl PtyManager {
         Ok(())
     }
 
+    /// #647 A: fire the Job Object tree-kill for a session WITHOUT tearing the
+    /// session down. Pure: no `ptys.remove`, no child reap, no idle/git/watcher
+    /// teardown, and the job handle is RETAINED so a Force/Retry can re-fire it.
+    /// Returns true if a live job was present and `terminate()` was called.
+    /// `TerminateJobObject` is idempotent, so repeated calls on a dead tree are safe.
+    /// On non-Windows builds the job is always `None`, so this returns false and the
+    /// caller falls back to the per-process reaper.
+    pub fn terminate_job_for_session(&self, id: Uuid) -> bool {
+        let ptys = self.ptys.lock().unwrap();
+        match ptys.get(&id).and_then(|inst| inst.job.as_ref()) {
+            Some(job) => {
+                job.terminate();
+                true
+            }
+            None => false,
+        }
+    }
+
     /// #632 - terminate every live agent's Job Object at app shutdown. Atomically
     /// kills each session's whole descendant tree via the job handle (immune to PID
     /// reuse / ACCESS_DENIED, no snapshot walking, no per-process waits). Returns

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -405,6 +405,7 @@ impl ResourceMonitorState {
                     killed_processes: Vec::new(),
                     quarantined: false,
                     message: "resource group not registered".to_string(),
+                    blocked_by_security: false,
                 });
             };
             match group.state {
@@ -415,6 +416,7 @@ impl ResourceMonitorState {
                         killed_processes: Vec::new(),
                         quarantined: false,
                         message: "resource group is already terminating".to_string(),
+                        blocked_by_security: false,
                     });
                 }
                 ResourceGroupState::Terminated => {
@@ -424,6 +426,7 @@ impl ResourceMonitorState {
                         killed_processes: Vec::new(),
                         quarantined: false,
                         message: "resource group already terminated".to_string(),
+                        blocked_by_security: false,
                     });
                 }
                 ResourceGroupState::Running | ResourceGroupState::Quarantined => {}
@@ -573,11 +576,24 @@ impl ResourceMonitorState {
                         session_id
                     );
                 }
-                Ok(Some(_)) | Err(_) => errors.push(error),
+                Ok(Some(_)) | Err(_) => {
+                    // #647 D: per-PID diagnostic so future AV-block repros are
+                    // conclusive from the log (the error already begins with `pid <n>:`).
+                    log::warn!(
+                        "[resource-monitor] kill-failed session={} reason={} error={}",
+                        session_id,
+                        reason.as_log_reason(),
+                        error
+                    );
+                    errors.push(error);
+                }
             }
         }
 
         let quarantined = !errors.is_empty();
+        // #647 D: flag an AV/EDR ACCESS_DENIED (exact `win32 error 5`) so the UI can
+        // add the exclusion guidance; the per-PID detail stays in `message`.
+        let blocked_by_security = quarantined && has_access_denied_signature(&errors);
         let state = if quarantined {
             ResourceGroupState::Quarantined
         } else {
@@ -625,6 +641,7 @@ impl ResourceMonitorState {
             killed_processes: killed,
             quarantined,
             message,
+            blocked_by_security,
         })
     }
 
@@ -670,9 +687,15 @@ impl ResourceMonitorState {
                     .groups
                     .iter()
                     .filter_map(|(id, group)| {
+                        // #647 C: include Quarantined so its process list is
+                        // re-observed each snapshot (unfreezes the display for the
+                        // root-alive / EDR-residual case). Reap-safe: merge_sample
+                        // only strike-counts/nominates Running groups.
                         matches!(
                             group.state,
-                            ResourceGroupState::Running | ResourceGroupState::Terminating
+                            ResourceGroupState::Running
+                                | ResourceGroupState::Terminating
+                                | ResourceGroupState::Quarantined
                         )
                         .then_some((*id, group.root_identity))
                     })
@@ -905,6 +928,19 @@ const MAX_TERMINATED_RETAINED: usize = 16;
 
 /// #559 - minimum interval between cleanup retries for a single quarantine.
 const QUARANTINE_RETRY_BACKOFF: Duration = Duration::from_secs(15);
+
+/// #647 D: true if any error carries the EXACT ACCESS_DENIED code (`win32 error 5`),
+/// so "win32 error 50/53/567" do NOT match. Errors are formatted "...win32 error {code}".
+fn has_access_denied_signature(errors: &[String]) -> bool {
+    errors.iter().any(|e| {
+        e.split("win32 error ").skip(1).any(|tail| {
+            tail.chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+                == "5"
+        })
+    })
+}
 
 fn is_missing_root_cleanup_error(error: &str, root_identity: ProcessIdentity) -> bool {
     error == format!("root pid {} was not in process snapshot", root_identity.pid)
@@ -2136,7 +2172,8 @@ mod tests {
         );
     }
 
-    // (T3) H1 never races H2: a Quarantined group is never sampled, so it is never reaped.
+    // (T3) H1 never races H2: a Quarantined group IS sampled (#647 C) but merge_sample
+    // only strike-counts/nominates Running groups, so it is still never reaped.
     #[test]
     fn reap_never_touches_quarantined_group() {
         let (state, backend) = state_with_fake();
@@ -2155,14 +2192,92 @@ mod tests {
         let result = state.kill_group(id, ResourceKillReason::User).unwrap();
         assert!(result.quarantined);
 
-        // Even with a missing-root signal + confirmed-gone root, sample_running_groups
-        // skips Quarantined, so H1 never reaps it to Terminated.
+        // Even with a missing-root signal + confirmed-gone root, merge_sample only
+        // strike-counts/nominates Running groups, so H1 never reaps Quarantined to
+        // Terminated (even though #647 C now re-samples it).
         backend.replace_tree(root, Vec::new(), missing_root_error(root));
         backend.mark_gone(root);
         state.snapshot(limits(1));
         state.snapshot(limits(1));
         assert_eq!(state.test_state(id), Some(ResourceGroupState::Quarantined));
         assert_eq!(state.active_agent_groups(), 1);
+    }
+
+    // #647 C: a Quarantined group IS included in sample_running_groups so its process
+    // list is re-observed each snapshot (unfreezing the display). Pairs with
+    // reap_never_touches_quarantined_group, which proves sampling it stays reap-safe.
+    #[test]
+    fn quarantined_group_is_resampled() {
+        let (state, backend) = state_with_fake();
+        let root = identity(81, 81);
+        let child = identity(82, 82);
+        backend.add_tree(
+            root,
+            vec![observed(81, 81, None, 0), observed(82, 82, Some(81), 1)],
+        );
+        backend.mark_stubborn(child);
+        let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
+        let id = Uuid::new_v4();
+        state
+            .register_group(permit, id, "agent".into(), None, None, None, None, None, root)
+            .unwrap();
+        let result = state.kill_group(id, ResourceKillReason::User).unwrap();
+        assert!(result.quarantined);
+
+        let sampled = state.sample_running_groups();
+        assert!(
+            sampled.iter().any(|(sid, _)| *sid == id),
+            "Quarantined group must be re-sampled (#647 C)"
+        );
+    }
+
+    // #647 D / E1: the ACCESS_DENIED signature must match the EXACT win32 code 5, so
+    // unrelated codes that merely start with the digit 5 (50/53/567) never trip it.
+    #[test]
+    fn access_denied_signature_matches_exact_code_5_only() {
+        assert!(has_access_denied_signature(&[
+            "pid 1: TerminateProcess failed: win32 error 5".to_string()
+        ]));
+        assert!(!has_access_denied_signature(&[
+            "pid 1: OpenProcess(1) failed: win32 error 50".to_string()
+        ]));
+        assert!(!has_access_denied_signature(&[
+            "pid 1: win32 error 53".to_string()
+        ]));
+        assert!(!has_access_denied_signature(&[
+            "pid 1: win32 error 567".to_string()
+        ]));
+        assert!(!has_access_denied_signature(&[
+            "pid 1: timed out waiting for pid 1 to exit".to_string()
+        ]));
+        // `any` policy (E2): a mixed set with one error-5 still flags. HIGH-2 keeps the
+        // per-PID detail in `message`, so this only ADDS the AV hint, never hides a failure.
+        assert!(has_access_denied_signature(&[
+            "pid 1: win32 error 5".to_string(),
+            "pid 2: timed out".to_string(),
+        ]));
+    }
+
+    // #647 D: blocked_by_security serializes as camelCase and, being serde(default),
+    // a legacy payload without the field deserializes to false.
+    #[test]
+    fn kill_result_blocked_by_security_round_trips_and_defaults() {
+        let result = ResourceKillResult {
+            session_id: "s".to_string(),
+            state: ResourceGroupState::Quarantined,
+            killed_processes: Vec::new(),
+            quarantined: true,
+            message: "pid 1: win32 error 5".to_string(),
+            blocked_by_security: false,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"blockedBySecurity\":false"));
+
+        // Strip the field to simulate a pre-#647 payload; serde(default) -> false.
+        let legacy = json.replace(",\"blockedBySecurity\":false", "");
+        assert!(!legacy.contains("blockedBySecurity"));
+        let parsed: ResourceKillResult = serde_json::from_str(&legacy).unwrap();
+        assert!(!parsed.blocked_by_security);
     }
 
     // (T4) H3 - retained Terminated rows are bounded by MAX_TERMINATED_RETAINED.

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -406,6 +406,7 @@ impl ResourceMonitorState {
                     quarantined: false,
                     message: "resource group not registered".to_string(),
                     blocked_by_security: false,
+                    finalized: false,
                 });
             };
             match group.state {
@@ -417,6 +418,7 @@ impl ResourceMonitorState {
                         quarantined: false,
                         message: "resource group is already terminating".to_string(),
                         blocked_by_security: false,
+                        finalized: false,
                     });
                 }
                 ResourceGroupState::Terminated => {
@@ -427,6 +429,7 @@ impl ResourceMonitorState {
                         quarantined: false,
                         message: "resource group already terminated".to_string(),
                         blocked_by_security: false,
+                        finalized: false,
                     });
                 }
                 ResourceGroupState::Running | ResourceGroupState::Quarantined => {}
@@ -642,6 +645,9 @@ impl ResourceMonitorState {
             quarantined,
             message,
             blocked_by_security,
+            // #647: kill_group only accounts/verifies; the command finalizes the
+            // session (PTY teardown + Exited tile), so this is always false here.
+            finalized: false,
         })
     }
 
@@ -2269,9 +2275,11 @@ mod tests {
             quarantined: true,
             message: "pid 1: win32 error 5".to_string(),
             blocked_by_security: false,
+            finalized: false,
         };
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("\"blockedBySecurity\":false"));
+        assert!(json.contains("\"finalized\":false"));
 
         // Strip the field to simulate a pre-#647 payload; serde(default) -> false.
         let legacy = json.replace(",\"blockedBySecurity\":false", "");

--- a/src-tauri/src/resource_monitor/types.rs
+++ b/src-tauri/src/resource_monitor/types.rs
@@ -191,6 +191,15 @@ pub struct ResourceKillResult {
     /// AV-exclusion guidance in the UI, so a non-security failure is never hidden.
     #[serde(default)]
     pub blocked_by_security: bool,
+    /// #647 (Step 7): true ONLY when `kill_resource_group` itself finalized the kill,
+    /// i.e. it verified the tree dead, tore down the PTY/job, and flipped the session
+    /// tile to `Exited`. The FE keys success off THIS, not `!quarantined`: a
+    /// `Terminating` early-return (a concurrent kill still settling) reports
+    /// `quarantined == false` but is not a finalized success. `kill_group` (incl. the
+    /// watchdog path) never finalizes, so it always reports `false`; only the command
+    /// sets it `true`.
+    #[serde(default)]
+    pub finalized: bool,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src-tauri/src/resource_monitor/types.rs
+++ b/src-tauri/src/resource_monitor/types.rs
@@ -185,6 +185,12 @@ pub struct ResourceKillResult {
     pub killed_processes: Vec<ProcessIdentity>,
     pub quarantined: bool,
     pub message: String,
+    /// #647 D: true when the kill quarantined AND ANY failure carried the exact
+    /// ACCESS_DENIED code (`win32 error 5`), i.e. a security product is stripping
+    /// PROCESS_TERMINATE. The per-PID detail stays in `message`; this only ADDS the
+    /// AV-exclusion guidance in the UI, so a non-security failure is never hidden.
+    #[serde(default)]
+    pub blocked_by_security: bool,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/resource-monitor/App.automation.test.tsx
+++ b/src/resource-monitor/App.automation.test.tsx
@@ -88,6 +88,15 @@ const quarantinedSnapshot = (): ResourceSnapshot => {
   return snapshot;
 };
 
+// #647 C: a group the backend is actively terminating (a kill in flight). Its row
+// shows the "Verifying..." indicator and its kill button is disabled.
+const terminatingSnapshot = (): ResourceSnapshot => {
+  const snapshot = activeSnapshot();
+  snapshot.overallState = "enforcing";
+  snapshot.groups[0].state = "terminating";
+  return snapshot;
+};
+
 // #566 - multiple groups spanning projects / workgroups / roles / states so the
 // filter dimensions visibly change the rendered row count.
 const multiGroupSnapshot = (): ResourceSnapshot => {
@@ -134,10 +143,11 @@ function setupResourceMonitor(fake: FakeTransport, snapshot: ResourceSnapshot): 
   fake.onInvoke("get_resource_snapshot", () => snapshot);
   fake.resolve("kill_resource_group", {
     sessionId: "session-1",
-    state: "terminating",
+    state: "terminated",
     quarantined: false,
-    message: "terminating",
+    message: "resource group terminated and verified",
     blockedBySecurity: false,
+    finalized: true,
   });
 }
 
@@ -503,10 +513,11 @@ describe("ResourceMonitorApp automation hooks", () => {
     fake.resolve("get_settings", baseSettings());
     fake.resolve("kill_resource_group", {
       sessionId: "session-1",
-      state: "terminating",
+      state: "terminated",
       quarantined: false,
-      message: "terminating",
+      message: "resource group terminated and verified",
       blockedBySecurity: false,
+      finalized: true,
     });
     // A controllable snapshot handler: returns rows normally, but once `hang` is
     // set the next call stays pending so the store's `loading` flag stays true.
@@ -581,9 +592,10 @@ describe("ResourceMonitorApp automation hooks", () => {
   });
 
   // #647 (test 6): a quarantined group is killable again (Force-kill), and a
-  // quarantined kill result keeps the confirm modal open showing the per-PID
-  // detail AND the English security guidance (the latter ADDS to, never replaces,
-  // the former).
+  // non-finalized quarantined result keeps the confirm modal open showing the
+  // per-PID detail AND the English security guidance (the latter ADDS to, never
+  // replaces, the former). The narrowed "Verifying..." indicator does NOT show on
+  // an idle quarantined row.
   it("exposes Force-kill on a quarantined group and surfaces the per-PID detail + security hint without auto-closing", async () => {
     const fake = new FakeTransport();
     fake.resolve("get_settings", baseSettings());
@@ -594,6 +606,7 @@ describe("ResourceMonitorApp automation hooks", () => {
       quarantined: true,
       message: "resource group cleanup incomplete: pid 4242: win32 error 5",
       blockedBySecurity: true,
+      finalized: false,
     });
 
     const rendered = renderWithFakeTransport(() => <ResourceMonitorApp />, fake);
@@ -608,12 +621,13 @@ describe("ResourceMonitorApp automation hooks", () => {
         expect(killBtn!.textContent).toContain("Force-kill");
       });
 
-      // The row shows the live "Verifying..." indicator.
+      // Narrowing: an idle quarantined row (no kill in flight) does NOT show the
+      // "Verifying..." indicator.
       expect(
         rendered.root.querySelector(
           '[data-ac-testid="resourceMonitor.group.session-1.verifying"]'
         )
-      ).not.toBeNull();
+      ).toBeNull();
 
       // Open the confirm modal and fire the force-kill.
       click(
@@ -634,7 +648,8 @@ describe("ResourceMonitorApp automation hooks", () => {
         )!
       );
 
-      // The quarantined result surfaces the per-PID message AND the security hint.
+      // The non-finalized quarantined result surfaces the per-PID message AND the
+      // security hint, and the modal stays open (not auto-closed) for a Retry.
       await waitFor(() => {
         expect(
           rendered.root.querySelector(
@@ -653,7 +668,154 @@ describe("ResourceMonitorApp automation hooks", () => {
         ).toContain("security software");
       });
 
-      // The modal stays open (not auto-closed) so the user can read it / Retry.
+      expect(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.killConfirm"]')
+      ).not.toBeNull();
+      expect(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.killConfirm.confirm"]'
+        )?.textContent
+      ).toContain("Retry");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // #647 (Step 7): success keys off `finalized`. A finalized kill closes the modal
+  // (the tile flips to Exited via the backend session_created emit, E5).
+  it("closes the kill modal when the result is finalized (verified success)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", baseSettings());
+    fake.onInvoke("get_resource_snapshot", () => activeSnapshot());
+    fake.resolve("kill_resource_group", {
+      sessionId: "session-1",
+      state: "terminated",
+      quarantined: false,
+      message: "resource group terminated and verified",
+      blockedBySecurity: false,
+      finalized: true,
+    });
+
+    const rendered = renderWithFakeTransport(() => <ResourceMonitorApp />, fake);
+    try {
+      // Wait until THIS test's (running) snapshot has loaded — the store is a
+      // module singleton, so a prior test's snapshot can linger for a tick.
+      await waitFor(() => {
+        const killBtn = rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.group.session-1.kill"]'
+        ) as HTMLButtonElement | null;
+        expect(killBtn).not.toBeNull();
+        expect(killBtn!.disabled).toBe(false);
+        expect(killBtn!.textContent?.trim()).toBe("Kill");
+      });
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.group.session-1.kill"]'
+        )!
+      );
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector(
+            '[data-ac-testid="resourceMonitor.killConfirm.confirm"]'
+          )
+        ).not.toBeNull();
+      });
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.killConfirm.confirm"]'
+        )!
+      );
+
+      // Finalized => the modal closes as success.
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector('[data-ac-testid="resourceMonitor.killConfirm"]')
+        ).toBeNull();
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // #647 C: a group the backend is actively terminating shows the "Verifying..."
+  // indicator and its kill button stays disabled (a kill is already in flight).
+  it("shows the Verifying indicator and disables Kill on a terminating group", async () => {
+    const fake = new FakeTransport();
+    setupResourceMonitor(fake, terminatingSnapshot());
+
+    const rendered = renderWithFakeTransport(() => <ResourceMonitorApp />, fake);
+    try {
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector(
+            '[data-ac-testid="resourceMonitor.group.session-1.verifying"]'
+          )
+        ).not.toBeNull();
+      });
+      const killBtn = rendered.root.querySelector(
+        '[data-ac-testid="resourceMonitor.group.session-1.kill"]'
+      ) as HTMLButtonElement | null;
+      expect(killBtn).not.toBeNull();
+      expect(killBtn!.disabled).toBe(true);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // #647 (Step 7): a non-finalized `terminating` result (a concurrent kill still
+  // settling) must keep the modal open with a "Verifying..." banner and a Retry,
+  // NOT close as a false success — the zombie-tile race grinch found.
+  it("keeps the modal open with a Verifying banner when the result is terminating and not finalized", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", baseSettings());
+    fake.onInvoke("get_resource_snapshot", () => quarantinedSnapshot());
+    fake.resolve("kill_resource_group", {
+      sessionId: "session-1",
+      state: "terminating",
+      quarantined: false,
+      message: "resource group cleanup pending",
+      blockedBySecurity: false,
+      finalized: false,
+    });
+
+    const rendered = renderWithFakeTransport(() => <ResourceMonitorApp />, fake);
+    try {
+      // Wait until THIS test's quarantined snapshot has loaded (enabled Force-kill),
+      // not a prior test's lingering snapshot (singleton store).
+      await waitFor(() => {
+        const killBtn = rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.group.session-1.kill"]'
+        ) as HTMLButtonElement | null;
+        expect(killBtn).not.toBeNull();
+        expect(killBtn!.disabled).toBe(false);
+        expect(killBtn!.textContent).toContain("Force-kill");
+      });
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.group.session-1.kill"]'
+        )!
+      );
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector(
+            '[data-ac-testid="resourceMonitor.killConfirm.confirm"]'
+          )
+        ).not.toBeNull();
+      });
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.killConfirm.confirm"]'
+        )!
+      );
+
+      // NOT finalized => modal stays open with the Verifying banner + Retry.
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector(
+            '[data-ac-testid="resourceMonitor.killConfirm.verifying"]'
+          )
+        ).not.toBeNull();
+      });
       expect(
         rendered.root.querySelector('[data-ac-testid="resourceMonitor.killConfirm"]')
       ).not.toBeNull();

--- a/src/resource-monitor/App.automation.test.tsx
+++ b/src/resource-monitor/App.automation.test.tsx
@@ -76,6 +76,18 @@ const nullIdentitySnapshot = (): ResourceSnapshot => {
   return snapshot;
 };
 
+// #647 C/D: a quarantined group — the kill was not verified dead (an AV is
+// stripping PROCESS_TERMINATE). It must stay killable (Force-kill) and carry the
+// per-PID detail in lastError.
+const quarantinedSnapshot = (): ResourceSnapshot => {
+  const snapshot = activeSnapshot();
+  snapshot.overallState = "critical";
+  snapshot.groups[0].state = "quarantined";
+  snapshot.groups[0].lastError =
+    "resource group cleanup incomplete: pid 4242: win32 error 5";
+  return snapshot;
+};
+
 // #566 - multiple groups spanning projects / workgroups / roles / states so the
 // filter dimensions visibly change the rendered row count.
 const multiGroupSnapshot = (): ResourceSnapshot => {
@@ -125,6 +137,7 @@ function setupResourceMonitor(fake: FakeTransport, snapshot: ResourceSnapshot): 
     state: "terminating",
     quarantined: false,
     message: "terminating",
+    blockedBySecurity: false,
   });
 }
 
@@ -493,6 +506,7 @@ describe("ResourceMonitorApp automation hooks", () => {
       state: "terminating",
       quarantined: false,
       message: "terminating",
+      blockedBySecurity: false,
     });
     // A controllable snapshot handler: returns rows normally, but once `hang` is
     // set the next call stays pending so the store's `loading` flag stays true.
@@ -563,6 +577,93 @@ describe("ResourceMonitorApp automation hooks", () => {
       } finally {
         rendered.cleanup();
       }
+    }
+  });
+
+  // #647 (test 6): a quarantined group is killable again (Force-kill), and a
+  // quarantined kill result keeps the confirm modal open showing the per-PID
+  // detail AND the English security guidance (the latter ADDS to, never replaces,
+  // the former).
+  it("exposes Force-kill on a quarantined group and surfaces the per-PID detail + security hint without auto-closing", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", baseSettings());
+    fake.onInvoke("get_resource_snapshot", () => quarantinedSnapshot());
+    fake.resolve("kill_resource_group", {
+      sessionId: "session-1",
+      state: "quarantined",
+      quarantined: true,
+      message: "resource group cleanup incomplete: pid 4242: win32 error 5",
+      blockedBySecurity: true,
+    });
+
+    const rendered = renderWithFakeTransport(() => <ResourceMonitorApp />, fake);
+    try {
+      // The quarantined row's kill button is enabled and reads "Force-kill".
+      await waitFor(() => {
+        const killBtn = rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.group.session-1.kill"]'
+        ) as HTMLButtonElement | null;
+        expect(killBtn).not.toBeNull();
+        expect(killBtn!.disabled).toBe(false);
+        expect(killBtn!.textContent).toContain("Force-kill");
+      });
+
+      // The row shows the live "Verifying..." indicator.
+      expect(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.group.session-1.verifying"]'
+        )
+      ).not.toBeNull();
+
+      // Open the confirm modal and fire the force-kill.
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.group.session-1.kill"]'
+        )!
+      );
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector(
+            '[data-ac-testid="resourceMonitor.killConfirm.confirm"]'
+          )
+        ).not.toBeNull();
+      });
+      click(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.killConfirm.confirm"]'
+        )!
+      );
+
+      // The quarantined result surfaces the per-PID message AND the security hint.
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector(
+            '[data-ac-testid="resourceMonitor.killConfirm.quarantined"]'
+          )
+        ).not.toBeNull();
+        expect(
+          rendered.root.querySelector(
+            '[data-ac-testid="resourceMonitor.killConfirm.message"]'
+          )?.textContent
+        ).toContain("win32 error 5");
+        expect(
+          rendered.root.querySelector(
+            '[data-ac-testid="resourceMonitor.killConfirm.securityHint"]'
+          )?.textContent
+        ).toContain("security software");
+      });
+
+      // The modal stays open (not auto-closed) so the user can read it / Retry.
+      expect(
+        rendered.root.querySelector('[data-ac-testid="resourceMonitor.killConfirm"]')
+      ).not.toBeNull();
+      expect(
+        rendered.root.querySelector(
+          '[data-ac-testid="resourceMonitor.killConfirm.confirm"]'
+        )?.textContent
+      ).toContain("Retry");
+    } finally {
+      rendered.cleanup();
     }
   });
 });

--- a/src/resource-monitor/App.tsx
+++ b/src/resource-monitor/App.tsx
@@ -31,13 +31,29 @@ const DEFAULT_RESOURCE_PREFERENCES = {
   resourceKeepLastSnapshot: true,
 };
 
+// #647 C: a `quarantined` group is now killable again — the Force-kill / Retry
+// affordance re-fires the durable Job Object kill (it was wrongly disabled,
+// stranding agents the AV kept alive). `terminating` stays non-killable (a kill
+// is already in flight); `terminated` is done; `failedCleanup` /
+// `unknownOwnership` are never emitted by the 4-variant backend state.
 const NON_KILLABLE_GROUP_STATES = new Set<ResourceGroupState>([
   "terminating",
   "terminated",
-  "quarantined",
   "failedCleanup",
   "unknownOwnership",
 ]);
+
+// #647 C: states where the backend is still working the kill (now re-sampled
+// every snapshot), so the row shows a "Verifying..." indicator.
+const VERIFYING_GROUP_STATES = new Set<ResourceGroupState>([
+  "terminating",
+  "quarantined",
+]);
+
+// #647 D: English guidance shown (ADDED to, never replacing, the per-PID detail)
+// when a kill is blocked by a security product stripping PROCESS_TERMINATE.
+const SECURITY_BLOCK_HINT =
+  "The OS or security software is blocking process termination. Add an exclusion for AgentsCommander and the agent binaries.";
 
 const formatBytes = (value?: number | null): string => {
   if (typeof value !== "number" || !Number.isFinite(value)) return "Unknown";
@@ -94,6 +110,14 @@ const groupOrigin = (group: ResourceAgentGroupSnapshot): string =>
 
 const canKillGroup = (group: ResourceAgentGroupSnapshot): boolean =>
   group.killAllowed !== false && !NON_KILLABLE_GROUP_STATES.has(group.state);
+
+// #647 C: a quarantined group is killable but its button re-fires the durable
+// kill, so it reads "Force-kill" rather than "Kill".
+const killActionLabel = (group: ResourceAgentGroupSnapshot): string =>
+  group.state === "quarantined" ? "Force-kill" : "Kill";
+
+const isVerifying = (group: ResourceAgentGroupSnapshot): boolean =>
+  VERIFYING_GROUP_STATES.has(group.state);
 
 const groupSeverity = (group: ResourceAgentGroupSnapshot): string => {
   if (group.state === "quarantined" || group.state === "failedCleanup") {
@@ -335,6 +359,26 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
     createSignal<ResourceAgentGroupSnapshot | null>(null);
   const [killError, setKillError] = createSignal("");
   const [killInFlight, setKillInFlight] = createSignal(false);
+  // #647 D: the outcome of the last kill attempt that quarantined (verified-dead
+  // kills clear it). Keyed by sessionId so the per-PID detail + security hint
+  // attach to the right row and modal. Held in the FE because blockedBySecurity
+  // is a per-attempt result flag, not part of the persisted group snapshot.
+  const [killResult, setKillResult] = createSignal<{
+    sessionId: string;
+    message: string;
+    blockedBySecurity: boolean;
+  } | null>(null);
+
+  const openKillModal = (group: ResourceAgentGroupSnapshot) => {
+    setKillError("");
+    setKillResult(null);
+    setKillTarget(group);
+  };
+
+  const closeKillModal = () => {
+    setKillTarget(null);
+    setKillError("");
+  };
 
   // #587 — pop the embedded RM out into its own OS window, then reveal the
   // terminal in the pane (preserves the embedded-XOR-detached invariant).
@@ -456,11 +500,26 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
     setKillError("");
     setKillInFlight(true);
     try {
-      await ResourceMonitorAPI.killGroup({
+      const result = await ResourceMonitorAPI.killGroup({
         sessionId: target.sessionId,
         reason: "user",
       });
-      setKillTarget(null);
+      if (result.quarantined) {
+        // #647 A: NOT verified dead — the agent may still be alive. Keep the
+        // modal open so the user can read the per-PID detail (+ AV-exclusion
+        // hint when blocked) and Retry; the durable job is preserved backend-side.
+        setKillResult({
+          sessionId: result.sessionId,
+          message: result.message,
+          blockedBySecurity: result.blockedBySecurity,
+        });
+      } else {
+        // #647 A: verified dead — the backend emitted session_created carrying
+        // the Exited SessionInfo (the sidebar tile flips via the addSession
+        // upsert, E5). Close the modal and refresh the snapshot.
+        setKillResult(null);
+        setKillTarget(null);
+      }
       await resourceMonitorStore.refresh();
     } catch (err) {
       setKillError(err instanceof Error ? err.message : String(err));
@@ -822,6 +881,15 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
                         >
                           {groupOrigin(group)}
                         </span>
+                        <Show when={isVerifying(group)}>
+                          <span
+                            class="rm-group-verifying"
+                            data-ac-testid={`resourceMonitor.group.${group.sessionId}.verifying`}
+                            data-ac-role="status"
+                          >
+                            Verifying...
+                          </span>
+                        </Show>
                       </span>
                       <span
                         class="rm-group-state"
@@ -867,16 +935,16 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
                     </button>
                     <button
                       class="rm-kill-btn"
-                      disabled={!canKillGroup(group)}
-                      onClick={() => {
-                        setKillError("");
-                        setKillTarget(group);
+                      classList={{
+                        "rm-kill-btn-force": group.state === "quarantined",
                       }}
+                      disabled={!canKillGroup(group)}
+                      onClick={() => openKillModal(group)}
                       data-ac-testid={`resourceMonitor.group.${group.sessionId}.kill`}
                       data-ac-role="button"
                       data-ac-state={canKillGroup(group) ? "ready" : "disabled"}
                     >
-                      Kill
+                      {killActionLabel(group)}
                     </button>
 
                     <Show when={expandedGroupId() === group.sessionId}>
@@ -961,6 +1029,25 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
                             {group.lastError}
                           </div>
                         </Show>
+                        {/* #647 D: ADD the security guidance below the per-PID
+                            detail (never replacing it) when the last kill on this
+                            still-quarantined group was blocked by a security
+                            product. */}
+                        <Show
+                          when={
+                            group.state === "quarantined" &&
+                            killResult()?.sessionId === group.sessionId &&
+                            killResult()?.blockedBySecurity
+                          }
+                        >
+                          <div
+                            class="rm-process-error rm-security-hint"
+                            data-ac-testid={`resourceMonitor.group.${group.sessionId}.securityHint`}
+                            data-ac-role="status"
+                          >
+                            {SECURITY_BLOCK_HINT}
+                          </div>
+                        </Show>
                       </div>
                     </Show>
                   </div>
@@ -994,7 +1081,9 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
         {(target) => (
           <div class="rm-modal-backdrop" data-ac-testid="resourceMonitor.killConfirm">
             <div class="rm-modal" role="dialog" aria-modal="true">
-              <h2>Kill agent</h2>
+              <h2>
+                {target.state === "quarantined" ? "Force-kill agent" : "Kill agent"}
+              </h2>
               <p
                 class="rm-modal-target"
                 title={groupOrigin(target)}
@@ -1011,8 +1100,34 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
                 {target.name}
               </p>
               <p class="rm-modal-detail">
-                Session {target.sessionId} will be terminated by the backend resource watchdog.
+                Session {target.sessionId} and its entire process tree will be
+                force-terminated via its Job Object.
               </p>
+              {/* #647 D: a quarantined (not-verified-dead) result keeps the modal
+                  open and shows the per-PID detail; the AV-exclusion hint is
+                  PREPENDED above it when the kill was blocked by security. */}
+              <Show when={killResult()} keyed>
+                {(res) => (
+                  <div
+                    class="rm-banner rm-banner-error"
+                    data-ac-testid="resourceMonitor.killConfirm.quarantined"
+                    data-ac-role="status"
+                  >
+                    <Show when={res.blockedBySecurity}>
+                      <div
+                        class="rm-security-hint"
+                        data-ac-testid="resourceMonitor.killConfirm.securityHint"
+                        data-ac-role="status"
+                      >
+                        {SECURITY_BLOCK_HINT}
+                      </div>
+                    </Show>
+                    <div data-ac-testid="resourceMonitor.killConfirm.message">
+                      {res.message}
+                    </div>
+                  </div>
+                )}
+              </Show>
               <Show when={killError()}>
                 <div class="rm-banner rm-banner-error">{killError()}</div>
               </Show>
@@ -1020,11 +1135,11 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
                 <button
                   class="rm-action-btn"
                   disabled={killInFlight()}
-                  onClick={() => setKillTarget(null)}
+                  onClick={closeKillModal}
                   data-ac-testid="resourceMonitor.killConfirm.cancel"
                   data-ac-role="button"
                 >
-                  Cancel
+                  {killResult() ? "Close" : "Cancel"}
                 </button>
                 <button
                   class="rm-action-btn rm-action-danger"
@@ -1033,7 +1148,13 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
                   data-ac-testid="resourceMonitor.killConfirm.confirm"
                   data-ac-role="button"
                 >
-                  {killInFlight() ? "Killing..." : "Kill Agent"}
+                  {killInFlight()
+                    ? "Verifying..."
+                    : killResult()
+                      ? "Retry"
+                      : target.state === "quarantined"
+                        ? "Force-kill"
+                        : "Kill Agent"}
                 </button>
               </div>
             </div>

--- a/src/resource-monitor/App.tsx
+++ b/src/resource-monitor/App.tsx
@@ -43,13 +43,6 @@ const NON_KILLABLE_GROUP_STATES = new Set<ResourceGroupState>([
   "unknownOwnership",
 ]);
 
-// #647 C: states where the backend is still working the kill (now re-sampled
-// every snapshot), so the row shows a "Verifying..." indicator.
-const VERIFYING_GROUP_STATES = new Set<ResourceGroupState>([
-  "terminating",
-  "quarantined",
-]);
-
 // #647 D: English guidance shown (ADDED to, never replacing, the per-PID detail)
 // when a kill is blocked by a security product stripping PROCESS_TERMINATE.
 const SECURITY_BLOCK_HINT =
@@ -115,9 +108,6 @@ const canKillGroup = (group: ResourceAgentGroupSnapshot): boolean =>
 // kill, so it reads "Force-kill" rather than "Kill".
 const killActionLabel = (group: ResourceAgentGroupSnapshot): string =>
   group.state === "quarantined" ? "Force-kill" : "Kill";
-
-const isVerifying = (group: ResourceAgentGroupSnapshot): boolean =>
-  VERIFYING_GROUP_STATES.has(group.state);
 
 const groupSeverity = (group: ResourceAgentGroupSnapshot): string => {
   if (group.state === "quarantined" || group.state === "failedCleanup") {
@@ -359,12 +349,15 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
     createSignal<ResourceAgentGroupSnapshot | null>(null);
   const [killError, setKillError] = createSignal("");
   const [killInFlight, setKillInFlight] = createSignal(false);
-  // #647 D: the outcome of the last kill attempt that quarantined (verified-dead
-  // kills clear it). Keyed by sessionId so the per-PID detail + security hint
-  // attach to the right row and modal. Held in the FE because blockedBySecurity
-  // is a per-attempt result flag, not part of the persisted group snapshot.
+  // #647: the outcome of the last kill attempt that did NOT finalize (a verified
+  // success clears it). Carries `state` to distinguish a blocked `quarantined`
+  // result (show per-PID + security hint) from an unsettled `terminating` one
+  // (a concurrent kill is still settling — show "Verifying...", offer Retry).
+  // Keyed by sessionId so the detail attaches to the right row/modal. Held in the
+  // FE because blockedBySecurity is a per-attempt flag, not on the group snapshot.
   const [killResult, setKillResult] = createSignal<{
     sessionId: string;
+    state: ResourceGroupState;
     message: string;
     blockedBySecurity: boolean;
   } | null>(null);
@@ -379,6 +372,14 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
     setKillTarget(null);
     setKillError("");
   };
+
+  // #647 C (Step-7 narrowing): show "Verifying..." only where a kill is genuinely
+  // in flight — a group the backend is actively terminating, or the group whose
+  // Force-kill/Retry we are awaiting right now. A group merely sitting in
+  // `quarantined` with no attempt running is NOT verifying (it needs Force-kill).
+  const isVerifying = (group: ResourceAgentGroupSnapshot): boolean =>
+    group.state === "terminating" ||
+    (killInFlight() && killTarget()?.sessionId === group.sessionId);
 
   // #587 — pop the embedded RM out into its own OS window, then reveal the
   // terminal in the pane (preserves the embedded-XOR-detached invariant).
@@ -504,21 +505,25 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
         sessionId: target.sessionId,
         reason: "user",
       });
-      if (result.quarantined) {
-        // #647 A: NOT verified dead — the agent may still be alive. Keep the
-        // modal open so the user can read the per-PID detail (+ AV-exclusion
-        // hint when blocked) and Retry; the durable job is preserved backend-side.
+      if (result.finalized) {
+        // #647 (Step 7): verified dead AND finalized by the backend — it tore the
+        // tree down and emitted session_created carrying the Exited SessionInfo
+        // (the sidebar tile flips via the addSession upsert, E5). Close + refresh.
+        // NB: success keys off `finalized`, NOT `!quarantined` — a `terminating`
+        // early-return reports `quarantined === false` yet is not a real success.
+        setKillResult(null);
+        setKillTarget(null);
+      } else {
+        // NOT finalized — keep the modal open. The agent may still be alive
+        // (`quarantined`) or a concurrent kill is still settling (`terminating`);
+        // the durable job is preserved backend-side for a Force/Retry. `state`
+        // drives whether we show the per-PID detail (+ hint) or "Verifying...".
         setKillResult({
           sessionId: result.sessionId,
+          state: result.state,
           message: result.message,
           blockedBySecurity: result.blockedBySecurity,
         });
-      } else {
-        // #647 A: verified dead — the backend emitted session_created carrying
-        // the Exited SessionInfo (the sidebar tile flips via the addSession
-        // upsert, E5). Close the modal and refresh the snapshot.
-        setKillResult(null);
-        setKillTarget(null);
       }
       await resourceMonitorStore.refresh();
     } catch (err) {
@@ -1103,30 +1108,44 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
                 Session {target.sessionId} and its entire process tree will be
                 force-terminated via its Job Object.
               </p>
-              {/* #647 D: a quarantined (not-verified-dead) result keeps the modal
-                  open and shows the per-PID detail; the AV-exclusion hint is
-                  PREPENDED above it when the kill was blocked by security. */}
+              {/* #647 (Step 7): a non-finalized result keeps the modal open. A
+                  `terminating` result means a concurrent kill is still settling
+                  (show "Verifying...", offer Retry); otherwise it is blocked
+                  (`quarantined`) — show the per-PID detail, with the AV-exclusion
+                  hint PREPENDED above it (never replacing it) when blocked by a
+                  security product. */}
               <Show when={killResult()} keyed>
-                {(res) => (
-                  <div
-                    class="rm-banner rm-banner-error"
-                    data-ac-testid="resourceMonitor.killConfirm.quarantined"
-                    data-ac-role="status"
-                  >
-                    <Show when={res.blockedBySecurity}>
-                      <div
-                        class="rm-security-hint"
-                        data-ac-testid="resourceMonitor.killConfirm.securityHint"
-                        data-ac-role="status"
-                      >
-                        {SECURITY_BLOCK_HINT}
-                      </div>
-                    </Show>
-                    <div data-ac-testid="resourceMonitor.killConfirm.message">
-                      {res.message}
+                {(res) =>
+                  res.state === "terminating" ? (
+                    <div
+                      class="rm-banner rm-banner-muted"
+                      data-ac-testid="resourceMonitor.killConfirm.verifying"
+                      data-ac-role="status"
+                    >
+                      Verifying... a concurrent kill is still settling. Click Retry
+                      to confirm.
                     </div>
-                  </div>
-                )}
+                  ) : (
+                    <div
+                      class="rm-banner rm-banner-error"
+                      data-ac-testid="resourceMonitor.killConfirm.quarantined"
+                      data-ac-role="status"
+                    >
+                      <Show when={res.blockedBySecurity}>
+                        <div
+                          class="rm-security-hint"
+                          data-ac-testid="resourceMonitor.killConfirm.securityHint"
+                          data-ac-role="status"
+                        >
+                          {SECURITY_BLOCK_HINT}
+                        </div>
+                      </Show>
+                      <div data-ac-testid="resourceMonitor.killConfirm.message">
+                        {res.message}
+                      </div>
+                    </div>
+                  )
+                }
               </Show>
               <Show when={killError()}>
                 <div class="rm-banner rm-banner-error">{killError()}</div>

--- a/src/resource-monitor/styles/resource-monitor.css
+++ b/src/resource-monitor/styles/resource-monitor.css
@@ -481,6 +481,20 @@ button {
   white-space: nowrap;
 }
 
+/* #647 C: live "Verifying..." indicator under the group identity while a kill /
+   re-sample is in flight (terminating | quarantined). */
+.rm-group-verifying {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--status-pending);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .rm-group-state {
   color: var(--sidebar-fg-dim);
   text-transform: capitalize;
@@ -528,6 +542,15 @@ button {
   background: rgba(255, 59, 92, 0.12);
 }
 
+/* #647 C: the Force-kill variant on a quarantined row reads as a stronger
+   affordance (the re-fire of the durable Job Object kill). Smaller weight-heavy
+   text keeps the longer label inside the fixed-width button. */
+.rm-kill-btn-force {
+  font-size: 11px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
 .rm-process-list {
   clear: both;
   padding: 0 var(--spacing-sm) var(--spacing-sm) 32px;
@@ -569,6 +592,20 @@ button {
 .rm-process-error,
 .rm-warning-line {
   color: var(--status-pending);
+}
+
+/* #647 D: AV/security guidance — shown beside (never replacing) the per-PID
+   detail, using the danger accent so it reads as an actionable callout. */
+.rm-security-hint {
+  color: var(--status-exited);
+  font-weight: 700;
+}
+
+/* Separate the hint from the per-PID detail it sits above (modal banner) or
+   below (expanded row). */
+.rm-security-hint + div,
+.rm-process-error + .rm-security-hint {
+  margin-top: 6px;
 }
 
 .rm-modal-backdrop {

--- a/src/shared/resource-monitor-ipc.test.ts
+++ b/src/shared/resource-monitor-ipc.test.ts
@@ -40,6 +40,7 @@ describe("resource monitor IPC", () => {
       quarantined: true,
       message: "queued",
       blockedBySecurity: false,
+      finalized: false,
     });
 
     await ResourceMonitorAPI.killGroup({
@@ -69,6 +70,7 @@ describe("resource monitor IPC", () => {
       quarantined: true,
       message: "resource group cleanup incomplete: pid 4242: win32 error 5",
       blockedBySecurity: true,
+      finalized: false,
     });
 
     const result = await ResourceMonitorAPI.killGroup({
@@ -79,5 +81,29 @@ describe("resource monitor IPC", () => {
     expect(result.quarantined).toBe(true);
     expect(result.blockedBySecurity).toBe(true);
     expect(result.message).toContain("win32 error 5");
+  });
+
+  // #647 (Step 7): success keys off `finalized`, not `!quarantined`. The wire
+  // result carries the flag so the FE can distinguish a verified teardown from a
+  // `terminating` early-return that also reports `quarantined === false`.
+  it("round-trips the finalized flag from the kill result", async () => {
+    const fake = useFakeTransport();
+    fake.resolve("kill_resource_group", {
+      sessionId: "session-1",
+      state: "terminated",
+      killedProcesses: [],
+      quarantined: false,
+      message: "resource group terminated and verified",
+      blockedBySecurity: false,
+      finalized: true,
+    });
+
+    const result = await ResourceMonitorAPI.killGroup({
+      sessionId: "session-1",
+      reason: "user",
+    });
+
+    expect(result.finalized).toBe(true);
+    expect(result.quarantined).toBe(false);
   });
 });

--- a/src/shared/resource-monitor-ipc.test.ts
+++ b/src/shared/resource-monitor-ipc.test.ts
@@ -39,6 +39,7 @@ describe("resource monitor IPC", () => {
       killedProcesses: [],
       quarantined: true,
       message: "queued",
+      blockedBySecurity: false,
     });
 
     await ResourceMonitorAPI.killGroup({
@@ -54,5 +55,29 @@ describe("resource monitor IPC", () => {
       },
     });
     expect(JSON.stringify(args).toLowerCase()).not.toContain("pid");
+  });
+
+  // #647 D: the result carries blockedBySecurity alongside the per-PID message;
+  // the FE shows the AV-exclusion guidance only when the flag is set, never
+  // replacing the per-PID detail.
+  it("surfaces blockedBySecurity and the per-PID message from the kill result", async () => {
+    const fake = useFakeTransport();
+    fake.resolve("kill_resource_group", {
+      sessionId: "session-1",
+      state: "quarantined",
+      killedProcesses: [],
+      quarantined: true,
+      message: "resource group cleanup incomplete: pid 4242: win32 error 5",
+      blockedBySecurity: true,
+    });
+
+    const result = await ResourceMonitorAPI.killGroup({
+      sessionId: "session-1",
+      reason: "user",
+    });
+
+    expect(result.quarantined).toBe(true);
+    expect(result.blockedBySecurity).toBe(true);
+    expect(result.message).toContain("win32 error 5");
   });
 });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -436,6 +436,15 @@ export interface ResourceKillResult {
    * camelCase). `#[serde(default)]` backend-side, so always present on the wire.
    */
   blockedBySecurity: boolean;
+  /**
+   * #647 (Step 7): true ONLY when `kill_resource_group` verified the tree dead,
+   * tore down the PTY/job, and flipped the tile to Exited. Success keys off THIS,
+   * NOT `!quarantined`: a `Terminating` early-return (a concurrent kill still
+   * settling) reports `quarantined === false` but is NOT a finalized success, so
+   * treating it as one would close the modal over a still-Running zombie tile.
+   * Mirrors Rust `ResourceKillResult.finalized` (`#[serde(default)]`).
+   */
+  finalized: boolean;
 }
 
 export type UiAutomationAction =

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -427,6 +427,15 @@ export interface ResourceKillResult {
   killedPids?: number[];
   quarantined: boolean;
   message: string;
+  /**
+   * #647 D: true when the kill quarantined AND a failure carried the exact
+   * ACCESS_DENIED code (`win32 error 5`) — a security product is stripping
+   * PROCESS_TERMINATE. The per-PID detail stays in `message`; this only ADDS
+   * the AV-exclusion guidance in the UI, so a non-security failure is never
+   * hidden. Mirrors Rust `ResourceKillResult.blocked_by_security` (serde
+   * camelCase). `#[serde(default)]` backend-side, so always present on the wire.
+   */
+  blockedBySecurity: boolean;
 }
 
 export type UiAutomationAction =

--- a/src/sidebar/stores/sessions-helpers.test.ts
+++ b/src/sidebar/stores/sessions-helpers.test.ts
@@ -173,6 +173,18 @@ describe("upsertSessionList (#274 banner-reuse hydration)", () => {
     expect(next[0].agentLabel).toBe("new");
   });
 
+  // #647 (test 7, E5): a verified RM Kill makes the backend emit session_created
+  // carrying the Exited SessionInfo for the SAME id. The sidebar's listener
+  // routes it through addSession -> upsertSessionList, which must UPDATE the
+  // existing tile's status to Exited (not append a duplicate) so the flip renders.
+  it("flips an existing running session to Exited on a verified-kill session_created (E5)", () => {
+    const sessions = [mkSession("agent-1", "running")];
+    const next = upsertSessionList(sessions, mkSession("agent-1", { exited: 0 }));
+    expect(next).toHaveLength(1);
+    expect(next[0].id).toBe("agent-1");
+    expect(next[0].status).toEqual({ exited: 0 });
+  });
+
   it("returns a new array reference on every call so SolidJS reactivity triggers", () => {
     const sessions = [mkSession("a", "idle")];
     const next = upsertSessionList(sessions, mkSession("a", "running"));


### PR DESCRIPTION
## Problem

The Resource Monitor **Kill** button could fail to kill an agent: it stayed alive while the group sat stuck in `Quarantined`. Reproduced on WG10 `tech-lead` — the agent tree survived ~30 min of kill attempts and was never terminated by AC.

Two-layer root cause (full diagnosis + live-log evidence in #647):
1. **External:** an AV/EDR (Norton 360 on the repro machine) strips `PROCESS_TERMINATE` from the handle machine-wide → the per-process reaper's `TerminateProcess` returns `win32 error 5` (ACCESS_DENIED) across many unrelated PIDs.
2. **AC-side bug (fixed here):** the manual Kill path used the per-process reaper only and **never fired the Job Object** atomic tree-kill that `destroy_session` / app-shutdown already use. The job is created+assigned at spawn (#632) and kills all members without a per-process terminate handle, bypassing the per-handle ACCESS_DENIED.

## Fix (A + C + D)

- **A — route Kill through the Job Object.** New pure `PtyManager::terminate_job_for_session` (fires the job, keeps the instance/job); `kill_resource_group` rewritten **fire-then-verify**: fire job → `verify_kill_settled` re-runs `kill_group` until the group leaves transient `Terminating` (settle budget 2500 ms) → finalize **only** on `state == Terminated` (`pty_mgr.kill` + `mark_exited` + emit `session_created` → tile flips to **Exited**); on quarantine/non-finalized the instance/job is preserved so Force/Retry can re-fire the durable kill. New `ResourceKillResult.finalized` is the verified-success signal.
- **C — UX/observability.** `sample_running_groups` now includes `Quarantined` (unfreezes the list); the row gets **Force-kill / Retry**; per-PID failure is shown; "Verifying…" is scoped to in-flight/terminating rows.
- **D — honest error.** Backend sets `blocked_by_security` via an anchored `win32 error 5` parser (rejects `error 50/53/567`); the FE renders an English security-guidance constant **alongside** (never replacing) the per-PID detail.
- **B (re-poll on ACCESS_DENIED): dropped** as moot.

Semantics: RM **Kill** force-terminates the tree and leaves the tile **Exited**, distinct from destroy-session. All new UI text is English. Windows-only Job Object; non-Windows degrades to reaper-only.

## Commits

- Backend: `32994e9` (Job Object fire-then-verify, D flag/anchored helper, C re-sample, 4 literals) + `edefb90` (`verify_kill_settled` + `finalized` flag — closes the Force-kill vs watchdog `Terminating` race).
- Frontend: `025d9a8` (type, Force/Retry, per-PID + security constant, E5 upsert) + `d70b2d5` (success keys off `finalized`, state-branched modal, "Verifying…" narrowing).

## Review & verification

- **architect** plan + Step-5 consensus (folded dev-rust E1–E8 + grinch's HIGHs; resolved `any`-vs-`all` by always showing the per-PID detail).
- **grinch** Step-7 found 1 HIGH (Force-kill racing an in-flight watchdog `kill_group` could report false success and leave a zombie tile) → fixed (`edefb90` + `d70b2d5`) → **grinch re-verify PASS** (race walked, invariants hold).
- **Gates:** `cargo test --lib --bins --tests` 1604 passed / 0 failed / 12 ignored; `cargo clippy -D warnings` clean; `npm run typecheck` clean; `npm run test` 506 passed; `npm run build` OK. `/code-review high` on each slice: no HIGH.
- **Shipper** built `agentscommander_standalone_wg-1.exe` to `0_AC`; user gave the go-ahead to land.

## Follow-ups (not in this PR)

- Watchdog **resource-breach auto-kill** still uses the reaper-only path (AV-fragile) — deferred; wire `PtyManager` + `mark_exited` into the watchdog loop.
- A live, owned process can be silently classified `AlreadyGone` and never attempted/reported.

Closes #647
