### PR TITLE
docs: Phase B coverage (session auto-close, config seed, log-filtering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ These are not accidents.
 - [Quickstart](docs/quickstart.md): 60-second install to first running agent
 - [Concepts](docs/concepts.md): agent, team, workgroup, coordinator, brief
 - [Teams and workgroups](docs/agents/teams-and-workgroups.md): coordinators, members, briefs, messaging
-- [Features](docs/features/): [Coding Agent Profiles](docs/features/coding-agent-profiles.md), Telegram bridge with image and screenshot sends, voice-to-text, portable instances, RTK integration
+- [Features](docs/features/): [Coding Agent Profiles](docs/features/coding-agent-profiles.md), [Session auto-close](docs/features/session-auto-close.md), [Config seed](docs/features/config-seed.md), Telegram bridge with image and screenshot sends, voice-to-text, portable instances, RTK integration
 - [Reference](docs/reference/): full CLI, `settings.json` schema, architecture, log filtering
 - [Roadmap](ROADMAP.md) · [Changelog](CHANGELOG.md) · [Docs style guide](docs/style-guide.md)
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -32,7 +32,7 @@ One running process bound to one agent directory, running inside a real PTY (Con
 - red — exited (clean or crash; detail in the row tooltip)
 - gray — idle (no recent activity)
 
-You can detach a session into its own window, attach a Telegram bot to it, or talk to it by voice.
+You can detach a session into its own window, attach a Telegram bot to it, or talk to it by voice. Idle teams can close their own sessions after a timeout; see [Session auto-close](features/session-auto-close.md).
 
 ## Team
 

--- a/docs/features/config-seed.md
+++ b/docs/features/config-seed.md
@@ -79,6 +79,16 @@ These are the same tokens documented in [Agent Matrix conventions, section 5](..
 - CRLF line endings and a UTF-8 byte-order mark survive the copy; only the known token substrings change.
 - Symlinks and Windows junctions in the template are skipped.
 
+## Verifying it worked
+
+A successful seed logs one `info`-level line. With `logLevel` at `info` (the default) or lower, look in `<config-dir>/app.log` for a line like:
+
+```text
+[config-seed] seeded 'C:\tools\.ac\wg-1-team\__agent_claude\.claude' into replica from WorkspaceBase source 'C:\tools\.ac\default.claude'
+```
+
+The tier in the message (`WorkspaceProfile`, `WorkspaceBase`, `MatrixProfile`, or `MatrixBase`) tells you which template won. If you see no `[config-seed]` line at all, the seed did not run; see [Troubleshooting](#troubleshooting). See [Log filtering](../reference/log-filtering.md#where-logs-go) for where `app.log` lives and how to raise the log level.
+
 ## What it does not do
 
 Config seed copies the template and, for `.claude`, re-applies the RTK hook. That is all. In particular:

--- a/docs/features/config-seed.md
+++ b/docs/features/config-seed.md
@@ -1,0 +1,104 @@
+# Config seed
+
+For developers who want each replica to start with a ready-made tool config (a `.claude` folder, for example) instead of an empty one. After this page you can point a coding agent at a template config folder and have AC copy it into every replica at spawn, with AC path tokens already substituted.
+
+When AgentsCommander spawns a replica for a coding agent, **config seed** copies a template config folder you maintain into that replica, so the agent starts with the settings, hooks, or files you want. The copy is atomic and best-effort: it never blocks or fails a launch.
+
+## What it does
+
+For a coding agent with config seed active, at spawn AC:
+
+1. Picks the highest-precedence template folder that exists (see [Where the template comes from](#where-the-template-comes-from)).
+2. Copies it to `<replica root>/<dest>`, substituting AC path tokens in text files.
+3. For a `.claude` destination only, re-applies the RTK PreToolUse hook to match your global `injectRtkHook` setting.
+
+The destination is replaced atomically. AC renames any existing folder to a trash name first, then moves the new copy into place, so the destination is always either fully old or fully new, never half-written. If anything goes wrong, AC logs it and the spawn continues. A seed failure never stops your session from launching.
+
+## Enabling it
+
+Config seed is configured **per coding agent**, on the agent's entry in `settings.json` under `configSeed`:
+
+```json
+{
+  "agents": [
+    {
+      "id": "claude",
+      "label": "Claude Code",
+      "command": "claude",
+      "configSeed": {
+        "enabled": true,
+        "dest": ".claude"
+      }
+    }
+  ]
+}
+```
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `enabled` | bool | `true` | Whether seeding runs for this agent. |
+| `dest` | string | `""` | Destination folder name under the replica root (for example `.claude`). |
+
+Config seed is **active only when `enabled` is true and `dest` is non-empty**. Omit `configSeed` entirely (the default) and no seeding happens. `dest` is a single folder name, validated as a safe name with no path separators or traversal, both at save time and again at spawn.
+
+## Where the template comes from
+
+You do not name a source folder. AC derives candidate template locations by convention and uses the first one that exists, in this order, highest precedence first:
+
+| Rank | Location | Folder name |
+|---|---|---|
+| 1 | Workspace, profile-lettered | `<workspace>/default_profile_<letter><dest>` |
+| 2 | Workspace, base | `<workspace>/default<dest>` |
+| 3 | Matrix, profile-lettered | `<matrix>/default_profile_<letter><dest>` |
+| 4 | Matrix, base | `<matrix>/default<dest>` |
+
+Two rules decide the winner:
+
+- **Workspace beats matrix.** Every workspace-level candidate outranks every matrix-level candidate.
+- **Profile beats base.** Within a location, the folder named for the session's resolved profile letter outranks the plain `default<dest>` folder.
+
+`<letter>` is the session's resolved profile letter, lowercased, so profile `B` looks for `default_profile_b.claude`. `<workspace>` is the project's `.ac` root, and `<matrix>` is the agent's canonical `_agent_<name>` directory. See [Coding Agent Profiles](coding-agent-profiles.md) for how the profile letter is resolved.
+
+> **The matrix's own `<dest>` is not a template.** A folder like `_agent_<name>/.claude` is the matrix agent's live config, not a seed source. AC deliberately never copies from it, so seeding cannot clobber the agent's real config. The matrix tiers use the `default<dest>` and `default_profile_<letter><dest>` naming instead.
+
+**Example.** For a `claude` agent with `dest = ".claude"` resolving profile `A`, AC looks, in order, for `<workspace>/default_profile_a.claude`, `<workspace>/default.claude`, `<matrix>/default_profile_a.claude`, then `<matrix>/default.claude`. The first that exists is copied to `<replica>/.claude`.
+
+## Token substitution
+
+AC substitutes the three AC path tokens inside the **content** of seeded files, so a template can refer to its own replica, workspace, or matrix path and have it resolve correctly per replica:
+
+- `%AC_REPLICA_ROOT%`
+- `%AC_WORKSPACE_ROOT%`
+- `%AC_MATRIX_ROOT%`
+
+These are the same tokens documented in [Agent Matrix conventions, section 5](../agent-matrix-conventions.md#5-profile-path-placeholders). The substitution rules:
+
+- Text files **5 MiB or smaller** are read and have the tokens substituted.
+- Files **larger than 5 MiB** are streamed and copied verbatim, never read whole into memory.
+- **Binary files** (a NUL byte in the first 8 KB) and non-UTF-8 files are copied verbatim.
+- CRLF line endings and a UTF-8 byte-order mark survive the copy; only the known token substrings change.
+- Symlinks and Windows junctions in the template are skipped.
+
+## What it does not do
+
+Config seed copies the template and, for `.claude`, re-applies the RTK hook. That is all. In particular:
+
+- It does **not** write any claude.md exclude settings. The exclude subsystem was removed in [#590](https://github.com/mblua/AgentsCommander/issues/590); there is nothing to configure and nothing to document here.
+- For any destination other than `.claude`, there is **no** post-copy re-apply step. The folder is copied as-is, with token substitution, and nothing further is stamped.
+
+The only post-seed step is the RTK PreToolUse hook, and only for a `.claude` destination: AC re-applies it to match your global `injectRtkHook` setting, adding it when injection is on and removing it when off. See [RTK integration](rtk-integration.md).
+
+## Troubleshooting
+
+**"Nothing got seeded."** Config seed is active only when `enabled` is true and `dest` is non-empty. Then at least one of the four convention folders must actually exist on disk. If none exists, AC has nothing to copy and skips silently. Check the spawn logs for `[config-seed]` lines (see [Log filtering](../reference/log-filtering.md)).
+
+**"My agent's config is overwritten on every launch."** That is expected: the destination is replaced atomically on every spawn. If `dest` matches the coding agent's actual config directory, the seed overwrites that live config each time. AC logs a heuristic warning when `dest` lines up with, or exactly matches, the agent's configured config-dir env. Point `dest` at a directory you intend AC to own, or turn seeding off for that agent.
+
+**"`invalid dest '...'` in the logs."** `dest` must be a plain, safe folder name with no path separators or traversal. Fix the value in `settings.json`.
+
+## See also
+
+- [Settings reference](../reference/settings.md#coding-agents) - the `configSeed` field on a coding agent
+- [Agent Matrix conventions, section 5](../agent-matrix-conventions.md#5-profile-path-placeholders) - the three AC path tokens
+- [Coding Agent Profiles](coding-agent-profiles.md) - how the profile letter is resolved
+- [RTK integration](rtk-integration.md) - the post-seed `.claude` hook

--- a/docs/features/session-auto-close.md
+++ b/docs/features/session-auto-close.md
@@ -19,7 +19,11 @@ A session counts as a team member only if it is a coordinator or has a coding ag
 Two more conditions gate an actual close:
 
 - The session must have a **live PTY**. A deferred or not-yet-spawned session has nothing to terminate and is skipped.
-- The team must be **established**: at least one member alive for more than 30 seconds. A team you just opened, or one that just woke on restore, is visible for at least that long before anything can close it.
+- The team must be **established**: at least one member alive for 30 seconds or more. A team you just opened, or one that just woke on restore, is visible for at least that long before anything can close it.
+
+## Two badges, two meanings
+
+This page describes two separate sidebar badges. The **idle badge** (`Nm`) counts how long a team has been idle. The **AUTO-CLOSED badge** marks a coordinator that auto-close has already shut down. The next two sections cover each one.
 
 ## The idle badge
 
@@ -95,7 +99,9 @@ When you reopen an abandoned team, the session replays its scrollback for a seco
 
 The watcher checks teams once every 60 seconds. A team that has crossed its timeout is closed on the next tick, so a close can trail the threshold by up to a minute. This is also why a team is not closed the instant you walk away.
 
-## How the badge value reaches the UI (backend contract)
+## Internals: how the badge value reaches the UI
+
+> **Skip this section** unless you are debugging the UI or building on AC's events. Everything above is all you need to use auto-close.
 
 There is **no idle field on the session object**. The anchor reaches the frontend out of band, on a Tauri event:
 
@@ -110,7 +116,7 @@ The frontend computes `Nm` from that timestamp. The clocks themselves persist pe
 
 **"My ad-hoc shell got closed."** It should not have. Auto-close only targets coordinators and agent-owned sessions; a plain shell with no coding agent is never a candidate. If you saw a shell close, it was not auto-close. Check the row tooltip for the real exit reason.
 
-**"My team did not close after the timeout."** Confirm `coordinatorAutoCloseEnabled` is true and `coordinatorAutoCloseMinutes` is non-zero. Then remember the team must be established (a member alive more than 30 seconds) and have a live PTY, and the close happens on the next 60-second tick. A team you just reopened restarts from fresh activity.
+**"My team did not close after the timeout."** Confirm `coordinatorAutoCloseEnabled` is true and `coordinatorAutoCloseMinutes` is non-zero. Then remember the team must be established (a member alive 30 seconds or more) and have a live PTY, and the close happens on the next 60-second tick. A team you just reopened restarts from fresh activity.
 
 **"The idle badge never reaches red."** Something is resetting the anchor. Any PTY output (an agent still working, a watchdog, a stray log) or any input counts as activity. Watch the `Nm` value: if it keeps dropping back to a low number, the team is not actually idle.
 

--- a/docs/features/session-auto-close.md
+++ b/docs/features/session-auto-close.md
@@ -1,0 +1,123 @@
+# Session auto-close
+
+For developers running long-lived teams who want idle coordinators and their agents to shut down on their own instead of lingering. After this page you know what AC auto-closes, when, how to read the idle badge, and how to change or turn off the timeout.
+
+AgentsCommander watches every team for inactivity. When a team sits idle past a timeout (60 minutes by default), AC closes its sessions for you, so abandoned teams stop holding PTYs, processes, and memory. A per-coordinator badge shows how long each team has been idle, so you can see a close coming.
+
+## What gets auto-closed
+
+Auto-close applies to **teams only**: coordinator sessions and agent-owned member sessions. It never touches an ad-hoc shell you opened yourself.
+
+| Session kind | Auto-closed? |
+|---|---|
+| Coordinator session | Yes |
+| Agent-owned member session (a replica running a coding agent) | Yes |
+| Ad-hoc user shell (no coding agent, not a coordinator) | Never |
+
+A session counts as a team member only if it is a coordinator or has a coding agent attached, and its working directory resolves to a team key `<project>:<wg>`. Everything else is left alone.
+
+Two more conditions gate an actual close:
+
+- The session must have a **live PTY**. A deferred or not-yet-spawned session has nothing to terminate and is skipped.
+- The team must be **established**: at least one member alive for more than 30 seconds. A team you just opened, or one that just woke on restore, is visible for at least that long before anything can close it.
+
+## The idle badge
+
+Every coordinator row in the sidebar shows an idle badge: the whole number of minutes since the team was last active, formatted `Nm`.
+
+- `0m` right after activity.
+- `45m` after 45 minutes of silence.
+- It counts minutes only, with no hour or day rollover, so a team idle for three days reads `4320m`.
+
+The badge changes color as idle time grows:
+
+| Idle time | Color |
+|---|---|
+| Below the yellow threshold (default 30m) | Default, no warning color |
+| At or above the yellow threshold (default 30m) | Yellow |
+| At or above the red threshold (default 60m) | Red |
+
+The badge is **informational and always on**. It shows even when auto-close is turned off, so you can monitor idle teams without letting AC close them.
+
+## The AUTO-CLOSED badge
+
+When auto-close fires and the session it destroys is the team's **coordinator**, AC stamps that coordinator row with an **AUTO-CLOSED** badge. This is your record that the team was closed by the timeout, not by you.
+
+If only a non-coordinator member is reaped while the coordinator survives (the coordinator was spared by a grace window or a late user message), the surviving coordinator keeps its idle counter and is **not** stamped. The AUTO-CLOSED badge means specifically "this coordinator's own session was auto-closed."
+
+## Settings
+
+All four keys live in `settings.json` (see the [settings reference](../reference/settings.md#session-auto-close)). Defaults shown.
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `coordinatorAutoCloseEnabled` | bool | `true` | Master switch. When false, AC never auto-closes a team (the badge still shows). |
+| `coordinatorAutoCloseMinutes` | number | `60` | Idle minutes before a team is closed. `0` also disables auto-close. |
+| `coordinatorIdleBadgeYellowMinutes` | number | `30` | Idle minutes at which the badge turns yellow. |
+| `coordinatorIdleBadgeRedMinutes` | number | `60` | Idle minutes at which the badge turns red. |
+
+Out of the box (`coordinatorAutoCloseEnabled` true, `coordinatorAutoCloseMinutes` 60), a team that sits idle for more than an hour is closed automatically.
+
+### Turning auto-close off
+
+Set either field:
+
+```json
+{
+  "coordinatorAutoCloseEnabled": false
+}
+```
+
+or:
+
+```json
+{
+  "coordinatorAutoCloseMinutes": 0
+}
+```
+
+Either one stops every close. The idle badge keeps counting, so you still see idle time at a glance.
+
+## How idle is measured
+
+Idle time is measured from a single anchor per team: **the more recent of two clocks**.
+
+- **Last user message.** Updated when you send input to any session in the team: typing in the terminal, a web keystroke, or a Telegram message.
+- **Last activity.** Updated from real PTY output (the agents doing work), advanced on the watcher's tick.
+
+The anchor is `max(last user message, last activity)`, and idle time is `now - anchor`. Either real work or your input resets the clock, so a team is only "idle" when both the human and the agents have gone quiet.
+
+### Why a reopened team keeps its old idle time
+
+When you reopen an abandoned team, the session replays its scrollback for a second or two. AC ignores output in the first 10 seconds of a woken session so that scrollback replay does not look like fresh activity and reset the idle clock. Genuine activity after that window advances the anchor normally.
+
+### Why a close can lag the timeout by up to a minute
+
+The watcher checks teams once every 60 seconds. A team that has crossed its timeout is closed on the next tick, so a close can trail the threshold by up to a minute. This is also why a team is not closed the instant you walk away.
+
+## How the badge value reaches the UI (backend contract)
+
+There is **no idle field on the session object**. The anchor reaches the frontend out of band, on a Tauri event:
+
+- Event: `coordinator_clock_updated`
+- Payload: `{ "replicaPath": "<coordinator cwd>", "lastUserMessageAt": "<RFC 3339 timestamp>" }`
+
+The frontend computes `Nm` from that timestamp. The clocks themselves persist per team in `coordinator_clocks.json`.
+
+> **Naming caveat.** The payload field is named `lastUserMessageAt`, but it carries the **unified** `max(user message, activity)` anchor, not the user-message clock alone. The name is kept for backward compatibility; read it as "the idle anchor."
+
+## Troubleshooting
+
+**"My ad-hoc shell got closed."** It should not have. Auto-close only targets coordinators and agent-owned sessions; a plain shell with no coding agent is never a candidate. If you saw a shell close, it was not auto-close. Check the row tooltip for the real exit reason.
+
+**"My team did not close after the timeout."** Confirm `coordinatorAutoCloseEnabled` is true and `coordinatorAutoCloseMinutes` is non-zero. Then remember the team must be established (a member alive more than 30 seconds) and have a live PTY, and the close happens on the next 60-second tick. A team you just reopened restarts from fresh activity.
+
+**"The idle badge never reaches red."** Something is resetting the anchor. Any PTY output (an agent still working, a watchdog, a stray log) or any input counts as activity. Watch the `Nm` value: if it keeps dropping back to a low number, the team is not actually idle.
+
+**"A member closed but the coordinator stayed."** Expected. Only the coordinator's own auto-close stamps the AUTO-CLOSED badge; a reaped sibling leaves a surviving coordinator counting normally.
+
+## See also
+
+- [Settings reference](../reference/settings.md#session-auto-close) - the four auto-close keys
+- [Concepts: Session](../concepts.md#session) - session status dots and lifecycle
+- [Glossary](../glossary.md) - session auto-close, idle badge

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -30,6 +30,10 @@ The single agent in a team that can send messages to any team member, edit the t
 
 A session popped out of the main window into its own dedicated terminal window. Useful for long-running sessions you want to keep visible while doing other work.
 
+## Idle badge
+
+The `Nm` badge on a coordinator row showing whole minutes since the team was last active. Turns yellow, then red, as idle time grows. See [Session auto-close](features/session-auto-close.md).
+
 ## Idle detector
 
 The PTY component that flags a session as idle after a configurable silence threshold (2.5 seconds by default). Drives the green-dot indicator in the sidebar.
@@ -85,6 +89,10 @@ A CLI proxy that compresses verbose command outputs to cut LLM token consumption
 ## Session
 
 A running process bound to one agent directory and one coding-agent CLI. Sessions live in the sidebar with status dots: green waiting (ready for your input), blue running, amber pending, red exited, gray idle.
+
+## Session auto-close
+
+Automatic shutdown of an idle team (coordinator plus agent-owned sessions) after a timeout (60 minutes by default). Ad-hoc shells are never auto-closed. See [Session auto-close](features/session-auto-close.md).
 
 ## Settings tab
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -18,6 +18,10 @@ The plain-language description of a workgroup's goal. Lives at `<workgroup>/TASK
 
 The CLI process that runs the LLM work: Claude Code, Codex, or Gemini. AC is **not** a coding agent.
 
+## Config seed
+
+A per-coding-agent option that copies a template config folder (for example `.claude`) into each replica at spawn, with AC path tokens substituted. See [Config seed](features/config-seed.md).
+
 ## ConPTY
 
 Windows' native PTY API. AC uses ConPTY via [portable-pty](https://github.com/wez/wezterm/tree/main/pty) on Windows; Unix PTYs on Linux/macOS.

--- a/docs/reference/log-filtering.md
+++ b/docs/reference/log-filtering.md
@@ -54,6 +54,8 @@ RUST_LOG=info,agentscommander_lib::config::teams=trace agentscommander.exe
 
 You should see normal log lines on stderr, plus trace output from the one module you targeted.
 
+The target `agentscommander` is a broad prefix: by env_logger's prefix matching it covers every AC module (all `agentscommander_lib::*`), so `RUST_LOG=agentscommander=trace` raises everything AC logs. Add `::<module>` to scope it to a single subsystem, as in the example above.
+
 `RUST_LOG` takes precedence over `logLevel`, and it behaves differently in two ways:
 
 - It is a full filter expression, not a single level: the same per-module syntax env_logger has always used.

--- a/docs/reference/log-filtering.md
+++ b/docs/reference/log-filtering.md
@@ -1,92 +1,91 @@
 # Log filtering
 
-For developers debugging AgentsCommander or chasing an intermittent issue. How AC resolves its runtime log filter and how to set it.
+For developers debugging AgentsCommander or chasing an intermittent issue. How AC sets its log verbosity, how to change it live, and the one escape hatch for fine-grained filters.
 
-## Resolution chain
+AC has one log verbosity setting, `logLevel`, with five levels. You pick a level in Settings or in `settings.json`, and the change applies immediately with no restart. For ad-hoc, per-module filtering from a terminal, the `RUST_LOG` environment variable still works as an escape hatch.
 
-AC picks its filter at startup from this chain (first match wins):
+## The five levels
 
-1. **`RUST_LOG` environment variable** — used as the filter expression. Preferred for ad-hoc debugging from a terminal.
-2. **`settings.logLevel` in `~/.agentscommander*/settings.json`** — used as the filter expression. Persistent across restarts and survives Windows GUI launches (shortcut, double-click).
-3. **Default**: `agentscommander=info`.
+`logLevel` is a single level, not a filter expression. Pick one of:
 
-Filter expressions follow standard [`env_logger`](https://docs.rs/env_logger/) syntax. Examples:
-
-| Filter | What you get |
+| Level | Shows |
 |---|---|
-| `info` | Info-level logs from every crate AC depends on. Loud. |
-| `agentscommander=info` | Default. Info+ from AC modules only. |
-| `agentscommander=debug` | Debug+ from every AC module. |
-| `info,agentscommander_lib::config::teams=trace` | Info baseline + trace for one module. |
-| `warn,agentscommander_lib::pty=trace,agentscommander_lib::telegram=trace` | Warnings everywhere + trace from two subsystems. |
+| `error` | Errors only. |
+| `warn` | Warnings and errors. |
+| `info` | Normal operational logs. The default. |
+| `debug` | Verbose detail for diagnosis. |
+| `trace` | Everything, including hot-path noise. |
 
-## Setting `RUST_LOG`
+Each level includes the ones above it: `debug` shows `debug`, `info`, `warn`, and `error`. The level applies to AC's own modules (`agentscommander*`). Third-party crates are pinned at `warn` regardless, so raising AC to `debug` does not flood you with dependency logs.
 
-**Bash / zsh:**
+Anything that is not one of the five names (an empty value, a typo, a legacy filter string like `agentscommander=debug`, or no setting at all) falls back to `info`. An invalid value never silences AC.
+
+## Setting the level live
+
+The level applies the moment you change it. No restart.
+
+**From Settings.** Open **Settings -> General -> Logging** and choose a level from the **Log level** dropdown (Error, Warn, Info, Debug, Trace). AC applies it to the running backend and every open window immediately.
+
+**From `settings.json`.** Set `logLevel` to one of the five names:
+
+```json
+{
+  "logLevel": "debug"
+}
+```
+
+See the [settings reference](settings.md#logging) for the file path. If you edit the file while AC is running, reload settings or use the Settings UI, so the change is picked up and not clobbered by the next in-memory save.
+
+To return to the default, set `"logLevel": "info"` (or `null`, or delete the field).
+
+> **One value, not a filter.** A value like `"agentscommander=debug"` is a legacy filter expression, not a level name, so it falls back to `info` and does nothing. Use `"debug"`.
+
+## Downgrade, not delete
+
+Some lines that used to print at `info` were moved **down** to `debug` or `trace` rather than removed. They were too noisy for normal operation but still useful when diagnosing a problem. If the `info` logs are not enough, switch to `debug` (or `trace`) to bring the quieter lines back. Nothing was deleted; it was just made quieter by default.
+
+## The `RUST_LOG` escape hatch
+
+For fine-grained, per-module filtering from a terminal, set the `RUST_LOG` environment variable before launching AC. It uses standard [`env_logger`](https://docs.rs/env_logger/) filter syntax and lets you target individual modules:
 
 ```bash
-RUST_LOG=agentscommander=debug agentscommander.exe
+RUST_LOG=info,agentscommander_lib::config::teams=trace agentscommander.exe
 ```
+
+You should see normal log lines on stderr, plus trace output from the one module you targeted.
+
+`RUST_LOG` takes precedence over `logLevel`, and it behaves differently in two ways:
+
+- It is a full filter expression, not a single level: the same per-module syntax env_logger has always used.
+- It **freezes** the live selector. While `RUST_LOG` is set, the Settings level picker cannot change the backend verbosity; AC stays on the `RUST_LOG` filter until you restart without it. The picker still adjusts the in-app console, and AC logs a debug line noting the backend stayed frozen.
+
+Use `RUST_LOG` for a one-off terminal debugging session. Use `logLevel` for a persistent level that survives restarts and works when you launch the GUI from Explorer with no terminal.
 
 **PowerShell:**
 
 ```powershell
-$env:RUST_LOG="agentscommander=debug"; .\agentscommander.exe
+$env:RUST_LOG="info,agentscommander_lib::pty=trace"; .\agentscommander.exe
 ```
 
-**One-shot from cmd.exe:**
+**cmd.exe:**
 
 ```cmd
-set RUST_LOG=agentscommander=debug && agentscommander.exe
+set RUST_LOG=info,agentscommander_lib::pty=trace && agentscommander.exe
 ```
 
-## Setting `settings.logLevel`
-
-Open `settings.json` (see [Settings reference](settings.md) for the path), add:
-
-```json
-{
-  "logLevel": "agentscommander=debug"
-}
-```
-
-Save, restart AC. The setting persists across launches — useful when you double-click the GUI from Explorer and have no terminal to set `RUST_LOG`.
-
-To revert, set `"logLevel": null` (or delete the field) and restart.
+> **Malformed `RUST_LOG` filters can suppress logs.** Unlike `logLevel`, which always falls back to `info`, a `RUST_LOG` string that does not parse as a valid `env_logger` expression (a typo, an unrecognized level keyword, a single `:` instead of `::`) can leave AC silent. Verify a candidate filter once by running from a terminal: if AC prints log lines, it parses; if AC is silent, fix the filter before you rely on it.
 
 ## Where logs go
 
 | Channel | Destination |
 |---|---|
 | Live runtime logs | stderr of the AC process (visible if you launched from a terminal) |
-| In-app console capture | The DevTools console plus a rolling 500-entry buffer in memory |
-| Exported logs | **Help → Save debug logs** writes `~/.agentscommander/debug-logs.txt` |
+| In-app console capture | The DevTools console plus a rolling 500-entry in-memory buffer |
+| Exported logs | **Help -> Save debug logs** writes `~/.agentscommander/debug-logs.txt` |
 
 Attach `debug-logs.txt` to any bug report.
 
-## ⚠ Malformed filters silently suppress logs
-
-If the filter does not parse as a valid `env_logger` expression — a typo, an unrecognized level keyword, a single `:` instead of `::` — `env_logger` produces no directives for AC's targets and **every** `agentscommander*` log line is suppressed at runtime.
-
-This is the same behavior the binary had before settings-level filter support landed. It will bite you the same way.
-
-**Verify any filter once before persisting it** by running AC from a terminal:
-
-```bash
-RUST_LOG="<your-candidate-filter>" agentscommander.exe
-```
-
-If AC prints normal log lines, the filter parses. If AC is silent, the filter is malformed — fix it before pasting into `settings.json`.
-
-## Future work
-
-- Phase 2 of [issue #93](https://github.com/mblua/AgentsCommander/issues/93) (if shipped) will expose the filter in the Settings UI as a dropdown.
-- Phase 3 will move to live reload via `tracing-subscriber` so changes take effect without a restart.
-
-Neither phase has shipped yet. Phase 1 (settings-level filter + `RUST_LOG` override) is the current state.
-
 ## See also
 
-- [Settings reference — `logLevel`](settings.md)
-- [`env_logger` filter syntax](https://docs.rs/env_logger/latest/env_logger/#filtering-events) — upstream docs
-- [Issue #93](https://github.com/mblua/AgentsCommander/issues/93) — the umbrella issue
+- [Settings reference: `logLevel`](settings.md#logging) - the field schema
+- [`env_logger` filter syntax](https://docs.rs/env_logger/latest/env_logger/#filtering-events) - upstream `RUST_LOG` docs

--- a/docs/reference/log-filtering.md
+++ b/docs/reference/log-filtering.md
@@ -79,11 +79,12 @@ set RUST_LOG=info,agentscommander_lib::pty=trace && agentscommander.exe
 
 | Channel | Destination |
 |---|---|
+| On-disk log file | `<config-dir>/app.log`, the persistent log. Rotated at 50 MB, keeping up to six files (`app.log` plus `app.log.1` through `app.log.5`). |
 | Live runtime logs | stderr of the AC process (visible if you launched from a terminal) |
 | In-app console capture | The DevTools console plus a rolling 500-entry in-memory buffer |
-| Exported logs | **Help -> Save debug logs** writes `~/.agentscommander/debug-logs.txt` |
+| Voice failure dump | `<config-dir>/debug-logs.txt`, written automatically when voice-to-text fails. A one-off console snapshot, not a user action. |
 
-Attach `debug-logs.txt` to any bug report.
+`<config-dir>` is the per-instance config directory next to the binary, the same directory as `settings.json` (see the [settings reference](settings.md#file-location)). Attach `app.log` to any bug report.
 
 ## See also
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -84,6 +84,16 @@ A minimal `settings.json`:
 | `label` | string | — | Display name in the launcher dropdown. |
 | `command` | string | — | Binary to spawn. Resolved against PATH unless absolute. |
 | `color` | string | — | CSS hex color for sidebar accent. |
+| `configSeed` | `ConfigSeedConfig` \| absent | absent | Optional config-folder seed copied into each replica at spawn. Absent (the default) means no seeding. See [Config seed](../features/config-seed.md). |
+
+`ConfigSeedConfig` (one optional object on a coding agent):
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `true` | Whether seeding runs for this agent. |
+| `dest` | string | `""` | Destination folder name under the replica root (for example `.claude`). Validated as a safe name, no path separators or traversal. |
+
+Seeding is active only when `enabled` is true and `dest` is non-empty. See [Config seed](../features/config-seed.md) for template precedence and token substitution.
 
 ### Coding agent profiles
 
@@ -144,6 +154,17 @@ The per-agent and per-replica assignments do **not** live here. They are stored 
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `restoreCoordinatorWakeState` | bool | `false` | On app start, wake coordinators whose PTY was awake at shutdown. Non-coordinators always stay asleep until clicked. |
+
+### Session auto-close
+
+Idle teams (coordinators plus agent-owned sessions) close themselves after a timeout. Ad-hoc shells are never auto-closed. See [Session auto-close](../features/session-auto-close.md).
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `coordinatorAutoCloseEnabled` | bool | `true` | Master switch for auto-close. When false, idle teams are never closed (the idle badge still shows). |
+| `coordinatorAutoCloseMinutes` | u32 | `60` | Idle minutes before a team is auto-closed. `0` also disables auto-close. |
+| `coordinatorIdleBadgeYellowMinutes` | u32 | `30` | Idle minutes at which the coordinator idle badge turns yellow. |
+| `coordinatorIdleBadgeRedMinutes` | u32 | `60` | Idle minutes at which the coordinator idle badge turns red. |
 
 ### Voice-to-text
 
@@ -211,7 +232,7 @@ See [RTK integration](../features/rtk-integration.md).
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `logLevel` | string \| null | `null` | Filter expression. Applied at startup if `RUST_LOG` is unset. Standard `env_logger` syntax (e.g. `info,agentscommander_lib::config::teams=trace`). |
+| `logLevel` | string \| null | `null` | One of `error`, `warn`, `info`, `debug`, `trace`. Applied live, no restart. An invalid value, a legacy filter string, or `null` falls back to `info`. The `RUST_LOG` env var, if set, overrides this and freezes the live selector until restart. |
 
 See [Log filtering](log-filtering.md).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -118,7 +118,7 @@ The Gemini transcription model is `gemini-2.5-flash` by default. Switch to `gemi
 If something fails and you cannot tell why, raise the log level. Pick a level in **Settings -> General -> Logging** (it applies live, no restart), set `logLevel` in `settings.json`, or set `RUST_LOG` before launching for per-module filtering from a terminal:
 
 ```bash
-RUST_LOG=agentscommander_lib=trace agentscommander.exe
+RUST_LOG=agentscommander=trace agentscommander.exe
 ```
 
 See [Log filtering](reference/log-filtering.md) for the five levels, the live selector, and precedence rules.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -115,13 +115,13 @@ The Gemini transcription model is `gemini-2.5-flash` by default. Switch to `gemi
 
 ## Logs
 
-If something fails and you cannot tell why, raise the log level. Set `RUST_LOG` before launching or set `logLevel` in `settings.json`:
+If something fails and you cannot tell why, raise the log level. Pick a level in **Settings -> General -> Logging** (it applies live, no restart), set `logLevel` in `settings.json`, or set `RUST_LOG` before launching for per-module filtering from a terminal:
 
 ```bash
 RUST_LOG=agentscommander=trace agentscommander.exe
 ```
 
-See [Log filtering](reference/log-filtering.md) for the full filter syntax and precedence rules.
+See [Log filtering](reference/log-filtering.md) for the five levels, the live selector, and precedence rules.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -118,7 +118,7 @@ The Gemini transcription model is `gemini-2.5-flash` by default. Switch to `gemi
 If something fails and you cannot tell why, raise the log level. Pick a level in **Settings -> General -> Logging** (it applies live, no restart), set `logLevel` in `settings.json`, or set `RUST_LOG` before launching for per-module filtering from a terminal:
 
 ```bash
-RUST_LOG=agentscommander=trace agentscommander.exe
+RUST_LOG=agentscommander_lib=trace agentscommander.exe
 ```
 
 See [Log filtering](reference/log-filtering.md) for the five levels, the live selector, and precedence rules.
@@ -129,4 +129,4 @@ Still stuck? Open an [issue](https://github.com/mblua/AgentsCommander/issues) wi
 
 - Your platform and version (`agentscommander --version`)
 - The exact error message
-- A copy of `~/.agentscommander/debug-logs.txt` (export via **Help → Save debug logs**)
+- A copy of `<config-dir>/app.log` (the persistent log next to the binary; see [Log filtering](reference/log-filtering.md#where-logs-go))


### PR DESCRIPTION
## Summary
Phase B of the AgentsCommander documentation coverage work: three user-facing gaps from the docs audit.

- **Session auto-close + idle badge** (`docs/features/session-auto-close.md`, new): only teams auto-close, defaults/toggles, the #580 idle anchor, the `Nm` and AUTO-CLOSED badges.
- **Config seed** (`docs/features/config-seed.md`, new): what is seeded at spawn, precedence, token substitution; post-#590 it only re-applies the RTK hook (no claude.md excludes).
- **Log filtering** (`docs/reference/log-filtering.md`, rewritten): the 5-level selector (#612), live no-restart, downgrade-not-delete; removed pre-#612 stale content; fixed a bogus "Save debug logs" menu claim (real on-disk log is `<config-dir>/app.log`).

Plus consistency updates to `settings.md`, `troubleshooting.md`, `concepts.md`, `glossary.md`, `README.md`.

Reviewed: dev-rust accuracy PASS, developer-advocate clarity PASS, focused re-check PASS. Docs only, no version bump. Zero em-dashes.

Closes #644
Closes #645
Closes #646
