### PR TITLE
fix: submit Cursor agent injected messages

### DIFF
--- a/src-tauri/src/cli/self_clear.rs
+++ b/src-tauri/src/cli/self_clear.rs
@@ -36,7 +36,7 @@ owns the token you present.\n\n\
 BEST-EFFORT: neither phase is guaranteed. A perpetually busy session that never reaches 30s sustained \
 idle, or a daemon restart mid-cycle, drops the remainder (a greppable warn line is logged). Re-issue \
 if your context is still present later.\n\n\
-SCOPE: only coding-agent CLIs (Claude / Codex / Gemini).")]
+SCOPE: only coding-agent CLIs (Claude / Codex / Gemini / Cursor agent).")]
 pub struct SelfClearArgs {
     /// Session token from AGENTSCOMMANDER_TOKEN. Shape-validated in the CLI;
     /// per-session authorization happens at the daemon mailbox.

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -2331,7 +2331,7 @@ impl MailboxPoller {
                     }
                     Some(s) if !crate::pty::inject::needs_explicit_enter(&s.shell) => {
                         return Err(format!(
-                            "Cannot execute remote command '/{}': session shell '{}' is not a coding-agent CLI (Claude / Codex / Gemini). cmd / pwsh wrappers around an agent are tracked separately as #233-followup-cmd-wrapper.",
+                            "Cannot execute remote command '/{}': session shell '{}' is not a coding-agent CLI (Claude / Codex / Gemini / Cursor agent). cmd / pwsh wrappers around an agent are tracked separately as #233-followup-cmd-wrapper.",
                             command, s.shell
                         ))
                     }
@@ -3170,7 +3170,7 @@ impl MailboxPoller {
                     path,
                     msg,
                     &format!(
-                        "self-clear: session shell '{}' is not a coding-agent CLI (Claude / Codex / Gemini); /clear is not supported here",
+                        "self-clear: session shell '{}' is not a coding-agent CLI (Claude / Codex / Gemini / Cursor agent); /clear is not supported here",
                         session.shell
                     ),
                 )
@@ -3424,7 +3424,7 @@ impl MailboxPoller {
                     path,
                     msg,
                     &format!(
-                        "self-handoff-and-switch: session shell '{}' is not a coding-agent CLI (Claude / Codex / Gemini); switch is not supported here",
+                        "self-handoff-and-switch: session shell '{}' is not a coding-agent CLI (Claude / Codex / Gemini / Cursor agent); switch is not supported here",
                         session.shell
                     ),
                 )

--- a/src-tauri/src/pty/inject.rs
+++ b/src-tauri/src/pty/inject.rs
@@ -6,9 +6,10 @@ use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
 
 /// Returns true when the given shell command requires a separate Enter keystroke
-/// to submit pasted input. Coding agents (Claude, Codex, etc.) all need explicit
-/// Enter after a text block paste. Plain shells (bash, powershell) don't go through
-/// this path — they're filtered out before reaching inject_text_into_session.
+/// to submit pasted input. Coding agents (Claude, Codex, Gemini, Cursor agent)
+/// need explicit Enter after a text block paste. Plain shells (bash, powershell)
+/// don't go through this path; they're filtered out before reaching
+/// inject_text_into_session.
 ///
 /// The shell may be a bare name ("claude") or a full path
 /// ("C:\Users\...\.claude\local\claude.exe"), so we extract the filename stem
@@ -19,16 +20,19 @@ pub(crate) fn needs_explicit_enter(shell: &str) -> bool {
         .and_then(|s| s.to_str())
         .unwrap_or(shell.trim())
         .to_lowercase();
-    stem.starts_with("codex") || stem.starts_with("claude") || stem.starts_with("gemini")
+    stem.starts_with("codex")
+        || stem.starts_with("claude")
+        || stem.starts_with("gemini")
+        || stem == "agent"
 }
 
 /// Inject a text block into a session's PTY stdin.
 ///
-/// For agents that require explicit Enter (Claude, Codex, Gemini), `\r` is
-/// sent twice — at 1500 ms and 2000 ms after the text write — as a reliability
-/// measure against Enter not registering on the first attempt. For plain shells
-/// (bash, powershell), no Enter is sent (the caller's text already controls
-/// submission).
+/// For agents that require explicit Enter (Claude, Codex, Gemini, Cursor agent),
+/// `\r` is sent twice, at 1500 ms and 2000 ms after the text write, as a
+/// reliability measure against Enter not registering on the first attempt. For
+/// plain shells (bash, powershell), no Enter is sent (the caller's text already
+/// controls submission).
 ///
 /// This is the ONLY function that should be used for text-block injection.
 /// Direct keystrokes from xterm.js (single chars, Ctrl sequences) bypass this
@@ -88,9 +92,10 @@ where
         );
     }
 
-    // Agent CLIs (Claude, Codex): send Enter twice with staggered delays.
+    // Agent CLIs (Claude, Codex, Gemini, Cursor agent): send Enter twice with
+    // staggered delays.
     // Sometimes a single \r doesn't register (race with paste-detection mode).
-    // The second \r is a safety net — if the first worked, the agent is already
+    // The second \r is a safety net. If the first worked, the agent is already
     // processing and an extra Enter on empty input is harmless.
     if send_enter {
         tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
@@ -145,6 +150,11 @@ mod tests {
             "C:\\Users\\maria\\.claude\\local\\claude.exe",
             "gemini",
             "gemini.exe",
+            "agent",
+            "agent.exe",
+            "agent.cmd",
+            "C:\\Users\\maria\\AppData\\Local\\Programs\\Cursor\\agent.exe",
+            "  agent  ",
             "  codex  ", // leading/trailing whitespace tolerated
         ] {
             assert!(
@@ -164,6 +174,8 @@ mod tests {
             "pwsh.exe",
             "cmd.exe",
             "zsh",
+            "agentctl",
+            "agentic",
             "",
             "   ",
         ] {


### PR DESCRIPTION
## Summary

- Treat exact Cursor CLI shell stem `agent` as a coding-agent TUI that needs explicit Enter after AgentsCommander message injection.
- Reuse the existing delayed double-Enter injection path; no Cursor-specific PTY path was added.
- Update guard/help text and tests so `agent` variants are covered while `agentctl` / `agentic` remain plain-shell negatives.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml pty::inject::tests`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `git diff --check origin/main..HEAD`
- dev-rust-grinch original review: PASS
- dev-rust-grinch post-WG1 merge review: PASS
- dev-rust-grinch post-PR #687 merge review: PASS

## Deployment

- Built and deployed final reviewed HEAD `634b2b4e31c9fa5821ac78bdf3b9adc5bd1595aa` to `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-9.exe`.
- Shipper verified `agentscommander_standalone_wg-9.exe --help` exits 0.
- User instructed WG9 to land after WG1 confirmed its own main landing. WG1 confirmed PR #686 merged at `f29f7adbc3a554a55f08ee1894eb03e78a96131d` before this PR was opened.

Closes #688