### PR TITLE
fix: process inter-agent file messages as operational messages

### DIFF
--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -2506,6 +2506,10 @@ fn render_inter_agent_messaging_block(rendered: &DefaultContextDynamicValues) ->
     format!(
         r#"## Inter-Agent Messaging
 
+### Incoming Message Notifications
+
+When your PTY receives `[Message from <peer>] Process this inter-agent message: <path>`, treat it as an operational inter-agent message. Read the file at `<path>`, follow its task instructions, and when you finish the delegated task or get blocked, reply to the sender with a concrete result or blocker using the two-step file-based send flow below. Do not merely summarize the file and stop unless the message explicitly asks only for a summary.
+
 ### Send a message to another agent
 
 **MANDATORY**: Before sending any message, resolve the exact agent name via `list-peers-lean`. Never guess agent names.
@@ -3884,6 +3888,28 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
     }
 
     #[test]
+    fn default_context_documents_incoming_inter_agent_processing() {
+        let out = default_context(
+            "C:/fake/wg-7-dev-team/__agent_architect",
+            None,
+            &no_skill_section(),
+        );
+
+        assert!(out.contains("### Incoming Message Notifications"));
+        assert!(out.contains("Process this inter-agent message"));
+        assert!(out.contains("operational inter-agent message"));
+        assert!(out.contains("Do not merely summarize the file and stop"));
+
+        let incoming = out
+            .find("### Incoming Message Notifications")
+            .expect("incoming subsection");
+        let send = out
+            .find("### Send a message to another agent")
+            .expect("send subsection");
+        assert!(incoming < send);
+    }
+
+    #[test]
     fn default_context_non_workgroup_omits_messaging_exception() {
         let out = default_context("C:/fake/plain/agent", None, &no_skill_section());
         assert!(
@@ -4812,6 +4838,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             Some(&path_string(&old_matrix)),
             &old_skills_section,
         );
+        assert!(!legacy.contains("### Incoming Message Notifications"));
+        assert!(!legacy.contains("Process this inter-agent message"));
         let template_path = workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
         std::fs::write(&template_path, &legacy).expect("write stale generated default");
 
@@ -4828,6 +4856,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             None,
         )
         .expect("resolve context");
+        assert!(rendered.contains("### Incoming Message Notifications"));
+        assert!(rendered.contains("Process this inter-agent message"));
 
         // (a) the returned render is the healthy current default for the NEW
         // agent: sections once, no placeholders, the new path baked in, the old

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -5673,6 +5673,29 @@ mod tests {
     }
 
     #[test]
+    fn root_sender_payload_accepts_legacy_file_notification() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root_dir = temp
+            .path()
+            .join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
+        let messaging_dir = root_dir.join(crate::phone::messaging::MESSAGING_DIR_NAME);
+        std::fs::create_dir_all(&messaging_dir).unwrap();
+        let filename = "20260524-040000-root-to-wg1-tech-lead-smoke.md";
+        let message_file = messaging_dir.join(filename);
+        std::fs::write(&message_file, "root message").unwrap();
+        let body = format!(
+            "New message: {}. Read this file.",
+            message_file.to_string_lossy()
+        );
+        let msg = root_outbox_message(body, None);
+
+        assert_eq!(
+            validate_root_sender_payload_with_root_dir(&msg, &root_dir),
+            Ok(())
+        );
+    }
+
+    #[test]
     fn root_sender_payload_rejects_existing_non_root_message_file() {
         let temp = tempfile::TempDir::new().unwrap();
         let root_dir = temp

--- a/src-tauri/src/phone/messaging.rs
+++ b/src-tauri/src/phone/messaging.rs
@@ -10,8 +10,10 @@ use std::path::{Component, Path, PathBuf};
 
 pub const MESSAGING_DIR_NAME: &str = "messaging";
 pub const PTY_SAFE_MAX: usize = 1024;
-pub const FILE_NOTIFICATION_PREFIX: &str = "New message: ";
-pub const FILE_NOTIFICATION_SUFFIX: &str = ". Read this file.";
+pub const FILE_NOTIFICATION_PREFIX: &str = "Process this inter-agent message: ";
+pub const FILE_NOTIFICATION_SUFFIX: &str = "";
+const LEGACY_FILE_NOTIFICATION_PREFIX: &str = "New message: ";
+const LEGACY_FILE_NOTIFICATION_SUFFIX: &str = ". Read this file.";
 
 const MAX_SLUG_LEN: usize = 50;
 const MAX_COLLISION_SUFFIX: u32 = 99;
@@ -40,6 +42,11 @@ pub fn parse_file_notification(body: &str) -> Option<&str> {
     body.strip_prefix(FILE_NOTIFICATION_PREFIX)
         .and_then(|rest| rest.strip_suffix(FILE_NOTIFICATION_SUFFIX))
         .filter(|path| !path.is_empty())
+        .or_else(|| {
+            body.strip_prefix(LEGACY_FILE_NOTIFICATION_PREFIX)
+                .and_then(|rest| rest.strip_suffix(LEGACY_FILE_NOTIFICATION_SUFFIX))
+                .filter(|path| !path.is_empty())
+        })
 }
 
 pub fn notification_filename(path: &str) -> Option<&str> {
@@ -726,11 +733,21 @@ mod tests {
         let path = r"C:\tmp\ac-root-agent\messaging\20260524-040000-root-to-wg1-tech-lead-smoke.md";
         let body = format_file_notification(path);
 
+        assert!(body.contains("Process this inter-agent message:"));
+        assert!(!body.contains("Read this file"));
         assert_eq!(parse_file_notification(&body), Some(path));
         assert_eq!(
             notification_filename(path),
             Some("20260524-040000-root-to-wg1-tech-lead-smoke.md")
         );
+    }
+
+    #[test]
+    fn legacy_file_notification_still_parses() {
+        let path = r"C:\tmp\wg-1-dev-team\messaging\20260630-120000-wg1-a-to-wg1-b-smoke.md";
+        let legacy = format!("New message: {}. Read this file.", path);
+
+        assert_eq!(parse_file_notification(&legacy), Some(path));
     }
 
     #[test]
@@ -778,7 +795,7 @@ mod tests {
     fn pty_safe_max_clamp_rejects_long_path() {
         let from = "wg99-extremely-long-agent-name-segment";
         // Synthetic body large enough to push the total past 1024.
-        let body_len = 34 + 1000; // 1000-char abs_path
+        let body_len = FILE_NOTIFICATION_PREFIX.len() + FILE_NOTIFICATION_SUFFIX.len() + 1000;
         let overhead = PTY_WRAP_FIXED + from.len();
         assert!(
             body_len + overhead > PTY_SAFE_MAX,


### PR DESCRIPTION
## Summary

Closes #705.

Changes:
- Change file-based agent PTY notifications from passive `Read this file` wording to `Process this inter-agent message: <path>`.
- Add a durable `### Incoming Message Notifications` rule to the generated modular AgentsCommander context so agents process incoming files as operational inter-agent messages.
- Preserve legacy parsing for queued/persisted `New message: <path>. Read this file.` notifications.
- Add regressions for new/legacy notification parsing, Root Agent legacy validation, and #664-safe stale legacy context healing.

Review and verification:
- Architect plan and consensus: READY_FOR_IMPLEMENTATION.
- Dev-rust implementation commit: 9578217a65ca2405e04f69ecb152044dca5cfaa7.
- Grinch review: PASS, non-visual.
- /feature-dev: N/A, dev-rust was running Codex, not Claude Code.

Tests reported by dev-rust and independently reviewed by grinch:
- cargo test file_notification_round_trips_path
- cargo test legacy_file_notification_still_parses
- cargo test pty_safe_max_clamp_rejects_long_path
- cargo test default_context_documents_incoming_inter_agent_processing
- cargo test stale_generated_legacy_default_heals_on_disk_and_converges
- cargo test root_sender_payload_accepts_legacy_file_notification
- cargo test phone::messaging::tests
- cargo test config::session_context::tests
- cargo test phone::mailbox::tests::root_sender_payload
- cargo check
- cargo clippy
- cargo test --lib
- cargo test --bins --tests

Visual verification: N/A - non-visual backend/context behavior change.