### PR TITLE
fix: hide TASK section in Terminal view for the Root Agent (#771)

### DIFF
--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -234,7 +234,7 @@ export function resetUiStoresForTests(): void {
   sessionsStore.clearDetached();
   workgroupGroupsStore.resetForTests();
   bridgesStore.setBridges([]);
-  terminalStore.setActiveSession(null, "", "", null, "", null);
+  terminalStore.setActiveSession(null, "", "", null, "", null, false);
   terminalStore.setActiveWorkgroupTask(null);
   toastStore.clear();
   __resetHomeStoreForTests();

--- a/src/terminal/App.tsx
+++ b/src/terminal/App.tsx
@@ -60,10 +60,10 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
       const sessions = await SessionAPI.list();
       const session = sessions.find((s) => s.id === props.lockedSessionId);
       if (session) {
-        terminalStore.setActiveSession(session.id, session.name, session.shell, session.effectiveShellArgs, session.workingDirectory, session.workgroupTask ?? null);
+        terminalStore.setActiveSession(session.id, session.name, session.shell, session.effectiveShellArgs, session.workingDirectory, session.workgroupTask ?? null, session.isRootAgent);
       } else {
         // Session no longer exists, close this window
-        terminalStore.setActiveSession(null, "", "", null, "", null);
+        terminalStore.setActiveSession(null, "", "", null, "", null, false);
       }
       return;
     }
@@ -74,10 +74,10 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
       const sessions = await SessionAPI.list();
       const active = sessions.find((s) => s.id === activeId);
       if (active) {
-        terminalStore.setActiveSession(active.id, active.name, active.shell, active.effectiveShellArgs, active.workingDirectory, active.workgroupTask ?? null);
+        terminalStore.setActiveSession(active.id, active.name, active.shell, active.effectiveShellArgs, active.workingDirectory, active.workgroupTask ?? null, active.isRootAgent);
       }
     } else {
-      terminalStore.setActiveSession(null, "", "", null, "", null);
+      terminalStore.setActiveSession(null, "", "", null, "", null, false);
     }
   };
 
@@ -156,7 +156,7 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
       unlisteners.push(
         await onSessionSwitched(async ({ id }) => {
           if (!id) {
-            terminalStore.setActiveSession(null, "", "", null, "", null);
+            terminalStore.setActiveSession(null, "", "", null, "", null, false);
             return;
           }
           const sessions = await SessionAPI.list();
@@ -168,7 +168,8 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
               session.shell,
               session.effectiveShellArgs,
               session.workingDirectory,
-              session.workgroupTask ?? null
+              session.workgroupTask ?? null,
+              session.isRootAgent
             );
           }
         })
@@ -183,7 +184,8 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
               session.shell,
               session.effectiveShellArgs,
               session.workingDirectory,
-              session.workgroupTask ?? null
+              session.workgroupTask ?? null,
+              session.isRootAgent
             );
           }
         })
@@ -261,7 +263,13 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
       <Show when={!props.embedded}>
         <Titlebar detached={props.detached} lockedSessionId={props.lockedSessionId} />
       </Show>
-      <WorkgroupTask />
+      {/* #771 — the TASK panel is hidden entirely for the Root Agent
+          (Agent's Commander); LAST PROMPT stays for every agent. Gated on the
+          terminalStore flag (not sessionsStore) so it works in the standalone
+          and detached terminal windows too, which don't load sidebar state. */}
+      <Show when={!terminalStore.activeIsRootAgent}>
+        <WorkgroupTask />
+      </Show>
       <LastPrompt sessionId={props.lockedSessionId} />
       <div class="terminal-content-area">
         <Show

--- a/src/terminal/App.workflow.test.tsx
+++ b/src/terminal/App.workflow.test.tsx
@@ -752,4 +752,95 @@ describe("TerminalApp workflow", () => {
       rendered.cleanup();
     }
   });
+
+  // #771 — the TASK panel must be hidden entirely for the Root Agent
+  // (Agent's Commander); LAST PROMPT stays for every agent.
+  it("hides the TASK panel for the Root Agent but keeps LAST PROMPT", async () => {
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake, [
+      session({
+        id: "root-1",
+        name: "Agent's Commander",
+        workingDirectory: "C:\\Project\\.ac\\ac-root-agent",
+        isRootAgent: true,
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".workgroup-task-panel")).toBeNull()
+      );
+      expect(rendered.root.querySelector(".last-prompt-panel")).not.toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows the TASK panel for a non-root agent", async () => {
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake, [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+        isRootAgent: false,
+      }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".workgroup-task-panel")).not.toBeNull()
+      );
+      expect(rendered.root.querySelector(".last-prompt-panel")).not.toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("hides TASK on switch to the Root Agent and restores it on switch back", async () => {
+    const sessions = [
+      session({
+        id: "session-1",
+        name: "wg-1-dev-team/architect",
+        workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+        isRootAgent: false,
+      }),
+      session({
+        id: "root-1",
+        name: "Agent's Commander",
+        workingDirectory: "C:\\Project\\.ac\\ac-root-agent",
+        isRootAgent: true,
+      }),
+    ];
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake, sessions);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      // Non-root is active on load → TASK visible.
+      expect(rendered.root.querySelector(".workgroup-task-panel")).not.toBeNull();
+
+      // Switch to the Root Agent → TASK hidden.
+      fake.emitFromBackend("session_switched", { id: "root-1" });
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".workgroup-task-panel")).toBeNull()
+      );
+
+      // Switch back to the non-root agent → TASK restored.
+      fake.emitFromBackend("session_switched", { id: "session-1" });
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".workgroup-task-panel")).not.toBeNull()
+      );
+
+      // LAST PROMPT is present throughout.
+      expect(rendered.root.querySelector(".last-prompt-panel")).not.toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
 });

--- a/src/terminal/stores/terminal.ts
+++ b/src/terminal/stores/terminal.ts
@@ -6,6 +6,7 @@ const [activeShell, setActiveShell] = createSignal<string>("");
 const [activeShellArgs, setActiveShellArgs] = createSignal<string[] | null>(null);
 const [activeWorkingDirectory, setActiveWorkingDirectory] = createSignal<string>('');
 const [activeWorkgroupTask, setActiveWorkgroupTask] = createSignal<string | null>(null);
+const [activeIsRootAgent, setActiveIsRootAgent] = createSignal<boolean>(false);
 
 export const terminalStore = {
   get activeSessionId() {
@@ -26,13 +27,17 @@ export const terminalStore = {
   get activeWorkgroupTask() {
     return activeWorkgroupTask();
   },
+  get activeIsRootAgent() {
+    return activeIsRootAgent();
+  },
 
   /**
    * Partial-update contract: `id` always applied; any of `name` / `shell` /
-   * `shellArgs` / `workingDirectory` / `workgroupTask` omitted or passed as `undefined` leaves
-   * the current value untouched. Rename events rely on this — they pass only
-   * `(id, name)` so shell/args/cwd are preserved. Do NOT change the
-   * undefined-skip semantics without auditing every caller.
+   * `shellArgs` / `workingDirectory` / `workgroupTask` / `isRootAgent` omitted or passed as
+   * `undefined` leaves the current value untouched. Rename events rely on this — they pass
+   * only `(id, name)` so shell/args/cwd/isRootAgent are preserved (renaming the Root Agent
+   * must NOT re-show the TASK panel). Do NOT change the undefined-skip semantics without
+   * auditing every caller.
    */
   setActiveSession(
     id: string | null,
@@ -40,7 +45,8 @@ export const terminalStore = {
     shell?: string,
     shellArgs?: string[] | null,
     workingDirectory?: string,
-    workgroupTask?: string | null
+    workgroupTask?: string | null,
+    isRootAgent?: boolean
   ) {
     setActiveSessionId(id);
     if (name !== undefined) setActiveSessionName(name);
@@ -48,6 +54,7 @@ export const terminalStore = {
     if (shellArgs !== undefined) setActiveShellArgs(shellArgs);
     if (workingDirectory !== undefined) setActiveWorkingDirectory(workingDirectory);
     if (workgroupTask !== undefined) setActiveWorkgroupTask(workgroupTask);
+    if (isRootAgent !== undefined) setActiveIsRootAgent(isRootAgent);
   },
 
   setActiveWorkgroupTask(task: string | null) {


### PR DESCRIPTION
Hides the Terminal `TASK` section when the selected agent is the **Root Agent** ("Agent's Commander"). The Root Agent is not a workgroup replica and has no TASK, so the empty header was visual noise. The whole section is hidden (label + area), only for the Root Agent, only in the terminal surfaces. `LAST PROMPT` remains for all agents.

## Change (frontend only, 4 files, +120/−14)
- `src/terminal/stores/terminal.ts` — `activeIsRootAgent` signal + getter + trailing `isRootAgent?: boolean` param on `setActiveSession` (undefined-skip contract).
- `src/terminal/App.tsx` — thread `session.isRootAgent` at the 4 real-session call sites, `false` at the 3 reset sites; `onSessionRenamed` left untouched; wrap `<WorkgroupTask />` in `<Show when={!terminalStore.activeIsRootAgent}>`.
- `src/shared/testing/ui-harness.tsx` — between-test reset passes `false`.
- `src/terminal/App.workflow.test.tsx` — +3 tests (hide-for-root, show-for-non-root, switch-to-root → back restore).

A single `TerminalApp` component backs every terminal surface (main embedded, standalone/browser, detached per-session window), so one `<Show>` gate covers all of them.

## Review
- **dev-webpage-ui** (implementation): `tsc --noEmit` clean; full vitest 86 files / 680 tests / 0 failures.
- **dev-rust-grinch** (adversarial, line-by-line): **PASS**. Stale-flag is impossible — `Session.isRootAgent` is a *required* boolean so undefined-skip never self-triggers, and the only arg-omitting call site (`onSessionRenamed`) is guarded by `id === activeSessionId`, preserving the already-correct flag. Gate hides label + area only for root only in terminal; `LAST PROMPT` verified intact in code; all 3 surfaces incl. detached-locked-to-root covered; no resize/Home-overlay regression. Gates re-run on `41c2417`: tsc clean, 680/680, `vite build` exit 0. 2 non-blocking INFO test-gaps (rename-safety + detached-surface regression tests).

Closes #771
