### PR TITLE
feat(sidebar): show raise-hand indicator on group rail tab (#763)

### DIFF
--- a/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AcWorkgroup, Session, WorkgroupGroupsConfig } from "../../shared/types";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import type { ProjectState } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
+import {
+  defaultGroupsConfig,
+  exactGroupRegexForWorkgroup,
+} from "../stores/workgroup-groups";
+import WorkgroupGroupRail from "./WorkgroupGroupRail";
+import { workgroupHasRaisedHand } from "./workgroup-session";
+
+const projectPath = "C:\\Project";
+
+/** A workgroup with one coordinator replica. `taskTitle` defaults to a real
+ *  title so the #763 `!!wg.taskTitle` gate passes; pass null to exercise it. */
+function wg(
+  name: string,
+  opts: { taskTitle?: string | null; coordinator?: boolean } = {}
+): AcWorkgroup {
+  const { taskTitle = "Ship the thing", coordinator = true } = opts;
+  return {
+    name,
+    path: `${projectPath}\\.ac\\${name}`,
+    task: null,
+    taskTitle,
+    agents: [
+      {
+        name: "dev-webpage-ui",
+        path: `${projectPath}\\.ac\\${name}\\__agent_dev-webpage-ui`,
+        repoPaths: [],
+        isCoordinator: coordinator,
+      },
+    ],
+  };
+}
+
+function project(workgroups: AcWorkgroup[]): ProjectState {
+  return {
+    path: projectPath,
+    folderName: "Project",
+    workgroups,
+    agents: [],
+    teams: [],
+    loops: [],
+    contextTemplateUpdates: [],
+  };
+}
+
+/** ui -> wg-1-dev-team, rust -> wg-2-rust-team; wg-3-docs-team stays ungrouped. */
+function groupsConfig(overrides: Partial<WorkgroupGroupsConfig> = {}): WorkgroupGroupsConfig {
+  return {
+    ...defaultGroupsConfig(),
+    ...overrides,
+    groups:
+      overrides.groups ?? [
+        { id: "ui", name: "UI", regex: exactGroupRegexForWorkgroup("wg-1-dev-team") },
+        { id: "rust", name: "Rust", regex: exactGroupRegexForWorkgroup("wg-2-rust-team") },
+      ],
+  };
+}
+
+const defaultWorkgroups = () => [
+  wg("wg-1-dev-team"),
+  wg("wg-2-rust-team"),
+  wg("wg-3-docs-team"),
+];
+
+/** A session for the workgroup's coordinator with a raised hand up. */
+function raisedSession(wgName: string, overrides: Partial<Session> = {}): Session {
+  return session({
+    id: `session-${wgName}`,
+    name: `${wgName}/dev-webpage-ui`,
+    workingDirectory: `${projectPath}\\.ac\\${wgName}\\__agent_dev-webpage-ui`,
+    status: "running",
+    isCoordinator: true,
+    communication: { kind: "raiseHand", visible: true, updatedAt: "2026-07-03T00:00:00Z" },
+    ...overrides,
+  });
+}
+
+function target<T extends Element>(testId: string): T {
+  const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing element ${testId}`);
+  return element;
+}
+
+function railButtonOrder(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-ac-testid^="workgroupGroups.button."]')
+  ).map((button) => button.dataset.acTestid!.replace("workgroupGroups.button.", ""));
+}
+
+function railRaiseHands(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-ac-testid^="workgroupGroups.raiseHand."]')
+  ).map((el) => el.dataset.acTestid!.replace("workgroupGroups.raiseHand.", ""));
+}
+
+describe("workgroupHasRaisedHand (#763 predicate — mirrors the #747 row)", () => {
+  beforeEach(() => resetUiStoresForTests());
+  afterEach(() => resetUiStoresForTests());
+
+  it("is true for a coordinator with a visible raised hand and a task title", () => {
+    sessionsStore.setSessions([raisedSession("wg-1-dev-team")]);
+    expect(workgroupHasRaisedHand(wg("wg-1-dev-team"))).toBe(true);
+  });
+
+  it("stays true when the coordinator session has EXITED (no live gate — #747/decision C)", () => {
+    // The whole point of decision C: a restored/dormant coordinator keeps its
+    // persisted hand, so the tab must light even though the PTY is gone.
+    sessionsStore.setSessions([raisedSession("wg-1-dev-team", { status: { exited: 0 } })]);
+    expect(workgroupHasRaisedHand(wg("wg-1-dev-team"))).toBe(true);
+  });
+
+  it("is false when the hand is not visible", () => {
+    sessionsStore.setSessions([
+      raisedSession("wg-1-dev-team", {
+        communication: { kind: "raiseHand", visible: false, updatedAt: "2026-07-03T00:00:00Z" },
+      }),
+    ]);
+    expect(workgroupHasRaisedHand(wg("wg-1-dev-team"))).toBe(false);
+  });
+
+  it("is false when there is no communication at all", () => {
+    sessionsStore.setSessions([raisedSession("wg-1-dev-team", { communication: null })]);
+    expect(workgroupHasRaisedHand(wg("wg-1-dev-team"))).toBe(false);
+  });
+
+  it("is false when the workgroup has no task title (mirrors the row's !!taskTitle gate)", () => {
+    sessionsStore.setSessions([raisedSession("wg-1-dev-team")]);
+    expect(workgroupHasRaisedHand(wg("wg-1-dev-team", { taskTitle: null }))).toBe(false);
+  });
+
+  it("is false when the raised replica is not a coordinator", () => {
+    sessionsStore.setSessions([raisedSession("wg-1-dev-team", { isCoordinator: false })]);
+    expect(workgroupHasRaisedHand(wg("wg-1-dev-team", { coordinator: false }))).toBe(false);
+  });
+
+  it("is false when no session matches the replica", () => {
+    sessionsStore.setSessions([]);
+    expect(workgroupHasRaisedHand(wg("wg-1-dev-team"))).toBe(false);
+  });
+});
+
+describe("WorkgroupGroupRail raise-hand badge (#763 render + aggregation)", () => {
+  beforeEach(() => resetUiStoresForTests());
+  afterEach(() => {
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("lights the amber badge on All and on the group whose coordinator raised a hand", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    sessionsStore.setSessions([raisedSession("wg-1-dev-team")]);
+
+    const rendered = renderWithFakeTransport(
+      () => <WorkgroupGroupRail projects={[project(defaultWorkgroups())]} />,
+      fake
+    );
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      // Aggregates up to All; lights the matching group; leaves the rest dark.
+      await waitFor(() => expect(railRaiseHands()).toEqual(["all", "ui"]));
+
+      const badge = target<HTMLElement>("workgroupGroups.raiseHand.ui");
+      expect(badge.classList.contains("workgroup-group-rail-raise-hand")).toBe(true);
+      expect(badge.textContent?.trim()).toBe("!");
+      expect(badge.getAttribute("aria-label")).toBe("A coordinator raised its hand");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("aggregates onto All and Ungrouped when an ungrouped workgroup's coordinator raised", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    sessionsStore.setSessions([raisedSession("wg-3-docs-team")]);
+
+    const rendered = renderWithFakeTransport(
+      () => <WorkgroupGroupRail projects={[project(defaultWorkgroups())]} />,
+      fake
+    );
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      await waitFor(() => expect(railRaiseHands()).toEqual(["all", "ungrouped"]));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows no badge anywhere when no coordinator has a hand up", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    sessionsStore.setSessions([raisedSession("wg-1-dev-team", { communication: null })]);
+
+    const rendered = renderWithFakeTransport(
+      () => <WorkgroupGroupRail projects={[project(defaultWorkgroups())]} />,
+      fake
+    );
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      expect(railRaiseHands()).toEqual([]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("reactively lights and clears the badge as the coordinator's hand toggles", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+
+    const rendered = renderWithFakeTransport(
+      () => <WorkgroupGroupRail projects={[project(defaultWorkgroups())]} />,
+      fake
+    );
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      expect(railRaiseHands()).toEqual([]);
+
+      // Hand goes up -> badge appears on All + the group.
+      sessionsStore.setSessions([raisedSession("wg-1-dev-team")]);
+      await waitFor(() => expect(railRaiseHands()).toEqual(["all", "ui"]));
+
+      // User attends (backend clears communication) -> badge disappears.
+      sessionsStore.setCommunication("session-wg-1-dev-team", null);
+      await waitFor(() => expect(railRaiseHands()).toEqual([]));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -11,6 +11,7 @@ import {
 import {
   isWorkingReplicaDot,
   replicaDotClass,
+  workgroupHasRaisedHand,
   workgroupIsWorking,
 } from "./workgroup-session";
 import WorkgroupGroupsModal from "./WorkgroupGroupsModal";
@@ -26,6 +27,9 @@ interface GroupButton {
   /** #746 — true when the button's workgroup set has >=1 working agent
    *  (same predicate as the counter's X: running/active, not waiting/pending). */
   working: boolean;
+  /** #763 — true when >=1 coordinator in the button's workgroup set has a
+   *  raised hand (mirrors ProjectPanel's per-row `showRaiseHand`). */
+  raiseHand: boolean;
   selection: WorkgroupGroupSelection;
   workgroups: AcWorkgroup[];
   title: string;
@@ -67,9 +71,14 @@ function tooltipFor(workgroups: AcWorkgroup[]): string {
 function buttonContent(
   name: string,
   workgroups: AcWorkgroup[]
-): Pick<GroupButton, "name" | "counter" | "working"> {
+): Pick<GroupButton, "name" | "counter" | "working" | "raiseHand"> {
   const working = workgroups.filter(workgroupIsWorking).length;
-  return { name, counter: `${working}/${workgroups.length}`, working: working > 0 };
+  return {
+    name,
+    counter: `${working}/${workgroups.length}`,
+    working: working > 0,
+    raiseHand: workgroups.some(workgroupHasRaisedHand),
+  };
 }
 
 const ProjectRailSection: Component<{
@@ -146,6 +155,16 @@ const ProjectRailSection: Component<{
             onClick={() => workgroupGroupsStore.select(props.project.path, button.selection)}
             data-ac-testid={`workgroupGroups.button.${button.key}`}
           >
+            <Show when={button.raiseHand}>
+              <span
+                class="workgroup-group-rail-raise-hand"
+                data-ac-testid={`workgroupGroups.raiseHand.${button.key}`}
+                title="A coordinator raised its hand"
+                aria-label="A coordinator raised its hand"
+              >
+                !
+              </span>
+            </Show>
             {button.name}
             {"\n"}
             <Show when={button.working}>

--- a/src/sidebar/components/workgroup-session.ts
+++ b/src/sidebar/components/workgroup-session.ts
@@ -35,3 +35,26 @@ export function isWorkingReplicaDot(dot: SessionDotClass): boolean {
 export function workgroupIsWorking(wg: AcWorkgroup): boolean {
   return wg.agents.some((replica) => isWorkingReplicaDot(replicaDotClass(wg, replica)));
 }
+
+/**
+ * #763 — true when this replica is a coordinator currently showing a raised
+ * hand. Mirrors ProjectPanel's per-row `showRaiseHand` predicate exactly so the
+ * group-tab badge lights iff a coordinator row shows the hand:
+ *  - no liveness gate — #747 keeps a restored/dormant coordinator's persisted
+ *    hand visible (every real-exit path clears communication), so the tab must
+ *    light for those too;
+ *  - the `wg.taskTitle` gate matches the coordinator quick-list row, which only
+ *    renders the hand inside its task line (`renderReplicaItem(..., wg.taskTitle,
+ *    "quick")`).
+ */
+export function replicaHasRaisedHand(wg: AcWorkgroup, replica: AcAgentReplica): boolean {
+  if (!replica.isCoordinator) return false;
+  if (!wg.taskTitle) return false;
+  const communication = findReplicaSession(wg, replica)?.communication;
+  return communication?.kind === "raiseHand" && communication?.visible === true;
+}
+
+/** #763 — true when any coordinator in the workgroup has a raised hand. */
+export function workgroupHasRaisedHand(wg: AcWorkgroup): boolean {
+  return wg.agents.some((replica) => replicaHasRaisedHand(wg, replica));
+}

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2786,6 +2786,7 @@ html.light-theme .settings-hint-warning {
 }
 
 .workgroup-group-rail-button {
+  position: relative; /* #763 — anchor for the raise-hand corner badge */
   display: block;
   width: 100%;
   min-height: 28px;
@@ -2829,6 +2830,30 @@ html.light-theme .settings-hint-warning {
   display: inline-block;
   margin-right: 3px;
   vertical-align: -1px;
+}
+
+/* #763 — raise-hand indicator on a group-rail tab. Amber '!' pinned to the
+   top-right corner (absolute, so it stays OUT of the button's pre-line text
+   flow and never reflows the name/counter — the #742 trap the working dot's
+   comment above warns about). Reuses the amber palette of the per-coordinator
+   row indicator (.coord-communication-slot) for visual consistency.
+   pointer-events:none keeps the whole tab uniformly clickable. */
+.workgroup-group-rail-button .workgroup-group-rail-raise-hand {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 12px;
+  height: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  background: rgba(234, 179, 8, 0.18);
+  color: #eab308;
+  font-size: 9px;
+  font-weight: 800;
+  line-height: 1;
+  pointer-events: none;
 }
 
 .workgroup-group-rail-error {


### PR DESCRIPTION
Closes #763

## What

Surfaces the coordinator **raise-hand** state on the **group rail tab** (the `WorkgroupGroupRail` tabs like `BugJoust 1/1`). When any coordinator in a group currently has a raised hand, an amber `!` corner badge appears on that group's tab — aggregated per group, exactly like the existing green "working" dot. Lets the user see at a glance which group needs attention without expanding it.

## How

Frontend-only. Reuses the `SessionCommunication` state from #747 — **no backend, no new types, no new deps.**

- `src/sidebar/components/workgroup-session.ts` — new `replicaHasRaisedHand` + `workgroupHasRaisedHand` helpers (mirror `workgroupIsWorking`).
- `src/sidebar/components/WorkgroupGroupRail.tsx` — `raiseHand` on `GroupButton`, aggregated in `buttonContent` (covers All / Ungrouped / per-group in one place); amber `!` corner badge via `<Show>`, test id `workgroupGroups.raiseHand.<key>`.
- `src/sidebar/styles/sidebar.css` — `position:relative` anchor + `.workgroup-group-rail-raise-hand` (absolute top-right, amber palette, `pointer-events:none`).
- `src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx` — new, 11 tests.

### Predicate (mirrors the #747 coordinator row exactly)

```ts
replica.isCoordinator && communication?.kind === "raiseHand" && communication?.visible === true && !!wg.taskTitle
```

No liveness gate (matches #747 — a persisted/restored raised hand on a dormant coordinator still shows). The tab lights **iff** the coordinator row shows the hand, in every case; clears automatically when the hand is lowered (user types into the coordinator, or session exits).

## Review

- **Implementation:** dev-webpage-ui.
- **Adversarial review:** dev-rust-grinch — **PASS**, no HIGH / no MED. Verified predicate parity with the #747 row (incl. the exited-still-true case), full All/Ungrouped/per-group aggregation, reactive light-and-clear, no #742 name-reflow regression (badge is out of flow), clean frontend-only scope, non-vacuous tests. One LOW cosmetic note (badge may graze a long centered name's last glyph on the narrow rail) — non-blocking; real group names are short.
- **Gates (reproduced by grinch):** `tsc --noEmit` 0 · `vitest run` **676/676** (665 baseline + 11 new, passing by name) · `vite build` 0.

## Design decisions

- Amber `!` as a **corner badge** (top-right), not inline — avoids the #742 text-reflow trap on the `white-space:pre-line` tab.
- **All / Ungrouped** pseudo-tabs aggregate too (consistent with the working dot).
