### PR TITLE
fix(#778): disk-authoritative project_paths to stop GUI clobbering CLI writes

### DIFF
--- a/src-tauri/src/cli/new_project.rs
+++ b/src-tauri/src/cli/new_project.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use crate::cli::workgroup::write_project_registration_refresh;
 use crate::config::projects::register_new_project;
-use crate::config::settings::{load_settings_for_cli, save_settings};
+use crate::config::settings::{load_settings_for_cli, save_settings_with_project_paths};
 
 #[derive(Args)]
 #[command(after_help = "\
@@ -42,7 +42,10 @@ pub fn execute(args: NewProjectArgs) -> i32 {
     // Save when we either created `.ac` or appended a new path entry.
     // (A pure no-op call still prints the status lines.)
     if result.created || result.registered {
-        if let Err(e) = save_settings(&settings) {
+        // #778: CLI verbs load fresh disk (load_settings_for_cli) then upsert, so
+        // the deliberate list is written verbatim via the explicit writer, not the
+        // preserve-disk default (which would discard this append).
+        if let Err(e) = save_settings_with_project_paths(&settings) {
             eprintln!("Error: failed to persist settings: {}", e);
             return 1;
         }

--- a/src-tauri/src/cli/open_project.rs
+++ b/src-tauri/src/cli/open_project.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 
 use crate::cli::workgroup::write_project_registration_refresh;
 use crate::config::projects::{register_existing_project, ProjectError};
-use crate::config::settings::{load_settings_for_cli, save_settings};
+use crate::config::settings::{load_settings_for_cli, save_settings_with_project_paths};
 
 #[derive(Args)]
 #[command(after_help = "\
@@ -54,7 +54,9 @@ pub fn execute(args: OpenProjectArgs) -> i32 {
         }
     };
     if result.registered {
-        if let Err(e) = save_settings(&settings) {
+        // #778: verbatim explicit writer (fresh disk already loaded above); the
+        // preserve-disk default would discard this deliberate append.
+        if let Err(e) = save_settings_with_project_paths(&settings) {
             eprintln!("Error: failed to persist settings: {}", e);
             return 1;
         }

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -1944,10 +1944,15 @@ pub async fn open_project(
     path: String,
 ) -> Result<crate::config::projects::ProjectRegistration, String> {
     let mut s = settings.write().await;
+    // #778: reconcile project_paths from disk BEFORE the upsert so a concurrent
+    // CLI append is folded in, not clobbered, then write the deliberate list
+    // verbatim (project_paths is disk-authoritative under Design S). Aborts on a
+    // non-NotFound read error (G2) rather than registering against a stale list.
+    crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
     let result = crate::config::projects::register_existing_project(&mut s, &path)
         .map_err(|e| e.to_string())?;
     let snapshot = s.clone();
-    crate::config::settings::save_settings(&snapshot)?;
+    crate::config::settings::save_settings_with_project_paths(&snapshot)?;
     drop(s); // explicit; lock released AFTER the disk write completes
     Ok(result)
 }
@@ -1961,12 +1966,39 @@ pub async fn new_project(
     path: String,
 ) -> Result<crate::config::projects::ProjectRegistration, String> {
     let mut s = settings.write().await;
+    // #778: reconcile project_paths from disk BEFORE the upsert (see open_project),
+    // then write the deliberate list verbatim. Aborts on a non-NotFound read
+    // error (G2).
+    crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
     let result =
         crate::config::projects::register_new_project(&mut s, &path).map_err(|e| e.to_string())?;
     let snapshot = s.clone();
-    crate::config::settings::save_settings(&snapshot)?;
+    crate::config::settings::save_settings_with_project_paths(&snapshot)?;
     drop(s); // explicit; lock released AFTER the disk write completes
     Ok(result)
+}
+
+/// #778 Part 3: targeted project removal. `project_paths` is disk-authoritative
+/// under Design S, so a removal cannot ride a whole-object settings save (the
+/// default `save_settings` preserves the on-disk list and would ignore the
+/// removal, and without a baseline the backend cannot tell a removal from a stale
+/// passthrough). So removal is its own command: reconcile the list from disk
+/// (G2: abort on a non-NotFound read error), drop the one entry whose
+/// `normalize_for_compare` key matches `path`, re-derive the head, and write the
+/// deliberate list verbatim. Removing against the FRESH disk list means a
+/// CLI-appended entry the sidebar never showed is preserved, not dropped.
+#[tauri::command]
+pub async fn remove_project(
+    settings: State<'_, SettingsState>,
+    path: String,
+) -> Result<(), String> {
+    let mut s = settings.write().await;
+    crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
+    crate::config::projects::remove_project_path(&mut s, &path);
+    let snapshot = s.clone();
+    crate::config::settings::save_settings_with_project_paths(&snapshot)?;
+    drop(s); // explicit; lock released AFTER the disk write completes
+    Ok(())
 }
 
 type TaskFields = (Option<String>, Option<String>);

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -300,6 +300,24 @@ fn upsert_project_path(settings: &mut AppSettings, abs_path: &str) -> bool {
     appended
 }
 
+/// #778: remove the entry whose `normalize_for_compare` key matches `abs_path`,
+/// then re-derive the legacy `project_path` head. The inverse of
+/// `upsert_project_path`; used by the `remove_project` command AFTER it has
+/// reconciled `project_paths` from disk, so removing against the fresh list
+/// cannot drop a CLI-appended entry the sidebar never showed. Returns `true` if
+/// an entry was removed. Byte-form of surviving entries is untouched.
+pub fn remove_project_path(settings: &mut AppSettings, abs_path: &str) -> bool {
+    let key = normalize_for_compare(abs_path);
+    let before = settings.project_paths.len();
+    settings
+        .project_paths
+        .retain(|p| normalize_for_compare(p) != key);
+    let removed = settings.project_paths.len() != before;
+    // Keep legacy `projectPath` in lockstep with the head (matches upsert).
+    settings.project_path = settings.project_paths.first().cloned();
+    removed
+}
+
 pub fn enumerate_registered_project_candidates(project_paths: &[String]) -> Vec<ProjectResolution> {
     let mut out = Vec::new();
     let mut seen = HashSet::new();
@@ -716,6 +734,58 @@ mod tests {
         // project_path tracks the HEAD of the list (same as FE persistProjectPaths).
         assert_eq!(s.project_path.as_deref(), Some(r1.path.as_str()));
         assert_eq!(s.project_paths, vec![r1.path.clone(), r2.path.clone()]);
+    }
+
+    // ── #778 remove_project_path (inverse of upsert) ──────────────────────
+
+    #[test]
+    fn remove_project_path_removes_matching_entry_and_rederives_head() {
+        let mut s = AppSettings {
+            project_paths: vec!["C:/a".to_string(), "C:/b".to_string()],
+            project_path: Some("C:/a".to_string()),
+            ..AppSettings::default()
+        };
+        assert!(remove_project_path(&mut s, "C:/a"));
+        assert_eq!(s.project_paths, vec!["C:/b".to_string()]);
+        assert_eq!(s.project_path.as_deref(), Some("C:/b"));
+    }
+
+    #[test]
+    fn remove_project_path_last_entry_clears_head_to_none() {
+        let mut s = AppSettings {
+            project_paths: vec!["C:/only".to_string()],
+            project_path: Some("C:/only".to_string()),
+            ..AppSettings::default()
+        };
+        assert!(remove_project_path(&mut s, "C:/only"));
+        assert!(s.project_paths.is_empty());
+        assert_eq!(s.project_path, None);
+    }
+
+    #[test]
+    fn remove_project_path_is_case_slash_insensitive_and_preserves_byte_form() {
+        // Stored byte-form uses backslashes + mixed case; remove via a normalized variant.
+        let mut s = AppSettings {
+            project_paths: vec![r"C:\Foo\".to_string(), "C:/keep".to_string()],
+            project_path: Some(r"C:\Foo\".to_string()),
+            ..AppSettings::default()
+        };
+        assert!(remove_project_path(&mut s, "c:/foo"));
+        // Only C:\Foo\ removed; the surviving entry keeps its original byte-form.
+        assert_eq!(s.project_paths, vec!["C:/keep".to_string()]);
+        assert_eq!(s.project_path.as_deref(), Some("C:/keep"));
+    }
+
+    #[test]
+    fn remove_project_path_no_match_returns_false_and_keeps_list() {
+        let mut s = AppSettings {
+            project_paths: vec!["C:/a".to_string()],
+            project_path: Some("C:/a".to_string()),
+            ..AppSettings::default()
+        };
+        assert!(!remove_project_path(&mut s, "C:/nope"));
+        assert_eq!(s.project_paths, vec!["C:/a".to_string()]);
+        assert_eq!(s.project_path.as_deref(), Some("C:/a"));
     }
 
     // ── absolutise: relative + dot-dot collapse (Round-1 G4 + G13) ────────

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1744,16 +1744,145 @@ pub fn read_log_level_only() -> Option<String> {
 /// counter so the two can be reasoned about independently in diagnostics.
 static SAVE_OP_ID: AtomicU64 = AtomicU64::new(0);
 
+/// #778: side-effect-free reader of ONLY `project_paths`/`project_path` from
+/// `settings.json` on disk. Under Design S `project_paths` is disk-authoritative,
+/// so the default `save_settings` uses this to preserve whatever another process
+/// (a CLI verb, a second instance) wrote, and the add/remove commands use it to
+/// reconcile before a deliberate mutation.
+///
+/// Error policy (grinch G2): a genuine `NotFound` yields empty (fresh install:
+/// nothing on disk to preserve). ANY other error (a transient os 5/32/33/1175
+/// lock, a permission failure, or unparseable JSON) returns `Err` so the caller
+/// ABORTS the save. The read runs BEFORE the #774 temp write, so disk is
+/// untouched and #774 is unaffected. For #778's threat model, aborting a
+/// geometry/theme save (retried later) beats silently dropping a project. A few
+/// tight retries absorb a transient lock without stacking latency onto
+/// `rename_with_retry`. This deliberately does NOT swallow-to-empty like
+/// `read_log_level_from_path`, whose transient-default is harmless.
+///
+/// G4a: `read_to_string` opens, reads, and CLOSES the handle before any write,
+/// so the later `MoveFileEx` rename cannot hit a sharing violation (os 32).
+/// MUST NOT call `load_settings` (it migrates, generates root_token, and
+/// re-saves: infinite recursion + side effects).
+fn read_project_paths_from_disk(path: &Path) -> Result<(Vec<String>, Option<String>), String> {
+    // 1 initial attempt + up to 2 retries on a transient (non-NotFound) read error.
+    const READ_RETRY_BACKOFFS_MS: [u64; 2] = [10, 40];
+    let mut attempt = 0usize;
+    let contents = loop {
+        match std::fs::read_to_string(path) {
+            Ok(c) => break c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Fresh install / never-saved: nothing on disk to preserve.
+                return Ok((Vec::new(), None));
+            }
+            Err(e) => {
+                if attempt < READ_RETRY_BACKOFFS_MS.len() {
+                    std::thread::sleep(std::time::Duration::from_millis(
+                        READ_RETRY_BACKOFFS_MS[attempt],
+                    ));
+                    attempt += 1;
+                    continue;
+                }
+                return Err(format!(
+                    "Failed to read {} to preserve project_paths (aborting save to avoid dropping a project): {}",
+                    path.display(),
+                    e
+                ));
+            }
+        }
+    };
+    let value: serde_json::Value = serde_json::from_str(&contents).map_err(|e| {
+        format!(
+            "Failed to parse {} to preserve project_paths (aborting save to avoid dropping a project): {}",
+            path.display(),
+            e
+        )
+    })?;
+    let project_paths = value
+        .get("projectPaths")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let project_path = value
+        .get("projectPath")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    Ok((project_paths, project_path))
+}
+
+/// #778: overwrite `settings`' in-memory project list with the disk-authoritative
+/// one. The deliberate list mutators (`open_project`/`new_project`/`remove_project`)
+/// call this under the `SettingsState` write lock BEFORE they add/remove, so a
+/// concurrent CLI append is reconciled into the list rather than clobbered by the
+/// following verbatim write. Aborts (propagates `Err`) on a non-`NotFound` read
+/// error per G2; a missing home dir is a no-op (the following save surfaces it).
+pub fn refresh_project_paths_from_disk(settings: &mut AppSettings) -> Result<(), String> {
+    let Some(path) = settings_path() else {
+        return Ok(());
+    };
+    let (project_paths, project_path) = read_project_paths_from_disk(&path)?;
+    settings.project_paths = project_paths;
+    settings.project_path = project_path;
+    Ok(())
+}
+
 /// Save settings to the app config directory (see config_dir()).
-/// Atomic write via `save_settings_to_path`: a per-writer unique temp plus
-/// `sessions_persistence::rename_with_retry` (#774), matching the concurrency
-/// hardening `save_sessions` already uses (sessions_persistence.rs #291/#280).
-/// Splitter-drag debouncing raises save frequency in 0.8.0; the atomic tmp+rename
-/// ensures a crash mid-write cannot corrupt the existing settings.json.
+///
+/// #778: this is the DEFAULT writer and treats `project_paths` as
+/// disk-authoritative (Design S). It preserves whatever `project_paths`/
+/// `project_path` is currently on disk and discards this (possibly stale)
+/// in-memory candidate's copy, so ANY whole-object GUI save is fail-safe for the
+/// project list: a project a CLI verb registered while the GUI ran is never
+/// clobbered. Deliberate list changes (the add/remove commands, the CLI verbs,
+/// the startup root_token/migration write) go through
+/// `save_settings_with_project_paths` instead.
+///
+/// The underlying write is the #774-hardened atomic tmp+rename
+/// (`save_settings_to_path`): a per-writer unique temp plus
+/// `sessions_persistence::rename_with_retry`. The disk read that preserves
+/// `project_paths` runs first and closes its handle before that write (G4a).
+///
+/// G4b (accepted, documented): a remove/add racing another writer within the
+/// sub-millisecond window between this preserve-read and the rename could
+/// momentarily resurrect an entry; orders of magnitude smaller than the prior
+/// snapshot-age window. Airtight cross-process safety would need an advisory
+/// file lock (tracked separately), deliberately not added here.
 pub fn save_settings(settings: &AppSettings) -> Result<(), String> {
     let dir = super::config_dir().ok_or("Could not determine home directory")?;
     let path = dir.join("settings.json");
+    save_settings_to_path_preserving_project_paths(settings, &path)
+}
+
+/// #778: EXPLICIT writer. Persists `project_paths`/`project_path` VERBATIM (the
+/// pre-#778 `save_settings` behavior, still #774-hardened). ONLY for deliberate
+/// list mutators that have already reconciled the list against disk: the add
+/// commands (`open_project`/`new_project`), the `remove_project` command, the two
+/// CLI verbs (which load fresh disk via `load_settings_for_cli`), and the startup
+/// root_token/migration save (whose `project_paths` was just loaded from disk).
+pub fn save_settings_with_project_paths(settings: &AppSettings) -> Result<(), String> {
+    let dir = super::config_dir().ok_or("Could not determine home directory")?;
+    let path = dir.join("settings.json");
     save_settings_to_path(settings, &path)
+}
+
+/// #778: the preserve-disk wrapper behind the default `save_settings`. Reads the
+/// current on-disk `project_paths`/`project_path` (G2 abort policy), substitutes
+/// them into a clone of `settings`, then hands off to the verbatim
+/// #774-hardened writer. Split out with an explicit `path` so tests can drive it
+/// against a `tempfile::tempdir()`.
+fn save_settings_to_path_preserving_project_paths(
+    settings: &AppSettings,
+    path: &Path,
+) -> Result<(), String> {
+    let (disk_paths, disk_head) = read_project_paths_from_disk(path)?;
+    let mut to_write = settings.clone();
+    to_write.project_paths = disk_paths;
+    to_write.project_path = disk_head;
+    save_settings_to_path(&to_write, path)
 }
 
 fn save_settings_to_path(settings: &AppSettings, path: &Path) -> Result<(), String> {
@@ -3019,6 +3148,156 @@ mod tests {
         std::fs::write(&path, r#"{"logLevel":"","other":"value"}"#).unwrap();
         assert_eq!(super::read_log_level_from_path(&path), Some(String::new()));
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── #778: disk-authoritative project_paths (Design S) ────────────────────
+
+    fn settings_with_project_paths(paths: &[&str]) -> AppSettings {
+        AppSettings {
+            project_paths: paths.iter().map(|p| p.to_string()).collect(),
+            project_path: paths.first().map(|p| p.to_string()),
+            ..AppSettings::default()
+        }
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_returns_list_and_head() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        super::save_settings_to_path(&settings_with_project_paths(&["C:/a", "C:/b"]), &path)
+            .unwrap();
+        let (paths, head) = super::read_project_paths_from_disk(&path).unwrap();
+        assert_eq!(paths, vec!["C:/a".to_string(), "C:/b".to_string()]);
+        assert_eq!(head.as_deref(), Some("C:/a"));
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_empty_when_file_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("does-not-exist.json");
+        // NotFound is the ONLY error that degrades to empty (fresh install).
+        assert_eq!(
+            super::read_project_paths_from_disk(&path).unwrap(),
+            (Vec::new(), None)
+        );
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_aborts_on_unparseable_json() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(&path, "{ not valid json").unwrap();
+        // G2: unparseable is NOT NotFound, so the reader aborts (Err), never disk=[].
+        assert!(super::read_project_paths_from_disk(&path).is_err());
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_aborts_on_non_notfound_read_error() {
+        // G2: a directory at the path yields a non-NotFound read error; the reader
+        // must abort (Err), not degrade to empty (which would silently drop a project).
+        let temp = tempfile::tempdir().unwrap();
+        let dir_as_path = temp.path().join("iam-a-dir");
+        std::fs::create_dir_all(&dir_as_path).unwrap();
+        assert!(super::read_project_paths_from_disk(&dir_as_path).is_err());
+    }
+
+    #[test]
+    fn save_settings_preserve_keeps_disk_project_paths_on_passthrough() {
+        // Marquee preserve: disk has [A, X] (X = an append this in-memory candidate
+        // never saw); a whole-object save that changed only an unrelated field must
+        // leave project_paths = [A, X] on disk (fail-safe) AND persist the field.
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        super::save_settings_to_path(&settings_with_project_paths(&["A", "X"]), &path).unwrap();
+
+        let mut candidate = settings_with_project_paths(&["A"]); // stale, missing X
+        candidate.sidebar_style = "deep-space".to_string(); // unrelated GUI field
+        super::save_settings_to_path_preserving_project_paths(&candidate, &path).unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let reloaded: AppSettings = serde_json::from_str(&contents).unwrap();
+        assert_eq!(
+            reloaded.project_paths,
+            vec!["A".to_string(), "X".to_string()]
+        ); // X preserved, not clobbered
+        assert_eq!(reloaded.project_path.as_deref(), Some("A"));
+        assert_eq!(reloaded.sidebar_style, "deep-space"); // unrelated field persisted
+    }
+
+    #[test]
+    fn save_settings_with_project_paths_writes_verbatim() {
+        // The explicit writer persists the in-memory list as-is (deliberate mutation).
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        super::save_settings_to_path(&settings_with_project_paths(&["A"]), &path).unwrap();
+        super::save_settings_to_path(&settings_with_project_paths(&["A", "Y"]), &path).unwrap();
+        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap();
+        assert_eq!(paths, vec!["A".to_string(), "Y".to_string()]);
+    }
+
+    #[test]
+    fn save_settings_preserve_twice_succeeds_no_sharing_violation() {
+        // G4a: the preserve-read closes its handle before the #774 rename, so two
+        // preserve-saves in a row both succeed on Windows (a lingering read handle
+        // would trip MoveFileEx with os 32).
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        super::save_settings_to_path(&settings_with_project_paths(&["A"]), &path).unwrap();
+        super::save_settings_to_path_preserving_project_paths(
+            &settings_with_project_paths(&["A"]),
+            &path,
+        )
+        .unwrap();
+        super::save_settings_to_path_preserving_project_paths(
+            &settings_with_project_paths(&["A"]),
+            &path,
+        )
+        .unwrap();
+        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap();
+        assert_eq!(paths, vec!["A".to_string()]);
+    }
+
+    #[test]
+    fn remove_project_disk_composition_preserves_unseen_entry() {
+        // remove_project command body against a tempdir: disk [A, X] (X unseen by the
+        // sidebar), reconcile from disk, remove A, write verbatim => disk ends [X].
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        super::save_settings_to_path(&settings_with_project_paths(&["A", "X"]), &path).unwrap();
+
+        let mut s = settings_with_project_paths(&["A"]); // stale in-memory
+        let (disk_paths, disk_head) = super::read_project_paths_from_disk(&path).unwrap();
+        s.project_paths = disk_paths;
+        s.project_path = disk_head; // reconciled to [A, X]
+        assert!(crate::config::projects::remove_project_path(&mut s, "A"));
+        super::save_settings_to_path(&s, &path).unwrap(); // verbatim
+
+        let (paths, head) = super::read_project_paths_from_disk(&path).unwrap();
+        assert_eq!(paths, vec!["X".to_string()]); // A gone, X preserved
+        assert_eq!(head.as_deref(), Some("X"));
+    }
+
+    #[test]
+    fn add_reconciles_from_disk_before_upsert() {
+        // Add command body: in-memory stale [A], disk [A, X]; reconcile then append Y
+        // and write verbatim => disk ends [A, X, Y] (the CLI append X is not lost).
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        super::save_settings_to_path(&settings_with_project_paths(&["A", "X"]), &path).unwrap();
+
+        let mut s = settings_with_project_paths(&["A"]); // stale
+        let (disk_paths, disk_head) = super::read_project_paths_from_disk(&path).unwrap();
+        s.project_paths = disk_paths;
+        s.project_path = disk_head; // [A, X]
+        s.project_paths.push("Y".to_string()); // stand-in for register upsert
+        s.project_path = s.project_paths.first().cloned();
+        super::save_settings_to_path(&s, &path).unwrap();
+
+        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap();
+        assert_eq!(
+            paths,
+            vec!["A".to_string(), "X".to_string(), "Y".to_string()]
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1989,6 +1989,7 @@ pub fn run(
             commands::ac_discovery::create_ac_project,
             commands::ac_discovery::open_project,
             commands::ac_discovery::new_project,
+            commands::ac_discovery::remove_project,
             commands::ac_discovery::discover_project,
             commands::project_settings::get_project_groups,
             commands::project_settings::update_project_groups,

--- a/src-tauri/tests/pty_lifecycle_regression.rs
+++ b/src-tauri/tests/pty_lifecycle_regression.rs
@@ -14,7 +14,9 @@ use agentscommander_lib::commands::session::{
 use agentscommander_lib::config::sessions_persistence::{
     load_sessions, persist_current_state_result,
 };
-use agentscommander_lib::config::settings::{save_settings, AppSettings, SettingsState};
+use agentscommander_lib::config::settings::{
+    save_settings_with_project_paths, AppSettings, SettingsState,
+};
 use agentscommander_lib::pty::git_watcher::GitWatcher;
 use agentscommander_lib::pty::idle_detector::IdleDetector;
 use agentscommander_lib::pty::manager::PtyManager;
@@ -163,7 +165,12 @@ fn make_lifecycle_fixture() -> LifecycleFixture {
         agentscommander_lib::config::config_dir().expect("config dir override"),
         config_dir
     );
-    save_settings(&AppSettings {
+    // #778: seeding project_paths to a fresh settings.json is a deliberate list
+    // write, so it must use the explicit verbatim writer. The default
+    // `save_settings` is now preserve-disk (it would read the not-yet-existent
+    // file as empty and write project_paths: []), which is exactly the fail-safe
+    // behavior #778 introduced.
+    save_settings_with_project_paths(&AppSettings {
         default_shell: "powershell.exe".to_string(),
         default_shell_args: vec!["-NoLogo".to_string()],
         project_paths: vec![path_to_string(&repo_root)],

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -765,6 +765,16 @@ export const ProjectAPI = {
    */
   new: (path: string) =>
     transport.invoke<ProjectRegistration>("new_project", { path }),
+  /**
+   * Remove the project registered at `path` from settings.projectPaths via the
+   * dedicated `remove_project` Tauri command (#778 Design S). Removal is
+   * disk-authoritative: the backend reconciles the list from disk before
+   * dropping `path`, so it never clobbers a CLI-registered project the way the
+   * retired whole-object settings save did. Removing a path not present is a
+   * successful no-op; the promise rejects with the backend error string on a
+   * hard failure (e.g. a G2 read abort when the settings file is locked).
+   */
+  remove: (path: string) => transport.invoke<void>("remove_project", { path }),
 };
 
 // Project Loops API

--- a/src/sidebar/stores/project.test.ts
+++ b/src/sidebar/stores/project.test.ts
@@ -5,6 +5,7 @@ const m = vi.hoisted(() => ({
   open: vi.fn(),
   newProject: vi.fn(),
   discover: vi.fn(),
+  removeProject: vi.fn(),
   getSettings: vi.fn(),
   updateSettings: vi.fn(),
 }));
@@ -14,6 +15,7 @@ vi.mock("../../shared/ipc", () => ({
     open: m.open,
     new: m.newProject,
     discover: m.discover,
+    remove: m.removeProject,
   },
   SettingsAPI: {
     get: m.getSettings,
@@ -320,6 +322,36 @@ describe("projectStore", () => {
 
       projectStore.removeLoop(PROJECT_PATH, "standup");
       expect(projectStore.projects[0].loops).toHaveLength(0);
+    });
+  });
+
+  // #778 — project removal routes through the dedicated disk-authoritative
+  // remove_project command, NOT a whole-object settings save (which under
+  // Design S preserves the on-disk list and would no longer remove anything).
+  describe("removeProject (#778)", () => {
+    it("routes removal through remove_project and never whole-object saves", async () => {
+      await loadProjectWith([]);
+      expect(projectStore.projects).toHaveLength(1);
+      m.removeProject.mockResolvedValueOnce(undefined);
+
+      await projectStore.removeProject(PROJECT_PATH);
+
+      // In-memory row is gone...
+      expect(projectStore.projects).toHaveLength(0);
+      // ...persisted via the dedicated command with the raw absolute path...
+      expect(m.removeProject).toHaveBeenCalledTimes(1);
+      expect(m.removeProject).toHaveBeenCalledWith(PROJECT_PATH);
+      // ...and NEVER via a whole-object settings save (the retired clobber path).
+      expect(m.updateSettings).not.toHaveBeenCalled();
+    });
+
+    it("still calls remove_project for a path not in the store (backend no-op)", async () => {
+      m.removeProject.mockResolvedValueOnce(undefined);
+
+      await projectStore.removeProject("C:\\not\\loaded");
+
+      expect(m.removeProject).toHaveBeenCalledWith("C:\\not\\loaded");
+      expect(m.updateSettings).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -7,7 +7,7 @@ import type {
   AcLoopSummary,
   ContextTemplateUpdate,
 } from "../../shared/types";
-import { ProjectAPI, SettingsAPI, AgentCreatorAPI } from "../../shared/ipc";
+import { ProjectAPI, AgentCreatorAPI } from "../../shared/ipc";
 import {
   findLoadedProjectPathForRefresh,
   normalizeProjectPathForCompare,
@@ -354,7 +354,11 @@ export const projectStore = {
         replicaVolatileStore.clearForPaths(workgroupReplicaPaths(removed));
       }
     });
-    await persistProjectPaths();
+    // #778 — persist the removal through the dedicated disk-authoritative
+    // command. A whole-object settings save no longer removes anything under
+    // Design S (it preserves the on-disk project_paths so it can't clobber
+    // CLI-registered projects), so removal must go through remove_project.
+    await ProjectAPI.remove(path);
   },
 
   /** #695 — drop exactly one resolved pending context-template update. The key
@@ -402,14 +406,3 @@ export const projectStore = {
     replicaVolatileStore.clearAll();
   },
 };
-
-/** Persist current project paths to settings */
-async function persistProjectPaths() {
-  const fresh = await SettingsAPI.get();
-  const paths = projects().map((p) => p.path);
-  await SettingsAPI.update({
-    ...fresh,
-    projectPaths: paths,
-    projectPath: paths[0] ?? null, // backward compat
-  });
-}


### PR DESCRIPTION
## Summary

Fixes silent, irrecoverable data loss where the running GUI's whole-object `settings.json` saves (built from a stale in-memory `SettingsState` snapshot) clobber project entries written concurrently by CLI verbs (`open-project` / `new-project`) running in a separate OS process.

Follow-up to #774 (which fixed only the shared-temp rename race, `os error 2`). This is the distinct content-level clobber that #774 did not address.

## Approach — Design S (disk-authoritative `project_paths`)

`project_paths` is the only field CLI verbs mutate (append-only). Under Design S it becomes disk-authoritative and the fix is fail-safe — a whole-object save can no longer drop a CLI append; only explicit add/remove change the list.

- **Whole-object GUI saves preserve disk by default.** `save_settings_to_path` is split: the default `save_settings` path re-reads `project_paths` from disk (via a targeted, side-effect-free `read_project_paths_from_disk` reader that never calls `load_settings`) and overwrites the outgoing object's list before the (#774-hardened) atomic write. A separate `save_settings_with_project_paths` writes the list verbatim and is reachable ONLY from deliberate mutators.
- **Add reconciles from disk** before upsert in `open_project` / `new_project`.
- **Remove is targeted:** a new `remove_project(path)` Tauri command (read disk / remove one / write); the FE `removeProject` is rewired to it and the whole-object `persistProjectPaths` (the second clobber source) is retired entirely.

## Safety details

- The reader aborts the save (never swallows to `[]`) on any non-`NotFound` read error (transient AV/indexer lock, permission), so a locked read cannot silently drop an append.
- The disk read closes its handle before the #774 rename (no Windows sharing violation); #774's unique-temp + `rename_with_retry` + cleanup are preserved.
- A residual micro-race (a CLI append landing between the preserve-read and the atomic rename) is accepted and documented; an advisory file lock is deferred to a separate issue.

## Review + gates

- architect design (Design S chosen over Design M) with dev-rust + grinch plan enrichment; grinch **Step-9 adversarial review PASS** (enumerated every writer caller — no stale in-memory `project_paths` reaches disk) and **Step-9.5 merge re-check PASS** (lossless + disjoint from the concurrently-landed #769-P2).
- Backend: `cargo build` + `cargo clippy --all-targets` clean; `cargo test --lib --bins --tests` **1886 passed / 0 failed / 12 ignored** (+13 new #778 tests, zero regressions).
- Frontend: `tsc --noEmit` clean; `vitest` **702/702**; `vite build` clean.
- Non-visual change (the removal UI behaves identically; this is a wire-level correctness fix).

Closes #778
