### PR TITLE
fix(#784): stop DECLARED ENV name/value overlap in profile selector

### DIFF
--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -3383,7 +3383,7 @@ html.light-theme .settings-hint-warning {
 
 .agent-profile-declared-env-row {
   display: grid;
-  grid-template-columns: minmax(82px, 0.45fr) minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 0.42fr) minmax(0, 1fr) auto;
   gap: 7px;
   min-width: 0;
   padding: 6px 8px;
@@ -3395,16 +3395,21 @@ html.light-theme .settings-hint-warning {
 }
 
 .agent-profile-declared-env-key {
+  min-width: 0;
   color: var(--sidebar-fg-dim);
   text-transform: uppercase;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .agent-profile-declared-env-value {
+  min-width: 0;
   color: var(--sidebar-fg);
   overflow-wrap: anywhere;
 }
 
 .agent-profile-declared-env-origin {
+  min-width: 0;
   justify-self: end;
   color: var(--status-active, #35f2a6);
   font-size: 8px;


### PR DESCRIPTION
## Summary

Fixes the DECLARED ENV name/value overlap in the profile selector (`AgentPickerModal`). When a profile declared env vars, the variable NAME rendered on top of the VALUE.

**Root cause:** the declared-env row is a CSS grid whose items kept the default `min-width: auto`. Env names are unbreakable uppercase tokens (`OPENCODE_DISABLE_GLOBAL_CONFIG`), so the key cell's min-content forced its track past `0.45fr` and painted over the value cell.

**Fix (CSS-only, `src/sidebar/styles/sidebar.css`, +6 / -1):**
- `.agent-profile-declared-env-key`: `min-width: 0`, `overflow-wrap: anywhere`, `word-break: break-word`
- `.agent-profile-declared-env-value` / `.agent-profile-declared-env-origin`: `min-width: 0`
- `.agent-profile-declared-env-row`: track template `minmax(82px, 0.45fr) …` → `minmax(0, 0.42fr) …`

Long env names now wrap inside the key cell (wrap chosen over ellipsis so names stay fully readable). No TSX / DOM / `data-ac-*` changes.

## Review
- **dev-webpage-ui** implemented: `tsc --noEmit` clean; vitest `AgentPickerModal.test.tsx` "shows declared env vars…" passes.
- **dev-rust-grinch** adversarial review: **PASS**. Fix is correct and scoped — the four `agent-profile-declared-env-*` selectors are used only in this block (grep-verified), the sibling `.agent-profile-param` command row is a separate class and untouched, and the narrow-width tradeoff (key wraps, never overlaps) is acceptable.

## Note
This is a layout fix. The existing vitest case asserts text/`data-ac-*` presence only (jsdom computes no layout), so it does not cover this bug; runtime visual confirmation follows via the wg-2 build.

Closes #784.
