### PR TITLE
fix: remove Claude prompt file injection

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1016,7 +1016,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         (target, managed, auto_self_clear)
     };
 
-    let materialized_context_path = if let Some(ref target_filename) = target_filename {
+    if let Some(ref target_filename) = target_filename {
         match crate::config::session_context::materialize_agent_context_file_with_filename(
             &cwd,
             target_filename,
@@ -1024,7 +1024,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             is_coordinator,
             auto_self_clear,
         ) {
-            Ok(context) => context,
+            Ok(_) => {}
             Err(e) => {
                 log::error!("Replica context validation failed: {}", e);
                 use tauri_plugin_dialog::DialogExt;
@@ -1047,31 +1047,10 @@ pub async fn create_session_inner<R: tauri::Runtime>(
                 return Err(e);
             }
         }
-    } else {
-        None
-    };
-
-    // Claude consumes the materialized CLAUDE.md via --append-system-prompt-file.
-    if agent_kind == Some(CodingAgentKind::Claude) {
-        if let Some(context_path) = materialized_context_path.as_ref() {
-            if executable_basename(&shell) == "cmd" {
-                if let Some(last) = shell_args.last_mut() {
-                    if last.to_lowercase().contains("claude") {
-                        *last =
-                            format!("{} --append-system-prompt-file \"{}\"", last, context_path);
-                        log::info!("Injected --append-system-prompt-file for Claude (cmd path)");
-                    }
-                }
-            } else {
-                shell_args.push("--append-system-prompt-file".to_string());
-                shell_args.push(context_path.to_string());
-                log::info!("Injected --append-system-prompt-file for Claude session");
-            }
-        }
     }
 
     // Capture the effective arg vector BEFORE spawn so SessionInfo::from(&session)
-    // (emitted at line ~439 as "session_created") carries the injected flags.
+    // (emitted at line ~439 as "session_created") carries provider resume flags.
     // Bind once, broadcast to two consumers: the store write is for later
     // `mgr.get_session` callers; the local-clone write is for the imminent emit.
     //

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -809,10 +809,12 @@ pub async fn snapshot_sessions(mgr: &SessionManager) -> Vec<PersistedSession> {
     deduplicate(all)
 }
 
-/// Strip auto-injected provider args from saved shell arguments.
-/// Removes Claude's `--continue` / `--append-system-prompt-file <path>` and Codex's
-/// `resume --last`, which are auto-injected at session creation time (see commands/session.rs).
-/// These must not be baked into the saved "recipe" — otherwise they self-perpetuate
+/// Strip AC-managed provider args from saved shell arguments.
+/// Current launch-time injections are Claude's `--continue`, Codex's
+/// `resume --last`, and Gemini's `--resume latest`. Also strips Claude's old
+/// `--append-system-prompt-file <path>` argument as legacy cleanup for saved
+/// recipes created by older builds.
+/// These must not be baked into the saved "recipe" because they self-perpetuate
 /// across app restarts (or session restarts) even when the conditions change.
 ///
 /// Handles two injection modes:
@@ -851,10 +853,10 @@ pub(crate) fn strip_auto_injected_args(shell: &str, args: &[String]) -> Vec<Stri
     }
 
     fn strip_claude_tokens(tokens: &mut Vec<String>, start: usize) {
-        // #260 — Claude's resume flag from the CodingAgentProfile. resume_tokens
+        // #260: Claude's resume flag from the CodingAgentProfile. resume_tokens
         // is a 1-element const for Claude, so [0] is provably in bounds. The
-        // `--append-system-prompt-file` flag below is the context-file flag,
-        // NOT a resume token — intentionally kept as a literal.
+        // `--append-system-prompt-file` flag below is legacy context-file
+        // cleanup, NOT a resume token, so it stays as a literal.
         let continue_flag = CodingAgentKind::Claude.profile().resume_tokens[0];
         let mut idx = start;
         while idx < tokens.len() {
@@ -1654,7 +1656,7 @@ mod tests {
     }
 
     #[test]
-    fn strip_auto_injected_args_removes_direct_claude_context_file() {
+    fn strip_auto_injected_args_removes_legacy_direct_claude_context_file() {
         let stripped = strip_auto_injected_args(
             "claude",
             &[
@@ -1667,7 +1669,7 @@ mod tests {
     }
 
     #[test]
-    fn strip_auto_injected_args_removes_embedded_claude_context_file_with_spaces() {
+    fn strip_auto_injected_args_removes_legacy_embedded_claude_context_file_with_spaces() {
         let stripped = strip_auto_injected_args(
             "cmd.exe",
             &[

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -811,9 +811,7 @@ pub async fn snapshot_sessions(mgr: &SessionManager) -> Vec<PersistedSession> {
 
 /// Strip AC-managed provider args from saved shell arguments.
 /// Current launch-time injections are Claude's `--continue`, Codex's
-/// `resume --last`, and Gemini's `--resume latest`. Also strips Claude's old
-/// `--append-system-prompt-file <path>` argument as legacy cleanup for saved
-/// recipes created by older builds.
+/// `resume --last`, and Gemini's `--resume latest`.
 /// These must not be baked into the saved "recipe" because they self-perpetuate
 /// across app restarts (or session restarts) even when the conditions change.
 ///
@@ -822,54 +820,14 @@ pub async fn snapshot_sessions(mgr: &SessionManager) -> Vec<PersistedSession> {
 /// - **cmd.exe wrapper**: tokens may be separate args (`["/C", "codex", "resume", "--last"]`)
 ///   or embedded in a single arg string (`["/K", "git pull && codex resume --last"]`)
 pub(crate) fn strip_auto_injected_args(shell: &str, args: &[String]) -> Vec<String> {
-    fn token_has_unclosed_quote(token: &str, quote: char) -> bool {
-        token.chars().filter(|c| *c == quote).count() % 2 == 1
-    }
-
-    fn advance_past_quoted_value(tokens: &[String], start: usize) -> usize {
-        if start >= tokens.len() {
-            return start;
-        }
-
-        let mut idx = start;
-        let mut in_single = false;
-        let mut in_double = false;
-
-        while idx < tokens.len() {
-            let token = &tokens[idx];
-            if token_has_unclosed_quote(token, '\'') {
-                in_single = !in_single;
-            }
-            if token_has_unclosed_quote(token, '"') {
-                in_double = !in_double;
-            }
-            idx += 1;
-            if !in_single && !in_double {
-                break;
-            }
-        }
-
-        idx
-    }
-
     fn strip_claude_tokens(tokens: &mut Vec<String>, start: usize) {
         // #260: Claude's resume flag from the CodingAgentProfile. resume_tokens
-        // is a 1-element const for Claude, so [0] is provably in bounds. The
-        // `--append-system-prompt-file` flag below is legacy context-file
-        // cleanup, NOT a resume token, so it stays as a literal.
+        // is a 1-element const for Claude, so [0] is provably in bounds.
         let continue_flag = CodingAgentKind::Claude.profile().resume_tokens[0];
         let mut idx = start;
         while idx < tokens.len() {
             if tokens[idx].eq_ignore_ascii_case(continue_flag) {
                 tokens.remove(idx);
-                continue;
-            }
-            if tokens[idx].eq_ignore_ascii_case("--append-system-prompt-file") {
-                tokens.remove(idx);
-                let end = advance_past_quoted_value(tokens, idx);
-                for _ in idx..end {
-                    tokens.remove(idx);
-                }
                 continue;
             }
             idx += 1;
@@ -1013,12 +971,7 @@ pub(crate) fn strip_auto_injected_args(shell: &str, args: &[String]) -> Vec<Stri
         result
     } else {
         let mut result = Vec::with_capacity(args.len());
-        let mut skip_next = false;
         for (idx, a) in args.iter().enumerate() {
-            if skip_next {
-                skip_next = false;
-                continue;
-            }
             if is_codex
                 && idx == 0
                 && a.eq_ignore_ascii_case("resume")
@@ -1061,10 +1014,6 @@ pub(crate) fn strip_auto_injected_args(shell: &str, args: &[String]) -> Vec<Stri
             }
 
             if is_claude && a.eq_ignore_ascii_case("--continue") {
-                continue;
-            }
-            if is_claude && a.eq_ignore_ascii_case("--append-system-prompt-file") {
-                skip_next = true; // skip the next arg (the file path)
                 continue;
             }
             result.push(a.clone());
@@ -1656,7 +1605,7 @@ mod tests {
     }
 
     #[test]
-    fn strip_auto_injected_args_removes_legacy_direct_claude_context_file() {
+    fn strip_auto_injected_args_preserves_user_authored_direct_claude_prompt_file() {
         let stripped = strip_auto_injected_args(
             "claude",
             &[
@@ -1665,11 +1614,18 @@ mod tests {
                 "--search".to_string(),
             ],
         );
-        assert_eq!(stripped, vec!["--search".to_string()]);
+        assert_eq!(
+            stripped,
+            vec![
+                "--append-system-prompt-file".to_string(),
+                "C:\\temp\\ctx.md".to_string(),
+                "--search".to_string()
+            ]
+        );
     }
 
     #[test]
-    fn strip_auto_injected_args_removes_legacy_embedded_claude_context_file_with_spaces() {
+    fn strip_auto_injected_args_preserves_embedded_claude_prompt_file_with_spaces() {
         let stripped = strip_auto_injected_args(
             "cmd.exe",
             &[
@@ -1679,7 +1635,11 @@ mod tests {
         );
         assert_eq!(
             stripped,
-            vec!["/K".to_string(), "claude --search".to_string(),]
+            vec![
+                "/K".to_string(),
+                "claude --append-system-prompt-file \"C:\\Program Files\\ctx.md\" --search"
+                    .to_string(),
+            ]
         );
     }
 

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -64,10 +64,10 @@ pub struct Session {
     pub shell: String,
     pub shell_args: Vec<String>,
     /// Effective arg vector actually handed to portable-pty at spawn time,
-    /// including dynamic injections (`--continue`, `codex resume --last`,
-    /// `--append-system-prompt-file <path>`). `None` until the PTY is
-    /// spawned for this session; set once by `create_session_inner` right
-    /// before `pty_mgr.spawn`. Runtime-only — NOT persisted to `sessions.toml`
+    /// including dynamic provider resume injections (`--continue`,
+    /// `codex resume --last`, `gemini --resume latest`). `None` until the PTY
+    /// is spawned for this session; set once by `create_session_inner` right
+    /// before `pty_mgr.spawn`. Runtime-only. NOT persisted to `sessions.toml`
     /// (configured args in `shell_args` are the persistence recipe; the
     /// effective args are re-derived at every spawn from current settings).
     #[serde(skip)]

--- a/src-tauri/tests/pty_lifecycle_regression.rs
+++ b/src-tauri/tests/pty_lifecycle_regression.rs
@@ -43,6 +43,17 @@ const POLL_INTERVAL: Duration = Duration::from_millis(75);
 
 type PtyCleanupEntries = Arc<Mutex<Vec<(Arc<Mutex<PtyManager>>, Uuid)>>>;
 
+static TEST_CONFIG_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn lifecycle_test_config_dir() -> PathBuf {
+    std::env::temp_dir()
+        .join(format!(
+            "agentscommander-pty-lifecycle-{}",
+            std::process::id()
+        ))
+        .join("config")
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct TestPtyOutputPayload {
@@ -113,8 +124,6 @@ impl Drop for LifecycleCleanup {
 }
 
 struct LifecycleFixture {
-    _temp: tempfile::TempDir,
-    _env_guard: TestConfigEnvGuard,
     cleanup: LifecycleCleanup,
     repo_root: PathBuf,
     config_dir: PathBuf,
@@ -127,16 +136,25 @@ struct LifecycleFixture {
     app: tauri::App,
     session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
     pty_mgr: Arc<Mutex<PtyManager>>,
+    _temp: tempfile::TempDir,
+    _env_guard: TestConfigEnvGuard,
+    _env_lock: std::sync::MutexGuard<'static, ()>,
 }
 
 fn make_lifecycle_fixture() -> LifecycleFixture {
+    let env_lock = TEST_CONFIG_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let temp = tempfile::TempDir::new().expect("create temp dir");
     let repo_root = temp.path().join("repo-pty-lifecycle");
-    let config_dir = temp.path().join("config");
+    let config_dir = lifecycle_test_config_dir();
     let session_cwd = repo_root.clone();
     let script_path = temp.path().join("pty-child.ps1");
 
     std::fs::create_dir_all(&repo_root).expect("create repo root");
+    if config_dir.exists() {
+        std::fs::remove_dir_all(&config_dir).expect("reset config dir");
+    }
     std::fs::create_dir_all(&config_dir).expect("create config dir");
     std::fs::write(repo_root.join(".gitignore"), "*\r\n").expect("seed repo file");
 
@@ -171,8 +189,6 @@ fn make_lifecycle_fixture() -> LifecycleFixture {
     );
 
     LifecycleFixture {
-        _temp: temp,
-        _env_guard: env_guard,
         cleanup,
         repo_root,
         config_dir,
@@ -185,6 +201,9 @@ fn make_lifecycle_fixture() -> LifecycleFixture {
         app,
         session_mgr,
         pty_mgr,
+        _temp: temp,
+        _env_guard: env_guard,
+        _env_lock: env_lock,
     }
 }
 

--- a/src-tauri/tests/pty_lifecycle_regression.rs
+++ b/src-tauri/tests/pty_lifecycle_regression.rs
@@ -798,6 +798,77 @@ fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup()
     });
 }
 
+#[test]
+fn claude_launch_materializes_context_without_prompt_file_arg() {
+    let mut fixture = make_lifecycle_fixture();
+    let agent_cwd = fixture._temp.path().join(".ac").join("_agent_claude");
+    std::fs::create_dir_all(&agent_cwd).expect("create claude agent cwd");
+    let script_path = agent_cwd.join("claude.ps1");
+    write_child_script(&script_path);
+    let pid_file = fixture.pid_path("claude_no_prompt_arg");
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    runtime.block_on(async {
+        let info = create_session_inner(
+            fixture.app.handle(),
+            &fixture.session_mgr,
+            &fixture.pty_mgr,
+            "powershell.exe".to_string(),
+            script_args(&script_path, &pid_file),
+            path_to_string(&agent_cwd),
+            Some("Claude context materialization".to_string()),
+            None,
+            None,
+            false,
+            Vec::new(),
+            true,
+            None,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("Claude launch failed: {e}"));
+
+        let session_id = parse_session_id(&info);
+        fixture.cleanup.record_session(&fixture.pty_mgr, session_id);
+        wait_for_output(&fixture, &info.id, "AC_READY", OUTPUT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        assert_eq!(
+            info.agent_kind,
+            Some(agentscommander_lib::session::profile::CodingAgentKind::Claude)
+        );
+        assert!(
+            agent_cwd.join("CLAUDE.md").is_file(),
+            "Claude managed instructions file should still be materialized"
+        );
+        let effective_args = info
+            .effective_shell_args
+            .as_ref()
+            .expect("effective args are captured before spawn");
+        assert!(
+            !effective_args
+                .iter()
+                .any(|arg| arg.to_lowercase().contains("--append-system-prompt-file")),
+            "Claude launch args must not include --append-system-prompt-file: {effective_args:?}"
+        );
+
+        let pid = wait_for_pid_file(&pid_file, PID_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+        fixture.cleanup.record_pid(pid);
+        destroy_session_inner(fixture.app.handle(), session_id)
+            .await
+            .unwrap_or_else(|e| panic!("destroy Claude materialization session failed: {e}"));
+        wait_for_process_exit(pid, EXIT_TIMEOUT)
+            .await
+            .unwrap_or_else(|e| panic!("{e}"));
+    });
+}
+
 impl LifecycleFixture {
     fn pid_path(&mut self, label: &str) -> PathBuf {
         let path = self.config_dir.join(format!("{label}.pid"));


### PR DESCRIPTION
## Summary
- Remove AgentsCommander-owned Claude `--append-system-prompt-file` startup argument injection.
- Keep managed instruction file materialization intact, including `CLAUDE.md` generation for Claude launches.
- Preserve user-authored Claude prompt-file args during persistence cleanup now that AC no longer owns that flag.

## Validation
- Dev verified Codex, Gemini, custom, and unknown command construction: no non-Claude direct startup prompt injection by command args; only resume args are added.
- Grinch re-review PASS with no findings or blockers.
- `cargo test strip_auto_injected_args --lib`
- `cargo test claude_launch_materializes_context_without_prompt_file_arg --test pty_lifecycle_regression`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- Shipper built and deployed `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe` from commit `d0000ec`; `--help` passed.

Closes #683