### PR TITLE
feat: add Telegram auto-close exemption, refs #817

### DIFF
--- a/docs/features/session-auto-close.md
+++ b/docs/features/session-auto-close.md
@@ -51,12 +51,13 @@ If only a non-coordinator member is reaped while the coordinator survives (the c
 
 ## Settings
 
-All four keys live in `settings.json` (see the [settings reference](../reference/settings.md#session-auto-close)). Defaults shown.
+These keys live in `settings.json` (see the [settings reference](../reference/settings.md#session-auto-close)). Defaults shown.
 
 | Key | Type | Default | Meaning |
 |---|---|---|---|
 | `coordinatorAutoCloseEnabled` | bool | `true` | Master switch. When false, AC never auto-closes a team (the badge still shows). |
 | `coordinatorAutoCloseMinutes` | number | `60` | Idle minutes before a team is closed. `0` also disables auto-close. |
+| `coordinatorAutoCloseSkipTelegramAssigned` | bool | `false` | When true, auto-close skips sessions with Telegram assigned. Other sessions keep following the normal auto-close rules. |
 | `coordinatorIdleBadgeYellowMinutes` | number | `30` | Idle minutes at which the badge turns yellow. |
 | `coordinatorIdleBadgeRedMinutes` | number | `60` | Idle minutes at which the badge turns red. |
 
@@ -81,6 +82,18 @@ or:
 ```
 
 Either one stops every close. The idle badge keeps counting, so you still see idle time at a glance.
+
+### Keeping Telegram-assigned sessions alive
+
+Set:
+
+```json
+{
+  "coordinatorAutoCloseSkipTelegramAssigned": true
+}
+```
+
+When enabled, auto-close skips only sessions with Telegram assigned. Non-Telegram sessions in the same team still follow the configured timeout. A Telegram-protected member may remain as an orphan after a non-Telegram coordinator is auto-closed, while the setting stays enabled and Telegram remains assigned.
 
 ## How idle is measured
 
@@ -124,6 +137,6 @@ The frontend computes `Nm` from that timestamp. The clocks themselves persist pe
 
 ## See also
 
-- [Settings reference](../reference/settings.md#session-auto-close) - the four auto-close keys
+- [Settings reference](../reference/settings.md#session-auto-close) - session auto-close keys
 - [Concepts: Session](../concepts.md#session) - session status dots and lifecycle
 - [Glossary](../glossary.md) - session auto-close, idle badge

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -165,6 +165,7 @@ Idle teams (coordinators plus agent-owned sessions) close themselves after a tim
 |---|---|---|---|
 | `coordinatorAutoCloseEnabled` | bool | `true` | Master switch for auto-close. When false, idle teams are never closed (the idle badge still shows). |
 | `coordinatorAutoCloseMinutes` | u32 | `60` | Idle minutes before a team is auto-closed. `0` also disables auto-close. |
+| `coordinatorAutoCloseSkipTelegramAssigned` | bool | `false` | When true, auto-close skips sessions with Telegram assigned. Other sessions keep following the normal auto-close rules. |
 | `coordinatorIdleBadgeYellowMinutes` | u32 | `30` | Idle minutes at which the coordinator idle badge turns yellow. |
 | `coordinatorIdleBadgeRedMinutes` | u32 | `60` | Idle minutes at which the coordinator idle badge turns red. |
 

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -2987,8 +2987,10 @@ mod tests {
 
     #[test]
     fn coordinator_auto_close_skip_telegram_assigned_round_trips() {
-        let mut s = AppSettings::default();
-        s.coordinator_auto_close_skip_telegram_assigned = true;
+        let s = AppSettings {
+            coordinator_auto_close_skip_telegram_assigned: true,
+            ..AppSettings::default()
+        };
 
         let json = serde_json::to_value(&s).expect("serialize settings");
         assert_eq!(

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -444,6 +444,10 @@ pub struct AppSettings {
     pub coordinator_auto_close_enabled: bool,
     #[serde(default = "default_coord_auto_close_minutes")]
     pub coordinator_auto_close_minutes: u32,
+    /// #817 When true, auto-close skips sessions with a persisted Telegram bot
+    /// assignment. Default false preserves legacy auto-close behavior.
+    #[serde(default)]
+    pub coordinator_auto_close_skip_telegram_assigned: bool,
     /// #588 When true, manually closing a coordinator also closes its team
     /// agents (cascade). When false, only the coordinator closes. Default true.
     #[serde(default = "default_true")]
@@ -682,6 +686,7 @@ impl Default for AppSettings {
             coordinator_idle_badge_red_minutes: default_coord_badge_red_minutes(),
             coordinator_auto_close_enabled: true,
             coordinator_auto_close_minutes: default_coord_auto_close_minutes(),
+            coordinator_auto_close_skip_telegram_assigned: false,
             coordinator_cascade_close_enabled: true,
             npm_update_notifications_enabled: true,
             auto_self_clear_enabled: true,
@@ -2961,8 +2966,8 @@ mod tests {
     #[test]
     fn coordinator_clock_settings_default_when_keys_absent() {
         // #552: an old settings.json (no coordinator-* keys) must deserialize
-        // cleanly to the documented defaults (true / 60 / 30 / 60), no migration.
-        // Serialize a default, strip ONLY the 4 coordinator keys, deserialize back.
+        // cleanly to the documented defaults, no migration.
+        // Serialize a default, strip ONLY these coordinator keys, deserialize back.
         let mut value =
             serde_json::to_value(AppSettings::default()).expect("serialize default to value");
         let obj = value.as_object_mut().expect("settings serializes to an object");
@@ -2970,12 +2975,29 @@ mod tests {
         obj.remove("coordinatorIdleBadgeRedMinutes");
         obj.remove("coordinatorAutoCloseEnabled");
         obj.remove("coordinatorAutoCloseMinutes");
+        obj.remove("coordinatorAutoCloseSkipTelegramAssigned");
 
         let back: AppSettings = serde_json::from_value(value).expect("deserialize without keys");
         assert!(back.coordinator_auto_close_enabled);
         assert_eq!(back.coordinator_auto_close_minutes, 60);
+        assert!(!back.coordinator_auto_close_skip_telegram_assigned);
         assert_eq!(back.coordinator_idle_badge_yellow_minutes, 30);
         assert_eq!(back.coordinator_idle_badge_red_minutes, 60);
+    }
+
+    #[test]
+    fn coordinator_auto_close_skip_telegram_assigned_round_trips() {
+        let mut s = AppSettings::default();
+        s.coordinator_auto_close_skip_telegram_assigned = true;
+
+        let json = serde_json::to_value(&s).expect("serialize settings");
+        assert_eq!(
+            json.get("coordinatorAutoCloseSkipTelegramAssigned"),
+            Some(&serde_json::Value::Bool(true))
+        );
+
+        let back: AppSettings = serde_json::from_value(json).expect("deserialize settings");
+        assert!(back.coordinator_auto_close_skip_telegram_assigned);
     }
 
     #[test]

--- a/src-tauri/src/session/auto_close.rs
+++ b/src-tauri/src/session/auto_close.rs
@@ -154,6 +154,20 @@ fn team_is_closeable(established: bool, anchor_secs: i64, now_secs: i64, timeout
     established && anchor_secs != i64::MIN && (now_secs - anchor_secs) > timeout_secs
 }
 
+fn session_is_telegram_protected(skip_telegram_assigned: bool, has_telegram: bool) -> bool {
+    skip_telegram_assigned && has_telegram
+}
+
+fn should_close_member(
+    telegram_protected: bool,
+    established: bool,
+    anchor_secs: i64,
+    now_secs: i64,
+    timeout_secs: i64,
+) -> bool {
+    !telegram_protected && team_is_closeable(established, anchor_secs, now_secs, timeout_secs)
+}
+
 /// (#589) Should a successful destroy stamp its team's coordinator row
 /// AUTO-CLOSED? True IFF the destroyed session IS that team's coordinator
 /// (`coord_id_of_team == Some(destroyed_id)`). A reaped sibling member while the
@@ -167,11 +181,12 @@ fn destroyed_is_team_coordinator(destroyed_id: Uuid, coord_id_of_team: Option<Uu
 
 async fn tick(app: &AppHandle, last_emitted: &mut HashMap<String, i64>) {
     let settings = app.state::<SettingsState>();
-    let (enabled, timeout_min) = {
+    let (enabled, timeout_min, skip_telegram_assigned) = {
         let s = settings.read().await;
         (
             s.coordinator_auto_close_enabled,
             s.coordinator_auto_close_minutes,
+            s.coordinator_auto_close_skip_telegram_assigned,
         )
     };
     // NOTE: the enabled/timeout gate moved DOWN: steps 1-2 (advance + badge
@@ -194,6 +209,19 @@ async fn tick(app: &AppHandle, last_emitted: &mut HashMap<String, i64>) {
             .filter(|(id, _)| pm.has_session(*id))
             .collect()
     };
+    let telegram_protected: HashSet<Uuid> = if skip_telegram_assigned {
+        let mgr = { session_mgr.read().await.clone() };
+        let mut out = HashSet::new();
+        for (id, _) in &members {
+            if mgr.session_has_telegram_bot(*id).await {
+                out.insert(*id);
+            }
+        }
+        out
+    } else {
+        HashSet::new()
+    };
+
     // KILL filter: teams with any member alive past WAKE_GRACE (kill-eligible).
     let established_teams: HashSet<String> = members
         .iter()
@@ -278,13 +306,18 @@ async fn tick(app: &AppHandle, last_emitted: &mut HashMap<String, i64>) {
     let to_close: Vec<Uuid> = members
         .iter()
         .filter(|(id, team)| {
+            let is_telegram_protected = session_is_telegram_protected(
+                skip_telegram_assigned,
+                telegram_protected.contains(id),
+            );
             let anchor = resolve_member_anchor(
                 coord_refs.get(team),
                 &snap,
                 idle.silence_age(*id),
                 now_secs,
             );
-            team_is_closeable(
+            should_close_member(
+                is_telegram_protected,
                 established_teams.contains(team),
                 anchor,
                 now_secs,
@@ -322,6 +355,16 @@ async fn tick(app: &AppHandle, last_emitted: &mut HashMap<String, i64>) {
                 &id.to_string()[..8]
             );
             continue;
+        }
+        if skip_telegram_assigned {
+            let mgr = { session_mgr.read().await.clone() };
+            if session_is_telegram_protected(true, mgr.session_has_telegram_bot(id).await) {
+                log::info!(
+                    "[auto-close] {} has Telegram assigned; skipped",
+                    &id.to_string()[..8]
+                );
+                continue;
+            }
         }
         if let Err(e) = crate::commands::session::destroy_session_inner(app, id).await {
             log::warn!("[auto-close] destroy {} failed: {}", &id.to_string()[..8], e);
@@ -616,6 +659,36 @@ mod tests {
             !team_is_closeable(true, i64::MIN, now, 3600),
             "a team with no anchor (i64::MIN) is never closeable"
         );
+    }
+
+    #[test]
+    fn telegram_protection_is_opt_in() {
+        assert!(!session_is_telegram_protected(false, true));
+        assert!(!session_is_telegram_protected(false, false));
+    }
+
+    #[test]
+    fn telegram_protection_skips_only_assigned_sessions_when_enabled() {
+        assert!(session_is_telegram_protected(true, true));
+        assert!(!session_is_telegram_protected(true, false));
+    }
+
+    #[test]
+    fn protected_member_not_selected_when_established_and_idle_past_timeout() {
+        let now = ts(10_000).timestamp();
+        let timeout = 3600;
+        let anchor = team_idle_since_secs(Some(ts(10_000 - 3700)), None);
+
+        assert!(!should_close_member(true, true, anchor, now, timeout));
+    }
+
+    #[test]
+    fn unprotected_member_selected_when_established_and_idle_past_timeout() {
+        let now = ts(10_000).timestamp();
+        let timeout = 3600;
+        let anchor = team_idle_since_secs(Some(ts(10_000 - 3700)), None);
+
+        assert!(should_close_member(false, true, anchor, now, timeout));
     }
 
     // ---- orphan_anchor_secs (#582 orphan fallback anchor) ----

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -630,6 +630,15 @@ impl SessionManager {
         }
     }
 
+    /// True when the session currently has a persisted Telegram bot assignment.
+    /// Used by auto-close; does not expose the bot id.
+    pub async fn session_has_telegram_bot(&self, id: Uuid) -> bool {
+        let sessions = self.sessions.read().await;
+        sessions
+            .get(&id)
+            .is_some_and(|s| s.telegram_bot_id.is_some())
+    }
+
     /// Set `was_detached` on the session. Authoritative store for persistence under
     /// Fix A (plan §A3.2). Mutated ONLY by `detach_terminal_inner` (→true) and
     /// `attach_terminal` (→false). See plan §10 rule — the `WindowEvent::Destroyed`
@@ -1356,8 +1365,11 @@ mod tests {
             .await
             .expect("create_session should succeed");
 
+        assert!(!mgr.session_has_telegram_bot(session.id).await);
+
         mgr.set_telegram_bot_id(session.id, Some("bot-1".to_string()))
             .await;
+        assert!(mgr.session_has_telegram_bot(session.id).await);
         assert_eq!(
             mgr.get_session(session.id)
                 .await
@@ -1368,6 +1380,7 @@ mod tests {
         );
 
         mgr.set_telegram_bot_id(session.id, None).await;
+        assert!(!mgr.session_has_telegram_bot(session.id).await);
         assert!(mgr
             .get_session(session.id)
             .await

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -160,6 +160,7 @@ export function baseSettings(overrides: Partial<AppSettings> = {}): AppSettings 
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorAutoCloseSkipTelegramAssigned: false,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
     autoSelfClearEnabled: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -410,6 +410,9 @@ export interface AppSettings {
    *  fully silent for `coordinatorAutoCloseMinutes` is terminated. */
   coordinatorAutoCloseEnabled: boolean;
   coordinatorAutoCloseMinutes: number;
+  /** #817 When true, background auto-close skips sessions with a Telegram
+   *  assignment. Default false preserves legacy behavior. */
+  coordinatorAutoCloseSkipTelegramAssigned: boolean;
   /** #588 When true, manually closing a coordinator also closes its team. */
   coordinatorCascadeCloseEnabled: boolean;
   /** #609 Check npm on startup (<=1x/24h) and notify when a newer published

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -171,6 +171,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorAutoCloseSkipTelegramAssigned: false,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
     autoSelfClearEnabled: true,

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -111,6 +111,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorAutoCloseSkipTelegramAssigned: false,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
     autoSelfClearEnabled: true,

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -143,6 +143,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorAutoCloseSkipTelegramAssigned: false,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
     autoSelfClearEnabled: true,
@@ -1210,6 +1211,50 @@ describe("SettingsModal automation hooks", () => {
 
     const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
     expect(saved?.coordinatorCascadeCloseEnabled).toBe(false);
+
+    dispose();
+  });
+
+  it("round-trips coordinatorAutoCloseSkipTelegramAssigned through the General auto-close checkbox (#817)", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {} }),
+      root,
+    );
+    await settle();
+
+    const autoCloseEnabled = byTestId<HTMLInputElement>(
+      "settings.general.coordinatorAutoCloseEnabled",
+    );
+    const checkbox = byTestId<HTMLInputElement>(
+      "settings.general.coordinatorAutoCloseSkipTelegramAssigned",
+    );
+    expect(checkbox.closest("label")?.textContent).toContain(
+      "Skip Telegram-assigned sessions during auto-close",
+    );
+    expect(checkbox.checked).toBe(false);
+    expect(checkbox.disabled).toBe(false);
+
+    autoCloseEnabled.checked = false;
+    autoCloseEnabled.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+    expect(checkbox.disabled).toBe(true);
+
+    autoCloseEnabled.checked = true;
+    autoCloseEnabled.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+    expect(checkbox.disabled).toBe(false);
+
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.coordinatorAutoCloseSkipTelegramAssigned).toBe(true);
 
     dispose();
   });

--- a/src/sidebar/components/SettingsModal.test.ts
+++ b/src/sidebar/components/SettingsModal.test.ts
@@ -72,6 +72,7 @@ function settings(overrides: Partial<AppSettings>): AppSettings {
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorAutoCloseSkipTelegramAssigned: false,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
     autoSelfClearEnabled: true,

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -984,6 +984,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             onChange={(e) =>
               updateField("coordinatorAutoCloseEnabled", e.currentTarget.checked)
             }
+            data-ac-testid="settings.general.coordinatorAutoCloseEnabled"
           />
           <span>Auto-close idle teams (terminate sessions to free resources)</span>
         </label>
@@ -1005,6 +1006,22 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             data-ac-testid="settings.general.coordinatorAutoCloseMinutes"
             data-ac-role="spinbutton"
           />
+        </label>
+        <label class="settings-checkbox-field">
+          <input
+            type="checkbox"
+            class="settings-checkbox"
+            checked={settings.data!.coordinatorAutoCloseSkipTelegramAssigned}
+            disabled={!settings.data!.coordinatorAutoCloseEnabled}
+            onChange={(e) =>
+              updateField(
+                "coordinatorAutoCloseSkipTelegramAssigned",
+                e.currentTarget.checked,
+              )
+            }
+            data-ac-testid="settings.general.coordinatorAutoCloseSkipTelegramAssigned"
+          />
+          <span>Skip Telegram-assigned sessions during auto-close</span>
         </label>
         <div class="settings-hint">
           The idle badge shows minutes since your last message to a coordinator

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -86,6 +86,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     coordinatorIdleBadgeRedMinutes: 60,
     coordinatorAutoCloseEnabled: true,
     coordinatorAutoCloseMinutes: 60,
+    coordinatorAutoCloseSkipTelegramAssigned: false,
     coordinatorCascadeCloseEnabled: true,
     npmUpdateNotificationsEnabled: true,
     autoSelfClearEnabled: true,


### PR DESCRIPTION
## Summary

Closes #817.

Adds a backward-compatible `coordinatorAutoCloseSkipTelegramAssigned` setting so background auto-close can skip sessions with Telegram assigned while leaving non-Telegram sessions under the existing idle-timeout behavior.

## What changed

- Added persisted backend setting, default `false`, with serialization/default tests.
- Added backend Telegram assignment reader and auto-close kill eligibility guards, including a pre-destroy re-check.
- Kept protected sessions in team bookkeeping and left manual coordinator close unchanged.
- Added Settings UI checkbox, TypeScript settings shape, fixtures, and automation coverage.
- Updated auto-close/settings docs, including the protected-orphan behavior note.

## Verification

- Backend: `cargo check`, `cargo clippy`, focused Rust tests for auto-close, manager, and settings.
- Frontend: `npm run typecheck`, `npm test -- --run src/sidebar/components/SettingsModal.automation.test.ts`.
- Step 9 grinch review: PASS.
- Step 9.5 merge re-review after origin/main update: PASS.

## Ship note

Visual app change: adds one Settings modal checkbox. Final wg build/deploy will run after merge.