### PR TITLE
chore: update npm package metadata, refs #722

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mblua/agentscommander",
   "version": "0.10.0",
-  "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams.",
+  "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams with Claude Code, Codex, Hermes, Cursor CLI, OpenCode, and more to come.",
   "bin": {
     "agentscommander": "run.js"
   },
@@ -15,7 +15,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "homepage": "https://github.com/mblua/AgentsCommander#readme",
+  "homepage": "https://agentscommander.dev",
   "bugs": {
     "url": "https://github.com/mblua/AgentsCommander/issues"
   },


### PR DESCRIPTION
## Summary
- Set the npm package homepage to `https://agentscommander.dev`.
- Update the npm package description to mention Claude Code, Codex, Hermes, Cursor CLI, OpenCode, and more to come.
- Keep the change scoped to package metadata only.

Closes #722

## Verification
- dev-rust verified `npm pkg get homepage description --prefix .\npm`.
- dev-rust verified `npm pack --dry-run --json .\npm` reports `@mblua/agentscommander@0.10.0` with no version change.
- dev-rust ran `cargo check` OK.
- dev-rust ran `cargo clippy` OK.
- local `npm run validate-branch-name` OK.
- local `git merge-base --is-ancestor origin/main HEAD` OK.

## Publication note
This changes source metadata for future npm publications. npm will not rewrite the already-published `0.10.0` package metadata in-place; making the public npm page reflect this immediately requires publishing a new package version.