### PR TITLE
fix(onboarding): fit all coding-agent options without scroll ; rtk OpenCode 'by Anomaly' (#768)

### DIFF
--- a/src/shared/agent-presets.test.ts
+++ b/src/shared/agent-presets.test.ts
@@ -29,6 +29,8 @@ describe("agent presets (#529)", () => {
     const opencode = AGENT_PRESETS.find((p) => p.key === "opencode");
     expect(opencode).toBeTruthy();
     expect(opencode?.label).toBe("OpenCode");
+    // #768 — subtitle re-attributed from SST to Anomaly.
+    expect(opencode?.description).toBe("Open-source terminal coding agent by Anomaly");
     expect(opencode?.config.command).toBe("opencode");
     expect(opencode?.config.instructionsFilename).toBe("AGENTS.md");
     // Reachable via the quick-add lookup the Config Screen buttons use.

--- a/src/shared/agent-presets.ts
+++ b/src/shared/agent-presets.ts
@@ -83,7 +83,7 @@ export const AGENT_PRESETS: AgentPreset[] = [
   {
     key: "opencode",
     label: "OpenCode",
-    description: "Open-source terminal coding agent by SST",
+    description: "Open-source terminal coding agent by Anomaly",
     color: "#64748b",
     config: {
       label: "OpenCode",

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -6796,7 +6796,12 @@ html.light-theme[data-sidebar-style="neon-circuit"] .coord-quick-access {
 
 .onboarding-modal {
   width: min(420px, 94%);
-  max-height: 80vh;
+  /* #768 — fit all 7 preset cards (Claude Code, Codex, Hermes, Cursor CLI,
+     Pi, OpenCode, Custom Agent) without an inner scrollbar. The resting list
+     is ~560px tall (header + welcome + 7×~50px cards + footer); 680px clears
+     it with headroom, and the 90vh cap keeps the modal on-screen — only a
+     genuinely short viewport falls back to scrolling. */
+  max-height: min(680px, 90vh);
 }
 
 .onboarding-body {
@@ -6804,6 +6809,11 @@ html.light-theme[data-sidebar-style="neon-circuit"] .coord-quick-access {
   flex-direction: column;
   padding: var(--spacing-lg) var(--spacing-md);
   gap: var(--spacing-md);
+  /* Drop the generic .wizard-body 50vh cap (which clipped the last cards
+     behind an inner scroll); the modal's own max-height now governs, and the
+     inherited `overflow-y: auto` still scrolls only when the modal is capped
+     on a small viewport. */
+  max-height: none;
 }
 
 .onboarding-welcome {


### PR DESCRIPTION
## Summary

Follow-up to #766. The Welcome first-run onboarding modal now shows **all coding-agent options without an inner scroll**, and OpenCode's subtitle is **"by Anomaly"**.

- **Fit (no scroll):** the generic `.wizard-body` carried `max-height: 50vh; overflow-y:auto`, which clipped the 7-card list on normal windows (Custom Agent hidden). Fix (`src/sidebar/styles/sidebar.css`):
  - `.onboarding-body { max-height: none }` — removes the inherited 50vh cap; keeps the inherited `overflow-y:auto` so the scroll fallback survives.
  - `.onboarding-modal { max-height: min(680px, 90vh) }` (was `80vh`).
  - Responsive: viewports ≥ ~618px show all 7 cards with no inner scroll; smaller windows fall back to scrolling (footer preserved). Scoped to the onboarding modal only.
- **OpenCode subtitle** (`src/shared/agent-presets.ts`): "…by SST" → "…by Anomaly" (+ test pin in `agent-presets.test.ts`).

Files: `sidebar.css`, `agent-presets.ts`, `agent-presets.test.ts` (3 `src/` files, no backend).

## Review

- **dev-webpage-ui** implemented (`93fea0c`) with real headless-Chrome pixel screenshots (FIT: `scrollH==clientH ⇒ no inner scroll`; FALLBACK: 382px viewport scrolls, footer visible).
- **Grinch Step-9 PASS:** 0 HIGH / 0 MED / 0 LOW, 2 INFO (the `680px` cap is intentional headroom for a future 8th preset; re-verify 9.5 if main drifts). Scoping/leak cleared (single consumers; generic `.wizard-body` and other wizards untouched), scroll fallback empirically intact, visual gate confirmed on both PNGs. Gates re-run by Grinch: `tsc` 0, `vitest` 677/0, `build` OK.
- Base == `origin/main` (`c524dbc`); branch contains main, no re-sync needed. No version bump.

Closes #768
