### PR TITLE
fix: show root agent avatar refs #690

### DIFF
--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -1,5 +1,6 @@
 import { Component, createMemo, createSignal, Show, For, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
+import iconUrl from "../../assets/icon-16.png";
 import { isTauri } from "../../shared/platform";
 import {
   SessionAPI,
@@ -383,18 +384,12 @@ const RootAgentBanner: Component = () => {
       >
         <div class={`session-item-status ${dotClass()}`} />
         <div class="root-agent-avatar">
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-          >
-            <path d="M12 2L2 7l10 5 10-5-10-5z" />
-            <path d="M2 17l10 5 10-5" />
-            <path d="M2 12l10 5 10-5" />
-          </svg>
+          <img
+            src={iconUrl}
+            class="root-agent-avatar-img"
+            alt=""
+            draggable={false}
+          />
         </div>
         <div class="root-agent-text">
           <span class="root-agent-title">Agent's Commander</span>

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -1,6 +1,6 @@
 import { Component, createMemo, createSignal, Show, For, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
-import iconUrl from "../../assets/icon-16.png";
+import iconUrl from "../../../src-tauri/icons/64x64.png";
 import { isTauri } from "../../shared/platform";
 import {
   SessionAPI,

--- a/src/sidebar/components/SessionAutomation.test.tsx
+++ b/src/sidebar/components/SessionAutomation.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import SessionItem from "./SessionItem";
 import RootAgentBanner from "./RootAgentBanner";
-import iconUrl from "../../assets/icon-16.png";
+import iconUrl from "../../../src-tauri/icons/64x64.png";
 import { FakeTransport } from "../../shared/testing/fake-transport";
 import {
   click,

--- a/src/sidebar/components/SessionAutomation.test.tsx
+++ b/src/sidebar/components/SessionAutomation.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import SessionItem from "./SessionItem";
 import RootAgentBanner from "./RootAgentBanner";
+import iconUrl from "../../assets/icon-16.png";
 import { FakeTransport } from "../../shared/testing/fake-transport";
 import {
   click,
@@ -106,6 +107,10 @@ describe("session workflow automation hooks", () => {
     try {
       const banner = rendered.root.querySelector('[data-ac-testid="rootAgent.banner"]');
       expect(banner?.getAttribute("data-ac-state")).toBe("live");
+      const avatar = rendered.root.querySelector<HTMLImageElement>(".root-agent-avatar-img");
+      expect(avatar?.getAttribute("src")).toBe(iconUrl);
+      expect(avatar?.getAttribute("alt")).toBe("");
+      expect(rendered.root.querySelector(".root-agent-avatar svg")).toBeNull();
 
       const detach = rendered.root.querySelector('[data-ac-testid="rootAgent.detachToggle"]');
       expect(detach?.getAttribute("data-ac-state")).toBe("attached");

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -943,6 +943,14 @@ html, body, #root {
   color: var(--sidebar-accent);
 }
 
+.root-agent-avatar-img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  border-radius: inherit;
+}
+
 .root-agent-text {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Replace the generic stacked-layers SVG in the Agent's Commander root row avatar slot with the real Agent's Commander mark.
- Use the tracked `src-tauri/icons/64x64.png` raster so the 28-32px row avatar is not upscaled from the old 16px titlebar asset.
- Preserve the independent status dot behavior from #689 and keep the avatar decorative with empty alt text.

## Verification
- dev-webpage-ui implemented and addressed grinch asset-quality feedback.
- dev-rust-grinch re-review: PASS, no findings.
- `npm test -- src/sidebar/components/SessionAutomation.test.tsx src/sidebar/components/session-status.test.ts` passed.
- `npm run typecheck` passed.
- `npm run build` passed and emitted the bundled 64x64 avatar asset.
- `git diff --check origin/main...HEAD` passed.
- Shipper built and deployed WG7 test executable: `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-7.exe` from commit `fa28822c1d6139190e1648f93b126abdc6d54b4c`.
- User explicitly approved landing.

Closes #690