### PR TITLE
feat: open agent Matrix folders from sidebar

### DIFF
--- a/src/sidebar/components/ProjectPanel.context-menu.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu.test.tsx
@@ -19,7 +19,7 @@ import type { AcDiscoveryResult, Session } from "../../shared/types";
 // Issue #545: gray (never launched) and red (exited) replicas could not open a
 // right-click menu, blocking the Coding Agent selector and the clear-task broom
 // before/between launches.
-//   - gray (no session): minimal Coding Agent + broom menu.
+//   - gray (no session): Coding Agent + Matrix folder + broom menu.
 //   - red (exited): the FULL active-replica menu (Restart Session, Coding Agent,
 //     Open in new window) PLUS the clear-task broom (#545 rework).
 //   - green (running): the full menu, unchanged (no broom).
@@ -28,6 +28,9 @@ const projectPath = "C:\\Project";
 const workgroupPath = `${projectPath}\\.ac\\wg-2-dev-team`;
 const coordPath = `${workgroupPath}\\__agent_dev-webpage-ui`;
 const memberPath = `${workgroupPath}\\__agent_dev-rust`;
+const coordMatrixPath = `${projectPath}\\.ac\\_agent_dev-webpage-ui`;
+const memberMatrixPath = `${projectPath}\\.ac\\_agent_dev-rust`;
+const originAgentPath = `${projectPath}\\.ac\\_agent_dev-docs`;
 // renderReplicaItem builds rowTestId() from rowContext + wg.name + replica.name
 // via automationIdPart (which keeps these slugs verbatim). The non-coordinator
 // member always renders in the "workgroups" section.
@@ -47,8 +50,20 @@ function projectDiscovery(
         task,
         taskTitle,
         agents: [
-          { name: "dev-webpage-ui", path: coordPath, repoPaths: [], isCoordinator: true },
-          { name: "dev-rust", path: memberPath, repoPaths: [], isCoordinator: false },
+          {
+            name: "dev-webpage-ui",
+            path: coordPath,
+            identityPath: `${coordMatrixPath}\\identity.json`,
+            repoPaths: [],
+            isCoordinator: true,
+          },
+          {
+            name: "dev-rust",
+            path: memberPath,
+            identityPath: `${memberMatrixPath}\\identity.json`,
+            repoPaths: [],
+            isCoordinator: false,
+          },
         ],
       },
     ],
@@ -89,9 +104,25 @@ function findBroom(menu: HTMLElement): HTMLButtonElement | null {
   );
 }
 
+function findMatrixFolderAction(menu: HTMLElement): HTMLButtonElement | null {
+  return (
+    Array.from(menu.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Open Matrix folder")
+    ) ?? null
+  );
+}
+
 function findRow(root: ParentNode, testId: string): HTMLElement {
   const el = root.querySelector<HTMLElement>(`[data-ac-testid="${testId}"]`);
   if (!el) throw new Error(`Row not found: ${testId}`);
+  return el;
+}
+
+function findAgentRow(root: ParentNode, label: string): HTMLElement {
+  const el = Array.from(root.querySelectorAll<HTMLElement>(".replica-item")).find((row) =>
+    row.textContent?.includes(label)
+  );
+  if (!el) throw new Error(`Agent row not found: ${label}`);
   return el;
 }
 
@@ -101,7 +132,8 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
 
   async function setupPanel(
     sessions: Session[] = [],
-    discoveryResult: AcDiscoveryResult = projectDiscovery()
+    discoveryResult: AcDiscoveryResult = projectDiscovery(),
+    expectedText = "dev-rust"
   ): Promise<FakeTransport> {
     const fake = new FakeTransport();
     fake.resolve("new_project", { path: projectPath, registered: true, created: false });
@@ -109,10 +141,11 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
     fake.resolve("task_clean", { workgroupRoot: workgroupPath, task: null });
     // #545: cold-workgroup broom routes here when no session resolves the root.
     fake.resolve("task_clean_at", { workgroupRoot: workgroupPath, task: null });
+    fake.resolve("open_in_explorer", null);
     if (sessions.length > 0) sessionsStore.setSessions(sessions);
     rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
     await projectStore.createAndLoad(projectPath);
-    await waitFor(() => expect(rendered!.root.textContent).toContain("dev-rust"));
+    await waitFor(() => expect(rendered!.root.textContent).toContain(expectedText));
     return fake;
   }
 
@@ -130,7 +163,7 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
     document.body.replaceChildren();
   });
 
-  it("opens a Coding Agent + broom menu on a gray (never-launched) replica", async () => {
+  it("opens a Coding Agent + Matrix folder + broom menu on a gray replica", async () => {
     await setupPanel([coordSession()]);
 
     contextMenu(findRow(rendered!.root, memberRowTestId));
@@ -144,6 +177,115 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
     const menu = replicaMenu()!;
     expect(menu.textContent).not.toContain("Restart Session");
     expect(menu.textContent).not.toContain("Open in new window");
+  });
+
+  it("opens the canonical Matrix folder from a gray workgroup replica", async () => {
+    const fake = await setupPanel([coordSession()]);
+
+    contextMenu(findRow(rendered!.root, memberRowTestId));
+
+    let action: HTMLButtonElement | null = null;
+    await waitFor(() => {
+      const menu = replicaMenu();
+      expect(menu).not.toBeNull();
+      action = findMatrixFolderAction(menu!);
+      expect(action).not.toBeNull();
+    });
+
+    click(action!);
+
+    await waitFor(() => {
+      const call = fake.lastCall("open_in_explorer");
+      expect(call).toBeDefined();
+      expect(call!.args.path).toBe(memberMatrixPath);
+    });
+    expect(fake.lastCall("open_in_explorer")!.args.path).not.toBe(memberPath);
+  });
+
+  it("opens the canonical Matrix folder from a live workgroup replica", async () => {
+    const fake = await setupPanel([coordSession(), memberSession()]);
+
+    contextMenu(findRow(rendered!.root, memberRowTestId));
+
+    let action: HTMLButtonElement | null = null;
+    await waitFor(() => {
+      const menu = replicaMenu();
+      expect(menu).not.toBeNull();
+      action = findMatrixFolderAction(menu!);
+      expect(action).not.toBeNull();
+    });
+
+    click(action!);
+
+    await waitFor(() => {
+      const call = fake.lastCall("open_in_explorer");
+      expect(call).toBeDefined();
+      expect(call!.args.path).toBe(memberMatrixPath);
+    });
+    expect(fake.lastCall("open_in_explorer")!.args.path).not.toBe(memberPath);
+  });
+
+  it("hides the Matrix folder action for a workgroup replica without identityPath", async () => {
+    const fake = await setupPanel(
+      [coordSession()],
+      discovery({
+        workgroups: [
+          {
+            name: "wg-2-dev-team",
+            path: workgroupPath,
+            task: null,
+            taskTitle: "Context menu states",
+            agents: [
+              { name: "dev-webpage-ui", path: coordPath, repoPaths: [], isCoordinator: true },
+              { name: "dev-rust", path: memberPath, repoPaths: [], isCoordinator: false },
+            ],
+          },
+        ],
+      })
+    );
+
+    contextMenu(findRow(rendered!.root, memberRowTestId));
+
+    await waitFor(() => {
+      const menu = replicaMenu();
+      expect(menu).not.toBeNull();
+      expect(findMatrixFolderAction(menu!)).toBeNull();
+    });
+    expect(fake.lastCall("open_in_explorer")).toBeUndefined();
+  });
+
+  it("opens the Matrix folder from an origin agent row", async () => {
+    const fake = await setupPanel(
+      [],
+      discovery({
+        agents: [
+          {
+            name: "dev-docs",
+            path: originAgentPath,
+            roleExists: true,
+          },
+        ],
+      }),
+      "dev-docs"
+    );
+
+    contextMenu(findAgentRow(rendered!.root, "dev-docs"));
+
+    let action: HTMLButtonElement | null = null;
+    await waitFor(() => {
+      const menu = replicaMenu();
+      expect(menu).not.toBeNull();
+      action = findMatrixFolderAction(menu!);
+      expect(action).not.toBeNull();
+    });
+
+    click(action!);
+
+    await waitFor(() => {
+      const call = fake.lastCall("open_in_explorer");
+      expect(call).toBeDefined();
+      expect(call!.args.path).toBe(originAgentPath);
+    });
   });
 
   it("opens the full menu PLUS broom on a red (exited) replica", async () => {

--- a/src/sidebar/components/ProjectPanel.context-menu.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu.test.tsx
@@ -28,7 +28,6 @@ const projectPath = "C:\\Project";
 const workgroupPath = `${projectPath}\\.ac\\wg-2-dev-team`;
 const coordPath = `${workgroupPath}\\__agent_dev-webpage-ui`;
 const memberPath = `${workgroupPath}\\__agent_dev-rust`;
-const coordMatrixPath = `${projectPath}\\.ac\\_agent_dev-webpage-ui`;
 const memberMatrixPath = `${projectPath}\\.ac\\_agent_dev-rust`;
 const originAgentPath = `${projectPath}\\.ac\\_agent_dev-docs`;
 // renderReplicaItem builds rowTestId() from rowContext + wg.name + replica.name
@@ -53,14 +52,14 @@ function projectDiscovery(
           {
             name: "dev-webpage-ui",
             path: coordPath,
-            identityPath: `${coordMatrixPath}\\identity.json`,
+            identityPath: "../../_agent_dev-webpage-ui",
             repoPaths: [],
             isCoordinator: true,
           },
           {
             name: "dev-rust",
             path: memberPath,
-            identityPath: `${memberMatrixPath}\\identity.json`,
+            identityPath: "../../_agent_dev-rust",
             repoPaths: [],
             isCoordinator: false,
           },

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -211,16 +211,72 @@ function isSessionLive(session: Session | undefined): boolean {
   return true;
 }
 
-function matrixFolderFromIdentityPath(identityPath: string | undefined): string | null {
+function pathSeparatorFor(path: string): "\\" | "/" {
+  return path.includes("\\") ? "\\" : "/";
+}
+
+function trimTrailingPathSeparators(path: string): string {
+  return path.replace(/[\\/]+$/, "") || path;
+}
+
+function isAbsolutePath(path: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(path) || /^[\\/]{2}[^\\/]+[\\/][^\\/]+/.test(path) || /^[\\/]/.test(path);
+}
+
+function normalizePath(path: string, separator: "\\" | "/"): string {
+  const trimmed = path.trim();
+  const driveMatch = trimmed.match(/^([A-Za-z]:)[\\/]+(.*)$/);
+  const uncMatch = driveMatch ? null : trimmed.match(/^[\\/]{2}([^\\/]+)[\\/]([^\\/]+)[\\/]?(.*)$/);
+  let root = "";
+  let rest = trimmed;
+
+  if (driveMatch) {
+    root = `${driveMatch[1]}${separator}`;
+    rest = driveMatch[2];
+  } else if (uncMatch) {
+    root = `${separator}${separator}${uncMatch[1]}${separator}${uncMatch[2]}${separator}`;
+    rest = uncMatch[3];
+  } else if (/^[\\/]/.test(trimmed)) {
+    root = separator;
+    rest = trimmed.replace(/^[\\/]+/, "");
+  }
+
+  const segments: string[] = [];
+  for (const segment of rest.split(/[\\/]+/)) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length > 0 && segments[segments.length - 1] !== "..") {
+        segments.pop();
+      } else if (!root) {
+        segments.push(segment);
+      }
+      continue;
+    }
+    segments.push(segment);
+  }
+
+  const suffix = segments.join(separator);
+  if (!root) return suffix || ".";
+  return suffix ? `${root}${suffix}` : root;
+}
+
+function matrixFolderFromIdentityPath(replicaPath: string, identityPath: string | undefined): string | null {
   const path = identityPath?.trim();
   if (!path) return null;
-  const normalized = path.replace(/[\\/]+$/, "");
-  const match = normalized.match(/^(.*)[\\/][^\\/]+$/);
-  return match?.[1] ?? null;
+
+  const separator = pathSeparatorFor(replicaPath || path);
+  const identityTarget = path.match(/(^|[\\/])identity\.json$/i)
+    ? path.replace(/[\\/][^\\/]+$/, "")
+    : path;
+  const absoluteTarget = isAbsolutePath(identityTarget)
+    ? identityTarget
+    : `${trimTrailingPathSeparators(replicaPath)}${separator}${identityTarget}`;
+
+  return normalizePath(absoluteTarget, separator);
 }
 
 function replicaMatrixFolder(replica: AcAgentReplica): string | null {
-  return matrixFolderFromIdentityPath(replica.identityPath);
+  return matrixFolderFromIdentityPath(replica.path, replica.identityPath);
 }
 
 function coordinatorItemKey(item: { replica: AcAgentReplica; wg: AcWorkgroup }): string {

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -211,6 +211,18 @@ function isSessionLive(session: Session | undefined): boolean {
   return true;
 }
 
+function matrixFolderFromIdentityPath(identityPath: string | undefined): string | null {
+  const path = identityPath?.trim();
+  if (!path) return null;
+  const normalized = path.replace(/[\\/]+$/, "");
+  const match = normalized.match(/^(.*)[\\/][^\\/]+$/);
+  return match?.[1] ?? null;
+}
+
+function replicaMatrixFolder(replica: AcAgentReplica): string | null {
+  return matrixFolderFromIdentityPath(replica.identityPath);
+}
+
 function coordinatorItemKey(item: { replica: AcAgentReplica; wg: AcWorkgroup }): string {
   return `${item.wg.path}\u0000${item.replica.path}`;
 }
@@ -484,7 +496,7 @@ const ProjectPanel: Component = () => {
         const [deleteInProgress, setDeleteInProgress] = createSignal(false);
         const [wgCtxMenu, setWgCtxMenu] = createSignal<{ wg: AcWorkgroup; x: number; y: number } | null>(null);
         const [replicaCtxMenu, setReplicaCtxMenu] = createSignal<
-          | { kind: "active"; sessionId: string; sessionName: string; wg: AcWorkgroup; exited: boolean; x: number; y: number }
+          | { kind: "active"; sessionId: string; sessionName: string; wg: AcWorkgroup; replica: AcAgentReplica; exited: boolean; x: number; y: number }
           | { kind: "inactive"; wg: AcWorkgroup; replica: AcAgentReplica; x: number; y: number }
           | null
         >(null);
@@ -971,6 +983,17 @@ const ProjectPanel: Component = () => {
           }
         };
 
+        const openMatrixFolder = async (path: string) => {
+          setAgentCtxMenu(null);
+          setReplicaCtxMenu(null);
+          cleanupCtx();
+          try {
+            await WindowAPI.openInExplorer(path);
+          } catch (e) {
+            console.error("Failed to open Matrix folder:", e);
+          }
+        };
+
         const handleProjectContextMenu = (e: MouseEvent) => {
           e.preventDefault();
           e.stopPropagation();
@@ -1199,7 +1222,7 @@ const ProjectPanel: Component = () => {
           });
         };
 
-        const handleReplicaContextMenu = (e: MouseEvent, session: Session, wg: AcWorkgroup) => {
+        const handleReplicaContextMenu = (e: MouseEvent, session: Session, wg: AcWorkgroup, replica: AcAgentReplica) => {
           e.preventDefault();
           e.stopPropagation();
           cleanupCtx();
@@ -1217,6 +1240,7 @@ const ProjectPanel: Component = () => {
             sessionId: session.id,
             sessionName: session.name,
             wg,
+            replica,
             // Red/exited replicas get the full menu PLUS the broom; green/live
             // gets the full menu with no broom (#545 rework).
             exited: !isSessionLive(session),
@@ -1465,7 +1489,7 @@ const ProjectPanel: Component = () => {
                 // red additionally shows the broom. Only gray (no session) falls
                 // into the minimal Coding Agent + broom menu (#545 rework).
                 if (s) {
-                  handleReplicaContextMenu(e, s, wg);
+                  handleReplicaContextMenu(e, s, wg, replica);
                 } else {
                   handleReplicaInactiveContextMenu(e, wg, replica);
                 }
@@ -2207,11 +2231,11 @@ const ProjectPanel: Component = () => {
                             class="session-context-option"
                             onClick={() => {
                               const menu = agentCtxMenu();
-                              setAgentCtxMenu(null);
-                              if (menu) WindowAPI.openInExplorer(menu.agent.path);
+                              if (menu) void openMatrixFolder(menu.agent.path);
                             }}
+                            title={agentCtxMenu()!.agent.path}
                           >
-                            Open in Explorer
+                            &#x1F4C2; Open Matrix folder
                           </button>
                           <button
                             class="session-context-option context-option-danger"
@@ -2622,6 +2646,7 @@ const ProjectPanel: Component = () => {
                       const broomDisabled = () => isTaskClean(menu().wg.taskTitle);
                       const broomTitle = () =>
                         broomDisabled() ? "Nothing to clear" : "Clear task title";
+                      const matrixFolder = () => replicaMatrixFolder(menu().replica);
                       return (
                       <>
                         <button
@@ -2644,6 +2669,17 @@ const ProjectPanel: Component = () => {
                         >
                           Coding Agent
                         </button>
+                        <Show when={matrixFolder()}>
+                          {(path) => (
+                            <button
+                              class="session-context-option"
+                              title={path()}
+                              onClick={() => void openMatrixFolder(path())}
+                            >
+                              &#x1F4C2; Open Matrix folder
+                            </button>
+                          )}
+                        </Show>
                         <div class="context-separator" />
                         <button
                           class="session-context-option"
@@ -2670,6 +2706,7 @@ const ProjectPanel: Component = () => {
                       const broomDisabled = () => isTaskClean(menu().wg.taskTitle);
                       const broomTitle = () =>
                         broomDisabled() ? "Nothing to clear" : "Clear task title";
+                      const matrixFolder = () => replicaMatrixFolder(menu().replica);
                       return (
                         <>
                           <button
@@ -2684,6 +2721,17 @@ const ProjectPanel: Component = () => {
                           >
                             Coding Agent
                           </button>
+                          <Show when={matrixFolder()}>
+                            {(path) => (
+                              <button
+                                class="session-context-option"
+                                title={path()}
+                                onClick={() => void openMatrixFolder(path())}
+                              >
+                                &#x1F4C2; Open Matrix folder
+                              </button>
+                            )}
+                          </Show>
                           <button
                             class="session-context-option"
                             classList={{ "context-option-disabled": broomDisabled() }}


### PR DESCRIPTION
## Summary
- Adds a Sidebar context-menu action labeled `📂 Open Matrix folder` for agent rows.
- Opens workgroup replica Matrix folders via the canonical `.ac\_agent_*` identity path instead of the workgroup `__agent_*` replica directory.
- Keeps the action hidden when a replica has no canonical identity path, avoiding misleading fallback behavior.

## Verification
- `npx vitest run src/sidebar/components/ProjectPanel.context-menu.test.tsx` — passed, 19 tests
- `npx tsc --noEmit` — passed
- Grinch re-review PASS on `dd5fb87b580c4ea46befe4b8e54d799acea60d27`
- Shipper built and deployed `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-1.exe`
- User tested the deployed build and confirmed the behavior

Closes #701