### PR TITLE
feat: add side group rail reorder, refs #808

### DIFF
--- a/src/sidebar/components/WorkgroupGroupRail.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AcWorkgroup, Session, WorkgroupGroupsConfig } from "../../shared/types";
 import { FakeTransport } from "../../shared/testing/fake-transport";
 import {
@@ -51,6 +51,26 @@ function project(): ProjectState {
   };
 }
 
+function otherProject(): ProjectState {
+  const path = "C:\\OtherProject";
+  const otherWg = (name: string): AcWorkgroup => ({
+    name,
+    path: `${path}\\.ac\\${name}`,
+    task: null,
+    taskTitle: null,
+    agents: [],
+  });
+  return {
+    path,
+    folderName: "OtherProject",
+    workgroups: [otherWg("wg-9-other-team")],
+    agents: [],
+    teams: [],
+    loops: [],
+    contextTemplateUpdates: [],
+  };
+}
+
 function groupsConfig(overrides: Partial<WorkgroupGroupsConfig> = {}): WorkgroupGroupsConfig {
   return {
     ...defaultGroupsConfig(),
@@ -67,6 +87,49 @@ function target<T extends Element>(testId: string): T {
   const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
   if (!element) throw new Error(`Missing element ${testId}`);
   return element;
+}
+
+function scopedTarget<T extends Element>(root: ParentNode, testId: string): T {
+  const element = root.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing scoped element ${testId}`);
+  return element;
+}
+
+function pointer(
+  el: Element,
+  type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel",
+  init: { clientX?: number; clientY?: number; button?: number; pointerId?: number } = {}
+): void {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 10,
+    clientY: init.clientY ?? 10,
+    button: init.button ?? 0,
+  });
+  Object.defineProperty(event, "pointerId", { value: init.pointerId ?? 1 });
+  Object.defineProperty(event, "pointerType", { value: "mouse" });
+  Object.defineProperty(event, "isPrimary", { value: true });
+  el.dispatchEvent(event);
+}
+
+function mockRect(el: HTMLElement, top: number, height = 30): void {
+  vi.spyOn(el, "getBoundingClientRect").mockReturnValue({
+    x: 0,
+    y: top,
+    top,
+    left: 0,
+    right: 68,
+    bottom: top + height,
+    width: 68,
+    height,
+    toJSON: () => ({}),
+  } as DOMRect);
+}
+
+function lastUpdatedGroupIds(fake: FakeTransport): string[] | undefined {
+  const config = fake.lastCall("update_project_groups")?.args.config as WorkgroupGroupsConfig | undefined;
+  return config?.groups.map((group) => group.id);
 }
 
 function changeCheckbox(input: HTMLInputElement, checked: boolean): void {
@@ -105,6 +168,8 @@ describe("WorkgroupGroupRail", () => {
   afterEach(() => {
     resetUiStoresForTests();
     document.body.replaceChildren();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("keeps All, All plus Ungrouped, and Ungrouped-only reachable while blocking none", async () => {
@@ -167,6 +232,9 @@ describe("WorkgroupGroupRail", () => {
     const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
     try {
       await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      click(target("workgroupGroups.button.ungrouped"));
+      await Promise.resolve();
+      expect(target("workgroupGroups.button.ungrouped").classList.contains("selected")).toBe(true);
 
       await workgroupGroupsStore.save(
         projectPath,
@@ -307,6 +375,223 @@ describe("WorkgroupGroupRail", () => {
     try {
       await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
       expect(document.querySelector('[data-ac-testid="workgroupGroups.button.nonstop"]')).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps quick click selection behavior and does not persist reorder before the hold threshold", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    fake.onInvoke("update_project_groups", (args) => args.config);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      const ui = target<HTMLElement>("workgroupGroups.button.ui");
+
+      vi.useFakeTimers();
+      pointer(ui, "pointerdown", { clientY: 100 });
+      vi.advanceTimersByTime(1999);
+      pointer(ui, "pointerup", { clientY: 100 });
+      vi.useRealTimers();
+      click(ui);
+      await Promise.resolve();
+
+      expect(fake.callsFor("update_project_groups")).toHaveLength(0);
+      expect(ui.classList.contains("selected")).toBe(true);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("long-press drags a user group to a new user-group position and persists the order", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    fake.onInvoke("update_project_groups", (args) => args.config);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      const projectRail = target<HTMLElement>("workgroupGroups.rail.Project");
+      const ui = target<HTMLElement>("workgroupGroups.button.ui");
+      const rust = target<HTMLElement>("workgroupGroups.button.rust");
+      mockRect(projectRail, 0, 160);
+      mockRect(ui, 80);
+      mockRect(rust, 114);
+
+      vi.useFakeTimers();
+      pointer(ui, "pointerdown", { clientY: 90 });
+      vi.advanceTimersByTime(2000);
+      pointer(ui, "pointermove", { clientY: 150 });
+      pointer(ui, "pointerup", { clientY: 150 });
+      vi.useRealTimers();
+
+      await waitFor(() => expect(lastUpdatedGroupIds(fake)).toEqual(["rust", "ui"]));
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "rust", "ui"]));
+      expect(target("workgroupGroups.button.all").classList.contains("selected")).toBe(true);
+
+      click(target("workgroupGroups.button.ui"));
+      await Promise.resolve();
+      expect(target("workgroupGroups.button.all").classList.contains("selected")).toBe(true);
+
+      const movedUi = target<HTMLElement>("workgroupGroups.button.ui");
+      pointer(movedUi, "pointerdown", { clientY: 150 });
+      pointer(movedUi, "pointerup", { clientY: 150 });
+      click(movedUi);
+      await Promise.resolve();
+      expect(target("workgroupGroups.button.ui").classList.contains("selected")).toBe(true);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("long-press drags a middle user group to the top of the user-group segment", async () => {
+    const fake = new FakeTransport();
+    fake.resolve(
+      "get_project_groups",
+      groupsConfig({
+        groups: [
+          { id: "ui", name: "UI", regex: exactGroupRegexForWorkgroup("wg-1-dev-team") },
+          { id: "rust", name: "Rust", regex: exactGroupRegexForWorkgroup("wg-2-rust-team") },
+          { id: "docs", name: "Docs", regex: exactGroupRegexForWorkgroup("wg-3-docs-team") },
+        ],
+      })
+    );
+    fake.onInvoke("update_project_groups", (args) => args.config);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust", "docs"]));
+      const projectRail = target<HTMLElement>("workgroupGroups.rail.Project");
+      const ui = target<HTMLElement>("workgroupGroups.button.ui");
+      const rust = target<HTMLElement>("workgroupGroups.button.rust");
+      const docs = target<HTMLElement>("workgroupGroups.button.docs");
+      mockRect(projectRail, 0, 200);
+      mockRect(ui, 80);
+      mockRect(rust, 114);
+      mockRect(docs, 148);
+
+      vi.useFakeTimers();
+      pointer(rust, "pointerdown", { clientY: 124 });
+      vi.advanceTimersByTime(2000);
+      pointer(rust, "pointermove", { clientY: 84 });
+      pointer(rust, "pointerup", { clientY: 84 });
+      vi.useRealTimers();
+
+      await waitFor(() => expect(lastUpdatedGroupIds(fake)).toEqual(["rust", "ui", "docs"]));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("reverts preview order, preserves selection, and surfaces the rail error when reorder save fails", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (event: PromiseRejectionEvent) => {
+      unhandled.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener("unhandledrejection", onUnhandled);
+
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    fake.reject("update_project_groups", "disk denied");
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      const projectRail = target<HTMLElement>("workgroupGroups.rail.Project");
+      const ui = target<HTMLElement>("workgroupGroups.button.ui");
+      const rust = target<HTMLElement>("workgroupGroups.button.rust");
+      mockRect(projectRail, 0, 160);
+      mockRect(ui, 80);
+      mockRect(rust, 114);
+
+      vi.useFakeTimers();
+      pointer(ui, "pointerdown", { clientY: 90 });
+      vi.advanceTimersByTime(2000);
+      pointer(ui, "pointermove", { clientY: 150 });
+      pointer(ui, "pointerup", { clientY: 150 });
+      vi.useRealTimers();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      await waitFor(() => {
+        const error = document.querySelector<HTMLElement>(".workgroup-group-rail-error");
+        expect(error?.title).toContain("disk denied");
+      });
+      expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]);
+      expect(target("workgroupGroups.button.all").classList.contains("selected")).toBe(true);
+      expect(unhandled).toEqual([]);
+    } finally {
+      window.removeEventListener("unhandledrejection", onUnhandled);
+      rendered.cleanup();
+    }
+  });
+
+  it("cancels a long-press drag on Escape without persisting", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    fake.onInvoke("update_project_groups", (args) => args.config);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]));
+      const ui = target<HTMLElement>("workgroupGroups.button.ui");
+      vi.useFakeTimers();
+      pointer(ui, "pointerdown", { clientY: 90 });
+      vi.advanceTimersByTime(2000);
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      pointer(ui, "pointerup", { clientY: 150 });
+      vi.useRealTimers();
+      await Promise.resolve();
+
+      expect(fake.callsFor("update_project_groups")).toHaveLength(0);
+      expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust"]);
+
+      click(ui);
+      await Promise.resolve();
+      expect(target("workgroupGroups.button.all").classList.contains("selected")).toBe(true);
+
+      pointer(ui, "pointerdown", { clientY: 90 });
+      pointer(ui, "pointerup", { clientY: 90 });
+      click(ui);
+      await Promise.resolve();
+      expect(ui.classList.contains("selected")).toBe(true);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("does not persist a reorder when the drop leaves the source project section", async () => {
+    const fake = new FakeTransport();
+    fake.onInvoke("get_project_groups", (args) =>
+      args.path === projectPath
+        ? groupsConfig()
+        : groupsConfig({ groups: [{ id: "other", name: "Other", regex: exactGroupRegexForWorkgroup("wg-9-other-team") }] })
+    );
+    fake.onInvoke("update_project_groups", (args) => args.config);
+
+    const rendered = renderWithFakeTransport(
+      () => <WorkgroupGroupRail projects={[project(), otherProject()]} />,
+      fake
+    );
+    try {
+      await waitFor(() => expect(target("workgroupGroups.rail.OtherProject")).not.toBeNull());
+      const sourceRail = target<HTMLElement>("workgroupGroups.rail.Project");
+      const ui = scopedTarget<HTMLElement>(sourceRail, "workgroupGroups.button.ui");
+      mockRect(sourceRail, 0, 160);
+      mockRect(ui, 80);
+
+      vi.useFakeTimers();
+      pointer(ui, "pointerdown", { clientY: 90 });
+      vi.advanceTimersByTime(2000);
+      pointer(ui, "pointermove", { clientY: 260 });
+      pointer(ui, "pointerup", { clientY: 260 });
+      vi.useRealTimers();
+      await Promise.resolve();
+
+      expect(fake.callsFor("update_project_groups")).toHaveLength(0);
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -1,4 +1,4 @@
-import { Component, For, Show, createEffect, createMemo, createSignal } from "solid-js";
+import { Component, For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 import type { AcWorkgroup, WorkgroupGroup } from "../../shared/types";
 import type { ProjectState } from "../stores/project";
 import {
@@ -36,6 +36,24 @@ interface GroupButton {
   selection: WorkgroupGroupSelection;
   workgroups: AcWorkgroup[];
   title: string;
+  reorderable: boolean;
+  groupId: string | null;
+  groupIndex: number | null;
+}
+
+const REORDER_HOLD_MS = 2000;
+const REORDER_MOVE_CANCEL_PX = 6;
+
+type ReorderPhase = "arming" | "dragging" | "saving";
+
+interface ReorderState {
+  phase: ReorderPhase;
+  pointerId: number;
+  groupId: string;
+  sourceIndex: number;
+  targetIndex: number | null;
+  startX: number;
+  startY: number;
 }
 
 function wgNumber(name: string): number {
@@ -116,6 +134,9 @@ const ProjectRailSection: Component<{
         selection: { kind: "all" },
         workgroups: props.project.workgroups,
         title: tooltipFor(props.project.workgroups),
+        reorderable: false,
+        groupId: null,
+        groupIndex: null,
       });
     }
     if (config().showUngrouped) {
@@ -126,6 +147,9 @@ const ProjectRailSection: Component<{
         selection: { kind: "ungrouped" },
         workgroups,
         title: tooltipFor(workgroups),
+        reorderable: false,
+        groupId: null,
+        groupIndex: null,
       });
     }
     // #777: the built-in Non-stop group pins directly after Ungrouped (or after
@@ -143,9 +167,12 @@ const ProjectRailSection: Component<{
         selection: { kind: "nonstop" },
         workgroups,
         title: tooltipFor(workgroups),
+        reorderable: false,
+        groupId: null,
+        groupIndex: null,
       });
     }
-    for (const group of config().groups) {
+    for (const [groupIndex, group] of config().groups.entries()) {
       const workgroups = props.project.workgroups.filter((wg) => groupMatches(group, wg));
       result.push({
         key: group.id,
@@ -153,6 +180,9 @@ const ProjectRailSection: Component<{
         selection: { kind: "group", id: group.id },
         workgroups,
         title: tooltipFor(workgroups),
+        reorderable: true,
+        groupId: group.id,
+        groupIndex,
       });
     }
     return result;
@@ -162,23 +192,256 @@ const ProjectRailSection: Component<{
     if (current.kind !== button.selection.kind) return false;
     return current.kind !== "group" || button.selection.kind !== "group" || current.id === button.selection.id;
   };
+  const [reorderState, setReorderState] = createSignal<ReorderState | null>(null);
+  let holdTimer: number | null = null;
+  let suppressClickGroupId: string | null = null;
+  let projectEl: HTMLDivElement | undefined;
+  const groupButtonEls = new Map<string, HTMLButtonElement>();
+
+  const clearHoldTimer = () => {
+    if (holdTimer !== null) {
+      window.clearTimeout(holdTimer);
+      holdTimer = null;
+    }
+  };
+
+  const cancelReorder = (suppressClick = false) => {
+    const current = reorderState();
+    clearHoldTimer();
+    if (suppressClick && current) {
+      suppressClickGroupId = current.groupId;
+    } else {
+      suppressClickGroupId = null;
+    }
+    setReorderState(null);
+  };
+
+  createEffect(() => {
+    const validIds = new Set(config().groups.map((group) => group.id));
+    for (const id of groupButtonEls.keys()) {
+      if (!validIds.has(id)) groupButtonEls.delete(id);
+    }
+  });
+
+  const targetIndexForPointer = (clientY: number, groupId: string): number | null => {
+    if (!projectEl) return null;
+    const projectRect = projectEl.getBoundingClientRect();
+    if (clientY < projectRect.top || clientY > projectRect.bottom) return null;
+
+    const candidates = Array.from(groupButtonEls.entries())
+      .filter(([id]) => id !== groupId)
+      .map(([id, el]) => ({ id, rect: el.getBoundingClientRect() }))
+      .filter(({ rect }) => rect.height > 0)
+      .sort((a, b) => a.rect.top - b.rect.top);
+
+    for (let index = 0; index < candidates.length; index++) {
+      const rect = candidates[index].rect;
+      if (clientY < rect.top + rect.height / 2) return index;
+    }
+    return candidates.length;
+  };
+
+  const startPress = (event: PointerEvent & { currentTarget: HTMLButtonElement }, button: GroupButton) => {
+    suppressClickGroupId = null;
+    if (
+      event.button !== 0 ||
+      event.isPrimary === false ||
+      !button.reorderable ||
+      !button.groupId ||
+      button.groupIndex === null
+    ) {
+      return;
+    }
+    if (workgroupGroupsStore.saving(props.project.path)) return;
+
+    try {
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+    } catch {
+      // Window-level pointerup/pointercancel fallback still unwinds the gesture.
+    }
+
+    setReorderState({
+      phase: "arming",
+      pointerId: event.pointerId,
+      groupId: button.groupId,
+      sourceIndex: button.groupIndex,
+      targetIndex: button.groupIndex,
+      startX: event.clientX,
+      startY: event.clientY,
+    });
+    clearHoldTimer();
+    holdTimer = window.setTimeout(() => {
+      holdTimer = null;
+      setReorderState((current) =>
+        current?.pointerId === event.pointerId && current.groupId === button.groupId
+          ? { ...current, phase: "dragging", targetIndex: current.sourceIndex }
+          : current
+      );
+      suppressClickGroupId = button.groupId;
+    }, REORDER_HOLD_MS);
+  };
+
+  const movePress = (event: PointerEvent) => {
+    const current = reorderState();
+    if (!current || current.pointerId !== event.pointerId) return;
+
+    if (current.phase === "arming") {
+      const dx = event.clientX - current.startX;
+      const dy = event.clientY - current.startY;
+      if (Math.hypot(dx, dy) > REORDER_MOVE_CANCEL_PX) cancelReorder(false);
+      return;
+    }
+
+    if (current.phase === "dragging") {
+      const targetIndex = targetIndexForPointer(event.clientY, current.groupId);
+      setReorderState({ ...current, targetIndex });
+    }
+  };
+
+  const finishPress = (event: PointerEvent) => {
+    const current = reorderState();
+    if (!current || current.pointerId !== event.pointerId) return;
+
+    if (current.phase === "arming") {
+      cancelReorder(false);
+      return;
+    }
+    if (current.phase === "saving") return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    suppressClickGroupId = current.groupId;
+
+    const dropTargetIndex = targetIndexForPointer(event.clientY, current.groupId);
+    if (dropTargetIndex === null || dropTargetIndex === current.sourceIndex) {
+      cancelReorder(true);
+      return;
+    }
+
+    setReorderState({ ...current, phase: "saving", targetIndex: dropTargetIndex });
+    void (async () => {
+      try {
+        await workgroupGroupsStore.reorderGroup(props.project.path, current.groupId, dropTargetIndex);
+      } catch {
+        // The store already exposes the save error.
+      } finally {
+        setReorderState(null);
+      }
+    })();
+  };
+
+  const cancelPress = (event: PointerEvent) => {
+    const current = reorderState();
+    if (!current || current.pointerId !== event.pointerId || current.phase === "saving") return;
+    cancelReorder(current.phase !== "arming");
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape" || !reorderState()) return;
+    event.preventDefault();
+    cancelReorder(true);
+  };
+
+  const onWindowPointerUp = (event: PointerEvent) => {
+    const current = reorderState();
+    if (!current || current.pointerId !== event.pointerId) return;
+    finishPress(event);
+  };
+
+  const onWindowPointerCancel = (event: PointerEvent) => {
+    cancelPress(event);
+  };
+
+  window.addEventListener("keydown", onKeyDown);
+  window.addEventListener("pointerup", onWindowPointerUp);
+  window.addEventListener("pointercancel", onWindowPointerCancel);
+  onCleanup(() => {
+    window.removeEventListener("keydown", onKeyDown);
+    window.removeEventListener("pointerup", onWindowPointerUp);
+    window.removeEventListener("pointercancel", onWindowPointerCancel);
+    clearHoldTimer();
+    suppressClickGroupId = null;
+    groupButtonEls.clear();
+  });
+
+  const previewButtons = createMemo(() => {
+    const current = reorderState();
+    const base = buttons();
+    if (!current || current.targetIndex === null || current.phase === "arming") return base;
+
+    const systemButtons = base.filter((button) => !button.reorderable);
+    const groupButtons = base.filter((button) => button.reorderable);
+    const sourceIndex = groupButtons.findIndex((button) => button.groupId === current.groupId);
+    if (sourceIndex < 0) return base;
+
+    const nextGroups = groupButtons.slice();
+    const [moved] = nextGroups.splice(sourceIndex, 1);
+    const clampedTarget = Math.max(0, Math.min(current.targetIndex, nextGroups.length));
+    nextGroups.splice(clampedTarget, 0, moved);
+    return [...systemButtons, ...nextGroups];
+  });
 
   return (
-    <div class="workgroup-group-rail-project" data-ac-testid={`workgroupGroups.rail.${props.project.folderName}`}>
+    <div
+      ref={(el) => {
+        projectEl = el;
+      }}
+      class="workgroup-group-rail-project"
+      classList={{ "reorder-active": reorderState()?.phase === "dragging" || reorderState()?.phase === "saving" }}
+      data-ac-testid={`workgroupGroups.rail.${props.project.folderName}`}
+    >
       <Show when={props.showProjectLabel}>
         <div class="workgroup-group-rail-project-label" title={props.project.path}>
           {props.project.folderName}
         </div>
       </Show>
 
-      <For each={buttons()}>
+      <For each={previewButtons()}>
         {(button) => (
           <button
+            ref={(el) => {
+              if (button.groupId) groupButtonEls.set(button.groupId, el);
+            }}
             class="workgroup-group-rail-button"
-            classList={{ selected: selected(button) }}
+            classList={{
+              selected: selected(button),
+              reorderable: button.reorderable,
+              "reorder-arming": reorderState()?.phase === "arming" && reorderState()?.groupId === button.groupId,
+              "reorder-dragging":
+                (reorderState()?.phase === "dragging" || reorderState()?.phase === "saving") &&
+                reorderState()?.groupId === button.groupId,
+              "reorder-invalid":
+                reorderState()?.phase === "dragging" &&
+                reorderState()?.groupId === button.groupId &&
+                reorderState()?.targetIndex === null,
+            }}
             aria-pressed={selected(button)}
+            aria-grabbed={button.reorderable ? reorderState()?.groupId === button.groupId : undefined}
             title={button.title}
-            onClick={() => workgroupGroupsStore.select(props.project.path, button.selection)}
+            onPointerDown={(event) => startPress(event, button)}
+            onPointerMove={movePress}
+            onPointerUp={finishPress}
+            onPointerCancel={cancelPress}
+            onLostPointerCapture={(event) => {
+              const current = reorderState();
+              if (
+                !current ||
+                current.pointerId !== event.pointerId ||
+                (current.phase !== "arming" && current.phase !== "dragging")
+              ) {
+                return;
+              }
+              cancelReorder(current.phase === "dragging");
+            }}
+            onClick={(event) => {
+              if (button.groupId && suppressClickGroupId === button.groupId) {
+                suppressClickGroupId = null;
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+              }
+              workgroupGroupsStore.select(props.project.path, button.selection);
+            }}
             data-ac-testid={`workgroupGroups.button.${button.key}`}
           >
             <span class="workgroup-group-rail-title-line">

--- a/src/sidebar/stores/workgroup-groups.test.ts
+++ b/src/sidebar/stores/workgroup-groups.test.ts
@@ -10,6 +10,7 @@ import {
   nonStopMatchesWorkgroup,
   normalizeNonStop,
   removeExactGroupToken,
+  reorderGroups,
   validateGroupsConfig,
   workgroupGroupsStore,
 } from "./workgroup-groups";
@@ -114,6 +115,50 @@ describe("workgroupGroupsStore", () => {
     expect(workgroupGroupsStore.config(projectPath).groups).toEqual([
       { id: "saved", name: "Saved", regex: "^wg-9-" },
     ]);
+  });
+
+  it("reorders groups by final insertion index and clamps to the list bounds", () => {
+    const groups = [
+      { id: "a", name: "A", regex: "a" },
+      { id: "b", name: "B", regex: "b" },
+      { id: "c", name: "C", regex: "c" },
+    ];
+
+    expect(reorderGroups(groups, "a", 2).map((group) => group.id)).toEqual(["b", "c", "a"]);
+    expect(reorderGroups(groups, "c", 0).map((group) => group.id)).toEqual(["c", "a", "b"]);
+    expect(reorderGroups(groups, "b", 99).map((group) => group.id)).toEqual(["a", "c", "b"]);
+    expect(reorderGroups(groups, "missing", 0)).toBe(groups);
+  });
+
+  it("persists a reordered group list without changing built-in group settings", async () => {
+    const fake = new FakeTransport();
+    restoreTransport?.();
+    restoreTransport = __setTransportForTests(fake);
+
+    fake.resolve(
+      "get_project_groups",
+      config({
+        showAll: false,
+        showUngrouped: true,
+        nonStop: { ...defaultNonStop(), show: true },
+        groups: [
+          { id: "a", name: "A", regex: "a" },
+          { id: "b", name: "B", regex: "b" },
+          { id: "c", name: "C", regex: "c" },
+        ],
+      })
+    );
+    fake.onInvoke("update_project_groups", (args) => args.config);
+
+    await workgroupGroupsStore.ensureLoaded(projectPath);
+    await workgroupGroupsStore.reorderGroup(projectPath, "a", 2);
+
+    expect(fake.lastCall("update_project_groups")?.args.config).toMatchObject({
+      showAll: false,
+      showUngrouped: true,
+      nonStop: { show: true },
+      groups: [{ id: "b" }, { id: "c" }, { id: "a" }],
+    });
   });
 
   it("adds an exact workgroup token to an existing generated regex", async () => {

--- a/src/sidebar/stores/workgroup-groups.ts
+++ b/src/sidebar/stores/workgroup-groups.ts
@@ -138,6 +138,22 @@ function cloneConfig(config: WorkgroupGroupsConfig): WorkgroupGroupsConfig {
   };
 }
 
+export function reorderGroups(
+  groups: WorkgroupGroup[],
+  groupId: string,
+  targetIndex: number
+): WorkgroupGroup[] {
+  const sourceIndex = groups.findIndex((group) => group.id === groupId);
+  if (sourceIndex < 0) return groups;
+
+  const next = groups.slice();
+  const [moved] = next.splice(sourceIndex, 1);
+  const safeTarget = Number.isFinite(targetIndex) ? Math.round(targetIndex) : sourceIndex;
+  const clampedTarget = Math.max(0, Math.min(safeTarget, next.length));
+  next.splice(clampedTarget, 0, moved);
+  return next;
+}
+
 function defaultEntry(): ProjectGroupsEntry {
   return {
     config: defaultGroupsConfig(),
@@ -494,6 +510,15 @@ export const workgroupGroupsStore = {
       setEntries(key, { ...latest, saving: false, error: message });
       throw new Error(message);
     }
+  },
+
+  async reorderGroup(projectPath: string, groupId: string, targetIndex: number): Promise<void> {
+    const config = this.config(projectPath);
+    const groups = reorderGroups(config.groups, groupId, targetIndex);
+    const before = config.groups.map((group) => group.id).join("\0");
+    const after = groups.map((group) => group.id).join("\0");
+    if (before === after) return;
+    await this.save(projectPath, { ...config, groups });
   },
 
   async addWorkgroupToGroup(projectPath: string, groupId: string, wgName: string): Promise<void> {

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2790,6 +2790,8 @@ html.light-theme .settings-hint-warning {
 }
 
 .workgroup-group-rail-button {
+  position: relative;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -2849,6 +2851,53 @@ html.light-theme .settings-hint-warning {
 
 .workgroup-group-rail-button.selected {
   box-shadow: inset 3px 0 0 var(--sidebar-accent);
+}
+
+.workgroup-group-rail-project.reorder-active {
+  cursor: grabbing;
+}
+
+.workgroup-group-rail-button.reorderable {
+  cursor: grab;
+  user-select: none;
+}
+
+.workgroup-group-rail-button.reorder-arming,
+.workgroup-group-rail-button.reorder-dragging {
+  border-color: rgba(0, 212, 255, 0.42);
+  color: var(--sidebar-fg);
+}
+
+.workgroup-group-rail-button.reorder-arming::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background: var(--sidebar-accent);
+  transform-origin: left center;
+  animation: workgroup-group-reorder-hold 2s linear forwards; /* Keep in sync with REORDER_HOLD_MS. */
+}
+
+.workgroup-group-rail-button.reorder-dragging {
+  cursor: grabbing;
+  background: rgba(0, 212, 255, 0.16);
+  box-shadow: inset 3px 0 0 var(--sidebar-accent), 0 0 0 1px rgba(0, 212, 255, 0.24);
+}
+
+.workgroup-group-rail-button.reorder-invalid {
+  border-color: rgba(255, 107, 107, 0.48);
+  box-shadow: inset 3px 0 0 var(--danger, #ff6b6b);
+}
+
+@keyframes workgroup-group-reorder-hold {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
 }
 
 .workgroup-group-rail-button.edit {


### PR DESCRIPTION
## Summary
- Adds long-press (2 second) drag reordering for user-created groups in the side group rail.
- Persists the order through the existing `WorkgroupGroupsConfig.groups` array and `update_project_groups` IPC path.
- Keeps built-in rail slots pinned: `All`, `Ungrouped`, and `Alert me!`.
- Constrains drag/drop to the source project rail, so groups cannot move across projects.

## Verification
- `npx vitest run src/sidebar/stores/workgroup-groups.test.ts src/sidebar/components/WorkgroupGroupRail.test.tsx` passed: 2 files, 30 tests.
- `npx tsc --noEmit` passed.
- `git diff --check` passed with CRLF warnings only.
- After merging current `origin/main`, focused tests and typecheck passed again.

## Review
- Architect consensus: READY_FOR_IMPLEMENTATION; user-created groups only accepted for #808, system slots remain pinned.
- Grinch Step 9 review: PASS on `be5e4923426cf743fb3e49e24698890d17792769`.
- Grinch Step 9.5 recheck: PASS on `03c3c6a2a7df67bdc0ea753b001e7492fd33657a`; visual classification remains VISUAL.

## Visual follow-up
- Final build/deploy and live visual verification follow after landing because this is a visible interaction change.

Closes #808