### PR TITLE
fix(#738): protect user-set task titles

### DIFF
--- a/docs/agents/teams-and-workgroups.md
+++ b/docs/agents/teams-and-workgroups.md
@@ -108,6 +108,8 @@ agentscommander task-append-body --token "$TOKEN" --root "$ROOT" --text "We drop
 
 Both verbs validate the caller is a coordinator of any team in the project and create a timestamped `.bak.md` of the previous `TASK.md` before writing.
 
+Coordinator title updates do not overwrite titles that begin with `USER:` (a human set those through the in-app title editor). Coordinator-supplied titles also cannot start with the reserved `USER:` prefix. Use Clean to reset a user-owned task before coordinator auto-title updates resume.
+
 ## Activating a workgroup
 
 From the UI, click **Activate** on the team. From the CLI, use `workgroup add`. AC creates the same disk layout:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -441,6 +441,26 @@ agentscommander task-set-title \
 
 The verb writes a timestamped `*.bak.md` of the previous `TASK.md` on every successful write. Concurrent writes are serialized via an advisory lockfile (5s timeout). External edits between read and write abort the verb.
 
+On success, stdout is exactly:
+
+```text
+Updated
+```
+
+If the existing title starts with `USER:` (a human set it through the in-app title editor), the command exits `0`, leaves `TASK.md` unchanged, and stdout is exactly:
+
+```text
+Rejected: title set by user
+```
+
+If `--title` itself starts with the reserved `USER:` prefix and the current title is not already user-owned, the command exits `1`, writes no stdout, leaves `TASK.md` unchanged, and stderr starts with:
+
+```text
+Error: --title cannot start with reserved USER: prefix
+```
+
+Use Clean to reset a user-owned task before coordinator title updates resume. Operational audit details are written to the app log, not normal command output.
+
 ---
 
 ## `task-append-body`

--- a/src-tauri/src/cli/task_append_body.rs
+++ b/src-tauri/src/cli/task_append_body.rs
@@ -146,6 +146,12 @@ pub fn execute(args: TaskAppendBodyArgs) -> i32 {
             crate::cli_println!("TASK.md unchanged");
             0
         }
+        Ok(EditOutcome::RejectedUserTitle { .. }) => {
+            // Unreachable for AppendBody (the #738 user-lock guard only fires on
+            // TaskOp::SetTitle); defensive arm so the match stays exhaustive.
+            crate::cli_println!("TASK.md unchanged");
+            0
+        }
         Err(e) => {
             eprintln!("Error: {}", e);
             1

--- a/src-tauri/src/cli/task_ops.rs
+++ b/src-tauri/src/cli/task_ops.rs
@@ -35,8 +35,13 @@ const LOCK_STALE_AFTER_5M: Duration = Duration::from_secs(300);
 /// Edit operation requested by a verb.
 #[derive(Debug, Clone)]
 pub enum TaskOp {
-    /// Replace or insert the YAML-frontmatter `title:` field.
+    /// Coordinator/agent title write. Writes the value verbatim (no `USER:`
+    /// marker) and is subject to the user-lock + reserved-prefix guards.
     SetTitle(String),
+    /// Human title write (GUI editor + workgroup creation). Prefixes the value
+    /// with `USER:` (unless already present) and bypasses the coordinator
+    /// user-lock guard so a human can always edit a prior human title.
+    SetUserTitle(String),
     /// Append a body paragraph (frontmatter untouched).
     AppendBody(String),
     /// Replace BOTH frontmatter title AND body with the canonical Clean form
@@ -61,12 +66,81 @@ pub enum EditOutcome {
         content: String,
         title: Option<String>,
     },
+    /// Coordinator set-title rejected because the current title is user-owned
+    /// (`USER:`). NOT an error: exit code 0, no write, no backup. The GUI/human
+    /// path (`SetUserTitle`) never produces this.
+    RejectedUserTitle {
+        content: String,
+        title: Option<String>,
+    },
+}
+
+/// Reserved marker that flags a task title as human-set (#738).
+pub(crate) const USER_TITLE_PREFIX: &str = "USER:";
+
+#[derive(Debug, Clone, Copy)]
+struct TitleLine<'a> {
+    leading: &'a str,
+    value: &'a str,
+}
+
+/// Recognize a frontmatter `title:` line the same way the UI/backend readers do:
+/// split on the first `:`, match the key case-insensitively, and keep the
+/// leading whitespace so replacement can preserve indentation. `value` is the
+/// trimmed raw scalar (still quoted, if it was).
+fn title_line(line: &str) -> Option<TitleLine<'_>> {
+    let leading_len = line.len() - line.trim_start().len();
+    let leading = &line[..leading_len];
+    let rest = &line[leading_len..];
+    let (key, value) = rest.split_once(':')?;
+    if key.trim().eq_ignore_ascii_case("title") {
+        Some(TitleLine {
+            leading,
+            value: value.trim(),
+        })
+    } else {
+        None
+    }
+}
+
+/// Decode a YAML scalar as broadly as the app's title readers: single-quoted
+/// (with `''` unescape), double-quoted (stripped), or bare (trimmed).
+fn decode_title_scalar(value: &str) -> String {
+    let value = value.trim();
+    if value.len() >= 2 && value.starts_with('\'') && value.ends_with('\'') {
+        return value[1..value.len() - 1].replace("''", "'");
+    }
+    if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
+        return value[1..value.len() - 1].to_string();
+    }
+    value.to_string()
+}
+
+/// True when a title value carries the reserved human-owned marker.
+pub(crate) fn is_user_owned_title(title: &str) -> bool {
+    title.trim_start().starts_with(USER_TITLE_PREFIX)
+}
+
+/// Normalize a human-set title to the `USER: <value>` form, without double
+/// prefixing an already-marked value.
+pub(crate) fn user_owned_title(input: &str) -> String {
+    let trimmed = input.trim();
+    if is_user_owned_title(trimmed) {
+        trimmed.to_string()
+    } else {
+        format!("{} {}", USER_TITLE_PREFIX, trimmed)
+    }
 }
 
 /// Errors emitted by [`perform`]. `Display` impls match the §3 error matrix
 /// of plan #137 verbatim.
 #[derive(Debug, thiserror::Error)]
 pub enum TaskOpError {
+    /// Coordinator `--title` input itself started with the reserved `USER:`
+    /// prefix while the current title was not already user-owned (#738). Invalid
+    /// input: exit 1, no stdout, TASK.md unchanged, no backup.
+    #[error("--title cannot start with reserved USER: prefix")]
+    ReservedUserTitlePrefix,
     #[error("TASK.md is locked by another writer (5s timeout). Try again.")]
     LockTimeout,
     #[error("failed to acquire TASK.md lock at {}: {}. Aborting; TASK.md left unchanged.", .0.display(), .1)]
@@ -213,6 +287,7 @@ pub(crate) fn render(parsed: &ParsedTask) -> String {
 pub(crate) fn apply_edit(parsed: &ParsedTask, op: &TaskOp) -> ParsedTask {
     match op {
         TaskOp::SetTitle(title) => apply_set_title(parsed, title),
+        TaskOp::SetUserTitle(title) => apply_set_title(parsed, &user_owned_title(title)),
         TaskOp::AppendBody(text) => apply_append_body(parsed, text),
         TaskOp::Clean => apply_clean(parsed),
     }
@@ -249,11 +324,13 @@ fn apply_set_title(parsed: &ParsedTask, title: &str) -> ParsedTask {
         };
     }
 
-    // Has frontmatter — find existing title-shaped line(s) (NIT-5).
+    // Has frontmatter — find existing title-shaped line(s) (NIT-5). Match the
+    // key case-insensitively (via `title_line`) so `Title:`/`TITLE:` lines are
+    // replaced in place instead of leaving a stranded key + a new duplicate.
     let title_count = parsed
         .frontmatter
         .iter()
-        .filter(|line| line.trim_start().starts_with("title:"))
+        .filter(|line| title_line(line).is_some())
         .count();
     if title_count > 1 {
         log::warn!(
@@ -264,17 +341,15 @@ fn apply_set_title(parsed: &ParsedTask, title: &str) -> ParsedTask {
     }
 
     let mut new_fm: Vec<String> = parsed.frontmatter.clone();
-    let title_idx = new_fm
-        .iter()
-        .position(|line| line.trim_start().starts_with("title:"));
+    let title_idx = new_fm.iter().position(|line| title_line(line).is_some());
 
     match title_idx {
         Some(idx) => {
-            // Replace, preserving leading whitespace (so an indented `  title: x`
-            // becomes `  title: 'NewTitle'`).
-            let original = &new_fm[idx];
-            let leading_len = original.len() - original.trim_start().len();
-            let leading = &original[..leading_len];
+            // Replace, preserving the existing leading whitespace (so an indented
+            // `  title: x` becomes `  title: 'NewTitle'`).
+            let leading = title_line(&new_fm[idx])
+                .map(|title| title.leading)
+                .unwrap_or("");
             new_fm[idx] = format!("{}{}", leading, new_title_line);
         }
         None => {
@@ -326,37 +401,16 @@ fn apply_clean(parsed: &ParsedTask) -> ParsedTask {
     }
 }
 
-/// Extract the YAML-decoded value of the first `title:` line in the
-/// frontmatter, for the semantic idempotence short-circuit (MED-3). Returns
-/// `None` when the frontmatter has no title-shaped line.
+/// Extract the decoded value of the first `title:` line in the frontmatter, for
+/// the semantic idempotence short-circuit (MED-3) and the #738 user-lock guard.
+/// Matches the key case-insensitively and decodes single/double-quoted and bare
+/// scalars via [`decode_title_scalar`], mirroring the app's other title readers.
+/// Returns `None` when the frontmatter has no title-shaped line.
 pub(crate) fn title_value_of(parsed: &ParsedTask) -> Option<String> {
     parsed
         .frontmatter
         .iter()
-        .find(|line| line.trim_start().starts_with("title:"))
-        .map(|line| {
-            let after_prefix = line
-                .trim_start()
-                .strip_prefix("title:")
-                .unwrap_or("")
-                .trim();
-            extract_yaml_single_quoted(after_prefix)
-        })
-}
-
-/// Decode a YAML scalar from the canonical single-quoted form `'value with '' escapes'`.
-/// For non-canonical inputs (bare scalar, double-quoted, etc.) returns the raw
-/// trimmed input. Sufficient for "did the user-visible title change?" — the
-/// conservative direction (returning false → write a new backup) is harmless;
-/// the unsafe direction (returning true → skip a real edit) is impossible because
-/// the parsed-after-edit form is always canonical single-quoted.
-fn extract_yaml_single_quoted(s: &str) -> String {
-    let s = s.trim();
-    if s.len() >= 2 && s.starts_with('\'') && s.ends_with('\'') {
-        let inner = &s[1..s.len() - 1];
-        return inner.replace("''", "'");
-    }
-    s.to_string()
+        .find_map(|line| title_line(line).map(|title| decode_title_scalar(title.value)))
 }
 
 // ── Lock guard ──────────────────────────────────────────────────────────────
@@ -465,6 +519,30 @@ where
 
     // ── 3-4. Parse + apply edit ───────────────────────────────────────────
     let parsed = parse_task(&existing);
+    let current_title = title_value_of(&parsed);
+    let current_is_user_owned = current_title.as_deref().is_some_and(is_user_owned_title);
+
+    // #738 user-lock: a coordinator SetTitle must never overwrite a human-owned
+    // (`USER:`) title. This is a successful outcome (exit 0): no write, no backup.
+    // Ordered before the reserved-prefix check so a coordinator re-sending the
+    // same `USER: X` is rejected here (not treated as invalid input).
+    if matches!(op, TaskOp::SetTitle(_)) && current_is_user_owned {
+        return Ok(EditOutcome::RejectedUserTitle {
+            content: existing.clone(),
+            title: current_title.clone(),
+        });
+    }
+
+    // #738 reserved-prefix: a coordinator SetTitle whose own input starts with
+    // `USER:` is invalid input (it would forge a human lock) unless an existing
+    // user-owned title already blocked the write above. Hard error, exit 1, no
+    // write, no backup. SetUserTitle/creation are unaffected (human-owned paths).
+    if let TaskOp::SetTitle(title) = &op {
+        if is_user_owned_title(title) {
+            return Err(TaskOpError::ReservedUserTitlePrefix);
+        }
+    }
+
     let new_parsed = apply_edit(&parsed, &op);
 
     // ── 5. Idempotence short-circuit ──────────────────────────────────────
@@ -474,7 +552,9 @@ where
     //   body byte-match the pre-edit shape (covers repeated clean clicks).
     // AppendBody: never NoOp.
     let is_noop = match op {
-        TaskOp::SetTitle(_) => title_value_of(&new_parsed) == title_value_of(&parsed),
+        TaskOp::SetTitle(_) | TaskOp::SetUserTitle(_) => {
+            title_value_of(&new_parsed) == current_title
+        }
         TaskOp::Clean => {
             new_parsed.frontmatter == parsed.frontmatter && new_parsed.body == parsed.body
         }
@@ -1353,5 +1433,165 @@ mod tests {
                 panic!("unexpected final disk content");
             }
         }
+    }
+
+    // ── #738: user-owned (USER:) title ownership ────────────────────────
+
+    fn bak_count(wg: &Path) -> usize {
+        std::fs::read_dir(wg)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".bak.md"))
+            .count()
+    }
+
+    #[test]
+    fn user_owned_title_prefixes_plain_title() {
+        assert_eq!(user_owned_title("Build login"), "USER: Build login");
+    }
+
+    #[test]
+    fn user_owned_title_does_not_double_prefix() {
+        assert_eq!(user_owned_title("USER: Build login"), "USER: Build login");
+    }
+
+    #[test]
+    fn set_title_rejects_when_existing_title_is_user_owned() {
+        let fix = FixtureRoot::new("task-738-reject");
+        let wg = fix.path().join("wg-1");
+        std::fs::create_dir_all(&wg).unwrap();
+        let task = wg.join("TASK.md");
+        std::fs::write(&task, "---\ntitle: 'USER: Keep me'\n---\nbody\n").unwrap();
+        let before = std::fs::read(&task).unwrap();
+        let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
+        let r = perform_inner(&wg, TaskOp::SetTitle("Auto".into()), now).unwrap();
+        assert!(matches!(r, EditOutcome::RejectedUserTitle { .. }));
+        assert_eq!(
+            std::fs::read(&task).unwrap(),
+            before,
+            "TASK.md must be byte-unchanged on reject"
+        );
+        assert_eq!(bak_count(&wg), 0, "no backup on reject");
+    }
+
+    #[test]
+    fn set_title_rejects_case_variant_user_owned_titles() {
+        // A UI-visible user-owned title with a case-variant key must still block
+        // the coordinator overwrite (Grinch MUST-FIX #1).
+        for key in ["Title", "TITLE", "tItLe"] {
+            let fix = FixtureRoot::new("task-738-case");
+            let wg = fix.path().join("wg-1");
+            std::fs::create_dir_all(&wg).unwrap();
+            let task = wg.join("TASK.md");
+            std::fs::write(&task, format!("---\n{key}: 'USER: Manual'\n---\n")).unwrap();
+            let before = std::fs::read(&task).unwrap();
+            let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
+            let r = perform_inner(&wg, TaskOp::SetTitle("Auto".into()), now).unwrap();
+            assert!(
+                matches!(r, EditOutcome::RejectedUserTitle { .. }),
+                "key {key} must reject"
+            );
+            assert_eq!(std::fs::read(&task).unwrap(), before, "key {key} unchanged");
+            assert_eq!(bak_count(&wg), 0, "key {key} no backup");
+        }
+    }
+
+    #[test]
+    fn set_title_rejects_double_quoted_user_owned_title() {
+        // Double-quoted scalar must decode to the same USER: marker (Grinch #1).
+        let fix = FixtureRoot::new("task-738-dq");
+        let wg = fix.path().join("wg-1");
+        std::fs::create_dir_all(&wg).unwrap();
+        let task = wg.join("TASK.md");
+        std::fs::write(&task, "---\ntitle: \"USER: Manual\"\n---\n").unwrap();
+        let before = std::fs::read(&task).unwrap();
+        let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
+        let r = perform_inner(&wg, TaskOp::SetTitle("Auto".into()), now).unwrap();
+        assert!(matches!(r, EditOutcome::RejectedUserTitle { .. }));
+        assert_eq!(std::fs::read(&task).unwrap(), before);
+        assert_eq!(bak_count(&wg), 0);
+    }
+
+    #[test]
+    fn apply_set_title_replaces_case_variant_title_key() {
+        // A coordinator SetTitle over a PLAIN case-variant `Title: Old` (not
+        // user-owned) must replace that line in place, not leave it plus a new
+        // lowercase duplicate (Grinch MUST-FIX #1 second half).
+        let parsed = parse_task("---\nTitle: Old\n---\nbody\n");
+        let p = apply_set_title(&parsed, "Auto");
+        let title_lines = p.frontmatter.iter().filter(|l| title_line(l).is_some()).count();
+        assert_eq!(title_lines, 1, "exactly one title line after replacement");
+        assert_eq!(p.frontmatter, vec!["title: 'Auto'".to_string()]);
+    }
+
+    #[test]
+    fn set_title_rejects_reserved_user_prefix_input() {
+        // Coordinator input that itself starts with USER: is invalid input when
+        // the current title is not already user-owned (Grinch MUST-FIX #2).
+        let fix = FixtureRoot::new("task-738-reserved");
+        let wg = fix.path().join("wg-1");
+        std::fs::create_dir_all(&wg).unwrap();
+        let task = wg.join("TASK.md");
+        std::fs::write(&task, "---\ntitle: 'Auto'\n---\n").unwrap();
+        let before = std::fs::read(&task).unwrap();
+        let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
+        let r = perform_inner(&wg, TaskOp::SetTitle("USER: forged".into()), now);
+        assert!(matches!(r, Err(TaskOpError::ReservedUserTitlePrefix)));
+        assert_eq!(std::fs::read(&task).unwrap(), before, "unchanged on invalid input");
+        assert_eq!(bak_count(&wg), 0, "no backup on invalid input");
+    }
+
+    #[test]
+    fn set_title_allowed_after_clean_clears_user_lock() {
+        let fix = FixtureRoot::new("task-738-clean");
+        let wg = fix.path().join("wg-1");
+        std::fs::create_dir_all(&wg).unwrap();
+        std::fs::write(
+            wg.join("TASK.md"),
+            "---\ntitle: 'USER: Keep me'\n---\nbody\n",
+        )
+        .unwrap();
+        let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
+        // Clean resets the user-owned lock (writes canonical title 'Clean').
+        perform_inner(&wg, TaskOp::Clean, now).unwrap();
+        // Coordinator SetTitle is now allowed and writes a plain title.
+        let r = perform_inner(&wg, TaskOp::SetTitle("Auto".into()), now).unwrap();
+        assert!(matches!(r, EditOutcome::Wrote { .. }));
+        let parsed = parse_task(&std::fs::read_to_string(wg.join("TASK.md")).unwrap());
+        assert_eq!(title_value_of(&parsed).as_deref(), Some("Auto"));
+    }
+
+    #[test]
+    fn set_user_title_prefixes_plain_title() {
+        let fix = FixtureRoot::new("task-738-suser");
+        let wg = fix.path().join("wg-1");
+        std::fs::create_dir_all(&wg).unwrap();
+        let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
+        perform_inner(&wg, TaskOp::SetUserTitle("Manual".into()), now).unwrap();
+        let parsed = parse_task(&std::fs::read_to_string(wg.join("TASK.md")).unwrap());
+        assert_eq!(title_value_of(&parsed).as_deref(), Some("USER: Manual"));
+    }
+
+    #[test]
+    fn set_user_title_overwrites_existing_user_title() {
+        let fix = FixtureRoot::new("task-738-suser2");
+        let wg = fix.path().join("wg-1");
+        std::fs::create_dir_all(&wg).unwrap();
+        std::fs::write(wg.join("TASK.md"), "---\ntitle: 'USER: Old'\n---\n").unwrap();
+        let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
+        perform_inner(&wg, TaskOp::SetUserTitle("New".into()), now).unwrap();
+        let parsed = parse_task(&std::fs::read_to_string(wg.join("TASK.md")).unwrap());
+        assert_eq!(title_value_of(&parsed).as_deref(), Some("USER: New"));
+    }
+
+    #[test]
+    fn set_title_noop_on_plain_existing_title_still_updates_contract() {
+        let fix = FixtureRoot::new("task-738-noop");
+        let wg = fix.path().join("wg-1");
+        std::fs::create_dir_all(&wg).unwrap();
+        std::fs::write(wg.join("TASK.md"), "---\ntitle: 'Auto'\n---\nbody\n").unwrap();
+        let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
+        let r = perform_inner(&wg, TaskOp::SetTitle("Auto".into()), now).unwrap();
+        assert!(matches!(r, EditOutcome::NoOp { .. }));
     }
 }

--- a/src-tauri/src/cli/task_set_title.rs
+++ b/src-tauri/src/cli/task_set_title.rs
@@ -23,7 +23,9 @@ INVARIANTS: A timestamped backup is created on every successful write that had a
 prior file. Concurrent writes are serialized via an advisory lockfile (5s timeout). \
 External edits between our read and our write are detected and the verb aborts.\n\n\
 TITLE INPUT: --title is a single-line string. Embedded \\n / \\r / NUL / other \
-control characters (except tab) are rejected.")]
+control characters (except tab) are rejected. A coordinator --title also cannot \
+start with the reserved USER: prefix; that marker is reserved for human-set \
+titles applied through the in-app title editor.")]
 pub struct TaskSetTitleArgs {
     /// Session token from AGENTSCOMMANDER_TOKEN. Shape-validated in the CLI;
     /// per-session authorization happens at the daemon mailbox. See `--help` TOKEN VALIDATION MODEL.
@@ -114,27 +116,24 @@ pub fn execute(args: TaskSetTitleArgs) -> i32 {
     // tree. `sender=` and `wg=` are both caller-derived (--root) and a forged
     // --root produces a forged-but-consistent line; pid disambiguates.
     match task_ops::perform(&wg_root, TaskOp::SetTitle(args.title.clone())) {
-        Ok(EditOutcome::Wrote {
-            backup: Some(bp), ..
-        }) => {
-            log::info!(
-                "[task] set-title: sender={} wg={} pid={} backup={}",
-                sender,
-                wg_root.display(),
-                std::process::id(),
-                bp.display()
-            );
-            crate::cli_println!("TASK.md title updated; backup: {}", bp.display());
-            0
-        }
-        Ok(EditOutcome::Wrote { backup: None, .. }) => {
-            log::info!(
-                "[task] set-title: sender={} wg={} pid={} backup=<no prior file>",
-                sender,
-                wg_root.display(),
-                std::process::id()
-            );
-            crate::cli_println!("TASK.md created; no prior content to back up");
+        Ok(EditOutcome::Wrote { backup, .. }) => {
+            if let Some(bp) = backup {
+                log::info!(
+                    "[task] set-title: sender={} wg={} pid={} backup={}",
+                    sender,
+                    wg_root.display(),
+                    std::process::id(),
+                    bp.display()
+                );
+            } else {
+                log::info!(
+                    "[task] set-title: sender={} wg={} pid={} backup=<no prior file>",
+                    sender,
+                    wg_root.display(),
+                    std::process::id()
+                );
+            }
+            crate::cli_println!("Updated");
             0
         }
         Ok(EditOutcome::NoOp { .. }) => {
@@ -144,7 +143,17 @@ pub fn execute(args: TaskSetTitleArgs) -> i32 {
                 wg_root.display(),
                 std::process::id()
             );
-            crate::cli_println!("TASK.md unchanged (title value already matches)");
+            crate::cli_println!("Updated");
+            0
+        }
+        Ok(EditOutcome::RejectedUserTitle { .. }) => {
+            log::info!(
+                "[task] set-title rejected user-owned title: sender={} wg={} pid={}",
+                sender,
+                wg_root.display(),
+                std::process::id()
+            );
+            crate::cli_println!("Rejected: title set by user");
             0
         }
         Err(e) => {

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use tauri::{AppHandle, Emitter, Manager, State};
 
+use crate::cli::task_ops;
 use crate::commands::ac_discovery::DiscoveryBranchWatcher;
 use crate::config::replica_identity::{
     expected_wg_replica_identity, normalize_wg_replica_context_entries,
@@ -324,7 +325,11 @@ pub(crate) fn parse_task_title(content: &str) -> Option<String> {
 /// auto-title prompt. Store the title in the same frontmatter shape used by
 /// the title editor.
 fn build_task_content(task_title: &str) -> String {
-    let escaped = task_title.trim().replace('\'', "''");
+    // #738: the workgroup-creation title is a human decision, so store it as
+    // user-owned (`USER:`). This locks it against coordinator auto-retitle until
+    // a Clean resets the task. `user_owned_title` trims and avoids double-prefix.
+    let title = task_ops::user_owned_title(task_title);
+    let escaped = title.replace('\'', "''");
     format!("---\ntitle: '{}'\n---\n", escaped)
 }
 
@@ -3374,6 +3379,33 @@ mod tests {
         assert!(
             !is_rename_blocked_by_handle(&e),
             "non-Windows must always return false"
+        );
+    }
+
+    // ── #738: build_task_content marks creation titles as user-owned ──
+
+    #[test]
+    fn build_task_content_prefixes_user_title() {
+        assert_eq!(
+            build_task_content("Build login"),
+            "---\ntitle: 'USER: Build login'\n---\n"
+        );
+    }
+
+    #[test]
+    fn build_task_content_does_not_double_prefix() {
+        assert_eq!(
+            build_task_content("USER: Existing"),
+            "---\ntitle: 'USER: Existing'\n---\n"
+        );
+    }
+
+    #[test]
+    fn build_task_content_escapes_quotes_after_prefix() {
+        // The single quote is YAML-escaped (doubled) after the USER: prefix.
+        assert_eq!(
+            build_task_content("Ana's task"),
+            "---\ntitle: 'USER: Ana''s task'\n---\n"
         );
     }
 

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -238,7 +238,7 @@ pub async fn task_set_title(
     }
     let wg_root = resolve_wg_root(&session_mgr, &session_id).await?;
     let outcome =
-        task_ops::perform(&wg_root, TaskOp::SetTitle(title)).map_err(|e| e.to_string())?;
+        task_ops::perform(&wg_root, TaskOp::SetUserTitle(title)).map_err(|e| e.to_string())?;
     log::info!(
         "[task] set_title for session {} -> {:?}",
         session_id,
@@ -248,6 +248,9 @@ pub async fn task_set_title(
     let (content, task_title) = match &outcome {
         task_ops::EditOutcome::Wrote { content, title, .. } => (content.clone(), title.clone()),
         task_ops::EditOutcome::NoOp { content, title } => (content.clone(), title.clone()),
+        task_ops::EditOutcome::RejectedUserTitle { content, title } => {
+            (content.clone(), title.clone())
+        }
     };
     let trimmed = content.trim();
     let task = if trimmed.is_empty() {
@@ -279,6 +282,9 @@ pub async fn task_clean(
     let (content, task_title) = match &outcome {
         task_ops::EditOutcome::Wrote { content, title, .. } => (content.clone(), title.clone()),
         task_ops::EditOutcome::NoOp { content, title } => (content.clone(), title.clone()),
+        task_ops::EditOutcome::RejectedUserTitle { content, title } => {
+            (content.clone(), title.clone())
+        }
     };
     let trimmed = content.trim();
     let task = if trimmed.is_empty() {
@@ -316,6 +322,9 @@ pub async fn task_clean_at(
     let (content, task_title) = match &outcome {
         task_ops::EditOutcome::Wrote { content, title, .. } => (content.clone(), title.clone()),
         task_ops::EditOutcome::NoOp { content, title } => (content.clone(), title.clone()),
+        task_ops::EditOutcome::RejectedUserTitle { content, title } => {
+            (content.clone(), title.clone())
+        }
     };
     let trimmed = content.trim();
     let task = if trimmed.is_empty() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -41,6 +41,7 @@ fn main() {
                                 | agentscommander_lib::cli::Commands::UiType(_)
                                 | agentscommander_lib::cli::Commands::UiBackend(_)
                                 | agentscommander_lib::cli::Commands::UiWait(_)
+                                | agentscommander_lib::cli::Commands::TaskSetTitle(_)
                         ) {
                             std::env::set_var("AC_MACHINE_OUTPUT", "1");
                         }

--- a/src-tauri/tests/cli_behavior_contract.rs
+++ b/src-tauri/tests/cli_behavior_contract.rs
@@ -818,3 +818,178 @@ fn window_info_no_gui_contract() {
         assert_eq!(json["error"], "window_info_unsupported_on_platform");
     }
 }
+
+// ── #738: task-set-title user-owned title output contract ───────────────────
+
+fn seed_master_token(config_dir: &Path, token: &str) {
+    std::fs::create_dir_all(config_dir).expect("create config dir");
+    std::fs::write(config_dir.join("master-token.txt"), token).expect("write master-token.txt");
+}
+
+fn make_wg_agent_root(tmp: &Path) -> PathBuf {
+    let root = tmp
+        .join("proj")
+        .join(".ac")
+        .join("wg-1-dev-team")
+        .join("__agent_architect");
+    std::fs::create_dir_all(&root).expect("create agent root");
+    root
+}
+
+/// Run `task-set-title` with `RUST_LOG=agentscommander=info` pinned, so the
+/// clean-output assertions hold even under verbose logging: the AC_MACHINE_OUTPUT
+/// allowlist must suppress stderr log lines and the startup log-path line.
+fn run_task_title(
+    bin: &Path,
+    agent_root: &Path,
+    master: &str,
+    title: &str,
+) -> (Option<i32>, String, String) {
+    let out = Command::new(bin)
+        .args([
+            "task-set-title",
+            "--token",
+            master,
+            "--root",
+            &agent_root.to_string_lossy(),
+            "--title",
+            title,
+        ])
+        .env("RUST_LOG", "agentscommander=info")
+        .output()
+        .expect("spawn task-set-title");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn bak_files(wg_root: &Path) -> Vec<PathBuf> {
+    std::fs::read_dir(wg_root)
+        .map(|rd| {
+            rd.flatten()
+                .map(|e| e.path())
+                .filter(|p| {
+                    p.file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.starts_with("TASK.") && n.ends_with(".bak.md"))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn assert_no_leak(stdout: &str, stderr: &str) {
+    for stream in [stdout, stderr] {
+        for needle in [
+            "backup",
+            "pid=",
+            "[task]",
+            "app.log",
+            "INFO",
+            "agentscommander",
+            "module",
+        ] {
+            assert!(
+                !stream.contains(needle),
+                "normal output leaked {needle:?}:\nstdout={stdout:?}\nstderr={stderr:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn task_set_title_success_stdout_is_exact_updated() {
+    let tmp = Tmp::new("task-title-ok");
+    let bin = copy_binary_into(tmp.path());
+    let master = "test-master-738-ok";
+    seed_master_token(&config_dir_for_bin(&bin), master);
+    let agent_root = make_wg_agent_root(tmp.path());
+    let wg_root = agent_root.parent().unwrap().to_path_buf();
+
+    let (code, stdout, stderr) = run_task_title(&bin, &agent_root, master, "Auto");
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "Updated\n");
+    assert!(stderr.trim().is_empty(), "stderr must be empty: {stderr}");
+
+    let task = std::fs::read_to_string(wg_root.join("TASK.md")).expect("read TASK.md");
+    assert!(
+        task.contains("title: 'Auto'") && !task.contains("USER:"),
+        "coordinator title must be plain, not USER:-marked:\n{task}"
+    );
+}
+
+#[test]
+fn task_set_title_rejects_user_owned_title_with_exact_output() {
+    let tmp = Tmp::new("task-title-reject");
+    let bin = copy_binary_into(tmp.path());
+    let master = "test-master-738-reject";
+    seed_master_token(&config_dir_for_bin(&bin), master);
+    let agent_root = make_wg_agent_root(tmp.path());
+    let wg_root = agent_root.parent().unwrap().to_path_buf();
+    let task_path = wg_root.join("TASK.md");
+    std::fs::write(&task_path, "---\ntitle: 'USER: Manual'\n---\n").unwrap();
+    let before = std::fs::read(&task_path).unwrap();
+
+    let (code, stdout, stderr) = run_task_title(&bin, &agent_root, master, "Auto");
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "Rejected: title set by user\n");
+    assert!(stderr.trim().is_empty(), "stderr must be empty: {stderr}");
+    assert_eq!(
+        std::fs::read(&task_path).unwrap(),
+        before,
+        "TASK.md must be byte-unchanged on reject"
+    );
+    assert!(bak_files(&wg_root).is_empty(), "no backup on reject");
+}
+
+#[test]
+fn task_set_title_reserved_user_prefix_input_is_invalid() {
+    let tmp = Tmp::new("task-title-reserved");
+    let bin = copy_binary_into(tmp.path());
+    let master = "test-master-738-reserved";
+    seed_master_token(&config_dir_for_bin(&bin), master);
+    let agent_root = make_wg_agent_root(tmp.path());
+    let wg_root = agent_root.parent().unwrap().to_path_buf();
+    let task_path = wg_root.join("TASK.md");
+    std::fs::write(&task_path, "---\ntitle: 'Auto'\n---\n").unwrap();
+    let before = std::fs::read(&task_path).unwrap();
+
+    let (code, stdout, stderr) = run_task_title(&bin, &agent_root, master, "USER: forged");
+    assert_eq!(code, Some(1), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(stdout.is_empty(), "no stdout on invalid input: {stdout}");
+    assert_eq!(
+        stderr,
+        "Error: --title cannot start with reserved USER: prefix\n"
+    );
+    assert_eq!(
+        std::fs::read(&task_path).unwrap(),
+        before,
+        "TASK.md must be byte-unchanged on invalid input"
+    );
+    assert!(bak_files(&wg_root).is_empty(), "no backup on invalid input");
+}
+
+#[test]
+fn task_set_title_normal_output_does_not_leak_logs_or_paths() {
+    let tmp = Tmp::new("task-title-leak");
+    let bin = copy_binary_into(tmp.path());
+    let master = "test-master-738-leak";
+    seed_master_token(&config_dir_for_bin(&bin), master);
+    let agent_root = make_wg_agent_root(tmp.path());
+    let wg_root = agent_root.parent().unwrap().to_path_buf();
+
+    // Accepted path (fresh file -> Wrote): exact stdout, no log/path leak.
+    let (code, stdout, stderr) = run_task_title(&bin, &agent_root, master, "First");
+    assert_eq!(code, Some(0), "stderr: {stderr}");
+    assert_eq!(stdout, "Updated\n");
+    assert_no_leak(&stdout, &stderr);
+
+    // Rejected path (seed a USER: title so the next coordinator write is rejected).
+    std::fs::write(wg_root.join("TASK.md"), "---\ntitle: 'USER: Manual'\n---\n").unwrap();
+    let (code, stdout, stderr) = run_task_title(&bin, &agent_root, master, "Second");
+    assert_eq!(code, Some(0), "stderr: {stderr}");
+    assert_eq!(stdout, "Rejected: title set by user\n");
+    assert_no_leak(&stdout, &stderr);
+}


### PR DESCRIPTION
## Summary
- Protect human-authored workgroup Task Titles by storing/displaying them as `USER: <title>`.
- Make coordinator `task-set-title` reject current user-owned titles with exit code 0 and exact output `Rejected: title set by user`.
- Make accepted coordinator title updates print only `Updated`, with CLI log/path noise suppressed.
- Reject coordinator input that attempts to forge the reserved `USER:` prefix.
- Add broad title parsing/replacement coverage for case-variant title keys and quoted scalars.

## Verification
- Dev-rust: `cargo check`, `cargo clippy --all-targets -- -D warnings`, targeted Rust tests, full `cargo test --lib --bins --tests` = 1803 passed / 12 ignored / 0 failed.
- Grinch PASS: targeted review/tests passed (`task_ops`, `cli_behavior_contract task_set_title`, `build_task_content`, `cli_task_logger`).
- Visual classification: non-visual backend/CLI behavior change; shipper build N/A.

Closes #738