### PR TITLE
feat: persist raise-hand indicator across app restarts, refs #747

### DIFF
--- a/src-tauri/src/cli/list_sessions.rs
+++ b/src-tauri/src/cli/list_sessions.rs
@@ -12,7 +12,7 @@ OUTPUT: JSON array of current sessions. Each entry contains:\n  \
   workingDirectory  Session's working directory path\n  \
   status            One of: \"active\", \"running\", \"idle\", or {\"exited\": <code>}\n  \
   waitingForInput   true when the session is waiting for user input\n  \
-  raisedHand        true when a visible raise-hand request is active\n  \
+  raisedHand        true when a visible raise-hand request is active (persists across app restarts until real user input)\n  \
   createdAt         ISO 8601 timestamp of session creation\n\n\
 REQUIREMENTS: The app must be running (sessions.json is kept up-to-date while the app runs).\n\n\
 EXAMPLES:\n  \
@@ -47,16 +47,17 @@ fn status_tag(status: &SessionStatus) -> &'static str {
     }
 }
 
-/// #698 - derive the public `raisedHand` boolean from a persisted row. True only
-/// when the full valid-visible contract holds: the row is a coordinator, has a
-/// present non-exited status, and carries a visible `RaiseHand` communication.
-/// Every other shape (missing status, missing/hidden/non-raise communication,
-/// non-coordinator, exited, restore-only) maps to false.
+/// #698/#747 - derive the public `raisedHand` boolean from a persisted row.
+/// True when the row is a coordinator, has a present status, and carries a
+/// visible `RaiseHand` communication. `Exited` status is deliberately NOT a
+/// disqualifier since #747: a dormant restored coordinator legitimately keeps
+/// its persisted raised hand until real user input clears it. Every real-exit
+/// path clears `communication` in the same critical section (`mark_exited`),
+/// so an exited row with a visible hand can only be the #747 dormant restore.
+/// Missing status, missing/hidden/non-raise communication, non-coordinator,
+/// and restore-only rows map to false.
 fn raised_hand_from_persisted(s: &PersistedSession) -> bool {
-    let Some(status) = s.status.as_ref() else {
-        return false;
-    };
-    if !s.is_coordinator || matches!(status, SessionStatus::Exited(_)) {
+    if s.status.is_none() || !s.is_coordinator {
         return false;
     }
     s.communication.as_ref().is_some_and(|communication| {

--- a/src-tauri/src/cli/raise_hand.rs
+++ b/src-tauri/src/cli/raise_hand.rs
@@ -9,7 +9,8 @@ use super::self_clear::resolve_self_clear_sender;
 #[derive(Args)]
 #[command(after_help = "\
 Raises this session's Sidebar communication indicator when the caller token belongs to a \
-live coordinator session with a visible TASK.md title slot.\n\n\
+live coordinator session with a visible TASK.md title slot. The indicator persists across \
+app restarts until cleared by real user input to the session.\n\n\
 OUTPUT: prints exactly true or false on stdout when the daemon processes the request. \
 Infrastructure failures, stale tokens, daemon rejection, delivery timeout, and malformed \
 responses exit non-zero and write errors to stderr.")]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -16,7 +16,9 @@ use crate::resource_monitor::{
 };
 use crate::session::manager::SessionManager;
 use crate::session::profile::CodingAgentKind;
-use crate::session::session::{SessionInfo, SessionRepo, SessionStatus};
+use crate::session::session::{
+    SessionCommunication, SessionCommunicationKind, SessionInfo, SessionRepo, SessionStatus,
+};
 use crate::telegram::manager::TelegramBridgeState;
 use crate::DetachedSessionsState;
 
@@ -2065,6 +2067,31 @@ fn restart_skip_auto_resume_with_intent(stored_start_fresh: bool, requested: Opt
     stored_start_fresh || effective_restart_skip_auto_resume(requested)
 }
 
+/// (#747) Decide whether a raised hand carries across the restart
+/// destroy+create boundary. Carry ONLY a visible `RaiseHand` and ONLY when the
+/// conversation resumes (`restart_start_fresh == false`, i.e. the Branch-A
+/// reopen of a dormant session). A fresh restart starts a new conversation;
+/// the raise belonged to the old one and is dropped, consistent with
+/// "destroyed sessions leave no stale raised-hand state" (#747 AC 4).
+///
+/// Seam map: the explicit "Restart Session" command and the bulk
+/// profile-assignment restart (commands/config.rs:627-637) pass fresh and drop
+/// (user-initiated resets); the sidebar dormant reopen passes `Some(false)`
+/// and carries; the startup wake arm reuses this helper with the persisted
+/// intent (#747 plan change 3); the agent-initiated self-clear-and-handoff
+/// restart carries via its own capture/re-apply (#747 plan change 10) because
+/// it is not user input. `pub(crate)` so lib.rs's wake arm shares the exact
+/// same decision.
+pub(crate) fn carry_communication_for_restart(
+    stored: Option<SessionCommunication>,
+    restart_start_fresh: bool,
+) -> Option<SessionCommunication> {
+    if restart_start_fresh {
+        return None;
+    }
+    stored.filter(|c| c.kind == SessionCommunicationKind::RaiseHand && c.visible)
+}
+
 /// (#599) Resolves the effective `skip_auto_resume` for the `create_session`
 /// command. Defaults to `true` (fresh conversation) so every existing
 /// create-in-place / new-agent / open-agent / CLI / web call site keeps its
@@ -2185,6 +2212,7 @@ pub async fn restart_session_inner_with_activation<R: tauri::Runtime>(
         telegram_bot_id,
         stored_requested_profile,
         stored_start_fresh,
+        stored_communication,
     ) = {
         let mgr = session_mgr.read().await;
         let session = mgr.get_session(uuid).await.ok_or("Session not found")?;
@@ -2201,6 +2229,7 @@ pub async fn restart_session_inner_with_activation<R: tauri::Runtime>(
             session.telegram_bot_id.clone(),
             session.requested_profile.clone(),
             session.start_fresh_on_restore, // (#630/#631) honor an unconsumed durable fresh intent
+            session.communication.clone(),  // (#747) candidate raised-hand carry across the reopen
         )
     };
 
@@ -2299,6 +2328,29 @@ pub async fn restart_session_inner_with_activation<R: tauri::Runtime>(
         let mgr = session_mgr.read().await;
         mgr.set_start_fresh_on_restore(new_uuid, restart_start_fresh)
             .await;
+    }
+
+    // (#747) Carry a visible raised hand across the destroy+create reopen when
+    // the conversation resumes (Branch-A wake of a dormant session). Explicit
+    // fresh restarts drop it. Emitted so the sidebar syncs (the session_created
+    // from create_session_inner carried communication: None). The
+    // persist_current_state in step 7 below writes it durably.
+    if let Some(communication) =
+        carry_communication_for_restart(stored_communication, restart_start_fresh)
+    {
+        let mgr = session_mgr.read().await;
+        if mgr
+            .restore_communication(new_uuid, communication.clone())
+            .await
+        {
+            let _ = app.emit(
+                "session_communication_changed",
+                serde_json::json!({
+                    "sessionId": new_uuid.to_string(),
+                    "communication": communication,
+                }),
+            );
+        }
     }
 
     if activate_after {
@@ -3767,6 +3819,46 @@ mod tests {
     fn restart_intent_stored_fresh_with_restart_button_is_fresh() {
         // Stored fresh AND an explicit restart => still fresh (no regression).
         assert!(super::restart_skip_auto_resume_with_intent(true, None));
+    }
+
+    // ── (#747) carry_communication_for_restart: shared decision for the
+    //    Branch-A reopen (restart_session_inner_with_activation) AND the
+    //    startup wake arm (lib.rs restore loop), which reuses this helper with
+    //    the persisted intent. This matrix pins the fresh gate for BOTH. ──
+
+    #[test]
+    fn carry_communication_for_restart_matrix() {
+        let visible_hand = || {
+            Some(crate::session::session::SessionCommunication {
+                kind: crate::session::session::SessionCommunicationKind::RaiseHand,
+                visible: true,
+                updated_at: "2026-06-30T11:00:00+00:00".to_string(),
+            })
+        };
+        let hidden_hand = || {
+            Some(crate::session::session::SessionCommunication {
+                kind: crate::session::session::SessionCommunicationKind::RaiseHand,
+                visible: false,
+                updated_at: "2026-06-30T11:00:00+00:00".to_string(),
+            })
+        };
+
+        // (visible raise, fresh=false): the reopen resumes the conversation,
+        // so the pending user-attention marker carries.
+        let carried = super::carry_communication_for_restart(visible_hand(), false)
+            .expect("visible hand must carry on a resuming reopen");
+        assert!(carried.visible);
+        assert_eq!(carried.updated_at, "2026-06-30T11:00:00+00:00");
+
+        // (visible raise, fresh=true): a fresh restart abandons the old
+        // conversation; the raise belonged to it and drops.
+        assert!(super::carry_communication_for_restart(visible_hand(), true).is_none());
+
+        // (hidden raise, fresh=false): non-visible payloads never carry.
+        assert!(super::carry_communication_for_restart(hidden_hand(), false).is_none());
+
+        // (None, fresh=false): nothing to carry.
+        assert!(super::carry_communication_for_restart(None, false).is_none());
     }
 
     // ── #599 R1 effective_create_skip_auto_resume tests ──

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -236,7 +236,8 @@ pub struct PersistedSession {
     pub git_branch_prefix: Option<String>,
 
     // ── Runtime fields (populated during live snapshots; `status` consumed on
-    //    restore per issue #248, the others ignored on restore) ──
+    //    restore per issue #248 and `communication` consumed on restore per
+    //    issue #747, the others ignored on restore) ──
     /// Session UUID (only present in live snapshots)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
@@ -248,7 +249,11 @@ pub struct PersistedSession {
     /// Whether the session is waiting for user input (only present in live snapshots)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub waiting_for_input: Option<bool>,
-    /// Current visible session communication state (only present in live snapshots)
+    /// Current visible session communication state. Populated during live
+    /// snapshots; **consumed on restore** since issue #747 (a persisted raised
+    /// hand re-applies to the restored record), and preserved on
+    /// failed-recoverable rows by `sanitize_failed_recoverable` so the
+    /// next-startup retry can restore it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub communication: Option<SessionCommunication>,
     /// ISO 8601 creation timestamp (only present in live snapshots)
@@ -1068,16 +1073,23 @@ pub(crate) fn strip_auto_injected_args(shell: &str, args: &[String]) -> Vec<Stri
 
 /// Pure: produce a sanitized copy of a failed-recoverable PersistedSession
 /// suitable for merging into a fresh snapshot. Drops runtime fields (`id`,
-/// `status`, `waiting_for_input`, `communication`, `created_at`) since those describe the
+/// `status`, `waiting_for_input`, `created_at`) since those describe the
 /// PRIOR run's state; the session is no longer live, and persisting them
 /// would make `list-sessions` (which filters on `id.is_some()`) report the
 /// session as alive when it is not. See §224.
+///
+/// `communication` is deliberately PRESERVED (#747): a raised hand is durable
+/// intent, not prior-run runtime state, so a transiently failed restore keeps
+/// it for the next startup attempt. `list-sessions` still reports
+/// `raisedHand: false` for these rows because `id` and `status` are stripped
+/// (both the `id.is_some()` row filter and the `status.is_none()` gate exclude
+/// them). Best-effort with the SAME LIFETIME AS THE RECIPE ROW: the row (hand
+/// included) survives only until the next `persist_current_state` (§224 G5).
 pub(crate) fn sanitize_failed_recoverable(ps: &PersistedSession) -> PersistedSession {
     let mut clean = ps.clone();
     clean.id = None;
     clean.status = None;
     clean.waiting_for_input = None;
-    clean.communication = None;
     clean.created_at = None;
     clean
 }
@@ -1105,7 +1117,8 @@ async fn persist_merging_failed_to_dir_for_project_paths_result(
     let _guard = sessions_save_lock().lock().await;
     let mut snapshot = snapshot_sessions(mgr).await;
     // §224 — strip stale runtime fields (`id`, `status`, `waiting_for_input`,
-    // `communication`, `created_at`) from failed-recoverable entries. Without this, the prior
+    // `created_at`) from failed-recoverable entries (`communication` is kept,
+    // #747, see `sanitize_failed_recoverable`). Without this, the prior
     // run's runtime fields travel into the new snapshot, and `list-sessions`
     // reports a session as alive (its `s.id.is_some()` filter passes) while
     // the in-memory `SessionManager` does not contain it. `close-session`
@@ -1342,9 +1355,11 @@ mod tests {
     use std::time::Duration;
 
     /// §224 D.2 — the strip drops every runtime field but preserves the recipe
-    /// fields needed for the next-startup restore attempt.
+    /// fields needed for the next-startup restore attempt. Since #747 a raised
+    /// hand counts as durable intent, not runtime state: `communication`
+    /// survives the strip so the retry can restore it.
     #[test]
-    fn sanitize_failed_recoverable_drops_runtime_fields() {
+    fn sanitize_failed_recoverable_drops_runtime_fields_keeps_raise_hand() {
         let ps = PersistedSession {
             last_prompt: None,
             name: "alice".into(),
@@ -1385,13 +1400,15 @@ mod tests {
             clean.waiting_for_input.is_none(),
             "waiting_for_input must be cleared"
         );
-        assert!(
-            clean.communication.is_none(),
-            "communication must be cleared"
-        );
         assert!(clean.created_at.is_none(), "created_at must be cleared");
 
         // Recipe fields preserved (so next-run restore can retry):
+        let kept = clean
+            .communication
+            .as_ref()
+            .expect("#747: the raised hand must survive the strip");
+        assert_eq!(kept.kind, SessionCommunicationKind::RaiseHand);
+        assert!(kept.visible, "visibility must survive the strip");
         assert_eq!(clean.name, "alice");
         assert_eq!(clean.shell, "claude");
         assert_eq!(clean.shell_args, vec!["--continue".to_string()]);
@@ -1855,6 +1872,93 @@ mod tests {
         let outcome = fut.await.expect("raise-hand persist should succeed");
         assert!(matches!(outcome, RaiseHandPersistOutcome::Raised(_)));
         assert!(mgr.list_sessions().await[0].communication.is_some());
+    }
+
+    /// (#747) Acceptance criterion 5's persist-restore-persist half: a hand
+    /// raised and persisted in run A re-applies onto run B's dormant (Exited)
+    /// record via `restore_communication` and survives B's own persist, so a
+    /// SECOND restart still sees it. The user-input clear tail is already
+    /// pinned by `clear_user_input_transitions_persists_both_cleared_fields`.
+    #[tokio::test]
+    async fn dormant_restore_round_trip_preserves_visible_raise_hand() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        // Run A: live coordinator raises its hand; #698 persists it durably.
+        let mgr_a = SessionManager::new();
+        let session_a = mgr_a
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                true,
+            )
+            .await
+            .expect("create_session should succeed");
+        let raise_time = chrono::DateTime::parse_from_rfc3339("2026-06-30T11:00:00+00:00")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let outcome =
+            raise_hand_and_persist_to_dir_result(&mgr_a, session_a.id, raise_time, temp.path(), None)
+                .await
+                .expect("raise+persist should succeed");
+        assert!(matches!(outcome, RaiseHandPersistOutcome::Raised(_)));
+
+        let rows = load_sessions_raw_from_dir_for_test(temp.path());
+        assert_eq!(rows.len(), 1);
+        let persisted_hand = rows[0]
+            .communication
+            .clone()
+            .expect("run A must persist the visible hand");
+        assert_eq!(persisted_hand.kind, SessionCommunicationKind::RaiseHand);
+        assert!(persisted_hand.visible);
+
+        // Run B (simulated relaunch, default settings): the defer arm creates
+        // the record, marks it Exited, then re-applies the persisted hand.
+        let mgr_b = SessionManager::new();
+        let session_b = mgr_b
+            .create_session(
+                rows[0].shell.clone(),
+                rows[0].shell_args.clone(),
+                rows[0].working_directory.clone(),
+                None,
+                None,
+                Vec::new(),
+                true,
+            )
+            .await
+            .expect("create_session should succeed");
+        mgr_b.mark_exited(session_b.id, 0).await;
+        assert!(
+            mgr_b
+                .restore_communication(session_b.id, persisted_hand.clone())
+                .await,
+            "dormant coordinator must accept the restored hand"
+        );
+
+        persist_current_state_to_dir_result(&mgr_b, temp.path())
+            .await
+            .expect("run B persist should succeed");
+
+        let rows_b = load_sessions_raw_from_dir_for_test(temp.path());
+        assert_eq!(rows_b.len(), 1);
+        assert!(
+            matches!(rows_b[0].status, Some(SessionStatus::Exited(0))),
+            "run B must persist the dormant status, got {:?}",
+            rows_b[0].status
+        );
+        let hand_b = rows_b[0]
+            .communication
+            .as_ref()
+            .expect("the restored hand must survive run B's persist");
+        assert_eq!(hand_b.kind, SessionCommunicationKind::RaiseHand);
+        assert!(hand_b.visible);
+        assert_eq!(
+            hand_b.updated_at, persisted_hand.updated_at,
+            "the original raise time must survive the round trip"
+        );
     }
 
     // ---- #698 grinch MEDIUM: single-critical-section user-input clear ----

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1566,6 +1566,13 @@ pub fn run(
 
                                     mgr.mark_exited(session.id, 0).await;
                                     mgr.clear_active_if(session.id).await;
+                                    // (#747) Re-apply a persisted raised hand onto the dormant
+                                    // placeholder. Must run AFTER mark_exited (which clears
+                                    // communication) and BEFORE the get_session below, so the
+                                    // emitted session_created event carries the restored hand.
+                                    if let Some(communication) = ps.communication.clone() {
+                                        mgr.restore_communication(session.id, communication).await;
+                                    }
                                     // Read updated session so emitted event reflects Exited status
                                     if let Some(updated) = mgr.get_session(session.id).await {
                                         let info = crate::session::session::SessionInfo::from(&updated);
@@ -1666,6 +1673,41 @@ pub fn run(
                                     if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
                                         let mgr = session_mgr_clone.read().await;
                                         mgr.set_start_fresh_on_restore(uuid, true).await;
+                                    }
+                                }
+                                // (#747) Re-apply a persisted raised hand onto the woken live
+                                // session. create_session_inner already emitted session_created
+                                // with communication: None, so emit the change event after
+                                // applying. Gated like the reopen carry (change 4): a stored
+                                // unconsumed fresh intent means this wake spawned a FRESH
+                                // conversation (skip_auto_resume_for_restore(true) above), so
+                                // the hand drops with the conversation it belonged to.
+                                // Applied as early as possible in this branch: an
+                                // idle/busy persist racing in between would transiently write
+                                // communication: None to disk; the persist_merging_failed at the
+                                // end of the restore task reconciles it (accepted window, see
+                                // plan #747 §7).
+                                if let Some(communication) =
+                                    crate::commands::session::carry_communication_for_restart(
+                                        ps.communication.clone(),
+                                        ps.start_fresh_on_restore,
+                                    )
+                                {
+                                    if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
+                                        let restored = {
+                                            let mgr = session_mgr_clone.read().await;
+                                            mgr.restore_communication(uuid, communication.clone()).await
+                                        };
+                                        if restored {
+                                            let _ = tauri::Emitter::emit(
+                                                &app_handle,
+                                                "session_communication_changed",
+                                                serde_json::json!({
+                                                    "sessionId": info.id,
+                                                    "communication": communication,
+                                                }),
+                                            );
+                                        }
                                     }
                                 }
                                 // (#630/#631) Restore-decision trace (INFO during stabilization).

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -17,8 +17,8 @@ use crate::phone::types::OutboxMessage;
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
 #[cfg(test)]
-use crate::session::session::{SessionCommunicationKind, SessionRepo};
-use crate::session::session::{SessionInfo, SessionStatus};
+use crate::session::session::{SessionCommunication, SessionRepo};
+use crate::session::session::{SessionCommunicationKind, SessionInfo, SessionStatus};
 use crate::{AppOutbox, MasterToken};
 
 fn sender_name_for_session_cwd_with_root_flag(
@@ -1222,6 +1222,12 @@ struct MailboxTestHooks {
     spawn_calls: Arc<Mutex<Vec<MailboxSpawnCall>>>,
     attach_calls: MailboxAttachCalls,
     events: Arc<Mutex<Vec<MailboxTestEvent>>>,
+    /// (#747) `is_coordinator` for sessions created by the test spawn hook
+    /// (default false, matching the historical harness). Production
+    /// `create_session_inner` recomputes the flag from teams discovery, so a
+    /// wake that respawns a coordinator target yields a coordinator record;
+    /// tests exercising the raised-hand carry set this to mirror that.
+    spawn_is_coordinator: Arc<Mutex<bool>>,
 }
 
 #[cfg(test)]
@@ -1864,6 +1870,12 @@ impl MailboxPoller {
         let mut spawn_with_resume = false;
         let mut pending_exited_destroy: Option<Uuid> = None;
         let mut pending_exited_telegram_bot_id: Option<String> = None;
+        let mut pending_exited_communication: Option<crate::session::session::SessionCommunication> =
+            None;
+        // (#747) Set only when the deferred destroy FAILS: the orphan Exited
+        // record then still holds the restored hand and must be cleared once
+        // the replacement spawn succeeds (single-carrier rule, 5d).
+        let mut pending_exited_orphan_to_clear: Option<Uuid> = None;
         // HIGH-1 (Step-7 review): symmetric AC5 protection. Tracks whether
         // every iter'd Inject candidate hit the `err_is_pty_session_missing`
         // race arm — if so, the post-loop fall-through must still promote
@@ -1933,14 +1945,20 @@ impl MailboxPoller {
                     // semantic.
                     if pending_exited_destroy.is_none() {
                         pending_exited_destroy = Some(session_id);
-                        pending_exited_telegram_bot_id = {
+                        let (bot_id, communication) = {
                             let session_mgr =
                                 app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
                             let mgr = session_mgr.read().await;
                             mgr.get_session(session_id)
                                 .await
-                                .and_then(|s| s.telegram_bot_id.clone())
+                                .map(|s| (s.telegram_bot_id.clone(), s.communication.clone()))
+                                .unwrap_or((None, None))
                         };
+                        pending_exited_telegram_bot_id = bot_id;
+                        // (#747) carry a restored raised hand across the
+                        // destroy+respawn; the wake injection is not user input
+                        // and must not clear it (#676).
+                        pending_exited_communication = communication;
                         spawn_with_resume = true;
                         log::debug!(
                             "[mailbox] wake: deferring Exited destroy for {} (status={:?}) pending later Inject success",
@@ -1989,6 +2007,12 @@ impl MailboxPoller {
                     exited_id,
                     e
                 );
+                // (#747) The orphan Exited record still holds its restored
+                // raised hand. Do NOT clear it here: if the spawn below also
+                // fails, the orphan must stay the sole carrier (the hand is
+                // not lost with the failed wake). Remember it so 5d moves the
+                // hand to the new session once the spawn succeeds.
+                pending_exited_orphan_to_clear = Some(exited_id);
             }
         }
 
@@ -2125,6 +2149,56 @@ impl MailboxPoller {
             .await;
         }
 
+        // (#747) Single-carrier rule. If the deferred destroy failed, the
+        // orphan Exited record still holds the restored hand while the carry
+        // below plants it on the new session. Clear the orphan's copy now
+        // (the spawn succeeded, so the live session is the carrier) and tell
+        // the frontend; otherwise the stale orphan badge survives attending
+        // the live session, and deduplicate (name+cwd, first-kept) can
+        // persist the orphan's Exited+hand row, resurrecting an already
+        // attended hand on the next restart.
+        if let Some(orphan_id) = pending_exited_orphan_to_clear.take() {
+            let cleared = {
+                let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+                let mgr = session_mgr.read().await;
+                mgr.clear_communication_if_kind(orphan_id, SessionCommunicationKind::RaiseHand)
+                    .await
+            };
+            if cleared {
+                let _ = tauri::Emitter::emit(
+                    app,
+                    "session_communication_changed",
+                    serde_json::json!({
+                        "sessionId": orphan_id.to_string(),
+                        "communication": null,
+                    }),
+                );
+            }
+        }
+
+        // (#747) Re-apply a raised hand carried from the destroyed dormant
+        // record. spawn_with_resume is true on this path (set in the
+        // RespawnExited arm), so the resumed conversation keeps its pending
+        // user-attention marker until real user input.
+        if let Some(communication) = pending_exited_communication.take() {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let restored = {
+                let mgr = session_mgr.read().await;
+                mgr.restore_communication(session_id, communication.clone())
+                    .await
+            };
+            if restored {
+                let _ = tauri::Emitter::emit(
+                    app,
+                    "session_communication_changed",
+                    serde_json::json!({
+                        "sessionId": session_id.to_string(),
+                        "communication": communication,
+                    }),
+                );
+            }
+        }
+
         self.wait_for_spawned_wake_idle(app, session_id).await?;
 
         // Inject message — interactive mode (session persists, user sees reply instructions)
@@ -2257,6 +2331,7 @@ impl MailboxPoller {
                 events.push(MailboxTestEvent::Spawn(call));
             }
 
+            let spawn_is_coordinator = *hooks.spawn_is_coordinator.lock().unwrap();
             let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
             let mgr = session_mgr.read().await;
             let session = mgr
@@ -2270,7 +2345,7 @@ impl MailboxPoller {
                         .or_else(|| resolved_command.agent_id.clone()),
                     spawn_label.clone(),
                     Vec::<SessionRepo>::new(),
-                    false,
+                    spawn_is_coordinator,
                 )
                 .await
                 .map_err(|e| e.to_string())?;
@@ -3958,7 +4033,18 @@ impl MailboxPoller {
                 let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
                 let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
                 let settings = app.state::<SettingsState>();
-                crate::commands::session::restart_session_inner_with_activation(
+                // (#747) The self-clear restart is agent-initiated, not user
+                // input: a pending raised hand must survive it (the injected
+                // handoff continues the same work). Capture before the
+                // destroy; restore_communication re-gates kind, visibility,
+                // and coordinator, so no pre-filter is needed here.
+                let carried_communication = {
+                    let mgr = session_mgr.read().await;
+                    mgr.get_session(session_id)
+                        .await
+                        .and_then(|s| s.communication.clone())
+                };
+                let result = crate::commands::session::restart_session_inner_with_activation(
                     &app,
                     session_mgr.inner(),
                     pty_mgr.inner(),
@@ -3969,8 +4055,26 @@ impl MailboxPoller {
                     Some(true),
                     true,
                 )
-                .await
-                .map(|info| info.id)
+                .await;
+                if let (Ok(info), Some(communication)) = (&result, carried_communication) {
+                    if let Ok(new_uuid) = Uuid::parse_str(&info.id) {
+                        let restored = {
+                            let mgr = session_mgr.read().await;
+                            mgr.restore_communication(new_uuid, communication.clone()).await
+                        };
+                        if restored {
+                            let _ = tauri::Emitter::emit(
+                                &app,
+                                "session_communication_changed",
+                                serde_json::json!({
+                                    "sessionId": info.id.clone(),
+                                    "communication": communication,
+                                }),
+                            );
+                        }
+                    }
+                }
+                result.map(|info| info.id)
             }
         };
 
@@ -9245,6 +9349,97 @@ mod tests {
             .position(|event| *event == MailboxTestEvent::Inject(new_session_id))
             .unwrap();
         assert!(attach_pos < inject_pos);
+        assert_inject_results_consumed(&hooks);
+    }
+
+    /// (#747) A dormant coordinator restored with a raised hand (Exited(0) +
+    /// visible communication, exactly what the startup defer arm produces)
+    /// receives a peer wake: the RespawnExited destroy+spawn must carry the
+    /// hand onto the NEW session (the wake injection is not user input) and
+    /// emit one `session_communication_changed` for it. The spawn hook is told
+    /// to create a coordinator record, mirroring production where
+    /// `create_session_inner` recomputes `is_coordinator` from teams discovery
+    /// for the same cwd.
+    #[tokio::test]
+    async fn deliver_wake_respawn_carries_restored_raise_hand_to_new_session() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let (exited_id, _token) =
+            seed_raise_hand_session(&app, &fixture.target_cwd, true, SessionStatus::Exited(0))
+                .await;
+        let original_raise_time = "2026-07-01T10:00:00+00:00".to_string();
+        {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let mgr = session_mgr.read().await;
+            assert!(
+                mgr.restore_communication(
+                    exited_id,
+                    SessionCommunication {
+                        kind: SessionCommunicationKind::RaiseHand,
+                        visible: true,
+                        updated_at: original_raise_time.clone(),
+                    },
+                )
+                .await,
+                "seeding the dormant-restored hand must succeed"
+            );
+        }
+        let events = Arc::new(Mutex::new(Vec::<String>::new()));
+        let captured = Arc::clone(&events);
+        fixture
+            .app
+            .listen_any("session_communication_changed", move |event| {
+                captured.lock().unwrap().push(event.payload().to_string());
+            });
+
+        let hooks = MailboxTestHooks::default();
+        *hooks.spawn_is_coordinator.lock().unwrap() = true;
+        hooks.pty_presence.lock().unwrap().insert(exited_id, false);
+        hooks.inject_results.lock().unwrap().push_back(Ok(()));
+        let message_path = write_wake_outbox_message(&fixture.sender_cwd, "msg-respawn-hand");
+
+        run_mailbox_message(&app, &message_path, hooks.clone()).await;
+
+        assert_eq!(*hooks.destroy_calls.lock().unwrap(), vec![exited_id]);
+        let spawn_calls = hooks.spawn_calls.lock().unwrap().clone();
+        assert_eq!(spawn_calls.len(), 1);
+        assert!(!spawn_calls[0].skip_auto_resume);
+        let injected = hooks.inject_calls.lock().unwrap().clone();
+        assert_eq!(injected.len(), 1);
+        let new_session_id = injected[0];
+        assert_ne!(new_session_id, exited_id);
+
+        let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+        let mgr = session_mgr.read().await;
+        assert!(
+            mgr.get_session(exited_id).await.is_none(),
+            "the orphan record was destroyed; exactly one carrier remains"
+        );
+        let spawned = mgr
+            .get_session(new_session_id)
+            .await
+            .expect("spawned session record");
+        let carried = spawned
+            .communication
+            .expect("the respawned session must carry the restored hand");
+        assert_eq!(carried.kind, SessionCommunicationKind::RaiseHand);
+        assert!(carried.visible);
+        assert_eq!(
+            carried.updated_at, original_raise_time,
+            "the carry must preserve the original raise time"
+        );
+        drop(mgr);
+
+        let captured = events.lock().unwrap().clone();
+        assert_eq!(
+            captured.len(),
+            1,
+            "exactly one communication event (the carry re-apply): {captured:?}"
+        );
+        let event: serde_json::Value = serde_json::from_str(&captured[0]).unwrap();
+        assert_eq!(event["sessionId"], new_session_id.to_string());
+        assert_eq!(event["communication"]["kind"], "raiseHand");
+        assert_eq!(event["communication"]["visible"], true);
         assert_inject_results_consumed(&hooks);
     }
 

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -475,6 +475,33 @@ impl SessionManager {
         should_clear
     }
 
+    /// (#747) Re-apply a persisted raise-hand onto a restored session record.
+    /// Unlike `raise_hand`, this deliberately ACCEPTS records in
+    /// `SessionStatus::Exited(_)`: the startup defer arm restores dormant
+    /// placeholders that must keep their raised hand until real user input
+    /// (issue #747 supersedes #676's ephemeral-only rule). Gates: coordinator
+    /// records only, visible `RaiseHand` payloads only. Preserves the caller's
+    /// `updated_at` (the original raise time) so the indicator's age stays
+    /// truthful. Returns true when the communication was applied.
+    pub async fn restore_communication(
+        &self,
+        id: Uuid,
+        communication: SessionCommunication,
+    ) -> bool {
+        if communication.kind != SessionCommunicationKind::RaiseHand || !communication.visible {
+            return false;
+        }
+        let mut sessions = self.sessions.write().await;
+        let Some(session) = sessions.get_mut(&id) else {
+            return false;
+        };
+        if !session.is_coordinator {
+            return false;
+        }
+        session.communication = Some(communication);
+        true
+    }
+
     /// (#630/#631) Stamp the durable resume intent. Used by the restart path and
     /// the restore wake/defer paths.
     pub async fn set_start_fresh_on_restore(&self, id: Uuid, value: bool) {
@@ -1054,6 +1081,113 @@ mod tests {
             .unwrap()
             .communication
             .is_none());
+    }
+
+    /// (#747) The restore seam accepts an Exited coordinator record (the defer
+    /// arm calls it right after `mark_exited`) and keeps the original raise
+    /// time so the indicator's age stays truthful.
+    #[tokio::test]
+    async fn restore_communication_applies_visible_raise_hand_to_dormant_coordinator() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                true,
+            )
+            .await
+            .expect("create_session should succeed");
+        mgr.mark_exited(session.id, 0).await;
+
+        let original_raise_time = "2026-06-30T11:00:00+00:00".to_string();
+        let communication = SessionCommunication {
+            kind: SessionCommunicationKind::RaiseHand,
+            visible: true,
+            updated_at: original_raise_time.clone(),
+        };
+
+        assert!(
+            mgr.restore_communication(session.id, communication.clone())
+                .await,
+            "dormant coordinator must accept the restored hand"
+        );
+        let stored = mgr.get_session(session.id).await.unwrap();
+        assert!(matches!(stored.status, SessionStatus::Exited(0)));
+        let restored = stored.communication.expect("restored hand stored");
+        assert_eq!(restored.kind, SessionCommunicationKind::RaiseHand);
+        assert!(restored.visible);
+        assert_eq!(
+            restored.updated_at, original_raise_time,
+            "restore must preserve the ORIGINAL raise time, not re-stamp it"
+        );
+    }
+
+    /// (#747) Restore gates: non-coordinator records, hidden payloads, and
+    /// unknown ids are all rejected without mutating state.
+    #[tokio::test]
+    async fn restore_communication_rejects_non_coordinator_hidden_payload_and_unknown_id() {
+        let mgr = SessionManager::new();
+        let visible_hand = SessionCommunication {
+            kind: SessionCommunicationKind::RaiseHand,
+            visible: true,
+            updated_at: "2026-06-30T11:00:00+00:00".to_string(),
+        };
+
+        // Non-coordinator record: rejected, communication stays None.
+        let member = mgr
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+            )
+            .await
+            .expect("create_session should succeed");
+        assert!(
+            !mgr.restore_communication(member.id, visible_hand.clone())
+                .await
+        );
+        assert!(mgr
+            .get_session(member.id)
+            .await
+            .unwrap()
+            .communication
+            .is_none());
+
+        // Hidden payload on a coordinator: rejected.
+        let coordinator = mgr
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp2".to_string(),
+                None,
+                None,
+                Vec::new(),
+                true,
+            )
+            .await
+            .expect("create_session should succeed");
+        let hidden_hand = SessionCommunication {
+            visible: false,
+            ..visible_hand.clone()
+        };
+        assert!(!mgr.restore_communication(coordinator.id, hidden_hand).await);
+        assert!(mgr
+            .get_session(coordinator.id)
+            .await
+            .unwrap()
+            .communication
+            .is_none());
+
+        // Unknown id: rejected.
+        assert!(!mgr.restore_communication(Uuid::new_v4(), visible_hand).await);
     }
 
     /// #698 MEDIUM fix: `clear_user_input_transitions` lowers a visible raise-hand

--- a/src-tauri/tests/cli_behavior_contract.rs
+++ b/src-tauri/tests/cli_behavior_contract.rs
@@ -532,6 +532,11 @@ fn read_only_json_commands_missing_config_contracts() {
     }
 }
 
+/// #698 raisedHand contract with negative cases; #747 flipped the exited row:
+/// a coordinator row with `{"exited":0}` + visible raise-hand is EXACTLY the
+/// dormant-restored shape (every real-exit path clears communication in
+/// `mark_exited`, so it can only be produced by the #747 restore) and now
+/// reports `raisedHand: true`.
 #[test]
 fn list_sessions_outputs_raised_hand_boolean_with_negative_cases() {
     let tmp = Tmp::new("cli-list-sessions-raised-hand");
@@ -598,7 +603,7 @@ fn list_sessions_outputs_raised_hand_boolean_with_negative_cases() {
             "createdAt": "2026-06-30T10:15:00+00:00"
         },
         {
-            "name": "coord-exited",
+            "name": "coord-dormant-restored-hand",
             "shell": "codex",
             "shellArgs": [],
             "workingDirectory": "C:/proj/.ac/wg-1-dev-team/__agent_old-tech-lead",
@@ -624,7 +629,7 @@ fn list_sessions_outputs_raised_hand_boolean_with_negative_cases() {
     assert_eq!(rows[1]["raisedHand"], false);
     assert_eq!(rows[2]["raisedHand"], false);
     assert_eq!(rows[3]["raisedHand"], false);
-    assert_eq!(rows[4]["raisedHand"], false);
+    assert_eq!(rows[4]["raisedHand"], true);
     assert!(rows
         .as_array()
         .unwrap()

--- a/src/sidebar/App.raise-hand.workflow.test.tsx
+++ b/src/sidebar/App.raise-hand.workflow.test.tsx
@@ -147,4 +147,78 @@ describe("SidebarApp raise-hand communication workflow (#676)", () => {
       rendered.cleanup();
     }
   });
+
+  it("renders a hydrated raise-hand slot for a dormant (exited) restored coordinator (#747)", async () => {
+    const fake = new FakeTransport();
+    setupRaiseHandTransport(fake, [
+      coordSession({
+        status: { exited: 0 },
+        communication: {
+          kind: "raiseHand",
+          visible: true,
+          updatedAt,
+        },
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).not.toBeNull());
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("carries the raise-hand slot across the reopen event sequence (#747)", async () => {
+    const newSessionId = "coord-session-reopened";
+    const fake = new FakeTransport();
+    setupRaiseHandTransport(fake, [
+      coordSession({
+        status: { exited: 0 },
+        communication: {
+          kind: "raiseHand",
+          visible: true,
+          updatedAt,
+        },
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      // Dormant restored coordinator shows the hand before the reopen.
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).not.toBeNull());
+
+      // Reopen destroys the dormant record, recreates it (session_created
+      // carries communication: null), then the carry lands as a follow-up
+      // session_communication_changed (#747 change 4c). The order is
+      // load-bearing: emitted before session_created, the communication
+      // event would hit a store without the new id and setCommunication
+      // would silently no-op, losing the hand.
+      fake.emitFromBackend("session_destroyed", { id: sessionId });
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).toBeNull());
+
+      fake.emitFromBackend(
+        "session_created",
+        coordSession({ id: newSessionId, communication: null })
+      );
+      await waitFor(() => {
+        expect(sessionsStore.sessions.find((s) => s.id === newSessionId)).toBeTruthy();
+        expect(rendered.root.querySelector(slotSelector)).toBeNull();
+      });
+
+      fake.emitFromBackend("session_communication_changed", {
+        sessionId: newSessionId,
+        communication: {
+          kind: "raiseHand",
+          visible: true,
+          updatedAt,
+        },
+      });
+
+      await waitFor(() => expect(rendered.root.querySelector(slotSelector)).not.toBeNull());
+      expect(sessionsStore.sessions.find((s) => s.id === sessionId)).toBeUndefined();
+    } finally {
+      rendered.cleanup();
+    }
+  });
 });

--- a/src/sidebar/components/ProjectPanel.raise-hand.test.tsx
+++ b/src/sidebar/components/ProjectPanel.raise-hand.test.tsx
@@ -180,7 +180,7 @@ describe("ProjectPanel raise-hand communication slot (#676)", () => {
     }
   });
 
-  it("does not render for non-coordinator rows or stale exited-session communication", async () => {
+  it("does not render for non-coordinator rows", async () => {
     const nonCoord = await mountProject(
       [workgroup("wg-3-dev-team", "worker", "Worker task", false)],
       [
@@ -194,9 +194,9 @@ describe("ProjectPanel raise-hand communication slot (#676)", () => {
     } finally {
       nonCoord.cleanup();
     }
+  });
 
-    resetUiStoresForTests();
-
+  it("renders for a dormant (exited) coordinator session with restored raise-hand communication (#747)", async () => {
     const exited = await mountProject(
       [workgroup("wg-4-dev-team", "dev-webpage-ui", "Exited task")],
       [
@@ -206,7 +206,13 @@ describe("ProjectPanel raise-hand communication slot (#676)", () => {
       ]
     );
     try {
-      expect(exited.root.querySelector(".coord-communication-slot")).toBeNull();
+      await waitFor(() => {
+        const slot = exited.root.querySelector(
+          `[data-ac-testid="${rowSlotTestId("wg-4-dev-team", "dev-webpage-ui")}"]`
+        );
+        expect(slot).not.toBeNull();
+        expect(slot?.getAttribute("data-kind")).toBe("raiseHand");
+      });
     } finally {
       exited.cleanup();
     }

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1803,9 +1803,12 @@ const ProjectPanel: Component = () => {
           const isCoord = () => replica.isCoordinator;
           const session = () => replicaSession(wg, replica);
           const communication = createMemo(() => session()?.communication ?? null);
+          // #747: no liveness gate. A dormant restored coordinator keeps its
+          // persisted raised hand; every real-exit path clears communication
+          // and emits session_communication_changed, so exited-with-hand can
+          // only be the restored state.
           const showRaiseHand = createMemo(() =>
             isCoord() &&
-            isSessionLive(session()) &&
             !!taskTitle &&
             communication()?.kind === "raiseHand" &&
             communication()?.visible === true


### PR DESCRIPTION
## Summary

- Persist the raise-hand Sidebar indicator across app restarts. Supersedes #676's ephemeral-only requirement by explicit user decision (see #747).
- Backend: rehydrate the already-persisted `PersistedSession.communication` in BOTH `lib.rs` restore arms via a new `SessionManager::restore_communication` (coordinator-only, visible-RaiseHand-only, preserves the original `updated_at`, deliberately accepts Exited records); carry the hand across dormant-to-live transitions (sidebar reopen when the conversation resumes, `deliver_wake` respawn under a single-carrier rule, self-clear-and-handoff restart); `sanitize_failed_recoverable` now keeps `communication`; CLI `list-sessions` reports dormant-restored hands (`raisedHand: true`).
- Frontend: the `showRaiseHand` memo drops the `isSessionLive` gate (keeps `!!taskTitle`) so a restored dormant coordinator card shows the hand.
- Clear semantics unchanged: only real user PTY input clears the hand (memory + disk), never PTY output or agent injection (#676), never failed WS binary PTY writes (#678). Exited-with-visible-hand is unambiguous: `mark_exited` is the sole `Exited` writer and clears the hand in the same critical section.

## Validation

- Full-path workflow: architect plan -> dev-rust + dev-webpage-ui + grinch plan enrichment -> consensus round 1 = READY_FOR_IMPLEMENTATION (all MED findings folded as code: wake-arm fresh-intent gate, single-carrier orphan rule, per-caller restart-carry semantics).
- Backend `131d595` (dev-rust): `cargo test --lib --bins --tests` 1822/0/12, clippy `-D warnings` clean, 7 new tests incl. e2e `deliver_wake` carry; /code-review high: no HIGH.
- Frontend `c0d90d2` (dev-webpage-ui): tsc clean, vitest full suite green, vite build OK, 4 new/changed tests (dormant-render invert, dormant hydration, reopen event-ordering); /code-review high: no HIGH.
- Grinch Step-9 review of `2c9a4b4..c0d90d2`: PASS, no HIGH/MED/LOW; all gates re-run independently, 11 new tests verified by exact name.
- Re-sync onto origin/main `ac875d2` (PR #755): merge `db4b66f`, clean auto-merge, single shared file with disjoint hunks; grinch focused merge review: PASS - cleared to land (gates re-run on merged tree: 1822/0/12, 642/642, clippy/tsc/vite clean).
- Follow-up issues to be filed at landing: auto-close vs raised-hand interaction (plan G6), `is_coordinator` respawn-recompute backstop, `mark_exited` clear+emit pairing contract.

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)
