### PR TITLE
fix(#733): show last Coding Agent + Profile on powered-off tiles; keep sidebar filter consistent (#515)

### DIFF
--- a/src/sidebar/components/ProjectPanel.offline-badges.test.tsx
+++ b/src/sidebar/components/ProjectPanel.offline-badges.test.tsx
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
+import { settingsStore } from "../../shared/stores/settings";
+import type { AcAgentReplica, AgentConfig } from "../../shared/types";
+
+// #733 — a shut-down replica (gray, no live session) must still advertise its
+// last Coding Agent + Profile. The row's three badge helpers now fall back to the
+// persisted replica config (currentCodingAgentId/currentProfile, filled at
+// discovery from disk) when session() is undefined, mirroring repoBadges(). Per
+// Maria's scope decision this applies to ALL dormant replicas — coordinators AND
+// members (no isCoord() gate) — and the live-session branch stays byte-identical.
+
+const projectPath = "C:\\Project";
+const workgroupPath = `${projectPath}\\.ac\\wg-3-dev-team`;
+const replicaPath = `${workgroupPath}\\__agent_dev-webpage-ui`;
+const replicaSessionName = "wg-3-dev-team/dev-webpage-ui";
+
+const codexAgent: AgentConfig = {
+  id: "codex",
+  label: "Codex",
+  command: "codex",
+  color: "#4ade80",
+  envs: [],
+  isolatedHome: false,
+};
+const claudeAgent: AgentConfig = {
+  id: "claude",
+  label: "Claude",
+  command: "claude",
+  color: "#c084fc",
+  envs: [],
+  isolatedHome: false,
+};
+
+/** Settings whose profiles resolve `codex`/`A` to the human label "Fast" so the
+ *  persisted tooltip (A-FAST) is meaningful, and which know the codex + claude
+ *  agents so the agent-id → label lookup resolves. */
+function settingsWithAgents() {
+  return baseSettings({
+    agents: [codexAgent, claudeAgent],
+    codingAgentProfiles: {
+      schemaVersion: 2,
+      profileSlots: { A: { label: "" }, B: { label: "" } },
+      defaultProfileByAgent: {},
+      profilesByAgent: {},
+      profileLabelsByAgent: { codex: { A: "Fast" } },
+    },
+  });
+}
+
+/** Discovery with a single replica (member or coordinator) carrying `fields`. */
+function replicaDiscovery(fields: Partial<AcAgentReplica>) {
+  return discovery({
+    workgroups: [
+      {
+        name: "wg-3-dev-team",
+        path: workgroupPath,
+        task: null,
+        taskTitle: "Offline badges",
+        agents: [
+          {
+            name: "dev-webpage-ui",
+            path: replicaPath,
+            repoPaths: [],
+            isCoordinator: false,
+            ...fields,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+const agentBadges = (root: HTMLElement): Element[] =>
+  Array.from(root.querySelectorAll(".ac-discovery-badge.agent"));
+const profileBadges = (root: HTMLElement): Element[] =>
+  Array.from(root.querySelectorAll(".profile-badge"));
+const closedPills = (root: HTMLElement): Element[] =>
+  Array.from(root.querySelectorAll(".coord-autoclosed"));
+
+async function mount(discoveryResult: ReturnType<typeof discovery>, settings = settingsWithAgents()) {
+  const fake = new FakeTransport();
+  fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+  fake.resolve("get_settings", settings);
+  fake.resolve("discover_project", discoveryResult);
+  const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+  await settingsStore.load();
+  await projectStore.createAndLoad(projectPath);
+  await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+  return rendered;
+}
+
+describe("ProjectPanel offline Coding Agent + Profile badges (#733)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("shows both the Coding Agent and Profile badges for a shut-down NON-coordinator replica from persisted config", async () => {
+    // Member replica (isCoordinator: false), no live session, but persisted
+    // currentCodingAgentId + currentProfile — proves the fallback fires for ALL
+    // replicas, not just coordinators (no isCoord() gate).
+    const rendered = await mount(
+      replicaDiscovery({ currentCodingAgentId: "codex", currentProfile: "A" })
+    );
+    try {
+      await waitFor(() => {
+        const agents = agentBadges(rendered.root);
+        const profiles = profileBadges(rendered.root);
+        expect(agents.length).toBeGreaterThan(0);
+        expect(agents.every((b) => b.textContent === "Codex")).toBe(true);
+        expect(profiles.length).toBeGreaterThan(0);
+        expect(profiles.every((b) => b.textContent === "A")).toBe(true);
+      });
+      // The tooltip resolves from the persisted agent id + profile letter.
+      expect(profileBadges(rendered.root)[0]?.getAttribute("title")).toBe("A-FAST");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows NO Coding Agent or Profile badge for a shut-down replica with no persisted config (never invents)", async () => {
+    // Gray replica that was never assigned an agent/profile: no
+    // currentCodingAgentId, no currentProfile, no preferredAgentId hint.
+    const rendered = await mount(replicaDiscovery({}));
+    try {
+      // The row itself renders (name is visible) so the absence of badges is a
+      // real "no badge", not a missing row.
+      expect(rendered.root.textContent).toContain("dev-webpage-ui");
+      expect(agentBadges(rendered.root)).toHaveLength(0);
+      expect(profileBadges(rendered.root)).toHaveLength(0);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows the AUTO-CLOSED pill together with the persisted Coding Agent + Profile badges", async () => {
+    // Auto-closed coordinators are DESTROYED (no live session), so before #733
+    // their agent/profile badges vanished with the session. The pill and the
+    // persisted badges must now coexist.
+    const rendered = await mount(
+      replicaDiscovery({
+        isCoordinator: true,
+        autoClosedAt: "2026-06-30T00:00:00.000Z",
+        currentCodingAgentId: "codex",
+        currentProfile: "A",
+      })
+    );
+    try {
+      await waitFor(() => {
+        const pills = closedPills(rendered.root);
+        expect(pills.length).toBeGreaterThan(0);
+        expect(pills.every((p) => p.textContent === "AUTO-CLOSED")).toBe(true);
+        const agents = agentBadges(rendered.root);
+        const profiles = profileBadges(rendered.root);
+        expect(agents.length).toBeGreaterThan(0);
+        expect(agents.every((b) => b.textContent === "Codex")).toBe(true);
+        expect(profiles.length).toBeGreaterThan(0);
+        expect(profiles.every((b) => b.textContent === "A")).toBe(true);
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows the MANUALLY-CLOSED pill together with the persisted Coding Agent + Profile badges", async () => {
+    const rendered = await mount(
+      replicaDiscovery({
+        isCoordinator: true,
+        manuallyClosedAt: "2026-06-30T00:00:00.000Z",
+        currentCodingAgentId: "codex",
+        currentProfile: "A",
+      })
+    );
+    try {
+      await waitFor(() => {
+        const pills = closedPills(rendered.root);
+        expect(pills.length).toBeGreaterThan(0);
+        expect(pills.every((p) => p.textContent === "MANUALLY-CLOSED")).toBe(true);
+        const agents = agentBadges(rendered.root);
+        const profiles = profileBadges(rendered.root);
+        expect(agents.length).toBeGreaterThan(0);
+        expect(agents.every((b) => b.textContent === "Codex")).toBe(true);
+        expect(profiles.length).toBeGreaterThan(0);
+        expect(profiles.every((b) => b.textContent === "A")).toBe(true);
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps the live session as the source of truth — persisted replica config does not override a live session's badges", async () => {
+    // Live coordinator running claude/B, while the persisted replica config says
+    // codex/A. The live-session branch must win (byte-identical to today): badges
+    // read claude/B and the persisted codex/A must NOT leak through.
+    sessionsStore.setSessions([
+      session({
+        id: "live-coord",
+        name: replicaSessionName,
+        workingDirectory: replicaPath,
+        isCoordinator: true,
+        status: "running",
+        agentId: "claude",
+        agentLabel: "Claude",
+        requestedProfile: "B",
+        effectiveProfile: "B",
+      }),
+    ]);
+
+    const rendered = await mount(
+      replicaDiscovery({
+        isCoordinator: true,
+        currentCodingAgentId: "codex",
+        currentProfile: "A",
+      })
+    );
+    try {
+      await waitFor(() => {
+        const agents = agentBadges(rendered.root);
+        expect(agents.length).toBeGreaterThan(0);
+        expect(agents.every((b) => b.textContent === "Claude")).toBe(true);
+      });
+      const profiles = profileBadges(rendered.root);
+      expect(profiles.length).toBeGreaterThan(0);
+      expect(profiles.every((b) => b.textContent === "B")).toBe(true);
+      // The persisted codex/A fallback must not surface while the session is live.
+      expect(agentBadges(rendered.root).some((b) => b.textContent === "Codex")).toBe(false);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
@@ -952,4 +952,82 @@ describe("ProjectPanel regex filter", () => {
       rendered.cleanup();
     }
   });
+
+  it("matches a shut-down replica by its persisted Coding Agent label and Profile letter (#733/#515)", async () => {
+    // #733 makes a gray replica show its persisted Coding Agent + Profile badges;
+    // #515 requires the filter to match what is visible. Both rows are dormant
+    // members (no session): dev-webpage-ui carries a persisted codex/Z, dev-rust
+    // carries nothing. Neither "codex" nor "z" appears anywhere in dev-webpage-ui's
+    // row text except its badges, so a match proves the persisted label + letter
+    // now flow into replicaSearchText (before the fix they did not -> the row would
+    // be filtered out while visibly showing a Codex badge).
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve(
+      "get_settings",
+      baseSettings({ agents: [agentConfig({ id: "codex", label: "Codex", command: "codex" })] })
+    );
+    fake.resolve(
+      "discover_project",
+      discovery({
+        agents: [],
+        teams: [],
+        workgroups: [
+          {
+            name: "wg-2-dev-team",
+            path: workgroupPath,
+            task: null,
+            taskTitle: "Sidebar regex filter",
+            agents: [
+              {
+                name: "dev-webpage-ui",
+                path: `${workgroupPath}\\__agent_dev-webpage-ui`,
+                repoPaths: [],
+                isCoordinator: false,
+                currentCodingAgentId: "codex",
+                currentProfile: "Z",
+              },
+              {
+                name: "dev-rust",
+                path: `${workgroupPath}\\__agent_dev-rust`,
+                repoPaths: [],
+                isCoordinator: false,
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+      // Both dormant rows are visible unfiltered, and the persisted badge shows.
+      expect(rendered.root.textContent).toContain("dev-rust");
+      expect(rendered.root.textContent).toContain("Codex");
+
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      // (a) filter by the persisted Coding Agent label — matchable only via the badge.
+      input(filterInput, "codex");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).not.toContain("dev-rust");
+      });
+
+      // (b) filter by the persisted Profile letter — "z" is nowhere in the row text
+      // except the persisted profile badge.
+      input(filterInput, "z");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).not.toContain("dev-rust");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
 });

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -910,6 +910,30 @@ const ProjectPanel: Component = () => {
           if (!session.agentId) return null;
           return settingsStore.current?.agents?.find((a) => a.id === session.agentId)?.label ?? null;
         };
+        // #733/#515: single source of truth for a replica row's Coding Agent label
+        // and Profile badge, so the row render (renderReplicaItem) and the sidebar
+        // filter search text (replicaSearchText) can never diverge — a badge that is
+        // visible is always matchable. A live session wins and stays byte-identical
+        // to the pre-#733 behavior (reuses liveAgentLabel / sessionProfileBadge); a
+        // shut-down replica falls back to its persisted config (currentCodingAgentId
+        // ?? preferredAgentId — same precedence as the launch path at :616 — and
+        // currentProfile), mirroring repoBadges()' configured fallback.
+        const resolveReplicaAgentLabel = (
+          session: Session | undefined,
+          replica: AcAgentReplica
+        ): string | null => {
+          if (session) return liveAgentLabel(session);
+          const agentId = replica.currentCodingAgentId ?? replica.preferredAgentId;
+          if (!agentId) return null;
+          return settingsStore.current?.agents?.find((a) => a.id === agentId)?.label ?? null;
+        };
+        const resolveReplicaProfileBadge = (
+          session: Session | undefined,
+          replica: AcAgentReplica
+        ): string | null => {
+          if (session) return sessionProfileBadge(session);
+          return replica.currentProfile ?? null;
+        };
         const replicaSearchText = (
           replica: AcAgentReplica,
           wg: AcWorkgroup,
@@ -931,10 +955,12 @@ const ProjectPanel: Component = () => {
             replica.isCoordinator
               ? repos.map((repo) => formatReplicaRepoBadgeLabel(repo)).join(" ")
               : null,
-            liveAgentLabel(session),
-            // A replica row renders the profile badge unconditionally whenever the
-            // session has one (renderReplicaItem) → always matchable here (#515 bug 2).
-            session ? sessionProfileBadge(session) : null,
+            resolveReplicaAgentLabel(session, replica),
+            // #733/#515: mirror the row badges via the shared resolvers so a dormant
+            // replica's persisted Coding Agent label + Profile letter are matchable
+            // exactly when they are visible (renderReplicaItem uses the same helpers).
+            // A live session keeps sessionProfileBadge's `X->Y` fallback text.
+            resolveReplicaProfileBadge(session, replica),
             replica.isCoordinator ? "coordinator" : null,
             extraBadge,
             sessionSearchText(session)
@@ -1573,35 +1599,15 @@ const ProjectPanel: Component = () => {
             `replica.badges.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}`;
           const repoBadgeTestId = (label: string, index: number) =>
             `replica.repoBadge.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}.${index}.${automationIdPart(label)}`;
-          // #733: a shut-down replica has no live session, so each of the three
-          // badge helpers below falls back to the persisted replica config
-          // (currentCodingAgentId/currentProfile, filled at discovery from the
-          // on-disk config) when session() is undefined — mirroring repoBadges()
-          // above, which already falls to configuredReplicaRepoBadges(). The
-          // live-session branch is kept byte-identical (guarded by `if (s)`). The
-          // id precedence `currentCodingAgentId ?? preferredAgentId` matches the
-          // launch path at :616. Applies to ALL dormant replicas, coordinators AND
-          // members (Maria's scope decision — no isCoord() gate), so an auto- or
-          // manually-closed coordinator now shows its pill AND its last Coding
-          // Agent + Profile together.
-          const liveAgentLabel = () => {
-            const s = session();
-            if (s) {
-              if (s.agentLabel) return s.agentLabel;
-              if (!s.agentId) return null;
-              return settingsStore.current?.agents?.find((a) => a.id === s.agentId)?.label ?? null;
-            }
-            const agentId = replica.currentCodingAgentId ?? replica.preferredAgentId;
-            if (!agentId) return null;
-            return settingsStore.current?.agents?.find((a) => a.id === agentId)?.label ?? null;
-          };
-          const profileBadge = () => {
-            const s = session();
-            // Live session keeps the `X->Y` fallback rendering of sessionProfileBadge;
-            // a dormant replica shows its persisted profile letter (#733).
-            if (s) return sessionProfileBadge(s);
-            return replica.currentProfile ?? null;
-          };
+          // #733: the Coding Agent + Profile badges fall back to the persisted
+          // replica config when there is no live session, so a shut-down replica
+          // (incl. AUTO-/MANUALLY-CLOSED coordinators — no isCoord() gate, Maria's
+          // scope decision) still shows its last agent/profile. Both the render
+          // (here) and the sidebar filter (replicaSearchText) route through the
+          // shared resolveReplica* helpers so a visible badge is always matchable
+          // (#515). The live-session branch stays byte-identical.
+          const liveAgentLabel = () => resolveReplicaAgentLabel(session(), replica);
+          const profileBadge = () => resolveReplicaProfileBadge(session(), replica);
           // #548: resolver-backed tooltip naming the EFFECTIVE profile (the one
           // actually in effect) for this session's coding agent. Plain function
           // (NOT createMemo) — row-local and recomputes on settings reload.

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1573,27 +1573,54 @@ const ProjectPanel: Component = () => {
             `replica.badges.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}`;
           const repoBadgeTestId = (label: string, index: number) =>
             `replica.repoBadge.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}.${index}.${automationIdPart(label)}`;
+          // #733: a shut-down replica has no live session, so each of the three
+          // badge helpers below falls back to the persisted replica config
+          // (currentCodingAgentId/currentProfile, filled at discovery from the
+          // on-disk config) when session() is undefined — mirroring repoBadges()
+          // above, which already falls to configuredReplicaRepoBadges(). The
+          // live-session branch is kept byte-identical (guarded by `if (s)`). The
+          // id precedence `currentCodingAgentId ?? preferredAgentId` matches the
+          // launch path at :616. Applies to ALL dormant replicas, coordinators AND
+          // members (Maria's scope decision — no isCoord() gate), so an auto- or
+          // manually-closed coordinator now shows its pill AND its last Coding
+          // Agent + Profile together.
           const liveAgentLabel = () => {
             const s = session();
-            if (!s) return null;
-            if (s.agentLabel) return s.agentLabel;
-            if (!s.agentId) return null;
-            return settingsStore.current?.agents?.find((a) => a.id === s.agentId)?.label ?? null;
+            if (s) {
+              if (s.agentLabel) return s.agentLabel;
+              if (!s.agentId) return null;
+              return settingsStore.current?.agents?.find((a) => a.id === s.agentId)?.label ?? null;
+            }
+            const agentId = replica.currentCodingAgentId ?? replica.preferredAgentId;
+            if (!agentId) return null;
+            return settingsStore.current?.agents?.find((a) => a.id === agentId)?.label ?? null;
           };
           const profileBadge = () => {
             const s = session();
-            return s ? sessionProfileBadge(s) : null;
+            // Live session keeps the `X->Y` fallback rendering of sessionProfileBadge;
+            // a dormant replica shows its persisted profile letter (#733).
+            if (s) return sessionProfileBadge(s);
+            return replica.currentProfile ?? null;
           };
           // #548: resolver-backed tooltip naming the EFFECTIVE profile (the one
           // actually in effect) for this session's coding agent. Plain function
           // (NOT createMemo) — row-local and recomputes on settings reload.
+          // #733: same session-less fallback as the two helpers above — the tooltip
+          // resolves from the persisted agent id + profile letter when there is no
+          // live session (cfg-missing still short-circuits to undefined, unchanged).
           const profileBadgeTitle = () => {
             const s = session();
             const cfg = settingsStore.current?.codingAgentProfiles;
-            if (!s || !cfg) return undefined;
-            const letter = s.effectiveProfile || s.requestedProfile;
+            if (!cfg) return undefined;
+            if (s) {
+              const letter = s.effectiveProfile || s.requestedProfile;
+              if (!letter) return undefined;
+              return profileDisplayLabel(cfg, settingsStore.current?.agents ?? [], s.agentId, letter);
+            }
+            const letter = replica.currentProfile;
             if (!letter) return undefined;
-            return profileDisplayLabel(cfg, settingsStore.current?.agents ?? [], s.agentId, letter);
+            const agentId = replica.currentCodingAgentId ?? replica.preferredAgentId;
+            return profileDisplayLabel(cfg, settingsStore.current?.agents ?? [], agentId, letter);
           };
           const isLive = () => isSessionLive(session());
           const bridge = () => { const s = session(); return s ? bridgesStore.getBridge(s.id) : undefined; };


### PR DESCRIPTION
## What

On a **powered-off / gray** coordinator or replica tile (`session()===undefined` — never launched, or the session was destroyed, e.g. after AUTO-CLOSE / MANUALLY-CLOSE), the **last Coding Agent** and **Profile** badges disappeared, even though the data is already persisted (`replica.currentCodingAgentId` / `currentProfile`) and delivered to the frontend at discovery time. Live and exited (red) tiles already showed them.

This change makes those badges fall back to the persisted `replica` config when there is no live session, mirroring the existing `repoBadges()` fallback. UI-only, no backend, no new types.

## How

In `src/sidebar/components/ProjectPanel.tsx`:

- Two shared resolvers — `resolveReplicaAgentLabel(session, replica)` and `resolveReplicaProfileBadge(session, replica)` — return the live-session value when a session exists, else fall back to `replica.currentCodingAgentId ?? preferredAgentId` / `replica.currentProfile`.
- The `renderReplicaItem` row helpers (`liveAgentLabel` / `profileBadge` / `profileBadgeTitle`) delegate to these resolvers.
- **Filter consistency (#515):** `replicaSearchText()` uses the **same** resolvers, so the sidebar regex filter matches exactly what is visible — a powered-off tile showing a "Codex"/profile badge is now matchable by it, and never matchable by a badge it does not show. A stale "always matchable" comment was refreshed.

**Scope:** applies to all powered-off replica tiles (coordinators and non-coordinators; no `isCoord()` gate) — user decision.

The live/exited-session branch is byte-identical to before (including `sessionProfileBadge`'s `X→Y` fallback). AUTO-CLOSED / MANUALLY-CLOSED pills and `ProfileOutdatedBadge` gating are untouched; a closed coordinator now correctly shows its pill **and** its last agent/profile. Gray tiles with no persisted config still show no badge.

## Tests

- `ProjectPanel.offline-badges.test.tsx` (new, 5 cases): non-coordinator gray replica shows both badges from persisted config; gray replica with no config shows none; AUTO-CLOSED and MANUALLY-CLOSED coordinators each show pill + badges together; live session wins over persisted config (byte-identity guard).
- `ProjectPanel.regex-filter.test.tsx` (+1): filtering by the persisted coding-agent label and by the profile letter surfaces a powered-off replica and hides one with no config.

## Review

- **dev-webpage-ui** implemented: `tsc` 0 errors, `vitest` full suite 613/613, new tests pass by name, `/code-review` high (MEDIUM #515 folded in and closed).
- **dev-rust-grinch** Step-9 adversarial review → **PASS** (ran gates himself: tsc 0, vitest 613/613, new tests 22/22 by name; genuine-test proof: reverting `ProjectPanel.tsx` to base fails 4 of the new tests). No HIGH, no MED. One LOW is pre-existing and out of scope (`resetUiStoresForTests` does not reset `settingsStore` — inert here; follow-up), plus 2 INFO non-defects.

Closes #733
