### PR TITLE
feat(#791): in-daemon control-plane API (increment 1: send + list-peers-lean)

### DIFF
--- a/src-tauri/src/api/README.md
+++ b/src-tauri/src/api/README.md
@@ -1,0 +1,75 @@
+# Control-plane API (#791, increment 1)
+
+A local, opt-in HTTP API hosted inside the daemon (a sibling of `web/`) that
+lets a machine client (first: a Dockerized coding agent) speak the inter-agent
+control-plane over a token instead of the filesystem outbox. The filesystem
+messaging path stays fully live; this is a strangler-fig second front door into
+the SAME actuation (`deliver_wake`).
+
+## Enabling
+
+Off by default. Set in settings:
+
+- `apiServerEnabled: true`
+- `apiServerBind` (default `127.0.0.1`) - widen to a Docker/WSL-reachable
+  interface ONLY when serving a container. Any non-loopback bind logs a loud
+  startup warning; the token, not the interface, is the trust boundary.
+- `apiServerPort` - profile-aware default (`profile::api_server_port`), distinct
+  from the web port so dev/prod builds do not collide.
+
+A bind/port change requires a daemon restart (or a future stop/start command).
+
+## Auth
+
+Every request except `healthz` needs `Authorization: Bearer <client-token>`.
+Tokens are minted host-side and stored HASHED (SHA-256) in
+`api-clients.json` (host-only `config_dir()`, never mounted into a container):
+
+```
+agentscommander api-client mint --token <MASTER/ROOT> \
+  --root <replica-working-dir> --scopes send,list-peers-lean [--label ..] [--expires <rfc3339>]
+agentscommander api-client revoke --token <MASTER/ROOT> --client-id <id>
+agentscommander api-client list   --token <MASTER/ROOT>
+```
+
+Mint prints the secret ONCE. The registry is read THROUGH to disk on every
+request (mtime-gated), so a revoke takes effect on the next request. Identity is
+the token's bound replica: `from` is derived at request time from `boundRoot`,
+never from the request body. The Root Agent is rejected (mint-time + request-time).
+Auth is unconditional in all build profiles (no debug bypass). A per-source-IP
+failed-auth lockout throttles unauthenticated probing.
+
+## Endpoints (`/api/v1`)
+
+- `POST /api/v1/send` - mirrors `send --mode wake --send <file>` (no `--command`).
+  Body (`deny_unknown_fields`; `from`/`root`/`token`/`command`/`action` rejected):
+  ```json
+  { "apiVersion": "1", "opId": "<uuid>", "to": "<fqn>",
+    "message": { "send": "<bare-filename-in-messaging/>" } }
+  ```
+  `inline` is reserved and rejected with 400 in v1. `opId` is the idempotency
+  key: a replay returns the prior result and never re-delivers (persisted across
+  restarts in `api-idempotency.json`). Response: `200` delivered, `422` rejected,
+  `400/401/403/429` on client/auth/routing/lockout failures.
+- `GET /api/v1/peers[?peer=<fqn>...]` - `list-peers-lean` for the caller's bound
+  replica; `reachable` is computed from the bound identity.
+- `GET /api/v1/healthz` - unauthenticated liveness, body exactly `{"ok":true}`.
+
+## Wrapper env contract (external)
+
+The `claude-docker.*` wrapper injects, and must NOT mount the host config dir:
+
+- `AGENTSCOMMANDER_API_URL=http://host.docker.internal:<apiServerPort>`
+- `AGENTSCOMMANDER_API_TOKEN=<the minted client secret>`
+
+## Versioning
+
+URL-versioned (`/api/v1`). Additive changes (new optional fields, new verbs)
+stay in v1; a breaking change introduces `/api/v2` mounted alongside. The
+`apiVersion` envelope field is a redundant explicit echo.
+
+## Audit
+
+Every mint/revoke and authenticated request appends `(ts, clientId, boundFqn,
+op, outcome)` to `api-audit.log` (host-only, 10 MB cap + one rotation, never
+fails closed). Secrets and hashes are never logged.

--- a/src-tauri/src/api/actuation.rs
+++ b/src-tauri/src/api/actuation.rs
@@ -1,0 +1,228 @@
+//! The non-forking actuation seam (#791 §8, §0.5 HIGH-1 + HIGH-3).
+//!
+//! Both the filesystem poller and the API funnel through the SAME
+//! `MailboxPoller::deliver_wake` and the SAME `can_communicate` /
+//! `resolve_agent_target`, so the two planes cannot diverge in canonicalization
+//! or actuation for the non-root verb set. `deliver_wake` is an instance method
+//! and `MailboxPoller` is never `.manage()`d, so the bridge calls it on a
+//! throwaway `MailboxPoller::new()` (delivery-stateless: it and its whole
+//! `&self` callee chain read only `app.state::<...>()`). Root-Agent routing is
+//! intentionally API-excluded in increment 1 (`can_communicate` does not model
+//! the root branches) and rejected at the boundary.
+
+use std::path::Path;
+
+use tauri::Manager;
+
+use crate::config::settings::SettingsState;
+use crate::phone::types::OutboxMessage;
+
+use super::error::ApiError;
+
+/// Outcome of an actuation attempt after routing/resolution succeeded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeliveryOutcome {
+    /// The wake was injected/spawned (HTTP 200).
+    Delivered { to: String },
+    /// The engine refused delivery (HTTP 422); `reason` is unscrubbed.
+    Rejected { to: String, reason: String },
+}
+
+/// Reject either direction of a Root-Agent send (§0.5 HIGH-3). Pure, so it is
+/// unit-testable without an `AppHandle`.
+pub fn reject_if_root(from: &str, to: &str) -> Result<(), ApiError> {
+    if from == crate::config::root_agent::ROOT_AGENT_SENDER
+        || crate::config::root_agent::is_root_agent_target(to)
+    {
+        return Err(ApiError::Forbidden(
+            "root-agent not reachable over the API in increment 1".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Build the host-absolute notification body for a `send`, mirroring
+/// `cli/send.rs`'s `--send` path exactly: validate the bare filename, resolve
+/// it inside the sender's `<workgroup>/messaging/` on the HOST (canonicalized-
+/// parent confinement), and format the pointer notification. The container path
+/// is never embedded because the CLI helper canonicalizes host-side.
+pub fn build_send_body(bound_root: &str, basename: &str, from: &str) -> Result<String, ApiError> {
+    crate::phone::messaging::validate_filename_only(basename)
+        .map_err(|e| ApiError::BadRequest(format!("invalid filename: {}", e)))?;
+
+    let agent_root = Path::new(bound_root);
+    let wg_root = crate::phone::messaging::workgroup_root(agent_root).map_err(|e| {
+        ApiError::BadRequest(format!("bound replica is not under a workgroup: {}", e))
+    })?;
+    let msg_dir = crate::phone::messaging::messaging_dir(&wg_root)
+        .map_err(|e| ApiError::Internal(format!("cannot resolve messaging dir: {}", e)))?;
+    let abs = crate::phone::messaging::resolve_existing_message(&msg_dir, basename)
+        .map_err(|e| ApiError::BadRequest(format!("message file not found: {}", e)))?;
+
+    // UNC-strip at the single emission site, mirroring cli/send.rs.
+    let abs_str = abs.to_string_lossy();
+    let abs_display = abs_str.trim_start_matches(r"\\?\");
+    let body = crate::phone::messaging::format_file_notification(abs_display);
+
+    // PTY_SAFE_MAX clamp, mirroring the live wake path (get_output = false).
+    let overhead = crate::phone::messaging::PTY_WRAP_FIXED + from.len();
+    if body.len() + overhead > crate::phone::messaging::PTY_SAFE_MAX {
+        return Err(ApiError::BadRequest(
+            "notification exceeds PTY-safe length; shorten the slug or use a shallower workgroup path"
+                .to_string(),
+        ));
+    }
+    Ok(body)
+}
+
+/// Resolve + route + actuate a `send` through the shared engine.
+///
+/// Errors returned as `Err(ApiError)` are pre-actuation failures (400 resolve,
+/// 403 root/routing). A successful resolution+route yields `Ok(DeliveryOutcome)`
+/// carrying the engine's delivered/rejected result (200 / 422).
+pub async fn deliver_wake_via_api<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    from: &str,
+    to: &str,
+    body: String,
+    op_id: &str,
+) -> Result<DeliveryOutcome, ApiError> {
+    reject_if_root(from, to)?;
+
+    // Project paths: the same source `process_message` reads (SettingsState).
+    let paths = {
+        let state = app.state::<SettingsState>();
+        let settings = state.read().await;
+        settings.project_paths.clone()
+    };
+
+    // (1) canonicalize the target (belt-and-braces; the CLI resolves too).
+    let resolved_to = crate::config::teams::resolve_agent_target(to, &paths)
+        .map_err(|e| ApiError::BadRequest(format!("unresolvable target: {}", e)))?;
+
+    // Re-check after resolution: a bare name could canonicalize to the root.
+    reject_if_root(from, &resolved_to)?;
+
+    // (2) route via the SAME predicate the poller uses.
+    if !crate::config::teams::can_communicate(
+        from,
+        &resolved_to,
+        &crate::config::teams::discover_teams(),
+    ) {
+        return Err(ApiError::Forbidden(format!(
+            "routing rejected: '{}' cannot reach '{}'",
+            from, resolved_to
+        )));
+    }
+
+    // (3) construct the in-memory OutboxMessage. token = None (§0.5 open-item 4):
+    // the API bypasses process_message and deliver_wake never reads the sender
+    // token; the invariant is never a master/root token, never a token not owned
+    // by `from`.
+    let msg = OutboxMessage {
+        id: op_id.to_string(),
+        token: None,
+        from: from.to_string(),
+        to: resolved_to.clone(),
+        body,
+        mode: "wake".to_string(),
+        get_output: false,
+        request_id: None,
+        sender_agent: None,
+        preferred_agent: String::new(),
+        priority: "normal".to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        command: None,
+        action: None,
+        target: None,
+        force: None,
+        timeout_secs: None,
+        switch_coding_agent: None,
+        switch_profile: None,
+    };
+
+    // (4) actuate through the SAME engine the poller uses. A throwaway
+    // MailboxPoller is delivery-stateless (§0.5 HIGH-1).
+    match crate::phone::mailbox::MailboxPoller::new()
+        .deliver_wake(app, &msg)
+        .await
+    {
+        Ok(()) => Ok(DeliveryOutcome::Delivered { to: resolved_to }),
+        Err(reason) => Ok(DeliveryOutcome::Rejected {
+            to: resolved_to,
+            reason,
+        }),
+    }
+}
+
+/// In-process `list-peers-lean` for the caller's bound replica, reusing the
+/// exact CLI discovery + `reachable` computation (no subprocess).
+pub fn lean_peers_via_api(
+    bound_root: &str,
+) -> Result<Vec<crate::cli::list_peers::LeanPeerInfo>, ApiError> {
+    crate::cli::list_peers::lean_peers(bound_root)
+        .map_err(|e| ApiError::Internal(format!("peer discovery failed: {}", e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reject_if_root_blocks_root_target_and_sender() {
+        let root = crate::config::root_agent::ROOT_AGENT_SENDER;
+        assert!(reject_if_root("proj:wg-1/dev", "proj:wg-1/lead").is_ok());
+        assert!(reject_if_root(root, "proj:wg-1/lead").is_err());
+        assert!(reject_if_root("proj:wg-1/dev", root).is_err());
+        assert_eq!(
+            reject_if_root(root, "x").unwrap_err().status(),
+            axum::http::StatusCode::FORBIDDEN
+        );
+    }
+
+    #[test]
+    fn build_send_body_resolves_existing_message_and_formats_pointer() {
+        // Real WG-replica layout with a messaging file present.
+        let temp = tempfile::TempDir::new().unwrap();
+        let wg_root = temp.path().join("proj-x").join(".ac").join("wg-1-team");
+        let replica = wg_root.join("__agent_dev-rust");
+        let messaging = wg_root.join("messaging");
+        std::fs::create_dir_all(&replica).unwrap();
+        std::fs::create_dir_all(&messaging).unwrap();
+        let fname = "20260704-000000-wg1-a-to-wg1-b-hello.md";
+        std::fs::write(messaging.join(fname), "hi").unwrap();
+
+        let body = build_send_body(
+            replica.to_str().unwrap(),
+            fname,
+            "proj-x:wg-1-team/dev-rust",
+        )
+        .expect("existing message should resolve");
+        assert!(body.starts_with(crate::phone::messaging::FILE_NOTIFICATION_PREFIX));
+        assert!(body.contains(fname));
+        // The container path is never embedded: the body carries a host path.
+        assert!(!body.contains("/workspace/"));
+    }
+
+    #[test]
+    fn build_send_body_rejects_path_traversal_basename() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let replica = temp.path().join("proj").join(".ac").join("wg-1").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        let err = build_send_body(replica.to_str().unwrap(), "..\\secret.md", "proj:wg-1/x")
+            .unwrap_err();
+        assert_eq!(err.status(), axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn build_send_body_rejects_missing_message_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let wg_root = temp.path().join("proj").join(".ac").join("wg-1");
+        let replica = wg_root.join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        std::fs::create_dir_all(wg_root.join("messaging")).unwrap();
+        let err = build_send_body(replica.to_str().unwrap(), "nope.md", "proj:wg-1/x")
+            .unwrap_err();
+        assert_eq!(err.status(), axum::http::StatusCode::BAD_REQUEST);
+    }
+}

--- a/src-tauri/src/api/audit.rs
+++ b/src-tauri/src/api/audit.rs
@@ -1,0 +1,109 @@
+//! Host-only audit log for the control-plane API (#791, §0.5 G8).
+//!
+//! Appends one line per mint / revoke / authenticated request to
+//! `api-audit.log` in `config_dir()`. The log is capped at 10 MB with a single
+//! `.1` rotation; the secret and its hash are NEVER logged (only `clientId` /
+//! `boundFqn`, which are safe). Auditing NEVER fails closed: any I/O error is
+//! logged via `log::warn!` and swallowed, so a full disk cannot take the API
+//! down.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Max audit-log size before rotation (10 MB).
+const AUDIT_MAX_BYTES: u64 = 10 * 1024 * 1024;
+
+fn audit_path() -> Option<PathBuf> {
+    crate::config::config_dir().map(|d| d.join("api-audit.log"))
+}
+
+/// Append a single audit line `(ts, clientId, boundFqn, op, outcome)`.
+/// Best-effort: never returns an error, never panics.
+pub fn record(client_id: &str, bound_fqn: &str, op: &str, outcome: &str) {
+    let Some(path) = audit_path() else {
+        return;
+    };
+    // Rotate BEFORE appending if the current file is at/over the cap.
+    rotate_if_needed(&path);
+
+    let ts = chrono::Utc::now().to_rfc3339();
+    // Sanitize embedded newlines so one field cannot forge extra log lines.
+    let line = format!(
+        "{}\t{}\t{}\t{}\t{}\n",
+        ts,
+        sanitize(client_id),
+        sanitize(bound_fqn),
+        sanitize(op),
+        sanitize(outcome),
+    );
+    if let Err(e) = append(&path, &line) {
+        log::warn!("[api-audit] failed to write audit line (continuing): {}", e);
+    }
+}
+
+fn sanitize(field: &str) -> String {
+    field.replace(['\n', '\r', '\t'], " ")
+}
+
+fn append(path: &std::path::Path, line: &str) -> std::io::Result<()> {
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    f.write_all(line.as_bytes())
+}
+
+/// If the log is at/over `AUDIT_MAX_BYTES`, move it to `<name>.1` (replacing any
+/// prior `.1`) so the live file restarts empty. Best-effort.
+fn rotate_if_needed(path: &std::path::Path) {
+    let size = match std::fs::metadata(path) {
+        Ok(m) => m.len(),
+        Err(_) => return, // no file yet, or unreadable: nothing to rotate
+    };
+    if size < AUDIT_MAX_BYTES {
+        return;
+    }
+    let rotated = path.with_extension("log.1");
+    if let Err(e) = std::fs::rename(path, &rotated) {
+        log::warn!("[api-audit] rotation failed (continuing): {}", e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_newlines_and_tabs() {
+        assert_eq!(sanitize("a\nb\tc\rd"), "a b c d");
+    }
+
+    #[test]
+    fn append_then_rotate_moves_to_dot_one() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("api-audit.log");
+        // Write >10MB worth so rotation triggers on the next check.
+        let big = "x".repeat(1024);
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            for _ in 0..(AUDIT_MAX_BYTES / 1024 + 1) {
+                f.write_all(big.as_bytes()).unwrap();
+            }
+        }
+        assert!(std::fs::metadata(&path).unwrap().len() >= AUDIT_MAX_BYTES);
+        rotate_if_needed(&path);
+        let rotated = path.with_extension("log.1");
+        assert!(rotated.exists(), "rotated .1 file must exist");
+        assert!(!path.exists(), "live log must be moved away on rotation");
+    }
+
+    #[test]
+    fn append_creates_and_appends() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("api-audit.log");
+        append(&path, "line1\n").unwrap();
+        append(&path, "line2\n").unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "line1\nline2\n");
+    }
+}

--- a/src-tauri/src/api/auth.rs
+++ b/src-tauri/src/api/auth.rs
@@ -1,0 +1,574 @@
+//! Scoped, revocable, per-client API token registry (#791 §5).
+//!
+//! The store is host-only (`api-clients.json` in `config_dir()`, outside any
+//! workgroup mount). Tokens are stored HASHED (SHA-256); the plaintext is shown
+//! once at mint and never persisted. Because `api-client mint`/`revoke` run in a
+//! SEPARATE CLI process, the daemon's auth check reads the file THROUGH to disk
+//! on every request via an mtime-gated reload cache (§0.5 HIGH-2): a CLI-side
+//! mint/revoke takes effect on the next request. The file is the source of
+//! truth; the in-memory copy is a cache keyed by mtime.
+
+use std::collections::{HashMap, VecDeque};
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::error::ApiError;
+
+/// The `send` scope (POST /api/v1/send).
+pub const SCOPE_SEND: &str = "send";
+/// The `list-peers-lean` scope (GET /api/v1/peers).
+pub const SCOPE_LIST_PEERS: &str = "list-peers-lean";
+/// The only scopes mintable in increment 1.
+pub const VALID_SCOPES: &[&str] = &[SCOPE_SEND, SCOPE_LIST_PEERS];
+
+/// Registry file basename in `config_dir()`.
+pub const REGISTRY_FILENAME: &str = "api-clients.json";
+
+/// One registered API client. `boundRoot` is the identity source (the `from` is
+/// derived from it at request time); `boundFqn` is an audit hint only (§0.5 G5).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiClient {
+    /// Stable id, safe to log.
+    pub client_id: String,
+    /// Human note.
+    #[serde(default)]
+    pub label: String,
+    /// `"sha256:<hex>"` of the secret. The plaintext is never stored.
+    pub token_hash: String,
+    /// Audit/log hint of the bound identity at mint time (may go stale).
+    pub bound_fqn: String,
+    /// The replica working directory: the authoritative identity source.
+    pub bound_root: String,
+    /// Allowlisted ops (verb names).
+    pub scopes: Vec<String>,
+    /// RFC3339 mint time.
+    pub issued_at: String,
+    /// Optional RFC3339 expiry, or `null`.
+    #[serde(default)]
+    pub expires_at: Option<String>,
+    /// Revocation flag.
+    #[serde(default)]
+    pub revoked: bool,
+}
+
+impl ApiClient {
+    /// Whether this client holds the given scope.
+    pub fn has_scope(&self, scope: &str) -> bool {
+        self.scopes.iter().any(|s| s == scope)
+    }
+}
+
+/// On-disk registry document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiClientRegistry {
+    pub version: u32,
+    #[serde(default)]
+    pub clients: Vec<ApiClient>,
+}
+
+impl Default for ApiClientRegistry {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            clients: Vec::new(),
+        }
+    }
+}
+
+/// SHA-256 the secret, formatted `"sha256:<lowercase-hex>"`.
+pub fn hash_token(secret: &str) -> String {
+    let digest = Sha256::digest(secret.as_bytes());
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        // Two lowercase hex chars per byte.
+        hex.push(char::from_digit((byte >> 4) as u32, 16).unwrap());
+        hex.push(char::from_digit((byte & 0x0f) as u32, 16).unwrap());
+    }
+    format!("sha256:{}", hex)
+}
+
+/// Constant-time equality over two equal-length strings (the fixed-length hex
+/// digests). Mirrors `MasterToken::matches` (`lib.rs:89`). The length check
+/// leaks only length, which for fixed-length digests is a constant.
+pub fn constant_time_eq(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b.iter()).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+/// Whether the client is expired as of `now`. A present-but-unparseable
+/// `expiresAt` is treated as EXPIRED (fail-closed).
+pub fn is_expired(client: &ApiClient, now: chrono::DateTime<chrono::Utc>) -> bool {
+    match client.expires_at.as_deref() {
+        None => false,
+        Some(raw) => match chrono::DateTime::parse_from_rfc3339(raw) {
+            Ok(exp) => exp.with_timezone(&chrono::Utc) <= now,
+            Err(_) => true,
+        },
+    }
+}
+
+/// Parse a registry from raw JSON, tolerating an absent/malformed file by
+/// returning an empty registry (fail-safe: no clients => everything 401).
+fn parse_registry(path: &Path) -> ApiClientRegistry {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => serde_json::from_str(&raw).unwrap_or_else(|e| {
+            log::warn!(
+                "[api-auth] {} is malformed ({}); treating as empty registry",
+                REGISTRY_FILENAME,
+                e
+            );
+            ApiClientRegistry::default()
+        }),
+        Err(_) => ApiClientRegistry::default(),
+    }
+}
+
+struct CacheInner {
+    mtime: Option<SystemTime>,
+    loaded: bool,
+    registry: ApiClientRegistry,
+}
+
+/// Read-through, mtime-gated registry cache. The source of truth is the file on
+/// disk (written by the separate CLI process); the cache reloads only when the
+/// file's mtime changes.
+pub struct ApiClientStore {
+    path: PathBuf,
+    cache: Mutex<CacheInner>,
+}
+
+impl ApiClientStore {
+    /// Build a store over an explicit path (used by tests).
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            cache: Mutex::new(CacheInner {
+                mtime: None,
+                loaded: false,
+                registry: ApiClientRegistry::default(),
+            }),
+        }
+    }
+
+    /// Build a store over `config_dir()/api-clients.json`.
+    pub fn at_config_dir() -> Option<Self> {
+        crate::config::config_dir().map(|d| Self::new(d.join(REGISTRY_FILENAME)))
+    }
+
+    /// Registry file path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Return the current registry, reloading from disk only if the file's
+    /// mtime changed since the last load (or it was never loaded).
+    fn current(&self) -> ApiClientRegistry {
+        let disk_mtime = std::fs::metadata(&self.path)
+            .and_then(|m| m.modified())
+            .ok();
+        let mut cache = self.cache.lock().unwrap();
+        if !cache.loaded || cache.mtime != disk_mtime {
+            cache.registry = parse_registry(&self.path);
+            cache.mtime = disk_mtime;
+            cache.loaded = true;
+        }
+        cache.registry.clone()
+    }
+
+    /// Look up the client owning `presented` (read-through). Returns the client
+    /// only if it matches, is not revoked, and is not expired. The hash compare
+    /// is constant-time per candidate.
+    pub fn authenticate(&self, presented: &str) -> Option<ApiClient> {
+        let registry = self.current();
+        let presented_hash = hash_token(presented);
+        let now = chrono::Utc::now();
+        registry.clients.into_iter().find(|c| {
+            !c.revoked
+                && constant_time_eq(&c.token_hash, &presented_hash)
+                && !is_expired(c, now)
+        })
+    }
+}
+
+/// Outcome of a successful mint: the plaintext secret (shown ONCE) + the id.
+pub struct MintOutcome {
+    pub client_id: String,
+    pub secret: String,
+}
+
+/// Validate a requested scope set against the increment-1 allowlist.
+pub fn validate_scopes(scopes: &[String]) -> Result<(), String> {
+    if scopes.is_empty() {
+        return Err("at least one scope is required".to_string());
+    }
+    for s in scopes {
+        if !VALID_SCOPES.contains(&s.as_str()) {
+            return Err(format!(
+                "unknown scope '{}'; valid scopes: {}",
+                s,
+                VALID_SCOPES.join(", ")
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Parameters for [`mint`], bundled to keep the call arity low. `client_id` /
+/// `secret` / `issued_at` are injected so the caller owns randomness and the
+/// timestamp (the CLI passes fresh UUIDs and `Utc::now()`).
+pub struct MintRequest {
+    pub client_id: String,
+    pub secret: String,
+    pub label: String,
+    pub bound_root: String,
+    pub bound_fqn: String,
+    pub scopes: Vec<String>,
+    pub issued_at: String,
+    pub expires_at: Option<String>,
+}
+
+/// Mint a new client bound to `bound_root`, persisting atomically. Returns the
+/// plaintext secret to show once.
+pub fn mint(path: &Path, req: MintRequest) -> Result<MintOutcome, String> {
+    validate_scopes(&req.scopes)?;
+    let client = ApiClient {
+        client_id: req.client_id.clone(),
+        label: req.label,
+        token_hash: hash_token(&req.secret),
+        bound_fqn: req.bound_fqn,
+        bound_root: req.bound_root,
+        scopes: req.scopes,
+        issued_at: req.issued_at,
+        expires_at: req.expires_at,
+        revoked: false,
+    };
+    write_registry(path, |reg| {
+        reg.clients.push(client.clone());
+        Ok(())
+    })?;
+    Ok(MintOutcome {
+        client_id: req.client_id,
+        secret: req.secret,
+    })
+}
+
+/// Mark a client revoked (idempotent). Returns whether a matching client was
+/// found. Persists atomically.
+pub fn revoke(path: &Path, client_id: &str) -> Result<bool, String> {
+    let mut found = false;
+    write_registry(path, |reg| {
+        for c in reg.clients.iter_mut() {
+            if c.client_id == client_id {
+                c.revoked = true;
+                found = true;
+            }
+        }
+        Ok(())
+    })?;
+    Ok(found)
+}
+
+/// List clients (secrets/hashes are the caller's concern to redact).
+pub fn list(path: &Path) -> ApiClientRegistry {
+    parse_registry(path)
+}
+
+/// Atomic read-modify-write of the whole typed registry, reusing the process-
+/// wide-locked `update_config_json_object` primitive (temp + `ReplaceFileW` /
+/// rename publish).
+fn write_registry<F>(path: &Path, mutate: F) -> Result<(), String>
+where
+    F: FnOnce(&mut ApiClientRegistry) -> Result<(), String>,
+{
+    crate::config::local_config_io::update_config_json_object(path, true, |obj| {
+        let mut reg: ApiClientRegistry =
+            serde_json::from_value(serde_json::Value::Object(obj.clone()))
+                .unwrap_or_default();
+        if reg.version == 0 {
+            reg.version = 1;
+        }
+        mutate(&mut reg)?;
+        let new = serde_json::to_value(&reg).map_err(|e| e.to_string())?;
+        if let serde_json::Value::Object(map) = new {
+            *obj = map;
+        }
+        Ok(())
+    })
+    .map(|_| ())
+}
+
+// ── Per-source failed-auth lockout (§0.5 DESIGN DECISION) ──────────────────
+
+struct SourceState {
+    failures: VecDeque<Instant>,
+    locked_until: Option<Instant>,
+}
+
+/// Unconditional per-source-IP failed-auth lockout. After `threshold` failed
+/// auths within `window`, a source is locked for `lockout`. Covers the
+/// unauthenticated-traffic gap the per-client rate limit cannot (an attacker
+/// with no valid token never reaches the per-client limiter).
+pub struct FailedAuthLockout {
+    inner: Mutex<HashMap<IpAddr, SourceState>>,
+    threshold: usize,
+    window: Duration,
+    lockout: Duration,
+}
+
+impl Default for FailedAuthLockout {
+    fn default() -> Self {
+        // 10 failed auths in 10s -> 60s lockout.
+        Self::new(10, Duration::from_secs(10), Duration::from_secs(60))
+    }
+}
+
+impl FailedAuthLockout {
+    /// Build a lockout with explicit thresholds (tests use tight values).
+    pub fn new(threshold: usize, window: Duration, lockout: Duration) -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+            threshold,
+            window,
+            lockout,
+        }
+    }
+
+    /// Reject (429) if the source is currently locked. Call before auth.
+    pub fn check(&self, ip: IpAddr) -> Result<(), ApiError> {
+        self.check_at(ip, Instant::now())
+    }
+
+    fn check_at(&self, ip: IpAddr, now: Instant) -> Result<(), ApiError> {
+        let map = self.inner.lock().unwrap();
+        if let Some(state) = map.get(&ip) {
+            if let Some(until) = state.locked_until {
+                if until > now {
+                    return Err(ApiError::TooManyRequests(
+                        "too many failed authentications from this source; locked out".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Record a failed auth; may transition the source into a lockout.
+    pub fn record_failure(&self, ip: IpAddr) {
+        self.record_failure_at(ip, Instant::now());
+    }
+
+    fn record_failure_at(&self, ip: IpAddr, now: Instant) {
+        let mut map = self.inner.lock().unwrap();
+        let state = map.entry(ip).or_insert_with(|| SourceState {
+            failures: VecDeque::new(),
+            locked_until: None,
+        });
+        // Drop failures outside the sliding window.
+        while let Some(&front) = state.failures.front() {
+            if now.duration_since(front) > self.window {
+                state.failures.pop_front();
+            } else {
+                break;
+            }
+        }
+        state.failures.push_back(now);
+        if state.failures.len() >= self.threshold {
+            state.locked_until = Some(now + self.lockout);
+            state.failures.clear();
+        }
+    }
+
+    /// Clear a source's failure history after a successful auth.
+    pub fn record_success(&self, ip: IpAddr) {
+        let mut map = self.inner.lock().unwrap();
+        map.remove(&ip);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn client(hash: &str, revoked: bool, expires: Option<&str>) -> ApiClient {
+        ApiClient {
+            client_id: "c1".into(),
+            label: "l".into(),
+            token_hash: hash.into(),
+            bound_fqn: "proj:wg-1/dev".into(),
+            bound_root: "C:/root".into(),
+            scopes: vec![SCOPE_SEND.into(), SCOPE_LIST_PEERS.into()],
+            issued_at: "2026-01-01T00:00:00Z".into(),
+            expires_at: expires.map(|s| s.to_string()),
+            revoked,
+        }
+    }
+
+    #[test]
+    fn hash_is_deterministic_and_prefixed() {
+        let h = hash_token("secret-abc");
+        assert!(h.starts_with("sha256:"));
+        assert_eq!(h, hash_token("secret-abc"));
+        assert_ne!(h, hash_token("secret-abd"));
+        // sha256 hex is 64 chars after the prefix.
+        assert_eq!(h.len(), "sha256:".len() + 64);
+    }
+
+    #[test]
+    fn hash_never_contains_plaintext() {
+        let secret = "super-secret-value";
+        let h = hash_token(secret);
+        assert!(!h.contains(secret));
+    }
+
+    #[test]
+    fn constant_time_eq_matches_semantics() {
+        assert!(constant_time_eq("abc", "abc"));
+        assert!(!constant_time_eq("abc", "abd"));
+        assert!(!constant_time_eq("abc", "abcd"));
+    }
+
+    #[test]
+    fn expiry_fail_closed_on_garbage() {
+        let now = chrono::Utc::now();
+        assert!(!is_expired(&client("h", false, None), now));
+        assert!(is_expired(&client("h", false, Some("not-a-date")), now));
+        assert!(is_expired(
+            &client("h", false, Some("2000-01-01T00:00:00Z")),
+            now
+        ));
+        assert!(!is_expired(
+            &client("h", false, Some("2099-01-01T00:00:00Z")),
+            now
+        ));
+    }
+
+    #[test]
+    fn validate_scopes_rejects_unknown_and_empty() {
+        assert!(validate_scopes(&[]).is_err());
+        assert!(validate_scopes(&["send".into()]).is_ok());
+        assert!(validate_scopes(&["send".into(), "list-peers-lean".into()]).is_ok());
+        assert!(validate_scopes(&["close-session".into()]).is_err());
+    }
+
+    #[test]
+    fn mint_stores_hash_not_plaintext_and_authenticate_reads_through() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(REGISTRY_FILENAME);
+        let out = mint(
+            &path,
+            MintRequest {
+                client_id: "client-1".into(),
+                secret: "the-secret".into(),
+                label: "docker:test".into(),
+                bound_root: "C:/root/replica".into(),
+                bound_fqn: "proj:wg-1/dev".into(),
+                scopes: vec![SCOPE_SEND.into()],
+                issued_at: "2026-01-01T00:00:00Z".into(),
+                expires_at: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(out.secret, "the-secret");
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(!raw.contains("the-secret"), "plaintext must not be persisted");
+        assert!(raw.contains("sha256:"));
+
+        // A fresh store (empty cache) reads through to disk on first auth.
+        let store = ApiClientStore::new(path.clone());
+        assert!(store.authenticate("the-secret").is_some());
+        assert!(store.authenticate("wrong-secret").is_none());
+    }
+
+    #[test]
+    fn revoke_takes_effect_on_next_read_through() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(REGISTRY_FILENAME);
+        mint(
+            &path,
+            MintRequest {
+                client_id: "client-1".into(),
+                secret: "s".into(),
+                label: "l".into(),
+                bound_root: "C:/root".into(),
+                bound_fqn: "proj:wg-1/dev".into(),
+                scopes: vec![SCOPE_SEND.into()],
+                issued_at: "2026-01-01T00:00:00Z".into(),
+                expires_at: None,
+            },
+        )
+        .unwrap();
+        let store = ApiClientStore::new(path.clone());
+        assert!(store.authenticate("s").is_some());
+
+        // Revoke via the (separate-process-equivalent) file write.
+        assert!(revoke(&path, "client-1").unwrap());
+        // Read-through picks up the change (mtime advanced).
+        assert!(
+            store.authenticate("s").is_none(),
+            "revocation must take effect on the next read-through"
+        );
+    }
+
+    #[test]
+    fn store_authenticate_skips_revoked_and_expired() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(REGISTRY_FILENAME);
+        let reg = ApiClientRegistry {
+            version: 1,
+            clients: vec![
+                client(&hash_token("revoked-tok"), true, None),
+                client(&hash_token("expired-tok"), false, Some("2000-01-01T00:00:00Z")),
+            ],
+        };
+        std::fs::write(&path, serde_json::to_string_pretty(&reg).unwrap()).unwrap();
+        let store = ApiClientStore::new(path);
+        assert!(store.authenticate("revoked-tok").is_none());
+        assert!(store.authenticate("expired-tok").is_none());
+    }
+
+    #[test]
+    fn lockout_triggers_after_threshold_and_check_rejects() {
+        let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let lock = FailedAuthLockout::new(3, Duration::from_secs(10), Duration::from_secs(60));
+        let t0 = Instant::now();
+        assert!(lock.check_at(ip, t0).is_ok());
+        lock.record_failure_at(ip, t0);
+        lock.record_failure_at(ip, t0);
+        assert!(lock.check_at(ip, t0).is_ok(), "below threshold: allowed");
+        lock.record_failure_at(ip, t0);
+        assert!(
+            lock.check_at(ip, t0).is_err(),
+            "at threshold: source is locked"
+        );
+        // After lockout expires, allowed again.
+        assert!(lock.check_at(ip, t0 + Duration::from_secs(61)).is_ok());
+    }
+
+    #[test]
+    fn lockout_success_clears_history() {
+        let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let lock = FailedAuthLockout::new(3, Duration::from_secs(10), Duration::from_secs(60));
+        let t0 = Instant::now();
+        lock.record_failure_at(ip, t0);
+        lock.record_failure_at(ip, t0);
+        lock.record_success(ip);
+        lock.record_failure_at(ip, t0);
+        lock.record_failure_at(ip, t0);
+        assert!(
+            lock.check_at(ip, t0).is_ok(),
+            "success reset the counter, so 2 more failures stay below threshold"
+        );
+    }
+}

--- a/src-tauri/src/api/error.rs
+++ b/src-tauri/src/api/error.rs
@@ -1,0 +1,150 @@
+//! Typed API errors and their HTTP mapping (#791).
+//!
+//! Error bodies never leak host absolute paths: `scrub_host_paths` redacts any
+//! Windows drive-letter path (e.g. an outbox / messaging dir that an internal
+//! error string might carry) before the detail crosses the socket.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+
+use super::schema::{ErrorBody, API_VERSION};
+
+/// A control-plane API failure with a fixed HTTP mapping.
+#[derive(Debug, Clone)]
+pub enum ApiError {
+    /// 400 - malformed body, missing/forbidden field, unsupported `inline`.
+    BadRequest(String),
+    /// 401 - missing/invalid/revoked/expired token, or bound replica gone.
+    Unauthorized(String),
+    /// 403 - valid token but not scoped / routing denied / root-agent excluded.
+    Forbidden(String),
+    /// 422 - the engine refused delivery (`deliver_wake` returned `Err`).
+    Rejected(String),
+    /// 429 - per-source failed-auth lockout or per-client rate limit.
+    TooManyRequests(String),
+    /// 500 - internal error (never leaks a host path).
+    Internal(String),
+}
+
+impl ApiError {
+    fn parts(&self) -> (StatusCode, &'static str, &str) {
+        match self {
+            ApiError::BadRequest(d) => (StatusCode::BAD_REQUEST, "bad_request", d),
+            ApiError::Unauthorized(d) => (StatusCode::UNAUTHORIZED, "unauthorized", d),
+            ApiError::Forbidden(d) => (StatusCode::FORBIDDEN, "forbidden", d),
+            ApiError::Rejected(d) => (StatusCode::UNPROCESSABLE_ENTITY, "rejected", d),
+            ApiError::TooManyRequests(d) => (StatusCode::TOO_MANY_REQUESTS, "rate_limited", d),
+            ApiError::Internal(d) => (StatusCode::INTERNAL_SERVER_ERROR, "internal", d),
+        }
+    }
+
+    /// The HTTP status this error maps to (used by handlers/tests).
+    pub fn status(&self) -> StatusCode {
+        self.parts().0
+    }
+
+    /// The stable machine code (used by tests).
+    pub fn code(&self) -> &'static str {
+        self.parts().1
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, code, detail) = self.parts();
+        let body = ErrorBody {
+            api_version: API_VERSION.to_string(),
+            error: code.to_string(),
+            detail: scrub_host_paths(detail),
+        };
+        (status, Json(body)).into_response()
+    }
+}
+
+/// Redact Windows drive-letter absolute paths from an error detail so a host
+/// filesystem layout never crosses the socket. Replaces each `X:\...` /
+/// `X:/...` run (up to the next whitespace) with `<path>`. Conservative: it
+/// only touches drive-letter runs, leaving FQNs / agent names intact.
+pub fn scrub_host_paths(detail: &str) -> String {
+    let mut out = String::with_capacity(detail.len());
+    let mut chars = detail.char_indices().peekable();
+    let bytes = detail.as_bytes();
+    while let Some((i, c)) = chars.next() {
+        // A drive-letter path starts as `<letter>:` followed by `\` or `/`.
+        let is_drive_start = c.is_ascii_alphabetic()
+            && bytes.get(i + 1) == Some(&b':')
+            && matches!(bytes.get(i + 2), Some(&b'\\') | Some(&b'/'))
+            // Must be at a token boundary so `https://` (no drive letter) and
+            // mid-word colons are not misread. Preceding char is start-or-space.
+            && (i == 0 || bytes.get(i - 1).map(|b| b.is_ascii_whitespace()).unwrap_or(false));
+        if is_drive_start {
+            out.push_str("<path>");
+            // Consume until whitespace.
+            for (_, cc) in chars.by_ref() {
+                if cc.is_whitespace() {
+                    out.push(cc);
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrub_redacts_windows_drive_path() {
+        let s = "failed to open C:\\Users\\maria\\repo\\messaging\\x.md now";
+        let scrubbed = scrub_host_paths(s);
+        assert!(!scrubbed.contains("C:\\Users"));
+        assert!(scrubbed.contains("<path>"));
+        assert!(scrubbed.contains("failed to open"));
+        assert!(scrubbed.contains("now"));
+    }
+
+    #[test]
+    fn scrub_redacts_forward_slash_drive_path() {
+        let s = "outbox D:/data/outbox failed";
+        let scrubbed = scrub_host_paths(s);
+        assert!(!scrubbed.contains("D:/data"));
+        assert!(scrubbed.contains("<path>"));
+    }
+
+    #[test]
+    fn scrub_leaves_non_paths_intact() {
+        let s = "routing rejected: 'proj:wg-1/dev-rust' cannot reach 'proj:wg-1/tech-lead'";
+        assert_eq!(scrub_host_paths(s), s);
+    }
+
+    #[test]
+    fn scrub_does_not_treat_url_as_drive_path() {
+        // `https://host` has no drive letter (h,t,t,p,s before `:`), so it stays.
+        let s = "see https://example.com/x for detail";
+        assert_eq!(scrub_host_paths(s), s);
+    }
+
+    #[test]
+    fn error_status_mapping() {
+        assert_eq!(ApiError::BadRequest("x".into()).status(), StatusCode::BAD_REQUEST);
+        assert_eq!(ApiError::Unauthorized("x".into()).status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(ApiError::Forbidden("x".into()).status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            ApiError::Rejected("x".into()).status(),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert_eq!(
+            ApiError::TooManyRequests("x".into()).status(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        assert_eq!(
+            ApiError::Internal("x".into()).status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+}

--- a/src-tauri/src/api/handlers/list_peers.rs
+++ b/src-tauri/src/api/handlers/list_peers.rs
@@ -1,0 +1,142 @@
+//! `GET /api/v1/peers` (#791 §6.2). Mirrors `list-peers-lean` for the caller's
+//! bound replica; `reachable` is computed from the bound FQN, so a client sees
+//! exactly the peers its identity may reach.
+
+use std::net::SocketAddr;
+
+use axum::extract::{ConnectInfo, RawQuery, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use uuid::Uuid;
+
+use crate::api::actuation;
+use crate::api::auth::SCOPE_LIST_PEERS;
+use crate::api::error::ApiError;
+use crate::api::schema::{PeersResponse, API_VERSION};
+use crate::api::{handlers, ApiState};
+
+/// Axum entry point for `GET /api/v1/peers`.
+pub async fn handle(
+    State(state): State<ApiState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    RawQuery(query): RawQuery,
+    headers: HeaderMap,
+) -> Response {
+    match handle_inner(&state, addr.ip(), &headers, query.as_deref()) {
+        Ok(resp) => (StatusCode::OK, Json(resp)).into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
+fn handle_inner(
+    state: &ApiState,
+    ip: std::net::IpAddr,
+    headers: &HeaderMap,
+    query: Option<&str>,
+) -> Result<PeersResponse, ApiError> {
+    let client = handlers::authenticate(state, headers, ip, SCOPE_LIST_PEERS)?;
+    // Validate the bound replica still exists and is not the root agent. The
+    // derived FQN is not needed here (lean_peers computes reachability from the
+    // root itself), but the validation must run.
+    crate::api::identity::resolve_from(&client)?;
+
+    let mut peers = actuation::lean_peers_via_api(&client.bound_root)?;
+
+    let filters = parse_peer_filters(query);
+    if !filters.is_empty() {
+        peers.retain(|p| filters.iter().any(|f| f == &p.name));
+    }
+
+    Ok(PeersResponse {
+        api_version: API_VERSION.to_string(),
+        // list-peers-lean is safely re-runnable, so opId is server-generated.
+        op_id: Uuid::new_v4().to_string(),
+        peers,
+    })
+}
+
+/// Parse repeatable `?peer=<fqn>` filters from a raw query string, percent-
+/// decoding each value. Non-`peer` keys are ignored.
+fn parse_peer_filters(query: Option<&str>) -> Vec<String> {
+    let Some(query) = query else {
+        return Vec::new();
+    };
+    query
+        .split('&')
+        .filter_map(|pair| {
+            let (key, value) = pair.split_once('=')?;
+            if key == "peer" {
+                Some(percent_decode(value))
+            } else {
+                None
+            }
+        })
+        .filter(|v| !v.is_empty())
+        .collect()
+}
+
+/// Minimal `application/x-www-form-urlencoded` value decode: `+` -> space and
+/// `%XX` -> byte. Invalid escapes are passed through literally.
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                if let (Some(hi), Some(lo)) = (hi, lo) {
+                    out.push((hi * 16 + lo) as u8);
+                    i += 3;
+                } else {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_query_yields_no_filters() {
+        assert!(parse_peer_filters(None).is_empty());
+        assert!(parse_peer_filters(Some("")).is_empty());
+    }
+
+    #[test]
+    fn parses_repeatable_peer_filter() {
+        let q = "peer=proj%3Awg-1%2Fdev&peer=proj%3Awg-1%2Flead&other=x";
+        let filters = parse_peer_filters(Some(q));
+        assert_eq!(filters, vec!["proj:wg-1/dev", "proj:wg-1/lead"]);
+    }
+
+    #[test]
+    fn ignores_non_peer_keys() {
+        let filters = parse_peer_filters(Some("token=abc&foo=bar"));
+        assert!(filters.is_empty());
+    }
+
+    #[test]
+    fn percent_decode_handles_plus_and_escapes() {
+        assert_eq!(percent_decode("a%3Ab"), "a:b");
+        assert_eq!(percent_decode("a+b"), "a b");
+        assert_eq!(percent_decode("plain"), "plain");
+        // Invalid escape is passed through literally.
+        assert_eq!(percent_decode("a%zz"), "a%zz");
+    }
+}

--- a/src-tauri/src/api/handlers/mod.rs
+++ b/src-tauri/src/api/handlers/mod.rs
@@ -1,0 +1,81 @@
+//! HTTP handlers for the control-plane API (#791 §6, §7).
+
+pub mod list_peers;
+pub mod send;
+
+use std::net::IpAddr;
+
+use axum::http::HeaderMap;
+use axum::Json;
+
+use crate::api::auth::ApiClient;
+use crate::api::error::ApiError;
+use crate::api::schema::HealthResponse;
+use crate::api::ApiState;
+
+/// `GET /api/v1/healthz` - unauthenticated liveness. Body pinned to exactly
+/// `{"ok":true}` (§0.5 G9): no version, bind, or client count.
+pub async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse { ok: true })
+}
+
+/// Extract a non-empty bearer token from `Authorization: Bearer <token>`.
+pub fn bearer_token(headers: &HeaderMap) -> Option<String> {
+    let raw = headers.get(axum::http::header::AUTHORIZATION)?.to_str().ok()?;
+    let token = raw.strip_prefix("Bearer ")?.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+/// Full auth pipeline shared by every authenticated endpoint:
+/// lockout check (429) -> bearer extraction -> read-through registry lookup
+/// (401) -> scope check (403). Records failed-auth attempts for the per-source
+/// lockout and audits the outcome. Returns the matched client on success.
+pub fn authenticate(
+    state: &ApiState,
+    headers: &HeaderMap,
+    ip: IpAddr,
+    scope: &str,
+) -> Result<ApiClient, ApiError> {
+    // 429 if this source is locked out (checked BEFORE any token work).
+    state.lockout.check(ip)?;
+
+    let token = match bearer_token(headers) {
+        Some(t) => t,
+        None => {
+            state.lockout.record_failure(ip);
+            crate::api::audit::record("-", "-", scope, "missing_token");
+            return Err(ApiError::Unauthorized(
+                "missing or malformed Authorization: Bearer header".to_string(),
+            ));
+        }
+    };
+
+    let client = match state.store.authenticate(&token) {
+        Some(c) => c,
+        None => {
+            state.lockout.record_failure(ip);
+            crate::api::audit::record("-", "-", scope, "invalid_token");
+            return Err(ApiError::Unauthorized(
+                "invalid, revoked, or expired token".to_string(),
+            ));
+        }
+    };
+
+    // A valid token proves this source is not a brute-forcer: clear its history.
+    state.lockout.record_success(ip);
+
+    if !client.has_scope(scope) {
+        crate::api::audit::record(&client.client_id, &client.bound_fqn, scope, "forbidden_scope");
+        return Err(ApiError::Forbidden(format!(
+            "token is not scoped for '{}'",
+            scope
+        )));
+    }
+
+    crate::api::audit::record(&client.client_id, &client.bound_fqn, scope, "authenticated");
+    Ok(client)
+}

--- a/src-tauri/src/api/handlers/send.rs
+++ b/src-tauri/src/api/handlers/send.rs
@@ -1,0 +1,159 @@
+//! `POST /api/v1/send` (#791 §6.1). Mirrors `send --mode wake --send <file>`,
+//! MINUS `--command` (out of scope). Identity is the token's bound replica,
+//! never client input; `inline` is rejected in v1; replays are deduped.
+
+use std::net::SocketAddr;
+
+use axum::body::Bytes;
+use axum::extract::{ConnectInfo, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+
+use crate::api::actuation::{self, DeliveryOutcome};
+use crate::api::auth::SCOPE_SEND;
+use crate::api::error::{scrub_host_paths, ApiError};
+use crate::api::idempotency::StoredResult;
+use crate::api::schema::{SendRequest, SendResponse, API_VERSION};
+use crate::api::{handlers, ApiState};
+
+/// Max accepted request body (16 KB). Large content belongs in the `.md` file,
+/// referenced by basename, never inlined.
+const MAX_BODY_BYTES: usize = 16 * 1024;
+
+/// Axum entry point. Buffers the body (bounded by a router layer), then defers
+/// to `handle_inner`, mapping its `(StatusCode, SendResponse)` or `ApiError`.
+pub async fn handle(
+    State(state): State<ApiState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    match handle_inner(&state, addr.ip(), &headers, &body).await {
+        Ok((status, resp)) => (status, Json(resp)).into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
+async fn handle_inner(
+    state: &ApiState,
+    ip: std::net::IpAddr,
+    headers: &HeaderMap,
+    body: &Bytes,
+) -> Result<(StatusCode, SendResponse), ApiError> {
+    if body.len() > MAX_BODY_BYTES {
+        return Err(ApiError::BadRequest(
+            "request body too large (>16 KB); put large content in the .md file".to_string(),
+        ));
+    }
+
+    // deny_unknown_fields rejects forbidden identity fields at parse time.
+    let req: SendRequest = serde_json::from_slice(body)
+        .map_err(|e| ApiError::BadRequest(format!("invalid request body: {}", e)))?;
+
+    // Auth + scope. Identity comes from the token, never the body.
+    let client = handlers::authenticate(state, headers, ip, SCOPE_SEND)?;
+    let from = crate::api::identity::resolve_from(&client)?;
+
+    // Idempotency: a replayed opId returns the SAME stored result, never
+    // re-delivers (across restarts, since the ledger is disk-persisted).
+    if let Some(prev) = state.ledger.get(&req.op_id) {
+        return Ok(replay(prev));
+    }
+
+    // Message one-of: `inline` is reserved but rejected in v1; `send` required.
+    if req.message.inline.is_some() {
+        return Err(ApiError::BadRequest(
+            "inline messages are not supported in v1; write the .md into messaging/ and use `send`"
+                .to_string(),
+        ));
+    }
+    let basename = req.message.send.as_deref().ok_or_else(|| {
+        ApiError::BadRequest("message.send (a bare filename) is required".to_string())
+    })?;
+
+    // Build the host-absolute notification body (path confinement inside).
+    let notif = actuation::build_send_body(&client.bound_root, basename, &from)?;
+
+    // Resolve + route + actuate through the shared engine.
+    let outcome =
+        actuation::deliver_wake_via_api(&state.app_handle, &from, &req.to, notif, &req.op_id)
+            .await?;
+
+    match outcome {
+        DeliveryOutcome::Delivered { to } => {
+            state.ledger.put(&req.op_id, "delivered", &to, None);
+            crate::api::audit::record(&client.client_id, &from, "send", "delivered");
+            Ok((StatusCode::OK, SendResponse::delivered(&req.op_id, &to)))
+        }
+        DeliveryOutcome::Rejected { to, reason } => {
+            let detail = scrub_host_paths(&reason);
+            state
+                .ledger
+                .put(&req.op_id, "rejected", &to, Some(detail.clone()));
+            crate::api::audit::record(&client.client_id, &from, "send", "rejected");
+            Ok((
+                StatusCode::UNPROCESSABLE_ENTITY,
+                SendResponse {
+                    api_version: API_VERSION.to_string(),
+                    op_id: req.op_id.clone(),
+                    status: "rejected".to_string(),
+                    to,
+                    detail: Some(detail),
+                },
+            ))
+        }
+    }
+}
+
+/// Map a stored (replayed) result back to a status + response body.
+fn replay(prev: StoredResult) -> (StatusCode, SendResponse) {
+    let status_code = if prev.status == "delivered" {
+        StatusCode::OK
+    } else {
+        StatusCode::UNPROCESSABLE_ENTITY
+    };
+    (
+        status_code,
+        SendResponse {
+            api_version: API_VERSION.to_string(),
+            op_id: prev.op_id,
+            status: prev.status,
+            to: prev.to,
+            detail: prev.detail,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replay_delivered_is_200() {
+        let (code, resp) = replay(StoredResult {
+            op_id: "o".into(),
+            status: "delivered".into(),
+            to: "proj/agent".into(),
+            detail: None,
+            first_seen: "2026-01-01T00:00:00Z".into(),
+        });
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(resp.status, "delivered");
+        assert!(resp.detail.is_none());
+    }
+
+    #[test]
+    fn replay_rejected_is_422_with_detail() {
+        let (code, resp) = replay(StoredResult {
+            op_id: "o".into(),
+            status: "rejected".into(),
+            to: "proj/agent".into(),
+            detail: Some("no route".into()),
+            first_seen: "2026-01-01T00:00:00Z".into(),
+        });
+        assert_eq!(code, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(resp.status, "rejected");
+        assert_eq!(resp.detail.as_deref(), Some("no route"));
+    }
+}

--- a/src-tauri/src/api/idempotency.rs
+++ b/src-tauri/src/api/idempotency.rs
@@ -1,0 +1,236 @@
+//! Persisted idempotency ledger for `send` (#791 §6.3, §0.5 G6).
+//!
+//! `send` is not safely repeatable (a duplicate would double-wake the peer), so
+//! a client-generated `opId` keys a bounded, TTL'd, DISK-PERSISTED ledger of
+//! `opId -> result`. A replay returns the SAME stored result and never
+//! re-delivers, and the persistence means an API-server restart cannot reset
+//! dedup and double-deliver. The daemon (API server) is the sole writer, so no
+//! cross-process reload is needed; the file is reloaded on construction.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+/// Default retention window: replays older than this are pruned (and hence
+/// re-deliverable). Bounds the ledger's time horizon.
+const DEFAULT_TTL_SECS: i64 = 24 * 60 * 60;
+/// Default max entries retained (oldest evicted first). Bounds the file size.
+const DEFAULT_CAP: usize = 2000;
+/// Ledger file basename in `config_dir()`.
+pub const LEDGER_FILENAME: &str = "api-idempotency.json";
+
+/// A stored `send` result, replayed verbatim on a duplicate `opId`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredResult {
+    pub op_id: String,
+    /// `"delivered"` | `"rejected"`.
+    pub status: String,
+    pub to: String,
+    #[serde(default)]
+    pub detail: Option<String>,
+    /// RFC3339 first-seen timestamp (for TTL pruning).
+    pub first_seen: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct LedgerDoc {
+    #[serde(default)]
+    version: u32,
+    #[serde(default)]
+    entries: Vec<StoredResult>,
+}
+
+/// Disk-persisted, bounded, TTL'd replay ledger.
+pub struct IdempotencyLedger {
+    path: PathBuf,
+    ttl_secs: i64,
+    cap: usize,
+    entries: Mutex<Vec<StoredResult>>,
+}
+
+impl IdempotencyLedger {
+    /// Load a ledger from `path` (empty if absent/malformed), with explicit
+    /// bounds (tests use tight values).
+    pub fn load(path: PathBuf, ttl_secs: i64, cap: usize) -> Self {
+        let entries = match std::fs::read_to_string(&path) {
+            Ok(raw) => serde_json::from_str::<LedgerDoc>(&raw)
+                .map(|d| d.entries)
+                .unwrap_or_else(|e| {
+                    log::warn!(
+                        "[api-idempotency] {} malformed ({}); starting empty",
+                        LEDGER_FILENAME,
+                        e
+                    );
+                    Vec::new()
+                }),
+            Err(_) => Vec::new(),
+        };
+        Self {
+            path,
+            ttl_secs,
+            cap,
+            entries: Mutex::new(entries),
+        }
+    }
+
+    /// Load from `config_dir()/api-idempotency.json` with default bounds.
+    pub fn at_config_dir() -> Option<Self> {
+        crate::config::config_dir()
+            .map(|d| Self::load(d.join(LEDGER_FILENAME), DEFAULT_TTL_SECS, DEFAULT_CAP))
+    }
+
+    /// Return a prior result for `op_id` if it is present and not expired.
+    pub fn get(&self, op_id: &str) -> Option<StoredResult> {
+        self.get_at(op_id, chrono::Utc::now())
+    }
+
+    fn get_at(&self, op_id: &str, now: chrono::DateTime<chrono::Utc>) -> Option<StoredResult> {
+        let entries = self.entries.lock().unwrap();
+        entries
+            .iter()
+            .find(|e| e.op_id == op_id && !self.is_expired(e, now))
+            .cloned()
+    }
+
+    /// Record a result for `op_id` (first-write-wins: a duplicate is ignored so
+    /// the original result is stable). Prunes expired + over-cap entries and
+    /// persists to disk. Best-effort persistence: an I/O failure is logged, not
+    /// propagated (the in-memory ledger still dedups within this run).
+    pub fn put(&self, op_id: &str, status: &str, to: &str, detail: Option<String>) {
+        self.put_at(op_id, status, to, detail, chrono::Utc::now())
+    }
+
+    fn put_at(
+        &self,
+        op_id: &str,
+        status: &str,
+        to: &str,
+        detail: Option<String>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) {
+        let snapshot = {
+            let mut entries = self.entries.lock().unwrap();
+            if entries.iter().any(|e| e.op_id == op_id) {
+                return; // first-write-wins
+            }
+            entries.push(StoredResult {
+                op_id: op_id.to_string(),
+                status: status.to_string(),
+                to: to.to_string(),
+                detail,
+                first_seen: now.to_rfc3339(),
+            });
+            // Prune expired.
+            entries.retain(|e| !self.is_expired(e, now));
+            // Evict oldest beyond the cap (entries are appended in time order).
+            if entries.len() > self.cap {
+                let overflow = entries.len() - self.cap;
+                entries.drain(0..overflow);
+            }
+            entries.clone()
+        };
+        self.persist(&snapshot);
+    }
+
+    fn is_expired(&self, entry: &StoredResult, now: chrono::DateTime<chrono::Utc>) -> bool {
+        match chrono::DateTime::parse_from_rfc3339(&entry.first_seen) {
+            Ok(seen) => now.signed_duration_since(seen.with_timezone(&chrono::Utc))
+                > chrono::Duration::seconds(self.ttl_secs),
+            // Unparseable stamp: treat as expired so it cannot linger forever.
+            Err(_) => true,
+        }
+    }
+
+    fn persist(&self, entries: &[StoredResult]) {
+        let doc = LedgerDoc {
+            version: 1,
+            entries: entries.to_vec(),
+        };
+        let result = crate::config::local_config_io::update_config_json_object(
+            &self.path,
+            true,
+            |obj| {
+                let new = serde_json::to_value(&doc).map_err(|e| e.to_string())?;
+                if let serde_json::Value::Object(map) = new {
+                    *obj = map;
+                }
+                Ok(())
+            },
+        );
+        if let Err(e) = result {
+            log::warn!(
+                "[api-idempotency] failed to persist ledger (continuing in-memory): {}",
+                e
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn put_then_get_returns_stored_result() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger = IdempotencyLedger::load(dir.path().join(LEDGER_FILENAME), 3600, 100);
+        ledger.put("op-1", "delivered", "proj/agent", None);
+        let got = ledger.get("op-1").expect("op-1 present");
+        assert_eq!(got.status, "delivered");
+        assert_eq!(got.to, "proj/agent");
+        assert!(ledger.get("op-2").is_none());
+    }
+
+    #[test]
+    fn put_is_first_write_wins() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger = IdempotencyLedger::load(dir.path().join(LEDGER_FILENAME), 3600, 100);
+        ledger.put("op-1", "delivered", "a", None);
+        ledger.put("op-1", "rejected", "b", Some("late".into()));
+        let got = ledger.get("op-1").unwrap();
+        assert_eq!(got.status, "delivered", "the first result must be stable");
+        assert_eq!(got.to, "a");
+    }
+
+    #[test]
+    fn survives_reload_from_disk() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(LEDGER_FILENAME);
+        {
+            let ledger = IdempotencyLedger::load(path.clone(), 3600, 100);
+            ledger.put("op-1", "delivered", "a", None);
+        }
+        // A fresh ledger (mirrors an API-server restart) reloads from disk.
+        let reloaded = IdempotencyLedger::load(path, 3600, 100);
+        assert!(
+            reloaded.get("op-1").is_some(),
+            "a restart must not reset dedup (§0.5 G6)"
+        );
+    }
+
+    #[test]
+    fn expired_entries_are_not_returned() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger = IdempotencyLedger::load(dir.path().join(LEDGER_FILENAME), 60, 100);
+        let now = chrono::Utc::now();
+        ledger.put_at("op-1", "delivered", "a", None, now);
+        // 61s later, the 60s TTL has elapsed.
+        let later = now + chrono::Duration::seconds(61);
+        assert!(ledger.get_at("op-1", later).is_none());
+    }
+
+    #[test]
+    fn cap_evicts_oldest() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger = IdempotencyLedger::load(dir.path().join(LEDGER_FILENAME), 3600, 2);
+        let now = chrono::Utc::now();
+        ledger.put_at("op-1", "delivered", "a", None, now);
+        ledger.put_at("op-2", "delivered", "b", None, now);
+        ledger.put_at("op-3", "delivered", "c", None, now);
+        assert!(ledger.get_at("op-1", now).is_none(), "oldest evicted");
+        assert!(ledger.get_at("op-2", now).is_some());
+        assert!(ledger.get_at("op-3", now).is_some());
+    }
+}

--- a/src-tauri/src/api/identity.rs
+++ b/src-tauri/src/api/identity.rs
@@ -1,0 +1,96 @@
+//! API identity resolution (#791 §9, §0.5 G5 + HIGH-3).
+//!
+//! The API replaces the filesystem model's LOCATION-based identity with a
+//! TOKEN-based one. The `from` is derived AT REQUEST TIME from the matched
+//! client's `boundRoot` via `agent_fqn_from_path` (the SAME function the CLI and
+//! daemon use), never from client input and never from the stored `boundFqn`
+//! hint (which can go stale if the replica is relocated).
+
+use super::auth::ApiClient;
+use super::error::ApiError;
+
+/// Resolve the sender FQN for an authenticated client.
+///
+/// - 401 if `boundRoot` no longer exists (the replica was removed; re-mint).
+/// - 403 if the derived FQN is the Root Agent (root-agent is API-excluded in
+///   increment 1, §0.5 HIGH-3). This is defense-in-depth behind the mint-time
+///   guard.
+/// - Logs a `WARN` if the freshly-derived FQN differs from the stored
+///   `boundFqn` hint (replica moved since mint), and uses the fresh value.
+pub fn resolve_from(client: &ApiClient) -> Result<String, ApiError> {
+    if !std::path::Path::new(&client.bound_root).exists() {
+        return Err(ApiError::Unauthorized(
+            "bound replica no longer exists; re-mint".to_string(),
+        ));
+    }
+
+    let fqn = crate::config::teams::agent_fqn_from_path(&client.bound_root);
+
+    if crate::config::root_agent::is_root_agent_target(&fqn)
+        || fqn == crate::config::root_agent::ROOT_AGENT_SENDER
+    {
+        return Err(ApiError::Forbidden(
+            "root-agent not reachable over the API in increment 1".to_string(),
+        ));
+    }
+
+    if fqn != client.bound_fqn {
+        log::warn!(
+            "[api-identity] client {} replica moved since mint (stored '{}' != derived '{}'); re-mint recommended",
+            client.client_id,
+            client.bound_fqn,
+            fqn
+        );
+    }
+
+    Ok(fqn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::auth::ApiClient;
+
+    fn client_with_root(root: &str, bound_fqn: &str) -> ApiClient {
+        ApiClient {
+            client_id: "c1".into(),
+            label: "l".into(),
+            token_hash: "sha256:x".into(),
+            bound_fqn: bound_fqn.into(),
+            bound_root: root.into(),
+            scopes: vec!["send".into()],
+            issued_at: "2026-01-01T00:00:00Z".into(),
+            expires_at: None,
+            revoked: false,
+        }
+    }
+
+    #[test]
+    fn missing_bound_root_is_401() {
+        let c = client_with_root(
+            "C:/definitely/not/a/real/replica/path/xyz",
+            "proj:wg-1/dev",
+        );
+        let err = resolve_from(&c).unwrap_err();
+        assert_eq!(err.status(), axum::http::StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn wg_replica_root_resolves_to_fqn() {
+        // Build a real WG-replica layout so agent_fqn_from_path yields a
+        // non-root FQN and the existence check passes.
+        let temp = tempfile::TempDir::new().unwrap();
+        let replica = temp
+            .path()
+            .join("proj-x")
+            .join(".ac")
+            .join("wg-1-team")
+            .join("__agent_dev-rust");
+        std::fs::create_dir_all(&replica).unwrap();
+        let root = replica.to_string_lossy().to_string();
+        let c = client_with_root(&root, "stale-hint");
+        let from = resolve_from(&c).expect("existing replica should resolve");
+        assert!(from.ends_with("/dev-rust"), "got: {}", from);
+        assert_ne!(from, crate::config::root_agent::ROOT_AGENT_SENDER);
+    }
+}

--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -1,0 +1,137 @@
+//! In-daemon control-plane API (#791). A sibling of `web/`: same axum stack and
+//! lifecycle, but a distinct trust model (per-client scoped tokens, not the
+//! single web token) and its own router. Increment 1 serves exactly two verbs
+//! (`send`, `list-peers-lean`) over a locally-bound TCP transport, funnelling
+//! through the SAME actuation the filesystem poller uses (`actuation.rs`).
+//!
+//! Auth is UNCONDITIONAL in every build profile (no `web/`-style debug bypass):
+//! a machine-to-machine control-plane that can wake/inject peer PTYs must never
+//! skip token validation.
+
+pub mod actuation;
+pub mod audit;
+pub mod auth;
+pub mod error;
+pub mod handlers;
+pub mod identity;
+pub mod idempotency;
+pub mod schema;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::extract::DefaultBodyLimit;
+use axum::routing::{get, post};
+use axum::Router;
+
+/// Hard ceiling on a buffered request body (defense in depth above the send
+/// handler's 16 KB semantic cap).
+const MAX_BODY_LIMIT_BYTES: usize = 64 * 1024;
+
+/// Shared state injected into every handler.
+#[derive(Clone)]
+pub struct ApiState {
+    /// Read-through client-token registry (mtime-gated).
+    pub store: Arc<auth::ApiClientStore>,
+    /// Disk-persisted `send` idempotency ledger.
+    pub ledger: Arc<idempotency::IdempotencyLedger>,
+    /// Per-source failed-auth lockout.
+    pub lockout: Arc<auth::FailedAuthLockout>,
+    /// Reach to the live daemon (SessionManager / PtyManager / SettingsState)
+    /// for actuation, via `app.state::<...>()`.
+    pub app_handle: tauri::AppHandle,
+}
+
+/// Build the router (state already assembled). Split out so tests can mount it
+/// without a socket.
+pub fn build_router(state: ApiState) -> Router {
+    Router::new()
+        .route("/api/v1/send", post(handlers::send::handle))
+        .route("/api/v1/peers", get(handlers::list_peers::handle))
+        // Unauthenticated liveness; body pinned to {"ok":true} (§0.5 G9).
+        .route("/api/v1/healthz", get(handlers::health))
+        .layer(DefaultBodyLimit::max(MAX_BODY_LIMIT_BYTES))
+        .with_state(state)
+}
+
+/// Start the control-plane API server on the shared tokio runtime, mirroring
+/// `web::start_server`. Returns the join handle for the managed
+/// `ApiServerHandle`. On any startup failure (unresolvable config dir, invalid
+/// address, or `bind` error) it logs at error and the task returns cleanly: it
+/// does NOT panic (§0.5 dev-rust F7, unlike `web/mod.rs`'s `.expect()`).
+pub fn start_server(
+    bind: String,
+    port: u16,
+    app_handle: tauri::AppHandle,
+    shutdown: crate::shutdown::ShutdownSignal,
+) -> tauri::async_runtime::JoinHandle<()> {
+    let store = match auth::ApiClientStore::at_config_dir() {
+        Some(s) => Arc::new(s),
+        None => {
+            log::error!("[api-server] cannot resolve config_dir; API server not started");
+            return tauri::async_runtime::spawn(async {});
+        }
+    };
+    let ledger = match idempotency::IdempotencyLedger::at_config_dir() {
+        Some(l) => Arc::new(l),
+        None => {
+            log::error!("[api-server] cannot resolve config_dir for idempotency ledger; API server not started");
+            return tauri::async_runtime::spawn(async {});
+        }
+    };
+
+    let state = ApiState {
+        store,
+        ledger,
+        lockout: Arc::new(auth::FailedAuthLockout::default()),
+        app_handle,
+    };
+    let router = build_router(state);
+
+    tauri::async_runtime::spawn(async move {
+        let addr: SocketAddr = match format!("{}:{}", bind, port).parse() {
+            Ok(a) => a,
+            Err(e) => {
+                log::error!("[api-server] invalid bind address {}:{}: {}", bind, port, e);
+                return;
+            }
+        };
+
+        // Loud warning on any non-loopback bind (§0.5 DESIGN DECISION).
+        if !addr.ip().is_loopback() {
+            let warning = format!(
+                "[api-server] WARNING: bound on {} (non-loopback); ensure a host firewall restricts this port to the Docker/WSL subnet.",
+                addr
+            );
+            log::warn!("{}", warning);
+            println!("{}", warning);
+        }
+
+        // Bind-failure = log-and-return, NOT panic (§0.5 dev-rust F7).
+        let listener = match tokio::net::TcpListener::bind(addr).await {
+            Ok(l) => l,
+            Err(e) => {
+                log::error!(
+                    "[api-server] bind failed on {} (port occupied?): {}; API server not started",
+                    addr,
+                    e
+                );
+                return;
+            }
+        };
+
+        log::info!("[api-server] listening on http://{}", addr);
+        println!("[api-server] listening on http://{}", addr);
+
+        let service = router.into_make_service_with_connect_info::<SocketAddr>();
+        if let Err(e) = axum::serve(listener, service)
+            .with_graceful_shutdown(async move {
+                shutdown.token().cancelled().await;
+                log::info!("[api-server] shutdown signal received, stopping");
+            })
+            .await
+        {
+            log::error!("[api-server] server error: {}", e);
+        }
+    })
+}

--- a/src-tauri/src/api/schema.rs
+++ b/src-tauri/src/api/schema.rs
@@ -1,0 +1,157 @@
+//! Versioned request/response DTOs for the in-daemon control-plane API (#791).
+//!
+//! Every request DTO layer carries `#[serde(deny_unknown_fields)]` so any
+//! client-supplied field outside the declared shape (notably the forbidden
+//! `from` / `root` / `token` / `command` / `action`) is rejected at parse time
+//! with a 400. All DTOs use camelCase to match the IPC convention
+//! (`OutboxMessage`, `phone/types.rs`).
+
+use serde::{Deserialize, Serialize};
+
+/// Contract version. URL-versioned (`/api/v1`); this echo is a redundant,
+/// explicit assertion field for clients.
+pub const API_VERSION: &str = "1";
+
+/// `POST /api/v1/send` request envelope.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SendRequest {
+    /// Client-asserted contract version (redundant with the URL). Required so a
+    /// malformed client that omits it is rejected.
+    pub api_version: String,
+    /// Client-generated idempotency key. A replay returns the prior result.
+    pub op_id: String,
+    /// Destination agent canonical FQN.
+    pub to: String,
+    /// The message payload. Exactly one of `send` (increment 1) or `inline` ([H]).
+    pub message: SendMessage,
+}
+
+/// The `message` one-of. Increment 1 accepts only `send` (a bare filename that
+/// already exists in the sender's `<workgroup>/messaging/`); `inline` is
+/// reserved in the schema but rejected with 400 in v1.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SendMessage {
+    /// Bare filename (no path separators) present in `<workgroup>/messaging/`.
+    #[serde(default)]
+    pub send: Option<String>,
+    /// Reserved [H]: inline message text. Rejected with 400 in increment 1.
+    #[serde(default)]
+    pub inline: Option<String>,
+}
+
+/// `POST /api/v1/send` response.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendResponse {
+    pub api_version: String,
+    pub op_id: String,
+    /// `"delivered"` on success, `"rejected"` when the engine refused delivery.
+    pub status: String,
+    /// Canonical target FQN the message was routed to.
+    pub to: String,
+    /// Human-readable reason on `rejected`; `null` on `delivered`.
+    pub detail: Option<String>,
+}
+
+impl SendResponse {
+    /// Build the `delivered` response for a target FQN.
+    pub fn delivered(op_id: &str, to: &str) -> Self {
+        Self {
+            api_version: API_VERSION.to_string(),
+            op_id: op_id.to_string(),
+            status: "delivered".to_string(),
+            to: to.to_string(),
+            detail: None,
+        }
+    }
+}
+
+/// `GET /api/v1/peers` response (mirrors `list-peers-lean`).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PeersResponse {
+    pub api_version: String,
+    /// Server-generated correlation id (`list-peers-lean` is not deduped).
+    pub op_id: String,
+    pub peers: Vec<crate::cli::list_peers::LeanPeerInfo>,
+}
+
+/// `GET /api/v1/healthz` response. Pinned to exactly `{"ok":true}` (§0.5 G9):
+/// no version, bind, or client-count is exposed on the unauthenticated route.
+#[derive(Debug, Serialize)]
+pub struct HealthResponse {
+    pub ok: bool,
+}
+
+/// Error body returned for every non-2xx response. Never contains host
+/// absolute paths (scrubbed in `error.rs`).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorBody {
+    pub api_version: String,
+    /// Stable machine-readable code, e.g. `"unauthorized"`, `"forbidden"`.
+    pub error: String,
+    /// Human-readable, host-path-scrubbed detail.
+    pub detail: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn send_request_rejects_unknown_top_level_field() {
+        // The forbidden identity fields are "unknown" to the DTO, so
+        // deny_unknown_fields rejects them at parse time.
+        for forbidden in ["from", "root", "token", "command", "action"] {
+            let json = format!(
+                r#"{{"apiVersion":"1","opId":"o","to":"a/b","message":{{"send":"f.md"}},"{}":"x"}}"#,
+                forbidden
+            );
+            let parsed: Result<SendRequest, _> = serde_json::from_str(&json);
+            assert!(
+                parsed.is_err(),
+                "body field '{}' must be rejected by deny_unknown_fields",
+                forbidden
+            );
+        }
+    }
+
+    #[test]
+    fn send_message_rejects_unknown_field() {
+        let json = r#"{"apiVersion":"1","opId":"o","to":"a/b","message":{"send":"f.md","bogus":1}}"#;
+        let parsed: Result<SendRequest, _> = serde_json::from_str(json);
+        assert!(parsed.is_err(), "unknown message field must be rejected");
+    }
+
+    #[test]
+    fn send_request_parses_minimal_valid_body() {
+        let json = r#"{"apiVersion":"1","opId":"o","to":"proj/agent","message":{"send":"20260101-x.md"}}"#;
+        let req: SendRequest = serde_json::from_str(json).expect("valid body should parse");
+        assert_eq!(req.api_version, "1");
+        assert_eq!(req.op_id, "o");
+        assert_eq!(req.to, "proj/agent");
+        assert_eq!(req.message.send.as_deref(), Some("20260101-x.md"));
+        assert!(req.message.inline.is_none());
+    }
+
+    #[test]
+    fn health_response_is_exactly_ok_true() {
+        let json = serde_json::to_value(HealthResponse { ok: true }).unwrap();
+        assert_eq!(json, serde_json::json!({ "ok": true }));
+        // No other field may serialize (§0.5 G9).
+        assert_eq!(json.as_object().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn send_response_delivered_has_null_detail_and_camel_case() {
+        let json = serde_json::to_value(SendResponse::delivered("op1", "proj/agent")).unwrap();
+        assert_eq!(json["apiVersion"], "1");
+        assert_eq!(json["opId"], "op1");
+        assert_eq!(json["status"], "delivered");
+        assert_eq!(json["to"], "proj/agent");
+        assert!(json["detail"].is_null());
+    }
+}

--- a/src-tauri/src/cli/api_client.rs
+++ b/src-tauri/src/cli/api_client.rs
@@ -1,0 +1,288 @@
+//! `api-client` host CLI verb (#791 §5.4): mint / revoke / list control-plane
+//! API client tokens. All subcommands require HOST AUTHORITY (the master or
+//! root token) so a container (which has no master token by construction)
+//! cannot self-mint. Mint binds a token to exactly one replica FQN and rejects
+//! the Root Agent (§0.5 HIGH-3).
+
+use clap::{Args, Subcommand};
+use uuid::Uuid;
+
+use crate::api::auth;
+
+#[derive(Args)]
+#[command(after_help = "\
+AUTHORITY: every subcommand requires the master/root token (host authority). A \
+container cannot self-mint (it has no master token by construction).\n\n\
+MINT prints the secret token exactly ONCE on stdout as JSON; capture it then. \
+The registry stores only a SHA-256 hash. The bound replica identity is derived \
+from --root; the Root Agent is rejected (API-excluded in increment 1).")]
+pub struct ApiClientArgs {
+    #[command(subcommand)]
+    pub command: ApiClientCommand,
+}
+
+#[derive(Subcommand)]
+pub enum ApiClientCommand {
+    /// Mint a new scoped, revocable API client token bound to a replica.
+    Mint(MintArgs),
+    /// Revoke a client by id (takes effect on the next API request).
+    Revoke(RevokeArgs),
+    /// List registered clients (secrets and hashes are never shown).
+    List(ListArgs),
+}
+
+#[derive(Args)]
+pub struct MintArgs {
+    /// Host authority token (master/root). Required.
+    #[arg(long)]
+    pub token: Option<String>,
+    /// Replica working directory to bind the token to (the identity source).
+    #[arg(long)]
+    pub root: String,
+    /// Comma-separated scopes. Increment 1 allows: send, list-peers-lean.
+    #[arg(long)]
+    pub scopes: String,
+    /// Optional human label.
+    #[arg(long)]
+    pub label: Option<String>,
+    /// Optional RFC3339 expiry (e.g. 2026-12-31T00:00:00Z).
+    #[arg(long)]
+    pub expires: Option<String>,
+}
+
+#[derive(Args)]
+pub struct RevokeArgs {
+    /// Host authority token (master/root). Required.
+    #[arg(long)]
+    pub token: Option<String>,
+    /// The clientId to revoke.
+    #[arg(long = "client-id")]
+    pub client_id: String,
+}
+
+#[derive(Args)]
+pub struct ListArgs {
+    /// Host authority token (master/root). Required.
+    #[arg(long)]
+    pub token: Option<String>,
+}
+
+pub fn execute(args: ApiClientArgs) -> i32 {
+    match args.command {
+        ApiClientCommand::Mint(a) => mint(a),
+        ApiClientCommand::Revoke(a) => revoke(a),
+        ApiClientCommand::List(a) => list(a),
+    }
+}
+
+/// True only for the master/root token. `validate_cli_token` returns `is_root`
+/// for both the persisted `root_token` and `master-token.txt`; a session UUID
+/// passes shape validation but returns `is_root = false`, so it is rejected.
+fn host_authority_ok(token: &Option<String>) -> bool {
+    matches!(crate::cli::validate_cli_token(token), Ok((_, true)))
+}
+
+fn registry_path() -> Result<std::path::PathBuf, i32> {
+    match crate::config::config_dir() {
+        Some(d) => Ok(d.join(auth::REGISTRY_FILENAME)),
+        None => {
+            eprintln!("Error: cannot resolve the host config directory.");
+            Err(1)
+        }
+    }
+}
+
+fn mint(a: MintArgs) -> i32 {
+    if !host_authority_ok(&a.token) {
+        eprintln!(
+            "Error: `api-client mint` requires the master/root token (host authority). A container cannot self-mint."
+        );
+        return 1;
+    }
+
+    // Derive + gate the bound identity (§0.5 HIGH-3 mint-time guard).
+    let bound_fqn = crate::config::teams::agent_fqn_from_path(&a.root);
+    if crate::config::root_agent::is_root_agent_path(&a.root)
+        || crate::config::root_agent::is_root_agent_target(&bound_fqn)
+        || bound_fqn == crate::config::root_agent::ROOT_AGENT_SENDER
+    {
+        eprintln!(
+            "Error: cannot mint an API client bound to the Root Agent; root-agent is API-excluded in increment 1."
+        );
+        return 1;
+    }
+
+    let scopes: Vec<String> = a
+        .scopes
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if let Err(e) = auth::validate_scopes(&scopes) {
+        eprintln!("Error: {}", e);
+        return 1;
+    }
+
+    let path = match registry_path() {
+        Ok(p) => p,
+        Err(code) => return code,
+    };
+
+    let client_id = Uuid::new_v4().to_string();
+    let secret = Uuid::new_v4().to_string();
+    let issued_at = chrono::Utc::now().to_rfc3339();
+
+    match auth::mint(
+        &path,
+        auth::MintRequest {
+            client_id,
+            secret,
+            label: a.label.unwrap_or_default(),
+            bound_root: a.root.clone(),
+            bound_fqn: bound_fqn.clone(),
+            scopes: scopes.clone(),
+            issued_at,
+            expires_at: a.expires,
+        },
+    ) {
+        Ok(out) => {
+            crate::api::audit::record(&out.client_id, &bound_fqn, "mint", "ok");
+            let output = serde_json::json!({
+                "clientId": out.client_id,
+                "token": out.secret,
+                "boundFqn": bound_fqn,
+                "boundRoot": a.root,
+                "scopes": scopes,
+                "note": "Store this token now; it is shown only once. The registry keeps only a hash."
+            });
+            crate::cli_println!(
+                "{}",
+                serde_json::to_string_pretty(&output).unwrap_or_else(|_| output.to_string())
+            );
+            0
+        }
+        Err(e) => {
+            eprintln!("Error: mint failed: {}", e);
+            1
+        }
+    }
+}
+
+fn revoke(a: RevokeArgs) -> i32 {
+    if !host_authority_ok(&a.token) {
+        eprintln!("Error: `api-client revoke` requires the master/root token (host authority).");
+        return 1;
+    }
+    let path = match registry_path() {
+        Ok(p) => p,
+        Err(code) => return code,
+    };
+    match auth::revoke(&path, &a.client_id) {
+        Ok(true) => {
+            crate::api::audit::record(&a.client_id, "-", "revoke", "ok");
+            crate::cli_println!("Revoked client '{}'.", a.client_id);
+            0
+        }
+        Ok(false) => {
+            eprintln!("Error: no client with id '{}'.", a.client_id);
+            1
+        }
+        Err(e) => {
+            eprintln!("Error: revoke failed: {}", e);
+            1
+        }
+    }
+}
+
+fn list(a: ListArgs) -> i32 {
+    if !host_authority_ok(&a.token) {
+        eprintln!("Error: `api-client list` requires the master/root token (host authority).");
+        return 1;
+    }
+    let path = match registry_path() {
+        Ok(p) => p,
+        Err(code) => return code,
+    };
+    let registry = auth::list(&path);
+    // Redact the hash: list shows identity + scope + status, never the digest.
+    let redacted: Vec<serde_json::Value> = registry
+        .clients
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "clientId": c.client_id,
+                "label": c.label,
+                "boundFqn": c.bound_fqn,
+                "boundRoot": c.bound_root,
+                "scopes": c.scopes,
+                "issuedAt": c.issued_at,
+                "expiresAt": c.expires_at,
+                "revoked": c.revoked,
+            })
+        })
+        .collect();
+    match serde_json::to_string_pretty(&redacted) {
+        Ok(json) => {
+            crate::cli_println!("{}", json);
+            0
+        }
+        Err(e) => {
+            eprintln!("Error: failed to serialize client list: {}", e);
+            1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn mint_parses_scopes_and_root() {
+        let parsed = crate::cli::Cli::try_parse_from([
+            "agentscommander",
+            "api-client",
+            "mint",
+            "--token",
+            "11111111-1111-1111-1111-111111111111",
+            "--root",
+            "C:/proj/.ac/wg-1/__agent_dev",
+            "--scopes",
+            "send,list-peers-lean",
+            "--label",
+            "docker:agent-1",
+        ])
+        .expect("api-client mint should parse");
+        match parsed.command {
+            Some(crate::cli::Commands::ApiClient(ApiClientArgs {
+                command: ApiClientCommand::Mint(a),
+            })) => {
+                assert_eq!(a.scopes, "send,list-peers-lean");
+                assert_eq!(a.root, "C:/proj/.ac/wg-1/__agent_dev");
+                assert_eq!(a.label.as_deref(), Some("docker:agent-1"));
+            }
+            _ => panic!("expected api-client mint"),
+        }
+    }
+
+    #[test]
+    fn revoke_parses_client_id() {
+        let parsed = crate::cli::Cli::try_parse_from([
+            "agentscommander",
+            "api-client",
+            "revoke",
+            "--token",
+            "11111111-1111-1111-1111-111111111111",
+            "--client-id",
+            "abc",
+        ])
+        .expect("api-client revoke should parse");
+        match parsed.command {
+            Some(crate::cli::Commands::ApiClient(ApiClientArgs {
+                command: ApiClientCommand::Revoke(a),
+            })) => assert_eq!(a.client_id, "abc"),
+            _ => panic!("expected api-client revoke"),
+        }
+    }
+}

--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -150,23 +150,26 @@ pub struct ListPeersLeanArgs {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct LeanPeerInfo {
+/// Lean peer projection emitted by `list-peers-lean`. Made `pub` (#791 §8.2)
+/// so the in-daemon API can reuse the exact projection via `lean_peers`; only
+/// this lean view crosses the module boundary, `PeerInfo` stays private.
+pub struct LeanPeerInfo {
     /// Canonical FQN. Same value as `PeerInfo.name`.
-    name: String,
+    pub name: String,
     /// Same predicate as `PeerInfo.working`.
-    working: bool,
+    pub working: bool,
     /// Same domain as `PeerInfo.session_status`.
-    session_status: String,
+    pub session_status: String,
     /// Same value as `PeerInfo.waiting_for_input`.
-    waiting_for_input: bool,
+    pub waiting_for_input: bool,
     /// Same value as `PeerInfo.reachable`.
-    reachable: bool,
+    pub reachable: bool,
     /// Same value as `PeerInfo.teams`.
-    teams: Vec<String>,
+    pub teams: Vec<String>,
     /// Short single-line summary derived from `PeerInfo.role`, ≤80 chars
     /// total (including any trailing `…`). Omitted when empty.
     #[serde(skip_serializing_if = "String::is_empty")]
-    role_summary: String,
+    pub role_summary: String,
 }
 
 /// Maximum length (in Unicode chars) of `roleSummary`, **including any
@@ -1105,6 +1108,19 @@ fn discover_peers(root: &str) -> Result<Vec<PeerInfo>, String> {
     } else {
         Ok(discover_origin_peers(root))
     }
+}
+
+/// #791 §8.2 - public in-process `list-peers-lean` for the in-daemon API.
+///
+/// Runs the SAME discovery as `execute_lean` (WG-replica / origin / root
+/// dispatch) and the SAME `reachable` computation (via `can_communicate`),
+/// returning the lean projection directly instead of printing to stdout. The
+/// API handler calls this with the caller's bound replica root, so an API
+/// `peers` response is byte-identical to the CLI's for the same fixture. Keeps
+/// `PeerInfo` and `discover_peers` private; only `LeanPeerInfo` is exposed.
+pub fn lean_peers(root: &str) -> Result<Vec<LeanPeerInfo>, String> {
+    let peers = discover_peers(root)?;
+    Ok(peers.iter().map(LeanPeerInfo::from).collect())
 }
 
 fn serialize_full_peers(peers: &[PeerInfo]) -> i32 {

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod agency_templates;
+pub mod api_client;
 pub mod close_session;
 pub mod coding_agent;
 pub mod create_agent;
@@ -169,6 +170,8 @@ pub enum Commands {
     Harness(harness::HarnessArgs),
     /// Manage Coding Agent configurations (settings.agents)
     CodingAgent(coding_agent::CodingAgentArgs),
+    /// Manage control-plane API client tokens (mint / revoke / list; host authority required)
+    ApiClient(api_client::ApiClientArgs),
     /// Delete only the disposable testable app state
     #[command(hide = true)]
     TestReset(crate::testability::reset::TestResetArgs),
@@ -323,6 +326,7 @@ pub fn handle_cli(cmd: Commands) -> i32 {
         Commands::Loop(args) => loop_cmd::execute(args),
         Commands::Harness(args) => harness::execute(args),
         Commands::CodingAgent(args) => coding_agent::execute(args),
+        Commands::ApiClient(args) => api_client::execute(args),
         Commands::TestReset(args) => crate::testability::reset::execute(args),
         Commands::WindowInfo(args) => crate::testability::window_info::execute(args),
         Commands::UiQuery(args) => crate::testability::ui_automation::execute_query(args),

--- a/src-tauri/src/config/profile.rs
+++ b/src-tauri/src/config/profile.rs
@@ -189,6 +189,28 @@ pub fn web_server_port() -> u16 {
     }
 }
 
+/// Default control-plane API server port (#791). Distinct from the web server
+/// port so a dev and a prod build on one host do not collide. Mirrors
+/// `web_server_port`'s profile-awareness (dev/stage hardcoded, unknown suffix
+/// hashed, prod fallback), offset into the 98xx range above the web ports.
+pub fn api_server_port() -> u16 {
+    match binary_suffix() {
+        Some("dev") => 9886,
+        Some("stage") => 9888,
+        Some(suffix) => {
+            let hash = suffix
+                .bytes()
+                .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
+            9900 + (hash % 20) as u16
+        }
+        None => match BUILD_PROFILE {
+            "dev" => 9886,
+            "stage" => 9888,
+            _ => 9887, // prod
+        },
+    }
+}
+
 /// Whether this is the STAGE profile (via suffix or BUILD_PROFILE fallback).
 pub fn is_stage() -> bool {
     binary_suffix() == Some("stage") || (binary_suffix().is_none() && BUILD_PROFILE == "stage")

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -340,6 +340,19 @@ pub struct AppSettings {
     /// Bind address: "127.0.0.1" (local only) or "0.0.0.0" (all interfaces)
     #[serde(default = "default_web_bind")]
     pub web_server_bind: String,
+    /// #791 - enable the in-daemon control-plane API server (Docker/distributed
+    /// agents). Default false: no new listening socket unless the operator opts in.
+    #[serde(default)]
+    pub api_server_enabled: bool,
+    /// #791 - control-plane API port. Profile-aware default so dev/prod builds
+    /// do not collide on one host.
+    #[serde(default = "default_api_port")]
+    pub api_server_port: u16,
+    /// #791 - control-plane API bind address. Default "127.0.0.1" (safe, loopback).
+    /// Reaching a Linux container requires a deliberate operator widening; any
+    /// non-loopback bind logs a loud startup warning.
+    #[serde(default = "default_api_bind")]
+    pub api_server_bind: String,
     /// Currently loaded project path (legacy single-project, kept for backward compat)
     #[serde(default)]
     pub project_path: Option<String>,
@@ -533,6 +546,18 @@ fn default_web_bind() -> String {
     "127.0.0.1".to_string()
 }
 
+/// #791 - profile-aware default control-plane API port (delegates to
+/// `profile::api_server_port`, mirroring `default_web_port`).
+fn default_api_port() -> u16 {
+    super::profile::api_server_port()
+}
+
+/// #791 - default control-plane API bind: loopback, safe-by-default. Mirrors
+/// `default_web_bind`. Widening for Docker is a deliberate operator action.
+fn default_api_bind() -> String {
+    "127.0.0.1".to_string()
+}
+
 fn default_sidebar_style() -> String {
     "noir-minimal".to_string()
 }
@@ -627,6 +652,9 @@ impl Default for AppSettings {
             web_server_enabled: false,
             web_server_port: default_web_port(),
             web_server_bind: default_web_bind(),
+            api_server_enabled: false,
+            api_server_port: default_api_port(),
+            api_server_bind: default_api_bind(),
             project_path: None,
             project_paths: vec![],
             sidebar_style: default_sidebar_style(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod cli;
 pub mod commands;
 pub mod config;
@@ -41,6 +42,11 @@ pub type DetachedSessionsState = Arc<Mutex<HashSet<uuid::Uuid>>>;
 
 /// Handle to the running web server task, allowing stop control.
 pub type WebServerHandle = Arc<Mutex<Option<tauri::async_runtime::JoinHandle<()>>>>;
+
+/// #791 - handle to the running control-plane API server task, for stop control.
+/// Mirrors `WebServerHandle`; stored so a future `stop_api_server` command can
+/// abort the task.
+pub type ApiServerHandle = Arc<Mutex<Option<tauri::async_runtime::JoinHandle<()>>>>;
 
 /// Issue #120 — serializes in-process writers of `.claude/settings.local.json`.
 ///
@@ -458,6 +464,7 @@ pub fn run(
         .manage(web_access_token.clone())
         .manage(broadcaster.clone())
         .manage(WebServerHandle::default())
+        .manage(ApiServerHandle::default())
         .manage(rtk_sweep_lock)
         .manage(rtk_startup_mode)
         .manage(update_check_state)
@@ -560,6 +567,26 @@ pub fn run(
 
                     let ws_handle = app.state::<WebServerHandle>();
                     *ws_handle.lock().unwrap() = Some(join_handle);
+                }
+            }
+
+            // #791 - start the control-plane API server if enabled in settings.
+            // Opt-in (default false), mirroring the web server block above. On
+            // any startup failure `api::start_server`'s task logs and returns
+            // (no panic); a listening server is stored in the managed handle.
+            {
+                let api_settings = config::settings::load_settings();
+                if api_settings.api_server_enabled {
+                    let bind = api_settings.api_server_bind.clone();
+                    let port = api_settings.api_server_port;
+                    let join_handle = api::start_server(
+                        bind,
+                        port,
+                        app.handle().clone(),
+                        shutdown_for_setup.clone(),
+                    );
+                    let api_handle = app.state::<ApiServerHandle>();
+                    *api_handle.lock().unwrap() = Some(join_handle);
                 }
             }
 

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -2039,7 +2039,12 @@ impl MailboxPoller {
     /// session; destroy and respawn if Exited; spawn persistent if none. Always
     /// delivers (no busy-gate — stdin buffer absorbs input while the agent is
     /// mid-turn).
-    async fn deliver_wake<R: tauri::Runtime>(
+    // #791: `pub(crate)` so the in-daemon control-plane API can funnel through
+    // the SAME actuation the poller uses (no fork). The API calls this on a
+    // throwaway `MailboxPoller::new()` (delivery-stateless: this method and its
+    // whole `&self` callee chain read only `app.state::<...>()`, never the
+    // poller's `poll_interval` / `retry_tracker` fields). See plan #791 §0.5 HIGH-1.
+    pub(crate) async fn deliver_wake<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
         msg: &OutboxMessage,


### PR DESCRIPTION
Introduces a local in-daemon API as the long-term inter-agent control-plane, with the Dockerized coding agent as its first client. This is a strangler-fig migration from the filesystem messaging path, which stays fully live and unchanged.

## Increment 1 (this PR)

- New `src-tauri/src/api/` module: an axum server hosted in the daemon, gated on `api_server_enabled` (default **false**, so this is inert until explicitly enabled), bound to `127.0.0.1` by default, profile-aware port.
- Two verbs: `POST /api/v1/send` (`--command` not exposed) and `GET /api/v1/peers`.
- First-class auth: scoped, revocable per-client tokens in host-only `api-clients.json` (SHA-256 hash-at-rest, constant-time compare, mtime-gated read-through so CLI revoke takes effect next request), identity derived from the token (`from` from `boundRoot`), never the master token, never inside the container.
- Root-agent excluded at the API boundary (403, both directions, pre/post canonicalization + a mint-time guard).
- New `api-client` CLI verb (mint / revoke / list).
- Reuses the existing actuation (`deliver_wake`, `can_communicate`, `resolve_agent_target`) with no fork; the filesystem messaging path is unchanged.
- Persisted idempotency ledger, per-source failed-auth lockout, strict DTO validation (`deny_unknown_fields`), rotating audit log.

## Review

- Design: architect plan (`_plans/791-in-daemon-api-control-plane-plan.md`) + dev-rust + grinch enrichment, consensus `READY_FOR_IMPLEMENTATION` (round 1).
- Implementation: dev-rust, commit `27d3c3b`, 19 files +2543/-9, all backend.
- Gates: `cargo check` clean, `clippy -D warnings` clean, `cargo test --lib` 1833 pass / 0 fail / 8 ignored (+45 new tests), integration suites 0 fail.
- Grinch Step-9 review: **PASS**. All three Step-6 HIGH findings (seam compile, auth revocation staleness, root-agent routing divergence) verified fixed in code. 5 new findings, all LOW (non-blocking follow-ups).

## Follow-ups (LOW, tracked separately)

N1 idempotency key (`op_id` to `client_id`+`op_id`), N2 shared-NAT lockout doc, N3 mutex-poison hardening, N4 malformed-registry log level, N5 hot-reload on settings change. Plus deferred [H] increments: FE toggle + mint UI, start/stop Tauri commands, the `deliver_validated` extraction, and the true end-to-end dogfood with the Docker wrapper.

Non-visual (backend + CLI, no GUI change).

Closes #791
