### PR TITLE
fix: groups UI polish r2 — Ungrouped-only state, flyout lifecycle, ordering, membership toggle (#744)

### DIFF
--- a/src/sidebar/components/ProjectPanel.context-menu.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu.test.tsx
@@ -360,7 +360,6 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
     expect(menuButtonLabels(replicaMenu()!)).toEqual([
       "Restart Session",
       "Coding Agent",
-      "Add to Group",
       "Open Replica's Folder",
       "AgentsCommander",
       "docs",
@@ -368,6 +367,7 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
       "cli",
       "Open Matrix folder",
       "Open in new window",
+      "Add to Group",
       "Clear task title",
     ]);
 
@@ -457,11 +457,11 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
       expect(items[1].title).toBe(repos[1]);
       expect(menuButtonLabels(menu!)).toEqual([
         "Coding Agent",
-        "Add to Group",
         "Open Replica's Folder",
         "AgentsCommander",
         "docs",
         "Open Matrix folder",
+        "Add to Group",
         "Clear task title",
       ]);
     });

--- a/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProjectPanel from "./ProjectPanel";
 import { FakeTransport } from "../../shared/testing/fake-transport";
 import {
@@ -84,6 +84,10 @@ function target<T extends Element>(testId: string): T {
   const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
   if (!element) throw new Error(`Missing element ${testId}`);
   return element;
+}
+
+function mouse(el: Element, type: "mouseenter" | "mouseleave"): void {
+  el.dispatchEvent(new MouseEvent(type, { bubbles: false, cancelable: true }));
 }
 
 function panelTarget<T extends Element>(root: ParentNode, testId: string): T {
@@ -199,6 +203,184 @@ describe("ProjectPanel workgroup groups", () => {
     }
   });
 
+  it("removes a coordinator workgroup from an exact generated group from the context menu", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+    sessionsStore.setSessions([
+      session({
+        id: "coord-session",
+        name: "wg-1-dev-team/dev-webpage-ui",
+        workingDirectory: `${wg1Path}\\__agent_dev-webpage-ui`,
+        status: "running",
+        isCoordinator: true,
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await workgroupGroupsStore.save(
+        projectPath,
+        groupsConfig([
+          {
+            id: "frontend",
+            name: "Frontend",
+            regex: "^(wg-1-dev-team|wg-2-rust-team)$",
+          },
+        ])
+      );
+      fake.clearCalls();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await openCoordinatorMenu(rendered.root);
+      await openGroupFlyout();
+      expect(target("replica.wg-1-dev-team.groups.frontend").textContent).toContain("\u2713");
+      click(target("replica.wg-1-dev-team.groups.frontend"));
+
+      await waitFor(() =>
+        expect(fake.lastCall("update_project_groups")?.args.config).toMatchObject({
+          groups: [
+            {
+              id: "frontend",
+              regex: exactGroupRegexForWorkgroup("wg-2-rust-team"),
+            },
+          ],
+        })
+      );
+      await waitFor(() =>
+        expect(target("replica.wg-1-dev-team.groups.frontend").textContent).not.toContain("\u2713")
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps custom regex membership checked but non-toggleable in the group flyout", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+    sessionsStore.setSessions([
+      session({
+        id: "coord-session",
+        name: "wg-1-dev-team/dev-webpage-ui",
+        workingDirectory: `${wg1Path}\\__agent_dev-webpage-ui`,
+        status: "running",
+        isCoordinator: true,
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await workgroupGroupsStore.save(
+        projectPath,
+        groupsConfig([{ id: "custom", name: "Custom", regex: "^wg-1-" }])
+      );
+      fake.clearCalls();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await openCoordinatorMenu(rendered.root);
+      await openGroupFlyout();
+      const option = target<HTMLButtonElement>("replica.wg-1-dev-team.groups.custom");
+      expect(option.textContent).toContain("\u2713");
+      expect(option.disabled).toBe(true);
+      expect(option.title).toContain("custom regex");
+      click(option);
+      expect(fake.callsFor("update_project_groups")).toHaveLength(0);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps the context menu and flyout open when group removal fails", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+    sessionsStore.setSessions([
+      session({
+        id: "coord-session",
+        name: "wg-1-dev-team/dev-webpage-ui",
+        workingDirectory: `${wg1Path}\\__agent_dev-webpage-ui`,
+        status: "running",
+        isCoordinator: true,
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await workgroupGroupsStore.save(
+        projectPath,
+        groupsConfig([
+          {
+            id: "frontend",
+            name: "Frontend",
+            regex: exactGroupRegexForWorkgroup("wg-1-dev-team"),
+          },
+        ])
+      );
+      fake.reject("update_project_groups", "groups.toml changed on disk");
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await openCoordinatorMenu(rendered.root);
+      await openGroupFlyout();
+      click(target("replica.wg-1-dev-team.groups.frontend"));
+
+      await waitFor(() => {
+        expect(document.querySelector(".session-context-menu")).not.toBeNull();
+        expect(target("replica.wg-1-dev-team.groups.flyout")).not.toBeNull();
+        expect(target("replica.groups.error").textContent).toContain("groups.toml changed on disk");
+      });
+
+      vi.useFakeTimers();
+      try {
+        mouse(target("replica.wg-1-dev-team.groups.flyout"), "mouseleave");
+        vi.advanceTimersByTime(240);
+        await Promise.resolve();
+        expect(target("replica.wg-1-dev-team.groups.flyout")).not.toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("auto-hides the Add to Group flyout after the pointer leaves the trigger and flyout", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await workgroupGroupsStore.save(projectPath, groupsConfig([]));
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await openCoordinatorMenu(rendered.root);
+      await openGroupFlyout();
+      const trigger = target("replica.wg-1-dev-team.groups.trigger");
+      const flyout = target("replica.wg-1-dev-team.groups.flyout");
+
+      vi.useFakeTimers();
+      try {
+        mouse(trigger, "mouseleave");
+        vi.advanceTimersByTime(120);
+        expect(document.querySelector('[data-ac-testid="replica.wg-1-dev-team.groups.flyout"]')).not.toBeNull();
+
+        mouse(flyout, "mouseenter");
+        vi.advanceTimersByTime(240);
+        expect(document.querySelector('[data-ac-testid="replica.wg-1-dev-team.groups.flyout"]')).not.toBeNull();
+
+        mouse(flyout, "mouseleave");
+        vi.advanceTimersByTime(180);
+        await Promise.resolve();
+        expect(document.querySelector('[data-ac-testid="replica.wg-1-dev-team.groups.flyout"]')).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
   it("keeps the context menu open and shows an error when inline group creation fails", async () => {
     const fake = new FakeTransport();
     setupProjectTransport(fake);
@@ -271,7 +453,7 @@ describe("ProjectPanel workgroup groups", () => {
           y: 0,
           toJSON: () => ({}),
         }) as DOMRect;
-      click(trigger);
+      mouse(trigger, "mouseenter");
 
       await waitFor(() => {
         const left = Number.parseFloat(flyout.style.left);

--- a/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
@@ -90,6 +90,15 @@ function mouse(el: Element, type: "mouseenter" | "mouseleave"): void {
   el.dispatchEvent(new MouseEvent(type, { bubbles: false, cancelable: true }));
 }
 
+function focus(el: Element): void {
+  el.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+  el.dispatchEvent(new FocusEvent("focus", { bubbles: false }));
+}
+
+function keydown(el: Element, key: string): void {
+  el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+}
+
 function panelTarget<T extends Element>(root: ParentNode, testId: string): T {
   const element = root.querySelector<T>(`[data-ac-testid="${testId}"]`);
   if (!element) throw new Error(`Missing element ${testId}`);
@@ -376,6 +385,61 @@ describe("ProjectPanel workgroup groups", () => {
       } finally {
         vi.useRealTimers();
       }
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps the Add to Group flyout open when pointer click follows hover open", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await workgroupGroupsStore.save(projectPath, groupsConfig([]));
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await openCoordinatorMenu(rendered.root);
+      const trigger = target("replica.wg-1-dev-team.groups.trigger");
+      mouse(trigger, "mouseenter");
+      await waitFor(() =>
+        expect(document.querySelector('[data-ac-testid="replica.wg-1-dev-team.groups.flyout"]')).not.toBeNull()
+      );
+
+      click(trigger);
+
+      await waitFor(() =>
+        expect(document.querySelector('[data-ac-testid="replica.wg-1-dev-team.groups.flyout"]')).not.toBeNull()
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps the Add to Group flyout open when keyboard activation follows focus open", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await workgroupGroupsStore.save(projectPath, groupsConfig([]));
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await openCoordinatorMenu(rendered.root);
+      const trigger = target("replica.wg-1-dev-team.groups.trigger");
+      focus(trigger);
+      await waitFor(() =>
+        expect(document.querySelector('[data-ac-testid="replica.wg-1-dev-team.groups.flyout"]')).not.toBeNull()
+      );
+
+      keydown(trigger, "Enter");
+      click(trigger);
+
+      await waitFor(() =>
+        expect(document.querySelector('[data-ac-testid="replica.wg-1-dev-team.groups.flyout"]')).not.toBeNull()
+      );
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -51,6 +51,7 @@ import {
   MAX_GROUP_MATCH_ID_LENGTH,
   compileGroupRegex,
   groupMatchId,
+  removeExactGroupToken,
   workgroupGroupsStore,
 } from "../stores/workgroup-groups";
 
@@ -703,6 +704,7 @@ const ProjectPanel: Component = () => {
         const [groupFlyoutPos, setGroupFlyoutPos] = createSignal({ x: 0, y: 0 });
         let groupFlyoutEl: HTMLDivElement | undefined;
         let groupFlyoutAnchorEl: HTMLElement | undefined;
+        let groupFlyoutCloseTimer: number | undefined;
         const [agentCtxMenu, setAgentCtxMenu] = createSignal<{ agent: { name: string; path: string; preferredAgentId?: string }; x: number; y: number } | null>(null);
         const [agentsHeaderCtxMenu, setAgentsHeaderCtxMenu] = createSignal<{ x: number; y: number } | null>(null);
         const [workgroupsHeaderCtxMenu, setWorkgroupsHeaderCtxMenu] = createSignal<{ x: number; y: number } | null>(null);
@@ -854,10 +856,27 @@ const ProjectPanel: Component = () => {
           setFilterPattern("");
           focusFilterInput();
         };
+        const cancelGroupFlyoutClose = () => {
+          if (groupFlyoutCloseTimer === undefined) return;
+          window.clearTimeout(groupFlyoutCloseTimer);
+          groupFlyoutCloseTimer = undefined;
+        };
         const closeGroupFlyout = () => {
+          cancelGroupFlyoutClose();
           setGroupFlyoutOpen(false);
           groupFlyoutAnchorEl = undefined;
           groupFlyoutEl = undefined;
+        };
+        const groupFlyoutHasError = () =>
+          !!groupMenuError() || !!workgroupGroupsStore.error(proj.path);
+        const scheduleGroupFlyoutClose = () => {
+          cancelGroupFlyoutClose();
+          if (groupFlyoutHasError()) return;
+          groupFlyoutCloseTimer = window.setTimeout(() => {
+            groupFlyoutCloseTimer = undefined;
+            if (groupFlyoutHasError()) return;
+            closeGroupFlyout();
+          }, 180);
         };
         const resetGroupCreateState = () => {
           setGroupCreateWgPath(null);
@@ -1181,11 +1200,21 @@ const ProjectPanel: Component = () => {
         };
 
         const openGroupFlyout = (anchor: HTMLElement) => {
+          cancelGroupFlyoutClose();
           groupFlyoutAnchorEl = anchor;
           positionGroupFlyout(anchor);
           setGroupFlyoutOpen(true);
           reclampGroupFlyout();
         };
+
+        const toggleGroupFlyout = (anchor: HTMLElement) => {
+          if (groupFlyoutOpen() && groupFlyoutAnchorEl === anchor) {
+            closeGroupFlyout();
+            return;
+          }
+          openGroupFlyout(anchor);
+        };
+        onCleanup(cancelGroupFlyoutClose);
 
         const restartReplicaSession = async (
           sessionId: string,
@@ -1240,10 +1269,14 @@ const ProjectPanel: Component = () => {
         const groupAlreadyMatches = (wg: AcWorkgroup, groupId: string) =>
           groupMatchesWorkgroup(wg, groupId);
 
-        const addToExistingGroup = async (wg: AcWorkgroup, groupId: string) => {
+        const toggleExistingGroup = async (wg: AcWorkgroup, groupId: string) => {
           setGroupMenuError("");
           try {
-            await workgroupGroupsStore.addWorkgroupToGroup(proj.path, groupId, wg.name);
+            if (groupAlreadyMatches(wg, groupId)) {
+              await workgroupGroupsStore.removeWorkgroupFromGroup(proj.path, groupId, wg.name);
+            } else {
+              await workgroupGroupsStore.addWorkgroupToGroup(proj.path, groupId, wg.name);
+            }
           } catch (error) {
             setGroupMenuError(error instanceof Error ? error.message : String(error));
             reclampGroupFlyout();
@@ -1279,6 +1312,8 @@ const ProjectPanel: Component = () => {
                 class="session-context-flyout"
                 ref={groupFlyoutEl}
                 style={{ left: `${groupFlyoutPos().x}px`, top: `${groupFlyoutPos().y}px` }}
+                onMouseEnter={cancelGroupFlyoutClose}
+                onMouseLeave={scheduleGroupFlyoutClose}
                 onClick={(e) => e.stopPropagation()}
                 onContextMenu={(e) => e.stopPropagation()}
                 data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.flyout`}
@@ -1286,17 +1321,31 @@ const ProjectPanel: Component = () => {
                 <For each={groupsConfig().groups}>
                   {(group) => {
                     const valid = () => !!compileGroupRegex(group);
+                    const selected = () => groupAlreadyMatches(wg, group.id);
+                    const removable = () => removeExactGroupToken(group.regex, wg.name) !== null;
+                    const customMembership = () => selected() && !removable();
+                    const disabled = () => !valid() || customMembership();
+                    const title = () => {
+                      if (!valid()) return "Fix this group's regex before adding a workgroup";
+                      if (customMembership()) {
+                        return "Membership comes from a custom regex. Use Edit groups to change it.";
+                      }
+                      return selected() ? "Remove this workgroup from the group" : group.regex;
+                    };
                     return (
                       <button
                         class="session-context-option session-context-group-option"
-                        classList={{ "context-option-disabled": !valid() }}
-                        disabled={!valid()}
-                        title={valid() ? group.regex : "Fix this group's regex before adding a workgroup"}
-                        onClick={() => void addToExistingGroup(wg, group.id)}
+                        classList={{ "context-option-disabled": disabled() }}
+                        disabled={disabled()}
+                        title={title()}
+                        onClick={() => {
+                          if (disabled()) return;
+                          void toggleExistingGroup(wg, group.id);
+                        }}
                         data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.${automationIdPart(group.id)}`}
                       >
                         <span class="session-context-option-check">
-                          {groupAlreadyMatches(wg, group.id) ? "\u2713" : ""}
+                          {selected() ? "\u2713" : ""}
                         </span>
                         <span>{group.name}</span>
                       </button>
@@ -1365,11 +1414,12 @@ const ProjectPanel: Component = () => {
             <button
               class="session-context-option session-context-submenu-trigger"
               onMouseEnter={(e) => openGroupFlyout(e.currentTarget)}
+              onMouseLeave={scheduleGroupFlyoutClose}
               onFocus={(e) => openGroupFlyout(e.currentTarget)}
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                openGroupFlyout(e.currentTarget);
+                toggleGroupFlyout(e.currentTarget);
               }}
               data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.trigger`}
             >
@@ -3070,7 +3120,6 @@ const ProjectPanel: Component = () => {
                         >
                           Coding Agent
                         </button>
-                        {renderAddToGroupItem(menu().wg, menu().replica)}
                         <button
                           class="session-context-option"
                           title={menu().replica.path}
@@ -3121,6 +3170,7 @@ const ProjectPanel: Component = () => {
                         >
                           {sessionsStore.isDetached(menu().sessionId) ? "Re-attach to main" : "Open in new window"}
                         </button>
+                        {renderAddToGroupItem(menu().wg, menu().replica)}
                         <div class="context-separator" />
                         <button
                           class="session-context-option"
@@ -3160,7 +3210,6 @@ const ProjectPanel: Component = () => {
                           >
                             Coding Agent
                           </button>
-                          {renderAddToGroupItem(menu().wg, menu().replica)}
                           <button
                             class="session-context-option"
                             title={menu().replica.path}
@@ -3204,6 +3253,7 @@ const ProjectPanel: Component = () => {
                               </button>
                             )}
                           </Show>
+                          {renderAddToGroupItem(menu().wg, menu().replica)}
                           <button
                             class="session-context-option"
                             classList={{ "context-option-disabled": broomDisabled() }}

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1207,9 +1207,11 @@ const ProjectPanel: Component = () => {
           reclampGroupFlyout();
         };
 
-        const toggleGroupFlyout = (anchor: HTMLElement) => {
+        const activateGroupFlyout = (anchor: HTMLElement) => {
           if (groupFlyoutOpen() && groupFlyoutAnchorEl === anchor) {
-            closeGroupFlyout();
+            cancelGroupFlyoutClose();
+            positionGroupFlyout(anchor);
+            reclampGroupFlyout();
             return;
           }
           openGroupFlyout(anchor);
@@ -1419,7 +1421,13 @@ const ProjectPanel: Component = () => {
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                toggleGroupFlyout(e.currentTarget);
+                activateGroupFlyout(e.currentTarget);
+              }}
+              onKeyDown={(e) => {
+                if (e.key !== "Enter" && e.key !== " ") return;
+                e.preventDefault();
+                e.stopPropagation();
+                activateGroupFlyout(e.currentTarget);
               }}
               data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.trigger`}
             >

--- a/src/sidebar/components/WorkgroupGroupRail.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AcWorkgroup, WorkgroupGroupsConfig } from "../../shared/types";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import type { ProjectState } from "../stores/project";
+import {
+  defaultGroupsConfig,
+  exactGroupRegexForWorkgroup,
+  workgroupGroupsStore,
+} from "../stores/workgroup-groups";
+import WorkgroupGroupRail from "./WorkgroupGroupRail";
+
+const projectPath = "C:\\Project";
+
+function wg(name: string): AcWorkgroup {
+  return {
+    name,
+    path: `${projectPath}\\.ac\\${name}`,
+    task: null,
+    taskTitle: null,
+    agents: [
+      {
+        name: "dev-webpage-ui",
+        path: `${projectPath}\\.ac\\${name}\\__agent_dev-webpage-ui`,
+        repoPaths: [],
+        isCoordinator: true,
+      },
+    ],
+  };
+}
+
+function project(): ProjectState {
+  return {
+    path: projectPath,
+    folderName: "Project",
+    workgroups: [wg("wg-1-dev-team"), wg("wg-2-rust-team"), wg("wg-3-docs-team")],
+    agents: [],
+    teams: [],
+    loops: [],
+    contextTemplateUpdates: [],
+  };
+}
+
+function groupsConfig(overrides: Partial<WorkgroupGroupsConfig> = {}): WorkgroupGroupsConfig {
+  return {
+    ...defaultGroupsConfig(),
+    ...overrides,
+    groups:
+      overrides.groups ?? [
+        { id: "ui", name: "UI", regex: exactGroupRegexForWorkgroup("wg-1-dev-team") },
+        { id: "rust", name: "Rust", regex: exactGroupRegexForWorkgroup("wg-2-rust-team") },
+      ],
+  };
+}
+
+function target<T extends Element>(testId: string): T {
+  const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing element ${testId}`);
+  return element;
+}
+
+function changeCheckbox(input: HTMLInputElement, checked: boolean): void {
+  input.checked = checked;
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function railButtonOrder(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-ac-testid^="workgroupGroups.button."]')
+  ).map((button) => button.dataset.acTestid!.replace("workgroupGroups.button.", ""));
+}
+
+describe("WorkgroupGroupRail", () => {
+  beforeEach(() => {
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("keeps All, All plus Ungrouped, and Ungrouped-only reachable while blocking none", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    fake.onInvoke("update_project_groups", (args) => args.config);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+
+      click(target("workgroupGroups.edit"));
+      changeCheckbox(target<HTMLInputElement>("workgroupGroups.toggle.showUngrouped"), false);
+      click(target("workgroupGroups.save"));
+
+      await waitFor(() =>
+        expect(fake.lastCall("update_project_groups")?.args.config).toMatchObject({
+          showAll: true,
+          showUngrouped: false,
+        })
+      );
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ui", "rust"]));
+
+      click(target("workgroupGroups.edit"));
+      changeCheckbox(target<HTMLInputElement>("workgroupGroups.toggle.showUngrouped"), true);
+      changeCheckbox(target<HTMLInputElement>("workgroupGroups.toggle.showAll"), false);
+      click(target("workgroupGroups.save"));
+
+      await waitFor(() =>
+        expect(fake.lastCall("update_project_groups")?.args.config).toMatchObject({
+          showAll: false,
+          showUngrouped: true,
+        })
+      );
+      await waitFor(() => expect(railButtonOrder()).toEqual(["ungrouped", "ui", "rust"]));
+
+      click(target("workgroupGroups.edit"));
+      changeCheckbox(target<HTMLInputElement>("workgroupGroups.toggle.showUngrouped"), false);
+      await waitFor(() =>
+        expect(target<HTMLInputElement>("workgroupGroups.toggle.showUngrouped").checked).toBe(true)
+      );
+      click(target("workgroupGroups.save"));
+
+      await waitFor(() =>
+        expect(fake.lastCall("update_project_groups")?.args.config).toMatchObject({
+          showAll: false,
+          showUngrouped: true,
+        })
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("renders Ungrouped immediately after All and first when All is hidden", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    fake.onInvoke("update_project_groups", (args) => args.config);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+
+      await workgroupGroupsStore.save(
+        projectPath,
+        groupsConfig({
+          showAll: false,
+          showUngrouped: true,
+        })
+      );
+
+      await waitFor(() => expect(railButtonOrder()).toEqual(["ungrouped", "ui", "rust"]));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -93,22 +93,22 @@ const ProjectRailSection: Component<{
         title: tooltipFor(props.project.workgroups),
       });
     }
-    for (const group of config().groups) {
-      const workgroups = props.project.workgroups.filter((wg) => groupMatches(group, wg));
-      result.push({
-        key: group.id,
-        label: counterLabel(group.name, workgroups),
-        selection: { kind: "group", id: group.id },
-        workgroups,
-        title: tooltipFor(workgroups),
-      });
-    }
     if (config().showUngrouped) {
       const workgroups = ungroupedWorkgroups();
       result.push({
         key: "ungrouped",
         label: counterLabel("Ungrouped", workgroups),
         selection: { kind: "ungrouped" },
+        workgroups,
+        title: tooltipFor(workgroups),
+      });
+    }
+    for (const group of config().groups) {
+      const workgroups = props.project.workgroups.filter((wg) => groupMatches(group, wg));
+      result.push({
+        key: group.id,
+        label: counterLabel(group.name, workgroups),
+        selection: { kind: "group", id: group.id },
         workgroups,
         title: tooltipFor(workgroups),
       });

--- a/src/sidebar/components/WorkgroupGroupsModal.tsx
+++ b/src/sidebar/components/WorkgroupGroupsModal.tsx
@@ -81,12 +81,21 @@ const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
     setSaveError(null);
   };
 
-  const setToggle = (field: "showAll" | "showUngrouped", value: boolean) => {
+  const setToggle = (
+    field: "showAll" | "showUngrouped",
+    value: boolean,
+    input: HTMLInputElement
+  ) => {
+    let accepted = false;
+    let previous = input.checked;
     setDraft((current) => {
+      previous = current[field];
       const next = { ...current, [field]: value };
       if (!next.showAll && !next.showUngrouped) return current;
+      accepted = true;
       return next;
     });
+    if (!accepted) input.checked = previous;
     setSaveError(null);
   };
 
@@ -122,8 +131,8 @@ const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
               <input
                 type="checkbox"
                 checked={draft().showAll}
-                disabled={draft().showAll && !draft().showUngrouped}
-                onChange={(e) => setToggle("showAll", e.currentTarget.checked)}
+                onChange={(e) => setToggle("showAll", e.currentTarget.checked, e.currentTarget)}
+                data-ac-testid="workgroupGroups.toggle.showAll"
               />
               <span>Show All</span>
             </label>
@@ -131,8 +140,8 @@ const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
               <input
                 type="checkbox"
                 checked={draft().showUngrouped}
-                disabled={draft().showUngrouped && !draft().showAll}
-                onChange={(e) => setToggle("showUngrouped", e.currentTarget.checked)}
+                onChange={(e) => setToggle("showUngrouped", e.currentTarget.checked, e.currentTarget)}
+                data-ac-testid="workgroupGroups.toggle.showUngrouped"
               />
               <span>Show Ungrouped</span>
             </label>

--- a/src/sidebar/stores/workgroup-groups.test.ts
+++ b/src/sidebar/stores/workgroup-groups.test.ts
@@ -6,6 +6,7 @@ import {
   appendExactGroupToken,
   defaultGroupsConfig,
   exactGroupRegexForWorkgroup,
+  removeExactGroupToken,
   validateGroupsConfig,
   workgroupGroupsStore,
 } from "./workgroup-groups";
@@ -172,5 +173,22 @@ describe("workgroup group validation helpers", () => {
 
   it("returns null when appending to an invalid regex", () => {
     expect(appendExactGroupToken("(", "wg-2-dev-team")).toBeNull();
+  });
+
+  it("removes an exact workgroup token from a generated regex union", () => {
+    expect(removeExactGroupToken("^(wg-1-dev-team|wg-2-dev-team)$", "wg-1-dev-team")).toBe(
+      exactGroupRegexForWorkgroup("wg-2-dev-team")
+    );
+    expect(removeExactGroupToken(exactGroupRegexForWorkgroup("wg-1-dev-team"), "wg-1-dev-team")).toBe(
+      "(?!)"
+    );
+  });
+
+  it("does not remove regex-derived custom memberships without an exact token", () => {
+    expect(removeExactGroupToken("^wg-1-", "wg-1-dev-team")).toBeNull();
+  });
+
+  it("does not report a token as removable when another regex branch would still match", () => {
+    expect(removeExactGroupToken("^(wg-1-.*|wg-1-dev-team)$", "wg-1-dev-team")).toBeNull();
   });
 });

--- a/src/sidebar/stores/workgroup-groups.ts
+++ b/src/sidebar/stores/workgroup-groups.ts
@@ -128,6 +128,72 @@ export function appendExactGroupToken(regex: string, wgName: string): string | n
   return `(?:${pattern})|^(${token})$`;
 }
 
+function splitEscapedAlternatives(body: string): string[] {
+  const alternatives: string[] = [];
+  let current = "";
+  let escaped = false;
+  for (const char of body) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === "|") {
+      alternatives.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  alternatives.push(current);
+  return alternatives;
+}
+
+function splitGeneratedAppend(pattern: string): { inner: string; token: string } | null {
+  if (!pattern.startsWith("(?:") || !pattern.endsWith(")$")) return null;
+  const markerIndex = pattern.lastIndexOf(")|^(");
+  if (markerIndex < 3) return null;
+  return {
+    inner: pattern.slice(3, markerIndex),
+    token: pattern.slice(markerIndex + 4, -2),
+  };
+}
+
+function removeExactGroupTokenUnchecked(regex: string, wgName: string): string | null {
+  const pattern = regex.trim();
+  const token = escapeRegexLiteral(wgName);
+  const generated = pattern.match(/^\^\((.*)\)\$$/);
+  if (generated) {
+    const alternatives = splitEscapedAlternatives(generated[1]);
+    if (!alternatives.includes(token)) return null;
+    const remaining = alternatives.filter((alternative) => alternative !== token);
+    return remaining.length > 0 ? `^(${remaining.join("|")})$` : "(?!)";
+  }
+
+  const appended = splitGeneratedAppend(pattern);
+  if (!appended) return null;
+  if (appended.token === token) return appended.inner || "(?!)";
+
+  const nextInner = removeExactGroupTokenUnchecked(appended.inner, wgName);
+  if (nextInner === null) return null;
+  return nextInner === "(?!)" ? `^(${appended.token})$` : `(?:${nextInner})|^(${appended.token})$`;
+}
+
+export function removeExactGroupToken(regex: string, wgName: string): string | null {
+  const nextRegex = removeExactGroupTokenUnchecked(regex, wgName);
+  if (nextRegex === null) return null;
+  try {
+    return new RegExp(nextRegex).test(wgName) ? null : nextRegex;
+  } catch {
+    return null;
+  }
+}
+
 export function compileGroupRegex(group: WorkgroupGroup): RegExp | null {
   if (charLength(group.regex) > MAX_GROUP_REGEX_LENGTH) return null;
   try {
@@ -325,6 +391,31 @@ export const workgroupGroupsStore = {
     const nextRegex = appendExactGroupToken(group.regex, wgName);
     if (nextRegex === null) {
       const message = "Fix this group's regex before adding a workgroup.";
+      const key = keyFor(projectPath);
+      setEntries(key, { ...ensureEntry(projectPath), error: message });
+      throw new Error(message);
+    }
+    await this.save(projectPath, {
+      ...config,
+      groups: config.groups.map((candidate) =>
+        candidate.id === groupId ? { ...candidate, regex: nextRegex } : candidate
+      ),
+    });
+  },
+
+  async removeWorkgroupFromGroup(projectPath: string, groupId: string, wgName: string): Promise<void> {
+    if (charLength(wgName) > MAX_GROUP_MATCH_ID_LENGTH) {
+      const message = `Workgroup id cannot exceed ${MAX_GROUP_MATCH_ID_LENGTH} characters.`;
+      const key = keyFor(projectPath);
+      setEntries(key, { ...ensureEntry(projectPath), error: message });
+      throw new Error(message);
+    }
+    const config = this.config(projectPath);
+    const group = config.groups.find((candidate) => candidate.id === groupId);
+    if (!group) throw new Error("Group no longer exists.");
+    const nextRegex = removeExactGroupToken(group.regex, wgName);
+    if (nextRegex === null) {
+      const message = "This membership comes from a custom regex. Use Edit groups to change it.";
       const key = keyFor(projectPath);
       setEntries(key, { ...ensureEntry(projectPath), error: message });
       throw new Error(message);


### PR DESCRIPTION
## What

Second round of user-testing polish on Workgroup UI Groups (#737, #742) — five UX changes from real-build feedback.

## Changes

1. **`Ungrouped`-only visibility state is now reachable.** Root cause was FE-only: the Edit modal disabled whichever special checkbox was the only one checked (blocking `All+Ungrouped → Ungrouped`), and the zero-state guard didn't force a DOM re-render (making "none" appear reachable). All three valid states now work (`All` / `All+Ungrouped` / `Ungrouped`); "none" stays impossible (guard + immediate checkbox restore on rejection).
2. **Flyout auto-hides on mouse-leave** of both trigger and flyout, with a 180ms grace delay (diagonal hover path safe; re-enter cancels; error-visible flyouts stay open; timers cleaned up on unmount).
3. **Menu ordering:** `Add to Group` now sits below `Open in new window`.
4. **Rail ordering:** `All` → `Ungrouped` → user groups → `Edit`; `Ungrouped` renders first when `All` is hidden.
5. **Membership toggle-off in the flyout:** clicking a checked group removes the workgroup's exact generated token (`^(a|b)$` → `^(a)$`, empty → `(?!)`); removal is only offered when the resulting regex no longer matches. Custom-regex membership stays checked but disabled with a hint (`Membership comes from a custom regex. Use Edit groups to change it.`) — custom regexes are never silently rewritten. Failed saves keep the menu open with the error.

Review round 2 fix: `Add to Group` trigger activation is now **idempotent** — real pointer order (`mouseenter` then `click`) and keyboard activation (focus then Enter/Space) keep the flyout open instead of toggling it closed; Escape still dismisses via the window-level handler.

## Review & gates

- Grinch Step-9 round 1: FAIL with 1 MED (hover-open + same-anchor click-toggle closed the flyout on a real click; test harness didn't model `mouseenter` before `click`). Fixed in `3282abb` with two new real-event-order tests.
- Grinch Step-9 round 2: **PASS** (0 HIGH / 0 MED; MED verified closed; intentional close paths verified; no regressions in modal states, ordering, token toggle-off, failed-save behavior).
- FE-only diff (`src/sidebar`). Gates: `tsc --noEmit` clean; `vitest` **634 passed** (82 files); `vite build` OK. Headless screenshots (rail full order, Ungrouped-only, menu order + custom-regex hint row) manually verified.

Closes #744
