### PR TITLE
fix: replay native terminal snapshots by PTY watermark

### DIFF
--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -5,6 +5,15 @@ use uuid::Uuid;
 use crate::pty::manager::PtyManager;
 use crate::voice::tracker::VoiceTrackingState;
 
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PtyScreenSnapshotPayload {
+    pub session_id: String,
+    pub data: Vec<u8>,
+    pub rows: Option<u16>,
+    pub cols: Option<u16>,
+}
+
 #[tauri::command]
 pub async fn pty_write(
     app: AppHandle,
@@ -129,4 +138,38 @@ pub fn pty_resize(
         .unwrap()
         .resize(uuid, cols, rows)
         .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_screen_snapshot(
+    pty_mgr: State<'_, Arc<Mutex<PtyManager>>>,
+    session_id: String,
+) -> Result<Option<PtyScreenSnapshotPayload>, String> {
+    let uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+
+    let (snapshot, size) = {
+        let pty_mgr = pty_mgr
+            .lock()
+            .map_err(|_| "PtyManager lock poisoned".to_string())?;
+        (
+            pty_mgr.get_screen_snapshot(uuid),
+            pty_mgr.get_pty_size(uuid),
+        )
+    };
+
+    let Some(data) = snapshot else {
+        return Ok(None);
+    };
+
+    let (rows, cols) = match size {
+        Some((rows, cols)) => (Some(rows), Some(cols)),
+        None => (None, None),
+    };
+
+    Ok(Some(PtyScreenSnapshotPayload {
+        session_id,
+        data,
+        rows,
+        cols,
+    }))
 }

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -12,6 +12,7 @@ pub struct PtyScreenSnapshotPayload {
     pub data: Vec<u8>,
     pub rows: Option<u16>,
     pub cols: Option<u16>,
+    pub sequence: u64,
 }
 
 #[tauri::command]
@@ -147,29 +148,22 @@ pub fn get_screen_snapshot(
 ) -> Result<Option<PtyScreenSnapshotPayload>, String> {
     let uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
 
-    let (snapshot, size) = {
+    let snapshot = {
         let pty_mgr = pty_mgr
             .lock()
             .map_err(|_| "PtyManager lock poisoned".to_string())?;
-        (
-            pty_mgr.get_screen_snapshot(uuid),
-            pty_mgr.get_pty_size(uuid),
-        )
+        pty_mgr.get_screen_snapshot(uuid)
     };
 
-    let Some(data) = snapshot else {
+    let Some(snapshot) = snapshot else {
         return Ok(None);
-    };
-
-    let (rows, cols) = match size {
-        Some((rows, cols)) => (Some(rows), Some(cols)),
-        None => (None, None),
     };
 
     Ok(Some(PtyScreenSnapshotPayload {
         session_id,
-        data,
-        rows,
-        cols,
+        data: snapshot.data,
+        rows: Some(snapshot.rows),
+        cols: Some(snapshot.cols),
+        sequence: snapshot.sequence,
     }))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1812,6 +1812,7 @@ pub fn run(
             commands::task::task_clean_at,
                         commands::pty::pty_write,
             commands::pty::pty_resize,
+            commands::pty::get_screen_snapshot,
             commands::config::get_settings,
             commands::config::update_settings,
             commands::resource_monitor::get_resource_snapshot,

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -180,8 +180,20 @@ pub struct PtyManager {
     pub response_watchers: ResponseWatcherMap,
     /// Optional WS broadcaster for remote access
     ws_broadcaster: Option<crate::web::broadcast::WsBroadcaster>,
-    /// VT100 screen state per session for replay to late-joining WS clients
-    screen_parsers: Arc<Mutex<HashMap<Uuid, vt100::Parser>>>,
+    /// VT100 screen state and native output watermark per session.
+    screen_parsers: Arc<Mutex<HashMap<Uuid, ScreenReplayState>>>,
+}
+
+pub struct PtyScreenSnapshot {
+    pub data: Vec<u8>,
+    pub rows: u16,
+    pub cols: u16,
+    pub sequence: u64,
+}
+
+struct ScreenReplayState {
+    parser: vt100::Parser,
+    output_sequence: u64,
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -189,6 +201,8 @@ pub struct PtyManager {
 struct PtyOutputPayload {
     session_id: String,
     data: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sequence: Option<u64>,
 }
 
 /// Strip ANSI escape sequences so that marker detection is not fooled
@@ -446,10 +460,13 @@ impl PtyManager {
         // evaluated by the watcher. Must run before the read loop starts.
         self.idle_detector.register_session(id, idle_tuning);
 
-        // Initialize vt100 screen parser for this session (for WS replay)
+        // Initialize vt100 screen parser and output watermark for replay.
         {
-            let parser = vt100::Parser::new(rows, cols, 0);
-            self.screen_parsers.lock().unwrap().insert(id, parser);
+            let replay = ScreenReplayState {
+                parser: vt100::Parser::new(rows, cols, 0),
+                output_sequence: 0,
+            };
+            self.screen_parsers.lock().unwrap().insert(id, replay);
         }
 
         // Spawn read loop that emits PTY output to the frontend,
@@ -521,14 +538,21 @@ impl PtyManager {
                             }
                         }
 
-                        // Feed vt100 screen parser for WS replay
-                        if let Ok(mut parsers) = screen_parsers.lock() {
-                            if let Some(parser) = parsers.get_mut(&id) {
-                                parser.process(&data);
+                        // Feed vt100 screen parser and assign the event watermark.
+                        let sequence = if let Ok(mut parsers) = screen_parsers.lock() {
+                            if let Some(state) = parsers.get_mut(&id) {
+                                state.parser.process(&data);
+                                state.output_sequence = state.output_sequence.saturating_add(1);
+                                Some(state.output_sequence)
+                            } else {
+                                None
                             }
-                        }
+                        } else {
+                            None
+                        };
 
-                        // Broadcast to WebSocket clients (non-blocking)
+                        // Broadcast to WebSocket clients (non-blocking).
+                        // Keep the binary WS frame unchanged: UUID prefix + raw bytes.
                         if let Some(ref bc) = ws_broadcaster {
                             bc.broadcast_pty_output(&session_id_str, &data);
                         }
@@ -536,6 +560,7 @@ impl PtyManager {
                         let payload = PtyOutputPayload {
                             session_id: session_id_str.clone(),
                             data,
+                            sequence,
                         };
                         let _ = app_handle.emit("pty_output", payload);
                     }
@@ -596,10 +621,10 @@ impl PtyManager {
             })
             .map_err(|e| AppError::PtyError(e.to_string()))?;
 
-        // Keep the vt100 screen parser in sync so snapshots match the new size
+        // Keep the vt100 screen parser in sync so snapshots match the new size.
         if let Ok(mut parsers) = self.screen_parsers.lock() {
-            if let Some(parser) = parsers.get_mut(&id) {
-                parser.set_size(rows, cols);
+            if let Some(state) = parsers.get_mut(&id) {
+                state.parser.set_size(rows, cols);
             }
         }
 
@@ -736,20 +761,26 @@ impl PtyManager {
         (terminated, jobless)
     }
 
-    /// Get a screen snapshot for replay to late-joining WS clients.
-    /// Returns the visible screen content as raw bytes that can be written to xterm.js.
-    pub fn get_screen_snapshot(&self, id: Uuid) -> Option<Vec<u8>> {
+    /// Get a screen snapshot for replay to late-joining clients.
+    /// The returned sequence is the latest PTY output sequence included in data.
+    pub fn get_screen_snapshot(&self, id: Uuid) -> Option<PtyScreenSnapshot> {
         let parsers = self.screen_parsers.lock().ok()?;
-        let parser = parsers.get(&id)?;
-        let screen = parser.screen();
-        Some(screen.contents_formatted())
+        let state = parsers.get(&id)?;
+        let screen = state.parser.screen();
+        let (rows, cols) = screen.size();
+        Some(PtyScreenSnapshot {
+            data: screen.contents_formatted(),
+            rows,
+            cols,
+            sequence: state.output_sequence,
+        })
     }
 
     /// Get the current PTY dimensions (rows, cols) from the vt100 parser.
     pub fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)> {
         let parsers = self.screen_parsers.lock().ok()?;
-        let parser = parsers.get(&id)?;
-        Some(parser.screen().size())
+        let state = parsers.get(&id)?;
+        Some(state.parser.screen().size())
     }
 
     pub fn register_response_watcher(

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -373,11 +373,16 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
 
             let pty_mgr = state.pty_mgr.lock().unwrap();
             let snapshot = pty_mgr.get_screen_snapshot(uuid);
-            let size = pty_mgr.get_pty_size(uuid);
+            let size = snapshot
+                .as_ref()
+                .map(|snapshot| (snapshot.rows, snapshot.cols))
+                .or_else(|| pty_mgr.get_pty_size(uuid));
             drop(pty_mgr);
 
-            if let Some(data) = snapshot {
-                state.broadcaster.broadcast_pty_output(&session_id, &data);
+            if let Some(snapshot) = snapshot {
+                state
+                    .broadcaster
+                    .broadcast_pty_output(&session_id, &snapshot.data);
             }
 
             match size {

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -300,11 +300,31 @@ async fn handle_binary_message(state: &WsState, data: &[u8]) {
     let pty_data = &data[36..];
     // Write FIRST (the std Mutex guard is dropped at the end of this statement,
     // never held across the await below), then record the user message (#552).
-    let _ = state.pty_mgr.lock().unwrap().write(uuid, pty_data);
+    let write_result = state.pty_mgr.lock().unwrap().write(uuid, pty_data);
+    if !binary_pty_write_succeeded(write_result, uuid) {
+        return;
+    }
 
     // #552 web UI keystrokes (binary frame) are the real web input path and a
     // genuine user message: reset the badge clock + auto-close silence.
     crate::commands::pty::note_user_message_to_session(&state.app_handle, uuid).await;
+}
+
+fn binary_pty_write_succeeded(
+    result: Result<(), crate::errors::AppError>,
+    uuid: uuid::Uuid,
+) -> bool {
+    match result {
+        Ok(()) => true,
+        Err(err) => {
+            log::warn!(
+                "[web-server] PTY binary write failed for session {}: {}",
+                uuid,
+                err
+            );
+            false
+        }
+    }
 }
 
 /// Resolve the dist/ directory for static file serving.
@@ -351,4 +371,23 @@ fn resolve_dist_path(app_handle: &tauri::AppHandle) -> Option<std::path::PathBuf
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::AppError;
+
+    #[test]
+    fn binary_pty_write_success_allows_user_message_note() {
+        assert!(binary_pty_write_succeeded(Ok(()), uuid::Uuid::new_v4()));
+    }
+
+    #[test]
+    fn binary_pty_write_failure_blocks_user_message_note() {
+        let uuid = uuid::Uuid::new_v4();
+        let result = Err(AppError::SessionNotFound(uuid.to_string()));
+
+        assert!(!binary_pty_write_succeeded(result, uuid));
+    }
 }

--- a/src-tauri/tests/pty_lifecycle_regression.rs
+++ b/src-tauri/tests/pty_lifecycle_regression.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use agentscommander_lib::commands::pty::{get_screen_snapshot, PtyScreenSnapshotPayload};
 use agentscommander_lib::commands::session::{
     create_session_inner, destroy_session_inner, restart_session_inner,
 };
@@ -280,8 +281,43 @@ fn make_test_app(
 }
 
 #[test]
+fn pty_screen_snapshot_payload_serializes_camel_case_bytes_and_optional_size() {
+    let value = serde_json::to_value(PtyScreenSnapshotPayload {
+        session_id: "session-1".to_string(),
+        data: vec![27, 91, 72],
+        rows: Some(30),
+        cols: Some(120),
+    })
+    .expect("serialize snapshot payload");
+
+    assert_eq!(
+        value,
+        serde_json::json!({
+            "sessionId": "session-1",
+            "data": [27, 91, 72],
+            "rows": 30,
+            "cols": 120,
+        })
+    );
+    assert!(value.get("session_id").is_none());
+}
+
+#[test]
 fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup() {
     let mut fixture = make_lifecycle_fixture();
+    assert!(get_screen_snapshot(
+        fixture.app.state::<Arc<Mutex<PtyManager>>>(),
+        "not-a-uuid".to_string(),
+    )
+    .is_err());
+
+    let missing = get_screen_snapshot(
+        fixture.app.state::<Arc<Mutex<PtyManager>>>(),
+        Uuid::nil().to_string(),
+    )
+    .expect("missing session lookup should not fail");
+    assert!(missing.is_none());
+
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -308,6 +344,23 @@ fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup()
                     fixture.dump("Phase A", &[id_a], std::slice::from_ref(&pid_a))
                 )
             });
+        {
+            let snapshot = get_screen_snapshot(
+                fixture.app.state::<Arc<Mutex<PtyManager>>>(),
+                session_a.id.clone(),
+            )
+            .expect("snapshot command succeeds")
+            .expect("screen snapshot exists after PTY output");
+            let snapshot_text = String::from_utf8_lossy(&snapshot.data);
+            assert_eq!(snapshot.session_id, session_a.id);
+            assert!(snapshot.rows.is_some(), "Phase A snapshot rows missing");
+            assert!(snapshot.cols.is_some(), "Phase A snapshot cols missing");
+            assert!(
+                snapshot_text.contains("AC_READY"),
+                "Phase A snapshot missing AC_READY; snapshot={snapshot_text:?}\n{}",
+                fixture.dump("Phase A snapshot", &[id_a], std::slice::from_ref(&pid_a))
+            );
+        }
         let pid_a_value = wait_for_pid_file(&pid_a, PID_TIMEOUT)
             .await
             .unwrap_or_else(|e| {
@@ -492,6 +545,27 @@ fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup()
                     )
                 )
             });
+        {
+            let snapshot = get_screen_snapshot(
+                fixture.app.state::<Arc<Mutex<PtyManager>>>(),
+                restarted.id.clone(),
+            )
+            .expect("restarted snapshot command succeeds")
+            .expect("restarted screen snapshot exists after PTY output");
+            let snapshot_text = String::from_utf8_lossy(&snapshot.data);
+            assert_eq!(snapshot.session_id, restarted.id);
+            assert!(snapshot.rows.is_some(), "Phase F snapshot rows missing");
+            assert!(snapshot.cols.is_some(), "Phase F snapshot cols missing");
+            assert!(
+                snapshot_text.contains("AC_READY"),
+                "Phase F snapshot missing AC_READY; snapshot={snapshot_text:?}\n{}",
+                fixture.dump(
+                    "Phase F snapshot",
+                    &[restart_new_id],
+                    std::slice::from_ref(&pid_restart)
+                )
+            );
+        }
         assert_no_pty(&fixture.pty_mgr, restart_old_id, "Phase F", &fixture);
         assert_has_pty(&fixture.pty_mgr, restart_new_id, "Phase F", &fixture);
         assert_active_session(&fixture.session_mgr, restart_new_id).await;

--- a/src-tauri/tests/pty_lifecycle_regression.rs
+++ b/src-tauri/tests/pty_lifecycle_regression.rs
@@ -48,6 +48,7 @@ type PtyCleanupEntries = Arc<Mutex<Vec<(Arc<Mutex<PtyManager>>, Uuid)>>>;
 struct TestPtyOutputPayload {
     session_id: String,
     data: Vec<u8>,
+    sequence: Option<u64>,
 }
 
 struct TestConfigEnvGuard {
@@ -121,6 +122,7 @@ struct LifecycleFixture {
     script_path: PathBuf,
     pid_files: Vec<PathBuf>,
     captured_output: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    captured_sequences: Arc<Mutex<HashMap<String, Vec<u64>>>>,
     listener_errors: Arc<Mutex<Vec<String>>>,
     app: tauri::App,
     session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
@@ -155,11 +157,13 @@ fn make_lifecycle_fixture() -> LifecycleFixture {
     run_powershell_preflight();
 
     let captured_output = Arc::new(Mutex::new(HashMap::new()));
+    let captured_sequences = Arc::new(Mutex::new(HashMap::new()));
     let listener_errors = Arc::new(Mutex::new(Vec::new()));
     let cleanup = LifecycleCleanup::new();
     let (app, session_mgr, pty_mgr) = make_test_app(
         &repo_root,
         &captured_output,
+        &captured_sequences,
         &listener_errors,
         &cleanup,
         None,
@@ -176,6 +180,7 @@ fn make_lifecycle_fixture() -> LifecycleFixture {
         script_path,
         pid_files: Vec::new(),
         captured_output,
+        captured_sequences,
         listener_errors,
         app,
         session_mgr,
@@ -186,6 +191,7 @@ fn make_lifecycle_fixture() -> LifecycleFixture {
 fn make_test_app(
     repo_root: &Path,
     captured_output: &Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    captured_sequences: &Arc<Mutex<HashMap<String, Vec<u64>>>>,
     listener_errors: &Arc<Mutex<Vec<String>>>,
     _cleanup: &LifecycleCleanup,
     session_mgr_override: Option<Arc<tokio::sync::RwLock<SessionManager>>>,
@@ -232,6 +238,7 @@ fn make_test_app(
     let shutdown_signal = ShutdownSignal::new();
 
     let captured = Arc::clone(captured_output);
+    let captured_sequences = Arc::clone(captured_sequences);
     let listener_errors = Arc::clone(listener_errors);
     let app = tauri::Builder::default()
         .any_thread()
@@ -267,9 +274,22 @@ fn make_test_app(
                 captured
                     .lock()
                     .unwrap()
-                    .entry(payload.session_id)
+                    .entry(payload.session_id.clone())
                     .or_default()
                     .extend(payload.data);
+
+                match payload.sequence {
+                    Some(sequence) => captured_sequences
+                        .lock()
+                        .unwrap()
+                        .entry(payload.session_id)
+                        .or_default()
+                        .push(sequence),
+                    None => listener_errors
+                        .lock()
+                        .unwrap()
+                        .push(format!("pty_output payload missing sequence; raw={raw}")),
+                }
             }
             Err(err) => listener_errors.lock().unwrap().push(format!(
                 "failed to parse pty_output payload: {err}; raw={raw}"
@@ -287,6 +307,7 @@ fn pty_screen_snapshot_payload_serializes_camel_case_bytes_and_optional_size() {
         data: vec![27, 91, 72],
         rows: Some(30),
         cols: Some(120),
+        sequence: 7,
     })
     .expect("serialize snapshot payload");
 
@@ -297,6 +318,7 @@ fn pty_screen_snapshot_payload_serializes_camel_case_bytes_and_optional_size() {
             "data": [27, 91, 72],
             "rows": 30,
             "cols": 120,
+            "sequence": 7,
         })
     );
     assert!(value.get("session_id").is_none());
@@ -345,6 +367,8 @@ fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup()
                 )
             });
         {
+            let last_event_sequence =
+                last_strictly_increasing_sequence(&fixture, &session_a.id, "Phase A");
             let snapshot = get_screen_snapshot(
                 fixture.app.state::<Arc<Mutex<PtyManager>>>(),
                 session_a.id.clone(),
@@ -355,6 +379,12 @@ fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup()
             assert_eq!(snapshot.session_id, session_a.id);
             assert!(snapshot.rows.is_some(), "Phase A snapshot rows missing");
             assert!(snapshot.cols.is_some(), "Phase A snapshot cols missing");
+            assert!(
+                snapshot.sequence >= last_event_sequence,
+                "Phase A snapshot sequence {} should cover last event sequence {}",
+                snapshot.sequence,
+                last_event_sequence
+            );
             assert!(
                 snapshot_text.contains("AC_READY"),
                 "Phase A snapshot missing AC_READY; snapshot={snapshot_text:?}\n{}",
@@ -546,6 +576,8 @@ fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup()
                 )
             });
         {
+            let last_event_sequence =
+                last_strictly_increasing_sequence(&fixture, &restarted.id, "Phase F");
             let snapshot = get_screen_snapshot(
                 fixture.app.state::<Arc<Mutex<PtyManager>>>(),
                 restarted.id.clone(),
@@ -556,6 +588,12 @@ fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup()
             assert_eq!(snapshot.session_id, restarted.id);
             assert!(snapshot.rows.is_some(), "Phase F snapshot rows missing");
             assert!(snapshot.cols.is_some(), "Phase F snapshot cols missing");
+            assert!(
+                snapshot.sequence >= last_event_sequence,
+                "Phase F snapshot sequence {} should cover last event sequence {}",
+                snapshot.sequence,
+                last_event_sequence
+            );
             assert!(
                 snapshot_text.contains("AC_READY"),
                 "Phase F snapshot missing AC_READY; snapshot={snapshot_text:?}\n{}",
@@ -665,10 +703,12 @@ fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup()
             .expect("persisted recipe row");
         let second_session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
         let second_captured = Arc::clone(&fixture.captured_output);
+        let second_sequences = Arc::clone(&fixture.captured_sequences);
         let second_errors = Arc::clone(&fixture.listener_errors);
         let (second_app, second_mgr, second_pty_mgr) = make_test_app(
             &fixture.repo_root,
             &second_captured,
+            &second_sequences,
             &second_errors,
             &fixture.cleanup,
             Some(second_session_mgr),
@@ -795,6 +835,14 @@ impl LifecycleFixture {
             .map(|(id, bytes)| format!("{id}: {}", String::from_utf8_lossy(bytes)))
             .collect::<Vec<_>>()
             .join("\n");
+        let captured_sequences = self
+            .captured_sequences
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(id, sequences)| format!("{id}: {sequences:?}"))
+            .collect::<Vec<_>>()
+            .join("\n");
         let listener_errors = self.listener_errors.lock().unwrap().join("\n");
         let pid_info = pid_files
             .iter()
@@ -824,7 +872,7 @@ impl LifecycleFixture {
             .collect::<Vec<_>>()
             .join("\n");
         format!(
-            "phase={phase}\nconfig_dir={}\nrepo_root={}\nsession_cwd={}\nsessions_json={sessions_json}\npids=\n{pid_info}\npty=\n{pty_info}\nlistener_errors=\n{listener_errors}\ncaptured=\n{captured}",
+            "phase={phase}\nconfig_dir={}\nrepo_root={}\nsession_cwd={}\nsessions_json={sessions_json}\npids=\n{pid_info}\npty=\n{pty_info}\nlistener_errors=\n{listener_errors}\ncaptured_sequences=\n{captured_sequences}\ncaptured=\n{captured}",
             self.config_dir.display(),
             self.repo_root.display(),
             self.session_cwd.display()
@@ -911,6 +959,31 @@ async fn wait_for_output(
     Err(format!(
         "timeout waiting for output marker '{marker}' in session {session_id}"
     ))
+}
+
+fn last_strictly_increasing_sequence(
+    fixture: &LifecycleFixture,
+    session_id: &str,
+    phase: &str,
+) -> u64 {
+    let sequences = fixture
+        .captured_sequences
+        .lock()
+        .unwrap()
+        .get(session_id)
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !sequences.is_empty(),
+        "{phase}: expected at least one pty_output sequence for {session_id}"
+    );
+    for pair in sequences.windows(2) {
+        assert!(
+            pair[0] < pair[1],
+            "{phase}: sequences must be strictly increasing: {sequences:?}"
+        );
+    }
+    *sequences.last().unwrap()
 }
 
 async fn wait_for_pid_file(path: &Path, timeout: Duration) -> Result<u32, String> {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -6,6 +6,7 @@ import type {
   Session,
   SessionRepo,
   PtyOutputEvent,
+  PtyScreenSnapshot,
   AppSettings,
   LogLevel,
   UpdateInfo,
@@ -225,6 +226,9 @@ export const PtyAPI = {
 
   resize: (sessionId: string, cols: number, rows: number) =>
     transport.invoke<void>("pty_resize", { sessionId, cols, rows }),
+
+  getScreenSnapshot: (sessionId: string) =>
+    transport.invoke<PtyScreenSnapshot | null>("get_screen_snapshot", { sessionId }),
 
   /** Request screen snapshot replay for late-joining browser clients.
    *  Returns PTY dimensions so the browser can mirror them. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -91,6 +91,13 @@ export interface PtyOutputEvent {
   data: number[];
 }
 
+export interface PtyScreenSnapshot {
+  sessionId: string;
+  data: number[];
+  rows: number | null;
+  cols: number | null;
+}
+
 /**
  * #598 — per-agent config-folder seed. Mirrors the Rust `ConfigSeedConfig`
  * (`#[serde(rename_all = "camelCase")]`): `enabled` (serde default true) and

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -89,6 +89,7 @@ export interface TerminalConfig {
 export interface PtyOutputEvent {
   sessionId: string;
   data: number[];
+  sequence?: number;
 }
 
 export interface PtyScreenSnapshot {
@@ -96,6 +97,7 @@ export interface PtyScreenSnapshot {
   data: number[];
   rows: number | null;
   cols: number | null;
+  sequence: number;
 }
 
 /**

--- a/src/terminal/App.workflow.test.tsx
+++ b/src/terminal/App.workflow.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import TerminalApp from "./App";
 import { FakeTransport } from "../shared/testing/fake-transport";
+import type { PtyScreenSnapshot, Session } from "../shared/types";
 import {
   baseSettings,
   installBrowserDomStubs,
@@ -16,12 +17,19 @@ interface FakeTerminalInstance {
   rows: number;
   element: HTMLElement | null;
   writes: unknown[];
+  resizes: { cols: number; rows: number }[];
   emitData(data: string): void;
   emitResize(cols: number, rows: number): void;
+  resize(cols: number, rows: number): void;
 }
 
 const xterm = vi.hoisted(() => ({
   instances: [] as FakeTerminalInstance[],
+}));
+
+const fitViewport = vi.hoisted(() => ({
+  cols: 88,
+  rows: 26,
 }));
 
 vi.mock("@xterm/xterm", () => ({
@@ -30,6 +38,7 @@ vi.mock("@xterm/xterm", () => ({
     rows = 24;
     element: HTMLElement | null = null;
     writes: unknown[] = [];
+    resizes: { cols: number; rows: number }[] = [];
     private dataHandlers = new Set<(data: string) => void>();
     private resizeHandlers = new Set<(size: { cols: number; rows: number }) => void>();
 
@@ -37,7 +46,9 @@ vi.mock("@xterm/xterm", () => ({
       xterm.instances.push(this);
     }
 
-    loadAddon(): void {}
+    loadAddon(addon?: { activate?: (terminal: FakeTerminalInstance) => void }): void {
+      addon?.activate?.(this);
+    }
 
     open(element: HTMLElement): void {
       this.element = element;
@@ -89,16 +100,29 @@ vi.mock("@xterm/xterm", () => ({
     emitResize(cols: number, rows: number): void {
       this.cols = cols;
       this.rows = rows;
+      this.resizes.push({ cols, rows });
       for (const handler of Array.from(this.resizeHandlers)) {
         handler({ cols, rows });
       }
+    }
+
+    resize(cols: number, rows: number): void {
+      this.emitResize(cols, rows);
     }
   },
 }));
 
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: class {
-    fit = vi.fn();
+    private terminal: FakeTerminalInstance | null = null;
+
+    activate(terminal: FakeTerminalInstance): void {
+      this.terminal = terminal;
+    }
+
+    fit = vi.fn(() => {
+      this.terminal?.resize(fitViewport.cols, fitViewport.rows);
+    });
   },
 }));
 
@@ -111,13 +135,46 @@ vi.mock("@xterm/addon-webgl", () => ({
 
 vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 
+vi.mock("../shared/platform", () => ({
+  isTauri: true,
+  isBrowser: false,
+}));
+
 function setupTerminalTransport(fake: FakeTransport, sessions = [session()]): void {
   fake.resolve("get_settings", baseSettings());
   fake.resolve("get_active_session", sessions[0]?.id ?? null);
   fake.onInvoke("list_sessions", () => sessions);
   fake.resolve("pty_write", undefined);
   fake.resolve("pty_resize", undefined);
+  fake.resolve("get_screen_snapshot", null);
   fake.resolve("set_last_prompt", undefined);
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function hasPtyResizeCall(
+  fake: FakeTransport,
+  sessionId: string,
+  cols: number,
+  rows: number
+): boolean {
+  return fake.callsFor("pty_resize").some((call) =>
+    call.args.sessionId === sessionId &&
+    call.args.cols === cols &&
+    call.args.rows === rows
+  );
 }
 
 describe("TerminalApp workflow", () => {
@@ -219,6 +276,227 @@ describe("TerminalApp workflow", () => {
           data: [122],
         })
       );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("replays the first native snapshot once without echoing snapshot resize to PTY", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+      }),
+    ]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() =>
+        expect(fake.callsFor("get_screen_snapshot")[0]?.args).toEqual({
+          sessionId: "session-1",
+        })
+      );
+
+      await waitFor(() => expect(fake.callsFor("pty_resize").length).toBeGreaterThan(0));
+      fake.clearCalls();
+
+      snapshot.resolve({
+        sessionId: "session-1",
+        data: [83, 78, 65, 80],
+        rows: 30,
+        cols: 120,
+      });
+
+      const terminal = xterm.instances[0];
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+
+      expect(terminal.resizes).toContainEqual({ cols: 120, rows: 30 });
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([83, 78, 65, 80]);
+      expect(hasPtyResizeCall(fake, "session-1", 120, 30)).toBe(false);
+      await waitFor(() =>
+        expect(hasPtyResizeCall(fake, "session-1", fitViewport.cols, fitViewport.rows)).toBe(true)
+      );
+      expect(terminal.writes).toHaveLength(1);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("does not request another snapshot when switching away and back to an existing terminal", async () => {
+    const sessions = [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+      }),
+      session({
+        id: "session-2",
+        name: "wg-1-dev-team/dev-webpage-ui",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_dev-webpage-ui",
+      }),
+    ];
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake, sessions);
+    fake.onInvoke("get_screen_snapshot", ({ sessionId }) => ({
+      sessionId,
+      data: sessionId === "session-1" ? [49] : [50],
+      rows: null,
+      cols: null,
+    }));
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      fake.emitFromBackend("session_switched", { id: "session-2" });
+
+      await waitFor(() => expect(xterm.instances).toHaveLength(2));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(2));
+
+      fake.emitFromBackend("session_switched", { id: "session-1" });
+
+      await waitFor(() => {
+        const sessionOne = rendered.root.querySelector<HTMLElement>(
+          '[data-ac-testid="terminal.session.session-1"]'
+        );
+        expect(sessionOne?.hidden).toBe(false);
+      });
+      expect(fake.callsFor("get_screen_snapshot")).toHaveLength(2);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps live output immediate when the native snapshot is unavailable", async () => {
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake, [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: [76, 73, 86, 69],
+      });
+
+      const terminal = xterm.instances[0];
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([76, 73, 86, 69]);
+      const replayStatus = rendered.root.querySelector<HTMLDivElement>(
+        '[data-ac-testid="terminal.replay-status.session-1"]'
+      );
+      expect(replayStatus?.hidden).toBe(true);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps live output immediate when the native snapshot request fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake, [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+      }),
+    ]);
+    fake.reject("get_screen_snapshot", "missing parser");
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: [76, 73, 86, 69],
+      });
+
+      const terminal = xterm.instances[0];
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([76, 73, 86, 69]);
+      const replayStatus = rendered.root.querySelector<HTMLDivElement>(
+        '[data-ac-testid="terminal.replay-status.session-1"]'
+      );
+      expect(replayStatus?.hidden).toBe(true);
+    } finally {
+      rendered.cleanup();
+      warn.mockRestore();
+    }
+  });
+
+  it("recovers output dropped during the async session switch list gap by replaying a snapshot", async () => {
+    const sessionOne = session({
+      id: "session-1",
+      name: "wg-1-dev-team/architect",
+      workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+    });
+    const sessionTwo = session({
+      id: "session-2",
+      name: "wg-1-dev-team/dev-webpage-ui",
+      workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_dev-webpage-ui",
+    });
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake, [sessionOne]);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      fake.clearCalls();
+
+      const listSessions = deferred<Session[]>();
+      fake.onInvoke("list_sessions", () => listSessions.promise);
+
+      fake.emitFromBackend("session_switched", { id: "session-2" });
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-2",
+        data: [68, 82, 79, 80],
+      });
+
+      expect(xterm.instances).toHaveLength(1);
+      expect(
+        xterm.instances[0].writes.some((write) =>
+          Array.from(write as Uint8Array).join(",") === "68,82,79,80"
+        )
+      ).toBe(false);
+
+      fake.onInvoke("get_screen_snapshot", ({ sessionId }) =>
+        sessionId === "session-2"
+          ? {
+              sessionId: "session-2",
+              data: [82, 69, 80, 76, 65, 89],
+              rows: null,
+              cols: null,
+            }
+          : null
+      );
+      listSessions.resolve([sessionOne, sessionTwo]);
+
+      await waitFor(() => expect(xterm.instances).toHaveLength(2));
+      await waitFor(() =>
+        expect(
+          fake.callsFor("get_screen_snapshot").some((call) =>
+            call.args.sessionId === "session-2"
+          )
+        ).toBe(true)
+      );
+
+      const sessionTwoTerminal = xterm.instances[1];
+      await waitFor(() => expect(sessionTwoTerminal.writes).toHaveLength(1));
+      expect(Array.from(sessionTwoTerminal.writes[0] as Uint8Array)).toEqual([
+        82, 69, 80, 76, 65, 89,
+      ]);
     } finally {
       rendered.cleanup();
     }

--- a/src/terminal/App.workflow.test.tsx
+++ b/src/terminal/App.workflow.test.tsx
@@ -164,6 +164,11 @@ function deferred<T>(): {
   return { promise, resolve, reject };
 }
 
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 function hasPtyResizeCall(
   fake: FakeTransport,
   sessionId: string,
@@ -327,7 +332,7 @@ describe("TerminalApp workflow", () => {
     }
   });
 
-  it("queues live output behind a delayed first native snapshot", async () => {
+  it("renders live output immediately when it beats the first native snapshot", async () => {
     const fake = new FakeTransport();
     const snapshot = deferred<PtyScreenSnapshot | null>();
     setupTerminalTransport(fake, [
@@ -345,12 +350,14 @@ describe("TerminalApp workflow", () => {
       await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
 
       const terminal = xterm.instances[0];
+      const liveOutput = [76, 73, 86, 69];
       fake.emitFromBackend("pty_output", {
         sessionId: "session-1",
-        data: [76, 73, 86, 69],
+        data: liveOutput,
       });
 
-      expect(terminal.writes).toHaveLength(0);
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
 
       snapshot.resolve({
         sessionId: "session-1",
@@ -359,9 +366,51 @@ describe("TerminalApp workflow", () => {
         cols: null,
       });
 
-      await waitFor(() => expect(terminal.writes).toHaveLength(2));
-      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([83, 78, 65, 80]);
-      expect(Array.from(terminal.writes[1] as Uint8Array)).toEqual([76, 73, 86, 69]);
+      await flushPromises();
+      expect(terminal.writes).toHaveLength(1);
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("ignores a delayed native snapshot that already includes live output", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+      }),
+    ]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
+      const liveOutput = [76, 73, 86, 69];
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: liveOutput,
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
+
+      snapshot.resolve({
+        sessionId: "session-1",
+        data: [83, 78, 65, 80, 76, 73, 86, 69],
+        rows: null,
+        cols: null,
+      });
+
+      await flushPromises();
+      expect(terminal.writes).toHaveLength(1);
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
     } finally {
       rendered.cleanup();
     }
@@ -413,7 +462,7 @@ describe("TerminalApp workflow", () => {
     }
   });
 
-  it("flushes queued live output when the native snapshot is unavailable", async () => {
+  it("keeps live output when the native snapshot is unavailable later", async () => {
     const fake = new FakeTransport();
     const snapshot = deferred<PtyScreenSnapshot | null>();
     setupTerminalTransport(fake, [
@@ -431,17 +480,20 @@ describe("TerminalApp workflow", () => {
       await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
 
       const terminal = xterm.instances[0];
+      const liveOutput = [76, 73, 86, 69];
       fake.emitFromBackend("pty_output", {
         sessionId: "session-1",
-        data: [76, 73, 86, 69],
+        data: liveOutput,
       });
 
-      expect(terminal.writes).toHaveLength(0);
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
 
       snapshot.resolve(null);
 
-      await waitFor(() => expect(terminal.writes).toHaveLength(1));
-      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([76, 73, 86, 69]);
+      await flushPromises();
+      expect(terminal.writes).toHaveLength(1);
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
       const replayStatus = rendered.root.querySelector<HTMLDivElement>(
         '[data-ac-testid="terminal.replay-status.session-1"]'
       );
@@ -451,7 +503,7 @@ describe("TerminalApp workflow", () => {
     }
   });
 
-  it("flushes queued live output when the native snapshot request fails", async () => {
+  it("keeps live output when the native snapshot request fails later", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const fake = new FakeTransport();
     const snapshot = deferred<PtyScreenSnapshot | null>();
@@ -470,17 +522,20 @@ describe("TerminalApp workflow", () => {
       await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
 
       const terminal = xterm.instances[0];
+      const liveOutput = [76, 73, 86, 69];
       fake.emitFromBackend("pty_output", {
         sessionId: "session-1",
-        data: [76, 73, 86, 69],
+        data: liveOutput,
       });
 
-      expect(terminal.writes).toHaveLength(0);
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
 
       snapshot.reject("missing parser");
 
-      await waitFor(() => expect(terminal.writes).toHaveLength(1));
-      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([76, 73, 86, 69]);
+      await flushPromises();
+      expect(terminal.writes).toHaveLength(1);
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
       const replayStatus = rendered.root.querySelector<HTMLDivElement>(
         '[data-ac-testid="terminal.replay-status.session-1"]'
       );

--- a/src/terminal/App.workflow.test.tsx
+++ b/src/terminal/App.workflow.test.tsx
@@ -315,6 +315,7 @@ describe("TerminalApp workflow", () => {
         data: [83, 78, 65, 80],
         rows: 30,
         cols: 120,
+        sequence: 0,
       });
 
       const terminal = xterm.instances[0];
@@ -332,7 +333,7 @@ describe("TerminalApp workflow", () => {
     }
   });
 
-  it("renders live output immediately when it beats the first native snapshot", async () => {
+  it("replays buffered live output when the first native snapshot excludes it", async () => {
     const fake = new FakeTransport();
     const snapshot = deferred<PtyScreenSnapshot | null>();
     setupTerminalTransport(fake, [
@@ -354,27 +355,29 @@ describe("TerminalApp workflow", () => {
       fake.emitFromBackend("pty_output", {
         sessionId: "session-1",
         data: liveOutput,
+        sequence: 1,
       });
 
-      await waitFor(() => expect(terminal.writes).toHaveLength(1));
-      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
+      await flushPromises();
+      expect(terminal.writes).toHaveLength(0);
 
       snapshot.resolve({
         sessionId: "session-1",
         data: [83, 78, 65, 80],
         rows: null,
         cols: null,
+        sequence: 0,
       });
 
-      await flushPromises();
-      expect(terminal.writes).toHaveLength(1);
-      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
+      await waitFor(() => expect(terminal.writes).toHaveLength(2));
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([83, 78, 65, 80]);
+      expect(Array.from(terminal.writes[1] as Uint8Array)).toEqual(liveOutput);
     } finally {
       rendered.cleanup();
     }
   });
 
-  it("ignores a delayed native snapshot that already includes live output", async () => {
+  it("drops buffered live output when the first native snapshot already includes it", async () => {
     const fake = new FakeTransport();
     const snapshot = deferred<PtyScreenSnapshot | null>();
     setupTerminalTransport(fake, [
@@ -396,21 +399,114 @@ describe("TerminalApp workflow", () => {
       fake.emitFromBackend("pty_output", {
         sessionId: "session-1",
         data: liveOutput,
+        sequence: 1,
       });
 
-      await waitFor(() => expect(terminal.writes).toHaveLength(1));
-      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
+      await flushPromises();
+      expect(terminal.writes).toHaveLength(0);
 
       snapshot.resolve({
         sessionId: "session-1",
         data: [83, 78, 65, 80, 76, 73, 86, 69],
         rows: null,
         cols: null,
+        sequence: 1,
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([
+        83, 78, 65, 80, 76, 73, 86, 69,
+      ]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("drops delayed live output already covered by the first native snapshot", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+      }),
+    ]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
+      snapshot.resolve({
+        sessionId: "session-1",
+        data: [83, 78, 65, 80, 76, 73, 86, 69],
+        rows: null,
+        cols: null,
+        sequence: 1,
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: [76, 73, 86, 69],
+        sequence: 1,
       });
 
       await flushPromises();
       expect(terminal.writes).toHaveLength(1);
-      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
+
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: [78, 69, 87],
+        sequence: 2,
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(2));
+      expect(Array.from(terminal.writes[1] as Uint8Array)).toEqual([78, 69, 87]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("writes unsequenced live output after the first native snapshot", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+      }),
+    ]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
+      snapshot.resolve({
+        sessionId: "session-1",
+        data: [83, 78, 65, 80],
+        rows: null,
+        cols: null,
+        sequence: 1,
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: [79, 75],
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(2));
+      expect(Array.from(terminal.writes[1] as Uint8Array)).toEqual([79, 75]);
     } finally {
       rendered.cleanup();
     }
@@ -436,6 +532,7 @@ describe("TerminalApp workflow", () => {
       data: sessionId === "session-1" ? [49] : [50],
       rows: null,
       cols: null,
+      sequence: 0,
     }));
 
     const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
@@ -484,14 +581,15 @@ describe("TerminalApp workflow", () => {
       fake.emitFromBackend("pty_output", {
         sessionId: "session-1",
         data: liveOutput,
+        sequence: 1,
       });
 
-      await waitFor(() => expect(terminal.writes).toHaveLength(1));
-      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
+      await flushPromises();
+      expect(terminal.writes).toHaveLength(0);
 
       snapshot.resolve(null);
 
-      await flushPromises();
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
       expect(terminal.writes).toHaveLength(1);
       expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
       const replayStatus = rendered.root.querySelector<HTMLDivElement>(
@@ -526,14 +624,15 @@ describe("TerminalApp workflow", () => {
       fake.emitFromBackend("pty_output", {
         sessionId: "session-1",
         data: liveOutput,
+        sequence: 1,
       });
 
-      await waitFor(() => expect(terminal.writes).toHaveLength(1));
-      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
+      await flushPromises();
+      expect(terminal.writes).toHaveLength(0);
 
       snapshot.reject("missing parser");
 
-      await flushPromises();
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
       expect(terminal.writes).toHaveLength(1);
       expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
       const replayStatus = rendered.root.querySelector<HTMLDivElement>(
@@ -572,6 +671,7 @@ describe("TerminalApp workflow", () => {
       fake.emitFromBackend("pty_output", {
         sessionId: "session-2",
         data: [68, 82, 79, 80],
+        sequence: 1,
       });
 
       expect(xterm.instances).toHaveLength(1);
@@ -588,6 +688,7 @@ describe("TerminalApp workflow", () => {
               data: [82, 69, 80, 76, 65, 89],
               rows: null,
               cols: null,
+              sequence: 1,
             }
           : null
       );

--- a/src/terminal/App.workflow.test.tsx
+++ b/src/terminal/App.workflow.test.tsx
@@ -327,6 +327,46 @@ describe("TerminalApp workflow", () => {
     }
   });
 
+  it("queues live output behind a delayed first native snapshot", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+      }),
+    ]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: [76, 73, 86, 69],
+      });
+
+      expect(terminal.writes).toHaveLength(0);
+
+      snapshot.resolve({
+        sessionId: "session-1",
+        data: [83, 78, 65, 80],
+        rows: null,
+        cols: null,
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(2));
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([83, 78, 65, 80]);
+      expect(Array.from(terminal.writes[1] as Uint8Array)).toEqual([76, 73, 86, 69]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
   it("does not request another snapshot when switching away and back to an existing terminal", async () => {
     const sessions = [
       session({
@@ -373,8 +413,9 @@ describe("TerminalApp workflow", () => {
     }
   });
 
-  it("keeps live output immediate when the native snapshot is unavailable", async () => {
+  it("flushes queued live output when the native snapshot is unavailable", async () => {
     const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
     setupTerminalTransport(fake, [
       session({
         id: "session-1",
@@ -382,16 +423,23 @@ describe("TerminalApp workflow", () => {
         workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
       }),
     ]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
 
     const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
     try {
       await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
       fake.emitFromBackend("pty_output", {
         sessionId: "session-1",
         data: [76, 73, 86, 69],
       });
 
-      const terminal = xterm.instances[0];
+      expect(terminal.writes).toHaveLength(0);
+
+      snapshot.resolve(null);
+
       await waitFor(() => expect(terminal.writes).toHaveLength(1));
       expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([76, 73, 86, 69]);
       const replayStatus = rendered.root.querySelector<HTMLDivElement>(
@@ -403,9 +451,10 @@ describe("TerminalApp workflow", () => {
     }
   });
 
-  it("keeps live output immediate when the native snapshot request fails", async () => {
+  it("flushes queued live output when the native snapshot request fails", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
     setupTerminalTransport(fake, [
       session({
         id: "session-1",
@@ -413,17 +462,23 @@ describe("TerminalApp workflow", () => {
         workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
       }),
     ]);
-    fake.reject("get_screen_snapshot", "missing parser");
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
 
     const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
     try {
       await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
       fake.emitFromBackend("pty_output", {
         sessionId: "session-1",
         data: [76, 73, 86, 69],
       });
 
-      const terminal = xterm.instances[0];
+      expect(terminal.writes).toHaveLength(0);
+
+      snapshot.reject("missing parser");
+
       await waitFor(() => expect(terminal.writes).toHaveLength(1));
       expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([76, 73, 86, 69]);
       const replayStatus = rendered.root.querySelector<HTMLDivElement>(

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../shared/ipc";
 import { isBrowser, isTauri } from "../../shared/platform";
 import { terminalStore } from "../stores/terminal";
+import type { PtyOutputEvent } from "../../shared/types";
 import type { UnlistenFn } from "../../shared/transport";
 import { updatePromptCapture } from "./prompt-input-capture";
 import { createTerminalOptions } from "./terminal-options";
@@ -26,6 +27,8 @@ interface SessionTerminal {
   snapshotResizeSuppressed: boolean;
   hasRenderedOutput: boolean;
   replayStatus: HTMLDivElement;
+  pendingSnapshotEvents: PtyOutputEvent[];
+  lastAppliedSequence: number | null;
 }
 
 interface TerminalViewProps {
@@ -122,28 +125,65 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     entry.terminal.write(data);
   };
 
-  const writeLiveTerminalBytes = (entry: SessionTerminal, data: Uint8Array) => {
-    if (entry.snapshotReplayPending) {
-      // The backend parser may already include these live bytes in the
-      // in-flight snapshot. Let live output win and ignore that replay.
-      entry.snapshotReplayPending = false;
+  const eventSequence = (event: PtyOutputEvent): number | null =>
+    typeof event.sequence === "number" ? event.sequence : null;
+
+  const shouldDropAlreadyAppliedEvent = (
+    entry: SessionTerminal,
+    sequence: number | null
+  ) =>
+    sequence !== null &&
+    entry.lastAppliedSequence !== null &&
+    sequence <= entry.lastAppliedSequence;
+
+  const markAppliedSequence = (entry: SessionTerminal, sequence: number | null) => {
+    if (sequence === null) {
+      return;
     }
 
-    writeTerminalBytes(entry, data);
+    entry.lastAppliedSequence =
+      entry.lastAppliedSequence === null
+        ? sequence
+        : Math.max(entry.lastAppliedSequence, sequence);
   };
 
-  const claimPendingSnapshotReplay = (sessionId: string, entry: SessionTerminal) => {
-    if (terminals.get(sessionId) !== entry || !entry.snapshotReplayPending) {
-      return false;
+  const writeLivePtyOutput = (entry: SessionTerminal, event: PtyOutputEvent) => {
+    const sequence = eventSequence(event);
+
+    if (entry.snapshotReplayPending) {
+      entry.pendingSnapshotEvents.push(event);
+      return;
     }
 
-    if (entry.hasRenderedOutput) {
-      entry.snapshotReplayPending = false;
-      return false;
+    if (shouldDropAlreadyAppliedEvent(entry, sequence)) {
+      return;
+    }
+
+    writeTerminalBytes(entry, new Uint8Array(event.data));
+    markAppliedSequence(entry, sequence);
+  };
+
+  const finishPendingSnapshotReplay = (
+    sessionId: string,
+    entry: SessionTerminal
+  ): PtyOutputEvent[] | null => {
+    if (terminals.get(sessionId) !== entry || !entry.snapshotReplayPending) {
+      return null;
     }
 
     entry.snapshotReplayPending = false;
-    return true;
+    const pendingEvents = entry.pendingSnapshotEvents;
+    entry.pendingSnapshotEvents = [];
+    return pendingEvents;
+  };
+
+  const flushPendingEvents = (
+    entry: SessionTerminal,
+    events: PtyOutputEvent[]
+  ) => {
+    for (const event of events) {
+      writeLivePtyOutput(entry, event);
+    }
   };
 
   const resizeTerminalForSnapshot = (
@@ -166,14 +206,17 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
 
     entry.snapshotReplayRequested = true;
     entry.snapshotReplayPending = true;
+    entry.pendingSnapshotEvents = [];
 
     void PtyAPI.getScreenSnapshot(sessionId)
       .then((snapshot) => {
-        if (!claimPendingSnapshotReplay(sessionId, entry)) {
+        const pendingEvents = finishPendingSnapshotReplay(sessionId, entry);
+        if (!pendingEvents) {
           return;
         }
 
         if (!snapshot || snapshot.data.length === 0) {
+          flushPendingEvents(entry, pendingEvents);
           if (!entry.hasRenderedOutput) {
             setReplayStatus(
               entry,
@@ -192,17 +235,21 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         }
 
         writeTerminalBytes(entry, new Uint8Array(snapshot.data));
+        markAppliedSequence(entry, snapshot.sequence);
+        flushPendingEvents(entry, pendingEvents);
 
         if (sessionId === activeSessionId) {
           scheduleViewportSync(sessionId);
         }
       })
       .catch((err) => {
-        if (!claimPendingSnapshotReplay(sessionId, entry)) {
+        const pendingEvents = finishPendingSnapshotReplay(sessionId, entry);
+        if (!pendingEvents) {
           return;
         }
 
         console.warn("[terminal] snapshot replay failed:", err);
+        flushPendingEvents(entry, pendingEvents);
 
         if (!entry.hasRenderedOutput) {
           setReplayStatus(
@@ -260,6 +307,8 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       snapshotResizeSuppressed: false,
       hasRenderedOutput: false,
       replayStatus,
+      pendingSnapshotEvents: [],
+      lastAppliedSequence: null,
     };
 
     // Per-terminal keyboard shortcuts. Match keys via event.key (layout-aware,
@@ -394,7 +443,8 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     });
     resizeObserver.observe(hostRef);
 
-    unlistenPtyOutput = await onPtyOutput(({ sessionId, data }) => {
+    unlistenPtyOutput = await onPtyOutput((event) => {
+      const { sessionId } = event;
       const entry =
         terminals.get(sessionId) ?? (sessionId === activeSessionId
           ? createSessionTerminal(sessionId)
@@ -404,7 +454,7 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         return;
       }
 
-      writeLiveTerminalBytes(entry, new Uint8Array(data));
+      writeLivePtyOutput(entry, event);
     });
 
     unlistenSessionDestroyed = await onSessionDestroyed(({ id }) => {

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -25,7 +25,6 @@ interface SessionTerminal {
   snapshotReplayPending: boolean;
   snapshotResizeSuppressed: boolean;
   hasRenderedOutput: boolean;
-  queuedSnapshotOutput: Uint8Array[];
   replayStatus: HTMLDivElement;
 }
 
@@ -123,22 +122,28 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     entry.terminal.write(data);
   };
 
-  const flushQueuedSnapshotOutput = (entry: SessionTerminal) => {
-    const queuedOutput = entry.queuedSnapshotOutput;
-    entry.queuedSnapshotOutput = [];
-
-    for (const data of queuedOutput) {
-      writeTerminalBytes(entry, data);
-    }
-  };
-
-  const writeOrQueueTerminalBytes = (entry: SessionTerminal, data: Uint8Array) => {
+  const writeLiveTerminalBytes = (entry: SessionTerminal, data: Uint8Array) => {
     if (entry.snapshotReplayPending) {
-      entry.queuedSnapshotOutput.push(data);
-      return;
+      // The backend parser may already include these live bytes in the
+      // in-flight snapshot. Let live output win and ignore that replay.
+      entry.snapshotReplayPending = false;
     }
 
     writeTerminalBytes(entry, data);
+  };
+
+  const claimPendingSnapshotReplay = (sessionId: string, entry: SessionTerminal) => {
+    if (terminals.get(sessionId) !== entry || !entry.snapshotReplayPending) {
+      return false;
+    }
+
+    if (entry.hasRenderedOutput) {
+      entry.snapshotReplayPending = false;
+      return false;
+    }
+
+    entry.snapshotReplayPending = false;
+    return true;
   };
 
   const resizeTerminalForSnapshot = (
@@ -164,14 +169,11 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
 
     void PtyAPI.getScreenSnapshot(sessionId)
       .then((snapshot) => {
-        if (terminals.get(sessionId) !== entry) {
+        if (!claimPendingSnapshotReplay(sessionId, entry)) {
           return;
         }
 
-        entry.snapshotReplayPending = false;
-
         if (!snapshot || snapshot.data.length === 0) {
-          flushQueuedSnapshotOutput(entry);
           if (!entry.hasRenderedOutput) {
             setReplayStatus(
               entry,
@@ -190,20 +192,17 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         }
 
         writeTerminalBytes(entry, new Uint8Array(snapshot.data));
-        flushQueuedSnapshotOutput(entry);
 
         if (sessionId === activeSessionId) {
           scheduleViewportSync(sessionId);
         }
       })
       .catch((err) => {
-        console.warn("[terminal] snapshot replay failed:", err);
-        if (terminals.get(sessionId) !== entry) {
+        if (!claimPendingSnapshotReplay(sessionId, entry)) {
           return;
         }
 
-        entry.snapshotReplayPending = false;
-        flushQueuedSnapshotOutput(entry);
+        console.warn("[terminal] snapshot replay failed:", err);
 
         if (!entry.hasRenderedOutput) {
           setReplayStatus(
@@ -260,7 +259,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       snapshotReplayPending: false,
       snapshotResizeSuppressed: false,
       hasRenderedOutput: false,
-      queuedSnapshotOutput: [],
       replayStatus,
     };
 
@@ -406,7 +404,7 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         return;
       }
 
-      writeOrQueueTerminalBytes(entry, new Uint8Array(data));
+      writeLiveTerminalBytes(entry, new Uint8Array(data));
     });
 
     unlistenSessionDestroyed = await onSessionDestroyed(({ id }) => {

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -21,6 +21,10 @@ interface SessionTerminal {
   terminal: Terminal;
   fitAddon: FitAddon;
   inputBuffer: string;
+  snapshotReplayRequested: boolean;
+  snapshotResizeSuppressed: boolean;
+  hasRenderedOutput: boolean;
+  replayStatus: HTMLDivElement;
 }
 
 interface TerminalViewProps {
@@ -106,6 +110,78 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     }
   };
 
+  const setReplayStatus = (entry: SessionTerminal, message: string | null) => {
+    entry.replayStatus.textContent = message ?? "";
+    entry.replayStatus.hidden = !message;
+  };
+
+  const writeTerminalBytes = (entry: SessionTerminal, data: Uint8Array) => {
+    entry.hasRenderedOutput = true;
+    setReplayStatus(entry, null);
+    entry.terminal.write(data);
+  };
+
+  const resizeTerminalForSnapshot = (
+    entry: SessionTerminal,
+    cols: number,
+    rows: number
+  ) => {
+    entry.snapshotResizeSuppressed = true;
+    try {
+      entry.terminal.resize(cols, rows);
+    } finally {
+      entry.snapshotResizeSuppressed = false;
+    }
+  };
+
+  const replayNativeSnapshot = (sessionId: string, entry: SessionTerminal) => {
+    if (!isTauri || entry.snapshotReplayRequested) {
+      return;
+    }
+
+    entry.snapshotReplayRequested = true;
+
+    void PtyAPI.getScreenSnapshot(sessionId)
+      .then((snapshot) => {
+        if (terminals.get(sessionId) !== entry) {
+          return;
+        }
+
+        if (!snapshot || snapshot.data.length === 0) {
+          if (!entry.hasRenderedOutput) {
+            setReplayStatus(
+              entry,
+              "Terminal buffer unavailable. Resize the window to request a repaint."
+            );
+          }
+          return;
+        }
+
+        if (
+          snapshot.rows !== null &&
+          snapshot.cols !== null &&
+          (entry.terminal.rows !== snapshot.rows || entry.terminal.cols !== snapshot.cols)
+        ) {
+          resizeTerminalForSnapshot(entry, snapshot.cols, snapshot.rows);
+        }
+
+        writeTerminalBytes(entry, new Uint8Array(snapshot.data));
+
+        if (sessionId === activeSessionId) {
+          scheduleViewportSync(sessionId);
+        }
+      })
+      .catch((err) => {
+        console.warn("[terminal] snapshot replay failed:", err);
+        if (terminals.get(sessionId) === entry && !entry.hasRenderedOutput) {
+          setReplayStatus(
+            entry,
+            "Terminal buffer unavailable. Resize the window to request a repaint."
+          );
+        }
+      });
+  };
+
   const createSessionTerminal = (sessionId: string) => {
     const existing = terminals.get(sessionId);
     if (existing) {
@@ -127,6 +203,12 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     terminal.loadAddon(fitAddon);
     terminal.open(container);
 
+    const replayStatus = document.createElement("div");
+    replayStatus.className = "terminal-replay-status";
+    replayStatus.hidden = true;
+    replayStatus.setAttribute("data-ac-testid", `terminal.replay-status.${sessionId}`);
+    container.appendChild(replayStatus);
+
     try {
       const webglAddon = new WebglAddon();
       webglAddon.onContextLoss(() => {
@@ -142,6 +224,10 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       terminal,
       fitAddon,
       inputBuffer: "",
+      snapshotReplayRequested: false,
+      snapshotResizeSuppressed: false,
+      hasRenderedOutput: false,
+      replayStatus,
     };
 
     // Per-terminal keyboard shortcuts. Match keys via event.key (layout-aware,
@@ -227,7 +313,7 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     });
 
     terminal.onResize(({ cols, rows }) => {
-      if (activeSessionId !== sessionId) {
+      if (activeSessionId !== sessionId || entry.snapshotResizeSuppressed) {
         return;
       }
 
@@ -235,6 +321,7 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     });
 
     terminals.set(sessionId, entry);
+    replayNativeSnapshot(sessionId, entry);
     return entry;
   };
 
@@ -285,7 +372,7 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         return;
       }
 
-      entry.terminal.write(new Uint8Array(data));
+      writeTerminalBytes(entry, new Uint8Array(data));
     });
 
     unlistenSessionDestroyed = await onSessionDestroyed(({ id }) => {

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -22,8 +22,10 @@ interface SessionTerminal {
   fitAddon: FitAddon;
   inputBuffer: string;
   snapshotReplayRequested: boolean;
+  snapshotReplayPending: boolean;
   snapshotResizeSuppressed: boolean;
   hasRenderedOutput: boolean;
+  queuedSnapshotOutput: Uint8Array[];
   replayStatus: HTMLDivElement;
 }
 
@@ -121,6 +123,24 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     entry.terminal.write(data);
   };
 
+  const flushQueuedSnapshotOutput = (entry: SessionTerminal) => {
+    const queuedOutput = entry.queuedSnapshotOutput;
+    entry.queuedSnapshotOutput = [];
+
+    for (const data of queuedOutput) {
+      writeTerminalBytes(entry, data);
+    }
+  };
+
+  const writeOrQueueTerminalBytes = (entry: SessionTerminal, data: Uint8Array) => {
+    if (entry.snapshotReplayPending) {
+      entry.queuedSnapshotOutput.push(data);
+      return;
+    }
+
+    writeTerminalBytes(entry, data);
+  };
+
   const resizeTerminalForSnapshot = (
     entry: SessionTerminal,
     cols: number,
@@ -140,6 +160,7 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     }
 
     entry.snapshotReplayRequested = true;
+    entry.snapshotReplayPending = true;
 
     void PtyAPI.getScreenSnapshot(sessionId)
       .then((snapshot) => {
@@ -147,7 +168,10 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
           return;
         }
 
+        entry.snapshotReplayPending = false;
+
         if (!snapshot || snapshot.data.length === 0) {
+          flushQueuedSnapshotOutput(entry);
           if (!entry.hasRenderedOutput) {
             setReplayStatus(
               entry,
@@ -166,6 +190,7 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         }
 
         writeTerminalBytes(entry, new Uint8Array(snapshot.data));
+        flushQueuedSnapshotOutput(entry);
 
         if (sessionId === activeSessionId) {
           scheduleViewportSync(sessionId);
@@ -173,7 +198,14 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       })
       .catch((err) => {
         console.warn("[terminal] snapshot replay failed:", err);
-        if (terminals.get(sessionId) === entry && !entry.hasRenderedOutput) {
+        if (terminals.get(sessionId) !== entry) {
+          return;
+        }
+
+        entry.snapshotReplayPending = false;
+        flushQueuedSnapshotOutput(entry);
+
+        if (!entry.hasRenderedOutput) {
           setReplayStatus(
             entry,
             "Terminal buffer unavailable. Resize the window to request a repaint."
@@ -225,8 +257,10 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       fitAddon,
       inputBuffer: "",
       snapshotReplayRequested: false,
+      snapshotReplayPending: false,
       snapshotResizeSuppressed: false,
       hasRenderedOutput: false,
+      queuedSnapshotOutput: [],
       replayStatus,
     };
 
@@ -372,7 +406,7 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         return;
       }
 
-      writeTerminalBytes(entry, new Uint8Array(data));
+      writeOrQueueTerminalBytes(entry, new Uint8Array(data));
     });
 
     unlistenSessionDestroyed = await onSessionDestroyed(({ id }) => {

--- a/src/terminal/styles/terminal.css
+++ b/src/terminal/styles/terminal.css
@@ -478,6 +478,25 @@ html.light-theme .last-prompt-panel::-webkit-scrollbar-thumb {
   inset: 0;
 }
 
+.terminal-replay-status {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-md);
+  color: var(--statusbar-fg);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  text-align: center;
+  pointer-events: none;
+}
+
+.terminal-replay-status[hidden] {
+  display: none;
+}
+
 .terminal-automation-input {
   position: absolute;
   left: 0;


### PR DESCRIPTION
## Summary
- Add native PTY screen snapshot replay for first terminal attach, backed by a per-PTY output sequence watermark.
- Use the watermark in TerminalView so snapshots and live PTY events cannot duplicate or reorder output during attach races.
- Gate WebSocket binary PTY user-message handling so failed writes do not clear RaiseHand state.

## Verification
- cargo test --test pty_lifecycle_regression
- cargo test --lib binary_pty_write
- cargo test --test cli_raise_hand
- cargo check
- cargo clippy -- -D warnings
- npm test -- src/terminal/App.workflow.test.tsx
- npm run typecheck
- git diff --check origin/main..HEAD
- Grinch review: PASS for #666 watermark contract and #678 blocker fix
- Shipper built and deployed C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe, size 33,404,416 bytes, timestamp 2026-06-28 16:06:25 local; --help passed

Closes #666
Closes #678