### PR TITLE
feat(sidebar): hide raise-hand on All, hand icon left of title, bold system groups (#775)

### DIFF
--- a/src/sidebar/components/ProjectPanel.raise-hand.test.tsx
+++ b/src/sidebar/components/ProjectPanel.raise-hand.test.tsx
@@ -130,6 +130,9 @@ describe("ProjectPanel raise-hand communication slot (#676)", () => {
       const slot = rendered.root.querySelector(
         `[data-ac-testid="${rowSlotTestId("wg-2-dev-team", "dev-webpage-ui")}"]`
       );
+      // #775: the raise-hand slot now renders the shared SVG hand, not "!".
+      expect(slot?.querySelector("svg")).not.toBeNull();
+      expect(slot?.textContent ?? "").not.toContain("!");
       const line = slot?.closest(".coord-task-line");
       expect(line?.querySelector(".coord-task-title")?.textContent).toBe("Second task");
     } finally {

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -14,6 +14,7 @@ import { isTauri } from "../../shared/platform";
 import { stripFrontmatter } from "../../shared/markdown";
 import { launchErrorMessage } from "../../shared/launch-errors";
 import { focusOnMount } from "../../shared/focus-on-mount";
+import RaiseHandIcon from "./RaiseHandIcon";
 import { projectStore } from "../stores/project";
 import {
   effectiveAutoClosedAt,
@@ -2059,7 +2060,7 @@ const ProjectPanel: Component = () => {
                         title="Raised hand"
                         aria-label="Raised hand"
                       >
-                        <span class="coord-communication-icon" aria-hidden="true">!</span>
+                        <RaiseHandIcon class="coord-communication-icon" />
                       </span>
                     </Show>
                   </div>

--- a/src/sidebar/components/RaiseHandIcon.tsx
+++ b/src/sidebar/components/RaiseHandIcon.tsx
@@ -1,0 +1,16 @@
+import type { Component } from "solid-js";
+
+/**
+ * #775 — the raised-hand glyph shared by every raise-hand indicator (the
+ * group-rail tabs and the per-coordinator row). A monochrome SVG (not an
+ * emoji) so it stays crisp and inherits the caller's amber `color` in the
+ * Tauri webview regardless of emoji-font availability. Callers size/tint it
+ * via the passed-in `class` (fill: currentColor). Heroicons `hand-raised`.
+ */
+const RaiseHandIcon: Component<{ class?: string }> = (props) => (
+  <svg class={props.class} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M10.5 1.875a1.125 1.125 0 0 1 2.25 0v8.219c.517.162 1.02.382 1.5.659V3.375a1.125 1.125 0 0 1 2.25 0v10.937a4.505 4.505 0 0 0-3.25 2.373 8.963 8.963 0 0 1 4-.935A.75.75 0 0 0 18 15v-2.266a3.368 3.368 0 0 1 .988-2.37 1.125 1.125 0 0 1 1.591 1.59 1.118 1.118 0 0 0-.329.79v3.006h-.005a6 6 0 0 1-1.752 4.007l-1.736 1.736a6 6 0 0 1-4.242 1.757H10.5a7.5 7.5 0 0 1-7.5-7.5V6.375a1.125 1.125 0 0 1 2.25 0v5.519c.46-.452.965-.832 1.5-1.141V3.375a1.125 1.125 0 0 1 2.25 0v6.526c.495-.1.997-.151 1.5-.151V1.875Z" />
+  </svg>
+);
+
+export default RaiseHandIcon;

--- a/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
@@ -12,6 +12,7 @@ import type { ProjectState } from "../stores/project";
 import { sessionsStore } from "../stores/sessions";
 import {
   defaultGroupsConfig,
+  defaultNonStop,
   exactGroupRegexForWorkgroup,
 } from "../stores/workgroup-groups";
 import WorkgroupGroupRail from "./WorkgroupGroupRail";
@@ -327,6 +328,40 @@ describe("WorkgroupGroupRail raise-hand badge (#763 render + aggregation)", () =
         ".workgroup-group-rail-title"
       );
       expect(builtinAll?.classList.contains("workgroup-group-rail-title-system")).toBe(true);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("bolds the built-in Non-stop group; All still never shows the hand (#775 + #777 merge)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve(
+      "get_project_groups",
+      groupsConfig({
+        nonStop: {
+          ...defaultNonStop(),
+          show: true,
+          regex: exactGroupRegexForWorkgroup("wg-1-dev-team"),
+        },
+      })
+    );
+    // wg-1 (a Non-stop + "UI"-group member) raises a hand.
+    sessionsStore.setSessions([raisedSession("wg-1-dev-team")]);
+
+    const rendered = renderWithFakeTransport(
+      () => <WorkgroupGroupRail projects={[project(defaultWorkgroups())]} />,
+      fake
+    );
+    try {
+      await waitFor(() => expect(railButtonOrder()).toContain("nonstop"));
+      // Non-stop is a built-in/system rail group (selection.kind "nonstop") -> the
+      // structural bold gate (kind !== "group") already covers it, no string match.
+      const nonstopTitle = target<HTMLElement>("workgroupGroups.button.nonstop").querySelector(
+        ".workgroup-group-rail-title"
+      );
+      expect(nonstopTitle?.classList.contains("workgroup-group-rail-title-system")).toBe(true);
+      // Rule 1 survives the merge: All never shows the hand, even with Non-stop present.
+      expect(railRaiseHands()).not.toContain("all");
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
@@ -276,4 +276,59 @@ describe("WorkgroupGroupRail raise-hand badge (#763 render + aggregation)", () =
       rendered.cleanup();
     }
   });
+
+  it("bolds built-in group labels (All, Ungrouped) and leaves user groups normal (#775)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+
+    const rendered = renderWithFakeTransport(
+      () => <WorkgroupGroupRail projects={[project(defaultWorkgroups())]} />,
+      fake
+    );
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      const isBold = (key: string) =>
+        target<HTMLElement>(`workgroupGroups.button.${key}`)
+          .querySelector(".workgroup-group-rail-title")
+          ?.classList.contains("workgroup-group-rail-title-system") ?? false;
+      expect(isBold("all")).toBe(true);
+      expect(isBold("ungrouped")).toBe(true);
+      expect(isBold("ui")).toBe(false);
+      expect(isBold("rust")).toBe(false);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("never bolds a user group merely named like a built-in (#775 structural gate)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve(
+      "get_project_groups",
+      groupsConfig({
+        groups: [
+          { id: "myall", name: "All", regex: exactGroupRegexForWorkgroup("wg-1-dev-team") },
+        ],
+      })
+    );
+
+    const rendered = renderWithFakeTransport(
+      () => <WorkgroupGroupRail projects={[project(defaultWorkgroups())]} />,
+      fake
+    );
+    try {
+      await waitFor(() => expect(railButtonOrder()).toContain("myall"));
+      const userAll = target<HTMLElement>("workgroupGroups.button.myall").querySelector(
+        ".workgroup-group-rail-title"
+      );
+      expect(userAll?.textContent).toBe("All");
+      expect(userAll?.classList.contains("workgroup-group-rail-title-system")).toBe(false);
+      // The built-in All (key "all") stays bold.
+      const builtinAll = target<HTMLElement>("workgroupGroups.button.all").querySelector(
+        ".workgroup-group-rail-title"
+      );
+      expect(builtinAll?.classList.contains("workgroup-group-rail-title-system")).toBe(true);
+    } finally {
+      rendered.cleanup();
+    }
+  });
 });

--- a/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
@@ -173,13 +173,23 @@ describe("WorkgroupGroupRail raise-hand badge (#763 render + aggregation)", () =
 
       const badge = target<HTMLElement>("workgroupGroups.raiseHand.ui");
       expect(badge.classList.contains("workgroup-group-rail-raise-hand")).toBe(true);
-      expect(badge.textContent?.trim()).toBe("!");
+      // #775 round 2: a raised-hand SVG glyph, not the old amber "!".
+      expect(
+        badge.querySelector("svg.workgroup-group-rail-raise-hand-icon")
+      ).not.toBeNull();
+      expect(badge.textContent ?? "").not.toContain("!");
       expect(badge.getAttribute("aria-label")).toBe("A coordinator raised its hand");
 
-      // #775 rule 3: the indicator renders before (to the left of) the title —
-      // it is the button's first element child, ahead of the name/dot/counter.
+      // #775 rule 3 (Option B): the hand renders inline, to the LEFT of the
+      // title — first child of the title line, ahead of the title text.
       const button = target<HTMLElement>("workgroupGroups.button.ui");
-      expect(button.firstElementChild).toBe(badge);
+      const titleLine = button.querySelector(".workgroup-group-rail-title-line");
+      const title = button.querySelector<HTMLElement>(".workgroup-group-rail-title");
+      expect(titleLine?.firstElementChild).toBe(badge);
+      expect(title?.textContent).toBe("UI");
+      expect(
+        Boolean(badge.compareDocumentPosition(title!) & Node.DOCUMENT_POSITION_FOLLOWING)
+      ).toBe(true);
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
@@ -157,7 +157,7 @@ describe("WorkgroupGroupRail raise-hand badge (#763 render + aggregation)", () =
     document.body.replaceChildren();
   });
 
-  it("lights the amber badge on All and on the group whose coordinator raised a hand", async () => {
+  it("lights the amber badge on the group whose coordinator raised a hand, never on All (#775)", async () => {
     const fake = new FakeTransport();
     fake.resolve("get_project_groups", groupsConfig());
     sessionsStore.setSessions([raisedSession("wg-1-dev-team")]);
@@ -168,19 +168,47 @@ describe("WorkgroupGroupRail raise-hand badge (#763 render + aggregation)", () =
     );
     try {
       await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
-      // Aggregates up to All; lights the matching group; leaves the rest dark.
-      await waitFor(() => expect(railRaiseHands()).toEqual(["all", "ui"]));
+      // #775: lights the matching group; All never lights; the rest stay dark.
+      await waitFor(() => expect(railRaiseHands()).toEqual(["ui"]));
 
       const badge = target<HTMLElement>("workgroupGroups.raiseHand.ui");
       expect(badge.classList.contains("workgroup-group-rail-raise-hand")).toBe(true);
       expect(badge.textContent?.trim()).toBe("!");
       expect(badge.getAttribute("aria-label")).toBe("A coordinator raised its hand");
+
+      // #775 rule 3: the indicator renders before (to the left of) the title —
+      // it is the button's first element child, ahead of the name/dot/counter.
+      const button = target<HTMLElement>("workgroupGroups.button.ui");
+      expect(button.firstElementChild).toBe(badge);
     } finally {
       rendered.cleanup();
     }
   });
 
-  it("aggregates onto All and Ungrouped when an ungrouped workgroup's coordinator raised", async () => {
+  it("never lights All even when every member workgroup has a raised hand (#775)", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    sessionsStore.setSessions([
+      raisedSession("wg-1-dev-team"),
+      raisedSession("wg-2-rust-team"),
+      raisedSession("wg-3-docs-team"),
+    ]);
+
+    const rendered = renderWithFakeTransport(
+      () => <WorkgroupGroupRail projects={[project(defaultWorkgroups())]} />,
+      fake
+    );
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      // Ungrouped + every dynamic group lights, but All stays dark regardless.
+      await waitFor(() => expect(railRaiseHands()).toEqual(["ungrouped", "ui", "rust"]));
+      expect(railRaiseHands()).not.toContain("all");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("aggregates onto Ungrouped (never All) when an ungrouped workgroup's coordinator raised (#775)", async () => {
     const fake = new FakeTransport();
     fake.resolve("get_project_groups", groupsConfig());
     sessionsStore.setSessions([raisedSession("wg-3-docs-team")]);
@@ -191,7 +219,8 @@ describe("WorkgroupGroupRail raise-hand badge (#763 render + aggregation)", () =
     );
     try {
       await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
-      await waitFor(() => expect(railRaiseHands()).toEqual(["all", "ungrouped"]));
+      // #775: Ungrouped still aggregates the ungrouped raise; All never lights.
+      await waitFor(() => expect(railRaiseHands()).toEqual(["ungrouped"]));
     } finally {
       rendered.cleanup();
     }
@@ -226,9 +255,9 @@ describe("WorkgroupGroupRail raise-hand badge (#763 render + aggregation)", () =
       await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
       expect(railRaiseHands()).toEqual([]);
 
-      // Hand goes up -> badge appears on All + the group.
+      // Hand goes up -> badge appears on the group only (never All, #775).
       sessionsStore.setSessions([raisedSession("wg-1-dev-team")]);
-      await waitFor(() => expect(railRaiseHands()).toEqual(["all", "ui"]));
+      await waitFor(() => expect(railRaiseHands()).toEqual(["ui"]));
 
       // User attends (backend clears communication) -> badge disappears.
       sessionsStore.setCommunication("session-wg-1-dev-team", null);

--- a/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.raise-hand.test.tsx
@@ -360,6 +360,9 @@ describe("WorkgroupGroupRail raise-hand badge (#763 render + aggregation)", () =
         ".workgroup-group-rail-title"
       );
       expect(nonstopTitle?.classList.contains("workgroup-group-rail-title-system")).toBe(true);
+      // #775 — Non-stop is a real member group, so wg-1's raised hand DOES light
+      // it (locks in Maria's "Non-stop keeps the hand" decision).
+      expect(railRaiseHands()).toContain("nonstop");
       // Rule 1 survives the merge: All never shows the hand, even with Non-stop present.
       expect(railRaiseHands()).not.toContain("all");
     } finally {

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -15,6 +15,7 @@ import {
   workgroupIsWorking,
 } from "./workgroup-session";
 import WorkgroupGroupsModal from "./WorkgroupGroupsModal";
+import RaiseHandIcon from "./RaiseHandIcon";
 
 interface WorkgroupGroupRailProps {
   projects: ProjectState[];
@@ -169,17 +170,21 @@ const ProjectRailSection: Component<{
                   title="A coordinator raised its hand"
                   aria-label="A coordinator raised its hand"
                 >
-                  <svg
-                    class="workgroup-group-rail-raise-hand-icon"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path d="M10.5 1.875a1.125 1.125 0 0 1 2.25 0v8.219c.517.162 1.02.382 1.5.659V3.375a1.125 1.125 0 0 1 2.25 0v10.937a4.505 4.505 0 0 0-3.25 2.373 8.963 8.963 0 0 1 4-.935A.75.75 0 0 0 18 15v-2.266a3.368 3.368 0 0 1 .988-2.37 1.125 1.125 0 0 1 1.591 1.59 1.118 1.118 0 0 0-.329.79v3.006h-.005a6 6 0 0 1-1.752 4.007l-1.736 1.736a6 6 0 0 1-4.242 1.757H10.5a7.5 7.5 0 0 1-7.5-7.5V6.375a1.125 1.125 0 0 1 2.25 0v5.519c.46-.452.965-.832 1.5-1.141V3.375a1.125 1.125 0 0 1 2.25 0v6.526c.495-.1.997-.151 1.5-.151V1.875Z" />
-                  </svg>
+                  <RaiseHandIcon class="workgroup-group-rail-raise-hand-icon" />
                 </span>
               </Show>
-              <span class="workgroup-group-rail-title">{button.name}</span>
+              <span
+                class="workgroup-group-rail-title"
+                classList={{
+                  // #775 — built-in/system groups (All, Ungrouped, …) render bold
+                  // to stand out from user-created groups. Gated on the selection
+                  // kind, not the display name, so a user group named "All" stays
+                  // normal weight.
+                  "workgroup-group-rail-title-system": button.selection.kind !== "group",
+                }}
+              >
+                {button.name}
+              </span>
             </span>
             <span class="workgroup-group-rail-counter-line">
               <Show when={button.working}>

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -161,25 +161,35 @@ const ProjectRailSection: Component<{
             onClick={() => workgroupGroupsStore.select(props.project.path, button.selection)}
             data-ac-testid={`workgroupGroups.button.${button.key}`}
           >
-            <Show when={button.raiseHand}>
-              <span
-                class="workgroup-group-rail-raise-hand"
-                data-ac-testid={`workgroupGroups.raiseHand.${button.key}`}
-                title="A coordinator raised its hand"
-                aria-label="A coordinator raised its hand"
-              >
-                !
-              </span>
-            </Show>
-            {button.name}
-            {"\n"}
-            <Show when={button.working}>
-              <span
-                class="session-item-status running workgroup-group-rail-dot"
-                data-ac-testid={`workgroupGroups.dot.${button.key}`}
-              />
-            </Show>
-            {button.counter}
+            <span class="workgroup-group-rail-title-line">
+              <Show when={button.raiseHand}>
+                <span
+                  class="workgroup-group-rail-raise-hand"
+                  data-ac-testid={`workgroupGroups.raiseHand.${button.key}`}
+                  title="A coordinator raised its hand"
+                  aria-label="A coordinator raised its hand"
+                >
+                  <svg
+                    class="workgroup-group-rail-raise-hand-icon"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path d="M10.5 1.875a1.125 1.125 0 0 1 2.25 0v8.219c.517.162 1.02.382 1.5.659V3.375a1.125 1.125 0 0 1 2.25 0v10.937a4.505 4.505 0 0 0-3.25 2.373 8.963 8.963 0 0 1 4-.935A.75.75 0 0 0 18 15v-2.266a3.368 3.368 0 0 1 .988-2.37 1.125 1.125 0 0 1 1.591 1.59 1.118 1.118 0 0 0-.329.79v3.006h-.005a6 6 0 0 1-1.752 4.007l-1.736 1.736a6 6 0 0 1-4.242 1.757H10.5a7.5 7.5 0 0 1-7.5-7.5V6.375a1.125 1.125 0 0 1 2.25 0v5.519c.46-.452.965-.832 1.5-1.141V3.375a1.125 1.125 0 0 1 2.25 0v6.526c.495-.1.997-.151 1.5-.151V1.875Z" />
+                  </svg>
+                </span>
+              </Show>
+              <span class="workgroup-group-rail-title">{button.name}</span>
+            </span>
+            <span class="workgroup-group-rail-counter-line">
+              <Show when={button.working}>
+                <span
+                  class="session-item-status running workgroup-group-rail-dot"
+                  data-ac-testid={`workgroupGroups.dot.${button.key}`}
+                />
+              </Show>
+              {button.counter}
+            </span>
           </button>
         )}
       </For>

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -104,6 +104,12 @@ const ProjectRailSection: Component<{
       result.push({
         key: "all",
         ...buttonContent("All", props.project.workgroups),
+        // #775 — the built-in "All" group never shows the raise-hand indicator,
+        // under any condition (even when a member workgroup's coordinator has a
+        // raised hand). Gated here on the statically-built "all" entry, not on
+        // the display name, so a user group coincidentally named "All" is
+        // unaffected. Ungrouped + dynamic groups keep their aggregation below.
+        raiseHand: false,
         selection: { kind: "all" },
         workgroups: props.project.workgroups,
         title: tooltipFor(props.project.workgroups),

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2759,7 +2759,7 @@ html.light-theme .settings-hint-warning {
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 6px 5px;
+  padding: 6px 4px;
   background: rgba(255, 255, 255, 0.025);
   border-left: 1px solid rgba(255, 255, 255, 0.06);
 }
@@ -2794,13 +2794,13 @@ html.light-theme .settings-hint-warning {
   width: 100%;
   min-height: 28px;
   margin-bottom: 4px;
-  padding: 4px 5px;
+  padding: 4px 3px;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--sidebar-fg-dim);
   font-family: var(--font-ui);
-  font-size: 8.5px;
+  font-size: 7.5px;
   line-height: 1.15;
   text-align: center;
   cursor: pointer;
@@ -2816,7 +2816,7 @@ html.light-theme .settings-hint-warning {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 3px;
+  gap: 2px;
   max-width: 100%;
   min-width: 0;
 }
@@ -2826,6 +2826,14 @@ html.light-theme .settings-hint-warning {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* #775 — built-in/system group labels (All, Ungrouped, …) render bold so they
+   stand out from user-created groups. Applied via a class gated on the
+   selection kind (never the display string), so a user group literally named
+   "All" stays normal weight. */
+.workgroup-group-rail-title-system {
+  font-weight: 700;
 }
 
 .workgroup-group-rail-button:hover,
@@ -2872,8 +2880,8 @@ html.light-theme .settings-hint-warning {
 }
 
 .workgroup-group-rail-button .workgroup-group-rail-raise-hand-icon {
-  width: 11px;
-  height: 11px;
+  width: 8px;
+  height: 8px;
   display: block;
   fill: currentColor;
 }
@@ -4624,8 +4632,14 @@ html.light-theme .settings-hint-warning {
   line-height: 1;
 }
 
+/* #775 — the raise-hand glyph inside the amber coordinator-row slot is now the
+   shared SVG hand (RaiseHandIcon), sized to sit in the 15px amber chip and
+   tinted by the slot's amber `color` via fill: currentColor. */
 .coord-communication-icon {
-  transform: translateY(-0.5px);
+  width: 11px;
+  height: 11px;
+  display: block;
+  fill: currentColor;
 }
 
 .coord-quick-access .replica-item-info .coord-task-title {

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2786,8 +2786,11 @@ html.light-theme .settings-hint-warning {
 }
 
 .workgroup-group-rail-button {
-  position: relative; /* #763 — anchor for the raise-hand corner badge */
-  display: block;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
   width: 100%;
   min-height: 28px;
   margin-bottom: 4px;
@@ -2800,10 +2803,29 @@ html.light-theme .settings-hint-warning {
   font-size: 8.5px;
   line-height: 1.15;
   text-align: center;
-  white-space: pre-line;
   cursor: pointer;
-  overflow-wrap: break-word;
   transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+/* #775 (Option B) — first line = optional raise-hand symbol + the group title,
+   laid out inline so the symbol sits to the LEFT of the title and NEVER
+   overlaps it. The title truncates with an ellipsis (nowrap) rather than
+   wrapping or splitting mid-word — that is how the #742 no-mid-word-split
+   guarantee is now kept once a symbol shares the line on the 68px rail. */
+.workgroup-group-rail-title-line {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.workgroup-group-rail-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .workgroup-group-rail-button:hover,
@@ -2832,31 +2854,28 @@ html.light-theme .settings-hint-warning {
   vertical-align: -1px;
 }
 
-/* #763/#775 — raise-hand indicator on a group-rail tab. Amber '!' pinned to
-   the top-LEFT corner, i.e. to the left of the group title (#775: it reads as
-   "(!) <title>" and never sits by the counter). Kept absolute so it stays OUT
-   of the button's pre-line text flow and never reflows the name/counter — the
-   #742 no-mid-word-split trap the working dot's comment above warns about;
-   an inline badge before the name would re-tighten the name line on the 68px
-   rail. Reuses the amber palette of the per-coordinator row indicator
-   (.coord-communication-slot) for visual consistency. pointer-events:none
-   keeps the whole tab uniformly clickable. */
+/* #763/#775 — raise-hand indicator on a group-rail tab: an amber raised-hand
+   glyph rendered INLINE just to the left of the group title (#775 Option B, so
+   it reads as "(hand) <title>" and never overlaps — the title ellipsizes to
+   make room). Uses an SVG glyph (not an emoji) so it stays crisp and
+   theme-amber in the Tauri webview regardless of emoji-font availability, and
+   so `color` actually tints it. Amber keeps the "needs attention" reading of
+   the per-coordinator row indicator (.coord-communication-slot).
+   pointer-events:none keeps the whole tab uniformly clickable. */
 .workgroup-group-rail-button .workgroup-group-rail-raise-hand {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 12px;
-  height: 12px;
-  display: flex;
+  flex: 0 0 auto;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 3px;
-  background: rgba(234, 179, 8, 0.18);
   color: #eab308;
-  font-size: 9px;
-  font-weight: 800;
-  line-height: 1;
   pointer-events: none;
+}
+
+.workgroup-group-rail-button .workgroup-group-rail-raise-hand-icon {
+  width: 11px;
+  height: 11px;
+  display: block;
+  fill: currentColor;
 }
 
 .workgroup-group-rail-error {

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -4704,8 +4704,6 @@ html.light-theme .settings-hint-warning {
   border-radius: 3px;
   background: rgba(234, 179, 8, 0.18);
   color: #eab308;
-  font-size: 10px;
-  font-weight: 800;
   line-height: 1;
 }
 

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2832,16 +2832,19 @@ html.light-theme .settings-hint-warning {
   vertical-align: -1px;
 }
 
-/* #763 — raise-hand indicator on a group-rail tab. Amber '!' pinned to the
-   top-right corner (absolute, so it stays OUT of the button's pre-line text
-   flow and never reflows the name/counter — the #742 trap the working dot's
-   comment above warns about). Reuses the amber palette of the per-coordinator
-   row indicator (.coord-communication-slot) for visual consistency.
-   pointer-events:none keeps the whole tab uniformly clickable. */
+/* #763/#775 — raise-hand indicator on a group-rail tab. Amber '!' pinned to
+   the top-LEFT corner, i.e. to the left of the group title (#775: it reads as
+   "(!) <title>" and never sits by the counter). Kept absolute so it stays OUT
+   of the button's pre-line text flow and never reflows the name/counter — the
+   #742 no-mid-word-split trap the working dot's comment above warns about;
+   an inline badge before the name would re-tighten the name line on the 68px
+   rail. Reuses the amber palette of the per-coordinator row indicator
+   (.coord-communication-slot) for visual consistency. pointer-events:none
+   keeps the whole tab uniformly clickable. */
 .workgroup-group-rail-button .workgroup-group-rail-raise-hand {
   position: absolute;
   top: 2px;
-  right: 2px;
+  left: 2px;
   width: 12px;
   height: 12px;
   display: flex;


### PR DESCRIPTION
## Summary

Reworks the raise-hand indicator on the sidebar group rail (and unifies it app-wide), per Maria's request.

**Behavior:**
- The built-in **"All"** group **never** shows the raise-hand indicator (it's the everything-aggregate — always noisy, not actionable). Gated structurally on `kind:"all"` via a `raiseHand:false` override, collision-proof against a user group named "All".
- **"Ungrouped"**, dynamically-created groups, **and "Non-stop"** show the indicator when a member raises a hand (they're real workgroup subsets). Non-stop keeping the hand was an explicit product decision.
- The indicator now renders as an inline **monochrome SVG raised-hand icon** (amber), to the **left of the group title**, with the **full group name visible** (no truncation) on the narrow 68px rail — achieved via a modest uniform font/spacing compaction, not a mid-word split.
- The same hand icon replaces the old amber `!` **everywhere it appears** (group rail + per-coordinator row), via a shared `RaiseHandIcon` component.
- **System/built-in group labels** (All, Ungrouped, Non-stop) render **bold** to distinguish them from user-created groups; gated structurally (`selection.kind !== "group"`), never by display string.

## Why a hand SVG, not an emoji
Color emoji ignore CSS `color` (can't be tinted to the theme amber), look muddy at 8.5px, and vary across OS/fonts. An inline SVG is crisp, theme-tintable, and renders identically everywhere.

## Review
- **dev-webpage-ui** implemented across iterations (corner→inline placement, hand icon, full-name fit, bold system groups, app-wide unification) + re-synced with a moving `main`.
- **dev-rust-grinch** adversarial review: **PASS** on the merged state, plus a focused re-check of the final delta. Rule 1 verified airtight (single construction site, override wins, no reactive/second-site escape, collision-proof); merge integrity verified (both sides intact); both hand sites + bold gate confirmed.
- Gates (reproduced by grinch): `tsc --noEmit` 0 errors · `vitest run` 91 files / 718 tests / 0 failed · `vite build` OK.

## Notes
- Branch is current with `main`; merges auto-resolved clean (disjoint regions in `sidebar.css`).
- No version bump (not a release).

Closes #775
