### PR TITLE
fix(#801): make test-debt checker comment-masking string-aware

### DIFF
--- a/scripts/check-test-debt.mjs
+++ b/scripts/check-test-debt.mjs
@@ -41,9 +41,131 @@ function blankPreserveNewlines(text) {
   return text.replace(/[^\n\r]/g, ' ');
 }
 
-function maskComments(source) {
+function isIdentifierChar(ch) {
+  return ch !== undefined && /[A-Za-z0-9_]/.test(ch);
+}
+
+function isTokenBoundary(source, index) {
+  return index === 0 || !isIdentifierChar(source[index - 1]);
+}
+
+function rustRawStringStop(source, index) {
+  if (!isTokenBoundary(source, index)) return -1;
+  let markerStart;
+  if (source[index] === 'r') {
+    markerStart = index + 1;
+  } else if (source[index] === 'b' && source[index + 1] === 'r') {
+    markerStart = index + 2;
+  } else {
+    return -1;
+  }
+
+  let quote = markerStart;
+  while (source[quote] === '#') quote += 1;
+  if (source[quote] !== '"') return -1;
+
+  const hashes = source.slice(markerStart, quote);
+  const terminator = `"${hashes}`;
+  const end = source.indexOf(terminator, quote + 1);
+  return end === -1 ? source.length : end + terminator.length;
+}
+
+function quotedStringStop(source, index, quote) {
+  let i = index + 1;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    i += 1;
+    if (ch === quote) return i;
+  }
+  return source.length;
+}
+
+function rustCharLiteralStop(source, index) {
+  if (source[index] !== '\'') return -1;
+  let i = index + 1;
+  if (i >= source.length || source[i] === '\n' || source[i] === '\r') return -1;
+
+  if (source[i] === '\\') {
+    i += 1;
+    if (i >= source.length || source[i] === '\n' || source[i] === '\r') return -1;
+    if (source[i] === 'x') {
+      i += 1;
+      for (let count = 0; count < 2; count += 1) {
+        if (!/[0-9A-Fa-f]/.test(source[i] ?? '')) return -1;
+        i += 1;
+      }
+    } else if (source[i] === 'u' && source[i + 1] === '{') {
+      i += 2;
+      while (i < source.length && source[i] !== '}') {
+        if (source[i] === '\n' || source[i] === '\r') return -1;
+        i += 1;
+      }
+      if (source[i] !== '}') return -1;
+      i += 1;
+    } else {
+      i += 1;
+    }
+  } else {
+    i += 1;
+  }
+
+  return source[i] === '\'' ? i + 1 : -1;
+}
+
+function appendLiteral(out, source, start, stop, maskStrings) {
+  const slice = source.slice(start, stop);
+  return out + (maskStrings ? blankPreserveNewlines(slice) : slice);
+}
+
+function maskSource(source, options = {}) {
+  const maskStrings = options.maskStrings ?? false;
+  const singleQuote = options.singleQuote ?? true;
   let out = '';
   for (let i = 0; i < source.length;) {
+    const rawStop = rustRawStringStop(source, i);
+    if (rawStop !== -1) {
+      out = appendLiteral(out, source, i, rawStop, maskStrings);
+      i = rawStop;
+      continue;
+    }
+
+    if (isTokenBoundary(source, i) && source[i] === 'b' && source[i + 1] === '"') {
+      const stop = quotedStringStop(source, i + 1, '"');
+      out = appendLiteral(out, source, i, stop, maskStrings);
+      i = stop;
+      continue;
+    }
+
+    if (isTokenBoundary(source, i) && source[i] === 'b' && source[i + 1] === '\'') {
+      const stop = rustCharLiteralStop(source, i + 1);
+      if (stop !== -1) {
+        out = appendLiteral(out, source, i, stop, maskStrings);
+        i = stop;
+        continue;
+      }
+    }
+
+    const ch = source[i];
+    if (ch === '"' || ch === '`' || (singleQuote && ch === '\'')) {
+      const stop = quotedStringStop(source, i, ch);
+      out = appendLiteral(out, source, i, stop, maskStrings);
+      i = stop;
+      continue;
+    }
+
+    if (!singleQuote && ch === '\'') {
+      const stop = rustCharLiteralStop(source, i);
+      if (stop !== -1) {
+        out = appendLiteral(out, source, i, stop, maskStrings);
+        i = stop;
+        continue;
+      }
+    }
+
     if (source.startsWith('//', i)) {
       const end = source.indexOf('\n', i);
       if (end === -1) {
@@ -67,71 +189,12 @@ function maskComments(source) {
   return out;
 }
 
+function maskComments(source) {
+  return maskSource(source, { maskStrings: false });
+}
+
 function maskCommentsAndStrings(source, options = {}) {
-  const singleQuote = options.singleQuote ?? true;
-  const noComments = maskComments(source);
-  let out = '';
-  for (let i = 0; i < noComments.length;) {
-    const ch = noComments[i];
-    if ((ch === 'r' || (ch === 'b' && noComments[i + 1] === 'r')) && /[br#"]/.test(noComments[i + 1] ?? '')) {
-      const start = ch === 'b' ? i + 2 : i + 1;
-      let j = start;
-      while (noComments[j] === '#') j += 1;
-      if (noComments[j] === '"') {
-        const hashes = noComments.slice(start, j);
-        const terminator = `"${hashes}`;
-        const contentStart = j + 1;
-        const end = noComments.indexOf(terminator, contentStart);
-        const stop = end === -1 ? noComments.length : end + terminator.length;
-        out += noComments.slice(i, contentStart).replace(/[^\n\r]/g, ' ');
-        out += blankPreserveNewlines(noComments.slice(contentStart, stop));
-        i = stop;
-        continue;
-      }
-    }
-    if (ch === 'b' && noComments[i + 1] === '"') {
-      out += '  ';
-      i += 2;
-      while (i < noComments.length) {
-        const c = noComments[i];
-        if (c === '\\') {
-          out += ' ';
-          if (i + 1 < noComments.length) {
-            out += noComments[i + 1] === '\n' ? '\n' : ' ';
-          }
-          i += 2;
-          continue;
-        }
-        out += c === '\n' || c === '\r' ? c : ' ';
-        i += 1;
-        if (c === '"') break;
-      }
-      continue;
-    }
-    if (ch === '"' || (singleQuote && ch === '\'') || ch === '`') {
-      const quote = ch;
-      out += ch;
-      i += 1;
-      while (i < noComments.length) {
-        const c = noComments[i];
-        if (c === '\\') {
-          out += ' ';
-          if (i + 1 < noComments.length) {
-            out += noComments[i + 1] === '\n' ? '\n' : ' ';
-          }
-          i += 2;
-          continue;
-        }
-        out += c === '\n' || c === '\r' ? c : ' ';
-        i += 1;
-        if (c === quote) break;
-      }
-      continue;
-    }
-    out += ch;
-    i += 1;
-  }
-  return out;
+  return maskSource(source, { ...options, maskStrings: true });
 }
 
 function findMatchingBrace(masked, openIndex) {
@@ -644,6 +707,20 @@ function selfTest() {
 fn clean_rust() {
     assert_eq!(1, 1);
 }
+
+#[test]
+fn string_with_line_comment_marker_is_not_placeholder() {
+    let s = "see https://example.com/x for detail";
+    assert_eq!(s.len() > 0, true);
+}
+
+#[test]
+fn string_with_block_comment_marker_is_not_placeholder() {
+    let s = "literal /* marker */ stays data";
+    let raw = r#"raw /* marker */ and https://example.com/x"#;
+    assert_eq!(s.len() > 0, true);
+    assert_eq!(raw.len() > 0, true);
+}
 `);
     writeFile(path.join(root, 'src/clean.test.ts'), `
 import { describe, expect, it } from "vitest";
@@ -655,6 +732,14 @@ describe("clean suite", () => {
 `);
     let result = runFixture(root);
     assertSelf(result.code === 0, 'clean fixture should pass');
+    assertSelf(
+      !result.findings.some((f) => f.category === 'placeholder-rust-test' && f.id.endsWith('clean.rs::string_with_line_comment_marker_is_not_placeholder')),
+      'line comment marker in Rust string false positive detected',
+    );
+    assertSelf(
+      !result.findings.some((f) => f.category === 'placeholder-rust-test' && f.id.endsWith('clean.rs::string_with_block_comment_marker_is_not_placeholder')),
+      'block comment marker in Rust string false positive detected',
+    );
 
     writeFile(path.join(root, 'src-tauri/tests/ignored.rs'), `
 #[test]


### PR DESCRIPTION
Fixes the `test-debt` CI gate false-positive introduced by #791 (commit `27d3c3b`). The new API-error test `scrub_does_not_treat_url_as_drive_path` (`src-tauri/src/api/error.rs`) is real and passing, but its string literal contains `https://`. `scripts/check-test-debt.mjs` stripped comments **before** masking string literals, so the `//` in the URL was treated as a line comment — blanking the string close and the fn's closing brace. `findMatchingBrace` then fell back and mis-reported the test as an unallowlisted `placeholder-rust-test` (plus a `close brace not found` parse-warning). The gate scans the whole repo and runs **only on PRs, never on push to main**, so the #791 merge slipped this onto `main` un-gated and it now blocks every new PR.

## Fix (root cause)
Replaced the comment-first masking with a single scanner that strips comments only **outside** literals — recognizing ordinary/byte/raw Rust strings (`r#"..."#`), char/byte-char literals, and frontend template strings. Detection/classification (placeholder/ignored/frontend, brace matching) is byte-identical to `main`; only the mask primitive changed. `src-tauri/src/api/error.rs` is untouched.

Extended the checker's `--self-test` with fixtures whose bodies contain `//`, `/* */`, and a raw string with both — asserting they are NOT flagged as placeholders (regression guard for the class).

## Verification
- **dev-rust**: `node scripts/check-test-debt.mjs` exit 1 (repro) → exit 0 after; `--self-test` pass; `cargo test --lib api::error` 5/5 (incl. the previously-flagged test); `cargo check` + `clippy --lib -D warnings` clean.
- **grinch (independent, adversarial)**: re-ran from clean `8b68b36`; exact-delta = exactly one finding vanished (the false positive), ignored unchanged (12); a hostile false-negative probe could not slip genuine debt (empty / `todo!()` / `unimplemented!()` / comment-only / raw-string phantom / frontend skip+placeholder) past the rewrite; unterminated literals fail closed; 1 masking pass vs 2 (not slower). **PASS.**

Scope: `scripts/check-test-debt.mjs` only (+150/−65). CI-tooling change, non-visual, no version bump.

Closes #801.
