### PR TITLE
feat: replace coding agent projection with profile comparison, refs #674

### DIFF
--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -451,10 +451,13 @@ describe("AgentPickerModal", () => {
     expect(text("agentPicker.profile.B.env")).toContain("Declared env");
     expect(text("agentPicker.profile.B.env")).toContain("CODEX_PROFILE");
     expect(text("agentPicker.profile.B.env")).toContain("fast");
+    expect(text("agentPicker.comparison.row.codex")).toContain("2 env vars");
+    expect(text("agentPicker.comparison.row.codex")).toContain("CODEX_PROFILE=fast");
     expect(target("agentPicker.comparison").querySelector("[data-ac-profile-letter]")).toBeNull();
     expect(text("agentPicker.comparison")).toContain("Same Profile In Other Agents");
     expect(text("agentPicker.comparison")).not.toContain("Effective Projection");
     expect(text("agentPicker.comparison")).not.toContain("Chosen pair");
+    expect(maybe("agentPicker.fallback")).toBeNull();
 
     dispose();
   });
@@ -858,6 +861,7 @@ describe("AgentPickerModal", () => {
     await settle();
 
     expect(text("agentPicker.fallback")).toContain("Profile warning: invalid persisted override ignored");
+    expect(text("agentPicker.fallback")).not.toContain("launches with configured");
     expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(false);
 
     dispose();

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -436,12 +436,13 @@ describe("AgentPickerModal", () => {
     expect(target("agentPicker.provider.claude").getAttribute("data-ac-state")).toBe("active");
     expect(target("agentPicker.comparison.row.claude").getAttribute("data-ac-state")).toBe("active");
     expect(text("agentPicker.comparison.row.claude")).toContain("Claude Code");
-    expect(text("agentPicker.comparison.row.claude")).toContain("claude --dangerously-skip-permissions");
+    expect(text("agentPicker.comparison.row.claude")).toContain("A direct");
+    expect(text("agentPicker.comparison.row.claude")).not.toContain("claude --dangerously-skip-permissions");
 
     dispose();
   });
 
-  it("shows declared env vars for the selected profile and keeps comparison free of profile-letter controls", async () => {
+  it("shows declared env vars for the selected profile and keeps comparison compact", async () => {
     const { dispose } = renderPicker({ agentPath: REPO_PATH });
     await settle();
 
@@ -451,12 +452,16 @@ describe("AgentPickerModal", () => {
     expect(text("agentPicker.profile.B.env")).toContain("Declared env");
     expect(text("agentPicker.profile.B.env")).toContain("CODEX_PROFILE");
     expect(text("agentPicker.profile.B.env")).toContain("fast");
-    expect(text("agentPicker.comparison.row.codex")).toContain("2 env vars");
-    expect(text("agentPicker.comparison.row.codex")).toContain("CODEX_PROFILE=fast");
+    expect(text("agentPicker.comparison.row.codex")).toContain("B-FAST direct");
     expect(target("agentPicker.comparison").querySelector("[data-ac-profile-letter]")).toBeNull();
-    expect(text("agentPicker.comparison")).toContain("Same Profile In Other Agents");
-    expect(text("agentPicker.comparison")).not.toContain("Effective Projection");
-    expect(text("agentPicker.comparison")).not.toContain("Chosen pair");
+    const comparisonText = text("agentPicker.comparison");
+    expect(comparisonText).toContain("Same Profile In Other Agents");
+    expect(comparisonText).not.toContain("Effective Projection");
+    expect(comparisonText).not.toContain("Chosen pair");
+    expect(comparisonText).not.toMatch(/Command Delta/i);
+    expect(comparisonText).not.toMatch(/Env Summary/i);
+    expect(comparisonText).not.toContain("2 env vars");
+    expect(comparisonText).not.toContain("CODEX_PROFILE=fast");
     expect(maybe("agentPicker.fallback")).toBeNull();
 
     dispose();
@@ -515,7 +520,8 @@ describe("AgentPickerModal", () => {
     await settle();
     expect(target("agentPicker.provider.claude").getAttribute("data-ac-state")).toBe("active");
     expect(target("agentPicker.comparison.row.claude").getAttribute("data-ac-state")).toBe("active");
-    expect(text("agentPicker.comparison.row.claude")).toContain("claude --dangerously-skip-permissions");
+    expect(text("agentPicker.comparison.row.claude")).toContain("A direct");
+    expect(text("agentPicker.comparison.row.claude")).not.toContain("claude --dangerously-skip-permissions");
 
     dispose();
   });

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -391,7 +391,7 @@ describe("AgentPickerModal", () => {
 
     expect(target("agentPicker.providers")).toBeTruthy();
     expect(target("agentPicker.profiles")).toBeTruthy();
-    expect(target("agentPicker.projected")).toBeTruthy();
+    expect(target("agentPicker.comparison")).toBeTruthy();
     expect(target("agentPicker.cancel")).toBeTruthy();
     expect(target("agentPicker.apply")).toBeTruthy();
     expect(text("agentPicker.apply")).toContain("Assign to this replica");
@@ -426,7 +426,7 @@ describe("AgentPickerModal", () => {
     dispose();
   });
 
-  it("updates active provider state and projected command when a coding agent is clicked", async () => {
+  it("updates active provider state and the active comparison row when a coding agent is clicked", async () => {
     const { dispose } = renderPicker({ agentPath: REPO_PATH });
     await settle();
 
@@ -434,9 +434,27 @@ describe("AgentPickerModal", () => {
     await settle();
 
     expect(target("agentPicker.provider.claude").getAttribute("data-ac-state")).toBe("active");
-    // Effective Projection chosen-pair shows the selected coding agent + resolved command.
-    expect(text("agentPicker.projected")).toContain("Claude Code");
-    expect(text("agentPicker.projected")).toContain("claude --dangerously-skip-permissions");
+    expect(target("agentPicker.comparison.row.claude").getAttribute("data-ac-state")).toBe("active");
+    expect(text("agentPicker.comparison.row.claude")).toContain("Claude Code");
+    expect(text("agentPicker.comparison.row.claude")).toContain("claude --dangerously-skip-permissions");
+
+    dispose();
+  });
+
+  it("shows declared env vars for the selected profile and keeps comparison free of profile-letter controls", async () => {
+    const { dispose } = renderPicker({ agentPath: REPO_PATH });
+    await settle();
+
+    target<HTMLButtonElement>("agentPicker.profile.B").click();
+    await settle();
+
+    expect(text("agentPicker.profile.B.env")).toContain("Declared env");
+    expect(text("agentPicker.profile.B.env")).toContain("CODEX_PROFILE");
+    expect(text("agentPicker.profile.B.env")).toContain("fast");
+    expect(target("agentPicker.comparison").querySelector("[data-ac-profile-letter]")).toBeNull();
+    expect(text("agentPicker.comparison")).toContain("Same Profile In Other Agents");
+    expect(text("agentPicker.comparison")).not.toContain("Effective Projection");
+    expect(text("agentPicker.comparison")).not.toContain("Chosen pair");
 
     dispose();
   });
@@ -475,31 +493,31 @@ describe("AgentPickerModal", () => {
     const { dispose } = renderPicker({ agentPath: REPO_PATH });
     await settle();
 
-    // Baseline: codex is the initial selection and drives the projection.
+    // Baseline: codex is the initial selection and drives the active comparison row.
     expect(target("agentPicker.provider.codex").getAttribute("data-ac-state")).toBe("active");
-    expect(text("agentPicker.projected")).toContain("Codex");
+    expect(target("agentPicker.comparison.row.codex").getAttribute("data-ac-state")).toBe("active");
 
-    // Hovering claude must NOT activate it nor update the Effective Projection.
+    // Hovering claude must NOT activate it nor update the active comparison row.
     const claudeCard = target<HTMLButtonElement>("agentPicker.provider.claude");
     claudeCard.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false }));
     claudeCard.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
     await settle();
     expect(target("agentPicker.provider.claude").getAttribute("data-ac-state")).toBe("inactive");
     expect(target("agentPicker.provider.codex").getAttribute("data-ac-state")).toBe("active");
-    expect(text("agentPicker.projected")).toContain("Codex");
-    expect(text("agentPicker.projected")).not.toContain("Claude Code");
+    expect(target("agentPicker.comparison.row.codex").getAttribute("data-ac-state")).toBe("active");
+    expect(target("agentPicker.comparison.row.claude").getAttribute("data-ac-state")).toBe("inactive");
 
-    // Clicking still selects and updates the projection.
+    // Clicking still selects and updates the active comparison row.
     claudeCard.click();
     await settle();
     expect(target("agentPicker.provider.claude").getAttribute("data-ac-state")).toBe("active");
-    expect(text("agentPicker.projected")).toContain("Claude Code");
-    expect(text("agentPicker.projected")).toContain("claude --dangerously-skip-permissions");
+    expect(target("agentPicker.comparison.row.claude").getAttribute("data-ac-state")).toBe("active");
+    expect(text("agentPicker.comparison.row.claude")).toContain("claude --dangerously-skip-permissions");
 
     dispose();
   });
 
-  it("shows fallback on missing profile cards and in the projected panel", async () => {
+  it("shows fallback on missing profile cards and in the comparison row", async () => {
     const { dispose } = renderPicker({ agentPath: REPO_PATH });
     await settle();
 
@@ -510,8 +528,8 @@ describe("AgentPickerModal", () => {
     expect(text("agentPicker.profile.C")).toContain("Fallback C->B");
     expect(text("agentPicker.fallback")).toContain("C-REVIEW is not configured");
     expect(text("agentPicker.fallback")).toContain("A remains the final fallback");
-    // Effective Projection chosen-pair Resolution row reports the fallback hop.
-    expect(text("agentPicker.projected")).toContain("C-REVIEW → B-FAST (fallback)");
+    expect(text("agentPicker.comparison.row.codex")).toContain("C-REVIEW → B-FAST (fallback)");
+    expect(target("agentPicker.comparison.row.codex").getAttribute("data-ac-profile-status")).toBe("fallback");
 
     dispose();
   });
@@ -868,7 +886,7 @@ describe("AgentPickerModal", () => {
     );
     await settle();
     expect(text("agentPicker.fallback")).not.toContain("old warning");
-    expect(text("agentPicker.projected")).toContain("Claude Code");
+    expect(target("agentPicker.comparison.row.claude").getAttribute("data-ac-state")).toBe("active");
 
     dispose();
   });

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -14,7 +14,6 @@ import { automationAttrs } from "../../shared/automation-hooks";
 import {
   agentNameFromPathOrSession,
   composeEffectiveCommand,
-  effectiveEnvProjection,
   expandAcPlaceholdersPreview,
   isAcAgentPath,
   isWgReplicaPath,
@@ -248,7 +247,6 @@ const AgentPickerModal: Component<{
       }));
   const declaredProfileEnv = (agent: AgentConfig | null, letter: string) =>
     profileEnvEntries(profileCellFor(agent, letter));
-  const envCountText = (count: number) => `${count} env var${count === 1 ? "" : "s"}`;
   const comparisonResolutionText = (
     agentId: string,
     preview: ReturnType<typeof resolveProfilePreview>,
@@ -268,7 +266,6 @@ const AgentPickerModal: Component<{
         composeEffectiveCommand(agent.command, profileCellCommandText(cell)),
         acRoot(),
       );
-      const envEntries = effectiveEnvProjection(agent.envs, cell.env, acRoot());
       const status = command.trim().length === 0
         ? "missing"
         : preview.fallbackApplied
@@ -278,9 +275,6 @@ const AgentPickerModal: Component<{
         agent,
         index,
         preview,
-        cell,
-        command,
-        envEntries,
         status,
         active: index === highlightIndex(),
       };
@@ -890,65 +884,48 @@ const AgentPickerModal: Component<{
                 <div class="agent-comparison-table-head" role="row">
                   <span>Coding Agent</span>
                   <span>Resolution</span>
-                  <span>Command delta</span>
-                  <span>Env summary</span>
                 </div>
-                <For each={comparisonRows()}>
-                  {(row) => (
-                    <button
-                      type="button"
-                      class="agent-comparison-row"
-                      classList={{ active: row.active }}
-                      role="row"
-                      onClick={() => setHighlightIndex(row.index)}
-                      data-ac-agent-id={row.agent.id}
-                      data-ac-profile-status={row.status}
-                      data-ac-effective-profile={row.preview.effectiveProfile}
-                      data-ac-requested-profile={row.preview.requestedProfile}
-                      {...automationAttrs(
-                        `agentPicker.comparison.row.${row.agent.id}`,
-                        "button",
-                        row.active ? "active" : "inactive",
-                      )}
-                    >
-                      <span class="agent-comparison-agent-cell">
-                        <span class="agent-comparison-agent-name">{row.agent.label}</span>
-                        <span class="agent-comparison-agent-sub">
-                          {row.active ? "selected coding agent" : "configured peer"}
-                        </span>
-                      </span>
-                      <span class="agent-comparison-resolution-cell">
-                        <span
-                          class={`agent-comparison-status ${row.status}`}
-                          data-ac-role="status"
-                          data-ac-state={row.status}
-                        >
-                          {comparisonStatusLabel(row.status)}
-                        </span>
-                        <span class="agent-comparison-resolution">
-                          {comparisonResolutionText(row.agent.id, row.preview)}
-                        </span>
-                      </span>
-                      <span class="agent-comparison-command-cell">
-                        <span class="agent-comparison-command">{row.command || "none"}</span>
-                        <Show when={row.cell.notes}>
-                          <span class="agent-comparison-note">{row.cell.notes}</span>
-                        </Show>
-                      </span>
-                      <span class="agent-comparison-env-cell">
-                        <span class="agent-comparison-env-count">{envCountText(row.envEntries.length)}</span>
-                        <Show
-                          when={row.envEntries.length > 0}
-                          fallback={<span class="agent-comparison-env-muted">No launch env declared</span>}
-                        >
-                          <span class="agent-comparison-env-preview">
-                            {row.envEntries[0].key}={row.envEntries[0].value}
+                <div class="agent-comparison-table-body" role="rowgroup">
+                  <For each={comparisonRows()}>
+                    {(row) => (
+                      <button
+                        type="button"
+                        class="agent-comparison-row"
+                        classList={{ active: row.active }}
+                        role="row"
+                        onClick={() => setHighlightIndex(row.index)}
+                        data-ac-agent-id={row.agent.id}
+                        data-ac-profile-status={row.status}
+                        data-ac-effective-profile={row.preview.effectiveProfile}
+                        data-ac-requested-profile={row.preview.requestedProfile}
+                        {...automationAttrs(
+                          `agentPicker.comparison.row.${row.agent.id}`,
+                          "button",
+                          row.active ? "active" : "inactive",
+                        )}
+                      >
+                        <span class="agent-comparison-agent-cell">
+                          <span class="agent-comparison-agent-name">{row.agent.label}</span>
+                          <span class="agent-comparison-agent-sub">
+                            {row.active ? "selected coding agent" : "configured peer"}
                           </span>
-                        </Show>
-                      </span>
-                    </button>
-                  )}
-                </For>
+                        </span>
+                        <span class="agent-comparison-resolution-cell">
+                          <span
+                            class={`agent-comparison-status ${row.status}`}
+                            data-ac-role="status"
+                            data-ac-state={row.status}
+                          >
+                            {comparisonStatusLabel(row.status)}
+                          </span>
+                          <span class="agent-comparison-resolution">
+                            {comparisonResolutionText(row.agent.id, row.preview)}
+                          </span>
+                        </span>
+                      </button>
+                    )}
+                  </For>
+                </div>
               </div>
 
               <Show when={effectivePreview().fallbackApplied || hasBackendWarnings()}>

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -14,17 +14,15 @@ import { automationAttrs } from "../../shared/automation-hooks";
 import {
   agentNameFromPathOrSession,
   composeEffectiveCommand,
-  effectiveEnvProjection,
   expandAcPlaceholdersPreview,
-  hasAcPlaceholder,
   isAcAgentPath,
-  isCodexAgent,
   isWgReplicaPath,
   normalizeProfileLetter,
   profileBadgeKind,
   type ProfileBadgeKind,
   profileCellCommandText,
   profileDisplayLabel,
+  profileEnvOrigin,
   resolveProfilePreview,
   sortedProfileLetters,
   targetProfileFqn,
@@ -238,42 +236,60 @@ const AgentPickerModal: Component<{
     }
     return localSelectionPreview();
   });
-  const projectedCell = createMemo(() => {
-    const agent = selectedAgent();
-    if (!agent) return EMPTY_DISPLAY_CELL;
-    return enabledLaunchCellFor(agent, effectivePreview().effectiveProfile);
+  const profileEnvEntries = (cell: ProfileCellConfig | null) =>
+    Object.entries(cell?.enabled ? cell.env : {})
+      .filter(([key]) => key.trim().length > 0)
+      .sort(([a], [b]) => a.localeCompare(b, "en", { sensitivity: "base" }))
+      .map(([key, value]) => ({
+        key,
+        value: expandAcPlaceholdersPreview(value, acRoot()),
+        origin: profileEnvOrigin(key, value),
+      }));
+  const declaredProfileEnv = (agent: AgentConfig | null, letter: string) =>
+    profileEnvEntries(profileCellFor(agent, letter));
+  const envCountText = (count: number) => `${count} env var${count === 1 ? "" : "s"}`;
+  const comparisonResolutionText = (
+    agentId: string,
+    preview: ReturnType<typeof resolveProfilePreview>,
+  ) =>
+    preview.fallbackApplied
+      ? `${profileLabel(preview.requestedProfile, agentId)} → ${profileLabel(preview.effectiveProfile, agentId)} (fallback)`
+      : `${profileLabel(preview.requestedProfile, agentId)} direct`;
+  const comparisonStatusLabel = (status: string) =>
+    status === "direct" ? "direct" : status === "fallback" ? "fallback" : "missing";
+  const comparisonRows = createMemo(() => {
+    const current = settings();
+    if (!current) return [];
+    return sortedAgents().map((agent, index) => {
+      const preview = resolveProfilePreview(current.codingAgentProfiles, agent.id, selectedProfile());
+      const cell = enabledLaunchCellFor(agent, preview.effectiveProfile);
+      const command = expandAcPlaceholdersPreview(
+        composeEffectiveCommand(agent.command, profileCellCommandText(cell)),
+        acRoot(),
+      );
+      const envEntries = profileEnvEntries(cell);
+      const status = command.trim().length === 0
+        ? "missing"
+        : preview.fallbackApplied
+        ? "fallback"
+        : "direct";
+      return {
+        agent,
+        index,
+        preview,
+        cell,
+        command,
+        envEntries,
+        status,
+        active: index === highlightIndex(),
+      };
+    });
   });
-  // #597: the effective command is the agent base command followed by the cell params.
-  // Display-only AC placeholder expansion uses the replica root.
-  const projectedCommand = createMemo(() => {
-    const cmd = composeEffectiveCommand(
-      selectedAgent()?.command ?? "",
-      profileCellCommandText(projectedCell()),
-    );
-    return expandAcPlaceholdersPreview(cmd, acRoot());
-  });
-  // #527 Effective Projection: merged effective env (agent env + profile env) with
-  // per-value origin badges, plus the chosen-pair resolution descriptors.
-  const effectiveEnv = createMemo(() =>
-    effectiveEnvProjection(selectedAgent()?.envs, projectedCell().env, acRoot()),
-  );
-  const projectionFallback = createMemo(() => effectivePreview().fallbackApplied);
-  const projectionBadgeKind = createMemo<"match" | "fallback">(() =>
-    projectionFallback() ? "fallback" : "match",
-  );
-  const resolutionText = createMemo(() =>
-    projectionFallback()
-      ? `${profileLabel(effectivePreview().requestedProfile)} → ${profileLabel(effectivePreview().effectiveProfile)} (fallback)`
-      : "Direct match",
-  );
-  const commandUsesAcPlaceholder = createMemo(() =>
-    hasAcPlaceholder(
-      composeEffectiveCommand(
-        selectedAgent()?.command ?? "",
-        profileCellCommandText(projectedCell()),
-      ),
-    ),
-  );
+  const comparisonSummary = createMemo(() => ({
+    direct: comparisonRows().filter((row) => row.status === "direct").length,
+    fallback: comparisonRows().filter((row) => row.status === "fallback").length,
+    missing: comparisonRows().filter((row) => row.status === "missing").length,
+  }));
   const providerDefaultPreview = (agent: AgentConfig) => {
     const current = settings();
     if (!current) {
@@ -292,10 +308,6 @@ const AgentPickerModal: Component<{
   };
   const backendWarnings = createMemo(() => backendPreview()?.warnings ?? []);
   const hasBackendWarnings = createMemo(() => backendWarnings().length > 0);
-  const selectedIsCodex = createMemo(() => {
-    const agent = selectedAgent();
-    return agent ? isCodexAgent(agent) : false;
-  });
 
   onMount(async () => {
     overlayRef?.focus();
@@ -316,7 +328,7 @@ const AgentPickerModal: Component<{
     setInitialProfileShouldLaunch(Boolean(currentRequested) || Boolean(acDefault));
   });
 
-  // Backend profile resolution for the projected preview (effective letter, fallback).
+  // Backend profile resolution for the selected pair (effective letter, fallback).
   createEffect(() => {
     const current = settings();
     const agent = selectedAgent();
@@ -798,6 +810,39 @@ const AgentPickerModal: Component<{
                             <span>Command </span>
                             <span>{composeEffectiveCommand(selectedAgent()?.command ?? "", profileCellCommandText(cell())) || "none"}</span>
                           </span>
+                          <Show when={selected()}>
+                            <span
+                              class="agent-profile-declared-env"
+                              data-ac-testid={`agentPicker.profile.${letter}.env`}
+                              data-ac-role="list"
+                            >
+                              <span class="agent-profile-declared-env-head">Declared env</span>
+                              <Show
+                                when={declaredProfileEnv(selectedAgent(), letter).length > 0}
+                                fallback={
+                                  <span class="agent-profile-declared-env-empty">
+                                    No declared env vars for {profileLabel(letter)}
+                                  </span>
+                                }
+                              >
+                                <span class="agent-profile-declared-env-grid">
+                                  <For each={declaredProfileEnv(selectedAgent(), letter)}>
+                                    {(entry) => (
+                                      <span
+                                        class="agent-profile-declared-env-row"
+                                        data-ac-role="row"
+                                        data-ac-env-origin={entry.origin}
+                                      >
+                                        <span class="agent-profile-declared-env-key">{entry.key}</span>
+                                        <span class="agent-profile-declared-env-value">{entry.value}</span>
+                                        <span class="agent-profile-declared-env-origin">{entry.origin}</span>
+                                      </span>
+                                    )}
+                                  </For>
+                                </span>
+                              </Show>
+                            </span>
+                          </Show>
                           <Show when={!configured()}>
                             <span class="agent-profile-token warn">
                               Fallback {letter}-&gt;{preview().effectiveProfile}
@@ -813,147 +858,119 @@ const AgentPickerModal: Component<{
 
             <section
               class="agent-profile-panel agent-projection-panel"
-              data-component="Effective projection panel"
-              {...automationAttrs("agentPicker.projected", "status")}
+              data-component="Same profile comparison panel"
+              {...automationAttrs("agentPicker.comparison", "status")}
             >
               <div class="agent-projection-head">
                 <div class="agent-projection-heading">
-                  <div class="agent-profile-panel-title">Effective Projection</div>
-                  <div class="agent-profile-panel-kicker">Projected command and env for the chosen pair</div>
-                </div>
-                <span
-                  class={`agent-projection-badge ${projectionBadgeKind()}`}
-                  data-ac-role="status"
-                  data-ac-state={projectionBadgeKind()}
-                >
-                  {projectionBadgeKind()}
-                </span>
-              </div>
-
-              {/* Chosen pair — AGENT THEN PROFILE */}
-              <div class="agent-projection-card">
-                <div class="agent-projection-card-head">
-                  <span class="agent-projection-card-title">Chosen pair</span>
-                  <span class="agent-projection-tag cyan">agent then profile</span>
-                </div>
-                <div class="agent-projection-grid">
-                  <div class="agent-projection-row" data-ac-role="row">
-                    <span class="agent-projection-label">Coding agent</span>
-                    <span class="agent-projection-value" data-component="Selected coding agent">
-                      {selectedAgent()?.label ?? "none"}
-                    </span>
-                    <span class="agent-projection-pill green">selected</span>
-                  </div>
-                  <div class="agent-projection-row" data-ac-role="row">
-                    <span class="agent-projection-label">Profile letter</span>
-                    <span class="agent-projection-value">{effectivePreview().requestedProfile}</span>
-                    <span class={`agent-projection-pill ${projectionBadgeKind() === "fallback" ? "yellow" : "green"}`}>
-                      {projectionBadgeKind()}
-                    </span>
-                  </div>
-                  <div class="agent-projection-row" data-ac-role="row">
-                    <span class="agent-projection-label">Resolution</span>
-                    <span class="agent-projection-value" data-component="Profile resolution">{resolutionText()}</span>
-                    <span class={`agent-projection-pill ${projectionBadgeKind() === "fallback" ? "yellow" : "green"}`}>
-                      {projectionBadgeKind()}
-                    </span>
+                  <div class="agent-profile-panel-title">Same Profile In Other Agents</div>
+                  <div class="agent-profile-panel-kicker">
+                    {profileLabel(selectedProfile())} compared across configured Coding Agents
                   </div>
                 </div>
               </div>
 
-              {/* Command (RESOLVED) + Env (EFFECTIVE) */}
-              <div class="agent-projection-pair">
-                <div class="agent-projection-card">
-                  <div class="agent-projection-card-head">
-                    <span class="agent-projection-card-title">Command</span>
-                    <span class="agent-projection-tag cyan">resolved</span>
-                  </div>
-                  <div class="agent-projection-command" data-component="Resolved invocation">
-                    <span class="agent-projection-command-label">Invocation</span>
-                    <span class="agent-projection-command-value">{projectedCommand() || "none"}</span>
-                  </div>
-                  <Show when={commandUsesAcPlaceholder()}>
-                    <div class="agent-projection-ph">
-                      <span class="arrow">→</span>
-                      <span>AC path placeholders expand at launch; the backend validates the path.</span>
-                    </div>
-                  </Show>
-                  <Show when={selectedIsCodex() || selectedAgent()?.isolatedHome}>
-                    <div class="agent-projection-note">
-                      Home isolation {selectedAgent()?.isolatedHome ? "enabled" : "disabled"}
-                    </div>
-                  </Show>
-                  {/* #598 — read-only hint that this agent reseeds a config
-                      folder each spawn. The winning template tier needs a live
-                      FS check the picker must not do, so we only name the dest. */}
-                  <Show
-                    when={
-                      !!selectedAgent()?.configSeed?.enabled &&
-                      !!selectedAgent()?.configSeed?.dest?.trim()
-                    }
-                  >
-                    <div class="agent-projection-note">
-                      Seeds {selectedAgent()?.configSeed?.dest?.trim()} on every spawn
-                    </div>
-                  </Show>
-                  <Show when={projectedCell().notes}>
-                    <div class="agent-projection-note">Note: {projectedCell().notes}</div>
-                  </Show>
+              <div class="agent-comparison-summary" aria-label="Profile status summary">
+                <div class="agent-comparison-summary-tile">
+                  <span class="agent-comparison-summary-value direct">{comparisonSummary().direct}</span>
+                  <span class="agent-comparison-summary-label">Direct</span>
                 </div>
+                <div class="agent-comparison-summary-tile">
+                  <span class="agent-comparison-summary-value fallback">{comparisonSummary().fallback}</span>
+                  <span class="agent-comparison-summary-label">Fallback</span>
+                </div>
+                <div class="agent-comparison-summary-tile">
+                  <span class="agent-comparison-summary-value missing">{comparisonSummary().missing}</span>
+                  <span class="agent-comparison-summary-label">Missing</span>
+                </div>
+              </div>
 
-                <div class="agent-projection-card">
-                  <div class="agent-projection-card-head">
-                    <span class="agent-projection-card-title">Env</span>
-                    <span class="agent-projection-tag cyan">effective</span>
-                  </div>
-                  <div class="agent-projection-grid" data-ac-testid="agentPicker.projectedEnv" data-ac-role="list">
-                    <Show
-                      when={effectiveEnv().length > 0}
-                      fallback={
-                        <div class="agent-projection-row">
-                          <span class="agent-projection-label">env</span>
-                          <span class="agent-projection-value">No additional env vars</span>
-                          <span class="agent-projection-pill">none</span>
-                        </div>
-                      }
+              <div class="agent-comparison-table" role="table" aria-label="Same profile comparison">
+                <div class="agent-comparison-table-head" role="row">
+                  <span>Coding Agent</span>
+                  <span>Resolution</span>
+                  <span>Command delta</span>
+                  <span>Env summary</span>
+                </div>
+                <For each={comparisonRows()}>
+                  {(row) => (
+                    <button
+                      type="button"
+                      class="agent-comparison-row"
+                      classList={{ active: row.active }}
+                      role="row"
+                      onClick={() => setHighlightIndex(row.index)}
+                      data-ac-agent-id={row.agent.id}
+                      data-ac-profile-status={row.status}
+                      data-ac-effective-profile={row.preview.effectiveProfile}
+                      data-ac-requested-profile={row.preview.requestedProfile}
+                      {...automationAttrs(
+                        `agentPicker.comparison.row.${row.agent.id}`,
+                        "button",
+                        row.active ? "active" : "inactive",
+                      )}
                     >
-                      <For each={effectiveEnv()}>
-                        {(entry) => (
-                          <div class="agent-projection-row" data-ac-role="row" data-ac-env-origin={entry.origin}>
-                            <span class="agent-projection-label">{entry.key}</span>
-                            <span class="agent-projection-value">{entry.value}</span>
-                            <span
-                              class={`agent-projection-pill ${entry.origin === "profile" ? "" : "green"}`}
-                            >
-                              {entry.origin}
-                            </span>
-                          </div>
-                        )}
-                      </For>
-                    </Show>
-                  </div>
-                </div>
+                      <span class="agent-comparison-agent-cell">
+                        <span class="agent-comparison-agent-name">{row.agent.label}</span>
+                        <span class="agent-comparison-agent-sub">
+                          {row.active ? "selected coding agent" : "configured peer"}
+                        </span>
+                      </span>
+                      <span class="agent-comparison-resolution-cell">
+                        <span
+                          class={`agent-comparison-status ${row.status}`}
+                          data-ac-role="status"
+                          data-ac-state={row.status}
+                        >
+                          {comparisonStatusLabel(row.status)}
+                        </span>
+                        <span class="agent-comparison-resolution">
+                          {comparisonResolutionText(row.agent.id, row.preview)}
+                        </span>
+                      </span>
+                      <span class="agent-comparison-command-cell">
+                        <span class="agent-comparison-command">{row.command || "none"}</span>
+                        <Show when={row.cell.notes}>
+                          <span class="agent-comparison-note">{row.cell.notes}</span>
+                        </Show>
+                      </span>
+                      <span class="agent-comparison-env-cell">
+                        <span class="agent-comparison-env-count">{envCountText(row.envEntries.length)}</span>
+                        <Show
+                          when={row.envEntries.length > 0}
+                          fallback={<span class="agent-comparison-env-muted">No profile env declared</span>}
+                        >
+                          <span class="agent-comparison-env-preview">
+                            {row.envEntries[0].key}={row.envEntries[0].value}
+                          </span>
+                        </Show>
+                      </span>
+                    </button>
+                  )}
+                </For>
               </div>
 
-              <div
-                class="agent-profile-warning-strip agent-projection-status"
-                classList={{ visible: effectivePreview().fallbackApplied || hasBackendWarnings() }}
-                data-component="Coding Agent profile fallback explanation"
-                {...automationAttrs(
-                  "agentPicker.fallback",
-                  "status",
-                  effectivePreview().fallbackApplied || hasBackendWarnings() ? "warning" : "neutral"
-                )}
-              >
-                <span>
-                  {effectivePreview().fallbackApplied
-                    ? `${profileLabel(effectivePreview().requestedProfile)} is not configured for ${selectedAgent()?.label ?? "the selected coding agent"}; launch resolves through ${profileLabel(effectivePreview().effectiveProfile)}. A remains the final fallback.`
-                    : `${selectedAgent()?.label ?? "Selected coding agent"} launches with configured ${profileLabel(selectedProfile())} parameters.`}
-                </span>
-                <Show when={hasBackendWarnings()}>
-                  <span>Profile warning: {backendWarnings().join(" ")}</span>
-                </Show>
-              </div>
+              <Show when={selectedAgent()}>
+                <div
+                  class="agent-profile-warning-strip agent-projection-status"
+                  classList={{ visible: effectivePreview().fallbackApplied || hasBackendWarnings() }}
+                  data-component="Coding Agent profile fallback explanation"
+                  {...automationAttrs(
+                    "agentPicker.fallback",
+                    "status",
+                    effectivePreview().fallbackApplied || hasBackendWarnings() ? "warning" : "neutral"
+                  )}
+                >
+                  <span>
+                    {effectivePreview().fallbackApplied
+                      ? `${profileLabel(effectivePreview().requestedProfile)} is not configured for ${selectedAgent()?.label ?? "the selected coding agent"}; launch resolves through ${profileLabel(effectivePreview().effectiveProfile)}. A remains the final fallback.`
+                      : `${selectedAgent()?.label ?? "Selected coding agent"} launches with configured ${profileLabel(selectedProfile())} parameters.`}
+                  </span>
+                  <Show when={hasBackendWarnings()}>
+                    <span>Profile warning: {backendWarnings().join(" ")}</span>
+                  </Show>
+                </div>
+              </Show>
             </section>
           </div>
         </div>

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -14,6 +14,7 @@ import { automationAttrs } from "../../shared/automation-hooks";
 import {
   agentNameFromPathOrSession,
   composeEffectiveCommand,
+  effectiveEnvProjection,
   expandAcPlaceholdersPreview,
   isAcAgentPath,
   isWgReplicaPath,
@@ -267,7 +268,7 @@ const AgentPickerModal: Component<{
         composeEffectiveCommand(agent.command, profileCellCommandText(cell)),
         acRoot(),
       );
-      const envEntries = profileEnvEntries(cell);
+      const envEntries = effectiveEnvProjection(agent.envs, cell.env, acRoot());
       const status = command.trim().length === 0
         ? "missing"
         : preview.fallbackApplied
@@ -938,7 +939,7 @@ const AgentPickerModal: Component<{
                         <span class="agent-comparison-env-count">{envCountText(row.envEntries.length)}</span>
                         <Show
                           when={row.envEntries.length > 0}
-                          fallback={<span class="agent-comparison-env-muted">No profile env declared</span>}
+                          fallback={<span class="agent-comparison-env-muted">No launch env declared</span>}
                         >
                           <span class="agent-comparison-env-preview">
                             {row.envEntries[0].key}={row.envEntries[0].value}
@@ -950,22 +951,18 @@ const AgentPickerModal: Component<{
                 </For>
               </div>
 
-              <Show when={selectedAgent()}>
+              <Show when={effectivePreview().fallbackApplied || hasBackendWarnings()}>
                 <div
                   class="agent-profile-warning-strip agent-projection-status"
-                  classList={{ visible: effectivePreview().fallbackApplied || hasBackendWarnings() }}
+                  classList={{ visible: true }}
                   data-component="Coding Agent profile fallback explanation"
-                  {...automationAttrs(
-                    "agentPicker.fallback",
-                    "status",
-                    effectivePreview().fallbackApplied || hasBackendWarnings() ? "warning" : "neutral"
-                  )}
+                  {...automationAttrs("agentPicker.fallback", "status", "warning")}
                 >
-                  <span>
-                    {effectivePreview().fallbackApplied
-                      ? `${profileLabel(effectivePreview().requestedProfile)} is not configured for ${selectedAgent()?.label ?? "the selected coding agent"}; launch resolves through ${profileLabel(effectivePreview().effectiveProfile)}. A remains the final fallback.`
-                      : `${selectedAgent()?.label ?? "Selected coding agent"} launches with configured ${profileLabel(selectedProfile())} parameters.`}
-                  </span>
+                  <Show when={effectivePreview().fallbackApplied}>
+                    <span>
+                      {`${profileLabel(effectivePreview().requestedProfile)} is not configured for ${selectedAgent()?.label ?? "the selected coding agent"}; launch resolves through ${profileLabel(effectivePreview().effectiveProfile)}. A remains the final fallback.`}
+                    </span>
+                  </Show>
                   <Show when={hasBackendWarnings()}>
                     <span>Profile warning: {backendWarnings().join(" ")}</span>
                   </Show>

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2989,7 +2989,7 @@ html.light-theme .settings-hint-warning {
 }
 
 /* #563: cosmetic-only hover affordance. Selection is click-driven — hovering a
-   card must never pre-select it or update the Effective Projection. Only color
+   card must never pre-select it or update the active comparison row. Only color
    shifts here (border width and box size are unchanged), so nothing reflows.
    `:not(.active)` keeps the selected card's distinct accent tint. */
 .agent-profile-provider-card:hover:not(.active),
@@ -3096,6 +3096,66 @@ html.light-theme .settings-hint-warning {
 .agent-profile-param span:last-child {
   color: var(--sidebar-fg);
   overflow-wrap: anywhere;
+}
+
+.agent-profile-declared-env {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  margin-top: 1px;
+}
+
+.agent-profile-declared-env-head {
+  color: var(--sidebar-accent);
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.agent-profile-declared-env-grid {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.agent-profile-declared-env-row {
+  display: grid;
+  grid-template-columns: minmax(82px, 0.45fr) minmax(0, 1fr) auto;
+  gap: 7px;
+  min-width: 0;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  background: rgba(4, 8, 14, 0.55);
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 10px;
+  line-height: 1.3;
+}
+
+.agent-profile-declared-env-key {
+  color: var(--sidebar-fg-dim);
+  text-transform: uppercase;
+}
+
+.agent-profile-declared-env-value {
+  color: var(--sidebar-fg);
+  overflow-wrap: anywhere;
+}
+
+.agent-profile-declared-env-origin {
+  justify-self: end;
+  color: var(--status-active, #35f2a6);
+  font-size: 8px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.agent-profile-declared-env-empty {
+  color: var(--sidebar-fg-dim);
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 9.5px;
+  line-height: 1.35;
 }
 
 .agent-profile-warning-strip {
@@ -3332,7 +3392,7 @@ html.light-theme .settings-hint-warning {
   color: var(--sidebar-fg-dim);
 }
 
-/* ── #527 Selection Screen: step guides + Effective Projection ── */
+/* ── Selection Screen: step guides + same-profile comparison ── */
 .agent-profile-panel-head {
   display: flex;
   align-items: flex-start;
@@ -3386,171 +3446,164 @@ html.light-theme .settings-hint-warning {
   min-width: 0;
 }
 
-.agent-projection-badge {
-  flex: 0 0 auto;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 9px;
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  border: 1px solid var(--sidebar-border);
-  color: var(--sidebar-fg-dim);
-}
-
-.agent-projection-badge.match {
-  color: var(--status-active, #35f2a6);
-  border-color: rgba(53, 242, 166, 0.4);
-  background: rgba(53, 242, 166, 0.12);
-}
-
-.agent-projection-badge.fallback {
-  color: var(--status-pending, #f8c657);
-  border-color: rgba(248, 198, 87, 0.4);
-  background: rgba(248, 198, 87, 0.12);
-}
-
-.agent-projection-card {
+.agent-comparison-summary {
   display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
+}
+
+.agent-comparison-summary-tile {
+  display: grid;
+  gap: 2px;
   min-width: 0;
-  padding: 10px;
+  padding: 9px;
   border: 1px solid var(--sidebar-border);
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.025);
 }
 
-.agent-projection-card-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--spacing-xs);
-}
-
-.agent-projection-card-title {
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--sidebar-fg);
-}
-
-.agent-projection-tag {
-  padding: 2px 6px;
-  border-radius: 999px;
-  font-size: 9px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  border: 1px solid var(--sidebar-border);
-  color: var(--sidebar-fg-dim);
-  white-space: nowrap;
-}
-
-.agent-projection-tag.cyan {
-  color: var(--sidebar-accent);
-  border-color: rgba(0, 212, 255, 0.28);
-  background: rgba(0, 212, 255, 0.1);
-}
-
-.agent-projection-grid {
-  display: grid;
-  gap: 6px;
-  min-width: 0;
-}
-
-.agent-projection-row {
-  display: grid;
-  grid-template-columns: minmax(92px, 0.5fr) minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  border-radius: var(--radius-sm);
-  background: rgba(4, 8, 14, 0.4);
+.agent-comparison-summary-value {
   font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: 18px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.agent-comparison-summary-value.direct {
+  color: var(--status-active, #35f2a6);
+}
+
+.agent-comparison-summary-value.fallback {
+  color: var(--status-pending, #f8c657);
+}
+
+.agent-comparison-summary-value.missing {
+  color: var(--status-exited, #ff5d5d);
+}
+
+.agent-comparison-summary-label {
+  color: var(--sidebar-fg-dim);
   font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.agent-comparison-table {
+  min-width: 0;
+  overflow: auto;
+  border: 1px solid var(--sidebar-border);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.agent-comparison-table-head,
+.agent-comparison-row {
+  display: grid;
+  grid-template-columns: minmax(118px, 0.7fr) minmax(116px, 0.62fr) minmax(180px, 1.08fr) minmax(130px, 0.72fr);
+  gap: 8px;
+  min-width: 640px;
+}
+
+.agent-comparison-table-head {
+  padding: 8px;
+  color: var(--sidebar-fg-dim);
+  background: rgba(4, 8, 14, 0.7);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.agent-comparison-row {
+  width: 100%;
+  padding: 8px;
+  border: 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  background: transparent;
+  color: var(--sidebar-fg);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  text-align: left;
+}
+
+.agent-comparison-row:hover,
+.agent-comparison-row.active {
+  background: rgba(0, 212, 255, 0.065);
+}
+
+.agent-comparison-row.active {
+  box-shadow: inset 2px 0 0 var(--sidebar-accent);
+}
+
+.agent-comparison-agent-cell,
+.agent-comparison-resolution-cell,
+.agent-comparison-command-cell,
+.agent-comparison-env-cell {
+  display: grid;
+  align-content: start;
+  gap: 4px;
   min-width: 0;
 }
 
-.agent-projection-label {
-  color: var(--sidebar-fg-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
+.agent-comparison-agent-name {
+  color: var(--sidebar-fg);
+  font-weight: 800;
 }
 
-.agent-projection-value {
-  color: var(--sidebar-fg);
+.agent-comparison-agent-sub,
+.agent-comparison-note,
+.agent-comparison-env-muted,
+.agent-comparison-env-preview {
+  color: var(--sidebar-fg-dim);
+  line-height: 1.35;
+}
+
+.agent-comparison-resolution,
+.agent-comparison-command,
+.agent-comparison-env-count,
+.agent-comparison-env-preview {
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+}
+
+.agent-comparison-resolution,
+.agent-comparison-command,
+.agent-comparison-env-preview {
   overflow-wrap: anywhere;
 }
 
-.agent-projection-pill {
-  justify-self: end;
-  padding: 1px 6px;
+.agent-comparison-status {
+  justify-self: start;
+  padding: 2px 6px;
+  border: 1px solid var(--sidebar-border);
   border-radius: 999px;
   font-size: 8px;
   font-weight: 800;
-  text-transform: uppercase;
   letter-spacing: 0.03em;
-  border: 1px solid var(--sidebar-border);
-  color: var(--sidebar-fg-dim);
-  white-space: nowrap;
+  text-transform: uppercase;
 }
 
-.agent-projection-pill.green {
+.agent-comparison-status.direct {
   color: var(--status-active, #35f2a6);
   border-color: rgba(53, 242, 166, 0.35);
   background: rgba(53, 242, 166, 0.1);
 }
 
-.agent-projection-pill.yellow {
+.agent-comparison-status.fallback {
   color: var(--status-pending, #f8c657);
   border-color: rgba(248, 198, 87, 0.4);
   background: rgba(248, 198, 87, 0.12);
 }
 
-.agent-projection-pair {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 10px;
-  min-width: 0;
+.agent-comparison-status.missing {
+  color: var(--status-exited, #ff5d5d);
+  border-color: rgba(255, 93, 93, 0.4);
+  background: rgba(255, 93, 93, 0.1);
 }
 
-.agent-projection-command {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 8px;
-  align-items: baseline;
-  padding: 7px 8px;
-  border-radius: var(--radius-sm);
-  background: rgba(4, 8, 14, 0.55);
-  font-family: "Cascadia Code", "JetBrains Mono", monospace;
-  font-size: 10px;
-}
-
-.agent-projection-command-label {
-  color: var(--sidebar-fg-dim);
-}
-
-.agent-projection-command-value {
+.agent-comparison-env-count {
   color: var(--sidebar-fg);
-  overflow-wrap: anywhere;
-}
-
-.agent-projection-ph {
-  display: flex;
-  gap: 6px;
-  font-family: "Cascadia Code", "JetBrains Mono", monospace;
-  font-size: 9.5px;
-  color: var(--sidebar-fg-dim);
-  line-height: 1.4;
-}
-
-.agent-projection-ph .arrow {
-  color: var(--status-active, #35f2a6);
-  font-weight: 800;
-}
-
-.agent-projection-note {
-  font-size: 10px;
-  color: var(--sidebar-fg-dim);
+  font-weight: 700;
 }
 
 .agent-picker-bar {

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -3584,7 +3584,7 @@ html.light-theme .settings-hint-warning {
 
 .agent-comparison-agent-name,
 .agent-comparison-agent-sub,
-.agent-comparison-resolution,
+.agent-comparison-resolution {
   overflow-wrap: anywhere;
 }
 

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -3431,8 +3431,10 @@ html.light-theme .settings-hint-warning {
 }
 
 .agent-projection-panel {
-  align-content: start;
+  align-content: stretch;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
   gap: 10px;
+  min-height: 0;
 }
 
 .agent-projection-head {
@@ -3490,18 +3492,40 @@ html.light-theme .settings-hint-warning {
 
 .agent-comparison-table {
   min-width: 0;
-  overflow: auto;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  max-height: clamp(220px, 42vh, 420px);
+  overflow: hidden;
   border: 1px solid var(--sidebar-border);
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.02);
 }
 
+.agent-comparison-table-body {
+  min-width: 0;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}
+
+.agent-comparison-table-body::-webkit-scrollbar {
+  width: 4px;
+}
+
+.agent-comparison-table-body::-webkit-scrollbar-thumb {
+  background: var(--sidebar-border);
+  border-radius: 2px;
+}
+
 .agent-comparison-table-head,
 .agent-comparison-row {
   display: grid;
-  grid-template-columns: minmax(118px, 0.7fr) minmax(116px, 0.62fr) minmax(180px, 1.08fr) minmax(130px, 0.72fr);
+  grid-template-columns: minmax(0, 0.72fr) minmax(0, 1.28fr);
   gap: 8px;
-  min-width: 640px;
+  width: 100%;
+  min-width: 0;
 }
 
 .agent-comparison-table-head {
@@ -3537,9 +3561,7 @@ html.light-theme .settings-hint-warning {
 }
 
 .agent-comparison-agent-cell,
-.agent-comparison-resolution-cell,
-.agent-comparison-command-cell,
-.agent-comparison-env-cell {
+.agent-comparison-resolution-cell {
   display: grid;
   align-content: start;
   gap: 4px;
@@ -3551,24 +3573,18 @@ html.light-theme .settings-hint-warning {
   font-weight: 800;
 }
 
-.agent-comparison-agent-sub,
-.agent-comparison-note,
-.agent-comparison-env-muted,
-.agent-comparison-env-preview {
+.agent-comparison-agent-sub {
   color: var(--sidebar-fg-dim);
   line-height: 1.35;
 }
 
-.agent-comparison-resolution,
-.agent-comparison-command,
-.agent-comparison-env-count,
-.agent-comparison-env-preview {
+.agent-comparison-resolution {
   font-family: "Cascadia Code", "JetBrains Mono", monospace;
 }
 
+.agent-comparison-agent-name,
+.agent-comparison-agent-sub,
 .agent-comparison-resolution,
-.agent-comparison-command,
-.agent-comparison-env-preview {
   overflow-wrap: anywhere;
 }
 
@@ -3599,11 +3615,6 @@ html.light-theme .settings-hint-warning {
   color: var(--status-exited, #ff5d5d);
   border-color: rgba(255, 93, 93, 0.4);
   background: rgba(255, 93, 93, 0.1);
-}
-
-.agent-comparison-env-count {
-  color: var(--sidebar-fg);
-  font-weight: 700;
 }
 
 .agent-picker-bar {


### PR DESCRIPTION
## Summary
- Replace the Coding Agent selector's Effective Projection panel with a same-profile comparison across configured Coding Agents.
- Show declared env values on the selected Profile card.
- Preserve replica/kind/workgroup assignment controls and confirmation behavior.
- Remove the Command Delta / Env Summary columns from the comparison table and use vertical-only row scrolling.

## Validation
- npx vitest run src/sidebar/components/AgentPickerModal.test.tsx src/sidebar/components/SettingsModal.automation.test.ts src/shared/profile-utils.test.ts
- npm run smoke:profile-matrix
- npx tsc --noEmit
- npm run build
- Shipper deployed C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-9.exe and --help passed
- dev-rust-grinch approved implementation, layout fix, and final pre-landing review

Closes #674