### PR TITLE
fix: auto-dismiss screenshot-saved toast after 30s with fade (#750)

### DIFF
--- a/src/shared/components/ToastHost.test.tsx
+++ b/src/shared/components/ToastHost.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "solid-js/web";
 import ToastHost from "./ToastHost";
-import { toastStore } from "../stores/toasts";
+import { toastStore, TOAST_EXIT_MS } from "../stores/toasts";
 
 function q<T extends HTMLElement = HTMLElement>(testId: string): T | null {
   return document.body.querySelector<T>(`[data-ac-testid="${testId}"]`);
@@ -31,6 +31,7 @@ describe("ToastHost (#574)", () => {
     dispose?.();
     dispose = null;
     toastStore.clear();
+    vi.useRealTimers();
     document.body.replaceChildren();
   });
 
@@ -44,13 +45,17 @@ describe("ToastHost (#574)", () => {
     expect(item?.textContent ?? "").toContain("boom");
   });
 
-  it("clicking the dismiss button removes the item", () => {
+  it("clicking the dismiss button fades then removes the item", async () => {
+    vi.useFakeTimers();
     dispose = renderHost();
     toastStore.error("boom");
     expect(q("toast.item")).toBeTruthy();
     q("toast.item.dismiss")!.dispatchEvent(
       new MouseEvent("click", { bubbles: true, cancelable: true }),
     );
+    expect(q("toast.item")).toBeTruthy();
+    expect(q("toast.item")?.classList.contains("toast-item--exiting")).toBe(true);
+    await vi.advanceTimersByTimeAsync(TOAST_EXIT_MS);
     expect(q("toast.item")).toBeNull();
   });
 

--- a/src/shared/components/ToastHost.tsx
+++ b/src/shared/components/ToastHost.tsx
@@ -31,7 +31,9 @@ const ToastHost: Component = () => {
         <For each={toastStore.items}>
           {(toast) => (
             <div
-              class={`toast-item toast-item--${toast.kind}`}
+              class={`toast-item toast-item--${toast.kind}${
+                toast.exiting ? " toast-item--exiting" : ""
+              }`}
               data-ac-testid="toast.item"
               data-ac-kind={toast.kind}
               data-ac-toast-id={toast.id}

--- a/src/shared/stores/toasts.test.ts
+++ b/src/shared/stores/toasts.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { toastStore } from "./toasts";
+import { toastStore, TOAST_EXIT_MS } from "./toasts";
 
 // The store is a module singleton, so every test must reset it. vi.useRealTimers()
 // is defensive: the timed cases install fake timers and a throw inside that window
 // could otherwise leak frozen timers into the next test.
 afterEach(() => {
-  vi.useRealTimers();
   toastStore.clear();
+  vi.useRealTimers();
 });
 
 describe("toastStore (#574)", () => {
@@ -38,8 +38,12 @@ describe("toastStore (#574)", () => {
       toastStore.success("done");
       expect(toastStore.items).toHaveLength(2);
       await vi.advanceTimersByTimeAsync(4000);
+      expect(toastStore.items).toHaveLength(2);
+      expect(toastStore.items.every((t) => t.exiting)).toBe(true);
+      await vi.advanceTimersByTimeAsync(TOAST_EXIT_MS);
       expect(toastStore.items).toHaveLength(0);
     } finally {
+      toastStore.clear();
       vi.useRealTimers();
     }
   });
@@ -54,7 +58,11 @@ describe("toastStore (#574)", () => {
       expect(toastStore.items).toHaveLength(2);
 
       await vi.advanceTimersByTimeAsync(1000);
-      // The error auto-dismissed; the sticky info remains.
+      // The error auto-dismissed into its exit phase; the sticky info remains.
+      expect(toastStore.items).toHaveLength(2);
+      expect(toastStore.items.find((t) => t.message === "transient error")?.exiting).toBe(true);
+      await vi.advanceTimersByTimeAsync(TOAST_EXIT_MS);
+      // The error finished fading out; the sticky info remains.
       expect(toastStore.items).toHaveLength(1);
       expect(toastStore.items[0].message).toBe("sticky info");
 
@@ -63,16 +71,29 @@ describe("toastStore (#574)", () => {
       expect(toastStore.items).toHaveLength(1);
       expect(toastStore.items[0].message).toBe("sticky info");
     } finally {
+      toastStore.clear();
       vi.useRealTimers();
     }
   });
 
-  it("dismiss(id) removes only that toast", () => {
-    const a = toastStore.error("a");
-    const b = toastStore.error("b");
-    toastStore.dismiss(a);
-    expect(toastStore.items).toHaveLength(1);
-    expect(toastStore.items[0].id).toBe(b);
+  it("dismiss(id) fades and removes only that toast", async () => {
+    vi.useFakeTimers();
+    try {
+      const a = toastStore.error("a");
+      const b = toastStore.error("b");
+      toastStore.dismiss(a);
+      toastStore.dismiss(a);
+      expect(toastStore.items).toHaveLength(2);
+      expect(toastStore.items.find((t) => t.id === a)?.exiting).toBe(true);
+      expect(toastStore.items.find((t) => t.id === b)?.exiting).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(TOAST_EXIT_MS);
+      expect(toastStore.items).toHaveLength(1);
+      expect(toastStore.items[0].id).toBe(b);
+    } finally {
+      toastStore.clear();
+      vi.useRealTimers();
+    }
   });
 
   it("clear() empties items and cancels pending timers", async () => {
@@ -80,12 +101,14 @@ describe("toastStore (#574)", () => {
     try {
       toastStore.info("note");
       expect(toastStore.items).toHaveLength(1);
+      toastStore.dismiss(toastStore.items[0].id);
       toastStore.clear();
       expect(toastStore.items).toHaveLength(0);
       // The cancelled timer must not fire (no throw, items stays empty).
-      await vi.advanceTimersByTimeAsync(4000);
+      await vi.advanceTimersByTimeAsync(4000 + TOAST_EXIT_MS);
       expect(toastStore.items).toHaveLength(0);
     } finally {
+      toastStore.clear();
       vi.useRealTimers();
     }
   });
@@ -109,9 +132,13 @@ describe("toastStore (#574)", () => {
         const dismissSpy = vi.spyOn(toastStore, "dismiss");
         await vi.advanceTimersByTimeAsync(4000);
         expect(dismissSpy).toHaveBeenCalledTimes(4);
+        expect(toastStore.items).toHaveLength(4);
+        expect(toastStore.items.every((t) => t.exiting)).toBe(true);
+        await vi.advanceTimersByTimeAsync(TOAST_EXIT_MS);
         expect(toastStore.items).toHaveLength(0);
         dismissSpy.mockRestore();
       } finally {
+        toastStore.clear();
         vi.useRealTimers();
       }
     });

--- a/src/shared/stores/toasts.ts
+++ b/src/shared/stores/toasts.ts
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { createStore, reconcile } from "solid-js/store";
 
 export type ToastKind = "error" | "success" | "info";
 
@@ -14,6 +14,7 @@ export interface Toast {
   id: number;
   kind: ToastKind;
   message: string;
+  exiting: boolean;
 }
 
 // Errors stay until dismissed (the #574 failure MUST be noticed); info/success
@@ -29,10 +30,12 @@ const DEFAULT_DURATION_MS: Record<ToastKind, number | null> = {
 // info/success can never silently bury an unread sticky error; only when every
 // visible toast is an error do we fall back to evicting the oldest error.
 const MAX_VISIBLE = 4;
+export const TOAST_EXIT_MS = 180;
 
-const [toasts, setToasts] = createSignal<Toast[]>([]);
+const [toasts, setToasts] = createStore<Toast[]>([]);
 let nextId = 1;
 const timers = new Map<number, ReturnType<typeof setTimeout>>();
+const exitTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
 function clearTimer(id: number): void {
   const t = timers.get(id);
@@ -42,52 +45,83 @@ function clearTimer(id: number): void {
   }
 }
 
+function clearExitTimer(id: number): void {
+  const t = exitTimers.get(id);
+  if (t !== undefined) {
+    clearTimeout(t);
+    exitTimers.delete(id);
+  }
+}
+
+function clearToastTimers(id: number): void {
+  clearTimer(id);
+  clearExitTimer(id);
+}
+
+function removeToastImmediately(id: number): void {
+  clearToastTimers(id);
+  setToasts(reconcile(toasts.filter((t) => t.id !== id), { key: "id" }));
+}
+
+function startToastExit(id: number): void {
+  clearTimer(id);
+
+  const index = toasts.findIndex((toast) => toast.id === id);
+  if (index === -1 || toasts[index].exiting || exitTimers.has(id)) return;
+
+  setToasts(index, "exiting", true);
+  exitTimers.set(
+    id,
+    setTimeout(() => {
+      removeToastImmediately(id);
+    }, TOAST_EXIT_MS),
+  );
+}
+
 export const toastStore = {
   /** Reactive accessor (read inside JSX / effects to subscribe). */
   get items(): Toast[] {
-    return toasts();
+    return toasts;
   },
 
   push(opts: PushToastOptions): number {
     const id = nextId++;
     const kind = opts.kind ?? "info";
-    const toast: Toast = { id, kind, message: opts.message };
+    const toast: Toast = { id, kind, message: opts.message, exiting: false };
 
     const evicted: number[] = [];
-    setToasts((prev) => {
-      const next = [...prev, toast];
-      // Kind-aware eviction (§15.3): evict the oldest NON-error first so an
-      // unread sticky error is never silently dropped by a transient toast.
-      // Fall back to the oldest overall only when all visible toasts are errors
-      // (keeps MAX_VISIBLE an honest hard cap). Pure: only mutates the local
-      // `next` copy; timer cleanup happens after via `evicted`.
-      while (next.length > MAX_VISIBLE) {
-        let victim = next.findIndex((t) => t.kind !== "error");
-        if (victim === -1) victim = 0;
-        evicted.push(next.splice(victim, 1)[0].id);
-      }
-      return next;
-    });
-    evicted.forEach(clearTimer);
+    const next = [...toasts, toast];
+    // Kind-aware eviction (§15.3): evict the oldest NON-error first so an
+    // unread sticky error is never silently dropped by a transient toast.
+    // Fall back to the oldest overall only when all visible toasts are errors
+    // (keeps MAX_VISIBLE an honest hard cap).
+    while (next.length > MAX_VISIBLE) {
+      let victim = next.findIndex((t) => t.kind !== "error");
+      if (victim === -1) victim = 0;
+      evicted.push(next.splice(victim, 1)[0].id);
+    }
+    setToasts(reconcile(next, { key: "id" }));
+    evicted.forEach(clearToastTimers);
 
     const duration =
       opts.durationMs === undefined ? DEFAULT_DURATION_MS[kind] : opts.durationMs;
-    if (duration !== null) {
+    if (duration !== null && toasts.some((t) => t.id === id)) {
       timers.set(id, setTimeout(() => toastStore.dismiss(id), duration));
     }
     return id;
   },
 
   dismiss(id: number): void {
-    clearTimer(id);
-    setToasts((prev) => prev.filter((t) => t.id !== id));
+    startToastExit(id);
   },
 
   /** Remove all toasts + cancel all timers (onCleanup + test reset). */
   clear(): void {
     timers.forEach((t) => clearTimeout(t));
     timers.clear();
-    setToasts([]);
+    exitTimers.forEach((t) => clearTimeout(t));
+    exitTimers.clear();
+    setToasts(reconcile([]));
   },
 
   // Convenience wrappers.

--- a/src/shared/styles/toast.css
+++ b/src/shared/styles/toast.css
@@ -24,6 +24,12 @@
   font-family: var(--font-ui);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   pointer-events: auto;      /* dismissible */
+  transition: opacity 180ms ease-in, transform 180ms ease-in;
+}
+
+.toast-item--exiting {
+  opacity: 0;
+  transform: translateY(4px);
 }
 
 .toast-item--error {

--- a/src/sidebar/listeners-screenshot.test.ts
+++ b/src/sidebar/listeners-screenshot.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { FakeTransport } from "../shared/testing/fake-transport";
 import { __setTransportForTests } from "../shared/ipc";
-import { toastStore } from "../shared/stores/toasts";
+import { toastStore, TOAST_EXIT_MS } from "../shared/stores/toasts";
 import type { ScreenshotHotkeyStatus } from "../shared/types";
-import { wireScreenshotListeners } from "./listeners-screenshot";
+import {
+  SCREENSHOT_TOAST_DURATION_MS,
+  wireScreenshotListeners,
+} from "./listeners-screenshot";
 
 const OK_STATUS: ScreenshotHotkeyStatus = {
   configured: "Ctrl+Q",
@@ -23,29 +26,49 @@ describe("wireScreenshotListeners", () => {
 
   afterEach(() => {
     toastStore.clear();
+    vi.useRealTimers();
     restore();
     vi.restoreAllMocks();
   });
 
-  it("pushes a sticky success toast carrying the saved path on screenshot_capture_saved", async () => {
-    fake.resolve("screenshot_get_hotkey_status", OK_STATUS);
-    const unlisteners = await wireScreenshotListeners();
+  it("pushes a 30s success toast carrying the saved path on screenshot_capture_saved", async () => {
+    vi.useFakeTimers();
+    try {
+      fake.resolve("screenshot_get_hotkey_status", OK_STATUS);
+      const unlisteners = await wireScreenshotListeners();
 
-    const path = "C:\\proj\\.ac\\wg-6-dev-team\\__agent_x\\agentscommander-screenshot.png";
-    fake.emitFromBackend("screenshot_capture_saved", {
-      path,
-      sessionId: "s1",
-      sessionName: "wg-6-dev-team/dev-webpage-ui",
-    });
+      const path = "C:\\proj\\.ac\\wg-6-dev-team\\__agent_x\\agentscommander-screenshot.png";
+      fake.emitFromBackend("screenshot_capture_saved", {
+        path,
+        sessionId: "s1",
+        sessionName: "wg-6-dev-team/dev-webpage-ui",
+      });
 
-    expect(toastStore.items).toHaveLength(1);
-    expect(toastStore.items[0].kind).toBe("success");
-    expect(toastStore.items[0].message).toContain(path);
+      expect(toastStore.items).toHaveLength(1);
+      expect(toastStore.items[0].kind).toBe("success");
+      expect(toastStore.items[0].message).toContain(path);
+      expect(toastStore.items[0].exiting).toBe(false);
 
-    unlisteners.forEach((u) => u());
+      await vi.advanceTimersByTimeAsync(SCREENSHOT_TOAST_DURATION_MS - 1);
+      expect(toastStore.items).toHaveLength(1);
+      expect(toastStore.items[0].exiting).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(toastStore.items).toHaveLength(1);
+      expect(toastStore.items[0].exiting).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(TOAST_EXIT_MS);
+      expect(toastStore.items).toHaveLength(0);
+
+      unlisteners.forEach((u) => u());
+    } finally {
+      toastStore.clear();
+      vi.useRealTimers();
+    }
   });
 
   it("pushes a sticky error toast with the backend message on screenshot_capture_failed", async () => {
+    vi.useFakeTimers();
     fake.resolve("screenshot_get_hotkey_status", OK_STATUS);
     const unlisteners = await wireScreenshotListeners();
 
@@ -58,6 +81,11 @@ describe("wireScreenshotListeners", () => {
     expect(errors[0].message).toBe(
       "No active session to save the screenshot into."
     );
+
+    await vi.advanceTimersByTimeAsync(SCREENSHOT_TOAST_DURATION_MS + TOAST_EXIT_MS);
+    expect(toastStore.items).toHaveLength(1);
+    expect(toastStore.items[0].kind).toBe("error");
+    expect(toastStore.items[0].exiting).toBe(false);
 
     unlisteners.forEach((u) => u());
   });

--- a/src/sidebar/listeners-screenshot.ts
+++ b/src/sidebar/listeners-screenshot.ts
@@ -6,10 +6,12 @@ import {
 } from "../shared/ipc";
 import { toastStore } from "../shared/stores/toasts";
 
+export const SCREENSHOT_TOAST_DURATION_MS = 30_000;
+
 /**
  * #714 Wire the sidebar's screenshot-capture notifications:
- *  - `screenshot_capture_saved` → a sticky success toast carrying the saved PNG
- *    path (which is also on the clipboard).
+ *  - `screenshot_capture_saved` → a success toast carrying the saved PNG path
+ *    (which is also on the clipboard), auto-dismissing after 30s.
  *  - `screenshot_capture_failed` → a sticky error toast (the global hotkey often
  *    fires while another app is focused, so failures must be un-missable).
  *  - a one-shot startup check: if the hotkey is configured but the OS refused to
@@ -26,7 +28,7 @@ export async function wireScreenshotListeners(): Promise<UnlistenFn[]> {
   unlisteners.push(
     await onScreenshotCaptureSaved((result) => {
       toastStore.success(`Screenshot saved. Path copied: ${result.path}`, {
-        durationMs: null,
+        durationMs: SCREENSHOT_TOAST_DURATION_MS,
       });
     })
   );


### PR DESCRIPTION
## Summary

Screenshot-saved (green) toasts previously persisted until manually closed (`durationMs: null`), stacking up across captures. This PR:

- Auto-dismisses the screenshot-saved success toast after **30 s** (`SCREENSHOT_TOAST_DURATION_MS = 30_000` in `src/sidebar/listeners-screenshot.ts`).
- Adds a **two-phase fade-out** to the shared toast system (`exiting` state → removal after `TOAST_EXIT_MS = 180`): auto-expiry and manual `×` share one fade path, repeated dismisses are no-ops, eviction/`clear()` keep immediate removal, and all auto/exit timers are cleaned up. Toast list migrated to Solid `createStore` so the in-place `exiting` update animates the existing DOM node instead of remounting under keyed `<For>`.
- `ToastHost` renders `toast-item--exiting`; `toast.css` adds the opacity/transform transition.

Per product decision, the red capture-failure toast and the startup hotkey-registration warning **remain sticky**. No changes to the global sticky-error default, hover-pause, progress indicators, eviction policy, or `src-tauri/`.

## Review & gates

- Implemented by dev-webpage-ui (commit `95bee05`), single commit over `2c9a4b4`.
- Adversarial review (dev-rust-grinch): **PASS, zero findings**; scope, timer hygiene, sticky guarantees, `createStore` migration and test honesty all verified.
- Gates (run by dev, re-run independently by grinch): `npx tsc --noEmit` clean; full frontend vitest suite **82 files / 634 tests PASS** (includes new fake-timer coverage: green toast survives <30 s, exits at 30 s, removed after +180 ms; red stays sticky; manual-close fade); `git diff --check` clean.

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)
