### PR TITLE
fix: normalize Windows verbatim cwd paths (#730)

### DIFF
--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -292,17 +292,12 @@ fn extract_task_first_line(content: &str) -> Option<String> {
         .map(|l| l.trim_start_matches("# ").to_string())
 }
 
-/// Strip the Windows verbatim/UNC `\\?\` prefix if present so the emitted
-/// path matches the form `discover_project` produces (which never has the
-/// prefix because it comes from a `read_dir` walk). The codebase already
-/// applies the same strip downstream when embedding paths into the agent
-/// init prompt — see the `find_workgroup_task_path_handles_unc_prefix_input`
-/// test note in `session.rs`.
-fn strip_verbatim_prefix(p: &Path) -> PathBuf {
-    let s = p.to_string_lossy();
-    s.strip_prefix(r"\\?\")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| p.to_path_buf())
+fn normalize_projected_path(p: &Path) -> PathBuf {
+    crate::path_utils::normalize_windows_verbatim_path_buf(p)
+}
+
+fn projected_path_string(p: &Path) -> String {
+    crate::path_utils::path_to_string_without_windows_verbatim_prefix(p)
 }
 
 /// Detect git branch synchronously for a given directory path.
@@ -469,11 +464,8 @@ impl DiscoveryBranchWatcher {
         // output vs `discover_project` receiving a user-typed path) and emit doubled.
         let canonical_key = std::fs::canonicalize(project_dir)
             .ok()
-            .map(|p| {
-                let s = p.to_string_lossy();
-                s.strip_prefix(r"\\?\").unwrap_or(&s).to_string()
-            })
-            .unwrap_or_else(|| project_dir.to_string());
+            .map(|p| projected_path_string(&p))
+            .unwrap_or_else(|| projected_path_string(Path::new(project_dir)));
 
         // Invariant: git_repos order = replica.repo_paths order (which follows config.json `repos`).
         // Never sort or dedupe here.
@@ -728,7 +720,9 @@ impl DiscoveryBranchWatcher {
             // here because the parent is already the answer; calling it
             // would re-walk and add no information.
             if let Some(parent) = Path::new(&entry.replica_path).parent() {
-                wg_roots.entry(strip_verbatim_prefix(parent)).or_default();
+                wg_roots
+                    .entry(normalize_projected_path(parent))
+                    .or_default();
             }
         }
 
@@ -741,7 +735,7 @@ impl DiscoveryBranchWatcher {
             {
                 if let Some(parent) = task_path.parent() {
                     wg_roots
-                        .entry(strip_verbatim_prefix(parent))
+                        .entry(normalize_projected_path(parent))
                         .or_default()
                         .push(id);
                 }
@@ -975,7 +969,7 @@ pub async fn discover_ac_agents(
             let Some(workspace_dir) = existing_workspace_dir(&repo_dir) else {
                 continue;
             };
-            let repo_dir_str = repo_dir.to_string_lossy().to_string();
+            let repo_dir_str = projected_path_string(&repo_dir);
 
             // Opportunistic: ensure gitignore exists for existing projects
             let _ = ensure_workspace_gitignore(&workspace_dir);
@@ -1029,7 +1023,7 @@ pub async fn discover_ac_agents(
 
                     agents.push(AcAgentMatrix {
                         name: display_name,
-                        path: path.to_string_lossy().to_string(),
+                        path: projected_path_string(&path),
                         role_exists,
                         preferred_agent_id,
                     });
@@ -1049,7 +1043,7 @@ pub async fn discover_ac_agents(
                                 name.starts_with("repo-") && e.path().is_dir()
                             })
                         })
-                        .map(|e| e.path().to_string_lossy().to_string());
+                        .map(|e| projected_path_string(&e.path()));
 
                     // Scan __agent_* replicas inside the WG
                     let mut wg_agents: Vec<AcAgentReplica> = Vec::new();
@@ -1106,11 +1100,9 @@ pub async fn discover_ac_agents(
                                     .filter_map(|r| r.as_str())
                                     .filter_map(|rel| {
                                         let resolved = wg_path.join(rel);
-                                        std::fs::canonicalize(&resolved).ok().map(|p| {
-                                            let s = p.to_string_lossy();
-                                            // Strip \\?\ UNC prefix that canonicalize adds on Windows
-                                            s.strip_prefix(r"\\?\").unwrap_or(&s).to_string()
-                                        })
+                                        std::fs::canonicalize(&resolved)
+                                            .ok()
+                                            .map(|p| projected_path_string(&p))
                                     })
                                     .collect();
 
@@ -1170,7 +1162,7 @@ pub async fn discover_ac_agents(
 
                                 wg_agents.push(AcAgentReplica {
                                     name: replica_name,
-                                    path: wg_path.to_string_lossy().to_string(),
+                                    path: projected_path_string(&wg_path),
                                     identity_path,
                                     origin_project,
                                     preferred_agent_id,
@@ -1190,7 +1182,7 @@ pub async fn discover_ac_agents(
 
                     workgroups.push(AcWorkgroup {
                         name: dir_name.clone(),
-                        path: path.to_string_lossy().to_string(),
+                        path: projected_path_string(&path),
                         task,
                         task_title,
                         agents: wg_agents,
@@ -1556,7 +1548,7 @@ pub async fn discover_project(
 
             agents.push(AcAgentMatrix {
                 name: display_name,
-                path: entry_path.to_string_lossy().to_string(),
+                path: projected_path_string(&entry_path),
                 role_exists,
                 preferred_agent_id,
             });
@@ -1575,7 +1567,7 @@ pub async fn discover_project(
                         name.starts_with("repo-") && e.path().is_dir()
                     })
                 })
-                .map(|e| e.path().to_string_lossy().to_string());
+                .map(|e| projected_path_string(&e.path()));
 
             let mut wg_agents: Vec<AcAgentReplica> = Vec::new();
             if let Ok(wg_entries) = std::fs::read_dir(&entry_path) {
@@ -1628,10 +1620,9 @@ pub async fn discover_project(
                             .filter_map(|r| r.as_str())
                             .filter_map(|rel| {
                                 let resolved = wg_path.join(rel);
-                                std::fs::canonicalize(&resolved).ok().map(|p| {
-                                    let s = p.to_string_lossy();
-                                    s.strip_prefix(r"\\?\").unwrap_or(&s).to_string()
-                                })
+                                std::fs::canonicalize(&resolved)
+                                    .ok()
+                                    .map(|p| projected_path_string(&p))
                             })
                             .collect();
 
@@ -1687,7 +1678,7 @@ pub async fn discover_project(
 
                         wg_agents.push(AcAgentReplica {
                             name: replica_name,
-                            path: wg_path.to_string_lossy().to_string(),
+                            path: projected_path_string(&wg_path),
                             identity_path,
                             origin_project,
                             preferred_agent_id,
@@ -1707,7 +1698,7 @@ pub async fn discover_project(
 
             workgroups.push(AcWorkgroup {
                 name: dir_name.clone(),
-                path: entry_path.to_string_lossy().to_string(),
+                path: projected_path_string(&entry_path),
                 task,
                 task_title,
                 agents: wg_agents,
@@ -1993,6 +1984,15 @@ fn read_task_fields(wg_path: &Path) -> TaskFields {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn projected_path_string_converts_verbatim_unc() {
+        assert_eq!(
+            projected_path_string(Path::new(r"\\?\UNC\server\share\repo")),
+            r"\\server\share\repo"
+        );
+    }
 
     #[tokio::test]
     async fn check_project_path_accepts_ac() {

--- a/src-tauri/src/commands/codex_resolver.rs
+++ b/src-tauri/src/commands/codex_resolver.rs
@@ -54,8 +54,8 @@ pub(crate) fn resolve_codex_sessions_root_at(
 /// Canonicalize a path-string for cwd comparison against Codex's
 /// `session_meta.cwd` field.
 ///
-/// On Windows: lowercase + normalize `/` → `\` + strip the `\\?\` extended-
-/// length prefix that `std::fs::canonicalize` sometimes returns.
+/// On Windows: lowercase, convert `/` to `\`, and strip verbatim drive or
+/// verbatim UNC prefixes that `std::fs::canonicalize` sometimes returns.
 /// On Unix: lowercase only.
 ///
 /// **Must be applied to BOTH sides** inside `find_session_file` (H6): AC's
@@ -65,8 +65,8 @@ pub(crate) fn resolve_codex_sessions_root_at(
 pub(crate) fn canonicalize_cwd_for_codex(cwd: &str) -> String {
     #[cfg(windows)]
     {
-        let stripped = cwd.strip_prefix(r"\\?\").unwrap_or(cwd);
-        stripped.replace('/', "\\").to_lowercase()
+        let normalized = crate::path_utils::normalize_windows_verbatim_path(cwd);
+        normalized.replace('/', "\\").to_lowercase()
     }
     #[cfg(not(windows))]
     {
@@ -136,6 +136,19 @@ mod tests {
         assert_eq!(
             canonicalize_cwd_for_codex(r"\\?\C:/Users/Foo"),
             "c:\\users\\foo"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn canonicalize_cwd_for_codex_matches_ordinary_and_verbatim_unc() {
+        assert_eq!(
+            canonicalize_cwd_for_codex(r"\\?\UNC\server\share\Repo"),
+            canonicalize_cwd_for_codex(r"\\server\share\Repo")
+        );
+        assert_eq!(
+            canonicalize_cwd_for_codex(r"\\?\UNC\server\share\Repo"),
+            r"\\server\share\repo"
         );
     }
 

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -833,10 +833,8 @@ fn enumerate_profile_assignment_targets(
 
 pub(crate) fn canonical_compare_key(path: &Path) -> String {
     let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    let mut text = path
-        .to_string_lossy()
-        .trim_start_matches(r"\\?\")
-        .replace('\\', "/");
+    let mut text =
+        crate::path_utils::path_to_string_without_windows_verbatim_prefix(&path).replace('\\', "/");
     if cfg!(windows) {
         text = text.to_ascii_lowercase();
     }
@@ -854,12 +852,7 @@ fn canonical_real_dir(path: &Path, label: &str) -> Result<PathBuf, String> {
         ));
     }
     std::fs::canonicalize(path)
-        .map(|path| {
-            let text = path.to_string_lossy();
-            text.strip_prefix(r"\\?\")
-                .map(PathBuf::from)
-                .unwrap_or(path)
-        })
+        .map(|path| crate::path_utils::normalize_windows_verbatim_path_buf(&path))
         .map_err(|e| {
             format!(
                 "Failed to canonicalize {} '{}': {}",
@@ -966,9 +959,11 @@ fn build_profile_assignment_target(
         .map(str::to_string);
     ProfileAssignmentTarget {
         workgroup_name,
-        workgroup_path: wg_dir.to_string_lossy().to_string(),
+        workgroup_path: crate::path_utils::path_to_string_without_windows_verbatim_prefix(wg_dir),
         replica_name,
-        replica_path: replica_dir.to_string_lossy().to_string(),
+        replica_path: crate::path_utils::path_to_string_without_windows_verbatim_prefix(
+            replica_dir,
+        ),
         identity_path: identity.identity.clone(),
         origin_project,
         live_session_ids: live_by_cwd
@@ -1373,6 +1368,8 @@ pub async fn fetch_home_markdown(network: State<'_, OutboundNetwork>) -> Result<
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
+    use super::{build_profile_assignment_target, canonical_compare_key};
     use super::{
         persist_coding_agent_env_settings_update, persist_coding_agent_profiles_update,
         persist_narrow_settings_update_with_saver, persist_protected_settings_update_with_saver,
@@ -1384,6 +1381,8 @@ mod tests {
     };
     use crate::session::manager::SessionManager;
     use std::collections::BTreeMap;
+    #[cfg(windows)]
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use tokio::sync::RwLock;
 
@@ -1401,6 +1400,39 @@ mod tests {
             }],
             ..AppSettings::default()
         }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn canonical_compare_key_converts_verbatim_unc() {
+        assert_eq!(
+            canonical_compare_key(Path::new(r"\\?\UNC\server\share\Repo")),
+            "//server/share/repo"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn profile_assignment_target_paths_convert_verbatim_unc() {
+        let live_by_cwd = BTreeMap::new();
+        let identity = crate::config::replica_identity::WgReplicaIdentity {
+            agent_name: "dev".to_string(),
+            workspace_dir: PathBuf::from(r"\\?\UNC\server\share\repo\.ac"),
+            matrix_dir: PathBuf::from(r"\\?\UNC\server\share\repo\.ac\_agent_dev"),
+            identity: "../../_agent_dev".to_string(),
+        };
+
+        let target = build_profile_assignment_target(
+            Path::new(r"\\?\UNC\server\share\repo\.ac\wg-1\__agent_dev"),
+            &identity,
+            &live_by_cwd,
+        );
+
+        assert_eq!(target.workgroup_path, r"\\server\share\repo\.ac\wg-1");
+        assert_eq!(
+            target.replica_path,
+            r"\\server\share\repo\.ac\wg-1\__agent_dev"
+        );
     }
 
     fn state_for(settings: AppSettings) -> SettingsState {
@@ -1545,7 +1577,10 @@ mod tests {
 
         let events = super::settings_draft_update_events(&before, &after);
         assert_eq!(events.env_agent_ids, vec!["agent-0".to_string()]);
-        assert!(!events.profiles_changed, "env-only edit is not a profiles change");
+        assert!(
+            !events.profiles_changed,
+            "env-only edit is not a profiles change"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -838,7 +838,7 @@ pub(crate) async fn create_workgroup_on_disk(
     }
 
     let clone_errors = clone_missing_repos_for_workgroup(&wg_dir, &team_config.repos).await;
-    let result_path = wg_dir.to_string_lossy().to_string();
+    let result_path = crate::path_utils::path_to_string_without_windows_verbatim_prefix(&wg_dir);
     log::info!(
         "[entity_creation] Created workgroup: {} ({} clone errors)",
         result_path,
@@ -995,7 +995,8 @@ pub async fn create_agent_matrix(
         let _warnings = apply_agent_matrix_settings_files(&created.agent_dir, flags);
     }
 
-    let result_path = created.agent_dir.to_string_lossy().to_string();
+    let result_path =
+        crate::path_utils::path_to_string_without_windows_verbatim_prefix(&created.agent_dir);
     log::debug!(
         "[entity_creation] Created agent matrix safe name: {}",
         created.safe_name
@@ -1172,7 +1173,7 @@ pub async fn create_team(
     )?;
     let team_dir = create_new_team_config_on_disk(&base, &safe_name, &config)?;
 
-    let result_path = team_dir.to_string_lossy().to_string();
+    let result_path = crate::path_utils::path_to_string_without_windows_verbatim_prefix(&team_dir);
     log::info!("[entity_creation] Created team: {}", result_path);
     emit_coordinator_refresh(&app, session_mgr.inner()).await;
     Ok(CreatedEntityResult { path: result_path })
@@ -1332,7 +1333,7 @@ pub async fn create_workgroup(
         }
     }
 
-    let result_path = wg_dir.to_string_lossy().to_string();
+    let result_path = crate::path_utils::path_to_string_without_windows_verbatim_prefix(&wg_dir);
     log::info!(
         "[entity_creation] Created workgroup: {} ({} clone errors)",
         result_path,
@@ -1414,7 +1415,9 @@ pub async fn delete_team(
             log::info!("[entity_creation] Deleted workgroup: {}", wg_name);
             // (#621) Drop this workgroup's coordinator_clocks keys (in-memory only;
             // one persist after the loop, see below).
-            if let Some(project_name) = Path::new(&project_path).file_name().and_then(|n| n.to_str())
+            if let Some(project_name) = Path::new(&project_path)
+                .file_name()
+                .and_then(|n| n.to_str())
             {
                 if let Some(clocks) =
                     app.try_state::<crate::config::coordinator_clocks::CoordinatorClocksState>()
@@ -1489,7 +1492,10 @@ pub async fn delete_workgroup(
     delete_workgroup_dir_backend(&wg_dir, &workgroup_name, session_mgr.inner()).await?;
     // (#621) Drop the workgroup's coordinator_clocks keys from the in-memory store
     // and persist immediately (this command is not on the auto-close flush tick).
-    if let Some(project_name) = Path::new(&project_path).file_name().and_then(|n| n.to_str()) {
+    if let Some(project_name) = Path::new(&project_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+    {
         if let Some(clocks) =
             app.try_state::<crate::config::coordinator_clocks::CoordinatorClocksState>()
         {
@@ -1643,8 +1649,7 @@ pub async fn update_team(
 fn build_session_repo(replica_dir: &Path, rel: &str) -> Option<SessionRepo> {
     let resolved = replica_dir.join(rel);
     let abs = std::fs::canonicalize(&resolved).ok()?;
-    let s = abs.to_string_lossy();
-    let source_path = s.strip_prefix(r"\\?\").unwrap_or(&s).to_string();
+    let source_path = crate::path_utils::path_to_string_without_windows_verbatim_prefix(&abs);
     let dir = source_path
         .replace('\\', "/")
         .split('/')
@@ -2179,10 +2184,8 @@ async fn ensure_no_live_sessions_under_manager(
 
 fn path_key_for_delete(path: &Path) -> String {
     let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    let text = resolved.to_string_lossy();
-    text.strip_prefix(r"\\?\")
-        .unwrap_or(&text)
-        .replace('\\', "/")
+    let text = crate::path_utils::path_to_string_without_windows_verbatim_prefix(&resolved);
+    text.replace('\\', "/")
         .trim_end_matches('/')
         .to_ascii_lowercase()
 }
@@ -2407,14 +2410,7 @@ async fn git_clone_async(url: &str, target: &Path) -> Result<(), String> {
 
 #[cfg(windows)]
 fn git_cli_path(path: &Path) -> PathBuf {
-    let s = path.as_os_str().to_string_lossy();
-    if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
-        PathBuf::from(format!(r"\\{}", rest))
-    } else if let Some(rest) = s.strip_prefix(r"\\?\") {
-        PathBuf::from(rest)
-    } else {
-        path.to_path_buf()
-    }
+    crate::path_utils::normalize_windows_verbatim_path_buf(path)
 }
 
 #[cfg(not(windows))]
@@ -3885,25 +3881,44 @@ mod tests {
         let old = SystemTime::now() - Duration::from_secs(40 * 24 * 60 * 60);
         let stale = cache.join("replica-context-aaa.md");
         std::fs::write(&stale, "x").unwrap();
-        std::fs::File::options().write(true).open(&stale).unwrap().set_modified(old).unwrap();
+        std::fs::File::options()
+            .write(true)
+            .open(&stale)
+            .unwrap()
+            .set_modified(old)
+            .unwrap();
         let fresh = cache.join("replica-context-bbb.md");
         std::fs::write(&fresh, "x").unwrap();
 
         // Remove wg-1: dir + clock key (cache via the age sweep).
-        assert!(matches!(try_atomic_delete_wg(&wg1), WgDeleteOutcome::Deleted));
+        assert!(matches!(
+            try_atomic_delete_wg(&wg1),
+            WgDeleteOutcome::Deleted
+        ));
         assert_eq!(clocks.remove_workgroup("Proj", "wg-1-team"), 1);
-        let swept =
-            sweep_context_cache_dir(&cache, SystemTime::now(), Duration::from_secs(30 * 24 * 60 * 60));
+        let swept = sweep_context_cache_dir(
+            &cache,
+            SystemTime::now(),
+            Duration::from_secs(30 * 24 * 60 * 60),
+        );
 
         assert!(!wg1.exists() && wg2.exists(), "only wg-1 dir removed");
         assert_eq!(clocks.last_user_message_at("Proj:wg-1-team/coord"), None);
         assert!(
-            clocks.last_user_message_at("Proj:wg-2-team/coord").is_some(),
+            clocks
+                .last_user_message_at("Proj:wg-2-team/coord")
+                .is_some(),
             "sibling clock intact"
         );
-        assert!(clocks.last_user_message_at("Proj/architect").is_some(), "origin clock intact");
+        assert!(
+            clocks.last_user_message_at("Proj/architect").is_some(),
+            "origin clock intact"
+        );
         assert_eq!(swept, 1);
-        assert!(!stale.exists() && fresh.exists(), "stale cache gone, fresh kept");
+        assert!(
+            !stale.exists() && fresh.exists(),
+            "stale cache gone, fresh kept"
+        );
     }
 
     #[test]
@@ -3935,10 +3950,15 @@ mod tests {
         assert_eq!(clocks.last_user_message_at("Proj:wg-2-squad/coord"), None);
         assert_eq!(clocks.last_user_message_at("Proj:wg-2-squad/dev"), None);
         assert!(
-            clocks.last_user_message_at("Proj:wg-9-other/coord").is_some(),
+            clocks
+                .last_user_message_at("Proj:wg-9-other/coord")
+                .is_some(),
             "other team wg intact"
         );
-        assert!(clocks.last_user_message_at("Proj/architect").is_some(), "origin intact");
+        assert!(
+            clocks.last_user_message_at("Proj/architect").is_some(),
+            "origin intact"
+        );
     }
 
     #[test]
@@ -3957,7 +3977,10 @@ mod tests {
 
         // Force the remove step to fail (rename succeeds, remove_dir_all errors -> Partial).
         let outcome = try_atomic_delete_wg_with_remove(&wg, |_p| {
-            Err(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "blocked"))
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "blocked",
+            ))
         });
         // The production gate: clean the clock ONLY on Deleted.
         if matches!(outcome, WgDeleteOutcome::Deleted) {
@@ -3968,7 +3991,9 @@ mod tests {
             "forced failure is not a Deleted outcome"
         );
         assert!(
-            clocks.last_user_message_at("Proj:wg-1-team/coord").is_some(),
+            clocks
+                .last_user_message_at("Proj:wg-1-team/coord")
+                .is_some(),
             "a failed delete must keep the clock key"
         );
     }

--- a/src-tauri/src/commands/gemini_resolver.rs
+++ b/src-tauri/src/commands/gemini_resolver.rs
@@ -48,12 +48,12 @@ pub(crate) fn lookup_chats_dir_for_cwd(gemini_home: &Path, cwd: &str) -> Option<
 }
 
 /// Canonicalize a path-string for cwd comparison against `projects.json` keys.
-/// On Windows: strip `\\?\` prefix + normalize `/` -> `\` + lowercase. On Unix:
-/// lowercase only.
+/// On Windows: strip verbatim drive or UNC prefixes, convert `/` to `\`, and
+/// lowercase. On Unix: lowercase only.
 #[cfg(windows)]
 pub(crate) fn canonicalize_cwd_for_gemini(cwd: &str) -> String {
-    let stripped = cwd.strip_prefix(r"\\?\").unwrap_or(cwd);
-    stripped.replace('/', "\\").to_lowercase()
+    let normalized = crate::path_utils::normalize_windows_verbatim_path(cwd);
+    normalized.replace('/', "\\").to_lowercase()
 }
 
 #[cfg(not(windows))]
@@ -131,6 +131,19 @@ mod tests {
 
         let chats = lookup_chats_dir_for_cwd(&gemini, "C:/Users/Foo");
         assert!(chats.is_some());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn canonicalize_cwd_for_gemini_matches_ordinary_and_verbatim_unc() {
+        assert_eq!(
+            canonicalize_cwd_for_gemini(r"\\?\UNC\server\share\Repo"),
+            canonicalize_cwd_for_gemini(r"\\server\share\Repo")
+        );
+        assert_eq!(
+            canonicalize_cwd_for_gemini(r"\\?\UNC\server\share\Repo"),
+            r"\\server\share\repo"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -738,6 +738,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     skip_auto_resume: bool,
     resolved_spawn: Option<AgentSpawnCommand>,
 ) -> Result<SessionInfo, String> {
+    let cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
     let (agent_id, agent_label) = {
         if let Some(spawn) = resolved_spawn.as_ref() {
             (
@@ -1347,10 +1348,11 @@ pub(crate) fn build_configured_agent_spawn_for_cwd(
     if !settings.agents.iter().any(|agent| agent.id == agent_id) {
         return Ok(None);
     }
+    let cwd = crate::path_utils::normalize_windows_verbatim_path(cwd);
     crate::config::agent_command::build_agent_spawn_command(
         settings,
         agent_id,
-        Some(std::path::Path::new(cwd)),
+        Some(std::path::Path::new(&cwd)),
         requested_profile,
     )
     .map(Some)
@@ -1436,6 +1438,7 @@ pub async fn create_session(
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_else(|| "C:\\".to_string())
     });
+    let cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
 
     let resolved_spawn = if let Some(aid) = agent_id.as_deref() {
         build_configured_agent_spawn_for_cwd(&cfg, aid, &cwd, requested_profile.as_deref())?
@@ -2211,6 +2214,7 @@ pub async fn restart_session_inner_with_activation<R: tauri::Runtime>(
     } else {
         cwd
     };
+    let cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
 
     // 2. Strip auto-injected args before restart so the new session starts from the saved recipe.
     let clean_args =

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -529,8 +529,7 @@ enum OpencodeConfigDirOutcome {
 /// Executable file_name forms that count as opencode when found among the
 /// command ARGS. The bare `opencode` covers the `cmd /c opencode` wrapper; the
 /// `.exe`/`.cmd`/`.bat` forms cover a direct path or an npm-style shim.
-const OPENCODE_ARG_FORMS: [&str; 4] =
-    ["opencode", "opencode.exe", "opencode.cmd", "opencode.bat"];
+const OPENCODE_ARG_FORMS: [&str; 4] = ["opencode", "opencode.exe", "opencode.cmd", "opencode.bat"];
 
 /// True when the launch command runs opencode, matched by executable name.
 /// There is no `CodingAgentKind::OpenCode` (the enum is Claude/Codex/Gemini and
@@ -567,7 +566,11 @@ fn find_opencode_config_dir<'a>(
     profile_env
         .iter()
         .find(|(key, _)| is_opencode_config_dir_key(key))
-        .or_else(|| agent_env.iter().find(|(key, _)| is_opencode_config_dir_key(key)))
+        .or_else(|| {
+            agent_env
+                .iter()
+                .find(|(key, _)| is_opencode_config_dir_key(key))
+        })
         .map(|(_, value)| value)
 }
 
@@ -611,7 +614,10 @@ fn ensure_opencode_config_dir(
     }
     match std::fs::create_dir_all(&path) {
         Ok(()) => {
-            log::info!("[opencode] Ensured OPENCODE_CONFIG_DIR '{}'", path.display());
+            log::info!(
+                "[opencode] Ensured OPENCODE_CONFIG_DIR '{}'",
+                path.display()
+            );
             OpencodeConfigDirOutcome::Ensured
         }
         Err(e) => {
@@ -700,7 +706,12 @@ pub fn profile_content_hash(command: &str, env: &BTreeMap<String, String>) -> St
     // Versioned, NUL-tagged serialization. NUL cannot appear in commands/env we
     // accept, and the field tags stop a value from forging a record boundary.
     let mut buf = String::new();
-    let _ = write!(buf, "v1\u{0}cmd\u{0}{}\u{0}envc\u{0}{}\u{0}", command, normalized.len());
+    let _ = write!(
+        buf,
+        "v1\u{0}cmd\u{0}{}\u{0}envc\u{0}{}\u{0}",
+        command,
+        normalized.len()
+    );
     for (key, value) in &normalized {
         let _ = write!(buf, "k\u{0}{}\u{0}v\u{0}{}\u{0}", key, value);
     }
@@ -709,12 +720,18 @@ pub fn profile_content_hash(command: &str, env: &BTreeMap<String, String>) -> St
     digest[..16].to_string()
 }
 
+fn normalize_launch_path_for_spawn(launch_path: Option<&Path>) -> Option<PathBuf> {
+    launch_path.map(crate::path_utils::normalize_windows_verbatim_path_buf)
+}
+
 pub fn build_agent_spawn_command(
     settings: &AppSettings,
     agent_id: &str,
     launch_path: Option<&Path>,
     requested_profile: Option<&str>,
 ) -> Result<AgentSpawnCommand, String> {
+    let normalized_launch_path = normalize_launch_path_for_spawn(launch_path);
+    let launch_path = normalized_launch_path.as_deref();
     let agent = settings
         .agents
         .iter()
@@ -905,11 +922,14 @@ pub fn build_agent_spawn_command(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
+    use super::normalize_launch_path_for_spawn;
     use super::{
-        build_agent_spawn_command, command_runs_opencode, default_instructions_filename_for_command,
-        ensure_opencode_config_dir, find_opencode_config_dir, is_safe_instructions_filename,
-        managed_instructions_filenames, normalize_legacy_agent_command, profile_content_hash,
-        resolve_instructions_filename, resolve_target_filename, OpencodeConfigDirOutcome,
+        build_agent_spawn_command, command_runs_opencode,
+        default_instructions_filename_for_command, ensure_opencode_config_dir,
+        find_opencode_config_dir, is_safe_instructions_filename, managed_instructions_filenames,
+        normalize_legacy_agent_command, profile_content_hash, resolve_instructions_filename,
+        resolve_target_filename, OpencodeConfigDirOutcome,
     };
     use crate::config::settings::{
         AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ConfigSeedConfig,
@@ -922,6 +942,20 @@ mod tests {
         let got = normalize_legacy_agent_command("codex --yolo").unwrap();
         assert_eq!(got.shell, "codex");
         assert_eq!(got.shell_args, vec!["--yolo"]);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn normalize_launch_path_for_spawn_converts_verbatim_unc() {
+        let path = normalize_launch_path_for_spawn(Some(std::path::Path::new(
+            r"\\?\UNC\server\share\repo\.ac\wg-1\__agent_dev",
+        )))
+        .expect("normalized path");
+
+        assert_eq!(
+            path,
+            std::path::PathBuf::from(r"\\server\share\repo\.ac\wg-1\__agent_dev")
+        );
     }
 
     #[test]
@@ -1220,7 +1254,10 @@ mod tests {
 
         assert_eq!(
             spawn.shell,
-            expected_root.join("bin").join("codex.exe").to_string_lossy()
+            expected_root
+                .join("bin")
+                .join("codex.exe")
+                .to_string_lossy()
         );
         assert_eq!(spawn.shell_args, vec!["--flag"]);
     }
@@ -1438,7 +1475,10 @@ mod tests {
             default_instructions_filename_for_command("gemini -m gpt-5"),
             "GEMINI.md"
         );
-        assert_eq!(default_instructions_filename_for_command("codex"), "AGENTS.md");
+        assert_eq!(
+            default_instructions_filename_for_command("codex"),
+            "AGENTS.md"
+        );
         assert_eq!(
             default_instructions_filename_for_command("opencode"),
             "AGENTS.md"
@@ -1535,7 +1575,10 @@ mod tests {
         );
         // 4. neither configured agent nor detection -> None.
         assert_eq!(resolve_target_filename(None, &settings, None), None);
-        assert_eq!(resolve_target_filename(Some("ghost"), &settings, None), None);
+        assert_eq!(
+            resolve_target_filename(Some("ghost"), &settings, None),
+            None
+        );
     }
 
     #[test]
@@ -1559,24 +1602,24 @@ mod tests {
     #[test]
     fn is_safe_instructions_filename_rejects_unsafe_names() {
         let bad = [
-            "",                 // empty
-            "   ",              // whitespace only
-            ".md",              // empty stem
-            "AGENTS.txt",       // wrong extension
-            "AGENTS",           // no extension
-            "a/b.md",           // forward separator
-            "a\\b.md",          // backslash separator
-            "..\\x.md",         // traversal + separator
-            "../x.md",          // traversal
-            "a..md",            // contains ..
-            "C:x.md",           // drive prefix (colon)
-            "AGENTS.md:evil",   // NTFS Alternate Data Stream (colon)
-            "AGENTS.md ",       // trailing space
-            "AGENTS.md.",       // trailing dot
-            "AGENTS .md",       // space immediately before extension
-            "a\nb.md",          // control char
-            "CON.md",           // reserved device
-            "con.md",           // reserved device (case-insensitive)
+            "",               // empty
+            "   ",            // whitespace only
+            ".md",            // empty stem
+            "AGENTS.txt",     // wrong extension
+            "AGENTS",         // no extension
+            "a/b.md",         // forward separator
+            "a\\b.md",        // backslash separator
+            "..\\x.md",       // traversal + separator
+            "../x.md",        // traversal
+            "a..md",          // contains ..
+            "C:x.md",         // drive prefix (colon)
+            "AGENTS.md:evil", // NTFS Alternate Data Stream (colon)
+            "AGENTS.md ",     // trailing space
+            "AGENTS.md.",     // trailing dot
+            "AGENTS .md",     // space immediately before extension
+            "a\nb.md",        // control char
+            "CON.md",         // reserved device
+            "con.md",         // reserved device (case-insensitive)
             "PRN.md",
             "aux.md",
             "NUL.md",
@@ -1591,7 +1634,10 @@ mod tests {
             "LAST_AC_CONTEXT.md", // G9 (case-insensitive)
         ];
         for name in bad {
-            assert!(!is_safe_instructions_filename(name), "should reject {name:?}");
+            assert!(
+                !is_safe_instructions_filename(name),
+                "should reject {name:?}"
+            );
         }
         // Length cap (> 128 chars).
         let long = format!("{}.md", "a".repeat(130));
@@ -1625,7 +1671,10 @@ mod tests {
             "cmd.exe",
             &["/c".to_string(), r"C:\tools\opencode.cmd".to_string()]
         ));
-        assert!(command_runs_opencode("cmd.exe", &["/c opencode.bat".to_string()]));
+        assert!(command_runs_opencode(
+            "cmd.exe",
+            &["/c opencode.bat".to_string()]
+        ));
         // Non-opencode commands do not match.
         assert!(!command_runs_opencode("codex", &[]));
         assert!(!command_runs_opencode("claude", &["--resume".to_string()]));
@@ -1645,8 +1694,14 @@ mod tests {
             "claude",
             &[r"C:\Users\me\opencode.md".to_string()]
         ));
-        assert!(!command_runs_opencode("claude", &["opencode.json".to_string()]));
-        assert!(!command_runs_opencode("claude", &["opencode.txt".to_string()]));
+        assert!(!command_runs_opencode(
+            "claude",
+            &["opencode.json".to_string()]
+        ));
+        assert!(!command_runs_opencode(
+            "claude",
+            &["opencode.txt".to_string()]
+        ));
     }
 
     #[test]
@@ -1711,7 +1766,10 @@ mod tests {
         let outcome = ensure_opencode_config_dir("codex", &[], &BTreeMap::new(), &profile_env);
 
         assert_eq!(outcome, OpencodeConfigDirOutcome::Skipped);
-        assert!(!target.exists(), "must not create the dir for a non-opencode command");
+        assert!(
+            !target.exists(),
+            "must not create the dir for a non-opencode command"
+        );
     }
 
     #[test]
@@ -1789,7 +1847,10 @@ mod tests {
         // launch_path None is fine: a literal absolute value needs no placeholder context.
         let spawn = build_agent_spawn_command(&settings, "opencode", None, Some("A")).unwrap();
 
-        assert!(target.is_dir(), "build should have created OPENCODE_CONFIG_DIR");
+        assert!(
+            target.is_dir(),
+            "build should have created OPENCODE_CONFIG_DIR"
+        );
         let env: BTreeMap<_, _> = spawn.child_env.into_iter().collect();
         assert_eq!(
             env.get("OPENCODE_CONFIG_DIR").map(String::as_str),
@@ -1902,7 +1963,10 @@ mod tests {
         let expected_replica = canonical_replica(&replica);
         let workspace = expected_replica.parent().unwrap().parent().unwrap();
         let matrix = workspace.join("_agent_dev-rust");
-        let letter = spawn.profile_resolution.effective_profile.to_ascii_lowercase();
+        let letter = spawn
+            .profile_resolution
+            .effective_profile
+            .to_ascii_lowercase();
 
         use crate::config::config_seed::ConfigSeedTier;
         // Workspace tiers outrank matrix tiers; profile beats base in each. The
@@ -2075,7 +2139,11 @@ mod tests {
         }
     }
 
-    fn settings_with_cell(agent_command: &str, letter: &str, cell: ProfileCellConfig) -> AppSettings {
+    fn settings_with_cell(
+        agent_command: &str,
+        letter: &str,
+        cell: ProfileCellConfig,
+    ) -> AppSettings {
         let mut settings = AppSettings {
             agents: vec![agent("codex", agent_command)],
             ..AppSettings::default()
@@ -2098,7 +2166,8 @@ mod tests {
         assert_eq!(a, b, "same inputs must hash identically");
         assert_eq!(a.len(), 16, "hash must be 16 chars");
         assert!(
-            a.chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            a.chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
             "hash must be lowercase hex: {a}"
         );
     }
@@ -2126,7 +2195,10 @@ mod tests {
         let h2 = build_agent_spawn_command(&s2, "codex", None, Some("A"))
             .unwrap()
             .profile_content_hash;
-        assert_ne!(h1, h2, "an agent-base edit must flip the effective-command hash");
+        assert_ne!(
+            h1, h2,
+            "an agent-base edit must flip the effective-command hash"
+        );
     }
 
     #[test]
@@ -2177,7 +2249,10 @@ mod tests {
 
     #[test]
     fn compose_effective_command_joins_and_drops_empty_sides() {
-        assert_eq!(super::compose_effective_command("claude", "--x"), "claude --x");
+        assert_eq!(
+            super::compose_effective_command("claude", "--x"),
+            "claude --x"
+        );
         assert_eq!(super::compose_effective_command("claude", ""), "claude");
         assert_eq!(super::compose_effective_command("", "--x"), "--x");
         assert_eq!(super::compose_effective_command("", ""), "");
@@ -2289,7 +2364,10 @@ mod tests {
         assert_eq!(merged.get(&key("ka")).map(String::as_str), Some("agent"));
         assert_eq!(merged.get(&key("kb")).map(String::as_str), Some("cell")); // profile wins
         assert_eq!(merged.get(&key("kc")).map(String::as_str), Some("cell"));
-        assert!(!merged.contains_key(&key("koff")), "disabled rows are excluded");
+        assert!(
+            !merged.contains_key(&key("koff")),
+            "disabled rows are excluded"
+        );
     }
 
     #[cfg(windows)]

--- a/src-tauri/src/config/coding_agent_profiles.rs
+++ b/src-tauri/src/config/coding_agent_profiles.rs
@@ -92,8 +92,7 @@ fn write_tooling_string(agent_dir: &Path, key: &str, value: Option<&str>) -> Res
 }
 
 fn strip_extended_prefix(path: PathBuf) -> PathBuf {
-    let s = path.to_string_lossy();
-    s.strip_prefix(r"\\?\").map(PathBuf::from).unwrap_or(path)
+    crate::path_utils::normalize_windows_verbatim_path_buf(&path)
 }
 
 fn canonical_existing_dir(path: &Path, label: &str) -> Result<PathBuf, String> {
@@ -728,6 +727,8 @@ mod tests {
     use crate::config::settings::{AgentConfig, ProfileCellConfig, ProfileSlotConfig};
     use std::collections::BTreeMap;
     use std::path::Path;
+    #[cfg(windows)]
+    use std::path::PathBuf;
 
     fn settings_with_cells(cells: &[(&str, Vec<&str>)]) -> AppSettings {
         let mut settings = AppSettings::default();
@@ -780,6 +781,15 @@ mod tests {
             })
             .collect();
         settings
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn strip_extended_prefix_converts_verbatim_unc() {
+        assert_eq!(
+            strip_extended_prefix(PathBuf::from(r"\\?\UNC\server\share\repo")),
+            PathBuf::from(r"\\server\share\repo")
+        );
     }
 
     fn settings_with_project(project: &Path) -> AppSettings {
@@ -1058,7 +1068,9 @@ mod tests {
         // The Root Agent dir name does NOT start with `__agent_`/`_agent_`, but it
         // is a legitimate replica running a coding agent: the hash must persist
         // and round-trip so drift survives an AC restart (#592 Root Agent fix).
-        let root_agent = temp.path().join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
+        let root_agent = temp
+            .path()
+            .join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
         std::fs::create_dir_all(&root_agent).unwrap();
 
         set_replica_profile_content_hash(&root_agent, "cafef00dcafef00d").unwrap();

--- a/src-tauri/src/config/placeholders.rs
+++ b/src-tauri/src/config/placeholders.rs
@@ -20,8 +20,7 @@ const AC_REPLICA_ROOT_ERROR: &str =
     "%AC_REPLICA_ROOT% requires an AC replica or root-agent launch root";
 const AC_WORKSPACE_ROOT_ERROR: &str =
     "%AC_WORKSPACE_ROOT% requires a launch root inside an AC (.ac) workspace";
-const AC_MATRIX_ROOT_ERROR: &str =
-    "%AC_MATRIX_ROOT% requires an AC workgroup replica launch root";
+const AC_MATRIX_ROOT_ERROR: &str = "%AC_MATRIX_ROOT% requires an AC workgroup replica launch root";
 const AC_PLACEHOLDER_LAUNCH_ROOT_ERROR: &str = "AC path placeholders require an AC launch root";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -180,7 +179,9 @@ pub fn reject_unexpanded_markers(
 }
 
 pub fn value_contains_ac_placeholder(value: &str) -> bool {
-    AC_PLACEHOLDER_TOKENS.iter().any(|token| value.contains(*token))
+    AC_PLACEHOLDER_TOKENS
+        .iter()
+        .any(|token| value.contains(*token))
 }
 
 pub fn ac_placeholder_error() -> &'static str {
@@ -221,8 +222,7 @@ fn is_marker_continue(byte: u8) -> bool {
 }
 
 fn strip_extended_prefix(path: PathBuf) -> PathBuf {
-    let s = path.to_string_lossy();
-    s.strip_prefix(r"\\?\").map(PathBuf::from).unwrap_or(path)
+    crate::path_utils::normalize_windows_verbatim_path_buf(&path)
 }
 
 fn is_ac_replica_dir(path: &Path) -> bool {
@@ -250,9 +250,9 @@ fn is_root_agent_dir(path: &Path) -> bool {
 
 #[cfg(windows)]
 fn same_path_text(left: &Path, right: &Path) -> bool {
-    left.to_string_lossy()
-        .trim_start_matches(r"\\?\")
-        .eq_ignore_ascii_case(right.to_string_lossy().trim_start_matches(r"\\?\"))
+    let left = crate::path_utils::path_to_string_without_windows_verbatim_prefix(left);
+    let right = crate::path_utils::path_to_string_without_windows_verbatim_prefix(right);
+    left.eq_ignore_ascii_case(&right)
 }
 
 #[cfg(not(windows))]
@@ -267,6 +267,24 @@ mod tests {
     #[test]
     fn non_path_values_allow_dollar_markers() {
         reject_unexpanded_markers("s3cr$tP4ss ${NAME} $NAME", "env", false).unwrap();
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn strip_extended_prefix_converts_verbatim_unc() {
+        assert_eq!(
+            strip_extended_prefix(PathBuf::from(r"\\?\UNC\server\share\repo")),
+            PathBuf::from(r"\\server\share\repo")
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn same_path_text_matches_ordinary_and_verbatim_unc() {
+        assert!(same_path_text(
+            Path::new(r"\\server\share\repo"),
+            Path::new(r"\\?\UNC\server\share\repo")
+        ));
     }
 
     #[test]
@@ -290,7 +308,10 @@ mod tests {
 
     /// Create a real WG-replica launch root `<temp>/.ac/wg-7-dev-team/__agent_dev-rust`.
     fn make_replica(temp: &Path) -> PathBuf {
-        let replica = temp.join(".ac").join("wg-7-dev-team").join("__agent_dev-rust");
+        let replica = temp
+            .join(".ac")
+            .join("wg-7-dev-team")
+            .join("__agent_dev-rust");
         std::fs::create_dir_all(&replica).unwrap();
         replica
     }
@@ -368,12 +389,17 @@ mod tests {
         let replica = make_replica(temp.path());
         let ctx = placeholder_context_for_launch_root(&replica).unwrap();
 
-        let expected_replica = canonical_stripped(&replica).to_string_lossy().replace('\\', "/");
+        let expected_replica = canonical_stripped(&replica)
+            .to_string_lossy()
+            .replace('\\', "/");
         let out = expand_placeholders_in_content(
             "root=%AC_REPLICA_ROOT%/x and %AC_WORKSPACE_ROOT% and %AC_MATRIX_ROOT%",
             &ctx,
         );
-        assert!(out.contains(&format!("root={}/x", expected_replica)), "{out}");
+        assert!(
+            out.contains(&format!("root={}/x", expected_replica)),
+            "{out}"
+        );
         // No backslashes from the substituted paths (forward-slash normalized).
         assert!(!out.contains('\\'), "{out}");
     }
@@ -403,7 +429,10 @@ mod tests {
             "%AC_REPLICA_ROOT% %AC_WORKSPACE_ROOT% %AC_MATRIX_ROOT%",
             &normal,
         );
-        assert_eq!(out, "%AC_REPLICA_ROOT% %AC_WORKSPACE_ROOT% %AC_MATRIX_ROOT%");
+        assert_eq!(
+            out,
+            "%AC_REPLICA_ROOT% %AC_WORKSPACE_ROOT% %AC_MATRIX_ROOT%"
+        );
     }
 
     #[test]
@@ -458,7 +487,11 @@ mod tests {
 
     #[test]
     fn derive_matrix_root_matches_canonical_formula() {
-        let workspace = PathBuf::from(if cfg!(windows) { r"C:\proj\.ac" } else { "/proj/.ac" });
+        let workspace = PathBuf::from(if cfg!(windows) {
+            r"C:\proj\.ac"
+        } else {
+            "/proj/.ac"
+        });
         let replica = workspace.join("wg-7-dev-team").join("__agent_dev-rust");
         assert_eq!(
             derive_matrix_root(&replica, Some(&workspace)),

--- a/src-tauri/src/config/replica_identity.rs
+++ b/src-tauri/src/config/replica_identity.rs
@@ -17,14 +17,11 @@ pub struct WgReplicaIdentity {
 }
 
 fn strip_unc(path: PathBuf) -> PathBuf {
-    let s = path.to_string_lossy();
-    s.strip_prefix(r"\\?\").map(PathBuf::from).unwrap_or(path)
+    crate::path_utils::normalize_windows_verbatim_path_buf(&path)
 }
 
 fn display_path(path: &Path) -> String {
-    path.to_string_lossy()
-        .trim_start_matches(r"\\?\")
-        .to_string()
+    crate::path_utils::path_to_string_without_windows_verbatim_prefix(path)
 }
 
 fn canonical_or_original(path: &Path) -> PathBuf {
@@ -420,6 +417,17 @@ pub fn read_and_repair_wg_replica_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(windows)]
+    fn replica_identity_path_helpers_convert_verbatim_unc() {
+        let path = PathBuf::from(r"\\?\UNC\server\share\repo");
+        assert_eq!(strip_unc(path), PathBuf::from(r"\\server\share\repo"));
+        assert_eq!(
+            display_path(Path::new(r"\\?\UNC\server\share\repo")),
+            r"\\server\share\repo"
+        );
+    }
 
     fn setup_replica(project_workspace_name: &str) -> tempfile::TempDir {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/src-tauri/src/config/root_agent.rs
+++ b/src-tauri/src/config/root_agent.rs
@@ -1084,14 +1084,21 @@ fn normalize_for_compare(path: &Path) -> String {
 }
 
 fn display_path(path: &Path) -> String {
-    path.to_string_lossy()
-        .trim_start_matches(r"\\?\")
-        .to_string()
+    crate::path_utils::path_to_string_without_windows_verbatim_prefix(path)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(windows)]
+    fn display_path_converts_verbatim_unc() {
+        assert_eq!(
+            display_path(Path::new(r"\\?\UNC\server\share\ac-root-agent")),
+            r"\\server\share\ac-root-agent"
+        );
+    }
 
     #[cfg(unix)]
     fn try_symlink_file(target: &Path, link: &Path) -> std::io::Result<()> {

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -115,9 +115,7 @@ Skill metadata is not an instruction body. It must not override the surrounding 
 
 /// Convert a path to a stable, user-facing display string on Windows.
 fn display_path(path: &std::path::Path) -> String {
-    path.to_string_lossy()
-        .trim_start_matches(r"\\?\")
-        .to_string()
+    crate::path_utils::path_to_string_without_windows_verbatim_prefix(path)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -99,10 +99,7 @@ const RENAME_BACKOFFS_MS: [u64; 3] = [10, 50, 200];
 /// out of scope for #280 (observability hardening, not concurrency
 /// rework). File a follow-up if the 260 ms tail latency becomes
 /// user-perceptible.
-pub(crate) fn rename_with_retry(
-    tmp: &Path,
-    dst: &Path,
-) -> Result<(), (String, RenameDiagnostics)> {
+pub(crate) fn rename_with_retry(tmp: &Path, dst: &Path) -> Result<(), (String, RenameDiagnostics)> {
     static OP_ID: AtomicU64 = AtomicU64::new(0);
     let op_id = OP_ID.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id();
@@ -264,17 +261,7 @@ fn sessions_path() -> Option<PathBuf> {
 }
 
 fn strip_long_prefix_str(s: &str) -> String {
-    if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
-        format!(r"\\{}", rest)
-    } else if let Some(rest) = s.strip_prefix(r"\\?\") {
-        rest.to_string()
-    } else if let Some(rest) = s.strip_prefix(r"\??\UNC\") {
-        format!(r"\\{}", rest)
-    } else if let Some(rest) = s.strip_prefix(r"\??\") {
-        rest.to_string()
-    } else {
-        s.to_string()
-    }
+    crate::path_utils::normalize_windows_verbatim_path(s)
 }
 
 fn normalize_for_project_compare(path: &Path) -> String {
@@ -366,7 +353,7 @@ fn deduplicate(sessions: Vec<PersistedSession>) -> Vec<PersistedSession> {
     let mut result: Vec<PersistedSession> = Vec::with_capacity(total);
 
     for session in sessions {
-        let norm_cwd = session.working_directory.replace('\\', "/").to_lowercase();
+        let norm_cwd = normalized_cwd_key(&session.working_directory);
         let is_root_agent = session.is_root_agent
             || crate::config::root_agent::is_root_agent_path(&session.working_directory);
 
@@ -378,10 +365,7 @@ fn deduplicate(sessions: Vec<PersistedSession>) -> Vec<PersistedSession> {
                     session.working_directory
                 );
                 if !result[idx].was_active || session.was_active {
-                    let old_cwd = result[idx]
-                        .working_directory
-                        .replace('\\', "/")
-                        .to_lowercase();
+                    let old_cwd = normalized_cwd_key(&result[idx].working_directory);
                     name_index.remove(&result[idx].name);
                     cwd_index.remove(&old_cwd);
                     name_index.insert(session.name.clone(), idx);
@@ -403,10 +387,7 @@ fn deduplicate(sessions: Vec<PersistedSession>) -> Vec<PersistedSession> {
             );
             if !result[idx].was_active || session.was_active {
                 // Patch cwd_index if the CWD changed
-                let old_cwd = result[idx]
-                    .working_directory
-                    .replace('\\', "/")
-                    .to_lowercase();
+                let old_cwd = normalized_cwd_key(&result[idx].working_directory);
                 if old_cwd != norm_cwd {
                     cwd_index.remove(&old_cwd);
                     cwd_index.insert(norm_cwd, idx);
@@ -455,6 +436,20 @@ fn deduplicate(sessions: Vec<PersistedSession>) -> Vec<PersistedSession> {
     }
 
     result
+}
+
+fn normalized_cwd_key(cwd: &str) -> String {
+    crate::path_utils::normalize_windows_verbatim_path(cwd)
+        .replace('\\', "/")
+        .to_lowercase()
+}
+
+fn normalize_persisted_session_paths(session: &mut PersistedSession) {
+    session.working_directory =
+        crate::path_utils::normalize_windows_verbatim_path(&session.working_directory);
+    for repo in &mut session.git_repos {
+        repo.source_path = crate::path_utils::normalize_windows_verbatim_path(&repo.source_path);
+    }
 }
 
 /// Load sessions from disk without deduplication or temp-session filtering.
@@ -599,6 +594,10 @@ fn load_sessions_from_path(path: &Path) -> Vec<PersistedSession> {
                             );
                         }
                     }
+                }
+
+                for ps in deduped.iter_mut() {
+                    normalize_persisted_session_paths(ps);
                 }
 
                 log::info!(
@@ -1336,6 +1335,8 @@ mod tests {
         working_directory_under_any_project_path, PersistedSession, RaiseHandPersistOutcome,
         RENAME_ATTEMPTS,
     };
+    #[cfg(windows)]
+    use super::{deduplicate, load_sessions_from_path};
     use crate::session::manager::SessionManager;
     use crate::session::session::{SessionCommunication, SessionCommunicationKind, SessionStatus};
     use std::time::Duration;
@@ -2203,6 +2204,70 @@ mod tests {
             r"c:\users\maria\project\.ac\wg-1\__agent_a",
             &project_paths
         ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn project_path_comparison_handles_windows_verbatim_cwd() {
+        let project_paths = vec![r"C:\Users\Maria\Project".to_string()];
+
+        assert!(working_directory_under_any_project_path(
+            r"\\?\C:\Users\Maria\Project\.ac\wg-1\__agent_a",
+            &project_paths
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn deduplicate_treats_windows_verbatim_and_ordinary_cwd_as_same_key() {
+        let rows = vec![
+            PersistedSession {
+                name: "verbatim".to_string(),
+                working_directory: r"\\?\C:\repo\.ac\wg-1\__agent_a".to_string(),
+                was_active: false,
+                ..Default::default()
+            },
+            PersistedSession {
+                name: "ordinary".to_string(),
+                working_directory: r"C:\repo\.ac\wg-1\__agent_a".to_string(),
+                was_active: true,
+                ..Default::default()
+            },
+        ];
+
+        let deduped = deduplicate(rows);
+
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].name, "ordinary");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn load_sessions_from_path_normalizes_windows_verbatim_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("sessions.json");
+        let sessions = serde_json::json!([
+            {
+                "name": "wg-1/a",
+                "shell": "cmd",
+                "shellArgs": [],
+                "workingDirectory": r"\\?\C:\repo\.ac\wg-1\__agent_a",
+                "gitRepos": [
+                    {
+                        "label": "repo",
+                        "sourcePath": r"\\?\UNC\server\share\repo",
+                        "branch": null
+                    }
+                ]
+            }
+        ]);
+        std::fs::write(&path, sessions.to_string()).expect("write sessions");
+
+        let loaded = load_sessions_from_path(&path);
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].working_directory, r"C:\repo\.ac\wg-1\__agent_a");
+        assert_eq!(loaded[0].git_repos[0].source_path, r"\\server\share\repo");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod errors;
 pub mod logging;
 pub mod loops;
 pub mod network;
+pub mod path_utils;
 pub mod phone;
 pub mod pty;
 pub mod resource_monitor;

--- a/src-tauri/src/loops/delivery.rs
+++ b/src-tauri/src/loops/delivery.rs
@@ -333,13 +333,16 @@ async fn spawn_coordinator_session(
     );
     let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
     let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
+    let cwd = crate::path_utils::path_to_string_without_windows_verbatim_prefix(
+        &target.coordinator_replica_dir,
+    );
     let info = crate::commands::session::create_session_inner(
         app,
         session_mgr.inner(),
         pty_mgr.inner(),
         command.shell,
         command.shell_args,
-        target.coordinator_replica_dir.to_string_lossy().to_string(),
+        cwd,
         Some(session_name),
         command.agent_id,
         command.agent_label,
@@ -415,6 +418,8 @@ async fn resolve_loop_agent_command(
     app: &AppHandle,
     replica_dir: &Path,
 ) -> Result<ResolvedLoopAgentCommand, String> {
+    let replica_dir = crate::path_utils::normalize_windows_verbatim_path_buf(replica_dir);
+    let replica_dir = replica_dir.as_path();
     let settings = {
         let settings_state = app.state::<SettingsState>();
         let settings = settings_state.read().await.clone();
@@ -471,8 +476,7 @@ fn read_last_coding_agent(replica_dir: &Path) -> Option<String> {
 
 fn path_compare_key(path: &Path) -> String {
     let resolved: PathBuf = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    let value = resolved.to_string_lossy().to_string();
-    let value = value.strip_prefix(r"\\?\").unwrap_or(&value).to_string();
+    let value = crate::path_utils::path_to_string_without_windows_verbatim_prefix(&resolved);
     let value = value.replace('\\', "/").trim_end_matches('/').to_string();
     if cfg!(windows) {
         value.to_lowercase()
@@ -488,6 +492,15 @@ mod tests {
         write_loop_config, LoopDef, LoopPolicy, LoopPrompt, LoopTarget, LoopTargetKind,
         LoopTrigger, LoopTriggerKind, LOOP_TIMEZONE_LOCAL,
     };
+
+    #[test]
+    #[cfg(windows)]
+    fn path_compare_key_converts_verbatim_unc() {
+        assert_eq!(
+            path_compare_key(Path::new(r"\\?\UNC\server\share\repo")),
+            "//server/share/repo"
+        );
+    }
 
     fn sample_config() -> LoopConfigToml {
         LoopConfigToml {

--- a/src-tauri/src/path_utils.rs
+++ b/src-tauri/src/path_utils.rs
@@ -1,0 +1,96 @@
+use std::path::{Path, PathBuf};
+
+fn strip_windows_verbatim_prefix_str(path: &str) -> Option<String> {
+    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        Some(format!(r"\\{}", rest))
+    } else if let Some(rest) = path.strip_prefix(r"\\?\") {
+        Some(rest.to_string())
+    } else if let Some(rest) = path.strip_prefix(r"\??\UNC\") {
+        Some(format!(r"\\{}", rest))
+    } else {
+        path.strip_prefix(r"\??\").map(str::to_string)
+    }
+}
+
+pub(crate) fn normalize_windows_verbatim_path(path: &str) -> String {
+    if cfg!(windows) {
+        strip_windows_verbatim_prefix_str(path).unwrap_or_else(|| path.to_string())
+    } else {
+        path.to_string()
+    }
+}
+
+pub(crate) fn normalize_windows_verbatim_path_buf(path: &Path) -> PathBuf {
+    if cfg!(windows) {
+        let raw = path.as_os_str().to_string_lossy();
+        PathBuf::from(normalize_windows_verbatim_path(raw.as_ref()))
+    } else {
+        path.to_path_buf()
+    }
+}
+
+pub(crate) fn path_to_string_without_windows_verbatim_prefix(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    normalize_windows_verbatim_path(raw.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_windows_verbatim_prefix_str_converts_drive_path() {
+        assert_eq!(
+            strip_windows_verbatim_prefix_str(r"\\?\C:\tmp\repo").as_deref(),
+            Some(r"C:\tmp\repo")
+        );
+    }
+
+    #[test]
+    fn strip_windows_verbatim_prefix_str_converts_unc_path() {
+        assert_eq!(
+            strip_windows_verbatim_prefix_str(r"\\?\UNC\server\share\repo").as_deref(),
+            Some(r"\\server\share\repo")
+        );
+    }
+
+    #[test]
+    fn strip_windows_verbatim_prefix_str_converts_nt_drive_and_unc_paths() {
+        assert_eq!(
+            strip_windows_verbatim_prefix_str(r"\??\C:\tmp\repo").as_deref(),
+            Some(r"C:\tmp\repo")
+        );
+        assert_eq!(
+            strip_windows_verbatim_prefix_str(r"\??\UNC\server\share\repo").as_deref(),
+            Some(r"\\server\share\repo")
+        );
+    }
+
+    #[test]
+    fn strip_windows_verbatim_prefix_str_leaves_ordinary_paths() {
+        assert_eq!(strip_windows_verbatim_prefix_str(r"C:\tmp\repo"), None);
+        assert_eq!(
+            strip_windows_verbatim_prefix_str(r"\\server\share\repo"),
+            None
+        );
+        assert_eq!(strip_windows_verbatim_prefix_str("/tmp/repo"), None);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn normalize_windows_verbatim_path_strips_prefix_on_windows() {
+        assert_eq!(
+            normalize_windows_verbatim_path(r"\\?\C:\tmp\repo"),
+            r"C:\tmp\repo"
+        );
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn normalize_windows_verbatim_path_preserves_prefix_off_windows() {
+        assert_eq!(
+            normalize_windows_verbatim_path(r"\\?\C:\tmp\repo"),
+            r"\\?\C:\tmp\repo"
+        );
+    }
+}

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -2259,6 +2259,7 @@ impl MailboxPoller {
         #[cfg(not(test))]
         let _ = msg;
         let skip_auto_resume = wake_spawn_skip_auto_resume(spawn_with_resume);
+        let cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
 
         #[cfg(test)]
         if let Some(hooks) = &self.test_hooks {
@@ -4848,13 +4849,14 @@ impl MailboxPoller {
 
             let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
             let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
+            let cwd = crate::path_utils::normalize_windows_verbatim_path(&request.cwd);
             let resolved_spawn = {
                 let settings = app.state::<SettingsState>();
                 let cfg = settings.read().await;
                 match crate::commands::session::build_configured_agent_spawn_for_cwd(
                     &cfg,
                     &request.agent_id,
-                    &request.cwd,
+                    &cwd,
                     request.requested_profile.as_deref(),
                 ) {
                     Ok(spawn) => spawn,
@@ -4885,7 +4887,7 @@ impl MailboxPoller {
                 pty_mgr.inner(),
                 shell,
                 shell_args,
-                request.cwd.clone(),
+                cwd,
                 Some(request.session_name.clone()),
                 Some(request.agent_id.clone()),
                 agent_label, // No agent label for legacy custom-shell fallback

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -313,6 +313,7 @@ impl PtyManager {
         mut resource_registration: Option<ResourceLaunchRegistration>,
     ) -> Result<(), AppError> {
         let pty_system = native_pty_system();
+        let spawn_cwd = crate::path_utils::normalize_windows_verbatim_path(cwd);
 
         let size = PtySize {
             rows,
@@ -348,7 +349,7 @@ impl PtyManager {
             }
             c
         };
-        command.cwd(cwd);
+        command.cwd(&spawn_cwd);
         for key in env_remove_keys {
             command.env_remove(key);
         }
@@ -375,12 +376,12 @@ impl PtyManager {
         }
 
         if let Some(git_ceiling_dirs) =
-            crate::config::session_context::git_ceiling_directories_for_session_root(cwd)
+            crate::config::session_context::git_ceiling_directories_for_session_root(&spawn_cwd)
         {
             command.env("GIT_CEILING_DIRECTORIES", &git_ceiling_dirs);
             log::info!(
                 "[pty] Applied GIT_CEILING_DIRECTORIES for session cwd {}: {}",
-                cwd,
+                spawn_cwd,
                 git_ceiling_dirs
             );
 
@@ -389,7 +390,10 @@ impl PtyManager {
                 command.env("PATH", &git_guard_env.path);
                 command.env("PATHEXT", &git_guard_env.pathext);
                 command.env("AC_REAL_GIT", &git_guard_env.real_git);
-                log::info!("[pty] Enabled git guard wrapper for session cwd {}", cwd);
+                log::info!(
+                    "[pty] Enabled git guard wrapper for session cwd {}",
+                    spawn_cwd
+                );
             }
         }
 
@@ -408,7 +412,9 @@ impl PtyManager {
         // app-exit can kill the whole tree atomically via the job handle. Created
         // before the resource registration so the early-return error paths below
         // drop `job` and let KILL_ON_JOB_CLOSE reap the child too.
-        let job = child.process_id().and_then(crate::pty::job::JobObject::for_child);
+        let job = child
+            .process_id()
+            .and_then(crate::pty::job::JobObject::for_child);
 
         if let Some(registration) = resource_registration.as_mut() {
             let Some(pid) = child.process_id() else {

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -69,6 +69,7 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
                     .map(|p| p.to_string_lossy().to_string())
                     .unwrap_or_else(|| "C:\\".to_string()),
             );
+            let cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
             let session_name = args
                 .get("sessionName")
                 .and_then(|v| v.as_str())


### PR DESCRIPTION
## Summary

- Normalize Windows verbatim path forms before PTY/session cwd launch paths reach `cmd.exe`.
- Add shared path normalization and apply it to session ingress, configured-agent resolution, persistence/discovery projections, root/session helpers, loop coordinator wake, and Codex/Gemini cwd matching.
- Add focused regression coverage for drive, UNC, and NT-style verbatim path handling.

## Review and Verification

Dev implementation commit: da08cbc355302d60efcf7a61d1351fd24fa70643

Dev-rust verification:
- `cargo test --manifest-path src-tauri/Cargo.toml path_utils`: PASS
- Focused Rust test loop for touched modules: PASS
- `cargo check --manifest-path src-tauri/Cargo.toml`: PASS
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: PASS
- `git diff --check`: PASS

Grinch review:
- `PASS_NON_VISUAL`
- Re-ran focused test loop, cargo check, clippy, and diff check: PASS
- No findings

Final shipper build: N/A - non-visual backend/session launch fix.

Closes #730