### PR TITLE
feat(#810): sidebar group auto-focus - collapse others, expand+focus owner

### DIFF
--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -14,6 +14,7 @@ import { projectStore } from "../../sidebar/stores/project";
 import { sessionsStore } from "../../sidebar/stores/sessions";
 import { bridgesStore } from "../../sidebar/stores/bridges";
 import { workgroupGroupsStore } from "../../sidebar/stores/workgroup-groups";
+import { projectCollapseStore } from "../../sidebar/stores/project-collapse";
 import { codingAgentsStore } from "../../sidebar/stores/coding-agents";
 import { terminalStore } from "../../terminal/stores/terminal";
 import { __resetHomeStoreForTests } from "../../main/stores/home";
@@ -234,6 +235,7 @@ export function resetUiStoresForTests(): void {
   sessionsStore.setCoordSortByActivity(false);
   sessionsStore.clearDetached();
   workgroupGroupsStore.resetForTests();
+  projectCollapseStore.resetForTests();
   codingAgentsStore.resetForTests();
   bridgesStore.setBridges([]);
   terminalStore.setActiveSession(null, "", "", null, "", null, false);

--- a/src/sidebar/components/ProjectPanel.collapse-state.test.tsx
+++ b/src/sidebar/components/ProjectPanel.collapse-state.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProjectPanel from "./ProjectPanel";
+import WorkgroupGroupRail from "./WorkgroupGroupRail";
 import { FakeTransport } from "../../shared/testing/fake-transport";
 import {
   click,
@@ -11,6 +12,8 @@ import {
   waitFor,
 } from "../../shared/testing/ui-harness";
 import { projectStore } from "../stores/project";
+import { defaultGroupsConfig } from "../stores/workgroup-groups";
+import { projectCollapseStore } from "../stores/project-collapse";
 import type { AcDiscoveryResult, AcLoopSummary } from "../../shared/types";
 
 const projectPath = "C:\\Project";
@@ -194,6 +197,109 @@ describe("ProjectPanel collapse state", () => {
       await projectStore.reloadProject(projectPath);
       await waitFor(() => expect(fake.callsFor("discover_project")).toHaveLength(3));
       await waitFor(() => expect(headerCollapsed(headerByName(rendered.root, "Teams"))).toBe(true));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("preserves sub-section collapse of a project collapsed by #810 rail auto-focus", async () => {
+    // #810 cross-project case: owner A is auto-focused from the rail, other
+    // project B gets its project-level collapsed by collapseAllExceptKnown,
+    // but B's "Workgroups" sub-section collapse choice must survive (sub-
+    // sections stay in ProjectPanel's local collapsedByKey signal and are NOT
+    // touched by the rail's auto-focus). Two backslash Windows paths (grinch
+    // F4) so the focus lookup exercises the real production code path.
+    const otherProjectPath = "C:\\ProjectB";
+    let scrollIntoViewMock: ReturnType<typeof vi.fn>;
+    const scrollCalls: HTMLElement[] = [];
+
+    const fake = new FakeTransport();
+    fake.onInvoke("new_project", (args) => ({
+      path: args.path as string,
+      registered: true,
+      created: false,
+    }));
+    fake.onInvoke("discover_project", (args) => {
+      const path = args.path as string;
+      if (path === projectPath) return projectDiscovery("Stable task title");
+      if (path === otherProjectPath) {
+        // Minimal discovery for B: a single workgroup so the project renders.
+        return discovery({
+          workgroups: [
+            {
+              name: "wg-1-dev-team",
+              path: `${otherProjectPath}\\.ac\\wg-1-dev-team`,
+              task: null,
+              taskTitle: null,
+              agents: [
+                {
+                  name: "dev-webpage-ui",
+                  path: `${otherProjectPath}\\.ac\\wg-1-dev-team\\__agent_dev-webpage-ui`,
+                  repoPaths: [],
+                  isCoordinator: true,
+                },
+              ],
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected discover_project path: ${path}`);
+    });
+    fake.resolve("get_project_groups", { ...defaultGroupsConfig() });
+
+    scrollIntoViewMock = vi.fn(function (this: HTMLElement) {
+      scrollCalls.push(this);
+    });
+    Element.prototype.scrollIntoView = scrollIntoViewMock as any;
+
+    const rendered = renderWithFakeTransport(
+      () => (
+        <div class="sidebar-body">
+          <WorkgroupGroupRail projects={projectStore.projects} />
+          <div class="sidebar-scrollable">
+            <ProjectPanel />
+          </div>
+        </div>
+      ),
+      fake
+    );
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await projectStore.createAndLoad(otherProjectPath);
+      await waitFor(() => {
+        expect(rendered.root.textContent).toContain("Project: Project");
+        expect(rendered.root.textContent).toContain("Project: ProjectB");
+      });
+
+      // Collapse B's "Workgroups" sub-section header before triggering auto-focus.
+      const projectBHeader = Array.from(
+        rendered.root.querySelectorAll<HTMLElement>(".project-header")
+      ).find((h) => h.getAttribute("title") === otherProjectPath);
+      if (!projectBHeader) throw new Error("ProjectB header not found");
+      const projectBPanel = projectBHeader.closest(".project-panel");
+      const workgroupsHeaderB = Array.from(
+        projectBPanel!.querySelectorAll<HTMLElement>(".ac-wg-header--collapsible")
+      ).find((h) => h.querySelector(".ac-wg-name")?.textContent?.trim() === "Workgroups");
+      if (!workgroupsHeaderB) throw new Error("Workgroups sub-header not found in ProjectB");
+      click(workgroupsHeaderB);
+      await waitFor(() =>
+        expect(workgroupsHeaderB.querySelector(".ac-discovery-chevron")?.classList.contains("collapsed")).toBe(true)
+      );
+
+      // Click a rail group button in ProjectA's section (owner).
+      const railSectionA = document.querySelector<HTMLElement>('[data-ac-testid="workgroupGroups.rail.Project"]');
+      if (!railSectionA) throw new Error("rail section for Project not found");
+      const allButton = railSectionA.querySelector<HTMLElement>('[data-ac-testid="workgroupGroups.button.all"]');
+      if (!allButton) throw new Error("All button not found in Project rail section");
+      click(allButton);
+
+      // B's project-level chevron is collapsed by auto-focus...
+      await waitFor(() => {
+        const chev = projectBHeader.querySelector(".ac-discovery-chevron");
+        expect(chev?.classList.contains("collapsed")).toBe(true);
+      });
+      // ...but B's "Workgroups" sub-section collapse choice survives.
+      expect(workgroupsHeaderB.querySelector(".ac-discovery-chevron")?.classList.contains("collapsed")).toBe(true);
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -24,6 +24,20 @@ import {
   replicaVolatileStore,
 } from "../stores/replica-volatile";
 import { normalizeProjectPathForCompare } from "../stores/project-refresh";
+import {
+  projectCollapseStore,
+  projectPanelCollapseKey,
+  PROJECT_PANEL_COLLAPSE_KEY_SEP,
+} from "../stores/project-collapse";
+// #810 - PROJECT_PANEL_COLLAPSE_KEY_SEP, ProjectPanelCollapseSection, and
+// projectPanelCollapseKey moved to the project-collapse store (canonical
+// home). Re-exported here so any external importer that previously read them
+// from ProjectPanel keeps compiling.
+export {
+  PROJECT_PANEL_COLLAPSE_KEY_SEP,
+  projectPanelCollapseKey,
+  type ProjectPanelCollapseSection,
+} from "../stores/project-collapse";
 import { sessionsStore } from "../stores/sessions";
 import { bridgesStore } from "../stores/bridges";
 import { settingsStore } from "../../shared/stores/settings";
@@ -172,29 +186,6 @@ function deriveScopeContextFromSession(
 }
 
 const CONTEXT_MENU_VIEWPORT_MARGIN = 8;
-const PROJECT_PANEL_COLLAPSE_KEY_SEP = "\u0000";
-
-type ProjectPanelCollapseSection =
-  | "project"
-  | "selected-workgroup"
-  | "workgroups"
-  | "workgroup"
-  | "loops"
-  | "agents"
-  | "teams"
-  | "team";
-
-function projectPanelCollapseKey(
-  projectPath: string,
-  section: ProjectPanelCollapseSection,
-  id = ""
-): string {
-  return [
-    normalizeProjectPathForCompare(projectPath),
-    section,
-    id,
-  ].join(PROJECT_PANEL_COLLAPSE_KEY_SEP);
-}
 
 function workgroupCollapseId(wg: AcWorkgroup, rowContext: string): string {
   return [
@@ -398,6 +389,58 @@ const ProjectPanel: Component = () => {
       [key]: !(prev[key] ?? defaultCollapsed),
     }));
   };
+
+  // #810 - project-level collapse lives in projectCollapseStore so the rail
+  // can drive auto-focus (collapse others, expand owner, scroll owner into
+  // view). Sub-section keys stay in the local collapsedByKey signal above.
+  const isProjectPanelCollapsed = (projectPath: string) =>
+    projectCollapseStore.isProjectCollapsed(projectPath);
+  const toggleProjectPanelCollapsed = (projectPath: string) =>
+    projectCollapseStore.toggleProjectCollapsed(projectPath);
+
+  // #810 (grinch F1) - ref-Map of rendered .project-header elements keyed by
+  // the NORMALIZED project path. Lives in the stable ProjectPanel scope (not
+  // per-row) so it is not disposed mid-focus. A row's ref callback writes its
+  // header here on mount and clears it on cleanup. Replaces the original
+  // CSS-attribute-selector approach, which silently no-oped on Windows
+  // backslash paths because CSS string tokens consume `\` as an escape char.
+  const projectHeaderEls = new Map<string, HTMLElement>();
+  const registerProjectHeader = (projectPath: string, el: HTMLElement | null) => {
+    const key = normalizeProjectPathForCompare(projectPath);
+    if (el) {
+      projectHeaderEls.set(key, el);
+    } else {
+      // Only delete if the registered entry is still the same el; a stale
+      // ref from a disposed row may have already been overwritten by the
+      // new row's mount.
+      if (projectHeaderEls.get(key) === el) {
+        projectHeaderEls.delete(key);
+      }
+    }
+  };
+
+  // #810 - one-shot focus: scroll the owner project header into view when
+  // the rail requests it. block:"nearest" so an already-visible owner does
+  // not jump. The target from the store is already NORMALIZED; the ref-Map
+  // is keyed on the same normalized form, so map.get(target) resolves
+  // without any CSS selector. Grinch F6: capture target before deferring to
+  // the microtask and only consume the focus if the live signal still
+  // equals the captured value, so two fast clicks (A then B) cannot have
+  // microtask-A clear B's pending target.
+  createEffect(() => {
+    const target = projectCollapseStore.focusTarget();
+    if (!target) return;
+    // Defer to next microtask so the expand (setProjectCollapsed false)
+    // applied by the rail onClick has propagated and the header/body are
+    // mounted before we scroll.
+    queueMicrotask(() => {
+      const live = projectCollapseStore.focusTarget();
+      if (live !== target) return;
+      const el = projectHeaderEls.get(target);
+      el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      projectCollapseStore.consumeProjectFocus();
+    });
+  });
 
   // #537: post-assign "Restart now?" prompt. Hoisted to the stable ProjectPanel
   // scope (NOT inside the projects <For>) so a background replica-list refresh,
@@ -1588,7 +1631,12 @@ const ProjectPanel: Component = () => {
 
         const hasTeams = () => proj.teams.length > 0;
         const projectAutomationId = () => automationIdPart(proj.path);
-        const projectCollapsedKey = projectPanelCollapseKey(proj.path, "project");
+        // #810 - the "project" section key moved to the project-collapse store.
+        // Sub-section keys below still use the local collapsedByKey signal.
+        // Clear the ref-Map entry for this row when the <For> disposes it
+        // (background discovery refresh re-creates rows; registerProjectHeader
+        // null-branch is a no-op if a newer row already overwrote the key).
+        onCleanup(() => registerProjectHeader(proj.path, null));
         const selectedWorkgroupCollapsedKey = projectPanelCollapseKey(proj.path, "selected-workgroup");
         const workgroupsCollapsedKey = projectPanelCollapseKey(proj.path, "workgroups");
         const loopsCollapsedKey = projectPanelCollapseKey(proj.path, "loops");
@@ -2275,10 +2323,18 @@ const ProjectPanel: Component = () => {
             <button
               class="project-header"
               title={proj.path}
-              onClick={() => togglePanelCollapsed(projectCollapsedKey)}
+              ref={(el) => {
+                // #810 (grinch F1) - register this header element in the
+                // stable-scope ref-Map so the focus effect can scroll it
+                // into view by normalized path key. CSS attribute selector
+                // approach was dropped: backslashes in Windows paths break
+                // the CSS string-token parser.
+                registerProjectHeader(proj.path, el);
+              }}
+              onClick={() => toggleProjectPanelCollapsed(proj.path)}
               onContextMenu={handleProjectContextMenu}
             >
-              <span class="ac-discovery-chevron" classList={{ collapsed: isPanelCollapsed(projectCollapsedKey) }}>
+              <span class="ac-discovery-chevron" classList={{ collapsed: isProjectPanelCollapsed(proj.path) }}>
                 &#x25BE;
               </span>
               <span class="project-title">Project: {proj.folderName}</span>
@@ -2397,7 +2453,7 @@ const ProjectPanel: Component = () => {
                 background refresh that re-creates the row no longer disposes an
                 open modal. See the hoisted render blocks below. */}
 
-            <Show when={!isPanelCollapsed(projectCollapsedKey)}>
+            <Show when={!isProjectPanelCollapsed(proj.path)}>
               <div class="project-content">
                 {/* Coordinator Quick-Access — shown by styles that enable it via CSS */}
                 {(() => {

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -405,19 +405,6 @@ const ProjectPanel: Component = () => {
   // CSS-attribute-selector approach, which silently no-oped on Windows
   // backslash paths because CSS string tokens consume `\` as an escape char.
   const projectHeaderEls = new Map<string, HTMLElement>();
-  const registerProjectHeader = (projectPath: string, el: HTMLElement | null) => {
-    const key = normalizeProjectPathForCompare(projectPath);
-    if (el) {
-      projectHeaderEls.set(key, el);
-    } else {
-      // Only delete if the registered entry is still the same el; a stale
-      // ref from a disposed row may have already been overwritten by the
-      // new row's mount.
-      if (projectHeaderEls.get(key) === el) {
-        projectHeaderEls.delete(key);
-      }
-    }
-  };
 
   // #810 - one-shot focus: scroll the owner project header into view when
   // the rail requests it. block:"nearest" so an already-visible owner does
@@ -1633,10 +1620,6 @@ const ProjectPanel: Component = () => {
         const projectAutomationId = () => automationIdPart(proj.path);
         // #810 - the "project" section key moved to the project-collapse store.
         // Sub-section keys below still use the local collapsedByKey signal.
-        // Clear the ref-Map entry for this row when the <For> disposes it
-        // (background discovery refresh re-creates rows; registerProjectHeader
-        // null-branch is a no-op if a newer row already overwrote the key).
-        onCleanup(() => registerProjectHeader(proj.path, null));
         const selectedWorkgroupCollapsedKey = projectPanelCollapseKey(proj.path, "selected-workgroup");
         const workgroupsCollapsedKey = projectPanelCollapseKey(proj.path, "workgroups");
         const loopsCollapsedKey = projectPanelCollapseKey(proj.path, "loops");
@@ -2324,12 +2307,23 @@ const ProjectPanel: Component = () => {
               class="project-header"
               title={proj.path}
               ref={(el) => {
-                // #810 (grinch F1) - register this header element in the
-                // stable-scope ref-Map so the focus effect can scroll it
+                // #810 (grinch F1 + B1) - register this header element in
+                // the stable-scope ref-Map so the focus effect can scroll it
                 // into view by normalized path key. CSS attribute selector
                 // approach was dropped: backslashes in Windows paths break
-                // the CSS string-token parser.
-                registerProjectHeader(proj.path, el);
+                // the CSS string-token parser. Cleanup owns the deletion
+                // here (captures this specific el): on true project removal
+                // it frees the detached node; on a refresh re-mount the
+                // guard `get(key) === el` is false because the newer row
+                // already `set` a different element, so the fresh entry is
+                // correctly left intact.
+                const key = normalizeProjectPathForCompare(proj.path);
+                projectHeaderEls.set(key, el);
+                onCleanup(() => {
+                  if (projectHeaderEls.get(key) === el) {
+                    projectHeaderEls.delete(key);
+                  }
+                });
               }}
               onClick={() => toggleProjectPanelCollapsed(proj.path)}
               onContextMenu={handleProjectContextMenu}

--- a/src/sidebar/components/WorkgroupGroupRail.autofocus.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.autofocus.test.tsx
@@ -1,0 +1,301 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Component } from "solid-js";
+import type { AcDiscoveryResult, WorkgroupGroupsConfig } from "../../shared/types";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { defaultGroupsConfig, workgroupGroupsStore } from "../stores/workgroup-groups";
+import { projectCollapseStore } from "../stores/project-collapse";
+import WorkgroupGroupRail from "./WorkgroupGroupRail";
+import ProjectPanel from "./ProjectPanel";
+
+// #810 - Two backslash Windows paths (grinch F4). Forward-slash or simplified
+// paths would hide the F1 regression (CSS selector happened to parse cleanly).
+// With the ref-Map fix, backslash paths exercise the real production code path.
+const projectPathA = "C:\\ProjectA";
+const projectPathB = "C:\\ProjectB";
+
+function projectDiscovery(path: string, folderName: string): AcDiscoveryResult {
+  const wgPath = `${path}\\.ac\\wg-1-dev-team`;
+  return discovery({
+    workgroups: [
+      {
+        name: "wg-1-dev-team",
+        path: wgPath,
+        task: null,
+        taskTitle: null,
+        agents: [
+          {
+            name: "dev-webpage-ui",
+            path: `${wgPath}\\__agent_dev-webpage-ui`,
+            repoPaths: [],
+            isCoordinator: true,
+          },
+        ],
+      },
+    ],
+    agents: [],
+    teams: [],
+    loops: [],
+  });
+}
+
+function groupsConfig(): WorkgroupGroupsConfig {
+  return { ...defaultGroupsConfig() };
+}
+
+// #810 (grinch F1) - find the .project-header button by its title ATTRIBUTE
+// value via getAttribute, NOT via a CSS attribute selector. A CSS selector
+// like `[title="C:\ProjectA"]` would parse `\P` as `P` (CSS string-token
+// escape) and fail to match the real attribute - the exact bug F1 fixed in
+// the production code. The test must NOT use the broken pattern.
+function findProjectHeader(root: ParentNode, projectPath: string): HTMLElement {
+  const headers = Array.from(root.querySelectorAll<HTMLElement>(".project-header"));
+  const header = headers.find((h) => h.getAttribute("title") === projectPath);
+  if (!header) throw new Error(`project-header not found for ${projectPath}`);
+  return header;
+}
+
+function headerCollapsed(header: HTMLElement): boolean {
+  const chevron = header.querySelector(".ac-discovery-chevron");
+  if (!chevron) throw new Error("Header chevron not found");
+  return chevron.classList.contains("collapsed");
+}
+
+// Scope a rail button click to a specific project's rail section. The rail
+// renders `data-ac-testid="workgroupGroups.rail.${folderName}"` per project.
+function railButton(projectFolder: string, buttonKey: string): HTMLElement {
+  const section = document.querySelector<HTMLElement>(
+    `[data-ac-testid="workgroupGroups.rail.${projectFolder}"]`
+  );
+  if (!section) throw new Error(`rail section not found for ${projectFolder}`);
+  const btn = section.querySelector<HTMLElement>(`[data-ac-testid="workgroupGroups.button.${buttonKey}"]`);
+  if (!btn) throw new Error(`rail button ${buttonKey} not found in ${projectFolder}`);
+  return btn;
+}
+
+// Component that renders both siblings the same way App.tsx does (rail +
+// scrollable ProjectPanel), so the rail's onClick can drive the shared
+// projectCollapseStore that ProjectPanel reads.
+const SidebarHarness: Component<{ projects: typeof projectStore.projects }> = () => {
+  return (
+    <div class="sidebar-body">
+      <WorkgroupGroupRail projects={projectStore.projects} />
+      <div class="sidebar-scrollable">
+        <ProjectPanel />
+      </div>
+    </div>
+  );
+};
+
+describe("WorkgroupGroupRail autofocus (#810)", () => {
+  let cleanupDom: (() => void) | null = null;
+  let scrollIntoViewMock: ReturnType<typeof vi.fn>;
+  let scrollCalls: HTMLElement[] = [];
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+    scrollCalls = [];
+    // #810 - jsdom throws "Not implemented: window.scrollIntoView" without a
+    // mock. Capture the `this` element of each call so we can assert the
+    // scroll targeted the owner's specific header element (grinch F4).
+    scrollIntoViewMock = vi.fn(function (this: HTMLElement, _options: ScrollIntoViewOptions) {
+      scrollCalls.push(this);
+    });
+    Element.prototype.scrollIntoView = scrollIntoViewMock as any;
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("collapses other projects, expands the owner, and scrolls the owner header into view", async () => {
+    const fake = new FakeTransport();
+    fake.onInvoke("new_project", (args) => ({
+      path: args.path as string,
+      registered: true,
+      created: false,
+    }));
+    fake.onInvoke("discover_project", (args) => {
+      const path = args.path as string;
+      if (path === projectPathA) return projectDiscovery(path, "ProjectA");
+      if (path === projectPathB) return projectDiscovery(path, "ProjectB");
+      throw new Error(`unexpected discover_project path: ${path}`);
+    });
+    fake.resolve("get_project_groups", groupsConfig());
+
+    const rendered = renderWithFakeTransport(() => <SidebarHarness projects={projectStore.projects} />, fake);
+    try {
+      await projectStore.createAndLoad(projectPathA);
+      await projectStore.createAndLoad(projectPathB);
+      await waitFor(() => {
+        expect(findProjectHeader(rendered.root, projectPathA)).toBeTruthy();
+        expect(findProjectHeader(rendered.root, projectPathB)).toBeTruthy();
+      });
+
+      // Both start expanded (default).
+      expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(false);
+      expect(headerCollapsed(findProjectHeader(rendered.root, projectPathB))).toBe(false);
+
+      // Click the "All" group button in ProjectA's rail section.
+      click(railButton("ProjectA", "all"));
+
+      // Owner (A) stays/becomes expanded; other (B) is collapsed.
+      await waitFor(() => {
+        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(false);
+      });
+      await waitFor(() => {
+        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathB))).toBe(true);
+      });
+
+      // scrollIntoView fired on ProjectA's specific .project-header element
+      // (the one whose title attr equals ProjectA's path), with the mandated
+      // options. This is the F1 regression guard: a CSS-selector-based lookup
+      // would have returned null on the backslash path and no-op'd.
+      await waitFor(() => expect(scrollCalls.length).toBeGreaterThanOrEqual(1));
+      const ownerHeader = findProjectHeader(rendered.root, projectPathA);
+      const ownerScrollCall = scrollCalls.find((el) => el === ownerHeader);
+      expect(ownerScrollCall).toBeTruthy();
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest", behavior: "smooth" });
+
+      // Focus target is consumed (one-shot).
+      expect(projectCollapseStore.focusTarget()).toBe(null);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("expands the owner even if it was manually collapsed beforehand (locked decision: expand owner always)", async () => {
+    const fake = new FakeTransport();
+    fake.onInvoke("new_project", (args) => ({
+      path: args.path as string,
+      registered: true,
+      created: false,
+    }));
+    fake.onInvoke("discover_project", (args) => {
+      const path = args.path as string;
+      if (path === projectPathA) return projectDiscovery(path, "ProjectA");
+      if (path === projectPathB) return projectDiscovery(path, "ProjectB");
+      throw new Error(`unexpected discover_project path: ${path}`);
+    });
+    fake.resolve("get_project_groups", groupsConfig());
+
+    const rendered = renderWithFakeTransport(() => <SidebarHarness projects={projectStore.projects} />, fake);
+    try {
+      await projectStore.createAndLoad(projectPathA);
+      await projectStore.createAndLoad(projectPathB);
+      await waitFor(() => expect(findProjectHeader(rendered.root, projectPathA)).toBeTruthy());
+
+      // Manually collapse ProjectA first.
+      click(findProjectHeader(rendered.root, projectPathA));
+      await waitFor(() =>
+        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(true)
+      );
+
+      // Auto-focus from the rail must override the manual collapse.
+      click(railButton("ProjectA", "all"));
+      await waitFor(() =>
+        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(false)
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("preserves the other project's sub-section collapse when auto-focus collapses its project", async () => {
+    const fake = new FakeTransport();
+    fake.onInvoke("new_project", (args) => ({
+      path: args.path as string,
+      registered: true,
+      created: false,
+    }));
+    fake.onInvoke("discover_project", (args) => {
+      const path = args.path as string;
+      if (path === projectPathA) return projectDiscovery(path, "ProjectA");
+      if (path === projectPathB) return projectDiscovery(path, "ProjectB");
+      throw new Error(`unexpected discover_project path: ${path}`);
+    });
+    fake.resolve("get_project_groups", groupsConfig());
+
+    const rendered = renderWithFakeTransport(() => <SidebarHarness projects={projectStore.projects} />, fake);
+    try {
+      await projectStore.createAndLoad(projectPathA);
+      await projectStore.createAndLoad(projectPathB);
+      await waitFor(() => expect(findProjectHeader(rendered.root, projectPathB)).toBeTruthy());
+
+      // Collapse the "Workgroups" sub-section header in ProjectB before auto-focus.
+      const workgroupsHeaderB = Array.from(
+        rendered.root.querySelectorAll<HTMLElement>(".ac-wg-header--collapsible")
+      ).find((h) => h.querySelector(".ac-wg-name")?.textContent?.trim() === "Workgroups");
+      if (!workgroupsHeaderB) throw new Error("Workgroups sub-header not found in ProjectB");
+      // First locate ProjectB's panel to scope the sub-header lookup.
+      const projectBPanel = findProjectHeader(rendered.root, projectPathB).closest(".project-panel");
+      const workgroupsHeaderInB = Array.from(
+        projectBPanel!.querySelectorAll<HTMLElement>(".ac-wg-header--collapsible")
+      ).find((h) => h.querySelector(".ac-wg-name")?.textContent?.trim() === "Workgroups");
+      if (!workgroupsHeaderInB) throw new Error("Workgroups sub-header not found inside ProjectB panel");
+      click(workgroupsHeaderInB);
+      await waitFor(() => {
+        const chev = workgroupsHeaderInB.querySelector(".ac-discovery-chevron");
+        expect(chev?.classList.contains("collapsed")).toBe(true);
+      });
+
+      // Auto-focus ProjectA -> ProjectB's project-level collapses, but its
+      // "Workgroups" sub-section collapse choice must survive (sub-sections
+      // are NOT touched by #810 - they live in the local collapsedByKey signal).
+      click(railButton("ProjectA", "all"));
+      await waitFor(() =>
+        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathB))).toBe(true)
+      );
+
+      // ProjectB is now project-collapsed, but its Workgroups sub-section
+      // header chevron is still collapsed (preserved).
+      expect(workgroupsHeaderInB.querySelector(".ac-discovery-chevron")?.classList.contains("collapsed")).toBe(true);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("does not throw on a single-project layout and still scrolls the owner into view", async () => {
+    const fake = new FakeTransport();
+    fake.onInvoke("new_project", (args) => ({
+      path: args.path as string,
+      registered: true,
+      created: false,
+    }));
+    fake.onInvoke("discover_project", (args) => {
+      const path = args.path as string;
+      if (path === projectPathA) return projectDiscovery(path, "ProjectA");
+      throw new Error(`unexpected discover_project path: ${path}`);
+    });
+    fake.resolve("get_project_groups", groupsConfig());
+
+    const rendered = renderWithFakeTransport(() => <SidebarHarness projects={projectStore.projects} />, fake);
+    try {
+      await projectStore.createAndLoad(projectPathA);
+      await waitFor(() => expect(findProjectHeader(rendered.root, projectPathA)).toBeTruthy());
+
+      // Single project: collapse-others is a no-op (only owner in the list),
+      // but the click must not throw and the owner still scrolls into view.
+      click(railButton("ProjectA", "all"));
+      await waitFor(() => expect(scrollCalls.length).toBeGreaterThanOrEqual(1));
+      const ownerHeader = findProjectHeader(rendered.root, projectPathA);
+      expect(scrollCalls.find((el) => el === ownerHeader)).toBeTruthy();
+      expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(false);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -1,6 +1,8 @@
 import { Component, For, Show, createEffect, createMemo, createSignal } from "solid-js";
 import type { AcWorkgroup, WorkgroupGroup } from "../../shared/types";
 import type { ProjectState } from "../stores/project";
+import { projectStore } from "../stores/project";
+import { projectCollapseStore } from "../stores/project-collapse";
 import {
   MAX_GROUP_MATCH_ID_LENGTH,
   compileGroupRegex,
@@ -178,7 +180,21 @@ const ProjectRailSection: Component<{
             classList={{ selected: selected(button) }}
             aria-pressed={selected(button)}
             title={button.title}
-            onClick={() => workgroupGroupsStore.select(props.project.path, button.selection)}
+            onClick={() => {
+              workgroupGroupsStore.select(props.project.path, button.selection);
+              // #810 - auto-focus: collapse other projects, expand owner,
+              // scroll owner into view. One-shot at click time; we do NOT
+              // re-collapse projects the user re-expands afterwards manually.
+              // Grinch F2: feed the live projectStore.projects list to the
+              // explicit-list overload so collapse-others works on a fresh
+              // session where the collapse map is still empty.
+              projectCollapseStore.collapseAllExceptKnown(
+                props.project.path,
+                projectStore.projects.map((p) => p.path)
+              );
+              projectCollapseStore.setProjectCollapsed(props.project.path, false);
+              projectCollapseStore.requestProjectFocus(props.project.path);
+            }}
             data-ac-testid={`workgroupGroups.button.${button.key}`}
           >
             <span class="workgroup-group-rail-title-line">

--- a/src/sidebar/stores/project-collapse.test.ts
+++ b/src/sidebar/stores/project-collapse.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  PROJECT_PANEL_COLLAPSE_KEY_SEP,
+  projectCollapseStore,
+  projectPanelCollapseKey,
+} from "./project-collapse";
+
+const projectA = "C:\\ProjectA";
+const projectB = "C:\\ProjectB";
+
+describe("projectCollapseStore", () => {
+  beforeEach(() => {
+    projectCollapseStore.resetForTests();
+  });
+
+  afterEach(() => {
+    projectCollapseStore.resetForTests();
+  });
+
+  it("defaults to expanded (false) for an unknown project path", () => {
+    expect(projectCollapseStore.isProjectCollapsed(projectA)).toBe(false);
+  });
+
+  it("setProjectCollapsed / isProjectCollapsed round-trip", () => {
+    projectCollapseStore.setProjectCollapsed(projectA, true);
+    expect(projectCollapseStore.isProjectCollapsed(projectA)).toBe(true);
+    projectCollapseStore.setProjectCollapsed(projectA, false);
+    expect(projectCollapseStore.isProjectCollapsed(projectA)).toBe(false);
+  });
+
+  it("normalizes paths before keying (C:\\ProjectA == c:/projecta)", () => {
+    projectCollapseStore.setProjectCollapsed("C:\\ProjectA", true);
+    expect(projectCollapseStore.isProjectCollapsed("c:/projecta")).toBe(true);
+    expect(projectCollapseStore.isProjectCollapsed("C:\\ProjectA\\")).toBe(true);
+  });
+
+  it("toggleProjectCollapsed flips state", () => {
+    expect(projectCollapseStore.isProjectCollapsed(projectA)).toBe(false);
+    projectCollapseStore.toggleProjectCollapsed(projectA);
+    expect(projectCollapseStore.isProjectCollapsed(projectA)).toBe(true);
+    projectCollapseStore.toggleProjectCollapsed(projectA);
+    expect(projectCollapseStore.isProjectCollapsed(projectA)).toBe(false);
+  });
+
+  it("collapseAllProjectsExcept only touches keys already in the map (known-set semantics)", () => {
+    // Seed A and B so the map has both keys.
+    projectCollapseStore.setProjectCollapsed(projectA, false);
+    projectCollapseStore.setProjectCollapsed(projectB, false);
+    // Collapse every known project except A.
+    projectCollapseStore.collapseAllProjectsExcept(projectA);
+    expect(projectCollapseStore.isProjectCollapsed(projectA)).toBe(false);
+    expect(projectCollapseStore.isProjectCollapsed(projectB)).toBe(true);
+  });
+
+  it("collapseAllProjectsExcept is a no-op on a fresh (empty) map (grinch F2 rationale)", () => {
+    // No project has been toggled yet -> map is {} -> nothing to collapse.
+    projectCollapseStore.collapseAllProjectsExcept(projectA);
+    expect(projectCollapseStore.isProjectCollapsed(projectB)).toBe(false);
+  });
+
+  it("collapseAllExceptKnown collapses every path in the list except owner (grinch F2 fix)", () => {
+    // Fresh session: map is {}. The rail feeds the live project list.
+    projectCollapseStore.collapseAllExceptKnown(projectA, [projectA, projectB]);
+    expect(projectCollapseStore.isProjectCollapsed(projectA)).toBe(false);
+    expect(projectCollapseStore.isProjectCollapsed(projectB)).toBe(true);
+  });
+
+  it("collapseAllExceptKnown preserves owner's prior state and other known entries", () => {
+    projectCollapseStore.setProjectCollapsed(projectA, true);
+    projectCollapseStore.setProjectCollapsed(projectB, false);
+    projectCollapseStore.collapseAllExceptKnown(projectA, [projectA, projectB]);
+    // Owner is deliberately untouched by collapseAllExceptKnown; caller must
+    // explicitly expand it.
+    expect(projectCollapseStore.isProjectCollapsed(projectA)).toBe(true);
+    expect(projectCollapseStore.isProjectCollapsed(projectB)).toBe(true);
+  });
+
+  it("requestProjectFocus / focusTarget / consumeProjectFocus: consume returns once then null", () => {
+    expect(projectCollapseStore.focusTarget()).toBe(null);
+    projectCollapseStore.requestProjectFocus(projectA);
+    // Stored normalized.
+    expect(projectCollapseStore.focusTarget()).toBe("c:/projecta");
+    expect(projectCollapseStore.consumeProjectFocus()).toBe("c:/projecta");
+    expect(projectCollapseStore.focusTarget()).toBe(null);
+    // Second consume is null (already consumed).
+    expect(projectCollapseStore.consumeProjectFocus()).toBe(null);
+  });
+
+  it("requestProjectFocus normalizes the path before storing", () => {
+    projectCollapseStore.requestProjectFocus("C:\\ProjectA\\");
+    expect(projectCollapseStore.focusTarget()).toBe("c:/projecta");
+  });
+
+  it("resetForTests clears collapse state and focus target", () => {
+    projectCollapseStore.setProjectCollapsed(projectA, true);
+    projectCollapseStore.requestProjectFocus(projectB);
+    projectCollapseStore.resetForTests();
+    expect(projectCollapseStore.isProjectCollapsed(projectA)).toBe(false);
+    expect(projectCollapseStore.focusTarget()).toBe(null);
+  });
+
+  it("projectPanelCollapseKey joins normalized path + section + id with the separator", () => {
+    expect(projectPanelCollapseKey("C:\\Project", "project")).toBe(
+      `c:/project${PROJECT_PANEL_COLLAPSE_KEY_SEP}project${PROJECT_PANEL_COLLAPSE_KEY_SEP}`
+    );
+    expect(projectPanelCollapseKey("C:\\Project", "workgroup", "wg-1")).toBe(
+      `c:/project${PROJECT_PANEL_COLLAPSE_KEY_SEP}workgroup${PROJECT_PANEL_COLLAPSE_KEY_SEP}wg-1`
+    );
+  });
+});

--- a/src/sidebar/stores/project-collapse.ts
+++ b/src/sidebar/stores/project-collapse.ts
@@ -1,0 +1,120 @@
+import { createSignal } from "solid-js";
+import { normalizeProjectPathForCompare } from "./project-refresh";
+
+// #810 - Project-level (NOT sub-section) collapse state hoisted into a shared
+// store so WorkgroupGroupRail can drive auto-focus (collapse others, expand
+// owner, scroll owner into view) without App.tsx threading a callback prop
+// into ProjectPanel internals. Sub-section collapse (workgroups/loops/agents/
+// teams/workgroup/team) STAYS in ProjectPanel's local collapsedByKey signal;
+// this store only owns the "project" section key. Session-only, no persistence
+// (consistent with Role.md: no localStorage for UI state).
+export const PROJECT_PANEL_COLLAPSE_KEY_SEP = "\u0000";
+
+export type ProjectPanelCollapseSection =
+  | "project"
+  | "selected-workgroup"
+  | "workgroups"
+  | "workgroup"
+  | "loops"
+  | "agents"
+  | "teams"
+  | "team";
+
+export function projectPanelCollapseKey(
+  projectPath: string,
+  section: ProjectPanelCollapseSection,
+  id = ""
+): string {
+  return [
+    normalizeProjectPathForCompare(projectPath),
+    section,
+    id,
+  ].join(PROJECT_PANEL_COLLAPSE_KEY_SEP);
+}
+
+// Only the "project" section lives here. Keyed by the SAME composite string
+// ProjectPanel used locally (projectPath-normalized + "project" + "").
+const [collapsedProjects, setCollapsedProjects] = createSignal<Record<string, boolean>>({});
+
+// #810 - one-shot focus target. Stored NORMALIZED (via
+// normalizeProjectPathForCompare) so the rail can pass the raw props.project.path
+// and ProjectPanel's ref-Map (keyed on the same normalized form) resolves it.
+// ProjectPanel reads focusTarget() in a createEffect, scrolls the matching
+// header element into view via its own Map<string, HTMLElement>, then consumes
+// it. Stays null when no focus is requested.
+const [focusTarget, setFocusTarget] = createSignal<string | null>(null);
+
+function projectKey(projectPath: string): string {
+  return projectPanelCollapseKey(projectPath, "project");
+}
+
+export const projectCollapseStore = {
+  isProjectCollapsed(projectPath: string): boolean {
+    return collapsedProjects()[projectKey(projectPath)] ?? false;
+  },
+  setProjectCollapsed(projectPath: string, collapsed: boolean): void {
+    const key = projectKey(projectPath);
+    setCollapsedProjects((prev) => ({ ...prev, [key]: collapsed }));
+  },
+  toggleProjectCollapsed(projectPath: string): void {
+    const key = projectKey(projectPath);
+    setCollapsedProjects((prev) => ({ ...prev, [key]: !(prev[key] ?? false) }));
+  },
+  // #810 - one-shot: collapse every KNOWN project except the owner. "Known"
+  // means any project path that has an entry in the map (i.e. has been
+  // toggled or auto-focused before). The rail does NOT use this overload -
+  // it uses collapseAllExceptKnown with the live projectStore.projects list,
+  // because on a fresh session the map is {} and this method would no-op
+  // (grinch F2). This method is kept for the unit test to assert the
+  // known-set semantics and as a future-proof API.
+  collapseAllProjectsExcept(projectPath: string): void {
+    const ownerKey = projectKey(projectPath);
+    setCollapsedProjects((prev) => {
+      const next: Record<string, boolean> = {};
+      for (const k of Object.keys(prev)) {
+        next[k] = k === ownerKey ? prev[k] : true;
+      }
+      return next;
+    });
+  },
+  // Overload for collapsing an explicit list of project paths. Used by the
+  // rail onClick (grinch F2): feeds the live projectStore.projects so
+  // "collapse others" works on a fresh session where the map is empty. The
+  // owner is deliberately left untouched so the caller composes the two
+  // intents (this + setProjectCollapsed(owner, false)).
+  collapseAllExceptKnown(ownerPath: string, allPaths: string[]): void {
+    const ownerKey = projectKey(ownerPath);
+    setCollapsedProjects((prev) => {
+      const next: Record<string, boolean> = { ...prev };
+      for (const p of allPaths) {
+        const k = projectKey(p);
+        if (k !== ownerKey) next[k] = true;
+      }
+      return next;
+    });
+  },
+  // #810 - focus target is stored NORMALIZED. The rail passes the raw
+  // props.project.path; ProjectPanel's ref-Map is keyed on the same
+  // normalized form, so the effect's map.get(target) resolves.
+  focusTarget(): string | null {
+    return focusTarget();
+  },
+  requestProjectFocus(projectPath: string): void {
+    setFocusTarget(normalizeProjectPathForCompare(projectPath));
+  },
+  // #810 - one-shot consume: returns the current target and clears it.
+  // The focus effect in ProjectPanel captures target BEFORE deferring to a
+  // microtask (grinch F6): on two fast clicks (A then B), microtask-A must
+  // NOT clear B's pending target. The effect handles that by checking the
+  // live signal against its captured value before calling consume; this
+  // method just clears-and-returns whatever is live.
+  consumeProjectFocus(): string | null {
+    const current = focusTarget();
+    if (current !== null) setFocusTarget(null);
+    return current;
+  },
+  resetForTests(): void {
+    setCollapsedProjects({});
+    setFocusTarget(null);
+  },
+};


### PR DESCRIPTION
Closes #810

## What

When a group is selected in the sidebar rail, the sidebar now auto-focuses that group's project: it collapses every other project (project-level only, sub-section collapse choices preserved), expands the owner project (always, even if manually collapsed), and scrolls the owner header into view.

## Product decisions (confirmed with user)
- Expand the owner project always, even if manually collapsed.
- One-shot collapse at click time; projects manually re-expanded afterward are not re-collapsed.
- Always collapse other projects (a regex filter being typed elsewhere is hidden, not cleared).
- Session-only state; no persistence change. Pure frontend, no backend/`src-tauri`.

## Approach
New shared `project-collapse` store bridges the rail and `ProjectPanel` (mirrors the existing group-selection store pattern). Only the project-level collapse key moves to the store; sub-section keys stay local to `ProjectPanel`. Owner header located via a `Map<normalizedPath, HTMLElement>` ref registry (no CSS selector).

## Review trail (full delivery pipeline)
- **Architect** wrote the plan; verdict READY_FOR_IMPLEMENTATION.
- **Grinch adversarial enrich** found 2 blockers in the plan, both fixed before coding:
  - **F1:** original CSS attribute-selector focus lookup silently no-ops on Windows backslash paths (`\` is the CSS string escape char) → replaced with a normalized ref-Map. Test guard added (two backslash paths, asserts scroll on the specific element).
  - **F2:** "collapse others" no-op on a fresh session (known-set never populated) → rail now feeds the live project list explicitly.
- **Grinch diff review** found **B1** (dead ref-Map cleanup → detached header leak on true project removal); fixed (cleanup owned in the ref callback, capturing the element).
- **Merged origin/main** (which had restructured `.project-header` and added group-rail drag-reorder in the same files); conflicts reconciled so both behaviors coexist (a reorder drag correctly suppresses auto-focus). Grinch re-reviewed the merge resolution: PASS.

## Tests
`npx tsc --noEmit` PASS · `npx vitest run` **753/753** (95 files), including new `project-collapse.test.ts` (12), `WorkgroupGroupRail.autofocus.test.tsx` (4), a new cross-project `ProjectPanel.collapse-state.test.tsx` case, and all of main's newly-added tests.

## Files
`src/sidebar/stores/project-collapse.ts` (new) + test, `src/sidebar/components/WorkgroupGroupRail.autofocus.test.tsx` (new), edits to `ProjectPanel.tsx`, `WorkgroupGroupRail.tsx`, `ProjectPanel.collapse-state.test.tsx`, `src/shared/testing/ui-harness.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
