### PR TITLE
feat: embed frontend dist into binary for single self-contained web-server exe (#796)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -23,10 +23,12 @@ dependencies = [
  "futures-util",
  "image",
  "log",
+ "mime_guess",
  "open",
  "portable-pty",
  "reqwest 0.12.28",
  "rfd 0.15.4",
+ "rust-embed",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4985,6 +4987,40 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,8 @@ toml = "0.8"
 open = "5"
 axum = { version = "0.8", features = ["ws"] }
 tower-http = { version = "0.6", features = ["fs", "cors"] }
+rust-embed = "8"
+mime_guess = "2"
 futures-util = "0.3"
 futures = "0.3"
 rfd = "0.15"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,4 +1,8 @@
+use std::path::Path;
+
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(has_embedded_dist)");
+
     // Determine build profile: "dev", "prod", or "stage".
     // BUILD_PROFILE env var takes precedence; otherwise default based on cargo profile.
     let profile = std::env::var("BUILD_PROFILE").unwrap_or_else(|_| {
@@ -11,13 +15,71 @@ fn main() {
         .to_string()
     });
 
-    // Make BUILD_PROFILE available via env!("BUILD_PROFILE") in Rust code
+    // Make BUILD_PROFILE available via env!("BUILD_PROFILE") in Rust code.
     println!("cargo:rustc-env=BUILD_PROFILE={}", profile);
     println!("cargo:rerun-if-env-changed=BUILD_PROFILE");
 
+    let has_dist = configure_embedded_dist(&profile);
+    if !has_dist {
+        omit_missing_dist_resource_for_dev_check();
+    }
     embed_windows_test_manifest();
 
     tauri_build::build()
+}
+
+fn configure_embedded_dist(profile: &str) -> bool {
+    let dist_dir = Path::new("../dist");
+    let index_html = dist_dir.join("index.html");
+
+    println!("cargo:rerun-if-changed={}", dist_dir.display());
+    println!("cargo:rerun-if-changed={}", index_html.display());
+
+    if index_html.is_file() {
+        println!("cargo:rustc-cfg=has_embedded_dist");
+        emit_dist_rerun_paths(dist_dir);
+        return true;
+    }
+
+    if profile != "dev" {
+        panic!(
+            "missing ../dist/index.html for {} build; run npm run build before compiling src-tauri",
+            profile
+        );
+    }
+
+    println!(
+        "cargo:warning=../dist/index.html missing; embedded web UI disabled for this dev/check build"
+    );
+    false
+}
+
+fn omit_missing_dist_resource_for_dev_check() {
+    if std::env::var_os("TAURI_CONFIG").is_some() {
+        println!(
+            "cargo:warning=TAURI_CONFIG already set; leaving configured bundle resources unchanged"
+        );
+        return;
+    }
+
+    println!(
+        "cargo:warning=overriding Tauri bundle resources for this dev/check build because ../dist is missing"
+    );
+    std::env::set_var("TAURI_CONFIG", r#"{"bundle":{"resources":[]}}"#);
+}
+
+fn emit_dist_rerun_paths(path: &Path) {
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        println!("cargo:rerun-if-changed={}", path.display());
+        if path.is_dir() {
+            emit_dist_rerun_paths(&path);
+        }
+    }
 }
 
 fn embed_windows_test_manifest() {

--- a/src-tauri/src/web/embedded.rs
+++ b/src-tauri/src/web/embedded.rs
@@ -1,0 +1,215 @@
+#[cfg(has_embedded_dist)]
+use axum::body::Body;
+#[cfg(has_embedded_dist)]
+use axum::http::{header, HeaderValue, StatusCode, Uri};
+#[cfg(has_embedded_dist)]
+use axum::response::{IntoResponse, Response};
+#[cfg(has_embedded_dist)]
+use rust_embed::RustEmbed;
+
+#[cfg(any(has_embedded_dist, test))]
+const INDEX_HTML: &str = "index.html";
+#[cfg(has_embedded_dist)]
+const LONG_CACHE: &str = "public, max-age=31536000, immutable";
+#[cfg(has_embedded_dist)]
+const NO_CACHE: &str = "no-cache";
+
+#[cfg(has_embedded_dist)]
+#[derive(RustEmbed)]
+#[folder = "../dist"]
+struct EmbeddedDist;
+
+#[cfg(any(has_embedded_dist, test))]
+#[derive(Debug, PartialEq, Eq)]
+enum StaticRequest {
+    Invalid,
+    Exact(String),
+    SpaFallback,
+}
+
+#[cfg(has_embedded_dist)]
+pub async fn embedded_static_handler(uri: Uri) -> Response {
+    match classify_request_path(uri.path()) {
+        StaticRequest::Invalid => not_found(),
+        StaticRequest::SpaFallback => serve_embedded(INDEX_HTML, true).unwrap_or_else(not_found),
+        StaticRequest::Exact(path) => {
+            if let Some(response) = serve_embedded(&path, false) {
+                return response;
+            }
+
+            if should_spa_fallback(&path) {
+                serve_embedded(INDEX_HTML, true).unwrap_or_else(not_found)
+            } else {
+                not_found()
+            }
+        }
+    }
+}
+
+#[cfg(any(has_embedded_dist, test))]
+fn classify_request_path(raw_path: &str) -> StaticRequest {
+    if is_suspicious_path(raw_path) {
+        return StaticRequest::Invalid;
+    }
+
+    let path = raw_path.trim_start_matches('/');
+    if path.is_empty() || path == INDEX_HTML {
+        return StaticRequest::Exact(INDEX_HTML.to_string());
+    }
+
+    if path.ends_with('/') {
+        if path.starts_with("assets/") || path.starts_with("api/") || path == "ws/" {
+            return StaticRequest::Exact(path.to_string());
+        }
+        return StaticRequest::SpaFallback;
+    }
+
+    StaticRequest::Exact(path.to_string())
+}
+
+#[cfg(any(has_embedded_dist, test))]
+fn is_suspicious_path(raw_path: &str) -> bool {
+    let lower = raw_path.to_ascii_lowercase();
+
+    raw_path.contains('\\')
+        || lower.contains("%2e")
+        || lower.contains("%2f")
+        || lower.contains("%5c")
+        || raw_path.split('/').any(|part| part == "." || part == "..")
+}
+
+#[cfg(any(has_embedded_dist, test))]
+fn should_spa_fallback(path: &str) -> bool {
+    if path == INDEX_HTML
+        || path.starts_with("assets/")
+        || path.starts_with("api/")
+        || path == "ws"
+        || path.starts_with("ws/")
+    {
+        return false;
+    }
+
+    let last_segment = path.rsplit('/').next().unwrap_or(path);
+    !last_segment.contains('.')
+}
+
+#[cfg(has_embedded_dist)]
+fn serve_embedded(path: &str, spa_fallback: bool) -> Option<Response> {
+    let file = EmbeddedDist::get(path)?;
+    let mut response = Response::new(Body::from(file.data.into_owned()));
+
+    let headers = response.headers_mut();
+    headers.insert(header::CONTENT_TYPE, content_type_for(path));
+    headers.insert(header::CACHE_CONTROL, cache_control_for(path, spa_fallback));
+
+    Some(response)
+}
+
+#[cfg(has_embedded_dist)]
+fn content_type_for(path: &str) -> HeaderValue {
+    let mime = mime_guess::from_path(path).first_or_octet_stream();
+    HeaderValue::from_str(mime.essence_str())
+        .unwrap_or_else(|_| HeaderValue::from_static("application/octet-stream"))
+}
+
+#[cfg(has_embedded_dist)]
+fn cache_control_for(path: &str, spa_fallback: bool) -> HeaderValue {
+    if spa_fallback || path == INDEX_HTML {
+        HeaderValue::from_static(NO_CACHE)
+    } else if path.starts_with("assets/") {
+        HeaderValue::from_static(LONG_CACHE)
+    } else {
+        HeaderValue::from_static(NO_CACHE)
+    }
+}
+
+#[cfg(has_embedded_dist)]
+fn not_found() -> Response {
+    (StatusCode::NOT_FOUND, "Not found").into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_and_index_resolve_to_index() {
+        assert_eq!(
+            classify_request_path("/"),
+            StaticRequest::Exact("index.html".to_string())
+        );
+        assert_eq!(
+            classify_request_path("/index.html"),
+            StaticRequest::Exact("index.html".to_string())
+        );
+    }
+
+    #[test]
+    fn exact_asset_paths_are_asset_candidates() {
+        assert_eq!(
+            classify_request_path("/assets/app.123.js"),
+            StaticRequest::Exact("assets/app.123.js".to_string())
+        );
+    }
+
+    #[test]
+    fn extensionless_app_routes_use_spa_fallback() {
+        assert!(should_spa_fallback("sessions/abc"));
+        assert_eq!(
+            classify_request_path("/sessions/"),
+            StaticRequest::SpaFallback
+        );
+    }
+
+    #[test]
+    fn file_like_and_api_paths_do_not_use_spa_fallback() {
+        assert!(!should_spa_fallback("assets/missing.js"));
+        assert!(!should_spa_fallback("favicon.ico"));
+        assert!(!should_spa_fallback("api/unknown"));
+        assert!(!should_spa_fallback("ws/unknown"));
+    }
+
+    #[test]
+    fn suspicious_paths_are_rejected() {
+        assert_eq!(classify_request_path("/../secret"), StaticRequest::Invalid);
+        assert_eq!(classify_request_path("/foo\\bar"), StaticRequest::Invalid);
+        assert_eq!(
+            classify_request_path("/%2e%2e/secret"),
+            StaticRequest::Invalid
+        );
+        assert_eq!(
+            classify_request_path("/foo/%5c/bar"),
+            StaticRequest::Invalid
+        );
+    }
+
+    #[cfg(has_embedded_dist)]
+    #[test]
+    fn cache_headers_match_asset_type() {
+        assert_eq!(
+            cache_control_for(INDEX_HTML, false),
+            HeaderValue::from_static(NO_CACHE)
+        );
+        assert_eq!(
+            cache_control_for("sessions/abc", true),
+            HeaderValue::from_static(NO_CACHE)
+        );
+        assert_eq!(
+            cache_control_for("assets/app.123.js", false),
+            HeaderValue::from_static(LONG_CACHE)
+        );
+    }
+
+    #[cfg(has_embedded_dist)]
+    #[test]
+    fn content_type_uses_mime_guess() {
+        assert_eq!(
+            content_type_for("assets/app.123.css"),
+            HeaderValue::from_static("text/css")
+        );
+        assert_eq!(
+            content_type_for("assets/app.123.js"),
+            HeaderValue::from_static("text/javascript")
+        );
+    }
+}

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod broadcast;
 pub mod commands;
+mod embedded;
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -31,7 +32,7 @@ struct AppState {
 }
 
 /// Start the embedded HTTP/WebSocket server.
-/// Called from Tauri's setup() — runs on the same tokio runtime.
+/// Called from Tauri's setup(), runs on the same tokio runtime.
 // Wired by a single setup() call with all shared state already in scope; an
 // args struct would just rename the same fields.
 #[allow(clippy::too_many_arguments)]
@@ -67,12 +68,27 @@ pub fn start_server(
         .route("/api/sessions", get(api_sessions_handler))
         .with_state(state);
 
-    // Serve static files if dist/ exists
-    if let Some(path) = dist_path {
-        log::info!("[web-server] Serving static files from {:?}", path);
-        app = app.fallback_service(ServeDir::new(path).append_index_html_on_directories(true));
-    } else {
-        log::warn!("[web-server] No dist/ directory found — static file serving disabled");
+    #[cfg(has_embedded_dist)]
+    {
+        if prefer_embedded_dist() {
+            log::info!("[web-server] Serving static files from embedded dist");
+            app = app.fallback(embedded::embedded_static_handler);
+        } else if let Some(path) = dist_path {
+            log::info!("[web-server] Serving static files from {:?}", path);
+            app = app.fallback_service(ServeDir::new(path).append_index_html_on_directories(true));
+        } else {
+            log::warn!("[web-server] No dist/ directory found; static file serving disabled");
+        }
+    }
+
+    #[cfg(not(has_embedded_dist))]
+    {
+        if let Some(path) = dist_path {
+            log::info!("[web-server] Serving static files from {:?}", path);
+            app = app.fallback_service(ServeDir::new(path).append_index_html_on_directories(true));
+        } else {
+            log::warn!("[web-server] No dist/ directory found; static file serving disabled");
+        }
     }
 
     let handle = tauri::async_runtime::spawn(async move {
@@ -116,7 +132,7 @@ async fn ws_handler(
     ws.on_upgrade(move |socket| handle_ws_connection(socket, state.ws_state))
 }
 
-/// Public session view for the HTTP API — omits sensitive fields like `token`.
+/// Public session view for the HTTP API, omits sensitive fields like `token`.
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ApiSessionView {
@@ -131,7 +147,7 @@ struct ApiSessionView {
     last_prompt: Option<String>,
 }
 
-/// HTTP GET /api/sessions — returns JSON array of all sessions.
+/// HTTP GET /api/sessions, returns JSON array of all sessions.
 async fn api_sessions_handler(
     Query(params): Query<HashMap<String, String>>,
     State(state): State<AppState>,
@@ -173,7 +189,7 @@ async fn api_sessions_handler(
             created_at: s.created_at,
             shell: s.shell,
             // Back-compat: present each repo as "<label>/<branch>" (or bare label when
-            // branch unknown), joined with ", ". Comma — not newline — so single-line
+            // branch unknown), joined with ", ". Comma, not newline, so single-line
             // JSON clients don't truncate.
             git_branch: if s.git_repos.is_empty() {
                 None
@@ -327,6 +343,11 @@ fn binary_pty_write_succeeded(
     }
 }
 
+#[cfg(has_embedded_dist)]
+fn prefer_embedded_dist() -> bool {
+    crate::config::profile::BUILD_PROFILE != "dev"
+}
+
 /// Resolve the dist/ directory for static file serving.
 fn resolve_dist_path(app_handle: &tauri::AppHandle) -> Option<std::path::PathBuf> {
     // 1. Tauri resource dir (production NSIS bundle)
@@ -346,7 +367,7 @@ fn resolve_dist_path(app_handle: &tauri::AppHandle) -> Option<std::path::PathBuf
                 log::info!("[web-server] Found dist next to exe: {:?}", dist);
                 return Some(dist);
             }
-            // Dev mode: target/debug/exe → project root/dist
+            // Dev mode: target/debug/exe to project root/dist.
             if let Some(grandparent) = parent.parent() {
                 let dist = grandparent.join("dist");
                 if dist.exists() && dist.is_dir() {


### PR DESCRIPTION
Closes #796.

## Problem
The built-in web server served the web UI from an on-disk `dist` directory resolved at startup. The standalone/testable exe (`scripts/copy-testable-binary.mjs`) copies only the exe, so when run without a sibling `dist` the static fallback was never registered and every page returned **HTTP 404** (only `/ws` and `/api/sessions` worked). This made the "open browser" web UI a guaranteed 404 for a moved/copied exe.

## Change
Embed the built frontend into the Rust binary so the web UI works from a single self-contained exe with no external `dist`.

- Add deps `rust-embed = "8"` and `mime_guess = "2"` (`src-tauri/Cargo.toml`).
- Embed `../dist` at compile time and serve it via a custom Axum fallback handler (`src-tauri/src/web/embedded.rs`): exact asset match first, extension-sensitive SPA fallback to `index.html`, path-traversal / encoded-separator rejection, MIME via `mime_guess`, `Cache-Control: no-cache` for `index.html`/SPA fallback and long immutable cache for hashed `/assets/*`.
- `build.rs`: `has_embedded_dist` cfg wiring — prod/stage/release **fail loudly** if `../dist/index.html` is missing; dev / backend-only `cargo check` proceed without a fresh frontend build; `rerun-if-changed` over the dist tree.
- `web::start_server()` prefers embedded dist outside `BUILD_PROFILE=dev`, keeping `resolve_dist_path()` + `ServeDir` as the dev/diagnostic fallback.
- `bundle.resources` and `copy-testable-binary.mjs` left intact (duplicate-resource removal deferred to #797).

## Verification (dev-rust)
`npm run build`, `cargo check`, `cargo test web::embedded` (7 tests), `cargo clippy --all-targets --all-features`, and `npm run build:prod` (produced release exe + testeable + MSI/NSIS) all passed. Single-exe runtime probe from a dist-less directory: `GET /` → 200 `text/html`, `/assets/*.css` → 200 immutable, `/assets/missing.js` → 404, `/api/sessions` → 401, `/ws` → 400; log: `Serving static files from embedded dist`.

## Adversarial review (dev-rust-grinch): PASS
Traced traversal (structurally safe — `EmbeddedDist` is a compile-time in-memory map, filesystem escape impossible in release), SPA fallback (missing `.js` correctly 404s, not masked as index.html), cache-control, MIME (no panic), build.rs fail-loud, and the build-script `TAURI_CONFIG` dev-only override (unreachable in prod/stage/release, never mutates disk). 4 advisory LOW findings, none blocking; F1 (rust-embed release-only embedding) tracked as follow-up.

## Notes
- Not a visual/GUI change; backend + build. Web UI appearance unchanged — it now loads instead of 404ing.
