### PR TITLE
feat: workgroup UI groups (Telegram-style sidebar rail filter) (#737)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod entity_creation;
 pub mod gemini_resolver;
 pub mod loops;
 pub mod phone;
+pub mod project_settings;
 pub mod pty;
 pub mod repos;
 pub mod resource_monitor;

--- a/src-tauri/src/commands/project_settings.rs
+++ b/src-tauri/src/commands/project_settings.rs
@@ -1,0 +1,68 @@
+use std::path::Path;
+
+use crate::config::project_settings::{
+    load_workgroup_groups, save_workgroup_groups, WorkgroupGroupsConfig,
+};
+
+#[tauri::command]
+pub async fn get_project_groups(path: String) -> Result<WorkgroupGroupsConfig, String> {
+    load_workgroup_groups(Path::new(&path))
+}
+
+#[tauri::command]
+pub async fn update_project_groups(
+    path: String,
+    config: WorkgroupGroupsConfig,
+) -> Result<WorkgroupGroupsConfig, String> {
+    save_workgroup_groups(Path::new(&path), config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::project_settings::WorkgroupGroup;
+
+    fn project_with_workspace() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(temp.path().join(".ac")).expect("create .ac");
+        temp
+    }
+
+    fn sample_config() -> WorkgroupGroupsConfig {
+        WorkgroupGroupsConfig {
+            groups: vec![WorkgroupGroup {
+                id: "bots".to_string(),
+                name: "BOTS".to_string(),
+                regex: "^(wg-9)$".to_string(),
+            }],
+            show_all: true,
+            show_ungrouped: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn get_project_groups_returns_default_for_missing_file() {
+        let project = project_with_workspace();
+
+        let loaded = get_project_groups(project.path().to_string_lossy().to_string())
+            .await
+            .expect("get groups");
+
+        assert_eq!(loaded, WorkgroupGroupsConfig::default());
+    }
+
+    #[tokio::test]
+    async fn update_project_groups_round_trips_saved_config() {
+        let project = project_with_workspace();
+        let path = project.path().to_string_lossy().to_string();
+        let config = sample_config();
+
+        let saved = update_project_groups(path.clone(), config.clone())
+            .await
+            .expect("update groups");
+        let loaded = get_project_groups(path).await.expect("get groups");
+
+        assert_eq!(saved, config);
+        assert_eq!(loaded, config);
+    }
+}

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -10,6 +10,7 @@ pub mod local_config_io;
 pub mod loops;
 pub mod placeholders;
 pub mod profile;
+pub mod project_settings;
 pub mod projects;
 pub mod replica_identity;
 pub mod root_agent;

--- a/src-tauri/src/config/project_settings.rs
+++ b/src-tauri/src/config/project_settings.rs
@@ -1,0 +1,451 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+pub const PROJECT_SETTINGS_FILE: &str = "project-settings.json";
+pub const MAX_WORKGROUP_GROUPS: usize = 80;
+pub const MAX_GROUP_ID_LEN: usize = 128;
+pub const MAX_GROUP_NAME_LEN: usize = 80;
+pub const MAX_GROUP_REGEX_LEN: usize = 1024;
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkgroupGroup {
+    pub id: String,
+    pub name: String,
+    pub regex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkgroupGroupsConfig {
+    #[serde(default)]
+    pub groups: Vec<WorkgroupGroup>,
+    #[serde(default = "default_true")]
+    pub show_all: bool,
+    #[serde(default = "default_true")]
+    pub show_ungrouped: bool,
+}
+
+impl Default for WorkgroupGroupsConfig {
+    fn default() -> Self {
+        Self {
+            groups: Vec::new(),
+            show_all: true,
+            show_ungrouped: true,
+        }
+    }
+}
+
+fn project_settings_path(project_path: &Path) -> Result<PathBuf, String> {
+    let workspace = crate::config::workspace::existing_workspace_dir(project_path)
+        .ok_or_else(|| format!("Project has no .ac directory: {}", project_path.display()))?;
+    Ok(workspace.join(PROJECT_SETTINGS_FILE))
+}
+
+fn normalize_groups_config(mut config: WorkgroupGroupsConfig) -> WorkgroupGroupsConfig {
+    if !config.show_all && !config.show_ungrouped {
+        config.show_all = true;
+    }
+    config
+}
+
+fn validate_groups_config_structure(config: &WorkgroupGroupsConfig) -> Result<(), String> {
+    if !config.show_all && !config.show_ungrouped {
+        return Err("At least one of showAll or showUngrouped must be true".to_string());
+    }
+    if config.groups.len() > MAX_WORKGROUP_GROUPS {
+        return Err(format!("At most {MAX_WORKGROUP_GROUPS} groups are allowed"));
+    }
+
+    let mut ids = HashSet::new();
+    let mut names = HashSet::new();
+
+    for group in &config.groups {
+        let id = group.id.trim();
+        if id.is_empty() {
+            return Err("Group id cannot be blank".to_string());
+        }
+        if group.id.chars().count() > MAX_GROUP_ID_LEN {
+            return Err(format!(
+                "Group id cannot exceed {MAX_GROUP_ID_LEN} characters"
+            ));
+        }
+        if !ids.insert(id.to_string()) {
+            return Err("Duplicate group id".to_string());
+        }
+
+        let name = group.name.trim();
+        if name.is_empty() {
+            return Err("Group name cannot be blank".to_string());
+        }
+        if group.name.chars().count() > MAX_GROUP_NAME_LEN {
+            return Err(format!(
+                "Group name cannot exceed {MAX_GROUP_NAME_LEN} characters"
+            ));
+        }
+        if !names.insert(name.to_lowercase()) {
+            return Err("Duplicate group name".to_string());
+        }
+
+        if group.regex.chars().count() > MAX_GROUP_REGEX_LEN {
+            return Err(format!(
+                "Group regex cannot exceed {MAX_GROUP_REGEX_LEN} characters"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn load_workgroup_groups(project_path: &Path) -> Result<WorkgroupGroupsConfig, String> {
+    let path = project_settings_path(project_path)?;
+    if !path.exists() {
+        return Ok(WorkgroupGroupsConfig::default());
+    }
+
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+    let root: Value = serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+    let obj = root
+        .as_object()
+        .ok_or_else(|| format!("Project settings {} must be a JSON object", path.display()))?;
+    let config: WorkgroupGroupsConfig = serde_json::from_value(Value::Object(obj.clone()))
+        .map_err(|e| {
+            format!(
+                "Failed to parse project groups from {}: {}",
+                path.display(),
+                e
+            )
+        })?;
+    let config = normalize_groups_config(config);
+    validate_groups_config_structure(&config)?;
+    Ok(config)
+}
+
+pub fn save_workgroup_groups(
+    project_path: &Path,
+    config: WorkgroupGroupsConfig,
+) -> Result<WorkgroupGroupsConfig, String> {
+    validate_groups_config_structure(&config)?;
+    let path = project_settings_path(project_path)?;
+
+    // This is a last-successful-writer-wins update across processes. The shared
+    // helper serializes in-process writes and prevents torn JSON, but it is not
+    // a merge or compare-and-swap layer. If another process wins a first-create
+    // race on Windows after the helper's existence precheck, surfacing that
+    // filesystem error is acceptable and the caller keeps its prior state.
+    crate::config::local_config_io::update_config_json_object(&path, true, |obj| {
+        let groups = serde_json::to_value(&config.groups)
+            .map_err(|e| format!("Failed to serialize project groups: {}", e))?;
+        obj.insert("groups".to_string(), groups);
+        obj.insert("showAll".to_string(), Value::Bool(config.show_all));
+        obj.insert(
+            "showUngrouped".to_string(),
+            Value::Bool(config.show_ungrouped),
+        );
+        Ok(())
+    })?;
+
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn project_with_workspace() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(temp.path().join(".ac")).expect("create .ac");
+        temp
+    }
+
+    fn settings_path(project: &Path) -> PathBuf {
+        project.join(".ac").join(PROJECT_SETTINGS_FILE)
+    }
+
+    fn group(id: &str, name: &str, regex: &str) -> WorkgroupGroup {
+        WorkgroupGroup {
+            id: id.to_string(),
+            name: name.to_string(),
+            regex: regex.to_string(),
+        }
+    }
+
+    fn config_with_groups(groups: Vec<WorkgroupGroup>) -> WorkgroupGroupsConfig {
+        WorkgroupGroupsConfig {
+            groups,
+            show_all: true,
+            show_ungrouped: true,
+        }
+    }
+
+    #[test]
+    fn missing_project_settings_returns_default_groups_config() {
+        let project = project_with_workspace();
+
+        let loaded = load_workgroup_groups(project.path()).expect("load groups");
+
+        assert_eq!(loaded, WorkgroupGroupsConfig::default());
+        assert!(!settings_path(project.path()).exists());
+    }
+
+    #[test]
+    fn empty_object_deserializes_to_defaults() {
+        let project = project_with_workspace();
+        std::fs::write(settings_path(project.path()), "{}").expect("write settings");
+
+        let loaded = load_workgroup_groups(project.path()).expect("load groups");
+
+        assert_eq!(loaded, WorkgroupGroupsConfig::default());
+    }
+
+    #[test]
+    fn partial_json_with_only_groups_defaults_toggles_true() {
+        let project = project_with_workspace();
+        std::fs::write(
+            settings_path(project.path()),
+            r#"{"groups":[{"id":"bots","name":"BOTS","regex":"^(wg-9)$"}]}"#,
+        )
+        .expect("write settings");
+
+        let loaded = load_workgroup_groups(project.path()).expect("load groups");
+
+        assert_eq!(loaded.groups, vec![group("bots", "BOTS", "^(wg-9)$")]);
+        assert!(loaded.show_all);
+        assert!(loaded.show_ungrouped);
+    }
+
+    #[test]
+    fn load_both_toggles_false_normalizes_show_all_without_rewriting() {
+        let project = project_with_workspace();
+        let path = settings_path(project.path());
+        let original = r#"{"groups":[],"showAll":false,"showUngrouped":false}"#;
+        std::fs::write(&path, original).expect("write settings");
+
+        let loaded = load_workgroup_groups(project.path()).expect("load groups");
+
+        assert!(loaded.show_all);
+        assert!(!loaded.show_ungrouped);
+        assert_eq!(
+            std::fs::read_to_string(path).expect("read settings"),
+            original
+        );
+    }
+
+    #[test]
+    fn save_rejects_both_toggles_false() {
+        let project = project_with_workspace();
+        let config = WorkgroupGroupsConfig {
+            groups: Vec::new(),
+            show_all: false,
+            show_ungrouped: false,
+        };
+
+        let err = save_workgroup_groups(project.path(), config).expect_err("reject config");
+
+        assert!(err.contains("showAll"), "{err}");
+        assert!(!settings_path(project.path()).exists());
+    }
+
+    #[test]
+    fn save_rejects_invalid_group_structure() {
+        let project = project_with_workspace();
+        let oversized_id = "i".repeat(MAX_GROUP_ID_LEN + 1);
+        let oversized_name = "n".repeat(MAX_GROUP_NAME_LEN + 1);
+        let oversized_regex = "r".repeat(MAX_GROUP_REGEX_LEN + 1);
+        let too_many_groups = (0..=MAX_WORKGROUP_GROUPS)
+            .map(|idx| group(&format!("g{idx}"), &format!("G{idx}"), ".*"))
+            .collect::<Vec<_>>();
+        let cases = vec![
+            (
+                config_with_groups(vec![group(" ", "Name", ".*")]),
+                "Group id cannot be blank",
+            ),
+            (
+                config_with_groups(vec![group("dup", "One", ".*"), group("dup", "Two", ".*")]),
+                "Duplicate group id",
+            ),
+            (
+                config_with_groups(vec![group("id", " ", ".*")]),
+                "Group name cannot be blank",
+            ),
+            (
+                config_with_groups(vec![group("a", "Bots", ".*"), group("b", " bots ", ".*")]),
+                "Duplicate group name",
+            ),
+            (
+                config_with_groups(vec![group(&oversized_id, "Name", ".*")]),
+                "Group id cannot exceed",
+            ),
+            (
+                config_with_groups(vec![group("id", &oversized_name, ".*")]),
+                "Group name cannot exceed",
+            ),
+            (
+                config_with_groups(vec![group("id", "Name", &oversized_regex)]),
+                "Group regex cannot exceed",
+            ),
+            (
+                config_with_groups(too_many_groups),
+                "At most 80 groups are allowed",
+            ),
+        ];
+
+        for (config, expected) in cases {
+            let err = save_workgroup_groups(project.path(), config).expect_err("reject config");
+            assert!(err.contains(expected), "expected {expected:?}, got {err:?}");
+        }
+        assert!(!settings_path(project.path()).exists());
+    }
+
+    #[test]
+    fn load_rejects_invalid_group_structure_after_defaults() {
+        let project = project_with_workspace();
+        let path = settings_path(project.path());
+        let too_many = (0..=MAX_WORKGROUP_GROUPS)
+            .map(|idx| json!({"id": format!("g{idx}"), "name": format!("G{idx}"), "regex": ".*"}))
+            .collect::<Vec<_>>();
+        let cases = vec![
+            (
+                json!({"groups":[{"id":"dup","name":"One","regex":".*"},{"id":"dup","name":"Two","regex":".*"}]}),
+                "Duplicate group id",
+            ),
+            (
+                json!({"groups":[{"id":"a","name":"Ops","regex":".*"},{"id":"b","name":" ops ","regex":".*"}]}),
+                "Duplicate group name",
+            ),
+            (
+                json!({"groups":[{"id":"","name":"Name","regex":".*"}]}),
+                "Group id cannot be blank",
+            ),
+            (
+                json!({"groups":[{"id":"id","name":"","regex":".*"}]}),
+                "Group name cannot be blank",
+            ),
+            (json!({"groups": too_many}), "At most 80 groups are allowed"),
+            (
+                json!({"groups":[{"id":"i".repeat(MAX_GROUP_ID_LEN + 1),"name":"Name","regex":".*"}]}),
+                "Group id cannot exceed",
+            ),
+            (
+                json!({"groups":[{"id":"id","name":"n".repeat(MAX_GROUP_NAME_LEN + 1),"regex":".*"}]}),
+                "Group name cannot exceed",
+            ),
+            (
+                json!({"groups":[{"id":"id","name":"Name","regex":"r".repeat(MAX_GROUP_REGEX_LEN + 1)}]}),
+                "Group regex cannot exceed",
+            ),
+        ];
+
+        for (value, expected) in cases {
+            std::fs::write(&path, serde_json::to_string(&value).expect("json"))
+                .expect("write settings");
+            let err = load_workgroup_groups(project.path()).expect_err("reject loaded config");
+            assert!(err.contains(expected), "expected {expected:?}, got {err:?}");
+        }
+    }
+
+    #[test]
+    fn save_preserves_unknown_root_keys_and_documented_agents_key() {
+        let project = project_with_workspace();
+        let path = settings_path(project.path());
+        let original = json!({
+            "agents": [
+                {
+                    "id": "agent_1",
+                    "label": "Claude Code",
+                    "command": "codex",
+                    "color": "#d97706"
+                }
+            ],
+            "tooling": {
+                "custom": true
+            }
+        });
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&original).expect("json"),
+        )
+        .expect("write settings");
+        let config = config_with_groups(vec![group("bots", "BOTS", "^(wg-9)$")]);
+
+        let saved = save_workgroup_groups(project.path(), config).expect("save groups");
+
+        assert_eq!(saved.groups[0].id, "bots");
+        let persisted: Value =
+            serde_json::from_str(&std::fs::read_to_string(path).expect("read settings"))
+                .expect("parse settings");
+        assert_eq!(persisted["agents"], original["agents"]);
+        assert_eq!(persisted["tooling"], original["tooling"]);
+        assert_eq!(persisted["groups"][0]["name"], "BOTS");
+        assert_eq!(persisted["showAll"], true);
+        assert_eq!(persisted["showUngrouped"], true);
+    }
+
+    #[test]
+    fn missing_workspace_returns_error() {
+        let project = tempfile::tempdir().expect("tempdir");
+
+        let err = load_workgroup_groups(project.path()).expect_err("missing .ac");
+
+        assert!(err.contains("Project has no .ac directory"), "{err}");
+    }
+
+    #[test]
+    fn malformed_json_returns_error_and_save_does_not_clobber_file() {
+        let project = project_with_workspace();
+        let path = settings_path(project.path());
+        let malformed = "{ invalid";
+        std::fs::write(&path, malformed).expect("write settings");
+
+        let load_err = load_workgroup_groups(project.path()).expect_err("reject malformed load");
+        assert!(load_err.contains("Failed to parse"), "{load_err}");
+
+        let save_err = save_workgroup_groups(project.path(), WorkgroupGroupsConfig::default())
+            .expect_err("reject malformed save");
+        assert!(save_err.contains("Failed to parse"), "{save_err}");
+        assert_eq!(
+            std::fs::read_to_string(path).expect("read settings"),
+            malformed
+        );
+    }
+
+    #[test]
+    fn round_trip_save_load_preserves_unknown_root_keys() {
+        let project = project_with_workspace();
+        let path = settings_path(project.path());
+        std::fs::write(&path, r#"{"identity":"keep-me","metadata":{"nested":1}}"#)
+            .expect("write settings");
+        let config = config_with_groups(vec![group("dev", "Dev", "wg-.*")]);
+
+        let saved = save_workgroup_groups(project.path(), config).expect("save groups");
+        let loaded = load_workgroup_groups(project.path()).expect("load groups");
+        save_workgroup_groups(project.path(), loaded).expect("save loaded groups");
+
+        assert_eq!(saved.groups[0].regex, "wg-.*");
+        let persisted: Value =
+            serde_json::from_str(&std::fs::read_to_string(path).expect("read settings"))
+                .expect("parse settings");
+        assert_eq!(persisted["identity"], "keep-me");
+        assert_eq!(persisted["metadata"]["nested"], 1);
+        assert_eq!(persisted["groups"][0]["id"], "dev");
+    }
+
+    #[test]
+    fn non_object_root_returns_clear_error() {
+        let project = project_with_workspace();
+        std::fs::write(settings_path(project.path()), "[]").expect("write settings");
+
+        let err = load_workgroup_groups(project.path()).expect_err("reject non-object root");
+
+        assert!(err.contains("must be a JSON object"), "{err}");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1942,6 +1942,8 @@ pub fn run(
             commands::ac_discovery::open_project,
             commands::ac_discovery::new_project,
             commands::ac_discovery::discover_project,
+            commands::project_settings::get_project_groups,
+            commands::project_settings::update_project_groups,
             commands::ac_discovery::keep_custom_context_template,
             commands::ac_discovery::overwrite_context_template_with_default,
             commands::ac_discovery::get_replica_context_files,

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -92,7 +92,7 @@ const BrowserApp: Component = () => {
   return (
     <div class="browser-layout" classList={{ "browser-dragging": dragging() }}>
       <div class="browser-sidebar" style={{ width: `${sidebarWidth()}px` }}>
-        <SidebarApp embedded />
+        <SidebarApp embedded railSide="left" />
       </div>
       <div
         class="browser-divider"

--- a/src/browser/App.workflow.test.tsx
+++ b/src/browser/App.workflow.test.tsx
@@ -119,6 +119,7 @@ function setupBrowserTransport(
     created: false,
   });
   fake.resolve("discover_project", browserDiscovery());
+  fake.resolve("get_project_groups", { groups: [], showAll: true, showUngrouped: true });
   fake.resolve("search_repos", []);
   fake.resolve("list_sessions", [architectSession]);
   fake.resolve("get_active_session", architectSession.id);
@@ -153,6 +154,8 @@ describe("BrowserApp workflow", () => {
         expect(rendered.root.querySelector(".browser-layout")).not.toBeNull();
         expect(rendered.root.querySelector(".browser-sidebar")).not.toBeNull();
         expect(rendered.root.querySelector(".browser-terminal")).not.toBeNull();
+        expect(rendered.root.querySelector(".sidebar-body")?.getAttribute("data-rail-side")).toBe("left");
+        expect(rendered.root.querySelector(".workgroup-group-rail")).not.toBeNull();
         expect(rendered.root.textContent).toContain("wg-1-dev-team");
         expect(rendered.root.textContent).toContain("architect");
       });

--- a/src/main/App.tsx
+++ b/src/main/App.tsx
@@ -239,7 +239,7 @@ const MainApp: Component = () => {
       <RtkBanner />
       <div class="main-body">
         <div class="main-sidebar-pane" style={{ width: `${sidebarWidth()}px` }}>
-          <SidebarApp embedded />
+          <SidebarApp embedded railSide={sidebarSide()} />
         </div>
         <div
           class="main-divider"

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -55,7 +55,8 @@ import type {
   ScreenshotSelection,
   ScreenshotCaptureResult,
   ScreenshotCaptureFailedEvent,
-  ScreenshotHotkeyStatus
+  ScreenshotHotkeyStatus,
+  WorkgroupGroupsConfig
 } from "./types";
 
 export interface SessionRepoInput {
@@ -716,6 +717,10 @@ export const ProjectAPI = {
     transport.invoke<void>("create_ac_project", { path }),
   discover: (path: string) =>
     transport.invoke<AcDiscoveryResult>("discover_project", { path }),
+  getGroups: (path: string) =>
+    transport.invoke<WorkgroupGroupsConfig>("get_project_groups", { path }),
+  updateGroups: (path: string, config: WorkgroupGroupsConfig) =>
+    transport.invoke<WorkgroupGroupsConfig>("update_project_groups", { path, config }),
   keepCustomContextTemplate: (update: ContextTemplateUpdate) =>
     transport.invoke<void>("keep_custom_context_template", {
       path: update.projectPath,

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -13,6 +13,7 @@ import { toastStore } from "../stores/toasts";
 import { projectStore } from "../../sidebar/stores/project";
 import { sessionsStore } from "../../sidebar/stores/sessions";
 import { bridgesStore } from "../../sidebar/stores/bridges";
+import { workgroupGroupsStore } from "../../sidebar/stores/workgroup-groups";
 import { terminalStore } from "../../terminal/stores/terminal";
 import { __resetHomeStoreForTests } from "../../main/stores/home";
 
@@ -231,6 +232,7 @@ export function resetUiStoresForTests(): void {
   sessionsStore.setAlwaysShowSelectedWorkgroup(true);
   sessionsStore.setCoordSortByActivity(false);
   sessionsStore.clearDetached();
+  workgroupGroupsStore.resetForTests();
   bridgesStore.setBridges([]);
   terminalStore.setActiveSession(null, "", "", null, "", null);
   terminalStore.setActiveWorkgroupTask(null);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -726,6 +726,18 @@ export interface AcWorkgroup {
   teamName?: string;
 }
 
+export interface WorkgroupGroup {
+  id: string;
+  name: string;
+  regex: string;
+}
+
+export interface WorkgroupGroupsConfig {
+  groups: WorkgroupGroup[];
+  showAll: boolean;
+  showUngrouped: boolean;
+}
+
 export type LoopTriggerKind = "cron";
 export type LoopTargetKind = "workgroupCoordinator";
 export type MissedWhileClosedPolicy = "notify";

--- a/src/sidebar/App.context-template-updates.test.tsx
+++ b/src/sidebar/App.context-template-updates.test.tsx
@@ -37,6 +37,7 @@ function setupTransport(fake: FakeTransport, updates: ContextTemplateUpdate[]): 
   fake.resolve("get_update_status", null);
   fake.resolve("open_project", { path: projectPath, registered: true, created: false });
   fake.resolve("discover_project", discovery({ contextTemplateUpdates: updates }));
+  fake.resolve("get_project_groups", { groups: [], showAll: true, showUngrouped: true });
   fake.resolve("search_repos", []);
   fake.resolve("list_sessions", []);
   fake.resolve("get_active_session", null);

--- a/src/sidebar/App.messaging.workflow.test.tsx
+++ b/src/sidebar/App.messaging.workflow.test.tsx
@@ -66,6 +66,7 @@ function setupMessagingTransport(fake: FakeTransport): void {
       workgroups: [],
     })
   );
+  fake.resolve("get_project_groups", { groups: [], showAll: true, showUngrouped: true });
   fake.resolve("search_repos", []);
   fake.resolve("list_sessions", [generalSession]);
   fake.resolve("get_active_session", "session-1");

--- a/src/sidebar/App.profile-drift.test.tsx
+++ b/src/sidebar/App.profile-drift.test.tsx
@@ -36,6 +36,7 @@ function setupTransport(fake: FakeTransport, isOutdated: () => boolean): void {
       workgroups: [],
     }),
   );
+  fake.resolve("get_project_groups", { groups: [], showAll: true, showUngrouped: true });
   fake.resolve("search_repos", []);
   // Dynamic: the drift flag the backend would compute in list_sessions flips
   // between calls without any event being emitted.

--- a/src/sidebar/App.raise-hand.workflow.test.tsx
+++ b/src/sidebar/App.raise-hand.workflow.test.tsx
@@ -71,6 +71,7 @@ function setupRaiseHandTransport(fake: FakeTransport, sessions: Session[]): void
       ],
     })
   );
+  fake.resolve("get_project_groups", { groups: [], showAll: true, showUngrouped: true });
   fake.resolve("search_repos", []);
   fake.resolve("list_sessions", sessions);
   fake.resolve("get_active_session", null);

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -1,7 +1,7 @@
 import { Component, createSignal, createEffect, onMount, onCleanup, Show } from "solid-js";
 import { isTauri } from "../shared/platform";
 import type { UnlistenFn } from "../shared/transport";
-import type { SessionStatus, ContextTemplateUpdate } from "../shared/types";
+import type { SessionStatus, ContextTemplateUpdate, MainSidebarSide } from "../shared/types";
 import {
   SessionAPI,
   SettingsAPI,
@@ -46,6 +46,7 @@ import Titlebar from "./components/Titlebar";
 import ActionBar from "./components/ActionBar";
 import RootAgentBanner from "./components/RootAgentBanner";
 import ProjectPanel from "./components/ProjectPanel";
+import WorkgroupGroupRail from "./components/WorkgroupGroupRail";
 import OnboardingModal from "./components/OnboardingModal";
 import ContextTemplateUpdateModal from "./components/ContextTemplateUpdateModal";
 import ToastHost from "../shared/components/ToastHost";
@@ -63,6 +64,7 @@ interface SidebarAppProps {
    * initializers; those are main-window concerns.
    */
   embedded?: boolean;
+  railSide?: MainSidebarSide;
 }
 
 function isExitedStatus(status: SessionStatus): boolean {
@@ -72,6 +74,7 @@ function isExitedStatus(status: SessionStatus): boolean {
 const SidebarApp: Component<SidebarAppProps> = (props) => {
   const [showOnboarding, setShowOnboarding] = createSignal(false);
   const [loopToast, setLoopToast] = createSignal<LoopToast | null>(null);
+  const [settingsRailSide, setSettingsRailSide] = createSignal<MainSidebarSide>("right");
   // #695 — one-at-a-time seeded context-template update modal. `seen` is keyed
   // by `(projectPath, filename, defaultSha256, fileSha256)` so a resolved or
   // skipped update is not re-shown, while a genuinely new pending update (the
@@ -90,6 +93,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
   let loopToastTimer: ReturnType<typeof setTimeout> | null = null;
   let raiseTerminalEnabled = true;
   let lastRaiseTime = 0;
+  const railSide = () => props.railSide ?? settingsRailSide();
   // #592 - debounce handle for the profile-drift re-list (collapses bursts).
   let profileDriftRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   const blockContextMenu = (e: Event) => {
@@ -98,6 +102,11 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     // remain blocked.
     if (e.target instanceof Element && e.target.closest(".terminal-host")) return;
     e.preventDefault();
+  };
+
+  const handleMainSidebarSideChange = (event: Event) => {
+    const side = (event as CustomEvent<{ side?: MainSidebarSide }>).detail?.side;
+    setSettingsRailSide(side === "left" ? "left" : "right");
   };
 
   const handleRaiseTerminal = async (e: MouseEvent) => {
@@ -333,6 +342,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
 
     // Apply window settings
     const appSettings = await SettingsAPI.get();
+    setSettingsRailSide(appSettings.mainSidebarSide === "left" ? "left" : "right");
     if (!props.embedded) {
       document.documentElement.classList.toggle("light-theme", appSettings.themeLight);
     }
@@ -353,6 +363,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
 
     // Block the default browser context menu globally — custom menus are used instead
     document.addEventListener("contextmenu", blockContextMenu);
+    window.addEventListener("main-sidebar-side-change", handleMainSidebarSideChange);
 
     if (!props.embedded) {
       try {
@@ -546,6 +557,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     sessionsStore.setSidebarPointerInside(false);
     document.removeEventListener("mousedown", handleRaiseTerminal);
     document.removeEventListener("contextmenu", blockContextMenu);
+    window.removeEventListener("main-sidebar-side-change", handleMainSidebarSideChange);
     window.removeEventListener("focus", handleWindowFocusDriftRefresh);
     document.removeEventListener("visibilitychange", handleWindowFocusDriftRefresh);
   });
@@ -564,8 +576,16 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
         </Show>
         <ActionBar />
         <RootAgentBanner />
-        <div class="sidebar-scrollable">
-          <ProjectPanel />
+        <div class="sidebar-body" data-rail-side={railSide()}>
+          <Show when={railSide() === "left"}>
+            <WorkgroupGroupRail projects={projectStore.projects} />
+          </Show>
+          <div class="sidebar-scrollable">
+            <ProjectPanel />
+          </div>
+          <Show when={railSide() === "right"}>
+            <WorkgroupGroupRail projects={projectStore.projects} />
+          </Show>
         </div>
       </div>
       <Show when={showOnboarding()}>

--- a/src/sidebar/components/ProjectPanel.context-menu.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu.test.tsx
@@ -360,6 +360,7 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
     expect(menuButtonLabels(replicaMenu()!)).toEqual([
       "Restart Session",
       "Coding Agent",
+      "Crear grupo nuevo",
       "Open Replica's Folder",
       "AgentsCommander",
       "docs",
@@ -454,11 +455,12 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
       expect(items.map(repoFolderLabel)).toEqual(["AgentsCommander", "docs"]);
       expect(items[0].title).toBe(repos[0]);
       expect(items[1].title).toBe(repos[1]);
-      expect(menuButtonLabels(menu!)).toEqual([
-        "Coding Agent",
-        "Open Replica's Folder",
-        "AgentsCommander",
-        "docs",
+    expect(menuButtonLabels(menu!)).toEqual([
+      "Coding Agent",
+      "Crear grupo nuevo",
+      "Open Replica's Folder",
+      "AgentsCommander",
+      "docs",
         "Open Matrix folder",
         "Clear task title",
       ]);

--- a/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  contextMenu,
+  discovery,
+  input,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
+import {
+  defaultGroupsConfig,
+  exactGroupRegexForWorkgroup,
+  workgroupGroupsStore,
+} from "../stores/workgroup-groups";
+
+const projectPath = "C:\\Project";
+const wg1Path = `${projectPath}\\.ac\\wg-1-dev-team`;
+const wg2Path = `${projectPath}\\.ac\\wg-2-rust-team`;
+const coordRowTestId = "replica.row.quick.wg-1-dev-team.dev-webpage-ui";
+
+function groupsConfig(groups = [{ id: "frontend", name: "Frontend", regex: "^wg-1-" }]) {
+  return {
+    ...defaultGroupsConfig(),
+    groups,
+  };
+}
+
+function projectDiscovery() {
+  return discovery({
+    workgroups: [
+      {
+        name: "wg-1-dev-team",
+        path: wg1Path,
+        task: null,
+        taskTitle: "Frontend work",
+        agents: [
+          {
+            name: "dev-webpage-ui",
+            path: `${wg1Path}\\__agent_dev-webpage-ui`,
+            repoPaths: [],
+            isCoordinator: true,
+          },
+          {
+            name: "dev-rust",
+            path: `${wg1Path}\\__agent_dev-rust`,
+            repoPaths: [],
+            isCoordinator: false,
+          },
+        ],
+      },
+      {
+        name: "wg-2-rust-team",
+        path: wg2Path,
+        task: null,
+        taskTitle: "Rust work",
+        agents: [
+          {
+            name: "dev-rust",
+            path: `${wg2Path}\\__agent_dev-rust`,
+            repoPaths: [],
+            isCoordinator: true,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function setupProjectTransport(fake: FakeTransport): void {
+  fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+  fake.resolve("discover_project", projectDiscovery());
+  fake.onInvoke("update_project_groups", (args) => args.config);
+}
+
+function target<T extends Element>(testId: string): T {
+  const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing element ${testId}`);
+  return element;
+}
+
+function panelTarget<T extends Element>(root: ParentNode, testId: string): T {
+  const element = root.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing element ${testId}`);
+  return element;
+}
+
+async function openCoordinatorMenu(root: ParentNode): Promise<void> {
+  contextMenu(panelTarget(root, coordRowTestId));
+  await waitFor(() => expect(document.querySelector(".session-context-menu")).not.toBeNull());
+}
+
+describe("ProjectPanel workgroup groups", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("ANDs the selected group with the existing visible regex filter", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await workgroupGroupsStore.save(projectPath, groupsConfig());
+      workgroupGroupsStore.select(projectPath, { kind: "group", id: "frontend" });
+      await projectStore.createAndLoad(projectPath);
+
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("wg-1-dev-team");
+        expect(rendered.root.textContent).not.toContain("wg-2-rust-team");
+      });
+
+      const toggle = panelTarget<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      click(toggle);
+      const filterInput = panelTarget<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      input(filterInput, "rust-team");
+      await waitFor(() => {
+        expect(rendered.root.textContent).not.toContain("wg-1-dev-team");
+        expect(rendered.root.textContent).not.toContain("wg-2-rust-team");
+      });
+
+      input(filterInput, "webpage");
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("dev-webpage-ui");
+        expect(rendered.root.textContent).not.toContain("dev-rust");
+        expect(rendered.root.textContent).not.toContain("wg-2-rust-team");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("adds a coordinator workgroup to an existing group from the context menu", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+    sessionsStore.setSessions([
+      session({
+        id: "coord-session",
+        name: "wg-1-dev-team/dev-webpage-ui",
+        workingDirectory: `${wg1Path}\\__agent_dev-webpage-ui`,
+        status: "running",
+        isCoordinator: true,
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await workgroupGroupsStore.save(
+        projectPath,
+        groupsConfig([{ id: "frontend", name: "Frontend", regex: "(?!)" }])
+      );
+      fake.clearCalls();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await openCoordinatorMenu(rendered.root);
+      click(target(`replica.wg-1-dev-team.groups.frontend`));
+
+      await waitFor(() =>
+        expect(fake.lastCall("update_project_groups")?.args.config).toMatchObject({
+          groups: [
+            {
+              id: "frontend",
+              regex: exactGroupRegexForWorkgroup("wg-1-dev-team"),
+            },
+          ],
+        })
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps the context menu open and shows an error when inline group creation fails", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+    fake.resolve("get_project_groups", groupsConfig([]));
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await workgroupGroupsStore.ensureLoaded(projectPath);
+      fake.reject("update_project_groups", "groups.toml changed on disk");
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await openCoordinatorMenu(rendered.root);
+      click(target("replica.wg-1-dev-team.groups.create"));
+      input(target<HTMLInputElement>("replica.groups.create.input"), "Frontend");
+      click(target("replica.groups.create.save"));
+
+      await waitFor(() => {
+        expect(document.querySelector(".session-context-menu")).not.toBeNull();
+        expect(target("replica.groups.error").textContent).toContain("groups.toml changed on disk");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -42,6 +42,17 @@ import {
   repoLabelFromPath,
 } from "./replica-repo-badges";
 import { sessionDotClass } from "./session-status";
+import {
+  findReplicaSession as replicaSession,
+  replicaDotClass,
+  replicaSessionName,
+} from "./workgroup-session";
+import {
+  MAX_GROUP_MATCH_ID_LENGTH,
+  compileGroupRegex,
+  groupMatchId,
+  workgroupGroupsStore,
+} from "../stores/workgroup-groups";
 
 interface PendingLaunch {
   path: string;
@@ -193,29 +204,6 @@ function workgroupCollapseId(wg: AcWorkgroup, rowContext: string): string {
  */
 export const RESTART_TIMEOUT_MS = 30_000;
 
-/** Build the session name used to link a replica to its session */
-function replicaSessionName(wg: AcWorkgroup, replica: AcAgentReplica): string {
-  return `${wg.name}/${replica.name}`;
-}
-
-function normalizedReplicaSessionPath(path: string | null | undefined): string | null {
-  const trimmed = path?.trim();
-  return trimmed ? normalizeProjectPathForCompare(trimmed) : null;
-}
-
-/** Find existing session for a replica, if any */
-function replicaSession(wg: AcWorkgroup, replica: AcAgentReplica): Session | undefined {
-  const expectedName = replicaSessionName(wg, replica);
-  const expectedPath = normalizedReplicaSessionPath(replica.path);
-  if (!expectedPath) return undefined;
-
-  return sessionsStore.sessions.find(
-    (session) =>
-      session.name === expectedName &&
-      normalizedReplicaSessionPath(session.workingDirectory) === expectedPath
-  );
-}
-
 function replicaRepoMenuEntries(wg: AcWorkgroup, replica: AcAgentReplica): SessionRepo[] {
   if (!replica.isCoordinator) return [];
   const session = replicaSession(wg, replica);
@@ -223,11 +211,6 @@ function replicaRepoMenuEntries(wg: AcWorkgroup, replica: AcAgentReplica): Sessi
     ? session.gitRepos
     : configuredReplicaRepoBadges(replica, wg);
   return repos.filter(hasValidRepoSourcePath);
-}
-
-/** Compute CSS class for replica status dot */
-function replicaDotClass(wg: AcWorkgroup, replica: AcAgentReplica): string {
-  return sessionDotClass(replicaSession(wg, replica));
 }
 
 /** Check if a session has a live PTY process (not exited, not offline) */
@@ -713,6 +696,9 @@ const ProjectPanel: Component = () => {
         const [filterOpen, setFilterOpen] = createSignal(false);
         const [filterPattern, setFilterPattern] = createSignal("");
         let filterInputEl: HTMLInputElement | undefined;
+        const [groupCreateWgPath, setGroupCreateWgPath] = createSignal<string | null>(null);
+        const [groupCreateName, setGroupCreateName] = createSignal("");
+        const [groupMenuError, setGroupMenuError] = createSignal("");
         const [agentCtxMenu, setAgentCtxMenu] = createSignal<{ agent: { name: string; path: string; preferredAgentId?: string }; x: number; y: number } | null>(null);
         const [agentsHeaderCtxMenu, setAgentsHeaderCtxMenu] = createSignal<{ x: number; y: number } | null>(null);
         const [workgroupsHeaderCtxMenu, setWorkgroupsHeaderCtxMenu] = createSignal<{ x: number; y: number } | null>(null);
@@ -863,6 +849,11 @@ const ProjectPanel: Component = () => {
         const clearFilter = () => {
           setFilterPattern("");
           focusFilterInput();
+        };
+        const resetGroupMenuState = () => {
+          setGroupCreateWgPath(null);
+          setGroupCreateName("");
+          setGroupMenuError("");
         };
         const handleFilterKeyDown = (e: KeyboardEvent) => {
           if (e.key !== "Escape") return;
@@ -1023,6 +1014,28 @@ const ProjectPanel: Component = () => {
           if (!filterActive() || matchesFilterText("Teams") || teamOwnMatches(team)) return team.agents;
           return team.agents.filter((agentName) => teamMemberMatches(team, agentName));
         };
+        const groupsConfig = () => workgroupGroupsStore.config(proj.path);
+        const selectedGroup = () => workgroupGroupsStore.selection(proj.path);
+        const compiledGroups = createMemo(() =>
+          groupsConfig().groups.map((group) => ({ group, regex: compileGroupRegex(group) }))
+        );
+        const canTestGroupMatchId = (wg: AcWorkgroup) =>
+          groupMatchId(wg).length <= MAX_GROUP_MATCH_ID_LENGTH;
+        const groupMatchesWorkgroup = (wg: AcWorkgroup, groupId: string) => {
+          if (!canTestGroupMatchId(wg)) return false;
+          const compiled = compiledGroups().find((entry) => entry.group.id === groupId);
+          return !!compiled?.regex?.test(groupMatchId(wg));
+        };
+        const workgroupMatchesAnyGroup = (wg: AcWorkgroup) =>
+          canTestGroupMatchId(wg) &&
+          compiledGroups().some((entry) => entry.regex?.test(groupMatchId(wg)));
+        const groupPredicate = (wg: AcWorkgroup) => {
+          const selected = selectedGroup();
+          if (selected.kind === "all") return true;
+          if (selected.kind === "ungrouped") return !workgroupMatchesAnyGroup(wg);
+          return groupMatchesWorkgroup(wg, selected.id);
+        };
+        const groupVisibleWorkgroups = createMemo(() => proj.workgroups.filter(groupPredicate));
         // Memoized so each section reads one cached pass per (filter, store)
         // change instead of rebuilding search text + re-running regex.test on
         // every access (these are read 3-4× per render). Dependencies are all
@@ -1032,8 +1045,9 @@ const ProjectPanel: Component = () => {
         // coordinatorItems memo it reads — createMemo runs eagerly, so it must
         // follow that declaration (not lead it) to avoid a temporal dead zone.
         const filteredWorkgroups = createMemo(() => {
-          if (!filterActive() || matchesFilterText("Workgroups")) return proj.workgroups;
-          return proj.workgroups.filter((wg) => workgroupMatches(wg, "Workgroups"));
+          const base = groupVisibleWorkgroups();
+          if (!filterActive() || matchesFilterText("Workgroups")) return base;
+          return base.filter((wg) => workgroupMatches(wg, "Workgroups"));
         });
         const filteredAgents = createMemo(() => {
           if (!filterActive() || matchesFilterText("Agents")) return proj.agents;
@@ -1045,7 +1059,8 @@ const ProjectPanel: Component = () => {
         });
         const selectedWorkgroupVisible = () => {
           const wg = selectedWorkgroup();
-          return !filterActive() || matchesFilterText("Selected Workgroup") || (wg ? workgroupMatches(wg, "Selected Workgroup") : false);
+          if (!wg || !groupPredicate(wg)) return false;
+          return !filterActive() || matchesFilterText("Selected Workgroup") || workgroupMatches(wg, "Selected Workgroup");
         };
         // Status line shown on each loop row — shared with the filter search
         // text so what the regex matches always equals what the user sees.
@@ -1108,6 +1123,17 @@ const ProjectPanel: Component = () => {
           );
         };
 
+        const reclampReplicaCtxMenu = () => {
+          const menu = replicaCtxMenu();
+          if (!menu) return;
+          const clamp = () => positionReplicaCtxMenu(menu.x, menu.y);
+          if (typeof window.requestAnimationFrame === "function") {
+            window.requestAnimationFrame(clamp);
+            return;
+          }
+          window.setTimeout(clamp, 0);
+        };
+
         const restartReplicaSession = async (
           sessionId: string,
           agentId?: string,
@@ -1157,6 +1183,117 @@ const ProjectPanel: Component = () => {
           }
           return null;
         };
+
+        const groupAlreadyMatches = (wg: AcWorkgroup, groupId: string) =>
+          groupMatchesWorkgroup(wg, groupId);
+
+        const addToExistingGroup = async (wg: AcWorkgroup, groupId: string) => {
+          setGroupMenuError("");
+          try {
+            await workgroupGroupsStore.addWorkgroupToGroup(proj.path, groupId, wg.name);
+          } catch (error) {
+            setGroupMenuError(error instanceof Error ? error.message : String(error));
+            reclampReplicaCtxMenu();
+          }
+        };
+
+        const createGroupFromMenu = async (wg: AcWorkgroup) => {
+          const name = groupCreateName().trim();
+          if (!name) {
+            setGroupMenuError("Group name cannot be blank.");
+            reclampReplicaCtxMenu();
+            return;
+          }
+          setGroupMenuError("");
+          try {
+            await workgroupGroupsStore.createGroupForWorkgroup(proj.path, name, wg.name);
+            resetGroupMenuState();
+            reclampReplicaCtxMenu();
+          } catch (error) {
+            setGroupMenuError(error instanceof Error ? error.message : String(error));
+            reclampReplicaCtxMenu();
+          }
+        };
+
+        const renderAddToGroupSection = (wg: AcWorkgroup, replica: AcAgentReplica) => (
+          <Show when={replica.isCoordinator}>
+            <div class="context-separator" />
+            <div class="session-context-submenu" data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.menu`}>
+              <div class="session-context-submenu-title">Add to Group</div>
+              <For each={groupsConfig().groups}>
+                {(group) => {
+                  const valid = () => !!compileGroupRegex(group);
+                  return (
+                    <button
+                      class="session-context-option session-context-group-option"
+                      classList={{ "context-option-disabled": !valid() }}
+                      disabled={!valid()}
+                      title={valid() ? group.regex : "Fix this group's regex before adding a workgroup"}
+                      onClick={() => void addToExistingGroup(wg, group.id)}
+                      data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.${automationIdPart(group.id)}`}
+                    >
+                      <span class="session-context-option-check">
+                        {groupAlreadyMatches(wg, group.id) ? "\u2713" : ""}
+                      </span>
+                      <span>{group.name}</span>
+                    </button>
+                  );
+                }}
+              </For>
+              <Show when={groupsConfig().groups.length === 0}>
+                <div class="session-context-note">No groups yet</div>
+              </Show>
+              <Show when={workgroupGroupsStore.error(proj.path)}>
+                {(error) => <div class="session-context-error">{error()}</div>}
+              </Show>
+              <Show when={groupMenuError()}>
+                <div class="session-context-error" data-ac-testid="replica.groups.error">
+                  {groupMenuError()}
+                </div>
+              </Show>
+              <Show
+                when={groupCreateWgPath() === wg.path}
+                fallback={
+                  <button
+                    class="session-context-option"
+                    onClick={() => {
+                      setGroupCreateWgPath(wg.path);
+                      setGroupCreateName("");
+                      setGroupMenuError("");
+                      reclampReplicaCtxMenu();
+                    }}
+                    data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.create`}
+                  >
+                    Crear grupo nuevo
+                  </button>
+                }
+              >
+                <div class="session-context-inline-create">
+                  <input
+                    class="session-context-inline-input"
+                    value={groupCreateName()}
+                    onInput={(e) => setGroupCreateName(e.currentTarget.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        void createGroupFromMenu(wg);
+                      }
+                    }}
+                    placeholder="Group name"
+                    data-ac-testid="replica.groups.create.input"
+                  />
+                  <button
+                    class="session-context-option"
+                    onClick={() => void createGroupFromMenu(wg)}
+                    data-ac-testid="replica.groups.create.save"
+                  >
+                    Create
+                  </button>
+                </div>
+              </Show>
+            </div>
+          </Show>
+        );
 
         // Broom (clear task title) for a gray/red replica — reuses the
         // active-agent TaskAPI.clean. The backend emits workgroup_task_updated,
@@ -1250,7 +1387,7 @@ const ProjectPanel: Component = () => {
           proj.workgroups.some((wg) => wg.agents.some((agent) => agent.isCoordinator));
         const naturalCoordinatorItems = createMemo(() => {
           const result: { replica: AcAgentReplica; wg: AcWorkgroup }[] = [];
-          for (const wg of proj.workgroups) {
+          for (const wg of groupVisibleWorkgroups()) {
             for (const replica of wg.agents) {
               if (replica.isCoordinator) {
                 result.push({ replica, wg });
@@ -1451,6 +1588,7 @@ const ProjectPanel: Component = () => {
           setLoopCtxMenu(null);
           setLoopsHeaderCtxMenu(null);
           setTeamsHeaderCtxMenu(null);
+          resetGroupMenuState();
           setReplicaCtxMenu({
             kind: "active",
             sessionId: session.id,
@@ -1494,6 +1632,7 @@ const ProjectPanel: Component = () => {
           setLoopCtxMenu(null);
           setLoopsHeaderCtxMenu(null);
           setTeamsHeaderCtxMenu(null);
+          resetGroupMenuState();
           setReplicaCtxMenu({ kind: "inactive", wg, replica, x: e.clientX, y: e.clientY });
           const dismiss = (ev?: Event) => {
             if (ev instanceof KeyboardEvent && ev.key !== "Escape") return;
@@ -2846,6 +2985,7 @@ const ProjectPanel: Component = () => {
                         >
                           Coding Agent
                         </button>
+                        {renderAddToGroupSection(menu().wg, menu().replica)}
                         <button
                           class="session-context-option"
                           title={menu().replica.path}
@@ -2935,6 +3075,7 @@ const ProjectPanel: Component = () => {
                           >
                             Coding Agent
                           </button>
+                          {renderAddToGroupSection(menu().wg, menu().replica)}
                           <button
                             class="session-context-option"
                             title={menu().replica.path}

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -1,0 +1,188 @@
+import { Component, For, Show, createEffect, createMemo, createSignal } from "solid-js";
+import type { AcWorkgroup, WorkgroupGroup } from "../../shared/types";
+import type { ProjectState } from "../stores/project";
+import {
+  MAX_GROUP_MATCH_ID_LENGTH,
+  compileGroupRegex,
+  groupMatchId,
+  workgroupGroupsStore,
+  type WorkgroupGroupSelection,
+} from "../stores/workgroup-groups";
+import {
+  isWorkingReplicaDot,
+  replicaDotClass,
+  workgroupIsWorking,
+} from "./workgroup-session";
+import WorkgroupGroupsModal from "./WorkgroupGroupsModal";
+
+interface WorkgroupGroupRailProps {
+  projects: ProjectState[];
+}
+
+interface GroupButton {
+  key: string;
+  label: string;
+  selection: WorkgroupGroupSelection;
+  workgroups: AcWorkgroup[];
+  title: string;
+}
+
+function wgNumber(name: string): number {
+  const match = name.match(/^wg-(\d+)/i);
+  return match ? Number.parseInt(match[1], 10) : Number.MAX_SAFE_INTEGER;
+}
+
+function wgTooltipLabel(wgName: string): string {
+  const match = wgName.match(/^wg-(\d+)/i);
+  return match ? `WG${match[1]}` : wgName;
+}
+
+function groupMatches(group: WorkgroupGroup, wg: AcWorkgroup): boolean {
+  const id = groupMatchId(wg);
+  if (id.length > MAX_GROUP_MATCH_ID_LENGTH) return false;
+  const regex = compileGroupRegex(group);
+  return !!regex?.test(id);
+}
+
+function tooltipFor(workgroups: AcWorkgroup[]): string {
+  const rows = workgroups
+    .flatMap((wg) =>
+      wg.agents
+        .filter((replica) => isWorkingReplicaDot(replicaDotClass(wg, replica)))
+        .map((replica) => ({ wg, replica }))
+    )
+    .sort((a, b) => {
+      const wgDelta = wgNumber(a.wg.name) - wgNumber(b.wg.name);
+      if (wgDelta !== 0) return wgDelta;
+      return a.replica.name.localeCompare(b.replica.name, "en", { sensitivity: "base", numeric: true });
+    })
+    .map(({ wg, replica }) => `${wgTooltipLabel(wg.name)}:(${replica.name})`);
+  return rows.length > 0 ? rows.join("\n") : "No running agents";
+}
+
+function counterLabel(name: string, workgroups: AcWorkgroup[]): string {
+  const working = workgroups.filter(workgroupIsWorking).length;
+  return `${name} ${working}/${workgroups.length}`;
+}
+
+const ProjectRailSection: Component<{
+  project: ProjectState;
+  showProjectLabel: boolean;
+}> = (props) => {
+  const [editing, setEditing] = createSignal(false);
+
+  createEffect(() => {
+    void workgroupGroupsStore.ensureLoaded(props.project.path);
+  });
+
+  const config = () => workgroupGroupsStore.config(props.project.path);
+  const selection = () => workgroupGroupsStore.selection(props.project.path);
+  const ungroupedWorkgroups = createMemo(() =>
+    props.project.workgroups.filter(
+      (wg) => !config().groups.some((group) => groupMatches(group, wg))
+    )
+  );
+  const buttons = createMemo<GroupButton[]>(() => {
+    const result: GroupButton[] = [];
+    if (config().showAll) {
+      result.push({
+        key: "all",
+        label: counterLabel("Todos", props.project.workgroups),
+        selection: { kind: "all" },
+        workgroups: props.project.workgroups,
+        title: tooltipFor(props.project.workgroups),
+      });
+    }
+    for (const group of config().groups) {
+      const workgroups = props.project.workgroups.filter((wg) => groupMatches(group, wg));
+      result.push({
+        key: group.id,
+        label: counterLabel(group.name, workgroups),
+        selection: { kind: "group", id: group.id },
+        workgroups,
+        title: tooltipFor(workgroups),
+      });
+    }
+    if (config().showUngrouped) {
+      const workgroups = ungroupedWorkgroups();
+      result.push({
+        key: "ungrouped",
+        label: counterLabel("Sin Grupo", workgroups),
+        selection: { kind: "ungrouped" },
+        workgroups,
+        title: tooltipFor(workgroups),
+      });
+    }
+    return result;
+  });
+  const selected = (button: GroupButton) => {
+    const current = selection();
+    if (current.kind !== button.selection.kind) return false;
+    return current.kind !== "group" || button.selection.kind !== "group" || current.id === button.selection.id;
+  };
+
+  return (
+    <div class="workgroup-group-rail-project" data-ac-testid={`workgroupGroups.rail.${props.project.folderName}`}>
+      <Show when={props.showProjectLabel}>
+        <div class="workgroup-group-rail-project-label" title={props.project.path}>
+          {props.project.folderName}
+        </div>
+      </Show>
+
+      <For each={buttons()}>
+        {(button) => (
+          <button
+            class="workgroup-group-rail-button"
+            classList={{ selected: selected(button) }}
+            aria-pressed={selected(button)}
+            title={button.title}
+            onClick={() => workgroupGroupsStore.select(props.project.path, button.selection)}
+            data-ac-testid={`workgroupGroups.button.${button.key}`}
+          >
+            {button.label}
+          </button>
+        )}
+      </For>
+
+      <Show when={workgroupGroupsStore.error(props.project.path)}>
+        {(error) => (
+          <div class="workgroup-group-rail-error" title={error()}>
+            !
+          </div>
+        )}
+      </Show>
+
+      <button
+        class="workgroup-group-rail-button edit"
+        onClick={() => setEditing(true)}
+        data-ac-testid="workgroupGroups.edit"
+      >
+        Editar
+      </button>
+
+      <Show when={editing()}>
+        <WorkgroupGroupsModal
+          projectPath={props.project.path}
+          projectName={props.project.folderName}
+          onClose={() => setEditing(false)}
+        />
+      </Show>
+    </div>
+  );
+};
+
+const WorkgroupGroupRail: Component<WorkgroupGroupRailProps> = (props) => {
+  const showProjectLabels = () => props.projects.length > 1;
+
+  return (
+    <aside class="workgroup-group-rail" data-ac-testid="workgroupGroups.rail">
+      <For each={props.projects}>
+        {(project) => (
+          <ProjectRailSection project={project} showProjectLabel={showProjectLabels()} />
+        )}
+      </For>
+    </aside>
+  );
+};
+
+export default WorkgroupGroupRail;

--- a/src/sidebar/components/WorkgroupGroupsModal.tsx
+++ b/src/sidebar/components/WorkgroupGroupsModal.tsx
@@ -1,0 +1,211 @@
+import { Component, For, Show, createMemo, createSignal } from "solid-js";
+import type { WorkgroupGroupsConfig } from "../../shared/types";
+import {
+  MAX_GROUP_NAME_LENGTH,
+  MAX_GROUP_REGEX_LENGTH,
+  createGroupId,
+  exactGroupRegexForWorkgroup,
+  validateGroupsConfig,
+  workgroupGroupsStore,
+} from "../stores/workgroup-groups";
+
+interface WorkgroupGroupsModalProps {
+  projectPath: string;
+  projectName: string;
+  initialWorkgroupName?: string;
+  onClose: () => void;
+}
+
+function cloneConfig(config: WorkgroupGroupsConfig): WorkgroupGroupsConfig {
+  return {
+    groups: config.groups.map((group) => ({ ...group })),
+    showAll: config.showAll,
+    showUngrouped: config.showUngrouped,
+  };
+}
+
+function nextGroupName(config: WorkgroupGroupsConfig): string {
+  const used = new Set(config.groups.map((group) => group.name.trim().toLowerCase()));
+  let index = config.groups.length + 1;
+  while (used.has(`group ${index}`)) index++;
+  return `Group ${index}`;
+}
+
+const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
+  const [draft, setDraft] = createSignal<WorkgroupGroupsConfig>(
+    cloneConfig(workgroupGroupsStore.config(props.projectPath))
+  );
+  const [saveError, setSaveError] = createSignal<string | null>(null);
+  const [saving, setSaving] = createSignal(false);
+
+  const validationErrors = createMemo(() =>
+    validateGroupsConfig(draft(), { validateRegexSyntax: true })
+  );
+  const canSave = () => !saving() && validationErrors().length === 0;
+  const errorText = () => saveError() ?? workgroupGroupsStore.error(props.projectPath);
+
+  const updateGroup = (id: string, patch: { name?: string; regex?: string }) => {
+    setDraft((current) => ({
+      ...current,
+      groups: current.groups.map((group) =>
+        group.id === id ? { ...group, ...patch } : group
+      ),
+    }));
+    setSaveError(null);
+  };
+
+  const addGroup = () => {
+    const current = draft();
+    const existingIds = new Set(current.groups.map((group) => group.id));
+    setDraft({
+      ...current,
+      groups: [
+        ...current.groups,
+        {
+          id: createGroupId(existingIds),
+          name: nextGroupName(current),
+          regex: props.initialWorkgroupName
+            ? exactGroupRegexForWorkgroup(props.initialWorkgroupName)
+            : "(?!)",
+        },
+      ],
+    });
+    setSaveError(null);
+  };
+
+  const deleteGroup = (id: string) => {
+    setDraft((current) => ({
+      ...current,
+      groups: current.groups.filter((group) => group.id !== id),
+    }));
+    setSaveError(null);
+  };
+
+  const setToggle = (field: "showAll" | "showUngrouped", value: boolean) => {
+    setDraft((current) => {
+      const next = { ...current, [field]: value };
+      if (!next.showAll && !next.showUngrouped) return current;
+      return next;
+    });
+    setSaveError(null);
+  };
+
+  const save = async () => {
+    if (!canSave()) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await workgroupGroupsStore.save(props.projectPath, draft());
+      props.onClose();
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div class="modal-overlay" data-ac-testid="workgroupGroups.modal">
+      <div class="agent-modal workgroup-groups-modal">
+        <div class="agent-modal-header">
+          <span class="agent-modal-title">Editar grupos</span>
+          <button class="modal-close" onClick={props.onClose} aria-label="Close groups editor">
+            &times;
+          </button>
+        </div>
+
+        <div class="workgroup-groups-form">
+          <div class="workgroup-groups-project">{props.projectName}</div>
+
+          <div class="workgroup-groups-toggles">
+            <label class="settings-checkbox-field">
+              <input
+                type="checkbox"
+                checked={draft().showAll}
+                disabled={draft().showAll && !draft().showUngrouped}
+                onChange={(e) => setToggle("showAll", e.currentTarget.checked)}
+              />
+              <span>Mostrar Todos</span>
+            </label>
+            <label class="settings-checkbox-field">
+              <input
+                type="checkbox"
+                checked={draft().showUngrouped}
+                disabled={draft().showUngrouped && !draft().showAll}
+                onChange={(e) => setToggle("showUngrouped", e.currentTarget.checked)}
+              />
+              <span>Mostrar Sin Grupo</span>
+            </label>
+          </div>
+
+          <div class="workgroup-groups-table">
+            <For each={draft().groups}>
+              {(group) => (
+                <div class="workgroup-group-edit-row" data-ac-testid={`workgroupGroups.row.${group.id}`}>
+                  <input
+                    class="workgroup-group-name-input"
+                    value={group.name}
+                    maxLength={MAX_GROUP_NAME_LENGTH}
+                    onInput={(e) => updateGroup(group.id, { name: e.currentTarget.value })}
+                    aria-label="Group name"
+                  />
+                  <input
+                    class="workgroup-group-regex-input"
+                    value={group.regex}
+                    maxLength={MAX_GROUP_REGEX_LENGTH}
+                    onInput={(e) => updateGroup(group.id, { regex: e.currentTarget.value })}
+                    aria-label="Group regex"
+                    data-ac-testid={`workgroupGroups.regex.${group.id}`}
+                  />
+                  <button
+                    class="workgroup-group-delete"
+                    onClick={() => deleteGroup(group.id)}
+                    aria-label={`Delete ${group.name}`}
+                  >
+                    Delete
+                  </button>
+                </div>
+              )}
+            </For>
+            <Show when={draft().groups.length === 0}>
+              <div class="workgroup-groups-empty">No groups configured</div>
+            </Show>
+          </div>
+
+          <button class="workgroup-group-add" onClick={addGroup} data-ac-testid="workgroupGroups.add">
+            Add group
+          </button>
+
+          <Show when={validationErrors().length > 0}>
+            <div class="workgroup-groups-errors" role="alert" data-ac-testid="workgroupGroups.validation">
+              <For each={validationErrors()}>{(error) => <div>{error}</div>}</For>
+            </div>
+          </Show>
+          <Show when={errorText()}>
+            {(message) => (
+              <div class="workgroup-groups-errors" role="alert" data-ac-testid="workgroupGroups.error">
+                {message()}
+              </div>
+            )}
+          </Show>
+        </div>
+
+        <div class="agent-modal-footer">
+          <button class="modal-btn modal-btn-cancel" onClick={props.onClose}>
+            Cancel
+          </button>
+          <button
+            class="modal-btn modal-btn-save"
+            disabled={!canSave()}
+            onClick={save}
+            data-ac-testid="workgroupGroups.save"
+          >
+            {saving() ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkgroupGroupsModal;

--- a/src/sidebar/components/workgroup-session.ts
+++ b/src/sidebar/components/workgroup-session.ts
@@ -1,0 +1,37 @@
+import type { AcAgentReplica, AcWorkgroup, Session } from "../../shared/types";
+import { normalizeProjectPathForCompare } from "../stores/project-refresh";
+import { sessionsStore } from "../stores/sessions";
+import { sessionDotClass, type SessionDotClass } from "./session-status";
+
+export function replicaSessionName(wg: AcWorkgroup, replica: AcAgentReplica): string {
+  return `${wg.name}/${replica.name}`;
+}
+
+function normalizedReplicaSessionPath(path: string | null | undefined): string | null {
+  const trimmed = path?.trim();
+  return trimmed ? normalizeProjectPathForCompare(trimmed) : null;
+}
+
+export function findReplicaSession(wg: AcWorkgroup, replica: AcAgentReplica): Session | undefined {
+  const expectedName = replicaSessionName(wg, replica);
+  const expectedPath = normalizedReplicaSessionPath(replica.path);
+  if (!expectedPath) return undefined;
+
+  return sessionsStore.sessions.find(
+    (session) =>
+      session.name === expectedName &&
+      normalizedReplicaSessionPath(session.workingDirectory) === expectedPath
+  );
+}
+
+export function replicaDotClass(wg: AcWorkgroup, replica: AcAgentReplica): SessionDotClass {
+  return sessionDotClass(findReplicaSession(wg, replica));
+}
+
+export function isWorkingReplicaDot(dot: SessionDotClass): boolean {
+  return dot === "running" || dot === "active";
+}
+
+export function workgroupIsWorking(wg: AcWorkgroup): boolean {
+  return wg.agents.some((replica) => isWorkingReplicaDot(replicaDotClass(wg, replica)));
+}

--- a/src/sidebar/stores/workgroup-groups.test.ts
+++ b/src/sidebar/stores/workgroup-groups.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { WorkgroupGroupsConfig } from "../../shared/types";
+import { __setTransportForTests } from "../../shared/ipc";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  appendExactGroupToken,
+  defaultGroupsConfig,
+  exactGroupRegexForWorkgroup,
+  validateGroupsConfig,
+  workgroupGroupsStore,
+} from "./workgroup-groups";
+
+const projectPath = "C:\\Project";
+
+function config(overrides: Partial<WorkgroupGroupsConfig> = {}): WorkgroupGroupsConfig {
+  return {
+    ...defaultGroupsConfig(),
+    ...overrides,
+    groups: overrides.groups ?? [],
+  };
+}
+
+describe("workgroupGroupsStore", () => {
+  let restoreTransport: (() => void) | null = null;
+
+  beforeEach(() => {
+    const fake = new FakeTransport();
+    restoreTransport = __setTransportForTests(fake);
+    workgroupGroupsStore.resetForTests();
+  });
+
+  afterEach(() => {
+    workgroupGroupsStore.resetForTests();
+    restoreTransport?.();
+    restoreTransport = null;
+  });
+
+  it("deduplicates concurrent loads for equivalent project paths", async () => {
+    const fake = new FakeTransport();
+    restoreTransport?.();
+    restoreTransport = __setTransportForTests(fake);
+
+    let resolveLoad!: (value: WorkgroupGroupsConfig) => void;
+    const loadPromise = new Promise<WorkgroupGroupsConfig>((resolve) => {
+      resolveLoad = resolve;
+    });
+    fake.onInvoke("get_project_groups", () => loadPromise);
+
+    const first = workgroupGroupsStore.ensureLoaded("C:\\Project\\");
+    const second = workgroupGroupsStore.ensureLoaded("c:/project");
+    expect(fake.callsFor("get_project_groups")).toHaveLength(1);
+
+    resolveLoad?.(
+      config({
+        groups: [{ id: "ui", name: "UI", regex: "^wg-1-" }],
+      })
+    );
+    await Promise.all([first, second]);
+
+    expect(workgroupGroupsStore.config(projectPath).groups).toEqual([
+      { id: "ui", name: "UI", regex: "^wg-1-" },
+    ]);
+  });
+
+  it("preserves the previous config and exposes the error when a save fails", async () => {
+    const fake = new FakeTransport();
+    restoreTransport?.();
+    restoreTransport = __setTransportForTests(fake);
+
+    fake.resolve(
+      "get_project_groups",
+      config({ groups: [{ id: "a", name: "Alpha", regex: "^wg-1-" }] })
+    );
+    fake.reject("update_project_groups", "disk denied");
+
+    await workgroupGroupsStore.ensureLoaded(projectPath);
+    await expect(
+      workgroupGroupsStore.save(
+        projectPath,
+        config({ groups: [{ id: "b", name: "Beta", regex: "^wg-2-" }] })
+      )
+    ).rejects.toThrow("disk denied");
+
+    expect(workgroupGroupsStore.config(projectPath).groups).toEqual([
+      { id: "a", name: "Alpha", regex: "^wg-1-" },
+    ]);
+    expect(workgroupGroupsStore.error(projectPath)).toBe("disk denied");
+  });
+
+  it("does not let a stale initial load overwrite a completed save", async () => {
+    const fake = new FakeTransport();
+    restoreTransport?.();
+    restoreTransport = __setTransportForTests(fake);
+
+    let resolveLoad!: (value: WorkgroupGroupsConfig) => void;
+    const loadPromise = new Promise<WorkgroupGroupsConfig>((resolve) => {
+      resolveLoad = resolve;
+    });
+    fake.onInvoke("get_project_groups", () => loadPromise);
+    fake.onInvoke("update_project_groups", (args) => args.config);
+
+    const load = workgroupGroupsStore.ensureLoaded(projectPath);
+    await workgroupGroupsStore.save(
+      projectPath,
+      config({ groups: [{ id: "saved", name: "Saved", regex: "^wg-9-" }] })
+    );
+    resolveLoad(config({ groups: [{ id: "stale", name: "Stale", regex: "^wg-1-" }] }));
+    await load;
+
+    expect(workgroupGroupsStore.config(projectPath).groups).toEqual([
+      { id: "saved", name: "Saved", regex: "^wg-9-" },
+    ]);
+  });
+
+  it("adds an exact workgroup token to an existing generated regex", async () => {
+    const fake = new FakeTransport();
+    restoreTransport?.();
+    restoreTransport = __setTransportForTests(fake);
+
+    fake.resolve(
+      "get_project_groups",
+      config({
+        groups: [
+          {
+            id: "frontend",
+            name: "Frontend",
+            regex: exactGroupRegexForWorkgroup("wg-1-dev-team"),
+          },
+        ],
+      })
+    );
+    fake.onInvoke("update_project_groups", (args) => args.config);
+
+    await workgroupGroupsStore.ensureLoaded(projectPath);
+    await workgroupGroupsStore.addWorkgroupToGroup(
+      projectPath,
+      "frontend",
+      "wg-2-dev-team"
+    );
+
+    expect(fake.lastCall("update_project_groups")?.args.config).toMatchObject({
+      groups: [
+        {
+          id: "frontend",
+          regex: "^(wg-1-dev-team|wg-2-dev-team)$",
+        },
+      ],
+    });
+  });
+});
+
+describe("workgroup group validation helpers", () => {
+  it("rejects duplicate names, blank toggles, and invalid regex syntax", () => {
+    expect(
+      validateGroupsConfig(
+        config({
+          showAll: false,
+          showUngrouped: false,
+          groups: [
+            { id: "a", name: "UI", regex: "^wg-1-" },
+            { id: "b", name: " ui ", regex: "(" },
+          ],
+        }),
+        { validateRegexSyntax: true }
+      )
+    ).toEqual([
+      "At least one of Todos or Sin Grupo must be visible.",
+      "Duplicate group name.",
+      "Group 2: regex is invalid.",
+    ]);
+  });
+
+  it("returns null when appending to an invalid regex", () => {
+    expect(appendExactGroupToken("(", "wg-2-dev-team")).toBeNull();
+  });
+});

--- a/src/sidebar/stores/workgroup-groups.ts
+++ b/src/sidebar/stores/workgroup-groups.ts
@@ -1,0 +1,369 @@
+import { createStore } from "solid-js/store";
+import type { AcWorkgroup, WorkgroupGroup, WorkgroupGroupsConfig } from "../../shared/types";
+import { ProjectAPI } from "../../shared/ipc";
+import { normalizeProjectPathForCompare } from "./project-refresh";
+
+export const MAX_WORKGROUP_GROUPS = 80;
+export const MAX_GROUP_ID_LENGTH = 128;
+export const MAX_GROUP_NAME_LENGTH = 80;
+export const MAX_GROUP_REGEX_LENGTH = 1024;
+export const MAX_GROUP_MATCH_ID_LENGTH = 160;
+
+export type WorkgroupGroupSelection =
+  | { kind: "all" }
+  | { kind: "ungrouped" }
+  | { kind: "group"; id: string };
+
+interface ProjectGroupsEntry {
+  config: WorkgroupGroupsConfig;
+  selection: WorkgroupGroupSelection;
+  loaded: boolean;
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+}
+
+const [entries, setEntries] = createStore<Record<string, ProjectGroupsEntry | undefined>>({});
+const inFlightLoads = new Map<string, Promise<void>>();
+const saveVersions = new Map<string, number>();
+
+function charLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function keyFor(projectPath: string): string {
+  return normalizeProjectPathForCompare(projectPath);
+}
+
+export function defaultGroupsConfig(): WorkgroupGroupsConfig {
+  return {
+    groups: [],
+    showAll: true,
+    showUngrouped: true,
+  };
+}
+
+function cloneConfig(config: WorkgroupGroupsConfig): WorkgroupGroupsConfig {
+  return {
+    groups: config.groups.map((group) => ({ ...group })),
+    showAll: config.showAll,
+    showUngrouped: config.showUngrouped,
+  };
+}
+
+function defaultEntry(): ProjectGroupsEntry {
+  return {
+    config: defaultGroupsConfig(),
+    selection: { kind: "all" },
+    loaded: false,
+    loading: false,
+    saving: false,
+    error: null,
+  };
+}
+
+function entryFor(projectPath: string): ProjectGroupsEntry {
+  return entries[keyFor(projectPath)] ?? defaultEntry();
+}
+
+function formatError(error: unknown): string {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function normalizeSelection(
+  selection: WorkgroupGroupSelection,
+  config: WorkgroupGroupsConfig
+): WorkgroupGroupSelection {
+  if (selection.kind === "group") {
+    if (config.groups.some((group) => group.id === selection.id)) return selection;
+    return config.showAll ? { kind: "all" } : { kind: "ungrouped" };
+  }
+  if (selection.kind === "all" && !config.showAll) {
+    return config.showUngrouped ? { kind: "ungrouped" } : { kind: "all" };
+  }
+  if (selection.kind === "ungrouped" && !config.showUngrouped) {
+    return config.showAll ? { kind: "all" } : { kind: "ungrouped" };
+  }
+  return selection;
+}
+
+function ensureEntry(projectPath: string): ProjectGroupsEntry {
+  const key = keyFor(projectPath);
+  const current = entries[key];
+  if (current) return current;
+  const next = defaultEntry();
+  setEntries(key, next);
+  return next;
+}
+
+export function groupMatchId(wg: AcWorkgroup): string {
+  return wg.name;
+}
+
+export function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function exactGroupRegexForWorkgroup(wgName: string): string {
+  return `^(${escapeRegexLiteral(wgName)})$`;
+}
+
+export function appendExactGroupToken(regex: string, wgName: string): string | null {
+  const pattern = regex.trim();
+  const token = escapeRegexLiteral(wgName);
+  if (!pattern || pattern === "(?!)") return `^(${token})$`;
+  try {
+    if (new RegExp(pattern).test(wgName)) return pattern;
+  } catch {
+    return null;
+  }
+  const generated = pattern.match(/^\^\((.*)\)\$$/);
+  if (generated) return `^(${generated[1]}|${token})$`;
+  return `(?:${pattern})|^(${token})$`;
+}
+
+export function compileGroupRegex(group: WorkgroupGroup): RegExp | null {
+  if (charLength(group.regex) > MAX_GROUP_REGEX_LENGTH) return null;
+  try {
+    return new RegExp(group.regex);
+  } catch {
+    return null;
+  }
+}
+
+export function validateGroupsConfig(
+  config: WorkgroupGroupsConfig,
+  options: { validateRegexSyntax?: boolean } = {}
+): string[] {
+  const errors: string[] = [];
+  if (!config.showAll && !config.showUngrouped) {
+    errors.push("At least one of Todos or Sin Grupo must be visible.");
+  }
+  if (config.groups.length > MAX_WORKGROUP_GROUPS) {
+    errors.push(`At most ${MAX_WORKGROUP_GROUPS} groups are allowed.`);
+  }
+
+  const ids = new Set<string>();
+  const names = new Set<string>();
+  config.groups.forEach((group, index) => {
+    const label = `Group ${index + 1}`;
+    const id = group.id.trim();
+    const name = group.name.trim();
+    if (!id) errors.push(`${label}: id cannot be blank.`);
+    if (charLength(group.id) > MAX_GROUP_ID_LENGTH) {
+      errors.push(`${label}: id cannot exceed ${MAX_GROUP_ID_LENGTH} characters.`);
+    }
+    if (id && ids.has(id)) errors.push("Duplicate group id.");
+    if (id) ids.add(id);
+
+    if (!name) errors.push(`${label}: name cannot be blank.`);
+    if (charLength(group.name) > MAX_GROUP_NAME_LENGTH) {
+      errors.push(`${label}: name cannot exceed ${MAX_GROUP_NAME_LENGTH} characters.`);
+    }
+    const normalizedName = name.toLowerCase();
+    if (normalizedName && names.has(normalizedName)) errors.push("Duplicate group name.");
+    if (normalizedName) names.add(normalizedName);
+
+    if (charLength(group.regex) > MAX_GROUP_REGEX_LENGTH) {
+      errors.push(`${label}: regex cannot exceed ${MAX_GROUP_REGEX_LENGTH} characters.`);
+    } else if (options.validateRegexSyntax) {
+      try {
+        new RegExp(group.regex);
+      } catch {
+        errors.push(`${label}: regex is invalid.`);
+      }
+    }
+  });
+
+  return Array.from(new Set(errors));
+}
+
+export function createGroupId(existingIds: Set<string>): string {
+  const randomUUID = globalThis.crypto?.randomUUID;
+  if (typeof randomUUID === "function") {
+    const id = randomUUID.call(globalThis.crypto);
+    if (!existingIds.has(id)) return id;
+  }
+  let index = 1;
+  while (existingIds.has(`group-${index}`)) index++;
+  return `group-${index}`;
+}
+
+function setConfig(
+  projectPath: string,
+  config: WorkgroupGroupsConfig,
+  patch: Partial<Pick<ProjectGroupsEntry, "loaded" | "loading" | "saving" | "error">> = {}
+) {
+  const key = keyFor(projectPath);
+  const current = ensureEntry(projectPath);
+  const nextConfig = cloneConfig(config);
+  setEntries(key, {
+    ...current,
+    config: nextConfig,
+    selection: normalizeSelection(current.selection, nextConfig),
+    ...patch,
+  });
+}
+
+export const workgroupGroupsStore = {
+  async ensureLoaded(projectPath: string): Promise<void> {
+    const key = keyFor(projectPath);
+    const current = ensureEntry(projectPath);
+    if (current.loaded) return;
+    const inFlight = inFlightLoads.get(key);
+    if (inFlight) return inFlight;
+    const saveVersionAtStart = saveVersions.get(key) ?? 0;
+
+    const promise = (async () => {
+      setEntries(key, { ...entryFor(projectPath), loading: true, error: null });
+      try {
+        const loaded = await ProjectAPI.getGroups(projectPath);
+        if ((saveVersions.get(key) ?? 0) !== saveVersionAtStart) return;
+        const structuralErrors = validateGroupsConfig(loaded, { validateRegexSyntax: false });
+        if (structuralErrors.length > 0) {
+          setConfig(projectPath, defaultGroupsConfig(), {
+            loaded: true,
+            loading: false,
+            error: structuralErrors.join(" "),
+          });
+          return;
+        }
+        setConfig(projectPath, loaded, { loaded: true, loading: false, error: null });
+      } catch (error) {
+        if ((saveVersions.get(key) ?? 0) !== saveVersionAtStart) return;
+        setConfig(projectPath, defaultGroupsConfig(), {
+          loaded: true,
+          loading: false,
+          error: formatError(error),
+        });
+      } finally {
+        inFlightLoads.delete(key);
+      }
+    })();
+
+    inFlightLoads.set(key, promise);
+    return promise;
+  },
+
+  config(projectPath: string): WorkgroupGroupsConfig {
+    return cloneConfig(entryFor(projectPath).config);
+  },
+
+  selection(projectPath: string): WorkgroupGroupSelection {
+    return entryFor(projectPath).selection;
+  },
+
+  select(projectPath: string, selection: WorkgroupGroupSelection): void {
+    const key = keyFor(projectPath);
+    const current = ensureEntry(projectPath);
+    setEntries(key, {
+      ...current,
+      selection: normalizeSelection(selection, current.config),
+    });
+  },
+
+  error(projectPath: string): string | null {
+    return entryFor(projectPath).error;
+  },
+
+  loading(projectPath: string): boolean {
+    return entryFor(projectPath).loading;
+  },
+
+  saving(projectPath: string): boolean {
+    return entryFor(projectPath).saving;
+  },
+
+  async save(projectPath: string, config: WorkgroupGroupsConfig): Promise<void> {
+    const key = keyFor(projectPath);
+    const current = ensureEntry(projectPath);
+    const errors = validateGroupsConfig(config, { validateRegexSyntax: true });
+    if (errors.length > 0) {
+      const message = errors.join(" ");
+      setEntries(key, { ...current, error: message });
+      throw new Error(message);
+    }
+
+    setEntries(key, { ...current, saving: true, error: null });
+    try {
+      const saved = await ProjectAPI.updateGroups(projectPath, cloneConfig(config));
+      const structuralErrors = validateGroupsConfig(saved, { validateRegexSyntax: false });
+      if (structuralErrors.length > 0) {
+        throw new Error(structuralErrors.join(" "));
+      }
+      saveVersions.set(key, (saveVersions.get(key) ?? 0) + 1);
+      setConfig(projectPath, saved, {
+        loaded: true,
+        loading: false,
+        saving: false,
+        error: null,
+      });
+    } catch (error) {
+      const latest = entryFor(projectPath);
+      const message = formatError(error);
+      setEntries(key, { ...latest, saving: false, error: message });
+      throw new Error(message);
+    }
+  },
+
+  async addWorkgroupToGroup(projectPath: string, groupId: string, wgName: string): Promise<void> {
+    if (charLength(wgName) > MAX_GROUP_MATCH_ID_LENGTH) {
+      const message = `Workgroup id cannot exceed ${MAX_GROUP_MATCH_ID_LENGTH} characters.`;
+      const key = keyFor(projectPath);
+      setEntries(key, { ...ensureEntry(projectPath), error: message });
+      throw new Error(message);
+    }
+    const config = this.config(projectPath);
+    const group = config.groups.find((candidate) => candidate.id === groupId);
+    if (!group) throw new Error("Group no longer exists.");
+    const nextRegex = appendExactGroupToken(group.regex, wgName);
+    if (nextRegex === null) {
+      const message = "Fix this group's regex before adding a workgroup.";
+      const key = keyFor(projectPath);
+      setEntries(key, { ...ensureEntry(projectPath), error: message });
+      throw new Error(message);
+    }
+    await this.save(projectPath, {
+      ...config,
+      groups: config.groups.map((candidate) =>
+        candidate.id === groupId ? { ...candidate, regex: nextRegex } : candidate
+      ),
+    });
+  },
+
+  async createGroupForWorkgroup(projectPath: string, name: string, wgName: string): Promise<void> {
+    if (charLength(wgName) > MAX_GROUP_MATCH_ID_LENGTH) {
+      const message = `Workgroup id cannot exceed ${MAX_GROUP_MATCH_ID_LENGTH} characters.`;
+      const key = keyFor(projectPath);
+      setEntries(key, { ...ensureEntry(projectPath), error: message });
+      throw new Error(message);
+    }
+    const config = this.config(projectPath);
+    const existingIds = new Set(config.groups.map((group) => group.id));
+    await this.save(projectPath, {
+      ...config,
+      groups: [
+        ...config.groups,
+        {
+          id: createGroupId(existingIds),
+          name: name.trim(),
+          regex: exactGroupRegexForWorkgroup(wgName),
+        },
+      ],
+    });
+  },
+
+  resetForTests(): void {
+    for (const key of Object.keys(entries)) {
+      setEntries(key, undefined);
+    }
+    inFlightLoads.clear();
+    saveVersions.clear();
+  },
+};

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2474,6 +2474,63 @@ html.light-theme .root-agent-avatar {
   background: rgba(0, 212, 255, 0.08);
 }
 
+.session-context-submenu {
+  padding: 2px 0;
+}
+
+.session-context-submenu-title,
+.session-context-note,
+.session-context-error {
+  padding: 5px var(--spacing-md);
+  color: var(--sidebar-fg-dim);
+  font-size: 10px;
+}
+
+.session-context-submenu-title {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.session-context-error {
+  color: var(--danger, #ff6b6b);
+  white-space: normal;
+}
+
+.session-context-option-check {
+  width: 14px;
+  flex: 0 0 14px;
+  color: var(--sidebar-accent);
+}
+
+.session-context-group-option span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-context-inline-create {
+  display: flex;
+  gap: 6px;
+  padding: 4px var(--spacing-md);
+}
+
+.session-context-inline-input {
+  min-width: 0;
+  width: 130px;
+  height: 26px;
+  padding: 0 7px;
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-sm);
+  background: var(--sidebar-bg);
+  color: var(--sidebar-fg);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  outline: none;
+}
+
+.session-context-inline-input:focus {
+  border-color: var(--sidebar-accent);
+}
+
 .session-context-repo-option {
   min-width: 0;
 }
@@ -2661,10 +2718,104 @@ html.light-theme .settings-hint-warning {
   width: 100%;
 }
 
+.sidebar-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+}
+
+.sidebar-body[data-rail-side="left"],
+.sidebar-body[data-rail-side="right"] {
+  flex-direction: row;
+}
+
 .sidebar-scrollable {
   flex: 1;
+  min-width: 0;
+  min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
+}
+
+.workgroup-group-rail {
+  flex: 0 0 68px;
+  min-width: 68px;
+  max-width: 68px;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 6px 5px;
+  background: rgba(255, 255, 255, 0.025);
+  border-left: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.sidebar-body[data-rail-side="left"] .workgroup-group-rail {
+  border-left: none;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.workgroup-group-rail-project + .workgroup-group-rail-project {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.workgroup-group-rail-project-label {
+  margin-bottom: 5px;
+  color: var(--sidebar-fg-dim);
+  font-size: 9px;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workgroup-group-rail-button {
+  display: block;
+  width: 100%;
+  min-height: 28px;
+  margin-bottom: 4px;
+  padding: 4px 5px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--sidebar-fg-dim);
+  font-family: var(--font-ui);
+  font-size: 10px;
+  line-height: 1.15;
+  text-align: center;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.workgroup-group-rail-button:hover,
+.workgroup-group-rail-button.selected {
+  background: rgba(0, 212, 255, 0.1);
+  border-color: rgba(0, 212, 255, 0.22);
+  color: var(--sidebar-fg);
+}
+
+.workgroup-group-rail-button.selected {
+  box-shadow: inset 3px 0 0 var(--sidebar-accent);
+}
+
+.workgroup-group-rail-button.edit {
+  margin-top: 8px;
+  color: var(--sidebar-accent);
+}
+
+.workgroup-group-rail-error {
+  margin: 4px auto;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: rgba(255, 107, 107, 0.12);
+  color: var(--danger, #ff6b6b);
+  font-size: 12px;
+  line-height: 20px;
+  text-align: center;
 }
 
 .sidebar-scrollable::-webkit-scrollbar {
@@ -3734,6 +3885,121 @@ html.light-theme .settings-hint-warning {
   font-size: 9px;
   color: var(--sidebar-fg-dim);
   letter-spacing: 0.3px;
+}
+
+/* ===== Workgroup Groups Modal ===== */
+.workgroup-groups-modal {
+  width: min(760px, 94vw);
+  max-height: min(720px, 88vh);
+}
+
+.workgroup-groups-form {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  min-height: 0;
+  padding: var(--spacing-md);
+  overflow-y: auto;
+}
+
+.workgroup-groups-project {
+  color: var(--sidebar-fg-dim);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  overflow-wrap: anywhere;
+}
+
+.workgroup-groups-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+}
+
+.workgroup-groups-toggles input {
+  accent-color: var(--sidebar-accent);
+}
+
+.workgroup-groups-table {
+  display: grid;
+  gap: var(--spacing-xs);
+  min-height: 0;
+}
+
+.workgroup-group-edit-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.7fr) minmax(180px, 1fr) auto;
+  gap: var(--spacing-xs);
+  align-items: center;
+}
+
+.workgroup-group-name-input,
+.workgroup-group-regex-input {
+  min-width: 0;
+  height: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--sidebar-fg);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  padding: 0 var(--spacing-sm);
+  outline: none;
+}
+
+.workgroup-group-name-input:focus,
+.workgroup-group-regex-input:focus {
+  border-color: rgba(0, 212, 255, 0.38);
+}
+
+.workgroup-group-delete,
+.workgroup-group-add {
+  height: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--sidebar-fg-dim);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.workgroup-group-delete {
+  padding: 0 var(--spacing-sm);
+}
+
+.workgroup-group-add {
+  align-self: flex-start;
+  padding: 0 var(--spacing-md);
+}
+
+.workgroup-group-delete:hover,
+.workgroup-group-add:hover {
+  background: rgba(0, 212, 255, 0.09);
+  color: var(--sidebar-fg);
+}
+
+.workgroup-groups-empty,
+.workgroup-groups-errors {
+  color: var(--sidebar-fg-dim);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.workgroup-groups-errors {
+  color: var(--danger, #ff6b6b);
+}
+
+@media (max-width: 680px) {
+  .workgroup-group-edit-row {
+    grid-template-columns: 1fr;
+  }
+
+  .workgroup-group-delete {
+    justify-self: flex-start;
+  }
 }
 
 /* ===== New Agent Modal ===== */


### PR DESCRIPTION
## What

Adds **Workgroup UI Groups** — a Telegram-folder-style vertical rail attached to the sidebar (on the side opposite the Terminal) that filters which coordinators/workgroups are shown, via named groups. Purely a **UI-only view filter + labels**; no effect on how workgroups/agents run.

## Behavior

- Rail buttons: **All** / **[user groups]** / **Ungrouped** / **Edit**, with an obvious selected state. Settings toggles for showing All / Ungrouped (never both hidden; default both on).
- Each group is a saved regex tested against a stable `groupMatchId(wg) = wg.name`; the group predicate is AND'ed with the existing visible search filter. `Ungrouped` = matches no group's regex (complement of the union — no membership field stored).
- **Add to Group** on a coordinator's context menu (existing groups with ✓ + inline "Create new group"); assignment appends an escaped exact-match token to the group's regex.
- **Edit** modal: add / delete / rename / edit-regex + toggles. Deleting a group removes only the grouping (never touches a WG). Invalid regex blocks save.
- Group name shows `X/Y` (WGs working / total; working = ≥1 replica `running`/`active`) and a hover tooltip listing running agents as `WG#:(agent)`.
- Persisted **per project** in `.ac/project-settings.json` (unknown root keys — including the documented `agents` key — are preserved; save mutates only `groups`/`showAll`/`showUngrouped`).

## Implementation

- **Backend** (`558f4eb`, `src-tauri/`): `config::project_settings` (DTOs, serde defaults, caps, structural validation on save+load), IPC `get_project_groups`/`update_project_groups`, safe write via `local_config_io::update_config_json_object` (last-writer-wins). Rust does not compile/evaluate regexes.
- **Frontend** (`d1b39df`, `src/`): shared types/IPC, `workgroup-groups` store (in-flight load dedupe, failed-save preserves prior state, stale-load guard), path-aware session helper, `WorkgroupGroupRail` + `WorkgroupGroupsModal`, `ProjectPanel` filter/context-menu integration, rail-side wiring (main + browser), CSS.
- Merged with `origin/main` (#738) at `790b4d8` (clean, no conflicts).

## Review & gates

- Architect plan `READY_FOR_IMPLEMENTATION` with review findings A–M folded in.
- Enrichment: dev-rust (BE) + dev-webpage-ui (FE) + dev-rust-grinch (adversarial: initial FAIL → all findings folded into plan).
- **Grinch Step-9 code review: PASS** (0 HIGH / 0 MED; one non-blocking LOW = residual test coverage, tracked in #740). **Grinch Step-9.5 re-sync re-review: PASS** (lossless #737+#738; no adverse `sanitize_name`↔caps interaction).
- Gates on merged tree: `cargo build` + `cargo clippy -- -D warnings` clean; `cargo test --lib --bins --tests` **1817 passed / 0 failed**; `tsc` clean; `vitest` **622 passed**; `vite build` OK. Rail verified via headless screenshot.

## Follow-up

- #740 — add explicit test coverage for multi-project isolation, counter/tooltip collision, main-embedded rail-side layout, and context-menu viewport reclamp (grinch manually verified these paths; no functional failure).

Closes #737
