### PR TITLE
fix(#748): stop sidebar DOM recreation from swallowing first clicks

### DIFF
--- a/src/sidebar/components/ProjectPanel.idle-badge.test.tsx
+++ b/src/sidebar/components/ProjectPanel.idle-badge.test.tsx
@@ -12,6 +12,7 @@ import {
   waitFor,
 } from "../../shared/testing/ui-harness";
 import { projectStore } from "../stores/project";
+import { replicaVolatileStore } from "../stores/replica-volatile";
 import { sessionsStore } from "../stores/sessions";
 import { settingsStore } from "../../shared/stores/settings";
 import { clockStore } from "../stores/clock";
@@ -103,7 +104,9 @@ describe("ProjectPanel coordinator idle badge (#580 XOR gate + conditional toolt
 
       // Reopen (clear the marker, as the auto-close event does) → the pill
       // disappears and the red 90m counter returns from the same anchor.
-      projectStore.updateCoordinatorAutoClosed(coordPath, null);
+      // #748: the clear lands in the volatile store; the pill memo must react
+      // WITHOUT the row being re-created (row identity is stable now).
+      replicaVolatileStore.setAutoClosedAt(coordPath, null);
       await waitFor(() => {
         expect(rendered.root.querySelector(".coord-autoclosed")).toBeNull();
         const counter = rendered.root.querySelector(".coord-idle");

--- a/src/sidebar/components/ProjectPanel.modal-refresh.test.tsx
+++ b/src/sidebar/components/ProjectPanel.modal-refresh.test.tsx
@@ -21,6 +21,7 @@ import {
   waitFor,
 } from "../../shared/testing/ui-harness";
 import { projectStore } from "../stores/project";
+import { replicaVolatileStore } from "../stores/replica-volatile";
 import { sessionsStore } from "../stores/sessions";
 import { automationIdPart } from "./replica-repo-badges";
 
@@ -265,15 +266,19 @@ describe("ProjectPanel modal survival across project refresh (#710)", () => {
 
     await waitFor(() => expect(q("agentPicker.modal")).toBeTruthy());
 
-    // Background discovery refresh: rebuilds the project object → re-creates the
-    // <For> row. Before #710 this disposed the per-row signal and the picker
-    // vanished; hoisted to the stable root and resolved by sessionId, it survives.
+    // Background discovery refresh WITH changed data: rebuilds the project
+    // object → re-creates the <For> row. (#748 made an identical snapshot a
+    // no-op, so the refresh must carry a real change to exercise re-creation.)
+    // Before #710 this disposed the per-row signal and the picker vanished;
+    // hoisted to the stable root and resolved by sessionId, it survives.
+    fake.resolve("discover_project", discoveryResult(["ops-team"]));
     await projectStore.reloadProject(projectPath);
     await expectSecondDiscover(fake);
     expect(q("agentPicker.modal")).toBeTruthy();
 
-    // A replica-branch update rebuilds every project object too — still survives.
-    projectStore.updateReplicaBranch(replicaPath, "feature/x");
+    // A replica-branch event lands in the volatile store (#748) and must not
+    // disturb the modal either.
+    replicaVolatileStore.setRepoBranch(replicaPath, "feature/x");
     expect(q("agentPicker.modal")).toBeTruthy();
   });
 
@@ -294,13 +299,15 @@ describe("ProjectPanel modal survival across project refresh (#710)", () => {
 
     await waitFor(() => expect(q("agentPicker.modal")).toBeTruthy());
 
+    // Changed snapshot so the reload still re-creates the row (#748).
+    fake.resolve("discover_project", discoveryResult(["ops-team"]));
     await projectStore.reloadProject(projectPath);
     await expectSecondDiscover(fake);
     // Re-resolved by stable project/wg/replica paths, so the picker stays open
     // with fresh data instead of being disposed with the row.
     expect(q("agentPicker.modal")).toBeTruthy();
 
-    projectStore.updateReplicaBranch(replicaPath, "feature/y");
+    replicaVolatileStore.setRepoBranch(replicaPath, "feature/y");
     expect(q("agentPicker.modal")).toBeTruthy();
   });
 
@@ -335,6 +342,12 @@ describe("ProjectPanel modal survival across project refresh (#710)", () => {
 
     // The loop is re-resolved by stable id (editingLoopResolved). Before #710 the
     // refresh disposed the row's editingLoop signal and the modal vanished.
+    // #748: the snapshot carries a changed loop so the reload still re-creates
+    // the project row (an identical snapshot is a no-op now).
+    fake.resolve(
+      "discover_project",
+      discoveryResult([], [{ ...loopFixture(), promptPreview: "Changed preview" }]),
+    );
     await projectStore.reloadProject(projectPath);
     await expectSecondDiscover(fake);
 

--- a/src/sidebar/components/ProjectPanel.restart-prompt.test.tsx
+++ b/src/sidebar/components/ProjectPanel.restart-prompt.test.tsx
@@ -21,6 +21,7 @@ import {
   waitFor,
 } from "../../shared/testing/ui-harness";
 import { projectStore } from "../stores/project";
+import { replicaVolatileStore } from "../stores/replica-volatile";
 import { sessionsStore } from "../stores/sessions";
 import { automationIdPart } from "./replica-repo-badges";
 
@@ -113,7 +114,7 @@ function applyResult(): ApplyCodingAgentProfileSelectionResult {
   };
 }
 
-function discoveryResult() {
+function discoveryResult(taskTitle = "Restart prompt") {
   return discovery({
     teams: [{ name: "dev-team", agents: [replicaName], coordinator: replicaName }],
     workgroups: [
@@ -121,7 +122,7 @@ function discoveryResult() {
         name: workgroupName,
         path: workgroupPath,
         task: null,
-        taskTitle: "Restart prompt",
+        taskTitle,
         teamName: "dev-team",
         agents: [
           {
@@ -232,17 +233,20 @@ describe("ProjectPanel post-assign restart prompt (#537)", () => {
     try {
       await driveToRestartPrompt(rendered.root);
 
-      // A discovery poll re-discovers the project and replaces its object
-      // reference (projectStore.reloadProject), re-creating the projects <For>
-      // row. Before the fix this disposed the per-row signal and the modal
-      // vanished; hoisted to the stable root, it must survive.
+      // A discovery poll re-discovers the project WITH changed data and
+      // replaces its object reference (projectStore.reloadProject), re-creating
+      // the projects <For> row. (#748 made an identical snapshot a no-op, so
+      // the poll must carry a real change to exercise re-creation.) Before the
+      // fix this disposed the per-row signal and the modal vanished; hoisted to
+      // the stable root, it must survive.
+      fake.resolve("discover_project", discoveryResult("Restart prompt v2"));
       await projectStore.reloadProject(projectPath);
       await waitFor(() => expect(fake.callsFor("discover_project").length).toBeGreaterThanOrEqual(2));
       expect(q("restartPrompt.modal")).toBeTruthy();
 
-      // The same resilience must hold for a replica-branch update, which rebuilds
-      // every project object in the store.
-      projectStore.updateReplicaBranch(replicaPath, "feature/x");
+      // The same resilience must hold for a replica-branch event, which now
+      // lands in the volatile store (#748) without touching row identity.
+      replicaVolatileStore.setRepoBranch(replicaPath, "feature/x");
       expect(q("restartPrompt.modal")).toBeTruthy();
 
       // Later dismisses without restarting the live session.

--- a/src/sidebar/components/ProjectPanel.row-identity.test.tsx
+++ b/src/sidebar/components/ProjectPanel.row-identity.test.tsx
@@ -123,7 +123,8 @@ describe("ProjectPanel row identity across volatile events (#748)", () => {
     const fake = new FakeTransport();
     fake.resolve("new_project", { path: projectPath, registered: true, created: false });
     fake.resolve("get_settings", baseSettings());
-    fake.resolve("discover_project", coordDiscovery());
+    const firstSnapshot = coordDiscovery();
+    fake.resolve("discover_project", firstSnapshot);
 
     const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
     try {
@@ -132,7 +133,12 @@ describe("ProjectPanel row identity across volatile events (#748)", () => {
       await waitFor(() => expect(rendered.root.querySelector(rowSelector)).toBeTruthy());
       const row = rendered.root.querySelector(rowSelector);
 
-      // Identical snapshot (fresh objects, equal data) → complete no-op.
+      // Identical snapshot → complete no-op. Serve a deep CLONE so the merge
+      // sees fresh objects with equal data: FakeTransport re-serves the same
+      // reference on every invoke, and without the clone the no-op verdict
+      // would ride deepEqual's `a === b` fast-path instead of proving real
+      // structural comparison.
+      fake.resolve("discover_project", structuredClone(firstSnapshot));
       await projectStore.reloadProject(projectPath);
       await waitFor(() =>
         expect(fake.callsFor("discover_project").length).toBeGreaterThanOrEqual(2),

--- a/src/sidebar/components/ProjectPanel.row-identity.test.tsx
+++ b/src/sidebar/components/ProjectPanel.row-identity.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { replicaVolatileStore } from "../stores/replica-volatile";
+import { settingsStore } from "../../shared/stores/settings";
+import { clockStore } from "../stores/clock";
+import { automationIdPart } from "./replica-repo-badges";
+
+// #748 — the lost-first-click root cause: volatile events (coordinator clock,
+// close markers, repo branch) used to replace every project object reference,
+// so the reference-keyed <For>s disposed and re-created the whole clickable
+// panel DOM. A click whose press straddled that swap never fired (Chromium
+// drops `click` when the mousedown target is detached, w3c/uievents#141).
+// These tests pin the fix at the DOM level: after each volatile event the row
+// must be the SAME element (identity stable ⇒ no click can be lost to it),
+// while the badge/pill content still updates in place. An actually-changed
+// discovery reload must still re-create the row (real data changes render).
+
+const projectPath = "C:\\Project";
+const workgroupName = "wg-2-dev-team";
+const workgroupPath = `${projectPath}\\.ac\\${workgroupName}`;
+const coordName = "dev-webpage-ui";
+const coordPath = `${workgroupPath}\\__agent_${coordName}`;
+
+const rowSelector = `[data-ac-testid="replica.row.quick.${automationIdPart(
+  workgroupName,
+)}.${automationIdPart(coordName)}"]`;
+
+function isoMinutesAgo(minutes: number): string {
+  return new Date(clockStore.nowMs - minutes * 60_000).toISOString();
+}
+
+function coordDiscovery(taskTitle = "Row identity") {
+  return discovery({
+    workgroups: [
+      {
+        name: workgroupName,
+        path: workgroupPath,
+        task: null,
+        taskTitle,
+        agents: [
+          {
+            name: coordName,
+            path: coordPath,
+            repoPaths: [],
+            isCoordinator: true,
+            lastUserMessageAt: isoMinutesAgo(90),
+          },
+        ],
+      },
+    ],
+  });
+}
+
+describe("ProjectPanel row identity across volatile events (#748)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("keeps the same row DOM node across clock/close/branch events while the badge updates in place", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("get_settings", baseSettings({ coordinatorAutoCloseEnabled: true }));
+    fake.resolve("discover_project", coordDiscovery());
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.querySelector(rowSelector)).toBeTruthy());
+
+      const row = rendered.root.querySelector(rowSelector);
+      expect(rendered.root.querySelector(".coord-idle")?.textContent).toBe("90m");
+
+      // Clock event → badge text moves, row node does not.
+      replicaVolatileStore.setLastUserMessageAt(coordPath, isoMinutesAgo(0));
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".coord-idle")?.textContent).toBe("0m"),
+      );
+      expect(rendered.root.querySelector(rowSelector)).toBe(row);
+
+      // Close-marker event → pill appears (XOR gates the counter off), same row.
+      replicaVolatileStore.setAutoClosedAt(coordPath, isoMinutesAgo(1));
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".coord-autoclosed")).not.toBeNull(),
+      );
+      expect(rendered.root.querySelector(rowSelector)).toBe(row);
+
+      // Reopen clear + branch event → still the same node.
+      replicaVolatileStore.setAutoClosedAt(coordPath, null);
+      replicaVolatileStore.setRepoBranch(coordPath, "feature/x");
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".coord-autoclosed")).toBeNull(),
+      );
+      expect(rendered.root.querySelector(rowSelector)).toBe(row);
+      expect(row?.isConnected).toBe(true);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("an identical discovery reload keeps the row node; a changed one re-creates it", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("get_settings", baseSettings());
+    fake.resolve("discover_project", coordDiscovery());
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await settingsStore.load();
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.querySelector(rowSelector)).toBeTruthy());
+      const row = rendered.root.querySelector(rowSelector);
+
+      // Identical snapshot (fresh objects, equal data) → complete no-op.
+      await projectStore.reloadProject(projectPath);
+      await waitFor(() =>
+        expect(fake.callsFor("discover_project").length).toBeGreaterThanOrEqual(2),
+      );
+      expect(rendered.root.querySelector(rowSelector)).toBe(row);
+
+      // Changed workgroup data → the row legitimately re-renders.
+      fake.resolve("discover_project", coordDiscovery("Row identity v2"));
+      await projectStore.reloadProject(projectPath);
+      await waitFor(() =>
+        expect(rendered.root.textContent).toContain("Row identity v2"),
+      );
+      expect(rendered.root.querySelector(rowSelector)).not.toBe(row);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -14,6 +14,13 @@ import { isTauri } from "../../shared/platform";
 import { stripFrontmatter } from "../../shared/markdown";
 import { launchErrorMessage } from "../../shared/launch-errors";
 import { projectStore } from "../stores/project";
+import {
+  effectiveAutoClosedAt,
+  effectiveLastUserMessageAt,
+  effectiveManuallyClosedAt,
+  effectiveRepoBranch,
+  replicaVolatileStore,
+} from "../stores/replica-volatile";
 import { normalizeProjectPathForCompare } from "../stores/project-refresh";
 import { sessionsStore } from "../stores/sessions";
 import { bridgesStore } from "../stores/bridges";
@@ -205,12 +212,24 @@ function workgroupCollapseId(wg: AcWorkgroup, rowContext: string): string {
  */
 export const RESTART_TIMEOUT_MS = 30_000;
 
+/** #748 — resolve the repo badges' branch through the volatile live layer so a
+ *  branch event updates badge text without touching row identity. */
+function configuredReplicaRepoBadgesLive(
+  replica: AcAgentReplica,
+  workgroup: Pick<AcWorkgroup, "repoPath">
+): SessionRepo[] {
+  return configuredReplicaRepoBadges(
+    { repoPaths: replica.repoPaths, repoBranch: effectiveRepoBranch(replica) },
+    workgroup
+  );
+}
+
 function replicaRepoMenuEntries(wg: AcWorkgroup, replica: AcAgentReplica): SessionRepo[] {
   if (!replica.isCoordinator) return [];
   const session = replicaSession(wg, replica);
   const repos = session && session.gitRepos.length > 0
     ? session.gitRepos
-    : configuredReplicaRepoBadges(replica, wg);
+    : configuredReplicaRepoBadgesLive(replica, wg);
   return repos.filter(hasValidRepoSourcePath);
 }
 
@@ -326,6 +345,13 @@ const ProjectPanel: Component = () => {
   // updates are wired in sidebar/App.tsx (it owns the listener for the
   // canonical `workgroup_task_updated` event); ProjectPanel reads the
   // resulting state through projectStore.
+  //
+  // #748 — these four events write to replicaVolatileStore, NOT projectStore.
+  // The old in-place patches rebuilt every project/workgroup reference, and the
+  // reference-keyed <For>s below then re-created the whole panel DOM per event
+  // — losing any click whose press straddled the swap. The volatile store is
+  // fine-grained (keyed by normalized replica path), so only the badge/pill
+  // reading the changed field re-runs; row identity is stable.
   let unlistenBranch: (() => void) | null = null;
   let unlistenClock: (() => void) | null = null;
   let unlistenAutoClose: (() => void) | null = null;
@@ -336,19 +362,19 @@ const ProjectPanel: Component = () => {
   onCleanup(registerCoordinatorCloseModalHost());
   onMount(async () => {
     unlistenBranch = await onDiscoveryBranchUpdated((data) => {
-      projectStore.updateReplicaBranch(data.replicaPath, data.branch);
+      replicaVolatileStore.setRepoBranch(data.replicaPath, data.branch);
     });
-    // #552 coordinator idle badge + auto-closed pill: patch the replica in place
-    // (mirrors the branch watcher). Discovery reload self-heals on any path miss.
+    // #552 coordinator idle badge + auto-closed pill. Discovery reload
+    // supersedes these overrides on any path miss (clearForPaths).
     unlistenClock = await onCoordinatorClockUpdated((data) => {
-      projectStore.updateCoordinatorClock(data.replicaPath, data.lastUserMessageAt);
+      replicaVolatileStore.setLastUserMessageAt(data.replicaPath, data.lastUserMessageAt);
     });
     unlistenAutoClose = await onCoordinatorAutoCloseChanged((data) => {
-      projectStore.updateCoordinatorAutoClosed(data.replicaPath, data.autoClosedAt);
+      replicaVolatileStore.setAutoClosedAt(data.replicaPath, data.autoClosedAt);
     });
-    // #588 manually-closed pill: patch in place, same as the auto-close marker.
+    // #588 manually-closed pill: same live layer as the auto-close marker.
     unlistenManualClose = await onCoordinatorManualCloseChanged((data) => {
-      projectStore.updateCoordinatorManuallyClosed(data.replicaPath, data.manuallyClosedAt);
+      replicaVolatileStore.setManuallyClosedAt(data.replicaPath, data.manuallyClosedAt);
     });
   });
   onCleanup(() => {
@@ -590,8 +616,12 @@ const ProjectPanel: Component = () => {
     // presence is the discriminator "reopen of an already-run replica" vs
     // "genuinely fresh first launch". Carry a resume intent so the eventual
     // create injects --continue (Claude still disk-gates it via claude_project_exists).
+    // #748: read through the volatile layer — a close event that has not been
+    // through a discovery reload yet lives only there.
     const gitRepos = buildGitRepos(replica);
-    const resumeOnLaunch = !!(replica.autoClosedAt || replica.manuallyClosedAt);
+    const resumeOnLaunch = !!(
+      effectiveAutoClosedAt(replica) || effectiveManuallyClosedAt(replica)
+    );
 
     setPendingLaunch({
       path: replica.path,
@@ -966,7 +996,7 @@ const ProjectPanel: Component = () => {
           const session = replicaSession(wg, replica);
           const repos = session && session.gitRepos.length > 0
             ? session.gitRepos
-            : configuredReplicaRepoBadges(replica, wg);
+            : configuredReplicaRepoBadgesLive(replica, wg);
           return joinSearchText(
             taskTitle,
             stripFrontmatter(taskTitle ?? ""),
@@ -1528,12 +1558,28 @@ const ProjectPanel: Component = () => {
         const teamsCollapsedKey = projectPanelCollapseKey(proj.path, "teams");
         const hasLoopTargets = () =>
           proj.workgroups.some((wg) => wg.agents.some((agent) => agent.isCoordinator));
+        // #748 — pair objects are the <For> keys of the coordinator list, so
+        // they must keep identity across memo re-runs (with coordSortByActivity
+        // on, every session busy→idle markActivity re-runs this memo; fresh
+        // pairs would dispose and re-create every coordinator row — the exact
+        // lost-click mechanism this fix removes). Reuse the cached pair while
+        // its replica+wg objects are unchanged; <For> then MOVES rows on
+        // reorder instead of re-creating them.
+        const coordinatorPairCache = new Map<string, { replica: AcAgentReplica; wg: AcWorkgroup }>();
         const naturalCoordinatorItems = createMemo(() => {
           const result: { replica: AcAgentReplica; wg: AcWorkgroup }[] = [];
           for (const wg of groupVisibleWorkgroups()) {
             for (const replica of wg.agents) {
               if (replica.isCoordinator) {
-                result.push({ replica, wg });
+                const key = coordinatorItemKey({ replica, wg });
+                const cached = coordinatorPairCache.get(key);
+                if (cached && cached.replica === replica && cached.wg === wg) {
+                  result.push(cached);
+                } else {
+                  const pair = { replica, wg };
+                  coordinatorPairCache.set(key, pair);
+                  result.push(pair);
+                }
               }
             }
           }
@@ -1814,7 +1860,7 @@ const ProjectPanel: Component = () => {
             const s = session();
             return s && s.gitRepos.length > 0
               ? s.gitRepos
-              : configuredReplicaRepoBadges(replica, wg);
+              : configuredReplicaRepoBadgesLive(replica, wg);
           });
           // #552/#580 coordinator idle badge. The value is now the unified
           // team-idle anchor (#580): minutes since the whole team was last truly
@@ -1824,36 +1870,39 @@ const ProjectPanel: Component = () => {
           // the FE derivation is unchanged. A createMemo (NOT an IIFE — the IIFE
           // froze; confirmed blocker) so it subscribes to clockStore.nowMs (the
           // live 30s tick) and settingsStore.current (threshold edits apply
-          // instantly). replica.lastUserMessageAt is a plain prop read; a reset
-          // event recreates this row via the keyed <For>, re-running the memo.
+          // instantly). #748: the anchor reads through the volatile live layer
+          // (effectiveLastUserMessageAt), which the memo subscribes to — a clock
+          // event updates this badge in place instead of re-creating the row.
           const idleBadge = createMemo(() =>
             isCoord()
               ? coordinatorIdleBadge(
-                  replica.lastUserMessageAt,
+                  effectiveLastUserMessageAt(replica),
                   clockStore.nowMs,
                   settingsStore.current
                 )
               : null
           );
           // #552 auto-closed pill. Driven by the persisted autoClosedAt marker,
-          // patched in place. #580: MUTUALLY EXCLUSIVE with the minutes badge —
-          // when autoClosed() is true the counter is gated off (XOR below), so a
-          // closed team shows ONLY the gray AUTO-CLOSED pill; clearing the marker
-          // on reopen makes autoClosed() false and the counter returns.
+          // read through the volatile live layer (#748). #580: MUTUALLY
+          // EXCLUSIVE with the minutes badge — when autoClosed() is true the
+          // counter is gated off (XOR below), so a closed team shows ONLY the
+          // gray AUTO-CLOSED pill; clearing the marker on reopen makes
+          // autoClosed() false and the counter returns.
           // #589: ALSO gate on liveness. On raise the dot turns green from the
-          // sessionsStore (live session), but a discovery reload can clobber the
-          // event-cleared autoClosedAt back to its stale value (reloadProject's
-          // wholesale `workgroups` replace, project.ts:311-323), leaving the pill
-          // stuck while the dot is green. An auto-closed team is DESTROYED, so it is
-          // never live — there is no legitimate "live + auto-closed" state. Gating
-          // on `!live` hides the pill the moment the session goes live, reusing the
-          // exact signal the status dot reads, so it self-heals regardless of the
-          // stale marker; the XOR'd idle counter returns automatically. Inlined
-          // isSessionLive(session()) (=== isLive() below) because createMemo runs
-          // EAGERLY and `isLive` is declared further down — calling it here would
-          // hit its temporal dead zone for a coordinator already auto-closed at mount.
+          // sessionsStore (live session), but a discovery reload can still
+          // surface a stale marker (reloadProject supersedes the event-cleared
+          // override with a snapshot that may predate the clear), leaving the
+          // pill stuck while the dot is green. An auto-closed team is DESTROYED,
+          // so it is never live — there is no legitimate "live + auto-closed"
+          // state. Gating on `!live` hides the pill the moment the session goes
+          // live, reusing the exact signal the status dot reads, so it
+          // self-heals regardless of the stale marker; the XOR'd idle counter
+          // returns automatically. Inlined isSessionLive(session()) (===
+          // isLive() below) because createMemo runs EAGERLY and `isLive` is
+          // declared further down — calling it here would hit its temporal dead
+          // zone for a coordinator already auto-closed at mount.
           const autoClosed = createMemo(
-            () => isCoord() && !!replica.autoClosedAt && !isSessionLive(session())
+            () => isCoord() && !!effectiveAutoClosedAt(replica) && !isSessionLive(session())
           );
           // #588 manually-closed pill. Mirrors autoClosed, but ALSO gated on
           // !isSessionLive(session()): a dormant coordinator has no live session
@@ -1863,7 +1912,7 @@ const ProjectPanel: Component = () => {
           // isSessionLive(session()), NOT isLive() — isLive is declared later and
           // this memo is eager (TDZ).
           const manuallyClosed = createMemo(
-            () => isCoord() && !!replica.manuallyClosedAt && !isSessionLive(session())
+            () => isCoord() && !!effectiveManuallyClosedAt(replica) && !isSessionLive(session())
           );
           // #580 idle-badge tooltip. The auto-close clause is appended ONLY when
           // the setting is enabled: Decision 3 keeps the badge (and its red >=60

--- a/src/sidebar/stores/project-merge.test.ts
+++ b/src/sidebar/stores/project-merge.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import type { AcAgentReplica, AcDiscoveryResult, AcLoopSummary, AcWorkgroup } from "../../shared/types";
+import type { ProjectState } from "./project";
+import { deepEqual, mergeDiscoveryResult } from "./project-merge";
+
+// #748 — the identity-preserving discovery merge. Object references drive the
+// reference-keyed <For>s in ProjectPanel: every ref preserved here is a DOM row
+// NOT disposed/re-created on reload (and a click over it NOT lost).
+
+const PROJECT_PATH = "C:\\Users\\Maria\\Project";
+
+function makeReplica(path: string, overrides: Partial<AcAgentReplica> = {}): AcAgentReplica {
+  return {
+    name: path.split(/[\\/]/).pop() ?? "agent",
+    path,
+    repoPaths: [],
+    isCoordinator: true,
+    ...overrides,
+  };
+}
+
+function makeWorkgroup(
+  name: string,
+  agents: AcAgentReplica[],
+  overrides: Partial<AcWorkgroup> = {}
+): AcWorkgroup {
+  return { name, path: `${PROJECT_PATH}\\.ac\\${name}`, task: null, agents, ...overrides };
+}
+
+function makeLoop(id: string, overrides: Partial<AcLoopSummary> = {}): AcLoopSummary {
+  return {
+    id,
+    name: id,
+    enabled: false,
+    expr: "0 9 * * 1-5",
+    timezone: "local",
+    targetKind: "workgroupCoordinator",
+    workgroup: "wg-1-team",
+    promptPreview: "preview",
+    busyCoordinator: "skip",
+    path: `${PROJECT_PATH}\\.ac\\_loop_${id}`,
+    configPath: `${PROJECT_PATH}\\.ac\\_loop_${id}\\config.toml`,
+    lastCheckedAt: null,
+    lastDueAt: null,
+    lastDeliveredAt: null,
+    lastResult: null,
+    pendingDueAt: null,
+    lastMissedClosedAt: null,
+    nextDueAt: null,
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Partial<AcDiscoveryResult> = {}): AcDiscoveryResult {
+  return {
+    workgroups: [],
+    agents: [],
+    teams: [],
+    loops: [],
+    contextTemplateUpdates: [],
+    ...overrides,
+  };
+}
+
+function makeProject(result: AcDiscoveryResult): ProjectState {
+  return {
+    path: PROJECT_PATH,
+    folderName: "Project",
+    workgroups: result.workgroups,
+    agents: result.agents,
+    teams: result.teams,
+    loops: result.loops,
+    contextTemplateUpdates: result.contextTemplateUpdates,
+  };
+}
+
+const COORD_A = `${PROJECT_PATH}\\.ac\\wg-1-team\\__agent_coord-a`;
+const COORD_B = `${PROJECT_PATH}\\.ac\\wg-1-team\\__agent_coord-b`;
+const COORD_C = `${PROJECT_PATH}\\.ac\\wg-2-team\\__agent_coord-c`;
+
+/** Two workgroups + a loop, built FRESH each call so every object reference
+ *  differs between snapshots even when the data is identical. */
+function snapshot(): AcDiscoveryResult {
+  return makeResult({
+    workgroups: [
+      makeWorkgroup("wg-1-team", [makeReplica(COORD_A), makeReplica(COORD_B)]),
+      makeWorkgroup("wg-2-team", [makeReplica(COORD_C)]),
+    ],
+    teams: [{ name: "dev-team", agents: ["coord-a"], coordinator: "coord-a" }],
+    loops: [makeLoop("standup")],
+  });
+}
+
+describe("mergeDiscoveryResult (#748)", () => {
+  it("returns the existing project object itself for an identical snapshot", () => {
+    const existing = makeProject(snapshot());
+
+    const merged = mergeDiscoveryResult(existing, snapshot());
+
+    expect(merged).toBe(existing);
+  });
+
+  it("re-creates only the entities whose data changed, preserving every sibling reference", () => {
+    const existing = makeProject(snapshot());
+    const next = snapshot();
+    next.workgroups[0].agents[0] = makeReplica(COORD_A, { currentProfile: "B" });
+
+    const merged = mergeDiscoveryResult(existing, next);
+
+    expect(merged).not.toBe(existing);
+    // Changed chain: wg-1 and coord-a are new objects.
+    expect(merged.workgroups[0]).not.toBe(existing.workgroups[0]);
+    expect(merged.workgroups[0].agents[0]).not.toBe(existing.workgroups[0].agents[0]);
+    expect(merged.workgroups[0].agents[0].currentProfile).toBe("B");
+    // Untouched siblings keep identity: coord-b inside the changed wg, the
+    // whole wg-2, and the teams/loops arrays.
+    expect(merged.workgroups[0].agents[1]).toBe(existing.workgroups[0].agents[1]);
+    expect(merged.workgroups[1]).toBe(existing.workgroups[1]);
+    expect(merged.teams).toBe(existing.teams);
+    expect(merged.loops).toBe(existing.loops);
+    expect(merged.contextTemplateUpdates).toBe(existing.contextTemplateUpdates);
+  });
+
+  it("a loop-only change leaves the workgroup tree untouched", () => {
+    const existing = makeProject(snapshot());
+    const next = snapshot();
+    next.loops = [makeLoop("standup", { enabled: true })];
+
+    const merged = mergeDiscoveryResult(existing, next);
+
+    expect(merged).not.toBe(existing);
+    expect(merged.workgroups).toBe(existing.workgroups);
+    expect(merged.loops).not.toBe(existing.loops);
+    expect(merged.loops[0].enabled).toBe(true);
+  });
+
+  it("matches entities by NORMALIZED path, so a path-shape drift updates in place", () => {
+    const existing = makeProject(snapshot());
+    const next = snapshot();
+    next.workgroups[1] = makeWorkgroup("wg-2-team", [
+      makeReplica("c:/users/maria/project/.ac/wg-2-team/__agent_coord-c"),
+    ]);
+    next.workgroups[1].path = "c:/users/maria/project/.ac/wg-2-team";
+
+    const merged = mergeDiscoveryResult(existing, next);
+
+    // The drifted entity is recognized as the SAME entity (matched by
+    // normalized key) and adopts the new path — a textual path change IS a
+    // data change, so its object is new — while the untouched sibling
+    // workgroup keeps identity.
+    expect(merged.workgroups).toHaveLength(2);
+    expect(merged.workgroups[1]).not.toBe(existing.workgroups[1]);
+    expect(merged.workgroups[1].path).toBe("c:/users/maria/project/.ac/wg-2-team");
+    expect(merged.workgroups[0]).toBe(existing.workgroups[0]);
+  });
+
+  it("added and removed entities change the array; survivors keep identity", () => {
+    const existing = makeProject(snapshot());
+    const next = snapshot();
+    next.workgroups = [next.workgroups[0]]; // wg-2 removed
+
+    const merged = mergeDiscoveryResult(existing, next);
+
+    expect(merged.workgroups).toHaveLength(1);
+    expect(merged.workgroups[0]).toBe(existing.workgroups[0]);
+  });
+
+  it("a reorder with identical entities still preserves item identity", () => {
+    const existing = makeProject(snapshot());
+    const next = snapshot();
+    next.workgroups = [next.workgroups[1], next.workgroups[0]];
+
+    const merged = mergeDiscoveryResult(existing, next);
+
+    expect(merged.workgroups[0]).toBe(existing.workgroups[1]);
+    expect(merged.workgroups[1]).toBe(existing.workgroups[0]);
+  });
+});
+
+describe("deepEqual (#748)", () => {
+  it("treats an undefined-valued key and a missing key as equal (optional fields)", () => {
+    expect(deepEqual({ a: 1, b: undefined }, { a: 1 })).toBe(true);
+    expect(deepEqual({ a: 1 }, { a: 1, b: undefined })).toBe(true);
+    expect(deepEqual({ a: 1 }, { a: 1, b: null })).toBe(false);
+  });
+
+  it("compares nested arrays/objects structurally", () => {
+    expect(deepEqual({ a: [{ b: 1 }] }, { a: [{ b: 1 }] })).toBe(true);
+    expect(deepEqual({ a: [{ b: 1 }] }, { a: [{ b: 2 }] })).toBe(false);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+    expect(deepEqual({ a: [1] }, { a: { 0: 1 } })).toBe(false);
+    expect(deepEqual(null, {})).toBe(false);
+  });
+});

--- a/src/sidebar/stores/project-merge.ts
+++ b/src/sidebar/stores/project-merge.ts
@@ -1,0 +1,121 @@
+import type { AcDiscoveryResult, AcWorkgroup } from "../../shared/types";
+import type { ProjectState } from "./project";
+import { normalizeProjectPathForCompare } from "./project-refresh";
+
+/**
+ * #748 — identity-preserving merge of a fresh discovery snapshot over the
+ * loaded project state. ProjectPanel keys everything with reference-keyed
+ * <For>s, so an object that changes reference is disposed and re-created in
+ * the DOM — and a click whose press straddles that swap is lost (no `click`
+ * for a detached mousedown target).
+ *
+ * DOM guarantee is PROJECT-granular: a fully identical snapshot returns the
+ * existing project object itself (the store skips the write — zero DOM work),
+ * and other projects always keep their reference. When something inside a
+ * project DID change, that project's reference changes and its whole <For>
+ * row re-renders; the nested entity references this merge still preserves do
+ * not keep DOM alive in that case (the row's nested <For>s are fresh
+ * instances) — they keep downstream memos/derivations cheap and make the
+ * store contents diff-friendly. Finer-than-project DOM stability would need
+ * the createStore+reconcile refactor that is explicitly out of scope here.
+ */
+
+/** Structural equality for JSON-shaped discovery data (no functions/Dates).
+ *  A key holding `undefined` and a missing key compare as equal, matching
+ *  how the optional fields behave everywhere they are read. */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") return false;
+  const aIsArray = Array.isArray(a);
+  if (aIsArray !== Array.isArray(b)) return false;
+  if (aIsArray) {
+    const arrA = a as unknown[];
+    const arrB = b as unknown[];
+    if (arrA.length !== arrB.length) return false;
+    for (let i = 0; i < arrA.length; i++) {
+      if (!deepEqual(arrA[i], arrB[i])) return false;
+    }
+    return true;
+  }
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+  for (const key in objA) {
+    if (!deepEqual(objA[key], objB[key])) return false;
+  }
+  for (const key in objB) {
+    if (!(key in objA) && objB[key] !== undefined) return false;
+  }
+  return true;
+}
+
+/**
+ * Keyed identity-preserving array merge: each incoming item keeps the existing
+ * object reference when the entity (matched by key) is unchanged; only changed
+ * or new entities take the incoming object. Returns the EXISTING array
+ * reference when nothing changed at any position.
+ */
+function mergeKeyedArray<T>(
+  existing: readonly T[],
+  incoming: readonly T[],
+  keyOf: (item: T) => string,
+  mergeItem: (oldItem: T, newItem: T) => T = (oldItem, newItem) =>
+    deepEqual(oldItem, newItem) ? oldItem : newItem
+): T[] {
+  const byKey = new Map<string, T>();
+  for (const item of existing) byKey.set(keyOf(item), item);
+  let changed = incoming.length !== existing.length;
+  const merged = incoming.map((newItem, index) => {
+    const oldItem = byKey.get(keyOf(newItem));
+    const result = oldItem === undefined ? newItem : mergeItem(oldItem, newItem);
+    if (result !== existing[index]) changed = true;
+    return result;
+  });
+  // The only cast in this module: `existing` is only ever the caller's own
+  // mutable array, accepted as readonly for variance.
+  return changed ? merged : (existing as T[]);
+}
+
+/** Preserve per-agent references inside a workgroup that changed elsewhere. */
+function mergeWorkgroup(oldWg: AcWorkgroup, newWg: AcWorkgroup): AcWorkgroup {
+  if (deepEqual(oldWg, newWg)) return oldWg;
+  const agents = mergeKeyedArray(oldWg.agents, newWg.agents, (agent) =>
+    normalizeProjectPathForCompare(agent.path)
+  );
+  return { ...newWg, agents };
+}
+
+/** Merge a discovery result into the loaded project, preserving identity of
+ *  every unchanged entity. Returns `existing` itself when nothing changed. */
+export function mergeDiscoveryResult(
+  existing: ProjectState,
+  result: AcDiscoveryResult
+): ProjectState {
+  const workgroups = mergeKeyedArray(
+    existing.workgroups,
+    result.workgroups,
+    (wg) => normalizeProjectPathForCompare(wg.path),
+    mergeWorkgroup
+  );
+  const agents = mergeKeyedArray(existing.agents, result.agents, (agent) =>
+    normalizeProjectPathForCompare(agent.path)
+  );
+  const teams = mergeKeyedArray(existing.teams, result.teams, (team) => team.name);
+  const loops = mergeKeyedArray(existing.loops, result.loops, (loop) => loop.id);
+  const contextTemplateUpdates = deepEqual(
+    existing.contextTemplateUpdates,
+    result.contextTemplateUpdates
+  )
+    ? existing.contextTemplateUpdates
+    : result.contextTemplateUpdates;
+
+  if (
+    workgroups === existing.workgroups &&
+    agents === existing.agents &&
+    teams === existing.teams &&
+    loops === existing.loops &&
+    contextTemplateUpdates === existing.contextTemplateUpdates
+  ) {
+    return existing;
+  }
+  return { ...existing, workgroups, agents, teams, loops, contextTemplateUpdates };
+}

--- a/src/sidebar/stores/project.test.ts
+++ b/src/sidebar/stores/project.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AcAgentReplica, AcWorkgroup } from "../../shared/types";
+import type { AcAgentReplica, AcLoopSummary, AcWorkgroup } from "../../shared/types";
 
 const m = vi.hoisted(() => ({
   open: vi.fn(),
+  newProject: vi.fn(),
   discover: vi.fn(),
   getSettings: vi.fn(),
   updateSettings: vi.fn(),
@@ -11,6 +12,7 @@ const m = vi.hoisted(() => ({
 vi.mock("../../shared/ipc", () => ({
   ProjectAPI: {
     open: m.open,
+    new: m.newProject,
     discover: m.discover,
   },
   SettingsAPI: {
@@ -23,6 +25,7 @@ vi.mock("../../shared/ipc", () => ({
 }));
 
 import { projectStore } from "./project";
+import { effectiveAutoClosedAt, replicaVolatileStore } from "./replica-volatile";
 
 const PROJECT_PATH = "C:\\Users\\Maria\\Project";
 
@@ -126,62 +129,197 @@ describe("projectStore", () => {
     expect(projectStore.initState).toEqual({ attempted: false, pathCount: 0 });
   });
 
-  // #552 coordinator idle badge + auto-closed pill. Both patch methods match by
-  // NORMALIZED path: the event carries the session working_directory, which can
-  // differ in slash/case from the discovery path on Windows. These cover that
-  // load-bearing match plus the field-level set/clear semantics.
-  describe("coordinator clock + auto-closed patches (#552)", () => {
-    const COORD_A = `${PROJECT_PATH}\\.ac\\wg-1-team\\__agent_coord-a`;
+  // #748 — identity preservation. Object references drive ProjectPanel's
+  // reference-keyed <For>s: every reference these methods preserve is a DOM row
+  // NOT disposed/re-created (and a click over it NOT lost). The #552 event
+  // patch semantics (normalized-path match, set/clear) moved to
+  // replicaVolatileStore — see replica-volatile.test.ts.
+  describe("identity preservation (#748)", () => {
+    const WG_1 = `${PROJECT_PATH}\\.ac\\wg-1-team`;
+    const COORD_A = `${WG_1}\\__agent_coord-a`;
     const COORD_B = `${PROJECT_PATH}\\.ac\\wg-2-team\\__agent_coord-b`;
-    // Same replica as COORD_A but lower-cased with forward slashes, as the
-    // backend session working_directory arrives on the clock/auto-close events.
-    const COORD_A_EVENT = "c:/users/maria/project/.ac/wg-1-team/__agent_coord-a";
+    // Event/task paths arrive with the session working_directory shape, which
+    // can differ in slash/case from the discovery path on Windows.
+    const WG_1_EVENT = "c:/users/maria/project/.ac/wg-1-team";
 
-    it("updateCoordinatorClock patches the matching replica by normalized path and leaves others untouched", async () => {
-      await loadProjectWith([
-        makeWorkgroup("wg-1-team", [
-          // A carries a pre-existing auto-closed marker to prove the clock patch
-          // preserves sibling fields (it must only touch lastUserMessageAt).
-          makeReplica(COORD_A, { autoClosedAt: "2026-06-19T17:00:00Z" }),
-          makeReplica(COORD_B, { lastUserMessageAt: "2020-01-01T00:00:00Z" }),
-        ]),
-      ]);
+    function twoWorkgroups(coordAOverrides: Partial<AcAgentReplica> = {}): AcWorkgroup[] {
+      return [
+        makeWorkgroup("wg-1-team", [makeReplica(COORD_A, coordAOverrides)]),
+        makeWorkgroup("wg-2-team", [makeReplica(COORD_B)]),
+      ];
+    }
 
-      projectStore.updateCoordinatorClock(COORD_A_EVENT, "2026-06-19T18:00:00Z");
+    it("reloadProject with an identical snapshot keeps every object reference", async () => {
+      await loadProjectWith(twoWorkgroups());
+      const beforeProjects = projectStore.projects;
+      const beforeProject = beforeProjects[0];
 
-      const a = findReplica(COORD_A);
-      expect(a?.lastUserMessageAt).toBe("2026-06-19T18:00:00Z");
-      expect(a?.autoClosedAt).toBe("2026-06-19T17:00:00Z"); // sibling field preserved
-      // Non-matching replica is left exactly as discovered.
-      expect(findReplica(COORD_B)?.lastUserMessageAt).toBe("2020-01-01T00:00:00Z");
+      // Fresh (deep-equal but reference-distinct) snapshot: the preserved refs
+      // below must come from the merge, not from object reuse in the mock.
+      m.discover.mockResolvedValueOnce({
+        workgroups: twoWorkgroups(),
+        agents: [],
+        teams: [],
+        loops: [],
+      });
+      await projectStore.reloadProject(PROJECT_PATH);
+
+      expect(projectStore.projects).toBe(beforeProjects);
+      expect(projectStore.projects[0]).toBe(beforeProject);
     });
 
-    it("updateCoordinatorAutoClosed sets autoClosedAt from a string by normalized path and leaves others untouched", async () => {
-      await loadProjectWith([
-        makeWorkgroup("wg-1-team", [
-          makeReplica(COORD_A),
-          makeReplica(COORD_B),
-        ]),
-      ]);
+    it("reloadProject re-creates only the changed entities, preserving siblings", async () => {
+      await loadProjectWith(twoWorkgroups());
+      const before = projectStore.projects[0];
 
-      projectStore.updateCoordinatorAutoClosed(COORD_A_EVENT, "2026-06-19T18:05:00Z");
+      m.discover.mockResolvedValueOnce({
+        workgroups: twoWorkgroups({ currentProfile: "B" }),
+        agents: [],
+        teams: [],
+        loops: [],
+      });
+      await projectStore.reloadProject(PROJECT_PATH);
 
-      expect(findReplica(COORD_A)?.autoClosedAt).toBe("2026-06-19T18:05:00Z");
-      expect(findReplica(COORD_B)?.autoClosedAt).toBeUndefined();
+      const after = projectStore.projects[0];
+      expect(after).not.toBe(before);
+      expect(after.workgroups[0]).not.toBe(before.workgroups[0]);
+      expect(findReplica(COORD_A)?.currentProfile).toBe("B");
+      // The untouched sibling workgroup keeps its identity (its DOM survives).
+      expect(after.workgroups[1]).toBe(before.workgroups[1]);
     });
 
-    it("updateCoordinatorAutoClosed clears autoClosedAt when passed null (reopen)", async () => {
-      await loadProjectWith([
-        makeWorkgroup("wg-1-team", [
-          makeReplica(COORD_A, { autoClosedAt: "2026-06-19T18:05:00Z" }),
-        ]),
-      ]);
-      // Precondition: the marker is present before the clear.
-      expect(findReplica(COORD_A)?.autoClosedAt).toBe("2026-06-19T18:05:00Z");
+    it("a dedup-discarded duplicate load does NOT wipe live volatile overrides (#748 review fix)", async () => {
+      await loadProjectWith(twoWorkgroups());
+      const before = projectStore.projects;
+      // A live event lands after the initial load.
+      replicaVolatileStore.setAutoClosedAt(COORD_A, "2026-06-19T18:05:00Z");
 
-      projectStore.updateCoordinatorAutoClosed(COORD_A_EVENT, null);
+      // createAndLoad on the already-loaded project: discovery runs but the
+      // inner dedup guard discards the snapshot — the store keeps the ORIGINAL
+      // objects, so the newer live override must survive too.
+      m.newProject.mockResolvedValueOnce({ path: PROJECT_PATH });
+      m.discover.mockResolvedValueOnce({
+        workgroups: twoWorkgroups(),
+        agents: [],
+        teams: [],
+        loops: [],
+      });
+      await projectStore.createAndLoad(PROJECT_PATH);
 
-      expect(findReplica(COORD_A)?.autoClosedAt).toBeUndefined();
+      expect(projectStore.projects).toBe(before);
+      expect(effectiveAutoClosedAt(findReplica(COORD_A)!)).toBe("2026-06-19T18:05:00Z");
+    });
+
+    it("updateWorkgroupTask normalizes an event's null taskTitle to undefined (no phantom diff vs the snapshot)", async () => {
+      await loadProjectWith(twoWorkgroups());
+
+      // The task event serializes taskTitle: null; the discovery snapshot OMITS
+      // the field. Storing null would make the next reload's deepEqual see a
+      // phantom change and re-create the row.
+      projectStore.updateWorkgroupTask(WG_1_EVENT, "task body", null);
+      const afterEvent = projectStore.projects;
+      expect(afterEvent[0].workgroups[0].taskTitle).toBeUndefined();
+
+      // A fresh deep-equal snapshot (taskTitle omitted, same task) is a no-op.
+      m.discover.mockResolvedValueOnce({
+        workgroups: [
+          { ...makeWorkgroup("wg-1-team", [makeReplica(COORD_A)]), task: "task body" },
+          makeWorkgroup("wg-2-team", [makeReplica(COORD_B)]),
+        ],
+        agents: [],
+        teams: [],
+        loops: [],
+      });
+      await projectStore.reloadProject(PROJECT_PATH);
+      expect(projectStore.projects).toBe(afterEvent);
+
+      // A repeat of the same event (null title again) is also a strict no-op.
+      projectStore.updateWorkgroupTask(WG_1_EVENT, "task body", null);
+      expect(projectStore.projects).toBe(afterEvent);
+    });
+
+    it("reloadProject supersedes volatile overrides with the fresh snapshot", async () => {
+      await loadProjectWith(twoWorkgroups());
+      replicaVolatileStore.setAutoClosedAt(COORD_A, "2026-06-19T18:05:00Z");
+      expect(effectiveAutoClosedAt(findReplica(COORD_A)!)).toBe("2026-06-19T18:05:00Z");
+
+      m.discover.mockResolvedValueOnce({
+        workgroups: twoWorkgroups({ autoClosedAt: "2026-06-19T19:00:00Z" }),
+        agents: [],
+        teams: [],
+        loops: [],
+      });
+      await projectStore.reloadProject(PROJECT_PATH);
+
+      // Discovery wins on reload (the override is cleared), events re-patch after.
+      expect(effectiveAutoClosedAt(findReplica(COORD_A)!)).toBe("2026-06-19T19:00:00Z");
+    });
+
+    it("updateWorkgroupTask clones only the matched workgroup's chain, by normalized path", async () => {
+      await loadProjectWith(twoWorkgroups());
+      const before = projectStore.projects;
+
+      projectStore.updateWorkgroupTask(WG_1_EVENT, "task body", "New title");
+
+      const after = projectStore.projects;
+      expect(after).not.toBe(before);
+      expect(after[0].workgroups[0]).not.toBe(before[0].workgroups[0]);
+      expect(after[0].workgroups[0].taskTitle).toBe("New title");
+      // The matched workgroup's agents array and the sibling workgroup keep identity.
+      expect(after[0].workgroups[0].agents).toBe(before[0].workgroups[0].agents);
+      expect(after[0].workgroups[1]).toBe(before[0].workgroups[1]);
+    });
+
+    it("updateWorkgroupTask is a strict no-op on no match or no change", async () => {
+      await loadProjectWith(twoWorkgroups());
+      const before = projectStore.projects;
+
+      projectStore.updateWorkgroupTask("C:\\elsewhere\\wg-9", "task", "Title");
+      expect(projectStore.projects).toBe(before);
+
+      projectStore.updateWorkgroupTask(WG_1_EVENT, "task body", "Same title");
+      const mid = projectStore.projects;
+      projectStore.updateWorkgroupTask(WG_1_EVENT, "task body", "Same title");
+      expect(projectStore.projects).toBe(mid);
+    });
+
+    it("upsertLoop and removeLoop are strict no-ops for identical or unknown data", async () => {
+      const loop: AcLoopSummary = {
+        id: "standup",
+        name: "Standup",
+        enabled: false,
+        expr: "0 9 * * 1-5",
+        timezone: "local",
+        targetKind: "workgroupCoordinator",
+        workgroup: "wg-1-team",
+        promptPreview: "preview",
+        busyCoordinator: "skip",
+        path: `${PROJECT_PATH}\\.ac\\_loop_standup`,
+        configPath: `${PROJECT_PATH}\\.ac\\_loop_standup\\config.toml`,
+        lastCheckedAt: null,
+        lastDueAt: null,
+        lastDeliveredAt: null,
+        lastResult: null,
+        pendingDueAt: null,
+        lastMissedClosedAt: null,
+        nextDueAt: null,
+      };
+      await loadProjectWith(twoWorkgroups());
+
+      projectStore.upsertLoop(PROJECT_PATH, loop);
+      const withLoop = projectStore.projects;
+      expect(withLoop[0].loops).toHaveLength(1);
+
+      // Duplicate event with a deep-equal summary: identity untouched.
+      projectStore.upsertLoop(PROJECT_PATH, { ...loop });
+      expect(projectStore.projects).toBe(withLoop);
+
+      // Unknown loop id: identity untouched.
+      projectStore.removeLoop(PROJECT_PATH, "nope");
+      expect(projectStore.projects).toBe(withLoop);
+
+      projectStore.removeLoop(PROJECT_PATH, "standup");
+      expect(projectStore.projects[0].loops).toHaveLength(0);
     });
   });
 });

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -1,7 +1,8 @@
-import { createSignal } from "solid-js";
+import { batch, createSignal } from "solid-js";
 import type {
   AcWorkgroup,
   AcAgentMatrix,
+  AcDiscoveryResult,
   AcTeam,
   AcLoopSummary,
   ContextTemplateUpdate,
@@ -11,6 +12,8 @@ import {
   findLoadedProjectPathForRefresh,
   normalizeProjectPathForCompare,
 } from "./project-refresh";
+import { deepEqual, mergeDiscoveryResult } from "./project-merge";
+import { replicaVolatileStore } from "./replica-volatile";
 
 export interface ProjectState {
   path: string;
@@ -39,6 +42,47 @@ let loadingCount = 0;
 
 function normalizePath(p: string): string {
   return normalizeProjectPathForCompare(p);
+}
+
+/** Replica paths of every workgroup agent in a project/discovery shape — the
+ *  set of paths whose live volatile overrides a fresh snapshot supersedes. */
+function workgroupReplicaPaths(source: { workgroups: AcWorkgroup[] }): string[] {
+  return source.workgroups.flatMap((wg) => wg.agents.map((agent) => agent.path));
+}
+
+/** Append a freshly discovered project unless an equivalent path is already
+ *  loaded (Round-1 G2 dedup: re-check against the BACKEND-absolutised regPath,
+ *  which may differ from the caller's input in case/slashes/`..` — closes the
+ *  double-render race when two concurrent calls pass differently-shaped
+ *  strings that resolve to the same registered entry). The volatile overrides
+ *  this snapshot supersedes are cleared ONLY when the append actually applied:
+ *  a dedup-discarded snapshot must not wipe live event overrides that are
+ *  newer than the state the store kept (#748). */
+function appendDiscoveredProject(regPath: string, result: AcDiscoveryResult) {
+  const folderName = regPath.replace(/\\/g, "/").split("/").pop() ?? "unknown";
+  const normalizedReg = normalizePath(regPath);
+  batch(() => {
+    let appended = false;
+    setProjects((prev) => {
+      if (prev.some((p) => normalizePath(p.path) === normalizedReg)) return prev;
+      appended = true;
+      return [
+        ...prev,
+        {
+          path: regPath,
+          folderName,
+          workgroups: result.workgroups,
+          agents: result.agents,
+          teams: result.teams,
+          loops: result.loops,
+          contextTemplateUpdates: result.contextTemplateUpdates,
+        },
+      ];
+    });
+    if (appended) {
+      replicaVolatileStore.clearForPaths(workgroupReplicaPaths(result));
+    }
+  });
 }
 
 /** Stringify whatever a rejected Tauri command throws (usually the Err string). */
@@ -99,29 +143,7 @@ export const projectStore = {
         // when that case is expected.
         const reg = await ProjectAPI.open(path);
         const result = await ProjectAPI.discover(reg.path);
-        const folderName =
-          reg.path.replace(/\\/g, "/").split("/").pop() ?? "unknown";
-        // Round-1 G2: re-check against the BACKEND-absolutised reg.path
-        // (which may differ from the input `path` in case/slashes/`..`),
-        // mirroring the inner dedup pattern in createAndLoad. Closes the
-        // double-render race when two concurrent calls pass differently-
-        // shaped strings that resolve to the same registered entry.
-        const normalizedReg = normalizePath(reg.path);
-        setProjects((prev) => {
-          if (prev.some((p) => normalizePath(p.path) === normalizedReg)) return prev;
-          return [
-            ...prev,
-            {
-              path: reg.path,
-              folderName,
-              workgroups: result.workgroups,
-              agents: result.agents,
-              teams: result.teams,
-              loops: result.loops,
-              contextTemplateUpdates: result.contextTemplateUpdates,
-            },
-          ];
-        });
+        appendDiscoveredProject(reg.path, result);
         setLastLoadError(null);
       } catch (e) {
         // Round-1 G11: surface the failure instead of only logging it. The
@@ -161,24 +183,7 @@ export const projectStore = {
     const reg = await ProjectAPI.new(path);
     // After ensuring Project AC Root exists and persistence is set, run discovery for UI.
     const result = await ProjectAPI.discover(reg.path);
-    const folderName =
-      reg.path.replace(/\\/g, "/").split("/").pop() ?? "unknown";
-    const normalized = normalizePath(reg.path);
-    setProjects((prev) => {
-      if (prev.some((p) => normalizePath(p.path) === normalized)) return prev;
-      return [
-        ...prev,
-        {
-          path: reg.path,
-          folderName,
-          workgroups: result.workgroups,
-          agents: result.agents,
-          teams: result.teams,
-          loops: result.loops,
-          contextTemplateUpdates: result.contextTemplateUpdates,
-        },
-      ];
-    });
+    appendDiscoveredProject(reg.path, result);
   },
 
   /** Full open flow: pick folder, check Project AC Root, auto-load if found */
@@ -193,131 +198,83 @@ export const projectStore = {
     return { picked, hasWorkspace };
   },
 
-  /** Update a replica's branch from the discovery branch watcher */
-  updateReplicaBranch(replicaPath: string, branch: string | null) {
-    setProjects((prev) =>
-      prev.map((proj) => ({
-        ...proj,
-        workgroups: proj.workgroups.map((wg) => ({
-          ...wg,
-          agents: wg.agents.map((a) =>
-            a.path === replicaPath
-              ? { ...a, repoBranch: branch ?? undefined }
-              : a
-          ),
-        })),
-      }))
-    );
-  },
+  // #748 — the former updateReplicaBranch / updateCoordinatorClock /
+  // updateCoordinatorAutoClosed / updateCoordinatorManuallyClosed patchers
+  // lived here and rebuilt EVERY project/workgroup object reference per event,
+  // which made ProjectPanel's reference-keyed <For>s dispose and re-create the
+  // whole clickable sidebar DOM (losing any click in flight). Those live
+  // fields are now written to replicaVolatileStore (stores/replica-volatile.ts)
+  // and read through its effective* accessors, so events never touch project
+  // identity.
 
-  /** #552/#580 patch a coordinator replica's lastUserMessageAt (which now carries
-   *  the unified team-idle anchor, #580 — "team idle since", not just the user's
-   *  last message) from the clock event. Match by NORMALIZED path (required, not
-   *  a deviation: the event path is the session working_directory, which can
-   *  differ in slash/case from the discovery path on Windows). Discovery reload
-   *  self-heals on any miss. */
-  updateCoordinatorClock(replicaPath: string, lastUserMessageAt: string) {
-    const target = normalizePath(replicaPath);
-    setProjects((prev) =>
-      prev.map((proj) => ({
-        ...proj,
-        workgroups: proj.workgroups.map((wg) => ({
-          ...wg,
-          agents: wg.agents.map((a) =>
-            normalizePath(a.path) === target ? { ...a, lastUserMessageAt } : a
-          ),
-        })),
-      }))
-    );
-  },
-
-  /** #552 patch a coordinator replica's autoClosedAt from the auto-close event.
-   *  A string sets the marker (auto-closed); `null` clears it (reopen). Matched
-   *  by normalized path, same as updateCoordinatorClock. */
-  updateCoordinatorAutoClosed(replicaPath: string, autoClosedAt: string | null) {
-    const target = normalizePath(replicaPath);
-    setProjects((prev) =>
-      prev.map((proj) => ({
-        ...proj,
-        workgroups: proj.workgroups.map((wg) => ({
-          ...wg,
-          agents: wg.agents.map((a) =>
-            normalizePath(a.path) === target
-              ? { ...a, autoClosedAt: autoClosedAt ?? undefined }
-              : a
-          ),
-        })),
-      }))
-    );
-  },
-
-  /** #588 patch a coordinator replica's manuallyClosedAt from the event.
-   *  A string sets the marker; `null` clears it (reopen). Matched by normalized
-   *  path, same as updateCoordinatorAutoClosed. */
-  updateCoordinatorManuallyClosed(replicaPath: string, manuallyClosedAt: string | null) {
-    const target = normalizePath(replicaPath);
-    setProjects((prev) =>
-      prev.map((proj) => ({
-        ...proj,
-        workgroups: proj.workgroups.map((wg) => ({
-          ...wg,
-          agents: wg.agents.map((a) =>
-            normalizePath(a.path) === target
-              ? { ...a, manuallyClosedAt: manuallyClosedAt ?? undefined }
-              : a
-          ),
-        })),
-      }))
-    );
-  },
-
-  /** Update a workgroup's TASK.md fields from the discovery watcher. */
+  /** Update a workgroup's TASK.md fields from the discovery watcher. Clones
+   *  ONLY the project + workgroup on the matched path (#748 — unrelated rows
+   *  must keep their object identity); no match or no change leaves the store
+   *  value untouched. `taskTitle` is normalized null→undefined: the task event
+   *  serializes an explicit null while the discovery snapshot OMITS the field
+   *  (`skip_serializing_if` on task_title), so storing null would make the
+   *  next reload's deepEqual see a phantom change and re-create the row. */
   updateWorkgroupTask(
     workgroupPath: string,
     task: string | null,
     taskTitle: string | null | undefined
   ) {
-
     const normalized = normalizePath(workgroupPath);
-    setProjects((prev) =>
-      prev.map((proj) => ({
-        ...proj,
-        workgroups: proj.workgroups.map((wg) =>
-          normalizePath(wg.path) === normalized
-            ? { ...wg, task, taskTitle }
-
-            : wg
-        ),
-      }))
-    );
+    const normalizedTitle = taskTitle ?? undefined;
+    setProjects((prev) => {
+      let anyChanged = false;
+      const next = prev.map((proj) => {
+        const index = proj.workgroups.findIndex(
+          (wg) => normalizePath(wg.path) === normalized
+        );
+        if (index === -1) return proj;
+        const wg = proj.workgroups[index];
+        if (wg.task === task && (wg.taskTitle ?? undefined) === normalizedTitle) return proj;
+        anyChanged = true;
+        const workgroups = proj.workgroups.slice();
+        workgroups[index] = { ...wg, task, taskTitle: normalizedTitle };
+        return { ...proj, workgroups };
+      });
+      return anyChanged ? next : prev;
+    });
   },
 
-  /** Apply a Loop summary returned by a mutation/event without waiting for discovery. */
+  /** Apply a Loop summary returned by a mutation/event without waiting for
+   *  discovery. Identity-preserving (#748): an already-identical summary (a
+   *  duplicate event) leaves the store value untouched. */
   upsertLoop(projectPath: string, loop: AcLoopSummary) {
     const normalized = normalizePath(projectPath);
-    setProjects((prev) =>
-      prev.map((proj) => {
+    setProjects((prev) => {
+      let anyChanged = false;
+      const next = prev.map((proj) => {
         if (normalizePath(proj.path) !== normalized) return proj;
         const existingIndex = proj.loops.findIndex((candidate) => candidate.id === loop.id);
+        if (existingIndex !== -1 && deepEqual(proj.loops[existingIndex], loop)) return proj;
+        anyChanged = true;
         const loops =
           existingIndex === -1
             ? [...proj.loops, loop]
             : proj.loops.map((candidate) => (candidate.id === loop.id ? loop : candidate));
         return { ...proj, loops };
-      })
-    );
+      });
+      return anyChanged ? next : prev;
+    });
   },
 
-  /** Remove a Loop summary returned by a delete event without waiting for discovery. */
+  /** Remove a Loop summary returned by a delete event without waiting for
+   *  discovery. Identity-preserving (#748): an unknown loop id is a no-op. */
   removeLoop(projectPath: string, loopId: string) {
     const normalized = normalizePath(projectPath);
-    setProjects((prev) =>
-      prev.map((proj) =>
-        normalizePath(proj.path) === normalized
-          ? { ...proj, loops: proj.loops.filter((loop) => loop.id !== loopId) }
-          : proj
-      )
-    );
+    setProjects((prev) => {
+      let anyChanged = false;
+      const next = prev.map((proj) => {
+        if (normalizePath(proj.path) !== normalized) return proj;
+        if (!proj.loops.some((loop) => loop.id === loopId)) return proj;
+        anyChanged = true;
+        return { ...proj, loops: proj.loops.filter((loop) => loop.id !== loopId) };
+      });
+      return anyChanged ? next : prev;
+    });
   },
 
   /** Re-discover a single project and update its data in place */
@@ -340,20 +297,30 @@ export const projectStore = {
               // discovery was awaiting. Let the queued discovery provide the next full state.
               continue;
             }
-            setProjects((prev) =>
-              prev.map((p) =>
-                normalizePath(p.path) === normalized
-                  ? {
-                      ...p,
-                      workgroups: result.workgroups,
-                      agents: result.agents,
-                      teams: result.teams,
-                      loops: result.loops,
-                      contextTemplateUpdates: result.contextTemplateUpdates,
-                    }
-                  : p
-              )
-            );
+            // #748 — identity-preserving merge: entities the snapshot did not
+            // change keep their object references (an identical snapshot is a
+            // complete no-op). The volatile overrides for the replicas this
+            // snapshot covers are superseded in the same batch — discovery
+            // wins on reload, events re-patch after, exactly as the old
+            // wholesale replace behaved — but ONLY when the project is
+            // actually loaded: clearing for a snapshot the map cannot apply
+            // would wipe live overrides while installing nothing.
+            const loaded = projects().some((p) => normalizePath(p.path) === normalized);
+            batch(() => {
+              setProjects((prev) => {
+                let anyChanged = false;
+                const next = prev.map((p) => {
+                  if (normalizePath(p.path) !== normalized) return p;
+                  const merged = mergeDiscoveryResult(p, result);
+                  if (merged !== p) anyChanged = true;
+                  return merged;
+                });
+                return anyChanged ? next : prev;
+              });
+              if (loaded) {
+                replicaVolatileStore.clearForPaths(workgroupReplicaPaths(result));
+              }
+            });
           } catch (e) {
             console.error("Failed to reload project:", e);
           }
@@ -378,7 +345,15 @@ export const projectStore = {
   /** Remove a project from the list by path */
   async removeProject(path: string) {
     const normalized = normalizePath(path);
-    setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== normalized));
+    const removed = projects().find((p) => normalizePath(p.path) === normalized);
+    batch(() => {
+      setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== normalized));
+      // #748 — drop the removed project's live overrides so a later re-add
+      // starts from its fresh discovery snapshot, not a stale live layer.
+      if (removed) {
+        replicaVolatileStore.clearForPaths(workgroupReplicaPaths(removed));
+      }
+    });
     await persistProjectPaths();
   },
 
@@ -394,21 +369,25 @@ export const projectStore = {
     fileSha256: string
   ) {
     const normalized = normalizePath(projectPath);
-    setProjects((prev) =>
-      prev.map((project) =>
-        normalizePath(project.path) === normalized
-          ? {
-              ...project,
-              contextTemplateUpdates: project.contextTemplateUpdates.filter(
-                (update) =>
-                  update.filename !== filename ||
-                  update.currentDefaultSha256 !== defaultSha256 ||
-                  update.currentFileSha256 !== fileSha256
-              ),
-            }
-          : project
-      )
-    );
+    setProjects((prev) => {
+      let anyChanged = false;
+      const next = prev.map((project) => {
+        if (normalizePath(project.path) !== normalized) return project;
+        const contextTemplateUpdates = project.contextTemplateUpdates.filter(
+          (update) =>
+            update.filename !== filename ||
+            update.currentDefaultSha256 !== defaultSha256 ||
+            update.currentFileSha256 !== fileSha256
+        );
+        // #748 — nothing matched the exact key: keep the project identity.
+        if (contextTemplateUpdates.length === project.contextTemplateUpdates.length) {
+          return project;
+        }
+        anyChanged = true;
+        return { ...project, contextTemplateUpdates };
+      });
+      return anyChanged ? next : prev;
+    });
   },
 
   clear() {
@@ -420,6 +399,7 @@ export const projectStore = {
     inFlightLoads.clear();
     inFlightReloads.clear();
     queuedReloads.clear();
+    replicaVolatileStore.clearAll();
   },
 };
 

--- a/src/sidebar/stores/replica-volatile.test.ts
+++ b/src/sidebar/stores/replica-volatile.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createMemo, createRoot } from "solid-js";
+import {
+  effectiveAutoClosedAt,
+  effectiveLastUserMessageAt,
+  effectiveManuallyClosedAt,
+  effectiveRepoBranch,
+  replicaVolatileStore,
+} from "./replica-volatile";
+
+// #748 — the live event layer for the volatile replica fields. These cover the
+// contract the old in-place projectStore patches had (#552 normalized-path
+// matching, set/clear semantics) plus the new one: reads are reactive and
+// fine-grained, so a badge/pill updates WITHOUT re-creating its row.
+
+const COORD_A = "C:\\Users\\Maria\\Project\\.ac\\wg-1-team\\__agent_coord-a";
+const COORD_B = "C:\\Users\\Maria\\Project\\.ac\\wg-2-team\\__agent_coord-b";
+// Same replica as COORD_A but lower-cased with forward slashes, as the backend
+// session working_directory arrives on the clock/auto-close events (#552).
+const COORD_A_EVENT = "c:/users/maria/project/.ac/wg-1-team/__agent_coord-a";
+
+describe("replicaVolatileStore (#748)", () => {
+  beforeEach(() => {
+    replicaVolatileStore.clearAll();
+  });
+
+  it("matches event paths to discovery paths by normalization and leaves others untouched", () => {
+    replicaVolatileStore.setLastUserMessageAt(COORD_A_EVENT, "2026-06-19T18:00:00Z");
+
+    expect(effectiveLastUserMessageAt({ path: COORD_A })).toBe("2026-06-19T18:00:00Z");
+    expect(
+      effectiveLastUserMessageAt({ path: COORD_B, lastUserMessageAt: "2020-01-01T00:00:00Z" })
+    ).toBe("2020-01-01T00:00:00Z");
+  });
+
+  it("falls back to the discovery snapshot when no override exists", () => {
+    expect(effectiveAutoClosedAt({ path: COORD_A, autoClosedAt: "2026-06-19T17:00:00Z" })).toBe(
+      "2026-06-19T17:00:00Z"
+    );
+    expect(effectiveRepoBranch({ path: COORD_A, repoBranch: "main" })).toBe("main");
+    expect(effectiveManuallyClosedAt({ path: COORD_A })).toBeUndefined();
+  });
+
+  it("a null override explicitly masks a stale snapshot marker (reopen clear)", () => {
+    const replica = { path: COORD_A, autoClosedAt: "2026-06-19T17:00:00Z" };
+    replicaVolatileStore.setAutoClosedAt(COORD_A_EVENT, null);
+
+    expect(effectiveAutoClosedAt(replica)).toBeUndefined();
+  });
+
+  it("a null branch override masks the snapshot branch (branch gone)", () => {
+    const replica = { path: COORD_A, repoBranch: "main" };
+    replicaVolatileStore.setRepoBranch(COORD_A_EVENT, null);
+
+    expect(effectiveRepoBranch(replica)).toBeUndefined();
+  });
+
+  it("fields on the same replica override independently (sibling fields preserved)", () => {
+    const replica = { path: COORD_A, autoClosedAt: "2026-06-19T17:00:00Z" };
+    replicaVolatileStore.setLastUserMessageAt(COORD_A, "2026-06-19T18:00:00Z");
+
+    expect(effectiveLastUserMessageAt(replica)).toBe("2026-06-19T18:00:00Z");
+    // The clock write must not disturb the untouched marker field.
+    expect(effectiveAutoClosedAt(replica)).toBe("2026-06-19T17:00:00Z");
+  });
+
+  it("clearForPaths drops exactly the given paths' overrides (snapshot supersede)", () => {
+    replicaVolatileStore.setAutoClosedAt(COORD_A, "2026-06-19T18:05:00Z");
+    replicaVolatileStore.setAutoClosedAt(COORD_B, "2026-06-19T18:06:00Z");
+
+    // The reload path clears by the DISCOVERY path shape; overrides were keyed
+    // from event-shaped paths — normalization must line them up.
+    replicaVolatileStore.clearForPaths([COORD_A_EVENT]);
+
+    expect(effectiveAutoClosedAt({ path: COORD_A })).toBeUndefined();
+    expect(effectiveAutoClosedAt({ path: COORD_B })).toBe("2026-06-19T18:06:00Z");
+  });
+
+  it("clearAll resets every override", () => {
+    replicaVolatileStore.setRepoBranch(COORD_A, "feature/x");
+    replicaVolatileStore.setManuallyClosedAt(COORD_B, "2026-06-19T18:07:00Z");
+
+    replicaVolatileStore.clearAll();
+
+    expect(effectiveRepoBranch({ path: COORD_A })).toBeUndefined();
+    expect(effectiveManuallyClosedAt({ path: COORD_B })).toBeUndefined();
+  });
+
+  it("reads are reactive: a memo re-evaluates on set and clear without any row re-creation", () => {
+    createRoot((dispose) => {
+      const replica = { path: COORD_A, autoClosedAt: "2026-06-19T17:00:00Z" };
+      const marker = createMemo(() => effectiveAutoClosedAt(replica));
+      expect(marker()).toBe("2026-06-19T17:00:00Z");
+
+      replicaVolatileStore.setAutoClosedAt(COORD_A_EVENT, null);
+      expect(marker()).toBeUndefined();
+
+      replicaVolatileStore.setAutoClosedAt(COORD_A_EVENT, "2026-06-19T19:00:00Z");
+      expect(marker()).toBe("2026-06-19T19:00:00Z");
+
+      replicaVolatileStore.clearForPaths([COORD_A]);
+      expect(marker()).toBe("2026-06-19T17:00:00Z");
+
+      dispose();
+    });
+  });
+});

--- a/src/sidebar/stores/replica-volatile.ts
+++ b/src/sidebar/stores/replica-volatile.ts
@@ -1,0 +1,109 @@
+import { batch } from "solid-js";
+import { createStore } from "solid-js/store";
+import type { AcAgentReplica } from "../../shared/types";
+import { normalizeProjectPathForCompare } from "./project-refresh";
+
+/**
+ * #748 — live event-driven layer for the volatile per-replica fields that used
+ * to be patched INTO projectStore's replica objects (repoBranch,
+ * lastUserMessageAt, autoClosedAt, manuallyClosedAt). Patching them in place
+ * replaced every project/workgroup object reference, and ProjectPanel's
+ * reference-keyed <For> then disposed and re-created the entire clickable
+ * sidebar DOM on every event — a click whose press straddled that swap never
+ * produced a `click` (detached mousedown target → no common inclusive
+ * ancestor; Chromium fires nothing, w3c/uievents#141). Keeping the volatile
+ * fields in a separate fine-grained store keyed by NORMALIZED replica path
+ * (events carry the session working_directory, which can differ in slash/case
+ * from the discovery path on Windows) leaves row identity stable: an event
+ * re-runs only the badge/pill memo that reads it.
+ *
+ * Entry-field semantics: `undefined` = no live override (fall back to the
+ * discovery snapshot on the replica object); `null` = an event explicitly
+ * cleared the value (masks a stale discovery marker until the next snapshot).
+ */
+export interface ReplicaVolatileEntry {
+  repoBranch?: string | null;
+  lastUserMessageAt?: string;
+  autoClosedAt?: string | null;
+  manuallyClosedAt?: string | null;
+}
+
+const [entries, setEntries] = createStore<Record<string, ReplicaVolatileEntry | undefined>>({});
+
+function volatileKey(path: string): string {
+  return normalizeProjectPathForCompare(path);
+}
+
+function setField<K extends keyof ReplicaVolatileEntry>(
+  path: string,
+  field: K,
+  value: ReplicaVolatileEntry[K]
+) {
+  // Merge-function form so a first write creates the entry ({...undefined} = {}).
+  setEntries(volatileKey(path), (prev) => ({ ...prev, [field]: value }));
+}
+
+export const replicaVolatileStore = {
+  setRepoBranch(replicaPath: string, branch: string | null) {
+    setField(replicaPath, "repoBranch", branch);
+  },
+
+  setLastUserMessageAt(replicaPath: string, lastUserMessageAt: string) {
+    setField(replicaPath, "lastUserMessageAt", lastUserMessageAt);
+  },
+
+  setAutoClosedAt(replicaPath: string, autoClosedAt: string | null) {
+    setField(replicaPath, "autoClosedAt", autoClosedAt);
+  },
+
+  setManuallyClosedAt(replicaPath: string, manuallyClosedAt: string | null) {
+    setField(replicaPath, "manuallyClosedAt", manuallyClosedAt);
+  },
+
+  /**
+   * Drop overrides for replica paths a fresh discovery snapshot now covers.
+   * Discovery fills all four fields (ac_discovery.rs reads the branch and the
+   * persisted CoordinatorClocks), so on load/reload the snapshot is the newer
+   * truth and a pre-reload live override must not mask it — the same
+   * "discovery wins on reload, events re-patch after" contract the old
+   * in-place patches had.
+   */
+  clearForPaths(replicaPaths: Iterable<string>) {
+    batch(() => {
+      for (const path of replicaPaths) {
+        const key = volatileKey(path);
+        if (entries[key] !== undefined) {
+          setEntries(key, undefined); // deleting the key notifies its readers
+        }
+      }
+    });
+  },
+
+  clearAll() {
+    // Stored keys are already normalized, so volatileKey is a no-op on them.
+    replicaVolatileStore.clearForPaths(Object.keys(entries));
+  },
+};
+
+type ReplicaVolatileBase = Pick<AcAgentReplica, "path"> &
+  Partial<Pick<AcAgentReplica, "repoBranch" | "lastUserMessageAt" | "autoClosedAt" | "manuallyClosedAt">>;
+
+/** Live branch when an event patched it (null = branch gone), else the discovery snapshot. */
+export function effectiveRepoBranch(replica: ReplicaVolatileBase): string | undefined {
+  const override = entries[volatileKey(replica.path)]?.repoBranch;
+  return override === undefined ? replica.repoBranch : override ?? undefined;
+}
+
+export function effectiveLastUserMessageAt(replica: ReplicaVolatileBase): string | undefined {
+  return entries[volatileKey(replica.path)]?.lastUserMessageAt ?? replica.lastUserMessageAt;
+}
+
+export function effectiveAutoClosedAt(replica: ReplicaVolatileBase): string | undefined {
+  const override = entries[volatileKey(replica.path)]?.autoClosedAt;
+  return override === undefined ? replica.autoClosedAt : override ?? undefined;
+}
+
+export function effectiveManuallyClosedAt(replica: ReplicaVolatileBase): string | undefined {
+  const override = entries[volatileKey(replica.path)]?.manuallyClosedAt;
+  return override === undefined ? replica.manuallyClosedAt : override ?? undefined;
+}


### PR DESCRIPTION
Closes #748

## Problem

Occasionally the first click on a Sidebar element did nothing and a second click was required. Root cause: all clickable Sidebar DOM lives inside reference-keyed `<For>` blocks, and every event touching `projectStore` (coordinator clock tick — 60 s per active team —, branch/task updates, discovery reloads) replaced the references of ALL projects, disposing and recreating the whole clickable subtree. When that recreation landed between `mousedown` and `mouseup`, Chromium fires no `click` at all (detached mousedown target, w3c/uievents#141). Full analysis in #748.

## Fix (frontend only, no `src-tauri/` changes)

1. **Identity-preserving patchers** in `src/sidebar/stores/project.ts`: clone only the matched path; unaffected objects keep their reference; strict no-op (return `prev`) when nothing changes. Extended to `upsertLoop`/`removeLoop`/`removeContextTemplateUpdate`.
2. **Volatile fields moved out of row identity**: `repoBranch`, `lastUserMessageAt`, `autoClosedAt`, `manuallyClosedAt` now live in a new fine-grained store (`src/sidebar/stores/replica-volatile.ts`) keyed by normalized path; the 4 event listeners no longer touch `projectStore` at all.
3. **Identity-preserving discovery merge** (`src/sidebar/stores/project-merge.ts`): `reloadProject` keeps existing object references when the fresh snapshot is deep-equal; an identical snapshot is a full no-op (zero signal writes).

Plus three fixes found by high-effort self code-review during implementation: clear-on-dedup race gate (`appended` flag), `taskTitle` null→undefined normalization (serde `skip_serializing_if` phantom-diff), and a stable pair-cache for the coordinators `<For>` (sort-by-activity re-runs recreated all coordinator rows — same click-eating mechanism).

Side benefits: sidebar context menus / filter no longer close by themselves during agent activity; the ~1/min full panel rebuild is gone.

## Review

- Grinch Step-9 adversarial review of `4ead88d`: **PASS** — 0 HIGH / 0 MED / 1 LOW / 5 INFO; gates run independently. The LOW (structural-equality pin in `ProjectPanel.row-identity.test.tsx`) was fixed in `5186e3e` and approved.
- Step 9.5 re-sync with `origin/main` (`ac875d2`, brings #746/#750): merge `05ee4ea` verified **byte-identical to the mechanical `git merge-tree` result** (zero manual edits); #746/#748 composition verified (rail blue dot reads `sessionsStore`, not `projectStore`; `focusOnMount` benefits from stable identity). Focused Grinch review: **PASS — 0 new findings**.
- Gates on the merged tree (run by Grinch): `tsc` clean, `vitest` **85 files / 662 tests / 0 fails**, `vite build` OK.
- New regression coverage: DOM-level row-identity pins (same node across volatile events; new node on real change), identity-preservation store suites (replica-volatile: 8, project-merge: 8), clear-on-dedup and taskTitle pins.

Ship: visual/interaction change — wg-7 standalone build to 0_AC follows after landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
