### PR TITLE
fix: groups UI polish r3 — auto-focus create-group inputs + working dot on rail buttons (#746)

### DIFF
--- a/src/shared/focus-on-mount.ts
+++ b/src/shared/focus-on-mount.ts
@@ -1,0 +1,20 @@
+/**
+ * #746 — focus (and optionally select) an element right after it mounts.
+ *
+ * Solid `ref` callbacks run while the element is being created, before it is
+ * connected to the document, where `.focus()` is a silent no-op — so the focus
+ * must be deferred one frame. Guarded-rAF with a setTimeout fallback, mirroring
+ * ProjectPanel's flyout-reclamp idiom. If the element was disposed before the
+ * frame fires, the focus call is a harmless no-op.
+ */
+export function focusOnMount(el: HTMLElement, options: { select?: boolean } = {}): void {
+  const run = () => {
+    el.focus();
+    if (options.select && el instanceof HTMLInputElement) el.select();
+  };
+  if (typeof window.requestAnimationFrame === "function") {
+    window.requestAnimationFrame(run);
+  } else {
+    window.setTimeout(run, 0);
+  }
+}

--- a/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
@@ -445,6 +445,34 @@ describe("ProjectPanel workgroup groups", () => {
     }
   });
 
+  it("focuses the inline create-group input when it appears (#746)", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+    fake.resolve("get_project_groups", groupsConfig([]));
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await workgroupGroupsStore.ensureLoaded(projectPath);
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await openCoordinatorMenu(rendered.root);
+      await openGroupFlyout();
+      click(target("replica.wg-1-dev-team.groups.create"));
+
+      // Resolve the input inside waitFor: a discovery-driven row re-render can
+      // re-create the flyout subtree once after the click, and the fresh
+      // input's ref re-focuses it — assert the live element ends up focused.
+      await waitFor(() =>
+        expect(document.activeElement).toBe(target<HTMLInputElement>("replica.groups.create.input"))
+      );
+      // The flyout stays open and expanded around the focused input.
+      expect(target("replica.wg-1-dev-team.groups.flyout")).not.toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
   it("keeps the context menu open and shows an error when inline group creation fails", async () => {
     const fake = new FakeTransport();
     setupProjectTransport(fake);

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { isTauri } from "../../shared/platform";
 import { stripFrontmatter } from "../../shared/markdown";
 import { launchErrorMessage } from "../../shared/launch-errors";
+import { focusOnMount } from "../../shared/focus-on-mount";
 import { projectStore } from "../stores/project";
 import { normalizeProjectPathForCompare } from "../stores/project-refresh";
 import { sessionsStore } from "../stores/sessions";
@@ -830,15 +831,7 @@ const ProjectPanel: Component = () => {
         const filterActive = () => filterState().regex !== null;
         const filterError = () => filterState().error;
         const focusFilterInput = () => {
-          const focus = () => {
-            filterInputEl?.focus();
-            filterInputEl?.select();
-          };
-          if (typeof window.requestAnimationFrame === "function") {
-            window.requestAnimationFrame(focus);
-            return;
-          }
-          window.setTimeout(focus, 0);
+          if (filterInputEl) focusOnMount(filterInputEl, { select: true });
         };
         const toggleFilter = () => {
           // Magnifier acts as a toggle. Closing also drops any in-flight
@@ -1383,8 +1376,13 @@ const ProjectPanel: Component = () => {
                   }
                 >
                   <div class="session-context-inline-create">
+                    {/* #746 — deliberately unconditional: a discovery-driven
+                        re-render disposes this subtree (focus falls to <body>
+                        regardless), so re-focusing the fresh input preserves
+                        typing continuity; the value lives in groupCreateName. */}
                     <input
                       class="session-context-inline-input"
+                      ref={(el) => focusOnMount(el)}
                       value={groupCreateName()}
                       onInput={(e) => setGroupCreateName(e.currentTarget.value)}
                       onKeyDown={(e) => {

--- a/src/sidebar/components/WorkgroupGroupRail.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.test.tsx
@@ -1,14 +1,17 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { AcWorkgroup, WorkgroupGroupsConfig } from "../../shared/types";
+import type { AcWorkgroup, Session, WorkgroupGroupsConfig } from "../../shared/types";
 import { FakeTransport } from "../../shared/testing/fake-transport";
 import {
   click,
+  input,
   renderWithFakeTransport,
   resetUiStoresForTests,
+  session,
   waitFor,
 } from "../../shared/testing/ui-harness";
 import type { ProjectState } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
 import {
   defaultGroupsConfig,
   exactGroupRegexForWorkgroup,
@@ -74,6 +77,23 @@ function railButtonOrder(): string[] {
   return Array.from(
     document.querySelectorAll<HTMLElement>('[data-ac-testid^="workgroupGroups.button."]')
   ).map((button) => button.dataset.acTestid!.replace("workgroupGroups.button.", ""));
+}
+
+function railDots(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-ac-testid^="workgroupGroups.dot."]')
+  ).map((dot) => dot.dataset.acTestid!.replace("workgroupGroups.dot.", ""));
+}
+
+/** A session that makes the given workgroup "working" (running dot class). */
+function replicaSession(wgName: string, overrides: Partial<Session> = {}): Session {
+  return session({
+    id: `session-${wgName}`,
+    name: `${wgName}/dev-webpage-ui`,
+    workingDirectory: `${projectPath}\\.ac\\${wgName}\\__agent_dev-webpage-ui`,
+    status: "running",
+    ...overrides,
+  });
 }
 
 describe("WorkgroupGroupRail", () => {
@@ -156,6 +176,98 @@ describe("WorkgroupGroupRail", () => {
       );
 
       await waitFor(() => expect(railButtonOrder()).toEqual(["ungrouped", "ui", "rust"]));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows the working dot on All and on the group whose workgroup is running (#746)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    sessionsStore.setSessions([replicaSession("wg-1-dev-team")]);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      await waitFor(() => expect(railDots()).toEqual(["all", "ui"]));
+
+      // Same visual language as session/replica rows: the standard blue
+      // running dot, rendered on the counter line.
+      const dot = target<HTMLElement>("workgroupGroups.dot.ui");
+      expect(dot.classList.contains("session-item-status")).toBe(true);
+      expect(dot.classList.contains("running")).toBe(true);
+      // Dot condition matches the counter's X definition.
+      expect(target("workgroupGroups.button.all").textContent).toContain("1/3");
+      expect(target("workgroupGroups.button.ui").textContent).toContain("1/1");
+      expect(target("workgroupGroups.button.rust").textContent).toContain("0/1");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows the working dot on Ungrouped when an ungrouped workgroup is running (#746)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    sessionsStore.setSessions([replicaSession("wg-3-docs-team")]);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      await waitFor(() => expect(railDots()).toEqual(["all", "ungrouped"]));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps every dot off for waiting/pending agents, matching the counter (#746)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    sessionsStore.setSessions([
+      replicaSession("wg-1-dev-team", { waitingForInput: true }),
+      replicaSession("wg-2-rust-team", { pendingReview: true }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      expect(railDots()).toEqual([]);
+      expect(target("workgroupGroups.button.all").textContent).toContain("0/3");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("focuses and selects the new row's name input after Add group (#746)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+
+      click(target("workgroupGroups.edit"));
+      click(target("workgroupGroups.add"));
+
+      let added!: HTMLInputElement;
+      await waitFor(() => {
+        const inputs = document.querySelectorAll<HTMLInputElement>(".workgroup-group-name-input");
+        added = inputs[inputs.length - 1];
+        expect(added.value).toBe("Group 3");
+        expect(document.activeElement).toBe(added);
+        // Pre-filled name is selected so typing replaces it.
+        expect(added.selectionStart).toBe(0);
+        expect(added.selectionEnd).toBe("Group 3".length);
+      });
+
+      // Typing must not drop focus: <Index> keeps the row's DOM stable while
+      // updateGroup replaces the row object per keystroke (the #614 trap).
+      input(added, "B");
+      input(added, "Ba");
+      await waitFor(() => {
+        expect(added.isConnected).toBe(true);
+        expect(document.activeElement).toBe(added);
+        expect(added.value).toBe("Ba");
+      });
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -21,7 +21,11 @@ interface WorkgroupGroupRailProps {
 
 interface GroupButton {
   key: string;
-  label: string;
+  name: string;
+  counter: string;
+  /** #746 — true when the button's workgroup set has >=1 working agent
+   *  (same predicate as the counter's X: running/active, not waiting/pending). */
+  working: boolean;
   selection: WorkgroupGroupSelection;
   workgroups: AcWorkgroup[];
   title: string;
@@ -60,9 +64,12 @@ function tooltipFor(workgroups: AcWorkgroup[]): string {
   return rows.length > 0 ? rows.join("\n") : "No running agents";
 }
 
-function counterLabel(name: string, workgroups: AcWorkgroup[]): string {
+function buttonContent(
+  name: string,
+  workgroups: AcWorkgroup[]
+): Pick<GroupButton, "name" | "counter" | "working"> {
   const working = workgroups.filter(workgroupIsWorking).length;
-  return `${name}\n${working}/${workgroups.length}`;
+  return { name, counter: `${working}/${workgroups.length}`, working: working > 0 };
 }
 
 const ProjectRailSection: Component<{
@@ -87,7 +94,7 @@ const ProjectRailSection: Component<{
     if (config().showAll) {
       result.push({
         key: "all",
-        label: counterLabel("All", props.project.workgroups),
+        ...buttonContent("All", props.project.workgroups),
         selection: { kind: "all" },
         workgroups: props.project.workgroups,
         title: tooltipFor(props.project.workgroups),
@@ -97,7 +104,7 @@ const ProjectRailSection: Component<{
       const workgroups = ungroupedWorkgroups();
       result.push({
         key: "ungrouped",
-        label: counterLabel("Ungrouped", workgroups),
+        ...buttonContent("Ungrouped", workgroups),
         selection: { kind: "ungrouped" },
         workgroups,
         title: tooltipFor(workgroups),
@@ -107,7 +114,7 @@ const ProjectRailSection: Component<{
       const workgroups = props.project.workgroups.filter((wg) => groupMatches(group, wg));
       result.push({
         key: group.id,
-        label: counterLabel(group.name, workgroups),
+        ...buttonContent(group.name, workgroups),
         selection: { kind: "group", id: group.id },
         workgroups,
         title: tooltipFor(workgroups),
@@ -139,7 +146,15 @@ const ProjectRailSection: Component<{
             onClick={() => workgroupGroupsStore.select(props.project.path, button.selection)}
             data-ac-testid={`workgroupGroups.button.${button.key}`}
           >
-            {button.label}
+            {button.name}
+            {"\n"}
+            <Show when={button.working}>
+              <span
+                class="session-item-status running workgroup-group-rail-dot"
+                data-ac-testid={`workgroupGroups.dot.${button.key}`}
+              />
+            </Show>
+            {button.counter}
           </button>
         )}
       </For>

--- a/src/sidebar/components/WorkgroupGroupsModal.tsx
+++ b/src/sidebar/components/WorkgroupGroupsModal.tsx
@@ -1,4 +1,5 @@
-import { Component, For, Show, createMemo, createSignal } from "solid-js";
+import { Component, For, Index, Show, createMemo, createSignal } from "solid-js";
+import { focusOnMount } from "../../shared/focus-on-mount";
 import type { WorkgroupGroupsConfig } from "../../shared/types";
 import {
   MAX_GROUP_NAME_LENGTH,
@@ -54,15 +55,23 @@ const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
     setSaveError(null);
   };
 
+  // #746 — id of the row just added via "Add group"; its name input's ref
+  // consumes this to focus+select the pre-filled name so the user can type
+  // over it immediately. Plain variable (not a signal): addGroup sets it
+  // synchronously right before setDraft creates the new row.
+  let pendingFocusGroupId: string | null = null;
+
   const addGroup = () => {
     const current = draft();
     const existingIds = new Set(current.groups.map((group) => group.id));
+    const id = createGroupId(existingIds);
+    pendingFocusGroupId = id;
     setDraft({
       ...current,
       groups: [
         ...current.groups,
         {
-          id: createGroupId(existingIds),
+          id,
           name: nextGroupName(current),
           regex: props.initialWorkgroupName
             ? exactGroupRegexForWorkgroup(props.initialWorkgroupName)
@@ -148,34 +157,43 @@ const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
           </div>
 
           <div class="workgroup-groups-table">
-            <For each={draft().groups}>
+            {/* #746 — <Index>, NOT <For>: updateGroup replaces the edited row
+                object on every keystroke, and a reference-keyed <For> would
+                dispose+recreate the row, dropping focus after one character
+                (the #614 trap). Position-keyed rows keep the inputs stable. */}
+            <Index each={draft().groups}>
               {(group) => (
-                <div class="workgroup-group-edit-row" data-ac-testid={`workgroupGroups.row.${group.id}`}>
+                <div class="workgroup-group-edit-row" data-ac-testid={`workgroupGroups.row.${group().id}`}>
                   <input
                     class="workgroup-group-name-input"
-                    value={group.name}
+                    ref={(el) => {
+                      if (group().id !== pendingFocusGroupId) return;
+                      pendingFocusGroupId = null;
+                      focusOnMount(el, { select: true });
+                    }}
+                    value={group().name}
                     maxLength={MAX_GROUP_NAME_LENGTH}
-                    onInput={(e) => updateGroup(group.id, { name: e.currentTarget.value })}
+                    onInput={(e) => updateGroup(group().id, { name: e.currentTarget.value })}
                     aria-label="Group name"
                   />
                   <input
                     class="workgroup-group-regex-input"
-                    value={group.regex}
+                    value={group().regex}
                     maxLength={MAX_GROUP_REGEX_LENGTH}
-                    onInput={(e) => updateGroup(group.id, { regex: e.currentTarget.value })}
+                    onInput={(e) => updateGroup(group().id, { regex: e.currentTarget.value })}
                     aria-label="Group regex"
-                    data-ac-testid={`workgroupGroups.regex.${group.id}`}
+                    data-ac-testid={`workgroupGroups.regex.${group().id}`}
                   />
                   <button
                     class="workgroup-group-delete"
-                    onClick={() => deleteGroup(group.id)}
-                    aria-label={`Delete ${group.name}`}
+                    onClick={() => deleteGroup(group().id)}
+                    aria-label={`Delete ${group().name}`}
                   >
                     Delete
                   </button>
                 </div>
               )}
-            </For>
+            </Index>
             <Show when={draft().groups.length === 0}>
               <div class="workgroup-groups-empty">No groups configured</div>
             </Show>

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2821,6 +2821,16 @@ html.light-theme .settings-hint-warning {
   color: var(--sidebar-accent);
 }
 
+/* #746 — working indicator on the counter line. Reuses the session-card
+   .session-item-status.running circle; inline-block so the 8px width/height
+   apply in the button's pre-line text flow (never before the name, which
+   would re-tighten the line and regress #742's no-mid-word-split). */
+.workgroup-group-rail-button .workgroup-group-rail-dot {
+  display: inline-block;
+  margin-right: 3px;
+  vertical-align: -1px;
+}
+
 .workgroup-group-rail-error {
   margin: 4px auto;
   width: 20px;


### PR DESCRIPTION
## What

Third round of user-testing polish on Workgroup UI Groups (#737/#742/#744) — two UX items from real-build feedback.

## Changes

1. **Auto-focus the create-group input.** Selecting `Create new group` in the `Add to Group` flyout focuses the textbox immediately (type right away). The Edit-groups modal's `Add group` now focuses AND selects the pre-filled row name so typing replaces it. New shared `src/shared/focus-on-mount.ts` helper (guarded rAF + fallback); ProjectPanel's hand-rolled `focusFilterInput` defer-focus consolidated onto it (behavior-identical, grinch-verified).
   - **Structural fix found during review:** the modal rows were a reference-keyed `<For>` while `updateGroup` replaces the row object per keystroke — the focused input was disposed after one character (same Solid trap as #614). Rows switched to position-keyed `<Index>`; a type-through regression test asserts the input survives keystrokes connected and focused.
2. **Working blue dot on rail buttons.** Rail buttons show the standard session-card blue dot when their workgroup set has ≥1 agent running. The dot reuses `.session-item-status.running` verbatim and is computed from the exact same expression as the `X/Y` counter (`running`/`active` only; `waiting`/`pending` excluded) — dot ⟺ X>0 by construction, per button (`All` / groups / `Ungrouped`). Rendered on the counter line to preserve #742's no-mid-word-split labels; `Edit` is structurally dot-free.

## Review & gates

- Grinch Step-9: **PASS** (0 HIGH/MED; 1 LOW accepted-by-design [documented unconditional flyout refocus], 1 INFO [test count +5 not +6]). `<For>`→`<Index>` verified sound under mid-list deletes; #742/#744 behaviors spot-checked with their named tests; no theme CSS leaks into the rail dot.
- Gates (grinch re-ran): `tsc --noEmit` clean · `vitest` **639 passed** (82 files, +5 new tests) · `vite build` OK. FE-only diff (7 files under `src/`).
- Headless screenshots (rail dots on `All 1/3` + `GROUPS 1/1`, none on `0/x`; flyout create-input focused) manually verified.

Closes #746
