### PR TITLE
feat: add coordinator repo folder shortcuts

### DIFF
--- a/src/sidebar/components/ProjectPanel.context-menu.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu.test.tsx
@@ -30,6 +30,7 @@ const coordPath = `${workgroupPath}\\__agent_dev-webpage-ui`;
 const memberPath = `${workgroupPath}\\__agent_dev-rust`;
 const memberMatrixPath = `${projectPath}\\.ac\\_agent_dev-rust`;
 const originAgentPath = `${projectPath}\\.ac\\_agent_dev-docs`;
+const otherProjectPath = "D:\\OtherProject";
 // renderReplicaItem builds rowTestId() from rowContext + wg.name + replica.name
 // via automationIdPart (which keeps these slugs verbatim). The non-coordinator
 // member always renders in the "workgroups" section.
@@ -63,6 +64,30 @@ function projectDiscovery(
             identityPath: "../../_agent_dev-rust",
             repoPaths: [],
             isCoordinator: false,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function projectDiscoveryWithCoordinatorRepos(path: string, repoPaths: string[]): AcDiscoveryResult {
+  const wgPath = `${path}\\.ac\\wg-2-dev-team`;
+  const replicaPath = `${wgPath}\\__agent_dev-webpage-ui`;
+  return discovery({
+    workgroups: [
+      {
+        name: "wg-2-dev-team",
+        path: wgPath,
+        task: null,
+        taskTitle: "Context menu states",
+        agents: [
+          {
+            name: "dev-webpage-ui",
+            path: replicaPath,
+            identityPath: "../../_agent_dev-webpage-ui",
+            repoPaths,
+            isCoordinator: true,
           },
         ],
       },
@@ -121,7 +146,7 @@ function findReplicaFolderAction(menu: HTMLElement): HTMLButtonElement | null {
 }
 
 function repoFolderActions(menu: HTMLElement): HTMLButtonElement[] {
-  return Array.from(menu.querySelectorAll<HTMLButtonElement>('[data-ac-testid^="replica.coord-session.menu.repo."]'));
+  return Array.from(menu.querySelectorAll<HTMLButtonElement>(".session-context-repo-option"));
 }
 
 function repoFolderLabel(item: HTMLElement): string | null {
@@ -132,6 +157,14 @@ function findRow(root: ParentNode, testId: string): HTMLElement {
   const el = root.querySelector<HTMLElement>(`[data-ac-testid="${testId}"]`);
   if (!el) throw new Error(`Row not found: ${testId}`);
   return el;
+}
+
+function findProjectPanel(root: ParentNode, path: string): HTMLElement {
+  const panel = Array.from(root.querySelectorAll<HTMLElement>(".project-panel")).find((candidate) =>
+    candidate.querySelector<HTMLElement>(".project-header")?.getAttribute("title") === path
+  );
+  if (!panel) throw new Error(`Project panel not found: ${path}`);
+  return panel;
 }
 
 function findAgentRow(root: ParentNode, label: string): HTMLElement {
@@ -326,6 +359,91 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
       }),
     );
     expect(replicaMenu()).toBeNull();
+  });
+
+  it("falls back to the row's configured repos when a same-name live session belongs to another project", async () => {
+    const wrongLiveRepo = `${projectPath}\\.ac\\wg-2-dev-team\\repo-wrong-live`;
+    const otherConfiguredRepo = `${otherProjectPath}\\.ac\\wg-2-dev-team\\repo-correct-fallback`;
+    const fake = new FakeTransport();
+    fake.onInvoke("new_project", (args) => ({
+      path: args.path as string,
+      registered: true,
+      created: false,
+    }));
+    fake.onInvoke("discover_project", (args) => {
+      const path = args.path as string;
+      if (path === projectPath) return projectDiscoveryWithCoordinatorRepos(projectPath, [wrongLiveRepo]);
+      if (path === otherProjectPath) return projectDiscoveryWithCoordinatorRepos(otherProjectPath, [otherConfiguredRepo]);
+      throw new Error(`unexpected discovery path: ${path}`);
+    });
+    fake.resolve("open_in_explorer", null);
+    sessionsStore.setSessions([
+      coordSession({
+        id: "same-name-other-project",
+        workingDirectory: coordPath,
+        gitRepos: [{ label: "wrong-live", sourcePath: wrongLiveRepo, branch: "main" }],
+      }),
+    ]);
+    rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    await projectStore.createAndLoad(projectPath);
+    await projectStore.createAndLoad(otherProjectPath);
+    await waitFor(() => expect(rendered!.root.textContent).toContain("OtherProject"));
+
+    contextMenu(findRow(findProjectPanel(rendered!.root, otherProjectPath), coordQuickRowTestId));
+
+    let items: HTMLButtonElement[] = [];
+    await waitFor(() => {
+      const menu = replicaMenu();
+      expect(menu).not.toBeNull();
+      expect(menu!.textContent).not.toContain("Restart Session");
+      items = repoFolderActions(menu!);
+      expect(items).toHaveLength(1);
+      expect(repoFolderLabel(items[0])).toBe("correct-fallback");
+      expect(items[0].title).toBe(otherConfiguredRepo);
+    });
+
+    click(items[0]);
+
+    await waitFor(() =>
+      expect(fake.lastCall("open_in_explorer")?.args).toEqual({
+        path: otherConfiguredRepo,
+      }),
+    );
+    expect(fake.lastCall("open_in_explorer")!.args.path).not.toBe(wrongLiveRepo);
+  });
+
+  it("renders repo folder actions for a gray inactive coordinator from configured repo paths", async () => {
+    const repos = [
+      `${projectPath}\\.ac\\wg-2-dev-team\\repo-AgentsCommander`,
+      `${projectPath}\\.ac\\wg-2-dev-team\\repo-docs`,
+    ];
+    const fake = await setupPanel(
+      [],
+      projectDiscoveryWithCoordinatorRepos(projectPath, repos),
+      "dev-webpage-ui"
+    );
+
+    contextMenu(findRow(rendered!.root, coordQuickRowTestId));
+
+    let items: HTMLButtonElement[] = [];
+    await waitFor(() => {
+      const menu = replicaMenu();
+      expect(menu).not.toBeNull();
+      expect(menu!.textContent).not.toContain("Restart Session");
+      items = repoFolderActions(menu!);
+      expect(items).toHaveLength(2);
+      expect(items.map(repoFolderLabel)).toEqual(["AgentsCommander", "docs"]);
+      expect(items[0].title).toBe(repos[0]);
+      expect(items[1].title).toBe(repos[1]);
+    });
+
+    click(items[1]);
+
+    await waitFor(() =>
+      expect(fake.lastCall("open_in_explorer")?.args).toEqual({
+        path: repos[1],
+      }),
+    );
   });
 
   it("hides the Matrix folder action for a workgroup replica without identityPath", async () => {

--- a/src/sidebar/components/ProjectPanel.context-menu.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu.test.tsx
@@ -34,6 +34,7 @@ const originAgentPath = `${projectPath}\\.ac\\_agent_dev-docs`;
 // via automationIdPart (which keeps these slugs verbatim). The non-coordinator
 // member always renders in the "workgroups" section.
 const memberRowTestId = "replica.row.workgroups.wg-2-dev-team.dev-rust";
+const coordQuickRowTestId = "replica.row.quick.wg-2-dev-team.dev-webpage-ui";
 
 // #545: taskTitle/task are parametrized so tests can drive the broom's
 // title-only disable predicate (isTaskClean) across Clean/empty/real titles.
@@ -117,6 +118,14 @@ function findReplicaFolderAction(menu: HTMLElement): HTMLButtonElement | null {
       b.textContent?.includes("Open Replica's Folder")
     ) ?? null
   );
+}
+
+function repoFolderActions(menu: HTMLElement): HTMLButtonElement[] {
+  return Array.from(menu.querySelectorAll<HTMLButtonElement>('[data-ac-testid^="replica.coord-session.menu.repo."]'));
+}
+
+function repoFolderLabel(item: HTMLElement): string | null {
+  return item.querySelector<HTMLElement>(".session-context-repo-label")?.textContent ?? null;
 }
 
 function findRow(root: ParentNode, testId: string): HTMLElement {
@@ -277,6 +286,46 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
       expect(call!.args.path).toBe(memberPath);
     });
     expect(fake.lastCall("open_in_explorer")!.args.path).not.toBe(memberMatrixPath);
+  });
+
+  it("renders coordinator repo folder actions from live gitRepos and opens duplicate labels by index", async () => {
+    const repos = [
+      { label: "AgentsCommander", sourcePath: "C:\\Project\\.ac\\wg-2-dev-team\\repo-AgentsCommander", branch: "feature/x" },
+      { label: "empty", sourcePath: "", branch: null },
+      { label: "missing", branch: null },
+      { label: "number", sourcePath: 42, branch: null },
+      { label: "spaces", sourcePath: "   ", branch: null },
+      { label: "docs", sourcePath: "C:\\Project\\.ac\\wg-2-dev-team\\repo-docs-primary", branch: null },
+      { label: "docs", sourcePath: "C:\\Project\\.ac\\wg-2-dev-team\\repo-docs-secondary", branch: "docs-alt" },
+      { label: "cli", sourcePath: "C:\\Project\\.ac\\wg-2-dev-team\\repo-cli", branch: "main" },
+    ] as unknown as Session["gitRepos"];
+    const fake = await setupPanel([coordSession({ gitRepos: repos })], projectDiscovery(), "dev-webpage-ui");
+
+    contextMenu(findRow(rendered!.root, coordQuickRowTestId));
+
+    let items: HTMLButtonElement[] = [];
+    await waitFor(() => {
+      const menu = replicaMenu();
+      expect(menu).not.toBeNull();
+      items = repoFolderActions(menu!);
+      expect(items).toHaveLength(4);
+      expect(items.map(repoFolderLabel)).toEqual(["AgentsCommander", "docs", "docs", "cli"]);
+    });
+
+    expect(items.map((item) => item.textContent?.trim())).toEqual(["AgentsCommander", "docs", "docs", "cli"]);
+    expect(items[0].textContent).not.toContain("Open");
+    expect(items[0].textContent).not.toContain("feature/x");
+    expect(items[2].textContent).not.toContain("docs-alt");
+    expect(items[3].textContent).not.toContain("main");
+
+    click(document.querySelector('[data-ac-testid="replica.coord-session.menu.repo.2"]')!);
+
+    await waitFor(() =>
+      expect(fake.lastCall("open_in_explorer")?.args).toEqual({
+        path: "C:\\Project\\.ac\\wg-2-dev-team\\repo-docs-secondary",
+      }),
+    );
+    expect(replicaMenu()).toBeNull();
   });
 
   it("hides the Matrix folder action for a workgroup replica without identityPath", async () => {

--- a/src/sidebar/components/ProjectPanel.manually-closed-badge.test.tsx
+++ b/src/sidebar/components/ProjectPanel.manually-closed-badge.test.tsx
@@ -147,7 +147,13 @@ describe("ProjectPanel MANUALLY-CLOSED pill (#588)", () => {
     // so the manual pill must NOT render even though the marker is present. This
     // is the exact stale-on-raise trap #589 fixes for AUTO-CLOSED.
     sessionsStore.setSessions([
-      session({ id: "live-coord", name: coordSessionName, isCoordinator: true, status: "running" }),
+      session({
+        id: "live-coord",
+        name: coordSessionName,
+        workingDirectory: coordPath,
+        isCoordinator: true,
+        status: "running",
+      }),
     ]);
 
     const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -198,9 +198,22 @@ function replicaSessionName(wg: AcWorkgroup, replica: AcAgentReplica): string {
   return `${wg.name}/${replica.name}`;
 }
 
+function normalizedReplicaSessionPath(path: string | null | undefined): string | null {
+  const trimmed = path?.trim();
+  return trimmed ? normalizeProjectPathForCompare(trimmed) : null;
+}
+
 /** Find existing session for a replica, if any */
 function replicaSession(wg: AcWorkgroup, replica: AcAgentReplica): Session | undefined {
-  return sessionsStore.findSessionByName(replicaSessionName(wg, replica));
+  const expectedName = replicaSessionName(wg, replica);
+  const expectedPath = normalizedReplicaSessionPath(replica.path);
+  if (!expectedPath) return undefined;
+
+  return sessionsStore.sessions.find(
+    (session) =>
+      session.name === expectedName &&
+      normalizedReplicaSessionPath(session.workingDirectory) === expectedPath
+  );
 }
 
 function replicaRepoMenuEntries(wg: AcWorkgroup, replica: AcAgentReplica): SessionRepo[] {
@@ -2823,6 +2836,7 @@ const ProjectPanel: Component = () => {
                       const broomTitle = () =>
                         broomDisabled() ? "Nothing to clear" : "Clear task title";
                       const matrixFolder = () => replicaMatrixFolder(menu().replica);
+                      const repoEntries = () => replicaRepoMenuEntries(menu().wg, menu().replica);
                       return (
                         <>
                           <button
@@ -2855,6 +2869,31 @@ const ProjectPanel: Component = () => {
                           >
                             &#x1F4C2; Open Replica's Folder
                           </button>
+                          <Show when={repoEntries().length > 0}>
+                            <For each={repoEntries()}>
+                              {(repo, index) => (
+                                <button
+                                  class="session-context-option session-context-repo-option"
+                                  title={repo.sourcePath}
+                                  onClick={() => void openRepoFolder(repo.sourcePath)}
+                                  data-ac-testid={`replica.inactive.menu.repo.${index()}`}
+                                  data-ac-role="menuitem"
+                                >
+                                  <svg
+                                    class="session-context-repo-icon"
+                                    viewBox="0 0 16 16"
+                                    aria-hidden="true"
+                                  >
+                                    <path
+                                      fill="currentColor"
+                                      d="M1.75 4.25A1.75 1.75 0 0 1 3.5 2.5h3.1c.46 0 .9.18 1.22.5l.9.9h3.78A1.75 1.75 0 0 1 14.25 5.65v5.1a1.75 1.75 0 0 1-1.75 1.75h-9A1.75 1.75 0 0 1 1.75 10.75v-6.5Z"
+                                    />
+                                  </svg>
+                                  <span class="session-context-repo-label">{repo.label}</span>
+                                </button>
+                              )}
+                            </For>
+                          </Show>
                           <button
                             class="session-context-option"
                             classList={{ "context-option-disabled": broomDisabled() }}

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1,6 +1,6 @@
 import { Component, For, Show, createEffect, createMemo, createSignal, onMount, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
-import type { AcWorkgroup, AcAgentReplica, AcTeam, AcLoopSummary, Session, TelegramBotConfig, BlockerReport } from "../../shared/types";
+import type { AcWorkgroup, AcAgentReplica, AcTeam, AcLoopSummary, Session, SessionRepo, TelegramBotConfig, BlockerReport } from "../../shared/types";
 import { SessionAPI, WindowAPI, EntityAPI, LoopAPI, TelegramAPI, SettingsAPI, TaskAPI, onDiscoveryBranchUpdated, onCoordinatorClockUpdated, onCoordinatorAutoCloseChanged, onCoordinatorManualCloseChanged, emitOpenSettings } from "../../shared/ipc";
 import type { SessionRepoInput } from "../../shared/ipc";
 import {
@@ -95,6 +95,10 @@ function buildGitRepos(replica: AcAgentReplica): SessionRepoInput[] {
   return (replica.repoPaths ?? []).map((p) => {
     return { label: repoLabelFromPath(p), sourcePath: p };
   });
+}
+
+function hasValidRepoSourcePath(repo: Pick<SessionRepo, "sourcePath">): boolean {
+  return typeof repo.sourcePath === "string" && repo.sourcePath.trim().length > 0;
 }
 
 /**
@@ -197,6 +201,15 @@ function replicaSessionName(wg: AcWorkgroup, replica: AcAgentReplica): string {
 /** Find existing session for a replica, if any */
 function replicaSession(wg: AcWorkgroup, replica: AcAgentReplica): Session | undefined {
   return sessionsStore.findSessionByName(replicaSessionName(wg, replica));
+}
+
+function replicaRepoMenuEntries(wg: AcWorkgroup, replica: AcAgentReplica): SessionRepo[] {
+  if (!replica.isCoordinator) return [];
+  const session = replicaSession(wg, replica);
+  const repos = session && session.gitRepos.length > 0
+    ? session.gitRepos
+    : configuredReplicaRepoBadges(replica, wg);
+  return repos.filter(hasValidRepoSourcePath);
 }
 
 /** Compute CSS class for replica status dot */
@@ -1057,6 +1070,16 @@ const ProjectPanel: Component = () => {
             await WindowAPI.openInExplorer(path);
           } catch (e) {
             console.error("Failed to open Replica folder:", e);
+          }
+        };
+
+        const openRepoFolder = async (path: string) => {
+          setReplicaCtxMenu(null);
+          cleanupCtx();
+          try {
+            await WindowAPI.openInExplorer(path);
+          } catch (e) {
+            console.error("Failed to open repo folder:", e);
           }
         };
 
@@ -2707,6 +2730,7 @@ const ProjectPanel: Component = () => {
                       const broomTitle = () =>
                         broomDisabled() ? "Nothing to clear" : "Clear task title";
                       const matrixFolder = () => replicaMatrixFolder(menu().replica);
+                      const repoEntries = () => replicaRepoMenuEntries(menu().wg, menu().replica);
                       return (
                       <>
                         <button
@@ -2747,6 +2771,31 @@ const ProjectPanel: Component = () => {
                         >
                           &#x1F4C2; Open Replica's Folder
                         </button>
+                        <Show when={repoEntries().length > 0}>
+                          <For each={repoEntries()}>
+                            {(repo, index) => (
+                              <button
+                                class="session-context-option session-context-repo-option"
+                                title={repo.sourcePath}
+                                onClick={() => void openRepoFolder(repo.sourcePath)}
+                                data-ac-testid={`replica.${menu().sessionId}.menu.repo.${index()}`}
+                                data-ac-role="menuitem"
+                              >
+                                <svg
+                                  class="session-context-repo-icon"
+                                  viewBox="0 0 16 16"
+                                  aria-hidden="true"
+                                >
+                                  <path
+                                    fill="currentColor"
+                                    d="M1.75 4.25A1.75 1.75 0 0 1 3.5 2.5h3.1c.46 0 .9.18 1.22.5l.9.9h3.78A1.75 1.75 0 0 1 14.25 5.65v5.1a1.75 1.75 0 0 1-1.75 1.75h-9A1.75 1.75 0 0 1 1.75 10.75v-6.5Z"
+                                  />
+                                </svg>
+                                <span class="session-context-repo-label">{repo.label}</span>
+                              </button>
+                            )}
+                          </For>
+                        </Show>
                         <div class="context-separator" />
                         <button
                           class="session-context-option"

--- a/src/sidebar/components/SessionItem.test.tsx
+++ b/src/sidebar/components/SessionItem.test.tsx
@@ -4,6 +4,8 @@ import SessionItem from "./SessionItem";
 import { FakeTransport } from "../../shared/testing/fake-transport";
 import {
   baseSettings,
+  click,
+  contextMenu,
   installBrowserDomStubs,
   renderWithFakeTransport,
   resetUiStoresForTests,
@@ -206,6 +208,210 @@ describe("SessionItem profile badge tooltip (#548)", () => {
         expect(badge(rendered.root).textContent).toBe("B->A");
         expect(badge(rendered.root).getAttribute("title")).toBe("A-BASELINE");
       });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});
+
+describe("SessionItem coordinator repo folder menu (#708)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  function repoMenuItems(sessionId: string): HTMLElement[] {
+    return Array.from(
+      document.querySelectorAll<HTMLElement>(`[data-ac-testid^="session.${sessionId}.menu.repo."]`),
+    );
+  }
+
+  function repoMenuLabel(item: HTMLElement): string | null {
+    return item.querySelector<HTMLElement>(".session-context-repo-label")?.textContent ?? null;
+  }
+
+  it("renders one folder action per valid coordinator repo and opens duplicate labels by index", async () => {
+    const repos = [
+      { label: "AgentsCommander", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-AgentsCommander", branch: "feature/x" },
+      { label: "docs", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-docs-primary", branch: null },
+      { label: "docs", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-docs-secondary", branch: "docs-alt" },
+      { label: "cli", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-cli", branch: null },
+      { label: "mobile", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-mobile", branch: "main" },
+    ];
+    const fake = new FakeTransport();
+    fake.resolve("open_in_explorer", null);
+
+    const rendered = renderWithFakeTransport(
+      () => (
+        <SessionItem
+          session={session({
+            id: "coord-1",
+            name: "wg-7-dev-team/architect",
+            isCoordinator: true,
+            gitRepos: repos,
+          })}
+          isActive={false}
+        />
+      ),
+      fake,
+    );
+    try {
+      contextMenu(rendered.root.querySelector('[data-ac-testid="session.coord-1"]')!);
+
+      await waitFor(() => {
+        const items = repoMenuItems("coord-1");
+        expect(items).toHaveLength(repos.length);
+        expect(items.map(repoMenuLabel)).toEqual(["AgentsCommander", "docs", "docs", "cli", "mobile"]);
+        expect(repoMenuLabel(items[0])).toBe("AgentsCommander");
+        expect(items[0].textContent).not.toContain("Open");
+        expect(items[0].textContent).not.toContain("feature/x");
+        expect(repoMenuLabel(items[1])).toBe("docs");
+        expect(repoMenuLabel(items[2])).toBe("docs");
+      });
+
+      click(document.querySelector('[data-ac-testid="session.coord-1.menu.repo.2"]')!);
+
+      await waitFor(() =>
+        expect(fake.lastCall("open_in_explorer")?.args).toEqual({
+          path: "C:\\Project\\.ac\\wg-7-dev-team\\repo-docs-secondary",
+        }),
+      );
+      expect(document.querySelector('[data-ac-testid="session.coord-1.menu"]')).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("filters malformed repo entries before rendering folder actions", async () => {
+    const repos = [
+      { label: "empty", sourcePath: "", branch: null },
+      { label: "missing", branch: null },
+      { label: "spaces", sourcePath: "   ", branch: null },
+      { label: "valid", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-valid", branch: null },
+    ] as unknown as Session["gitRepos"];
+    const fake = new FakeTransport();
+    fake.resolve("open_in_explorer", null);
+
+    const rendered = renderWithFakeTransport(
+      () => (
+        <SessionItem
+          session={session({
+            id: "coord-filtered",
+            name: "wg-7-dev-team/architect",
+            isCoordinator: true,
+            gitRepos: repos,
+          })}
+          isActive={false}
+        />
+      ),
+      fake,
+    );
+    try {
+      contextMenu(rendered.root.querySelector('[data-ac-testid="session.coord-filtered"]')!);
+
+      await waitFor(() => {
+        const items = repoMenuItems("coord-filtered");
+        expect(items).toHaveLength(1);
+        expect(repoMenuLabel(items[0])).toBe("valid");
+      });
+
+      click(document.querySelector('[data-ac-testid="session.coord-filtered.menu.repo.0"]')!);
+
+      await waitFor(() =>
+        expect(fake.lastCall("open_in_explorer")?.args).toEqual({
+          path: "C:\\Project\\.ac\\wg-7-dev-team\\repo-valid",
+        }),
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("hides repo folder actions for non-coordinators and coordinators without repos", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("open_in_explorer", null);
+
+    const nonCoordinator = renderWithFakeTransport(
+      () => (
+        <SessionItem
+          session={session({
+            id: "member-1",
+            isCoordinator: false,
+            gitRepos: [
+              { label: "AgentsCommander", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-AgentsCommander", branch: null },
+            ],
+          })}
+          isActive={false}
+        />
+      ),
+      fake,
+    );
+    try {
+      contextMenu(nonCoordinator.root.querySelector('[data-ac-testid="session.member-1"]')!);
+      await waitFor(() => expect(document.querySelector('[data-ac-testid="session.member-1.menu"]')).not.toBeNull());
+      expect(repoMenuItems("member-1")).toHaveLength(0);
+    } finally {
+      nonCoordinator.cleanup();
+      document.body.replaceChildren();
+    }
+
+    const noRepoCoordinator = renderWithFakeTransport(
+      () => (
+        <SessionItem
+          session={session({
+            id: "coord-empty",
+            isCoordinator: true,
+            gitRepos: [],
+          })}
+          isActive={false}
+        />
+      ),
+      fake,
+    );
+    try {
+      contextMenu(noRepoCoordinator.root.querySelector('[data-ac-testid="session.coord-empty"]')!);
+      await waitFor(() => expect(document.querySelector('[data-ac-testid="session.coord-empty.menu"]')).not.toBeNull());
+      expect(repoMenuItems("coord-empty")).toHaveLength(0);
+    } finally {
+      noRepoCoordinator.cleanup();
+    }
+  });
+
+  it("does not open a context menu for inactive coordinators even when repos exist", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("open_in_explorer", null);
+
+    const rendered = renderWithFakeTransport(
+      () => (
+        <SessionItem
+          session={session({
+            id: "inactive-coord-1",
+            name: "wg-7-dev-team/architect",
+            isCoordinator: true,
+            gitRepos: [
+              { label: "AgentsCommander", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-AgentsCommander", branch: null },
+            ],
+          })}
+          isActive={false}
+        />
+      ),
+      fake,
+    );
+    try {
+      contextMenu(rendered.root.querySelector('[data-ac-testid="session.inactive-coord-1"]')!);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(document.querySelector('[data-ac-testid="session.inactive-coord-1.menu"]')).toBeNull();
+      expect(repoMenuItems("inactive-coord-1")).toHaveLength(0);
+      expect(fake.lastCall("open_in_explorer")).toBeUndefined();
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -137,6 +137,21 @@ const SessionItem: Component<{
     }
   };
 
+  const repoMenuEntries = () =>
+    props.session.gitRepos.filter(
+      (repo) => typeof repo.sourcePath === "string" && repo.sourcePath.trim().length > 0,
+    );
+
+  const handleOpenRepoExplorer = async (sourcePath: string) => {
+    setShowContextMenu(false);
+    cleanupContextMenu();
+    try {
+      await WindowAPI.openInExplorer(sourcePath);
+    } catch (err) {
+      console.error("Failed to open repo folder:", err);
+    }
+  };
+
   const isDetached = () => sessionsStore.isDetached(props.session.id);
 
   const handleDetachToggle = async (e: MouseEvent) => {
@@ -514,6 +529,32 @@ const SessionItem: Component<{
             >
               Coding Agent
             </button>
+            <Show when={props.session.isCoordinator && !isInactive() && repoMenuEntries().length > 0}>
+              <div class="context-separator" />
+              <For each={repoMenuEntries()}>
+                {(repo, index) => (
+                  <button
+                    class="session-context-option session-context-repo-option"
+                    onClick={() => void handleOpenRepoExplorer(repo.sourcePath)}
+                    title={`Open repo folder: ${repo.sourcePath}`}
+                    data-ac-testid={`session.${props.session.id}.menu.repo.${index()}`}
+                    data-ac-role="menuitem"
+                  >
+                    <svg
+                      class="session-context-repo-icon"
+                      viewBox="0 0 16 16"
+                      aria-hidden="true"
+                    >
+                      <path
+                        fill="currentColor"
+                        d="M1.75 4.25A1.75 1.75 0 0 1 3.5 2.5h3.1c.46 0 .9.18 1.22.5l.9.9h3.78A1.75 1.75 0 0 1 14.25 5.65v5.1a1.75 1.75 0 0 1-1.75 1.75h-9A1.75 1.75 0 0 1 1.75 10.75v-6.5Z"
+                      />
+                    </svg>
+                    <span class="session-context-repo-label">{repo.label}</span>
+                  </button>
+                )}
+              </For>
+            </Show>
             <div class="context-separator" />
             <button
               class="session-context-option"

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2446,6 +2446,9 @@ html.light-theme .root-agent-avatar {
   border-radius: var(--radius-md);
   padding: var(--spacing-xs) 0;
   min-width: 180px;
+  max-width: min(320px, calc(100vw - 16px));
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   z-index: 9999;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
 }
@@ -2469,6 +2472,23 @@ html.light-theme .root-agent-avatar {
 
 .session-context-option:hover {
   background: rgba(0, 212, 255, 0.08);
+}
+
+.session-context-repo-option {
+  min-width: 0;
+}
+
+.session-context-repo-icon {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+  color: #a855f7;
+}
+
+.session-context-repo-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Settings: Test button for Telegram bots */


### PR DESCRIPTION
## Summary
- Adds coordinator repo folder shortcuts to the right-click coordinator menus.
- Shows one purple folder action per valid enabled repo, preserving configured order and duplicate labels.
- Opens the selected repo root via the existing OS explorer path, scoped to the correct project/workgroup.
- Covers both active coordinator rows and inactive/gray coordinator rows.

## Validation
- Dev verification: `npm test -- src/sidebar/components/ProjectPanel.context-menu.test.tsx` (26 tests)
- Dev verification: `npm test -- src/sidebar/components/SessionItem.test.tsx` (11 tests)
- Dev verification: `npm test -- src/sidebar/components/ProjectPanel.manually-closed-badge.test.tsx` (3 tests)
- Dev verification: `npx tsc --noEmit`
- Dev verification: `git diff --check`
- Grinch final review: PASS
- Shipper build/deploy: PASS, deployed `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-7.exe` from `7bbcd407e3e46e17b49d5d493d847b87646a7883`
- User go-ahead: Maria requested landing to `origin/main` after deployment

Closes #708