### PR TITLE
chore: release 0.10.0, refs #718

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.9.16"; // Must match package.json
+const VERSION = "0.10.0"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.9.16",
+  "version": "0.10.0",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
   "bin": {
     "agentscommander": "run.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.9.16",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.9.16",
+      "version": "0.10.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.9.16",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.9.16"
+version = "0.10.0"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.9.16"
+version = "0.10.0"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.9.16",
+  "version": "0.10.0",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {


### PR DESCRIPTION
## Summary
- Bump AgentsCommander release metadata to 0.10.0 across all version surfaces.
- Keep `npm/install.js` aligned so the npm postinstall downloads v0.10.0 release assets.
- Refresh the release branch onto the latest `origin/main` before landing.

Closes #718

## Verification
- `npm run version:check` OK locally and by dev-rust.
- `npm run validate-branch-name` OK locally.
- dev-rust ran `npm run typecheck` OK.
- dev-rust ran `npm run build` OK after `npm ci`.
- dev-rust ran `cargo check` OK.
- dev-rust ran `cargo clippy -- -D warnings` OK.
- `git merge-base --is-ancestor origin/main HEAD` OK after refresh.

## Release Follow-up
After merge, tag `v0.10.0`, wait for the release workflow draft/assets/checksums, publish the GitHub release, then publish `@mblua/agentscommander@0.10.0` to npm.