### PR TITLE
fix: align exited session status indicator refs #689

### DIFF
--- a/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
@@ -537,6 +537,56 @@ describe("ProjectPanel regex filter", () => {
     }
   });
 
+  it("does not match an exited replica by stale waiting/pending flags (#689)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", projectDiscovery());
+
+    sessionsStore.setSessions([
+      session({
+        id: "coord-session",
+        name: "wg-2-dev-team/dev-webpage-ui",
+        workingDirectory: `${workgroupPath}\\__agent_dev-webpage-ui`,
+        status: "running",
+        isCoordinator: true,
+      }),
+      session({
+        id: "peer-session",
+        name: "wg-2-dev-team/dev-rust",
+        workingDirectory: `${workgroupPath}\\__agent_dev-rust`,
+        status: { exited: 0 },
+        waitingForInput: true,
+        pendingReview: true,
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-rust"));
+      const staleRow = findByTestId<HTMLElement>(
+        rendered.root,
+        "replica.row.workgroups.wg-2-dev-team.dev-rust"
+      );
+      expect(staleRow.querySelector(".session-item-status")?.classList.contains("exited")).toBe(true);
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      input(filterInput, "waiting");
+      await waitFor(() => expect(rendered.root.textContent).not.toContain("dev-rust"));
+
+      input(filterInput, "pending");
+      await waitFor(() => expect(rendered.root.textContent).not.toContain("dev-rust"));
+
+      input(filterInput, "exited");
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-rust"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
   it("does not match a loop's promptPreview (hover-only), but the loop name still matches (bug 1)", async () => {
     const fake = new FakeTransport();
     fake.resolve("new_project", { path: projectPath, registered: true, created: false });

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -40,6 +40,7 @@ import {
   formatReplicaRepoBadgeLabel,
   repoLabelFromPath,
 } from "./replica-repo-badges";
+import { sessionDotClass } from "./session-status";
 
 interface PendingLaunch {
   path: string;
@@ -164,12 +165,7 @@ function replicaSession(wg: AcWorkgroup, replica: AcAgentReplica): Session | und
 
 /** Compute CSS class for replica status dot */
 function replicaDotClass(wg: AcWorkgroup, replica: AcAgentReplica): string {
-  const session = replicaSession(wg, replica);
-  if (!session) return "offline";
-  if (session.pendingReview) return "pending";
-  if (session.waitingForInput) return "waiting";
-  if (typeof session.status === "string") return session.status;
-  return "exited";
+  return sessionDotClass(replicaSession(wg, replica));
 }
 
 /** Check if a session has a live PTY process (not exited, not offline) */

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -84,6 +84,11 @@ function sessionStatusSearchText(status: Session["status"]): string {
   return typeof status === "string" ? status : `exited ${status.exited}`;
 }
 
+function sessionEffectiveStatusSearchText(session: Session): string {
+  const dotClass = sessionDotClass(session);
+  return dotClass === "exited" ? sessionStatusSearchText(session.status) : dotClass;
+}
+
 /** Build the gitRepos list for a replica. Order = replica.repoPaths order (invariant §3.1.2). */
 function buildGitRepos(replica: AcAgentReplica): SessionRepoInput[] {
   return (replica.repoPaths ?? []).map((p) => {
@@ -631,17 +636,15 @@ const ProjectPanel: Component = () => {
         // contributed by the per-row callers under the gate that matches their
         // render — repo/branch (replicaSearchText / sessionRepoSearchText) and the
         // profile badge — so "what you match == what you see" (#515 bug 1).
-        // `shell` is dropped: it is never shown on any row. status/waiting/pending
-        // stay — they are the visible status dot's state, so dropping them would
-        // hide a row whose dot the user can see.
+        // `shell` is dropped: it is never shown on any row. Status text comes
+        // from the same effective state as the dot, so stale live flags cannot
+        // index an exited row as waiting/pending.
         const sessionSearchText = (session: Session | undefined) => {
           if (!session) return "";
           return joinSearchText(
             session.name,
             session.agentLabel,
-            sessionStatusSearchText(session.status),
-            session.waitingForInput ? "waiting" : null,
-            session.pendingReview ? "pending" : null
+            sessionEffectiveStatusSearchText(session)
           );
         };
         // Repo/branch chips on an agent SessionItem render only for a coordinator

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -12,17 +12,13 @@ import { sessionsStore } from "../stores/sessions";
 import { bridgesStore } from "../stores/bridges";
 import { settingsStore } from "../../shared/stores/settings";
 import { voiceRecorder, formatRecordingTime } from "../../shared/voice-recorder";
-import type { Session, SessionStatus, TelegramBotConfig } from "../../shared/types";
+import type { Session, TelegramBotConfig } from "../../shared/types";
 import { sessionProfileBadge } from "../../shared/profile-utils";
 import AgentPickerModal, { type AgentPickerSelection } from "./AgentPickerModal";
 import ProfileOutdatedBadge from "./ProfileOutdatedBadge";
 import { rootAgentCodingAgentAction } from "./root-agent-action";
 import { TelegramIcon } from "./TelegramIcon";
-
-function statusClass(status: SessionStatus): string {
-  if (typeof status === "string") return status;
-  return "exited";
-}
+import { sessionDotClass } from "./session-status";
 
 const CONTEXT_MENU_VIEWPORT_MARGIN = 8;
 
@@ -54,11 +50,7 @@ const RootAgentBanner: Component = () => {
   });
 
   const dotClass = createMemo(() => {
-    const r = rootSession();
-    if (!r) return "offline";
-    if (r.pendingReview) return "pending";
-    if (r.waitingForInput) return "waiting";
-    return statusClass(r.status);
+    return sessionDotClass(rootSession());
   });
 
   const subtitle = createMemo(() => {

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -1,6 +1,6 @@
 import { Component, createSignal, Show, For, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
-import type { Session, SessionStatus, TelegramBotConfig, RepoMatch } from "../../shared/types";
+import type { Session, TelegramBotConfig, RepoMatch } from "../../shared/types";
 import { SessionAPI, TelegramAPI, SettingsAPI, WindowAPI, emitOpenSettings } from "../../shared/ipc";
 import { extractProjectName } from "../../shared/path-extractors";
 import { isTauri } from "../../shared/platform";
@@ -15,11 +15,7 @@ import AgentPickerModal from "./AgentPickerModal";
 import ProfileOutdatedBadge from "./ProfileOutdatedBadge";
 import { TelegramIcon } from "./TelegramIcon";
 import { profileDisplayLabel, sessionProfileBadge } from "../../shared/profile-utils";
-
-function statusClass(status: SessionStatus): string {
-  if (typeof status === "string") return status;
-  return "exited";
-}
+import { sessionDotClass } from "./session-status";
 
 const CONTEXT_MENU_VIEWPORT_MARGIN = 8;
 
@@ -292,7 +288,7 @@ const SessionItem: Component<{
       data-ac-state={props.isActive ? "active" : isInactive() ? "inactive" : "idle"}
     >
       <div
-        class={`session-item-status ${isInactive() ? "offline" : props.session.pendingReview ? "pending" : props.session.waitingForInput ? "waiting" : statusClass(props.session.status)}`}
+        class={`session-item-status ${sessionDotClass(props.session, { inactive: isInactive() })}`}
       />
       <div class="session-item-info">
         <div class="session-item-name" onDblClick={handleDoubleClick} title={props.session.workingDirectory}>

--- a/src/sidebar/components/session-status.test.ts
+++ b/src/sidebar/components/session-status.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { sessionDotClass } from "./session-status";
+import type { SessionStatus } from "../../shared/types";
+
+function dotSession(
+  status: SessionStatus,
+  flags: { pendingReview?: boolean; waitingForInput?: boolean } = {},
+) {
+  return {
+    status,
+    pendingReview: flags.pendingReview ?? false,
+    waitingForInput: flags.waitingForInput ?? false,
+  };
+}
+
+describe("sessionDotClass", () => {
+  it("uses exited for dormant sessions even when stale live flags remain", () => {
+    expect(sessionDotClass(dotSession({ exited: 0 }, { waitingForInput: true }))).toBe("exited");
+    expect(sessionDotClass(dotSession({ exited: 0 }, { pendingReview: true }))).toBe("exited");
+  });
+
+  it("preserves live pending/waiting overrides and runtime states", () => {
+    expect(sessionDotClass(dotSession("running", { waitingForInput: true }))).toBe("waiting");
+    expect(sessionDotClass(dotSession("running", { pendingReview: true }))).toBe("pending");
+    expect(sessionDotClass(dotSession("running"))).toBe("running");
+    expect(sessionDotClass(dotSession("active"))).toBe("active");
+  });
+
+  it("uses offline for missing or inactive rows", () => {
+    expect(sessionDotClass(null)).toBe("offline");
+    expect(sessionDotClass(dotSession("running"), { inactive: true })).toBe("offline");
+  });
+});

--- a/src/sidebar/components/session-status.ts
+++ b/src/sidebar/components/session-status.ts
@@ -1,0 +1,30 @@
+import type { Session, SessionStatus } from "../../shared/types";
+
+export type SessionDotClass =
+  | "active"
+  | "running"
+  | "idle"
+  | "exited"
+  | "pending"
+  | "waiting"
+  | "offline";
+
+type DotSession = Pick<Session, "status" | "pendingReview" | "waitingForInput">;
+
+export function sessionStatusClass(status: SessionStatus): "active" | "running" | "idle" | "exited" {
+  if (typeof status === "string") return status;
+  return "exited";
+}
+
+export function sessionDotClass(
+  session: DotSession | null | undefined,
+  options: { inactive?: boolean } = {},
+): SessionDotClass {
+  if (!session || options.inactive) return "offline";
+
+  const status = sessionStatusClass(session.status);
+  if (status === "exited") return "exited";
+  if (session.pendingReview) return "pending";
+  if (session.waitingForInput) return "waiting";
+  return status;
+}


### PR DESCRIPTION
## Summary
- Align session status dots with the effective displayed session state.
- Treat dormant `{ exited }` session statuses as authoritative over stale `waitingForInput` / `pendingReview` flags.
- Keep ProjectPanel regex status indexing aligned with the rendered dot state so exited rows do not match stale waiting/pending filters.

## Verification
- dev-webpage-ui implemented and refreshed branch against latest `origin/main`.
- dev-rust-grinch final review: PASS, no findings.
- `npm test -- src/sidebar/components/session-status.test.ts src/sidebar/components/ProjectPanel.regex-filter.test.tsx` passed.
- `npx tsc --noEmit` passed.
- WG7 executable deployed for user review at `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-7.exe` from earlier reviewed build.
- User explicitly approved landing after WG6 and WG9 landing gates completed.

Closes #689