### PR TITLE
fix: expand Coding Agent profile cards by default

### DIFF
--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -494,10 +494,8 @@ describe("SettingsModal automation hooks", () => {
     expect(document.querySelector('[data-ac-testid="settings.profileCard.0.B.missing"]')).toBeNull();
     expect(document.querySelector('[data-ac-testid="settings.profileCard.0.B.add"]')).toBeNull();
     // Instead it exposes the same expand/edit affordance as every cell: a chevron
-    // toggle that reveals an (empty) command input the user can fill in.
+    // toggle plus an expanded-by-default empty command input the user can fill in.
     expect(byTestId<HTMLButtonElement>("settings.profileCard.0.B.toggle")).toBeTruthy();
-    byTestId<HTMLButtonElement>("settings.profileCard.0.B.toggle").click();
-    await settle();
     expect(byTestId<HTMLInputElement>("settings.profileCard.0.B.command").value).toBe("");
     // Claude rail: B has its own enabled cell (non-A, direct match) → CONFIGURED,
     // NOT MATCH. MATCH is reserved for the A baseline (#526).
@@ -566,7 +564,7 @@ describe("SettingsModal automation hooks", () => {
     dispose();
   });
 
-  it("collapses non-A profile cards by default and expands them on toggle", async () => {
+  it("expands non-A profile cards by default and toggles them closed and open", async () => {
     vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
       agents: [
         {
@@ -599,10 +597,15 @@ describe("SettingsModal automation hooks", () => {
     );
     await settle();
 
-    // The "A" slot is expanded by default → its command input is present.
+    // All profile slots are expanded by default, including non-A slots.
     expect(byTestId("settings.profileCard.0.A.command")).toBeTruthy();
-    // A non-A configured slot is collapsed → command hidden until expanded.
+    expect(byTestId<HTMLInputElement>("settings.profileCard.0.B.command").value).toBe("claude --model opus");
+    expect(byTestId<HTMLButtonElement>("settings.profileCard.0.B.toggle").getAttribute("aria-expanded")).toBe("true");
+
+    byTestId<HTMLButtonElement>("settings.profileCard.0.B.toggle").click();
+    await settle();
     expect(document.querySelector('[data-ac-testid="settings.profileCard.0.B.command"]')).toBeNull();
+    expect(byTestId<HTMLButtonElement>("settings.profileCard.0.B.toggle").getAttribute("aria-expanded")).toBe("false");
 
     byTestId<HTMLButtonElement>("settings.profileCard.0.B.toggle").click();
     await settle();
@@ -989,9 +992,7 @@ describe("SettingsModal automation hooks", () => {
     expect(byTestId("settings.profileCard.0.B")).toBeTruthy();
     expect(byTestId("settings.profileCard.1.B")).toBeTruthy();
 
-    // Expand codex's B card to reach the slot-level "Delete Profile" affordance.
-    byTestId<HTMLButtonElement>("settings.profileCard.0.B.toggle").click();
-    await settle();
+    // B starts expanded, so the slot-level "Delete Profile" affordance is visible.
     byTestId<HTMLButtonElement>("settings.profileCard.0.B.deleteProfile").click();
     await settle();
 

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -202,16 +202,16 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   const toggleAgentEditor = (agentId: string) =>
     setActiveAgentId((prev) => (prev === agentId ? null : agentId));
 
-  // Per profile-cell expand state on the Config rails. Cells collapse to a summary
-  // row (letter + label + status badge); the "A" slot is expanded by default,
-  // matching the prototype. Keyed by `${agentId}:${letter}`.
+  // Per profile-cell expand state on the Config rails. Cells can collapse to a
+  // summary row (letter + label + status badge), but start expanded by default.
+  // Keyed by `${agentId}:${letter}`.
   const [expandedCells, setExpandedCells] = createStore<Record<string, boolean | undefined>>({});
   const isCellExpanded = (agentId: string, letter: string): boolean => {
     // Read the key directly so the store tracks it even while still unset — a
     // hasOwnProperty short-circuit would skip the subscription and the card
-    // would never react to a later toggle. `undefined` → default (A expanded).
+    // would never react to a later toggle. `undefined` → default expanded.
     const value = expandedCells[`${agentId}:${letter}`];
-    return value === undefined ? letter === "A" : value;
+    return value === undefined ? true : value;
   };
   const toggleCell = (agentId: string, letter: string) =>
     setExpandedCells(`${agentId}:${letter}`, !isCellExpanded(agentId, letter));


### PR DESCRIPTION
## Summary

Closes #789.

- Default Coding Agent profile cards to expanded for every profile letter instead of expanding only profile A.
- Preserve the existing per-card chevron toggle behavior for collapsing and re-expanding cards during the modal session.
- Update `SettingsModal` automation coverage so non-A cards are visible by default and the B-card toggle still closes/reopens.

## Review and verification

Implementation by `dev-webpage-ui` on commit `73ff38010c31762bfe5b6a314b495835e61710d8`.

Developer verification:

- `npm run typecheck` passed.
- `npx vitest run src/sidebar/components/SettingsModal.automation.test.ts` passed, 26 tests.

Grinch review:

- PASS from `dev-rust-grinch`.
- Grinch independently reran the targeted Vitest test and `npm run typecheck`, both clean.
- Classified as a VISUAL app change, so final build/deploy follows after merge.

Step 9.5:

- `origin/main` was verified as an ancestor of the feature branch before PR creation.

## Final ship

Pending post-merge Step 11 visual build/deploy.