### PR TITLE
feat: update unchanged seeded context templates (#695)

### DIFF
--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -153,6 +153,8 @@ pub struct AcDiscoveryResult {
     pub teams: Vec<AcTeam>,
     pub workgroups: Vec<AcWorkgroup>,
     pub loops: Vec<crate::config::loops::AcLoopSummary>,
+    pub context_template_updates:
+        Vec<crate::config::seeded_context_templates::ContextTemplateUpdate>,
 }
 
 /// Extract the origin project name from a resolved identity path.
@@ -938,6 +940,7 @@ pub async fn discover_ac_agents(
     let mut teams: Vec<AcTeam> = Vec::new();
     let mut workgroups: Vec<AcWorkgroup> = Vec::new();
     let mut loops: Vec<crate::config::loops::AcLoopSummary> = Vec::new();
+    let mut context_template_updates = Vec::new();
     // Track the Project AC Root-containing dir each workgroup originated from. Keys are
     // `wg.name` values (unique within a discovery run; workgroup dir names include
     // the team name which collides only intentionally across projects). Populated as
@@ -976,6 +979,17 @@ pub async fn discover_ac_agents(
 
             // Opportunistic: ensure gitignore exists for existing projects
             let _ = ensure_workspace_gitignore(&workspace_dir);
+            match crate::config::seeded_context_templates::scan_project_context_template_updates(
+                &repo_dir,
+                &workspace_dir,
+            ) {
+                Ok(mut updates) => context_template_updates.append(&mut updates),
+                Err(e) => log::warn!(
+                    "[context-templates] scan failed for {}: {}",
+                    workspace_dir.display(),
+                    e
+                ),
+            }
             loops.extend(crate::config::loops::discover_loops_in_project(&repo_dir));
 
             let project_folder = repo_dir
@@ -1312,12 +1326,16 @@ pub async fn discover_ac_agents(
         total_replicas,
         total_coordinator
     );
+    crate::config::seeded_context_templates::dedupe_context_template_updates(
+        &mut context_template_updates,
+    );
 
     Ok(AcDiscoveryResult {
         agents,
         teams,
         workgroups,
         loops,
+        context_template_updates,
     })
 }
 
@@ -1472,11 +1490,27 @@ pub async fn discover_project(
             teams: vec![],
             workgroups: vec![],
             loops: vec![],
+            context_template_updates: vec![],
         });
     };
 
     // Opportunistic: ensure gitignore protects workgroup clones
     let _ = ensure_workspace_gitignore(&workspace_dir);
+    let mut context_template_updates =
+        match crate::config::seeded_context_templates::scan_project_context_template_updates(
+            base,
+            &workspace_dir,
+        ) {
+            Ok(updates) => updates,
+            Err(e) => {
+                log::warn!(
+                    "[context-templates] scan failed for {}: {}",
+                    workspace_dir.display(),
+                    e
+                );
+                Vec::new()
+            }
+        };
 
     // Discovery-wide team snapshot — see discover_ac_agents for rationale.
     // Lock-safe: discover_teams() reads settings from disk via load_settings()
@@ -1810,13 +1844,51 @@ pub async fn discover_project(
         total_replicas,
         total_coordinator
     );
+    crate::config::seeded_context_templates::dedupe_context_template_updates(
+        &mut context_template_updates,
+    );
 
     Ok(AcDiscoveryResult {
         agents,
         teams,
         workgroups,
         loops,
+        context_template_updates,
     })
+}
+
+#[tauri::command]
+pub async fn keep_custom_context_template(
+    path: String,
+    filename: String,
+    current_file_sha256: String,
+    current_default_sha256: String,
+) -> Result<(), String> {
+    let workspace_dir = existing_workspace_dir(Path::new(&path))
+        .ok_or_else(|| format!("Project AC Root not found for {}", path))?;
+    crate::config::seeded_context_templates::dismiss_context_template_update(
+        &workspace_dir,
+        &filename,
+        &current_file_sha256,
+        &current_default_sha256,
+    )
+}
+
+#[tauri::command]
+pub async fn overwrite_context_template_with_default(
+    path: String,
+    filename: String,
+    current_file_sha256: String,
+    current_default_sha256: String,
+) -> Result<crate::config::seeded_context_templates::ContextTemplateOverwriteResult, String> {
+    let workspace_dir = existing_workspace_dir(Path::new(&path))
+        .ok_or_else(|| format!("Project AC Root not found for {}", path))?;
+    crate::config::seeded_context_templates::overwrite_context_template_with_default(
+        &workspace_dir,
+        &filename,
+        &current_file_sha256,
+        &current_default_sha256,
+    )
 }
 
 /// Read the `context` array from a replica's config.json.
@@ -2018,6 +2090,24 @@ mod tests {
         assert!(!workspace
             .join(crate::config::session_context::COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
             .exists());
+    }
+
+    #[tokio::test]
+    async fn keep_custom_context_template_rejects_workspace_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create .ac");
+
+        let err = keep_custom_context_template(
+            workspace.to_string_lossy().to_string(),
+            crate::config::session_context::COORDINATOR_CONTEXT_TEMPLATE_FILENAME.to_string(),
+            "file".to_string(),
+            "default".to_string(),
+        )
+        .await
+        .expect_err("workspace path must not be accepted as project path");
+
+        assert!(err.contains("Project AC Root not found"));
     }
 
     #[test]

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -13,6 +13,7 @@ pub mod profile;
 pub mod projects;
 pub mod replica_identity;
 pub mod root_agent;
+pub mod seeded_context_templates;
 pub mod session_context;
 pub mod sessions_persistence;
 pub mod settings;

--- a/src-tauri/src/config/root_agent.rs
+++ b/src-tauri/src/config/root_agent.rs
@@ -310,6 +310,22 @@ Before creating any new specialist agent (any role-defined `create-agent-matrix`
     .to_string()
 });
 
+pub(crate) fn default_root_context_template() -> &'static str {
+    ROOT_ROLE_MD.as_str()
+}
+
+pub(crate) fn is_known_generated_root_context_template(content: &str) -> bool {
+    let normalized = normalize_role_text(content);
+    let old_generated = [
+        normalize_role_text(OLD_ROOT_ROLE_MD),
+        normalize_role_text(&OLD_ROOT_CONTEXT_WITH_COORDINATION_MD),
+        normalize_role_text(ROOT_CONTEXT_BEFORE_BOUNDARY_AUDIT_MD),
+        normalize_role_text(ROOT_CONTEXT_BEFORE_AGENCY_SKILL_MD),
+        normalize_role_text(ROOT_ROLE_MD.as_str()),
+    ];
+    old_generated.contains(&normalized)
+}
+
 const MINIMAL_ROOT_ROLE_MD: &str = r#"# Role
 
 You are the personal Root Agent for AgentsCommander.
@@ -585,84 +601,13 @@ fn migrate_root_role(role_path: &Path) -> Result<(), String> {
 }
 
 fn migrate_root_context_template(context_template_path: &Path) -> Result<(), String> {
-    let existing = match read_validated_template(context_template_path)? {
-        Some(existing) => existing,
-        None => {
-            crate::config::session_context::write_template_if_missing(
-                context_template_path,
-                ROOT_ROLE_MD.as_str(),
-            )?;
-            return read_validated_template(context_template_path)?
-                .map(|_| ())
-                .ok_or_else(|| {
-                    format!(
-                        "Template missing immediately after write_template_if_missing: {}",
-                        context_template_path.display()
-                    )
-                });
-        }
-    };
-
-    let existing_normalized = normalize_role_text(&existing);
-    let old_generated = [
-        normalize_role_text(OLD_ROOT_ROLE_MD),
-        normalize_role_text(&OLD_ROOT_CONTEXT_WITH_COORDINATION_MD),
-        normalize_role_text(ROOT_CONTEXT_BEFORE_BOUNDARY_AUDIT_MD),
-        normalize_role_text(ROOT_CONTEXT_BEFORE_AGENCY_SKILL_MD),
-    ];
-    if old_generated.contains(&existing_normalized) {
-        std::fs::write(context_template_path, ROOT_ROLE_MD.as_str()).map_err(|e| {
-            format!(
-                "Failed to migrate root agent context template {}: {}",
-                context_template_path.display(),
-                e
-            )
-        })?;
-    } else if existing.contains(ROOT_COORDINATION_MESSAGING_PARAGRAPH)
-        || existing.contains(OLD_DEFERRED_MESSAGING_PARAGRAPH)
-    {
-        log::warn!(
-            "Custom root agent context template {} appears to contain stale operational messaging prose; preserving custom content",
-            context_template_path.display()
-        );
-    }
-
-    Ok(())
-}
-
-fn read_validated_template(path: &Path) -> Result<Option<String>, String> {
-    let metadata = match std::fs::symlink_metadata(path) {
-        Ok(metadata) => metadata,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => {
-            return Err(format!(
-                "Failed to inspect root agent context template {}: {}",
-                path.display(),
-                e
-            ))
-        }
-    };
-    let file_type = metadata.file_type();
-    if file_type.is_symlink() || !metadata.is_file() {
-        return Err(format!(
-            "Root agent context template {} exists but is not a regular file",
-            path.display()
-        ));
-    }
-    let bytes = std::fs::read(path).map_err(|e| {
+    let config_dir = context_template_path.parent().ok_or_else(|| {
         format!(
-            "Failed to read root agent context template {}: {}",
-            path.display(),
-            e
+            "Could not resolve config directory from {}",
+            context_template_path.display()
         )
     })?;
-    String::from_utf8(bytes).map(Some).map_err(|e| {
-        format!(
-            "Root agent context template {} is not valid UTF-8: {}",
-            path.display(),
-            e
-        )
-    })
+    crate::config::seeded_context_templates::ensure_root_context_template(config_dir)
 }
 
 fn atomic_write_role(role_path: &Path, content: &str) -> Result<(), String> {

--- a/src-tauri/src/config/seeded_context_templates.rs
+++ b/src-tauri/src/config/seeded_context_templates.rs
@@ -1,0 +1,1424 @@
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashSet};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub const SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME: &str = ".agentscommander-context-templates.json";
+
+const STATE_SCHEMA_VERSION: u32 = 1;
+static STATE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+const CONTEXT_TEMPLATE_CHANGED: &str =
+    "Context template changed on disk; reload the project before overwriting.";
+const CONTEXT_TEMPLATE_DEFAULT_CHANGED: &str =
+    "Context template default changed; reload the project before overwriting.";
+
+const OLD_COORDINATOR_CONTEXT_TEMPLATE_BEFORE_RAISE_HAND: &str = "You are the coordinator for your team. You must:\n\
+     - Keep your base role; coordination is an additional assignment, not a replacement.\n\
+     - Receive team work requests.\n\
+     - Clarify scope, outcome, constraints, and acceptance criteria.\n\
+     - Always route work to the team member best prepared for each part of the request based on role, skills, and current assignment.\n\
+     - Delegate work instead of absorbing technical work when a more specialized agent is available.\n\
+     - Sequence work, track progress, surface blockers, and keep ownership clear.\n\
+     - Follow up after assignment to verify the assigned agent is active and working.\n\
+     - Contact silent or inactive assigned agents up to three total attempts.\n\
+     - Require assigned agents to explicitly report completion, outcome, blockers, and verification before treating delegated work as complete.\n\
+     - Not infer completion solely from files/logs/artifacts/status flags when the assigned agent has not reported the outcome.\n\
+     - Give recommendations to help an agent work better without removing or overriding that agent's role/scope.\n\n\
+     ## Sending Screenshots\n\
+     As a coordinator, you may need to send screenshots. Use the CLI subcommand:\n\
+         telegram-send-image --path <PATH> [--caption <CAPTION>] [--bot-id <ID> | --bot-label <LABEL>]\n\
+     - --path is required. --caption is optional and limited to 1024 UTF-16 units.\n\
+     - If multiple Telegram bots are configured, use --bot-id or --bot-label.\n\
+     - jpg/jpeg/png/webp up to 10 MB use sendPhoto; other formats including GIF use sendDocument up to 50 MB.\n\
+     - Symlinks/junctions are rejected.\n\n\
+     **Screenshot Capture Paths:**\n\
+     - Interactive desktop coordinator: PowerShell System.Drawing / CopyFromScreen can work. Important: cast Measure-Object results to [int] before passing dimensions to Bitmap.\n\
+     - Sandboxed harness coordinator: CopyFromScreen may return all-zero/black pixels. In that case ask the user to capture with Greenshot, use latest file from C:\\Users\\maria\\0_greenshot\\, and visually inspect the image content before sending.\n\
+     - Do not judge Greenshot screenshot relevance by filename; names can be misleading.\n";
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextTemplateUpdate {
+    pub project_path: String,
+    pub workspace_path: String,
+    pub file_path: String,
+    pub filename: String,
+    pub label: String,
+    pub current_file_sha256: String,
+    pub current_default_sha256: String,
+    pub current_default_version: u32,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextTemplateOverwriteResult {
+    pub file_path: String,
+    pub backup_path: String,
+    pub current_default_sha256: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SeededContextTemplateState {
+    schema_version: u32,
+    templates: BTreeMap<String, SeededContextTemplateEntry>,
+}
+
+impl Default for SeededContextTemplateState {
+    fn default() -> Self {
+        Self {
+            schema_version: STATE_SCHEMA_VERSION,
+            templates: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SeededContextTemplateEntry {
+    template_id: String,
+    current_version: u32,
+    last_seeded_sha256: Option<String>,
+    last_observed_sha256: Option<String>,
+    ignored_default_sha256: Option<String>,
+    ignored_observed_sha256: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+struct SeededContextTemplateSpec {
+    id: &'static str,
+    filename: &'static str,
+    label: &'static str,
+    current_version: u32,
+    current_content: fn() -> &'static str,
+    is_known_generated: fn(&str) -> bool,
+    project_actionable: bool,
+    suppress_unknown_without_state: bool,
+}
+
+#[derive(Clone)]
+struct FileSnapshot {
+    bytes: Vec<u8>,
+    content: String,
+    sha256: String,
+}
+
+struct LoadedState {
+    state: SeededContextTemplateState,
+    trusted: bool,
+    can_persist: bool,
+    dirty: bool,
+}
+
+impl LoadedState {
+    fn trusted_entry(
+        &self,
+        spec: SeededContextTemplateSpec,
+    ) -> Option<&SeededContextTemplateEntry> {
+        if !self.trusted {
+            return None;
+        }
+        self.state
+            .templates
+            .get(spec.id)
+            .filter(|entry| entry.template_id == spec.id)
+    }
+
+    fn entry_mut(&mut self, spec: SeededContextTemplateSpec) -> &mut SeededContextTemplateEntry {
+        let entry = self.state.templates.entry(spec.id.to_string()).or_default();
+        entry.template_id = spec.id.to_string();
+        entry.current_version = spec.current_version;
+        entry
+    }
+
+    fn mark_seeded(&mut self, spec: SeededContextTemplateSpec, current_default_sha256: &str) {
+        if !self.trusted {
+            return;
+        }
+        let entry = self.entry_mut(spec);
+        let next = Some(current_default_sha256.to_string());
+        if entry.last_seeded_sha256 != next
+            || entry.last_observed_sha256.is_some()
+            || entry.ignored_default_sha256.is_some()
+            || entry.ignored_observed_sha256.is_some()
+        {
+            entry.last_seeded_sha256 = next;
+            entry.last_observed_sha256 = None;
+            entry.ignored_default_sha256 = None;
+            entry.ignored_observed_sha256 = None;
+            self.dirty = true;
+        }
+    }
+
+    fn mark_observed(&mut self, spec: SeededContextTemplateSpec, current_file_sha256: &str) {
+        if !self.trusted {
+            return;
+        }
+        let entry = self.entry_mut(spec);
+        let next = Some(current_file_sha256.to_string());
+        if entry.last_observed_sha256 != next {
+            entry.last_observed_sha256 = next;
+            self.dirty = true;
+        }
+    }
+
+    fn mark_ignored(
+        &mut self,
+        spec: SeededContextTemplateSpec,
+        current_file_sha256: &str,
+        current_default_sha256: &str,
+    ) {
+        let entry = self.entry_mut(spec);
+        let observed = Some(current_file_sha256.to_string());
+        let default = Some(current_default_sha256.to_string());
+        if entry.ignored_observed_sha256 != observed || entry.ignored_default_sha256 != default {
+            entry.ignored_observed_sha256 = observed;
+            entry.ignored_default_sha256 = default;
+            entry.last_observed_sha256 = Some(current_file_sha256.to_string());
+            self.dirty = true;
+        }
+    }
+}
+
+fn project_specs() -> [SeededContextTemplateSpec; 2] {
+    [
+        SeededContextTemplateSpec {
+            id: "global",
+            filename: crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME,
+            label: "AgentsCommander shared context",
+            current_version: 1,
+            current_content: crate::config::session_context::get_default_agent_template,
+            is_known_generated: is_known_generated_global_template,
+            project_actionable: true,
+            suppress_unknown_without_state: true,
+        },
+        SeededContextTemplateSpec {
+            id: "coordinator",
+            filename: crate::config::session_context::COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            label: "Coordinator context",
+            current_version: 2,
+            current_content: crate::config::session_context::get_default_coordinator_template,
+            is_known_generated: is_known_generated_coordinator_template,
+            project_actionable: true,
+            suppress_unknown_without_state: false,
+        },
+    ]
+}
+
+fn root_spec() -> SeededContextTemplateSpec {
+    SeededContextTemplateSpec {
+        id: "rootAgent",
+        filename: crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME,
+        label: "Root agent context",
+        current_version: 4,
+        current_content: crate::config::root_agent::default_root_context_template,
+        is_known_generated: crate::config::root_agent::is_known_generated_root_context_template,
+        project_actionable: false,
+        suppress_unknown_without_state: false,
+    }
+}
+
+fn project_spec_by_filename(filename: &str) -> Option<SeededContextTemplateSpec> {
+    project_specs()
+        .into_iter()
+        .find(|spec| spec.filename == filename)
+}
+
+fn actionable_project_spec_by_filename(
+    filename: &str,
+) -> Result<SeededContextTemplateSpec, String> {
+    if filename.contains('/') || filename.contains('\\') {
+        return Err("Context template filename is not managed by AgentsCommander".to_string());
+    }
+    let spec = project_spec_by_filename(filename)
+        .ok_or_else(|| "Context template filename is not managed by AgentsCommander".to_string())?;
+    if !spec.project_actionable {
+        return Err("Context template filename is not actionable for this project".to_string());
+    }
+    Ok(spec)
+}
+
+fn is_known_generated_global_template(content: &str) -> bool {
+    content == crate::config::session_context::get_default_agent_template()
+}
+
+fn is_known_generated_coordinator_template(content: &str) -> bool {
+    content == crate::config::session_context::get_default_coordinator_template()
+        || content == OLD_COORDINATOR_CONTEXT_TEMPLATE_BEFORE_RAISE_HAND
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    format!("{:x}", digest)
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .to_string()
+}
+
+fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    }
+
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+fn validate_existing_dir(path: &Path, label: &str) -> Result<(), String> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|e| format!("Failed to inspect {} {}: {}", label, path.display(), e))?;
+    if is_link_or_reparse(&metadata) || !metadata.is_dir() {
+        return Err(format!(
+            "{} {} exists but is not a regular directory",
+            label,
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn validate_existing_file(path: &Path, label: &str) -> Result<(), String> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|e| format!("Failed to inspect {} {}: {}", label, path.display(), e))?;
+    if is_link_or_reparse(&metadata) || !metadata.is_file() {
+        return Err(format!(
+            "{} {} exists but is not a regular file",
+            label,
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn read_validated_snapshot(path: &Path, label: &str) -> Result<Option<FileSnapshot>, String> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if is_link_or_reparse(&metadata) || !metadata.is_file() {
+                return Err(format!(
+                    "{} {} exists but is not a regular file",
+                    label,
+                    path.display()
+                ));
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(format!(
+                "Failed to inspect {} {}: {}",
+                label,
+                path.display(),
+                e
+            ))
+        }
+    }
+
+    let bytes = std::fs::read(path)
+        .map_err(|e| format!("Failed to read {} {}: {}", label, path.display(), e))?;
+    let sha256 = sha256_hex(&bytes);
+    let content = String::from_utf8(bytes.clone())
+        .map_err(|e| format!("{} {} is not valid UTF-8: {}", label, path.display(), e))?;
+    Ok(Some(FileSnapshot {
+        bytes,
+        content,
+        sha256,
+    }))
+}
+
+fn load_state(workspace_dir: &Path, strict: bool) -> Result<LoadedState, String> {
+    let path = workspace_dir.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME);
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => {
+            if is_link_or_reparse(&metadata) || !metadata.is_file() {
+                let message = format!(
+                    "Context template state path {} exists but is not a regular file",
+                    path.display()
+                );
+                if strict {
+                    return Err(message);
+                }
+                log::warn!(
+                    "[context-templates] {}; skipping state persistence",
+                    message
+                );
+                return Ok(LoadedState {
+                    state: SeededContextTemplateState::default(),
+                    trusted: false,
+                    can_persist: false,
+                    dirty: false,
+                });
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(LoadedState {
+                state: SeededContextTemplateState::default(),
+                trusted: true,
+                can_persist: true,
+                dirty: false,
+            })
+        }
+        Err(e) => {
+            let message = format!(
+                "Failed to inspect context template state {}: {}",
+                path.display(),
+                e
+            );
+            if strict {
+                return Err(message);
+            }
+            log::warn!(
+                "[context-templates] {}; skipping state persistence",
+                message
+            );
+            return Ok(LoadedState {
+                state: SeededContextTemplateState::default(),
+                trusted: false,
+                can_persist: false,
+                dirty: false,
+            });
+        }
+    }
+
+    let bytes = std::fs::read(&path).map_err(|e| {
+        format!(
+            "Failed to read context template state {}: {}",
+            path.display(),
+            e
+        )
+    })?;
+    let state = match serde_json::from_slice::<SeededContextTemplateState>(&bytes) {
+        Ok(state) => state,
+        Err(e) => {
+            log::warn!(
+                "[context-templates] invalid state JSON at {}; treating as empty: {}",
+                path.display(),
+                e
+            );
+            return Ok(LoadedState {
+                state: SeededContextTemplateState::default(),
+                trusted: true,
+                can_persist: true,
+                dirty: true,
+            });
+        }
+    };
+
+    if state.schema_version != STATE_SCHEMA_VERSION {
+        let message = format!(
+            "Context template state schema version {} is unsupported; reload or upgrade AgentsCommander.",
+            state.schema_version
+        );
+        if strict {
+            return Err(message);
+        }
+        log::warn!(
+            "[context-templates] {}; skipping state persistence",
+            message
+        );
+        return Ok(LoadedState {
+            state: SeededContextTemplateState::default(),
+            trusted: false,
+            can_persist: false,
+            dirty: false,
+        });
+    }
+
+    Ok(LoadedState {
+        state,
+        trusted: true,
+        can_persist: true,
+        dirty: false,
+    })
+}
+
+fn unique_state_temp_path(path: &Path) -> PathBuf {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME);
+    let counter = STATE_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    parent.join(format!(
+        ".{file_name}.{}.{}.tmp",
+        std::process::id(),
+        counter
+    ))
+}
+
+fn cleanup_temp(path: &Path) {
+    if let Err(e) = std::fs::remove_file(path) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            log::warn!(
+                "[context-templates] failed to remove temporary file {}: {}",
+                path.display(),
+                e
+            );
+        }
+    }
+}
+
+fn persist_state(workspace_dir: &Path, state: &SeededContextTemplateState) -> Result<(), String> {
+    let path = workspace_dir.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME);
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => {
+            if is_link_or_reparse(&metadata) || !metadata.is_file() {
+                return Err(format!(
+                    "Context template state path {} exists but is not a regular file",
+                    path.display()
+                ));
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(format!(
+                "Failed to inspect context template state {}: {}",
+                path.display(),
+                e
+            ))
+        }
+    }
+
+    let content = serde_json::to_vec_pretty(state)
+        .map_err(|e| format!("Failed to serialize context template state: {}", e))?;
+    let temp = unique_state_temp_path(&path);
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp)
+        .map_err(|e| {
+            format!(
+                "Failed to create temporary context template state {}: {}",
+                temp.display(),
+                e
+            )
+        })?;
+    if let Err(e) = file.write_all(&content) {
+        drop(file);
+        cleanup_temp(&temp);
+        return Err(format!(
+            "Failed to write temporary context template state {}: {}",
+            temp.display(),
+            e
+        ));
+    }
+    if let Err(e) = file.flush() {
+        drop(file);
+        cleanup_temp(&temp);
+        return Err(format!(
+            "Failed to flush temporary context template state {}: {}",
+            temp.display(),
+            e
+        ));
+    }
+    if let Err(e) = file.sync_all() {
+        drop(file);
+        cleanup_temp(&temp);
+        return Err(format!(
+            "Failed to sync temporary context template state {}: {}",
+            temp.display(),
+            e
+        ));
+    }
+    drop(file);
+
+    if let Err(e) = crate::config::root_agent::atomic_replace_existing(&temp, &path) {
+        cleanup_temp(&temp);
+        return Err(e);
+    }
+    if let Some(parent) = path.parent() {
+        if let Ok(dir) = std::fs::File::open(parent) {
+            if let Err(e) = dir.sync_all() {
+                log::warn!(
+                    "[context-templates] failed to sync state directory {}: {}",
+                    parent.display(),
+                    e
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn persist_state_best_effort(workspace_dir: &Path, loaded: &LoadedState) {
+    if !loaded.dirty || !loaded.can_persist {
+        return;
+    }
+    if let Err(e) = persist_state(workspace_dir, &loaded.state) {
+        log::warn!(
+            "[context-templates] failed to persist state in {}: {}",
+            workspace_dir.display(),
+            e
+        );
+    }
+}
+
+fn persist_state_strict(workspace_dir: &Path, loaded: &LoadedState) -> Result<(), String> {
+    if !loaded.can_persist {
+        return Err("Context template state cannot be safely persisted".to_string());
+    }
+    if loaded.dirty {
+        persist_state(workspace_dir, &loaded.state)?;
+    }
+    Ok(())
+}
+
+fn make_update(
+    project_dir: &Path,
+    workspace_dir: &Path,
+    path: &Path,
+    spec: SeededContextTemplateSpec,
+    current_file_sha256: String,
+    current_default_sha256: String,
+) -> ContextTemplateUpdate {
+    ContextTemplateUpdate {
+        project_path: display_path(project_dir),
+        workspace_path: display_path(workspace_dir),
+        file_path: display_path(path),
+        filename: spec.filename.to_string(),
+        label: spec.label.to_string(),
+        current_file_sha256,
+        current_default_sha256,
+        current_default_version: spec.current_version,
+    }
+}
+
+fn create_missing_template(path: &Path, content: &str) -> Result<(), String> {
+    crate::config::session_context::write_template_if_missing(path, content)?;
+    validate_existing_file(path, "Context template")
+}
+
+fn auto_update_generated_template(
+    path: &Path,
+    spec: SeededContextTemplateSpec,
+    expected_file_sha256: &str,
+) -> Result<bool, String> {
+    let Some(snapshot) = read_validated_snapshot(path, "Context template")? else {
+        return Ok(false);
+    };
+    if snapshot.sha256 != expected_file_sha256 {
+        log::warn!(
+            "[context-templates] {} changed before generated update; preserving current content",
+            path.display()
+        );
+        return Ok(false);
+    }
+    if !(spec.is_known_generated)(&snapshot.content) {
+        log::warn!(
+            "[context-templates] {} no longer matches a known generated default; preserving current content",
+            path.display()
+        );
+        return Ok(false);
+    }
+    crate::config::session_context::atomically_replace_context_template(
+        path,
+        (spec.current_content)(),
+    )?;
+    Ok(true)
+}
+
+fn sync_one_template(
+    project_dir: Option<&Path>,
+    workspace_dir: &Path,
+    spec: SeededContextTemplateSpec,
+    loaded: &mut LoadedState,
+    allow_create_missing: bool,
+    return_pending: bool,
+) -> Result<Option<ContextTemplateUpdate>, String> {
+    let path = workspace_dir.join(spec.filename);
+    let current_default = (spec.current_content)();
+    let current_default_sha256 = sha256_hex(current_default.as_bytes());
+    let mut snapshot = read_validated_snapshot(&path, "Context template")?;
+
+    if snapshot.is_none() {
+        if !allow_create_missing {
+            return Ok(None);
+        }
+        create_missing_template(&path, current_default)?;
+        snapshot = read_validated_snapshot(&path, "Context template")?;
+        if let Some(snapshot) = &snapshot {
+            if snapshot.sha256 == current_default_sha256 {
+                loaded.mark_seeded(spec, &current_default_sha256);
+                return Ok(None);
+            }
+        }
+    }
+
+    let Some(snapshot) = snapshot else {
+        return Ok(None);
+    };
+
+    if snapshot.sha256 == current_default_sha256 {
+        loaded.mark_seeded(spec, &current_default_sha256);
+        return Ok(None);
+    }
+
+    let trusted_entry = loaded.trusted_entry(spec).cloned();
+    if let Some(entry) = trusted_entry.as_ref() {
+        if entry.last_seeded_sha256.as_deref() == Some(snapshot.sha256.as_str())
+            && entry.last_seeded_sha256.as_deref() != Some(current_default_sha256.as_str())
+            && (spec.is_known_generated)(&snapshot.content)
+        {
+            if auto_update_generated_template(&path, spec, &snapshot.sha256)? {
+                loaded.mark_seeded(spec, &current_default_sha256);
+            }
+            return Ok(None);
+        }
+    }
+
+    let has_valid_entry = trusted_entry.is_some();
+    if !has_valid_entry && (spec.is_known_generated)(&snapshot.content) {
+        if auto_update_generated_template(&path, spec, &snapshot.sha256)? {
+            loaded.mark_seeded(spec, &current_default_sha256);
+        }
+        return Ok(None);
+    }
+
+    if spec.suppress_unknown_without_state && !has_valid_entry {
+        log::debug!(
+            "[context-templates] preserving ambiguous global context template {} without prompting",
+            path.display()
+        );
+        return Ok(None);
+    }
+
+    if let Some(entry) = trusted_entry.as_ref() {
+        if entry.ignored_observed_sha256.as_deref() == Some(snapshot.sha256.as_str())
+            && entry.ignored_default_sha256.as_deref() == Some(current_default_sha256.as_str())
+        {
+            return Ok(None);
+        }
+    }
+
+    loaded.mark_observed(spec, &snapshot.sha256);
+    if return_pending {
+        let project_dir = project_dir.ok_or_else(|| {
+            format!(
+                "Cannot create context template update for {} without a project path",
+                path.display()
+            )
+        })?;
+        Ok(Some(make_update(
+            project_dir,
+            workspace_dir,
+            &path,
+            spec,
+            snapshot.sha256,
+            current_default_sha256,
+        )))
+    } else {
+        log::warn!(
+            "[context-templates] preserving customized context template {}; a newer default is available",
+            path.display()
+        );
+        Ok(None)
+    }
+}
+
+fn compute_pending_update(
+    project_dir: &Path,
+    workspace_dir: &Path,
+    spec: SeededContextTemplateSpec,
+    loaded: &LoadedState,
+) -> Result<Option<ContextTemplateUpdate>, String> {
+    let path = workspace_dir.join(spec.filename);
+    let current_default = (spec.current_content)();
+    let current_default_sha256 = sha256_hex(current_default.as_bytes());
+    let Some(snapshot) = read_validated_snapshot(&path, "Context template")? else {
+        return Ok(None);
+    };
+    if snapshot.sha256 == current_default_sha256 {
+        return Ok(None);
+    }
+
+    let trusted_entry = loaded.trusted_entry(spec);
+    let has_valid_entry = trusted_entry.is_some();
+    if !has_valid_entry && (spec.is_known_generated)(&snapshot.content) {
+        return Ok(None);
+    }
+    if spec.suppress_unknown_without_state && !has_valid_entry {
+        return Ok(None);
+    }
+    if let Some(entry) = trusted_entry {
+        if entry.ignored_observed_sha256.as_deref() == Some(snapshot.sha256.as_str())
+            && entry.ignored_default_sha256.as_deref() == Some(current_default_sha256.as_str())
+        {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(make_update(
+        project_dir,
+        workspace_dir,
+        &path,
+        spec,
+        snapshot.sha256,
+        current_default_sha256,
+    )))
+}
+
+fn validate_project_workspace_dir(workspace_dir: &Path) -> Result<PathBuf, String> {
+    validate_existing_dir(workspace_dir, "Project AC Root")?;
+    let name = workspace_dir.file_name().and_then(|name| name.to_str());
+    if name != Some(crate::config::workspace::canonical_workspace_dir_label()) {
+        return Err(format!(
+            "{} is not a Project AC Root directory",
+            workspace_dir.display()
+        ));
+    }
+    workspace_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| format!("Project AC Root {} has no parent", workspace_dir.display()))
+}
+
+fn validate_project_workspace_for_scan(
+    project_dir: &Path,
+    workspace_dir: &Path,
+) -> Result<(), String> {
+    validate_existing_dir(workspace_dir, "Project AC Root")?;
+    let expected = crate::config::workspace::workspace_dir_for_project(project_dir);
+    if workspace_dir != expected {
+        return Err(format!(
+            "Project AC Root {} is not the canonical child of {}",
+            workspace_dir.display(),
+            project_dir.display()
+        ));
+    }
+    Ok(())
+}
+
+pub fn ensure_project_context_templates(workspace_dir: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(workspace_dir).map_err(|e| {
+        format!(
+            "failed to create context templates directory {}: {}",
+            workspace_dir.display(),
+            e
+        )
+    })?;
+    validate_existing_dir(workspace_dir, "Context template directory")?;
+    let mut loaded = load_state(workspace_dir, false)?;
+    for spec in project_specs() {
+        sync_one_template(None, workspace_dir, spec, &mut loaded, true, false)?;
+    }
+    persist_state_best_effort(workspace_dir, &loaded);
+    Ok(())
+}
+
+pub fn scan_project_context_template_updates(
+    project_dir: &Path,
+    workspace_dir: &Path,
+) -> Result<Vec<ContextTemplateUpdate>, String> {
+    validate_project_workspace_for_scan(project_dir, workspace_dir)?;
+    let mut loaded = load_state(workspace_dir, false)?;
+    let mut updates = Vec::new();
+    for spec in project_specs() {
+        if let Some(update) = sync_one_template(
+            Some(project_dir),
+            workspace_dir,
+            spec,
+            &mut loaded,
+            false,
+            true,
+        )? {
+            updates.push(update);
+        }
+    }
+    persist_state_best_effort(workspace_dir, &loaded);
+    dedupe_context_template_updates(&mut updates);
+    Ok(updates)
+}
+
+pub fn sync_project_context_template_for_read(
+    context_dir: &Path,
+    filename: &str,
+) -> Result<(), String> {
+    let Some(spec) = project_spec_by_filename(filename) else {
+        return Ok(());
+    };
+    validate_existing_dir(context_dir, "Context template directory")?;
+    let mut loaded = load_state(context_dir, false)?;
+    let result = sync_one_template(None, context_dir, spec, &mut loaded, true, false);
+    persist_state_best_effort(context_dir, &loaded);
+    result.map(|_| ())
+}
+
+pub fn ensure_root_context_template(config_dir: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(config_dir).map_err(|e| {
+        format!(
+            "Failed to create root agent config directory {}: {}",
+            config_dir.display(),
+            e
+        )
+    })?;
+    validate_existing_dir(config_dir, "Root agent config directory")?;
+    let mut loaded = load_state(config_dir, false)?;
+    sync_one_template(None, config_dir, root_spec(), &mut loaded, true, false)?;
+    persist_state_best_effort(config_dir, &loaded);
+    Ok(())
+}
+
+fn validate_expected_hashes(
+    project_dir: &Path,
+    workspace_dir: &Path,
+    spec: SeededContextTemplateSpec,
+    loaded: &LoadedState,
+    expected_file_sha256: &str,
+    expected_default_sha256: &str,
+) -> Result<(), String> {
+    let current_default_sha256 = sha256_hex((spec.current_content)().as_bytes());
+    if current_default_sha256 != expected_default_sha256 {
+        return Err(CONTEXT_TEMPLATE_DEFAULT_CHANGED.to_string());
+    }
+    let Some(pending) = compute_pending_update(project_dir, workspace_dir, spec, loaded)? else {
+        return Err(CONTEXT_TEMPLATE_CHANGED.to_string());
+    };
+    if pending.current_file_sha256 != expected_file_sha256
+        || pending.current_default_sha256 != expected_default_sha256
+    {
+        return Err(CONTEXT_TEMPLATE_CHANGED.to_string());
+    }
+    Ok(())
+}
+
+pub fn dismiss_context_template_update(
+    workspace_dir: &Path,
+    filename: &str,
+    expected_file_sha256: &str,
+    expected_default_sha256: &str,
+) -> Result<(), String> {
+    let spec = actionable_project_spec_by_filename(filename)?;
+    let project_dir = validate_project_workspace_dir(workspace_dir)?;
+    let mut loaded = load_state(workspace_dir, true)?;
+    validate_expected_hashes(
+        &project_dir,
+        workspace_dir,
+        spec,
+        &loaded,
+        expected_file_sha256,
+        expected_default_sha256,
+    )?;
+    let path = workspace_dir.join(spec.filename);
+    let Some(snapshot) = read_validated_snapshot(&path, "Context template")? else {
+        return Err(CONTEXT_TEMPLATE_CHANGED.to_string());
+    };
+    if snapshot.sha256 != expected_file_sha256 {
+        return Err(CONTEXT_TEMPLATE_CHANGED.to_string());
+    }
+    loaded.mark_ignored(spec, expected_file_sha256, expected_default_sha256);
+    persist_state_strict(workspace_dir, &loaded)
+}
+
+pub fn overwrite_context_template_with_default(
+    workspace_dir: &Path,
+    filename: &str,
+    expected_file_sha256: &str,
+    expected_default_sha256: &str,
+) -> Result<ContextTemplateOverwriteResult, String> {
+    let spec = actionable_project_spec_by_filename(filename)?;
+    let project_dir = validate_project_workspace_dir(workspace_dir)?;
+    let mut loaded = load_state(workspace_dir, true)?;
+    validate_expected_hashes(
+        &project_dir,
+        workspace_dir,
+        spec,
+        &loaded,
+        expected_file_sha256,
+        expected_default_sha256,
+    )?;
+
+    let path = workspace_dir.join(spec.filename);
+    let Some(snapshot) = read_validated_snapshot(&path, "Context template")? else {
+        return Err(CONTEXT_TEMPLATE_CHANGED.to_string());
+    };
+    if snapshot.sha256 != expected_file_sha256 {
+        return Err(CONTEXT_TEMPLATE_CHANGED.to_string());
+    }
+    if sha256_hex((spec.current_content)().as_bytes()) != expected_default_sha256 {
+        return Err(CONTEXT_TEMPLATE_DEFAULT_CHANGED.to_string());
+    }
+
+    let backup_path = create_backup(&path, &snapshot.bytes)?;
+    let Some(snapshot_after_backup) = read_validated_snapshot(&path, "Context template")? else {
+        return Err(CONTEXT_TEMPLATE_CHANGED.to_string());
+    };
+    if snapshot_after_backup.sha256 != expected_file_sha256 {
+        return Err(CONTEXT_TEMPLATE_CHANGED.to_string());
+    }
+
+    if let Err(e) = crate::config::session_context::atomically_replace_context_template(
+        &path,
+        (spec.current_content)(),
+    ) {
+        log::warn!(
+            "[context-templates] replacement failed after backup {} was created: {}",
+            backup_path.display(),
+            e
+        );
+        return Err(e);
+    }
+
+    loaded.mark_seeded(spec, expected_default_sha256);
+    persist_state_strict(workspace_dir, &loaded)?;
+    Ok(ContextTemplateOverwriteResult {
+        file_path: display_path(&path),
+        backup_path: display_path(&backup_path),
+        current_default_sha256: expected_default_sha256.to_string(),
+    })
+}
+
+fn create_backup(path: &Path, bytes: &[u8]) -> Result<PathBuf, String> {
+    let parent = path.parent().ok_or_else(|| {
+        format!(
+            "Could not resolve parent directory for context template {}",
+            path.display()
+        )
+    })?;
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("Invalid context template filename {}", path.display()))?;
+    let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%SZ").to_string();
+
+    for index in 0..1000_u32 {
+        let backup_name = match index {
+            0 => format!("{filename}.bak"),
+            1 => format!("{filename}.{timestamp}.bak"),
+            n => format!("{filename}.{timestamp}.{n}.bak"),
+        };
+        let backup_path = parent.join(backup_name);
+        let mut file = match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&backup_path)
+        {
+            Ok(file) => file,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => {
+                return Err(format!(
+                    "Failed to create backup context template {}: {}",
+                    backup_path.display(),
+                    e
+                ))
+            }
+        };
+        if let Err(e) = file.write_all(bytes) {
+            return Err(format!(
+                "Failed to write backup context template {}: {}",
+                backup_path.display(),
+                e
+            ));
+        }
+        if let Err(e) = file.flush() {
+            return Err(format!(
+                "Failed to flush backup context template {}: {}",
+                backup_path.display(),
+                e
+            ));
+        }
+        if let Err(e) = file.sync_all() {
+            return Err(format!(
+                "Failed to sync backup context template {}: {}",
+                backup_path.display(),
+                e
+            ));
+        }
+        drop(file);
+        if let Ok(dir) = std::fs::File::open(parent) {
+            if let Err(e) = dir.sync_all() {
+                log::warn!(
+                    "[context-templates] failed to sync backup directory {}: {}",
+                    parent.display(),
+                    e
+                );
+            }
+        }
+        return Ok(backup_path);
+    }
+
+    Err(format!(
+        "Failed to create a unique backup path for {}",
+        path.display()
+    ))
+}
+
+pub fn dedupe_context_template_updates(updates: &mut Vec<ContextTemplateUpdate>) {
+    let mut seen = HashSet::new();
+    updates.retain(|update| {
+        seen.insert((
+            update.workspace_path.clone(),
+            update.filename.clone(),
+            update.current_file_sha256.clone(),
+            update.current_default_sha256.clone(),
+        ))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::session_context::{
+        get_default_coordinator_template, COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+        GLOBAL_CONTEXT_TEMPLATE_FILENAME,
+    };
+
+    fn hash_text(content: &str) -> String {
+        sha256_hex(content.as_bytes())
+    }
+
+    #[test]
+    fn old_coordinator_default_is_known_generated_without_raise_hand() {
+        assert!(
+            !OLD_COORDINATOR_CONTEXT_TEMPLATE_BEFORE_RAISE_HAND.contains("## Raising Your Hand")
+        );
+        assert!(
+            OLD_COORDINATOR_CONTEXT_TEMPLATE_BEFORE_RAISE_HAND.contains("## Sending Screenshots")
+        );
+        assert!(
+            OLD_COORDINATOR_CONTEXT_TEMPLATE_BEFORE_RAISE_HAND.contains("names can be misleading.")
+        );
+        assert!(is_known_generated_coordinator_template(
+            OLD_COORDINATOR_CONTEXT_TEMPLATE_BEFORE_RAISE_HAND
+        ));
+    }
+
+    #[test]
+    fn scan_existing_ac_does_not_create_missing_templates() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+
+        let updates =
+            scan_project_context_template_updates(temp.path(), &workspace).expect("scan updates");
+
+        assert!(updates.is_empty());
+        assert!(!workspace.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME).exists());
+        assert!(!workspace
+            .join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
+            .exists());
+    }
+
+    #[test]
+    fn read_sync_creates_missing_coordinator_template() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+
+        sync_project_context_template_for_read(&workspace, COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
+            .expect("sync for read");
+
+        let content =
+            std::fs::read_to_string(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+                .expect("read coordinator");
+        assert_eq!(content, get_default_coordinator_template());
+    }
+
+    #[test]
+    fn read_sync_updates_old_generated_coordinator_template() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        std::fs::write(
+            workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
+            OLD_COORDINATOR_CONTEXT_TEMPLATE_BEFORE_RAISE_HAND,
+        )
+        .expect("write old coordinator");
+
+        sync_project_context_template_for_read(&workspace, COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
+            .expect("sync for read");
+
+        let content =
+            std::fs::read_to_string(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+                .expect("read coordinator");
+        assert_eq!(content, get_default_coordinator_template());
+    }
+
+    #[test]
+    fn custom_coordinator_is_preserved_and_reported() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        let custom = "custom coordinator guidance";
+        std::fs::write(
+            workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
+            custom,
+        )
+        .expect("write custom coordinator");
+
+        let updates =
+            scan_project_context_template_updates(temp.path(), &workspace).expect("scan updates");
+
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].filename, COORDINATOR_CONTEXT_TEMPLATE_FILENAME);
+        assert_eq!(
+            std::fs::read_to_string(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+                .expect("read coordinator"),
+            custom
+        );
+    }
+
+    #[test]
+    fn global_unknown_without_state_is_not_reported() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        std::fs::write(
+            workspace.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
+            "legacy rendered global body with project paths",
+        )
+        .expect("write global");
+
+        let updates =
+            scan_project_context_template_updates(temp.path(), &workspace).expect("scan updates");
+
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn forged_manifest_does_not_auto_overwrite_custom_content() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        let custom = "custom coordinator with forged seeded hash";
+        std::fs::write(
+            workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
+            custom,
+        )
+        .expect("write custom coordinator");
+        let mut state = SeededContextTemplateState::default();
+        state.templates.insert(
+            "coordinator".to_string(),
+            SeededContextTemplateEntry {
+                template_id: "coordinator".to_string(),
+                current_version: 1,
+                last_seeded_sha256: Some(hash_text(custom)),
+                last_observed_sha256: None,
+                ignored_default_sha256: None,
+                ignored_observed_sha256: None,
+            },
+        );
+        persist_state(&workspace, &state).expect("persist forged state");
+
+        let updates =
+            scan_project_context_template_updates(temp.path(), &workspace).expect("scan updates");
+
+        assert_eq!(updates.len(), 1);
+        assert_eq!(
+            std::fs::read_to_string(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+                .expect("read coordinator"),
+            custom
+        );
+    }
+
+    #[test]
+    fn dismiss_suppresses_same_file_and_default_hash() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        let custom = "custom coordinator guidance";
+        std::fs::write(
+            workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
+            custom,
+        )
+        .expect("write custom coordinator");
+        let update = scan_project_context_template_updates(temp.path(), &workspace)
+            .expect("scan updates")
+            .pop()
+            .expect("pending update");
+
+        dismiss_context_template_update(
+            &workspace,
+            &update.filename,
+            &update.current_file_sha256,
+            &update.current_default_sha256,
+        )
+        .expect("dismiss");
+
+        let updates =
+            scan_project_context_template_updates(temp.path(), &workspace).expect("scan again");
+        assert!(updates.is_empty());
+    }
+
+    #[test]
+    fn explicit_keep_repairs_invalid_state_json() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        let custom = "custom coordinator guidance";
+        std::fs::write(
+            workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
+            custom,
+        )
+        .expect("write custom coordinator");
+        std::fs::write(
+            workspace.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME),
+            "not json",
+        )
+        .expect("write invalid state");
+
+        dismiss_context_template_update(
+            &workspace,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            &hash_text(custom),
+            &hash_text(get_default_coordinator_template()),
+        )
+        .expect("dismiss with invalid state");
+
+        let repaired =
+            std::fs::read_to_string(workspace.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME))
+                .expect("read repaired state");
+        let parsed: SeededContextTemplateState =
+            serde_json::from_str(&repaired).expect("state is repaired JSON");
+        assert_eq!(parsed.schema_version, STATE_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn overwrite_creates_backup_and_writes_default() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        let custom = "custom coordinator guidance";
+        std::fs::write(
+            workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
+            custom,
+        )
+        .expect("write custom coordinator");
+        let update = scan_project_context_template_updates(temp.path(), &workspace)
+            .expect("scan updates")
+            .pop()
+            .expect("pending update");
+
+        let result = overwrite_context_template_with_default(
+            &workspace,
+            &update.filename,
+            &update.current_file_sha256,
+            &update.current_default_sha256,
+        )
+        .expect("overwrite");
+
+        assert_eq!(
+            std::fs::read_to_string(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+                .expect("read coordinator"),
+            get_default_coordinator_template()
+        );
+        assert_eq!(
+            std::fs::read_to_string(result.backup_path).expect("read backup"),
+            custom
+        );
+    }
+
+    #[test]
+    fn future_schema_is_not_rewritten_by_scan() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        let state_path = workspace.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME);
+        std::fs::write(&state_path, r#"{"schemaVersion":999,"templates":{}}"#)
+            .expect("write future state");
+
+        let updates =
+            scan_project_context_template_updates(temp.path(), &workspace).expect("scan updates");
+
+        assert!(updates.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(state_path).expect("read state"),
+            r#"{"schemaVersion":999,"templates":{}}"#
+        );
+    }
+
+    #[test]
+    fn state_directory_blocks_explicit_commands() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        std::fs::create_dir(workspace.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME))
+            .expect("create state dir");
+
+        let err = dismiss_context_template_update(
+            &workspace,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            "file",
+            "default",
+        )
+        .expect_err("state dir must error");
+
+        assert!(err.contains("state path"));
+    }
+
+    #[test]
+    fn dedupe_keeps_distinct_file_hashes() {
+        let mut updates = vec![
+            ContextTemplateUpdate {
+                project_path: "project".to_string(),
+                workspace_path: "workspace".to_string(),
+                file_path: "workspace/Context.coordinator.md".to_string(),
+                filename: COORDINATOR_CONTEXT_TEMPLATE_FILENAME.to_string(),
+                label: "Coordinator context".to_string(),
+                current_file_sha256: "file-a".to_string(),
+                current_default_sha256: "default".to_string(),
+                current_default_version: 2,
+            },
+            ContextTemplateUpdate {
+                project_path: "project".to_string(),
+                workspace_path: "workspace".to_string(),
+                file_path: "workspace/Context.coordinator.md".to_string(),
+                filename: COORDINATOR_CONTEXT_TEMPLATE_FILENAME.to_string(),
+                label: "Coordinator context".to_string(),
+                current_file_sha256: "file-a".to_string(),
+                current_default_sha256: "default".to_string(),
+                current_default_version: 2,
+            },
+            ContextTemplateUpdate {
+                project_path: "project".to_string(),
+                workspace_path: "workspace".to_string(),
+                file_path: "workspace/Context.coordinator.md".to_string(),
+                filename: COORDINATOR_CONTEXT_TEMPLATE_FILENAME.to_string(),
+                label: "Coordinator context".to_string(),
+                current_file_sha256: "file-b".to_string(),
+                current_default_sha256: "default".to_string(),
+                current_default_version: 2,
+            },
+        ];
+
+        dedupe_context_template_updates(&mut updates);
+
+        assert_eq!(updates.len(), 2);
+        assert_eq!(updates[0].current_file_sha256, "file-a");
+        assert_eq!(updates[1].current_file_sha256, "file-b");
+    }
+
+    #[test]
+    fn root_custom_template_is_preserved() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let custom = "custom root context";
+        std::fs::write(
+            temp.path()
+                .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME),
+            custom,
+        )
+        .expect("write root custom");
+
+        ensure_root_context_template(temp.path()).expect("ensure root context");
+
+        assert_eq!(
+            std::fs::read_to_string(
+                temp.path()
+                    .join(crate::config::session_context::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME)
+            )
+            .expect("read root context"),
+            custom
+        );
+    }
+}

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -833,22 +833,7 @@ fn find_workspace_root(path: &std::path::Path) -> Option<std::path::PathBuf> {
 }
 
 pub fn create_default_context_templates(workspace_dir: &Path) -> Result<(), String> {
-    std::fs::create_dir_all(workspace_dir).map_err(|e| {
-        format!(
-            "failed to create context templates directory {}: {}",
-            workspace_dir.display(),
-            e
-        )
-    })?;
-    write_template_if_missing(
-        &workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
-        get_default_agent_template(),
-    )?;
-    write_template_if_missing(
-        &workspace_dir.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
-        get_default_coordinator_template(),
-    )?;
-    Ok(())
+    crate::config::seeded_context_templates::ensure_project_context_templates(workspace_dir)
 }
 
 pub(crate) fn write_template_if_missing(path: &Path, content: &str) -> Result<(), String> {
@@ -1023,6 +1008,14 @@ fn read_or_create_context_template(
     };
     if filename == GLOBAL_CONTEXT_TEMPLATE_FILENAME {
         migrate_legacy_agent_context_template(&context_dir)?;
+    }
+    if filename == GLOBAL_CONTEXT_TEMPLATE_FILENAME
+        || filename == COORDINATOR_CONTEXT_TEMPLATE_FILENAME
+    {
+        crate::config::seeded_context_templates::sync_project_context_template_for_read(
+            &context_dir,
+            filename,
+        )?;
     }
     if let Some(content) = read_context_template(agent_root, filename)? {
         return Ok(Some(content));
@@ -2160,7 +2153,10 @@ fn heal_stale_global_context_template(
 /// `root_agent::atomic_replace_existing` primitive (plain rename on Unix;
 /// rename-if-absent else `ReplaceFileW(REPLACEFILE_WRITE_THROUGH)` on Windows).
 /// The temp file is cleaned up on every failure path.
-fn atomically_replace_context_template(path: &Path, content: &str) -> Result<(), String> {
+pub(crate) fn atomically_replace_context_template(
+    path: &Path,
+    content: &str,
+) -> Result<(), String> {
     let temp = unique_context_template_temp_path(path);
     let mut file = std::fs::OpenOptions::new()
         .write(true)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1889,6 +1889,8 @@ pub fn run(
             commands::ac_discovery::open_project,
             commands::ac_discovery::new_project,
             commands::ac_discovery::discover_project,
+            commands::ac_discovery::keep_custom_context_template,
+            commands::ac_discovery::overwrite_context_template_with_default,
             commands::ac_discovery::get_replica_context_files,
             commands::ac_discovery::set_replica_context_files,
             commands::loops::create_loop,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -18,6 +18,8 @@ import type {
   PhoneMessage,
   AgentInfo,
   AcDiscoveryResult,
+  ContextTemplateOverwriteResult,
+  ContextTemplateUpdate,
   AcProjectRefreshRequestedPayload,
   LoopConfigDetails,
   LoopCreateInput,
@@ -688,6 +690,23 @@ export const ProjectAPI = {
     transport.invoke<void>("create_ac_project", { path }),
   discover: (path: string) =>
     transport.invoke<AcDiscoveryResult>("discover_project", { path }),
+  keepCustomContextTemplate: (update: ContextTemplateUpdate) =>
+    transport.invoke<void>("keep_custom_context_template", {
+      path: update.projectPath,
+      filename: update.filename,
+      currentFileSha256: update.currentFileSha256,
+      currentDefaultSha256: update.currentDefaultSha256,
+    }),
+  overwriteContextTemplateWithDefault: (update: ContextTemplateUpdate) =>
+    transport.invoke<ContextTemplateOverwriteResult>(
+      "overwrite_context_template_with_default",
+      {
+        path: update.projectPath,
+        filename: update.filename,
+        currentFileSha256: update.currentFileSha256,
+        currentDefaultSha256: update.currentDefaultSha256,
+      }
+    ),
   /**
    * Validate an existing AC project at `path` and register it in
    * settings.projectPaths. Wraps the `open_project` Tauri command added in

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -207,6 +207,7 @@ export function discovery(
     workgroups: [],
     loops: [],
     ...overrides,
+    contextTemplateUpdates: overrides.contextTemplateUpdates ?? [],
   };
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -741,11 +741,29 @@ export interface LoopEventPayload {
   message?: string | null;
 }
 
+export interface ContextTemplateUpdate {
+  projectPath: string;
+  workspacePath: string;
+  filePath: string;
+  filename: string;
+  label: string;
+  currentFileSha256: string;
+  currentDefaultSha256: string;
+  currentDefaultVersion: number;
+}
+
+export interface ContextTemplateOverwriteResult {
+  filePath: string;
+  backupPath: string;
+  currentDefaultSha256: string;
+}
+
 export interface AcDiscoveryResult {
   agents: AcAgentMatrix[];
   teams: AcTeam[];
   workgroups: AcWorkgroup[];
   loops: AcLoopSummary[];
+  contextTemplateUpdates: ContextTemplateUpdate[];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sidebar/App.context-template-updates.test.tsx
+++ b/src/sidebar/App.context-template-updates.test.tsx
@@ -1,0 +1,226 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SidebarApp from "./App";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../shared/testing/ui-harness";
+import { projectStore } from "./stores/project";
+import { toastStore } from "../shared/stores/toasts";
+import type { ContextTemplateUpdate } from "../shared/types";
+
+const projectPath = "C:\\Project";
+
+function update(
+  overrides: Partial<ContextTemplateUpdate> = {},
+): ContextTemplateUpdate {
+  return {
+    projectPath,
+    workspacePath: `${projectPath}\\.ac`,
+    filePath: `${projectPath}\\.ac\\Context.coordinator.md`,
+    filename: "Context.coordinator.md",
+    label: "Coordinator context",
+    currentFileSha256: "file-a",
+    currentDefaultSha256: "default-2",
+    currentDefaultVersion: 2,
+    ...overrides,
+  };
+}
+
+function setupTransport(fake: FakeTransport, updates: ContextTemplateUpdate[]): void {
+  fake.resolve("get_settings", baseSettings({ projectPaths: [projectPath], projectPath }));
+  fake.resolve("get_update_status", null);
+  fake.resolve("open_project", { path: projectPath, registered: true, created: false });
+  fake.resolve("discover_project", discovery({ contextTemplateUpdates: updates }));
+  fake.resolve("search_repos", []);
+  fake.resolve("list_sessions", []);
+  fake.resolve("get_active_session", null);
+  fake.resolve("list_detached_sessions", []);
+  fake.resolve("telegram_list_bridges", []);
+}
+
+function target<T extends HTMLElement = HTMLElement>(testId: string): T | null {
+  return document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+}
+
+describe("SidebarApp context-template update flow (#695)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+  });
+
+  it("opens the modal for a pending discovery update", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, [update()]);
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(
+        () => expect(target("contextTemplateUpdate.modal")).not.toBeNull(),
+        2000,
+      );
+      expect(target("contextTemplateUpdate.modal")!.textContent).toContain(
+        "Coordinator context",
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("Keep my version calls keep_custom_context_template and closes the modal", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, [update()]);
+    fake.resolve("keep_custom_context_template", null);
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(
+        () => expect(target("contextTemplateUpdate.keep")).not.toBeNull(),
+        2000,
+      );
+      target<HTMLButtonElement>("contextTemplateUpdate.keep")!.click();
+
+      await waitFor(() => expect(target("contextTemplateUpdate.modal")).toBeNull());
+      const call = fake.lastCall("keep_custom_context_template");
+      expect(call).toBeDefined();
+      expect(call!.args).toMatchObject({
+        path: projectPath,
+        filename: "Context.coordinator.md",
+        currentFileSha256: "file-a",
+        currentDefaultSha256: "default-2",
+      });
+      // The resolved update is removed from the store.
+      expect(projectStore.current?.contextTemplateUpdates).toEqual([]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("Overwrite with default calls the command, closes the modal, and shows a backup-path toast", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, [update()]);
+    const backupPath = "C:\\Project\\.ac\\Context.coordinator.md.bak";
+    fake.resolve("overwrite_context_template_with_default", {
+      filePath: `${projectPath}\\.ac\\Context.coordinator.md`,
+      backupPath,
+      currentDefaultSha256: "default-2",
+    });
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(
+        () => expect(target("contextTemplateUpdate.overwrite")).not.toBeNull(),
+        2000,
+      );
+      target<HTMLButtonElement>("contextTemplateUpdate.overwrite")!.click();
+
+      await waitFor(() => expect(target("contextTemplateUpdate.modal")).toBeNull());
+      const call = fake.lastCall("overwrite_context_template_with_default");
+      expect(call).toBeDefined();
+      expect(call!.args).toMatchObject({
+        path: projectPath,
+        filename: "Context.coordinator.md",
+        currentFileSha256: "file-a",
+        currentDefaultSha256: "default-2",
+      });
+      expect(projectStore.current?.contextTemplateUpdates).toEqual([]);
+      // Sticky info toast carries the backup path so the user can find the .bak.
+      await waitFor(() =>
+        expect(
+          toastStore.items.some((t) => t.message.includes(backupPath)),
+        ).toBe(true),
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps the modal open and shows the error when overwrite is rejected", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, [update()]);
+    fake.reject(
+      "overwrite_context_template_with_default",
+      "Context template changed on disk; reload the project before overwriting.",
+    );
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(
+        () => expect(target("contextTemplateUpdate.overwrite")).not.toBeNull(),
+        2000,
+      );
+      target<HTMLButtonElement>("contextTemplateUpdate.overwrite")!.click();
+
+      await waitFor(() =>
+        expect(target("contextTemplateUpdate.error")).not.toBeNull(),
+      );
+      expect(target("contextTemplateUpdate.error")!.textContent).toContain(
+        "changed on disk",
+      );
+      // The modal stays open and the pending update is still in the store.
+      expect(target("contextTemplateUpdate.modal")).not.toBeNull();
+      expect(projectStore.current?.contextTemplateUpdates).toHaveLength(1);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // grinch fix #5: two pending updates for the SAME project/filename/default but
+  // different file hashes (the user edited the file again before resolving).
+  // Resolving the first must NOT drop the second — both reach the backend.
+  it("resolving an older update does not drop a newer pending update for the same file", async () => {
+    const older = update({ currentFileSha256: "file-a" });
+    const newer = update({ currentFileSha256: "file-b" });
+    const fake = new FakeTransport();
+    setupTransport(fake, [older, newer]);
+    fake.resolve("keep_custom_context_template", null);
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      // Two updates queued; the first modal is the older one.
+      await waitFor(
+        () =>
+          expect(projectStore.current?.contextTemplateUpdates).toHaveLength(2),
+        2000,
+      );
+      await waitFor(() =>
+        expect(target("contextTemplateUpdate.modal")).not.toBeNull(),
+      );
+
+      // Resolve the first (older) update.
+      target<HTMLButtonElement>("contextTemplateUpdate.keep")!.click();
+      // Store drops exactly the older entry → length 1 (newer survives).
+      await waitFor(() =>
+        expect(projectStore.current?.contextTemplateUpdates).toHaveLength(1),
+      );
+      // The createEffect immediately surfaces the newer update — modal re-opens.
+      await waitFor(() =>
+        expect(target("contextTemplateUpdate.modal")).not.toBeNull(),
+      );
+
+      // Resolve the second (newer) update.
+      target<HTMLButtonElement>("contextTemplateUpdate.keep")!.click();
+      await waitFor(() =>
+        expect(projectStore.current?.contextTemplateUpdates).toHaveLength(0),
+      );
+      await waitFor(() => expect(target("contextTemplateUpdate.modal")).toBeNull());
+
+      // Both file hashes were sent to the backend — the newer update was never
+      // silently dropped by resolving the older one.
+      const sentFileHashes = fake
+        .callsFor("keep_custom_context_template")
+        .map((c) => c.args.currentFileSha256);
+      expect(sentFileHashes).toEqual(["file-a", "file-b"]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -1,13 +1,14 @@
-import { Component, createSignal, onMount, onCleanup, Show } from "solid-js";
+import { Component, createSignal, createEffect, onMount, onCleanup, Show } from "solid-js";
 import { isTauri } from "../shared/platform";
 import type { UnlistenFn } from "../shared/transport";
-import type { SessionStatus } from "../shared/types";
+import type { SessionStatus, ContextTemplateUpdate } from "../shared/types";
 import {
   SessionAPI,
   SettingsAPI,
   TelegramAPI,
   ReposAPI,
   WindowAPI,
+  ProjectAPI,
   onSessionCreated,
   onSessionDestroyed,
   onSessionSwitched,
@@ -46,7 +47,9 @@ import ActionBar from "./components/ActionBar";
 import RootAgentBanner from "./components/RootAgentBanner";
 import ProjectPanel from "./components/ProjectPanel";
 import OnboardingModal from "./components/OnboardingModal";
+import ContextTemplateUpdateModal from "./components/ContextTemplateUpdateModal";
 import ToastHost from "../shared/components/ToastHost";
+import { toastStore } from "../shared/stores/toasts";
 import { handleProjectRefreshRequested } from "./project-refresh-handler";
 import { loopToastFromEvent, type LoopToast } from "./loop-event-toast";
 import { createUpdateToaster } from "./update-toast";
@@ -68,6 +71,16 @@ function isExitedStatus(status: SessionStatus): boolean {
 const SidebarApp: Component<SidebarAppProps> = (props) => {
   const [showOnboarding, setShowOnboarding] = createSignal(false);
   const [loopToast, setLoopToast] = createSignal<LoopToast | null>(null);
+  // #695 — one-at-a-time seeded context-template update modal. `seen` is keyed
+  // by `(projectPath, filename, defaultSha256, fileSha256)` so a resolved or
+  // skipped update is not re-shown, while a genuinely new pending update (the
+  // user edited the file again, or the baked default bumped) gets a fresh key.
+  const [activeContextTemplateUpdate, setActiveContextTemplateUpdate] =
+    createSignal<ContextTemplateUpdate | null>(null);
+  const [contextTemplateUpdateBusy, setContextTemplateUpdateBusy] = createSignal(false);
+  const [contextTemplateUpdateError, setContextTemplateUpdateError] =
+    createSignal<string | null>(null);
+  const seenContextTemplateUpdates = new Set<string>();
   const unlisteners: UnlistenFn[] = [];
   let shortcutHandler: ((e: KeyboardEvent) => void) | null = null;
   let cleanupZoom: (() => void) | null = null;
@@ -113,6 +126,98 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
   // #609 — sticky "npm update available" toaster. Per-mount dedup state so the
   // startup event + the getUpdateStatus snapshot never double-toast a version.
   const showUpdateToast = createUpdateToaster();
+
+  // #695 — seeded context-template update flow. The exact removal key (grinch
+  // fix #5) includes the file hash so a resolved older modal never silently
+  // drops a newer pending update for the same project/file/default.
+  const contextTemplateUpdateKey = (update: ContextTemplateUpdate) =>
+    `${update.projectPath}\n${update.filename}\n${update.currentDefaultSha256}\n${update.currentFileSha256}`;
+
+  const nextContextTemplateUpdate = (): ContextTemplateUpdate | null => {
+    for (const project of projectStore.projects) {
+      for (const update of project.contextTemplateUpdates) {
+        if (!seenContextTemplateUpdates.has(contextTemplateUpdateKey(update))) {
+          return update;
+        }
+      }
+    }
+    return null;
+  };
+
+  const formatContextTemplateError = (e: unknown): string => {
+    if (typeof e === "string") return e;
+    if (e instanceof Error) return e.message;
+    try {
+      return JSON.stringify(e);
+    } catch {
+      return String(e);
+    }
+  };
+
+  // Drop exactly the resolved update from the store and close the modal. The
+  // createEffect below then surfaces the next unseen pending update, one at a
+  // time. Removal and `seen` both key on the file hash, so a concurrent newer
+  // pending update survives (grinch fix #5).
+  const resolveContextTemplateUpdate = (update: ContextTemplateUpdate) => {
+    projectStore.removeContextTemplateUpdate(
+      update.projectPath,
+      update.filename,
+      update.currentDefaultSha256,
+      update.currentFileSha256
+    );
+    setActiveContextTemplateUpdate(null);
+  };
+
+  const keepContextTemplateUpdate = async () => {
+    const update = activeContextTemplateUpdate();
+    if (!update) return;
+    setContextTemplateUpdateBusy(true);
+    setContextTemplateUpdateError(null);
+    try {
+      await ProjectAPI.keepCustomContextTemplate(update);
+      resolveContextTemplateUpdate(update);
+    } catch (e) {
+      // Keep the modal open so the user can retry; the backend made no durable
+      // change, so re-showing the same notice later would be correct anyway.
+      setContextTemplateUpdateError(formatContextTemplateError(e));
+    } finally {
+      setContextTemplateUpdateBusy(false);
+    }
+  };
+
+  const overwriteContextTemplateUpdate = async () => {
+    const update = activeContextTemplateUpdate();
+    if (!update) return;
+    setContextTemplateUpdateBusy(true);
+    setContextTemplateUpdateError(null);
+    try {
+      const result = await ProjectAPI.overwriteContextTemplateWithDefault(update);
+      resolveContextTemplateUpdate(update);
+      // Sticky info toast — the user must be able to find the `.bak` the old
+      // file was preserved as.
+      toastStore.info(
+        `${update.label} overwritten with the new default. Your previous version was saved to ${result.backupPath}`,
+        { durationMs: null }
+      );
+    } catch (e) {
+      setContextTemplateUpdateError(formatContextTemplateError(e));
+    } finally {
+      setContextTemplateUpdateBusy(false);
+    }
+  };
+
+  // Surface the next pending context-template update whenever no modal is open.
+  // Short-circuiting on an active modal keeps it one-at-a-time; closing the
+  // modal re-runs this effect, which re-reads projectStore.projects and picks
+  // up any update queued while the previous one was open.
+  createEffect(() => {
+    if (activeContextTemplateUpdate()) return;
+    const next = nextContextTemplateUpdate();
+    if (!next) return;
+    seenContextTemplateUpdates.add(contextTemplateUpdateKey(next));
+    setContextTemplateUpdateError(null);
+    setActiveContextTemplateUpdate(next);
+  });
 
   // #592 - pull the backend-computed drift flag and surgically patch each
   // session. Uses setProfileOutdated (never setSessions) so the frontend-only
@@ -468,6 +573,17 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
           <div class={toast().className} data-ac-testid="loop.toast">
             {toast().message}
           </div>
+        )}
+      </Show>
+      <Show when={activeContextTemplateUpdate()}>
+        {(update) => (
+          <ContextTemplateUpdateModal
+            update={update()}
+            busy={contextTemplateUpdateBusy()}
+            error={contextTemplateUpdateError()}
+            onKeep={() => void keepContextTemplateUpdate()}
+            onOverwrite={() => void overwriteContextTemplateUpdate()}
+          />
         )}
       </Show>
       <ToastHost />

--- a/src/sidebar/components/ContextTemplateUpdateModal.test.tsx
+++ b/src/sidebar/components/ContextTemplateUpdateModal.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "solid-js/web";
+import ContextTemplateUpdateModal from "./ContextTemplateUpdateModal";
+import type { ContextTemplateUpdate } from "../../shared/types";
+
+function target<T extends HTMLElement = HTMLElement>(testId: string): T {
+  const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing test target: ${testId}`);
+  return element;
+}
+
+function makeUpdate(
+  overrides: Partial<ContextTemplateUpdate> = {},
+): ContextTemplateUpdate {
+  return {
+    projectPath: "C:\\Project",
+    workspacePath: "C:\\Project\\.ac",
+    filePath: "C:\\Project\\.ac\\Context.coordinator.md",
+    filename: "Context.coordinator.md",
+    label: "Coordinator context",
+    currentFileSha256: "file-a",
+    currentDefaultSha256: "default-2",
+    currentDefaultVersion: 2,
+    ...overrides,
+  };
+}
+
+function renderModal(
+  overrides: Partial<{
+    update: ContextTemplateUpdate;
+    busy: boolean;
+    error: string | null;
+    onKeep: () => void;
+    onOverwrite: () => void;
+  }> = {},
+) {
+  const root = document.createElement("div");
+  const onKeep = vi.fn();
+  const onOverwrite = vi.fn();
+  document.body.append(root);
+  const dispose = render(
+    () => (
+      <ContextTemplateUpdateModal
+        update={overrides.update ?? makeUpdate()}
+        busy={overrides.busy ?? false}
+        error={overrides.error ?? null}
+        onKeep={overrides.onKeep ?? onKeep}
+        onOverwrite={overrides.onOverwrite ?? onOverwrite}
+      />
+    ),
+    root,
+  );
+  return { dispose, onKeep, onOverwrite };
+}
+
+describe("ContextTemplateUpdateModal (#695)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("renders the template label, file path, and both action buttons", () => {
+    const { dispose } = renderModal({
+      update: makeUpdate({
+        label: "Coordinator context",
+        filePath: "C:\\P\\.ac\\Context.coordinator.md",
+      }),
+    });
+    const body = target("contextTemplateUpdate.modal").textContent ?? "";
+    expect(body).toContain("Coordinator context");
+    expect(body).toContain("C:\\P\\.ac\\Context.coordinator.md");
+    expect(
+      target<HTMLButtonElement>("contextTemplateUpdate.keep").textContent?.trim(),
+    ).toBe("Keep my version");
+    expect(
+      target<HTMLButtonElement>("contextTemplateUpdate.overwrite").textContent?.trim(),
+    ).toBe("Overwrite with default");
+    dispose();
+  });
+
+  it("explains that overwrite preserves the old file as a .bak backup", () => {
+    const { dispose } = renderModal();
+    const body = (target("contextTemplateUpdate.modal").textContent ?? "").toLowerCase();
+    expect(body).toContain(".bak");
+    expect(body).toContain("customized");
+    dispose();
+  });
+
+  it("Keep my version triggers only onKeep", () => {
+    const { dispose, onKeep, onOverwrite } = renderModal();
+    target<HTMLButtonElement>("contextTemplateUpdate.keep").click();
+    expect(onKeep).toHaveBeenCalledTimes(1);
+    expect(onOverwrite).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("Overwrite with default triggers only onOverwrite", () => {
+    const { dispose, onKeep, onOverwrite } = renderModal();
+    target<HTMLButtonElement>("contextTemplateUpdate.overwrite").click();
+    expect(onOverwrite).toHaveBeenCalledTimes(1);
+    expect(onKeep).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("disables both buttons while busy and fires no callback when clicked", () => {
+    const { dispose, onKeep, onOverwrite } = renderModal({ busy: true });
+    const keep = target<HTMLButtonElement>("contextTemplateUpdate.keep");
+    const overwrite = target<HTMLButtonElement>("contextTemplateUpdate.overwrite");
+    expect(keep.disabled).toBe(true);
+    expect(overwrite.disabled).toBe(true);
+    keep.click();
+    overwrite.click();
+    expect(onKeep).not.toHaveBeenCalled();
+    expect(onOverwrite).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("renders no error chip by default", () => {
+    const { dispose } = renderModal();
+    expect(
+      document.querySelector('[data-ac-testid="contextTemplateUpdate.error"]'),
+    ).toBeNull();
+    dispose();
+  });
+
+  it("surfaces the error via the error chip when provided", () => {
+    const { dispose } = renderModal({
+      error: "Context template changed on disk; reload the project before overwriting.",
+    });
+    expect(target("contextTemplateUpdate.error").textContent ?? "").toContain(
+      "changed on disk",
+    );
+    dispose();
+  });
+
+  // grinch fix #6 / plan §15: the only resolution actions are the two buttons.
+  // A backdrop click must NOT dismiss the modal (closing without a backend
+  // keep/overwrite decision would re-show the same notice on next discovery).
+  it("does not resolve or unmount on a backdrop (overlay) click", () => {
+    const { dispose, onKeep, onOverwrite } = renderModal();
+    target("contextTemplateUpdate.overlay").click();
+    expect(onKeep).not.toHaveBeenCalled();
+    expect(onOverwrite).not.toHaveBeenCalled();
+    expect(
+      document.querySelector('[data-ac-testid="contextTemplateUpdate.modal"]'),
+    ).not.toBeNull();
+    dispose();
+  });
+
+  it("does not resolve or unmount on Escape", () => {
+    const { dispose, onKeep, onOverwrite } = renderModal();
+    target("contextTemplateUpdate.overlay").dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+    expect(onKeep).not.toHaveBeenCalled();
+    expect(onOverwrite).not.toHaveBeenCalled();
+    expect(
+      document.querySelector('[data-ac-testid="contextTemplateUpdate.modal"]'),
+    ).not.toBeNull();
+    dispose();
+  });
+});

--- a/src/sidebar/components/ContextTemplateUpdateModal.tsx
+++ b/src/sidebar/components/ContextTemplateUpdateModal.tsx
@@ -1,0 +1,97 @@
+import { Component, Show } from "solid-js";
+import type { ContextTemplateUpdate } from "../../shared/types";
+import { automationAttrs } from "../../shared/automation-hooks";
+
+/**
+ * #695 — Seeded context-template update notice. A baked context template (e.g.
+ * `Context.coordinator.md`) has a newer built-in default, but the on-disk file
+ * looks customized, so AC will not overwrite it silently. The user resolves it
+ * explicitly: keep their version (records a durable "ignore until it changes
+ * again" decision) or overwrite with the new default (which first preserves the
+ * old file as a `.bak` sibling).
+ *
+ * Resolution is intentionally two-action only. There is NO close button, and
+ * neither a backdrop click nor Escape dismisses the modal: closing without a
+ * backend keep/overwrite decision would leave the state file untouched, so the
+ * same notice would reappear on the next discovery (grinch fix #6 / plan §15).
+ *
+ * Presentational only — the caller (`SidebarApp`) owns the busy/error state and
+ * drives the keep/overwrite IPC calls, mirroring `RestartPromptModal`.
+ */
+const ContextTemplateUpdateModal: Component<{
+  update: ContextTemplateUpdate;
+  busy: boolean;
+  error: string | null;
+  onKeep: () => void;
+  onOverwrite: () => void;
+}> = (props) => {
+  // Defensive: while this modal is up, swallow Escape so a global shortcut
+  // handler can never dismiss it or an underlying surface. The modal itself has
+  // no Escape/close wiring — only the two explicit actions resolve it.
+  const swallowEscape = (e: KeyboardEvent) => {
+    if (e.key === "Escape") e.stopPropagation();
+  };
+
+  return (
+    <div
+      class="modal-overlay"
+      onKeyDown={swallowEscape}
+      {...automationAttrs("contextTemplateUpdate.overlay", "overlay")}
+    >
+      <div
+        class="modal-container context-template-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="contextTemplateUpdateTitle"
+        {...automationAttrs("contextTemplateUpdate.modal", "dialog")}
+      >
+        <div class="modal-header">
+          <span id="contextTemplateUpdateTitle" class="modal-title">
+            Context template update
+          </span>
+        </div>
+        <div class="modal-body">
+          <p class="context-template-note">
+            A newer built-in default is available for{" "}
+            <strong>{props.update.label}</strong>, but your copy of this file
+            appears customized, so it was left unchanged.
+          </p>
+          <div class="context-template-path">{props.update.filePath}</div>
+          <p class="context-template-note context-template-note-dim">
+            Keep your version, or overwrite it with the new default. Overwriting
+            first saves your current file as a <code>.bak</code> backup beside
+            it.
+          </p>
+        </div>
+        <div class="modal-footer">
+          <Show when={props.error}>
+            <div
+              class="modal-save-error"
+              {...automationAttrs("contextTemplateUpdate.error", "status")}
+            >
+              {props.error}
+            </div>
+          </Show>
+          <button
+            class="modal-btn modal-btn-cancel"
+            onClick={props.onKeep}
+            disabled={props.busy}
+            {...automationAttrs("contextTemplateUpdate.keep", "button")}
+          >
+            Keep my version
+          </button>
+          <button
+            class="modal-btn modal-btn-save"
+            onClick={props.onOverwrite}
+            disabled={props.busy}
+            {...automationAttrs("contextTemplateUpdate.overwrite", "button")}
+          >
+            Overwrite with default
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ContextTemplateUpdateModal;

--- a/src/sidebar/stores/project.context-template-updates.test.ts
+++ b/src/sidebar/stores/project.context-template-updates.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __setTransportForTests } from "../../shared/ipc";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import { discovery } from "../../shared/testing/ui-harness";
+import { projectStore } from "./project";
+import type { ContextTemplateUpdate } from "../../shared/types";
+
+const projectPath = "C:\\Project";
+
+function update(
+  overrides: Partial<ContextTemplateUpdate> = {},
+): ContextTemplateUpdate {
+  return {
+    projectPath,
+    workspacePath: `${projectPath}\\.ac`,
+    filePath: `${projectPath}\\.ac\\Context.coordinator.md`,
+    filename: "Context.coordinator.md",
+    label: "Coordinator context",
+    currentFileSha256: "file-a",
+    currentDefaultSha256: "default-2",
+    currentDefaultVersion: 2,
+    ...overrides,
+  };
+}
+
+let restore: (() => void) | null = null;
+
+function findProject(path: string) {
+  return projectStore.projects.find((p) => p.path === path);
+}
+
+describe("projectStore context-template updates (#695)", () => {
+  beforeEach(() => {
+    projectStore.clear();
+  });
+
+  afterEach(() => {
+    restore?.();
+    restore = null;
+    projectStore.clear();
+  });
+
+  it("loadProject stores contextTemplateUpdates from discovery", async () => {
+    const fake = new FakeTransport();
+    const pending = update();
+    fake.resolve("open_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", discovery({ contextTemplateUpdates: [pending] }));
+    restore = __setTransportForTests(fake);
+
+    await projectStore.loadProject(projectPath);
+
+    expect(projectStore.current?.contextTemplateUpdates).toEqual([pending]);
+  });
+
+  it("reloadProject replaces contextTemplateUpdates with the new discovery result", async () => {
+    const fake = new FakeTransport();
+    const first = update({ currentFileSha256: "file-a" });
+    fake.resolve("open_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", discovery({ contextTemplateUpdates: [first] }));
+    restore = __setTransportForTests(fake);
+
+    await projectStore.loadProject(projectPath);
+    expect(projectStore.current?.contextTemplateUpdates).toEqual([first]);
+
+    // A later discovery (e.g. the user edited the file again, or resolved one)
+    // returns a different pending set; reload must replace, not merge.
+    const second = update({ currentFileSha256: "file-b", currentDefaultSha256: "default-3" });
+    fake.resolve("discover_project", discovery({ contextTemplateUpdates: [second] }));
+    await projectStore.reloadProject(projectStore.current!.path);
+
+    expect(projectStore.current?.contextTemplateUpdates).toEqual([second]);
+  });
+
+  it("removeContextTemplateUpdate removes only the exact (project, filename, default, file) match", async () => {
+    const projectA = "C:\\ProjectA";
+    const projectB = "C:\\ProjectB";
+
+    // Project A: the modal being resolved (file-a) plus a NEWER pending update
+    // for the same filename+default but a different file hash (the user edited
+    // the template again before resolving). The newer one must survive.
+    const aRemove = update({ projectPath: projectA, currentFileSha256: "file-a" });
+    const aKeepNewer = update({ projectPath: projectA, currentFileSha256: "file-b" });
+    // Project B: an update whose key shape is identical to aRemove but in a
+    // different project. Must survive (removal is project-scoped).
+    const bSameKeyShape = update({ projectPath: projectB, currentFileSha256: "file-a" });
+
+    const fake = new FakeTransport();
+    fake.onInvoke("open_project", (args) => ({
+      path: args.path as string,
+      registered: true,
+      created: false,
+    }));
+    fake.onInvoke("discover_project", (args) => {
+      if (args.path === projectA) {
+        return discovery({ contextTemplateUpdates: [aRemove, aKeepNewer] });
+      }
+      return discovery({ contextTemplateUpdates: [bSameKeyShape] });
+    });
+    restore = __setTransportForTests(fake);
+
+    await projectStore.loadProject(projectA);
+    await projectStore.loadProject(projectB);
+    expect(findProject(projectA)?.contextTemplateUpdates).toHaveLength(2);
+    expect(findProject(projectB)?.contextTemplateUpdates).toHaveLength(1);
+
+    projectStore.removeContextTemplateUpdate(
+      aRemove.projectPath,
+      aRemove.filename,
+      aRemove.currentDefaultSha256,
+      aRemove.currentFileSha256,
+    );
+
+    const remainingA = findProject(projectA)?.contextTemplateUpdates ?? [];
+    expect(remainingA).toHaveLength(1);
+    // grinch fix #5: the newer edit (different file hash) must NOT be dropped.
+    expect(remainingA).toContainEqual(aKeepNewer);
+    expect(remainingA).not.toContainEqual(aRemove);
+    // Project scoping: B's identical-key-shape update is untouched.
+    expect(findProject(projectB)?.contextTemplateUpdates).toEqual([bSameKeyShape]);
+  });
+
+  it("removeContextTemplateUpdate is a no-op when filename/default/file do not all match", async () => {
+    const fake = new FakeTransport();
+    const pending = update({ currentFileSha256: "file-a", currentDefaultSha256: "default-2" });
+    fake.resolve("open_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", discovery({ contextTemplateUpdates: [pending] }));
+    restore = __setTransportForTests(fake);
+
+    await projectStore.loadProject(projectPath);
+
+    // Same filename+default, but a stale file hash → keep (this is exactly the
+    // scenario the exact-key guard protects against).
+    projectStore.removeContextTemplateUpdate(
+      projectPath,
+      "Context.coordinator.md",
+      "default-2",
+      "stale-file-hash",
+    );
+    expect(projectStore.current?.contextTemplateUpdates).toEqual([pending]);
+  });
+});

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -1,5 +1,11 @@
 import { createSignal } from "solid-js";
-import type { AcWorkgroup, AcAgentMatrix, AcTeam, AcLoopSummary } from "../../shared/types";
+import type {
+  AcWorkgroup,
+  AcAgentMatrix,
+  AcTeam,
+  AcLoopSummary,
+  ContextTemplateUpdate,
+} from "../../shared/types";
 import { ProjectAPI, SettingsAPI, AgentCreatorAPI } from "../../shared/ipc";
 import {
   findLoadedProjectPathForRefresh,
@@ -13,6 +19,10 @@ export interface ProjectState {
   agents: AcAgentMatrix[];
   teams: AcTeam[];
   loops: AcLoopSummary[];
+  /** #695 — pending seeded context-template updates surfaced by discovery. Each
+   *  entry is a customized template whose baked default has a newer version; the
+   *  sidebar resolves it through an explicit keep/overwrite modal. */
+  contextTemplateUpdates: ContextTemplateUpdate[];
 }
 
 const [projects, setProjects] = createSignal<ProjectState[]>([]);
@@ -108,6 +118,7 @@ export const projectStore = {
               agents: result.agents,
               teams: result.teams,
               loops: result.loops,
+              contextTemplateUpdates: result.contextTemplateUpdates,
             },
           ];
         });
@@ -164,6 +175,7 @@ export const projectStore = {
           agents: result.agents,
           teams: result.teams,
           loops: result.loops,
+          contextTemplateUpdates: result.contextTemplateUpdates,
         },
       ];
     });
@@ -337,6 +349,7 @@ export const projectStore = {
                       agents: result.agents,
                       teams: result.teams,
                       loops: result.loops,
+                      contextTemplateUpdates: result.contextTemplateUpdates,
                     }
                   : p
               )
@@ -367,6 +380,35 @@ export const projectStore = {
     const normalized = normalizePath(path);
     setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== normalized));
     await persistProjectPaths();
+  },
+
+  /** #695 — drop exactly one resolved pending context-template update. The key
+   *  is `(projectPath, filename, currentDefaultSha256, currentFileSha256)`: the
+   *  file hash is part of the key (grinch fix #5) so resolving a stale modal
+   *  cannot silently remove a newer pending update queued for the same
+   *  project/file/default after the user edited the template again. */
+  removeContextTemplateUpdate(
+    projectPath: string,
+    filename: string,
+    defaultSha256: string,
+    fileSha256: string
+  ) {
+    const normalized = normalizePath(projectPath);
+    setProjects((prev) =>
+      prev.map((project) =>
+        normalizePath(project.path) === normalized
+          ? {
+              ...project,
+              contextTemplateUpdates: project.contextTemplateUpdates.filter(
+                (update) =>
+                  update.filename !== filename ||
+                  update.currentDefaultSha256 !== defaultSha256 ||
+                  update.currentFileSha256 !== fileSha256
+              ),
+            }
+          : project
+      )
+    );
   },
 
   clear() {

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -1106,6 +1106,31 @@ html.light-theme .root-agent-avatar {
   cursor: not-allowed;
 }
 
+/* #695 — Context template update modal */
+.context-template-modal {
+  max-width: 480px;
+}
+
+.context-template-note {
+  margin: 0;
+  line-height: 1.5;
+  color: var(--sidebar-fg);
+}
+
+.context-template-note-dim {
+  opacity: 0.85;
+}
+
+.context-template-path {
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: var(--font-size-sm);
+  color: var(--sidebar-fg-dim);
+  word-break: break-all;
+  padding: var(--spacing-sm);
+  background: var(--sidebar-hover);
+  border-radius: var(--radius-sm);
+}
+
 /* Settings fields */
 .settings-section {
   display: flex;


### PR DESCRIPTION
## Summary
- Add manifest-backed update tracking for seeded context templates so unchanged old generated files can advance to newer defaults.
- Preserve customized templates and expose pending updates through sidebar discovery/UI with explicit keep or overwrite actions.
- Create `.bak` backups before explicit overwrite and keep root-agent template handling bootstrap/log-only per the final design.

## Validation
- Architect consensus plan: READY_FOR_IMPLEMENTATION.
- Backend/core validation: `cargo check`, `cargo test seeded_context_templates`, `cargo test context_template`, `cargo clippy`, `cargo test --lib --tests` passed in reported gates.
- Frontend validation: `npm run typecheck`, focused context-template update tests, and sidebar/shared regression suite passed in reported gates.
- Step 8b substitute: no HIGH findings.
- Grinch review: PASS before and after resync with current `origin/main`.
- Shipper build/deploy: `agentscommander_standalone_wg-6.exe` built from final head `933392088daffb01e6ed588fc8a72d82cf0af18e` and `--help` passed.
- User approved landing after deployed test build.

Closes #695