### PR TITLE
refactor: extract shared WG-replica walk-up helper (dedupe 3 hand-synced copies)

### DIFF
--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -5,9 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::config::agent_config::{AgentLocalConfig, CodingAgentEntry};
 use crate::config::sessions_persistence::{load_sessions_raw, PersistedSession};
-use crate::config::workspace::{
-    ensure_authoritative_workspace_dir, existing_workspace_dir, is_workspace_dir_name,
-};
+use crate::config::workspace::existing_workspace_dir;
 use crate::session::session::{SessionStatus, TEMP_SESSION_PREFIX};
 
 #[derive(Args)]
@@ -493,58 +491,29 @@ struct WgReplicaInfo {
 }
 
 /// Detect if `root` is a WG replica: path matches `*/<project_ac_root>/wg-*/__agent_*/`.
+///
+/// Thin wrapper over the shared walk-up in
+/// `config::workspace::wg_replica_layout_from_agent_dir` (single source with
+/// `send::derive_root_project_dir` and `mailbox::derive_project_from_outbox_path`,
+/// see #726). This caller keeps the project FOLDER NAME (`my_project`), the LHS
+/// of a WG replica's canonical FQN, rather than the full project path.
 fn detect_wg_replica(root: &str) -> Result<Option<WgReplicaInfo>, String> {
-    let path = PathBuf::from(root);
-    let canon = match std::fs::canonicalize(&path) {
+    let canon = match std::fs::canonicalize(root) {
         Ok(c) => c,
         Err(_) => return Ok(None),
     };
-
-    let Some(my_dir_name) = canon.file_name().and_then(|name| name.to_str()) else {
+    let Some(layout) = crate::config::workspace::wg_replica_layout_from_agent_dir(&canon)? else {
         return Ok(None);
     };
-    if !my_dir_name.starts_with("__agent_") {
-        return Ok(None);
-    }
-    let Some(my_agent_name) = my_dir_name.strip_prefix("__agent_") else {
-        return Ok(None);
-    };
-    let my_agent_name = my_agent_name.to_string();
-
-    let Some(wg_dir) = canon.parent() else {
-        return Ok(None);
-    };
-    let Some(wg_name) = wg_dir.file_name().and_then(|name| name.to_str()) else {
-        return Ok(None);
-    };
-    if !wg_name.starts_with("wg-") {
-        return Ok(None);
-    }
-
-    let Some(workspace_dir) = wg_dir.parent() else {
-        return Ok(None);
-    };
-    let Some(workspace_name) = workspace_dir.file_name().and_then(|name| name.to_str()) else {
-        return Ok(None);
-    };
-    if !is_workspace_dir_name(workspace_name) {
-        return Ok(None);
-    }
-    ensure_authoritative_workspace_dir(workspace_dir)?;
-
-    let Some(my_project) = workspace_dir
-        .parent()
-        .and_then(|project| project.file_name())
-        .and_then(|name| name.to_str())
-    else {
+    let Some(my_project) = layout.project_dir.file_name().and_then(|name| name.to_str()) else {
         return Ok(None);
     };
 
     Ok(Some(WgReplicaInfo {
-        my_agent_name,
-        my_wg_name: wg_name.to_string(),
-        my_wg_dir: wg_dir.to_path_buf(),
-        workspace_dir: workspace_dir.to_path_buf(),
+        my_agent_name: layout.agent_name,
+        my_wg_name: layout.wg_name,
+        my_wg_dir: layout.wg_dir,
+        workspace_dir: layout.workspace_dir,
         my_project: my_project.to_string(),
     }))
 }

--- a/src-tauri/src/cli/send.rs
+++ b/src-tauri/src/cli/send.rs
@@ -149,52 +149,24 @@ fn wait_for_delivery_confirmation(
 }
 
 /// If `root` lives inside `<project_dir>/<Project AC Root>/wg-<N>-*/__agent_*/`,
-/// return `project_dir` as a UTF-8 `String`. Returns `None` if `root` is not
-/// inside a WG-replica shape OR if the resulting `project_dir` is not valid
-/// UTF-8 (parity with `list_peers::detect_wg_replica`, which also uses
-/// `to_str()?` rather than `to_string_lossy()`).
+/// return `project_dir` as a UTF-8 `String` (`None` if the shape does not match
+/// or `project_dir` is not valid UTF-8, matching `list_peers::detect_wg_replica`
+/// which also uses `to_str()` rather than `to_string_lossy()`).
 ///
-/// Mirrors the WG-replica detection in `list_peers::detect_wg_replica` so that
-/// `send` resolves WG-peer targets against the same root-walk-up source that
-/// `list-peers` uses to emit them with `reachable: true`. See #228.
-///
-/// Keep in lockstep with `list_peers::detect_wg_replica` and
-/// `phone::mailbox::derive_project_from_outbox_path`.
+/// Thin wrapper over `config::workspace::wg_replica_layout_from_agent_dir`, the
+/// single source of the WG-replica walk-up shared with
+/// `list_peers::detect_wg_replica` and
+/// `phone::mailbox::derive_project_from_outbox_path`, so `send` resolves WG-peer
+/// targets against the same source `list-peers` reports as `reachable: true`.
+/// See #228 / #726.
 fn derive_root_project_dir(root: &str) -> Result<Option<String>, String> {
     let Some(canon) = std::fs::canonicalize(root).ok() else {
         return Ok(None);
     };
-    let Some(my_dir_name) = canon.file_name().and_then(|name| name.to_str()) else {
-        return Ok(None);
-    };
-    if !my_dir_name.starts_with("__agent_") {
-        return Ok(None);
+    match crate::config::workspace::wg_replica_layout_from_agent_dir(&canon)? {
+        Some(layout) => Ok(layout.project_dir.to_str().map(|path| path.to_string())),
+        None => Ok(None),
     }
-    let Some(wg_dir) = canon.parent() else {
-        return Ok(None);
-    };
-    let Some(wg_name) = wg_dir.file_name().and_then(|name| name.to_str()) else {
-        return Ok(None);
-    };
-    if !wg_name.starts_with("wg-") {
-        return Ok(None);
-    }
-    let Some(workspace_dir) = wg_dir.parent() else {
-        return Ok(None);
-    };
-    if !workspace_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(crate::config::workspace::is_workspace_dir_name)
-        .unwrap_or(false)
-    {
-        return Ok(None);
-    }
-    crate::config::workspace::ensure_authoritative_workspace_dir(workspace_dir)?;
-    let Some(project_dir) = workspace_dir.parent() else {
-        return Ok(None);
-    };
-    Ok(project_dir.to_str().map(|path| path.to_string()))
 }
 
 fn ensure_workgroup_root_is_authoritative(wg_root: &Path) -> Result<(), String> {

--- a/src-tauri/src/config/workspace.rs
+++ b/src-tauri/src/config/workspace.rs
@@ -97,3 +97,127 @@ pub fn ensure_authoritative_workspace_dir(workspace_dir: &Path) -> Result<(), St
         ))
     }
 }
+
+/// The WG-replica path layout `<project_dir>/<workspace>/wg-*/__agent_*`, as
+/// resolved by [`wg_replica_layout_from_agent_dir`]. Absolute paths, except the
+/// two names, which the shape checks already proved are valid UTF-8.
+pub struct WgReplicaLayout {
+    /// Agent name with the `__agent_` prefix stripped.
+    pub agent_name: String,
+    /// The `wg-<N>-*` directory name.
+    pub wg_name: String,
+    /// Absolute path to the `wg-<N>-*` directory.
+    pub wg_dir: PathBuf,
+    /// Absolute path to the Project AC Root directory.
+    pub workspace_dir: PathBuf,
+    /// Absolute path to the project directory (parent of the Project AC Root).
+    pub project_dir: PathBuf,
+}
+
+/// Given an already-canonicalized agent replica directory (the `__agent_*`
+/// folder), walk up the WG-replica layout `__agent_* -> wg-* -> <workspace> ->
+/// <project>` and return its pieces.
+///
+/// Returns `Ok(None)` when `agent_dir` is not a WG-replica shape (wrong name
+/// prefix, missing ancestor, or non-authoritative workspace name), and `Err`
+/// only when the workspace fails [`ensure_authoritative_workspace_dir`].
+///
+/// Single source for the walk-up shared by `cli::send::derive_root_project_dir`,
+/// `cli::list_peers::detect_wg_replica`, and
+/// `phone::mailbox::derive_project_from_outbox_path`. Each caller canonicalizes
+/// its own input (an agent root, or an outbox file walked up to the agent dir)
+/// and applies its own final projection (full project path, project name, or the
+/// richer struct); the shared shape checks live here so the three cannot drift.
+pub fn wg_replica_layout_from_agent_dir(
+    agent_dir: &Path,
+) -> Result<Option<WgReplicaLayout>, String> {
+    let Some(agent_name) = agent_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("__agent_"))
+    else {
+        return Ok(None);
+    };
+    let agent_name = agent_name.to_string();
+
+    let Some(wg_dir) = agent_dir.parent() else {
+        return Ok(None);
+    };
+    let Some(wg_name) = wg_dir.file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
+    if !wg_name.starts_with("wg-") {
+        return Ok(None);
+    }
+
+    let Some(workspace_dir) = wg_dir.parent() else {
+        return Ok(None);
+    };
+    if !workspace_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(is_workspace_dir_name)
+        .unwrap_or(false)
+    {
+        return Ok(None);
+    }
+    ensure_authoritative_workspace_dir(workspace_dir)?;
+
+    let Some(project_dir) = workspace_dir.parent() else {
+        return Ok(None);
+    };
+
+    Ok(Some(WgReplicaLayout {
+        agent_name,
+        wg_name: wg_name.to_string(),
+        wg_dir: wg_dir.to_path_buf(),
+        workspace_dir: workspace_dir.to_path_buf(),
+        project_dir: project_dir.to_path_buf(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wg_replica_layout_resolves_all_pieces() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-x");
+        let agent_dir = project.join(".ac").join("wg-1-devs").join("__agent_alice");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        let canon = std::fs::canonicalize(&agent_dir).unwrap();
+
+        let layout = wg_replica_layout_from_agent_dir(&canon)
+            .unwrap()
+            .expect("WG replica layout should resolve");
+
+        assert_eq!(layout.agent_name, "alice");
+        assert_eq!(layout.wg_name, "wg-1-devs");
+        assert_eq!(layout.project_dir, std::fs::canonicalize(&project).unwrap());
+        assert_eq!(
+            layout.workspace_dir,
+            std::fs::canonicalize(project.join(".ac")).unwrap()
+        );
+    }
+
+    #[test]
+    fn wg_replica_layout_none_for_non_agent_dir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let dir = temp.path().join("proj-x").join(".ac").join("wg-1-devs");
+        std::fs::create_dir_all(&dir).unwrap();
+        // Points at the wg dir, not an __agent_* dir.
+        let canon = std::fs::canonicalize(&dir).unwrap();
+        assert!(wg_replica_layout_from_agent_dir(&canon).unwrap().is_none());
+    }
+
+    #[test]
+    fn wg_replica_layout_none_for_non_wg_parent() {
+        let temp = tempfile::TempDir::new().unwrap();
+        // __agent_* dir whose parent is not a wg-* dir.
+        let agent_dir = temp.path().join("proj-x").join(".ac").join("__agent_alice");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        let canon = std::fs::canonicalize(&agent_dir).unwrap();
+        assert!(wg_replica_layout_from_agent_dir(&canon).unwrap().is_none());
+    }
+}

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -357,9 +357,13 @@ fn validate_root_sender_payload_with_root_dir(
 /// We walk ancestors: `<file>.json` → `outbox` → `<local-dir>` → `<__agent_*>` →
 /// `<wg-*>` → `<workspace>` → `<project_dir>`.
 ///
-/// Uses `to_str()?` (NOT `to_string_lossy()`) for parity with
-/// `list_peers::detect_wg_replica`. Keep this in lockstep with
-/// `cli::send::derive_root_project_dir`.
+/// Uses `to_str()` (NOT `to_string_lossy()`) for parity with
+/// `list_peers::detect_wg_replica`. The shared
+/// `__agent_* -> wg-* -> <workspace> -> <project>` walk-up is delegated to
+/// `config::workspace::wg_replica_layout_from_agent_dir` (single source with
+/// `cli::send::derive_root_project_dir` and `list_peers::detect_wg_replica`,
+/// see #726); only the outbox-specific `<file>.json -> outbox -> <local-dir>`
+/// prefix to reach the `__agent_*` dir stays here.
 fn derive_project_from_outbox_path(outbox_file: &Path) -> Result<Option<String>, String> {
     let Some(canon) = std::fs::canonicalize(outbox_file).ok() else {
         return Ok(None);
@@ -377,37 +381,10 @@ fn derive_project_from_outbox_path(outbox_file: &Path) -> Result<Option<String>,
     let Some(agent_dir) = local_dir.parent() else {
         return Ok(None);
     };
-    let Some(agent_name) = agent_dir.file_name().and_then(|n| n.to_str()) else {
-        return Ok(None);
-    };
-    if !agent_name.starts_with("__agent_") {
-        return Ok(None);
+    match crate::config::workspace::wg_replica_layout_from_agent_dir(agent_dir)? {
+        Some(layout) => Ok(layout.project_dir.to_str().map(|path| path.to_string())),
+        None => Ok(None),
     }
-    let Some(wg_dir) = agent_dir.parent() else {
-        return Ok(None);
-    };
-    let Some(wg_name) = wg_dir.file_name().and_then(|n| n.to_str()) else {
-        return Ok(None);
-    };
-    if !wg_name.starts_with("wg-") {
-        return Ok(None);
-    }
-    let Some(workspace_dir) = wg_dir.parent() else {
-        return Ok(None);
-    };
-    if !workspace_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .map(crate::config::workspace::is_workspace_dir_name)
-        .unwrap_or(false)
-    {
-        return Ok(None);
-    }
-    crate::config::workspace::ensure_authoritative_workspace_dir(workspace_dir)?;
-    let Some(project_dir) = workspace_dir.parent() else {
-        return Ok(None);
-    };
-    Ok(project_dir.to_str().map(|path| path.to_string()))
 }
 
 /// Tracks delivery attempts for a single outbox message.


### PR DESCRIPTION
Closes #726. Follow-up to #724 (BUG-2 from the same audit).

Three functions independently re-implemented the WG-replica path walk-up `__agent_* -> wg-* -> <workspace> -> <project>`, and their doc comments said to keep them in lockstep by hand. That is a real drift hazard: `list-peers` could advertise a peer as `reachable: true` that `send` then rejected with `not found in any known project`, or the reverse.

## Change
Extract one shared helper in `config::workspace`:

```
wg_replica_layout_from_agent_dir(agent_dir: &Path) -> Result<Option<WgReplicaLayout>, String>
```

It owns the shared shape checks (the `__agent_` / `wg-` name prefixes, `is_workspace_dir_name`, the `ensure_authoritative_workspace_dir` side effect, and the project dir) and returns the pieces as a `WgReplicaLayout`. All three callers now delegate to it:

- `cli::send::derive_root_project_dir`: `layout.project_dir` as a full path `String`
- `cli::list_peers::detect_wg_replica`: `WgReplicaInfo` (project NAME + wg/agent/dirs)
- `phone::mailbox::derive_project_from_outbox_path`: `layout.project_dir` as a `String`

Each caller keeps its own input canonicalization (an agent root vs an outbox file walked up to the agent dir) and its own final projection.

## Behavior preservation
Strictly behavior-preserving:
- The loose `wg-` prefix check (not `is_wg_dir`) is kept exactly.
- Each caller keeps its own `to_str()` decision (send/mailbox on the full project path, list-peers on the project name), so the non-UTF8 edge cases are unchanged.
- `ensure_authoritative_workspace_dir` runs once, in the same position, with the same `Err` propagation.
- The `__agent_` prefix strip is equivalent to the previous `starts_with` plus separate strip.

## Gates (from `src-tauri`)
- `cargo check`: clean
- `cargo clippy --all-targets -- -D warnings`: no issues
- `cargo test --lib --bins --tests`: 1732 passed / 0 failed / 12 ignored
- 12 relevant tests pass by name: 3 new helper tests plus the 9 pre-existing caller tests (send 4, mailbox 4, list-peers 1), proving each caller's behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
