### PR TITLE
feat: externalize coding-agent default config folders + re-seed button (Phase 2, refs #769)

### DIFF
--- a/src-tauri/resources/coding-agents/_seed/.claude/settings.json
+++ b/src-tauri/resources/coding-agents/_seed/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}

--- a/src-tauri/resources/coding-agents/_seed/.codex/config.toml
+++ b/src-tauri/resources/coding-agents/_seed/.codex/config.toml
@@ -1,0 +1,2 @@
+# AgentsCommander default Codex config (CODEX_HOME).
+# Minimal starter: no active settings. Add your Codex configuration below.

--- a/src-tauri/resources/coding-agents/_seed/.opencode/opencode.json
+++ b/src-tauri/resources/coding-agents/_seed/.opencode/opencode.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://opencode.ai/config.json"
+}

--- a/src-tauri/resources/coding-agents/agents.default.json
+++ b/src-tauri/resources/coding-agents/agents.default.json
@@ -10,6 +10,7 @@
       "instructionsFilename": "CLAUDE.md",
       "envs": [],
       "isolatedHome": false,
+      "configSeed": { "enabled": true, "dest": ".claude" },
       "removable": true
     },
     {
@@ -21,6 +22,7 @@
       "instructionsFilename": "AGENTS.md",
       "envs": [],
       "isolatedHome": false,
+      "configSeed": { "enabled": true, "dest": ".codex" },
       "removable": true
     },
     {
@@ -65,6 +67,7 @@
       "instructionsFilename": "AGENTS.md",
       "envs": [],
       "isolatedHome": false,
+      "configSeed": { "enabled": true, "dest": ".opencode" },
       "removable": true
     }
   ]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -107,6 +107,31 @@ pub async fn get_coding_agent_catalog(
     Ok(crate::config::coding_agents_catalog::load_catalog(&config_dir))
 }
 
+/// #769 Phase 2 - the coding-agent command executable basenames that ship a
+/// re-seedable default config-folder master (`claude`, `codex`, `opencode`). The
+/// frontend enables the "Re-seed default configuration" button only for a catalog
+/// def whose command reduces (exact basename) to one of these; the reseed command
+/// re-checks server-side.
+#[tauri::command]
+pub fn list_reseedable_agent_commands() -> Vec<String> {
+    crate::config::coding_agents_catalog::reseedable_command_basenames()
+}
+
+/// #769 Phase 2 - restore a built-in's shipped default config-folder master (the
+/// Settings "Re-seed default configuration" button). Gating is re-checked
+/// server-side (exact executable basename, never `starts_with`, so `pi`/`agent`
+/// cannot false-match): `command` must map to a built-in that ships a master, else
+/// `Err`. On success the current master is `.bak`ed first, then atomically
+/// replaced with the embedded default; it takes effect on NEW sessions via the
+/// absent-only fill. Running replicas and their live config are untouched.
+#[tauri::command]
+pub async fn reseed_coding_agent_default(
+    command: String,
+) -> Result<crate::config::coding_agents_catalog::ReseedResult, String> {
+    let config_dir = crate::config::config_dir().ok_or("No config dir")?;
+    crate::config::coding_agents_catalog::reseed_master_for_command(&config_dir, &command)
+}
+
 #[tauri::command]
 pub async fn update_settings(
     app: AppHandle,

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -863,6 +863,21 @@ pub fn build_agent_spawn_command(
                 placeholder_context.as_ref(),
             );
             if let Some(r) = resolved.as_mut() {
+                // #769 P2: append the absent-only, non-empty CatalogDefault tier
+                // LAST (lowest precedence). Pure path math here; perform_config_seed
+                // gates it on absent-dest + non-empty master, so it never overwrites
+                // an existing replica config. The master exists only for built-ins
+                // that ship one; for any other dest the candidate path is absent and
+                // the tier is inert.
+                if let Some(config_dir) = crate::config::config_dir() {
+                    r.candidates.push((
+                        crate::config::config_seed::ConfigSeedTier::CatalogDefault,
+                        crate::config::coding_agents_catalog::master_dir_for_dest(
+                            &config_dir,
+                            cfg.dest.trim(),
+                        ),
+                    ));
+                }
                 r.config_dir_warning = crate::config::config_seed::compute_config_dir_warning(
                     &r.dest,
                     &shell,
@@ -1971,24 +1986,30 @@ mod tests {
         use crate::config::config_seed::ConfigSeedTier;
         // Workspace tiers outrank matrix tiers; profile beats base in each. The
         // matrix's bare `.claude` (the agent's own live config) is never a source.
-        assert_eq!(
-            seed.candidates,
-            vec![
-                (
-                    ConfigSeedTier::WorkspaceProfile,
-                    workspace.join(format!("default_profile_{}.claude", letter))
-                ),
-                (
-                    ConfigSeedTier::WorkspaceBase,
-                    workspace.join("default.claude")
-                ),
-                (
-                    ConfigSeedTier::MatrixProfile,
-                    matrix.join(format!("default_profile_{}.claude", letter))
-                ),
-                (ConfigSeedTier::MatrixBase, matrix.join("default.claude")),
-            ]
-        );
+        // #769 P2 appends the absent-only CatalogDefault master LAST (still pure
+        // path math; perform_config_seed gates it on absent-dest + non-empty).
+        let mut expected = vec![
+            (
+                ConfigSeedTier::WorkspaceProfile,
+                workspace.join(format!("default_profile_{}.claude", letter)),
+            ),
+            (
+                ConfigSeedTier::WorkspaceBase,
+                workspace.join("default.claude"),
+            ),
+            (
+                ConfigSeedTier::MatrixProfile,
+                matrix.join(format!("default_profile_{}.claude", letter)),
+            ),
+            (ConfigSeedTier::MatrixBase, matrix.join("default.claude")),
+        ];
+        if let Some(config_dir) = crate::config::config_dir() {
+            expected.push((
+                ConfigSeedTier::CatalogDefault,
+                crate::config::coding_agents_catalog::master_dir_for_dest(&config_dir, ".claude"),
+            ));
+        }
+        assert_eq!(seed.candidates, expected);
         assert_eq!(seed.dest, expected_replica.join(".claude"));
         // Pure resolution: no template dirs were created.
         assert!(!workspace.join("default.claude").exists());

--- a/src-tauri/src/config/coding_agents_catalog.rs
+++ b/src-tauri/src/config/coding_agents_catalog.rs
@@ -313,6 +313,290 @@ fn write_manifest_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// #769 Phase 2 - dest-keyed config-folder masters + the re-seed button.
+//
+// A "master" is the shipped default config folder for a built-in, stored at
+// `<config_dir>/coding-agents/_seed/<dest>/` (e.g. `_seed/.claude/`). It is
+// seeded once at boot (create-if-absent, from the compiled-in embedded default),
+// user-editable thereafter, and used two ways:
+//   - the absent-only #598 `CatalogDefault` tier fills a NEW replica's `<dest>`
+//     from it (never overwriting existing config), and
+//   - the Settings re-seed button restores it to the embedded default (`.bak`
+//     first, then a trash-first atomic swap).
+// Masters are stored VERBATIM (raw `%AC_...%` tokens); substitution happens only
+// when the master is copied into a replica. Only Claude/Codex/OpenCode ship a
+// master (D5): agents with no verified config-folder convention get none.
+// ---------------------------------------------------------------------------
+
+/// Subdirectory of `coding-agents/` holding the dest-keyed masters.
+const SEED_MASTERS_DIR_NAME: &str = "_seed";
+
+/// One embedded default file within a master: a forward-slash relative path plus
+/// its raw bytes (compiled in via `include_bytes!`).
+struct EmbeddedMasterFile {
+    rel_path: &'static str,
+    bytes: &'static [u8],
+}
+
+/// A dest-keyed embedded master: the shipped default config folder for a built-in.
+struct EmbeddedSeedMaster {
+    /// The command executable basename (lowercase) this master belongs to. Used
+    /// for the re-seed button's exact-basename gating.
+    command_basename: &'static str,
+    /// The dest folder NAME (e.g. `.claude`): both the `_seed/<dest>/` master dir
+    /// and the replica fill destination.
+    dest: &'static str,
+    files: &'static [EmbeddedMasterFile],
+}
+
+/// The built-in default config-folder masters. Only agents with a real, minimal,
+/// non-intrusive default ship one; Hermes/Pi/Cursor CLI ship none (no verified
+/// convention) and therefore get no re-seed button. Content is provisional
+/// (Maria approves before land); swapping it is a resource-file-only change.
+const EMBEDDED_SEED_MASTERS: &[EmbeddedSeedMaster] = &[
+    EmbeddedSeedMaster {
+        command_basename: "claude",
+        dest: ".claude",
+        files: &[EmbeddedMasterFile {
+            rel_path: "settings.json",
+            bytes: include_bytes!("../../resources/coding-agents/_seed/.claude/settings.json"),
+        }],
+    },
+    EmbeddedSeedMaster {
+        command_basename: "codex",
+        dest: ".codex",
+        files: &[EmbeddedMasterFile {
+            rel_path: "config.toml",
+            bytes: include_bytes!("../../resources/coding-agents/_seed/.codex/config.toml"),
+        }],
+    },
+    EmbeddedSeedMaster {
+        command_basename: "opencode",
+        dest: ".opencode",
+        files: &[EmbeddedMasterFile {
+            rel_path: "opencode.json",
+            bytes: include_bytes!("../../resources/coding-agents/_seed/.opencode/opencode.json"),
+        }],
+    },
+];
+
+/// Result of a re-seed, returned to the frontend for the success toast.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReseedResult {
+    pub dest: String,
+    pub backup_path: String,
+}
+
+/// Serialize all re-seeds (rare, user-initiated) so two never race on a master
+/// mid-swap. Stricter than strictly per-dest, which is safe (never a partial or
+/// racy state).
+static RESEED_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Absolute path to the dest-keyed master: `<config>/coding-agents/_seed/<dest>/`.
+pub fn master_dir_for_dest(config_dir: &Path, dest: &str) -> PathBuf {
+    catalog_dir(config_dir)
+        .join(SEED_MASTERS_DIR_NAME)
+        .join(dest)
+}
+
+fn embedded_master_for_command_basename(basename: &str) -> Option<&'static EmbeddedSeedMaster> {
+    EMBEDDED_SEED_MASTERS
+        .iter()
+        .find(|m| m.command_basename == basename)
+}
+
+/// Lowercased command executable basenames that ship a non-empty embedded default
+/// config-folder master. The frontend enables the re-seed button only for a
+/// catalog def whose command reduces to one of these; the reseed command
+/// re-checks server-side. Derived from the shipped masters, so it stays in sync.
+pub fn reseedable_command_basenames() -> Vec<String> {
+    EMBEDDED_SEED_MASTERS
+        .iter()
+        .map(|m| m.command_basename.to_string())
+        .collect()
+}
+
+/// Reduce a coding-agent command to its executable basename (lowercase), mirroring
+/// the settings save path. `None` if the command does not tokenize.
+fn command_executable_basename(command: &str) -> Option<String> {
+    let normalized =
+        crate::config::agent_command::normalize_legacy_agent_command(command).ok()?;
+    Some(crate::config::settings::command_token_basename(
+        &normalized.shell,
+    ))
+}
+
+/// Write a master's embedded files verbatim into `dir` (creating it and any
+/// parents). Rejects a rel_path with empty/`.`/`..` segments.
+fn write_embedded_files_into(dir: &Path, master: &EmbeddedSeedMaster) -> Result<(), String> {
+    for f in master.files {
+        let mut path = dir.to_path_buf();
+        for seg in f.rel_path.split('/') {
+            if seg.is_empty() || seg == "." || seg == ".." {
+                return Err(format!("invalid embedded master rel_path '{}'", f.rel_path));
+            }
+            path.push(seg);
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create {}: {e}", parent.display()))?;
+        }
+        std::fs::write(&path, f.bytes).map_err(|e| format!("write {}: {e}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Seed the dest-keyed masters ONCE at boot: for each built-in master, if
+/// `_seed/<dest>/` is absent, stage the embedded default into a sibling temp dir
+/// and atomically rename it into place (first-writer-wins across a first-run
+/// race). Present masters are user-owned and never touched. Fail-soft: logs and
+/// continues; never panics or aborts boot.
+pub fn ensure_seeded_masters(config_dir: &Path) {
+    for master in EMBEDDED_SEED_MASTERS {
+        let dir = master_dir_for_dest(config_dir, master.dest);
+        match std::fs::symlink_metadata(&dir) {
+            Ok(_) => continue, // present (any form) -> user-owned, leave alone
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                log::warn!(
+                    "[coding-agents] cannot stat master {} ({e}); skipping seed",
+                    dir.display()
+                );
+                continue;
+            }
+        }
+        let sfx = unique_suffix();
+        let staging = staging_sibling(&dir, "seedtmp", &sfx);
+        let _ = std::fs::remove_dir_all(&staging);
+        let result = write_embedded_files_into(&staging, master)
+            .and_then(|()| rename_into_place(&staging, &dir));
+        match result {
+            Ok(()) => log::info!(
+                "[coding-agents] seeded default config master at {}",
+                dir.display()
+            ),
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&staging);
+                log::warn!("[coding-agents] failed to seed master {} ({e})", dir.display());
+            }
+        }
+    }
+}
+
+/// Re-seed the master for `command` back to AC's embedded default (the Settings
+/// button). Gating is re-checked server-side: `command`'s executable basename must
+/// EXACTLY equal a built-in that ships a master (never `starts_with`, so `pi` and
+/// `agent` cannot false-match). On success: a timestamped `.bak` of the current
+/// master is made FIRST, then a trash-first atomic swap installs the embedded
+/// default. On failure the prior master is restored; never a partial state.
+pub fn reseed_master_for_command(config_dir: &Path, command: &str) -> Result<ReseedResult, String> {
+    let basename = command_executable_basename(command)
+        .ok_or_else(|| format!("'{command}' is not a valid coding-agent command"))?;
+    let master = embedded_master_for_command_basename(&basename).ok_or_else(|| {
+        format!("'{command}' is not a recognized built-in with a shipped default config folder")
+    })?;
+    let dir = master_dir_for_dest(config_dir, master.dest);
+
+    let _guard = RESEED_LOCK
+        .lock()
+        .map_err(|_| "re-seed lock poisoned".to_string())?;
+
+    // 1. `.bak` the current master (verbatim), BEFORE any swap.
+    let backup_path = if dir.exists() {
+        Some(backup_master_dir(&dir)?)
+    } else {
+        None
+    };
+
+    // 2. Trash-first atomic swap of the embedded default into the master.
+    let sfx = unique_suffix();
+    let staging = staging_sibling(&dir, "reseedtmp", &sfx);
+    let trash = staging_sibling(&dir, "reseedold", &sfx);
+    let _ = std::fs::remove_dir_all(&staging);
+    let _ = std::fs::remove_dir_all(&trash);
+
+    write_embedded_files_into(&staging, master)?;
+
+    if dir.exists() {
+        if let Err(e) = std::fs::rename(&dir, &trash) {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(format!(
+                "master {} is in use ({e}); re-seed aborted, master unchanged",
+                dir.display()
+            ));
+        }
+    }
+    if let Err(e) = std::fs::rename(&staging, &dir) {
+        // Restore the prior master so we never leave a hole.
+        if !dir.exists() && trash.exists() {
+            let _ = std::fs::rename(&trash, &dir);
+        }
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(format!(
+            "failed to install re-seeded master {} ({e}); prior config restored",
+            dir.display()
+        ));
+    }
+    let _ = std::fs::remove_dir_all(&trash);
+
+    Ok(ReseedResult {
+        dest: master.dest.to_string(),
+        backup_path: backup_path
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default(),
+    })
+}
+
+/// Verbatim, timestamped `.bak` copy of a master dir (unique-suffix loop, mirrors
+/// `seeded_context_templates::create_backup`). Copies with substitution OFF so the
+/// raw `%AC_...%` tokens in the master are preserved in the backup.
+fn backup_master_dir(dir: &Path) -> Result<PathBuf, String> {
+    let parent = dir
+        .parent()
+        .ok_or_else(|| format!("master {} has no parent", dir.display()))?;
+    let name = dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| format!("master {} has no name", dir.display()))?;
+    let ts = chrono::Utc::now().format("%Y%m%d-%H%M%SZ").to_string();
+    for index in 0..1000u32 {
+        let bak_name = match index {
+            0 => format!("{name}.bak-{ts}"),
+            n => format!("{name}.bak-{ts}.{n}"),
+        };
+        let bak = parent.join(&bak_name);
+        if bak.exists() {
+            continue;
+        }
+        crate::config::config_seed::copy_tree(dir, &bak, 0, None, false)
+            .map_err(|e| format!("backup {} -> {}: {e}", dir.display(), bak.display()))?;
+        return Ok(bak);
+    }
+    Err(format!("could not find a unique .bak path for {}", dir.display()))
+}
+
+fn unique_suffix() -> String {
+    format!(
+        "{}-{}",
+        std::process::id(),
+        SEED_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn staging_sibling(dir: &Path, tag: &str, sfx: &str) -> PathBuf {
+    let parent = dir.parent().unwrap_or_else(|| Path::new("."));
+    let name = dir.file_name().and_then(|s| s.to_str()).unwrap_or("_seed");
+    parent.join(format!("{name}.{tag}-{sfx}"))
+}
+
+/// Publish a staged dir into `dest` (dest expected absent). Cleans staging on
+/// failure. `std::fs::rename` is first-writer-wins if `dest` appeared concurrently.
+fn rename_into_place(staging: &Path, dest: &Path) -> Result<(), String> {
+    std::fs::rename(staging, dest).map_err(|e| format!("install {} ({e})", dest.display()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -321,12 +605,13 @@ mod tests {
     /// current presets. Drift guard: the embedded default must equal these exact
     /// values so the externalized catalog is byte-for-byte the pre-#769 list. The
     /// frontend keeps a parallel `FALLBACK_CODING_AGENTS` test (E7).
-    const EXPECTED_PRESETS: [(&str, &str, &str, &str, &str, &str); 6] = [
-        ("claude", "Claude Code", "Coding Agent by Anthropic", "#d97706", "claude", "CLAUDE.md"),
-        ("codex", "Codex", "Coding Agent by OpenAI", "#10b981", "codex", "AGENTS.md"),
-        ("hermes", "Hermes", "Coding Agent by Nous Research", "#8b5cf6", "hermes", "AGENTS.md"),
-        ("cursor", "Cursor CLI", "Coding Agent by Cursor", "#22d3ee", "agent", "AGENTS.md"),
-        ("pi", "Pi", "Coding Agent by Earendil Inc", "#ec4899", "pi", "AGENTS.md"),
+    #[allow(clippy::type_complexity)]
+    const EXPECTED_PRESETS: [(&str, &str, &str, &str, &str, &str, Option<&str>); 6] = [
+        ("claude", "Claude Code", "Coding Agent by Anthropic", "#d97706", "claude", "CLAUDE.md", Some(".claude")),
+        ("codex", "Codex", "Coding Agent by OpenAI", "#10b981", "codex", "AGENTS.md", Some(".codex")),
+        ("hermes", "Hermes", "Coding Agent by Nous Research", "#8b5cf6", "hermes", "AGENTS.md", None),
+        ("cursor", "Cursor CLI", "Coding Agent by Cursor", "#22d3ee", "agent", "AGENTS.md", None),
+        ("pi", "Pi", "Coding Agent by Earendil Inc", "#ec4899", "pi", "AGENTS.md", None),
         (
             "opencode",
             "OpenCode",
@@ -334,6 +619,7 @@ mod tests {
             "#64748b",
             "opencode",
             "AGENTS.md",
+            Some(".opencode"),
         ),
     ];
 
@@ -362,7 +648,7 @@ mod tests {
         // Drift guard vs the pre-#769 AGENT_PRESETS field values.
         let catalog = embedded_default_catalog();
         assert_eq!(catalog.agents.len(), EXPECTED_PRESETS.len());
-        for (def, (key, label, desc, color, command, filename)) in
+        for (def, (key, label, desc, color, command, filename, seed_dest)) in
             catalog.agents.iter().zip(EXPECTED_PRESETS)
         {
             assert_eq!(def.key, key);
@@ -371,9 +657,19 @@ mod tests {
             assert_eq!(def.color, color);
             assert_eq!(def.command, command);
             assert_eq!(def.instructions_filename.as_deref(), Some(filename));
-            // Phase-1 invariants: no folder seed ships; every built-in removable;
-            // no base env rows; not isolated.
-            assert!(def.config_seed.is_none(), "{key} must ship configSeed UNSET");
+            // #769 P2: Claude/Codex/OpenCode ship an active configSeed; the other
+            // three ship none (no master, no re-seed button).
+            match seed_dest {
+                Some(dest) => {
+                    let cs = def
+                        .config_seed
+                        .as_ref()
+                        .unwrap_or_else(|| panic!("{key} must ship configSeed"));
+                    assert!(cs.enabled, "{key} configSeed must be enabled");
+                    assert_eq!(cs.dest, dest, "{key} configSeed dest");
+                }
+                None => assert!(def.config_seed.is_none(), "{key} must ship configSeed UNSET"),
+            }
             assert!(def.removable, "{key} must be removable");
             assert!(def.envs.is_empty());
             assert!(!def.isolated_home);
@@ -512,5 +808,131 @@ mod tests {
             })
             .collect();
         assert!(residue.is_empty(), "no leftover temp files after seed");
+    }
+
+    // ---- #769 Phase 2: masters + re-seed --------------------------------
+
+    fn master(cmd: &str) -> &'static EmbeddedSeedMaster {
+        EMBEDDED_SEED_MASTERS
+            .iter()
+            .find(|m| m.command_basename == cmd)
+            .unwrap()
+    }
+
+    #[test]
+    fn reseedable_commands_are_claude_codex_opencode() {
+        let mut got = reseedable_command_basenames();
+        got.sort();
+        assert_eq!(got, vec!["claude", "codex", "opencode"]);
+    }
+
+    #[test]
+    fn every_embedded_master_maps_to_a_catalog_def_with_matching_configseed() {
+        let catalog = embedded_default_catalog();
+        for m in EMBEDDED_SEED_MASTERS {
+            let def = catalog
+                .agents
+                .iter()
+                .find(|d| {
+                    command_executable_basename(&d.command).as_deref() == Some(m.command_basename)
+                })
+                .unwrap_or_else(|| panic!("no catalog def for master {}", m.command_basename));
+            let cs = def
+                .config_seed
+                .as_ref()
+                .unwrap_or_else(|| panic!("{} def missing configSeed", m.command_basename));
+            assert!(cs.enabled);
+            assert_eq!(cs.dest, m.dest, "master dest must match the def configSeed dest");
+            assert!(!m.files.is_empty(), "master {} must ship >=1 file", m.command_basename);
+        }
+    }
+
+    #[test]
+    fn ensure_seeded_masters_creates_nonempty_masters_and_preserves_edits() {
+        let dir = seed_dir();
+        ensure_seeded_masters(dir.path());
+        for cmd in ["claude", "codex", "opencode"] {
+            let m = master(cmd);
+            let md = master_dir_for_dest(dir.path(), m.dest);
+            assert!(
+                crate::config::config_seed::is_nonempty_seed_dir(&md),
+                "{cmd} master should be non-empty"
+            );
+            assert_eq!(
+                std::fs::read(md.join(m.files[0].rel_path)).unwrap(),
+                m.files[0].bytes
+            );
+        }
+        // Idempotent + never clobbers a user edit.
+        let m = master("claude");
+        let file = master_dir_for_dest(dir.path(), m.dest).join(m.files[0].rel_path);
+        std::fs::write(&file, b"USER EDIT").unwrap();
+        ensure_seeded_masters(dir.path());
+        assert_eq!(std::fs::read(&file).unwrap(), b"USER EDIT");
+    }
+
+    #[test]
+    fn reseed_installs_embedded_default_and_backs_up_current() {
+        let dir = seed_dir();
+        ensure_seeded_masters(dir.path());
+        let m = master("claude");
+        let master_dir = master_dir_for_dest(dir.path(), m.dest);
+        let file = master_dir.join(m.files[0].rel_path);
+        std::fs::write(&file, b"USER EDITED").unwrap();
+
+        let result = reseed_master_for_command(dir.path(), "claude").unwrap();
+        assert_eq!(result.dest, ".claude");
+        assert!(!result.backup_path.is_empty());
+        // Master restored to the embedded default.
+        assert_eq!(std::fs::read(&file).unwrap(), m.files[0].bytes);
+        // The `.bak` holds the user's prior edit (verbatim).
+        let bak_file = Path::new(&result.backup_path).join(m.files[0].rel_path);
+        assert_eq!(std::fs::read(&bak_file).unwrap(), b"USER EDITED");
+    }
+
+    #[test]
+    fn reseed_when_master_absent_installs_without_backup() {
+        let dir = seed_dir();
+        // Masters not seeded: the _seed dir is absent.
+        let m = master("codex");
+        let master_dir = master_dir_for_dest(dir.path(), m.dest);
+        assert!(!master_dir.exists());
+
+        let result = reseed_master_for_command(dir.path(), "codex").unwrap();
+        assert_eq!(result.dest, ".codex");
+        assert!(result.backup_path.is_empty(), "no backup when master was absent");
+        assert_eq!(
+            std::fs::read(master_dir.join(m.files[0].rel_path)).unwrap(),
+            m.files[0].bytes
+        );
+    }
+
+    #[test]
+    fn reseed_gating_is_exact_basename_never_startswith() {
+        let dir = seed_dir();
+        ensure_seeded_masters(dir.path());
+        // `pi` and `agent` are real built-in commands but ship NO master; `pip`
+        // and `clau` must not match `pi`/`claude` via any prefix rule; empty and
+        // unknown are rejected.
+        for bad in ["pi", "agent", "pip", "clau", "claudex", "notacommand", ""] {
+            assert!(
+                reseed_master_for_command(dir.path(), bad).is_err(),
+                "should reject {bad:?}"
+            );
+        }
+        // Path/extension forms of a real master command still resolve by basename.
+        for good in ["claude", "codex", "opencode", "claude.exe", "codex --model x"] {
+            assert!(
+                reseed_master_for_command(dir.path(), good).is_ok(),
+                "should accept {good:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn master_dir_for_dest_is_under_seed_subdir() {
+        let dir = seed_dir();
+        let p = master_dir_for_dest(dir.path(), ".claude");
+        assert_eq!(p, dir.path().join("coding-agents").join("_seed").join(".claude"));
     }
 }

--- a/src-tauri/src/config/config_seed.rs
+++ b/src-tauri/src/config/config_seed.rs
@@ -39,6 +39,15 @@ pub enum ConfigSeedTier {
     WorkspaceBase,
     MatrixProfile,
     MatrixBase,
+    /// #769 Phase 2 - the shipped default config-folder master at
+    /// `<config_dir>/coding-agents/_seed/<dest>/`. Appended LAST (lowest
+    /// precedence) by the spawn caller. Unlike the four tiers above, this one is
+    /// ABSENT-ONLY and NON-EMPTY-GATED in `perform_config_seed`: it fills
+    /// `%AC_REPLICA_ROOT%/<dest>` only when the dest does not already exist AND the
+    /// master has at least one regular file, so it can never overwrite accumulated
+    /// replica config, and an empty/absent master reads as "tier not present"
+    /// (today's spawn behavior stays byte-identical).
+    CatalogDefault,
 }
 
 /// After a successful seed of `.claude`, re-stamp the AC-managed
@@ -258,7 +267,14 @@ fn segments_eq(a: &str, b: &str) -> bool {
 /// chokepoint, holds `RtkSweepLockState` across this call for all dests.
 pub fn perform_config_seed(seed: &ResolvedConfigSeed, unique_sfx: &str) -> ConfigSeedReport {
     // 1. Pick the winning tier by source-folder presence (highest precedence first).
-    let Some((tier, src)) = seed.candidates.iter().find(|(_, src)| is_readable_dir(src)) else {
+    //    The four legacy tiers are unchanged (readable dir wins and overwrites).
+    //    The #769 P2 CatalogDefault tier is gated ABSENT-ONLY + NON-EMPTY here, so
+    //    it never overwrites an existing replica config and an empty/absent master
+    //    reads as "not present".
+    let Some((tier, src)) = seed.candidates.iter().find(|(tier, src)| match tier {
+        ConfigSeedTier::CatalogDefault => !seed.dest.exists() && is_nonempty_seed_dir(src),
+        _ => is_readable_dir(src),
+    }) else {
         // #598: seeding is active but no template exists at any tier. This is a
         // benign no-op (nothing to copy), but a SILENT one confused users who
         // enabled the feature, created no template, and saw nothing happen. Log
@@ -309,7 +325,8 @@ pub fn perform_config_seed(seed: &ResolvedConfigSeed, unique_sfx: &str) -> Confi
     clear_stale_seed_scratch(parent, dest_name);
 
     // 3. Stage the template into temp. On any error the dest is untouched.
-    if let Err(e) = copy_tree(src, &temp, 0, &seed.context) {
+    //    master->replica copy substitutes the 3 AC tokens (substitute = true).
+    if let Err(e) = copy_tree(src, &temp, 0, Some(&seed.context), true) {
         log::warn!(
             "[config-seed] failed to stage template {} -> {}: {}",
             src.display(),
@@ -378,6 +395,37 @@ fn is_readable_dir(path: &Path) -> bool {
     std::fs::metadata(path).map(|m| m.is_dir()).unwrap_or(false)
 }
 
+/// #769 P2 - true iff `path` is a readable directory containing at least one
+/// regular, non-reparse FILE (searched recursively). The CatalogDefault tier uses
+/// this so an empty master (or a dir of only subdirs/links) reads as "not present"
+/// and the tier stays inert, keeping today's spawn behavior byte-identical.
+pub(crate) fn is_nonempty_seed_dir(path: &Path) -> bool {
+    fn has_file(dir: &Path, depth: u32) -> bool {
+        if depth > MAX_SEED_DEPTH {
+            return false;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return false;
+        };
+        for entry in entries.flatten() {
+            if is_symlink_or_reparse(&entry) {
+                continue;
+            }
+            match entry.file_type() {
+                Ok(ft) if ft.is_file() => return true,
+                Ok(ft) if ft.is_dir() => {
+                    if has_file(&entry.path(), depth + 1) {
+                        return true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        false
+    }
+    is_readable_dir(path) && has_file(path, 0)
+}
+
 /// Remove every leftover seed-scratch sibling for `dest_name` (any session-id
 /// suffix), best-effort. Reclaims a temp/trash dir leaked by an earlier locked
 /// removal; the current spawn's `temp`/`trash` (same prefix) are cleared too.
@@ -401,11 +449,12 @@ fn clear_stale_seed_scratch(parent: &Path, dest_name: &str) {
     }
 }
 
-fn copy_tree(
+pub(crate) fn copy_tree(
     src_dir: &Path,
     dst_dir: &Path,
     depth: u32,
-    ctx: &PlaceholderContext,
+    ctx: Option<&PlaceholderContext>,
+    substitute: bool,
 ) -> Result<(), String> {
     if depth > MAX_SEED_DEPTH {
         log::warn!(
@@ -433,16 +482,31 @@ fn copy_tree(
             .map_err(|e| format!("file type of {}: {}", entry.path().display(), e))?;
         let dst = dst_dir.join(entry.file_name());
         if ft.is_dir() {
-            copy_tree(&entry.path(), &dst, depth + 1, ctx)?;
+            copy_tree(&entry.path(), &dst, depth + 1, ctx, substitute)?;
         } else if ft.is_file() {
-            copy_file_substituted(&entry.path(), &dst, ctx)?;
+            copy_file_substituted(&entry.path(), &dst, ctx, substitute)?;
         }
         // Anything else (already-filtered symlinks/reparse) is ignored.
     }
     Ok(())
 }
 
-fn copy_file_substituted(src: &Path, dst: &Path, ctx: &PlaceholderContext) -> Result<(), String> {
+fn copy_file_substituted(
+    src: &Path,
+    dst: &Path,
+    ctx: Option<&PlaceholderContext>,
+    substitute: bool,
+) -> Result<(), String> {
+    // #769 P2: verbatim stream-copy when substitution is off (embedded->master and
+    // the reseed backup keep raw %AC_% tokens intact) or when no context is given.
+    let ctx = match (substitute, ctx) {
+        (true, Some(ctx)) => ctx,
+        _ => {
+            return std::fs::copy(src, dst)
+                .map(|_| ())
+                .map_err(|e| format!("copy {} -> {}: {}", src.display(), dst.display(), e));
+        }
+    };
     let len = std::fs::metadata(src)
         .map_err(|e| format!("stat {}: {}", src.display(), e))?
         .len();
@@ -811,6 +875,124 @@ mod tests {
         assert!(!trash_a.exists(), "prefix-sweep deletes a concurrent spawn's only old copy");
     }
 
+    // ---- CatalogDefault tier (#769 P2: absent-only + non-empty) ------------
+
+    /// Append the absent-only CatalogDefault candidate LAST, exactly as the spawn
+    /// caller (`build_agent_spawn_command`) does.
+    fn with_catalog_default(mut resolved: ResolvedConfigSeed, master: &Path) -> ResolvedConfigSeed {
+        resolved
+            .candidates
+            .push((ConfigSeedTier::CatalogDefault, master.to_path_buf()));
+        resolved
+    }
+
+    #[test]
+    fn catalog_default_fills_absent_dest_from_nonempty_master() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        // No workspace/matrix templates on disk: the 4 legacy tiers are absent.
+        let master = temp.path().join("master");
+        write_file(&master.join("settings.json"), b"{\"seeded\":true}");
+
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).unwrap();
+        let resolved = with_catalog_default(resolved, &master);
+
+        // dest absent + master non-empty -> CatalogDefault wins and fills.
+        assert_eq!(
+            perform_config_seed(&resolved, "sfx"),
+            ConfigSeedReport::Seeded
+        );
+        assert_eq!(
+            std::fs::read(replica.join(".claude").join("settings.json")).unwrap(),
+            b"{\"seeded\":true}"
+        );
+    }
+
+    #[test]
+    fn catalog_default_absent_only_never_overwrites_existing_dest() {
+        // The E1/G1 data-loss killer: a present dest is preserved, tier skips.
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        // Live replica config the seed must never touch.
+        write_file(&replica.join(".claude").join("creds.json"), b"SECRET");
+        let master = temp.path().join("master");
+        write_file(&master.join("settings.json"), b"{\"seeded\":true}");
+
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).unwrap();
+        let resolved = with_catalog_default(resolved, &master);
+
+        // dest present -> CatalogDefault gate fails -> Skipped, dest fully intact.
+        assert_eq!(perform_config_seed(&resolved, "sfx"), ConfigSeedReport::Skipped);
+        assert_eq!(
+            std::fs::read(replica.join(".claude").join("creds.json")).unwrap(),
+            b"SECRET"
+        );
+        // The master content did NOT leak in.
+        assert!(!replica.join(".claude").join("settings.json").exists());
+    }
+
+    #[test]
+    fn catalog_default_empty_master_is_inert() {
+        // Non-empty gate: an empty master reads as "not present" -> Skipped, and
+        // (dest absent) nothing is created, so spawn behavior is byte-identical.
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        let master = temp.path().join("master");
+        std::fs::create_dir_all(&master).unwrap(); // exists but EMPTY
+
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).unwrap();
+        let resolved = with_catalog_default(resolved, &master);
+
+        assert_eq!(perform_config_seed(&resolved, "sfx"), ConfigSeedReport::Skipped);
+        assert!(!replica.join(".claude").exists());
+    }
+
+    #[test]
+    fn catalog_default_yields_to_a_present_legacy_tier() {
+        // A present workspace tier still wins (unchanged behavior); CatalogDefault
+        // is only reached when all 4 legacy tiers are absent.
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        write_file(&workspace.join("default.claude").join("f.txt"), b"WORKSPACE");
+        let master = temp.path().join("master");
+        write_file(&master.join("f.txt"), b"CATALOG");
+
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).unwrap();
+        let resolved = with_catalog_default(resolved, &master);
+
+        assert_eq!(perform_config_seed(&resolved, "sfx"), ConfigSeedReport::Seeded);
+        assert_eq!(
+            std::fs::read(replica.join(".claude").join("f.txt")).unwrap(),
+            b"WORKSPACE"
+        );
+    }
+
+    #[test]
+    fn copy_tree_verbatim_preserves_tokens_when_substitute_false() {
+        // The reseed backup copies the master verbatim (raw %AC_% tokens intact).
+        let temp = tempfile::tempdir().unwrap();
+        let src = temp.path().join("src");
+        write_file(&src.join("a.txt"), b"path=%AC_REPLICA_ROOT%/x");
+        let dst = temp.path().join("dst");
+        copy_tree(&src, &dst, 0, None, false).unwrap();
+        assert_eq!(
+            std::fs::read(dst.join("a.txt")).unwrap(),
+            b"path=%AC_REPLICA_ROOT%/x"
+        );
+    }
+
     // ---- copy_file_substituted (size-first, binary/UTF-8) ------------------
 
     #[test]
@@ -822,7 +1004,7 @@ mod tests {
         let src = temp.path().join("a.txt");
         std::fs::write(&src, b"path=%AC_REPLICA_ROOT%/x").unwrap();
         let dst = temp.path().join("a.out");
-        copy_file_substituted(&src, &dst, &ctx).unwrap();
+        copy_file_substituted(&src, &dst, Some(&ctx), true).unwrap();
 
         let expected = replica.to_string_lossy().replace('\\', "/");
         assert_eq!(
@@ -840,7 +1022,7 @@ mod tests {
         let raw: &[u8] = b"%AC_REPLICA_ROOT%\x00binary";
         std::fs::write(&src, raw).unwrap();
         let dst = temp.path().join("b.out");
-        copy_file_substituted(&src, &dst, &ctx).unwrap();
+        copy_file_substituted(&src, &dst, Some(&ctx), true).unwrap();
         // NUL present -> verbatim, no token substitution.
         assert_eq!(std::fs::read(&dst).unwrap(), raw);
     }
@@ -854,7 +1036,7 @@ mod tests {
         let raw: &[u8] = &[0xFF, 0xFE, b'h', b'i'];
         std::fs::write(&src, raw).unwrap();
         let dst = temp.path().join("c.out");
-        copy_file_substituted(&src, &dst, &ctx).unwrap();
+        copy_file_substituted(&src, &dst, Some(&ctx), true).unwrap();
         assert_eq!(std::fs::read(&dst).unwrap(), raw);
     }
 
@@ -868,7 +1050,7 @@ mod tests {
         content[..18].copy_from_slice(b"%AC_REPLICA_ROOT%\n");
         std::fs::write(&src, &content).unwrap();
         let dst = temp.path().join("big.out");
-        copy_file_substituted(&src, &dst, &ctx).unwrap();
+        copy_file_substituted(&src, &dst, Some(&ctx), true).unwrap();
 
         let out = std::fs::read(&dst).unwrap();
         assert_eq!(out.len(), content.len());
@@ -886,7 +1068,7 @@ mod tests {
         let dst = temp.path().join("dst");
         let ctx = ctx_with(&abs(r"C:\r", "/r"), Some(&abs(r"C:\ws", "/ws")), None);
         // Start already over the bound -> immediate Ok, nothing created.
-        copy_tree(&src, &dst, MAX_SEED_DEPTH + 1, &ctx).unwrap();
+        copy_tree(&src, &dst, MAX_SEED_DEPTH + 1, Some(&ctx), true).unwrap();
         assert!(!dst.exists(), "over-depth call must not create the dst tree");
     }
 
@@ -926,7 +1108,7 @@ mod tests {
 
         let dst = temp.path().join("dst");
         let ctx = ctx_with(&abs(r"C:\r", "/r"), Some(&abs(r"C:\ws", "/ws")), None);
-        copy_tree(&src, &dst, 0, &ctx).unwrap();
+        copy_tree(&src, &dst, 0, Some(&ctx), true).unwrap();
         assert!(dst.join("real.txt").exists(), "real file must be copied");
         assert!(
             !dst.join("linked").exists(),

--- a/src-tauri/src/config/config_seed.rs
+++ b/src-tauri/src/config/config_seed.rs
@@ -413,11 +413,11 @@ pub(crate) fn is_nonempty_seed_dir(path: &Path) -> bool {
             }
             match entry.file_type() {
                 Ok(ft) if ft.is_file() => return true,
-                Ok(ft) if ft.is_dir() => {
-                    if has_file(&entry.path(), depth + 1) {
-                        return true;
-                    }
-                }
+                // A directory counts only if it (recursively) contains a regular
+                // file; a dir with no files falls through to `_` (== "keep
+                // scanning"), so an empty dir and a dir-of-empty-dirs both yield
+                // false, exactly as before the collapse.
+                Ok(ft) if ft.is_dir() && has_file(&entry.path(), depth + 1) => return true,
                 _ => {}
             }
         }

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -698,7 +698,7 @@ pub fn compute_rtk_startup_mode(
     }
 }
 
-fn command_token_basename(token: &str) -> String {
+pub(crate) fn command_token_basename(token: &str) -> String {
     std::path::Path::new(token)
         .file_stem()
         .and_then(|s| s.to_str())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -244,6 +244,11 @@ pub fn run(
     // call `get_coding_agent_catalog`.
     config::coding_agents_catalog::ensure_seeded(&config_dir);
 
+    // #769 Phase 2 - seed the dest-keyed default config-folder masters once
+    // (create-if-absent, fail-soft). They back the absent-only spawn tier and the
+    // Settings re-seed button.
+    config::coding_agents_catalog::ensure_seeded_masters(&config_dir);
+
     let instance_id = uuid::Uuid::new_v4().to_string();
     let app_outbox_path = instances_dir.join(&instance_id).join("outbox");
     std::fs::create_dir_all(&app_outbox_path).expect("Failed to create app outbox directory");
@@ -1915,6 +1920,8 @@ pub fn run(
             commands::pty::get_screen_snapshot,
             commands::config::get_settings,
             commands::config::get_coding_agent_catalog,
+            commands::config::list_reseedable_agent_commands,
+            commands::config::reseed_coding_agent_default,
             commands::config::update_settings,
             commands::resource_monitor::get_resource_snapshot,
             commands::resource_monitor::kill_resource_group,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -13,6 +13,7 @@ import type {
   UpdateInfo,
   CodingAgentEnv,
   CodingAgentDefinition,
+  ReseedResult,
   CodingAgentProfilesConfig,
   RepoMatch,
   BridgeInfo,
@@ -260,6 +261,22 @@ export const CodingAgentsAPI = {
    */
   getCatalog: () =>
     transport.invoke<CodingAgentDefinition[]>("get_coding_agent_catalog"),
+
+  /**
+   * #769 Phase 2 — lowercased command basenames that ship a non-empty default
+   * config-folder master (today `["claude","codex","opencode"]`). Backend-derived
+   * from the shipped masters; the re-seed button is gated on EXACT membership.
+   */
+  listReseedableCommands: () =>
+    transport.invoke<string[]>("list_reseedable_agent_commands"),
+
+  /**
+   * #769 Phase 2 — restore an agent's default config-folder master to the shipped
+   * default, backing up the prior master. Resolves `Ok(ReseedResult)`; rejects if
+   * `command` is not a reseedable built-in (gating is re-checked server-side).
+   */
+  reseedDefault: (command: string) =>
+    transport.invoke<ReseedResult>("reseed_coding_agent_default", { command }),
 };
 
 export const SettingsAPI = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -190,6 +190,17 @@ export interface CodingAgentDefinition {
   removable: boolean;
 }
 
+/**
+ * #769 Phase 2 — result of `reseed_coding_agent_default`: the config-folder
+ * `dest` that was restored to the shipped default, plus the absolute path of the
+ * timestamped `.bak` of the prior master (empty string when the master was absent
+ * so nothing needed backing up).
+ */
+export interface ReseedResult {
+  dest: string;
+  backupPath: string;
+}
+
 export interface CodingAgentProfilesConfig {
   schemaVersion: number;
   /** v2 (#384): renamed from `letters`. Keyed by profile slot letter A–Z. */

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -29,6 +29,9 @@ vi.mock("../../shared/ipc", () => ({
         },
       ]),
     ),
+    // #769 Phase 2 — the store also fetches this; onboarding does not use it.
+    listReseedableCommands: vi.fn(() => Promise.resolve([])),
+    reseedDefault: vi.fn(() => Promise.resolve({ dest: "", backupPath: "" })),
   },
 }));
 

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -10,26 +10,40 @@ import {
   AC_WORKSPACE_ROOT_PLACEHOLDER,
 } from "../../shared/profile-utils";
 
-vi.mock("../../shared/ipc", () => ({
-  SettingsAPI: {
-    get: vi.fn(() => Promise.resolve(settings())),
-    update: vi.fn(() => Promise.resolve()),
-    saveDraft: vi.fn(() => Promise.resolve()),
-    updateCodingAgentProfiles: vi.fn(() => Promise.resolve()),
-    updateCodingAgentEnvSettings: vi.fn(() => Promise.resolve()),
-    getWebServerStatus: vi.fn(() => Promise.resolve(false)),
-    openWebRemote: vi.fn(() => Promise.resolve()),
-    startWebServer: vi.fn(() => Promise.resolve(false)),
-    stopWebServer: vi.fn(() => Promise.resolve(false)),
-    sweepRtkHook: vi.fn(() => Promise.resolve({ total: 0, updated: 0, errors: [] })),
-  },
-  TelegramAPI: {
-    sendTest: vi.fn(() => Promise.resolve(0)),
-  },
-  ReposAPI: {
-    search: vi.fn(() => Promise.resolve([])),
-  },
-}));
+vi.mock("../../shared/ipc", async () => {
+  // #769 — SettingsModal mounts codingAgentsStore.ensureLoaded(), so the ipc mock
+  // must expose CodingAgentsAPI or the store hits an undefined export. Resolve the
+  // catalog with the real built-in list so the preset quick-add buttons these
+  // automation tests address (codex/opencode) still render; no reseed set.
+  const { FALLBACK_CODING_AGENTS } = await vi.importActual<
+    typeof import("../../shared/agent-presets")
+  >("../../shared/agent-presets");
+  return {
+    SettingsAPI: {
+      get: vi.fn(() => Promise.resolve(settings())),
+      update: vi.fn(() => Promise.resolve()),
+      saveDraft: vi.fn(() => Promise.resolve()),
+      updateCodingAgentProfiles: vi.fn(() => Promise.resolve()),
+      updateCodingAgentEnvSettings: vi.fn(() => Promise.resolve()),
+      getWebServerStatus: vi.fn(() => Promise.resolve(false)),
+      openWebRemote: vi.fn(() => Promise.resolve()),
+      startWebServer: vi.fn(() => Promise.resolve(false)),
+      stopWebServer: vi.fn(() => Promise.resolve(false)),
+      sweepRtkHook: vi.fn(() => Promise.resolve({ total: 0, updated: 0, errors: [] })),
+    },
+    TelegramAPI: {
+      sendTest: vi.fn(() => Promise.resolve(0)),
+    },
+    ReposAPI: {
+      search: vi.fn(() => Promise.resolve([])),
+    },
+    CodingAgentsAPI: {
+      getCatalog: vi.fn(() => Promise.resolve(FALLBACK_CODING_AGENTS)),
+      listReseedableCommands: vi.fn(() => Promise.resolve([])),
+      reseedDefault: vi.fn(() => Promise.resolve({ dest: "", backupPath: "" })),
+    },
+  };
+});
 
 vi.mock("../../shared/stores/settings", () => ({
   settingsStore: {

--- a/src/sidebar/components/SettingsModal.reseed.test.tsx
+++ b/src/sidebar/components/SettingsModal.reseed.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SettingsModal from "./SettingsModal";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { toastStore } from "../../shared/stores/toasts";
+import type { AgentConfig, CodingAgentDefinition } from "../../shared/types";
+
+const RESEED_CMD = "reseed_coding_agent_default";
+const LIST_CMD = "list_reseedable_agent_commands";
+
+function def(key: string, label: string, command: string, dest?: string): CodingAgentDefinition {
+  return {
+    key,
+    label,
+    description: `Coding Agent ${label}`,
+    color: "#334155",
+    command,
+    envs: [],
+    isolatedHome: false,
+    removable: true,
+    ...(dest ? { configSeed: { enabled: true, dest } } : {}),
+  };
+}
+
+// Mirrors the Phase-2 default catalog: configSeed.dest present exactly for the
+// three re-seedable built-ins.
+const CATALOG: CodingAgentDefinition[] = [
+  def("claude", "Claude Code", "claude", ".claude"),
+  def("codex", "Codex", "codex", ".codex"),
+  def("hermes", "Hermes", "hermes"),
+  def("cursor", "Cursor CLI", "agent"),
+  def("pi", "Pi", "pi"),
+  def("opencode", "OpenCode", "opencode", ".opencode"),
+];
+
+const RESEEDABLE = ["claude", "codex", "opencode"];
+
+function agent(command: string, id = "a1", label = "Agent"): AgentConfig {
+  return { id, label, command, color: "#334155", envs: [], isolatedHome: false };
+}
+
+interface Opts {
+  catalog?: CodingAgentDefinition[];
+  reseedable?: string[];
+  reseedableReject?: boolean;
+  reseedResolve?: { dest: string; backupPath: string };
+  reseedReject?: string;
+}
+
+function renderAgents(agents: AgentConfig[], opts: Opts = {}) {
+  const fake = new FakeTransport();
+  fake.resolve("get_settings", baseSettings({ agents }));
+  fake.resolve("get_web_server_status", false);
+  fake.resolve("get_coding_agent_catalog", opts.catalog ?? CATALOG);
+  if (opts.reseedableReject) fake.reject(LIST_CMD, "boom");
+  else fake.resolve(LIST_CMD, opts.reseedable ?? RESEEDABLE);
+  if (opts.reseedReject !== undefined) fake.reject(RESEED_CMD, opts.reseedReject);
+  else fake.resolve(RESEED_CMD, opts.reseedResolve ?? { dest: ".claude", backupPath: "" });
+  return renderWithFakeTransport(() => <SettingsModal section="agents" onClose={() => {}} />, fake);
+}
+
+function click(el: Element | null): void {
+  (el as HTMLButtonElement | null)?.click();
+}
+
+async function expandRow(root: HTMLElement, i: number): Promise<void> {
+  await waitFor(() => expect(root.querySelector(`[data-ac-testid="settings.agentRow.${i}.toggle"]`)).toBeTruthy());
+  click(root.querySelector(`[data-ac-testid="settings.agentRow.${i}.toggle"]`));
+  await waitFor(() => expect(root.querySelector(`[data-ac-testid="settings.agentRow.${i}.editor"]`)).toBeTruthy());
+}
+
+function reseedBtn(root: HTMLElement, key: string): HTMLButtonElement | null {
+  return root.querySelector<HTMLButtonElement>(`[data-ac-testid="settings.agent.reseedDefault.${key}"]`);
+}
+
+describe("SettingsModal re-seed default configuration (#769 Phase 2)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("shows the button (correct testid) for a re-seedable built-in when expanded", async () => {
+    const r = renderAgents([agent("claude", "c", "Claude")]);
+    try {
+      await expandRow(r.root, 0);
+      await waitFor(() => expect(reseedBtn(r.root, "claude")).toBeTruthy());
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  it("hides the button for Cursor CLI (agent), Hermes, Pi and custom commands", async () => {
+    const r = renderAgents([
+      agent("agent", "cur", "Cursor CLI"),
+      agent("hermes", "her", "Hermes"),
+      agent("pi", "pi", "Pi"),
+      agent("mytool --flag", "cus", "Custom"),
+    ]);
+    try {
+      for (let i = 0; i < 4; i++) {
+        await expandRow(r.root, i);
+        // No re-seed button of any key should appear for these rows.
+        expect(
+          r.root.querySelector('[data-ac-testid^="settings.agent.reseedDefault."]'),
+        ).toBeNull();
+      }
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  it("gates by EXACT basename, not .startsWith (`pip` gets no button, `pi` does)", async () => {
+    const r = renderAgents([agent("pip", "pip", "Pip"), agent("pi", "pi", "Pi")], {
+      catalog: [def("pi", "Pi", "pi", ".pi")],
+      reseedable: ["pi"],
+    });
+    try {
+      await expandRow(r.root, 0); // pip
+      expect(r.root.querySelector('[data-ac-testid^="settings.agent.reseedDefault."]')).toBeNull();
+      await expandRow(r.root, 1); // pi
+      await waitFor(() => expect(reseedBtn(r.root, "pi")).toBeTruthy());
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  it("confirm → calls reseed with the command and toasts success including the backup path", async () => {
+    const backupPath = "C:/cfg/coding-agents/_seed/.claude.bak-20260703";
+    const r = renderAgents([agent("claude", "c", "Claude")], {
+      reseedResolve: { dest: ".claude", backupPath },
+    });
+    try {
+      await expandRow(r.root, 0);
+      await waitFor(() => expect(reseedBtn(r.root, "claude")).toBeTruthy());
+      click(reseedBtn(r.root, "claude"));
+      await waitFor(() =>
+        expect(r.root.querySelector('[data-ac-testid="settings.reseedConfirm.confirm"]')).toBeTruthy(),
+      );
+      click(r.root.querySelector('[data-ac-testid="settings.reseedConfirm.confirm"]'));
+
+      await waitFor(() =>
+        expect(
+          toastStore.items.some((t) => t.kind === "success" && t.message.includes(backupPath)),
+        ).toBe(true),
+      );
+      const call = r.fake.callsFor(RESEED_CMD)[0];
+      expect(call?.args).toEqual({ command: "claude" });
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  it("omits the backup clause when backupPath is empty", async () => {
+    const r = renderAgents([agent("claude", "c", "Claude")], {
+      reseedResolve: { dest: ".claude", backupPath: "" },
+    });
+    try {
+      await expandRow(r.root, 0);
+      await waitFor(() => expect(reseedBtn(r.root, "claude")).toBeTruthy());
+      click(reseedBtn(r.root, "claude"));
+      await waitFor(() =>
+        expect(r.root.querySelector('[data-ac-testid="settings.reseedConfirm.confirm"]')).toBeTruthy(),
+      );
+      click(r.root.querySelector('[data-ac-testid="settings.reseedConfirm.confirm"]'));
+
+      await waitFor(() =>
+        expect(toastStore.items.some((t) => t.kind === "success")).toBe(true),
+      );
+      const success = toastStore.items.find((t) => t.kind === "success")!;
+      expect(success.message).toBe("Default configuration restored");
+      expect(success.message).not.toContain("backup at");
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  it("shows a non-destructive error toast when re-seed fails", async () => {
+    const r = renderAgents([agent("claude", "c", "Claude")], { reseedReject: "not reseedable" });
+    try {
+      await expandRow(r.root, 0);
+      await waitFor(() => expect(reseedBtn(r.root, "claude")).toBeTruthy());
+      click(reseedBtn(r.root, "claude"));
+      await waitFor(() =>
+        expect(r.root.querySelector('[data-ac-testid="settings.reseedConfirm.confirm"]')).toBeTruthy(),
+      );
+      click(r.root.querySelector('[data-ac-testid="settings.reseedConfirm.confirm"]'));
+
+      await waitFor(() => expect(toastStore.items.some((t) => t.kind === "error")).toBe(true));
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  it("shows NO buttons when the reseedable-set fetch fails (failure-safe)", async () => {
+    const r = renderAgents([agent("claude", "c", "Claude")], { reseedableReject: true });
+    try {
+      await expandRow(r.root, 0);
+      // Give ensureLoaded a beat to settle its failed reseedable fetch.
+      await waitFor(() =>
+        expect(r.root.querySelector(`[data-ac-testid="settings.agentRow.0.editor"]`)).toBeTruthy(),
+      );
+      expect(reseedBtn(r.root, "claude")).toBeNull();
+    } finally {
+      r.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -5,11 +5,13 @@ import type {
   AppSettings,
   AgentConfig,
   CodingAgentEnv,
+  CodingAgentDefinition,
   LogLevel,
   TelegramBotConfig,
   ProfileCellConfig,
 } from "../../shared/types";
-import { SettingsAPI, TelegramAPI, ReposAPI } from "../../shared/ipc";
+import { SettingsAPI, TelegramAPI, ReposAPI, CodingAgentsAPI } from "../../shared/ipc";
+import { toastStore } from "../../shared/stores/toasts";
 import { validateScreenshotHotkeySyntax } from "../../shared/screenshot-hotkey";
 import { settingsStore } from "../../shared/stores/settings";
 import { setSoundsEnabled } from "../../shared/sound";
@@ -159,6 +161,11 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   const [leftRailId, setLeftRailId] = createSignal<string | null>(null);
   const [rightRailId, setRightRailId] = createSignal<string | null>(null);
   const [activeAgentId, setActiveAgentId] = createSignal<string | null>(null);
+
+  // #769 Phase 2 — "Re-seed default configuration" confirm flow. `reseedTarget`
+  // holds the catalog def being re-seeded (null = modal closed).
+  const [reseedTarget, setReseedTarget] = createSignal<CodingAgentDefinition | null>(null);
+  const [reseeding, setReseeding] = createSignal(false);
 
   const agentList = () => settings.data?.agents ?? [];
   const agentById = (id: string | null) =>
@@ -560,6 +567,48 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   const hasAgentByCommand = (command: string): boolean => {
     if (!settings.data) return false;
     return settings.data.agents.some((a) => a.command.startsWith(command));
+  };
+
+  // #769 Phase 2 — the catalog def a configured agent's command maps to IFF that
+  // command ships a re-seedable default config folder. Gating is EXACT
+  // executable-basename equality against the backend-derived reseedable set —
+  // deliberately NOT `hasAgentByCommand`'s `.startsWith` (so `pi` matches only
+  // `pi` not `pip`, and Cursor CLI `agent`/Hermes/Pi/custom get no button). The
+  // set is empty until loaded and stays empty on fetch failure, so a failure is
+  // fail-safe (no destructive button we cannot validate). Returns null → no button.
+  const reseedableDefForCommand = (command: string): CodingAgentDefinition | null => {
+    const basename = commandExecutableBasename(command).toLowerCase();
+    if (!basename) return null;
+    const inReseedableSet = codingAgentsStore
+      .reseedableCommands()
+      .some((c) => c.toLowerCase() === basename);
+    if (!inReseedableSet) return null;
+    const def = codingAgentsStore
+      .catalog()
+      .find((d) => commandExecutableBasename(d.command).toLowerCase() === basename);
+    // A dest is required to name the affected folder in the confirm copy.
+    return def && def.configSeed?.dest ? def : null;
+  };
+
+  const confirmReseed = async () => {
+    const def = reseedTarget();
+    if (!def) return;
+    setReseeding(true);
+    try {
+      const result = await CodingAgentsAPI.reseedDefault(def.command);
+      toastStore.success(
+        result.backupPath
+          ? `Default configuration restored (backup at ${result.backupPath})`
+          : "Default configuration restored",
+      );
+      setReseedTarget(null);
+    } catch (e) {
+      // Non-destructive: the server-side re-check refused or the swap failed; the
+      // prior master is intact.
+      toastStore.error(`Could not re-seed ${def.label} default configuration: ${String(e)}`);
+    } finally {
+      setReseeding(false);
+    }
   };
 
   const tokenHasUnclosedQuote = (token: string, quote: string): boolean =>
@@ -1488,6 +1537,24 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
               </div>
             </label>
             {renderAgentEnvEditor(agent, i())}
+            {/* #769 Phase 2 — re-seed this tool's default config folder to the
+                shipped default. Only for built-ins that ship a re-seedable
+                master (claude/codex/opencode today); gate is exact-basename. */}
+            <Show when={reseedableDefForCommand(agent.command)}>
+              {(def) => (
+                <div class="settings-field">
+                  <button
+                    class="settings-row-btn"
+                    onClick={() => setReseedTarget(def())}
+                    data-ac-testid={`settings.agent.reseedDefault.${def().key}`}
+                    data-ac-role="button"
+                    title={`Restore the shipped default ${def().configSeed?.dest} config folder for new ${def().label} sessions`}
+                  >
+                    Re-seed default configuration
+                  </button>
+                </div>
+              )}
+            </Show>
           </div>
         </Show>
       </div>
@@ -2354,6 +2421,63 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           </button>
         </div>
       </div>
+
+      {/* #769 Phase 2 — destructive-action confirm for re-seeding a default
+          config folder (§14.7.5). Stacks over Settings via its own fixed overlay. */}
+      <Show when={reseedTarget()}>
+        {(def) => (
+          <div
+            class="modal-overlay"
+            data-ac-testid="settings.reseedConfirm.overlay"
+            data-ac-role="overlay"
+          >
+            <div
+              class="agent-modal"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Re-seed default configuration"
+              data-ac-testid="settings.reseedConfirm.modal"
+              data-ac-role="dialog"
+            >
+              <div class="agent-modal-header">
+                <span class="agent-modal-title">Re-seed default configuration</span>
+              </div>
+              <div class="wizard-body">
+                <p class="settings-hint" data-ac-testid="settings.reseedConfirm.message">
+                  Re-seed {def().label} default configuration? This replaces the default{" "}
+                  <code>{def().configSeed?.dest}</code> config folder that AgentsCommander seeds for
+                  new {def().label} sessions with the shipped default. Your current edits to that
+                  default folder will be backed up to{" "}
+                  <code>{def().configSeed?.dest}.bak-&lt;timestamp&gt;</code>. Running sessions and
+                  their live config are not changed; new sessions will use the restored default.
+                  Continue?
+                </p>
+              </div>
+              <div class="new-agent-footer">
+                <button
+                  class="new-agent-cancel-btn"
+                  onClick={() => setReseedTarget(null)}
+                  disabled={reseeding()}
+                  data-ac-testid="settings.reseedConfirm.cancel"
+                  data-ac-role="button"
+                >
+                  Cancel
+                </button>
+                <button
+                  class="new-agent-create-btn"
+                  onClick={() => void confirmReseed()}
+                  disabled={reseeding()}
+                  data-ac-testid="settings.reseedConfirm.confirm"
+                  data-ac-role="button"
+                  data-ac-state={reseeding() ? "reseeding" : "ready"}
+                >
+                  {reseeding() ? "Re-seeding..." : "Re-seed"}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </Show>
     </div>
   );
 };

--- a/src/sidebar/stores/coding-agents.test.ts
+++ b/src/sidebar/stores/coding-agents.test.ts
@@ -6,6 +6,7 @@ import type { CodingAgentDefinition } from "../../shared/types";
 import { codingAgentsStore } from "./coding-agents";
 
 const CMD = "get_coding_agent_catalog";
+const LIST_CMD = "list_reseedable_agent_commands";
 
 function def(key: string): CodingAgentDefinition {
   return {
@@ -27,6 +28,9 @@ describe("codingAgentsStore (#769)", () => {
     codingAgentsStore.resetForTests();
     fake = new FakeTransport();
     __setTransportForTests(fake);
+    // Default the Phase-2 reseedable fetch so the catalog-focused cases don't hit
+    // an unhandled invoke; individual tests override it.
+    fake.resolve(LIST_CMD, []);
   });
 
   afterEach(() => {
@@ -78,5 +82,30 @@ describe("codingAgentsStore (#769)", () => {
     await codingAgentsStore.ensureLoaded();
     await codingAgentsStore.ensureLoaded();
     expect(fake.callsFor(CMD).length).toBe(1);
+  });
+
+  it("loads the reseedable command set on success", async () => {
+    fake.resolve(CMD, [def("claude")]);
+    fake.resolve(LIST_CMD, ["claude", "codex", "opencode"]);
+    await codingAgentsStore.ensureLoaded();
+    expect(codingAgentsStore.reseedableCommands()).toEqual(["claude", "codex", "opencode"]);
+  });
+
+  it("independent failure: catalog fails but the reseedable set still loads", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    fake.reject(CMD, "catalog dead");
+    fake.resolve(LIST_CMD, ["claude"]);
+    await codingAgentsStore.ensureLoaded();
+    expect(codingAgentsStore.catalog()).toBe(FALLBACK_CODING_AGENTS); // fallback kept
+    expect(codingAgentsStore.reseedableCommands()).toEqual(["claude"]);
+  });
+
+  it("independent failure: reseedable fails but the catalog still loads (set stays empty = no buttons)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    fake.resolve(CMD, [def("claude")]);
+    fake.reject(LIST_CMD, "reseedable dead");
+    await codingAgentsStore.ensureLoaded();
+    expect(codingAgentsStore.catalog()).toEqual([def("claude")]);
+    expect(codingAgentsStore.reseedableCommands()).toEqual([]);
   });
 });

--- a/src/sidebar/stores/coding-agents.ts
+++ b/src/sidebar/stores/coding-agents.ts
@@ -18,6 +18,11 @@ import { FALLBACK_CODING_AGENTS } from "../../shared/agent-presets";
  * own "Custom Agent" entry client-side.
  */
 const [catalog, setCatalog] = createSignal<CodingAgentDefinition[]>(FALLBACK_CODING_AGENTS);
+// #769 Phase 2 — command basenames that ship a re-seedable default config master.
+// Init EMPTY and stay empty on any fetch failure: the re-seed button is a
+// destructive action, so we never offer it for a set we could not validate (no
+// hardcoded fallback here, unlike the catalog).
+const [reseedableCommands, setReseedableCommands] = createSignal<string[]>([]);
 const [loaded, setLoaded] = createSignal(false);
 let inFlight: Promise<void> | null = null;
 
@@ -25,6 +30,8 @@ export const codingAgentsStore = {
   /** Reactive catalog. Starts as `FALLBACK_CODING_AGENTS`; replaced once loaded. */
   catalog,
   loaded,
+  /** Reactive re-seedable command-basename set. Empty until loaded, empty on failure. */
+  reseedableCommands,
 
   async ensureLoaded(): Promise<void> {
     if (loaded()) return;
@@ -32,14 +39,31 @@ export const codingAgentsStore = {
 
     inFlight = (async () => {
       try {
-        const fetched = await CodingAgentsAPI.getCatalog();
-        // Honor a valid empty list verbatim (do not fall back to the seed).
-        setCatalog(fetched);
+        // Independent failure domains: a catalog failure keeps the fallback list,
+        // a reseedable failure leaves the set empty (no buttons). Neither blocks
+        // the other. `allSettled` never rejects; the outer try also contains any
+        // synchronous throw so ensureLoaded can never reject into its caller.
+        const [catalogRes, reseedableRes] = await Promise.allSettled([
+          Promise.resolve().then(() => CodingAgentsAPI.getCatalog()),
+          Promise.resolve().then(() => CodingAgentsAPI.listReseedableCommands()),
+        ]);
+
+        if (catalogRes.status === "fulfilled") {
+          // Honor a valid empty list verbatim (do not fall back to the seed).
+          setCatalog(catalogRes.value);
+        } else {
+          // Keep the synchronously-seeded fallback so the list is never blank.
+          console.error("Failed to load coding-agent catalog; using fallback:", catalogRes.reason);
+        }
+
+        if (reseedableRes.status === "fulfilled") {
+          setReseedableCommands(reseedableRes.value);
+        } else {
+          // Leave the set empty → no re-seed buttons (failure-safe).
+          console.error("Failed to load reseedable commands; hiding re-seed buttons:", reseedableRes.reason);
+        }
       } catch (error) {
-        // Transport failure only (the command self-heals malformed files to the
-        // embedded default). Keep the synchronously-seeded fallback so the list
-        // is never blank; never rethrow into the mounting component.
-        console.error("Failed to load coding-agent catalog; using fallback:", error);
+        console.error("Unexpected error loading coding-agent catalog:", error);
       } finally {
         setLoaded(true);
         inFlight = null;
@@ -52,6 +76,7 @@ export const codingAgentsStore = {
   /** Test-only: restore the pristine pre-fetch state. */
   resetForTests(): void {
     setCatalog(FALLBACK_CODING_AGENTS);
+    setReseedableCommands([]);
     setLoaded(false);
     inFlight = null;
   },


### PR DESCRIPTION
## #769 Phase 2 — externalize coding-agent config folders + "Re-seed default configuration" button

Second and (pending Phase 3) likely-final phase of #769. Phase 1 (externalized editable catalog `agents.json` + `get_coding_agent_catalog`) landed in #773. This phase ships the per-agent default **config folders** and an explicit, safe **re-seed** control.

### What this delivers
- **Dest-keyed editable master config folders** at `<config_dir>/coding-agents/_seed/<dest>/`, seeded on first run (create-if-absent, non-empty only), user-editable. `AgentConfig` is untouched (dest-keyed, no `originKey`).
- **Absent-only + non-empty `CatalogDefault` spawn tier** — fills a replica's `<dest>` ONLY when it does not already exist (first-spawn) and only from a non-empty master. It **never overwrites** an existing config folder (this is the property that eliminates the E1/H1 auto-wipe data-loss surface). The four legacy #598 seed tiers are byte-identical.
- **"Re-seed default configuration" button** (per configured-agent row in Settings → Coding Agents), enabled only when the agent's command basename **exactly** matches a built-in that ships a master (never `.startsWith`, so `pi`≠`pip` and Cursor `agent` correctly get no button). Warns before applying, then `.bak`s the current master and atomically installs the shipped default. **Effect scope = new sessions (T1)**; running replicas and their live config are untouched.
- **`substitute:bool`** copy: embedded→master verbatim (raw `%AC_%` tokens); master→replica substitutes (existing #598 behavior unchanged).

### Scope decisions (Maria)
- Default config folder + button ship for **Claude (`.claude`), Codex (`.codex`), OpenCode (`.opencode`)** only — the three built-ins with a verifiable config-folder convention. **Hermes, Pi, Cursor CLI** get none (no verifiable/meaningful default; not fabricated). Addable later with no schema change.
- Default master content (approved): Claude `{ "includeCoAuthoredBy": false }` (suppresses the Co-Authored-By commit trailer for new Claude sessions), Codex comment-only starter, OpenCode `$schema`-only.
- Effect scope T1 (new sessions); no retroactive change to existing agents' `configSeed`.

### Backend commands
- `list_reseedable_agent_commands() -> ["claude","codex","opencode"]` (backend-derived from non-empty masters).
- `reseed_coding_agent_default(command) -> ReseedResult { dest, backupPath }` (gating re-checked server-side; `.bak` before atomic trash-first swap; per-dest lock; restore-on-failure).

### Review + gates
- **dev-rust-grinch Step-9 (full slice): PASS — 0 HIGH / 0 MED / 0 LOW.** Independently traced every data-loss path (absent-only never overwrites a present dest, non-empty gate incl. dir-of-empty-dirs→false, `.bak`-before-swap atomicity + restore-on-failure, exact-basename gating rejecting `pi`/`agent`/`pip`, first-run cross-process race, `substitute:bool` no-leak, FE never-throw store + failure-safe gating + verbatim modal copy). Genuine test coverage verified (not just test names).
- **Step-9.5 re-sync re-check: PASS** — merge of `origin/main` (settings.json persistence hardening, #774) is lossless and semantically disjoint from this slice; all data-loss-sensitive code byte-identical.
- Gates (run by dev-rust and independently by grinch): `cargo build`/`clippy -D warnings` clean, `cargo test --lib --bins --tests` **1873/0/12**; `tsc` clean, `vitest` **700/0** (0 unhandled), `vite build` OK. CI: `rust-regression` + `frontend-regression` + `test-debt` + `windows-release-cli-smoke` green.

### Known INFO (non-blocking, from grinch)
- absent-check and swap are not a single atomic op, but the window is closed by the global sweep lock + seed-runs-before-pty-spawn.
- `RESEED_LOCK` is in-process; concurrent cross-process re-seed fails-clean (atomic renames + unique suffixes), no corruption.
- the "prior config restored" message can be imprecise in a double-rename-failure (data still recoverable from `.bak`).
- minor test gap: dir-of-empty-dirs handled in code (verified by grinch) but only flat-empty is unit-tested.

refs #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)
