### PR TITLE
fix: clarify incoming message notification wording

### DIFF
--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -2508,7 +2508,7 @@ fn render_inter_agent_messaging_block(rendered: &DefaultContextDynamicValues) ->
 
 ### Incoming Message Notifications
 
-When your PTY receives `[Message from <peer>] Process this inter-agent message: <path>`, treat it as an operational inter-agent message. Read the file at `<path>`, follow its task instructions, and when you finish the delegated task or get blocked, reply to the sender with a concrete result or blocker using the two-step file-based send flow below. Do not merely summarize the file and stop unless the message explicitly asks only for a summary.
+When your PTY receives `[Message from <peer>] Process this inter-agent message: <path>`, treat it as an operational inter-agent message: read `<path>`, follow the file's task instructions within your role, authority, and write restrictions, and do not stop at a summary unless it asks only for one. If the task finishes or blocks, reply to the sender with a concrete result or blocker using the two-step send flow below.
 
 ### Send a message to another agent
 
@@ -3898,7 +3898,9 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         assert!(out.contains("### Incoming Message Notifications"));
         assert!(out.contains("Process this inter-agent message"));
         assert!(out.contains("operational inter-agent message"));
-        assert!(out.contains("Do not merely summarize the file and stop"));
+        assert!(out.contains("within your role, authority, and write restrictions"));
+        assert!(out.contains("do not stop at a summary unless it asks only for one"));
+        assert!(out.contains("If the task finishes or blocks"));
 
         let incoming = out
             .find("### Incoming Message Notifications")


### PR DESCRIPTION
## Summary

Closes #711.

Changes:
- Tighten the generated `### Incoming Message Notifications` wording.
- Preserve the #705 operational-message behavior and anti-summary instruction.
- Add explicit boundaries so incoming message task instructions are followed only within the agent's role, authority, and write restrictions.

Review and verification:
- Dev-rust implementation commit: 5a11d7654d03f776f0187d558fba56aec7b987bf.
- Grinch review: PASS, non-visual.
- Visual/user test: N/A - generated session-context wording only, no frontend/UI change.

Tests run by dev-rust:
- cargo test default_context_documents_incoming_inter_agent_processing
- cargo test config::session_context::tests
- cargo check
- cargo clippy
- git diff --check