### PR TITLE
fix(sidebar): APPLY TO scope counters compute correct counts for all scopes (#800)

### DIFF
--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -554,6 +554,11 @@ describe("AgentPickerModal", () => {
     expect(target("agentPicker.scope.replica")).toBeTruthy();
     expect(target("agentPicker.scope.kind")).toBeTruthy();
     expect(target("agentPicker.scope.workgroup")).toBeTruthy();
+    // #800: all three broad-scope previews are fetched up front, so each
+    // radio button shows its true targetCount (not 0 for the unselected ones).
+    expect(text("agentPicker.scope.replica")).toContain("1 replica");
+    expect(text("agentPicker.scope.kind")).toContain("3 replicas");
+    expect(text("agentPicker.scope.workgroup")).toContain("4 replicas");
     // Replica scope is safe → apply enabled immediately.
     expect(target<HTMLButtonElement>("agentPicker.apply").disabled).toBe(false);
 
@@ -673,7 +678,7 @@ describe("AgentPickerModal", () => {
     target<HTMLInputElement>("agentPicker.restartToggle").click();
     await settle();
 
-    expect(mockSettingsApi.previewCodingAgentProfileSelection).toHaveBeenLastCalledWith(
+    expect(mockSettingsApi.previewCodingAgentProfileSelection).toHaveBeenCalledWith(
       expect.objectContaining({ scope: "kind", restartSessions: true }),
     );
 

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -119,9 +119,31 @@ const AgentPickerModal: Component<{
   const [selectedScope, setSelectedScope] = createSignal<ProfileAssignmentScope>("replica");
   const [restartSessions, setRestartSessions] = createSignal(false);
   const [dangerArmed, setDangerArmed] = createSignal(false);
-  const [scopePreview, setScopePreview] = createSignal<PreviewCodingAgentProfileSelectionResult | null>(null);
-  const [scopePreviewBusy, setScopePreviewBusy] = createSignal(false);
-  const [scopePreviewError, setScopePreviewError] = createSignal("");
+  // #800: previews are kept per-scope so every radio button can display its
+  // true targetCount, not just the currently selected scope. The selected
+  // scope's slot is exposed via the `scopePreview` memo below so existing
+  // readers (apply, fingerprint, target review, warnings) are unchanged.
+  const emptyScopePreviews: Record<ProfileAssignmentScope, PreviewCodingAgentProfileSelectionResult | null> = {
+    replica: null,
+    kind: null,
+    workgroup: null,
+  };
+  const emptyScopeBusy: Record<ProfileAssignmentScope, boolean> = {
+    replica: false,
+    kind: false,
+    workgroup: false,
+  };
+  const emptyScopeErrors: Record<ProfileAssignmentScope, string> = {
+    replica: "",
+    kind: "",
+    workgroup: "",
+  };
+  const [scopePreviews, setScopePreviews] = createSignal<Record<ProfileAssignmentScope, PreviewCodingAgentProfileSelectionResult | null>>({ ...emptyScopePreviews });
+  const [scopePreviewBusyMap, setScopePreviewBusyMap] = createSignal<Record<ProfileAssignmentScope, boolean>>({ ...emptyScopeBusy });
+  const [scopePreviewErrorMap, setScopePreviewErrorMap] = createSignal<Record<ProfileAssignmentScope, string>>({ ...emptyScopeErrors });
+  const scopePreview = createMemo(() => scopePreviews()[selectedScope()]);
+  const scopePreviewBusy = createMemo(() => scopePreviewBusyMap()[selectedScope()]);
+  const scopePreviewError = createMemo(() => scopePreviewErrorMap()[selectedScope()]);
   const [applyErrors, setApplyErrors] = createSignal<ProfileAssignmentError[]>([]);
   // #537: transient toast so an assign failure is loud and unmissable (the
   // persistent banner below keeps the actionable detail once the toast fades).
@@ -129,7 +151,10 @@ const AgentPickerModal: Component<{
 
   let overlayRef!: HTMLDivElement;
   let profileResolveSeq = 0;
-  let previewSeq = 0;
+  // #800: per-scope race guard so a slow preview for one scope can't overwrite
+  // another scope's slot. Bumped in the createEffect (all three) and in
+  // runScopePreview (the scope being fetched).
+  let previewSeqByScope: Record<ProfileAssignmentScope, number> = { replica: 0, kind: 0, workgroup: 0 };
   let toastTimer: ReturnType<typeof setTimeout> | null = null;
 
   // #537: mirror the SidebarApp/SettingsModal toast pattern (.toast-error,
@@ -366,9 +391,9 @@ const AgentPickerModal: Component<{
   const runScopePreview = (scope: ProfileAssignmentScope, agentId: string, profile: string) => {
     const target = targetReplicaPath();
     if (!target || !isWgReplica()) return;
-    const seq = ++previewSeq;
-    setScopePreviewBusy(true);
-    setScopePreviewError("");
+    const seq = ++previewSeqByScope[scope];
+    setScopePreviewBusyMap((prev) => ({ ...prev, [scope]: true }));
+    setScopePreviewErrorMap((prev) => ({ ...prev, [scope]: "" }));
     SettingsAPI.previewCodingAgentProfileSelection({
       targetReplicaPath: target,
       codingAgentId: agentId,
@@ -377,16 +402,16 @@ const AgentPickerModal: Component<{
       restartSessions: restartSessions(),
     })
       .then((result) => {
-        if (seq !== previewSeq) return;
-        setScopePreview(result);
+        if (seq !== previewSeqByScope[scope]) return;
+        setScopePreviews((prev) => ({ ...prev, [scope]: result }));
       })
       .catch((err: unknown) => {
-        if (seq !== previewSeq) return;
-        setScopePreview(null);
-        setScopePreviewError(err instanceof Error ? err.message : String(err));
+        if (seq !== previewSeqByScope[scope]) return;
+        setScopePreviews((prev) => ({ ...prev, [scope]: null }));
+        setScopePreviewErrorMap((prev) => ({ ...prev, [scope]: err instanceof Error ? err.message : String(err) }));
       })
       .finally(() => {
-        if (seq === previewSeq) setScopePreviewBusy(false);
+        if (seq === previewSeqByScope[scope]) setScopePreviewBusyMap((prev) => ({ ...prev, [scope]: false }));
       });
   };
 
@@ -398,16 +423,23 @@ const AgentPickerModal: Component<{
     restartSessions();
     targetReplicaPath();
 
-    // Reset every transient confirmation/preview artifact on any input change.
-    previewSeq += 1;
+    // #800: invalidate all in-flight previews and reset transient artifacts.
+    previewSeqByScope.replica += 1;
+    previewSeqByScope.kind += 1;
+    previewSeqByScope.workgroup += 1;
     setDangerArmed(false);
-    setScopePreview(null);
-    setScopePreviewError("");
+    setScopePreviews({ ...emptyScopePreviews });
+    setScopePreviewErrorMap({ ...emptyScopeErrors });
     setApplyErrors([]);
-    setScopePreviewBusy(false);
+    setScopePreviewBusyMap({ ...emptyScopeBusy });
 
     if (!agent || !isWgReplica()) return;
-    runScopePreview(scope, agent.id, profile);
+    // Fetch all three broad-scope previews up front so each radio button
+    // displays its true targetCount (#800). The selected scope's slot drives
+    // apply, fingerprint, and the target review list (via `scopePreview`).
+    runScopePreview("replica", agent.id, profile);
+    runScopePreview("kind", agent.id, profile);
+    runScopePreview("workgroup", agent.id, profile);
   });
 
   const moveProfile = (delta: number) => {
@@ -429,9 +461,11 @@ const AgentPickerModal: Component<{
   };
 
   const scopeCount = (scope: ProfileAssignmentScope): number => {
-    const preview = scopePreview();
-    if (preview && selectedScope() === scope) return preview.targetCount;
-    return scope === "replica" ? 1 : 0;
+    // #800: replica scope is always exactly 1 (the target itself). For kind
+    // and workgroup, read the per-scope preview slot so the count is correct
+    // even before the user selects that scope.
+    if (scope === "replica") return 1;
+    return scopePreviews()[scope]?.targetCount ?? 0;
   };
 
   const scopeReplicaNoun = (count: number) => count === 1 ? "replica" : "replicas";
@@ -564,7 +598,7 @@ const AgentPickerModal: Component<{
           const extra = result.errors.length - 1;
           showToast(extra > 0 ? `${firstError.message} (+${extra} more)` : firstError.message);
           setDangerArmed(false);
-          if (scope !== "replica") setScopePreview(null);
+          if (scope !== "replica") setScopePreviews((prev) => ({ ...prev, [scope]: null }));
           setBusy(false);
           runScopePreview(scope, agent.id, selectedProfile());
           return;
@@ -591,7 +625,7 @@ const AgentPickerModal: Component<{
       showToast(message);
       if (scope !== "replica" && target && isWgReplica()) {
         setDangerArmed(false);
-        setScopePreview(null);
+        setScopePreviews((prev) => ({ ...prev, [scope]: null }));
         runScopePreview(scope, agent.id, selectedProfile());
       }
       setBusy(false);


### PR DESCRIPTION
## Summary

Fixes the "APPLY TO" scope selector in the Agent Picker modal, where **All replicas of this kind** and **Entire workgroup** always displayed `0 replicas` while **This replica** showed `1`.

Root cause was frontend-only: `scopeCount()` fetched the backend preview for the currently-selected scope only, and the two non-selected scopes fell through to a placeholder (`scope === "replica" ? 1 : 0`). The backend already returns correct per-scope counts.

## Fix (frontend-only, `src/sidebar/components/AgentPickerModal.tsx` + test)

- Replaced the single `scopePreview` signal with per-scope maps keyed by `ProfileAssignmentScope`; derived memos read the selected scope's slot so ~15 downstream readers stay unchanged.
- `createEffect` now fetches all three broad-scope previews up front (only when `isWgReplica()` is true), each with a per-scope race guard (`previewSeqByScope`).
- `scopeCount`: `replica` → 1; `kind`/`workgroup` read their per-scope slot.
- Apply-error paths clear only the selected scope's slot.
- No backend/Rust changes. Non-WG replicas unaffected (broad scopes not rendered there).

## Verification

- `npx tsc --noEmit` — clean (dev + grinch).
- `AgentPickerModal.test.tsx` — 34/34 pass, including new per-scope count assertions.
- **Adversarial review (dev-rust-grinch): PASS** — race guards, slot-clearing semantics, derived-memo refactor (all read sites), non-WG path, and 3x IPC error isolation all verified correct. No correctness bugs; only non-blocking UX nits.

Closes #800