### PR TITLE
feat(cli): scriptable coding-agent config management (#786)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -392,6 +392,60 @@ Output (stdout, JSON): `{ agentPath, agentName, rolePath, launched, launchAgent 
 
 ---
 
+## `coding-agent`
+
+Scriptable create/inspect/update/remove of Coding Agent configurations (`settings.agents[]`) without the GUI. Agents created here are consumed by [`create-agent`](#create-agent) / [`create-agent-matrix`](#create-agent-matrix) `--launch`. No `--token`: this mutates the user-local `settings.json`, which any local process can already write (same boundary as [`open-project`](#open-project)).
+
+```bash
+agentscommander coding-agent list
+agentscommander coding-agent show --id claude
+agentscommander coding-agent catalog
+agentscommander coding-agent add --from-catalog claude
+agentscommander coding-agent add --label "My Claude" --command "claude" --color "#6366f1" --env FOO=bar
+agentscommander coding-agent update --id agent_123_abc --command "claude --model opus" --clear-envs
+agentscommander coding-agent remove --id agent_123_abc
+```
+
+Subcommands:
+
+| Subcommand | Reads/Writes | Output (stdout JSON) |
+|---|---|---|
+| `list` | reads disk | array of `AgentConfig` |
+| `show --id <id>` | reads disk | one `AgentConfig` (exact id) |
+| `catalog` | reads disk | array of `CodingAgentDefinition` (read-only catalog) |
+| `add` | writes | `{ "ok": true, "op": "add", "agent": { ... } }` |
+| `update --id <id>` | writes | `{ "ok": true, "op": "update", "agent": { ... } }` |
+| `remove --id <id>` | writes | `{ "ok": true, "op": "remove", "id": "<id>" }` |
+
+`add` / `update` flags:
+
+| Flag | Description |
+|---|---|
+| `--from-catalog <key>` | (add) Seed label/command/color/envs/isolatedHome (and optional instructions/seed) from a catalog entry; explicit flags below override. Without it, `--label` and `--command` are required. |
+| `--id <id>` | (add) Custom id, `^[a-z0-9][a-z0-9_-]{0,63}$`. Default: a minted `agent_<ms>_<hex>` id. Ids are unique case-insensitively. |
+| `--label <s>` | Display label (non-empty, trimmed). |
+| `--command <s>` | Launch command. Banned: Claude `--continue`/`-c`, Codex `resume`/`--last`, Gemini `--resume` (AC injects resume automatically). |
+| `--color <#rrggbb>` | Strict 6-digit hex (only enforced for the explicit flag; catalog-seeded colors are accepted as-is). Default `#6366f1` for custom agents. |
+| `--env KEY=VALUE` | Repeatable. Split on the first `=` (`FOO=a=b` -> value `a=b`). All CLI envs are `source=user`, `enabled=true`. On `update`, any `--env` REPLACES the whole env list (including `source=system` rows). |
+| `--clear-envs` | (update) Empty the env list. Conflicts with `--env`. |
+| `--isolated-home <true\|false>` | Provide an isolated CODEX_HOME at spawn (Codex). |
+| `--instructions-filename <name.md>` | Bare `.md` filename AC writes into the agent root at launch. |
+| `--clear-instructions-filename` | (update) Clear it. Conflicts with `--instructions-filename`. |
+| `--config-seed-dest <folder>` | Config-folder seed destination NAME under the replica root. Implies enabled unless `--config-seed-enabled false`. |
+| `--config-seed-enabled <true\|false>` | Toggle the seed. Enabling with no destination is an error. |
+| `--clear-config-seed` | (update) Remove the seed. Conflicts with the other seed flags. |
+| `--confirm-timeout <secs>` | Seconds to wait for the GUI to process the request (daemon path only). Default 30. |
+
+`remove` leaves any `profilesByAgent[id]` / `profileLabelsByAgent[id]` entries in place (matching the GUI and settings repair), so a same-id re-add resurrects the old profile cells.
+
+**GUI-running routing.** While an AgentsCommander GUI for this binary identity is running (detected via the single-instance mutex), mutations are NOT written to `settings.json` directly. They are queued and applied by the running GUI against its authoritative in-memory state, then a result is returned to the CLI. While the GUI is closed, mutations load `settings.json` strictly (a present-but-unparseable file is refused, not silently defaulted) then apply and save. GUI detection is Windows-only; off-Windows a running GUI is not detected and the direct write path is always used.
+
+**Known limitation (documented for scripts).** The CLI does not clobber the GUI, but the reverse remains possible: a Settings dialog that is already open with an unsaved draft can, on its next Save, revert a concurrent CLI mutation (it writes a full snapshot). Run `--launch` (or re-`show`) right after `add` so consumption happens before a Settings Save can revert.
+
+**Exit codes.** 0 on success, 1 on error. Both terminal (validation) and retryable (GUI busy) failures exit 1; the stderr message carries the distinction. Only a `cancelled (safe to retry)` message is blind-retry-safe. A `may or may not have applied` message is NOT: run `coding-agent show --id <id>` before retrying.
+
+---
+
 ## `close-session`
 
 Close all sessions for a target agent. Coordinator-only.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -421,7 +421,7 @@ Subcommands:
 
 | Flag | Description |
 |---|---|
-| `--from-catalog <key>` | (add) Seed label/command/color/envs/isolatedHome (and optional instructions/seed) from a catalog entry; explicit flags below override. Without it, `--label` and `--command` are required. |
+| `--from-catalog <key>` | (add) Seed label/command/color/envs/isolatedHome (and optional instructions/seed) from a catalog entry; explicit flags below override. Without it, `--label` and `--command` are required. The final label must still be non-empty: a catalog entry with an empty label requires `--label`. |
 | `--id <id>` | (add) Custom id, `^[a-z0-9][a-z0-9_-]{0,63}$`. Default: a minted `agent_<ms>_<hex>` id. Ids are unique case-insensitively. |
 | `--label <s>` | Display label (non-empty, trimmed). |
 | `--command <s>` | Launch command. Banned: Claude `--continue`/`-c`, Codex `resume`/`--last`, Gemini `--resume` (AC injects resume automatically). |

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -76,6 +76,8 @@ A minimal `settings.json`:
 |---|---|---|---|
 | `agents` | `AgentConfig[]` | See example | The dropdown of available coding agents. |
 
+Besides the GUI Settings dialog and Onboarding, `agents[]` has a scriptable writer: the [`coding-agent`](cli.md#coding-agent) CLI verb (`list`/`show`/`catalog`/`add`/`update`/`remove`). It writes safely whether or not the GUI is running.
+
 `AgentConfig`:
 
 | Field | Type | Default | Description |

--- a/src-tauri/src/cli/coding_agent.rs
+++ b/src-tauri/src/cli/coding_agent.rs
@@ -1,0 +1,659 @@
+//! `coding-agent` CLI verb (#786) - scriptable create/inspect/update/remove of
+//! Coding Agent configs (`settings.agents[]`) without the GUI.
+//!
+//! No `--token`: this mutates the user-local `settings.json`, which any local
+//! process can already write (same boundary argument as `open-project`).
+//!
+//! Safe-write routing. `list`/`show`/`catalog` always read disk and print JSON.
+//! Mutations (`add`/`update`/`remove`) NEVER direct-write while a GUI for this
+//! binary identity is running:
+//!   - GUI running (probe via the single-instance mutex): the mutation is queued
+//!     as a file the GUI's `MailboxPoller` drains against its authoritative
+//!     in-memory settings, writing a result this CLI waits on. The poller claims
+//!     each request with an atomic `.processing` rename, so a timeout-cancel can
+//!     never be reported as "cancelled" for a mutation that actually applied.
+//!   - GUI not running: a strict load (refuses to modify a present-but-unparseable
+//!     settings.json rather than silently defaulting) then apply then save.
+//!
+//! Known limitation (documented for scripts): a SettingsModal already open with
+//! an unsaved draft can, on its next Save, revert a concurrent CLI mutation. The
+//! CLI does not clobber the GUI, but the reverse remains. Run `--launch` (or
+//! re-`show`) right after `add` so consumption happens before a Modal Save.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use clap::{Args, Subcommand};
+
+use crate::config::coding_agent_mutations::{
+    self as ops, AgentPatch, CodingAgentOp, CodingAgentOpOutcome, CodingAgentRequest,
+    CodingAgentResult, DEFAULT_CUSTOM_COLOR,
+};
+use crate::config::coding_agents_catalog::{load_catalog, CodingAgentDefinition};
+use crate::config::settings::{
+    load_settings_for_cli_strict, save_settings, validate_user_env_key, AgentConfig,
+    CodingAgentEnv, CodingAgentEnvSource, ConfigSeedConfig,
+};
+
+const DEFAULT_CONFIRM_TIMEOUT_SECS: u64 = 30;
+/// #786 R3: grace window (one poller interval + margin) after an ENOENT cancel.
+const GRACE_WAIT: Duration = Duration::from_secs(4);
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+#[derive(Args)]
+#[command(after_help = "\
+PURPOSE: Scriptable management of Coding Agent configs (settings.agents) without \
+the GUI. `create-agent` / `create-agent-matrix --launch` consume agents created \
+here.\n\n\
+OUTPUT: JSON on stdout, diagnostics on stderr, exit 0 on success, 1 on error.\n\n\
+GUI ROUTING: while the GUI runs, mutations are routed through it (safe against \
+clobber). While it is closed, they write settings.json directly.\n\n\
+EXIT 1 is either terminal (validation) or retryable (GUI busy). Only a \
+\"cancelled (safe to retry)\" message is blind-retry-safe; a \"may or may not have \
+applied\" message is NOT - run `coding-agent show --id <id>` first.\n\n\
+PLATFORM: GUI detection is Windows-only; off-Windows a running GUI is not \
+detected and the direct write path is always used.")]
+pub struct CodingAgentArgs {
+    #[command(subcommand)]
+    pub cmd: CodingAgentCmd,
+}
+
+#[derive(Subcommand)]
+pub enum CodingAgentCmd {
+    /// List configured coding agents (settings.agents) as a JSON array
+    List,
+    /// Show one configured coding agent by exact id as JSON
+    Show(ShowArgs),
+    /// List the read-only coding-agent catalog as JSON
+    Catalog,
+    /// Add a coding agent (custom, or seeded with --from-catalog <key>)
+    Add(AddArgs),
+    /// Update fields of an existing coding agent (partial; only given flags change)
+    Update(UpdateArgs),
+    /// Remove a coding agent by exact id (profile entries are left as orphans)
+    Remove(RemoveArgs),
+}
+
+#[derive(Args)]
+pub struct ShowArgs {
+    /// Exact agent id
+    #[arg(long)]
+    pub id: String,
+}
+
+#[derive(Args)]
+pub struct AddArgs {
+    /// Seed label/command/color/envs/isolatedHome (and optional instructions/seed)
+    /// from this catalog key; explicit flags below override seeded values.
+    #[arg(long = "from-catalog", value_name = "KEY")]
+    pub from_catalog: Option<String>,
+    /// Custom agent id (default: a minted `agent_<ms>_<hex>` id)
+    #[arg(long)]
+    pub id: Option<String>,
+    /// Display label (required unless --from-catalog supplies it)
+    #[arg(long)]
+    pub label: Option<String>,
+    /// Launch command (required unless --from-catalog supplies it)
+    #[arg(long)]
+    pub command: Option<String>,
+    /// Color as #RRGGBB (default #6366f1 for custom agents)
+    #[arg(long)]
+    pub color: Option<String>,
+    /// Env row KEY=VALUE (repeatable). All CLI envs are source=user, enabled=true.
+    #[arg(long = "env", value_name = "KEY=VALUE")]
+    pub env: Vec<String>,
+    /// Provide an isolated CODEX_HOME at spawn (Codex)
+    #[arg(long = "isolated-home", value_name = "true|false", action = clap::ArgAction::Set)]
+    pub isolated_home: Option<bool>,
+    /// Bare .md filename AC writes into the agent root at launch
+    #[arg(long = "instructions-filename", value_name = "NAME.md")]
+    pub instructions_filename: Option<String>,
+    /// Config-folder seed destination NAME under the replica root (implies enabled)
+    #[arg(long = "config-seed-dest", value_name = "FOLDER")]
+    pub config_seed_dest: Option<String>,
+    /// Enable/disable the config-folder seed
+    #[arg(long = "config-seed-enabled", value_name = "true|false", action = clap::ArgAction::Set)]
+    pub config_seed_enabled: Option<bool>,
+    /// Seconds to wait for the GUI to process the request (daemon path only)
+    #[arg(long = "confirm-timeout", default_value_t = DEFAULT_CONFIRM_TIMEOUT_SECS)]
+    pub confirm_timeout: u64,
+}
+
+#[derive(Args)]
+pub struct UpdateArgs {
+    /// Exact agent id to update
+    #[arg(long)]
+    pub id: String,
+    #[arg(long)]
+    pub label: Option<String>,
+    #[arg(long)]
+    pub command: Option<String>,
+    /// Color as #RRGGBB
+    #[arg(long)]
+    pub color: Option<String>,
+    /// Env row KEY=VALUE (repeatable). Any --env REPLACES the whole env list
+    /// (including source=system rows).
+    #[arg(long = "env", value_name = "KEY=VALUE")]
+    pub env: Vec<String>,
+    /// Clear the whole env list (conflicts with --env)
+    #[arg(long = "clear-envs")]
+    pub clear_envs: bool,
+    #[arg(long = "isolated-home", value_name = "true|false", action = clap::ArgAction::Set)]
+    pub isolated_home: Option<bool>,
+    #[arg(long = "instructions-filename", value_name = "NAME.md")]
+    pub instructions_filename: Option<String>,
+    /// Clear the instructions filename (conflicts with --instructions-filename)
+    #[arg(long = "clear-instructions-filename")]
+    pub clear_instructions_filename: bool,
+    #[arg(long = "config-seed-dest", value_name = "FOLDER")]
+    pub config_seed_dest: Option<String>,
+    #[arg(long = "config-seed-enabled", value_name = "true|false", action = clap::ArgAction::Set)]
+    pub config_seed_enabled: Option<bool>,
+    /// Clear the config-folder seed (conflicts with the other seed flags)
+    #[arg(long = "clear-config-seed")]
+    pub clear_config_seed: bool,
+    #[arg(long = "confirm-timeout", default_value_t = DEFAULT_CONFIRM_TIMEOUT_SECS)]
+    pub confirm_timeout: u64,
+}
+
+#[derive(Args)]
+pub struct RemoveArgs {
+    /// Exact agent id to remove
+    #[arg(long)]
+    pub id: String,
+    #[arg(long = "confirm-timeout", default_value_t = DEFAULT_CONFIRM_TIMEOUT_SECS)]
+    pub confirm_timeout: u64,
+}
+
+pub fn execute(args: CodingAgentArgs) -> i32 {
+    run(args, crate::config::profile::gui_instance_running())
+}
+
+/// Split from `execute` so the direct/daemon branch selection is unit-testable
+/// with an injected `gui_running` bool (no live mutex needed).
+fn run(args: CodingAgentArgs, gui_running: bool) -> i32 {
+    let result = match args.cmd {
+        CodingAgentCmd::List => cmd_list(),
+        CodingAgentCmd::Show(a) => cmd_show(a),
+        CodingAgentCmd::Catalog => cmd_catalog(),
+        CodingAgentCmd::Add(a) => cmd_add(a, gui_running),
+        CodingAgentCmd::Update(a) => cmd_update(a, gui_running),
+        CodingAgentCmd::Remove(a) => cmd_remove(a, gui_running),
+    };
+    match result {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            1
+        }
+    }
+}
+
+// ---- read verbs (R1: strict loader, never a silent-default read) -----------
+
+fn cmd_list() -> Result<(), String> {
+    let settings = load_settings_for_cli_strict()?;
+    print_json(&settings.agents)
+}
+
+fn cmd_show(a: ShowArgs) -> Result<(), String> {
+    let settings = load_settings_for_cli_strict()?;
+    let agent = settings
+        .agents
+        .iter()
+        .find(|ag| ag.id == a.id)
+        .ok_or_else(|| ops::unknown_agent_id_error(&a.id, &settings.agents))?;
+    print_json(agent)
+}
+
+fn cmd_catalog() -> Result<(), String> {
+    let dir = crate::config::config_dir().ok_or("Could not resolve config dir")?;
+    let catalog = load_catalog(&dir);
+    print_json(&catalog)
+}
+
+// ---- mutation verbs --------------------------------------------------------
+
+fn cmd_add(a: AddArgs, gui_running: bool) -> Result<(), String> {
+    // R6: strict color/label checks apply ONLY to explicitly typed flags.
+    if let Some(color) = &a.color {
+        ops::validate_agent_color(color)?;
+    }
+    if let Some(label) = &a.label {
+        if label.trim().is_empty() {
+            return Err("--label must not be empty".to_string());
+        }
+    }
+    let confirm_timeout = a.confirm_timeout;
+
+    // Seed from the catalog (Rust port of definitionToSeed) or start blank.
+    let mut agent = if let Some(key) = &a.from_catalog {
+        let dir = crate::config::config_dir().ok_or("Could not resolve config dir")?;
+        let catalog = load_catalog(&dir);
+        let def = catalog.iter().find(|d| &d.key == key).ok_or_else(|| {
+            let keys: Vec<&str> = catalog.iter().map(|d| d.key.as_str()).collect();
+            format!(
+                "catalog key '{key}' not found. Available: {}",
+                keys.join(", ")
+            )
+        })?;
+        definition_to_agent_seed(def)
+    } else {
+        blank_agent()
+    };
+
+    // Explicit flags override seeded values.
+    if let Some(label) = a.label {
+        agent.label = label.trim().to_string();
+    }
+    if let Some(command) = a.command {
+        agent.command = command;
+    }
+    if let Some(color) = a.color {
+        agent.color = color;
+    }
+    if !a.env.is_empty() {
+        agent.envs = parse_env_flags(&a.env)?;
+    }
+    if let Some(isolated) = a.isolated_home {
+        agent.isolated_home = isolated;
+    }
+    if let Some(name) = a.instructions_filename {
+        agent.instructions_filename = Some(name);
+    }
+    apply_seed_flags(&mut agent, a.config_seed_dest, a.config_seed_enabled);
+
+    // Custom (not from-catalog) requires label + command (mirrors Onboarding).
+    if a.from_catalog.is_none()
+        && (agent.label.trim().is_empty() || agent.command.trim().is_empty())
+    {
+        return Err("add requires --label and --command (or --from-catalog <key>)".to_string());
+    }
+
+    agent.id = match a.id {
+        Some(id) => {
+            ops::validate_custom_agent_id(&id)?;
+            id
+        }
+        None => ops::mint_agent_id(),
+    };
+
+    dispatch_mutation(CodingAgentOp::Add { agent }, gui_running, confirm_timeout)
+}
+
+fn cmd_update(a: UpdateArgs, gui_running: bool) -> Result<(), String> {
+    // Flag-conflict checks first (fast feedback, before any disk / routing).
+    if a.clear_envs && !a.env.is_empty() {
+        return Err("--clear-envs conflicts with --env".to_string());
+    }
+    if a.clear_instructions_filename && a.instructions_filename.is_some() {
+        return Err(
+            "--clear-instructions-filename conflicts with --instructions-filename".to_string(),
+        );
+    }
+    if a.clear_config_seed && (a.config_seed_dest.is_some() || a.config_seed_enabled.is_some()) {
+        return Err(
+            "--clear-config-seed conflicts with --config-seed-dest / --config-seed-enabled"
+                .to_string(),
+        );
+    }
+    if let Some(color) = &a.color {
+        ops::validate_agent_color(color)?;
+    }
+    if let Some(label) = &a.label {
+        if label.trim().is_empty() {
+            return Err("--label must not be empty".to_string());
+        }
+    }
+
+    let envs = if a.clear_envs {
+        Some(Vec::new())
+    } else if a.env.is_empty() {
+        None
+    } else {
+        Some(parse_env_flags(&a.env)?)
+    };
+
+    let patch = AgentPatch {
+        label: a.label.map(|l| l.trim().to_string()),
+        command: a.command,
+        color: a.color,
+        envs,
+        isolated_home: a.isolated_home,
+        instructions_filename: a.instructions_filename,
+        clear_instructions_filename: a.clear_instructions_filename,
+        config_seed_dest: a.config_seed_dest,
+        config_seed_enabled: a.config_seed_enabled,
+        clear_config_seed: a.clear_config_seed,
+    };
+    dispatch_mutation(
+        CodingAgentOp::Update { id: a.id, patch },
+        gui_running,
+        a.confirm_timeout,
+    )
+}
+
+fn cmd_remove(a: RemoveArgs, gui_running: bool) -> Result<(), String> {
+    dispatch_mutation(
+        CodingAgentOp::Remove { id: a.id },
+        gui_running,
+        a.confirm_timeout,
+    )
+}
+
+// ---- routing ---------------------------------------------------------------
+
+fn dispatch_mutation(
+    op: CodingAgentOp,
+    gui_running: bool,
+    confirm_timeout: u64,
+) -> Result<(), String> {
+    if gui_running {
+        let config_dir = crate::config::config_dir().ok_or("Could not resolve config dir")?;
+        dispatch_via_daemon(&config_dir, op, confirm_timeout)
+    } else {
+        dispatch_direct(op)
+    }
+}
+
+/// GUI closed: strict load (R1) -> apply -> save. `save_settings` is the
+/// preserve-project-paths default (this op never touches the project list).
+fn dispatch_direct(op: CodingAgentOp) -> Result<(), String> {
+    let mut settings = load_settings_for_cli_strict()?;
+    let outcome = ops::apply_coding_agent_op(&mut settings, &op)?;
+    save_settings(&settings)?;
+    print_outcome(&outcome)
+}
+
+/// GUI running: queue the request and wait on the result (R2/R3).
+fn dispatch_via_daemon(
+    config_dir: &Path,
+    op: CodingAgentOp,
+    confirm_timeout: u64,
+) -> Result<(), String> {
+    let requests_dir = config_dir.join(ops::CODING_AGENT_REQUESTS_DIR);
+    let results_dir = requests_dir.join(ops::RESULTS_SUBDIR);
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let request = CodingAgentRequest {
+        request_id: request_id.clone(),
+        created_at_ms: now_unix_ms(),
+        op,
+    };
+    let request_path = ops::write_coding_agent_request(&requests_dir, &request)?;
+
+    // Poll for the result up to the confirm timeout (check first, so a 0 timeout
+    // does one non-blocking check).
+    let deadline = Instant::now() + Duration::from_secs(confirm_timeout);
+    loop {
+        if let Some(result) = take_result(&results_dir, &request_id) {
+            return finish_daemon_result(result);
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+
+    // Timeout: cancel by removing our own request file (R2/R3).
+    match std::fs::remove_file(&request_path) {
+        Ok(()) => Err(format!(
+            "GUI did not process the request within {confirm_timeout}s; request cancelled (safe to retry)"
+        )),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // The poller already claimed it: bounded grace wait, then honest
+            // unknown-state (do NOT report a safe cancel).
+            grace_wait_for_result(&results_dir, &request_id)
+        }
+        Err(e) => Err(format!("failed to cancel request: {e}")),
+    }
+}
+
+fn grace_wait_for_result(results_dir: &Path, request_id: &str) -> Result<(), String> {
+    let deadline = Instant::now() + GRACE_WAIT;
+    loop {
+        if let Some(result) = take_result(results_dir, request_id) {
+            return finish_daemon_result(result);
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    Err(
+        "request was claimed by the GUI but no result arrived; the change may or may not have \
+applied. Run `coding-agent show --id <id>` before retrying. Do NOT blind-retry."
+            .to_string(),
+    )
+}
+
+/// Read a result and best-effort delete the result file.
+fn take_result(results_dir: &Path, request_id: &str) -> Option<CodingAgentResult> {
+    let result = ops::read_coding_agent_result(results_dir, request_id)?;
+    let _ = std::fs::remove_file(results_dir.join(format!("{request_id}.json")));
+    Some(result)
+}
+
+fn finish_daemon_result(result: CodingAgentResult) -> Result<(), String> {
+    if result.ok {
+        let json = if let Some(id) = result.removed_id {
+            serde_json::json!({ "ok": true, "op": "remove", "id": id })
+        } else {
+            serde_json::json!({ "ok": true, "agent": result.agent })
+        };
+        print_json(&json)
+    } else {
+        Err(result.error.unwrap_or_else(|| "request failed".to_string()))
+    }
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+fn print_outcome(outcome: &CodingAgentOpOutcome) -> Result<(), String> {
+    let json = if outcome.op == "remove" {
+        serde_json::json!({ "ok": true, "op": "remove", "id": outcome.removed_id })
+    } else {
+        serde_json::json!({ "ok": true, "op": outcome.op, "agent": outcome.agent })
+    };
+    print_json(&json)
+}
+
+fn print_json<T: serde::Serialize>(value: &T) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(value)
+        .map_err(|e| format!("Failed to serialize JSON: {e}"))?;
+    crate::cli_println!("{}", json);
+    Ok(())
+}
+
+fn blank_agent() -> AgentConfig {
+    AgentConfig {
+        id: String::new(),
+        label: String::new(),
+        command: String::new(),
+        color: DEFAULT_CUSTOM_COLOR.to_string(),
+        envs: Vec::new(),
+        isolated_home: false,
+        instructions_filename: None,
+        config_seed: None,
+    }
+}
+
+/// Rust port of `definitionToSeed` (agent-presets.ts): copy
+/// label/command/color/envs/isolatedHome; carry instructionsFilename/configSeed
+/// only when present; drop key/description/removable; id is minted by the caller.
+fn definition_to_agent_seed(def: &CodingAgentDefinition) -> AgentConfig {
+    AgentConfig {
+        id: String::new(),
+        label: def.label.clone(),
+        command: def.command.clone(),
+        color: def.color.clone(),
+        envs: def.envs.clone(),
+        isolated_home: def.isolated_home,
+        instructions_filename: def.instructions_filename.clone(),
+        config_seed: def.config_seed.clone(),
+    }
+}
+
+/// `--config-seed-dest` implies enabled=true unless `--config-seed-enabled false`.
+fn apply_seed_flags(agent: &mut AgentConfig, dest: Option<String>, enabled: Option<bool>) {
+    if dest.is_none() && enabled.is_none() {
+        return;
+    }
+    let mut seed = agent.config_seed.clone().unwrap_or(ConfigSeedConfig {
+        enabled: true,
+        dest: String::new(),
+    });
+    if let Some(dest) = dest {
+        seed.dest = dest;
+    }
+    if let Some(enabled) = enabled {
+        seed.enabled = enabled;
+    }
+    agent.config_seed = Some(seed);
+}
+
+/// Parse `--env KEY=VALUE` (C8): split on the FIRST `=`; missing `=` or an
+/// invalid key is a CLI error (surfaced here, not via a poller round-trip).
+fn parse_env_flags(raw: &[String]) -> Result<Vec<CodingAgentEnv>, String> {
+    let mut out = Vec::with_capacity(raw.len());
+    for item in raw {
+        let (key, value) = item
+            .split_once('=')
+            .ok_or_else(|| format!("--env '{item}' must be KEY=VALUE"))?;
+        validate_user_env_key(key, "--env")?;
+        out.push(CodingAgentEnv {
+            key: key.to_string(),
+            value: value.to_string(),
+            source: CodingAgentEnvSource::User,
+            enabled: true,
+        });
+    }
+    Ok(out)
+}
+
+fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn add_args() -> AddArgs {
+        AddArgs {
+            from_catalog: None,
+            id: None,
+            label: None,
+            command: None,
+            color: None,
+            env: Vec::new(),
+            isolated_home: None,
+            instructions_filename: None,
+            config_seed_dest: None,
+            config_seed_enabled: None,
+            confirm_timeout: 0,
+        }
+    }
+
+    fn update_args(id: &str) -> UpdateArgs {
+        UpdateArgs {
+            id: id.to_string(),
+            label: None,
+            command: None,
+            color: None,
+            env: Vec::new(),
+            clear_envs: false,
+            isolated_home: None,
+            instructions_filename: None,
+            clear_instructions_filename: false,
+            config_seed_dest: None,
+            config_seed_enabled: None,
+            clear_config_seed: false,
+            confirm_timeout: 0,
+        }
+    }
+
+    // ---- flag-conflict / early errors (return before touching disk) --------
+
+    #[test]
+    fn add_custom_requires_label_and_command() {
+        // No from-catalog, no label/command -> error before minting/dispatch.
+        let code = run(
+            CodingAgentArgs {
+                cmd: CodingAgentCmd::Add(add_args()),
+            },
+            false,
+        );
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn add_rejects_bad_color_flag() {
+        let mut a = add_args();
+        a.label = Some("L".into());
+        a.command = Some("claude".into());
+        a.color = Some("#fff".into());
+        assert!(cmd_add(a, false).is_err());
+    }
+
+    #[test]
+    fn update_clear_envs_conflicts_with_env() {
+        let mut a = update_args("x");
+        a.clear_envs = true;
+        a.env = vec!["FOO=bar".into()];
+        assert!(cmd_update(a, false).is_err());
+    }
+
+    #[test]
+    fn update_clear_instructions_conflicts() {
+        let mut a = update_args("x");
+        a.clear_instructions_filename = true;
+        a.instructions_filename = Some("AGENTS.md".into());
+        assert!(cmd_update(a, false).is_err());
+    }
+
+    #[test]
+    fn update_clear_seed_conflicts() {
+        let mut a = update_args("x");
+        a.clear_config_seed = true;
+        a.config_seed_dest = Some(".claude".into());
+        assert!(cmd_update(a, false).is_err());
+    }
+
+    #[test]
+    fn env_parse_first_equals_and_missing() {
+        let envs = parse_env_flags(&["FOO=a=b".to_string()]).unwrap();
+        assert_eq!(envs[0].key, "FOO");
+        assert_eq!(envs[0].value, "a=b");
+        assert!(parse_env_flags(&["NOEQUALS".to_string()]).is_err());
+    }
+
+    // ---- branch seam: daemon path writes a request and NEVER saves ---------
+
+    #[test]
+    fn daemon_path_queues_request_and_never_saves() {
+        let dir = tempfile::tempdir().unwrap();
+        let op = CodingAgentOp::Remove {
+            id: "whatever".into(),
+        };
+        // confirm_timeout 0 -> one non-blocking result check, then cancel.
+        let res = dispatch_via_daemon(dir.path(), op, 0);
+        assert!(res.is_err(), "no poller -> timeout/cancel");
+        // A request was written under coding-agent-requests/ (then cancelled),
+        // and settings.json was NEVER written by the daemon path.
+        assert!(dir.path().join(ops::CODING_AGENT_REQUESTS_DIR).is_dir());
+        assert!(!dir.path().join("settings.json").exists());
+    }
+
+    // ---- help text ---------------------------------------------------------
+
+    #[test]
+    fn help_text_documents_coding_agent() {
+        use clap::CommandFactory;
+        let help = crate::cli::Cli::command().render_help().to_string();
+        assert!(help.contains("coding-agent"), "help missing verb: {help}");
+    }
+}

--- a/src-tauri/src/cli/coding_agent.rs
+++ b/src-tauri/src/cli/coding_agent.rs
@@ -90,7 +90,7 @@ pub struct AddArgs {
     /// Custom agent id (default: a minted `agent_<ms>_<hex>` id)
     #[arg(long)]
     pub id: Option<String>,
-    /// Display label (required unless --from-catalog supplies it)
+    /// Display label (required unless --from-catalog supplies a non-empty one)
     #[arg(long)]
     pub label: Option<String>,
     /// Launch command (required unless --from-catalog supplies it)
@@ -439,7 +439,7 @@ fn finish_daemon_result(result: CodingAgentResult) -> Result<(), String> {
         let json = if let Some(id) = result.removed_id {
             serde_json::json!({ "ok": true, "op": "remove", "id": id })
         } else {
-            serde_json::json!({ "ok": true, "agent": result.agent })
+            serde_json::json!({ "ok": true, "op": result.op, "agent": result.agent })
         };
         print_json(&json)
     } else {

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1,5 +1,6 @@
 pub mod agency_templates;
 pub mod close_session;
+pub mod coding_agent;
 pub mod create_agent;
 pub mod create_agent_matrix;
 pub mod harness;
@@ -166,6 +167,8 @@ pub enum Commands {
     Loop(loop_cmd::LoopArgs),
     /// Execute commands through the policy harness
     Harness(harness::HarnessArgs),
+    /// Manage Coding Agent configurations (settings.agents)
+    CodingAgent(coding_agent::CodingAgentArgs),
     /// Delete only the disposable testable app state
     #[command(hide = true)]
     TestReset(crate::testability::reset::TestResetArgs),
@@ -319,6 +322,7 @@ pub fn handle_cli(cmd: Commands) -> i32 {
         Commands::Team(args) => team::execute(args),
         Commands::Loop(args) => loop_cmd::execute(args),
         Commands::Harness(args) => harness::execute(args),
+        Commands::CodingAgent(args) => coding_agent::execute(args),
         Commands::TestReset(args) => crate::testability::reset::execute(args),
         Commands::WindowInfo(args) => crate::testability::window_info::execute(args),
         Commands::UiQuery(args) => crate::testability::ui_automation::execute_query(args),

--- a/src-tauri/src/config/coding_agent_mutations.rs
+++ b/src-tauri/src/config/coding_agent_mutations.rs
@@ -103,6 +103,10 @@ pub struct CodingAgentRequest {
 pub struct CodingAgentResult {
     pub request_id: String,
     pub ok: bool,
+    /// #786: `"add"|"update"|"remove"` on success. Mirrored into the daemon-path
+    /// stdout so the JSON shape matches the direct (GUI-closed) path exactly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub op: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -488,6 +492,7 @@ fn process_claimed(
                 &CodingAgentResult {
                     request_id: request_id.to_string(),
                     ok: true,
+                    op: Some(outcome.op.to_string()),
                     error: None,
                     agent: outcome.agent,
                     removed_id: outcome.removed_id,
@@ -511,6 +516,7 @@ fn write_reject(results_dir: &Path, request_id: &str, error: String) {
         &CodingAgentResult {
             request_id: request_id.to_string(),
             ok: false,
+            op: None,
             error: Some(error),
             agent: None,
             removed_id: None,
@@ -667,6 +673,21 @@ mod tests {
             dest: String::new(),
         });
         assert!(apply_coding_agent_op(&mut s, &add(a)).is_err());
+    }
+
+    #[test]
+    fn add_accepts_catalog_seeded_non_hex_color() {
+        // §14.4 R6 carve-out: the op layer NEVER validates color (only the
+        // explicit `--color` CLI flag does, in cmd_add). A catalog-seeded agent
+        // whose color is a shorthand like "#fff" must be accepted as-is so that
+        // `add --from-catalog <key>` never rejects a trusted catalog color.
+        // Guards against a future regression that adds a color check here.
+        let mut s = AppSettings::default();
+        let mut a = agent("cat", "Catalog Agent", "claude");
+        a.color = "#fff".to_string();
+        let out = apply_coding_agent_op(&mut s, &add(a)).unwrap();
+        assert_eq!(out.op, "add");
+        assert_eq!(s.agents[0].color, "#fff", "catalog color persisted as-is");
     }
 
     // ---- update ------------------------------------------------------------
@@ -866,6 +887,7 @@ mod tests {
             &CodingAgentResult {
                 request_id: "req1".into(),
                 ok: true,
+                op: Some("add".into()),
                 error: None,
                 agent: None,
                 removed_id: None,
@@ -874,6 +896,7 @@ mod tests {
         .unwrap();
         let read = read_coding_agent_result(&results, "req1").unwrap();
         assert!(read.ok);
+        assert_eq!(read.op.as_deref(), Some("add"), "op round-trips");
     }
 
     #[test]
@@ -891,6 +914,7 @@ mod tests {
             &CodingAgentResult {
                 request_id: "x".into(),
                 ok: true,
+                op: None,
                 error: None,
                 agent: None,
                 removed_id: None,

--- a/src-tauri/src/config/coding_agent_mutations.rs
+++ b/src-tauri/src/config/coding_agent_mutations.rs
@@ -1,0 +1,1047 @@
+//! #786 - shared op layer for scriptable Coding Agent configuration.
+//!
+//! Single entry point (`apply_coding_agent_op`) used by BOTH the direct CLI
+//! write path (GUI closed) and the daemon-routed poller (GUI running), so the
+//! two paths behave identically by construction. The op layer is PURE: it
+//! mutates an in-memory `AppSettings` and runs the shared validator suite, but
+//! it NEVER touches disk. Callers own persistence (save + in-memory swap).
+//!
+//! The NEW rules this feature adds (agent id format/uniqueness, color hex,
+//! non-empty label) live ONLY here, never in `validate_and_repair_settings`, so
+//! legacy settings.json files with arbitrary ids/colors keep loading and saving.
+//! Command/env/instructions/config-seed validation is delegated to the existing
+//! `validate_and_repair_settings` -> `validate_agent_commands` suite that every
+//! other writer already runs.
+//!
+//! Queue transport (daemon path): the CLI drops a `CodingAgentRequest` JSON into
+//! `<config_dir>/coding-agent-requests/`; the `MailboxPoller` claims it with an
+//! atomic rename to `.processing` (#786 R2, closes the cancel false-negative
+//! race), applies it, writes a `CodingAgentResult` into `results/`, and deletes
+//! the `.processing` file LAST. The per-request handler is a pure,
+//! path-parameterized free function so it unit-tests against a tempdir with no
+//! Tauri handle (modeled on `mailbox::collect_project_refresh_requests`).
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::settings::{
+    validate_and_repair_settings, AgentConfig, AppSettings, CodingAgentEnv, ConfigSeedConfig,
+};
+
+/// Subdirectory of the config dir holding pending coding-agent mutation requests.
+pub const CODING_AGENT_REQUESTS_DIR: &str = "coding-agent-requests";
+/// Results subdirectory (under the requests dir) the CLI polls for outcomes.
+pub const RESULTS_SUBDIR: &str = "results";
+/// A request older than this (poller `now` minus the CLI `createdAtMs`) is
+/// rejected as expired, so a stale request cannot apply on a much later GUI boot.
+pub const REQUEST_EXPIRY_MS: u64 = 300_000;
+/// Default custom-agent color when none is supplied (matches OnboardingModal).
+pub const DEFAULT_CUSTOM_COLOR: &str = "#6366f1";
+
+/// A settings.agents mutation. Serialized (camelCase, internally tagged on
+/// `kind`) into the request file: `{ "kind": "add", "agent": { ... } }`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum CodingAgentOp {
+    /// Add a new agent. `id` is already minted and syntactically valid CLI-side.
+    Add { agent: AgentConfig },
+    /// Patch selected fields of the agent with this exact `id`.
+    Update { id: String, patch: AgentPatch },
+    /// Remove the agent with this exact `id`.
+    Remove { id: String },
+}
+
+/// Partial update for `coding-agent update`. Every field is optional; only the
+/// provided ones change. `envs: Some(vec)` replaces the WHOLE env list
+/// (`Some(empty)` clears it, matching `update_coding_agent_env_settings`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentPatch {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub envs: Option<Vec<CodingAgentEnv>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolated_home: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions_filename: Option<String>,
+    #[serde(default)]
+    pub clear_instructions_filename: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_seed_dest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_seed_enabled: Option<bool>,
+    #[serde(default)]
+    pub clear_config_seed: bool,
+}
+
+/// Result of a successful `apply_coding_agent_op`. `op` is `"add"|"update"|"remove"`.
+#[derive(Debug, Clone)]
+pub struct CodingAgentOpOutcome {
+    pub op: &'static str,
+    pub agent: Option<AgentConfig>,
+    pub removed_id: Option<String>,
+}
+
+/// The request file the CLI drops for the poller (daemon path).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodingAgentRequest {
+    pub request_id: String,
+    pub created_at_ms: u64,
+    pub op: CodingAgentOp,
+}
+
+/// The result file the poller writes and the CLI polls for.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodingAgentResult {
+    pub request_id: String,
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<AgentConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub removed_id: Option<String>,
+}
+
+/// Disposition of a single processed request, returned by the pure handler so
+/// the poller knows whether to swap in-memory state and emit an event.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RequestDisposition {
+    /// The request file was gone before we could claim it (a timed-out CLI
+    /// cancelled it). Nothing applied, no result written; caller must NOT swap.
+    Skipped,
+    /// A result file was written but settings were NOT mutated/persisted
+    /// (expired, malformed, validation error, or save failure). Do NOT swap.
+    Rejected,
+    /// Settings were mutated AND saved; a success result was written. The caller
+    /// SHOULD swap in-memory state and emit `coding_agent_settings_updated`.
+    Applied {
+        op: &'static str,
+        agent_id: Option<String>,
+    },
+}
+
+/// Validate a user-supplied custom agent id: `^[a-z0-9][a-z0-9_-]{0,63}$`.
+/// Deliberately distinct from (not a superset of) the catalog key rule
+/// (`^[a-z0-9-]+$`): first-char alnum + a 64-char cap, with `_` allowed so
+/// FE-minted `agent_<ms>_<n>` ids conform. Lowercase-only because
+/// `find_launch_agent` resolves ids case-insensitively.
+pub fn validate_custom_agent_id(id: &str) -> Result<(), String> {
+    let bytes = id.as_bytes();
+    if bytes.is_empty() {
+        return Err("agent id must not be empty".to_string());
+    }
+    if bytes.len() > 64 {
+        return Err(format!("agent id '{id}' must be at most 64 characters"));
+    }
+    let first = bytes[0];
+    if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
+        return Err(format!(
+            "agent id '{id}' must start with a lowercase letter or digit"
+        ));
+    }
+    if !bytes
+        .iter()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || *b == b'-' || *b == b'_')
+    {
+        return Err(format!(
+            "agent id '{id}' must match ^[a-z0-9][a-z0-9_-]{{0,63}}$ (lowercase letters, digits, hyphen, underscore)"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate an explicit `--color` flag value: strict `^#[0-9a-fA-F]{6}$`.
+pub fn validate_agent_color(color: &str) -> Result<(), String> {
+    let bytes = color.as_bytes();
+    let ok = bytes.len() == 7 && bytes[0] == b'#' && bytes[1..].iter().all(u8::is_ascii_hexdigit);
+    if ok {
+        Ok(())
+    } else {
+        Err(format!(
+            "color '{color}' must be a 6-digit hex value like #RRGGBB"
+        ))
+    }
+}
+
+/// Mint an agent id in the FE-compatible shape `agent_<unix_ms>_<6 hex>`.
+/// Collision-safe for scripted loops (the uuid suffix disambiguates same-ms
+/// mints); conforms to `validate_custom_agent_id`.
+pub fn mint_agent_id() -> String {
+    let ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let uuid = uuid::Uuid::new_v4().simple().to_string();
+    format!("agent_{}_{}", ms, &uuid[..6])
+}
+
+/// Error message for an unknown selector id that lists the available ids.
+pub fn unknown_agent_id_error(id: &str, agents: &[AgentConfig]) -> String {
+    let available: Vec<&str> = agents.iter().map(|a| a.id.as_str()).collect();
+    let list = if available.is_empty() {
+        "(none)".to_string()
+    } else {
+        available.join(", ")
+    };
+    format!("agent id '{id}' not found. Available ids: {list}")
+}
+
+/// #786 R8: PURE op application. Mutates `settings` in memory and runs the shared
+/// validator/repair suite; NEVER saves to disk. Both callers own persistence.
+pub fn apply_coding_agent_op(
+    settings: &mut AppSettings,
+    op: &CodingAgentOp,
+) -> Result<CodingAgentOpOutcome, String> {
+    let outcome = match op {
+        CodingAgentOp::Add { agent } => {
+            validate_custom_agent_id(&agent.id)?;
+            if settings
+                .agents
+                .iter()
+                .any(|a| a.id.eq_ignore_ascii_case(&agent.id))
+            {
+                return Err(format!("agent id '{}' already exists", agent.id));
+            }
+            if agent.label.trim().is_empty() {
+                return Err("agent label must not be empty".to_string());
+            }
+            ensure_seed_consistent(&agent.config_seed)?;
+            warn_on_duplicate_label(settings, agent.label.trim(), None);
+            let mut new_agent = agent.clone();
+            new_agent.label = new_agent.label.trim().to_string();
+            settings.agents.push(new_agent.clone());
+            CodingAgentOpOutcome {
+                op: "add",
+                agent: Some(new_agent),
+                removed_id: None,
+            }
+        }
+        CodingAgentOp::Update { id, patch } => {
+            let idx = settings
+                .agents
+                .iter()
+                .position(|a| a.id == *id)
+                .ok_or_else(|| unknown_agent_id_error(id, &settings.agents))?;
+            let mut updated = settings.agents[idx].clone();
+            apply_patch(&mut updated, patch)?;
+            warn_on_duplicate_label(settings, updated.label.trim(), Some(idx));
+            settings.agents[idx] = updated.clone();
+            CodingAgentOpOutcome {
+                op: "update",
+                agent: Some(updated),
+                removed_id: None,
+            }
+        }
+        CodingAgentOp::Remove { id } => {
+            let idx = settings
+                .agents
+                .iter()
+                .position(|a| a.id == *id)
+                .ok_or_else(|| unknown_agent_id_error(id, &settings.agents))?;
+            settings.agents.remove(idx);
+            // Orphan `profilesByAgent[id]` / label entries are intentionally left
+            // in place: `repair_coding_agent_profiles_config` never prunes by
+            // agent id, and the GUI leaves them too. A same-id re-add resurrects
+            // the old cells (documented, accepted).
+            CodingAgentOpOutcome {
+                op: "remove",
+                agent: None,
+                removed_id: Some(id.clone()),
+            }
+        }
+    };
+
+    // Authoritative shared suite: command bans, env rows, instructions filename,
+    // config-seed dest, plus profile repair (A-cell bookkeeping for a new agent).
+    // This is exactly what every existing writer enforces.
+    validate_and_repair_settings(settings)?;
+    Ok(outcome)
+}
+
+fn apply_patch(agent: &mut AgentConfig, patch: &AgentPatch) -> Result<(), String> {
+    if let Some(label) = &patch.label {
+        if label.trim().is_empty() {
+            return Err("agent label must not be empty".to_string());
+        }
+        agent.label = label.trim().to_string();
+    }
+    if let Some(command) = &patch.command {
+        agent.command = command.clone();
+    }
+    if let Some(color) = &patch.color {
+        agent.color = color.clone();
+    }
+    if let Some(envs) = &patch.envs {
+        agent.envs = envs.clone();
+    }
+    if let Some(isolated) = patch.isolated_home {
+        agent.isolated_home = isolated;
+    }
+    if patch.clear_instructions_filename {
+        agent.instructions_filename = None;
+    } else if let Some(name) = &patch.instructions_filename {
+        agent.instructions_filename = Some(name.clone());
+    }
+    if patch.clear_config_seed {
+        agent.config_seed = None;
+    } else if patch.config_seed_dest.is_some() || patch.config_seed_enabled.is_some() {
+        let mut seed = agent.config_seed.clone().unwrap_or(ConfigSeedConfig {
+            enabled: true,
+            dest: String::new(),
+        });
+        if let Some(dest) = &patch.config_seed_dest {
+            seed.dest = dest.clone();
+        }
+        if let Some(enabled) = patch.config_seed_enabled {
+            seed.enabled = enabled;
+        }
+        ensure_seed_consistent(&Some(seed.clone()))?;
+        agent.config_seed = Some(seed);
+    }
+    Ok(())
+}
+
+/// Reject an enabled seed with no destination (the GUI picker never produces
+/// this; enabling requires a dest). An inactive seed (disabled, any dest) is fine.
+fn ensure_seed_consistent(seed: &Option<ConfigSeedConfig>) -> Result<(), String> {
+    if let Some(s) = seed {
+        if s.enabled && s.dest.trim().is_empty() {
+            return Err(
+                "config seed is enabled but has no destination; pass --config-seed-dest"
+                    .to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn warn_on_duplicate_label(settings: &AppSettings, label: &str, skip_idx: Option<usize>) {
+    let dup = settings
+        .agents
+        .iter()
+        .enumerate()
+        .any(|(i, a)| Some(i) != skip_idx && a.label.trim().eq_ignore_ascii_case(label));
+    if dup {
+        log::warn!(
+            "[coding-agent] duplicate label '{label}'; launch-by-label resolution may be ambiguous"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Queue transport helpers (daemon path). All writes are atomic temp+rename.
+// ---------------------------------------------------------------------------
+
+/// Atomically write a request into `dir` as `<requestId>.json`. Returns the
+/// final path (used by the CLI to cancel on timeout).
+pub fn write_coding_agent_request(dir: &Path, req: &CodingAgentRequest) -> Result<PathBuf, String> {
+    std::fs::create_dir_all(dir)
+        .map_err(|e| format!("Failed to create coding-agent-requests dir: {e}"))?;
+    let final_path = dir.join(format!("{}.json", req.request_id));
+    let tmp_path = dir.join(format!("{}.json.tmp", req.request_id));
+    let json = serde_json::to_string_pretty(req)
+        .map_err(|e| format!("Failed to serialize request: {e}"))?;
+    std::fs::write(&tmp_path, json)
+        .map_err(|e| format!("Failed to write request temp file: {e}"))?;
+    std::fs::rename(&tmp_path, &final_path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        format!("Failed to finalize request file: {e}")
+    })?;
+    Ok(final_path)
+}
+
+/// #786 R4: the result writer OWNS the results dir (`create_dir_all` first) so
+/// the very first result on a fresh config dir cannot fail for a missing dir.
+pub fn write_coding_agent_result(
+    results_dir: &Path,
+    res: &CodingAgentResult,
+) -> Result<(), String> {
+    std::fs::create_dir_all(results_dir)
+        .map_err(|e| format!("Failed to create results dir: {e}"))?;
+    let final_path = results_dir.join(format!("{}.json", res.request_id));
+    let tmp_path = results_dir.join(format!("{}.json.tmp", res.request_id));
+    let json = serde_json::to_string_pretty(res)
+        .map_err(|e| format!("Failed to serialize result: {e}"))?;
+    std::fs::write(&tmp_path, json)
+        .map_err(|e| format!("Failed to write result temp file: {e}"))?;
+    std::fs::rename(&tmp_path, &final_path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        format!("Failed to finalize result file: {e}")
+    })?;
+    Ok(())
+}
+
+/// Read a result file if present (used by the CLI while polling).
+pub fn read_coding_agent_result(results_dir: &Path, request_id: &str) -> Option<CodingAgentResult> {
+    let path = results_dir.join(format!("{request_id}.json"));
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// #786 R5: expiry with a saturating subtraction. A `created_at_ms` in the
+/// future (wall clock stepped back between the CLI write and the poller read)
+/// yields age 0, so a fresh request is never wrongly rejected as expired.
+pub fn is_expired(created_at_ms: u64, now_ms: u64) -> bool {
+    now_ms.saturating_sub(created_at_ms) > REQUEST_EXPIRY_MS
+}
+
+fn processing_path_for(request_path: &Path) -> PathBuf {
+    let mut s = request_path.as_os_str().to_os_string();
+    s.push(".processing");
+    PathBuf::from(s)
+}
+
+/// #786 R8: process ONE request file end to end. PURE of Tauri:
+/// `settings` is the candidate to mutate and `save` persists it. Order (R2):
+/// claim (atomic rename to `.processing`) -> parse -> expiry -> apply -> write
+/// result -> delete `.processing` LAST. Path-parameterized for tempdir tests.
+pub fn process_coding_agent_request(
+    request_path: &Path,
+    results_dir: &Path,
+    now_ms: u64,
+    settings: &mut AppSettings,
+    save: &mut dyn FnMut(&AppSettings) -> Result<(), String>,
+) -> RequestDisposition {
+    // Claim: an atomic rename on the same volume. ENOENT means a timed-out CLI
+    // already removed the request; never apply it.
+    let processing_path = processing_path_for(request_path);
+    if std::fs::rename(request_path, &processing_path).is_err() {
+        return RequestDisposition::Skipped;
+    }
+    // The CLI polls `results/<stem>.json`, where `<stem>` is the request-file
+    // stem (also the requestId it generated).
+    let request_id = request_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let disposition = process_claimed(
+        &processing_path,
+        results_dir,
+        &request_id,
+        now_ms,
+        settings,
+        save,
+    );
+    // Delete the claim file LAST, after the result is durably written.
+    let _ = std::fs::remove_file(&processing_path);
+    disposition
+}
+
+fn process_claimed(
+    processing_path: &Path,
+    results_dir: &Path,
+    request_id: &str,
+    now_ms: u64,
+    settings: &mut AppSettings,
+    save: &mut dyn FnMut(&AppSettings) -> Result<(), String>,
+) -> RequestDisposition {
+    let content = match std::fs::read_to_string(processing_path) {
+        Ok(c) => c,
+        Err(e) => {
+            write_reject(
+                results_dir,
+                request_id,
+                format!("failed to read request: {e}"),
+            );
+            return RequestDisposition::Rejected;
+        }
+    };
+    let request: CodingAgentRequest = match serde_json::from_str(&content) {
+        Ok(r) => r,
+        Err(e) => {
+            write_reject(results_dir, request_id, format!("malformed request: {e}"));
+            return RequestDisposition::Rejected;
+        }
+    };
+    if is_expired(request.created_at_ms, now_ms) {
+        write_reject(results_dir, request_id, "request expired".to_string());
+        return RequestDisposition::Rejected;
+    }
+    match apply_coding_agent_op(settings, &request.op) {
+        Ok(outcome) => {
+            if let Err(e) = save(settings) {
+                write_reject(
+                    results_dir,
+                    request_id,
+                    format!("failed to persist settings: {e}"),
+                );
+                return RequestDisposition::Rejected;
+            }
+            let agent_id = outcome
+                .agent
+                .as_ref()
+                .map(|a| a.id.clone())
+                .or_else(|| outcome.removed_id.clone());
+            let _ = write_coding_agent_result(
+                results_dir,
+                &CodingAgentResult {
+                    request_id: request_id.to_string(),
+                    ok: true,
+                    error: None,
+                    agent: outcome.agent,
+                    removed_id: outcome.removed_id,
+                },
+            );
+            RequestDisposition::Applied {
+                op: outcome.op,
+                agent_id,
+            }
+        }
+        Err(e) => {
+            write_reject(results_dir, request_id, e);
+            RequestDisposition::Rejected
+        }
+    }
+}
+
+fn write_reject(results_dir: &Path, request_id: &str, error: String) {
+    let _ = write_coding_agent_result(
+        results_dir,
+        &CodingAgentResult {
+            request_id: request_id.to_string(),
+            ok: false,
+            error: Some(error),
+            agent: None,
+            removed_id: None,
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::CodingAgentEnvSource;
+
+    fn agent(id: &str, label: &str, command: &str) -> AgentConfig {
+        AgentConfig {
+            id: id.to_string(),
+            label: label.to_string(),
+            command: command.to_string(),
+            color: "#6366f1".to_string(),
+            envs: Vec::new(),
+            isolated_home: false,
+            instructions_filename: None,
+            config_seed: None,
+        }
+    }
+
+    fn add(agent: AgentConfig) -> CodingAgentOp {
+        CodingAgentOp::Add { agent }
+    }
+
+    fn noop_save() -> impl FnMut(&AppSettings) -> Result<(), String> {
+        |_s: &AppSettings| Ok(())
+    }
+
+    // ---- id / color validators ---------------------------------------------
+
+    #[test]
+    fn minted_id_conforms_and_is_lowercase() {
+        let id = mint_agent_id();
+        assert!(validate_custom_agent_id(&id).is_ok(), "minted id: {id}");
+        assert_eq!(id, id.to_lowercase());
+    }
+
+    #[test]
+    fn custom_id_rules() {
+        assert!(validate_custom_agent_id("claude-1").is_ok());
+        assert!(validate_custom_agent_id("agent_123_ab12cd").is_ok());
+        assert!(validate_custom_agent_id("").is_err());
+        assert!(
+            validate_custom_agent_id("Claude").is_err(),
+            "uppercase rejected"
+        );
+        assert!(
+            validate_custom_agent_id("-foo").is_err(),
+            "leading hyphen rejected"
+        );
+        assert!(validate_custom_agent_id("has space").is_err());
+        assert!(
+            validate_custom_agent_id(&"a".repeat(65)).is_err(),
+            "over 64 rejected"
+        );
+        assert!(
+            validate_custom_agent_id(&"a".repeat(64)).is_ok(),
+            "64 allowed"
+        );
+    }
+
+    #[test]
+    fn color_rules() {
+        assert!(validate_agent_color("#6366f1").is_ok());
+        assert!(validate_agent_color("#FFFFFF").is_ok());
+        assert!(validate_agent_color("#fff").is_err());
+        assert!(validate_agent_color("#6366f1ff").is_err());
+        assert!(validate_agent_color("6366f1").is_err());
+        assert!(validate_agent_color("red").is_err());
+    }
+
+    // ---- add ---------------------------------------------------------------
+
+    #[test]
+    fn add_appends_and_repairs_a_cell() {
+        let mut s = AppSettings::default();
+        let out = apply_coding_agent_op(&mut s, &add(agent("claude", "Claude", "claude"))).unwrap();
+        assert_eq!(out.op, "add");
+        assert_eq!(s.agents.len(), 1);
+        // repair ensures an 'A' profile cell exists for the new agent.
+        assert!(s
+            .coding_agent_profiles
+            .profiles_by_agent
+            .get("claude")
+            .map(|cells| cells.contains_key("A"))
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn add_rejects_duplicate_id() {
+        let mut s = AppSettings::default();
+        apply_coding_agent_op(&mut s, &add(agent("claude", "Claude", "claude"))).unwrap();
+        let err =
+            apply_coding_agent_op(&mut s, &add(agent("claude", "Other", "codex"))).unwrap_err();
+        assert!(err.contains("already exists"), "{err}");
+    }
+
+    #[test]
+    fn add_rejects_case_insensitive_dup_against_legacy_mixedcase_id() {
+        let mut s = AppSettings::default();
+        // A legacy agent with a mixed-case id predates the new lowercase-only
+        // rule; insert it directly to bypass validate_custom_agent_id. Adding a
+        // valid lowercase id that collides case-insensitively must be rejected
+        // (find_launch_agent resolves ids case-insensitively).
+        s.agents.push(agent("Claude", "Legacy", "claude"));
+        let err = apply_coding_agent_op(&mut s, &add(agent("claude", "New", "codex"))).unwrap_err();
+        assert!(err.contains("already exists"), "{err}");
+    }
+
+    #[test]
+    fn add_rejects_bad_id_and_empty_label() {
+        let mut s = AppSettings::default();
+        assert!(apply_coding_agent_op(&mut s, &add(agent("Bad Id", "L", "claude"))).is_err());
+        assert!(apply_coding_agent_op(&mut s, &add(agent("ok", "  ", "claude"))).is_err());
+    }
+
+    #[test]
+    fn add_rejects_banned_continue_and_dup_env() {
+        let mut s = AppSettings::default();
+        let err =
+            apply_coding_agent_op(&mut s, &add(agent("c", "C", "claude --continue"))).unwrap_err();
+        assert!(err.contains("continue"), "{err}");
+
+        let mut dup = agent("d", "D", "claude");
+        dup.envs = vec![
+            CodingAgentEnv {
+                key: "FOO".into(),
+                value: "1".into(),
+                source: CodingAgentEnvSource::User,
+                enabled: true,
+            },
+            CodingAgentEnv {
+                key: "FOO".into(),
+                value: "2".into(),
+                source: CodingAgentEnvSource::User,
+                enabled: true,
+            },
+        ];
+        let mut s2 = AppSettings::default();
+        assert!(apply_coding_agent_op(&mut s2, &add(dup)).is_err());
+    }
+
+    #[test]
+    fn add_rejects_enabled_seed_without_dest() {
+        let mut s = AppSettings::default();
+        let mut a = agent("s", "S", "claude");
+        a.config_seed = Some(ConfigSeedConfig {
+            enabled: true,
+            dest: String::new(),
+        });
+        assert!(apply_coding_agent_op(&mut s, &add(a)).is_err());
+    }
+
+    // ---- update ------------------------------------------------------------
+
+    #[test]
+    fn update_partial_keeps_other_fields() {
+        let mut s = AppSettings::default();
+        apply_coding_agent_op(&mut s, &add(agent("claude", "Claude", "claude"))).unwrap();
+        let patch = AgentPatch {
+            label: Some("Renamed".into()),
+            ..Default::default()
+        };
+        apply_coding_agent_op(
+            &mut s,
+            &CodingAgentOp::Update {
+                id: "claude".into(),
+                patch,
+            },
+        )
+        .unwrap();
+        assert_eq!(s.agents[0].label, "Renamed");
+        assert_eq!(s.agents[0].command, "claude");
+    }
+
+    #[test]
+    fn update_env_replace_all_and_clear() {
+        let mut s = AppSettings::default();
+        let mut a = agent("claude", "Claude", "claude");
+        a.envs = vec![CodingAgentEnv {
+            key: "OLD".into(),
+            value: "1".into(),
+            source: CodingAgentEnvSource::User,
+            enabled: true,
+        }];
+        apply_coding_agent_op(&mut s, &add(a)).unwrap();
+
+        let patch = AgentPatch {
+            envs: Some(vec![CodingAgentEnv {
+                key: "NEW".into(),
+                value: "2".into(),
+                source: CodingAgentEnvSource::User,
+                enabled: true,
+            }]),
+            ..Default::default()
+        };
+        apply_coding_agent_op(
+            &mut s,
+            &CodingAgentOp::Update {
+                id: "claude".into(),
+                patch,
+            },
+        )
+        .unwrap();
+        assert_eq!(s.agents[0].envs.len(), 1);
+        assert_eq!(s.agents[0].envs[0].key, "NEW");
+
+        let clear = AgentPatch {
+            envs: Some(Vec::new()),
+            ..Default::default()
+        };
+        apply_coding_agent_op(
+            &mut s,
+            &CodingAgentOp::Update {
+                id: "claude".into(),
+                patch: clear,
+            },
+        )
+        .unwrap();
+        assert!(s.agents[0].envs.is_empty());
+    }
+
+    #[test]
+    fn update_unknown_id_lists_available() {
+        let mut s = AppSettings::default();
+        apply_coding_agent_op(&mut s, &add(agent("claude", "Claude", "claude"))).unwrap();
+        let err = apply_coding_agent_op(
+            &mut s,
+            &CodingAgentOp::Update {
+                id: "nope".into(),
+                patch: AgentPatch::default(),
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("not found"), "{err}");
+        assert!(err.contains("claude"), "{err}");
+    }
+
+    #[test]
+    fn update_clear_instructions_and_seed() {
+        let mut s = AppSettings::default();
+        let mut a = agent("claude", "Claude", "claude");
+        a.instructions_filename = Some("CLAUDE.md".into());
+        a.config_seed = Some(ConfigSeedConfig {
+            enabled: true,
+            dest: ".claude".into(),
+        });
+        apply_coding_agent_op(&mut s, &add(a)).unwrap();
+
+        let patch = AgentPatch {
+            clear_instructions_filename: true,
+            clear_config_seed: true,
+            ..Default::default()
+        };
+        apply_coding_agent_op(
+            &mut s,
+            &CodingAgentOp::Update {
+                id: "claude".into(),
+                patch,
+            },
+        )
+        .unwrap();
+        assert!(s.agents[0].instructions_filename.is_none());
+        assert!(s.agents[0].config_seed.is_none());
+    }
+
+    // ---- remove (orphan-preserve) ------------------------------------------
+
+    #[test]
+    fn remove_preserves_profile_orphans() {
+        let mut s = AppSettings::default();
+        apply_coding_agent_op(&mut s, &add(agent("claude", "Claude", "claude"))).unwrap();
+        // repair created profiles_by_agent["claude"]; removing the agent must
+        // leave that orphan in place (matches repair/GUI semantics).
+        assert!(s
+            .coding_agent_profiles
+            .profiles_by_agent
+            .contains_key("claude"));
+        let out = apply_coding_agent_op(
+            &mut s,
+            &CodingAgentOp::Remove {
+                id: "claude".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(out.removed_id.as_deref(), Some("claude"));
+        assert!(s.agents.is_empty());
+        assert!(
+            s.coding_agent_profiles
+                .profiles_by_agent
+                .contains_key("claude"),
+            "profile orphan must survive remove"
+        );
+    }
+
+    #[test]
+    fn remove_unknown_id_errors() {
+        let mut s = AppSettings::default();
+        assert!(
+            apply_coding_agent_op(&mut s, &CodingAgentOp::Remove { id: "ghost".into() }).is_err()
+        );
+    }
+
+    // ---- purity ------------------------------------------------------------
+
+    #[test]
+    fn apply_is_pure_no_disk() {
+        // A bare AppSettings with no config dir override: apply must not touch
+        // disk (it takes &mut and validates only). If it saved, tests would need
+        // a config dir; they do not.
+        let mut s = AppSettings::default();
+        apply_coding_agent_op(&mut s, &add(agent("claude", "Claude", "claude"))).unwrap();
+        assert_eq!(s.agents.len(), 1);
+    }
+
+    // ---- queue helpers -----------------------------------------------------
+
+    #[test]
+    fn is_expired_backward_clock_and_old() {
+        // future createdAt (backward clock) -> not expired
+        assert!(!is_expired(1_000_000, 900_000));
+        // fresh -> not expired
+        assert!(!is_expired(1_000_000, 1_000_100));
+        // genuinely old -> expired
+        assert!(is_expired(0, REQUEST_EXPIRY_MS + 1));
+    }
+
+    #[test]
+    fn request_result_roundtrip_atomic() {
+        let dir = tempfile::tempdir().unwrap();
+        let requests = dir.path().join(CODING_AGENT_REQUESTS_DIR);
+        let req = CodingAgentRequest {
+            request_id: "req1".into(),
+            created_at_ms: 123,
+            op: add(agent("claude", "Claude", "claude")),
+        };
+        let path = write_coding_agent_request(&requests, &req).unwrap();
+        assert!(path.exists());
+        // no leftover temp file
+        assert!(std::fs::read_dir(&requests).unwrap().all(|e| {
+            let p = e.unwrap().path();
+            p.extension().and_then(|s| s.to_str()) == Some("json")
+        }));
+
+        let results = requests.join(RESULTS_SUBDIR);
+        write_coding_agent_result(
+            &results,
+            &CodingAgentResult {
+                request_id: "req1".into(),
+                ok: true,
+                error: None,
+                agent: None,
+                removed_id: None,
+            },
+        )
+        .unwrap();
+        let read = read_coding_agent_result(&results, "req1").unwrap();
+        assert!(read.ok);
+    }
+
+    #[test]
+    fn first_request_autocreates_results_dir() {
+        // R4: brand-new tempdir, results/ does not exist; write_coding_agent_result
+        // must create it.
+        let dir = tempfile::tempdir().unwrap();
+        let results = dir
+            .path()
+            .join(CODING_AGENT_REQUESTS_DIR)
+            .join(RESULTS_SUBDIR);
+        assert!(!results.exists());
+        write_coding_agent_result(
+            &results,
+            &CodingAgentResult {
+                request_id: "x".into(),
+                ok: true,
+                error: None,
+                agent: None,
+                removed_id: None,
+            },
+        )
+        .unwrap();
+        assert!(results.join("x.json").exists());
+    }
+
+    // ---- per-request handler ----------------------------------------------
+
+    fn write_request_file(
+        requests: &Path,
+        id: &str,
+        created_at_ms: u64,
+        op: CodingAgentOp,
+    ) -> PathBuf {
+        std::fs::create_dir_all(requests).unwrap();
+        let req = CodingAgentRequest {
+            request_id: id.to_string(),
+            created_at_ms,
+            op,
+        };
+        let path = requests.join(format!("{id}.json"));
+        std::fs::write(&path, serde_json::to_string_pretty(&req).unwrap()).unwrap();
+        path
+    }
+
+    #[test]
+    fn handler_applies_and_writes_result_and_deletes_processing() {
+        let dir = tempfile::tempdir().unwrap();
+        let requests = dir.path().join(CODING_AGENT_REQUESTS_DIR);
+        let results = requests.join(RESULTS_SUBDIR);
+        let path = write_request_file(
+            &requests,
+            "r1",
+            100,
+            add(agent("claude", "Claude", "claude")),
+        );
+
+        let mut settings = AppSettings::default();
+        let mut saved = false;
+        let disp = {
+            let mut save = |_s: &AppSettings| {
+                saved = true;
+                Ok(())
+            };
+            process_coding_agent_request(&path, &results, 200, &mut settings, &mut save)
+        };
+        assert!(matches!(
+            disp,
+            RequestDisposition::Applied { op: "add", .. }
+        ));
+        assert!(saved, "save callback invoked");
+        assert_eq!(settings.agents.len(), 1);
+        // result written, request + processing gone
+        assert!(read_coding_agent_result(&results, "r1").unwrap().ok);
+        assert!(!path.exists());
+        assert!(!processing_path_for(&path).exists());
+    }
+
+    #[test]
+    fn handler_skips_when_request_already_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let requests = dir.path().join(CODING_AGENT_REQUESTS_DIR);
+        let results = requests.join(RESULTS_SUBDIR);
+        std::fs::create_dir_all(&requests).unwrap();
+        let missing = requests.join("gone.json");
+        let mut settings = AppSettings::default();
+        let disp =
+            process_coding_agent_request(&missing, &results, 200, &mut settings, &mut noop_save());
+        assert_eq!(disp, RequestDisposition::Skipped);
+        assert!(settings.agents.is_empty());
+    }
+
+    #[test]
+    fn handler_rejects_expired_without_applying() {
+        let dir = tempfile::tempdir().unwrap();
+        let requests = dir.path().join(CODING_AGENT_REQUESTS_DIR);
+        let results = requests.join(RESULTS_SUBDIR);
+        let path = write_request_file(
+            &requests,
+            "old",
+            0,
+            add(agent("claude", "Claude", "claude")),
+        );
+        let mut settings = AppSettings::default();
+        let disp = process_coding_agent_request(
+            &path,
+            &results,
+            REQUEST_EXPIRY_MS + 10,
+            &mut settings,
+            &mut noop_save(),
+        );
+        assert_eq!(disp, RequestDisposition::Rejected);
+        assert!(settings.agents.is_empty());
+        let res = read_coding_agent_result(&results, "old").unwrap();
+        assert!(!res.ok);
+        assert!(res.error.unwrap().contains("expired"));
+    }
+
+    #[test]
+    fn handler_rejects_validation_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let requests = dir.path().join(CODING_AGENT_REQUESTS_DIR);
+        let results = requests.join(RESULTS_SUBDIR);
+        let path = write_request_file(&requests, "bad", 100, add(agent("BadId", "L", "claude")));
+        let mut settings = AppSettings::default();
+        let disp =
+            process_coding_agent_request(&path, &results, 150, &mut settings, &mut noop_save());
+        assert_eq!(disp, RequestDisposition::Rejected);
+        assert!(settings.agents.is_empty());
+        assert!(!read_coding_agent_result(&results, "bad").unwrap().ok);
+    }
+
+    // ---- T10: daemon-path launch consumption (acceptance criterion 2) ------
+
+    #[test]
+    fn daemon_applied_agent_is_launch_resolvable() {
+        // Apply an Add through the extracted per-request handler (the daemon-path
+        // seam), then confirm the new agent is resolvable to a subsequent
+        // `--launch` by id AND by label, and that a spawn command builds for it.
+        let dir = tempfile::tempdir().unwrap();
+        let requests = dir.path().join(CODING_AGENT_REQUESTS_DIR);
+        let results = requests.join(RESULTS_SUBDIR);
+        let path = write_request_file(
+            &requests,
+            "r",
+            100,
+            add(agent("claude", "Claude Code", "claude")),
+        );
+
+        let mut settings = AppSettings::default();
+        let disp =
+            process_coding_agent_request(&path, &results, 200, &mut settings, &mut noop_save());
+        assert!(matches!(disp, RequestDisposition::Applied { .. }));
+
+        // find_launch_agent (create_agent.rs) resolves by exact id and by label.
+        assert!(crate::cli::create_agent::find_launch_agent(&settings, "claude").is_some());
+        assert!(crate::cli::create_agent::find_launch_agent(&settings, "Claude Code").is_some());
+
+        // A spawn command builds against the same state (session.rs). Some(_)
+        // means the agent was found and the command composed.
+        let cwd = dir.path().to_string_lossy();
+        let spawn = crate::commands::session::build_configured_agent_spawn_for_cwd(
+            &settings, "claude", &cwd, None,
+        );
+        assert!(spawn.is_ok(), "spawn build failed: {:?}", spawn.err());
+        assert!(
+            spawn.unwrap().is_some(),
+            "expected a spawn command for the applied agent"
+        );
+    }
+}

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -2,6 +2,7 @@ pub mod agent_command;
 pub mod agent_config;
 pub mod agent_creation;
 pub mod claude_settings;
+pub mod coding_agent_mutations;
 pub mod coding_agent_profiles;
 pub mod coding_agents_catalog;
 pub mod config_seed;

--- a/src-tauri/src/config/profile.rs
+++ b/src-tauri/src/config/profile.rs
@@ -95,6 +95,46 @@ pub fn mutex_name() -> &'static str {
     })
 }
 
+/// #786: side-effect-free probe of whether a GUI instance for THIS binary
+/// identity is already running, by OPENING (not creating) the single-instance
+/// mutex. `OpenMutexW` never creates the mutex, so unlike `CreateMutexW` this
+/// cannot race a starting GUI into refusing to launch. The CLI uses it to route
+/// coding-agent mutations: GUI up -> queue through the poller; GUI down ->
+/// direct write. Windows-only; returns false off-Windows (single-instance is
+/// not enforced there, so a running GUI is not detected and callers fall back to
+/// the direct write path - a documented platform gap).
+#[cfg(target_os = "windows")]
+pub fn gui_instance_running() -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::OpenMutexW;
+
+    // The standard SYNCHRONIZE access right (0x0010_0000), defined inline rather
+    // than imported from windows_sys: the module that re-exports the bare
+    // constant may sit behind a Cargo feature we do not enable, and adding one is
+    // out of scope. Mirrors the inline `const ERROR_ALREADY_EXISTS` in main.rs.
+    const SYNCHRONIZE: u32 = 0x0010_0000;
+
+    let name: Vec<u16> = mutex_name().encode_utf16().collect();
+    // SAFETY: `name` is a NUL-terminated UTF-16 buffer (the trailing `\0` is
+    // embedded in `mutex_name()`) valid for the duration of the call. A non-null
+    // handle is owned by us and closed immediately; a null handle means the mutex
+    // does not exist (no GUI) or the open failed - both treated as "not running".
+    unsafe {
+        let handle = OpenMutexW(SYNCHRONIZE, 0, name.as_ptr());
+        if handle.is_null() {
+            false
+        } else {
+            let _ = CloseHandle(handle);
+            true
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn gui_instance_running() -> bool {
+    false
+}
+
 /// Executable name — actual binary filename from current_exe().
 /// Falls back to BUILD_PROFILE mapping if current_exe() fails.
 pub fn exe_name() -> &'static str {
@@ -165,4 +205,63 @@ pub fn instance_label() -> &'static str {
             _ => String::new(), // prod and dev-via-Vite (DEV badge handles that)
         },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mutex_name_is_nul_terminated_and_scoped() {
+        // #786 T9: the probe encodes exactly this name, including the embedded
+        // trailing NUL. If this shape ever changes, gui_instance_running() would
+        // silently open a different name and defeat the whole safe-write design.
+        let name = mutex_name();
+        assert!(name.ends_with('\0'), "mutex name must be NUL-terminated");
+        assert!(
+            name.starts_with("Local\\AgentsCommander_SingleInstance"),
+            "unexpected mutex name shape: {name:?}"
+        );
+    }
+
+    /// #786 T9: in-process round-trip. Create the single-instance mutex under the
+    /// SAME `mutex_name()` the acquirer uses, assert the probe detects it, then
+    /// close it and assert it no longer detects it. Windows-only (the probe is a
+    /// no-op false off-Windows). Nothing else holds this name during `cargo test`
+    /// (the test exe's suffix scopes the name), but the negative assertion is
+    /// guarded on the pre-existing state to stay robust under parallel tests.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn gui_instance_running_probe_roundtrip() {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::CreateMutexW;
+
+        let was_running_before = gui_instance_running();
+
+        let name: Vec<u16> = mutex_name().encode_utf16().collect();
+        // SAFETY: `name` is a NUL-terminated UTF-16 buffer valid for the call;
+        // the returned handle is closed below.
+        let handle = unsafe { CreateMutexW(std::ptr::null(), 0, name.as_ptr()) };
+        assert!(!handle.is_null(), "CreateMutexW failed");
+
+        // The named mutex now exists, so the OpenMutexW probe must see it.
+        assert!(
+            gui_instance_running(),
+            "probe should detect the held single-instance mutex"
+        );
+
+        // SAFETY: `handle` is a valid mutex handle from the CreateMutexW above.
+        unsafe {
+            let _ = CloseHandle(handle);
+        }
+
+        // Once our handle is closed and nothing else held the name, the probe
+        // must no longer detect it.
+        if !was_running_before {
+            assert!(
+                !gui_instance_running(),
+                "probe should not detect the mutex after it is released"
+            );
+        }
+    }
 }

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1687,6 +1687,60 @@ pub fn load_settings_for_cli() -> AppSettings {
     settings
 }
 
+/// #786 R1: strict CLI loader for MUTATING paths and `list`/`show`. Identical to
+/// `load_settings_for_cli` EXCEPT it distinguishes an ABSENT settings.json (fine:
+/// start from default) from a PRESENT-but-unparseable one (Err: refuse to touch
+/// it). This closes the silent-wipe hole: `load_settings_for_cli` returns a
+/// default on a strict parse error, and a subsequent `save_settings` (which
+/// preserves only `project_paths`, via a LENIENT `Value` read) would rewrite
+/// settings.json to defaults, destroying every agent/profile/hotkey. NEVER call
+/// the silent-default `load_settings_for_cli` for a write.
+///
+/// Keep the in-memory migration tail in lockstep with `load_settings_for_cli`
+/// (see the note above that function).
+pub fn load_settings_for_cli_strict() -> Result<AppSettings, String> {
+    let mut settings = match settings_path() {
+        // No home dir to locate settings.json: nothing to protect, and a later
+        // save would fail to resolve the dir anyway. Start from default.
+        None => AppSettings::default(),
+        Some(path) if !path.exists() => AppSettings::default(),
+        Some(path) => {
+            let contents = std::fs::read_to_string(&path).map_err(|e| {
+                format!(
+                    "settings.json exists at {} but could not be read ({e}); refusing to modify it - fix or remove the file first",
+                    path.display()
+                )
+            })?;
+            let (s, _migrated) =
+                parse_settings_json(&contents, &path.to_string_lossy()).map_err(|e| {
+                    format!(
+                        "settings.json exists but could not be parsed ({e}); refusing to modify it - fix or remove the file first"
+                    )
+                })?;
+            s
+        }
+    };
+
+    // Mirror `load_settings_for_cli`'s in-memory migrations (no disk write).
+    if settings.main_geometry.is_none() {
+        if let Some(ref g) = settings.terminal_geometry {
+            settings.main_geometry = Some(g.clone());
+        }
+    }
+    if (settings.main_zoom - default_zoom()).abs() < f64::EPSILON
+        && (settings.sidebar_zoom - default_zoom()).abs() > f64::EPSILON
+    {
+        settings.main_zoom = settings.sidebar_zoom;
+    }
+    if !settings.main_always_on_top && settings.sidebar_always_on_top {
+        settings.main_always_on_top = true;
+    }
+    apply_issue_248_migration(&mut settings);
+    repair_coding_agent_profiles_config(&mut settings.coding_agent_profiles, &settings.agents);
+
+    Ok(settings)
+}
+
 /// One-shot migration for issue #248: translate the legacy
 /// `startOnlyCoordinators` field into the new state-sensitive
 /// `restore_coordinator_wake_state`. Idempotent — once the legacy carrier is

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,6 +42,7 @@ fn main() {
                                 | agentscommander_lib::cli::Commands::UiBackend(_)
                                 | agentscommander_lib::cli::Commands::UiWait(_)
                                 | agentscommander_lib::cli::Commands::TaskSetTitle(_)
+                                | agentscommander_lib::cli::Commands::CodingAgent(_)
                         ) {
                             std::env::set_var("AC_MACHINE_OUTPUT", "1");
                         }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -1641,6 +1641,9 @@ impl MailboxPoller {
         // Poll session-requests directory (from create-agent CLI)
         self.poll_session_requests(app).await;
 
+        // #786: poll coding-agent-requests (from `coding-agent` CLI mutations).
+        self.poll_coding_agent_requests(app).await;
+
         Ok(())
     }
 
@@ -5204,6 +5207,81 @@ impl MailboxPoller {
 
             // Delete processed request file regardless of success/failure
             let _ = std::fs::remove_file(&path);
+        }
+    }
+
+    /// #786: poll `<config_dir>/coding-agent-requests/` for CLI mutation requests
+    /// while the GUI runs. Scans bare `.json` files only (so `.processing`,
+    /// `.tmp`, and the `results/` subdir are excluded). For each request, R8:
+    /// write-lock SettingsState, clone a candidate, run the pure per-request
+    /// handler (claim -> parse -> expiry -> apply -> write result -> delete
+    /// `.processing`) against it, and on Applied swap the in-memory state and emit
+    /// `coding_agent_settings_updated` AFTER the guard drops. `save_settings` is
+    /// synchronous, so the write guard is never held across an await.
+    async fn poll_coding_agent_requests(&self, app: &tauri::AppHandle) {
+        use crate::config::coding_agent_mutations as ca;
+        let config_dir = match crate::config::config_dir() {
+            Some(d) => d,
+            None => return,
+        };
+        let requests_dir = config_dir.join(ca::CODING_AGENT_REQUESTS_DIR);
+        if !requests_dir.is_dir() {
+            return;
+        }
+        let results_dir = requests_dir.join(ca::RESULTS_SUBDIR);
+
+        let entries: Vec<PathBuf> = match std::fs::read_dir(&requests_dir) {
+            Ok(rd) => rd
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("json"))
+                .collect(),
+            Err(_) => return,
+        };
+        if entries.is_empty() {
+            return;
+        }
+
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        let state = app.state::<SettingsState>();
+        for path in entries {
+            let applied = {
+                let mut s = state.write().await;
+                let mut candidate = s.clone();
+                let mut save = |st: &crate::config::settings::AppSettings| {
+                    crate::config::settings::save_settings(st)
+                };
+                let disposition = ca::process_coding_agent_request(
+                    &path,
+                    &results_dir,
+                    now_ms,
+                    &mut candidate,
+                    &mut save,
+                );
+                if let ca::RequestDisposition::Applied { op, agent_id } = disposition {
+                    *s = candidate;
+                    Some((op, agent_id))
+                } else {
+                    None
+                }
+            }; // write guard dropped here, before the emit
+
+            if let Some((op, agent_id)) = applied {
+                let _ = tauri::Emitter::emit(
+                    app,
+                    "coding_agent_settings_updated",
+                    serde_json::json!({ "op": op, "agentId": agent_id }),
+                );
+                log::info!(
+                    "[coding-agent-requests] applied op={} agentId={:?}",
+                    op,
+                    agent_id
+                );
+            }
         }
     }
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1009,6 +1009,21 @@ export function onCodingAgentProfilesUpdated(
   return transport.listen<unknown>("coding_agent_profiles_updated", () => callback());
 }
 
+/**
+ * #786 — a `coding-agent` CLI mutation applied through the running GUI's
+ * MailboxPoller emits this. Payload carries the op ("add"|"update"|"remove") and
+ * the affected agent id (null is possible if the poller could not resolve one).
+ * Mirrors the fire-and-refetch shape of onCodingAgentProfilesUpdated.
+ */
+export function onCodingAgentSettingsUpdated(
+  callback: (payload: { op: string; agentId: string | null }) => void
+): Promise<UnlistenFn> {
+  return transport.listen<{ op: string; agentId: string | null }>(
+    "coding_agent_settings_updated",
+    (payload) => callback(payload)
+  );
+}
+
 // #714 Screenshot capture result/failure events. Both emitted from the Rust
 // capture path; the sidebar renders them as toasts (the overlay window is
 // temporary and may be destroyed before the user reads anything).

--- a/src/shared/stores/settings.test.ts
+++ b/src/shared/stores/settings.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FakeTransport } from "../testing/fake-transport";
+import { __setTransportForTests } from "../ipc";
+
+// #786: the settings store subscribes at MODULE INIT to
+// `coding_agent_settings_updated` and re-fetches. We install the fake transport
+// BEFORE importing the store so its subscription binds to the fake. The default
+// transport is created lazily (only when used, and only when no test transport is
+// set), so no real WebSocket/timer is ever constructed by this test.
+describe("settingsStore #786 coding_agent_settings_updated", () => {
+  let restore: (() => void) | undefined;
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it("re-fetches settings when coding_agent_settings_updated fires", async () => {
+    const fake = new FakeTransport();
+    restore = __setTransportForTests(fake);
+    fake.resolve("get_settings", { soundsEnabled: true } as unknown);
+
+    // The module-init subscription is skipped under vitest; call it explicitly
+    // so it binds to the fake transport we just installed.
+    const settings = await import("./settings");
+    settings.__subscribeCodingAgentSettingsUpdates();
+    const before = fake.callsFor("get_settings").length;
+
+    fake.emitFromBackend("coding_agent_settings_updated", {
+      op: "add",
+      agentId: "agent_x",
+    });
+
+    await vi.waitFor(() => {
+      expect(fake.callsFor("get_settings").length).toBe(before + 1);
+    });
+  });
+});

--- a/src/shared/stores/settings.ts
+++ b/src/shared/stores/settings.ts
@@ -1,6 +1,6 @@
 import { createSignal } from "solid-js";
 import type { AppSettings } from "../types";
-import { SettingsAPI } from "../ipc";
+import { SettingsAPI, onCodingAgentSettingsUpdated } from "../ipc";
 import { setSoundsEnabled } from "../sound";
 
 const [settings, setSettings] = createSignal<AppSettings | null>(null);
@@ -31,3 +31,22 @@ export const settingsStore = {
     });
   },
 };
+
+// #786: a `coding-agent` CLI mutation applied through the running GUI's
+// MailboxPoller emits `coding_agent_settings_updated`. Re-fetch so long-lived
+// consumers of this app-lifetime store observe the change. Fire-and-refetch,
+// mirroring `onCodingAgentProfilesUpdated`. Surfaces that already fetch on open
+// (AgentPickerModal, SettingsModal draft) are unaffected.
+export function __subscribeCodingAgentSettingsUpdates() {
+  return onCodingAgentSettingsUpdated(() => {
+    settingsStore.refresh();
+  });
+}
+
+// Subscribe once at module init in the real app, and never unlisten (the store
+// lives for the whole app). Skipped under vitest so importing the store does not
+// force the default transport to construct in unit tests that have not installed
+// a fake transport yet; the dedicated test calls the exported fn explicitly.
+if (import.meta.env.MODE !== "test") {
+  void __subscribeCodingAgentSettingsUpdates();
+}


### PR DESCRIPTION
## Summary
- Add scriptable `coding-agent` CLI management for registered Coding Agent configs: `list`, `show`, `catalog`, `add`, `update`, and `remove`.
- Write runtime configs to `settings.agents[]`; keep the catalog read-only except as `add --from-catalog` input.
- Add GUI-safe mutation routing through `coding-agent-requests/` with `.processing` claims, result files, strict direct-path settings loading, and documented timeout semantics.
- Add frontend settings refresh wiring for external Coding Agent changes plus CLI/settings docs.

## Reviews
- Architect consensus: READY_FOR_IMPLEMENTATION, plan section 14 authoritative.
- dev-rust implementation: commit `0455185`, fix commit `8055753`, resync merge `799710f`.
- dev-webpage-ui courtesy review: PASS, non-visual.
- dev-rust-grinch Step 9: initial FAIL on daemon output contract, fixed in `8055753`, re-review PASS.
- dev-rust-grinch Step 9.5 resync check: PASS at `799710f`.

## Tests
- `cargo test --lib coding_agent`: 82 passed
- `cargo test --lib`: 1791 passed, 8 ignored
- `cargo clippy --lib -- -D warnings`: clean
- resync gates from dev-rust: `tsc --noEmit` PASS, full `vitest run` 719 tests PASS, `cargo clippy --all-targets` clean, `cargo test --lib` PASS
- grinch reproduced decisive resync checks: `npm run typecheck` PASS, targeted vitest for settings + raise-hand tests 20/20 PASS

## Ship
Non-visual CLI/backend/docs change with data-flow-only frontend refresh wiring. No screenshot gate and no shipper deploy required.

Closes #786