### PR TITLE
fix: keep team editor open across project refreshes

### DIFF
--- a/src/sidebar/components/EditTeamModal.tsx
+++ b/src/sidebar/components/EditTeamModal.tsx
@@ -2,11 +2,11 @@ import { Component, createSignal, createMemo, For, Show, onMount, onCleanup } fr
 import { EntityAPI } from "../../shared/ipc";
 import { AC_WORKSPACE_DIR } from "../../shared/constants";
 import { projectStore } from "../stores/project";
-import type { AcTeam, TeamWizardAgentEntry, TeamWizardRepoEntry, TeamWizardStep } from "../../shared/types";
+import type { TeamWizardAgentEntry, TeamWizardRepoEntry, TeamWizardStep } from "../../shared/types";
 
 const EditTeamModal: Component<{
   projectPath: string;
-  team: AcTeam;
+  teamName: string;
   onClose: () => void;
 }> = (props) => {
   const [step, setStep] = createSignal<TeamWizardStep>(1);
@@ -69,7 +69,7 @@ const EditTeamModal: Component<{
       const paths = projectStore.projects.map((p) => p.path);
       const [agentList, teamConfig] = await Promise.all([
         EntityAPI.listAllAgents(paths),
-        EntityAPI.getTeamConfig(props.projectPath, props.team.name),
+        EntityAPI.getTeamConfig(props.projectPath, props.teamName),
       ]);
 
       const entries: TeamWizardAgentEntry[] = agentList.map((a) => ({
@@ -204,7 +204,7 @@ const EditTeamModal: Component<{
       }));
       await EntityAPI.updateTeam(
         props.projectPath,
-        props.team.name,
+        props.teamName,
         Array.from(selectedAgents()).map(portableAgentRef),
         portableAgentRef(coordinator()),
         repoData
@@ -230,7 +230,7 @@ const EditTeamModal: Component<{
     <div class="modal-overlay">
       <div class="agent-modal entity-wizard-modal">
         <div class="agent-modal-header">
-          <span class="agent-modal-title">Edit Team: {props.team.name}</span>
+          <span class="agent-modal-title">Edit Team: {props.teamName}</span>
           <span class="wizard-step-indicator">Step {step()} of 3</span>
         </div>
 
@@ -248,7 +248,7 @@ const EditTeamModal: Component<{
                 <label class="new-agent-label">Team name</label>
                 <input
                   class="agent-search-input"
-                  value={props.team.name}
+                  value={props.teamName}
                   disabled
                 />
               </div>

--- a/src/sidebar/components/ProjectPanel.edit-team-modal.test.tsx
+++ b/src/sidebar/components/ProjectPanel.edit-team-modal.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  contextMenu,
+  discovery,
+  input,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+
+const projectPath = "C:\\Project";
+const teamName = "dev-team";
+const agentPath = `${projectPath}\\.ac\\_agent_dev-webpage-ui`;
+const unsavedRepoUrl = "https://github.com/acme/unsaved-repo.git";
+
+function setupTransport(fake: FakeTransport): void {
+  fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+  fake.resolve(
+    "discover_project",
+    discovery({
+      teams: [
+        {
+          name: teamName,
+          agents: ["dev-webpage-ui"],
+          coordinator: "dev-webpage-ui",
+        },
+      ],
+    }),
+  );
+  fake.resolve("list_all_agents", [
+    {
+      name: "dev-webpage-ui",
+      path: agentPath,
+      projectName: "Project",
+    },
+  ]);
+  fake.resolve("get_team_config", {
+    agents: ["_agent_dev-webpage-ui"],
+    coordinator: "_agent_dev-webpage-ui",
+    repos: [],
+  });
+  fake.resolve("update_team", undefined);
+}
+
+function findTeamHeader(root: ParentNode): HTMLElement {
+  const header = Array.from(root.querySelectorAll<HTMLElement>(".ac-team-header")).find(
+    (el) => el.textContent?.includes(teamName),
+  );
+  if (!header) throw new Error(`Team header not found: ${teamName}`);
+  return header;
+}
+
+function findButtonByText(label: string): HTMLButtonElement {
+  const button = Array.from(document.body.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!(button instanceof HTMLButtonElement)) throw new Error(`Button not found: ${label}`);
+  return button;
+}
+
+function repoInput(): HTMLInputElement {
+  const el = document.body.querySelector<HTMLInputElement>(
+    'input[placeholder="https://github.com/org/repo.git"]',
+  );
+  if (!el) throw new Error("Repo input not found");
+  return el;
+}
+
+function modalText(): string {
+  return document.body.textContent ?? "";
+}
+
+describe("ProjectPanel edit-team modal (#669)", () => {
+  let cleanupDom: (() => void) | null = null;
+  let rendered: ReturnType<typeof renderWithFakeTransport> | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    rendered?.cleanup();
+    rendered = null;
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("keeps the edit team modal and unsaved repo edits open across project refreshes", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+
+    rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    await projectStore.createAndLoad(projectPath);
+
+    await waitFor(() => expect(findTeamHeader(rendered!.root)).toBeTruthy());
+    contextMenu(findTeamHeader(rendered.root));
+    await waitFor(() => expect(findButtonByText("Edit Team")).toBeTruthy());
+    click(findButtonByText("Edit Team"));
+
+    await waitFor(() => expect(modalText()).toContain(`Edit Team: ${teamName}`));
+    await waitFor(() => expect(findButtonByText("Next").disabled).toBe(false));
+    click(findButtonByText("Next"));
+    await waitFor(() => expect(findButtonByText("Next").disabled).toBe(false));
+    click(findButtonByText("Next"));
+
+    await waitFor(() => expect(repoInput()).toBeTruthy());
+    input(repoInput(), unsavedRepoUrl);
+    click(findButtonByText("Add Repo"));
+    await waitFor(() => expect(modalText()).toContain("unsaved-repo"));
+
+    await projectStore.reloadProject(projectPath);
+    await waitFor(() =>
+      expect(fake.callsFor("discover_project").length).toBeGreaterThanOrEqual(2),
+    );
+
+    expect(modalText()).toContain(`Edit Team: ${teamName}`);
+    expect(modalText()).toContain("unsaved-repo");
+  });
+});

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -248,6 +248,11 @@ const ProjectPanel: Component = () => {
     agentLabel: string;
     requestedProfile: string | null;
   } | null>(null);
+  const [editingTeamTarget, setEditingTeamTarget] = createSignal<{
+    projectPath: string;
+    teamName: string;
+  } | null>(null);
+  const closeEditTeamModal = () => setEditingTeamTarget(null);
   // #573: in-flight + error state for the prompt's restart. The old code did a
   // consume-and-clear (setRestartPrompt(null) before the async settled) with a
   // bare `.catch(console.error)`, so a failed restart vanished silently and the
@@ -434,7 +439,6 @@ const ProjectPanel: Component = () => {
         const [showNewLoop, setShowNewLoop] = createSignal(false);
         const [editingLoop, setEditingLoop] = createSignal<AcLoopSummary | null>(null);
         const [teamCtxMenu, setTeamCtxMenu] = createSignal<{ team: AcTeam; x: number; y: number } | null>(null);
-        const [editingTeam, setEditingTeam] = createSignal<AcTeam | null>(null);
         const [deletingTeam, setDeletingTeam] = createSignal<AcTeam | null>(null);
         const [deleteError, setDeleteError] = createSignal("");
         const [deleteInProgress, setDeleteInProgress] = createSignal(false);
@@ -2364,7 +2368,12 @@ const ProjectPanel: Component = () => {
                     class="session-context-option"
                     onClick={() => {
                       const menu = teamCtxMenu();
-                      if (menu) setEditingTeam(menu.team);
+                      if (menu) {
+                        setEditingTeamTarget({
+                          projectPath: proj.path,
+                          teamName: menu.team.name,
+                        });
+                      }
                       setTeamCtxMenu(null);
                     }}
                   >
@@ -2946,17 +2955,6 @@ const ProjectPanel: Component = () => {
               </Portal>
             )}
 
-            {/* Edit team modal */}
-            {editingTeam() && (
-              <Portal>
-                <EditTeamModal
-                  projectPath={proj.path}
-                  team={editingTeam()!}
-                  onClose={() => setEditingTeam(null)}
-                />
-              </Portal>
-            )}
-
             {/* Delete team confirmation */}
             {deletingTeam() && (
               <Portal>
@@ -3011,6 +3009,18 @@ const ProjectPanel: Component = () => {
         );
       }}
     </For>
+
+    {/* #669: hoisted out of the project row so project refreshes that replace
+        row objects do not dispose the edit modal or its unsaved local state. */}
+    {editingTeamTarget() && (
+      <Portal>
+        <EditTeamModal
+          projectPath={editingTeamTarget()!.projectPath}
+          teamName={editingTeamTarget()!.teamName}
+          onClose={closeEditTeamModal}
+        />
+      </Portal>
+    )}
 
     {/* #588 Coordinator manual-close confirmation. Hoisted to the stable
         ProjectPanel root (outside the projects <For>, like pendingLaunch) so a


### PR DESCRIPTION
## Summary
- Hoist Edit Team modal ownership out of the per-project row so project refreshes no longer dispose the modal.
- Use stable `projectPath` + `teamName` identifiers for the edit target instead of keeping a row-local team object alive.
- Add a regression test proving unsaved repo edits survive `projectStore.reloadProject(projectPath)`.

## Verification
- dev-webpage-ui: `npm test -- src/sidebar/components/ProjectPanel.edit-team-modal.test.tsx` PASS.
- dev-webpage-ui: `npm test -- src/sidebar/components/ProjectPanel.restart-prompt.test.tsx src/sidebar/components/ProjectPanel.edit-team-modal.test.tsx` PASS.
- dev-webpage-ui: `npx tsc --noEmit` PASS.
- dev-rust-grinch review: PASS, no findings.
- dev-rust-grinch: same focused tests PASS, `npx tsc --noEmit` PASS, `git diff --check 2e5e84b~1 2e5e84b` PASS.
- Shipper: `npx tauri build` PASS and deployed `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-11.exe` from commit `2e5e84b700a6eec49391548ba040a2f8c0699465`.
- User approved landing after the 0_AC build.

## Follow-up
- #670 tracks the broader stateful ProjectPanel dialog refactor. This PR intentionally keeps that out of scope.

Closes #669