### PR TITLE
docs: expose code signing and privacy links on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,12 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'Agents Commander ${{ github.ref_name }}'
-          releaseBody: ${{ steps.changelog.outputs.body || 'See the assets below to download and install Agents Commander.' }}
+          releaseBody: |
+            ${{ steps.changelog.outputs.body || 'See the assets below to download and install Agents Commander.' }}
+
+            ### Trust and privacy
+            - [Code signing policy](https://github.com/mblua/AgentsCommander/blob/main/CODE_SIGNING_POLICY.md) - Windows code signing is pending SignPath setup and approval; current Windows artifacts may be unsigned.
+            - [Privacy](https://github.com/mblua/AgentsCommander/blob/main/PRIVACY.md)
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}


### PR DESCRIPTION
## Summary

- Add explicit Code signing policy and Privacy links to generated GitHub release bodies.
- Keep Windows signing copy truthful: SignPath setup and approval are still pending, and current Windows artifacts may be unsigned.
- Leave the real SignPath signing workflow untouched for post-acceptance setup.

## Review and verification

- Implemented by dev-rust on `fix/754-signpath-release-links`.
- `git diff --check` passed.
- `git show --check --format=short HEAD` passed.
- Focused grep checks confirmed the canonical links, pending/unsigned copy, and absence of current-signed Windows claims in the release workflow.
- Independent review by architect: PASS, no findings.
- Grinch was contacted three times for review but did not reply or become active, so this PR uses the documented independent architect review as the alternate review artifact.

Closes #754
