### PR TITLE
fix: single-slot Add to Group flyout submenu + English-only group strings (#742)

### DIFF
--- a/src/sidebar/components/ProjectPanel.context-menu.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu.test.tsx
@@ -155,7 +155,7 @@ function repoFolderLabel(item: HTMLElement): string | null {
 
 function menuButtonLabels(menu: HTMLElement): string[] {
   return Array.from(menu.querySelectorAll<HTMLButtonElement>("button")).map((button) =>
-    (button.textContent ?? "").trim().replace(/^[^A-Za-z0-9]+/, "").trim()
+    (button.textContent ?? "").trim().replace(/\u203a/g, "").replace(/^[^A-Za-z0-9]+/, "").trim()
   );
 }
 
@@ -360,7 +360,7 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
     expect(menuButtonLabels(replicaMenu()!)).toEqual([
       "Restart Session",
       "Coding Agent",
-      "Crear grupo nuevo",
+      "Add to Group",
       "Open Replica's Folder",
       "AgentsCommander",
       "docs",
@@ -455,12 +455,12 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
       expect(items.map(repoFolderLabel)).toEqual(["AgentsCommander", "docs"]);
       expect(items[0].title).toBe(repos[0]);
       expect(items[1].title).toBe(repos[1]);
-    expect(menuButtonLabels(menu!)).toEqual([
-      "Coding Agent",
-      "Crear grupo nuevo",
-      "Open Replica's Folder",
-      "AgentsCommander",
-      "docs",
+      expect(menuButtonLabels(menu!)).toEqual([
+        "Coding Agent",
+        "Add to Group",
+        "Open Replica's Folder",
+        "AgentsCommander",
+        "docs",
         "Open Matrix folder",
         "Clear task title",
       ]);

--- a/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
@@ -97,6 +97,13 @@ async function openCoordinatorMenu(root: ParentNode): Promise<void> {
   await waitFor(() => expect(document.querySelector(".session-context-menu")).not.toBeNull());
 }
 
+async function openGroupFlyout(): Promise<void> {
+  click(target("replica.wg-1-dev-team.groups.trigger"));
+  await waitFor(() =>
+    expect(target("replica.wg-1-dev-team.groups.flyout")).not.toBeNull()
+  );
+}
+
 describe("ProjectPanel workgroup groups", () => {
   let cleanupDom: (() => void) | null = null;
 
@@ -172,6 +179,9 @@ describe("ProjectPanel workgroup groups", () => {
       await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
 
       await openCoordinatorMenu(rendered.root);
+      expect(document.querySelector(".session-context-menu")?.textContent).toContain("Add to Group");
+      expect(document.querySelector(".session-context-menu")?.textContent).not.toContain("Create new group");
+      await openGroupFlyout();
       click(target(`replica.wg-1-dev-team.groups.frontend`));
 
       await waitFor(() =>
@@ -202,6 +212,9 @@ describe("ProjectPanel workgroup groups", () => {
       await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
 
       await openCoordinatorMenu(rendered.root);
+      await openGroupFlyout();
+      expect(target("replica.wg-1-dev-team.groups.flyout").textContent).toContain("No groups yet");
+      expect(target("replica.wg-1-dev-team.groups.flyout").textContent).toContain("Create new group");
       click(target("replica.wg-1-dev-team.groups.create"));
       input(target<HTMLInputElement>("replica.groups.create.input"), "Frontend");
       click(target("replica.groups.create.save"));
@@ -211,6 +224,66 @@ describe("ProjectPanel workgroup groups", () => {
         expect(target("replica.groups.error").textContent).toContain("groups.toml changed on disk");
       });
     } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("clamps the Add to Group flyout inside the viewport near the right and bottom edges", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    const originalWidth = window.innerWidth;
+    const originalHeight = window.innerHeight;
+    try {
+      await workgroupGroupsStore.save(projectPath, groupsConfig([]));
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await openCoordinatorMenu(rendered.root);
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: 320 });
+      Object.defineProperty(window, "innerHeight", { configurable: true, value: 220 });
+      const trigger = target<HTMLButtonElement>("replica.wg-1-dev-team.groups.trigger");
+      trigger.getBoundingClientRect = () =>
+        ({
+          left: 295,
+          right: 315,
+          top: 185,
+          bottom: 205,
+          width: 20,
+          height: 20,
+          x: 295,
+          y: 185,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      click(trigger);
+      const flyout = target<HTMLDivElement>("replica.wg-1-dev-team.groups.flyout");
+      flyout.getBoundingClientRect = () =>
+        ({
+          left: 0,
+          right: 220,
+          top: 0,
+          bottom: 180,
+          width: 220,
+          height: 180,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect;
+      click(trigger);
+
+      await waitFor(() => {
+        const left = Number.parseFloat(flyout.style.left);
+        const top = Number.parseFloat(flyout.style.top);
+        expect(left).toBeGreaterThanOrEqual(8);
+        expect(left + 220).toBeLessThanOrEqual(312);
+        expect(top).toBeGreaterThanOrEqual(8);
+        expect(top + 180).toBeLessThanOrEqual(212);
+      });
+    } finally {
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: originalWidth });
+      Object.defineProperty(window, "innerHeight", { configurable: true, value: originalHeight });
       rendered.cleanup();
     }
   });

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -699,6 +699,10 @@ const ProjectPanel: Component = () => {
         const [groupCreateWgPath, setGroupCreateWgPath] = createSignal<string | null>(null);
         const [groupCreateName, setGroupCreateName] = createSignal("");
         const [groupMenuError, setGroupMenuError] = createSignal("");
+        const [groupFlyoutOpen, setGroupFlyoutOpen] = createSignal(false);
+        const [groupFlyoutPos, setGroupFlyoutPos] = createSignal({ x: 0, y: 0 });
+        let groupFlyoutEl: HTMLDivElement | undefined;
+        let groupFlyoutAnchorEl: HTMLElement | undefined;
         const [agentCtxMenu, setAgentCtxMenu] = createSignal<{ agent: { name: string; path: string; preferredAgentId?: string }; x: number; y: number } | null>(null);
         const [agentsHeaderCtxMenu, setAgentsHeaderCtxMenu] = createSignal<{ x: number; y: number } | null>(null);
         const [workgroupsHeaderCtxMenu, setWorkgroupsHeaderCtxMenu] = createSignal<{ x: number; y: number } | null>(null);
@@ -850,10 +854,19 @@ const ProjectPanel: Component = () => {
           setFilterPattern("");
           focusFilterInput();
         };
-        const resetGroupMenuState = () => {
+        const closeGroupFlyout = () => {
+          setGroupFlyoutOpen(false);
+          groupFlyoutAnchorEl = undefined;
+          groupFlyoutEl = undefined;
+        };
+        const resetGroupCreateState = () => {
           setGroupCreateWgPath(null);
           setGroupCreateName("");
           setGroupMenuError("");
+        };
+        const resetGroupMenuState = () => {
+          resetGroupCreateState();
+          closeGroupFlyout();
         };
         const handleFilterKeyDown = (e: KeyboardEvent) => {
           if (e.key !== "Escape") return;
@@ -1134,6 +1147,46 @@ const ProjectPanel: Component = () => {
           window.setTimeout(clamp, 0);
         };
 
+        const positionGroupFlyout = (anchor: HTMLElement) => {
+          const rect = anchor.getBoundingClientRect();
+          const width = groupFlyoutEl?.getBoundingClientRect().width ?? 220;
+          const height = groupFlyoutEl?.getBoundingClientRect().height ?? 180;
+          let x = rect.right + 4;
+          if (x + width + CONTEXT_MENU_VIEWPORT_MARGIN > window.innerWidth) {
+            x = rect.left - width - 4;
+          }
+          const maxX = Math.max(
+            CONTEXT_MENU_VIEWPORT_MARGIN,
+            window.innerWidth - width - CONTEXT_MENU_VIEWPORT_MARGIN
+          );
+          const maxY = Math.max(
+            CONTEXT_MENU_VIEWPORT_MARGIN,
+            window.innerHeight - height - CONTEXT_MENU_VIEWPORT_MARGIN
+          );
+          setGroupFlyoutPos({
+            x: Math.min(Math.max(CONTEXT_MENU_VIEWPORT_MARGIN, x), maxX),
+            y: Math.min(Math.max(CONTEXT_MENU_VIEWPORT_MARGIN, rect.top), maxY),
+          });
+        };
+
+        const reclampGroupFlyout = () => {
+          const anchor = groupFlyoutAnchorEl;
+          if (!anchor || !groupFlyoutOpen()) return;
+          const clamp = () => positionGroupFlyout(anchor);
+          if (typeof window.requestAnimationFrame === "function") {
+            window.requestAnimationFrame(clamp);
+            return;
+          }
+          window.setTimeout(clamp, 0);
+        };
+
+        const openGroupFlyout = (anchor: HTMLElement) => {
+          groupFlyoutAnchorEl = anchor;
+          positionGroupFlyout(anchor);
+          setGroupFlyoutOpen(true);
+          reclampGroupFlyout();
+        };
+
         const restartReplicaSession = async (
           sessionId: string,
           agentId?: string,
@@ -1193,6 +1246,7 @@ const ProjectPanel: Component = () => {
             await workgroupGroupsStore.addWorkgroupToGroup(proj.path, groupId, wg.name);
           } catch (error) {
             setGroupMenuError(error instanceof Error ? error.message : String(error));
+            reclampGroupFlyout();
             reclampReplicaCtxMenu();
           }
         };
@@ -1201,97 +1255,128 @@ const ProjectPanel: Component = () => {
           const name = groupCreateName().trim();
           if (!name) {
             setGroupMenuError("Group name cannot be blank.");
+            reclampGroupFlyout();
             reclampReplicaCtxMenu();
             return;
           }
           setGroupMenuError("");
           try {
             await workgroupGroupsStore.createGroupForWorkgroup(proj.path, name, wg.name);
-            resetGroupMenuState();
+            resetGroupCreateState();
+            reclampGroupFlyout();
             reclampReplicaCtxMenu();
           } catch (error) {
             setGroupMenuError(error instanceof Error ? error.message : String(error));
+            reclampGroupFlyout();
             reclampReplicaCtxMenu();
           }
         };
 
-        const renderAddToGroupSection = (wg: AcWorkgroup, replica: AcAgentReplica) => (
+        const renderAddToGroupFlyout = (wg: AcWorkgroup) => (
+          <Portal>
+            <Show when={groupFlyoutOpen()}>
+              <div
+                class="session-context-flyout"
+                ref={groupFlyoutEl}
+                style={{ left: `${groupFlyoutPos().x}px`, top: `${groupFlyoutPos().y}px` }}
+                onClick={(e) => e.stopPropagation()}
+                onContextMenu={(e) => e.stopPropagation()}
+                data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.flyout`}
+              >
+                <For each={groupsConfig().groups}>
+                  {(group) => {
+                    const valid = () => !!compileGroupRegex(group);
+                    return (
+                      <button
+                        class="session-context-option session-context-group-option"
+                        classList={{ "context-option-disabled": !valid() }}
+                        disabled={!valid()}
+                        title={valid() ? group.regex : "Fix this group's regex before adding a workgroup"}
+                        onClick={() => void addToExistingGroup(wg, group.id)}
+                        data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.${automationIdPart(group.id)}`}
+                      >
+                        <span class="session-context-option-check">
+                          {groupAlreadyMatches(wg, group.id) ? "\u2713" : ""}
+                        </span>
+                        <span>{group.name}</span>
+                      </button>
+                    );
+                  }}
+                </For>
+                <Show when={groupsConfig().groups.length === 0}>
+                  <div class="session-context-note">No groups yet</div>
+                </Show>
+                <Show when={workgroupGroupsStore.error(proj.path)}>
+                  {(error) => <div class="session-context-error">{error()}</div>}
+                </Show>
+                <Show when={groupMenuError()}>
+                  <div class="session-context-error" data-ac-testid="replica.groups.error">
+                    {groupMenuError()}
+                  </div>
+                </Show>
+                <Show
+                  when={groupCreateWgPath() === wg.path}
+                  fallback={
+                    <button
+                      class="session-context-option"
+                      onClick={() => {
+                        setGroupCreateWgPath(wg.path);
+                        setGroupCreateName("");
+                        setGroupMenuError("");
+                        reclampGroupFlyout();
+                      }}
+                      data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.create`}
+                    >
+                      Create new group
+                    </button>
+                  }
+                >
+                  <div class="session-context-inline-create">
+                    <input
+                      class="session-context-inline-input"
+                      value={groupCreateName()}
+                      onInput={(e) => setGroupCreateName(e.currentTarget.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          void createGroupFromMenu(wg);
+                        }
+                      }}
+                      placeholder="Group name"
+                      data-ac-testid="replica.groups.create.input"
+                    />
+                    <button
+                      class="session-context-option"
+                      onClick={() => void createGroupFromMenu(wg)}
+                      data-ac-testid="replica.groups.create.save"
+                    >
+                      Create
+                    </button>
+                  </div>
+                </Show>
+              </div>
+            </Show>
+          </Portal>
+        );
+
+        const renderAddToGroupItem = (wg: AcWorkgroup, replica: AcAgentReplica) => (
           <Show when={replica.isCoordinator}>
             <div class="context-separator" />
-            <div class="session-context-submenu" data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.menu`}>
-              <div class="session-context-submenu-title">Add to Group</div>
-              <For each={groupsConfig().groups}>
-                {(group) => {
-                  const valid = () => !!compileGroupRegex(group);
-                  return (
-                    <button
-                      class="session-context-option session-context-group-option"
-                      classList={{ "context-option-disabled": !valid() }}
-                      disabled={!valid()}
-                      title={valid() ? group.regex : "Fix this group's regex before adding a workgroup"}
-                      onClick={() => void addToExistingGroup(wg, group.id)}
-                      data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.${automationIdPart(group.id)}`}
-                    >
-                      <span class="session-context-option-check">
-                        {groupAlreadyMatches(wg, group.id) ? "\u2713" : ""}
-                      </span>
-                      <span>{group.name}</span>
-                    </button>
-                  );
-                }}
-              </For>
-              <Show when={groupsConfig().groups.length === 0}>
-                <div class="session-context-note">No groups yet</div>
-              </Show>
-              <Show when={workgroupGroupsStore.error(proj.path)}>
-                {(error) => <div class="session-context-error">{error()}</div>}
-              </Show>
-              <Show when={groupMenuError()}>
-                <div class="session-context-error" data-ac-testid="replica.groups.error">
-                  {groupMenuError()}
-                </div>
-              </Show>
-              <Show
-                when={groupCreateWgPath() === wg.path}
-                fallback={
-                  <button
-                    class="session-context-option"
-                    onClick={() => {
-                      setGroupCreateWgPath(wg.path);
-                      setGroupCreateName("");
-                      setGroupMenuError("");
-                      reclampReplicaCtxMenu();
-                    }}
-                    data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.create`}
-                  >
-                    Crear grupo nuevo
-                  </button>
-                }
-              >
-                <div class="session-context-inline-create">
-                  <input
-                    class="session-context-inline-input"
-                    value={groupCreateName()}
-                    onInput={(e) => setGroupCreateName(e.currentTarget.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault();
-                        void createGroupFromMenu(wg);
-                      }
-                    }}
-                    placeholder="Group name"
-                    data-ac-testid="replica.groups.create.input"
-                  />
-                  <button
-                    class="session-context-option"
-                    onClick={() => void createGroupFromMenu(wg)}
-                    data-ac-testid="replica.groups.create.save"
-                  >
-                    Create
-                  </button>
-                </div>
-              </Show>
-            </div>
+            <button
+              class="session-context-option session-context-submenu-trigger"
+              onMouseEnter={(e) => openGroupFlyout(e.currentTarget)}
+              onFocus={(e) => openGroupFlyout(e.currentTarget)}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                openGroupFlyout(e.currentTarget);
+              }}
+              data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.trigger`}
+            >
+              <span>Add to Group</span>
+              <span class="session-context-submenu-arrow">&rsaquo;</span>
+            </button>
+            {renderAddToGroupFlyout(wg)}
           </Show>
         );
 
@@ -2985,7 +3070,7 @@ const ProjectPanel: Component = () => {
                         >
                           Coding Agent
                         </button>
-                        {renderAddToGroupSection(menu().wg, menu().replica)}
+                        {renderAddToGroupItem(menu().wg, menu().replica)}
                         <button
                           class="session-context-option"
                           title={menu().replica.path}
@@ -3075,7 +3160,7 @@ const ProjectPanel: Component = () => {
                           >
                             Coding Agent
                           </button>
-                          {renderAddToGroupSection(menu().wg, menu().replica)}
+                          {renderAddToGroupItem(menu().wg, menu().replica)}
                           <button
                             class="session-context-option"
                             title={menu().replica.path}

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -62,7 +62,7 @@ function tooltipFor(workgroups: AcWorkgroup[]): string {
 
 function counterLabel(name: string, workgroups: AcWorkgroup[]): string {
   const working = workgroups.filter(workgroupIsWorking).length;
-  return `${name} ${working}/${workgroups.length}`;
+  return `${name}\n${working}/${workgroups.length}`;
 }
 
 const ProjectRailSection: Component<{
@@ -87,7 +87,7 @@ const ProjectRailSection: Component<{
     if (config().showAll) {
       result.push({
         key: "all",
-        label: counterLabel("Todos", props.project.workgroups),
+        label: counterLabel("All", props.project.workgroups),
         selection: { kind: "all" },
         workgroups: props.project.workgroups,
         title: tooltipFor(props.project.workgroups),
@@ -107,7 +107,7 @@ const ProjectRailSection: Component<{
       const workgroups = ungroupedWorkgroups();
       result.push({
         key: "ungrouped",
-        label: counterLabel("Sin Grupo", workgroups),
+        label: counterLabel("Ungrouped", workgroups),
         selection: { kind: "ungrouped" },
         workgroups,
         title: tooltipFor(workgroups),
@@ -157,7 +157,7 @@ const ProjectRailSection: Component<{
         onClick={() => setEditing(true)}
         data-ac-testid="workgroupGroups.edit"
       >
-        Editar
+        Edit
       </button>
 
       <Show when={editing()}>

--- a/src/sidebar/components/WorkgroupGroupsModal.tsx
+++ b/src/sidebar/components/WorkgroupGroupsModal.tsx
@@ -108,7 +108,7 @@ const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
     <div class="modal-overlay" data-ac-testid="workgroupGroups.modal">
       <div class="agent-modal workgroup-groups-modal">
         <div class="agent-modal-header">
-          <span class="agent-modal-title">Editar grupos</span>
+          <span class="agent-modal-title">Edit groups</span>
           <button class="modal-close" onClick={props.onClose} aria-label="Close groups editor">
             &times;
           </button>
@@ -125,7 +125,7 @@ const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
                 disabled={draft().showAll && !draft().showUngrouped}
                 onChange={(e) => setToggle("showAll", e.currentTarget.checked)}
               />
-              <span>Mostrar Todos</span>
+              <span>Show All</span>
             </label>
             <label class="settings-checkbox-field">
               <input
@@ -134,7 +134,7 @@ const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
                 disabled={draft().showUngrouped && !draft().showAll}
                 onChange={(e) => setToggle("showUngrouped", e.currentTarget.checked)}
               />
-              <span>Mostrar Sin Grupo</span>
+              <span>Show Ungrouped</span>
             </label>
           </div>
 

--- a/src/sidebar/stores/workgroup-groups.test.ts
+++ b/src/sidebar/stores/workgroup-groups.test.ts
@@ -164,7 +164,7 @@ describe("workgroup group validation helpers", () => {
         { validateRegexSyntax: true }
       )
     ).toEqual([
-      "At least one of Todos or Sin Grupo must be visible.",
+      "At least one of All or Ungrouped must be visible.",
       "Duplicate group name.",
       "Group 2: regex is invalid.",
     ]);

--- a/src/sidebar/stores/workgroup-groups.ts
+++ b/src/sidebar/stores/workgroup-groups.ts
@@ -143,7 +143,7 @@ export function validateGroupsConfig(
 ): string[] {
   const errors: string[] = [];
   if (!config.showAll && !config.showUngrouped) {
-    errors.push("At least one of Todos or Sin Grupo must be visible.");
+    errors.push("At least one of All or Ungrouped must be visible.");
   }
   if (config.groups.length > MAX_WORKGROUP_GROUPS) {
     errors.push(`At most ${MAX_WORKGROUP_GROUPS} groups are allowed.`);

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2474,11 +2474,6 @@ html.light-theme .root-agent-avatar {
   background: rgba(0, 212, 255, 0.08);
 }
 
-.session-context-submenu {
-  padding: 2px 0;
-}
-
-.session-context-submenu-title,
 .session-context-note,
 .session-context-error {
   padding: 5px var(--spacing-md);
@@ -2486,14 +2481,33 @@ html.light-theme .root-agent-avatar {
   font-size: 10px;
 }
 
-.session-context-submenu-title {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
 .session-context-error {
   color: var(--danger, #ff6b6b);
   white-space: normal;
+}
+
+.session-context-submenu-trigger {
+  justify-content: space-between;
+}
+
+.session-context-submenu-arrow {
+  margin-left: auto;
+  color: var(--sidebar-fg-dim);
+  font-size: 13px;
+}
+
+.session-context-flyout {
+  position: fixed;
+  min-width: 220px;
+  max-width: min(320px, calc(100vw - 16px));
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
+  padding: var(--spacing-xs) 0;
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-md);
+  background: var(--sidebar-surface);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+  z-index: 10000;
 }
 
 .session-context-option-check {
@@ -2782,11 +2796,12 @@ html.light-theme .settings-hint-warning {
   background: transparent;
   color: var(--sidebar-fg-dim);
   font-family: var(--font-ui);
-  font-size: 10px;
+  font-size: 8.5px;
   line-height: 1.15;
   text-align: center;
+  white-space: pre-line;
   cursor: pointer;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
 }
 


### PR DESCRIPTION
## What

User-testing feedback on #737 (Workgroup UI Groups): collapse the coordinator context-menu groups section to a **single `Add to Group` item** with a hover/click **flyout submenu**, and make all group UI strings **English-only**.

## Changes

- One `Add to Group` menu slot; the flyout (fixed-position Portal) contains existing groups with membership check marks, a `No groups yet` empty state, and the `Create new group` inline-create flow.
- Failed assign/create keeps the menu/flyout open with a visible error (unchanged from #737 behavior).
- Independent viewport clamping for the flyout, with reclamp on expand/error/create-state changes; stale flyout refs cleared on close/reopen.
- English strings: rail `All` / `Ungrouped` / `Edit`; modal `Edit groups` / `Show All` / `Show Ungrouped`; menu `Add to Group` / `Create new group`; validation `At least one of All or Ungrouped must be visible.` Rail labels no longer split mid-word.
- FE-only (`src/sidebar`): `ProjectPanel.tsx`, `sidebar.css`, `WorkgroupGroupRail.tsx`, `WorkgroupGroupsModal.tsx`, `workgroup-groups.ts` + 3 test files. No backend or filtering/persistence changes.

## Review & gates

- Grinch Step-9 review: **PASS** (0 HIGH / 0 MED; #737 semantics verified intact; no Spanish strings remain — case-insensitive sweep clean; flyout lifecycle/clamp verified; viewport clamp test added).
- `tsc --noEmit` clean; `vitest` **623 passed** (81 files); `vite build` OK (pre-existing warnings only).
- Headless screenshots (with-groups / no-groups flyout) manually verified.

Closes #742
