### PR TITLE
fix: use checkbox confirmation for kind profile applies, refs #681

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -510,7 +510,9 @@ pub async fn preview_coding_agent_profile_selection(
         target_count: enumeration.targets.len(),
         live_session_count,
         target_fingerprint,
-        requires_explicit_confirmation: request.scope == ProfileAssignmentScope::Kind,
+        requires_explicit_confirmation: profile_assignment_requires_explicit_confirmation(
+            &request.scope,
+        ),
         targets: enumeration.targets,
         warnings: enumeration.warnings,
     })
@@ -546,11 +548,7 @@ pub async fn apply_coding_agent_profile_selection(
         request.restart_sessions,
         &enumeration.canonical_target_paths,
     );
-    validate_profile_assignment_confirmation(
-        &request,
-        &target_fingerprint,
-        enumeration.targets.len(),
-    )?;
+    validate_profile_assignment_confirmation(&request, &target_fingerprint)?;
 
     if request.restart_sessions {
         prevalidate_profile_assignment_restarts(
@@ -688,10 +686,13 @@ fn normalize_profile_letter_for_assignment(profile: &str) -> Result<String, Stri
         .ok_or_else(|| "Profile must be a single letter A through Z".to_string())
 }
 
+fn profile_assignment_requires_explicit_confirmation(scope: &ProfileAssignmentScope) -> bool {
+    *scope != ProfileAssignmentScope::Replica
+}
+
 fn validate_profile_assignment_confirmation(
     request: &ApplyCodingAgentProfileSelectionRequest,
     fingerprint: &str,
-    target_count: usize,
 ) -> Result<(), String> {
     if request.scope != ProfileAssignmentScope::Replica {
         match request.confirmed_target_fingerprint.as_deref() {
@@ -709,24 +710,6 @@ fn validate_profile_assignment_confirmation(
                 "Target selection changed. Rerun preview before applying profile selection."
                     .to_string(),
             );
-        }
-    }
-
-    if request.scope == ProfileAssignmentScope::Kind {
-        let restart = if request.restart_sessions {
-            "WITH RESTART"
-        } else {
-            "WITHOUT RESTART"
-        };
-        let expected = format!(
-            "APPLY {}:{} TO {} REPLICAS {}",
-            request.coding_agent_id,
-            normalize_profile_letter_for_assignment(&request.profile)?,
-            target_count,
-            restart
-        );
-        if request.typed_confirmation.as_deref() != Some(expected.as_str()) {
-            return Err("Typed confirmation does not match the current target preview".to_string());
         }
     }
     Ok(())
@@ -1422,6 +1405,23 @@ mod tests {
         Arc::new(RwLock::new(settings))
     }
 
+    fn profile_assignment_request(
+        scope: super::ProfileAssignmentScope,
+        confirmed_target_fingerprint: Option<&str>,
+        typed_confirmation: Option<&str>,
+    ) -> super::ApplyCodingAgentProfileSelectionRequest {
+        super::ApplyCodingAgentProfileSelectionRequest {
+            target_replica_path: "C:/ac/wg-1/__agent_dev-rust".to_string(),
+            coding_agent_id: "dev-rust".to_string(),
+            profile: "B".to_string(),
+            scope,
+            restart_sessions: false,
+            confirmed_target_fingerprint: confirmed_target_fingerprint
+                .map(|value| value.to_string()),
+            typed_confirmation: typed_confirmation.map(|value| value.to_string()),
+        }
+    }
+
     #[test]
     fn profile_assignment_fingerprint_uses_typed_fields() {
         let targets = vec!["c:/ac/wg-1/__agent_a".to_string()];
@@ -1439,6 +1439,62 @@ mod tests {
         assert_ne!(ab_c, a_bc);
         assert_ne!(ab_c, restart);
         assert_ne!(ab_c, other_targets);
+    }
+
+    #[test]
+    fn profile_assignment_confirmation_hint_tracks_broad_scopes() {
+        assert!(!super::profile_assignment_requires_explicit_confirmation(
+            &super::ProfileAssignmentScope::Replica
+        ));
+        assert!(super::profile_assignment_requires_explicit_confirmation(
+            &super::ProfileAssignmentScope::Workgroup
+        ));
+        assert!(super::profile_assignment_requires_explicit_confirmation(
+            &super::ProfileAssignmentScope::Kind
+        ));
+    }
+
+    #[test]
+    fn kind_assignment_accepts_fingerprint_without_typed_confirmation() {
+        let request =
+            profile_assignment_request(super::ProfileAssignmentScope::Kind, Some("fp-kind"), None);
+
+        assert_eq!(
+            super::validate_profile_assignment_confirmation(&request, "fp-kind"),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn kind_assignment_ignores_legacy_typed_confirmation() {
+        let request = profile_assignment_request(
+            super::ProfileAssignmentScope::Kind,
+            Some("fp-kind"),
+            Some("not the old exact phrase"),
+        );
+
+        assert_eq!(
+            super::validate_profile_assignment_confirmation(&request, "fp-kind"),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn broad_assignment_rejects_missing_or_stale_fingerprint() {
+        for scope in [
+            super::ProfileAssignmentScope::Kind,
+            super::ProfileAssignmentScope::Workgroup,
+        ] {
+            let missing = profile_assignment_request(scope.clone(), None, None);
+            let err = super::validate_profile_assignment_confirmation(&missing, "current-fp")
+                .unwrap_err();
+            assert!(err.contains("Target selection changed"), "{err}");
+
+            let stale = profile_assignment_request(scope, Some("old-fp"), None);
+            let err =
+                super::validate_profile_assignment_confirmation(&stale, "current-fp").unwrap_err();
+            assert!(err.contains("Target selection changed"), "{err}");
+        }
     }
 
     #[test]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -788,7 +788,7 @@ export interface PreviewCodingAgentProfileSelectionResult {
   liveSessionCount: number;
   /** Hash of (codingAgentId, profile, restart, sorted canonical target paths). */
   targetFingerprint: string;
-  /** True for `kind`; requires the typed confirmation phrase. */
+  /** Backend confirmation hint; frontend broad scopes use a checkbox confirmation gate. */
   requiresExplicitConfirmation: boolean;
   targets: ProfileAssignmentTarget[];
   warnings: string[];
@@ -802,7 +802,7 @@ export interface ApplyCodingAgentProfileSelectionRequest {
   restartSessions: boolean;
   /** Required for `kind`/`workgroup`; `null` allowed for single-target `replica`. */
   confirmedTargetFingerprint?: string | null;
-  /** Required for `kind`; the exact typed phrase from the preview. */
+  /** Legacy typed confirmation field; frontend sends `null` and relies on fingerprint + checkbox confirmation. */
   typedConfirmation?: string | null;
 }
 

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -579,7 +579,7 @@ describe("AgentPickerModal", () => {
     dispose();
   });
 
-  it("keeps kind apply disabled until preview succeeds and the typed phrase matches", async () => {
+  it("keeps kind apply disabled until the arm checkbox is checked", async () => {
     const { dispose } = renderPicker({
       agentPath: WG_REPLICA_PATH,
       scopeContext: WG_SCOPE_CONTEXT,
@@ -591,24 +591,19 @@ describe("AgentPickerModal", () => {
     await settle();
 
     expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
-    const phrase = target<HTMLInputElement>("agentPicker.kindConfirm").getAttribute("placeholder")!;
-    expect(phrase).toBe("APPLY codex:A TO 3 REPLICAS WITHOUT RESTART");
+    expect(maybe("agentPicker.kindConfirm")).toBeNull();
+    expect(target<HTMLInputElement>("agentPicker.armToggle").closest("label")?.textContent).toContain(
+      "I understand this overwrites 3 replicas of this kind",
+    );
 
-    const input = target<HTMLInputElement>("agentPicker.kindConfirm");
-    input.value = "APPLY codex:A TO 3 REPLICAS";
-    input.dispatchEvent(new Event("input", { bubbles: true }));
-    await settle();
-    expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
-
-    input.value = phrase;
-    input.dispatchEvent(new Event("input", { bubbles: true }));
+    target<HTMLInputElement>("agentPicker.armToggle").click();
     await settle();
     expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(false);
 
     dispose();
   });
 
-  it("resets the typed confirmation when the profile changes", async () => {
+  it("resets the kind arm checkbox when the profile changes", async () => {
     const { dispose } = renderPicker({
       agentPath: WG_REPLICA_PATH,
       scopeContext: WG_SCOPE_CONTEXT,
@@ -618,22 +613,20 @@ describe("AgentPickerModal", () => {
 
     clickRadio("agentPicker.scope.kind");
     await settle();
-    const input = target<HTMLInputElement>("agentPicker.kindConfirm");
-    input.value = target<HTMLInputElement>("agentPicker.kindConfirm").getAttribute("placeholder")!;
-    input.dispatchEvent(new Event("input", { bubbles: true }));
+    target<HTMLInputElement>("agentPicker.armToggle").click();
     await settle();
     expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(false);
 
-    // Changing the profile must reset the typed confirmation and re-disable apply.
+    // Changing the profile must reset the checkbox confirmation and re-disable apply.
     target<HTMLButtonElement>("agentPicker.profile.B").click();
     await settle();
-    expect(target<HTMLInputElement>("agentPicker.kindConfirm").value).toBe("");
+    expect(target<HTMLInputElement>("agentPicker.armToggle").checked).toBe(false);
     expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
 
     dispose();
   });
 
-  it("sends confirmedTargetFingerprint and typedConfirmation for a kind apply", async () => {
+  it("sends confirmedTargetFingerprint and null typedConfirmation for a kind apply", async () => {
     const { dispose, onSelect } = renderPicker({
       agentPath: WG_REPLICA_PATH,
       scopeContext: WG_SCOPE_CONTEXT,
@@ -643,10 +636,7 @@ describe("AgentPickerModal", () => {
 
     clickRadio("agentPicker.scope.kind");
     await settle();
-    const input = target<HTMLInputElement>("agentPicker.kindConfirm");
-    const phrase = input.getAttribute("placeholder")!;
-    input.value = phrase;
-    input.dispatchEvent(new Event("input", { bubbles: true }));
+    target<HTMLInputElement>("agentPicker.armToggle").click();
     await settle();
 
     target<HTMLButtonElement>("agentPicker.apply").click();
@@ -659,11 +649,46 @@ describe("AgentPickerModal", () => {
         profile: "A",
         restartSessions: false,
         confirmedTargetFingerprint: "fp-kind",
-        typedConfirmation: phrase,
+        typedConfirmation: null,
       }),
     );
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ scope: "kind", restartSessions: false }),
+    );
+
+    dispose();
+  });
+
+  it("keeps the restart toggle for kind scope and carries it into preview and apply", async () => {
+    const { dispose } = renderPicker({
+      agentPath: WG_REPLICA_PATH,
+      scopeContext: WG_SCOPE_CONTEXT,
+      currentRequestedProfile: "A",
+    });
+    await settle();
+
+    clickRadio("agentPicker.scope.kind");
+    await settle();
+
+    target<HTMLInputElement>("agentPicker.restartToggle").click();
+    await settle();
+
+    expect(mockSettingsApi.previewCodingAgentProfileSelection).toHaveBeenLastCalledWith(
+      expect.objectContaining({ scope: "kind", restartSessions: true }),
+    );
+
+    target<HTMLInputElement>("agentPicker.armToggle").click();
+    await settle();
+    target<HTMLButtonElement>("agentPicker.apply").click();
+    await settle();
+
+    expect(mockSettingsApi.applyCodingAgentProfileSelection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "kind",
+        restartSessions: true,
+        confirmedTargetFingerprint: "fp-kind",
+        typedConfirmation: null,
+      }),
     );
 
     dispose();
@@ -791,9 +816,7 @@ describe("AgentPickerModal", () => {
 
     clickRadio("agentPicker.scope.kind");
     await settle();
-    const input = target<HTMLInputElement>("agentPicker.kindConfirm");
-    input.value = input.getAttribute("placeholder")!;
-    input.dispatchEvent(new Event("input", { bubbles: true }));
+    target<HTMLInputElement>("agentPicker.armToggle").click();
     await settle();
 
     target<HTMLButtonElement>("agentPicker.apply").click();
@@ -806,9 +829,10 @@ describe("AgentPickerModal", () => {
     expect(text("agentPicker.errors")).toContain("Targets changed; rerun preview.");
     expect(maybe("agentPicker.toast")).toBeTruthy();
     expect(text("agentPicker.toast")).toContain("Targets changed; rerun preview.");
-    // Modal stays open; selection is not committed; typed confirmation is reset.
+    // Modal stays open; selection is not committed; checkbox confirmation is reset.
     expect(onSelect).not.toHaveBeenCalled();
     expect(maybe("agentPicker.modal")).toBeTruthy();
+    expect(target<HTMLInputElement>("agentPicker.armToggle").checked).toBe(false);
 
     dispose();
   });

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -837,6 +837,45 @@ describe("AgentPickerModal", () => {
     dispose();
   });
 
+  it("resets broad-scope confirmation and re-previews when stale fingerprint apply rejects", async () => {
+    const staleFingerprintMessage =
+      "Target selection changed. Rerun preview before applying profile selection.";
+    mockSettingsApi.applyCodingAgentProfileSelection.mockRejectedValue(
+      new Error(staleFingerprintMessage),
+    );
+    const { dispose, onSelect } = renderPicker({
+      agentPath: WG_REPLICA_PATH,
+      scopeContext: WG_SCOPE_CONTEXT,
+      currentRequestedProfile: "A",
+    });
+    await settle();
+
+    clickRadio("agentPicker.scope.kind");
+    await settle();
+    target<HTMLInputElement>("agentPicker.armToggle").click();
+    await settle();
+    expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(false);
+
+    mockSettingsApi.previewCodingAgentProfileSelection.mockClear();
+    target<HTMLButtonElement>("agentPicker.apply").click();
+    await settle();
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(text("agentPicker.toast")).toContain(staleFingerprintMessage);
+    expect(target<HTMLInputElement>("agentPicker.armToggle").checked).toBe(false);
+    expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(true);
+    expect(mockSettingsApi.previewCodingAgentProfileSelection).toHaveBeenCalledTimes(1);
+    expect(mockSettingsApi.previewCodingAgentProfileSelection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "kind",
+        codingAgentId: "codex",
+        profile: "A",
+      }),
+    );
+
+    dispose();
+  });
+
   it("applies a replica-scope selection through the backend and then commits", async () => {
     const { dispose, onSelect } = renderPicker({
       agentPath: WG_REPLICA_PATH,

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -119,7 +119,6 @@ const AgentPickerModal: Component<{
   const [selectedScope, setSelectedScope] = createSignal<ProfileAssignmentScope>("replica");
   const [restartSessions, setRestartSessions] = createSignal(false);
   const [dangerArmed, setDangerArmed] = createSignal(false);
-  const [kindConfirmationText, setKindConfirmationText] = createSignal("");
   const [scopePreview, setScopePreview] = createSignal<PreviewCodingAgentProfileSelectionResult | null>(null);
   const [scopePreviewBusy, setScopePreviewBusy] = createSignal(false);
   const [scopePreviewError, setScopePreviewError] = createSignal("");
@@ -361,8 +360,8 @@ const AgentPickerModal: Component<{
   });
 
   // Backend scope preview — authoritative target/live-session enumeration and the
-  // fingerprint that apply re-validates. Re-runs (and clears the typed confirmation,
-  // arm checkbox, preview, fingerprint) whenever scope, coding agent, profile,
+  // fingerprint that apply re-validates. Re-runs (and clears the broad-scope
+  // confirmation checkbox, preview, fingerprint) whenever scope, coding agent, profile,
   // restart toggle, or target replica changes (#384 Frontend §4).
   const runScopePreview = (scope: ProfileAssignmentScope, agentId: string, profile: string) => {
     const target = targetReplicaPath();
@@ -402,7 +401,6 @@ const AgentPickerModal: Component<{
     // Reset every transient confirmation/preview artifact on any input change.
     previewSeq += 1;
     setDangerArmed(false);
-    setKindConfirmationText("");
     setScopePreview(null);
     setScopePreviewError("");
     setApplyErrors([]);
@@ -430,25 +428,25 @@ const AgentPickerModal: Component<{
     return profileTouched() || initialProfileShouldLaunch() ? selectedProfile() : null;
   };
 
-  // Typed confirmation phrase for the cross-workgroup `kind` scope. Must match the
-  // backend phrase exactly, including count and restart wording (#384 §7).
-  const kindPhrase = createMemo(() => {
-    const preview = scopePreview();
-    const agent = selectedAgent();
-    if (!preview || !agent) return "";
-    const restart = restartSessions() ? "WITH RESTART" : "WITHOUT RESTART";
-    return `APPLY ${agent.id}:${selectedProfile()} TO ${preview.targetCount} REPLICAS ${restart}`;
-  });
-
   const scopeCount = (scope: ProfileAssignmentScope): number => {
     const preview = scopePreview();
     if (preview && selectedScope() === scope) return preview.targetCount;
     return scope === "replica" ? 1 : 0;
   };
 
+  const scopeReplicaNoun = (count: number) => count === 1 ? "replica" : "replicas";
+
   const distinctWorkgroupCount = createMemo(() => {
     const targets = scopePreview()?.targets ?? [];
     return new Set(targets.map((t) => t.workgroupName)).size;
+  });
+
+  const confirmationLabel = createMemo(() => {
+    const scope = selectedScope();
+    const count = scopeCount(scope);
+    const noun = scopeReplicaNoun(count);
+    if (scope === "kind") return `I understand this overwrites ${count} ${noun} of this kind`;
+    return `I understand this overwrites ${count} ${noun}`;
   });
 
   const applyLabel = createMemo(() => {
@@ -523,8 +521,7 @@ const AgentPickerModal: Component<{
     if (scope === "replica") return !isRedundantReplicaSelection();
     if (!isWgReplica()) return false;
     if (scopePreviewBusy() || !scopePreview()) return false;
-    if (scope === "workgroup") return dangerArmed();
-    if (scope === "kind") return kindConfirmationText().trim() === kindPhrase();
+    if (scope === "workgroup" || scope === "kind") return dangerArmed();
     return false;
   });
 
@@ -555,18 +552,17 @@ const AgentPickerModal: Component<{
           restartSessions: restart,
           confirmedTargetFingerprint:
             scope === "replica" ? null : scopePreview()?.targetFingerprint ?? null,
-          typedConfirmation: scope === "kind" ? kindConfirmationText().trim() : null,
+          typedConfirmation: null,
         });
         if (result.errors.length > 0) {
           // Stale fingerprint / failed targets: surface errors, keep the modal open,
-          // reset the typed confirmation and re-run preview so the user re-confirms.
+          // reset the broad confirmation and re-run preview so the user re-confirms.
           setApplyErrors(result.errors);
           // #537: the assign no longer silently no-ops. Fire a loud toast with the
           // backend's human-readable message so the failure cannot be missed.
           const firstError = result.errors[0];
           const extra = result.errors.length - 1;
           showToast(extra > 0 ? `${firstError.message} (+${extra} more)` : firstError.message);
-          setKindConfirmationText("");
           setDangerArmed(false);
           setBusy(false);
           runScopePreview(scope, agent.id, selectedProfile());
@@ -1110,7 +1106,7 @@ const AgentPickerModal: Component<{
 
             <div class="agent-picker-bar-spacer" />
 
-            <Show when={selectedScope() === "workgroup"}>
+            <Show when={selectedScope() === "workgroup" || selectedScope() === "kind"}>
               <label class="agent-scope-arm">
                 <input
                   type="checkbox"
@@ -1119,7 +1115,7 @@ const AgentPickerModal: Component<{
                   onChange={(e) => setDangerArmed(e.currentTarget.checked)}
                   {...automationAttrs("agentPicker.armToggle", "checkbox", dangerArmed() ? "checked" : "unchecked")}
                 />
-                <span>I understand this overwrites {scopeCount("workgroup")} replicas</span>
+                <span>{confirmationLabel()}</span>
               </label>
             </Show>
 
@@ -1147,21 +1143,6 @@ const AgentPickerModal: Component<{
             </button>
           </div>
 
-          <Show when={selectedScope() === "kind"}>
-            <div class="agent-scope-confirm">
-              <label class="agent-scope-confirm-label">
-                Type to confirm: <code>{kindPhrase()}</code>
-              </label>
-              <input
-                class="agent-scope-confirm-input"
-                value={kindConfirmationText()}
-                onInput={(e) => setKindConfirmationText(e.currentTarget.value)}
-                placeholder={kindPhrase()}
-                spellcheck={false}
-                {...automationAttrs("agentPicker.kindConfirm", "textbox", applyEnabled() ? "matched" : "unmatched")}
-              />
-            </div>
-          </Show>
         </div>
       </div>
     </div>

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -534,6 +534,7 @@ const AgentPickerModal: Component<{
     const scope = selectedScope();
     const requested = requestedProfileForSelection();
     const effective = effectivePreview().effectiveProfile;
+    const target = targetReplicaPath();
     // #537: replica scope no longer uses the pre-apply restart toggle; the post-assign
     // "Restart now?" modal (ProjectPanel) owns the restart. Force it off so a toggle
     // value carried over from kind/workgroup scope cannot trigger a backend restart.
@@ -541,7 +542,6 @@ const AgentPickerModal: Component<{
     try {
       let updatedCount: number | undefined;
       let restartedCount: number | undefined;
-      const target = targetReplicaPath();
       // Broad-scope writes are backend-owned; only call apply for a real WG replica.
       if (target && isWgReplica()) {
         const result = await SettingsAPI.applyCodingAgentProfileSelection({
@@ -564,6 +564,7 @@ const AgentPickerModal: Component<{
           const extra = result.errors.length - 1;
           showToast(extra > 0 ? `${firstError.message} (+${extra} more)` : firstError.message);
           setDangerArmed(false);
+          if (scope !== "replica") setScopePreview(null);
           setBusy(false);
           runScopePreview(scope, agent.id, selectedProfile());
           return;
@@ -588,6 +589,11 @@ const AgentPickerModal: Component<{
       setError(message);
       // #537: keep unexpected apply failures as loud as the structured ones.
       showToast(message);
+      if (scope !== "replica" && target && isWgReplica()) {
+        setDangerArmed(false);
+        setScopePreview(null);
+        runScopePreview(scope, agent.id, selectedProfile());
+      }
       setBusy(false);
     }
   };

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -3643,33 +3643,6 @@ html.light-theme .settings-hint-warning {
   color: var(--status-exited, #ff5d5d);
 }
 
-.agent-scope-confirm {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.agent-scope-confirm-label {
-  font-size: 10px;
-  color: var(--sidebar-fg-dim);
-}
-
-.agent-scope-confirm-label code {
-  font-family: "Cascadia Code", "JetBrains Mono", monospace;
-  color: var(--status-exited, #ff5d5d);
-}
-
-.agent-scope-confirm-input {
-  width: 100%;
-  padding: var(--spacing-xs) var(--spacing-sm);
-  border: 1px solid var(--sidebar-border);
-  border-radius: var(--radius-sm);
-  background: var(--sidebar-hover);
-  color: var(--sidebar-fg);
-  font-family: "Cascadia Code", "JetBrains Mono", monospace;
-  font-size: var(--font-size-sm);
-}
-
 @media (max-width: 900px) {
   .agent-profile-assignment-body {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- Replace the kind-wide Coding Agent assignment typed confirmation with the same checkbox confirmation pattern used for workgroup-wide assignments.
- Update backend validation so kind-wide applies no longer require the legacy exact typed phrase while still requiring a matching preview fingerprint.
- Reset broad-scope confirmation state and rerun preview when stale or missing fingerprint validation rejects an apply.

## Why
The modal had inconsistent confirmation UX: workgroup-wide applies used a checkbox, while kind-wide applies required typing a long exact phrase. Users could interpret the disabled Apply button as blocked or missing a confirmation control.

## Validation
- `npx vitest run src/sidebar/components/AgentPickerModal.test.tsx` passed, 34 tests.
- `npx tsc --noEmit` passed.
- `cargo test profile_assignment --lib` passed.
- `cargo test assignment --lib` passed.
- `cargo check` passed.
- `cargo clippy` passed.
- Grinch focused re-review: PASS, no findings.
- Built and deployed `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-9.exe` from `ba897efd6c23eca25e791a3148df000148bbb28e`; built exe and deployed exe `--help` smoke tests passed.

Closes #681