### PR TITLE
fix: unique per-writer temp filename for settings persistence (refs #774)

### DIFF
--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -1735,10 +1736,20 @@ pub fn read_log_level_only() -> Option<String> {
     read_log_level_from_path(&settings_path()?)
 }
 
+/// #774: counter feeding the per-call unique temp filename for settings saves.
+/// Combined with the PID it makes `settings.json.<pid>.<op_id>.tmp` distinct from
+/// any concurrent cross-process save (GUI startup, CLI verbs, closing flush) and
+/// from any leftover temp written by a prior crashed run. Mirrors
+/// `sessions_persistence::SAVE_OP_ID` (sessions_persistence.rs:47); a separate
+/// counter so the two can be reasoned about independently in diagnostics.
+static SAVE_OP_ID: AtomicU64 = AtomicU64::new(0);
+
 /// Save settings to the app config directory (see config_dir()).
-/// Atomic write (tmp + rename) per G.14 — mirrors `sessions_persistence::save_sessions`.
-/// Splitter-drag debouncing raises save frequency in 0.8.0; atomic writes ensure a crash
-/// mid-write cannot corrupt the existing settings.json.
+/// Atomic write via `save_settings_to_path`: a per-writer unique temp plus
+/// `sessions_persistence::rename_with_retry` (#774), matching the concurrency
+/// hardening `save_sessions` already uses (sessions_persistence.rs #291/#280).
+/// Splitter-drag debouncing raises save frequency in 0.8.0; the atomic tmp+rename
+/// ensures a crash mid-write cannot corrupt the existing settings.json.
 pub fn save_settings(settings: &AppSettings) -> Result<(), String> {
     let dir = super::config_dir().ok_or("Could not determine home directory")?;
     let path = dir.join("settings.json");
@@ -1756,11 +1767,37 @@ fn save_settings_to_path(settings: &AppSettings, path: &Path) -> Result<(), Stri
     let json = serde_json::to_string_pretty(settings)
         .map_err(|e| format!("Failed to serialize settings: {}", e))?;
 
-    let tmp_path = dir.join("settings.json.tmp");
-    std::fs::write(&tmp_path, &json)
-        .map_err(|e| format!("Failed to write temp settings file: {}", e))?;
-    std::fs::rename(&tmp_path, path)
-        .map_err(|e| format!("Failed to rename settings file: {}", e))?;
+    // #774 (A): unique temp filename per save. Combined with rename_with_retry
+    // below, this kills the shared-`settings.json.tmp` race: two cross-process
+    // writers (GUI startup, CLI verbs, closing flush) can never collide on the
+    // temp file, and any leftover `.tmp` from a prior crashed run cannot be
+    // mistaken for ours. Mirrors sessions_persistence.rs:763-765.
+    let op_id = SAVE_OP_ID.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let tmp_path = dir.join(format!("settings.json.{}.{}.tmp", pid, op_id));
+
+    if let Err(e) = std::fs::write(&tmp_path, &json) {
+        // Best-effort cleanup: the partial write may have created the file even
+        // though write returned Err (e.g. ENOSPC mid-stream).
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("Failed to write temp settings file: {}", e));
+    }
+
+    // #774 (B): route the rename through the reviewed retry helper. It absorbs
+    // transient cross-process contention on the DESTINATION (a second AC
+    // instance, AV, or the Indexer briefly holding settings.json; os errors
+    // 5/32/33/1175). With the unique temp above, our source can never be
+    // consumed by another writer, so os error 2 (source absent) is no longer a
+    // concurrency symptom; if it still surfaces it is propagated (with the OS
+    // error in the message) after the bounded retry, not masked.
+    if let Err((err_msg, _diag)) =
+        crate::config::sessions_persistence::rename_with_retry(&tmp_path, path)
+    {
+        // Best-effort cleanup of our unique temp so failed saves don't litter
+        // the config dir. The unique name guarantees this removes only OUR temp.
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("Failed to rename settings file: {}", err_msg));
+    }
 
     log::debug!("Saved settings to {:?}", path);
     Ok(())


### PR DESCRIPTION
## Problem

`save_settings_to_path` used a fixed, shared temp filename `settings.json.tmp` before renaming onto `settings.json`, with no per-writer uniqueness. When two OS processes persisted settings concurrently (GUI startup writing root_token/migrations, CLI verbs `new-project`/`open-project`, or startup/shutdown overlap between GUI instances), both wrote the same temp; the first `rename` consumed it and the second failed with:

```
Failed to persist settings (root_token gen and/or settings migration): Failed to rename settings file: The system cannot find the file specified. (os error 2)
```

Non-fatal, but the failed persist meant `root_token` was not saved (rotated every startup) and migrations re-ran each boot. `settings.rs` was the last atomic writer in the repo not hardened against this race.

## Fix (A + B)

Single file, `src-tauri/src/config/settings.rs`, mirroring the proven pattern in `sessions_persistence` (#291/#280) and `local_config_io` (#537):

- **A:** unique per-writer temp filename `settings.json.<pid>.<op_id>.tmp` (`static AtomicU64` + `std::process::id()`). Each writer renames its own temp, so concurrent renames onto the same destination no longer starve each other. Eliminates the os error 2 structurally.
- **B:** route the rename through the existing `sessions_persistence::rename_with_retry` to absorb transient destination contention (AV/indexer: os error 5/32/33/1175). Plus best-effort temp cleanup on both failure paths.

No process-wide mutex (the `SettingsState` RwLock already serializes in-process writers and `load_settings` runs before it exists). Also fixed the stale comment that claimed parity with `sessions_persistence`.

## Review

- Design: architect plan `READY_FOR_IMPLEMENTATION`.
- Grinch Step 6 (plan review): SOLID / cleared.
- Grinch Step 9 (diff `468caeb..75aa4b7`): **PASS** — byte-exact to the approved plan, correct cleanup (only-our-temp, both fail paths, no double-remove/leak), no regressions; gates reproduced by grinch.
- Gates: `cargo build` clean (no new warnings); `cargo test --lib --bins --tests` = **1861 passed / 0 failed / 12 ignored** (== baseline `468caeb`).

## Known accepted trade-offs (documented, no action)

- Retry logs appear under the `[sessions]` tag (the shared helper hardcodes it; same as `coordinator_clocks`).
- Hard kills/crashes may leave orphan `settings.json.<pid>.<opid>.tmp` temps unswept, matching the accepted posture in `sessions_persistence` / `local_config_io`.

## Out of scope (separate follow-up)

The GUI-vs-CLI old-snapshot clobber (`open_project.rs:14`) is not addressed by A+B; needs a reload watcher or merge-on-save.

Closes #774
