### PR TITLE
fix: browser-remote project loading — route project commands in web dispatcher + create-from-desktop modal

### DIFF
--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -1332,9 +1332,14 @@ pub async fn discover_ac_agents(
 }
 
 /// Check if a folder has a Project AC Root subdirectory.
+pub(crate) fn check_project_path_inner(path: &str) -> bool {
+    existing_workspace_dir(Path::new(path)).is_some()
+}
+
+/// Check if a folder has a Project AC Root subdirectory.
 #[tauri::command]
 pub async fn check_project_path(path: String) -> Result<bool, String> {
-    Ok(existing_workspace_dir(Path::new(&path)).is_some())
+    Ok(check_project_path_inner(&path))
 }
 
 /// Ensure the Project AC Root .gitignore exists and contains all required exclusion patterns.
@@ -1461,7 +1466,26 @@ pub async fn discover_project(
     branch_watcher: State<'_, Arc<DiscoveryBranchWatcher>>,
     coordinator_clocks: State<'_, crate::config::coordinator_clocks::CoordinatorClocksState>,
 ) -> Result<AcDiscoveryResult, String> {
-    let base = Path::new(&path);
+    discover_project_inner(
+        &app,
+        session_mgr.inner(),
+        &path,
+        settings.inner(),
+        branch_watcher.inner(),
+        coordinator_clocks.inner(),
+    )
+    .await
+}
+
+pub(crate) async fn discover_project_inner(
+    app: &AppHandle,
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+    path: &str,
+    settings: &SettingsState,
+    branch_watcher: &Arc<DiscoveryBranchWatcher>,
+    coordinator_clocks: &crate::config::coordinator_clocks::CoordinatorClocksState,
+) -> Result<AcDiscoveryResult, String> {
+    let base = Path::new(path);
     if !base.is_dir() {
         return Err(format!("Path is not a directory: {}", path));
     }
@@ -1790,7 +1814,7 @@ pub async fn discover_project(
 
     drop(cfg);
     // Update the branch watcher for THIS project only.
-    branch_watcher.update_replicas_for_project(&path, &workgroups);
+    branch_watcher.update_replicas_for_project(path, &workgroups);
 
     // Recompute coordinator flags on every live session against the hoisted team
     // snapshot. Spawned (not awaited) so populating the project tree NEVER blocks on
@@ -1802,7 +1826,7 @@ pub async fn discover_project(
     // the coordinator-flag events flowing.
     {
         let coordinator_app = app.clone();
-        let coordinator_session_mgr = Arc::clone(session_mgr.inner());
+        let coordinator_session_mgr = Arc::clone(session_mgr);
         tokio::spawn(async move {
             let changes = {
                 let mgr = coordinator_session_mgr.read().await;
@@ -1938,10 +1962,9 @@ pub async fn set_replica_context_files(path: String, files: Vec<String>) -> Resu
 /// Holds the SettingsState write lock through `save_settings` — same pattern
 /// as `set_inject_rtk_hook` (`src-tauri/src/commands/config.rs:184-194`) — so
 /// concurrent `update_settings` calls cannot race.
-#[tauri::command]
-pub async fn open_project(
-    settings: State<'_, SettingsState>,
-    path: String,
+pub(crate) async fn open_project_inner(
+    settings: &SettingsState,
+    path: &str,
 ) -> Result<crate::config::projects::ProjectRegistration, String> {
     let mut s = settings.write().await;
     // #778: reconcile project_paths from disk BEFORE the upsert so a concurrent
@@ -1949,12 +1972,20 @@ pub async fn open_project(
     // verbatim (project_paths is disk-authoritative under Design S). Aborts on a
     // non-NotFound read error (G2) rather than registering against a stale list.
     crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
-    let result = crate::config::projects::register_existing_project(&mut s, &path)
+    let result = crate::config::projects::register_existing_project(&mut s, path)
         .map_err(|e| e.to_string())?;
     let snapshot = s.clone();
     crate::config::settings::save_settings_with_project_paths(&snapshot)?;
     drop(s); // explicit; lock released AFTER the disk write completes
     Ok(result)
+}
+
+#[tauri::command]
+pub async fn open_project(
+    settings: State<'_, SettingsState>,
+    path: String,
+) -> Result<crate::config::projects::ProjectRegistration, String> {
+    open_project_inner(settings.inner(), &path).await
 }
 
 /// Ensure an AC project at `path` (creating `.ac/` if missing) and
@@ -1987,18 +2018,25 @@ pub async fn new_project(
 /// `normalize_for_compare` key matches `path`, re-derive the head, and write the
 /// deliberate list verbatim. Removing against the FRESH disk list means a
 /// CLI-appended entry the sidebar never showed is preserved, not dropped.
+pub(crate) async fn remove_project_inner(
+    settings: &SettingsState,
+    path: &str,
+) -> Result<(), String> {
+    let mut s = settings.write().await;
+    crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
+    crate::config::projects::remove_project_path(&mut s, path);
+    let snapshot = s.clone();
+    crate::config::settings::save_settings_with_project_paths(&snapshot)?;
+    drop(s); // explicit; lock released AFTER the disk write completes
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn remove_project(
     settings: State<'_, SettingsState>,
     path: String,
 ) -> Result<(), String> {
-    let mut s = settings.write().await;
-    crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
-    crate::config::projects::remove_project_path(&mut s, &path);
-    let snapshot = s.clone();
-    crate::config::settings::save_settings_with_project_paths(&snapshot)?;
-    drop(s); // explicit; lock released AFTER the disk write completes
-    Ok(())
+    remove_project_inner(settings.inner(), &path).await
 }
 
 type TaskFields = (Option<String>, Option<String>);

--- a/src-tauri/src/commands/project_settings.rs
+++ b/src-tauri/src/commands/project_settings.rs
@@ -4,9 +4,20 @@ use crate::config::project_settings::{
     load_workgroup_groups, save_workgroup_groups, WorkgroupGroupsConfig,
 };
 
+pub(crate) fn get_project_groups_inner(path: &str) -> Result<WorkgroupGroupsConfig, String> {
+    load_workgroup_groups(Path::new(path))
+}
+
 #[tauri::command]
 pub async fn get_project_groups(path: String) -> Result<WorkgroupGroupsConfig, String> {
-    load_workgroup_groups(Path::new(&path))
+    get_project_groups_inner(&path)
+}
+
+pub(crate) fn update_project_groups_inner(
+    path: &str,
+    config: WorkgroupGroupsConfig,
+) -> Result<WorkgroupGroupsConfig, String> {
+    save_workgroup_groups(Path::new(path), config)
 }
 
 #[tauri::command]
@@ -14,7 +25,7 @@ pub async fn update_project_groups(
     path: String,
     config: WorkgroupGroupsConfig,
 ) -> Result<WorkgroupGroupsConfig, String> {
-    save_workgroup_groups(Path::new(&path), config)
+    update_project_groups_inner(&path, config)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -20,6 +20,42 @@ pub struct WsState {
     pub app_handle: tauri::AppHandle,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BrowserProjectCommand {
+    CheckProjectPath,
+    DiscoverProject,
+    GetProjectGroups,
+    UpdateProjectGroups,
+    OpenProject,
+    RemoveProject,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WebCommandRoute {
+    BrowserProject(BrowserProjectCommand),
+    Other,
+}
+
+fn route_web_command(cmd: &str) -> WebCommandRoute {
+    match cmd {
+        "check_project_path" => {
+            WebCommandRoute::BrowserProject(BrowserProjectCommand::CheckProjectPath)
+        }
+        "discover_project" => {
+            WebCommandRoute::BrowserProject(BrowserProjectCommand::DiscoverProject)
+        }
+        "get_project_groups" => {
+            WebCommandRoute::BrowserProject(BrowserProjectCommand::GetProjectGroups)
+        }
+        "update_project_groups" => {
+            WebCommandRoute::BrowserProject(BrowserProjectCommand::UpdateProjectGroups)
+        }
+        "open_project" => WebCommandRoute::BrowserProject(BrowserProjectCommand::OpenProject),
+        "remove_project" => WebCommandRoute::BrowserProject(BrowserProjectCommand::RemoveProject),
+        _ => WebCommandRoute::Other,
+    }
+}
+
 /// Dispatch a WebSocket JSON command and return the result as JSON.
 /// Format: { "id": N, "cmd": "command_name", "args": { ... } }
 /// Returns: { "id": N, "result": ... } or { "id": N, "error": "..." }
@@ -31,6 +67,10 @@ pub async fn dispatch(state: &WsState, id: u64, cmd: &str, args: &Value) -> Valu
 }
 
 async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Value, String> {
+    if let WebCommandRoute::BrowserProject(project_cmd) = route_web_command(cmd) {
+        return dispatch_browser_project_command(state, project_cmd, args).await;
+    }
+
     match cmd {
         // --- Session commands ---
         "list_sessions" => {
@@ -495,6 +535,72 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
     }
 }
 
+async fn dispatch_browser_project_command(
+    state: &WsState,
+    cmd: BrowserProjectCommand,
+    args: &Value,
+) -> Result<Value, String> {
+    match cmd {
+        BrowserProjectCommand::CheckProjectPath => {
+            let path = require_str(args, "path")?;
+            Ok(json!(
+                crate::commands::ac_discovery::check_project_path_inner(&path)
+            ))
+        }
+
+        BrowserProjectCommand::DiscoverProject => {
+            let path = require_str(args, "path")?;
+            let branch_watcher = state
+                .app_handle
+                .state::<Arc<crate::commands::ac_discovery::DiscoveryBranchWatcher>>();
+            let coordinator_clocks = state
+                .app_handle
+                .state::<crate::config::coordinator_clocks::CoordinatorClocksState>(
+            );
+
+            let result = crate::commands::ac_discovery::discover_project_inner(
+                &state.app_handle,
+                &state.session_mgr,
+                &path,
+                &state.settings,
+                branch_watcher.inner(),
+                coordinator_clocks.inner(),
+            )
+            .await?;
+
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+
+        BrowserProjectCommand::GetProjectGroups => {
+            let path = require_str(args, "path")?;
+            let result = crate::commands::project_settings::get_project_groups_inner(&path)?;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+
+        BrowserProjectCommand::UpdateProjectGroups => {
+            let path = require_str(args, "path")?;
+            let config: crate::config::project_settings::WorkgroupGroupsConfig =
+                require_json(args, "config")?;
+            let result =
+                crate::commands::project_settings::update_project_groups_inner(&path, config)?;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+
+        BrowserProjectCommand::OpenProject => {
+            let path = require_str(args, "path")?;
+            let result =
+                crate::commands::ac_discovery::open_project_inner(&state.settings, &path).await?;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+
+        BrowserProjectCommand::RemoveProject => {
+            let path = require_str(args, "path")?;
+            crate::commands::ac_discovery::remove_project_inner(&state.settings, &path).await?;
+            Ok(json!(null))
+        }
+    }
+}
+
 /// Emit event to both Tauri windows and WebSocket clients.
 pub fn broadcast_all(
     app: &tauri::AppHandle,
@@ -515,6 +621,17 @@ fn require_str(args: &Value, key: &str) -> Result<String, String> {
         .ok_or_else(|| format!("Missing required field: {}", key))
 }
 
+fn require_json<T>(args: &Value, key: &str) -> Result<T, String>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let value = args
+        .get(key)
+        .cloned()
+        .ok_or_else(|| format!("Missing required field: {}", key))?;
+    serde_json::from_value(value).map_err(|e| format!("Invalid field {}: {}", key, e))
+}
+
 fn str_or(args: &Value, key: &str, default: &str) -> String {
     args.get(key)
         .and_then(|v| v.as_str())
@@ -531,4 +648,49 @@ fn str_vec_or(args: &Value, key: &str, default: &[String]) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_else(|| default.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_project_commands_route_before_unknown_fallback() {
+        let expected = [
+            ("open_project", BrowserProjectCommand::OpenProject),
+            ("discover_project", BrowserProjectCommand::DiscoverProject),
+            (
+                "check_project_path",
+                BrowserProjectCommand::CheckProjectPath,
+            ),
+            ("remove_project", BrowserProjectCommand::RemoveProject),
+            (
+                "get_project_groups",
+                BrowserProjectCommand::GetProjectGroups,
+            ),
+            (
+                "update_project_groups",
+                BrowserProjectCommand::UpdateProjectGroups,
+            ),
+        ];
+
+        for (command, route) in expected {
+            assert_eq!(
+                route_web_command(command),
+                WebCommandRoute::BrowserProject(route),
+                "{command} should be routed before Unknown command"
+            );
+        }
+    }
+
+    #[test]
+    fn deferred_and_cli_project_commands_are_not_web_commands() {
+        assert_eq!(
+            route_web_command("create_ac_project"),
+            WebCommandRoute::Other
+        );
+        assert_eq!(route_web_command("new_project"), WebCommandRoute::Other);
+        assert_eq!(route_web_command("open-project"), WebCommandRoute::Other);
+        assert_eq!(route_web_command("new-project"), WebCommandRoute::Other);
+    }
 }

--- a/src/sidebar/components/ActionBar.test.ts
+++ b/src/sidebar/components/ActionBar.test.ts
@@ -16,6 +16,7 @@ const mockState = vi.hoisted(() => ({
     themeLight: true,
     specBoardEnabled: false,
   } as { soundsEnabled: boolean; themeLight: boolean; specBoardEnabled: boolean } | null,
+  isBrowser: false,
 }));
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
@@ -87,6 +88,12 @@ vi.mock("../../shared/sound", () => ({
   setSoundsEnabled: vi.fn(),
 }));
 
+vi.mock("../../shared/platform", () => ({
+  get isBrowser() {
+    return mockState.isBrowser;
+  },
+}));
+
 vi.mock("../../main/stores/home", () => ({
   homeStore: {
     visible: false,
@@ -99,6 +106,7 @@ vi.mock("./SettingsModal", () => ({
 }));
 
 import ActionBar from "./ActionBar";
+import { projectStore } from "../stores/project";
 import {
   centralViewStore,
   __resetCentralViewStoreForTests,
@@ -123,6 +131,7 @@ describe("ActionBar selected workgroup visibility toggle", () => {
     mockState.sessions.hydrated = true;
     mockState.sessions.toggleInFlight = false;
     mockState.sessions.coordSortByActivity = false;
+    mockState.isBrowser = false;
     mockState.settings = {
       soundsEnabled: true,
       themeLight: true,
@@ -204,6 +213,78 @@ describe("ActionBar selected workgroup visibility toggle", () => {
     expect(themeButton.textContent).toContain("🌙");
     expect(themeButton.textContent).not.toContain("☀");
     expect(themeButton.getAttribute("data-ac-state")).toBe("disabled");
+
+    dispose();
+  });
+
+  it("shows the browser create-project notice without invoking the folder picker flow", () => {
+    mockState.isBrowser = true;
+    const { dispose } = renderActionBar();
+    const dropdownButton = document.body.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="actionBar.newOpen"]'
+    );
+    if (!dropdownButton) throw new Error("new/open dropdown button not rendered");
+
+    dropdownButton.click();
+
+    const newProjectItem = document.body.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="actionBar.menu.newProject"]'
+    );
+    if (!newProjectItem) throw new Error("new project menu item not rendered");
+
+    newProjectItem.click();
+
+    expect(projectStore.pickAndCheck).not.toHaveBeenCalled();
+    const modal = document.body.querySelector<HTMLElement>(
+      '[data-ac-testid="project.browserCreateNotice.dialog"]'
+    );
+    expect(modal).not.toBeNull();
+    expect(modal?.textContent).toContain("Create a project from the desktop app");
+    expect(modal?.textContent).toContain(
+      "Creating a new project isn't available in the browser view."
+    );
+
+    const dismiss = document.body.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="project.browserCreateNotice.dismiss"]'
+    );
+    if (!dismiss) throw new Error("browser create-project dismiss button not rendered");
+    dismiss.click();
+
+    expect(
+      document.body.querySelector('[data-ac-testid="project.browserCreateNotice.dialog"]')
+    ).toBeNull();
+
+    dispose();
+  });
+
+  it("keeps the desktop new-project flow unchanged", async () => {
+    vi.mocked(projectStore.pickAndCheck).mockResolvedValue({
+      picked: "C:\\Projects\\Example",
+      hasWorkspace: false,
+    });
+
+    const { dispose } = renderActionBar();
+    const dropdownButton = document.body.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="actionBar.newOpen"]'
+    );
+    if (!dropdownButton) throw new Error("new/open dropdown button not rendered");
+
+    dropdownButton.click();
+
+    const newProjectItem = document.body.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="actionBar.menu.newProject"]'
+    );
+    if (!newProjectItem) throw new Error("new project menu item not rendered");
+
+    newProjectItem.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(projectStore.pickAndCheck).toHaveBeenCalledTimes(1);
+    expect(projectStore.createAndLoad).toHaveBeenCalledWith("C:\\Projects\\Example");
+    expect(
+      document.body.querySelector('[data-ac-testid="project.browserCreateNotice.dialog"]')
+    ).toBeNull();
 
     dispose();
   });

--- a/src/sidebar/components/ActionBar.tsx
+++ b/src/sidebar/components/ActionBar.tsx
@@ -7,6 +7,7 @@ import { ProjectAPI, GuideAPI, SettingsAPI, SpecBoardAPI, emitThemeChanged, onOp
 import { settingsStore } from "../../shared/stores/settings";
 import { resourceMonitorStore } from "../../shared/stores/resourceMonitor";
 import { setSoundsEnabled } from "../../shared/sound";
+import { isBrowser } from "../../shared/platform";
 import { homeStore } from "../../main/stores/home";
 import { centralViewStore } from "../../main/stores/centralView";
 import SettingsModal from "./SettingsModal";
@@ -32,6 +33,7 @@ const ActionBar: Component = () => {
   const [confirmPath, setConfirmPath] = createSignal<string | null>(null);
   const [toastMsg, setToastMsg] = createSignal<string | null>(null);
   const [isPendingDialog, setIsPendingDialog] = createSignal(false);
+  const [showBrowserCreateProjectNotice, setShowBrowserCreateProjectNotice] = createSignal(false);
   // #289 — local synchronous mirror of the persisted theme. Drives the button
   // glyph directly so rapid double-clicks each see the freshly-toggled value
   // (a getter that reads settingsStore.current?.themeLight would see the
@@ -108,6 +110,11 @@ const ActionBar: Component = () => {
   });
 
   const handleNewProject = async () => {
+    if (isBrowser) {
+      setShowDropdown(false);
+      setShowBrowserCreateProjectNotice(true);
+      return;
+    }
     if (isPendingDialog()) return;
     setShowDropdown(false);
     setIsPendingDialog(true);
@@ -416,6 +423,46 @@ const ActionBar: Component = () => {
           section={pendingSection()}
         />
       )}
+      <Show when={showBrowserCreateProjectNotice()}>
+        <div
+          class="modal-overlay"
+          data-ac-testid="project.browserCreateNotice.overlay"
+          data-ac-role="overlay"
+        >
+          <div
+            class="agent-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="projectBrowserCreateNoticeTitle"
+            style={{ "max-width": "380px" }}
+            onClick={(e) => e.stopPropagation()}
+            data-ac-testid="project.browserCreateNotice.dialog"
+            data-ac-role="dialog"
+          >
+            <div class="agent-modal-header">
+              <span id="projectBrowserCreateNoticeTitle" class="agent-modal-title">
+                Create a project from the desktop app
+              </span>
+            </div>
+            <div class="new-agent-form">
+              <p style={{ margin: "0", "line-height": "1.5", opacity: 0.85 }}>
+                Creating a new project isn't available in the browser view. Open the
+                AgentsCommander desktop app to create a project — it will then appear here.
+              </p>
+              <div class="new-agent-footer">
+                <button
+                  class="new-agent-create-btn"
+                  onClick={() => setShowBrowserCreateProjectNotice(false)}
+                  data-ac-testid="project.browserCreateNotice.dismiss"
+                  data-ac-role="button"
+                >
+                  Got it
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Show>
       <Show when={confirmPath()}>
         <div
           class="confirm-overlay"


### PR DESCRIPTION
## Summary

Fixes #807: the browser-remote view couldn't load projects (`Failed to load project: Unknown command: open_project`) because the Rust web dispatcher (`src-tauri/src/web/commands.rs`) never registered the sidebar project commands that the desktop Tauri path has.

## Changes

**Backend (`43b9833`):** Route 6 safe project commands in the web dispatcher by extracting shared `_inner` helpers from `commands::ac_discovery` + `commands::project_settings`:
- `open_project`, `discover_project`, `check_project_path`, `remove_project`, `get_project_groups`, `update_project_groups`
- Guards that lived in the `#[tauri::command]` wrapper bodies (e.g. `discover_project`'s `is_dir` check) moved into the shared `_inner` helpers, since the web path calls `_inner` directly.
- `create_ac_project` / `new_project` intentionally **NOT** routed (see scope decision).

**Frontend (`45cf10c`):** Browser-only modal — clicking "New Project" in the browser view now shows "Create a project from the desktop app" instead of silently failing on the (also-missing) `pick_folder` command. Desktop/Tauri flow unchanged.

## Scope decision

Adversarial review found `create_ac_project` / `new_project` are an arbitrary-path filesystem-write surface with no legitimate browser trigger (fresh paths only come from the native OS folder picker, absent in browser). They are deferred from the browser; the modal directs users to the desktop app. Full rationale in the issue comment.

## Review

- **Backend:** `cargo build` / `check` / `clippy -D warnings` PASS; tests PASS (`web::commands`, `commands::ac_discovery` 24, `commands::project_settings`).
- **Frontend:** typecheck / build PASS; 7 `ActionBar` tests PASS; Playwright-verified: modal renders, 0 `pick_folder` sends, 0 `Unknown command`.
- **Grinch (adversarial) full-diff review: PASS.** G1 (create/new not web-reachable) + G4 (no guards stranded in wrappers) fully resolved; G5 routing correct and authoritative (one LOW, optional test-robustness follow-up); no behavior drift, no new bugs.

## Follow-ups (separate issues)

- G5: add a `dispatch_inner`-level regression test (the route helper is authoritative, but the new tests assert the route table in isolation, so deleting the dispatch wiring wouldn't fail a test).
- Browser-side project creation via a safe path mechanism (registered-root allow-list or a browser folder-select equivalent) if it's ever wanted.

Closes #807
