### PR TITLE
docs: correct Windows signing status (#719)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,10 +91,10 @@ jobs:
       - name: SignPath integration (Placeholder)
         if: matrix.platform == 'windows-latest'
         run: |
-          echo "SignPath integration requires maintainer setup."
-          echo "Future steps will use the SignPath GitHub Action to submit artifacts for signing."
+          echo "SignPath integration is pending maintainer setup and approval."
+          echo "After setup, this workflow can use the SignPath GitHub Action to submit artifacts for signing."
           echo "Prerequisites: SignPath org/project/policy/artifact config ids, and an API token."
-          echo "See docs/CODE_SIGNING_POLICY.md for details on the approval gate."
+          echo "See CODE_SIGNING_POLICY.md for the pending policy and approval gate."
       - name: Upload raw binaries and npm assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -1,14 +1,16 @@
 # Code Signing Policy
 
-Windows releases of **Agents Commander** are digitally signed to ensure authenticity and integrity.
+Windows code signing for **Agents Commander** is planned through SignPath Foundation and is pending SignPath setup and approval.
 
-## Certificate
+Current Windows release artifacts may be unsigned until [epic #717](https://github.com/mblua/AgentsCommander/issues/717) is complete. Use this policy as the intended signing policy and verification reference while the SignPath application and release workflow integration are in progress.
 
-- **Issued by**: SignPath Foundation
+## Planned Certificate
+
+- **Expected issuer**: SignPath Foundation
 - **Algorithm**: SHA256
-- **Private key storage**: SignPath Hardware Security Module (HSM)
+- **Private key storage after approval**: SignPath Hardware Security Module (HSM)
 
-All signing requests require manual approval. The private key never leaves the HSM.
+When signing is active, every signing request will require manual approval. The private key will never leave the HSM.
 
 ## Team
 
@@ -19,7 +21,7 @@ All signing requests require manual approval. The private key never leaves the H
 
 ## Verification
 
-You can verify the digital signature of any `.exe` or `.msi` file:
+You can inspect the Authenticode status of any Windows `.exe` or `.msi` file:
 
 **Windows Explorer**: Right-click the file > Properties > Digital Signatures tab
 
@@ -28,10 +30,14 @@ You can verify the digital signature of any `.exe` or `.msi` file:
 Get-AuthenticodeSignature "Agents Commander_X.Y.Z_x64-setup.exe"
 ```
 
+Until Windows signing is active, `Status` may read `NotSigned`. Once SignPath signing is active, signed artifacts should report `Valid` and identify SignPath Foundation as the signer.
+
+For every release, also verify the downloaded file against the attached `SHASUMS256.txt` checksum file.
+
 ## Privacy
 
 This program does not transmit data to any networked system unless the user enables an opt-in feature (Telegram Bridge, Voice-to-Text). See [PRIVACY.md](PRIVACY.md) for the canonical statement and data flow.
 
 ## Attribution
 
-Free code signing provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org).
+AgentsCommander intends to use free code signing provided by [SignPath.io](https://signpath.io), with certificate support by [SignPath Foundation](https://signpath.org), after approval.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="https://github.com/mblua/AgentsCommander/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/mblua/AgentsCommander/release.yml?style=flat-square&label=build" alt="Build" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License: MIT" /></a>
   <a href="https://github.com/mblua/AgentsCommander/stargazers"><img src="https://img.shields.io/github/stars/mblua/AgentsCommander?style=flat-square&color=00d4ff&label=stars" alt="GitHub stars" /></a>
-  <a href="CODE_SIGNING_POLICY.md"><img src="https://img.shields.io/badge/code--signed-SignPath-00d4ff?style=flat-square&logo=windows" alt="Code-signed · SignPath" /></a>
+  <a href="CODE_SIGNING_POLICY.md"><img src="https://img.shields.io/badge/code--signing-pending-00d4ff?style=flat-square&logo=windows" alt="Code signing pending" /></a>
   <a href="https://tauri.app"><img src="https://img.shields.io/badge/built%20with-Rust%20%2B%20Tauri%202-dea584?style=flat-square&logo=rust" alt="Built with Rust + Tauri 2" /></a>
 </p>
 
@@ -50,7 +50,7 @@ agentscommander new-project /path/to/project
 
 The npm package is `@mblua/agentscommander`. The installed command is still `agentscommander`.
 
-Prefer a desktop installer or a manual download? Get the signed Windows installer, Linux AppImage, macOS dmg, or portable assets from [GitHub Releases](https://github.com/mblua/AgentsCommander/releases/latest).
+Prefer a desktop installer or a manual download? Get the Windows installer, Linux AppImage, macOS dmg, or portable assets from [GitHub Releases](https://github.com/mblua/AgentsCommander/releases/latest).
 
 ## The 30-second pitch
 
@@ -150,7 +150,13 @@ These are not accidents.
 
 ## Trust
 
-AgentsCommander does not collect telemetry, analytics, or usage data. Optional features (Telegram Bridge, Voice-to-Text) transmit data to external services only when you enable them; see [`PRIVACY.md`](PRIVACY.md). Windows releases are digitally signed: certificate by [SignPath Foundation](https://signpath.org), free code signing courtesy of [SignPath.io](https://signpath.io). Full policy in [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md).
+AgentsCommander does not collect telemetry, analytics, or usage data. Optional features (Telegram Bridge, Voice-to-Text) transmit data to external services only when you enable them; see [`PRIVACY.md`](PRIVACY.md). Windows code signing is planned through [SignPath Foundation](https://signpath.org) with free signing courtesy of [SignPath.io](https://signpath.io), but current Windows release artifacts may be unsigned until [epic #717](https://github.com/mblua/AgentsCommander/issues/717) is complete. Verify downloads with the release `SHASUMS256.txt`; on Windows you can inspect signature status with:
+
+```powershell
+Get-AuthenticodeSignature "Agents Commander_X.Y.Z_x64-setup.exe"
+```
+
+Full signing policy in [`CODE_SIGNING_POLICY.md`](CODE_SIGNING_POLICY.md).
 
 ## Community
 

--- a/docs/assets/badges.md
+++ b/docs/assets/badges.md
@@ -1,4 +1,4 @@
-# README badges row — spec
+# README badges row - spec
 
 Helper file for whoever rewrites the README hero block. Copy the markdown
 under "Final block" into the README directly under the H1, above the
@@ -10,23 +10,25 @@ under "Final block" into the README directly under the H1, above the
   hurts first-impression credibility.
 - All badges are shields.io. No custom hosting, no third-party badge
   services that can break the README if they go down.
-- Style is locked to `flat-square` for the whole row — a single visual
+- Style is locked to `flat-square` for the whole row, keeping a single visual
   rhythm.
 - Color is locked to the brand cyan (`00d4ff`) for status/info badges and
   shields.io defaults for true categorical badges (license, language).
 - Wording is English. No localization in badge text.
+- Do not use a "code signed" badge until a Windows release artifact is
+  confirmed Authenticode-signed.
 
-## Order (left → right)
+## Order (left to right)
 
-The order is deliberate: identity → quality → trust → community → stack.
+The order is deliberate: identity, quality, trust, community, stack.
 
-1. **GitHub Release** — what version is current.
-2. **Build** — is it green right now.
-3. **License** — can I actually use this.
-4. **Stars** — social proof at a glance.
-5. **Code-signed (SignPath)** — the trust signal that separates this from
-   a weekend project on a stranger's GitHub.
-6. **Stack** — Rust + Tauri 2, in one combined badge to save a slot.
+1. **GitHub Release**: what version is current.
+2. **Build**: is it green right now.
+3. **License**: can I actually use this.
+4. **Stars**: social proof at a glance.
+5. **Code signing pending**: Windows signing is planned through SignPath, but
+   current artifacts may be unsigned until epic #717 is complete.
+6. **Stack**: Rust + Tauri 2, in one combined badge to save a slot.
 
 ## Final block (paste into README)
 
@@ -35,7 +37,7 @@ The order is deliberate: identity → quality → trust → community → stack.
 [![Build](https://img.shields.io/github/actions/workflow/status/mblua/AgentsCommander/release.yml?style=flat-square&label=build)](https://github.com/mblua/AgentsCommander/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/mblua/AgentsCommander?style=flat-square&color=00d4ff&label=stars)](https://github.com/mblua/AgentsCommander/stargazers)
-[![Code-signed · SignPath](https://img.shields.io/badge/code--signed-SignPath-00d4ff?style=flat-square&logo=windows)](CODE_SIGNING_POLICY.md)
+[![Code signing pending](https://img.shields.io/badge/code--signing-pending-00d4ff?style=flat-square&logo=windows)](CODE_SIGNING_POLICY.md)
 [![Built with Rust + Tauri 2](https://img.shields.io/badge/built%20with-Rust%20%2B%20Tauri%202-dea584?style=flat-square&logo=rust)](https://tauri.app)
 ```
 
@@ -48,21 +50,21 @@ The order is deliberate: identity → quality → trust → community → stack.
 - [ ] All 6 badges render in the GitHub README preview (paste, push, reload).
       Broken badge images degrade trust faster than no badge.
 - [ ] The 6 badges fit on **one row** on a 1280-wide viewport. If they wrap
-      to two lines, the row reads as cluttered — drop the stack badge first.
+      to two lines, the row reads as cluttered. Drop the stack badge first.
 - [ ] No badge links to a 404. `CODE_SIGNING_POLICY.md` must exist at repo
-      root (it does, as of 2026-05-27).
+      root.
+- [ ] The signing badge still says pending until an Authenticode-signed
+      Windows artifact is published and verified.
 
 ## Future additions (out of scope for this round)
 
-If we later want to surface these, here are the badge specs ready to drop in
-— but only if we remove one from the row above. Six is the cap.
+If we later want to surface these, here are the badge specs ready to drop in,
+but only if we remove one from the row above. Six is the cap.
 
-- **Discord** (only after ~500 stars per growth-hacker rec):
+- **Discord** (only after about 500 stars per growth-hacker rec):
   `https://img.shields.io/discord/<server_id>?style=flat-square&color=00d4ff&logo=discord&label=discord`
 - **Total downloads** (once release-asset counts are non-trivial):
   `https://img.shields.io/github/downloads/mblua/AgentsCommander/total?style=flat-square&color=00d4ff&label=downloads`
 - **Last commit** (only useful if velocity drops and we want to signal
-  active development — usually noise):
+  active development, usually noise):
   `https://img.shields.io/github/last-commit/mblua/AgentsCommander?style=flat-square`
-
-— ui-designer, wg-2-community

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,9 +33,15 @@ If you prefer a desktop installer or manual download, get the latest asset for y
 
 | Platform | Asset |
 |---|---|
-| Windows 10 1809+ | `Agents Commander_X.Y.Z_x64-setup.exe` (signed) or the portable `agentscommander.exe` |
+| Windows 10 1809+ | `Agents Commander_X.Y.Z_x64-setup.exe` or the portable `agentscommander.exe` |
 | Linux | `agentscommander_*_amd64.AppImage` |
 | macOS | `Agents Commander_*.dmg` (Apple Silicon + Intel) |
+
+Windows code signing is planned through SignPath and pending setup. Current Windows artifacts may be unsigned until [epic #717](https://github.com/mblua/AgentsCommander/issues/717) is complete. Verify downloads with the release `SHASUMS256.txt`; on Windows you can inspect signature status with:
+
+```powershell
+Get-AuthenticodeSignature "Agents Commander_X.Y.Z_x64-setup.exe"
+```
 
 Run the installer, or drop the portable `.exe` into any folder and double-click. On first launch AC creates its config directory next to the binary (e.g. `.agentscommander/` on Windows). See [Portable instances](features/portable-instances.md) for the rules.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -60,7 +60,7 @@ git push origin v0.8.43
 This creates a **draft release** with:
 
 - Auto-generated changelog (from commits since the previous tag)
-- Windows installers (signed by SignPath via the release workflow)
+- Windows installers (SignPath signing planned; artifacts may be unsigned until integration is complete)
 - Windows raw executables:
   - `src-tauri/target/release/agentscommander.exe`
   - `src-tauri/target/release/agentscommander_testeable.exe`
@@ -76,10 +76,12 @@ the macOS rows add their `--target` after the production config.
 The release shows up under [Releases](https://github.com/mblua/AgentsCommander/releases) as a **draft**. Open it and verify:
 
 - **Asset count.** Every platform produced an installer. Re-run the failing job if one is missing.
-- **Windows signature.** Right-click the installer → Properties → Digital Signatures → SignPath Foundation. Or:
+- **Windows signature status.** Until SignPath integration is active, the installer may be unsigned. Inspect the Authenticode status:
   ```powershell
   Get-AuthenticodeSignature "Agents Commander_X.Y.Z_x64-setup.exe"
   ```
+- **Checksums.** Verify downloaded assets against `SHASUMS256.txt`. If a Windows artifact is unsigned, keep the release notes truthful about that status.
+- **Signed Windows artifacts.** Once SignPath signing is active, right-click the installer, choose Properties > Digital Signatures, and confirm SignPath Foundation. `Get-AuthenticodeSignature` should report `Valid`.
 - **Changelog.** Add curated highlights at the top (the auto-generated list goes underneath). Use the previous release as a tone reference.
 - **Tag matches the bump.** If you tagged `v0.8.42` but the binary reports `0.8.41`, abort and re-bump.
 
@@ -112,5 +114,5 @@ For an urgent fix on an already-released line:
 ## See also
 
 - [`CONTRIBUTING.md`](../CONTRIBUTING.md) — branch naming and Husky hook
-- [`CODE_SIGNING_POLICY.md`](../CODE_SIGNING_POLICY.md) — SignPath chain
+- [`CODE_SIGNING_POLICY.md`](../CODE_SIGNING_POLICY.md) - pending SignPath policy
 - [`CHANGELOG.md`](../CHANGELOG.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,13 +55,20 @@ You can turn the integration off at any time via **Settings → General → RTK*
 
 ## Code signing
 
-Windows releases are digitally signed by SignPath. The private key never leaves SignPath's HSM, and every signing request requires manual approval. See [`CODE_SIGNING_POLICY.md`](../CODE_SIGNING_POLICY.md).
+Windows code signing is planned through SignPath Foundation and is pending setup and approval. Current Windows release artifacts may be unsigned until [epic #717](https://github.com/mblua/AgentsCommander/issues/717) is complete. See [`CODE_SIGNING_POLICY.md`](../CODE_SIGNING_POLICY.md).
 
-Linux and macOS builds are not signed today. Verify Linux assets with the SHA-256 sums attached to the GitHub release.
+Verify every downloaded release asset against the `SHASUMS256.txt` file attached to the GitHub release. On Windows, inspect Authenticode status with:
+
+```powershell
+Get-AuthenticodeSignature "Agents Commander_X.Y.Z_x64-setup.exe"
+```
+
+Linux and macOS builds are not signed today.
 
 ## Known gaps
 
 - **macOS code signing** is not yet in place ([#320](https://github.com/mblua/AgentsCommander/issues/320)).
+- **Windows code signing** is pending SignPath setup and approval ([#717](https://github.com/mblua/AgentsCommander/issues/717)).
 - **`--root` is unverified** at the CLI boundary. A malicious local process with shell access can spoof its own root. Mitigated by the daemon-side per-session token check, but not eliminated.
 - **No sandbox between agents.** Two agents in the same workgroup share filesystem access. If you need hard isolation, run each agent in its own VM or container.
 - **API keys live in plaintext** at `~/.agentscommander/settings.json`. Protect your user account; if your account is compromised, the keys are.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,13 +6,13 @@ For developers hitting an error. Skim the headings for the symptom that matches 
 
 ### Windows: SmartScreen blocks the installer
 
-The Windows release is signed by SignPath, but a freshly-released asset may not have reputation yet. Click **More info → Run anyway**. To verify the signature first:
+Windows code signing is planned through SignPath, but current release artifacts may be unsigned until [epic #717](https://github.com/mblua/AgentsCommander/issues/717) is complete. SmartScreen can also warn on newly signed apps before they build reputation. Before running a downloaded installer, verify its checksum against the release `SHASUMS256.txt` file and inspect Authenticode status:
 
 ```powershell
 Get-AuthenticodeSignature "Agents Commander_X.Y.Z_x64-setup.exe"
 ```
 
-`Status` should read `Valid`. See [`CODE_SIGNING_POLICY.md`](../CODE_SIGNING_POLICY.md).
+Until Windows signing is active, `Status` may read `NotSigned`. Once SignPath signing is active, `Status` should read `Valid`. See [`CODE_SIGNING_POLICY.md`](../CODE_SIGNING_POLICY.md).
 
 ### Linux: `.AppImage` will not execute
 


### PR DESCRIPTION
## Summary

- Correct premature Windows code-signing claims across app repo docs.
- Reframe SignPath as planned and pending setup/approval until a signed release exists.
- Keep code-signing policy and user verification guidance SignPath-ready without implying active signing.

## Verification

Developer verification:
- `rg -n "signed|digitally signed|SignPath|code signing|SmartScreen|Authenticode" README.md CODE_SIGNING_POLICY.md docs .github/workflows`
- `rg -n "signed Windows|digitally signed|signed by SignPath|Windows releases are signed|Windows releases are digitally signed|code--signed|Code-signed" README.md CODE_SIGNING_POLICY.md docs .github/workflows`
- `git diff --check`
- `git diff --cached --check`
- `npm run typecheck`
- `cargo check`
- `cargo clippy`

Review:
- `dev-rust-grinch`: PASS, no blocking findings.

Epic: #717
Closes #719