### PR TITLE
fix: align project header search controls

### DIFF
--- a/src/sidebar/App.context-menu.test.ts
+++ b/src/sidebar/App.context-menu.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { blockContextMenu } from "./App";
+
+function dispatchDocumentContextMenu(target: Element): MouseEvent {
+  const event = new MouseEvent("contextmenu", {
+    bubbles: true,
+    cancelable: true,
+    clientX: 80,
+    clientY: 96,
+  });
+
+  document.addEventListener("contextmenu", blockContextMenu);
+  try {
+    target.dispatchEvent(event);
+  } finally {
+    document.removeEventListener("contextmenu", blockContextMenu);
+  }
+
+  return event;
+}
+
+describe("SidebarApp global context-menu blocker", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("preserves the native context menu in the project regex filter input", () => {
+    const row = document.createElement("div");
+    row.className = "project-filter-row";
+    const input = document.createElement("input");
+    input.className = "project-filter-input";
+    row.append(input);
+    document.body.append(row);
+
+    const event = dispatchDocumentContextMenu(input);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("still blocks non-exempt sidebar surfaces", () => {
+    const surface = document.createElement("div");
+    surface.className = "sidebar-scrollable";
+    document.body.append(surface);
+
+    const event = dispatchDocumentContextMenu(surface);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -71,6 +71,12 @@ function isExitedStatus(status: SessionStatus): boolean {
   return typeof status === "object" && status !== null && "exited" in status;
 }
 
+export function blockContextMenu(e: Event): void {
+  // Allow native menus where users expect text Copy/Paste.
+  if (e.target instanceof Element && e.target.closest(".terminal-host, .project-filter-row")) return;
+  e.preventDefault();
+}
+
 const SidebarApp: Component<SidebarAppProps> = (props) => {
   const [showOnboarding, setShowOnboarding] = createSignal(false);
   const [loopToast, setLoopToast] = createSignal<LoopToast | null>(null);
@@ -96,14 +102,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
   const railSide = () => props.railSide ?? settingsRailSide();
   // #592 - debounce handle for the profile-drift re-list (collapses bursts).
   let profileDriftRefreshTimer: ReturnType<typeof setTimeout> | null = null;
-  const blockContextMenu = (e: Event) => {
-    // Allow the WebView2 native menu over the embedded terminal so users get
-    // Copy/Paste. Custom menus elsewhere (SessionItem, ProjectPanel, etc.)
-    // remain blocked.
-    if (e.target instanceof Element && e.target.closest(".terminal-host")) return;
-    e.preventDefault();
-  };
-
   const handleMainSidebarSideChange = (event: Event) => {
     const side = (event as CustomEvent<{ side?: MainSidebarSide }>).detail?.side;
     setSettingsRailSide(side === "left" ? "left" : "right");

--- a/src/sidebar/components/ProjectPanel.context-menu.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu.test.tsx
@@ -235,6 +235,34 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
     expect(menu.textContent).not.toContain("Open in new window");
   });
 
+  it("preserves the native context menu inside the project regex filter row", async () => {
+    await setupPanel([coordSession()]);
+
+    const header = rendered!.root.querySelector<HTMLElement>(".project-header");
+    const filterInput = header?.querySelector<HTMLInputElement>(".project-filter-input");
+    expect(header).not.toBeNull();
+    expect(filterInput).not.toBeNull();
+
+    const inputContextMenu = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 80,
+      clientY: 96,
+    });
+
+    expect(filterInput!.dispatchEvent(inputContextMenu)).toBe(true);
+    expect(inputContextMenu.defaultPrevented).toBe(false);
+    expect(replicaMenu()).toBeNull();
+
+    contextMenu(header!);
+
+    await waitFor(() => {
+      const menu = replicaMenu();
+      expect(menu).not.toBeNull();
+      expect(menu!.textContent).toContain("New Agent");
+    });
+  });
+
   it("opens the canonical Matrix folder from a gray workgroup replica", async () => {
     const fake = await setupPanel([coordSession()]);
 

--- a/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
@@ -202,6 +202,50 @@ describe("ProjectPanel regex filter", () => {
     }
   });
 
+  it("keeps the regex search controls in the project header and clears them when closed", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", {
+      path: projectPath,
+      registered: true,
+      created: false,
+    });
+    fake.resolve("discover_project", projectDiscovery());
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+
+      const header = rendered.root.querySelector<HTMLElement>(".project-header");
+      expect(header).toBeTruthy();
+
+      const title = header!.querySelector<HTMLElement>(".project-title");
+      const row = findByTestId<HTMLDivElement>(rendered.root, "project.regexFilter.row");
+      const toggle = findByTestId<HTMLButtonElement>(rendered.root, "project.regexFilter.toggle");
+      const filterInput = findByTestId<HTMLInputElement>(rendered.root, "project.regexFilter.input");
+
+      expect(title?.textContent).toBe("Project: Project");
+      expect(header!.contains(row)).toBe(true);
+      expect(header!.contains(toggle)).toBe(true);
+      expect(header!.contains(filterInput)).toBe(true);
+
+      click(toggle);
+      await waitFor(() => expect(toggle.getAttribute("aria-expanded")).toBe("true"));
+
+      input(filterInput, "dev-rust");
+      await waitFor(() => expect(filterInput.value).toBe("dev-rust"));
+
+      click(toggle);
+      await waitFor(() => {
+        expect(toggle.getAttribute("aria-expanded")).toBe("false");
+        expect(filterInput.value).toBe("");
+        expect(row.classList.contains("open")).toBe(false);
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
   it("matches visible team project labels and quick-access running-peer badges", async () => {
     const fake = new FakeTransport();
     fake.resolve("new_project", {

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1559,6 +1559,7 @@ const ProjectPanel: Component = () => {
         };
 
         const handleProjectContextMenu = (e: MouseEvent) => {
+          if (e.target instanceof Element && e.target.closest(".project-filter-row")) return;
           e.preventDefault();
           e.stopPropagation();
           cleanupCtx();

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -2272,61 +2272,69 @@ const ProjectPanel: Component = () => {
 
         return (
           <div class="project-panel">
-            <button
+            <div
               class="project-header"
+              classList={{ open: filterOpen(), active: filterActive(), invalid: !!filterError() }}
               title={proj.path}
-              onClick={() => togglePanelCollapsed(projectCollapsedKey)}
               onContextMenu={handleProjectContextMenu}
             >
-              <span class="ac-discovery-chevron" classList={{ collapsed: isPanelCollapsed(projectCollapsedKey) }}>
-                &#x25BE;
-              </span>
-              <span class="project-title">Project: {proj.folderName}</span>
-            </button>
-            <div
-              class="project-filter-row"
-              classList={{ open: filterOpen(), active: filterActive(), invalid: !!filterError() }}
-              data-ac-testid="project.regexFilter.row"
-            >
-              <div class="project-filter-field" classList={{ open: filterOpen() }}>
-                <input
-                  ref={filterInputEl}
-                  class="project-filter-input"
-                  value={filterPattern()}
-                  placeholder="wg-2.*"
-                  aria-label="Sidebar regex filter"
-                  aria-invalid={!!filterError()}
-                  data-ac-testid="project.regexFilter.input"
-                  onInput={(e) => setFilterPattern(e.currentTarget.value)}
-                  onKeyDown={handleFilterKeyDown}
-                />
-                <Show when={filterPattern()}>
-                  <button
-                    type="button"
-                    class="project-filter-clear"
-                    title="Clear regex filter"
-                    aria-label="Clear regex filter"
-                    data-ac-testid="project.regexFilter.clear"
-                    onClick={clearFilter}
-                  >
-                    &#x2715;
-                  </button>
-                </Show>
-              </div>
               <button
                 type="button"
-                class="project-filter-toggle"
-                title={filterOpen() ? "Hide regex filter" : "Filter sidebar (regex)"}
-                aria-label={filterOpen() ? "Hide regex filter" : "Filter sidebar (regex)"}
-                aria-expanded={filterOpen()}
-                data-ac-testid="project.regexFilter.toggle"
-                onClick={toggleFilter}
+                class="project-header-main"
+                title={proj.path}
+                aria-expanded={!isPanelCollapsed(projectCollapsedKey)}
+                onClick={() => togglePanelCollapsed(projectCollapsedKey)}
               >
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <circle cx="11" cy="11" r="7" />
-                  <path d="m20 20-4.2-4.2" />
-                </svg>
+                <span class="ac-discovery-chevron" classList={{ collapsed: isPanelCollapsed(projectCollapsedKey) }}>
+                  &#x25BE;
+                </span>
+                <span class="project-title">Project: {proj.folderName}</span>
               </button>
+              <div
+                class="project-filter-row"
+                classList={{ open: filterOpen(), active: filterActive(), invalid: !!filterError() }}
+                data-ac-testid="project.regexFilter.row"
+              >
+                <div class="project-filter-field" classList={{ open: filterOpen() }}>
+                  <input
+                    ref={filterInputEl}
+                    class="project-filter-input"
+                    value={filterPattern()}
+                    placeholder="wg-2.*"
+                    aria-label="Sidebar regex filter"
+                    aria-invalid={!!filterError()}
+                    data-ac-testid="project.regexFilter.input"
+                    onInput={(e) => setFilterPattern(e.currentTarget.value)}
+                    onKeyDown={handleFilterKeyDown}
+                  />
+                  <Show when={filterPattern()}>
+                    <button
+                      type="button"
+                      class="project-filter-clear"
+                      title="Clear regex filter"
+                      aria-label="Clear regex filter"
+                      data-ac-testid="project.regexFilter.clear"
+                      onClick={clearFilter}
+                    >
+                      &#x2715;
+                    </button>
+                  </Show>
+                </div>
+                <button
+                  type="button"
+                  class="project-filter-toggle"
+                  title={filterOpen() ? "Hide regex filter" : "Filter sidebar (regex)"}
+                  aria-label={filterOpen() ? "Hide regex filter" : "Filter sidebar (regex)"}
+                  aria-expanded={filterOpen()}
+                  data-ac-testid="project.regexFilter.toggle"
+                  onClick={toggleFilter}
+                >
+                  <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <circle cx="11" cy="11" r="7" />
+                    <path d="m20 20-4.2-4.2" />
+                  </svg>
+                </button>
+              </div>
             </div>
             <Show when={filterError()}>
               {(error) => (

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -4322,14 +4322,17 @@ html.light-theme .settings-hint-warning {
   display: flex;
   align-items: center;
   gap: 6px;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  isolation: isolate;
   width: 100%;
   padding: 8px var(--spacing-md);
   border: none;
-  background: transparent;
+  background: var(--sidebar-bg);
   color: var(--sidebar-fg);
   font-size: var(--font-size-sm);
   font-family: var(--font-ui);
-  cursor: pointer;
   transition: color var(--transition-fast);
   text-align: left;
 }
@@ -4338,24 +4341,47 @@ html.light-theme .settings-hint-warning {
   color: var(--sidebar-accent);
 }
 
+.project-header-main {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0 32px 0 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
 .project-filter-row {
   display: flex;
   align-items: center;
   justify-content: flex-end;
   gap: 6px;
-  min-height: 34px;
-  padding: 4px var(--spacing-md);
-  background: var(--sidebar-bg);
-  border-bottom: 1px solid var(--sidebar-border);
+  position: absolute;
+  top: 50%;
+  right: var(--spacing-md);
+  left: calc(var(--spacing-md) + 20px);
+  z-index: 2;
+  min-width: 0;
+  height: 26px;
+  padding: 0;
+  background: transparent;
+  border-bottom: none;
+  pointer-events: none;
+  transform: translateY(-50%);
 }
 
 .project-filter-row.open,
 .project-filter-row.active {
-  background: rgba(0, 212, 255, 0.04);
+  background: transparent;
 }
 
 .project-filter-row.invalid {
-  background: rgba(255, 107, 107, 0.04);
+  background: transparent;
 }
 
 .project-filter-field {
@@ -4363,6 +4389,7 @@ html.light-theme .settings-hint-warning {
   align-items: center;
   gap: 4px;
   width: 0;
+  max-width: calc(100% - 32px);
   min-width: 0;
   opacity: 0;
   overflow: hidden;
@@ -4411,6 +4438,7 @@ html.light-theme .settings-hint-warning {
   background: transparent;
   color: var(--sidebar-fg-dim);
   cursor: pointer;
+  pointer-events: auto;
   transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
 }
 
@@ -4448,9 +4476,18 @@ html.light-theme .settings-hint-warning {
 }
 
 .project-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-weight: 600;
   letter-spacing: 0.3px;
   font-size: 11px;
+  transition: opacity var(--transition-fast);
+}
+
+.project-header.open .project-title {
+  opacity: 0;
 }
 
 .project-content {
@@ -5440,7 +5477,7 @@ html.light-theme[data-sidebar-style="card-sections"] .ac-wg-subgroup {
   );
   border: 1px solid rgba(60, 100, 180, 0.12);
   border-radius: 8px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 [data-sidebar-style="deep-space"] .project-header {
@@ -5451,7 +5488,8 @@ html.light-theme[data-sidebar-style="card-sections"] .ac-wg-subgroup {
     rgba(10, 15, 45, 0.4) 100%
   );
   border-bottom: 1px solid rgba(60, 130, 220, 0.15);
-  position: relative;
+  border-radius: 8px 8px 0 0;
+  position: sticky;
 }
 
 [data-sidebar-style="deep-space"] .project-header::after {
@@ -5911,7 +5949,7 @@ html.light-theme[data-sidebar-style="arctic-ops"] .root-agent-avatar {
   );
   border-bottom: 2px solid rgba(220, 160, 40, 0.25);
   border-top: 1px solid rgba(220, 160, 40, 0.1);
-  position: relative;
+  position: sticky;
 }
 
 [data-sidebar-style="obsidian-mesh"] .project-header::before {
@@ -6179,7 +6217,7 @@ html.light-theme[data-sidebar-style="obsidian-mesh"] .replica-item:has(.ac-disco
   border: 1px solid rgba(255, 0, 180, 0.1);
   border-radius: 4px;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
 }
 
 [data-sidebar-style="neon-circuit"] .project-panel::before {
@@ -6203,6 +6241,7 @@ html.light-theme[data-sidebar-style="obsidian-mesh"] .replica-item:has(.ac-disco
   padding: 9px 14px;
   background: rgba(255, 0, 180, 0.03);
   border-bottom: 1px solid rgba(255, 0, 180, 0.1);
+  border-radius: 4px 4px 0 0;
 }
 
 html.light-theme[data-sidebar-style="neon-circuit"] .project-header {


### PR DESCRIPTION
## Summary
- Keep the project name and search icon on one sticky header line.
- Expand the regex search input over the project title while search is active, then restore the normal header when dismissed.
- Preserve native right-click/Paste behavior inside the search input while keeping project context menus on the header.

## Verification
- Dev: `npx vitest run src/sidebar/components/ProjectPanel.regex-filter.test.tsx` passed, 18 tests.
- Dev: `npx vitest run src/sidebar/components/ProjectPanel.context-menu.test.tsx` passed, 27 tests.
- Dev: `npx vitest run src/sidebar/App.context-menu.test.ts src/sidebar/components/ProjectPanel.context-menu.test.tsx` passed, 29 tests.
- Dev: Step 9.5 affected frontend suites passed, 7 files / 96 tests.
- Dev: `npx tsc --noEmit` passed.
- Dev: `npm run build` passed before the merge update with existing Vite warnings only.
- Grinch: Step 9 final PASS and Step 9.5 PASS, including affected vitest suites and typecheck.

## Delivery notes
Visual change. Final 0_AC shipper build/deploy will run after merge from landed `main`.

Closes #809