### PR TITLE
feat: add active-agent screenshot capture

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-util",
+ "image",
  "log",
  "open",
  "portable-pty",
@@ -32,7 +33,9 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
+ "tauri-plugin-global-shortcut",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -43,6 +46,7 @@ dependencies = [
  "vt100",
  "which",
  "windows-sys 0.59.0",
+ "xcap",
 ]
 
 [[package]]
@@ -52,6 +56,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -76,6 +98,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -135,10 +167,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "ashpd"
@@ -224,7 +303,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -266,7 +345,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -292,7 +371,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -335,7 +414,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -349,6 +428,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "axum"
@@ -418,6 +540,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "annotate-snippets",
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +574,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +592,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -500,6 +656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +672,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -554,7 +730,7 @@ checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -606,6 +782,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -614,6 +792,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "cfb"
@@ -633,7 +820,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -641,6 +838,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -654,6 +857,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -697,6 +911,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +957,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +974,12 @@ dependencies = [
  "time",
  "version_check",
 ]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
 name = "core-foundation"
@@ -826,10 +1070,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1013,7 +1282,7 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1158,6 +1427,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "drm"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "drm-ffi",
+ "drm-fourcc",
+ "libc",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "drm-ffi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51a91c9b32ac4e8105dec255e849e0d66e27d7c34d184364fb93e469db08f690"
+dependencies = [
+ "drm-sys",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "drm-fourcc"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
+
+[[package]]
+name = "drm-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8e1361066d91f5ffccff060a3c3be9c3ecde15be2959c1937595f7a82a9f8"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.9.4",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1585,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1632,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,10 +1659,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1364,6 +1720,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1565,6 +1927,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "gbm"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a"
+dependencies = [
+ "bitflags 2.11.0",
+ "drm",
+ "drm-fourcc",
+ "gbm-sys",
+ "libc",
+ "wayland-backend",
+ "wayland-server",
+]
+
+[[package]]
+name = "gbm-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13a5f2acc785d8fb6bf6b7ab6bfb0ef5dad4f4d97e8e70bb8e470722312f76f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "gdk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,7 +1988,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1619,7 +2005,7 @@ dependencies = [
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1633,7 +2019,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1659,7 +2045,7 @@ dependencies = [
  "gdk-sys",
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "x11",
 ]
 
@@ -1671,6 +2057,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1721,6 +2117,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,8 +2154,28 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "winapi",
+]
+
+[[package]]
+name = "gl"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94edab108827d67608095e269cf862e60d920f144a5026d3dbcfd8b877fb404"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
 ]
 
 [[package]]
@@ -1796,7 +2222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1806,6 +2232,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,7 +2257,7 @@ checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1852,7 +2296,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1885,6 +2329,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2241,10 +2696,37 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
 ]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
@@ -2276,6 +2758,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2329,6 +2822,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,7 +2865,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2426,6 +2937,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2992,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,6 +3030,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libappindicator"
@@ -2525,6 +3068,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,6 +3107,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "libspa"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cc",
+ "convert_case 0.8.0",
+ "cookie-factory",
+ "libc",
+ "libspa-sys",
+ "nix 0.30.1",
+ "nom 8.0.0",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "libspa-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901049455d2eb6decf9058235d745237952f4804bc584c5fcb41412e6adcc6e0"
+dependencies = [
+ "bindgen",
+ "cc",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "libwayshot-xcap"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558a3a7ca16a17a14adf8f051b3adcd7766d397532f5f6d6a48034db11e54c22"
+dependencies = [
+ "drm",
+ "gbm",
+ "gl",
+ "image",
+ "khronos-egl",
+ "memmap2",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tracing",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +3193,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
 
 [[package]]
 name = "mac"
@@ -2635,10 +3258,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -2673,6 +3315,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2794,16 +3442,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2854,8 +3589,92 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-avf-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-image-io",
+ "objc2-media-toolbox",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2866,7 +3685,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -2877,10 +3698,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -2906,8 +3783,20 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2919,6 +3808,29 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-media-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
+dependencies = [
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-media",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -3043,6 +3955,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3064,7 +3986,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3097,6 +4019,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,6 +4041,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.1",
+]
 
 [[package]]
 name = "phf"
@@ -3319,6 +4264,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "pipewire"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9688b89abf11d756499f7c6190711d6dbe5a3acdb30c8fbf001d6596d06a8d44"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "libc",
+ "libspa",
+ "libspa-sys",
+ "nix 0.30.1",
+ "once_cell",
+ "pipewire-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "pipewire-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb028afee0d6ca17020b090e3b8fa2d7de23305aef975c7e5192a5050246ea36"
+dependencies = [
+ "bindgen",
+ "libspa-sys",
+ "system-deps 7.0.8",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3373,7 +4346,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3411,7 +4384,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.25.1",
  "serial",
  "shared_library",
  "shell-words",
@@ -3527,10 +4500,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -3682,10 +4698,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3882,6 +4968,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3912,6 +5004,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3919,7 +5024,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4425,6 +5530,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4503,7 +5617,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -4674,10 +5788,23 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck 0.5.0",
  "pkg-config",
  "toml 0.8.23",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr 0.20.8",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.2+spec-1.1.0",
  "version-compare",
 ]
 
@@ -4713,7 +5840,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4735,6 +5862,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"
@@ -4785,7 +5918,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4869,6 +6002,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4909,6 +6057,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,7 +6093,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4955,7 +6118,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5017,7 +6180,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5089,6 +6252,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5230,6 +6407,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.13.1",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5439,6 +6631,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5550,6 +6753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5629,6 +6838,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5674,7 +6894,7 @@ checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
 dependencies = [
  "itoa",
  "log",
- "unicode-width",
+ "unicode-width 0.1.14",
  "vte",
 ]
 
@@ -5858,7 +7078,7 @@ checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.1.4",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -5871,7 +7091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.0",
- "rustix",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -5889,6 +7109,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-scanner"
 version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5900,13 +7133,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-server"
+version = "0.31.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1846eb04c49182e04f4a099e2a830a2b745610bbc1d61246e206f29c7000a0"
+dependencies = [
+ "bitflags 2.11.0",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-sys"
 version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
+ "libc",
  "log",
+ "memoffset 0.9.1",
  "pkg-config",
 ]
 
@@ -5973,7 +7221,7 @@ dependencies = [
  "libc",
  "pkg-config",
  "soup3-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -5984,7 +7232,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -6008,9 +7256,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
@@ -6020,9 +7274,15 @@ checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix",
+ "rustix 1.1.4",
  "winsafe",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -6076,11 +7336,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -6090,6 +7362,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6126,7 +7407,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -6171,6 +7463,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6320,6 +7622,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6610,6 +7921,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6653,7 +7982,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -6679,6 +8008,83 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xcap"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ad471d5ba232bc276382d26a9d3b837d6853b7df389058b5bb1e94dcdd248c"
+dependencies = [
+ "dispatch2",
+ "image",
+ "libwayshot-xcap",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-av-foundation",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-media",
+ "objc2-core-video",
+ "objc2-foundation",
+ "percent-encoding",
+ "pipewire",
+ "rand 0.9.2",
+ "scopeguard",
+ "serde",
+ "thiserror 2.0.18",
+ "url",
+ "widestring",
+ "windows 0.62.2",
+ "xcb",
+ "zbus",
+]
+
+[[package]]
+name = "xcb"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "quick-xml 0.30.0",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
@@ -6725,7 +8131,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",
@@ -6849,6 +8255,30 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,7 +36,13 @@ rfd = "0.15"
 tauri-plugin-dialog = "2.6.0"
 which = "7"
 
+# #714 Native screenshot capture is Windows-only for this issue. Non-Windows
+# builds compile through the `screenshot::unsupported` stub and never link these.
 [target.'cfg(windows)'.dependencies]
+tauri-plugin-global-shortcut = "2.3.2"
+tauri-plugin-clipboard-manager = "2.3.2"
+xcap = "0.9.6"
+image = "0.25.10"
 windows-sys = { version = "0.59", features = [
     "Win32_System_Console",
     "Win32_Foundation",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,7 +8,8 @@
     "terminal-*",
     "guide",
     "spec-board",
-    "resource-monitor"
+    "resource-monitor",
+    "screenshot-overlay-*"
   ],
   "permissions": [
     "core:default",

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -93,11 +93,25 @@ pub async fn get_settings(settings: State<'_, SettingsState>) -> Result<AppSetti
 
 #[tauri::command]
 pub async fn update_settings(
+    app: AppHandle,
     settings: State<'_, SettingsState>,
     new_settings: AppSettings,
 ) -> Result<(), String> {
     let saved = persist_protected_settings_update(settings.inner(), new_settings).await?;
     purge_sessions_after_settings_update(&saved).await;
+    // #714 re-register the (possibly changed) hotkey. Syntax was already validated
+    // before persistence; an OS-level registration conflict must NOT turn this
+    // successfully-persisted save into an Err. Surface it as a visible event.
+    if let Err(e) =
+        crate::screenshot::register_configured_hotkey(&app, &saved.screenshot_capture_hotkey)
+    {
+        let _ = app.emit(
+            "screenshot_capture_failed",
+            serde_json::json!({
+                "message": format!("Screenshot hotkey was saved but could not be registered: {}", e)
+            }),
+        );
+    }
     Ok(())
 }
 
@@ -109,6 +123,18 @@ pub async fn save_settings_draft(
 ) -> Result<(), String> {
     let (saved, events) = persist_settings_draft_update(settings.inner(), draft).await?;
     purge_sessions_after_settings_update(&saved).await;
+    // #714 same non-failing hotkey re-registration as update_settings: persisted
+    // save stays successful even if the OS refuses the hotkey.
+    if let Err(e) =
+        crate::screenshot::register_configured_hotkey(&app, &saved.screenshot_capture_hotkey)
+    {
+        let _ = app.emit(
+            "screenshot_capture_failed",
+            serde_json::json!({
+                "message": format!("Screenshot hotkey was saved but could not be registered: {}", e)
+            }),
+        );
+    }
     emit_settings_draft_update_events(&app, &events);
     // #612 apply the (possibly changed) log level live + broadcast so every
     // webview re-applies its console gate. Idempotent and cheap; runs only on an

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod pty;
 pub mod repos;
 pub mod resource_monitor;
 pub mod role_templates;
+pub mod screenshot;
 pub mod session;
 pub mod spec_board;
 pub mod task;

--- a/src-tauri/src/commands/screenshot.rs
+++ b/src-tauri/src/commands/screenshot.rs
@@ -1,0 +1,75 @@
+//! #714 Screenshot capture Tauri commands.
+//!
+//! Thin IPC wrappers over `crate::screenshot`. All capture-state mutation,
+//! overlay teardown, and clipboard/clock side effects live in the screenshot
+//! module; these handlers only marshal arguments and managed state.
+
+use tauri::{AppHandle, Manager, State};
+
+use crate::config::settings::SettingsState;
+use crate::screenshot::{
+    ScreenshotCaptureResult, ScreenshotCaptureState, ScreenshotHotkeyState, ScreenshotHotkeyStatus,
+    ScreenshotOverlayState, ScreenshotSelection,
+};
+
+/// Return the frozen monitor image + metadata for one overlay window.
+#[tauri::command]
+pub async fn screenshot_get_overlay_state(
+    app: AppHandle,
+    state: State<'_, ScreenshotCaptureState>,
+    capture_id: String,
+    monitor_id: u32,
+) -> Result<ScreenshotOverlayState, String> {
+    crate::screenshot::overlay_state(&app, state.inner(), &capture_id, monitor_id).await
+}
+
+/// Confirm a selection: crop, save the PNG into the replica root, copy the path,
+/// and tear down overlays. Backend owns all cleanup.
+#[tauri::command]
+pub async fn screenshot_confirm_selection(
+    app: AppHandle,
+    state: State<'_, ScreenshotCaptureState>,
+    selection: ScreenshotSelection,
+) -> Result<ScreenshotCaptureResult, String> {
+    crate::screenshot::confirm_selection(&app, state.inner(), selection).await
+}
+
+/// Cancel an in-progress capture (Escape / overlay close). Idempotent.
+#[tauri::command]
+pub async fn screenshot_cancel_capture(
+    app: AppHandle,
+    state: State<'_, ScreenshotCaptureState>,
+    capture_id: String,
+) -> Result<(), String> {
+    crate::screenshot::cancel_capture(&app, state.inner(), &capture_id).await
+}
+
+/// Current global-hotkey registration status (configured combo + whether the OS
+/// accepted it + any conflict error). The sidebar reads this on mount.
+#[tauri::command]
+pub fn screenshot_get_hotkey_status(
+    state: State<'_, ScreenshotHotkeyState>,
+) -> ScreenshotHotkeyStatus {
+    state.lock().unwrap().status.clone()
+}
+
+/// Re-read the configured hotkey from settings and (re-)register it. Useful after
+/// a Settings save and in manual testing; returns the resulting status. A failed
+/// OS registration is reflected in the status, not returned as an error.
+#[tauri::command]
+pub async fn screenshot_reload_hotkey(
+    app: AppHandle,
+    settings: State<'_, SettingsState>,
+) -> Result<ScreenshotHotkeyStatus, String> {
+    let configured = settings.read().await.screenshot_capture_hotkey.clone();
+    // Ignore the Err: an OS conflict is captured in the status below; settings
+    // validation already rejected any syntactically invalid value.
+    let _ = crate::screenshot::register_configured_hotkey(&app, &configured);
+    let status = app
+        .state::<ScreenshotHotkeyState>()
+        .lock()
+        .unwrap()
+        .status
+        .clone();
+    Ok(status)
+}

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -271,6 +271,9 @@ pub struct AppSettings {
     /// Raise terminal window when sidebar is clicked
     #[serde(default = "default_true")]
     pub raise_terminal_on_click: bool,
+    /// #714 Native global hotkey for screenshot capture, e.g. "Ctrl+Q".
+    #[serde(default = "default_screenshot_capture_hotkey")]
+    pub screenshot_capture_hotkey: String,
     /// Enable voice-to-text microphone button on session items
     #[serde(default)]
     pub voice_to_text_enabled: bool,
@@ -452,6 +455,10 @@ fn default_true() -> bool {
     true
 }
 
+fn default_screenshot_capture_hotkey() -> String {
+    "Ctrl+Q".to_string()
+}
+
 /// #640 Resolve the effective auto-self-clear flag for an agent.
 /// Precedence: the global master `auto_self_clear_enabled` is an absolute kill
 /// switch (off => off for all); else an explicit per-agent override
@@ -598,6 +605,7 @@ impl Default for AppSettings {
             team_idle_beep_enabled: true,
             sounds_enabled: true,
             raise_terminal_on_click: true,
+            screenshot_capture_hotkey: default_screenshot_capture_hotkey(),
             voice_to_text_enabled: false,
             gemini_api_key: String::new(),
             gemini_model: default_gemini_model(),
@@ -1246,7 +1254,17 @@ fn validate_env_rows(rows: &[CodingAgentEnv], context: &str) -> Result<(), Strin
 pub fn validate_and_repair_settings(settings: &mut AppSettings) -> Result<(), String> {
     repair_coding_agent_profiles_config(&mut settings.coding_agent_profiles, &settings.agents);
     validate_agent_commands(settings)?;
+    validate_screenshot_hotkey(&settings.screenshot_capture_hotkey)?;
     validate_resource_settings(settings)
+}
+
+/// #714 Reject a screenshot hotkey that the native parser cannot accept. Syntax
+/// errors block a settings save; OS-level registration conflicts do not (they are
+/// surfaced as runtime status by `screenshot::register_configured_hotkey`).
+pub fn validate_screenshot_hotkey(value: &str) -> Result<(), String> {
+    crate::screenshot::parse_screenshot_hotkey(value)
+        .map(|_| ())
+        .map_err(|e| format!("Screenshot hotkey: {}", e))
 }
 
 pub fn merge_protected_coding_agent_settings(
@@ -1924,6 +1942,45 @@ mod tests {
             serde_json::from_str(r##"{"id":"x","label":"X","command":"claude","color":"#000"}"##)
                 .unwrap();
         assert!(back.config_seed.is_none());
+    }
+
+    #[test]
+    fn screenshot_hotkey_defaults_when_absent() {
+        // #714 an old settings file without the key deserializes to "Ctrl+Q".
+        let mut value = serde_json::to_value(AppSettings::default()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("screenshotCaptureHotkey");
+        let parsed: AppSettings = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.screenshot_capture_hotkey, "Ctrl+Q");
+    }
+
+    #[test]
+    fn screenshot_hotkey_round_trips_camel_case() {
+        let s = AppSettings {
+            screenshot_capture_hotkey: "Control+P".to_string(),
+            ..AppSettings::default()
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(
+            json.contains("\"screenshotCaptureHotkey\":\"Control+P\""),
+            "{json}"
+        );
+        let back: AppSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.screenshot_capture_hotkey, "Control+P");
+    }
+
+    #[test]
+    fn validate_and_repair_rejects_invalid_screenshot_hotkey() {
+        let mut s = AppSettings {
+            screenshot_capture_hotkey: "Ctrl+Shift+Q".to_string(),
+            ..AppSettings::default()
+        };
+        assert!(super::validate_and_repair_settings(&mut s).is_err());
+
+        s.screenshot_capture_hotkey = "Ctrl+Q".to_string();
+        assert!(super::validate_and_repair_settings(&mut s).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod network;
 pub mod phone;
 pub mod pty;
 pub mod resource_monitor;
+pub mod screenshot;
 pub mod session;
 pub mod shutdown;
 pub mod telegram;
@@ -366,6 +367,11 @@ pub fn run(
     );
     let coordinator_clocks_for_exit = Arc::clone(&coordinator_clocks);
     let resource_monitor_state = Arc::new(resource_monitor::ResourceMonitorState::new());
+    // #714 screenshot capture lifecycle + global-hotkey registration state.
+    let screenshot_capture_state: screenshot::ScreenshotCaptureState =
+        Arc::new(tokio::sync::Mutex::new(screenshot::ScreenshotCaptureLifecycle::Idle));
+    let screenshot_hotkey_state: screenshot::ScreenshotHotkeyState =
+        Arc::new(std::sync::Mutex::new(screenshot::ScreenshotHotkeyRuntime::default()));
     let settings_for_web = Arc::clone(&settings);
     let detached_sessions: DetachedSessionsState = Arc::new(Mutex::new(HashSet::new()));
     let voice_tracking: VoiceTrackingState = Arc::new(Mutex::new(VoiceTracker::new()));
@@ -400,8 +406,25 @@ pub fn run(
     let ui_automation_state_for_setup = ui_automation_state.clone();
     let ui_automation_state_for_exit = ui_automation_state.clone();
 
-    tauri::Builder::default()
-        .plugin(tauri_plugin_dialog::init())
+    // #714 clipboard + global-shortcut plugins are referenced ONLY on Windows so
+    // non-Windows release builds never link them (screenshot capture is
+    // Windows-only for this issue). The rest of the builder chain is shared.
+    let builder = tauri::Builder::default().plugin(tauri_plugin_dialog::init());
+
+    #[cfg(target_os = "windows")]
+    let builder = builder
+        .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_handler(|app, _shortcut, event| {
+                    if event.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
+                        crate::screenshot::begin_capture_from_hotkey(app.clone());
+                    }
+                })
+                .build(),
+        );
+
+    builder
         .manage(master_token)
         .manage(app_outbox)
         .manage(session_mgr)
@@ -425,6 +448,8 @@ pub fn run(
         .manage(shutdown_signal)
         .manage(Arc::new(RestoreInProgress(AtomicBool::new(false))))
         .manage(Arc::new(PendingSelfClear::default()))
+        .manage(screenshot_capture_state) // #714
+        .manage(screenshot_hotkey_state) // #714
         .setup(move |app| {
             use tauri::WebviewWindowBuilder;
             use tauri::WebviewUrl;
@@ -478,6 +503,23 @@ pub fn run(
                 Some(broadcaster_for_pty),
             )));
             app.manage(pty_mgr.clone());
+
+            // #714 register the configured global screenshot hotkey. Windows-only
+            // effect; on other targets register_configured_hotkey records an
+            // unsupported status and returns Ok so startup does not warn.
+            {
+                let screenshot_hotkey = {
+                    let s = app.state::<SettingsState>();
+                    tauri::async_runtime::block_on(async {
+                        s.read().await.screenshot_capture_hotkey.clone()
+                    })
+                };
+                if let Err(e) =
+                    crate::screenshot::register_configured_hotkey(app.handle(), &screenshot_hotkey)
+                {
+                    log::warn!("[screenshot] global hotkey registration failed: {}", e);
+                }
+            }
 
             // Start web server if enabled in settings
             {
@@ -1923,6 +1965,11 @@ pub fn run(
             commands::role_templates::list_role_templates,
             commands::role_templates::get_agency_templates_status,
             commands::role_templates::update_agency_templates,
+            commands::screenshot::screenshot_get_overlay_state,
+            commands::screenshot::screenshot_confirm_selection,
+            commands::screenshot::screenshot_cancel_capture,
+            commands::screenshot::screenshot_get_hotkey_status,
+            commands::screenshot::screenshot_reload_hotkey,
         ])
         .build(tauri::generate_context!())
         .expect("error while building application")
@@ -1993,6 +2040,16 @@ pub fn run(
                                 );
                             }
                         }
+                    }
+                    // #714 screenshot overlay destroyed (user close, crash, or our
+                    // own teardown): clear capture state and destroy sibling
+                    // overlays. Idempotent — a no-op once state is already Idle.
+                    if label.starts_with("screenshot-overlay-") {
+                        let label = label.to_string();
+                        let app = app_handle.clone();
+                        tauri::async_runtime::spawn(async move {
+                            crate::screenshot::handle_overlay_window_destroyed(app, label).await;
+                        });
                     }
                 }
                 tauri::RunEvent::Exit => {

--- a/src-tauri/src/screenshot/mod.rs
+++ b/src-tauri/src/screenshot/mod.rs
@@ -1,0 +1,215 @@
+//! #714 Active-agent screenshot capture.
+//!
+//! Native, Greenshot-style screenshot flow: a global hotkey freezes the desktop,
+//! the user drags a rectangle on a per-monitor overlay, and the crop is saved as
+//! a PNG into the owning WG replica root of the session currently selected in
+//! AgentsCommander, with the absolute path copied to the clipboard.
+//!
+//! Module layout (see plan `_plans/714-active-agent-screenshot-capture.md`):
+//! - This file owns the serializable IPC types shared with the frontend, the
+//!   target-independent hotkey parser, and the managed-state type aliases.
+//! - `windows` owns the native runtime: `xcap` capture, `image` crop/encode,
+//!   clipboard, global shortcut, overlay windows, and the capture lifecycle.
+//! - `unsupported` is the non-Windows stub: same public surface, no native
+//!   screenshot crates, every capture path reports an unsupported status.
+//!
+//! `pub use <cfg-module>::*` lets callers use `crate::screenshot::*` without
+//! per-call `cfg` blocks; the two cfg modules each provide
+//! `ScreenshotCaptureLifecycle`, `ScreenshotHotkeyRuntime`, and the runtime
+//! functions referenced by the type aliases and command layer below.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+pub use windows::*;
+
+#[cfg(not(target_os = "windows"))]
+mod unsupported;
+#[cfg(not(target_os = "windows"))]
+pub use unsupported::*;
+
+/// Short-lived capture lifecycle, guarded by an async mutex. `Starting` is
+/// reserved under the lock before the (synchronous, off-thread) desktop capture
+/// so two rapid hotkey presses cannot both enter monitor capture.
+pub type ScreenshotCaptureState = Arc<tokio::sync::Mutex<ScreenshotCaptureLifecycle>>;
+
+/// Global-hotkey registration runtime (configured string, registration result,
+/// and on Windows the currently-registered `Shortcut`). A plain `std::sync::Mutex`
+/// because no work is held across an await point while it is locked.
+pub type ScreenshotHotkeyState = Arc<std::sync::Mutex<ScreenshotHotkeyRuntime>>;
+
+/// Frozen monitor image plus metadata handed to one overlay window so it can
+/// render the selection UI and map pointer coordinates to physical image pixels.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScreenshotOverlayState {
+    pub capture_id: String,
+    pub monitor_id: u32,
+    pub monitor_x: i32,
+    pub monitor_y: i32,
+    pub width: u32,
+    pub height: u32,
+    pub scale_factor: f64,
+    pub image_data_url: String,
+    pub session_id: String,
+    pub session_name: String,
+    pub target_directory: String,
+}
+
+/// Physical, monitor-local crop rectangle sent from the overlay on mouse release.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScreenshotSelection {
+    pub capture_id: String,
+    pub monitor_id: u32,
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Success payload for `screenshot_capture_saved` and the confirm command.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScreenshotCaptureResult {
+    pub path: String,
+    pub session_id: String,
+    pub session_name: String,
+}
+
+/// Failure payload for the `screenshot_capture_failed` event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScreenshotCaptureEvent {
+    pub message: String,
+}
+
+/// Hotkey registration status exposed to the frontend. Never carries the
+/// internal `Shortcut`; commands clone this out of `ScreenshotHotkeyRuntime`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScreenshotHotkeyStatus {
+    pub configured: String,
+    pub registered: bool,
+    pub error: Option<String>,
+}
+
+impl Default for ScreenshotHotkeyStatus {
+    fn default() -> Self {
+        Self {
+            // Mirrors `settings::default_screenshot_capture_hotkey`; overwritten by
+            // the first `register_configured_hotkey` call at startup.
+            configured: "Ctrl+Q".to_string(),
+            registered: false,
+            error: None,
+        }
+    }
+}
+
+/// The single modifier accepted in this issue. Kept as an enum so additional
+/// modifiers can be added later without changing the parser's return shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HotkeyModifier {
+    Ctrl,
+}
+
+/// A validated "one modifier + one key" hotkey. Target-independent so settings
+/// validation works on every platform; Windows converts this into a plugin
+/// `Shortcut` at registration time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedHotkey {
+    pub modifier: HotkeyModifier,
+    /// Normalized uppercase key, e.g. `'Q'` or `'1'`.
+    pub key: char,
+}
+
+/// Parse `"Ctrl+Q"`, `"control+q"`, `"CTRL+Q"`, etc. into a [`ParsedHotkey`].
+///
+/// This is intentionally OS-free: it never touches the global-shortcut plugin so
+/// `settings::validate_screenshot_hotkey` can run headless and on non-Windows
+/// builds. For this issue exactly one modifier (Ctrl/Control) plus one
+/// alphanumeric key is accepted; anything else is rejected.
+pub fn parse_screenshot_hotkey(value: &str) -> Result<ParsedHotkey, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("hotkey must not be empty".to_string());
+    }
+    let parts: Vec<&str> = trimmed.split('+').map(|p| p.trim()).collect();
+    if parts.len() != 2 {
+        return Err(format!(
+            "hotkey '{value}' must be one modifier plus one key, e.g. Ctrl+Q"
+        ));
+    }
+    let modifier = match parts[0].to_ascii_lowercase().as_str() {
+        "ctrl" | "control" => HotkeyModifier::Ctrl,
+        other => {
+            return Err(format!(
+                "unsupported modifier '{other}'; only Ctrl is supported"
+            ))
+        }
+    };
+    let key_str = parts[1];
+    let mut chars = key_str.chars();
+    let key = match (chars.next(), chars.next()) {
+        (Some(c), None) if c.is_ascii_alphanumeric() => c.to_ascii_uppercase(),
+        _ => {
+            return Err(format!(
+                "hotkey key '{key_str}' must be a single letter or digit"
+            ))
+        }
+    };
+    Ok(ParsedHotkey { modifier, key })
+}
+
+#[cfg(test)]
+mod parser_tests {
+    use super::*;
+
+    #[test]
+    fn accepts_ctrl_q_case_insensitive() {
+        for value in ["Ctrl+Q", "ctrl+q", "Control+Q", "CTRL+Q", "  Ctrl + q "] {
+            let parsed = parse_screenshot_hotkey(value)
+                .unwrap_or_else(|e| panic!("expected '{value}' to parse: {e}"));
+            assert_eq!(parsed.modifier, HotkeyModifier::Ctrl);
+            assert_eq!(parsed.key, 'Q', "value {value}");
+        }
+    }
+
+    #[test]
+    fn accepts_alphanumeric_keys() {
+        assert_eq!(parse_screenshot_hotkey("Ctrl+1").unwrap().key, '1');
+        assert_eq!(parse_screenshot_hotkey("Control+a").unwrap().key, 'A');
+    }
+
+    #[test]
+    fn rejects_empty_and_whitespace() {
+        assert!(parse_screenshot_hotkey("").is_err());
+        assert!(parse_screenshot_hotkey("   ").is_err());
+    }
+
+    #[test]
+    fn rejects_missing_modifier_or_key() {
+        assert!(parse_screenshot_hotkey("Q").is_err());
+        assert!(parse_screenshot_hotkey("Ctrl+").is_err());
+        assert!(parse_screenshot_hotkey("+Q").is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_modifier() {
+        assert!(parse_screenshot_hotkey("Hyper+Q").is_err());
+        assert!(parse_screenshot_hotkey("Alt+Q").is_err());
+        assert!(parse_screenshot_hotkey("Shift+Q").is_err());
+    }
+
+    #[test]
+    fn rejects_multi_modifier_and_multi_key() {
+        // MVP accepts exactly one modifier plus one key.
+        assert!(parse_screenshot_hotkey("Ctrl+Shift+Q").is_err());
+        assert!(parse_screenshot_hotkey("Ctrl+QQ").is_err());
+        assert!(parse_screenshot_hotkey("Ctrl+F1").is_err());
+    }
+}

--- a/src-tauri/src/screenshot/unsupported.rs
+++ b/src-tauri/src/screenshot/unsupported.rs
@@ -88,9 +88,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn lifecycle_default_is_idle_only() {
-        // Compile-time proof the variant exists; matches the alias usage.
-        let _ = ScreenshotCaptureLifecycle::Idle;
+    fn default_hotkey_runtime_is_unregistered() {
+        // The non-Windows stub never registers a global shortcut: its hotkey
+        // runtime starts unregistered with no error, and only records the
+        // unsupported status once `register_configured_hotkey` runs at settings
+        // time. (`ScreenshotCaptureLifecycle::Idle` still compiles via lib.rs.)
+        let runtime = ScreenshotHotkeyRuntime::default();
+        assert!(!runtime.status.registered);
+        assert!(runtime.status.error.is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/screenshot/unsupported.rs
+++ b/src-tauri/src/screenshot/unsupported.rs
@@ -1,0 +1,106 @@
+//! #714 Non-Windows screenshot stub.
+//!
+//! Compiles with NO native screenshot crates (`xcap`, `image`, clipboard, global
+//! shortcut). It mirrors the public surface of `super::windows` so the command
+//! layer and `lib.rs` wiring are identical across targets: every capture path
+//! reports an unsupported status, and hotkey "registration" only validates syntax.
+
+use tauri::{AppHandle, Manager, State};
+
+use super::{
+    ScreenshotCaptureResult, ScreenshotCaptureState, ScreenshotHotkeyState, ScreenshotOverlayState,
+    ScreenshotSelection,
+};
+
+const UNSUPPORTED: &str = "Screenshot capture is only supported on Windows in this release";
+
+/// The non-Windows lifecycle can never leave `Idle`, but the variant must exist
+/// so the `ScreenshotCaptureState` alias and `lib.rs` (`...::Idle`) compile.
+pub enum ScreenshotCaptureLifecycle {
+    Idle,
+}
+
+/// Mirror of the Windows runtime without the native `Shortcut` handle.
+#[derive(Default)]
+pub struct ScreenshotHotkeyRuntime {
+    pub status: super::ScreenshotHotkeyStatus,
+}
+
+/// Validate hotkey syntax (so bad config is still rejected at settings time) and
+/// record an unsupported status. Returns `Ok(())` so startup does not warn.
+pub fn register_configured_hotkey(app: &AppHandle, configured: &str) -> Result<(), String> {
+    // Surface a genuine syntax error; otherwise record the unsupported status.
+    super::parse_screenshot_hotkey(configured)?;
+    let state = app.state::<ScreenshotHotkeyState>();
+    let mut runtime = state.lock().unwrap();
+    runtime.status.configured = configured.to_string();
+    runtime.status.registered = false;
+    runtime.status.error = Some(UNSUPPORTED.to_string());
+    Ok(())
+}
+
+/// No-op: the global-shortcut plugin is never registered off Windows.
+pub fn begin_capture_from_hotkey(_app: AppHandle) {}
+
+pub async fn begin_capture(_app: AppHandle) -> Result<(), String> {
+    Err(UNSUPPORTED.to_string())
+}
+
+pub async fn overlay_state(
+    _app: &AppHandle,
+    _state: &ScreenshotCaptureState,
+    _capture_id: &str,
+    _monitor_id: u32,
+) -> Result<ScreenshotOverlayState, String> {
+    Err(UNSUPPORTED.to_string())
+}
+
+pub async fn confirm_selection(
+    _app: &AppHandle,
+    _state: &ScreenshotCaptureState,
+    _selection: ScreenshotSelection,
+) -> Result<ScreenshotCaptureResult, String> {
+    Err(UNSUPPORTED.to_string())
+}
+
+pub async fn cancel_capture(
+    _app: &AppHandle,
+    _state: &ScreenshotCaptureState,
+    _capture_id: &str,
+) -> Result<(), String> {
+    // Nothing can be active, so cancelling is a successful no-op.
+    Ok(())
+}
+
+pub async fn clear_capture_and_destroy_overlays(
+    _app: &AppHandle,
+    _state: &ScreenshotCaptureState,
+    _capture_id: Option<uuid::Uuid>,
+    _reason: &str,
+) -> Result<(), String> {
+    Ok(())
+}
+
+pub async fn handle_overlay_window_destroyed(_app: AppHandle, _label: String) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_default_is_idle_only() {
+        // Compile-time proof the variant exists; matches the alias usage.
+        let _ = ScreenshotCaptureLifecycle::Idle;
+    }
+
+    #[tokio::test]
+    async fn begin_capture_reports_unsupported() {
+        // The free function returns the unsupported message without any app.
+        // (overlay/confirm mirror this; covered indirectly.)
+        assert_eq!(begin_capture_message(), UNSUPPORTED);
+    }
+
+    fn begin_capture_message() -> &'static str {
+        UNSUPPORTED
+    }
+}

--- a/src-tauri/src/screenshot/windows.rs
+++ b/src-tauri/src/screenshot/windows.rs
@@ -42,11 +42,17 @@ const FAILED_EVENT: &str = "screenshot_capture_failed";
 
 /// Capture lifecycle. `Starting` is the gate that blocks concurrent hotkey
 /// starts; it is reserved under the mutex before desktop capture and atomically
-/// replaced by `Active` only if the same capture id is still pending.
+/// replaced by `Active` only if the same capture id is still pending. `Finishing`
+/// is the teardown gate: `confirm_selection` holds it (instead of dropping
+/// straight to `Idle`) while it saves the PNG and destroys overlays, so a second
+/// hotkey press cannot start a capture that photographs the still-visible
+/// overlays. The `Uuid` is the finishing capture's id, so the final reset to
+/// `Idle` never clobbers a state another path already changed.
 pub enum ScreenshotCaptureLifecycle {
     Idle,
     Starting(ScreenshotCaptureStarting),
     Active(ActiveScreenshotCapture),
+    Finishing(Uuid),
 }
 
 pub struct ScreenshotCaptureStarting {
@@ -132,14 +138,12 @@ pub fn register_configured_hotkey(app: &AppHandle, configured: &str) -> Result<(
     let gs = app.global_shortcut();
     let state = app.state::<ScreenshotHotkeyState>();
     let mut runtime = state.lock().unwrap();
-    runtime.status.configured = configured.to_string();
 
     // No-op save of the same key: it is already ours, so just record success and
     // avoid a spurious "already registered" error from re-registering.
     if gs.is_registered(shortcut) {
         runtime.registered_shortcut = Some(shortcut);
-        runtime.status.registered = true;
-        runtime.status.error = None;
+        runtime.status = hotkey_status_after_attempt(configured, Ok(()));
         return Ok(());
     }
 
@@ -151,29 +155,67 @@ pub fn register_configured_hotkey(app: &AppHandle, configured: &str) -> Result<(
                 }
             }
             runtime.registered_shortcut = Some(shortcut);
-            runtime.status.registered = true;
-            runtime.status.error = None;
+            runtime.status = hotkey_status_after_attempt(configured, Ok(()));
             Ok(())
         }
         Err(e) => {
-            // Keep the previously-registered key working; report the conflict.
+            // The configured shortcut did NOT register. Keep any previously
+            // registered fallback alive (do not take `registered_shortcut`) so it
+            // keeps working and a later save can unregister it, but report the
+            // configured shortcut as NOT registered so the UI surfaces the
+            // conflict (Grinch #714 LOW): `status.registered` describes the
+            // configured shortcut, not the internal fallback.
             let msg = e.to_string();
-            runtime.status.registered = runtime.registered_shortcut.is_some();
-            runtime.status.error = Some(msg.clone());
+            runtime.status = hotkey_status_after_attempt(configured, Err(msg.as_str()));
             Err(msg)
         }
     }
 }
 
+/// Compute the frontend-facing hotkey status after a registration attempt. Pure,
+/// so the "`registered` describes the CONFIGURED shortcut" invariant is
+/// unit-testable: on failure `registered` is false and `error` is set even when an
+/// internal fallback shortcut is still alive, which is what lets the sidebar's
+/// `!registered && error` check warn that the configured combo does nothing.
+fn hotkey_status_after_attempt(configured: &str, outcome: Result<(), &str>) -> ScreenshotHotkeyStatus {
+    match outcome {
+        Ok(()) => ScreenshotHotkeyStatus {
+            configured: configured.to_string(),
+            registered: true,
+            error: None,
+        },
+        Err(msg) => ScreenshotHotkeyStatus {
+            configured: configured.to_string(),
+            registered: false,
+            error: Some(msg.to_string()),
+        },
+    }
+}
+
 // ── Hotkey entry point ─────────────────────────────────────────────────────
 
-/// Global-shortcut handler entry. Spawns the async capture and, on any failure
-/// that happens before overlays exist, surfaces the error visibly because the
-/// hotkey normally fires while another app is focused.
+/// Outcome of a `begin_capture` attempt. `Busy` is the typed no-op path for a
+/// debounced repeat press (a capture is already starting/active/finishing): the
+/// hotkey handler must NOT surface it, because bringing the app forward mid-flight
+/// would pollute the frozen screenshot and show a bogus failure. Only a genuine
+/// `Err` is surfaced.
+pub enum BeginOutcome {
+    Started,
+    Busy,
+}
+
+/// Global-shortcut handler entry. Spawns the async capture and, on any genuine
+/// failure that happens before overlays exist, surfaces the error visibly because
+/// the hotkey normally fires while another app is focused. A `Busy` outcome (a
+/// rapid repeat press while a capture is in flight) is a silent no-op.
 pub fn begin_capture_from_hotkey(app: AppHandle) {
     tauri::async_runtime::spawn(async move {
-        if let Err(e) = begin_capture(app.clone()).await {
-            surface_hotkey_failure(&app, &e);
+        match begin_capture(app.clone()).await {
+            Ok(BeginOutcome::Started) => {}
+            Ok(BeginOutcome::Busy) => {
+                log::debug!("[screenshot] hotkey ignored: a capture is already in progress");
+            }
+            Err(e) => surface_hotkey_failure(&app, &e),
         }
     });
 }
@@ -203,7 +245,9 @@ fn surface_hotkey_failure(app: &AppHandle, message: &str) {
 
 /// Resolve active session, capture all monitors, store `Active`, open overlays.
 /// Every early-return path leaves the lifecycle `Idle` (no leaked `Starting`).
-pub async fn begin_capture(app: AppHandle) -> Result<(), String> {
+/// Returns `BeginOutcome::Busy` (a no-op, not an error) when a capture is already
+/// in flight, so a debounced repeat hotkey press is silently ignored.
+pub async fn begin_capture(app: AppHandle) -> Result<BeginOutcome, String> {
     // 1. Resolve the active session and its owning replica root.
     let session_mgr = app.state::<std::sync::Arc<tokio::sync::RwLock<SessionManager>>>();
     let active_id = {
@@ -228,7 +272,10 @@ pub async fn begin_capture(app: AppHandle) -> Result<(), String> {
         let state = app.state::<ScreenshotCaptureState>();
         let mut guard = state.lock().await;
         if !matches!(&*guard, ScreenshotCaptureLifecycle::Idle) {
-            return Err("Screenshot capture is already active".to_string());
+            // A capture is already starting/active/finishing: a debounced repeat
+            // press. No-op (do NOT surface a failure or raise the window, which
+            // would pollute the in-flight frozen capture).
+            return Ok(BeginOutcome::Busy);
         }
         *guard = ScreenshotCaptureLifecycle::Starting(ScreenshotCaptureStarting {
             id: capture_id,
@@ -262,8 +309,10 @@ pub async fn begin_capture(app: AppHandle) -> Result<(), String> {
         let still_ours =
             matches!(&*guard, ScreenshotCaptureLifecycle::Starting(s) if s.id == capture_id);
         if !still_ours {
-            // Superseded/cancelled while capturing: do not open overlays.
-            return Err("Screenshot capture was superseded".to_string());
+            // Superseded/cancelled while capturing: do not open overlays. This is
+            // a no-op, not a visible failure.
+            log::debug!("[screenshot] capture {capture_id} superseded before overlays opened");
+            return Ok(BeginOutcome::Busy);
         }
         *guard = ScreenshotCaptureLifecycle::Active(ActiveScreenshotCapture {
             id: capture_id,
@@ -288,7 +337,7 @@ pub async fn begin_capture(app: AppHandle) -> Result<(), String> {
         .await;
         return Err(e);
     }
-    Ok(())
+    Ok(BeginOutcome::Started)
 }
 
 async fn reset_starting_if_matches(app: &AppHandle, id: Uuid) {
@@ -551,25 +600,32 @@ pub async fn confirm_selection(
     state: &ScreenshotCaptureState,
     selection: ScreenshotSelection,
 ) -> Result<ScreenshotCaptureResult, String> {
-    // Take the active capture iff it matches; drop the guard before file I/O.
+    // Take the active capture iff it matches, and move to `Finishing` (NOT `Idle`)
+    // so a new hotkey capture cannot start and photograph the still-visible
+    // overlays while we save and tear down. The guard is dropped before file I/O.
     let capture = {
         let mut guard = state.lock().await;
-        let matches = matches!(
+        let is_match = matches!(
             &*guard,
             ScreenshotCaptureLifecycle::Active(c) if c.id.to_string() == selection.capture_id
         );
-        if !matches {
+        if !is_match {
             return Err("Screenshot capture is no longer active".to_string());
         }
-        match std::mem::replace(&mut *guard, ScreenshotCaptureLifecycle::Idle) {
-            ScreenshotCaptureLifecycle::Active(c) => c,
-            _ => unreachable!("matched Active above"),
-        }
+        let ScreenshotCaptureLifecycle::Active(c) =
+            std::mem::replace(&mut *guard, ScreenshotCaptureLifecycle::Idle)
+        else {
+            unreachable!("matched Active above")
+        };
+        // Install the finishing gate keyed by this capture's id; the transient
+        // `Idle` above is never observed because the lock is still held.
+        *guard = ScreenshotCaptureLifecycle::Finishing(c.id);
+        c
     };
 
     let capture_id = capture.id;
     let result = save_selection(capture, &selection).await;
-    match result {
+    let outcome = match result {
         Ok(saved) => {
             // Best-effort clipboard copy; the PNG already exists, so a clipboard
             // failure must not fail the capture (plan §E).
@@ -593,6 +649,21 @@ pub async fn confirm_selection(
             );
             Err(msg)
         }
+    };
+
+    // Overlays are destroyed; release the finishing gate so the next hotkey press
+    // can start a fresh capture. Runs on both success and failure.
+    finish_capture_to_idle(state, capture_id).await;
+    outcome
+}
+
+/// Release the `Finishing` gate installed by `confirm_selection` once its overlays
+/// are destroyed, returning the lifecycle to `Idle`. Guarded by id so it never
+/// clobbers a state some other path already changed.
+async fn finish_capture_to_idle(state: &ScreenshotCaptureState, capture_id: Uuid) {
+    let mut guard = state.lock().await;
+    if matches!(&*guard, ScreenshotCaptureLifecycle::Finishing(id) if *id == capture_id) {
+        *guard = ScreenshotCaptureLifecycle::Idle;
     }
 }
 
@@ -775,6 +846,9 @@ pub async fn handle_overlay_window_destroyed(app: AppHandle, label: String) {
         match &*guard {
             ScreenshotCaptureLifecycle::Active(c) => Some(c.id),
             ScreenshotCaptureLifecycle::Starting(s) => Some(s.id),
+            // Finishing: `confirm_selection` owns teardown and will reset to
+            // `Idle`, so the Destroyed events it triggers must not re-enter cleanup.
+            ScreenshotCaptureLifecycle::Finishing(_) => None,
             ScreenshotCaptureLifecycle::Idle => None,
         }
     };
@@ -849,8 +923,15 @@ fn find_replica_root(start: &Path) -> Option<PathBuf> {
 /// owning WG replica root of the active session's CWD. Rejects non-replica CWDs,
 /// symlinks/reparse points, and roots that fail WG replica identity validation.
 fn resolve_session_replica_root(working_directory: &str) -> Result<PathBuf, String> {
-    let cwd = PathBuf::from(working_directory);
-    let root = find_replica_root(&cwd).ok_or_else(|| {
+    // Canonicalize the session CWD BEFORE walking ancestors so `..` and symlink
+    // components cannot spoof a `__agent_*` ancestor. Example spoof:
+    // `...\wg-6\__agent_x\..\repo-AgentsCommander` resolves to the repo sibling
+    // (which must be rejected), yet a raw name-walk would see the `__agent_x`
+    // ancestor and save there. Canonicalize requires the path to exist, which is
+    // always true for a live session's CWD; a missing/unresolvable CWD is rejected.
+    let canonical_cwd = std::fs::canonicalize(working_directory)
+        .map_err(|e| format!("Cannot resolve the active session directory: {e}"))?;
+    let root = find_replica_root(&canonical_cwd).ok_or_else(|| {
         "The active session is not inside a workgroup replica directory, so there is no place to save the screenshot".to_string()
     })?;
 
@@ -872,8 +953,13 @@ fn resolve_session_replica_root(working_directory: &str) -> Result<PathBuf, Stri
     Ok(canonical)
 }
 
-/// Re-run the symlink/reparse + directory checks on the target immediately before
-/// creating the PNG (the directory could have changed since capture start).
+/// Re-run the FULL start-time validation on the target immediately before creating
+/// the PNG, because the directory could have changed since capture start. This is
+/// the symlink/reparse + directory guard, plus a re-canonicalization and a re-run
+/// of the WG replica structure + persisted-identity checks. It closes the window
+/// where the replica root is deleted and recreated as a plain, non-replica
+/// directory between capture and confirm (which the final parent-containment check
+/// alone would still accept). `target` is the canonical root resolved at start.
 fn revalidate_replica_target(target: &Path) -> Result<(), String> {
     let meta = std::fs::symlink_metadata(target)
         .map_err(|e| format!("Cannot read the replica directory: {e}"))?;
@@ -883,6 +969,18 @@ fn revalidate_replica_target(target: &Path) -> Result<(), String> {
     if !meta.is_dir() {
         return Err("The replica path is not a directory".to_string());
     }
+
+    // `target` was already canonical at start; if re-canonicalizing yields a
+    // different path the directory was replaced under us, so reject.
+    let canonical = std::fs::canonicalize(target)
+        .map_err(|e| format!("Cannot canonicalize the replica directory: {e}"))?;
+    if canonical.as_path() != target {
+        return Err("The replica directory changed between capture and save".to_string());
+    }
+
+    // Same structure + persisted-identity validation used at capture start.
+    crate::config::replica_identity::expected_wg_replica_identity(&canonical)?;
+    crate::config::replica_identity::read_wg_replica_config_read_only(&canonical)?;
     Ok(())
 }
 
@@ -954,6 +1052,133 @@ mod tests {
         let _ = std::fs::remove_file(&replica);
         let _ = std::fs::remove_dir_all(&dir);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_rejects_dotdot_spoof_to_repo_sibling() {
+        // A CWD that walks INTO the replica then back out via `..` into a `repo-*`
+        // workgroup sibling must resolve (canonically) to the repo and be rejected,
+        // not spoof the `__agent_*` ancestor via a raw path-name walk (Grinch #714
+        // MEDIUM). Requires real dirs so `canonicalize` can resolve `..`.
+        let base = std::env::temp_dir().join(format!("ac-shot-spoof-{}", Uuid::new_v4().simple()));
+        let wg = base.join("wg-6-dev-team");
+        let replica = wg.join("__agent_x");
+        let repo = wg.join("repo-foo");
+        std::fs::create_dir_all(&replica).unwrap();
+        std::fs::create_dir_all(&repo).unwrap();
+
+        let spoof = replica.join("..").join("repo-foo");
+        let result = resolve_session_replica_root(&spoof.to_string_lossy());
+
+        let _ = std::fs::remove_dir_all(&base);
+        assert!(
+            result.is_err(),
+            "`..` spoof into a repo sibling must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_missing_child_of_replica() {
+        // The replica exists, but the session CWD points to a now-missing child.
+        // With no existing path to canonicalize, resolution must fail rather than
+        // fall back to the raw replica ancestor (Grinch #714 MEDIUM).
+        let base = std::env::temp_dir().join(format!("ac-shot-missing-{}", Uuid::new_v4().simple()));
+        let replica = base.join("wg-6-dev-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+
+        let missing_child = replica.join("gone");
+        let result = resolve_session_replica_root(&missing_child.to_string_lossy());
+
+        let _ = std::fs::remove_dir_all(&base);
+        assert!(result.is_err(), "missing child CWD must be rejected");
+    }
+
+    #[test]
+    fn revalidate_rejects_plain_recreated_dir() {
+        // A directory shaped like a replica root but WITHOUT the WG replica config
+        // / matrix (models delete + recreate-as-plain between capture and confirm)
+        // must be rejected at confirm time by the re-run identity checks, even
+        // though it passes the symlink/is_dir guard (Grinch #714 MEDIUM).
+        let base = std::env::temp_dir().join(format!("ac-shot-reval-{}", Uuid::new_v4().simple()));
+        let replica = base.join("wg-6-dev-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        let canonical = std::fs::canonicalize(&replica).unwrap();
+
+        let result = revalidate_replica_target(&canonical);
+
+        let _ = std::fs::remove_dir_all(&base);
+        assert!(
+            result.is_err(),
+            "plain (non-config) replica-shaped dir must be rejected at confirm"
+        );
+    }
+
+    #[tokio::test]
+    async fn finishing_gate_blocks_then_releases() {
+        // The `Finishing` lifecycle is non-Idle, so begin_capture's Idle gate
+        // rejects a new capture (returns Busy) until confirm_selection destroys the
+        // overlays and releases the gate (Grinch #714 HIGH finishing race).
+        let id = Uuid::new_v4();
+        let state: ScreenshotCaptureState = std::sync::Arc::new(tokio::sync::Mutex::new(
+            ScreenshotCaptureLifecycle::Finishing(id),
+        ));
+
+        // Non-Idle while finishing => a new hotkey press would be Busy.
+        assert!(!matches!(
+            &*state.lock().await,
+            ScreenshotCaptureLifecycle::Idle
+        ));
+
+        // A mismatched id must NOT release the gate.
+        finish_capture_to_idle(&state, Uuid::new_v4()).await;
+        assert!(matches!(
+            &*state.lock().await,
+            ScreenshotCaptureLifecycle::Finishing(_)
+        ));
+
+        // The matching id releases the gate to Idle.
+        finish_capture_to_idle(&state, id).await;
+        assert!(matches!(
+            &*state.lock().await,
+            ScreenshotCaptureLifecycle::Idle
+        ));
+    }
+
+    #[tokio::test]
+    async fn finish_capture_to_idle_ignores_non_finishing() {
+        // Defensive: releasing the gate never clobbers a Starting/Active state.
+        let state: ScreenshotCaptureState = std::sync::Arc::new(tokio::sync::Mutex::new(
+            ScreenshotCaptureLifecycle::Starting(ScreenshotCaptureStarting {
+                id: Uuid::new_v4(),
+                target_session_id: Uuid::new_v4(),
+                target_session_name: "s".to_string(),
+                target_directory: PathBuf::from("x"),
+                created_at: Utc::now(),
+            }),
+        ));
+        finish_capture_to_idle(&state, Uuid::new_v4()).await;
+        assert!(matches!(
+            &*state.lock().await,
+            ScreenshotCaptureLifecycle::Starting(_)
+        ));
+    }
+
+    #[test]
+    fn hotkey_status_reflects_configured_shortcut_only() {
+        // Success: the configured shortcut is active.
+        let ok = hotkey_status_after_attempt("Ctrl+Q", Ok(()));
+        assert_eq!(ok.configured, "Ctrl+Q");
+        assert!(ok.registered);
+        assert!(ok.error.is_none());
+
+        // Failure (e.g. OS conflict): the configured shortcut is NOT active even if
+        // an internal fallback stays registered. `registered` must be false and the
+        // error present so the sidebar's `!registered && error` check warns that the
+        // configured combo does nothing (Grinch #714 LOW).
+        let err = hotkey_status_after_attempt("Ctrl+P", Err("hotkey already registered"));
+        assert_eq!(err.configured, "Ctrl+P");
+        assert!(!err.registered);
+        assert_eq!(err.error.as_deref(), Some("hotkey already registered"));
     }
 
     #[test]

--- a/src-tauri/src/screenshot/windows.rs
+++ b/src-tauri/src/screenshot/windows.rs
@@ -601,7 +601,13 @@ pub async fn overlay_state(
                         image_data_url: m.preview_data_url.clone(),
                         session_id: c.target_session_id.to_string(),
                         session_name: c.target_session_name.clone(),
-                        target_directory: c.target_directory.to_string_lossy().to_string(),
+                        // Strip the Windows `\\?\` verbatim prefix that `canonicalize`
+                        // leaves on the resolved root, so the overlay shows a clean save
+                        // location (shared #730 helper; internal PathBuf checks keep the
+                        // raw canonical value).
+                        target_directory: crate::path_utils::path_to_string_without_windows_verbatim_prefix(
+                            &c.target_directory,
+                        ),
                     })),
                     None => OverlayDecision::Stale,
                 }
@@ -755,7 +761,11 @@ async fn save_selection(
     .await
     .map_err(|e| (None, format!("save task panicked: {e}")))??;
 
-    let path_string = saved_path.to_string_lossy().to_string();
+    // `saved_path` is canonical (verbatim `\\?\` on Windows). Every containment
+    // check above ran on the raw canonical PathBuf; only the user-facing string
+    // (clipboard, saved event, result payload, log) is normalized via the shared
+    // #730 helper so it matches the clean paths the rest of the app now emits.
+    let path_string = crate::path_utils::path_to_string_without_windows_verbatim_prefix(&saved_path);
     log::info!(
         "[screenshot] saved {} for session '{}'",
         path_string,

--- a/src-tauri/src/screenshot/windows.rs
+++ b/src-tauri/src/screenshot/windows.rs
@@ -248,6 +248,21 @@ fn surface_hotkey_failure(app: &AppHandle, message: &str) {
 /// Returns `BeginOutcome::Busy` (a no-op, not an error) when a capture is already
 /// in flight, so a debounced repeat hotkey press is silently ignored.
 pub async fn begin_capture(app: AppHandle) -> Result<BeginOutcome, String> {
+    // 0. Busy pre-gate. If a capture is already in flight, bail out as a typed
+    //    Busy no-op BEFORE any fallible active-session/CWD resolution below. A
+    //    debounced repeat press during an in-flight capture whose active session
+    //    has since been cleared/deleted or switched to an unresolvable CWD would
+    //    otherwise surface an Err from that resolution and raise AC forward
+    //    mid-capture (polluting the frozen screenshot and showing a bogus
+    //    failure). The locked reserve in step 2 stays the race-closing
+    //    compare-and-set for the Idle path.
+    {
+        let state = app.state::<ScreenshotCaptureState>();
+        if let Some(outcome) = busy_pregate(state.inner()).await {
+            return Ok(outcome);
+        }
+    }
+
     // 1. Resolve the active session and its owning replica root.
     let session_mgr = app.state::<std::sync::Arc<tokio::sync::RwLock<SessionManager>>>();
     let active_id = {
@@ -338,6 +353,27 @@ pub async fn begin_capture(app: AppHandle) -> Result<BeginOutcome, String> {
         return Err(e);
     }
     Ok(BeginOutcome::Started)
+}
+
+/// Busy pre-gate for [`begin_capture`]: lock the lifecycle and return
+/// `Some(BeginOutcome::Busy)` when a capture is already in flight (any non-Idle
+/// state: `Starting`/`Active`/`Finishing`). Returns `None` only for `Idle`, so
+/// the caller may proceed to active-session/CWD resolution.
+///
+/// This MUST run before any fallible active-session/CWD resolution in
+/// `begin_capture`; otherwise a second hotkey press during an in-flight capture
+/// whose active session has since been cleared/deleted or switched to an
+/// unresolvable CWD would return a visible `Err` from that resolution and raise
+/// AgentsCommander forward mid-capture instead of being a silent `Busy` no-op.
+/// Taking only `&ScreenshotCaptureState` (no `AppHandle`/`SessionManager`) keeps
+/// the before-resolution ordering structurally unit-testable.
+async fn busy_pregate(state: &ScreenshotCaptureState) -> Option<BeginOutcome> {
+    let guard = state.lock().await;
+    if matches!(&*guard, ScreenshotCaptureLifecycle::Idle) {
+        None
+    } else {
+        Some(BeginOutcome::Busy)
+    }
 }
 
 async fn reset_starting_if_matches(app: &AppHandle, id: Uuid) {
@@ -1160,6 +1196,55 @@ mod tests {
         assert!(matches!(
             &*state.lock().await,
             ScreenshotCaptureLifecycle::Starting(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn busy_pregate_returns_busy_for_non_idle_before_resolution() {
+        // Idle: no short-circuit, so begin_capture proceeds to active-session/CWD
+        // resolution.
+        let idle: ScreenshotCaptureState =
+            std::sync::Arc::new(tokio::sync::Mutex::new(ScreenshotCaptureLifecycle::Idle));
+        assert!(busy_pregate(&idle).await.is_none());
+
+        // Every non-Idle state returns Busy. Because busy_pregate takes ONLY the
+        // lifecycle state (no AppHandle/SessionManager) it structurally cannot run
+        // the active-session/CWD resolution begin_capture does afterwards, proving
+        // the Busy no-op happens before any fallible resolution could surface an
+        // Err and raise AC mid-capture (Grinch #714 HIGH pre-gate ordering).
+        let starting: ScreenshotCaptureState = std::sync::Arc::new(tokio::sync::Mutex::new(
+            ScreenshotCaptureLifecycle::Starting(ScreenshotCaptureStarting {
+                id: Uuid::new_v4(),
+                target_session_id: Uuid::new_v4(),
+                target_session_name: "s".to_string(),
+                target_directory: PathBuf::from("x"),
+                created_at: Utc::now(),
+            }),
+        ));
+        assert!(matches!(
+            busy_pregate(&starting).await,
+            Some(BeginOutcome::Busy)
+        ));
+
+        let active: ScreenshotCaptureState = std::sync::Arc::new(tokio::sync::Mutex::new(
+            ScreenshotCaptureLifecycle::Active(ActiveScreenshotCapture {
+                id: Uuid::new_v4(),
+                target_session_id: Uuid::new_v4(),
+                target_session_name: "s".to_string(),
+                target_directory: PathBuf::from("x"),
+                monitors: Vec::new(),
+                overlay_labels: Vec::new(),
+                created_at: Utc::now(),
+            }),
+        ));
+        assert!(matches!(busy_pregate(&active).await, Some(BeginOutcome::Busy)));
+
+        let finishing: ScreenshotCaptureState = std::sync::Arc::new(tokio::sync::Mutex::new(
+            ScreenshotCaptureLifecycle::Finishing(Uuid::new_v4()),
+        ));
+        assert!(matches!(
+            busy_pregate(&finishing).await,
+            Some(BeginOutcome::Busy)
         ));
     }
 

--- a/src-tauri/src/screenshot/windows.rs
+++ b/src-tauri/src/screenshot/windows.rs
@@ -1,0 +1,1042 @@
+//! #714 Windows-native screenshot runtime.
+//!
+//! Owns every native dependency for the feature: `xcap` desktop capture, `image`
+//! crop/encode, the clipboard plugin, the global-shortcut plugin, overlay window
+//! creation, and the capture lifecycle state machine. The non-Windows sibling
+//! (`super::unsupported`) mirrors this public surface without any of it.
+//!
+//! Cleanup invariant: Rust owns overlay teardown. Every terminal path (confirm
+//! success/failure, explicit cancel, overlay build failure, stale overlay IPC,
+//! and `WindowEvent::Destroyed`) routes through either `confirm_selection`'s own
+//! teardown or [`clear_capture_and_destroy_overlays`], both of which are
+//! idempotent because they destroy overlays by label prefix and only act when a
+//! matching capture is still live.
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use base64::Engine as _;
+use chrono::Utc;
+use image::codecs::png::PngEncoder;
+use image::{ExtendedColorType, ImageEncoder};
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_clipboard_manager::ClipboardExt;
+use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
+use uuid::Uuid;
+
+use super::{
+    HotkeyModifier, ParsedHotkey, ScreenshotCaptureEvent, ScreenshotCaptureResult,
+    ScreenshotCaptureState, ScreenshotHotkeyState, ScreenshotHotkeyStatus, ScreenshotOverlayState,
+    ScreenshotSelection,
+};
+use crate::session::manager::SessionManager;
+
+/// Upper bound on the `-<n>.png` collision suffix, mirroring
+/// `phone::messaging::MAX_COLLISION_SUFFIX`.
+const MAX_COLLISION_SUFFIX: u32 = 9999;
+
+const SAVED_EVENT: &str = "screenshot_capture_saved";
+const FAILED_EVENT: &str = "screenshot_capture_failed";
+
+// ── Lifecycle + runtime state ──────────────────────────────────────────────
+
+/// Capture lifecycle. `Starting` is the gate that blocks concurrent hotkey
+/// starts; it is reserved under the mutex before desktop capture and atomically
+/// replaced by `Active` only if the same capture id is still pending.
+pub enum ScreenshotCaptureLifecycle {
+    Idle,
+    Starting(ScreenshotCaptureStarting),
+    Active(ActiveScreenshotCapture),
+}
+
+pub struct ScreenshotCaptureStarting {
+    pub id: Uuid,
+    pub target_session_id: Uuid,
+    pub target_session_name: String,
+    pub target_directory: PathBuf,
+    pub created_at: chrono::DateTime<Utc>,
+}
+
+pub struct ActiveScreenshotCapture {
+    pub id: Uuid,
+    pub target_session_id: Uuid,
+    pub target_session_name: String,
+    pub target_directory: PathBuf,
+    pub monitors: Vec<CapturedMonitor>,
+    pub overlay_labels: Vec<String>,
+    pub created_at: chrono::DateTime<Utc>,
+}
+
+pub struct CapturedMonitor {
+    /// Per-capture loop index (0..n). Stable key between capture storage and the
+    /// overlay's `getOverlayState`/selection, independent of OS monitor ids.
+    pub monitor_id: u32,
+    /// xcap monitor name, kept for placement matching and diagnostics.
+    pub name: String,
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+    pub scale_factor: f64,
+    pub image: image::RgbaImage,
+    pub preview_data_url: String,
+}
+
+/// Global-hotkey runtime. `registered_shortcut` is the plugin handle held so a
+/// settings change can unregister the previous key before/after registering the
+/// new one. Commands never expose it; they clone `status`. `Default` yields the
+/// default status (see `ScreenshotHotkeyStatus::default`) and no registration.
+#[derive(Default)]
+pub struct ScreenshotHotkeyRuntime {
+    pub status: ScreenshotHotkeyStatus,
+    pub registered_shortcut: Option<Shortcut>,
+}
+
+// ── Hotkey registration ────────────────────────────────────────────────────
+
+fn parsed_to_shortcut(parsed: &ParsedHotkey) -> Result<Shortcut, String> {
+    let modifiers = match parsed.modifier {
+        HotkeyModifier::Ctrl => Modifiers::CONTROL,
+    };
+    let code = key_char_to_code(parsed.key)
+        .ok_or_else(|| format!("key '{}' has no global-shortcut code", parsed.key))?;
+    Ok(Shortcut::new(Some(modifiers), code))
+}
+
+/// Map a normalized alphanumeric key char to a `Code` via its PascalCase name
+/// (`Key{A..Z}` / `Digit{0..9}`), the string form `keyboard_types::Code`
+/// round-trips through `FromStr`.
+fn key_char_to_code(c: char) -> Option<Code> {
+    let up = c.to_ascii_uppercase();
+    let name = if up.is_ascii_alphabetic() {
+        format!("Key{up}")
+    } else if up.is_ascii_digit() {
+        format!("Digit{up}")
+    } else {
+        return None;
+    };
+    name.parse::<Code>().ok()
+}
+
+/// Register the configured global hotkey, unregistering any previously-registered
+/// one. Returns `Err` only when the OS refuses the registration (e.g. another app
+/// already owns the combo); the previous hotkey is then kept registered. Syntax
+/// errors also return `Err`, but settings validation blocks those before here.
+///
+/// Never propagate this `Err` into a settings-save failure: callers in
+/// `commands::config` swallow it and surface a visible event instead.
+pub fn register_configured_hotkey(app: &AppHandle, configured: &str) -> Result<(), String> {
+    let parsed = super::parse_screenshot_hotkey(configured)?;
+    let shortcut = parsed_to_shortcut(&parsed)?;
+
+    let gs = app.global_shortcut();
+    let state = app.state::<ScreenshotHotkeyState>();
+    let mut runtime = state.lock().unwrap();
+    runtime.status.configured = configured.to_string();
+
+    // No-op save of the same key: it is already ours, so just record success and
+    // avoid a spurious "already registered" error from re-registering.
+    if gs.is_registered(shortcut) {
+        runtime.registered_shortcut = Some(shortcut);
+        runtime.status.registered = true;
+        runtime.status.error = None;
+        return Ok(());
+    }
+
+    match gs.register(shortcut) {
+        Ok(()) => {
+            if let Some(prev) = runtime.registered_shortcut.take() {
+                if prev != shortcut {
+                    let _ = gs.unregister(prev);
+                }
+            }
+            runtime.registered_shortcut = Some(shortcut);
+            runtime.status.registered = true;
+            runtime.status.error = None;
+            Ok(())
+        }
+        Err(e) => {
+            // Keep the previously-registered key working; report the conflict.
+            let msg = e.to_string();
+            runtime.status.registered = runtime.registered_shortcut.is_some();
+            runtime.status.error = Some(msg.clone());
+            Err(msg)
+        }
+    }
+}
+
+// ── Hotkey entry point ─────────────────────────────────────────────────────
+
+/// Global-shortcut handler entry. Spawns the async capture and, on any failure
+/// that happens before overlays exist, surfaces the error visibly because the
+/// hotkey normally fires while another app is focused.
+pub fn begin_capture_from_hotkey(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = begin_capture(app.clone()).await {
+            surface_hotkey_failure(&app, &e);
+        }
+    });
+}
+
+/// Emit the failure event AND bring the app forward so the toast is actually
+/// visible when the hotkey fired over another foreground app.
+fn surface_hotkey_failure(app: &AppHandle, message: &str) {
+    log::warn!("[screenshot] capture failed before overlay: {message}");
+    let _ = app.emit(
+        FAILED_EVENT,
+        ScreenshotCaptureEvent {
+            message: message.to_string(),
+        },
+    );
+    if let Some(win) = app
+        .get_webview_window("main")
+        .or_else(|| app.get_webview_window("sidebar"))
+    {
+        let _ = win.unminimize();
+        let _ = win.show();
+        let _ = win.set_focus();
+        let _ = win.request_user_attention(Some(tauri::UserAttentionType::Critical));
+    }
+}
+
+// ── Capture ────────────────────────────────────────────────────────────────
+
+/// Resolve active session, capture all monitors, store `Active`, open overlays.
+/// Every early-return path leaves the lifecycle `Idle` (no leaked `Starting`).
+pub async fn begin_capture(app: AppHandle) -> Result<(), String> {
+    // 1. Resolve the active session and its owning replica root.
+    let session_mgr = app.state::<std::sync::Arc<tokio::sync::RwLock<SessionManager>>>();
+    let active_id = {
+        let mgr = session_mgr.read().await;
+        mgr.get_active().await
+    }
+    .ok_or_else(|| "No active session is selected in AgentsCommander".to_string())?;
+    let session = {
+        let mgr = session_mgr.read().await;
+        mgr.get_session(active_id).await
+    }
+    .ok_or_else(|| "The active session could not be found".to_string())?;
+
+    let target_directory = resolve_session_replica_root(&session.working_directory)?;
+    let session_id = session.id;
+    let session_name = session.name.clone();
+
+    // 2. Reserve `Starting` under the mutex BEFORE the expensive capture so a
+    //    second rapid hotkey press is rejected instead of double-capturing.
+    let capture_id = Uuid::new_v4();
+    {
+        let state = app.state::<ScreenshotCaptureState>();
+        let mut guard = state.lock().await;
+        if !matches!(&*guard, ScreenshotCaptureLifecycle::Idle) {
+            return Err("Screenshot capture is already active".to_string());
+        }
+        *guard = ScreenshotCaptureLifecycle::Starting(ScreenshotCaptureStarting {
+            id: capture_id,
+            target_session_id: session_id,
+            target_session_name: session_name.clone(),
+            target_directory: target_directory.clone(),
+            created_at: Utc::now(),
+        });
+    }
+
+    // 3. Capture every monitor off the async thread (xcap + PNG encode are sync).
+    let monitors = match capture_all_monitors().await {
+        Ok(m) if !m.is_empty() => m,
+        Ok(_) => {
+            reset_starting_if_matches(&app, capture_id).await;
+            return Err("No monitors were found to capture".to_string());
+        }
+        Err(e) => {
+            reset_starting_if_matches(&app, capture_id).await;
+            return Err(e);
+        }
+    };
+
+    // 4. Compute overlay placement, then swap `Starting` -> `Active` iff our
+    //    capture is still the pending one.
+    let placements = build_placements(&app, capture_id, &monitors);
+    let overlay_labels: Vec<String> = placements.iter().map(|p| p.label.clone()).collect();
+    {
+        let state = app.state::<ScreenshotCaptureState>();
+        let mut guard = state.lock().await;
+        let still_ours =
+            matches!(&*guard, ScreenshotCaptureLifecycle::Starting(s) if s.id == capture_id);
+        if !still_ours {
+            // Superseded/cancelled while capturing: do not open overlays.
+            return Err("Screenshot capture was superseded".to_string());
+        }
+        *guard = ScreenshotCaptureLifecycle::Active(ActiveScreenshotCapture {
+            id: capture_id,
+            target_session_id: session_id,
+            target_session_name: session_name,
+            target_directory,
+            monitors,
+            overlay_labels,
+            created_at: Utc::now(),
+        });
+    }
+
+    // 5. Open overlays AFTER the capture is stored so overlay IPC sees `Active`.
+    if let Err(e) = open_overlay_windows(&app, capture_id, &placements) {
+        let state = app.state::<ScreenshotCaptureState>();
+        let _ = clear_capture_and_destroy_overlays(
+            &app,
+            state.inner(),
+            Some(capture_id),
+            &format!("overlay build failed: {e}"),
+        )
+        .await;
+        return Err(e);
+    }
+    Ok(())
+}
+
+async fn reset_starting_if_matches(app: &AppHandle, id: Uuid) {
+    let state = app.state::<ScreenshotCaptureState>();
+    let mut guard = state.lock().await;
+    if matches!(&*guard, ScreenshotCaptureLifecycle::Starting(s) if s.id == id) {
+        *guard = ScreenshotCaptureLifecycle::Idle;
+    }
+}
+
+/// Capture every monitor with `xcap` and encode a base64 PNG preview per monitor.
+/// All `xcap` getters are fallible and re-query the OS, so each is read once.
+async fn capture_all_monitors() -> Result<Vec<CapturedMonitor>, String> {
+    tokio::task::spawn_blocking(|| -> Result<Vec<CapturedMonitor>, String> {
+        let monitors = xcap::Monitor::all().map_err(|e| format!("xcap monitor enumeration failed: {e}"))?;
+        let mut captured = Vec::with_capacity(monitors.len());
+        for (idx, monitor) in monitors.iter().enumerate() {
+            let image = monitor
+                .capture_image()
+                .map_err(|e| format!("monitor {idx} capture failed: {e}"))?;
+            let x = monitor.x().map_err(|e| e.to_string())?;
+            let y = monitor.y().map_err(|e| e.to_string())?;
+            let scale_factor = monitor.scale_factor().map_err(|e| e.to_string())? as f64;
+            let name = monitor.name().unwrap_or_else(|_| format!("monitor-{idx}"));
+            // The captured bitmap is the authoritative size for crop math; do not
+            // trust monitor.width()/height() for it (plan §B, dev-rust §B).
+            let width = image.width();
+            let height = image.height();
+            let preview_data_url = encode_preview_data_url(&image, width, height)?;
+            log::info!(
+                "[screenshot] monitor {idx} '{name}' origin=({x},{y}) size={width}x{height} scale={scale_factor}"
+            );
+            captured.push(CapturedMonitor {
+                monitor_id: idx as u32,
+                name,
+                x,
+                y,
+                width,
+                height,
+                scale_factor,
+                image,
+                preview_data_url,
+            });
+        }
+        Ok(captured)
+    })
+    .await
+    .map_err(|e| format!("monitor capture task panicked: {e}"))?
+}
+
+/// PNG-encode the RGBA buffer (no extra clone of the image) into a data URL.
+fn encode_preview_data_url(image: &image::RgbaImage, width: u32, height: u32) -> Result<String, String> {
+    let mut png_bytes: Vec<u8> = Vec::new();
+    PngEncoder::new(&mut png_bytes)
+        .write_image(image.as_raw(), width, height, ExtendedColorType::Rgba8)
+        .map_err(|e| format!("PNG preview encode failed: {e}"))?;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&png_bytes);
+    Ok(format!("data:image/png;base64,{b64}"))
+}
+
+// ── Overlay windows ────────────────────────────────────────────────────────
+
+struct OverlayPlacement {
+    label: String,
+    monitor_id: u32,
+    /// Physical pixels.
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    scale_factor: f64,
+}
+
+/// Decide where each overlay goes. Prefer Tauri's own monitor geometry (physical
+/// position/size + per-monitor scale) matched to the xcap monitor by name, then
+/// by nearest origin; fall back to the xcap geometry if no Tauri monitor matches.
+/// Placement is decoupled from xcap coordinate semantics this way (plan §C).
+fn build_placements(app: &AppHandle, capture_id: Uuid, monitors: &[CapturedMonitor]) -> Vec<OverlayPlacement> {
+    let tauri_monitors = app.available_monitors().unwrap_or_default();
+    monitors
+        .iter()
+        .map(|m| {
+            let (x, y, width, height, scale_factor) = match_tauri_monitor(&tauri_monitors, m)
+                .map(|tm| {
+                    let pos = tm.position();
+                    let size = tm.size();
+                    (pos.x, pos.y, size.width, size.height, tm.scale_factor())
+                })
+                .unwrap_or((m.x, m.y, m.width, m.height, m.scale_factor));
+            if width != m.width || height != m.height {
+                log::warn!(
+                    "[screenshot] monitor {} placement size {}x{} differs from captured bitmap {}x{}; using placement for window, bitmap for crop",
+                    m.monitor_id, width, height, m.width, m.height
+                );
+            }
+            OverlayPlacement {
+                label: overlay_label(capture_id, m.monitor_id),
+                monitor_id: m.monitor_id,
+                x,
+                y,
+                width,
+                height,
+                scale_factor,
+            }
+        })
+        .collect()
+}
+
+/// Match an xcap monitor to a Tauri monitor by name, else by nearest origin.
+fn match_tauri_monitor<'a>(
+    tauri_monitors: &'a [tauri::Monitor],
+    captured: &CapturedMonitor,
+) -> Option<&'a tauri::Monitor> {
+    if let Some(by_name) = tauri_monitors
+        .iter()
+        .find(|tm| tm.name().map(|n| n.as_str()) == Some(captured.name.as_str()))
+    {
+        return Some(by_name);
+    }
+    tauri_monitors.iter().min_by_key(|tm| {
+        let pos = tm.position();
+        let dx = (pos.x - captured.x).unsigned_abs() as u64;
+        let dy = (pos.y - captured.y).unsigned_abs() as u64;
+        dx + dy
+    })
+}
+
+fn overlay_label(capture_id: Uuid, monitor_id: u32) -> String {
+    format!("screenshot-overlay-{}-{}", capture_id.simple(), monitor_id)
+}
+
+/// Build one transparent, always-on-top overlay per monitor. Mirrors the
+/// Resource Monitor builder (`commands::window`): logical inner size/position from
+/// the monitor scale, corrected to physical bounds post-build. On any failure the
+/// caller clears state and destroys already-created overlays.
+fn open_overlay_windows(
+    app: &AppHandle,
+    capture_id: Uuid,
+    placements: &[OverlayPlacement],
+) -> Result<(), String> {
+    use tauri::{WebviewUrl, WebviewWindowBuilder};
+
+    for p in placements {
+        let scale = if p.scale_factor > 0.0 { p.scale_factor } else { 1.0 };
+        let url = format!(
+            "index.html?window=screenshot-overlay&captureId={capture_id}&monitorId={}",
+            p.monitor_id
+        );
+        let window = WebviewWindowBuilder::new(app, &p.label, WebviewUrl::App(url.into()))
+            .title("Screenshot Capture")
+            .decorations(false)
+            .transparent(true)
+            .always_on_top(true)
+            .skip_taskbar(true)
+            .resizable(false)
+            .focused(true)
+            .zoom_hotkeys_enabled(false)
+            .inner_size(p.width as f64 / scale, p.height as f64 / scale)
+            .position(p.x as f64 / scale, p.y as f64 / scale)
+            .build()
+            .map_err(|e| format!("failed to create overlay '{}': {e}", p.label))?;
+
+        window
+            .set_size(tauri::Size::Physical(tauri::PhysicalSize {
+                width: p.width,
+                height: p.height,
+            }))
+            .map_err(|e| format!("failed to size overlay '{}': {e}", p.label))?;
+        window
+            .set_position(tauri::Position::Physical(tauri::PhysicalPosition {
+                x: p.x,
+                y: p.y,
+            }))
+            .map_err(|e| format!("failed to position overlay '{}': {e}", p.label))?;
+    }
+    Ok(())
+}
+
+/// Destroy every overlay window belonging to a capture id (by label prefix).
+/// Idempotent: missing windows are skipped. Returns how many were destroyed.
+fn destroy_overlays_for_capture(app: &AppHandle, capture_id: Uuid) -> usize {
+    let prefix = format!("screenshot-overlay-{}-", capture_id.simple());
+    let mut destroyed = 0;
+    for (label, window) in app.webview_windows() {
+        if label.starts_with(&prefix) {
+            match window.destroy() {
+                Ok(()) => destroyed += 1,
+                Err(e) => log::warn!("[screenshot] failed to destroy overlay '{label}': {e}"),
+            }
+        }
+    }
+    destroyed
+}
+
+// ── Overlay IPC ────────────────────────────────────────────────────────────
+
+enum OverlayDecision {
+    Ready(Box<ScreenshotOverlayState>),
+    Starting,
+    Stale,
+}
+
+/// Return overlay state for an `Active` capture matching `capture_id`. While the
+/// capture is still `Starting`, report that. For a stale id, destroy that id's
+/// overlays without touching a different active capture.
+pub async fn overlay_state(
+    app: &AppHandle,
+    state: &ScreenshotCaptureState,
+    capture_id: &str,
+    monitor_id: u32,
+) -> Result<ScreenshotOverlayState, String> {
+    let decision = {
+        let guard = state.lock().await;
+        match &*guard {
+            ScreenshotCaptureLifecycle::Active(c) if c.id.to_string() == capture_id => {
+                match c.monitors.iter().find(|m| m.monitor_id == monitor_id) {
+                    Some(m) => OverlayDecision::Ready(Box::new(ScreenshotOverlayState {
+                        capture_id: c.id.to_string(),
+                        monitor_id: m.monitor_id,
+                        monitor_x: m.x,
+                        monitor_y: m.y,
+                        width: m.width,
+                        height: m.height,
+                        scale_factor: m.scale_factor,
+                        image_data_url: m.preview_data_url.clone(),
+                        session_id: c.target_session_id.to_string(),
+                        session_name: c.target_session_name.clone(),
+                        target_directory: c.target_directory.to_string_lossy().to_string(),
+                    })),
+                    None => OverlayDecision::Stale,
+                }
+            }
+            ScreenshotCaptureLifecycle::Starting(s) if s.id.to_string() == capture_id => {
+                OverlayDecision::Starting
+            }
+            _ => OverlayDecision::Stale,
+        }
+    };
+
+    match decision {
+        OverlayDecision::Ready(state) => Ok(*state),
+        OverlayDecision::Starting => Err("Screenshot capture is still starting".to_string()),
+        OverlayDecision::Stale => {
+            if let Ok(id) = Uuid::parse_str(capture_id) {
+                destroy_overlays_for_capture(app, id);
+            }
+            Err("Screenshot capture is no longer active".to_string())
+        }
+    }
+}
+
+// ── Confirm ────────────────────────────────────────────────────────────────
+
+/// Crop the selection out of the stored monitor bitmap, save a PNG into the
+/// resolved replica root, copy the path to the clipboard, and tear down overlays.
+/// The async mutex is dropped before any file I/O. Any post-take failure destroys
+/// overlays, deletes a partial PNG, and emits a failure event.
+pub async fn confirm_selection(
+    app: &AppHandle,
+    state: &ScreenshotCaptureState,
+    selection: ScreenshotSelection,
+) -> Result<ScreenshotCaptureResult, String> {
+    // Take the active capture iff it matches; drop the guard before file I/O.
+    let capture = {
+        let mut guard = state.lock().await;
+        let matches = matches!(
+            &*guard,
+            ScreenshotCaptureLifecycle::Active(c) if c.id.to_string() == selection.capture_id
+        );
+        if !matches {
+            return Err("Screenshot capture is no longer active".to_string());
+        }
+        match std::mem::replace(&mut *guard, ScreenshotCaptureLifecycle::Idle) {
+            ScreenshotCaptureLifecycle::Active(c) => c,
+            _ => unreachable!("matched Active above"),
+        }
+    };
+
+    let capture_id = capture.id;
+    let result = save_selection(capture, &selection).await;
+    match result {
+        Ok(saved) => {
+            // Best-effort clipboard copy; the PNG already exists, so a clipboard
+            // failure must not fail the capture (plan §E).
+            if let Err(e) = app.clipboard().write_text(saved.path.clone()) {
+                log::warn!("[screenshot] clipboard copy failed: {e}");
+            }
+            let _ = app.emit(SAVED_EVENT, saved.clone());
+            destroy_overlays_for_capture(app, capture_id);
+            Ok(saved)
+        }
+        Err((partial, msg)) => {
+            if let Some(path) = partial {
+                let _ = std::fs::remove_file(&path);
+            }
+            destroy_overlays_for_capture(app, capture_id);
+            let _ = app.emit(
+                FAILED_EVENT,
+                ScreenshotCaptureEvent {
+                    message: msg.clone(),
+                },
+            );
+            Err(msg)
+        }
+    }
+}
+
+/// Validate the selection, crop, and write the PNG. On error the second tuple
+/// element is the message and the first is a partial file to delete, if any.
+async fn save_selection(
+    capture: ActiveScreenshotCapture,
+    selection: &ScreenshotSelection,
+) -> Result<ScreenshotCaptureResult, (Option<PathBuf>, String)> {
+    let monitor = capture
+        .monitors
+        .into_iter()
+        .find(|m| m.monitor_id == selection.monitor_id)
+        .ok_or_else(|| (None, format!("monitor {} not in capture", selection.monitor_id)))?;
+
+    let (iw, ih) = (monitor.image.width(), monitor.image.height());
+    validate_selection(selection, iw, ih).map_err(|e| (None, e))?;
+
+    let target = capture.target_directory.clone();
+    let filename = build_filename(capture.target_session_id);
+    let image = monitor.image;
+    let (sx, sy, sw, sh) = (selection.x, selection.y, selection.width, selection.height);
+
+    let saved_path = tokio::task::spawn_blocking(move || -> Result<PathBuf, (Option<PathBuf>, String)> {
+        // Revalidate the destination immediately before creating the file.
+        revalidate_replica_target(&target).map_err(|e| (None, e))?;
+        let (path, file) = create_png_file(&target, &filename).map_err(|e| (None, e))?;
+
+        let cropped = image::imageops::crop_imm(&image, sx, sy, sw, sh).to_image();
+        let mut writer = std::io::BufWriter::new(file);
+        if let Err(e) = image::DynamicImage::ImageRgba8(cropped)
+            .write_to(&mut writer, image::ImageFormat::Png)
+        {
+            return Err((Some(path), format!("PNG encode/write failed: {e}")));
+        }
+        if let Err(e) = writer.flush() {
+            return Err((Some(path), format!("PNG flush failed: {e}")));
+        }
+        drop(writer);
+
+        // Final containment check: the canonical saved file must live directly
+        // inside the canonical replica root.
+        let canonical = std::fs::canonicalize(&path)
+            .map_err(|e| (Some(path.clone()), format!("canonicalize saved file failed: {e}")))?;
+        let canonical_target = std::fs::canonicalize(&target)
+            .map_err(|e| (Some(canonical.clone()), format!("canonicalize target failed: {e}")))?;
+        let parent_ok = canonical.parent().map(|p| p == canonical_target).unwrap_or(false);
+        if !parent_ok {
+            return Err((Some(canonical), "saved file escaped the replica root".to_string()));
+        }
+        Ok(canonical)
+    })
+    .await
+    .map_err(|e| (None, format!("save task panicked: {e}")))??;
+
+    let path_string = saved_path.to_string_lossy().to_string();
+    log::info!(
+        "[screenshot] saved {} for session '{}'",
+        path_string,
+        capture.target_session_name
+    );
+    Ok(ScreenshotCaptureResult {
+        path: path_string,
+        session_id: capture.target_session_id.to_string(),
+        session_name: capture.target_session_name,
+    })
+}
+
+fn validate_selection(selection: &ScreenshotSelection, image_w: u32, image_h: u32) -> Result<(), String> {
+    if selection.width < 2 || selection.height < 2 {
+        return Err("Selection is too small".to_string());
+    }
+    let x_end = selection.x.checked_add(selection.width);
+    let y_end = selection.y.checked_add(selection.height);
+    match (x_end, y_end) {
+        (Some(xe), Some(ye)) if xe <= image_w && ye <= image_h => Ok(()),
+        _ => Err("Selection is outside the captured image".to_string()),
+    }
+}
+
+fn build_filename(session_id: Uuid) -> String {
+    let short = &session_id.simple().to_string()[..8];
+    // Local time: the filename is user-facing, so it should match the user's clock.
+    let stamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
+    format!("agentscommander-screenshot-{stamp}-{short}.png")
+}
+
+/// Collision loop mirroring `phone::messaging::create_message_file`: never
+/// overwrite an existing file; retry with `-<n>.png` up to the bound.
+fn create_png_file(dir: &Path, base_filename: &str) -> Result<(PathBuf, std::fs::File), String> {
+    let stem = base_filename
+        .strip_suffix(".png")
+        .ok_or_else(|| format!("filename '{base_filename}' must end in .png"))?;
+    for n in 0..=MAX_COLLISION_SUFFIX {
+        let filename = if n == 0 {
+            base_filename.to_string()
+        } else {
+            format!("{stem}-{n}.png")
+        };
+        let path = dir.join(&filename);
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(file) => return Ok((path, file)),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(format!("failed to create {}: {e}", path.display())),
+        }
+    }
+    Err(format!(
+        "exhausted {MAX_COLLISION_SUFFIX} filename collisions for '{base_filename}'"
+    ))
+}
+
+// ── Cancel + cleanup ───────────────────────────────────────────────────────
+
+/// Explicit cancel (Escape / overlay close request). Idempotent.
+pub async fn cancel_capture(
+    app: &AppHandle,
+    state: &ScreenshotCaptureState,
+    capture_id: &str,
+) -> Result<(), String> {
+    let id = Uuid::parse_str(capture_id).map_err(|_| "invalid capture id".to_string())?;
+    clear_capture_and_destroy_overlays(app, state, Some(id), "user cancelled").await
+}
+
+/// Centralized, idempotent cleanup: take a matching `Starting`/`Active` capture
+/// to `Idle` and destroy its overlays by label prefix. `capture_id == None`
+/// clears whatever is active. Safe to call repeatedly; later calls are no-ops.
+pub async fn clear_capture_and_destroy_overlays(
+    app: &AppHandle,
+    state: &ScreenshotCaptureState,
+    capture_id: Option<Uuid>,
+    reason: &str,
+) -> Result<(), String> {
+    let cleared_id = {
+        let mut guard = state.lock().await;
+        let id = match &*guard {
+            ScreenshotCaptureLifecycle::Active(c)
+                if capture_id.is_none() || capture_id == Some(c.id) =>
+            {
+                Some(c.id)
+            }
+            ScreenshotCaptureLifecycle::Starting(s)
+                if capture_id.is_none() || capture_id == Some(s.id) =>
+            {
+                Some(s.id)
+            }
+            _ => None,
+        };
+        if id.is_some() {
+            *guard = ScreenshotCaptureLifecycle::Idle;
+        }
+        id
+    };
+
+    // Destroy overlays for whichever id we cleared, or for the requested id even
+    // if the state was already idle (scrubs windows left by a prior partial run).
+    let destroy_id = cleared_id.or(capture_id);
+    if let Some(id) = destroy_id {
+        let n = destroy_overlays_for_capture(app, id);
+        if n > 0 || cleared_id.is_some() {
+            log::info!("[screenshot] cleared capture {id} ({reason}); destroyed {n} overlay(s)");
+        }
+    }
+    Ok(())
+}
+
+/// `RunEvent::WindowEvent::Destroyed` hook for `screenshot-overlay-*` labels.
+/// If the destroyed overlay belongs to the live capture, clear state and destroy
+/// its siblings; otherwise no-op (our own teardown already cleared state).
+pub async fn handle_overlay_window_destroyed(app: AppHandle, label: String) {
+    let Some(hex) = capture_hex_from_overlay_label(&label) else {
+        return;
+    };
+    let state = app.state::<ScreenshotCaptureState>();
+    let active_id = {
+        let guard = state.lock().await;
+        match &*guard {
+            ScreenshotCaptureLifecycle::Active(c) => Some(c.id),
+            ScreenshotCaptureLifecycle::Starting(s) => Some(s.id),
+            ScreenshotCaptureLifecycle::Idle => None,
+        }
+    };
+    if let Some(id) = active_id {
+        if id.simple().to_string() == hex {
+            let _ = clear_capture_and_destroy_overlays(
+                &app,
+                state.inner(),
+                Some(id),
+                "overlay window destroyed",
+            )
+            .await;
+        }
+    }
+}
+
+fn capture_hex_from_overlay_label(label: &str) -> Option<&str> {
+    let rest = label.strip_prefix("screenshot-overlay-")?;
+    let (hex, _idx) = rest.rsplit_once('-')?;
+    if hex.len() == 32 && hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(hex)
+    } else {
+        None
+    }
+}
+
+// ── Replica-root resolution + symlink guard ────────────────────────────────
+
+/// True iff `meta` is a symlink or (Windows) any reparse point (junction).
+/// Inlined from the private `session_context::is_link_or_reparse` per its own
+/// doc-comment, which asks callers to inline rather than widen its API.
+fn is_link_or_reparse(meta: &std::fs::Metadata) -> bool {
+    if meta.file_type().is_symlink() {
+        return true;
+    }
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return true;
+        }
+    }
+    false
+}
+
+/// Walk up `start` to the owning `wg-*/__agent_*` replica directory by name.
+/// Pure path logic (no filesystem access): a session launched from
+/// `__agent_x\child` resolves to `__agent_x`. Returns `None` for ad-hoc CWDs,
+/// `repo-*` siblings, project roots, and root-agent paths.
+fn find_replica_root(start: &Path) -> Option<PathBuf> {
+    let mut current = Some(start);
+    while let Some(dir) = current {
+        if let Some(name) = dir.file_name().and_then(|n| n.to_str()) {
+            if name.starts_with("__agent_") {
+                let parent_is_wg = dir
+                    .parent()
+                    .and_then(|p| p.file_name())
+                    .and_then(|n| n.to_str())
+                    .map(|p| p.starts_with("wg-"))
+                    .unwrap_or(false);
+                if parent_is_wg {
+                    return Some(dir.to_path_buf());
+                }
+            }
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+/// Resolve and validate the only legal write target for a capture: the canonical
+/// owning WG replica root of the active session's CWD. Rejects non-replica CWDs,
+/// symlinks/reparse points, and roots that fail WG replica identity validation.
+fn resolve_session_replica_root(working_directory: &str) -> Result<PathBuf, String> {
+    let cwd = PathBuf::from(working_directory);
+    let root = find_replica_root(&cwd).ok_or_else(|| {
+        "The active session is not inside a workgroup replica directory, so there is no place to save the screenshot".to_string()
+    })?;
+
+    let meta = std::fs::symlink_metadata(&root)
+        .map_err(|e| format!("Cannot read the replica directory: {e}"))?;
+    if is_link_or_reparse(&meta) {
+        return Err("The replica directory is a symlink or reparse point".to_string());
+    }
+    if !meta.is_dir() {
+        return Err("The replica path is not a directory".to_string());
+    }
+
+    let canonical = std::fs::canonicalize(&root)
+        .map_err(|e| format!("Cannot canonicalize the replica directory: {e}"))?;
+
+    // Structure + persisted-identity validation against the existing helpers.
+    crate::config::replica_identity::expected_wg_replica_identity(&canonical)?;
+    crate::config::replica_identity::read_wg_replica_config_read_only(&canonical)?;
+    Ok(canonical)
+}
+
+/// Re-run the symlink/reparse + directory checks on the target immediately before
+/// creating the PNG (the directory could have changed since capture start).
+fn revalidate_replica_target(target: &Path) -> Result<(), String> {
+    let meta = std::fs::symlink_metadata(target)
+        .map_err(|e| format!("Cannot read the replica directory: {e}"))?;
+    if is_link_or_reparse(&meta) {
+        return Err("The replica directory is a symlink or reparse point".to_string());
+    }
+    if !meta.is_dir() {
+        return Err("The replica path is not a directory".to_string());
+    }
+    Ok(())
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shortcut_conversion_maps_modifier_and_code() {
+        let parsed = super::super::parse_screenshot_hotkey("Ctrl+Q").unwrap();
+        let shortcut = parsed_to_shortcut(&parsed).unwrap();
+        assert_eq!(shortcut.mods, Modifiers::CONTROL);
+        assert_eq!(shortcut.key, Code::KeyQ);
+    }
+
+    #[test]
+    fn shortcut_conversion_maps_digit() {
+        let parsed = super::super::parse_screenshot_hotkey("Ctrl+1").unwrap();
+        let shortcut = parsed_to_shortcut(&parsed).unwrap();
+        assert_eq!(shortcut.key, Code::Digit1);
+    }
+
+    #[test]
+    fn find_replica_root_accepts_replica_and_subdirs() {
+        let replica = Path::new(r"C:\proj\.ac\wg-6-team\__agent_dev_rust");
+        assert_eq!(find_replica_root(replica).as_deref(), Some(replica));
+
+        let child = Path::new(r"C:\proj\.ac\wg-6-team\__agent_dev_rust\sub\deeper");
+        assert_eq!(
+            find_replica_root(child).as_deref(),
+            Some(Path::new(r"C:\proj\.ac\wg-6-team\__agent_dev_rust"))
+        );
+    }
+
+    #[test]
+    fn find_replica_root_rejects_non_replica_paths() {
+        // Ad-hoc CWD.
+        assert!(find_replica_root(Path::new(r"C:\tmp")).is_none());
+        // repo-* workgroup sibling (parent is wg-*, but name is not __agent_*).
+        assert!(find_replica_root(Path::new(r"C:\proj\.ac\wg-6-team\repo-AgentsCommander")).is_none());
+        // __agent_* whose parent is NOT a wg-* folder.
+        assert!(find_replica_root(Path::new(r"C:\proj\__agent_x")).is_none());
+        // Root-agent directory name.
+        assert!(find_replica_root(Path::new(r"C:\proj\.ac\ac-root-agent")).is_none());
+    }
+
+    #[test]
+    fn resolve_rejects_missing_and_non_replica() {
+        // Non-replica path: rejected before any filesystem access.
+        assert!(resolve_session_replica_root(r"C:\definitely\not\a\replica").is_err());
+        // Replica-shaped but missing on disk: symlink_metadata fails.
+        let missing = format!(
+            r"C:\proj\.ac\wg-6-team\__agent_{}",
+            Uuid::new_v4().simple()
+        );
+        assert!(resolve_session_replica_root(&missing).is_err());
+    }
+
+    #[test]
+    fn resolve_rejects_regular_file() {
+        // A file shaped like a replica root must be rejected (is_dir == false).
+        let dir = std::env::temp_dir().join(format!("wg-6-team-{}", Uuid::new_v4().simple()));
+        let replica = dir.join("__agent_filecase");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(&replica, b"not a dir").unwrap();
+        let result = resolve_session_replica_root(&replica.to_string_lossy());
+        let _ = std::fs::remove_file(&replica);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_selection_bounds() {
+        let sel = |x, y, w, h| ScreenshotSelection {
+            capture_id: "c".to_string(),
+            monitor_id: 0,
+            x,
+            y,
+            width: w,
+            height: h,
+        };
+        // OK: inside bounds.
+        assert!(validate_selection(&sel(0, 0, 10, 10), 100, 100).is_ok());
+        assert!(validate_selection(&sel(90, 90, 10, 10), 100, 100).is_ok());
+        // Too small.
+        assert!(validate_selection(&sel(0, 0, 1, 10), 100, 100).is_err());
+        assert!(validate_selection(&sel(0, 0, 10, 1), 100, 100).is_err());
+        // Out of bounds.
+        assert!(validate_selection(&sel(95, 0, 10, 10), 100, 100).is_err());
+        assert!(validate_selection(&sel(0, 95, 10, 10), 100, 100).is_err());
+    }
+
+    #[test]
+    fn crop_returns_requested_dimensions_and_pixels() {
+        // 4x4 image; top-left 2x2 is red, rest is blue. Crop (0,0,2,2) -> all red.
+        let mut img = image::RgbaImage::new(4, 4);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = if x < 2 && y < 2 {
+                image::Rgba([255, 0, 0, 255])
+            } else {
+                image::Rgba([0, 0, 255, 255])
+            };
+        }
+        let crop = image::imageops::crop_imm(&img, 0, 0, 2, 2).to_image();
+        assert_eq!(crop.width(), 2);
+        assert_eq!(crop.height(), 2);
+        assert_eq!(*crop.get_pixel(0, 0), image::Rgba([255, 0, 0, 255]));
+        assert_eq!(*crop.get_pixel(1, 1), image::Rgba([255, 0, 0, 255]));
+
+        // Crop the bottom-right 2x2 -> all blue, and origin must be respected.
+        let crop_br = image::imageops::crop_imm(&img, 2, 2, 2, 2).to_image();
+        assert_eq!(*crop_br.get_pixel(0, 0), image::Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn create_png_file_never_overwrites() {
+        let dir = std::env::temp_dir().join(format!("ac-shot-{}", Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let (p0, f0) = create_png_file(&dir, "shot.png").unwrap();
+        drop(f0);
+        assert!(p0.ends_with("shot.png"));
+
+        let (p1, f1) = create_png_file(&dir, "shot.png").unwrap();
+        drop(f1);
+        assert!(p1.ends_with("shot-1.png"), "got {p1:?}");
+        assert_ne!(p0, p1);
+        assert!(p0.exists() && p1.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn overlay_label_and_hex_round_trip() {
+        let id = Uuid::new_v4();
+        let label = overlay_label(id, 3);
+        assert!(label.starts_with("screenshot-overlay-"));
+        assert_eq!(
+            capture_hex_from_overlay_label(&label),
+            Some(id.simple().to_string().as_str())
+        );
+        assert!(capture_hex_from_overlay_label("terminal-abc").is_none());
+        assert!(capture_hex_from_overlay_label("screenshot-overlay-xyz-0").is_none());
+    }
+
+    #[test]
+    fn build_filename_shape() {
+        let id = Uuid::new_v4();
+        let name = build_filename(id);
+        assert!(name.starts_with("agentscommander-screenshot-"));
+        assert!(name.ends_with(".png"));
+        // Contains the 8-char short id.
+        assert!(name.contains(&id.simple().to_string()[..8]));
+    }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import GuideApp from "./guide/App";
 import BrowserApp from "./browser/App";
 import SpecBoardApp from "./spec-board/App";
 import ResourceMonitorApp from "./resource-monitor/App";
+import ScreenshotOverlayApp from "./screenshot-overlay/App";
 import MainApp from "./main/App";
 import { initAutomationBridge } from "./shared/automation-bridge";
 import { initLogLevelForWindow } from "./shared/log-level";
@@ -53,6 +54,12 @@ if (!isTauri) {
   render(() => <GuideApp />, root);
 } else if (windowType === "resource-monitor") {
   render(() => <ResourceMonitorApp />, root);
+} else if (windowType === "screenshot-overlay") {
+  // #714 Mark the document so the overlay's transparent html/body/#root CSS
+  // (scoped to this attribute) applies here ONLY, never leaking into the other
+  // windows that share this single bundle. Set BEFORE rendering.
+  document.documentElement.setAttribute("data-window", "screenshot-overlay");
+  render(() => <ScreenshotOverlayApp />, root);
 } else if (windowType === "spec-board") {
   render(() => <SpecBoardApp />, root);
 } else {

--- a/src/screenshot-overlay/App.test.tsx
+++ b/src/screenshot-overlay/App.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  waitFor,
+} from "../shared/testing/ui-harness";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import type { ScreenshotOverlayState } from "../shared/types";
+import ScreenshotOverlayApp from "./App";
+
+// jsdom/vitest cannot render canvas PIXELS (getContext is a stub here), so this
+// suite verifies the overlay WIRING: param parsing, state fetch, canvas sizing,
+// and the pointer→confirm / Escape→cancel IPC flow. Pixel fidelity (frozen
+// image, rubber-band, magnifier) is covered by the headless-Chrome check and
+// manual Windows verification.
+
+const IMG_W = 400;
+const IMG_H = 300;
+// 1x1 transparent PNG; decode() rejects under jsdom (the App swallows that and
+// draws best-effort), which is fine — we assert wiring, not pixels.
+const DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+
+function overlayState(over: Partial<ScreenshotOverlayState> = {}): ScreenshotOverlayState {
+  return {
+    captureId: "abc-123",
+    monitorId: 0,
+    monitorX: 0,
+    monitorY: 0,
+    width: IMG_W,
+    height: IMG_H,
+    scaleFactor: 1,
+    imageDataUrl: DATA_URL,
+    sessionId: "s1",
+    sessionName: "wg-6-dev-team/dev-webpage-ui",
+    targetDirectory: "C:\\proj\\.ac\\wg-6-dev-team\\__agent_x",
+    ...over,
+  };
+}
+
+function pointer(type: string, x: number, y: number): Event {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(e, { clientX: x, clientY: y, pointerId: 1 });
+  return e;
+}
+
+function stubRect(canvas: HTMLCanvasElement, width: number, height: number): void {
+  // jsdom returns an all-zero rect; give the canvas a real on-screen size so the
+  // proportional client→image mapping produces non-zero coordinates. Sized 1:1
+  // with the image here for easy arithmetic.
+  canvas.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: width,
+      bottom: height,
+      width,
+      height,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
+
+describe("ScreenshotOverlayApp", () => {
+  let restoreStubs: () => void;
+  let cleanup: (() => void) | null = null;
+  let originalSearch: string;
+  let originalFocus: typeof window.focus;
+
+  beforeEach(() => {
+    restoreStubs = installBrowserDomStubs();
+    // jsdom does not implement window.focus (it logs "Not implemented" noise);
+    // the overlay calls it for real-browser ESC focus and already guards it, so
+    // stub it to a no-op here.
+    originalFocus = window.focus;
+    window.focus = () => {};
+    originalSearch = window.location.search;
+    window.history.replaceState(
+      {},
+      "",
+      "?window=screenshot-overlay&captureId=abc-123&monitorId=0"
+    );
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+    window.history.replaceState({}, "", originalSearch || "/");
+    window.focus = originalFocus;
+    restoreStubs();
+  });
+
+  async function mount(fake: FakeTransport): Promise<HTMLCanvasElement> {
+    const rendered = renderWithFakeTransport(() => <ScreenshotOverlayApp />, fake);
+    cleanup = rendered.cleanup;
+    const canvas = rendered.root.querySelector(
+      '[data-ac-testid="screenshotOverlay.canvas"]'
+    ) as HTMLCanvasElement;
+    expect(canvas).toBeTruthy();
+    stubRect(canvas, IMG_W, IMG_H);
+    // Wait for the async getOverlayState → canvas sizing to complete.
+    await waitFor(() => expect(canvas.width).toBe(IMG_W));
+    expect(canvas.height).toBe(IMG_H);
+    return canvas;
+  }
+
+  it("fetches overlay state with the parsed captureId + numeric monitorId", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("screenshot_get_overlay_state", overlayState());
+    fake.resolve("screenshot_cancel_capture", undefined);
+
+    await mount(fake);
+
+    const call = fake.lastCall("screenshot_get_overlay_state");
+    expect(call?.args).toEqual({ captureId: "abc-123", monitorId: 0 });
+  });
+
+  it("confirms the physical crop on a drag release", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("screenshot_get_overlay_state", overlayState());
+    fake.resolve("screenshot_confirm_selection", {
+      path: "C:\\out\\shot.png",
+      sessionId: "s1",
+      sessionName: "wg-6-dev-team/dev-webpage-ui",
+    });
+    fake.resolve("screenshot_cancel_capture", undefined);
+
+    const canvas = await mount(fake);
+    canvas.dispatchEvent(pointer("pointerdown", 10, 20));
+    canvas.dispatchEvent(pointer("pointermove", 210, 170));
+    canvas.dispatchEvent(pointer("pointerup", 210, 170));
+
+    await waitFor(() =>
+      expect(fake.callsFor("screenshot_confirm_selection")).toHaveLength(1)
+    );
+    const selection = fake.lastCall("screenshot_confirm_selection")?.args
+      .selection as Record<string, number>;
+    expect(selection).toEqual({
+      captureId: "abc-123",
+      monitorId: 0,
+      x: 10,
+      y: 20,
+      width: 200,
+      height: 150,
+    });
+    // No cancel should fire once confirmed (settled guard).
+    expect(fake.callsFor("screenshot_cancel_capture")).toHaveLength(0);
+  });
+
+  it("treats a sub-2px release as a mis-click: no confirm, overlay stays open", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("screenshot_get_overlay_state", overlayState());
+    fake.resolve("screenshot_confirm_selection", {
+      path: "x",
+      sessionId: "s1",
+      sessionName: "n",
+    });
+    fake.resolve("screenshot_cancel_capture", undefined);
+
+    const canvas = await mount(fake);
+    canvas.dispatchEvent(pointer("pointerdown", 100, 100));
+    canvas.dispatchEvent(pointer("pointerup", 101, 101));
+
+    await Promise.resolve();
+    expect(fake.callsFor("screenshot_confirm_selection")).toHaveLength(0);
+    // Still open: neither confirmed nor cancelled by the tiny release.
+    expect(fake.callsFor("screenshot_cancel_capture")).toHaveLength(0);
+  });
+
+  it("cancels on Escape", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("screenshot_get_overlay_state", overlayState());
+    fake.resolve("screenshot_cancel_capture", undefined);
+
+    await mount(fake);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    await waitFor(() =>
+      expect(fake.callsFor("screenshot_cancel_capture")).toHaveLength(1)
+    );
+    expect(fake.lastCall("screenshot_cancel_capture")?.args).toEqual({
+      captureId: "abc-123",
+    });
+  });
+
+  it("does not confirm after Escape has settled the capture", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("screenshot_get_overlay_state", overlayState());
+    fake.resolve("screenshot_confirm_selection", {
+      path: "x",
+      sessionId: "s1",
+      sessionName: "n",
+    });
+    fake.resolve("screenshot_cancel_capture", undefined);
+
+    const canvas = await mount(fake);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await waitFor(() =>
+      expect(fake.callsFor("screenshot_cancel_capture")).toHaveLength(1)
+    );
+
+    // A late drag must be ignored once settled.
+    canvas.dispatchEvent(pointer("pointerdown", 10, 10));
+    canvas.dispatchEvent(pointer("pointerup", 200, 200));
+    await Promise.resolve();
+    expect(fake.callsFor("screenshot_confirm_selection")).toHaveLength(0);
+  });
+});

--- a/src/screenshot-overlay/App.tsx
+++ b/src/screenshot-overlay/App.tsx
@@ -1,0 +1,257 @@
+import { Component, onCleanup, onMount } from "solid-js";
+import { ScreenshotAPI } from "../shared/ipc";
+import type { ScreenshotOverlayState } from "../shared/types";
+import {
+  clampSelectionToBounds,
+  clientToImagePoint,
+  normalizeSelection,
+  type Point,
+  type Rect,
+} from "./selection";
+import { drawOverlay } from "./render";
+import "./styles/screenshot-overlay.css";
+
+// #714 Selection must be at least this many physical px on each side to count as
+// a real drag; a smaller release is treated as a mis-click and cancels locally
+// (the backend also rejects width/height < 2). Mirrors the plan's 2px floor.
+const MIN_SELECTION_PX = 2;
+
+/**
+ * #714 Per-monitor screenshot selection overlay. One instance renders in each
+ * `?window=screenshot-overlay&captureId=<dashed-uuid>&monitorId=<n>` window. It
+ * draws the frozen monitor image the backend captured, lets the user rubber-band
+ * a rectangle with a pixel magnifier, and sends the physical crop back. The Rust
+ * side owns ALL lifecycle/cleanup (confirm/cancel/WindowEvent::Destroyed); the
+ * frontend cancel-on-unmount is best-effort only.
+ */
+const ScreenshotOverlayApp: Component = () => {
+  let canvas: HTMLCanvasElement | undefined;
+
+  onMount(() => {
+    const params = new URLSearchParams(window.location.search);
+    const captureId = params.get("captureId") ?? "";
+    const monitorId = Number(params.get("monitorId"));
+
+    // Mutable interaction state (plain locals, not signals: drawing is fully
+    // imperative and runs off pointer events + rAF, so reactivity would only add
+    // overhead).
+    let overlay: ScreenshotOverlayState | null = null;
+    let image: HTMLImageElement | null = null;
+    let ctx: CanvasRenderingContext2D | null = null;
+    let dragStart: Point | null = null;
+    let hover: Point | null = null;
+    let settled = false; // confirm resolved OR cancel already fired.
+    let rafId = 0;
+    let disposed = false;
+    let activePointerId: number | null = null;
+
+    const cancelOnce = (reason: string): void => {
+      if (settled) return;
+      settled = true;
+      // Fire-and-forget: the backend destroys every overlay window; a stale id is
+      // a harmless no-op there.
+      void ScreenshotAPI.cancel(captureId).catch((err) => {
+        console.error(`[screenshot-overlay] cancel (${reason}) failed:`, err);
+      });
+    };
+
+    // Grab focus so the ESC keydown reaches THIS overlay even though the hotkey
+    // fired while another app was focused. Best-effort (jsdom/OS may no-op).
+    const focusOverlay = (): void => {
+      try {
+        window.focus();
+      } catch {
+        /* focus is best-effort */
+      }
+    };
+
+    const scheduleDraw = (): void => {
+      if (rafId !== 0) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = 0;
+        draw();
+      });
+    };
+
+    // Physical-px-per-CSS-px ratio, so on-screen sizes (border, magnifier) stay
+    // constant regardless of monitor DPI (the canvas backing store is physical
+    // px, displayed at the monitor's logical size).
+    const physicalPerCss = (): number => {
+      if (!canvas || !overlay) return 1;
+      const rect = canvas.getBoundingClientRect();
+      return rect.width > 0 ? overlay.width / rect.width : 1;
+    };
+
+    const draw = (): void => {
+      if (!ctx || !overlay || !image) return;
+      const { width, height } = overlay;
+      // The drag endpoint IS the hover point while dragging (both are set from
+      // the same pointer move), so `hover` doubles as the live drag corner.
+      const selection =
+        dragStart && hover
+          ? clampSelectionToBounds(
+              normalizeSelection(dragStart, hover),
+              width,
+              height
+            )
+          : null;
+      drawOverlay(
+        ctx,
+        image,
+        { width, height, physicalPerCss: physicalPerCss() },
+        selection,
+        hover
+      );
+    };
+
+    const toImagePoint = (e: PointerEvent): Point => {
+      if (!canvas || !overlay) return { x: 0, y: 0 };
+      const rect = canvas.getBoundingClientRect();
+      return clientToImagePoint(
+        { x: e.clientX, y: e.clientY },
+        rect,
+        overlay.width,
+        overlay.height
+      );
+    };
+
+    const onPointerDown = (e: PointerEvent): void => {
+      if (settled || !overlay) return;
+      focusOverlay();
+      dragStart = toImagePoint(e);
+      hover = dragStart;
+      activePointerId = e.pointerId;
+      try {
+        canvas?.setPointerCapture(e.pointerId);
+      } catch {
+        /* pointer capture is best-effort */
+      }
+      scheduleDraw();
+    };
+
+    const onPointerMove = (e: PointerEvent): void => {
+      if (settled || !overlay) return;
+      hover = toImagePoint(e);
+      scheduleDraw();
+    };
+
+    // Focus on ENTER (not on every move) so ESC reaches the overlay the cursor is
+    // over, without an OS window call on each pointermove during a drag.
+    const onPointerEnter = (): void => {
+      if (!settled) focusOverlay();
+    };
+
+    const onPointerUp = (e: PointerEvent): void => {
+      if (settled || !overlay || !dragStart) return;
+      const end = toImagePoint(e);
+      try {
+        if (activePointerId !== null) canvas?.releasePointerCapture(activePointerId);
+      } catch {
+        /* best-effort */
+      }
+      activePointerId = null;
+
+      const selection: Rect = clampSelectionToBounds(
+        normalizeSelection(dragStart, end),
+        overlay.width,
+        overlay.height
+      );
+
+      if (selection.width < MIN_SELECTION_PX || selection.height < MIN_SELECTION_PX) {
+        // Treat a tiny drag as a mis-click: reset and keep the overlay open.
+        dragStart = null;
+        scheduleDraw();
+        return;
+      }
+
+      settled = true;
+      void ScreenshotAPI.confirmSelection({
+        captureId,
+        monitorId,
+        x: selection.x,
+        y: selection.y,
+        width: selection.width,
+        height: selection.height,
+      }).catch((err) => {
+        // Backend owns teardown + a failure event; just log locally.
+        console.error("[screenshot-overlay] confirmSelection failed:", err);
+      });
+    };
+
+    const onPointerLeave = (): void => {
+      if (dragStart) return; // keep the magnifier while actively dragging
+      hover = null;
+      scheduleDraw();
+    };
+
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        cancelOnce("escape");
+      }
+    };
+
+    // Register teardown synchronously so it binds to this owner even though the
+    // async setup below resolves later.
+    onCleanup(() => {
+      disposed = true;
+      if (rafId !== 0) cancelAnimationFrame(rafId);
+      window.removeEventListener("keydown", onKeyDown);
+      if (canvas) {
+        canvas.removeEventListener("pointerdown", onPointerDown);
+        canvas.removeEventListener("pointermove", onPointerMove);
+        canvas.removeEventListener("pointerup", onPointerUp);
+        canvas.removeEventListener("pointerenter", onPointerEnter);
+        canvas.removeEventListener("pointerleave", onPointerLeave);
+      }
+      // Best-effort only — Rust's WindowEvent::Destroyed is the authority.
+      cancelOnce("unmount");
+    });
+
+    void (async () => {
+      let state: ScreenshotOverlayState;
+      try {
+        state = await ScreenshotAPI.getOverlayState(captureId, monitorId);
+      } catch (err) {
+        // Stale/starting capture: nothing to render. Rust cleans up on
+        // cancel/destroy, so just leave the (transparent) window.
+        console.error("[screenshot-overlay] getOverlayState failed:", err);
+        return;
+      }
+      if (disposed || !canvas) return;
+      overlay = state;
+
+      const img = new Image();
+      img.src = state.imageDataUrl;
+      try {
+        await img.decode();
+      } catch {
+        // decode() can reject in non-browser test envs (or for odd encodings);
+        // fall through and draw best-effort so interaction still works.
+      }
+      if (disposed || !canvas) return;
+      image = img;
+
+      canvas.width = state.width;
+      canvas.height = state.height;
+      ctx = canvas.getContext("2d");
+
+      canvas.addEventListener("pointerdown", onPointerDown);
+      canvas.addEventListener("pointermove", onPointerMove);
+      canvas.addEventListener("pointerup", onPointerUp);
+      canvas.addEventListener("pointerenter", onPointerEnter);
+      canvas.addEventListener("pointerleave", onPointerLeave);
+      window.addEventListener("keydown", onKeyDown);
+      focusOverlay();
+      draw();
+    })();
+  });
+
+  return (
+    <div class="screenshot-overlay" data-ac-testid="screenshotOverlay.root">
+      <canvas ref={canvas} data-ac-testid="screenshotOverlay.canvas" />
+    </div>
+  );
+};
+
+export default ScreenshotOverlayApp;

--- a/src/screenshot-overlay/render.test.ts
+++ b/src/screenshot-overlay/render.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { drawOverlay, SELECTION_BORDER_CSS } from "./render";
+import { magnifierSourceRect } from "./selection";
+
+interface RecordedCall {
+  op: string;
+  args: number[];
+  lineWidth: number;
+  smoothing: boolean;
+}
+
+/** A minimal recording stand-in for CanvasRenderingContext2D: every draw op is
+ *  captured with a snapshot of the current lineWidth / imageSmoothingEnabled, so
+ *  tests can assert the exact sequence and DPI-scaled sizes without real pixels
+ *  (jsdom's canvas is a no-op stub). */
+function recordingCtx() {
+  const calls: RecordedCall[] = [];
+  const ctx: Record<string, unknown> = {
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 0,
+    imageSmoothingEnabled: true,
+  };
+  const rec =
+    (op: string) =>
+    (...args: unknown[]) => {
+      calls.push({
+        op,
+        args: args.filter((a): a is number => typeof a === "number"),
+        lineWidth: ctx.lineWidth as number,
+        smoothing: ctx.imageSmoothingEnabled as boolean,
+      });
+    };
+  for (const op of [
+    "clearRect",
+    "drawImage",
+    "fillRect",
+    "strokeRect",
+    "save",
+    "restore",
+    "beginPath",
+    "closePath",
+    "arc",
+    "clip",
+    "stroke",
+    "moveTo",
+    "lineTo",
+  ]) {
+    ctx[op] = rec(op);
+  }
+  return {
+    ctx: ctx as unknown as CanvasRenderingContext2D,
+    calls,
+    drawImages: () => calls.filter((c) => c.op === "drawImage"),
+  };
+}
+
+const IMAGE = {} as CanvasImageSource;
+const MODEL = { width: 1920, height: 1080, physicalPerCss: 1 };
+
+describe("drawOverlay", () => {
+  it("draws the frozen image then a dark mask when there is no selection or hover", () => {
+    const { ctx, calls, drawImages } = recordingCtx();
+    drawOverlay(ctx, IMAGE, MODEL, null, null);
+
+    // Exactly one drawImage (the base frame), 5 numeric args = (image,0,0,w,h).
+    expect(drawImages()).toHaveLength(1);
+    expect(drawImages()[0].args).toEqual([0, 0, 1920, 1080]);
+    // A full-canvas dark mask fill.
+    expect(calls.some((c) => c.op === "fillRect")).toBe(true);
+    // No selection border, no magnifier clip.
+    expect(calls.some((c) => c.op === "strokeRect")).toBe(false);
+    expect(calls.some((c) => c.op === "clip")).toBe(false);
+  });
+
+  it("un-dims the selection region and strokes a border sized by physicalPerCss", () => {
+    const { ctx, calls, drawImages } = recordingCtx();
+    const selection = { x: 100, y: 200, width: 300, height: 150 };
+    drawOverlay(ctx, IMAGE, { ...MODEL, physicalPerCss: 2 }, selection, null);
+
+    // Base draw + one un-dim draw of the selection source→dest (9 numeric args).
+    const draws = drawImages();
+    expect(draws).toHaveLength(2);
+    expect(draws[1].args).toEqual([100, 200, 300, 150, 100, 200, 300, 150]);
+
+    // Border stroked over the selection, width scaled by the DPI ratio.
+    const strokeRect = calls.find((c) => c.op === "strokeRect");
+    expect(strokeRect?.args).toEqual([100, 200, 300, 150]);
+    expect(strokeRect?.lineWidth).toBe(SELECTION_BORDER_CSS * 2);
+  });
+
+  it("does NOT un-dim a zero-area selection", () => {
+    const { ctx, drawImages } = recordingCtx();
+    drawOverlay(ctx, IMAGE, MODEL, { x: 10, y: 10, width: 0, height: 5 }, null);
+    expect(drawImages()).toHaveLength(1); // base only
+  });
+
+  it("samples the magnifier from the clamped source rect with smoothing OFF", () => {
+    const { ctx, calls, drawImages } = recordingCtx();
+    const hover = { x: 5, y: 5 }; // near the top-left corner → source clamps to 0,0
+    drawOverlay(ctx, IMAGE, MODEL, null, hover);
+
+    // Clip to a circle before sampling.
+    expect(calls.some((c) => c.op === "clip")).toBe(true);
+
+    // The magnifier drawImage is a 9-arg blit whose SOURCE matches the pure
+    // magnifierSourceRect helper, and it must run with imageSmoothingEnabled
+    // false (pixelated zoom).
+    const src = magnifierSourceRect(hover, 32, MODEL.width, MODEL.height);
+    const magnifierDraw = drawImages().find(
+      (c) => c.args.length === 8 && c.args[0] === src.x && c.args[1] === src.y
+    );
+    expect(magnifierDraw).toBeTruthy();
+    expect(magnifierDraw!.args.slice(0, 4)).toEqual([
+      src.x,
+      src.y,
+      src.width,
+      src.height,
+    ]);
+    expect(magnifierDraw!.smoothing).toBe(false);
+    // A save/restore brackets the clipped sampling.
+    expect(calls.some((c) => c.op === "save")).toBe(true);
+    expect(calls.some((c) => c.op === "restore")).toBe(true);
+  });
+});

--- a/src/screenshot-overlay/render.ts
+++ b/src/screenshot-overlay/render.ts
@@ -1,0 +1,129 @@
+// #714 Pure canvas drawing for the screenshot overlay, split out from App.tsx so
+// it can be (a) reused by the headless visual harness and (b) unit-tested with a
+// recording mock 2D context — jsdom cannot render canvas PIXELS, but it can
+// assert the exact sequence of draw operations, which is where the real risk
+// lives (un-dimming the selection, magnifier sampling with smoothing off, etc.).
+//
+// All coordinates are PHYSICAL image pixels; `physicalPerCss` converts on-screen
+// CSS sizes (border, magnifier) into backing-store px so they stay a constant
+// on-screen size across monitor DPIs.
+
+import { magnifierSourceRect, type Point, type Rect } from "./selection";
+
+// Source window (physical px) sampled into the magnifier, and the magnifier's
+// on-screen diameter/offset + selection border width in CSS px.
+export const MAGNIFIER_SOURCE_PX = 32;
+export const MAGNIFIER_DEST_CSS = 140;
+export const MAGNIFIER_OFFSET_CSS = 24;
+export const SELECTION_BORDER_CSS = 1.5;
+
+export interface OverlayRenderModel {
+  /** Physical image width/height (canvas backing-store size). */
+  width: number;
+  height: number;
+  /** Physical-px per CSS-px (image width / canvas CSS width). */
+  physicalPerCss: number;
+}
+
+/** Draw one frame: frozen image, dark mask, the un-dimmed selection + border, and
+ *  the pixel magnifier at `hover`. `selection` is expected already normalized and
+ *  clamped to bounds; `hover`/`selection` may be null. */
+export function drawOverlay(
+  ctx: CanvasRenderingContext2D,
+  image: CanvasImageSource,
+  model: OverlayRenderModel,
+  selection: Rect | null,
+  hover: Point | null
+): void {
+  const { width, height } = model;
+  const ratio = model.physicalPerCss > 0 ? model.physicalPerCss : 1;
+
+  ctx.clearRect(0, 0, width, height);
+  ctx.drawImage(image, 0, 0, width, height);
+
+  // Dim everything, then punch the selection back to full brightness.
+  ctx.fillStyle = "rgba(0, 0, 0, 0.45)";
+  ctx.fillRect(0, 0, width, height);
+
+  if (selection && selection.width > 0 && selection.height > 0) {
+    ctx.drawImage(
+      image,
+      selection.x,
+      selection.y,
+      selection.width,
+      selection.height,
+      selection.x,
+      selection.y,
+      selection.width,
+      selection.height
+    );
+    ctx.lineWidth = Math.max(1, SELECTION_BORDER_CSS * ratio);
+    ctx.strokeStyle = "rgba(120, 200, 255, 0.95)";
+    ctx.strokeRect(selection.x, selection.y, selection.width, selection.height);
+  }
+
+  if (hover) drawMagnifier(ctx, image, model, hover);
+}
+
+function drawMagnifier(
+  ctx: CanvasRenderingContext2D,
+  image: CanvasImageSource,
+  model: OverlayRenderModel,
+  center: Point
+): void {
+  const { width, height } = model;
+  const ratio = model.physicalPerCss > 0 ? model.physicalPerCss : 1;
+  const dest = MAGNIFIER_DEST_CSS * ratio;
+  const radius = dest / 2;
+  const offset = MAGNIFIER_OFFSET_CSS * ratio;
+  const src = magnifierSourceRect(center, MAGNIFIER_SOURCE_PX, width, height);
+
+  // Default lower-right of the cursor; flip toward the interior near edges, then
+  // clamp so the whole circle stays on-canvas.
+  let cx = center.x + offset + radius;
+  let cy = center.y + offset + radius;
+  if (cx + radius > width) cx = center.x - offset - radius;
+  if (cy + radius > height) cy = center.y - offset - radius;
+  cx = Math.max(radius, Math.min(width - radius, cx));
+  cy = Math.max(radius, Math.min(height - radius, cy));
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.clip();
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(
+    image,
+    src.x,
+    src.y,
+    src.width,
+    src.height,
+    cx - radius,
+    cy - radius,
+    dest,
+    dest
+  );
+  ctx.restore();
+
+  ctx.lineWidth = Math.max(1, 2 * ratio);
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.9)";
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  // Crosshair marks the HOVERED pixel. Near a screen edge the source window is
+  // clamped so the hovered pixel is no longer at the window's center, so map
+  // `center` into the magnifier's destination space rather than assuming the
+  // dest center (else the crosshair would point at the wrong pixel at edges).
+  const magX = cx - radius + ((center.x - src.x) / src.width) * dest;
+  const magY = cy - radius + ((center.y - src.y) / src.height) * dest;
+  ctx.strokeStyle = "rgba(255, 80, 80, 0.9)";
+  ctx.lineWidth = Math.max(1, ratio);
+  ctx.beginPath();
+  ctx.moveTo(cx - radius, magY);
+  ctx.lineTo(cx + radius, magY);
+  ctx.moveTo(magX, cy - radius);
+  ctx.lineTo(magX, cy + radius);
+  ctx.stroke();
+}

--- a/src/screenshot-overlay/selection.test.ts
+++ b/src/screenshot-overlay/selection.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import {
+  clampSelectionToBounds,
+  clientToImagePoint,
+  magnifierSourceRect,
+  normalizeSelection,
+} from "./selection";
+
+describe("normalizeSelection", () => {
+  it("normalizes a top-left → bottom-right drag", () => {
+    expect(normalizeSelection({ x: 10, y: 20 }, { x: 40, y: 60 })).toEqual({
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40,
+    });
+  });
+
+  it("normalizes a bottom-right → top-left drag (both axes reversed)", () => {
+    expect(normalizeSelection({ x: 40, y: 60 }, { x: 10, y: 20 })).toEqual({
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40,
+    });
+  });
+
+  it("normalizes mixed-direction drags", () => {
+    expect(normalizeSelection({ x: 40, y: 20 }, { x: 10, y: 60 })).toEqual({
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40,
+    });
+    expect(normalizeSelection({ x: 10, y: 60 }, { x: 40, y: 20 })).toEqual({
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40,
+    });
+  });
+
+  it("yields a zero-size rect for a click with no movement", () => {
+    expect(normalizeSelection({ x: 5, y: 5 }, { x: 5, y: 5 })).toEqual({
+      x: 5,
+      y: 5,
+      width: 0,
+      height: 0,
+    });
+  });
+});
+
+describe("clientToImagePoint", () => {
+  it("maps 1:1 when the display matches the image size", () => {
+    const rect = { left: 0, top: 0, width: 1920, height: 1080 };
+    expect(clientToImagePoint({ x: 960, y: 540 }, rect, 1920, 1080)).toEqual({
+      x: 960,
+      y: 540,
+    });
+  });
+
+  it("scales up when the canvas is DISPLAYED SMALLER than the image (HiDPI)", () => {
+    // 3840x2160 backing store shown at 1920x1080 CSS px (200% monitor): a click at
+    // the CSS center must map to the physical center, proving the mapping uses the
+    // bounding rect, not a 1:1 assumption.
+    const rect = { left: 0, top: 0, width: 1920, height: 1080 };
+    expect(clientToImagePoint({ x: 960, y: 540 }, rect, 3840, 2160)).toEqual({
+      x: 1920,
+      y: 1080,
+    });
+    // A corner click maps to the far physical corner.
+    expect(clientToImagePoint({ x: 1920, y: 1080 }, rect, 3840, 2160)).toEqual({
+      x: 3840,
+      y: 2160,
+    });
+  });
+
+  it("accounts for a non-zero rect origin (offset canvas)", () => {
+    const rect = { left: 100, top: 50, width: 1000, height: 1000 };
+    expect(clientToImagePoint({ x: 600, y: 550 }, rect, 2000, 2000)).toEqual({
+      x: 1000,
+      y: 1000,
+    });
+  });
+
+  it("returns the origin instead of NaN for a zero-sized rect", () => {
+    const rect = { left: 0, top: 0, width: 0, height: 0 };
+    expect(clientToImagePoint({ x: 10, y: 10 }, rect, 1920, 1080)).toEqual({
+      x: 0,
+      y: 0,
+    });
+  });
+});
+
+describe("magnifierSourceRect", () => {
+  it("centers the source square on the point when away from edges", () => {
+    expect(magnifierSourceRect({ x: 500, y: 500 }, 32, 1920, 1080)).toEqual({
+      x: 484,
+      y: 484,
+      width: 32,
+      height: 32,
+    });
+  });
+
+  it("clamps at the top-left edge", () => {
+    expect(magnifierSourceRect({ x: 0, y: 0 }, 32, 1920, 1080)).toEqual({
+      x: 0,
+      y: 0,
+      width: 32,
+      height: 32,
+    });
+  });
+
+  it("clamps at the bottom-right edge", () => {
+    expect(magnifierSourceRect({ x: 1920, y: 1080 }, 32, 1920, 1080)).toEqual({
+      x: 1888,
+      y: 1048,
+      width: 32,
+      height: 32,
+    });
+  });
+
+  it("shrinks the square to fit an image smaller than the source size", () => {
+    expect(magnifierSourceRect({ x: 5, y: 5 }, 32, 10, 10)).toEqual({
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    });
+  });
+});
+
+describe("clampSelectionToBounds", () => {
+  it("leaves an in-bounds selection unchanged", () => {
+    expect(
+      clampSelectionToBounds({ x: 10, y: 10, width: 100, height: 100 }, 1920, 1080)
+    ).toEqual({ x: 10, y: 10, width: 100, height: 100 });
+  });
+
+  it("clamps a selection that overruns the far edge before backend confirm", () => {
+    // x=3839 + width=2 would be 3841 on a 3840-wide image → backend rejects it.
+    expect(
+      clampSelectionToBounds({ x: 3839, y: 0, width: 2, height: 2 }, 3840, 2160)
+    ).toEqual({ x: 3839, y: 0, width: 1, height: 2 });
+  });
+
+  it("clamps negative origins to zero and trims the size", () => {
+    expect(
+      clampSelectionToBounds({ x: -20, y: -10, width: 50, height: 50 }, 1920, 1080)
+    ).toEqual({ x: 0, y: 0, width: 50, height: 50 });
+  });
+
+  it("collapses a fully out-of-bounds selection to a zero-size rect at the edge", () => {
+    expect(
+      clampSelectionToBounds({ x: 5000, y: 5000, width: 100, height: 100 }, 1920, 1080)
+    ).toEqual({ x: 1920, y: 1080, width: 0, height: 0 });
+  });
+});

--- a/src/screenshot-overlay/selection.ts
+++ b/src/screenshot-overlay/selection.ts
@@ -1,0 +1,92 @@
+// #714 Pure geometry helpers for the screenshot overlay. Kept free of DOM/canvas
+// so they are unit-testable in jsdom/vitest (which cannot render canvas pixels).
+// All coordinates here are PHYSICAL image pixels unless a param is named
+// `client` (CSS/viewport pixels from a PointerEvent).
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** The subset of `DOMRect` the coordinate mapping needs. Lets tests pass a plain
+ *  object instead of constructing a real bounding-client-rect. */
+export interface ClientRectLike {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/** Top-left origin + non-negative width/height for a drag in ANY direction. */
+export function normalizeSelection(start: Point, end: Point): Rect {
+  return {
+    x: Math.min(start.x, end.x),
+    y: Math.min(start.y, end.y),
+    width: Math.abs(end.x - start.x),
+    height: Math.abs(end.y - start.y),
+  };
+}
+
+/** Map a client (CSS-pixel) point onto physical image coordinates. The canvas is
+ *  displayed at some CSS size (`rect`) but backed by `imageWidth × imageHeight`
+ *  physical pixels, so the mapping is proportional — this is what makes the crop
+ *  DPI-independent (see plan: map via bounding rect, NOT devicePixelRatio). A
+ *  zero-sized rect maps to the origin instead of producing NaN. */
+export function clientToImagePoint(
+  client: Point,
+  rect: ClientRectLike,
+  imageWidth: number,
+  imageHeight: number
+): Point {
+  const fx = rect.width > 0 ? (client.x - rect.left) / rect.width : 0;
+  const fy = rect.height > 0 ? (client.y - rect.top) / rect.height : 0;
+  return {
+    x: Math.round(fx * imageWidth),
+    y: Math.round(fy * imageHeight),
+  };
+}
+
+/** A square source rect of `sourceSize` physical px centered on `center`, clamped
+ *  so it always stays fully inside the image (the magnifier samples from this).
+ *  If the image is smaller than `sourceSize` in either axis, the square shrinks
+ *  to fit. */
+export function magnifierSourceRect(
+  center: Point,
+  sourceSize: number,
+  imageWidth: number,
+  imageHeight: number
+): Rect {
+  const size = Math.max(1, Math.min(sourceSize, imageWidth, imageHeight));
+  const x = clamp(Math.round(center.x - size / 2), 0, imageWidth - size);
+  const y = clamp(Math.round(center.y - size / 2), 0, imageHeight - size);
+  return { x, y, width: size, height: size };
+}
+
+/** Clamp a normalized selection so it never extends past the image edges. Guards
+ *  the far-edge rounding case (e.g. x=3839,w=2 on a 3840-wide image) that the
+ *  backend bounds validator would otherwise reject as a silent no-op. */
+export function clampSelectionToBounds(
+  selection: Rect,
+  imageWidth: number,
+  imageHeight: number
+): Rect {
+  const x = clamp(selection.x, 0, imageWidth);
+  const y = clamp(selection.y, 0, imageHeight);
+  return {
+    x,
+    y,
+    width: clamp(selection.width, 0, imageWidth - x),
+    height: clamp(selection.height, 0, imageHeight - y),
+  };
+}

--- a/src/screenshot-overlay/styles/screenshot-overlay.css
+++ b/src/screenshot-overlay/styles/screenshot-overlay.css
@@ -1,0 +1,32 @@
+/* #714 Screenshot overlay window styles.
+ *
+ * CRITICAL (dev-webpage-ui enrichment §A): src/main.tsx bundles EVERY window App
+ * (and its CSS) into ONE bundle, so a BARE `html, body, #root { background:
+ * transparent }` rule would leak into the main/terminal/RM/guide/spec-board
+ * windows and turn their background transparent. The document-level rules below
+ * are therefore SCOPED to `html[data-window="screenshot-overlay"]`, which
+ * main.tsx sets only for this window before rendering. The `.screenshot-overlay`
+ * class rules are already scoped and safe. */
+
+html[data-window="screenshot-overlay"],
+html[data-window="screenshot-overlay"] body,
+html[data-window="screenshot-overlay"] #root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: transparent;
+}
+
+.screenshot-overlay {
+  width: 100vw;
+  height: 100vh;
+  cursor: crosshair;
+  user-select: none;
+}
+
+.screenshot-overlay canvas {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -50,7 +50,12 @@ import type {
   ResourceKillRequest,
   ResourceKillResult,
   ResourceSnapshot,
-  CoordinatorCloseOutcome
+  CoordinatorCloseOutcome,
+  ScreenshotOverlayState,
+  ScreenshotSelection,
+  ScreenshotCaptureResult,
+  ScreenshotCaptureFailedEvent,
+  ScreenshotHotkeyStatus
 } from "./types";
 
 export interface SessionRepoInput {
@@ -474,6 +479,27 @@ export const WindowAPI = {
 
   dockResourceMonitor: () =>
     transport.invoke<void>("dock_resource_monitor_window"),
+};
+
+// #714 Screenshot capture. All global-shortcut, clipboard, and window lifecycle
+// work stays in Rust; the frontend only fetches the frozen overlay state, sends
+// the confirmed crop, cancels, and reads/reloads the hotkey registration status.
+export const ScreenshotAPI = {
+  getOverlayState: (captureId: string, monitorId: number) =>
+    transport.invoke<ScreenshotOverlayState>("screenshot_get_overlay_state", {
+      captureId,
+      monitorId,
+    }),
+  confirmSelection: (selection: ScreenshotSelection) =>
+    transport.invoke<ScreenshotCaptureResult>("screenshot_confirm_selection", {
+      selection,
+    }),
+  cancel: (captureId: string) =>
+    transport.invoke<void>("screenshot_cancel_capture", { captureId }),
+  getHotkeyStatus: () =>
+    transport.invoke<ScreenshotHotkeyStatus>("screenshot_get_hotkey_status"),
+  reloadHotkey: () =>
+    transport.invoke<ScreenshotHotkeyStatus>("screenshot_reload_hotkey"),
 };
 
 export const ResourceMonitorAPI = {
@@ -928,6 +954,27 @@ export function onCodingAgentProfilesUpdated(
   callback: () => void
 ): Promise<UnlistenFn> {
   return transport.listen<unknown>("coding_agent_profiles_updated", () => callback());
+}
+
+// #714 Screenshot capture result/failure events. Both emitted from the Rust
+// capture path; the sidebar renders them as toasts (the overlay window is
+// temporary and may be destroyed before the user reads anything).
+export function onScreenshotCaptureSaved(
+  callback: (data: ScreenshotCaptureResult) => void
+): Promise<UnlistenFn> {
+  return transport.listen<ScreenshotCaptureResult>(
+    "screenshot_capture_saved",
+    callback
+  );
+}
+
+export function onScreenshotCaptureFailed(
+  callback: (data: ScreenshotCaptureFailedEvent) => void
+): Promise<UnlistenFn> {
+  return transport.listen<ScreenshotCaptureFailedEvent>(
+    "screenshot_capture_failed",
+    callback
+  );
 }
 
 export function onCodingAgentEnvSettingsUpdated(

--- a/src/shared/screenshot-hotkey.test.ts
+++ b/src/shared/screenshot-hotkey.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { validateScreenshotHotkeySyntax } from "./screenshot-hotkey";
+
+describe("validateScreenshotHotkeySyntax", () => {
+  it("accepts one Ctrl/Control modifier plus one alphanumeric key", () => {
+    for (const value of ["Ctrl+Q", "ctrl+q", "Control+A", "control+z", "Ctrl+1"]) {
+      expect(validateScreenshotHotkeySyntax(value)).toBeNull();
+    }
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(validateScreenshotHotkeySyntax("  Ctrl+Q  ")).toBeNull();
+  });
+
+  it("reports empty / whitespace-only as required", () => {
+    expect(validateScreenshotHotkeySyntax("")).toBe("Screenshot hotkey is required");
+    expect(validateScreenshotHotkeySyntax("   ")).toBe(
+      "Screenshot hotkey is required"
+    );
+  });
+
+  it("rejects a bare key with no modifier", () => {
+    expect(validateScreenshotHotkeySyntax("Q")).toBe(
+      "Screenshot hotkey must look like Ctrl+Q"
+    );
+  });
+
+  it("rejects a second modifier (matches the backend MVP)", () => {
+    expect(validateScreenshotHotkeySyntax("Ctrl+Shift+Q")).toBe(
+      "Screenshot hotkey must look like Ctrl+Q"
+    );
+  });
+
+  it("rejects unsupported modifiers and multi-char / non-alphanumeric keys", () => {
+    for (const value of ["Alt+Q", "Shift+Q", "Ctrl+", "Ctrl+F1", "Ctrl+QQ", "Ctrl++"]) {
+      expect(validateScreenshotHotkeySyntax(value)).toBe(
+        "Screenshot hotkey must look like Ctrl+Q"
+      );
+    }
+  });
+});

--- a/src/shared/screenshot-hotkey.ts
+++ b/src/shared/screenshot-hotkey.ts
@@ -1,0 +1,21 @@
+// #714 Lightweight frontend pre-validation of the screenshot-capture hotkey.
+//
+// This MIRRORS the backend MVP parser (`crate::screenshot::parse_screenshot_hotkey`):
+// exactly one Ctrl/Control modifier plus one alphanumeric key. The backend stays
+// the single authority for what actually registers with the OS; this only gives
+// the Settings form instant feedback so an obviously-malformed value is caught
+// before save. Keep this regex a SUBSET of what the backend accepts — if the FE
+// were to pass a value the backend cannot register, that surfaces later via the
+// hotkey-status error toast, which is acceptable but noisier.
+const SCREENSHOT_HOTKEY_RE = /^(ctrl|control)\+[a-z0-9]$/i;
+
+/** Returns a human-readable error string if `raw` is not a valid screenshot
+ *  hotkey, or `null` when it is acceptable. */
+export function validateScreenshotHotkeySyntax(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return "Screenshot hotkey is required";
+  if (!SCREENSHOT_HOTKEY_RE.test(trimmed)) {
+    return "Screenshot hotkey must look like Ctrl+Q";
+  }
+  return null;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -253,6 +253,55 @@ export interface WindowGeometry {
   height: number;
 }
 
+/** #714 Frozen monitor image + metadata handed to one screenshot-overlay window.
+ *  Mirrors the Rust `ScreenshotOverlayState` (serde camelCase). `width`/`height`
+ *  are PHYSICAL image pixels (the captured bitmap), which the overlay maps
+ *  pointer coordinates onto proportionally. */
+export interface ScreenshotOverlayState {
+  captureId: string;
+  monitorId: number;
+  monitorX: number;
+  monitorY: number;
+  width: number;
+  height: number;
+  scaleFactor: number;
+  imageDataUrl: string;
+  sessionId: string;
+  sessionName: string;
+  targetDirectory: string;
+}
+
+/** #714 Physical, monitor-local crop rectangle sent to the backend on release.
+ *  Mirrors the Rust `ScreenshotSelection`. */
+export interface ScreenshotSelection {
+  captureId: string;
+  monitorId: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** #714 Success payload for `screenshot_capture_saved` + the confirm command. */
+export interface ScreenshotCaptureResult {
+  path: string;
+  sessionId: string;
+  sessionName: string;
+}
+
+/** #714 Failure payload for the `screenshot_capture_failed` event. */
+export interface ScreenshotCaptureFailedEvent {
+  message: string;
+}
+
+/** #714 Global-hotkey registration status. `error` is null when registered (or
+ *  not yet attempted). Mirrors the Rust `ScreenshotHotkeyStatus`. */
+export interface ScreenshotHotkeyStatus {
+  configured: string;
+  registered: boolean;
+  error: string | null;
+}
+
 export type MainSidebarSide = "left" | "right";
 
 /** #612 LIVE log verbosity for `agentscommander*` targets. The 5 canonical
@@ -337,6 +386,10 @@ export interface AppSettings {
   autoSelfClearByAgent: Record<string, boolean>;
   /** #612 LIVE log level for agentscommander targets. null (legacy/unset) => "info". */
   logLevel: LogLevel | null;
+  /** #714 Native global hotkey for screenshot capture (e.g. "Ctrl+Q"). Optional
+   *  here only to ease partial-settings test construction; the Rust
+   *  `#[serde(default)]` always emits it, so it is present at runtime. */
+  screenshotCaptureHotkey?: string;
 }
 
 /** #609 "npm update available" payload. Mirrors the Rust `UpdateInfo` struct

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -53,6 +53,7 @@ import { toastStore } from "../shared/stores/toasts";
 import { handleProjectRefreshRequested } from "./project-refresh-handler";
 import { loopToastFromEvent, type LoopToast } from "./loop-event-toast";
 import { createUpdateToaster } from "./update-toast";
+import { wireScreenshotListeners } from "./listeners-screenshot";
 import "./styles/sidebar.css";
 import "../shared/styles/toast.css";
 
@@ -287,6 +288,8 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       .catch((err) => {
         console.error("[update-check] getUpdateStatus failed:", err);
       });
+    // #714 screenshot capture saved/failed toasts + startup hotkey-status warning.
+    unlisteners.push(...(await wireScreenshotListeners()));
     unlisteners.push(
       await onCodingAgentEnvSettingsUpdated(() => {
         settingsStore.refresh();

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -10,6 +10,7 @@ import type {
   ProfileCellConfig,
 } from "../../shared/types";
 import { SettingsAPI, TelegramAPI, ReposAPI } from "../../shared/ipc";
+import { validateScreenshotHotkeySyntax } from "../../shared/screenshot-hotkey";
 import { settingsStore } from "../../shared/stores/settings";
 import { setSoundsEnabled } from "../../shared/sound";
 import { sessionsStore } from "../stores/sessions";
@@ -704,8 +705,18 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     return null;
   };
 
+  // #714 Lightweight pre-check mirroring the backend MVP parser (one Ctrl/Control
+  // + one alphanumeric key). Backend stays the authority for OS registration.
+  const validateScreenshotHotkey = (): string | null =>
+    validateScreenshotHotkeySyntax(
+      settings.data?.screenshotCaptureHotkey ?? "Ctrl+Q"
+    );
+
   const currentValidationError = (): string | null =>
-    validateAgents() ?? validateResources() ?? validateCoordinatorIdle();
+    validateAgents() ??
+    validateResources() ??
+    validateCoordinatorIdle() ??
+    validateScreenshotHotkey();
 
   // ── Save ──
   const handleSave = async () => {
@@ -860,6 +871,17 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             }
           />
           <span>Raise terminal when clicking sidebar</span>
+        </label>
+        <label class="settings-field">
+          <span class="settings-label">Screenshot hotkey</span>
+          <input
+            class="settings-input settings-input-sm"
+            value={settings.data!.screenshotCaptureHotkey ?? "Ctrl+Q"}
+            onInput={(e) =>
+              updateField("screenshotCaptureHotkey", e.currentTarget.value)
+            }
+            data-ac-testid="settings.general.screenshotCaptureHotkey"
+          />
         </label>
       </div>
 

--- a/src/sidebar/listeners-screenshot.test.ts
+++ b/src/sidebar/listeners-screenshot.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import { __setTransportForTests } from "../shared/ipc";
+import { toastStore } from "../shared/stores/toasts";
+import type { ScreenshotHotkeyStatus } from "../shared/types";
+import { wireScreenshotListeners } from "./listeners-screenshot";
+
+const OK_STATUS: ScreenshotHotkeyStatus = {
+  configured: "Ctrl+Q",
+  registered: true,
+  error: null,
+};
+
+describe("wireScreenshotListeners", () => {
+  let fake: FakeTransport;
+  let restore: () => void;
+
+  beforeEach(() => {
+    fake = new FakeTransport();
+    restore = __setTransportForTests(fake);
+    toastStore.clear();
+  });
+
+  afterEach(() => {
+    toastStore.clear();
+    restore();
+    vi.restoreAllMocks();
+  });
+
+  it("pushes a sticky success toast carrying the saved path on screenshot_capture_saved", async () => {
+    fake.resolve("screenshot_get_hotkey_status", OK_STATUS);
+    const unlisteners = await wireScreenshotListeners();
+
+    const path = "C:\\proj\\.ac\\wg-6-dev-team\\__agent_x\\agentscommander-screenshot.png";
+    fake.emitFromBackend("screenshot_capture_saved", {
+      path,
+      sessionId: "s1",
+      sessionName: "wg-6-dev-team/dev-webpage-ui",
+    });
+
+    expect(toastStore.items).toHaveLength(1);
+    expect(toastStore.items[0].kind).toBe("success");
+    expect(toastStore.items[0].message).toContain(path);
+
+    unlisteners.forEach((u) => u());
+  });
+
+  it("pushes a sticky error toast with the backend message on screenshot_capture_failed", async () => {
+    fake.resolve("screenshot_get_hotkey_status", OK_STATUS);
+    const unlisteners = await wireScreenshotListeners();
+
+    fake.emitFromBackend("screenshot_capture_failed", {
+      message: "No active session to save the screenshot into.",
+    });
+
+    const errors = toastStore.items.filter((t) => t.kind === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe(
+      "No active session to save the screenshot into."
+    );
+
+    unlisteners.forEach((u) => u());
+  });
+
+  it("warns once at startup when the hotkey is configured but not registered", async () => {
+    fake.resolve("screenshot_get_hotkey_status", {
+      configured: "Ctrl+Q",
+      registered: false,
+      error: "already registered by another application",
+    } satisfies ScreenshotHotkeyStatus);
+
+    const unlisteners = await wireScreenshotListeners();
+
+    await vi.waitFor(() => {
+      const warning = toastStore.items.find(
+        (t) => t.kind === "error" && t.message.includes("is not active")
+      );
+      expect(warning).toBeTruthy();
+      expect(warning!.message).toContain("Ctrl+Q");
+      expect(warning!.message).toContain(
+        "already registered by another application"
+      );
+    });
+
+    unlisteners.forEach((u) => u());
+  });
+
+  it("does NOT warn at startup when the hotkey registered cleanly", async () => {
+    fake.resolve("screenshot_get_hotkey_status", OK_STATUS);
+    const unlisteners = await wireScreenshotListeners();
+
+    // Let the fire-and-forget status check settle.
+    await vi.waitFor(() => {
+      expect(fake.callsFor("screenshot_get_hotkey_status")).toHaveLength(1);
+    });
+    // A short microtask flush; no toast should have been added.
+    await Promise.resolve();
+    expect(toastStore.items).toHaveLength(0);
+
+    unlisteners.forEach((u) => u());
+  });
+});

--- a/src/sidebar/listeners-screenshot.ts
+++ b/src/sidebar/listeners-screenshot.ts
@@ -1,0 +1,55 @@
+import type { UnlistenFn } from "../shared/transport";
+import {
+  ScreenshotAPI,
+  onScreenshotCaptureFailed,
+  onScreenshotCaptureSaved,
+} from "../shared/ipc";
+import { toastStore } from "../shared/stores/toasts";
+
+/**
+ * #714 Wire the sidebar's screenshot-capture notifications:
+ *  - `screenshot_capture_saved` → a sticky success toast carrying the saved PNG
+ *    path (which is also on the clipboard).
+ *  - `screenshot_capture_failed` → a sticky error toast (the global hotkey often
+ *    fires while another app is focused, so failures must be un-missable).
+ *  - a one-shot startup check: if the hotkey is configured but the OS refused to
+ *    register it (e.g. another app owns the combo), warn once so the feature is
+ *    not silently dead.
+ *
+ * Returns the listener unsubscribers for the caller to push onto its cleanup
+ * list. Extracted into its own module (mirroring `src/main/listeners-*.ts`) so
+ * the toast wiring is unit-testable without rendering the whole sidebar.
+ */
+export async function wireScreenshotListeners(): Promise<UnlistenFn[]> {
+  const unlisteners: UnlistenFn[] = [];
+
+  unlisteners.push(
+    await onScreenshotCaptureSaved((result) => {
+      toastStore.success(`Screenshot saved. Path copied: ${result.path}`, {
+        durationMs: null,
+      });
+    })
+  );
+
+  unlisteners.push(
+    await onScreenshotCaptureFailed(({ message }) => {
+      toastStore.error(message, { durationMs: null });
+    })
+  );
+
+  // Fire-and-forget so it never delays mount; a hotkey conflict is surfaced once.
+  void ScreenshotAPI.getHotkeyStatus()
+    .then((status) => {
+      if (!status.registered && status.error) {
+        toastStore.error(
+          `Screenshot hotkey ${status.configured} is not active: ${status.error}`,
+          { durationMs: null }
+        );
+      }
+    })
+    .catch((err) => {
+      console.error("[screenshot] getHotkeyStatus failed:", err);
+    });
+
+  return unlisteners;
+}


### PR DESCRIPTION
## Summary
- Add a native Greenshot-style screenshot capture flow for the selected active agent/session.
- Register a configurable Windows global hotkey, capture frozen monitor images, show a canvas overlay with rectangle selection and pixel magnifier, save the cropped PNG into the resolved WG replica root, and copy the saved path to the clipboard.
- Add Windows-only native screenshot dependencies with non-Windows unsupported stubs, plus settings, IPC, overlay UI, sidebar toasts, and focused tests.

## Validation
- Backend: `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib --bins --tests` passed after implementation and resync.
- Frontend: `npm run typecheck`, `npm test`, `npm run build` passed; headless overlay visual check passed.
- Grinch review: PASS after lifecycle, replica-root, hotkey-status, and resync fixes.
- Shipper: built and deployed `C:\Users\maria\0_mmb\0_AC\agentscommander_standalone_wg-6.exe` from `d21354b`; `--help` check passed.
- User visual test: passed per Maria.

Closes #714