### PR TITLE
fix: rename Non-stop option to Alert me!

### DIFF
--- a/scripts/check-test-debt.mjs
+++ b/scripts/check-test-debt.mjs
@@ -41,9 +41,60 @@ function blankPreserveNewlines(text) {
   return text.replace(/[^\n\r]/g, ' ');
 }
 
-function maskComments(source) {
+function rustRawStringBounds(source, index) {
+  const prefixLength = source[index] === 'b' && source[index + 1] === 'r'
+    ? 2
+    : source[index] === 'r'
+      ? 1
+      : 0;
+  if (prefixLength === 0) return null;
+
+  let marker = index + prefixLength;
+  while (source[marker] === '#') marker += 1;
+  if (source[marker] !== '"') return null;
+
+  const hashes = source.slice(index + prefixLength, marker);
+  const terminator = `"${hashes}`;
+  const contentStart = marker + 1;
+  const end = source.indexOf(terminator, contentStart);
+  const stop = end === -1 ? source.length : end + terminator.length;
+  return { contentStart, stop };
+}
+
+function maskQuotedLiteral(source, index) {
+  const quote = source[index];
+  let stop = index + 1;
+  while (stop < source.length) {
+    const c = source[stop];
+    stop += 1;
+    if (c === '\\') {
+      if (stop < source.length) stop += 1;
+      continue;
+    }
+    if (c === quote) break;
+  }
+  return stop;
+}
+
+function maskComments(source, options = {}) {
+  const singleQuote = options.singleQuote ?? true;
   let out = '';
   for (let i = 0; i < source.length;) {
+    const rawString = rustRawStringBounds(source, i);
+    if (rawString) {
+      out += source.slice(i, rawString.stop);
+      i = rawString.stop;
+      continue;
+    }
+
+    const ch = source[i];
+    if (ch === '"' || ch === '`' || (singleQuote && ch === '\'')) {
+      const stop = maskQuotedLiteral(source, i);
+      out += source.slice(i, stop);
+      i = stop;
+      continue;
+    }
+
     if (source.startsWith('//', i)) {
       const end = source.indexOf('\n', i);
       if (end === -1) {
@@ -69,25 +120,16 @@ function maskComments(source) {
 
 function maskCommentsAndStrings(source, options = {}) {
   const singleQuote = options.singleQuote ?? true;
-  const noComments = maskComments(source);
+  const noComments = maskComments(source, { singleQuote });
   let out = '';
   for (let i = 0; i < noComments.length;) {
     const ch = noComments[i];
-    if ((ch === 'r' || (ch === 'b' && noComments[i + 1] === 'r')) && /[br#"]/.test(noComments[i + 1] ?? '')) {
-      const start = ch === 'b' ? i + 2 : i + 1;
-      let j = start;
-      while (noComments[j] === '#') j += 1;
-      if (noComments[j] === '"') {
-        const hashes = noComments.slice(start, j);
-        const terminator = `"${hashes}`;
-        const contentStart = j + 1;
-        const end = noComments.indexOf(terminator, contentStart);
-        const stop = end === -1 ? noComments.length : end + terminator.length;
-        out += noComments.slice(i, contentStart).replace(/[^\n\r]/g, ' ');
-        out += blankPreserveNewlines(noComments.slice(contentStart, stop));
-        i = stop;
-        continue;
-      }
+    const rawString = rustRawStringBounds(noComments, i);
+    if (rawString) {
+      out += noComments.slice(i, rawString.contentStart).replace(/[^\n\r]/g, ' ');
+      out += blankPreserveNewlines(noComments.slice(rawString.contentStart, rawString.stop));
+      i = rawString.stop;
+      continue;
     }
     if (ch === 'b' && noComments[i + 1] === '"') {
       out += '  ';
@@ -220,7 +262,7 @@ function rustTestId(rel, modules, fnName) {
 function hasExecutableRustBody(originalBody, strippedBody) {
   const withoutComments = strippedBody.trim().replace(/;/g, '').trim();
   if (withoutComments.length === 0) return false;
-  const compact = maskComments(originalBody).trim();
+  const compact = maskComments(originalBody, { singleQuote: false }).trim();
   if (/^(todo!\s*\(\s*\)|unimplemented!\s*\(\s*\)|panic!\s*\(\s*["'`]TODO[\s\S]*["'`]\s*\))\s*;?$/.test(compact)) {
     return false;
   }
@@ -236,7 +278,7 @@ function hasExecutableRustBody(originalBody, strippedBody) {
 function scanRustFile(root, filePath) {
   const source = fs.readFileSync(filePath, 'utf8');
   const rel = relPath(root, filePath);
-  const maskedComments = maskComments(source);
+  const maskedComments = maskComments(source, { singleQuote: false });
   const masked = maskCommentsAndStrings(source, { singleQuote: false });
   const modules = moduleRanges(masked);
   const findings = [];
@@ -645,6 +687,13 @@ fn clean_rust() {
     assert_eq!(1, 1);
 }
 `);
+    writeFile(path.join(root, 'src-tauri/tests/url_string.rs'), `
+#[test]
+fn url_string_is_executable() {
+    let url = "https://example.com/path";
+    assert_eq!(url, "https://example.com/path");
+}
+`);
     writeFile(path.join(root, 'src/clean.test.ts'), `
 import { describe, expect, it } from "vitest";
 describe("clean suite", () => {
@@ -655,6 +704,10 @@ describe("clean suite", () => {
 `);
     let result = runFixture(root);
     assertSelf(result.code === 0, 'clean fixture should pass');
+    assertSelf(
+      !result.findings.some((f) => f.id.endsWith('url_string.rs::url_string_is_executable')),
+      'URL string Rust test false positive detected',
+    );
 
     writeFile(path.join(root, 'src-tauri/tests/ignored.rs'), `
 #[test]

--- a/src-tauri/src/config/project_settings.rs
+++ b/src-tauri/src/config/project_settings.rs
@@ -8,6 +8,8 @@ pub const MAX_WORKGROUP_GROUPS: usize = 80;
 pub const MAX_GROUP_ID_LEN: usize = 128;
 pub const MAX_GROUP_NAME_LEN: usize = 80;
 pub const MAX_GROUP_REGEX_LEN: usize = 1024;
+const DEFAULT_NON_STOP_NAME: &str = "Alert me!";
+const LEGACY_NON_STOP_NAME: &str = "Non-stop";
 
 fn default_true() -> bool {
     true
@@ -112,7 +114,7 @@ fn default_tolerance_seconds() -> u32 {
     30
 }
 fn default_non_stop_name() -> String {
-    "Non-stop".to_string()
+    DEFAULT_NON_STOP_NAME.to_string()
 }
 fn default_match_none_regex() -> String {
     "(?!)".to_string()
@@ -134,7 +136,7 @@ fn normalize_groups_config(mut config: WorkgroupGroupsConfig) -> WorkgroupGroups
     if let Some(ns) = config.non_stop.as_mut() {
         ns.tolerance_seconds = ns.tolerance_seconds.clamp(1, 3600);
         ns.sound.seconds = ns.sound.seconds.clamp(1, 60);
-        if ns.name.trim().is_empty() {
+        if ns.name.trim().is_empty() || ns.name.trim() == LEGACY_NON_STOP_NAME {
             ns.name = default_non_stop_name();
         } else if ns.name.chars().count() > MAX_GROUP_NAME_LEN {
             ns.name = ns.name.chars().take(MAX_GROUP_NAME_LEN).collect();
@@ -583,6 +585,34 @@ mod tests {
         let legacy = r#"{"groups":[{"id":"bots","name":"BOTS","regex":"^(wg-9)$"}],"showAll":true,"showUngrouped":true}"#;
         let config: WorkgroupGroupsConfig = serde_json::from_str(legacy).expect("parse legacy");
         assert_eq!(config.non_stop, None);
+    }
+
+    #[test]
+    fn normalize_migrates_legacy_non_stop_default_name() {
+        let project = project_with_workspace();
+        let raw = json!({
+            "groups": [],
+            "showAll": true,
+            "showUngrouped": true,
+            "nonStop": {
+                "show": true,
+                "name": LEGACY_NON_STOP_NAME,
+                "regex": "(?!)",
+                "toleranceSeconds": 30,
+                "telegram": {"enabled": false},
+                "sound": {"enabled": false, "seconds": 3}
+            }
+        });
+        std::fs::write(
+            settings_path(project.path()),
+            serde_json::to_string(&raw).expect("json"),
+        )
+        .expect("write settings");
+
+        let loaded = load_workgroup_groups(project.path()).expect("load groups");
+        let ns = loaded.non_stop.expect("nonStop present");
+
+        assert_eq!(ns.name, DEFAULT_NON_STOP_NAME);
     }
 
     #[test]

--- a/src-tauri/src/loops/non_stop_watchdog.rs
+++ b/src-tauri/src/loops/non_stop_watchdog.rs
@@ -338,7 +338,7 @@ async fn send_telegram(app: &AppHandle, r: &NonStopReport) {
         .inner()
         .clone();
     let text = format!(
-        "\u{26A0} Non-stop [{}]: {} {}/{} workgroups working. Not working: {}. Persisted >{}s.",
+        "\u{26A0} Alert me! [{}]: {} {}/{} workgroups working. Not working: {}. Persisted >{}s.",
         project_folder_name(&r.project_path),
         r.group_name,
         r.working,
@@ -372,7 +372,7 @@ mod tests {
     fn report(project: &str, disparity: bool, tolerance_seconds: u32) -> NonStopReport {
         NonStopReport {
             project_path: project.to_string(),
-            group_name: "Non-stop".to_string(),
+            group_name: "Alert me!".to_string(),
             disparity,
             working: if disparity { 1 } else { 2 },
             total: 2,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -784,7 +784,7 @@ export interface NonStopSoundConfig {
 export interface NonStopGroupConfig {
   /** Rail visibility AND watchdog-active. Single toggle (#777 D3/D4). Default false. */
   show: boolean;
-  /** Display name. Default "Non-stop". */
+  /** Display name. Default "Alert me!". */
   name: string;
   /** Membership regex, dynamic like user groups. Default "(?!)" (matches nothing). */
   regex: string;

--- a/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
@@ -212,7 +212,7 @@ describe("ProjectPanel workgroup groups", () => {
     }
   });
 
-  it("marks only the built-in Non-stop group option as bold in the group flyout", async () => {
+  it("marks only the built-in Alert me! group option as bold in the group flyout", async () => {
     const fake = new FakeTransport();
     setupProjectTransport(fake);
 
@@ -228,7 +228,7 @@ describe("ProjectPanel workgroup groups", () => {
       const nonStopOption = target<HTMLButtonElement>("replica.wg-1-dev-team.groups.nonstop");
       const userGroupOption = target<HTMLButtonElement>("replica.wg-1-dev-team.groups.frontend");
 
-      expect(nonStopOption.textContent).toContain("Non-stop");
+      expect(nonStopOption.textContent).toContain("Alert me!");
       expect(nonStopOption.classList.contains("session-context-group-option-nonstop")).toBe(true);
       expect(userGroupOption.classList.contains("session-context-group-option-nonstop")).toBe(false);
     } finally {

--- a/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
@@ -212,6 +212,30 @@ describe("ProjectPanel workgroup groups", () => {
     }
   });
 
+  it("marks only the built-in Non-stop group option as bold in the group flyout", async () => {
+    const fake = new FakeTransport();
+    setupProjectTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await workgroupGroupsStore.save(projectPath, groupsConfig());
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      await openCoordinatorMenu(rendered.root);
+      await openGroupFlyout();
+
+      const nonStopOption = target<HTMLButtonElement>("replica.wg-1-dev-team.groups.nonstop");
+      const userGroupOption = target<HTMLButtonElement>("replica.wg-1-dev-team.groups.frontend");
+
+      expect(nonStopOption.textContent).toContain("Non-stop");
+      expect(nonStopOption.classList.contains("session-context-group-option-nonstop")).toBe(true);
+      expect(userGroupOption.classList.contains("session-context-group-option-nonstop")).toBe(false);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
   it("removes a coordinator workgroup from an exact generated group from the context menu", async () => {
     const fake = new FakeTransport();
     setupProjectTransport(fake);

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1372,7 +1372,7 @@ const ProjectPanel: Component = () => {
               >
                 {/* #777: built-in Non-stop slot, pinned above the user groups. */}
                 <button
-                  class="session-context-option session-context-group-option"
+                  class="session-context-option session-context-group-option session-context-group-option-nonstop"
                   title="Watch this workgroup in the Non-stop group"
                   onClick={() => void toggleNonStop(wg)}
                   data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.nonstop`}

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -58,6 +58,7 @@ import {
 } from "./workgroup-session";
 import {
   MAX_GROUP_MATCH_ID_LENGTH,
+  DEFAULT_NON_STOP_NAME,
   compileGroupRegex,
   groupMatchId,
   nonStopMatchesWorkgroup,
@@ -1373,14 +1374,14 @@ const ProjectPanel: Component = () => {
                 {/* #777: built-in Non-stop slot, pinned above the user groups. */}
                 <button
                   class="session-context-option session-context-group-option session-context-group-option-nonstop"
-                  title="Watch this workgroup in the Non-stop group"
+                  title={`Watch this workgroup in the ${DEFAULT_NON_STOP_NAME} group`}
                   onClick={() => void toggleNonStop(wg)}
                   data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.nonstop`}
                 >
                   <span class="session-context-option-check">
                     {nonStopChecked(wg) ? "✓" : ""}
                   </span>
-                  <span>Non-stop</span>
+                  <span>{DEFAULT_NON_STOP_NAME}</span>
                 </button>
                 <For each={groupsConfig().groups}>
                   {(group) => {

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -5,6 +5,7 @@ import {
   MAX_GROUP_MATCH_ID_LENGTH,
   compileGroupRegex,
   groupMatchId,
+  nonStopDisplayName,
   nonStopMatchesWorkgroup,
   workgroupGroupsStore,
   type WorkgroupGroupSelection,
@@ -138,7 +139,7 @@ const ProjectRailSection: Component<{
       );
       result.push({
         key: "nonstop",
-        ...buttonContent(nonStop.name || "Non-stop", workgroups),
+        ...buttonContent(nonStopDisplayName(nonStop.name), workgroups),
         selection: { kind: "nonstop" },
         workgroups,
         title: tooltipFor(workgroups),

--- a/src/sidebar/components/WorkgroupGroupsModal.tsx
+++ b/src/sidebar/components/WorkgroupGroupsModal.tsx
@@ -6,6 +6,7 @@ import type { NonStopGroupConfig, WorkgroupGroupsConfig } from "../../shared/typ
 import {
   MAX_GROUP_NAME_LENGTH,
   MAX_GROUP_REGEX_LENGTH,
+  DEFAULT_NON_STOP_NAME,
   createGroupId,
   defaultNonStop,
   exactGroupRegexForWorkgroup,
@@ -206,7 +207,7 @@ const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
                 onChange={(e) => setNonStop({ show: e.currentTarget.checked })}
                 data-ac-testid="workgroupGroups.nonstop.show"
               />
-              <span>Non-stop (watchdog)</span>
+              <span>{DEFAULT_NON_STOP_NAME} (watchdog)</span>
             </label>
             <div class="workgroup-group-edit-row">
               <input
@@ -214,7 +215,7 @@ const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
                 value={ns().name}
                 maxLength={MAX_GROUP_NAME_LENGTH}
                 onInput={(e) => setNonStop({ name: e.currentTarget.value })}
-                aria-label="Non-stop name"
+                aria-label={`${DEFAULT_NON_STOP_NAME} name`}
                 data-ac-testid="workgroupGroups.nonstop.name"
               />
               <input
@@ -222,7 +223,7 @@ const WorkgroupGroupsModal: Component<WorkgroupGroupsModalProps> = (props) => {
                 value={ns().regex}
                 maxLength={MAX_GROUP_REGEX_LENGTH}
                 onInput={(e) => setNonStop({ regex: e.currentTarget.value })}
-                aria-label="Non-stop regex"
+                aria-label={`${DEFAULT_NON_STOP_NAME} regex`}
                 data-ac-testid="workgroupGroups.nonstop.regex"
               />
             </div>

--- a/src/sidebar/stores/workgroup-groups.test.ts
+++ b/src/sidebar/stores/workgroup-groups.test.ts
@@ -234,6 +234,7 @@ describe("#777 Non-stop group", () => {
       telegram: { enabled: true, botId: "bot-1" },
       sound: { enabled: true, seconds: 999 },
     });
+    const legacyDefaultName = normalizeNonStop({ ...defaultNonStop(), name: " Non-stop " });
     expect(clamped).toMatchObject({
       show: true,
       name: "Watcher",
@@ -242,6 +243,8 @@ describe("#777 Non-stop group", () => {
       telegram: { enabled: true, botId: "bot-1" },
       sound: { enabled: true, seconds: 60 },
     });
+    expect(defaultNonStop().name).toBe("Alert me!");
+    expect(legacyDefaultName?.name).toBe("Alert me!");
     expect(normalizeNonStop(null)).toBeNull();
     expect(normalizeNonStop(undefined)).toBeUndefined();
   });

--- a/src/sidebar/stores/workgroup-groups.ts
+++ b/src/sidebar/stores/workgroup-groups.ts
@@ -17,7 +17,8 @@ export type WorkgroupGroupSelection =
 
 // #777 Non-stop group defaults + clamp bounds (mirror the Rust side in
 // project_settings.rs so both ends agree).
-export const DEFAULT_NON_STOP_NAME = "Non-stop";
+export const DEFAULT_NON_STOP_NAME = "Alert me!";
+const LEGACY_NON_STOP_NAME = "Non-stop";
 export const MATCH_NONE_REGEX = "(?!)";
 const MIN_TOLERANCE_SECONDS = 1;
 const MAX_TOLERANCE_SECONDS = 3600;
@@ -41,6 +42,16 @@ const saveVersions = new Map<string, number>();
 
 function charLength(value: string): number {
   return Array.from(value).length;
+}
+
+function normalizeNonStopName(name: string | null | undefined): string {
+  const trimmedName = (name ?? "").trim();
+  if (!trimmedName || trimmedName === LEGACY_NON_STOP_NAME) return DEFAULT_NON_STOP_NAME;
+  return Array.from(trimmedName).slice(0, MAX_GROUP_NAME_LENGTH).join("");
+}
+
+export function nonStopDisplayName(name: string | null | undefined): string {
+  return normalizeNonStopName(name);
 }
 
 function keyFor(projectPath: string): string {
@@ -85,10 +96,7 @@ export function normalizeNonStop(
 ): NonStopGroupConfig | null | undefined {
   if (nonStop === null) return null;
   if (nonStop === undefined) return undefined;
-  const trimmedName = (nonStop.name ?? "").trim();
-  const name = trimmedName
-    ? Array.from(trimmedName).slice(0, MAX_GROUP_NAME_LENGTH).join("")
-    : DEFAULT_NON_STOP_NAME;
+  const name = normalizeNonStopName(nonStop.name);
   const regex = nonStop.regex ?? "";
   let regexOk = charLength(regex) <= MAX_GROUP_REGEX_LENGTH;
   if (regexOk) {
@@ -345,12 +353,12 @@ export function validateGroupsConfig(
   // never trips the fatal reset-to-defaults path; normalizeNonStop repairs it there.
   if (config.nonStop && options.validateRegexSyntax) {
     if (charLength(config.nonStop.regex) > MAX_GROUP_REGEX_LENGTH) {
-      errors.push(`Non-stop: regex cannot exceed ${MAX_GROUP_REGEX_LENGTH} characters.`);
+      errors.push(`Alert me!: regex cannot exceed ${MAX_GROUP_REGEX_LENGTH} characters.`);
     } else {
       try {
         new RegExp(config.nonStop.regex);
       } catch {
-        errors.push("Non-stop: regex is invalid.");
+        errors.push("Alert me!: regex is invalid.");
       }
     }
   }
@@ -581,7 +589,7 @@ export const workgroupGroupsStore = {
     }
     const nextRegex = appendExactGroupToken(current.regex, wgName);
     if (nextRegex === null) {
-      const message = "Fix the Non-stop regex before adding a workgroup.";
+      const message = "Fix the Alert me! regex before adding a workgroup.";
       const key = keyFor(projectPath);
       setEntries(key, { ...ensureEntry(projectPath), error: message });
       throw new Error(message);

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2521,6 +2521,10 @@ html.light-theme .root-agent-avatar {
   text-overflow: ellipsis;
 }
 
+.session-context-group-option-nonstop span:last-child {
+  font-weight: 700;
+}
+
 .session-context-inline-create {
   display: flex;
   gap: 6px;

--- a/src/sidebar/watchdog/non-stop-watchdog-client.ts
+++ b/src/sidebar/watchdog/non-stop-watchdog-client.ts
@@ -1,7 +1,7 @@
 import { createEffect, onCleanup } from "solid-js";
 import { NonStopAPI } from "../../shared/ipc";
 import type { NonStopReport } from "../../shared/types";
-import { workgroupGroupsStore, nonStopMatchesWorkgroup } from "../stores/workgroup-groups";
+import { workgroupGroupsStore, nonStopDisplayName, nonStopMatchesWorkgroup } from "../stores/workgroup-groups";
 import { workgroupIsWorking } from "../components/workgroup-session";
 import { projectStore } from "../stores/project";
 
@@ -36,7 +36,7 @@ export function buildSnapshot(): NonStopReport[] {
     const working = total - notWorking.length;
     reports.push({
       projectPath: project.path,
-      groupName: ns.name || "Non-stop",
+      groupName: nonStopDisplayName(ns.name),
       disparity: working < total,
       working,
       total,


### PR DESCRIPTION
## Summary
- Rename the built-in Non-stop group/watchdog display label to Alert me! across app user-facing surfaces.
- Preserve internal nonStop/non_stop/NonStop identifiers, persisted keys, behavior, and legacy migration.
- Keep the built-in group assignment flyout option bold without affecting user-created groups.

## Verification
- Frontend implementation reported: `npx tsc --noEmit`; targeted vitest suite for workgroup groups, ProjectPanel group filter, group rail, modal, and watchdog client; `git diff --check`.
- Backend implementation reported: `cargo test normalize_migrates_legacy_non_stop_default_name`; `cargo check`; `cargo clippy -- -D warnings`; `git diff --check`.
- Grinch review: PASS, static review of branch vs `origin/main`, residual user-facing string sweep, behavior/persistence/API/selector review, `git diff --check`.
- Post-merge visual shipper build: pending per visual-change workflow.

Closes #799