### PR TITLE
fix: adjust Matrix folder menu icon and ordering (#712)

### DIFF
--- a/src/sidebar/components/ProjectPanel.context-menu.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu.test.tsx
@@ -153,6 +153,12 @@ function repoFolderLabel(item: HTMLElement): string | null {
   return item.querySelector<HTMLElement>(".session-context-repo-label")?.textContent ?? null;
 }
 
+function menuButtonLabels(menu: HTMLElement): string[] {
+  return Array.from(menu.querySelectorAll<HTMLButtonElement>("button")).map((button) =>
+    (button.textContent ?? "").trim().replace(/^[^A-Za-z0-9]+/, "").trim()
+  );
+}
+
 function findRow(root: ParentNode, testId: string): HTMLElement {
   const el = root.querySelector<HTMLElement>(`[data-ac-testid="${testId}"]`);
   if (!el) throw new Error(`Row not found: ${testId}`);
@@ -240,6 +246,7 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
       expect(menu).not.toBeNull();
       action = findMatrixFolderAction(menu!);
       expect(action).not.toBeNull();
+      expect(action!.querySelector(".session-context-matrix-icon")).not.toBeNull();
     });
 
     click(action!);
@@ -350,6 +357,18 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
     expect(items[0].textContent).not.toContain("feature/x");
     expect(items[2].textContent).not.toContain("docs-alt");
     expect(items[3].textContent).not.toContain("main");
+    expect(menuButtonLabels(replicaMenu()!)).toEqual([
+      "Restart Session",
+      "Coding Agent",
+      "Open Replica's Folder",
+      "AgentsCommander",
+      "docs",
+      "docs",
+      "cli",
+      "Open Matrix folder",
+      "Open in new window",
+      "Clear task title",
+    ]);
 
     click(document.querySelector('[data-ac-testid="replica.coord-session.menu.repo.2"]')!);
 
@@ -435,6 +454,14 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
       expect(items.map(repoFolderLabel)).toEqual(["AgentsCommander", "docs"]);
       expect(items[0].title).toBe(repos[0]);
       expect(items[1].title).toBe(repos[1]);
+      expect(menuButtonLabels(menu!)).toEqual([
+        "Coding Agent",
+        "Open Replica's Folder",
+        "AgentsCommander",
+        "docs",
+        "Open Matrix folder",
+        "Clear task title",
+      ]);
     });
 
     click(items[1]);

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -305,6 +305,21 @@ function replicaMatrixFolder(replica: AcAgentReplica): string | null {
   return matrixFolderFromIdentityPath(replica.path, replica.identityPath);
 }
 
+function MatrixFolderIcon() {
+  return (
+    <svg
+      class="session-context-matrix-icon"
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+    >
+      <path
+        fill="currentColor"
+        d="M1.75 4.25A1.75 1.75 0 0 1 3.5 2.5h3.1c.46 0 .9.18 1.22.5l.9.9h3.78A1.75 1.75 0 0 1 14.25 5.65v5.1a1.75 1.75 0 0 1-1.75 1.75h-9A1.75 1.75 0 0 1 1.75 10.75v-6.5Z"
+      />
+    </svg>
+  );
+}
+
 function coordinatorItemKey(item: { replica: AcAgentReplica; wg: AcWorkgroup }): string {
   return `${item.wg.path}\u0000${item.replica.path}`;
 }
@@ -2331,7 +2346,7 @@ const ProjectPanel: Component = () => {
                             }}
                             title={agentCtxMenu()!.agent.path}
                           >
-                            &#x1F4C2; Open Matrix folder
+                            <MatrixFolderIcon /> Open Matrix folder
                           </button>
                           <button
                             class="session-context-option context-option-danger"
@@ -2766,17 +2781,6 @@ const ProjectPanel: Component = () => {
                         >
                           Coding Agent
                         </button>
-                        <Show when={matrixFolder()}>
-                          {(path) => (
-                            <button
-                              class="session-context-option"
-                              title={path()}
-                              onClick={() => void openMatrixFolder(path())}
-                            >
-                              &#x1F4C2; Open Matrix folder
-                            </button>
-                          )}
-                        </Show>
                         <button
                           class="session-context-option"
                           title={menu().replica.path}
@@ -2808,6 +2812,17 @@ const ProjectPanel: Component = () => {
                               </button>
                             )}
                           </For>
+                        </Show>
+                        <Show when={matrixFolder()}>
+                          {(path) => (
+                            <button
+                              class="session-context-option"
+                              title={path()}
+                              onClick={() => void openMatrixFolder(path())}
+                            >
+                              <MatrixFolderIcon /> Open Matrix folder
+                            </button>
+                          )}
                         </Show>
                         <div class="context-separator" />
                         <button
@@ -2851,17 +2866,6 @@ const ProjectPanel: Component = () => {
                           >
                             Coding Agent
                           </button>
-                          <Show when={matrixFolder()}>
-                            {(path) => (
-                              <button
-                                class="session-context-option"
-                                title={path()}
-                                onClick={() => void openMatrixFolder(path())}
-                              >
-                                &#x1F4C2; Open Matrix folder
-                              </button>
-                            )}
-                          </Show>
                           <button
                             class="session-context-option"
                             title={menu().replica.path}
@@ -2893,6 +2897,17 @@ const ProjectPanel: Component = () => {
                                 </button>
                               )}
                             </For>
+                          </Show>
+                          <Show when={matrixFolder()}>
+                            {(path) => (
+                              <button
+                                class="session-context-option"
+                                title={path()}
+                                onClick={() => void openMatrixFolder(path())}
+                              >
+                                <MatrixFolderIcon /> Open Matrix folder
+                              </button>
+                            )}
                           </Show>
                           <button
                             class="session-context-option"

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2485,6 +2485,13 @@ html.light-theme .root-agent-avatar {
   color: #a855f7;
 }
 
+.session-context-matrix-icon {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+  color: var(--danger, #ef4444);
+}
+
 .session-context-repo-label {
   min-width: 0;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Move `Open Matrix folder` below repository folder entries in Coding Agent context menus.
- Replace the Matrix folder emoji with a red folder SVG icon.
- Add focused context-menu tests for Matrix icon presence and repo-before-Matrix ordering.

## Verification
- `npx vitest run src/sidebar/components/ProjectPanel.context-menu.test.tsx` passed: 26 tests.
- `npx tsc --noEmit` passed.
- Grinch review PASS before and after updating the branch with current `origin/main`.
- Branch contains current `origin/main` before landing.

Closes #712
