### PR TITLE
feat(coding-agents): externalize catalog to a seeded, editable backend JSON — Phase 1 (#769)

### DIFF
--- a/src-tauri/resources/coding-agents/agents.default.json
+++ b/src-tauri/resources/coding-agents/agents.default.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": 1,
+  "agents": [
+    {
+      "key": "claude",
+      "label": "Claude Code",
+      "description": "Coding Agent by Anthropic",
+      "color": "#d97706",
+      "command": "claude",
+      "instructionsFilename": "CLAUDE.md",
+      "envs": [],
+      "isolatedHome": false,
+      "removable": true
+    },
+    {
+      "key": "codex",
+      "label": "Codex",
+      "description": "Coding Agent by OpenAI",
+      "color": "#10b981",
+      "command": "codex",
+      "instructionsFilename": "AGENTS.md",
+      "envs": [],
+      "isolatedHome": false,
+      "removable": true
+    },
+    {
+      "key": "hermes",
+      "label": "Hermes",
+      "description": "Coding Agent by Nous Research",
+      "color": "#8b5cf6",
+      "command": "hermes",
+      "instructionsFilename": "AGENTS.md",
+      "envs": [],
+      "isolatedHome": false,
+      "removable": true
+    },
+    {
+      "key": "cursor",
+      "label": "Cursor CLI",
+      "description": "Coding Agent by Cursor",
+      "color": "#22d3ee",
+      "command": "agent",
+      "instructionsFilename": "AGENTS.md",
+      "envs": [],
+      "isolatedHome": false,
+      "removable": true
+    },
+    {
+      "key": "pi",
+      "label": "Pi",
+      "description": "Coding Agent by Earendil Inc",
+      "color": "#ec4899",
+      "command": "pi",
+      "instructionsFilename": "AGENTS.md",
+      "envs": [],
+      "isolatedHome": false,
+      "removable": true
+    },
+    {
+      "key": "opencode",
+      "label": "OpenCode",
+      "description": "Open-source terminal coding agent by Anomaly",
+      "color": "#64748b",
+      "command": "opencode",
+      "instructionsFilename": "AGENTS.md",
+      "envs": [],
+      "isolatedHome": false,
+      "removable": true
+    }
+  ]
+}

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -91,6 +91,22 @@ pub async fn get_settings(settings: State<'_, SettingsState>) -> Result<AppSetti
     Ok(result)
 }
 
+/// #769 Phase 1 - return the externalized coding-agent catalog for the onboarding
+/// and Settings pick lists. Contract (§14.2, dev-rust E5): resolves `Ok(Vec)` in
+/// the normal AND self-heal cases (a missing or unparseable `agents.json` yields
+/// the embedded default IN MEMORY, never a disk write); `Ok([])` is honored
+/// verbatim when the user removed every built-in; `Err` only when the config
+/// directory cannot be resolved (a genuine environment failure the compiled
+/// fallback cannot satisfy). The frontend's never-empty fallback fires only on
+/// this `Err`/transport path, so keeping the self-heal on the `Ok` side is load-
+/// bearing for that contract.
+#[tauri::command]
+pub async fn get_coding_agent_catalog(
+) -> Result<Vec<crate::config::coding_agents_catalog::CodingAgentDefinition>, String> {
+    let config_dir = crate::config::config_dir().ok_or("No config dir")?;
+    Ok(crate::config::coding_agents_catalog::load_catalog(&config_dir))
+}
+
 #[tauri::command]
 pub async fn update_settings(
     app: AppHandle,

--- a/src-tauri/src/config/coding_agents_catalog.rs
+++ b/src-tauri/src/config/coding_agents_catalog.rs
@@ -1,0 +1,516 @@
+//! #769 Phase 1 - externalized, user-editable coding-agent catalog.
+//!
+//! The catalog is the "built-in coding agents you can add" list (display name,
+//! command, color, instructions filename, ...). Before #769 it was hardcoded in
+//! the frontend (`src/shared/agent-presets.ts`). This module makes it a
+//! backend-owned, on-disk, user-editable JSON manifest at
+//! `config_dir()/coding-agents/agents.json`, seeded once from an embedded default
+//! and user-owned thereafter.
+//!
+//! Phase 1 scope (see `_plans/769-...` §14.2): the manifest scalars + one read
+//! command, only. NO per-agent config folders, NO #598 seed tier, NO provenance
+//! state file. `settings.agents`, `AgentConfig`, and the spawn/profile/resolver
+//! path are untouched.
+//!
+//! Seed model is **whole-file seed-once** (§14.1): write the embedded default iff
+//! `agents.json` is absent, then never touch it. A user who hand-removes a
+//! built-in has a *present* file, so the removal sticks (no re-seed path). A
+//! present-but-corrupt file is **never overwritten**; the command serves the
+//! embedded default in memory for that session (self-heal is a return value, not
+//! a disk write).
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::agent_command::is_safe_instructions_filename;
+use crate::config::settings::{
+    validate_agent_command_text, validate_config_seed_dest, validate_env_rows, CodingAgentEnv,
+    ConfigSeedConfig,
+};
+
+/// Subdirectory of the config dir holding the catalog artifacts.
+const CATALOG_DIR_NAME: &str = "coding-agents";
+/// The catalog manifest filename.
+const CATALOG_MANIFEST_FILENAME: &str = "agents.json";
+/// Current manifest schema version.
+const CATALOG_SCHEMA_VERSION: u32 = 1;
+
+/// The embedded default catalog, authored byte-equal to the post-#766/#768
+/// frontend presets. This is the single source of truth AC ships; it is written
+/// to disk once (seed) and also served in memory when the on-disk file is missing
+/// or unparseable.
+const EMBEDDED_DEFAULT_CATALOG_JSON: &str =
+    include_str!("../../resources/coding-agents/agents.default.json");
+
+/// Unique-suffix counter for the seed temp file (mirrors the pattern in
+/// `seeded_context_templates::unique_state_temp_path`).
+static SEED_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_catalog_schema_version() -> u32 {
+    CATALOG_SCHEMA_VERSION
+}
+
+/// One catalog entry: a built-in (or user-added) coding agent the user can pick
+/// from. Maps cleanly onto `Omit<AgentConfig,"id">` plus `{key, description,
+/// removable}` on the frontend. `removable`, `envs`, and `isolated_home` are
+/// serde-guaranteed present (the frontend types them as required);
+/// `instructions_filename` and `config_seed` are optional.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CodingAgentDefinition {
+    /// Stable identity within the catalog. Must match `^[a-z0-9-]+$` and be
+    /// unique; it doubles as a testid/JSON-key/CSS token on the frontend and (in
+    /// the Full phase) a directory name.
+    pub key: String,
+    pub label: String,
+    pub description: String,
+    pub color: String,
+    pub command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions_filename: Option<String>,
+    #[serde(default)]
+    pub envs: Vec<CodingAgentEnv>,
+    #[serde(default)]
+    pub isolated_home: bool,
+    /// Optional per-agent config-folder seed. Passthrough/authoring data in
+    /// Phase 1: the embedded default ships it UNSET, so no agent seeds a folder
+    /// and spawn behavior is byte-unchanged. Phase 2 wires it to the #598 tier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_seed: Option<ConfigSeedConfig>,
+    /// May the user delete this built-in from the catalog? Ships `true` for all
+    /// built-ins; defaults `true` so a hand-authored entry omitting it stays
+    /// deletable.
+    #[serde(default = "default_true")]
+    pub removable: bool,
+}
+
+/// The manifest file shape: a schema version plus the ordered agent list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodingAgentCatalog {
+    #[serde(default = "default_catalog_schema_version")]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub agents: Vec<CodingAgentDefinition>,
+}
+
+fn catalog_dir(config_dir: &Path) -> PathBuf {
+    config_dir.join(CATALOG_DIR_NAME)
+}
+
+fn manifest_path(config_dir: &Path) -> PathBuf {
+    catalog_dir(config_dir).join(CATALOG_MANIFEST_FILENAME)
+}
+
+/// Parse the compiled-in default catalog. The content is authored valid and a
+/// unit test guards it, so the error branch is unreachable in practice; it logs
+/// and returns an empty catalog rather than panicking (this runs on the boot and
+/// IPC paths).
+pub fn embedded_default_catalog() -> CodingAgentCatalog {
+    serde_json::from_str(EMBEDDED_DEFAULT_CATALOG_JSON).unwrap_or_else(|e| {
+        log::error!("[coding-agents] embedded default catalog failed to parse: {e}");
+        CodingAgentCatalog {
+            schema_version: CATALOG_SCHEMA_VERSION,
+            agents: Vec::new(),
+        }
+    })
+}
+
+/// G6: a catalog `key` must be a non-empty `^[a-z0-9-]+$` token. Stricter than
+/// `validate_config_seed_dest` on purpose: the key is used verbatim as a testid,
+/// a JSON object key, and a CSS token on the frontend (and, in the Full phase, a
+/// directory name), so it is restricted to an unambiguous ASCII allowlist.
+fn validate_catalog_key(key: &str) -> Result<(), String> {
+    if key.is_empty() {
+        return Err("coding-agent key must not be empty".to_string());
+    }
+    if !key
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err(format!(
+            "coding-agent key '{key}' must match ^[a-z0-9-]+$ (lowercase letters, digits, hyphen)"
+        ));
+    }
+    Ok(())
+}
+
+/// Per-entry validation (G7). Reuses the same validators the settings save path
+/// uses so the catalog and `settings.agents` cannot disagree about what is legal.
+fn validate_definition(def: &CodingAgentDefinition) -> Result<(), String> {
+    validate_catalog_key(&def.key)?;
+    let context = format!("Coding agent '{}'", def.key);
+    validate_agent_command_text(&context, &def.command)?;
+    validate_env_rows(&def.envs, &context)?;
+    if let Some(name) = def.instructions_filename.as_deref() {
+        if !is_safe_instructions_filename(name) {
+            return Err(format!(
+                "{context}: unsafe instructions filename '{name}'"
+            ));
+        }
+    }
+    if let Some(cfg) = def.config_seed.as_ref() {
+        if !cfg.dest.trim().is_empty() {
+            validate_config_seed_dest(&cfg.dest)?;
+        }
+    }
+    Ok(())
+}
+
+/// Validate entries per-entry (G7): a bad entry is logged and skipped, the valid
+/// rest are kept. Duplicate keys are dropped (first wins). `source` labels the
+/// origin in log lines (the manifest path, or the embedded default).
+fn validate_and_filter(
+    agents: Vec<CodingAgentDefinition>,
+    source: &str,
+) -> Vec<CodingAgentDefinition> {
+    let mut out: Vec<CodingAgentDefinition> = Vec::with_capacity(agents.len());
+    let mut seen_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for def in agents {
+        if let Err(e) = validate_definition(&def) {
+            log::warn!("[coding-agents] skipping invalid entry in {source}: {e}");
+            continue;
+        }
+        if !seen_keys.insert(def.key.clone()) {
+            log::warn!(
+                "[coding-agents] skipping duplicate key '{}' in {source}",
+                def.key
+            );
+            continue;
+        }
+        out.push(def);
+    }
+    out
+}
+
+/// The embedded default, validated (defensive; also dedups). Used as the
+/// in-memory fallback when the on-disk manifest is missing or unparseable.
+fn validated_embedded_default() -> Vec<CodingAgentDefinition> {
+    validate_and_filter(embedded_default_catalog().agents, "embedded default catalog")
+}
+
+/// Load the catalog for the `get_coding_agent_catalog` command.
+///
+/// Contract (§14.2): NEVER errors. Returns the validated on-disk agents when the
+/// manifest parses; a valid empty list is honored verbatim (the user removed all
+/// built-ins). A **missing** or **unparseable** manifest self-heals to the
+/// embedded default IN MEMORY only, never writing to disk (G3 corrupt-preserve).
+pub fn load_catalog(config_dir: &Path) -> Vec<CodingAgentDefinition> {
+    let path = manifest_path(config_dir);
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            log::info!(
+                "[coding-agents] {} absent; serving embedded default catalog",
+                path.display()
+            );
+            return validated_embedded_default();
+        }
+        Err(e) => {
+            log::warn!(
+                "[coding-agents] failed to read {} ({e}); serving embedded default catalog",
+                path.display()
+            );
+            return validated_embedded_default();
+        }
+    };
+    match serde_json::from_slice::<CodingAgentCatalog>(&bytes) {
+        Ok(catalog) => validate_and_filter(catalog.agents, &path.display().to_string()),
+        Err(e) => {
+            // G3: never overwrite a present-but-corrupt file. Preserve it as-is
+            // and serve the built-in defaults for this session only.
+            log::warn!(
+                "[coding-agents] {} is not valid catalog JSON ({e}); preserving the file untouched and using built-in defaults for this session",
+                path.display()
+            );
+            validated_embedded_default()
+        }
+    }
+}
+
+/// Seed the manifest ONCE at boot: write the embedded default iff `agents.json`
+/// is absent, then never touch it (§14.1 whole-file seed-once). Fail-soft: logs
+/// and returns on any error; it must never panic or abort boot.
+pub fn ensure_seeded(config_dir: &Path) {
+    let dir = catalog_dir(config_dir);
+    let path = manifest_path(config_dir);
+
+    // Seed-once: any existing entry (file, dir, or link) means the catalog is
+    // user-owned; leave it strictly alone.
+    match std::fs::symlink_metadata(&path) {
+        Ok(_) => return,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            log::warn!(
+                "[coding-agents] cannot stat {} ({e}); skipping catalog seed",
+                path.display()
+            );
+            return;
+        }
+    }
+
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        log::warn!(
+            "[coding-agents] failed to create {} ({e}); skipping catalog seed",
+            dir.display()
+        );
+        return;
+    }
+
+    match write_manifest_atomic(&path, EMBEDDED_DEFAULT_CATALOG_JSON.as_bytes()) {
+        Ok(()) => log::info!("[coding-agents] seeded default catalog at {}", path.display()),
+        Err(e) => log::warn!("[coding-agents] failed to seed {} ({e})", path.display()),
+    }
+}
+
+/// Atomic temp+rename write, mirroring `seeded_context_templates::persist_state`:
+/// create-new a unique sibling temp, write+flush+fsync, then publish via the
+/// vetted `atomic_replace_existing` primitive (plain rename when the dest is
+/// absent, `ReplaceFileW` when it exists). Cleans up the temp on any failure.
+fn write_manifest_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    use std::io::Write as _;
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("manifest path {} has no parent", path.display()))?;
+    let counter = SEED_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let temp = parent.join(format!(
+        ".{CATALOG_MANIFEST_FILENAME}.{}.{counter}.tmp",
+        std::process::id()
+    ));
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp)
+        .map_err(|e| format!("create temp {}: {e}", temp.display()))?;
+    if let Err(e) = file.write_all(bytes) {
+        drop(file);
+        let _ = std::fs::remove_file(&temp);
+        return Err(format!("write temp {}: {e}", temp.display()));
+    }
+    if let Err(e) = file.flush() {
+        drop(file);
+        let _ = std::fs::remove_file(&temp);
+        return Err(format!("flush temp {}: {e}", temp.display()));
+    }
+    if let Err(e) = file.sync_all() {
+        drop(file);
+        let _ = std::fs::remove_file(&temp);
+        return Err(format!("sync temp {}: {e}", temp.display()));
+    }
+    drop(file);
+
+    if let Err(e) = crate::config::root_agent::atomic_replace_existing(&temp, path) {
+        let _ = std::fs::remove_file(&temp);
+        return Err(e);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// (key, label, description, color, command, instructionsFilename) for the 6
+    /// current presets. Drift guard: the embedded default must equal these exact
+    /// values so the externalized catalog is byte-for-byte the pre-#769 list. The
+    /// frontend keeps a parallel `FALLBACK_CODING_AGENTS` test (E7).
+    const EXPECTED_PRESETS: [(&str, &str, &str, &str, &str, &str); 6] = [
+        ("claude", "Claude Code", "Coding Agent by Anthropic", "#d97706", "claude", "CLAUDE.md"),
+        ("codex", "Codex", "Coding Agent by OpenAI", "#10b981", "codex", "AGENTS.md"),
+        ("hermes", "Hermes", "Coding Agent by Nous Research", "#8b5cf6", "hermes", "AGENTS.md"),
+        ("cursor", "Cursor CLI", "Coding Agent by Cursor", "#22d3ee", "agent", "AGENTS.md"),
+        ("pi", "Pi", "Coding Agent by Earendil Inc", "#ec4899", "pi", "AGENTS.md"),
+        (
+            "opencode",
+            "OpenCode",
+            "Open-source terminal coding agent by Anomaly",
+            "#64748b",
+            "opencode",
+            "AGENTS.md",
+        ),
+    ];
+
+    fn manifest_json(agents_json: &str) -> String {
+        format!("{{\"schemaVersion\":1,\"agents\":{agents_json}}}")
+    }
+
+    fn seed_dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn embedded_default_parses_with_six_agents_in_order() {
+        let catalog = embedded_default_catalog();
+        assert_eq!(catalog.schema_version, CATALOG_SCHEMA_VERSION);
+        let keys: Vec<&str> = catalog.agents.iter().map(|a| a.key.as_str()).collect();
+        assert_eq!(keys, ["claude", "codex", "hermes", "cursor", "pi", "opencode"]);
+        // OpenCode is last and carries the #768 "by Anomaly" subtitle.
+        let last = catalog.agents.last().unwrap();
+        assert_eq!(last.key, "opencode");
+        assert_eq!(last.description, "Open-source terminal coding agent by Anomaly");
+    }
+
+    #[test]
+    fn embedded_default_matches_current_presets_exactly() {
+        // Drift guard vs the pre-#769 AGENT_PRESETS field values.
+        let catalog = embedded_default_catalog();
+        assert_eq!(catalog.agents.len(), EXPECTED_PRESETS.len());
+        for (def, (key, label, desc, color, command, filename)) in
+            catalog.agents.iter().zip(EXPECTED_PRESETS)
+        {
+            assert_eq!(def.key, key);
+            assert_eq!(def.label, label);
+            assert_eq!(def.description, desc);
+            assert_eq!(def.color, color);
+            assert_eq!(def.command, command);
+            assert_eq!(def.instructions_filename.as_deref(), Some(filename));
+            // Phase-1 invariants: no folder seed ships; every built-in removable;
+            // no base env rows; not isolated.
+            assert!(def.config_seed.is_none(), "{key} must ship configSeed UNSET");
+            assert!(def.removable, "{key} must be removable");
+            assert!(def.envs.is_empty());
+            assert!(!def.isolated_home);
+        }
+    }
+
+    #[test]
+    fn every_embedded_entry_validates() {
+        for def in embedded_default_catalog().agents {
+            validate_definition(&def).unwrap_or_else(|e| panic!("{}: {e}", def.key));
+        }
+    }
+
+    #[test]
+    fn cursor_cli_command_is_agent() {
+        let catalog = embedded_default_catalog();
+        let cursor = catalog.agents.iter().find(|a| a.key == "cursor").unwrap();
+        assert_eq!(cursor.command, "agent");
+    }
+
+    #[test]
+    fn validate_catalog_key_accepts_allowlist_and_rejects_others() {
+        for ok in ["claude", "cursor-cli", "pi", "a1", "opencode", "x-2-y"] {
+            assert!(validate_catalog_key(ok).is_ok(), "should accept {ok:?}");
+        }
+        for bad in ["", "Claude", "cursor_cli", "cursor cli", "café", "a.b", "UP", "a/b"] {
+            assert!(validate_catalog_key(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn load_missing_manifest_returns_embedded_default() {
+        let dir = seed_dir();
+        let agents = load_catalog(dir.path());
+        assert_eq!(agents.len(), 6);
+        assert_eq!(agents[0].key, "claude");
+    }
+
+    #[test]
+    fn load_corrupt_manifest_returns_embedded_and_preserves_file() {
+        let dir = seed_dir();
+        let path = manifest_path(dir.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let garbage = b"{ this is not valid json";
+        std::fs::write(&path, garbage).unwrap();
+
+        let agents = load_catalog(dir.path());
+        assert_eq!(agents.len(), 6, "corrupt file self-heals to embedded default");
+        // G3: the corrupt file is preserved byte-for-byte, never overwritten.
+        assert_eq!(std::fs::read(&path).unwrap(), garbage);
+    }
+
+    #[test]
+    fn load_skips_invalid_entry_and_keeps_valid_rest() {
+        let dir = seed_dir();
+        let path = manifest_path(dir.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // First entry is valid; second has an illegal key (uppercase); third is
+        // valid. Only the two valid entries survive.
+        let agents = r##"[
+            {"key":"claude","label":"Claude","description":"d","color":"#000","command":"claude","envs":[],"isolatedHome":false,"removable":true},
+            {"key":"BAD KEY","label":"x","description":"d","color":"#000","command":"x","envs":[],"isolatedHome":false,"removable":true},
+            {"key":"mine","label":"Mine","description":"d","color":"#111","command":"mytool","envs":[],"isolatedHome":false,"removable":true}
+        ]"##;
+        std::fs::write(&path, manifest_json(agents)).unwrap();
+
+        let loaded = load_catalog(dir.path());
+        let keys: Vec<&str> = loaded.iter().map(|a| a.key.as_str()).collect();
+        assert_eq!(keys, ["claude", "mine"]);
+    }
+
+    #[test]
+    fn load_dedups_duplicate_keys_first_wins() {
+        let dir = seed_dir();
+        let path = manifest_path(dir.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let agents = r##"[
+            {"key":"claude","label":"First","description":"d","color":"#000","command":"claude","envs":[],"isolatedHome":false,"removable":true},
+            {"key":"claude","label":"Second","description":"d","color":"#000","command":"claude","envs":[],"isolatedHome":false,"removable":true}
+        ]"##;
+        std::fs::write(&path, manifest_json(agents)).unwrap();
+
+        let loaded = load_catalog(dir.path());
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].label, "First");
+    }
+
+    #[test]
+    fn load_honors_valid_empty_agents_list() {
+        // A user who removed every built-in has a valid, empty manifest. It is
+        // honored verbatim; the embedded default is NOT resurrected.
+        let dir = seed_dir();
+        let path = manifest_path(dir.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, manifest_json("[]")).unwrap();
+
+        assert!(load_catalog(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn ensure_seeded_writes_when_absent_then_is_idempotent() {
+        let dir = seed_dir();
+        let path = manifest_path(dir.path());
+        assert!(!path.exists());
+
+        ensure_seeded(dir.path());
+        assert!(path.exists(), "seed writes the manifest when absent");
+        assert_eq!(load_catalog(dir.path()).len(), 6);
+
+        // Idempotent + never clobbers a user edit: hand-edit to a single custom
+        // agent, re-seed, and confirm the edit is preserved.
+        let custom = manifest_json(
+            r##"[{"key":"mine","label":"Mine","description":"d","color":"#111","command":"mytool","envs":[],"isolatedHome":false,"removable":true}]"##,
+        );
+        std::fs::write(&path, &custom).unwrap();
+        ensure_seeded(dir.path());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), custom);
+        let loaded = load_catalog(dir.path());
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].key, "mine");
+    }
+
+    #[test]
+    fn seeded_manifest_leaves_no_temp_residue() {
+        let dir = seed_dir();
+        ensure_seeded(dir.path());
+        let catalog = catalog_dir(dir.path());
+        let residue: Vec<_> = std::fs::read_dir(&catalog)
+            .unwrap()
+            .flatten()
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .map(|n| n.contains(".tmp"))
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert!(residue.is_empty(), "no leftover temp files after seed");
+    }
+}

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -3,6 +3,7 @@ pub mod agent_config;
 pub mod agent_creation;
 pub mod claude_settings;
 pub mod coding_agent_profiles;
+pub mod coding_agents_catalog;
 pub mod config_seed;
 pub mod coordinator_clocks;
 pub mod daemon_pid;

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1236,7 +1236,7 @@ fn validate_env_map(env: &BTreeMap<String, String>, context: &str) -> Result<(),
     Ok(())
 }
 
-fn validate_env_rows(rows: &[CodingAgentEnv], context: &str) -> Result<(), String> {
+pub(crate) fn validate_env_rows(rows: &[CodingAgentEnv], context: &str) -> Result<(), String> {
     let mut seen = HashSet::new();
     for row in rows.iter().filter(|row| row.enabled) {
         validate_user_env_key(&row.key, context)?;
@@ -1414,7 +1414,7 @@ pub fn validate_agent_commands(settings: &AppSettings) -> Result<(), String> {
     Ok(())
 }
 
-fn validate_agent_command_text(context: &str, command: &str) -> Result<(), String> {
+pub(crate) fn validate_agent_command_text(context: &str, command: &str) -> Result<(), String> {
     let normalized = crate::config::agent_command::normalize_legacy_agent_command(command)
         .map_err(|e| format!("{context}: invalid command: {e}. command={command:?}"))?;
     let mut token_strings = Vec::with_capacity(normalized.shell_args.len() + 1);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -239,6 +239,11 @@ pub fn run(
         log::info!("[app-outbox] Cleaned stale instance directories");
     }
 
+    // #769 Phase 1 - seed the externalized coding-agent catalog once (whole-file
+    // seed-once, fail-soft; never aborts boot). Must run before the frontend can
+    // call `get_coding_agent_catalog`.
+    config::coding_agents_catalog::ensure_seeded(&config_dir);
+
     let instance_id = uuid::Uuid::new_v4().to_string();
     let app_outbox_path = instances_dir.join(&instance_id).join("outbox");
     std::fs::create_dir_all(&app_outbox_path).expect("Failed to create app outbox directory");
@@ -1909,6 +1914,7 @@ pub fn run(
             commands::pty::pty_resize,
             commands::pty::get_screen_snapshot,
             commands::config::get_settings,
+            commands::config::get_coding_agent_catalog,
             commands::config::update_settings,
             commands::resource_monitor::get_resource_snapshot,
             commands::resource_monitor::kill_resource_group,

--- a/src/shared/agent-presets.test.ts
+++ b/src/shared/agent-presets.test.ts
@@ -1,40 +1,92 @@
 import { describe, expect, it } from "vitest";
-import { AGENT_PRESETS, AGENT_PRESET_MAP } from "./agent-presets";
+import { FALLBACK_CODING_AGENTS, definitionToSeed } from "./agent-presets";
+import type { CodingAgentDefinition } from "./types";
 
-describe("agent presets (#529)", () => {
-  it("carries the default instructions filename on each built-in preset", () => {
-    expect(AGENT_PRESET_MAP.claude.instructionsFilename).toBe("CLAUDE.md");
-    expect(AGENT_PRESET_MAP.codex.instructionsFilename).toBe("AGENTS.md");
+// #769 — FALLBACK_CODING_AGENTS is a second copy of the backend's embedded
+// default (`src-tauri/resources/coding-agents/agents.default.json`). This is the
+// FE half of the drift guard: it pins the fallback to the exact same 6 built-ins
+// the backend ships, so the two copies cannot silently diverge (the backend's
+// `embedded_default_matches_current_presets_exactly` pins the other half).
+const EXPECTED_BUILTINS: Array<
+  Pick<
+    CodingAgentDefinition,
+    "key" | "label" | "description" | "color" | "command" | "instructionsFilename"
+  >
+> = [
+  { key: "claude", label: "Claude Code", description: "Coding Agent by Anthropic", color: "#d97706", command: "claude", instructionsFilename: "CLAUDE.md" },
+  { key: "codex", label: "Codex", description: "Coding Agent by OpenAI", color: "#10b981", command: "codex", instructionsFilename: "AGENTS.md" },
+  { key: "hermes", label: "Hermes", description: "Coding Agent by Nous Research", color: "#8b5cf6", command: "hermes", instructionsFilename: "AGENTS.md" },
+  { key: "cursor", label: "Cursor CLI", description: "Coding Agent by Cursor", color: "#22d3ee", command: "agent", instructionsFilename: "AGENTS.md" },
+  { key: "pi", label: "Pi", description: "Coding Agent by Earendil Inc", color: "#ec4899", command: "pi", instructionsFilename: "AGENTS.md" },
+  { key: "opencode", label: "OpenCode", description: "Open-source terminal coding agent by Anomaly", color: "#64748b", command: "opencode", instructionsFilename: "AGENTS.md" },
+];
+
+describe("FALLBACK_CODING_AGENTS drift guard (#769)", () => {
+  it("matches the backend embedded default: 6 built-ins, exact order and fields", () => {
+    expect(FALLBACK_CODING_AGENTS.map((a) => a.key)).toEqual([
+      "claude",
+      "codex",
+      "hermes",
+      "cursor",
+      "pi",
+      "opencode",
+    ]);
+    for (const expected of EXPECTED_BUILTINS) {
+      const actual = FALLBACK_CODING_AGENTS.find((a) => a.key === expected.key);
+      expect(actual).toBeTruthy();
+      expect(actual).toMatchObject(expected);
+    }
   });
 
-  it("ships Hermes / Cursor CLI / Pi and no longer ships Gemini (#766)", () => {
-    // Gemini removed from the catalog (backend gemini plumbing is untouched;
-    // existing user agents whose command is `gemini` are unaffected).
-    expect(AGENT_PRESET_MAP.gemini).toBeUndefined();
-    expect(AGENT_PRESETS.some((p) => p.key === "gemini")).toBe(false);
-
-    expect(AGENT_PRESET_MAP.hermes?.command).toBe("hermes");
-    expect(AGENT_PRESET_MAP.hermes?.instructionsFilename).toBe("AGENTS.md");
-    // Cursor CLI's executable is `agent`, not `cursor`.
-    expect(AGENT_PRESET_MAP.cursor?.command).toBe("agent");
-    expect(AGENT_PRESET_MAP.cursor?.instructionsFilename).toBe("AGENTS.md");
-    expect(AGENT_PRESET_MAP.pi?.command).toBe("pi");
-    expect(AGENT_PRESET_MAP.pi?.instructionsFilename).toBe("AGENTS.md");
-
-    // Label drives the onboarding card + settings quick-add button text.
-    expect(AGENT_PRESETS.find((p) => p.key === "cursor")?.label).toBe("Cursor CLI");
+  it("preserves the #766/#768 catalog facts: no Gemini, Cursor CLI runs `agent`, OpenCode 'by Anomaly'", () => {
+    expect(FALLBACK_CODING_AGENTS.some((a) => a.key === "gemini")).toBe(false);
+    expect(FALLBACK_CODING_AGENTS.find((a) => a.key === "cursor")?.command).toBe("agent");
+    expect(FALLBACK_CODING_AGENTS.find((a) => a.key === "opencode")?.description).toBe(
+      "Open-source terminal coding agent by Anomaly",
+    );
   });
 
-  it("ships an OpenCode preset with the bare `opencode` command and AGENTS.md", () => {
-    const opencode = AGENT_PRESETS.find((p) => p.key === "opencode");
-    expect(opencode).toBeTruthy();
-    expect(opencode?.label).toBe("OpenCode");
-    // #768 — subtitle re-attributed from SST to Anomaly.
-    expect(opencode?.description).toBe("Open-source terminal coding agent by Anomaly");
-    expect(opencode?.config.command).toBe("opencode");
-    expect(opencode?.config.instructionsFilename).toBe("AGENTS.md");
-    // Reachable via the quick-add lookup the Config Screen buttons use.
-    expect(AGENT_PRESET_MAP.opencode?.command).toBe("opencode");
-    expect(AGENT_PRESET_MAP.opencode?.instructionsFilename).toBe("AGENTS.md");
+  it("ships every built-in removable with no Phase-1 config seed", () => {
+    for (const def of FALLBACK_CODING_AGENTS) {
+      expect(def.removable).toBe(true);
+      expect(def.envs).toEqual([]);
+      expect(def.isolatedHome).toBe(false);
+      expect(def.configSeed).toBeUndefined();
+    }
+  });
+});
+
+describe("definitionToSeed (#769)", () => {
+  it("strips catalog-only fields and keeps the AgentConfig seed", () => {
+    const claude = FALLBACK_CODING_AGENTS.find((a) => a.key === "claude")!;
+    const seed = definitionToSeed(claude);
+    expect(seed).toEqual({
+      label: "Claude Code",
+      command: "claude",
+      color: "#d97706",
+      envs: [],
+      isolatedHome: false,
+      instructionsFilename: "CLAUDE.md",
+    });
+    // Catalog-only fields must not leak into the persisted agent.
+    expect("key" in seed).toBe(false);
+    expect("description" in seed).toBe(false);
+    expect("removable" in seed).toBe(false);
+  });
+
+  it("omits instructionsFilename and configSeed when the definition lacks them", () => {
+    const bare: CodingAgentDefinition = {
+      key: "bare",
+      label: "Bare",
+      description: "no extras",
+      color: "#000000",
+      command: "bare",
+      envs: [],
+      isolatedHome: false,
+      removable: true,
+    };
+    const seed = definitionToSeed(bare);
+    expect("instructionsFilename" in seed).toBe(false);
+    expect("configSeed" in seed).toBe(false);
   });
 });

--- a/src/shared/agent-presets.ts
+++ b/src/shared/agent-presets.ts
@@ -1,104 +1,113 @@
-import type { AgentConfig } from "./types";
+import type { AgentConfig, CodingAgentDefinition } from "./types";
 
-export interface AgentPreset {
-  key: string;
-  label: string;
-  description: string;
-  color: string;
-  config: Omit<AgentConfig, "id">;
-}
-
-export const AGENT_PRESETS: AgentPreset[] = [
+/**
+ * #769 — the coding-agent catalog is now backend-owned (the seeded, user-editable
+ * `<config_dir>/coding-agents/agents.json`, exposed by `get_coding_agent_catalog`
+ * and consumed through `codingAgentsStore`). This module keeps only:
+ *
+ *  - `newAgentId()` — id minter for the "+ Add" flow (unchanged), and
+ *  - `FALLBACK_CODING_AGENTS` — a synchronous never-empty seed and the offline
+ *    fallback the store falls back to when the IPC transport itself fails.
+ *
+ * `FALLBACK_CODING_AGENTS` is a second copy of the backend's embedded default
+ * (`src-tauri/resources/coding-agents/agents.default.json`). The duplication is
+ * intentional (it is what makes the onboarding/settings list resilient to a dead
+ * backend), and a drift-guard test keeps the two copies in lockstep with the
+ * backend's `embedded_default_matches_current_presets_exactly` test.
+ */
+export const FALLBACK_CODING_AGENTS: CodingAgentDefinition[] = [
   {
     key: "claude",
     label: "Claude Code",
     description: "Coding Agent by Anthropic",
     color: "#d97706",
-    config: {
-      label: "Claude Code",
-      command: "claude",
-      color: "#d97706",
-      envs: [],
-      isolatedHome: false,
-      instructionsFilename: "CLAUDE.md",
-    },
+    command: "claude",
+    instructionsFilename: "CLAUDE.md",
+    envs: [],
+    isolatedHome: false,
+    removable: true,
   },
   {
     key: "codex",
     label: "Codex",
     description: "Coding Agent by OpenAI",
     color: "#10b981",
-    config: {
-      label: "Codex",
-      command: "codex",
-      color: "#10b981",
-      envs: [],
-      isolatedHome: false,
-      instructionsFilename: "AGENTS.md",
-    },
+    command: "codex",
+    instructionsFilename: "AGENTS.md",
+    envs: [],
+    isolatedHome: false,
+    removable: true,
   },
   {
     key: "hermes",
     label: "Hermes",
     description: "Coding Agent by Nous Research",
     color: "#8b5cf6",
-    config: {
-      label: "Hermes",
-      command: "hermes",
-      color: "#8b5cf6",
-      envs: [],
-      isolatedHome: false,
-      instructionsFilename: "AGENTS.md",
-    },
+    command: "hermes",
+    instructionsFilename: "AGENTS.md",
+    envs: [],
+    isolatedHome: false,
+    removable: true,
   },
   {
     key: "cursor",
     label: "Cursor CLI",
     description: "Coding Agent by Cursor",
     color: "#22d3ee",
-    config: {
-      label: "Cursor CLI",
-      // Cursor's CLI executable is `agent`, not `cursor`.
-      command: "agent",
-      color: "#22d3ee",
-      envs: [],
-      isolatedHome: false,
-      instructionsFilename: "AGENTS.md",
-    },
+    // Cursor's CLI executable is `agent`, not `cursor`.
+    command: "agent",
+    instructionsFilename: "AGENTS.md",
+    envs: [],
+    isolatedHome: false,
+    removable: true,
   },
   {
     key: "pi",
     label: "Pi",
     description: "Coding Agent by Earendil Inc",
     color: "#ec4899",
-    config: {
-      label: "Pi",
-      command: "pi",
-      color: "#ec4899",
-      envs: [],
-      isolatedHome: false,
-      instructionsFilename: "AGENTS.md",
-    },
+    command: "pi",
+    instructionsFilename: "AGENTS.md",
+    envs: [],
+    isolatedHome: false,
+    removable: true,
   },
   {
     key: "opencode",
     label: "OpenCode",
     description: "Open-source terminal coding agent by Anomaly",
     color: "#64748b",
-    config: {
-      label: "OpenCode",
-      command: "opencode",
-      color: "#64748b",
-      envs: [],
-      isolatedHome: false,
-      instructionsFilename: "AGENTS.md",
-    },
+    command: "opencode",
+    instructionsFilename: "AGENTS.md",
+    envs: [],
+    isolatedHome: false,
+    removable: true,
   },
 ];
 
-/** Record-based lookup for SettingsModal quick-add buttons */
-export const AGENT_PRESET_MAP: Record<string, Omit<AgentConfig, "id">> =
-  Object.fromEntries(AGENT_PRESETS.map((p) => [p.key, p.config]));
+/**
+ * Project a catalog definition onto the persisted agent seed the onboarding and
+ * settings "+ Add" flows feed to `addAgent` — i.e. `Omit<AgentConfig, "id">`,
+ * dropping the catalog-only `{ key, description, removable }`. `instructionsFilename`
+ * and `configSeed` are carried through only when present, matching how the old
+ * `AGENT_PRESET_MAP.<key>` values were shaped.
+ */
+export function definitionToSeed(def: CodingAgentDefinition): Omit<AgentConfig, "id"> {
+  const seed: Omit<AgentConfig, "id"> = {
+    label: def.label,
+    command: def.command,
+    color: def.color,
+    envs: def.envs,
+    isolatedHome: def.isolatedHome,
+  };
+  if (def.instructionsFilename !== undefined) {
+    seed.instructionsFilename = def.instructionsFilename;
+  }
+  if (def.configSeed !== undefined) {
+    seed.configSeed = def.configSeed;
+  }
+  return seed;
+}
 
 let idCounter = 0;
 export function newAgentId(): string {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -12,6 +12,7 @@ import type {
   LogLevel,
   UpdateInfo,
   CodingAgentEnv,
+  CodingAgentDefinition,
   CodingAgentProfilesConfig,
   RepoMatch,
   BridgeInfo,
@@ -247,6 +248,18 @@ export const PtyAPI = {
   /** Get current PTY dimensions (rows, cols). */
   getPtySize: (sessionId: string) =>
     transport.invoke<{ rows: number; cols: number }>("get_pty_size", { sessionId }),
+};
+
+export const CodingAgentsAPI = {
+  /**
+   * #769 — the built-in coding-agent catalog. Resolves `Ok(list)` normally and
+   * on backend self-heal (missing/malformed `agents.json` → embedded default in
+   * memory, file never overwritten); a valid `Ok([])` (user removed all
+   * built-ins) is returned verbatim. Rejects only on a genuine config-dir
+   * failure, which is the sole case the store's fallback covers.
+   */
+  getCatalog: () =>
+    transport.invoke<CodingAgentDefinition[]>("get_coding_agent_catalog"),
 };
 
 export const SettingsAPI = {

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -14,6 +14,7 @@ import { projectStore } from "../../sidebar/stores/project";
 import { sessionsStore } from "../../sidebar/stores/sessions";
 import { bridgesStore } from "../../sidebar/stores/bridges";
 import { workgroupGroupsStore } from "../../sidebar/stores/workgroup-groups";
+import { codingAgentsStore } from "../../sidebar/stores/coding-agents";
 import { terminalStore } from "../../terminal/stores/terminal";
 import { __resetHomeStoreForTests } from "../../main/stores/home";
 
@@ -233,6 +234,7 @@ export function resetUiStoresForTests(): void {
   sessionsStore.setCoordSortByActivity(false);
   sessionsStore.clearDetached();
   workgroupGroupsStore.resetForTests();
+  codingAgentsStore.resetForTests();
   bridgesStore.setBridges([]);
   terminalStore.setActiveSession(null, "", "", null, "", null);
   terminalStore.setActiveWorkgroupTask(null);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -164,6 +164,32 @@ export interface CodingAgentEnv {
   enabled: boolean;
 }
 
+/**
+ * #769 — a built-in coding-agent catalog entry, returned by the backend
+ * `get_coding_agent_catalog` command (source of truth: the seeded, user-editable
+ * `<config_dir>/coding-agents/agents.json`). Replaces the old hardcoded
+ * `AGENT_PRESETS`. Maps onto `Omit<AgentConfig, "id">` plus `{ key, description,
+ * removable }`; `definitionToSeed()` performs that projection for the "+ Add"
+ * flow. `envs`, `isolatedHome`, and `removable` are always present (the backend
+ * fills serde defaults); `instructionsFilename` / `configSeed` are omitted from
+ * the JSON when unset.
+ */
+export interface CodingAgentDefinition {
+  /** Stable catalog identity, `^[a-z0-9-]+$`, unique; doubles as a testid/CSS token. */
+  key: string;
+  label: string;
+  /** "Coding Agent by …" subtitle shown on the onboarding card. */
+  description: string;
+  color: string;
+  command: string;
+  instructionsFilename?: string;
+  envs: CodingAgentEnv[];
+  isolatedHome: boolean;
+  configSeed?: ConfigSeedConfig;
+  /** Whether the user may delete this built-in (all Phase-1 built-ins are true). */
+  removable: boolean;
+}
+
 export interface CodingAgentProfilesConfig {
   schemaVersion: number;
   /** v2 (#384): renamed from `letters`. Keyed by profile slot letter A–Z. */

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -10,6 +10,26 @@ vi.mock("../../shared/ipc", () => ({
     get: vi.fn(() => Promise.resolve(settings())),
     update: vi.fn(() => Promise.resolve()),
   },
+  // #769 — OnboardingModal now drives its cards from codingAgentsStore, which
+  // fetches this. Resolve a catalog that includes Codex (the preset this suite
+  // selects); the store's synchronous fallback also carries Codex regardless.
+  CodingAgentsAPI: {
+    getCatalog: vi.fn(() =>
+      Promise.resolve([
+        {
+          key: "codex",
+          label: "Codex",
+          description: "Coding Agent by OpenAI",
+          color: "#10b981",
+          command: "codex",
+          instructionsFilename: "AGENTS.md",
+          envs: [],
+          isolatedHome: false,
+          removable: true,
+        },
+      ]),
+    ),
+  },
 }));
 
 vi.mock("../../shared/stores/settings", () => ({

--- a/src/sidebar/components/OnboardingModal.tsx
+++ b/src/sidebar/components/OnboardingModal.tsx
@@ -1,31 +1,33 @@
 import { Component, createSignal, For, onMount, Show } from "solid-js";
-import type { AgentConfig, AppSettings } from "../../shared/types";
+import type { AgentConfig, AppSettings, CodingAgentDefinition } from "../../shared/types";
 import { SettingsAPI } from "../../shared/ipc";
 import { settingsStore } from "../../shared/stores/settings";
-import { AGENT_PRESETS, newAgentId } from "../../shared/agent-presets";
-import type { AgentPreset } from "../../shared/agent-presets";
+import { newAgentId, definitionToSeed } from "../../shared/agent-presets";
+import { codingAgentsStore } from "../stores/coding-agents";
 
-const CUSTOM_PRESET: AgentPreset = {
+// Custom Agent is not a catalog entry: it triggers the inline name/command
+// fields and is always offered last, so it stays a client-side definition.
+const CUSTOM_PRESET: CodingAgentDefinition = {
   key: "custom",
   label: "Custom Agent",
   description: "Configure your own Coding Agent",
   color: "#6366f1",
-  config: {
-    label: "",
-    command: "",
-    color: "#6366f1",
-    envs: [],
-    isolatedHome: false,
-  },
+  command: "",
+  envs: [],
+  isolatedHome: false,
+  removable: false,
 };
-
-const ALL_PRESETS = [...AGENT_PRESETS, CUSTOM_PRESET];
 
 const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
   const [selectedPreset, setSelectedPreset] = createSignal<string | null>(null);
   const [saving, setSaving] = createSignal(false);
   const [done, setDone] = createSignal(false);
   const [addedLabel, setAddedLabel] = createSignal("");
+
+  // #769 — the catalog is backend-owned; the store is pre-seeded with the
+  // fallback so the card list (and the #768 no-scroll fit) renders immediately,
+  // with no wrong-length flash before the async fetch resolves.
+  const allPresets = () => [...codingAgentsStore.catalog(), CUSTOM_PRESET];
 
   const dismissAndClose = async () => {
     try {
@@ -55,7 +57,7 @@ const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
     const key = selectedPreset();
     if (!key) return;
 
-    const preset = ALL_PRESETS.find((p) => p.key === key);
+    const preset = allPresets().find((p) => p.key === key);
     if (!preset) return;
 
     setSaving(true);
@@ -68,12 +70,12 @@ const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
           id: newAgentId(),
           label: customLabel().trim(),
           command: customCommand().trim(),
-          color: preset.config.color,
+          color: preset.color,
           envs: [],
           isolatedHome: false,
         };
       } else {
-        agent = { id: newAgentId(), ...preset.config };
+        agent = { id: newAgentId(), ...definitionToSeed(preset) };
       }
 
       const updated: AppSettings = {
@@ -119,7 +121,10 @@ const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
 
   let overlayRef!: HTMLDivElement;
   let modalRef!: HTMLDivElement;
-  onMount(() => overlayRef.focus());
+  onMount(() => {
+    overlayRef.focus();
+    void codingAgentsStore.ensureLoaded();
+  });
 
   return (
     <div
@@ -165,7 +170,7 @@ const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
             </p>
 
             <div class="onboarding-cards">
-              <For each={ALL_PRESETS}>
+              <For each={allPresets()}>
                 {(preset) => (
                   <button
                     class={`onboarding-card ${selectedPreset() === preset.key ? "selected" : ""}`}

--- a/src/sidebar/components/SettingsModal.catalog.test.tsx
+++ b/src/sidebar/components/SettingsModal.catalog.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SettingsModal from "./SettingsModal";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { FALLBACK_CODING_AGENTS } from "../../shared/agent-presets";
+import type { AgentConfig, CodingAgentDefinition } from "../../shared/types";
+
+const CATALOG_CMD = "get_coding_agent_catalog";
+
+function def(key: string, label: string, command: string): CodingAgentDefinition {
+  return {
+    key,
+    label,
+    description: `Coding Agent ${label}`,
+    color: "#334155",
+    command,
+    envs: [],
+    isolatedHome: false,
+    removable: true,
+  };
+}
+
+function existingAgent(command: string): AgentConfig {
+  return {
+    id: "agent_existing",
+    label: `Existing ${command}`,
+    command,
+    color: "#334155",
+    envs: [],
+    isolatedHome: false,
+  };
+}
+
+function presetBtn(root: HTMLElement, key: string): HTMLButtonElement | null {
+  return root.querySelector<HTMLButtonElement>(`[data-ac-testid="settings.agentPreset.${key}"]`);
+}
+
+describe("SettingsModal coding-agent quick-add row (#769)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("renders one quick-add button per fetched definition, in order, and disables ones already added", async () => {
+    const fake = new FakeTransport();
+    // An agent whose command is `claude` already exists → the Claude quick-add
+    // must be disabled by hasAgentByCommand; codex/pi stay available.
+    fake.resolve("get_settings", baseSettings({ agents: [existingAgent("claude")] }));
+    fake.resolve("get_web_server_status", false);
+    fake.resolve(CATALOG_CMD, [
+      def("claude", "Claude Code", "claude"),
+      def("codex", "Codex", "codex"),
+      def("pi", "Pi", "pi"),
+    ]);
+
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="agents" onClose={() => {}} />,
+      fake,
+    );
+    try {
+      await waitFor(() => expect(presetBtn(rendered.root, "codex")).toBeTruthy());
+
+      // Exactly the three fetched keys, in file order (custom stays separate).
+      const keys = Array.from(
+        rendered.root.querySelectorAll<HTMLElement>('[data-ac-testid^="settings.agentPreset."]'),
+      ).map((el) => el.getAttribute("data-ac-testid"));
+      expect(keys).toEqual([
+        "settings.agentPreset.claude",
+        "settings.agentPreset.codex",
+        "settings.agentPreset.pi",
+      ]);
+
+      expect(presetBtn(rendered.root, "claude")!.disabled).toBe(true);
+      expect(presetBtn(rendered.root, "codex")!.disabled).toBe(false);
+      expect(presetBtn(rendered.root, "pi")!.disabled).toBe(false);
+      // The hardcoded Custom Agent button is still present, last.
+      expect(
+        rendered.root.querySelector('[data-ac-testid="settings.agent.addCustom"]'),
+      ).toBeTruthy();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("falls back to the built-in list (never blank) when the catalog fetch fails", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", baseSettings());
+    fake.resolve("get_web_server_status", false);
+    fake.reject(CATALOG_CMD, "config-dir failure");
+
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="agents" onClose={() => {}} />,
+      fake,
+    );
+    try {
+      // All six built-ins from the synchronous fallback render despite the reject.
+      await waitFor(() => expect(presetBtn(rendered.root, "opencode")).toBeTruthy());
+      for (const d of FALLBACK_CODING_AGENTS) {
+        expect(presetBtn(rendered.root, d.key)).toBeTruthy();
+      }
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -14,7 +14,8 @@ import { validateScreenshotHotkeySyntax } from "../../shared/screenshot-hotkey";
 import { settingsStore } from "../../shared/stores/settings";
 import { setSoundsEnabled } from "../../shared/sound";
 import { sessionsStore } from "../stores/sessions";
-import { AGENT_PRESET_MAP, newAgentId } from "../../shared/agent-presets";
+import { newAgentId, definitionToSeed } from "../../shared/agent-presets";
+import { codingAgentsStore } from "../stores/coding-agents";
 import { mergeSettingsForSavePreservingProjects } from "./settings-save";
 import {
   AC_MATRIX_ROOT_PLACEHOLDER,
@@ -209,6 +210,9 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     setExpandedCells(`${agentId}:${letter}`, !isCellExpanded(agentId, letter));
 
   onMount(async () => {
+    // #769 — populate the backend-owned coding-agent catalog for the quick-add
+    // row. Pre-seeded with the fallback, so the buttons render immediately.
+    void codingAgentsStore.ensureLoaded();
     const [loaded, wsRunning] = await Promise.all([
       SettingsAPI.get(),
       SettingsAPI.getWebServerStatus().catch(() => false),
@@ -1490,77 +1494,27 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     );
   };
 
+  // #769 — quick-add buttons are driven by the backend-owned catalog
+  // (`codingAgentsStore`) instead of a hand-maintained button per agent. Order,
+  // per-command `hasAgentByCommand` guards, testids, and `addAgent` are preserved
+  // verbatim; `+ Custom Agent` stays hardcoded last (it is not a catalog entry).
   const renderAgentPresets = () => (
     <div class="settings-agent-actions">
-      <button
-        class="settings-preset-btn"
-        onClick={() => addAgent(AGENT_PRESET_MAP.claude)}
-        disabled={hasAgentByCommand("claude")}
-        data-ac-testid="settings.agentPreset.claude"
-        data-ac-role="button"
-        data-ac-state={hasAgentByCommand("claude") ? "disabled" : "available"}
-      >
-        <span class="settings-color-dot" style={{ background: AGENT_PRESET_MAP.claude.color }} />
-        + Claude Code
-      </button>
-      <button
-        class="settings-preset-btn"
-        onClick={() => addAgent(AGENT_PRESET_MAP.codex)}
-        disabled={hasAgentByCommand("codex")}
-        data-ac-testid="settings.agentPreset.codex"
-        data-ac-role="button"
-        data-ac-state={hasAgentByCommand("codex") ? "disabled" : "available"}
-      >
-        <span class="settings-color-dot" style={{ background: AGENT_PRESET_MAP.codex.color }} />
-        + Codex
-      </button>
-      <button
-        class="settings-preset-btn"
-        onClick={() => addAgent(AGENT_PRESET_MAP.hermes)}
-        disabled={hasAgentByCommand("hermes")}
-        data-ac-testid="settings.agentPreset.hermes"
-        data-ac-role="button"
-        data-ac-state={hasAgentByCommand("hermes") ? "disabled" : "available"}
-      >
-        <span class="settings-color-dot" style={{ background: AGENT_PRESET_MAP.hermes.color }} />
-        + Hermes
-      </button>
-      <button
-        class="settings-preset-btn"
-        onClick={() => addAgent(AGENT_PRESET_MAP.cursor)}
-        disabled={hasAgentByCommand("agent")}
-        data-ac-testid="settings.agentPreset.cursor"
-        data-ac-role="button"
-        data-ac-state={hasAgentByCommand("agent") ? "disabled" : "available"}
-      >
-        <span class="settings-color-dot" style={{ background: AGENT_PRESET_MAP.cursor.color }} />
-        + Cursor CLI
-      </button>
-      <button
-        class="settings-preset-btn"
-        onClick={() => addAgent(AGENT_PRESET_MAP.pi)}
-        disabled={hasAgentByCommand("pi")}
-        data-ac-testid="settings.agentPreset.pi"
-        data-ac-role="button"
-        data-ac-state={hasAgentByCommand("pi") ? "disabled" : "available"}
-      >
-        <span class="settings-color-dot" style={{ background: AGENT_PRESET_MAP.pi.color }} />
-        + Pi
-      </button>
-      <button
-        class="settings-preset-btn"
-        onClick={() => addAgent(AGENT_PRESET_MAP.opencode)}
-        disabled={hasAgentByCommand("opencode")}
-        data-ac-testid="settings.agentPreset.opencode"
-        data-ac-role="button"
-        data-ac-state={hasAgentByCommand("opencode") ? "disabled" : "available"}
-      >
-        <span
-          class="settings-color-dot"
-          style={{ background: AGENT_PRESET_MAP.opencode.color }}
-        />
-        + OpenCode
-      </button>
+      <For each={codingAgentsStore.catalog()}>
+        {(def) => (
+          <button
+            class="settings-preset-btn"
+            onClick={() => addAgent(definitionToSeed(def))}
+            disabled={hasAgentByCommand(def.command)}
+            data-ac-testid={`settings.agentPreset.${def.key}`}
+            data-ac-role="button"
+            data-ac-state={hasAgentByCommand(def.command) ? "disabled" : "available"}
+          >
+            <span class="settings-color-dot" style={{ background: def.color }} />
+            + {def.label}
+          </button>
+        )}
+      </For>
       <button
         class="settings-add-btn"
         onClick={() => addAgent()}

--- a/src/sidebar/stores/coding-agents.test.ts
+++ b/src/sidebar/stores/coding-agents.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import { __setTransportForTests } from "../../shared/ipc";
+import { FALLBACK_CODING_AGENTS } from "../../shared/agent-presets";
+import type { CodingAgentDefinition } from "../../shared/types";
+import { codingAgentsStore } from "./coding-agents";
+
+const CMD = "get_coding_agent_catalog";
+
+function def(key: string): CodingAgentDefinition {
+  return {
+    key,
+    label: key,
+    description: `by ${key}`,
+    color: "#123456",
+    command: key,
+    envs: [],
+    isolatedHome: false,
+    removable: true,
+  };
+}
+
+describe("codingAgentsStore (#769)", () => {
+  let fake: FakeTransport;
+
+  beforeEach(() => {
+    codingAgentsStore.resetForTests();
+    fake = new FakeTransport();
+    __setTransportForTests(fake);
+  });
+
+  afterEach(() => {
+    codingAgentsStore.resetForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("is seeded synchronously with the fallback (never blank before a fetch)", () => {
+    expect(codingAgentsStore.catalog()).toBe(FALLBACK_CODING_AGENTS);
+    expect(codingAgentsStore.loaded()).toBe(false);
+  });
+
+  it("replaces the catalog with the fetched list on success", async () => {
+    const fetched = [def("alpha"), def("beta")];
+    fake.resolve(CMD, fetched);
+    await codingAgentsStore.ensureLoaded();
+    expect(codingAgentsStore.catalog()).toEqual(fetched);
+    expect(codingAgentsStore.loaded()).toBe(true);
+  });
+
+  it("honors a valid empty Ok([]) verbatim — does NOT resurrect the fallback", async () => {
+    fake.resolve(CMD, []);
+    await codingAgentsStore.ensureLoaded();
+    expect(codingAgentsStore.catalog()).toEqual([]);
+    expect(codingAgentsStore.loaded()).toBe(true);
+  });
+
+  it("keeps the fallback and does not throw when the transport fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    fake.reject(CMD, "config-dir failure");
+    // Must resolve (never reject into the mounting component).
+    await expect(codingAgentsStore.ensureLoaded()).resolves.toBeUndefined();
+    expect(codingAgentsStore.catalog()).toBe(FALLBACK_CODING_AGENTS);
+    expect(codingAgentsStore.loaded()).toBe(true);
+  });
+
+  it("dedups concurrent loads into a single invoke", async () => {
+    fake.resolve(CMD, [def("alpha")]);
+    await Promise.all([
+      codingAgentsStore.ensureLoaded(),
+      codingAgentsStore.ensureLoaded(),
+      codingAgentsStore.ensureLoaded(),
+    ]);
+    expect(fake.callsFor(CMD).length).toBe(1);
+  });
+
+  it("does not refetch once loaded", async () => {
+    fake.resolve(CMD, [def("alpha")]);
+    await codingAgentsStore.ensureLoaded();
+    await codingAgentsStore.ensureLoaded();
+    expect(fake.callsFor(CMD).length).toBe(1);
+  });
+});

--- a/src/sidebar/stores/coding-agents.ts
+++ b/src/sidebar/stores/coding-agents.ts
@@ -1,0 +1,58 @@
+import { createSignal } from "solid-js";
+import type { CodingAgentDefinition } from "../../shared/types";
+import { CodingAgentsAPI } from "../../shared/ipc";
+import { FALLBACK_CODING_AGENTS } from "../../shared/agent-presets";
+
+/**
+ * #769 — the coding-agent catalog consumed by OnboardingModal and SettingsModal.
+ * Mirrors `workgroupGroupsStore.ensureLoaded`: the signal is seeded SYNCHRONOUSLY
+ * with `FALLBACK_CODING_AGENTS`, so the onboarding/settings agent list is never
+ * blank for even one frame (the "never-empty" guarantee comes from the initial
+ * value, not a loading branch). `ensureLoaded()` fetches once (in-flight dedup +
+ * `loaded` guard); on transport failure it KEEPS the fallback, logs, and marks
+ * loaded — it never throws to the component.
+ *
+ * A valid `Ok([])` from the backend (the user removed every built-in) is honored
+ * verbatim — the fallback is NOT resurrected on a successful empty response, only
+ * on reject/pending. Onboarding stays actionable because the modal appends its
+ * own "Custom Agent" entry client-side.
+ */
+const [catalog, setCatalog] = createSignal<CodingAgentDefinition[]>(FALLBACK_CODING_AGENTS);
+const [loaded, setLoaded] = createSignal(false);
+let inFlight: Promise<void> | null = null;
+
+export const codingAgentsStore = {
+  /** Reactive catalog. Starts as `FALLBACK_CODING_AGENTS`; replaced once loaded. */
+  catalog,
+  loaded,
+
+  async ensureLoaded(): Promise<void> {
+    if (loaded()) return;
+    if (inFlight) return inFlight;
+
+    inFlight = (async () => {
+      try {
+        const fetched = await CodingAgentsAPI.getCatalog();
+        // Honor a valid empty list verbatim (do not fall back to the seed).
+        setCatalog(fetched);
+      } catch (error) {
+        // Transport failure only (the command self-heals malformed files to the
+        // embedded default). Keep the synchronously-seeded fallback so the list
+        // is never blank; never rethrow into the mounting component.
+        console.error("Failed to load coding-agent catalog; using fallback:", error);
+      } finally {
+        setLoaded(true);
+        inFlight = null;
+      }
+    })();
+
+    return inFlight;
+  },
+
+  /** Test-only: restore the pristine pre-fetch state. */
+  resetForTests(): void {
+    setCatalog(FALLBACK_CODING_AGENTS);
+    setLoaded(false);
+    inFlight = null;
+  },
+};


### PR DESCRIPTION
## Summary

**Phase 1 of #769** (externalize coding-agent definitions). Moves the coding-agent **catalog** from the hardcoded frontend to a **seeded, user-editable backend JSON** at `config_dir()/coding-agents/agents.json` — users can add/edit/remove coding agents and change their name / command / instructions-file / color / envs **without recompiling**.

- **Backend** (`src-tauri/`): new `config/coding_agents_catalog.rs` — whole-file **seed-once** manifest (written once if absent, then user-owned; atomic temp+rename; **fail-soft**, never breaks boot), `load_catalog` with **per-entry validation** + `^[a-z0-9-]+$` key charset + **corrupt-preserve** (a malformed `agents.json` is never overwritten — embedded default served in memory), an embedded default **byte-equal to the current post-#766/#768 presets**, and the `get_coding_agent_catalog` command (`Ok` normal + self-heal; `Ok([])` honored; `Err` only on config-dir failure). `settings.agents` / `AgentConfig` / spawn / profile / resolver / watcher **untouched**; `configSeed` ships unset so spawn behavior is byte-unchanged.
- **Frontend** (`src/`): a fallback-seeded store (`sidebar/stores/coding-agents.ts`) — **never blank** (synchronous fallback seed), fallback fires only on transport failure, a valid `Ok([])` is honored (not resurrected). `OnboardingModal` + `SettingsModal` consume the backend catalog; `agent-presets.ts` shrinks to a fallback constant. All #766/#768 behavior preserved (no Gemini; Hermes / Cursor CLI / Pi; OpenCode "by Anomaly"; onboarding no-scroll fit).
- **Two-sided drift guard**: BE embedded default == FE fallback == pre-#769 presets (tests fail on divergence).

**Not in this PR (later phases):** default config folders + the "Re-seed default configuration" button (Phase 2); automatic refresh / provenance (Phase 3).

## Review trail

- **dev-rust** backend `f4a199f`; **dev-webpage-ui** frontend `ce7731d`.
- **Grinch Step-9 PASS:** 0 HIGH / 0 MED / 0 LOW, 3 INFO (corrupt-file user-facing notice deferred to the Phase-2 editor — data-safety fully intact; a cosmetic async `<For>` re-render; the 9.5 drift). Gates re-run by Grinch: `cargo build`/`clippy` clean, `cargo test` 1861/0/12, `tsc` 0, `vitest` 687/0, `build` OK. Visual gate confirmed **backend-driven** (a distinct served catalog proved the UI reads the store).
- **Re-synced** onto `origin/main` `963cb0f` (a `#771` Terminal-view fix) — clean auto-merge `80c68b6`, fingerprint-proven lossless (Phase-1 byte-identical; the only hand-touched file `ui-harness.tsx` preserves both sides). **Focused Grinch re-check PASS**; gates on merged tree `tsc` 0 / `vitest` 690/0 / `build` OK.
- Design + decisions (D1–D6, 3-phase plan) recorded on #769. No version bump.

refs #769 (Phase 1 of 3 — does not close the issue)
