### PR TITLE
feat: add raise-hand sidebar indicator, refs #676

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod list_sessions;
 pub mod loop_cmd;
 pub mod new_project;
 pub mod open_project;
+pub mod raise_hand;
 pub mod role_experiment;
 pub mod self_clear;
 pub mod self_switch;
@@ -127,6 +128,9 @@ pub enum Commands {
     /// Hand off via SELF-HANDOFF.md, switch or hard-reset the caller, then resume from it
     #[command(name = "self-handoff-and-switch")]
     SelfSwitch(self_switch::SelfSwitchArgs),
+    /// Show this session's raised-hand communication indicator in the Sidebar coordinator row
+    #[command(name = "raise-hand")]
+    RaiseHand(raise_hand::RaiseHandArgs),
     /// List reachable peers (returns JSON array with name, status, role, teams)
     ListPeers(list_peers::ListPeersArgs),
     /// List reachable peers (lean JSON — name, working, sessionStatus, reachable, teams)
@@ -297,6 +301,7 @@ pub fn handle_cli(cmd: Commands) -> i32 {
         Commands::Send(args) => send::execute(args),
         Commands::SelfClear(args) => self_clear::execute(args),
         Commands::SelfSwitch(args) => self_switch::execute(args),
+        Commands::RaiseHand(args) => raise_hand::execute(args),
         Commands::ListPeers(args) => list_peers::execute(args),
         Commands::ListPeersLean(args) => list_peers::execute_lean(args),
         Commands::ListSessions(args) => list_sessions::execute(args),

--- a/src-tauri/src/cli/raise_hand.rs
+++ b/src-tauri/src/cli/raise_hand.rs
@@ -1,0 +1,233 @@
+use clap::Args;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+use crate::phone::types::OutboxMessage;
+
+use super::self_clear::resolve_self_clear_sender;
+
+#[derive(Args)]
+#[command(after_help = "\
+Raises this session's Sidebar communication indicator when the caller token belongs to a \
+live coordinator session with a visible TASK.md title slot.\n\n\
+OUTPUT: prints exactly true or false on stdout when the daemon processes the request. \
+Infrastructure failures, stale tokens, daemon rejection, delivery timeout, and malformed \
+responses exit non-zero and write errors to stderr.")]
+pub struct RaiseHandArgs {
+    /// Session token from AGENTSCOMMANDER_TOKEN. Shape-validated in the CLI;
+    /// per-session authorization happens at the daemon mailbox.
+    #[arg(long)]
+    pub token: Option<String>,
+
+    /// Agent root directory (required). Your working directory.
+    #[arg(long)]
+    pub root: Option<String>,
+
+    /// Seconds to wait for the daemon's response (default 15).
+    #[arg(long, default_value = "15")]
+    pub timeout: u64,
+}
+
+fn interpret_raise_hand_response(content: &str) -> Result<bool, i32> {
+    let resp: serde_json::Value = serde_json::from_str(content).map_err(|_| 2)?;
+    resp.get("raised").and_then(|v| v.as_bool()).ok_or(2)
+}
+
+pub fn execute(args: RaiseHandArgs) -> i32 {
+    let root = match args.root {
+        Some(ref r) => r.clone(),
+        None => {
+            eprintln!("Error: --root is required.");
+            return 1;
+        }
+    };
+
+    let is_root = match crate::cli::validate_cli_token(&args.token) {
+        Ok((_t, r)) => r,
+        Err(msg) => {
+            eprintln!("{}", msg);
+            return 1;
+        }
+    };
+
+    let sender = resolve_self_clear_sender(&root);
+    let ac_dir = PathBuf::from(&root).join(crate::config::agent_local_dir_name());
+
+    let msg_id = Uuid::new_v4().to_string();
+    let request_id = Uuid::new_v4().to_string();
+
+    let message = OutboxMessage {
+        id: msg_id.clone(),
+        token: args.token,
+        from: sender,
+        to: String::new(),
+        body: String::new(),
+        mode: String::new(),
+        get_output: false,
+        request_id: Some(request_id.clone()),
+        sender_agent: None,
+        preferred_agent: String::new(),
+        priority: "normal".to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        command: None,
+        action: Some(crate::phone::mailbox::RAISE_HAND_ACTION.to_string()),
+        target: None,
+        force: None,
+        timeout_secs: None,
+        switch_coding_agent: None,
+        switch_profile: None,
+    };
+
+    let outbox_dir = if is_root {
+        let app_outbox = crate::config::config_dir()
+            .map(|d| d.join("app-outbox-path.txt"))
+            .and_then(|p| std::fs::read_to_string(&p).ok())
+            .map(|s| PathBuf::from(s.trim()));
+        match app_outbox {
+            Some(p) if p.is_dir() => p,
+            _ => ac_dir.join("outbox"),
+        }
+    } else {
+        ac_dir.join("outbox")
+    };
+    if let Err(e) = std::fs::create_dir_all(&outbox_dir) {
+        eprintln!("Error: failed to create outbox directory: {}", e);
+        return 1;
+    }
+
+    let outbox_path = outbox_dir.join(format!("{}.json", msg_id));
+    let json = match serde_json::to_string_pretty(&message) {
+        Ok(j) => j,
+        Err(e) => {
+            eprintln!("Error: failed to serialize message: {}", e);
+            return 1;
+        }
+    };
+    if let Err(e) = std::fs::write(&outbox_path, json) {
+        eprintln!("Error: failed to write outbox file: {}", e);
+        return 1;
+    }
+
+    let delivered_path = outbox_dir
+        .join("delivered")
+        .join(format!("{}.json", msg_id));
+    let rejected_reason_path = outbox_dir
+        .join("rejected")
+        .join(format!("{}.reason.txt", msg_id));
+    let confirm_timeout = std::time::Duration::from_secs(30);
+    let confirm_poll = std::time::Duration::from_millis(250);
+    let start = std::time::Instant::now();
+    loop {
+        if delivered_path.exists() {
+            break;
+        }
+        if rejected_reason_path.exists() {
+            let reason = std::fs::read_to_string(&rejected_reason_path)
+                .unwrap_or_else(|_| "unknown reason".to_string());
+            eprintln!("Error: raise-hand rejected - {}", reason.trim());
+            return 1;
+        }
+        if start.elapsed() >= confirm_timeout {
+            eprintln!(
+                "Error: delivery confirmation timeout after 30s (request {} may still be pending)",
+                msg_id
+            );
+            return 1;
+        }
+        std::thread::sleep(confirm_poll);
+    }
+
+    let responses_dir = ac_dir.join("responses");
+    let response_path = responses_dir.join(format!("{}.json", request_id));
+    let resp_timeout = std::time::Duration::from_secs(args.timeout);
+    let resp_poll = std::time::Duration::from_millis(250);
+    let resp_start = std::time::Instant::now();
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => match interpret_raise_hand_response(&content) {
+                    Ok(raised) => {
+                        crate::cli_println!("{}", raised);
+                        return 0;
+                    }
+                    Err(code) => {
+                        eprintln!("Error: raise-hand response was malformed.");
+                        return code;
+                    }
+                },
+                Err(e) => {
+                    eprintln!("Error: failed to read response: {}", e);
+                    return 1;
+                }
+            }
+        }
+        if resp_start.elapsed() >= resp_timeout {
+            eprintln!(
+                "Error: raise-hand delivered but no response within {}s (request {})",
+                args.timeout, request_id
+            );
+            return 2;
+        }
+        std::thread::sleep(resp_poll);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn true_response_interprets_true() {
+        assert_eq!(
+            interpret_raise_hand_response(r#"{"raised":true}"#),
+            Ok(true)
+        );
+    }
+
+    #[test]
+    fn false_response_interprets_false() {
+        assert_eq!(
+            interpret_raise_hand_response(r#"{"raised":false}"#),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn missing_or_non_bool_raised_maps_to_exit_two() {
+        assert_eq!(
+            interpret_raise_hand_response(r#"{"status":"raised"}"#),
+            Err(2)
+        );
+        assert_eq!(
+            interpret_raise_hand_response(r#"{"raised":"true"}"#),
+            Err(2)
+        );
+        assert_eq!(interpret_raise_hand_response("not json"), Err(2));
+    }
+
+    #[test]
+    fn raise_hand_args_parse_with_default_timeout() {
+        use clap::Parser;
+        let parsed = crate::cli::Cli::try_parse_from([
+            "agentscommander",
+            "raise-hand",
+            "--token",
+            "11111111-1111-1111-1111-111111111111",
+            "--root",
+            "C:\\x",
+        ])
+        .expect("clap should accept raise-hand with token and root");
+        let cmd = parsed.command.expect("subcommand present");
+        match cmd {
+            crate::cli::Commands::RaiseHand(args) => {
+                assert_eq!(args.timeout, 15);
+                assert_eq!(
+                    args.token.as_deref(),
+                    Some("11111111-1111-1111-1111-111111111111")
+                );
+                assert_eq!(args.root.as_deref(), Some("C:\\x"));
+            }
+            _ => panic!("expected RaiseHand subcommand"),
+        }
+    }
+}

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -3,6 +3,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use uuid::Uuid;
 
 use crate::pty::manager::PtyManager;
+use crate::session::session::SessionCommunicationKind;
 use crate::voice::tracker::VoiceTrackingState;
 
 #[tauri::command]
@@ -64,8 +65,7 @@ pub(crate) async fn note_user_message_to_session<R: tauri::Runtime>(
     // MUST run before the coordinator-only early return below so non-coordinator
     // members re-arm too.
     {
-        let mgr =
-            app.state::<Arc<tokio::sync::RwLock<crate::session::manager::SessionManager>>>();
+        let mgr = app.state::<Arc<tokio::sync::RwLock<crate::session::manager::SessionManager>>>();
         let cleared = mgr
             .read()
             .await
@@ -77,16 +77,31 @@ pub(crate) async fn note_user_message_to_session<R: tauri::Runtime>(
         }
     }
 
+    let cleared_raise_hand = {
+        let mgr = app.state::<Arc<tokio::sync::RwLock<crate::session::manager::SessionManager>>>();
+        let manager = {
+            let guard = mgr.read().await;
+            guard.clone()
+        };
+        manager
+            .clear_communication_if_kind(session_id, SessionCommunicationKind::RaiseHand)
+            .await
+    };
+    if cleared_raise_hand {
+        let _ = app.emit(
+            "session_communication_changed",
+            serde_json::json!({ "sessionId": session_id.to_string(), "communication": null }),
+        );
+    }
+
     // (b) badge: reset only when the typed-to session is a coordinator.
     let cwd = {
-        let mgr = app
-            .state::<Arc<tokio::sync::RwLock<crate::session::manager::SessionManager>>>();
+        let mgr = app.state::<Arc<tokio::sync::RwLock<crate::session::manager::SessionManager>>>();
         let cwd = mgr.read().await.coordinator_cwd(session_id).await;
         cwd
     };
     let Some(cwd) = cwd else { return };
-    let Some(clocks) =
-        app.try_state::<crate::config::coordinator_clocks::CoordinatorClocksState>()
+    let Some(clocks) = app.try_state::<crate::config::coordinator_clocks::CoordinatorClocksState>()
     else {
         return;
     };

--- a/src-tauri/src/commands/resource_monitor.rs
+++ b/src-tauri/src/commands/resource_monitor.rs
@@ -6,8 +6,8 @@ use uuid::Uuid;
 
 use crate::config::settings::SettingsState;
 use crate::resource_monitor::types::{
-    ResourceGroupState, ResourceKillReason, ResourceKillRequest, ResourceKillResult, ResourceLimits,
-    ResourceSnapshot,
+    ResourceGroupState, ResourceKillReason, ResourceKillRequest, ResourceKillResult,
+    ResourceLimits, ResourceSnapshot,
 };
 use crate::resource_monitor::ResourceMonitorState;
 
@@ -49,7 +49,12 @@ pub async fn kill_resource_group(
 
     // Fire the Job Object FIRST (pure: keeps the instance/job for a Retry). The
     // std-Mutex guard is dropped before any await.
-    let job_fired = { pty_mgr.lock().unwrap().terminate_job_for_session(session_id) };
+    let job_fired = {
+        pty_mgr
+            .lock()
+            .unwrap()
+            .terminate_job_for_session(session_id)
+    };
     log::info!(
         "[resource-monitor] job-fire session={} job_present={}",
         session_id,
@@ -57,9 +62,14 @@ pub async fn kill_resource_group(
     );
 
     // Verify + account, settling past a concurrent kill's transient `Terminating`.
-    let mut result =
-        verify_kill_settled(Arc::clone(&monitor), session_id, reason, SETTLE_BUDGET, SETTLE_POLL)
-            .await?;
+    let mut result = verify_kill_settled(
+        Arc::clone(&monitor),
+        session_id,
+        reason,
+        SETTLE_BUDGET,
+        SETTLE_POLL,
+    )
+    .await?;
 
     if should_finalize_kill(result.state) {
         // Verified dead: full PTY cleanup (drops the job handle = KILL_ON_JOB_CLOSE
@@ -69,7 +79,17 @@ pub async fn kill_resource_group(
             let _ = pty_mgr.lock().unwrap().kill(session_id);
         }
         let mgr = session_mgr.read().await;
-        mgr.mark_exited(session_id, 0).await;
+        let cleared_raise_hand = mgr.mark_exited(session_id, 0).await;
+        if cleared_raise_hand {
+            let _ = tauri::Emitter::emit(
+                &app,
+                "session_communication_changed",
+                serde_json::json!({
+                    "sessionId": session_id.to_string(),
+                    "communication": null,
+                }),
+            );
+        }
         mgr.clear_active_if(session_id).await;
         if let Some(updated) = mgr.get_session(session_id).await {
             let info = crate::session::session::SessionInfo::from(&updated);
@@ -266,7 +286,10 @@ mod tests {
     }
 
     fn register_running(state: &ResourceMonitorState, id: Uuid, root: ProcessIdentity) {
-        let permit = state.try_reserve_agent_slot(test_limits()).unwrap().unwrap();
+        let permit = state
+            .try_reserve_agent_slot(test_limits())
+            .unwrap()
+            .unwrap();
         let mut reg = ResourceLaunchRegistration::new(
             state.clone(),
             permit,

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -374,8 +374,8 @@ fn expand_env_var_refs(input: &str) -> String {
         match after.find('%') {
             Some(end) => {
                 let name = &after[..end];
-                let valid = !name.is_empty()
-                    && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+                let valid =
+                    !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
                 if valid {
                     if let Ok(v) = std::env::var(name) {
                         buf.push_str(&v);
@@ -924,8 +924,12 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         .map(|p| p.is_dir())
         .unwrap_or(false);
     let is_claude = agent_kind == Some(CodingAgentKind::Claude);
-    let will_inject_continue =
-        should_inject_continue(is_claude, skip_auto_resume, claude_project_exists, &full_cmd);
+    let will_inject_continue = should_inject_continue(
+        is_claude,
+        skip_auto_resume,
+        claude_project_exists,
+        &full_cmd,
+    );
     // (#630/#631) Resume-decision trace. Widened beyond Claude: codex/gemini ride
     // the same `skip_auto_resume` axis (below) and were equally invisible. INFO
     // during the stabilization window; demote later.
@@ -1029,8 +1033,10 @@ pub async fn create_session_inner<R: tauri::Runtime>(
                 // during replica identity repair. State what actually failed;
                 // the interpolated error carries the precise, retry-suggesting
                 // detail from format_publish_error.
-                let dialog_msg =
-                    format!("Cannot launch session - failed to update replica config:\n\n{}", e);
+                let dialog_msg = format!(
+                    "Cannot launch session - failed to update replica config:\n\n{}",
+                    e
+                );
                 app.dialog()
                     .message(&dialog_msg)
                     .title("Session Launch Error")
@@ -1338,10 +1344,12 @@ pub async fn create_session_inner<R: tauri::Runtime>(
                     hash,
                     cwd,
                 );
-                if let Err(e) = crate::config::coding_agent_profiles::set_replica_profile_content_hash(
-                    std::path::Path::new(&cwd),
-                    hash,
-                ) {
+                if let Err(e) =
+                    crate::config::coding_agent_profiles::set_replica_profile_content_hash(
+                        std::path::Path::new(&cwd),
+                        hash,
+                    )
+                {
                     log::warn!("Failed to persist profileContentHash: {}", e);
                 }
             }
@@ -1760,7 +1768,16 @@ async fn destroy_session_inner_with_options<R: tauri::Runtime>(
 
     if is_root_agent && !force_destroy_root {
         mgr.set_is_root_agent(uuid, true).await;
-        mgr.mark_exited(uuid, 0).await;
+        let cleared_raise_hand = mgr.mark_exited(uuid, 0).await;
+        if cleared_raise_hand {
+            let _ = app.emit(
+                "session_communication_changed",
+                serde_json::json!({
+                    "sessionId": uuid.to_string(),
+                    "communication": null,
+                }),
+            );
+        }
         mgr.clear_active_if(uuid).await;
         let dormant_info = mgr.get_session(uuid).await.map(|s| SessionInfo::from(&s));
 
@@ -2297,7 +2314,8 @@ pub async fn restart_session_inner_with_activation<R: tauri::Runtime>(
     // The `persist_current_state` in step 7 below writes it durably.
     if !is_root_agent {
         let mgr = session_mgr.read().await;
-        mgr.set_start_fresh_on_restore(new_uuid, restart_start_fresh).await;
+        mgr.set_start_fresh_on_restore(new_uuid, restart_start_fresh)
+            .await;
     }
 
     if activate_after {
@@ -3137,6 +3155,7 @@ mod tests {
             working_directory: cwd.to_string(),
             status: SessionStatus::Running,
             waiting_for_input: false,
+            communication: None,
             pending_review: false,
             last_prompt: None,
             agent_id: agent_id.map(str::to_string),
@@ -3745,14 +3764,20 @@ mod tests {
     fn restart_intent_normal_member_reopen_resumes() {
         // Branch A reopen of a NORMAL member (no stored intent, Some(false))
         // => resume, unchanged from today.
-        assert!(!super::restart_skip_auto_resume_with_intent(false, Some(false)));
+        assert!(!super::restart_skip_auto_resume_with_intent(
+            false,
+            Some(false)
+        ));
     }
 
     #[test]
     fn restart_intent_deferred_fresh_member_reopen_stays_fresh() {
         // #631 closure: a "Restart Session"-then-app-restart member defers, then
         // reopens via Branch A (Some(false)), but its persisted fresh intent wins.
-        assert!(super::restart_skip_auto_resume_with_intent(true, Some(false)));
+        assert!(super::restart_skip_auto_resume_with_intent(
+            true,
+            Some(false)
+        ));
     }
 
     #[test]

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -15,6 +15,8 @@ use crate::phone::types::OutboxMessage;
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
 #[cfg(test)]
+use crate::session::session::SessionCommunicationKind;
+#[cfg(test)]
 use crate::session::session::SessionRepo;
 use crate::session::session::{SessionInfo, SessionStatus};
 use crate::{AppOutbox, MasterToken};
@@ -425,7 +427,8 @@ pub(crate) const SELF_CLEAR_SETTLE_SECS: u64 = 30;
 // `handle_self_clear`; test builds drive `run_self_clear_after_sustained_idle`
 // with explicit durations, so they are dead under `cfg(test)`.
 #[cfg_attr(test, allow(dead_code))]
-const SELF_CLEAR_SETTLE: std::time::Duration = std::time::Duration::from_secs(SELF_CLEAR_SETTLE_SECS);
+const SELF_CLEAR_SETTLE: std::time::Duration =
+    std::time::Duration::from_secs(SELF_CLEAR_SETTLE_SECS);
 #[cfg_attr(test, allow(dead_code))]
 const SELF_CLEAR_POLL: std::time::Duration = std::time::Duration::from_millis(500);
 /// Safety cap so a never-idle session cannot leave a task polling forever.
@@ -445,6 +448,8 @@ const SELF_HANDOFF_ARCHIVE_DELAY: std::time::Duration = std::time::Duration::fro
 /// silently not fire and the command would be lost with no agent-visible error). `pub(crate)` so
 /// `cli/self_clear.rs` reaches it as `crate::phone::mailbox::SELF_CLEAR_ACTION`.
 pub(crate) const SELF_CLEAR_ACTION: &str = "self-handoff-and-clear";
+
+pub(crate) const RAISE_HAND_ACTION: &str = "raise-hand";
 
 /// #626 - stand-alone prompt injected in Phase 2 after the post-clear sustained-idle window. Must be a
 /// SINGLE line (an embedded newline would submit early) and self-contained (the agent's context was just
@@ -845,7 +850,9 @@ pub(crate) fn self_clear_gate_advance(
         .unwrap_or_default();
     if phase_elapsed >= max_defer {
         let reason = match state.phase {
-            SelfClearPhase::Clear => "never reached sustained idle within MAX_DEFER cap (clear leg)",
+            SelfClearPhase::Clear => {
+                "never reached sustained idle within MAX_DEFER cap (clear leg)"
+            }
             SelfClearPhase::Handoff => {
                 "never reached sustained idle within MAX_DEFER cap (handoff leg)"
             }
@@ -1546,6 +1553,9 @@ impl MailboxPoller {
             return self
                 .handle_self_handoff_switch(app, path, &msg, is_app_outbox)
                 .await;
+        }
+        if msg.action.as_deref() == Some(RAISE_HAND_ACTION) {
+            return self.handle_raise_hand(app, path, &msg, is_app_outbox).await;
         }
 
         if root_agent_claim {
@@ -3173,8 +3183,7 @@ impl MailboxPoller {
         //     read-time safety net is SELF_CLEAR_HANDOFF_PROMPT's "if missing or empty, wait". Use
         //     .is_file() so a stray directory named SELF-HANDOFF.md does not pass. Runs BEFORE the
         //     idempotency insert and the archive, so nothing is queued/archived with nothing to resume.
-        let handoff_path =
-            std::path::Path::new(&session.working_directory).join("SELF-HANDOFF.md");
+        let handoff_path = std::path::Path::new(&session.working_directory).join("SELF-HANDOFF.md");
         if !handoff_path.is_file() {
             return self
                 .reject_message(
@@ -3261,6 +3270,99 @@ impl MailboxPoller {
 
         // 5. Write the queue-ack response, then move the message to delivered/.
         self.write_self_clear_response(app, path, msg, session_id, status, is_app_outbox)
+            .await
+    }
+
+    fn session_has_visible_raise_hand_slot(session: &SessionInfo) -> bool {
+        if !session.is_coordinator || matches!(&session.status, SessionStatus::Exited(_)) {
+            return false;
+        }
+        let Some(task_path) =
+            crate::session::session::find_workgroup_task_path_for_cwd(&session.working_directory)
+        else {
+            return false;
+        };
+        let Ok(content) = std::fs::read_to_string(task_path) else {
+            return false;
+        };
+        crate::commands::entity_creation::parse_task_title(&content).is_some()
+    }
+
+    async fn handle_raise_hand<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        path: &std::path::Path,
+        msg: &OutboxMessage,
+        is_app_outbox: bool,
+    ) -> Result<(), String> {
+        let token_uuid = match msg.token.as_deref().and_then(|t| Uuid::parse_str(t).ok()) {
+            Some(u) => u,
+            None => {
+                return self
+                    .reject_message(
+                        path,
+                        msg,
+                        "raise-hand requires a valid session token; restart or respawn the session",
+                    )
+                    .await;
+            }
+        };
+        let mgr = {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let guard = session_mgr.read().await;
+            guard.clone()
+        };
+        let Some(session) = mgr.find_by_token(token_uuid).await else {
+            return self
+                .reject_message(
+                    path,
+                    msg,
+                    "raise-hand: no live session owns this token; restart or respawn the session",
+                )
+                .await;
+        };
+        let session_id = match Uuid::parse_str(&session.id) {
+            Ok(u) => u,
+            Err(_) => {
+                return self
+                    .reject_message(path, msg, "raise-hand: internal error resolving session id")
+                    .await;
+            }
+        };
+
+        if !Self::session_has_visible_raise_hand_slot(&session) {
+            return self
+                .write_raise_hand_response(
+                    app,
+                    path,
+                    msg,
+                    session_id,
+                    false,
+                    "not_visible",
+                    is_app_outbox,
+                )
+                .await;
+        }
+
+        let outcome = mgr.raise_hand(session_id, chrono::Utc::now()).await;
+        let (raised, status, changed_communication) = match outcome {
+            Some((true, communication)) => (true, "raised", Some(communication)),
+            Some((false, _communication)) => (true, "already_visible", None),
+            None => (false, "not_visible", None),
+        };
+
+        if let Some(communication) = changed_communication {
+            let _ = tauri::Emitter::emit(
+                app,
+                "session_communication_changed",
+                serde_json::json!({
+                    "sessionId": session_id.to_string(),
+                    "communication": communication,
+                }),
+            );
+        }
+
+        self.write_raise_hand_response(app, path, msg, session_id, raised, status, is_app_outbox)
             .await
     }
 
@@ -3932,6 +4034,48 @@ impl MailboxPoller {
         self.move_to_delivered(path, msg).await
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn write_raise_hand_response<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        path: &std::path::Path,
+        msg: &OutboxMessage,
+        session_id: Uuid,
+        raised: bool,
+        status: &str,
+        is_app_outbox: bool,
+    ) -> Result<(), String> {
+        if let Some(ref rid) = msg.request_id {
+            let response = serde_json::json!({
+                "action": RAISE_HAND_ACTION,
+                "status": status,
+                "raised": raised,
+                "session_id": session_id.to_string(),
+                "requested_by": msg.from,
+            });
+            if let Ok(json) = serde_json::to_string_pretty(&response) {
+                if !is_app_outbox {
+                    if let Some(responses_dir) = path
+                        .parent()
+                        .and_then(|p| p.parent())
+                        .map(|ac| ac.join("responses"))
+                    {
+                        let _ = std::fs::create_dir_all(&responses_dir);
+                        let _ = std::fs::write(responses_dir.join(format!("{}.json", rid)), &json);
+                    }
+                }
+                if let Some(sender_path) = self.resolve_repo_path(&msg.from, app).await {
+                    let responses_dir = std::path::PathBuf::from(sender_path)
+                        .join(crate::config::agent_local_dir_name())
+                        .join("responses");
+                    let _ = std::fs::create_dir_all(&responses_dir);
+                    let _ = std::fs::write(responses_dir.join(format!("{}.json", rid)), &json);
+                }
+            }
+        }
+        self.move_to_delivered(path, msg).await
+    }
+
     /// Force-close a session immediately via destroy_session_inner.
     async fn force_close_session<R: tauri::Runtime>(
         &self,
@@ -4573,6 +4717,7 @@ mod tests {
     use crate::telegram::manager::TelegramBridgeManager;
     use std::collections::HashSet;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use tauri::Listener;
 
     // ── §224 D.5a — wait_for_restore_or_session unit tests ──
 
@@ -4595,6 +4740,7 @@ mod tests {
             working_directory: cwd.into(),
             status,
             waiting_for_input,
+            communication: None,
             pending_review: false,
             last_prompt: None,
             agent_id: None,
@@ -6067,6 +6213,11 @@ mod tests {
     }
 
     #[test]
+    fn raise_hand_action_const_pins_wire_value() {
+        assert_eq!(RAISE_HAND_ACTION, "raise-hand");
+    }
+
+    #[test]
     fn self_switch_handoff_prompt_is_single_line_self_contained() {
         assert!(!SELF_SWITCH_HANDOFF_PROMPT.is_empty());
         assert!(!SELF_SWITCH_HANDOFF_PROMPT.contains('\n'));
@@ -6430,6 +6581,91 @@ mod tests {
         serde_json::from_str(&content).ok()
     }
 
+    async fn seed_raise_hand_session(
+        app: &tauri::AppHandle<tauri::test::MockRuntime>,
+        cwd: &Path,
+        is_coordinator: bool,
+        status: SessionStatus,
+    ) -> (Uuid, Uuid) {
+        let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+        let mgr = session_mgr.read().await;
+        let session = mgr
+            .create_session(
+                "codex".into(),
+                vec![],
+                cwd.to_string_lossy().to_string(),
+                Some("codex".into()),
+                Some("Codex".into()),
+                Vec::new(),
+                is_coordinator,
+            )
+            .await
+            .unwrap();
+        match status {
+            SessionStatus::Active => {
+                mgr.switch_session(session.id).await.unwrap();
+            }
+            SessionStatus::Running => {}
+            SessionStatus::Idle => {
+                mgr.mark_idle(session.id).await;
+            }
+            SessionStatus::Exited(code) => {
+                mgr.mark_exited(session.id, code).await;
+            }
+        }
+        (session.id, session.token)
+    }
+
+    fn write_raise_hand_task_title(cwd: &Path, title: &str) {
+        let task_path =
+            crate::session::session::find_workgroup_task_path_for_cwd(&cwd.to_string_lossy())
+                .expect("raise-hand test cwd should be inside a workgroup");
+        std::fs::write(task_path, format!("---\ntitle: {}\n---\n\nbody", title)).unwrap();
+    }
+
+    fn build_raise_hand_message(
+        cwd: &Path,
+        msg_id: &str,
+        request_id: &str,
+        token: Option<String>,
+    ) -> (PathBuf, OutboxMessage) {
+        let outbox_dir = cwd
+            .join(crate::config::agent_local_dir_name())
+            .join("outbox");
+        std::fs::create_dir_all(&outbox_dir).unwrap();
+        let path = outbox_dir.join(format!("{}.json", msg_id));
+        let msg = OutboxMessage {
+            id: msg_id.into(),
+            token,
+            from: sender_name_for_session_cwd(&cwd.to_string_lossy()),
+            to: String::new(),
+            body: String::new(),
+            mode: String::new(),
+            get_output: false,
+            request_id: Some(request_id.into()),
+            sender_agent: None,
+            preferred_agent: String::new(),
+            priority: "normal".into(),
+            timestamp: "2026-06-28T00:00:00Z".into(),
+            command: None,
+            action: Some(RAISE_HAND_ACTION.into()),
+            target: None,
+            force: None,
+            timeout_secs: None,
+            switch_coding_agent: None,
+            switch_profile: None,
+        };
+        std::fs::write(&path, serde_json::to_string_pretty(&msg).unwrap()).unwrap();
+        (path, msg)
+    }
+
+    fn raise_hand_delivered_path(cwd: &Path, msg_id: &str) -> PathBuf {
+        cwd.join(crate::config::agent_local_dir_name())
+            .join("outbox")
+            .join("delivered")
+            .join(format!("{}.json", msg_id))
+    }
+
     fn read_self_clear_response_status(cwd: &Path, request_id: &str) -> Option<String> {
         let v = read_response_json(cwd, request_id)?;
         v.get("status").and_then(|s| s.as_str()).map(String::from)
@@ -6448,6 +6684,267 @@ mod tests {
         let pending = app.state::<Arc<crate::PendingSelfClear>>();
         let g = pending.0.lock().unwrap_or_else(|e| e.into_inner());
         g.contains(&id)
+    }
+
+    #[tokio::test]
+    async fn raise_hand_process_message_coordinator_with_task_title_sets_state_and_event() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let (session_id, token) =
+            seed_raise_hand_session(&app, &fixture.sender_cwd, true, SessionStatus::Running).await;
+        write_raise_hand_task_title(&fixture.sender_cwd, "Build the feature");
+        let events = Arc::new(Mutex::new(Vec::<String>::new()));
+        let captured = Arc::clone(&events);
+        fixture
+            .app
+            .listen_any("session_communication_changed", move |event| {
+                captured.lock().unwrap().push(event.payload().to_string());
+            });
+
+        let (path, _msg) = build_raise_hand_message(
+            &fixture.sender_cwd,
+            "msg-rh-1",
+            "rid-rh-1",
+            Some(token.to_string()),
+        );
+        let poller = MailboxPoller::new();
+        poller
+            .process_message(&app, &path, false)
+            .await
+            .expect("raise-hand process_message should succeed");
+
+        let response = read_response_json(&fixture.sender_cwd, "rid-rh-1").unwrap();
+        assert_eq!(response["action"], RAISE_HAND_ACTION);
+        assert_eq!(response["status"], "raised");
+        assert_eq!(response["raised"], true);
+        assert_eq!(response["session_id"], session_id.to_string());
+        assert!(raise_hand_delivered_path(&fixture.sender_cwd, "msg-rh-1").exists());
+        assert!(!path.exists());
+        let mgr = {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let guard = session_mgr.read().await;
+            guard.clone()
+        };
+        let stored = mgr.get_session(session_id).await.unwrap();
+        let communication = stored.communication.expect("raise-hand state stored");
+        assert_eq!(communication.kind, SessionCommunicationKind::RaiseHand);
+        assert!(communication.visible);
+
+        let captured = events.lock().unwrap().clone();
+        assert_eq!(captured.len(), 1, "raise-hand should emit one event");
+        let event: serde_json::Value = serde_json::from_str(&captured[0]).unwrap();
+        assert_eq!(event["sessionId"], session_id.to_string());
+        assert_eq!(event["communication"]["kind"], "raiseHand");
+        assert_eq!(event["communication"]["visible"], true);
+    }
+
+    #[tokio::test]
+    async fn raise_hand_process_message_second_request_reports_already_visible() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let (_session_id, token) =
+            seed_raise_hand_session(&app, &fixture.sender_cwd, true, SessionStatus::Running).await;
+        write_raise_hand_task_title(&fixture.sender_cwd, "Build the feature");
+        let events = Arc::new(Mutex::new(Vec::<String>::new()));
+        let captured = Arc::clone(&events);
+        fixture
+            .app
+            .listen_any("session_communication_changed", move |event| {
+                captured.lock().unwrap().push(event.payload().to_string());
+            });
+
+        let (first_path, _first_msg) = build_raise_hand_message(
+            &fixture.sender_cwd,
+            "msg-rh-2a",
+            "rid-rh-2a",
+            Some(token.to_string()),
+        );
+        let poller = MailboxPoller::new();
+        poller
+            .process_message(&app, &first_path, false)
+            .await
+            .expect("first raise-hand should succeed");
+        let (second_path, _second_msg) = build_raise_hand_message(
+            &fixture.sender_cwd,
+            "msg-rh-2b",
+            "rid-rh-2b",
+            Some(token.to_string()),
+        );
+        poller
+            .process_message(&app, &second_path, false)
+            .await
+            .expect("second raise-hand should succeed");
+
+        let response = read_response_json(&fixture.sender_cwd, "rid-rh-2b").unwrap();
+        assert_eq!(response["raised"], true);
+        assert_eq!(response["status"], "already_visible");
+        assert_eq!(
+            events.lock().unwrap().len(),
+            1,
+            "idempotent raise-hand should not emit a duplicate change event"
+        );
+    }
+
+    #[tokio::test]
+    async fn raise_hand_process_message_without_visible_title_slot_returns_false() {
+        for (idx, task_contents) in [
+            (0, None),
+            (1, Some("body only\n")),
+            (2, Some("---\ntitle: \n---\n\nbody")),
+        ] {
+            let fixture = make_mailbox_fixture();
+            let app = app_handle(&fixture.app);
+            let (session_id, token) =
+                seed_raise_hand_session(&app, &fixture.sender_cwd, true, SessionStatus::Running)
+                    .await;
+            if let Some(contents) = task_contents {
+                let task_path = crate::session::session::find_workgroup_task_path_for_cwd(
+                    &fixture.sender_cwd.to_string_lossy(),
+                )
+                .unwrap();
+                std::fs::write(task_path, contents).unwrap();
+            }
+            let events = Arc::new(Mutex::new(Vec::<String>::new()));
+            let captured = Arc::clone(&events);
+            fixture
+                .app
+                .listen_any("session_communication_changed", move |event| {
+                    captured.lock().unwrap().push(event.payload().to_string());
+                });
+
+            let msg_id = format!("msg-rh-noslot-{idx}");
+            let rid = format!("rid-rh-noslot-{idx}");
+            let (path, _msg) = build_raise_hand_message(
+                &fixture.sender_cwd,
+                &msg_id,
+                &rid,
+                Some(token.to_string()),
+            );
+            let poller = MailboxPoller::new();
+            poller
+                .process_message(&app, &path, false)
+                .await
+                .expect("raise-hand no-slot message should be processed");
+
+            let response = read_response_json(&fixture.sender_cwd, &rid).unwrap();
+            assert_eq!(response["raised"], false);
+            assert_eq!(response["status"], "not_visible");
+            assert!(events.lock().unwrap().is_empty());
+            let mgr = {
+                let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+                let guard = session_mgr.read().await;
+                guard.clone()
+            };
+            assert!(mgr
+                .get_session(session_id)
+                .await
+                .unwrap()
+                .communication
+                .is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn raise_hand_process_message_non_coordinator_returns_false() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let (session_id, token) =
+            seed_raise_hand_session(&app, &fixture.sender_cwd, false, SessionStatus::Running).await;
+        write_raise_hand_task_title(&fixture.sender_cwd, "Build the feature");
+
+        let (path, _msg) = build_raise_hand_message(
+            &fixture.sender_cwd,
+            "msg-rh-noncoord",
+            "rid-rh-noncoord",
+            Some(token.to_string()),
+        );
+        let poller = MailboxPoller::new();
+        poller
+            .process_message(&app, &path, false)
+            .await
+            .expect("non-coordinator raise-hand should be processed");
+
+        let response = read_response_json(&fixture.sender_cwd, "rid-rh-noncoord").unwrap();
+        assert_eq!(response["raised"], false);
+        assert_eq!(response["status"], "not_visible");
+        let mgr = {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let guard = session_mgr.read().await;
+            guard.clone()
+        };
+        assert!(mgr
+            .get_session(session_id)
+            .await
+            .unwrap()
+            .communication
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn raise_hand_process_message_exited_coordinator_returns_false() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let (session_id, token) =
+            seed_raise_hand_session(&app, &fixture.sender_cwd, true, SessionStatus::Exited(0))
+                .await;
+        write_raise_hand_task_title(&fixture.sender_cwd, "Build the feature");
+
+        let (path, _msg) = build_raise_hand_message(
+            &fixture.sender_cwd,
+            "msg-rh-exited",
+            "rid-rh-exited",
+            Some(token.to_string()),
+        );
+        let poller = MailboxPoller::new();
+        poller
+            .process_message(&app, &path, false)
+            .await
+            .expect("exited coordinator raise-hand should be processed");
+
+        let response = read_response_json(&fixture.sender_cwd, "rid-rh-exited").unwrap();
+        assert_eq!(response["raised"], false);
+        assert_eq!(response["status"], "not_visible");
+        let mgr = {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let guard = session_mgr.read().await;
+            guard.clone()
+        };
+        assert!(mgr
+            .get_session(session_id)
+            .await
+            .unwrap()
+            .communication
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn raise_hand_process_message_bad_tokens_are_rejected_not_false() {
+        for (idx, token) in [
+            (0, "not-a-uuid".to_string()),
+            (1, Uuid::new_v4().to_string()),
+        ] {
+            let fixture = make_mailbox_fixture();
+            let app = app_handle(&fixture.app);
+            write_raise_hand_task_title(&fixture.sender_cwd, "Build the feature");
+            let msg_id = format!("msg-rh-bad-token-{idx}");
+            let rid = format!("rid-rh-bad-token-{idx}");
+            let (path, _msg) =
+                build_raise_hand_message(&fixture.sender_cwd, &msg_id, &rid, Some(token));
+            let poller = MailboxPoller::new();
+            poller
+                .process_message(&app, &path, false)
+                .await
+                .expect("bad-token raise-hand should reject cleanly");
+
+            assert!(
+                read_reject_reason(&fixture.sender_cwd, &msg_id).is_some(),
+                "bad token should write a rejection reason"
+            );
+            assert!(
+                read_response_json(&fixture.sender_cwd, &rid).is_none(),
+                "bad token must not be converted into a false response"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -4,7 +4,10 @@ use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use super::profile::CodingAgentKind;
-use super::session::{Session, SessionInfo, SessionRepo, SessionStatus};
+use super::session::{
+    Session, SessionCommunication, SessionCommunicationKind, SessionInfo, SessionRepo,
+    SessionStatus,
+};
 use crate::config::settings::WindowGeometry;
 use crate::errors::AppError;
 
@@ -61,6 +64,7 @@ impl SessionManager {
             working_directory,
             status: SessionStatus::Running,
             waiting_for_input: false,
+            communication: None,
             pending_review: false,
             last_prompt: None,
             agent_id,
@@ -290,7 +294,9 @@ impl SessionManager {
                 // is_coordinator || agent_id guard above is the real scope gate.
                 // `s.id` is already a Uuid (Copy), so no parse is needed.
                 let fqn = crate::config::teams::agent_fqn_from_path(&s.working_directory);
-                let team_key = fqn.rsplit_once('/').map(|(team, _agent)| team.to_string())?;
+                let team_key = fqn
+                    .rsplit_once('/')
+                    .map(|(team, _agent)| team.to_string())?;
                 Some((s.id, team_key))
             })
             .collect()
@@ -341,7 +347,7 @@ impl SessionManager {
         out
     }
 
-    pub async fn mark_exited(&self, id: Uuid, code: i32) {
+    pub async fn mark_exited(&self, id: Uuid, code: i32) -> bool {
         let mut sessions = self.sessions.write().await;
         if let Some(s) = sessions.get_mut(&id) {
             log::info!(
@@ -351,8 +357,16 @@ impl SessionManager {
                 s.status,
                 code
             );
+            let cleared_raise_hand = s.communication.as_ref().is_some_and(|communication| {
+                communication.kind == SessionCommunicationKind::RaiseHand && communication.visible
+            });
+            if cleared_raise_hand {
+                s.communication = None;
+            }
             s.status = SessionStatus::Exited(code);
+            return cleared_raise_hand;
         }
+        false
     }
 
     /// Clear the active session if it matches the given ID.
@@ -414,6 +428,51 @@ impl SessionManager {
         if let Some(s) = sessions.get_mut(&id) {
             s.last_prompt = Some(prompt);
         }
+    }
+
+    pub async fn raise_hand(
+        &self,
+        id: Uuid,
+        updated_at: chrono::DateTime<chrono::Utc>,
+    ) -> Option<(bool, SessionCommunication)> {
+        let mut sessions = self.sessions.write().await;
+        let session = sessions.get_mut(&id)?;
+        if !session.is_coordinator || matches!(session.status, SessionStatus::Exited(_)) {
+            return None;
+        }
+
+        if let Some(existing) = session.communication.as_ref() {
+            if existing.kind == SessionCommunicationKind::RaiseHand && existing.visible {
+                return Some((false, existing.clone()));
+            }
+        }
+
+        let communication = SessionCommunication {
+            kind: SessionCommunicationKind::RaiseHand,
+            visible: true,
+            updated_at: updated_at.to_rfc3339(),
+        };
+        session.communication = Some(communication.clone());
+        Some((true, communication))
+    }
+
+    pub async fn clear_communication_if_kind(
+        &self,
+        id: Uuid,
+        kind: SessionCommunicationKind,
+    ) -> bool {
+        let mut sessions = self.sessions.write().await;
+        let Some(session) = sessions.get_mut(&id) else {
+            return false;
+        };
+        let should_clear = session
+            .communication
+            .as_ref()
+            .is_some_and(|communication| communication.kind == kind && communication.visible);
+        if should_clear {
+            session.communication = None;
+        }
+        should_clear
     }
 
     /// (#630/#631) Stamp the durable resume intent. Used by the restart path and
@@ -743,6 +802,218 @@ mod tests {
             !mgr.clear_start_fresh_on_restore_if_set(Uuid::new_v4())
                 .await
         );
+    }
+
+    #[tokio::test]
+    async fn raise_hand_coordinator_running_session_stores_communication() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                true,
+            )
+            .await
+            .expect("create_session should succeed");
+        let now = chrono::DateTime::parse_from_rfc3339("2026-06-28T17:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        let raised = mgr.raise_hand(session.id, now).await;
+
+        let Some((changed, communication)) = raised else {
+            panic!("coordinator should accept raise-hand");
+        };
+        assert!(changed);
+        assert_eq!(communication.kind, SessionCommunicationKind::RaiseHand);
+        assert!(communication.visible);
+        assert_eq!(communication.updated_at, now.to_rfc3339());
+        let stored = mgr.get_session(session.id).await.unwrap();
+        assert_eq!(stored.communication, Some(communication.clone()));
+        let infos = mgr.list_sessions().await;
+        assert_eq!(infos[0].communication, Some(communication));
+    }
+
+    #[tokio::test]
+    async fn raise_hand_second_request_returns_existing_without_mutation() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                true,
+            )
+            .await
+            .expect("create_session should succeed");
+        let first = chrono::DateTime::parse_from_rfc3339("2026-06-28T17:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let second = chrono::DateTime::parse_from_rfc3339("2026-06-28T18:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        let (_, first_comm) = mgr.raise_hand(session.id, first).await.unwrap();
+        let second_result = mgr.raise_hand(session.id, second).await;
+
+        assert_eq!(second_result, Some((false, first_comm.clone())));
+        let stored = mgr.get_session(session.id).await.unwrap();
+        assert_eq!(stored.communication, Some(first_comm));
+    }
+
+    #[tokio::test]
+    async fn raise_hand_non_coordinator_returns_none() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+            )
+            .await
+            .expect("create_session should succeed");
+
+        assert!(mgr
+            .raise_hand(session.id, chrono::Utc::now())
+            .await
+            .is_none());
+        assert!(mgr
+            .get_session(session.id)
+            .await
+            .unwrap()
+            .communication
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn raise_hand_exited_coordinator_returns_none() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                true,
+            )
+            .await
+            .expect("create_session should succeed");
+        assert!(!mgr.mark_exited(session.id, 0).await);
+
+        assert!(mgr
+            .raise_hand(session.id, chrono::Utc::now())
+            .await
+            .is_none());
+        assert!(mgr
+            .get_session(session.id)
+            .await
+            .unwrap()
+            .communication
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn raise_hand_clear_removes_visible_raise_hand_once() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                true,
+            )
+            .await
+            .expect("create_session should succeed");
+        mgr.raise_hand(session.id, chrono::Utc::now())
+            .await
+            .unwrap();
+
+        assert!(
+            mgr.clear_communication_if_kind(session.id, SessionCommunicationKind::RaiseHand)
+                .await
+        );
+        assert!(mgr
+            .get_session(session.id)
+            .await
+            .unwrap()
+            .communication
+            .is_none());
+        assert!(
+            !mgr.clear_communication_if_kind(session.id, SessionCommunicationKind::RaiseHand)
+                .await
+        );
+        assert!(
+            !mgr.clear_communication_if_kind(Uuid::new_v4(), SessionCommunicationKind::RaiseHand)
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn raise_hand_mark_exited_clears_visible_state() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                true,
+            )
+            .await
+            .expect("create_session should succeed");
+        mgr.raise_hand(session.id, chrono::Utc::now())
+            .await
+            .unwrap();
+
+        assert!(mgr.mark_exited(session.id, 7).await);
+        let stored = mgr.get_session(session.id).await.unwrap();
+        assert!(matches!(stored.status, SessionStatus::Exited(7)));
+        assert!(stored.communication.is_none());
+        let infos = mgr.list_sessions().await;
+        assert!(infos[0].communication.is_none());
+    }
+
+    #[tokio::test]
+    async fn raise_hand_mark_exited_returns_false_without_visible_state() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                true,
+            )
+            .await
+            .expect("create_session should succeed");
+
+        assert!(!mgr.mark_exited(session.id, 0).await);
+        assert!(mgr
+            .get_session(session.id)
+            .await
+            .unwrap()
+            .communication
+            .is_none());
     }
 
     #[tokio::test]
@@ -1090,7 +1361,15 @@ mod tests {
     async fn agent_team_members_includes_agent_owned_excludes_adhoc() {
         let mgr = SessionManager::new();
         let coord = mgr
-            .create_session("claude".into(), vec![], COORD_CWD.into(), None, None, vec![], true)
+            .create_session(
+                "claude".into(),
+                vec![],
+                COORD_CWD.into(),
+                None,
+                None,
+                vec![],
+                true,
+            )
             .await
             .unwrap();
         // agent_id set, not a coordinator -> still agent-owned.
@@ -1132,7 +1411,15 @@ mod tests {
     async fn coordinator_refs_by_team_maps_team_to_coordinator() {
         let mgr = SessionManager::new();
         let coord = mgr
-            .create_session("claude".into(), vec![], COORD_CWD.into(), None, None, vec![], true)
+            .create_session(
+                "claude".into(),
+                vec![],
+                COORD_CWD.into(),
+                None,
+                None,
+                vec![],
+                true,
+            )
             .await
             .unwrap();
         // A non-coordinator agent must NOT appear in the refs map.
@@ -1161,7 +1448,15 @@ mod tests {
     async fn coordinator_ids_by_team_maps_team_to_coordinator_id() {
         let mgr = SessionManager::new();
         let coord = mgr
-            .create_session("claude".into(), vec![], COORD_CWD.into(), None, None, vec![], true)
+            .create_session(
+                "claude".into(),
+                vec![],
+                COORD_CWD.into(),
+                None,
+                None,
+                vec![],
+                true,
+            )
             .await
             .unwrap();
         // A non-coordinator agent on the same team must NOT appear (only the coordinator).

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -42,6 +42,20 @@ pub struct SessionRepo {
     pub branch: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SessionCommunicationKind {
+    RaiseHand,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCommunication {
+    pub kind: SessionCommunicationKind,
+    pub visible: bool,
+    pub updated_at: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Session {
@@ -62,6 +76,8 @@ pub struct Session {
     pub working_directory: String,
     pub status: SessionStatus,
     pub waiting_for_input: bool,
+    #[serde(skip)]
+    pub communication: Option<SessionCommunication>,
     /// Frontend-only: true when agent finished but user hasn't focused yet
     #[serde(default)]
     pub pending_review: bool,
@@ -202,6 +218,8 @@ pub struct SessionInfo {
     pub working_directory: String,
     pub status: SessionStatus,
     pub waiting_for_input: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub communication: Option<SessionCommunication>,
     #[serde(default)]
     pub pending_review: bool,
     pub last_prompt: Option<String>,
@@ -270,6 +288,7 @@ impl From<&Session> for SessionInfo {
             working_directory: s.working_directory.clone(),
             status: s.status.clone(),
             waiting_for_input: s.waiting_for_input,
+            communication: s.communication.clone(),
             pending_review: false,
             last_prompt: s.last_prompt.clone(),
             agent_id: s.agent_id.clone(),
@@ -310,6 +329,7 @@ mod tests {
             working_directory: "C:\\tmp".to_string(),
             status: SessionStatus::Running,
             waiting_for_input: false,
+            communication: None,
             pending_review: false,
             last_prompt: None,
             agent_id: None,
@@ -361,6 +381,18 @@ mod tests {
         let s = sample_session(Some(Vec::new()));
         let info = SessionInfo::from(&s);
         assert_eq!(info.effective_shell_args, Some(Vec::new()));
+    }
+
+    #[test]
+    fn session_info_from_session_copies_communication() {
+        let mut s = sample_session(None);
+        s.communication = Some(SessionCommunication {
+            kind: SessionCommunicationKind::RaiseHand,
+            visible: true,
+            updated_at: "2026-06-28T17:00:00+00:00".to_string(),
+        });
+        let info = SessionInfo::from(&s);
+        assert_eq!(info.communication, s.communication);
     }
 
     #[test]

--- a/src-tauri/tests/cli_behavior_contract.rs
+++ b/src-tauri/tests/cli_behavior_contract.rs
@@ -168,6 +168,7 @@ fn root_help_lists_public_subcommands() {
         "create-agent",
         "create-agent-matrix",
         "close-session",
+        "raise-hand",
         "task-set-title",
         "task-append-body",
         "open-project",
@@ -274,6 +275,7 @@ fn public_subcommand_help_contracts() {
             &["close-session", "--help"],
             &["--token", "--root", "--target"],
         ),
+        (&["raise-hand", "--help"], &["--token", "--root", "OUTPUT"]),
         (
             &["task-set-title", "--help"],
             &["--token", "--root", "--title"],
@@ -353,6 +355,7 @@ fn token_gated_commands_missing_token_contracts() {
         &["send", "--to", "Project:wg-1/dev", "--root", &root_s],
         &["list-peers", "--root", &root_s],
         &["list-peers-lean", "--root", &root_s],
+        &["raise-hand", "--root", &root_s],
         &[
             "close-session",
             "--root",
@@ -413,6 +416,7 @@ fn token_gated_commands_invalid_token_redaction_contracts() {
             "--target",
             "Project:wg-1/dev",
         ],
+        &["raise-hand", "--token", LEAK_PROBE_TOKEN, "--root", &root_s],
         &[
             "task-set-title",
             "--token",
@@ -463,6 +467,7 @@ fn token_gated_commands_missing_root_contracts() {
     let cases: &[&[&str]] = &[
         &["list-peers", "--token", VALID_TOKEN],
         &["list-peers-lean", "--token", VALID_TOKEN],
+        &["raise-hand", "--token", VALID_TOKEN],
         &[
             "close-session",
             "--token",

--- a/src-tauri/tests/cli_raise_hand.rs
+++ b/src-tauri/tests/cli_raise_hand.rs
@@ -1,0 +1,475 @@
+//! Integration tests for the raise-hand CLI boolean stdout contract.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+#[cfg(not(target_os = "windows"))]
+use std::sync::mpsc;
+#[cfg(not(target_os = "windows"))]
+use std::time::{Duration, Instant};
+
+const VALID_TOKEN: &str = "11111111-1111-1111-1111-111111111111";
+
+struct Tmp(PathBuf);
+
+impl Drop for Tmp {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+impl Tmp {
+    fn new(prefix: &str) -> Self {
+        let path =
+            std::env::temp_dir().join(format!("ac-{}-{}", prefix, uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&path).expect("create tmp dir");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+fn copy_binary_into(tmp: &Path) -> PathBuf {
+    let src = Path::new(env!("CARGO_BIN_EXE_agentscommander-new"));
+    let dst = tmp.join(src.file_name().expect("binary file name"));
+    std::fs::copy(src, &dst).expect("copy binary");
+    dst
+}
+
+struct Fixture {
+    bin: PathBuf,
+    agent_root: PathBuf,
+}
+
+fn build_fixture(tmp: &Path) -> Fixture {
+    let bin = copy_binary_into(tmp);
+    let agent_root = tmp
+        .join("proj")
+        .join(".ac")
+        .join("wg-1-test")
+        .join("__agent_dev-rust");
+    std::fs::create_dir_all(&agent_root).expect("create agent dir");
+    Fixture { bin, agent_root }
+}
+
+#[cfg(target_os = "windows")]
+const WINDOWS_SIMULATOR_PS1: &str = r#"
+param(
+  [Parameter(Mandatory=$true)][string]$OutboxDir,
+  [Parameter(Mandatory=$true)][string]$ResponsesDir,
+  [Parameter(Mandatory=$true)][string]$ResponseBodyPath,
+  [Parameter(Mandatory=$true)][int]$TimeoutSec
+)
+
+$deadline = (Get-Date).AddSeconds($TimeoutSec)
+$lastReadinessError = $null
+
+while ((Get-Date) -lt $deadline) {
+  $messageFile = Get-ChildItem -LiteralPath $OutboxDir -Filter '*.json' -File -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTimeUtc, Name |
+    Select-Object -First 1
+
+  if ($null -ne $messageFile) {
+    $messagePath = $messageFile.FullName
+
+    try {
+      $messageBody = Get-Content -LiteralPath $messagePath -Raw -ErrorAction Stop
+      $message = $messageBody | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+      $lastReadinessError = "message visible but not parseable yet at ${messagePath}: $($_.Exception.Message)"
+      Start-Sleep -Milliseconds 50
+      continue
+    }
+
+    if (-not $message.id) {
+      $lastReadinessError = "message visible but missing id at ${messagePath}"
+      Start-Sleep -Milliseconds 50
+      continue
+    }
+    if (-not $message.requestId) {
+      $lastReadinessError = "message visible but missing requestId at ${messagePath}"
+      Start-Sleep -Milliseconds 50
+      continue
+    }
+
+    if ($message.action -ne 'raise-hand') {
+      Write-Error "contract violation: action was '$($message.action)'"
+      exit 13
+    }
+    if ($message.to -ne '') {
+      Write-Error "contract violation: to was '$($message.to)'"
+      exit 13
+    }
+    if ($message.mode -ne '') {
+      Write-Error "contract violation: mode was '$($message.mode)'"
+      exit 13
+    }
+    if ($message.getOutput -ne $false) {
+      Write-Error "contract violation: getOutput was '$($message.getOutput)'"
+      exit 13
+    }
+
+    $deliveredDir = Join-Path $OutboxDir 'delivered'
+    New-Item -ItemType Directory -Force -Path $deliveredDir | Out-Null
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText((Join-Path $deliveredDir "$($message.id).json"), $messageBody, $utf8NoBom)
+    Remove-Item -LiteralPath $messagePath -Force -ErrorAction SilentlyContinue
+
+    New-Item -ItemType Directory -Force -Path $ResponsesDir | Out-Null
+    $responseBody = Get-Content -LiteralPath $ResponseBodyPath -Raw -ErrorAction Stop
+    [System.IO.File]::WriteAllText((Join-Path $ResponsesDir "$($message.requestId).json"), $responseBody, $utf8NoBom)
+
+    Write-Output $message.id
+    exit 0
+  }
+
+  Start-Sleep -Milliseconds 50
+}
+
+if ($lastReadinessError) {
+  Write-Error "timeout waiting for ready CLI outbox message at $OutboxDir; last readiness error: $lastReadinessError"
+} else {
+  Write-Error "timeout waiting for CLI outbox write at $OutboxDir"
+}
+exit 12
+"#;
+
+#[cfg(target_os = "windows")]
+fn write_windows_simulator_script(tmp: &Path) -> PathBuf {
+    let script = tmp.join("raise-hand-simulator.ps1");
+    std::fs::write(&script, WINDOWS_SIMULATOR_PS1).expect("write simulator script");
+    script
+}
+
+struct SimulatorOutput {
+    stdout: String,
+    stderr: String,
+}
+
+#[cfg(target_os = "windows")]
+enum SimulatorHandle {
+    Process(std::process::Child),
+}
+
+#[cfg(not(target_os = "windows"))]
+enum SimulatorHandle {
+    Thread(mpsc::Receiver<Result<String, String>>),
+}
+
+impl SimulatorHandle {
+    fn wait(self) -> Result<SimulatorOutput, String> {
+        match self {
+            #[cfg(target_os = "windows")]
+            SimulatorHandle::Process(child) => {
+                let out = child
+                    .wait_with_output()
+                    .map_err(|e| format!("wait for simulator process: {}", e))?;
+                let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+                if !out.status.success() {
+                    return Err(format!(
+                        "simulator exited {:?}\nstdout: {}\nstderr: {}",
+                        out.status.code(),
+                        stdout,
+                        stderr
+                    ));
+                }
+                Ok(SimulatorOutput { stdout, stderr })
+            }
+            #[cfg(not(target_os = "windows"))]
+            SimulatorHandle::Thread(rx) => {
+                let msg_id = rx
+                    .recv_timeout(Duration::from_secs(25))
+                    .map_err(|e| format!("simulator thread did not finish: {}", e))?
+                    .map_err(|e| format!("simulator failed: {}", e))?;
+                Ok(SimulatorOutput {
+                    stdout: msg_id,
+                    stderr: String::new(),
+                })
+            }
+        }
+    }
+}
+
+fn spawn_daemon_simulator(
+    tmp: &Path,
+    outbox_dir: &Path,
+    responses_dir: &Path,
+    response_body: &str,
+) -> SimulatorHandle {
+    #[cfg(target_os = "windows")]
+    {
+        let response_body_path = tmp.join("raise-hand-response-body.json");
+        std::fs::write(&response_body_path, response_body).expect("write response body");
+        let script = write_windows_simulator_script(tmp);
+
+        let child = Command::new("powershell.exe")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                script.to_string_lossy().as_ref(),
+                "-OutboxDir",
+                outbox_dir.to_string_lossy().as_ref(),
+                "-ResponsesDir",
+                responses_dir.to_string_lossy().as_ref(),
+                "-ResponseBodyPath",
+                response_body_path.to_string_lossy().as_ref(),
+                "-TimeoutSec",
+                "20",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn PowerShell simulator");
+        SimulatorHandle::Process(child)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = tmp;
+        let outbox_for_thread = outbox_dir.to_path_buf();
+        let responses_for_thread = responses_dir.to_path_buf();
+        let response_owned = response_body.to_string();
+        let (tx, rx) = mpsc::channel::<Result<String, String>>();
+        std::thread::spawn(move || {
+            let result = simulate_daemon_response(
+                &outbox_for_thread,
+                &responses_for_thread,
+                &response_owned,
+                Duration::from_secs(20),
+            );
+            let _ = tx.send(result);
+        });
+        SimulatorHandle::Thread(rx)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn simulate_daemon_response(
+    outbox_dir: &Path,
+    responses_dir: &Path,
+    response_body: &str,
+    overall_timeout: Duration,
+) -> Result<String, String> {
+    let start = Instant::now();
+    let poll = Duration::from_millis(50);
+    let mut last_readiness_error = None::<String>;
+
+    let (msg_path, body, msg, msg_id, request_id) = loop {
+        if start.elapsed() >= overall_timeout {
+            return Err(match last_readiness_error {
+                Some(e) => format!(
+                    "timeout waiting for ready CLI outbox message at {:?}; last readiness error: {}",
+                    outbox_dir, e
+                ),
+                None => format!("timeout waiting for CLI outbox write at {:?}", outbox_dir),
+            });
+        }
+
+        let Some(path) = std::fs::read_dir(outbox_dir).ok().and_then(|rd| {
+            let mut files: Vec<_> = rd
+                .flatten()
+                .map(|entry| entry.path())
+                .filter(|p| p.is_file() && p.extension().and_then(|s| s.to_str()) == Some("json"))
+                .collect();
+            files.sort();
+            files.into_iter().next()
+        }) else {
+            std::thread::sleep(poll);
+            continue;
+        };
+
+        let body = match std::fs::read_to_string(&path) {
+            Ok(body) => body,
+            Err(e) => {
+                last_readiness_error = Some(format!(
+                    "message visible but not readable at {:?}: {}",
+                    path, e
+                ));
+                std::thread::sleep(poll);
+                continue;
+            }
+        };
+        let msg: serde_json::Value = match serde_json::from_str(&body) {
+            Ok(msg) => msg,
+            Err(e) => {
+                last_readiness_error = Some(format!(
+                    "message visible but not parseable at {:?}: {}",
+                    path, e
+                ));
+                std::thread::sleep(poll);
+                continue;
+            }
+        };
+        let Some(msg_id) = msg
+            .get("id")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        else {
+            last_readiness_error = Some(format!("message visible but missing id at {:?}", path));
+            std::thread::sleep(poll);
+            continue;
+        };
+        let Some(request_id) = msg
+            .get("requestId")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        else {
+            last_readiness_error = Some(format!(
+                "message visible but missing requestId at {:?}",
+                path
+            ));
+            std::thread::sleep(poll);
+            continue;
+        };
+
+        break (path, body, msg, msg_id.to_string(), request_id.to_string());
+    };
+
+    validate_raise_hand_message(&msg).map_err(|e| format!("contract violation: {}", e))?;
+
+    let delivered_dir = outbox_dir.join("delivered");
+    std::fs::create_dir_all(&delivered_dir).map_err(|e| e.to_string())?;
+    std::fs::write(delivered_dir.join(format!("{}.json", msg_id)), &body)
+        .map_err(|e| e.to_string())?;
+    let _ = std::fs::remove_file(&msg_path);
+
+    std::fs::create_dir_all(responses_dir).map_err(|e| e.to_string())?;
+    std::fs::write(
+        responses_dir.join(format!("{}.json", request_id)),
+        response_body,
+    )
+    .map_err(|e| e.to_string())?;
+
+    Ok(msg_id)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn validate_raise_hand_message(msg: &serde_json::Value) -> Result<(), String> {
+    let field = |name: &str| msg.get(name).ok_or_else(|| format!("missing {}", name));
+    if field("action")?.as_str() != Some("raise-hand") {
+        return Err(format!("action was {:?}", field("action")?));
+    }
+    if field("to")?.as_str() != Some("") {
+        return Err(format!("to was {:?}", field("to")?));
+    }
+    if field("mode")?.as_str() != Some("") {
+        return Err(format!("mode was {:?}", field("mode")?));
+    }
+    if field("body")?.as_str() != Some("") {
+        return Err(format!("body was {:?}", field("body")?));
+    }
+    if field("getOutput")?.as_bool() != Some(false) {
+        return Err(format!("getOutput was {:?}", field("getOutput")?));
+    }
+    if msg.get("requestId").and_then(|v| v.as_str()).is_none() {
+        return Err("missing requestId".to_string());
+    }
+    if msg.get("target").is_some() {
+        return Err(format!("target should be absent, got {:?}", msg["target"]));
+    }
+    Ok(())
+}
+
+fn run_raise_hand_with_simulator(
+    tmp: &Path,
+    fix: &Fixture,
+    response_body: &str,
+) -> (Option<i32>, String, String, String, String) {
+    let stem = fix.bin.file_stem().unwrap().to_string_lossy().to_string();
+    let ac_dir = fix.agent_root.join(format!(".{}", stem));
+    let outbox_dir = ac_dir.join("outbox");
+    let responses_dir = ac_dir.join("responses");
+    std::fs::create_dir_all(&outbox_dir).unwrap();
+
+    let simulator = spawn_daemon_simulator(tmp, &outbox_dir, &responses_dir, response_body);
+
+    let out = Command::new(&fix.bin)
+        .args([
+            "raise-hand",
+            "--token",
+            VALID_TOKEN,
+            "--root",
+            &fix.agent_root.to_string_lossy(),
+            "--timeout",
+            "5",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn binary");
+
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    let sim_output = simulator.wait().unwrap_or_else(|e| {
+        panic!(
+            "simulator failed: {}\nCLI exit code: {:?}\nCLI stdout: {}\nCLI stderr: {}",
+            e,
+            out.status.code(),
+            stdout,
+            stderr,
+        )
+    });
+
+    (
+        out.status.code(),
+        stdout,
+        stderr,
+        sim_output.stdout,
+        sim_output.stderr,
+    )
+}
+
+#[test]
+fn raise_hand_true_response_exits_zero_with_exact_stdout() {
+    let tmp = Tmp::new("raise-hand-true");
+    let fix = build_fixture(tmp.path());
+
+    let (code, stdout, stderr, sim_stdout, sim_stderr) =
+        run_raise_hand_with_simulator(tmp.path(), &fix, r#"{"raised":true}"#);
+
+    assert_eq!(
+        code,
+        Some(0),
+        "stdout: {stdout}\nstderr: {stderr}\nsim stdout: {sim_stdout}\nsim stderr: {sim_stderr}"
+    );
+    assert_eq!(stdout, "true\n");
+}
+
+#[test]
+fn raise_hand_false_response_exits_zero_with_exact_stdout() {
+    let tmp = Tmp::new("raise-hand-false");
+    let fix = build_fixture(tmp.path());
+
+    let (code, stdout, stderr, sim_stdout, sim_stderr) =
+        run_raise_hand_with_simulator(tmp.path(), &fix, r#"{"raised":false}"#);
+
+    assert_eq!(
+        code,
+        Some(0),
+        "stdout: {stdout}\nstderr: {stderr}\nsim stdout: {sim_stdout}\nsim stderr: {sim_stderr}"
+    );
+    assert_eq!(stdout, "false\n");
+}
+
+#[test]
+fn raise_hand_malformed_response_exits_two_without_boolean_stdout() {
+    let tmp = Tmp::new("raise-hand-malformed");
+    let fix = build_fixture(tmp.path());
+
+    let (code, stdout, stderr, sim_stdout, sim_stderr) =
+        run_raise_hand_with_simulator(tmp.path(), &fix, r#"{"status":"raised"}"#);
+
+    assert_eq!(
+        code,
+        Some(2),
+        "stdout: {stdout}\nstderr: {stderr}\nsim stdout: {sim_stdout}\nsim stderr: {sim_stderr}"
+    );
+    assert!(stdout.trim().is_empty(), "stdout: {stdout}");
+    assert!(stderr.contains("malformed"), "stderr: {stderr}");
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -4,6 +4,7 @@ import { TauriTransport } from "./transport-tauri";
 import { WsTransport } from "./transport-ws";
 import type {
   Session,
+  SessionCommunication,
   SessionRepo,
   PtyOutputEvent,
   AppSettings,
@@ -358,6 +359,15 @@ export function onSessionRenamed(
 ): Promise<UnlistenFn> {
   return transport.listen<{ id: string; name: string }>(
     "session_renamed",
+    callback
+  );
+}
+
+export function onSessionCommunicationChanged(
+  callback: (data: { sessionId: string; communication: SessionCommunication | null }) => void
+): Promise<UnlistenFn> {
+  return transport.listen<{ sessionId: string; communication: SessionCommunication | null }>(
+    "session_communication_changed",
     callback
   );
 }

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -179,6 +179,7 @@ export function session(overrides: Partial<Session> = {}): Session {
     workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
     status: "running",
     waitingForInput: false,
+    communication: null,
     pendingReview: false,
     lastPrompt: null,
     agentId: null,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4,6 +4,14 @@ export interface SessionRepo {
   branch: string | null;
 }
 
+export type SessionCommunicationKind = "raiseHand";
+
+export interface SessionCommunication {
+  kind: SessionCommunicationKind;
+  visible: boolean;
+  updatedAt: string;
+}
+
 export interface Session {
   id: string;
   name: string;
@@ -14,6 +22,7 @@ export interface Session {
   workingDirectory: string;
   status: SessionStatus;
   waitingForInput: boolean;
+  communication?: SessionCommunication | null;
   pendingReview: boolean;
   lastPrompt: string | null;
   agentId: string | null;

--- a/src/sidebar/App.raise-hand.workflow.test.tsx
+++ b/src/sidebar/App.raise-hand.workflow.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SidebarApp from "./App";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../shared/testing/ui-harness";
+import { sessionsStore } from "./stores/sessions";
+import type { Session } from "../shared/types";
+
+const projectPath = "C:\\Project";
+const wgName = "wg-2-dev-team";
+const replicaName = "dev-webpage-ui";
+const workgroupPath = `${projectPath}\\.ac\\${wgName}`;
+const replicaPath = `${workgroupPath}\\__agent_${replicaName}`;
+const sessionId = "coord-session";
+const updatedAt = "2026-06-28T17:00:00.000Z";
+const slotSelector =
+  `[data-ac-testid="replica.row.quick.${wgName}.${replicaName}.communicationSlot"]`;
+
+function coordSession(overrides: Partial<Session> = {}): Session {
+  return session({
+    id: sessionId,
+    name: `${wgName}/${replicaName}`,
+    workingDirectory: replicaPath,
+    status: "running",
+    isCoordinator: true,
+    communication: null,
+    ...overrides,
+  });
+}
+
+function setupRaiseHandTransport(fake: FakeTransport, sessions: Session[]): void {
+  fake.resolve(
+    "get_settings",
+    baseSettings({
+      projectPaths: [projectPath],
+      projectPath,
+    })
+  );
+  fake.resolve("get_update_status", null);
+  fake.resolve("open_project", {
+    path: projectPath,
+    registered: true,
+    created: false,
+  });
+  fake.resolve(
+    "discover_project",
+    discovery({
+      workgroups: [
+        {
+          name: wgName,
+          path: workgroupPath,
+          task: null,
+          taskTitle: "Raise event",
+          agents: [
+            {
+              name: replicaName,
+              path: replicaPath,
+              repoPaths: [],
+              isCoordinator: true,
+            },
+          ],
+        },
+      ],
+    })
+  );
+  fake.resolve("search_repos", []);
+  fake.resolve("list_sessions", sessions);
+  fake.resolve("get_active_session", null);
+  fake.resolve("list_detached_sessions", []);
+  fake.resolve("telegram_list_bridges", []);
+}
+
+describe("SidebarApp raise-hand communication workflow (#676)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("updates and clears the coordinator quick-access slot from backend events", async () => {
+    const fake = new FakeTransport();
+    setupRaiseHandTransport(fake, [coordSession()]);
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() => {
+        expect(fake.callsFor("list_sessions").length).toBeGreaterThan(0);
+        expect(sessionsStore.sessions.find((s) => s.id === sessionId)).toBeTruthy();
+      });
+      expect(rendered.root.querySelector(slotSelector)).toBeNull();
+
+      fake.emitFromBackend("session_communication_changed", {
+        sessionId,
+        communication: {
+          kind: "raiseHand",
+          visible: true,
+          updatedAt,
+        },
+      });
+
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).not.toBeNull());
+
+      fake.emitFromBackend("session_communication_changed", {
+        sessionId,
+        communication: null,
+      });
+
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).toBeNull());
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("renders a hydrated raise-hand slot from the initial list_sessions snapshot", async () => {
+    const fake = new FakeTransport();
+    setupRaiseHandTransport(fake, [
+      coordSession({
+        communication: {
+          kind: "raiseHand",
+          visible: true,
+          updatedAt,
+        },
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).not.toBeNull());
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -12,6 +12,7 @@ import {
   onSessionDestroyed,
   onSessionSwitched,
   onSessionRenamed,
+  onSessionCommunicationChanged,
   onSessionIdle,
   onSessionBusy,
   onSessionGitRepos,
@@ -282,6 +283,12 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       const allRepos = await ReposAPI.search("");
       sessionsStore.setRepos(allRepos.filter((r) => r.agents.length > 0));
     } catch {}
+
+    unlisteners.push(
+      await onSessionCommunicationChanged(({ sessionId, communication }) => {
+        sessionsStore.setCommunication(sessionId, communication);
+      })
+    );
 
     // Load initial sessions
     const sessions = await SessionAPI.list();

--- a/src/sidebar/components/ProjectPanel.raise-hand.test.tsx
+++ b/src/sidebar/components/ProjectPanel.raise-hand.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
+import { settingsStore } from "../../shared/stores/settings";
+import type { AcAgentReplica, AcWorkgroup, Session } from "../../shared/types";
+
+const projectPath = "C:\\Project";
+const updatedAt = "2026-06-28T17:00:00.000Z";
+
+function wgPath(wgName: string): string {
+  return `${projectPath}\\.ac\\${wgName}`;
+}
+
+function replicaPath(wgName: string, replicaName: string): string {
+  return `${wgPath(wgName)}\\__agent_${replicaName}`;
+}
+
+function rowSlotTestId(wgName: string, replicaName: string): string {
+  return `replica.row.quick.${wgName}.${replicaName}.communicationSlot`;
+}
+
+function replica(wgName: string, replicaName: string, isCoordinator = true): AcAgentReplica {
+  return {
+    name: replicaName,
+    path: replicaPath(wgName, replicaName),
+    repoPaths: [],
+    isCoordinator,
+  };
+}
+
+function workgroup(
+  wgName: string,
+  replicaName: string,
+  taskTitle: string | null,
+  isCoordinator = true
+): AcWorkgroup {
+  return {
+    name: wgName,
+    path: wgPath(wgName),
+    task: null,
+    taskTitle,
+    agents: [replica(wgName, replicaName, isCoordinator)],
+  };
+}
+
+function coordSession(
+  wgName: string,
+  replicaName: string,
+  overrides: Partial<Session> = {}
+): Session {
+  return session({
+    id: `${wgName}-${replicaName}`,
+    name: `${wgName}/${replicaName}`,
+    workingDirectory: replicaPath(wgName, replicaName),
+    isCoordinator: true,
+    status: "running",
+    communication: {
+      kind: "raiseHand",
+      visible: true,
+      updatedAt,
+    },
+    ...overrides,
+  });
+}
+
+async function mountProject(workgroups: AcWorkgroup[], sessions: Session[]) {
+  const fake = new FakeTransport();
+  fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+  fake.resolve("get_settings", baseSettings());
+  fake.resolve("discover_project", discovery({ workgroups }));
+  sessionsStore.setSessions(sessions);
+  const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+  await settingsStore.load();
+  await projectStore.createAndLoad(projectPath);
+  await waitFor(() => expect(rendered.root.querySelector(".replica-item")).not.toBeNull());
+  return rendered;
+}
+
+describe("ProjectPanel raise-hand communication slot (#676)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("renders the slot only on the matching coordinator task-title row", async () => {
+    const rendered = await mountProject(
+      [
+        workgroup("wg-1-dev-team", "architect", "First task"),
+        workgroup("wg-2-dev-team", "dev-webpage-ui", "Second task"),
+      ],
+      [
+        coordSession("wg-1-dev-team", "architect", { communication: null }),
+        coordSession("wg-2-dev-team", "dev-webpage-ui"),
+      ]
+    );
+
+    try {
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector(`[data-ac-testid="${rowSlotTestId("wg-2-dev-team", "dev-webpage-ui")}"]`)
+        ).not.toBeNull();
+      });
+
+      expect(rendered.root.querySelectorAll(".coord-communication-slot")).toHaveLength(1);
+      expect(
+        rendered.root.querySelector(`[data-ac-testid="${rowSlotTestId("wg-1-dev-team", "architect")}"]`)
+      ).toBeNull();
+
+      const slot = rendered.root.querySelector(
+        `[data-ac-testid="${rowSlotTestId("wg-2-dev-team", "dev-webpage-ui")}"]`
+      );
+      const line = slot?.closest(".coord-task-line");
+      expect(line?.querySelector(".coord-task-title")?.textContent).toBe("Second task");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("does not render for null clears, hidden communication, or missing task titles", async () => {
+    const wgName = "wg-2-dev-team";
+    const replicaName = "dev-webpage-ui";
+    const slotSelector = `[data-ac-testid="${rowSlotTestId(wgName, replicaName)}"]`;
+    const rendered = await mountProject(
+      [workgroup(wgName, replicaName, "Raise task")],
+      [coordSession(wgName, replicaName, { communication: null })]
+    );
+
+    try {
+      expect(rendered.root.querySelector(slotSelector)).toBeNull();
+
+      sessionsStore.setCommunication(`${wgName}-${replicaName}`, {
+        kind: "raiseHand",
+        visible: false,
+        updatedAt,
+      });
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).toBeNull());
+
+      sessionsStore.setCommunication(`${wgName}-${replicaName}`, {
+        kind: "raiseHand",
+        visible: true,
+        updatedAt,
+      });
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).not.toBeNull());
+
+      sessionsStore.setCommunication(`${wgName}-${replicaName}`, null);
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).toBeNull());
+
+      sessionsStore.setCommunication(`${wgName}-${replicaName}`, {
+        kind: "raiseHand",
+        visible: true,
+        updatedAt,
+      });
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).not.toBeNull());
+
+      projectStore.updateWorkgroupTask(wgPath(wgName), null, null);
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).toBeNull());
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("does not render for non-coordinator rows or stale exited-session communication", async () => {
+    const nonCoord = await mountProject(
+      [workgroup("wg-3-dev-team", "worker", "Worker task", false)],
+      [
+        coordSession("wg-3-dev-team", "worker", {
+          isCoordinator: false,
+        }),
+      ]
+    );
+    try {
+      expect(nonCoord.root.querySelector(".coord-communication-slot")).toBeNull();
+    } finally {
+      nonCoord.cleanup();
+    }
+
+    resetUiStoresForTests();
+
+    const exited = await mountProject(
+      [workgroup("wg-4-dev-team", "dev-webpage-ui", "Exited task")],
+      [
+        coordSession("wg-4-dev-team", "dev-webpage-ui", {
+          status: { exited: 0 },
+        }),
+      ]
+    );
+    try {
+      expect(exited.root.querySelector(".coord-communication-slot")).toBeNull();
+    } finally {
+      exited.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1236,6 +1236,14 @@ const ProjectPanel: Component = () => {
           const dotClass = () => replicaDotClass(wg, replica);
           const isCoord = () => replica.isCoordinator;
           const session = () => replicaSession(wg, replica);
+          const communication = createMemo(() => session()?.communication ?? null);
+          const showRaiseHand = createMemo(() =>
+            isCoord() &&
+            isSessionLive(session()) &&
+            !!taskTitle &&
+            communication()?.kind === "raiseHand" &&
+            communication()?.visible === true
+          );
           const repoBadges = createMemo(() => {
             const s = session();
             return s && s.gitRepos.length > 0
@@ -1302,6 +1310,7 @@ const ProjectPanel: Component = () => {
               : "");
           const rowTestId = () =>
             `replica.row.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}`;
+          const communicationSlotTestId = () => `${rowTestId()}.communicationSlot`;
           const badgesTestId = () =>
             `replica.badges.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}`;
           const repoBadgeTestId = (label: string, index: number) =>
@@ -1422,7 +1431,20 @@ const ProjectPanel: Component = () => {
               <div class={`session-item-status ${dotClass()}`} />
               <div class="replica-item-info">
                 <Show when={taskTitle}>
-                  <span class="coord-task-title" title={taskTitle ?? undefined}>{taskTitle}</span>
+                  <div class="coord-task-line">
+                    <span class="coord-task-title" title={taskTitle ?? undefined}>{taskTitle}</span>
+                    <Show when={showRaiseHand()}>
+                      <span
+                        class="coord-communication-slot"
+                        data-kind="raiseHand"
+                        data-ac-testid={communicationSlotTestId()}
+                        title="Raised hand"
+                        aria-label="Raised hand"
+                      >
+                        <span class="coord-communication-icon" aria-hidden="true">!</span>
+                      </span>
+                    </Show>
+                  </div>
                 </Show>
                 <span class="replica-item-name">{replica.originProject ? `${replica.name}@${replica.originProject}` : replica.name}</span>
                 <div class="ac-discovery-badges" data-ac-testid={badgesTestId()}>

--- a/src/sidebar/stores/sessions.test.ts
+++ b/src/sidebar/stores/sessions.test.ts
@@ -36,3 +36,74 @@ describe("sessionsStore.setProfileOutdated (#592)", () => {
     expect(sessionsStore.sessions.find((s) => s.id === "s2")?.profileOutdated).toBe(true);
   });
 });
+
+describe("sessionsStore.setCommunication (#676)", () => {
+  beforeEach(() => {
+    sessionsStore.setSessions([]);
+  });
+  afterEach(() => {
+    sessionsStore.setSessions([]);
+  });
+
+  it("sets and clears communication on the targeted session", () => {
+    sessionsStore.setSessions([
+      session({ id: "s1", communication: null }),
+      session({ id: "s2", communication: null }),
+    ]);
+
+    sessionsStore.setCommunication("s2", {
+      kind: "raiseHand",
+      visible: true,
+      updatedAt: "2026-06-28T17:00:00.000Z",
+    });
+
+    expect(sessionsStore.sessions.find((s) => s.id === "s1")?.communication).toBeNull();
+    expect(sessionsStore.sessions.find((s) => s.id === "s2")?.communication).toEqual({
+      kind: "raiseHand",
+      visible: true,
+      updatedAt: "2026-06-28T17:00:00.000Z",
+    });
+
+    sessionsStore.setCommunication("s2", null);
+
+    expect(sessionsStore.sessions.find((s) => s.id === "s2")?.communication).toBeNull();
+  });
+
+  it("preserves frontend-only fields while patching communication", () => {
+    sessionsStore.setSessions([
+      session({
+        id: "s1",
+        communication: null,
+        pendingReview: true,
+        profileOutdated: true,
+      }),
+    ]);
+
+    sessionsStore.setCommunication("s1", {
+      kind: "raiseHand",
+      visible: true,
+      updatedAt: "2026-06-28T17:00:00.000Z",
+    });
+
+    const updated = sessionsStore.sessions.find((s) => s.id === "s1");
+    expect(updated?.communication?.kind).toBe("raiseHand");
+    expect(updated?.pendingReview).toBe(true);
+    expect(updated?.profileOutdated).toBe(true);
+  });
+
+  it("ignores an unknown session id", () => {
+    sessionsStore.setSessions([
+      session({ id: "s1", communication: null }),
+    ]);
+
+    sessionsStore.setCommunication("missing", {
+      kind: "raiseHand",
+      visible: true,
+      updatedAt: "2026-06-28T17:00:00.000Z",
+    });
+
+    expect(sessionsStore.sessions).toEqual([
+      expect.objectContaining({ id: "s1", communication: null }),
+    ]);
+  });
+});

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -1,7 +1,7 @@
 import { createMemo, createSignal } from "solid-js";
 import { createStore } from "solid-js/store";
 import { NO_TEAM } from "../../shared/constants";
-import type { RepoMatch, Session, SessionRepo, SessionsState, Team, TeamSessionGroup } from "../../shared/types";
+import type { RepoMatch, Session, SessionCommunication, SessionRepo, SessionsState, Team, TeamSessionGroup } from "../../shared/types";
 import { projectStore } from "./project";
 import { SettingsAPI } from "../../shared/ipc";
 import { settingsStore } from "../../shared/stores/settings";
@@ -348,6 +348,10 @@ export const sessionsStore = {
     if (!waiting) {
       setState("sessions", (s) => s.id === id, "pendingReview", false);
     }
+  },
+
+  setCommunication(sessionId: string, communication: SessionCommunication | null) {
+    setState("sessions", (s) => s.id === sessionId, "communication", communication);
   },
 
   setGitRepos(sessionId: string, repos: SessionRepo[]) {

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -4160,6 +4160,39 @@ html.light-theme .settings-hint-warning {
   text-overflow: ellipsis;
 }
 
+.coord-task-line {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  width: 100%;
+  max-width: 100%;
+}
+
+.coord-task-line .coord-task-title {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.coord-communication-slot {
+  flex: 0 0 auto;
+  width: 15px;
+  height: 15px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  background: rgba(234, 179, 8, 0.18);
+  color: #eab308;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.coord-communication-icon {
+  transform: translateY(-0.5px);
+}
+
 .coord-quick-access .replica-item-info .coord-task-title {
   /* Title is the primary identifier on a Coordinator card. */
   font-weight: 700;


### PR DESCRIPTION
## Summary
- Add a `raise-hand` CLI command for agent sessions.
- Add runtime-only per-session communication state and mailbox handling for raised-hand visibility.
- Show the indicator in the Sidebar coordinator task-title row and clear it on real user PTY input or session exit.

## Validation
- `npx vitest run src/sidebar/components/ProjectPanel.raise-hand.test.tsx src/sidebar/App.raise-hand.workflow.test.tsx src/sidebar/stores/sessions.test.ts` passed, 10 tests.
- `npm run typecheck` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml raise_hand` passed, 18 unit tests plus 3 CLI integration tests.
- `cargo test --manifest-path src-tauri/Cargo.toml --test cli_behavior_contract` passed, 12 tests.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` passed.
- Grinch review: PASS / NO_BLOCKING_FINDINGS.
- Shipper deployed `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-11.exe` from SHA `7b1552174576d5b35c83a6e558946195924ceea0`; deployed exe `--help` succeeded.
- User requested landing to main after deployment.

Closes #676