### PR TITLE
feat(#820): PTY session backend refactor foundation (S1 of #819)

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1660,6 +1660,7 @@ mod tests {
                 Some("Codex".to_string()),
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -3206,6 +3206,7 @@ mod tests {
                     None,
                     Vec::new(),
                     false,
+                    crate::pty::backend::SessionBackendKind::LocalProcess,
                 )
                 .await
                 .expect("create live session");

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -9,6 +9,7 @@ use crate::config::agent_config::{self, AgentLocalConfig};
 use crate::config::coordinator_clocks::CoordinatorClocksState;
 use crate::config::sessions_persistence::persist_current_state;
 use crate::config::settings::{AppSettings, SettingsState};
+use crate::pty::backend::SessionBackendKind;
 use crate::pty::manager::PtyManager;
 use crate::resource_monitor::{
     AgentLaunchPermit, ResourceLaunchMetadata, ResourceLaunchRegistration, ResourceLimits,
@@ -894,6 +895,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     };
 
     let mgr = session_mgr.read().await;
+    let backend_kind = SessionBackendKind::LocalProcess;
     let mut session = match mgr
         .create_session(
             shell.clone(),
@@ -903,6 +905,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             agent_label.clone(),
             git_repos,
             is_coordinator,
+            backend_kind,
         )
         .await
     {
@@ -1281,6 +1284,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     let spawn_result = {
         pty_mgr.lock().unwrap().spawn(
             id,
+            session.backend_kind,
             &shell,
             &shell_args,
             &cwd,
@@ -3328,6 +3332,7 @@ mod tests {
             name: "s".to_string(),
             shell: "codex".to_string(),
             shell_args: Vec::new(),
+            backend_kind: crate::pty::backend::SessionBackendKind::LocalProcess,
             effective_shell_args: None,
             created_at: "2026-06-21T00:00:00Z".to_string(),
             working_directory: cwd.to_string(),
@@ -3558,6 +3563,7 @@ mod tests {
                     Some("Codex".to_string()),
                     Vec::new(),
                     false,
+                    crate::pty::backend::SessionBackendKind::LocalProcess,
                 )
                 .await
                 .expect("failed to create dormant root session");

--- a/src-tauri/src/commands/wg_delete_diagnostic.rs
+++ b/src-tauri/src/commands/wg_delete_diagnostic.rs
@@ -1511,6 +1511,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create inside session");
@@ -1523,6 +1524,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create outside session");
@@ -1563,6 +1565,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create inside session");
@@ -1600,6 +1603,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create live session");
@@ -1612,6 +1616,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create exited session");

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -1702,6 +1702,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1727,6 +1728,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1756,6 +1758,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1785,6 +1788,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1836,6 +1840,7 @@ mod tests {
             None,
             Vec::new(),
             false,
+            crate::pty::backend::SessionBackendKind::LocalProcess,
         )
         .await
         .expect("create_session should succeed");
@@ -1862,6 +1867,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true, // coordinator
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1916,6 +1922,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1954,6 +1961,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -2006,6 +2014,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -2039,6 +2048,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -2090,6 +2100,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -2142,6 +2153,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -2181,6 +2193,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -2238,6 +2251,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -2291,6 +2305,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -2330,6 +2345,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1502,6 +1502,7 @@ pub fn run(
                                             ps.agent_label.clone(),
                                             ps.git_repos.clone(),
                                             false,
+                                            crate::pty::backend::SessionBackendKind::LocalProcess,
                                         )
                                         .await
                                     {
@@ -1606,6 +1607,7 @@ pub fn run(
                                 ps.agent_label.clone(),
                                 ps.git_repos.clone(),
                                 is_coord, // #248 — pass live is_coord so dormant coords stay coords (Z7).
+                                crate::pty::backend::SessionBackendKind::LocalProcess,
                             ).await {
                                 Ok(session) => {
                                     mgr.rename_session(session.id, ps.name.clone()).await.ok();

--- a/src-tauri/src/loops/delivery.rs
+++ b/src-tauri/src/loops/delivery.rs
@@ -613,6 +613,7 @@ mod tests {
                 None,
                 Vec::<SessionRepo>::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create session")

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -2540,6 +2540,7 @@ impl MailboxPoller {
                     spawn_label.clone(),
                     Vec::<SessionRepo>::new(),
                     spawn_is_coordinator,
+                    crate::pty::backend::SessionBackendKind::LocalProcess,
                 )
                 .await
                 .map_err(|e| e.to_string())?;
@@ -5354,6 +5355,7 @@ mod tests {
             name: name.into(),
             shell: "claude".into(),
             shell_args: vec![],
+            backend_kind: crate::pty::backend::SessionBackendKind::LocalProcess,
             effective_shell_args: None,
             created_at: "2026-05-16T00:00:00Z".into(),
             working_directory: cwd.into(),
@@ -5600,6 +5602,7 @@ mod tests {
                 Some("Codex".into()),
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -7451,6 +7454,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -7538,6 +7542,7 @@ mod tests {
                 Some("Codex".into()),
                 Vec::new(),
                 is_coordinator,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -8287,6 +8292,7 @@ mod tests {
                 agent_id.map(|id| format!("Label for {}", id)),
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -1,0 +1,42 @@
+use std::any::Any;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::errors::AppError;
+use crate::pty::output::PtyScreenSnapshot;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SessionBackendKind {
+    #[default]
+    LocalProcess,
+}
+
+pub trait PtyBackend: Any + Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+
+    fn write(&self, id: Uuid, data: &[u8]) -> Result<(), AppError>;
+
+    fn resize(&self, id: Uuid, cols: u16, rows: u16) -> Result<(), AppError>;
+
+    fn kill(&self, id: Uuid) -> Result<(), AppError>;
+
+    fn has_session(&self, id: Uuid) -> bool;
+
+    fn get_screen_snapshot(&self, id: Uuid) -> Option<PtyScreenSnapshot>;
+
+    fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)>;
+
+    fn register_response_watcher(
+        &self,
+        session_id: Uuid,
+        request_id: String,
+        response_dir: PathBuf,
+    );
+
+    fn terminate_job_for_session(&self, id: Uuid) -> bool;
+
+    fn kill_all_jobs(&self) -> (usize, usize);
+}

--- a/src-tauri/src/pty/git_watcher.rs
+++ b/src-tauri/src/pty/git_watcher.rs
@@ -245,6 +245,7 @@ mod tests {
                     branch: None,
                 }],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session");

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -1,0 +1,535 @@
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::sync::{Arc, Mutex};
+
+use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
+use tauri::AppHandle;
+use uuid::Uuid;
+
+use crate::errors::AppError;
+use crate::pty::backend::PtyBackend;
+use crate::pty::git_watcher::GitWatcher;
+use crate::pty::idle_detector::IdleDetector;
+use crate::pty::output::{PtyScreenSnapshot, SessionIoFanout};
+use crate::resource_monitor::ResourceLaunchRegistration;
+use crate::session::profile::IdleTuning;
+use crate::telegram::manager::OutputSenderMap;
+
+struct PtyInstance {
+    master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    child: Option<Box<dyn portable_pty::Child + Send + Sync>>,
+    job: Option<crate::pty::job::JobObject>,
+}
+
+#[cfg(windows)]
+struct GitGuardEnv {
+    path: String,
+    pathext: String,
+    real_git: String,
+}
+
+#[cfg(windows)]
+fn resolve_real_git_path() -> Option<String> {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    let mut cmd = std::process::Command::new("where.exe");
+    crate::pty::credentials::scrub_credentials_from_std_command(&mut cmd);
+    cmd.arg("git.exe").creation_flags(CREATE_NO_WINDOW);
+    let output = cmd.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(|line| line.to_string())
+}
+
+#[cfg(windows)]
+fn ensure_git_guard_wrapper() -> Result<std::path::PathBuf, AppError> {
+    let config_dir = crate::config::config_dir()
+        .ok_or_else(|| AppError::Other("Could not resolve app config directory".to_string()))?;
+    let guard_dir = config_dir.join("git-guard");
+    std::fs::create_dir_all(&guard_dir)
+        .map_err(|e| AppError::Other(format!("Failed to create git-guard dir: {}", e)))?;
+
+    let cmd_path = guard_dir.join("git.cmd");
+    let ps1_path = guard_dir.join("git-guard.ps1");
+
+    let cmd_content = "@echo off\r\npowershell.exe -NoProfile -ExecutionPolicy Bypass -File \"%~dp0git-guard.ps1\" %*\r\nexit /b %ERRORLEVEL%\r\n";
+    let ps1_content = r#"$ErrorActionPreference = 'Stop'
+$realGit = $env:AC_REAL_GIT
+if ([string]::IsNullOrWhiteSpace($realGit)) {
+  Write-Error 'AgentsCommander git guard: AC_REAL_GIT is not set.'
+  exit 1
+}
+
+$originalArgs = @($args)
+$target = (Get-Location).Path
+
+for ($i = 0; $i -lt $originalArgs.Count; $i++) {
+  $arg = [string]$originalArgs[$i]
+  if ($arg -eq '-C') {
+    if ($i + 1 -ge $originalArgs.Count) {
+      Write-Error 'AgentsCommander git guard: missing path after -C.'
+      exit 1
+    }
+
+    $next = [string]$originalArgs[$i + 1]
+    if ([System.IO.Path]::IsPathRooted($next)) {
+      $target = [System.IO.Path]::GetFullPath($next)
+    } else {
+      $target = [System.IO.Path]::GetFullPath((Join-Path -Path $target -ChildPath $next))
+    }
+    $i++
+    continue
+  }
+
+  if ($arg -eq '--git-dir' -or $arg -like '--git-dir=*' -or $arg -eq '--work-tree' -or $arg -like '--work-tree=*') {
+    Write-Error 'AgentsCommander git guard: --git-dir and --work-tree are not allowed in agent sessions.'
+    exit 1
+  }
+}
+
+function Test-AllowedGitTarget([string]$path) {
+  try {
+    $current = [System.IO.Path]::GetFullPath($path)
+  } catch {
+    return $false
+  }
+
+  while ($true) {
+    $name = [System.IO.Path]::GetFileName($current)
+    if ($name -like 'repo-*') {
+      return $true
+    }
+
+    $parent = Split-Path -Path $current -Parent
+    if ([string]::IsNullOrWhiteSpace($parent) -or $parent -eq $current) {
+      break
+    }
+    $current = $parent
+  }
+
+  return $false
+}
+
+if (-not (Test-AllowedGitTarget $target)) {
+  Write-Error ('AgentsCommander git guard: git is only allowed inside repo-* directories. Target path: ' + $target)
+  exit 1
+}
+
+& $realGit @originalArgs
+exit $LASTEXITCODE
+"#;
+
+    std::fs::write(&cmd_path, cmd_content)
+        .map_err(|e| AppError::Other(format!("Failed to write git.cmd guard: {}", e)))?;
+    std::fs::write(&ps1_path, ps1_content)
+        .map_err(|e| AppError::Other(format!("Failed to write git-guard.ps1: {}", e)))?;
+
+    Ok(guard_dir)
+}
+
+#[cfg(windows)]
+fn build_git_guard_env() -> Result<Option<GitGuardEnv>, AppError> {
+    let Some(real_git) = resolve_real_git_path() else {
+        log::warn!("[pty] git.exe not found; skipping PATH git guard wrapper");
+        return Ok(None);
+    };
+
+    let guard_dir = ensure_git_guard_wrapper()?;
+    let current_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut path_entries: Vec<std::path::PathBuf> = vec![guard_dir];
+    path_entries.extend(std::env::split_paths(&current_path));
+    let path = std::env::join_paths(path_entries.iter())
+        .map_err(|e| AppError::Other(format!("Failed to join PATH for git guard: {}", e)))?
+        .to_string_lossy()
+        .to_string();
+
+    Ok(Some(GitGuardEnv {
+        path,
+        pathext: ".CMD;.BAT;.COM;.EXE".to_string(),
+        real_git,
+    }))
+}
+
+pub struct LocalProcessBackend {
+    ptys: Arc<Mutex<HashMap<Uuid, PtyInstance>>>,
+    fanout: SessionIoFanout,
+    git_watcher: Arc<GitWatcher>,
+}
+
+impl LocalProcessBackend {
+    pub fn new(
+        output_senders: OutputSenderMap,
+        idle_detector: Arc<IdleDetector>,
+        git_watcher: Arc<GitWatcher>,
+        ws_broadcaster: Option<crate::web::broadcast::WsBroadcaster>,
+    ) -> Self {
+        Self {
+            ptys: Arc::new(Mutex::new(HashMap::new())),
+            fanout: SessionIoFanout::new(output_senders, idle_detector, ws_broadcaster),
+            git_watcher,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn spawn<R: tauri::Runtime>(
+        &self,
+        id: Uuid,
+        cmd: &str,
+        args: &[String],
+        cwd: &str,
+        cols: u16,
+        rows: u16,
+        configured_env: &[(String, String)],
+        env_remove_keys: &[String],
+        extra_env: &[(String, String)],
+        idle_tuning: IdleTuning,
+        app_handle: AppHandle<R>,
+        mut resource_registration: Option<ResourceLaunchRegistration>,
+    ) -> Result<(), AppError> {
+        let pty_system = native_pty_system();
+        let spawn_cwd = crate::path_utils::normalize_windows_verbatim_path(cwd);
+
+        let size = PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+
+        let pair = pty_system
+            .openpty(size)
+            .map_err(|e| AppError::PtyError(e.to_string()))?;
+
+        let is_direct_exe = cmd.to_lowercase().ends_with(".exe")
+            || std::path::Path::new(cmd)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"));
+
+        let mut command = if cfg!(windows) && !is_direct_exe {
+            let mut c = CommandBuilder::new("cmd.exe");
+            c.arg("/C");
+            c.arg(cmd);
+            for arg in args {
+                c.arg(arg);
+            }
+            c
+        } else {
+            let mut c = CommandBuilder::new(cmd);
+            for arg in args {
+                c.arg(arg);
+            }
+            c
+        };
+        command.cwd(&spawn_cwd);
+        for key in env_remove_keys {
+            command.env_remove(key);
+        }
+        for (key, value) in configured_env {
+            command.env(key, value);
+        }
+        if !configured_env.is_empty() || !env_remove_keys.is_empty() {
+            log::info!(
+                "[pty] Applied {} configured env vars and removed {} inherited env vars for session {}",
+                configured_env.len(),
+                env_remove_keys.len(),
+                id
+            );
+        }
+        crate::pty::credentials::apply_credential_env_to_pty_command(&mut command, extra_env);
+        command.env("TERM", "xterm-256color");
+
+        if !extra_env.is_empty() {
+            log::info!(
+                "[pty] Applied {} per-process credential environment variables for session {}",
+                extra_env.len(),
+                id
+            );
+        }
+
+        if let Some(git_ceiling_dirs) =
+            crate::config::session_context::git_ceiling_directories_for_session_root(&spawn_cwd)
+        {
+            command.env("GIT_CEILING_DIRECTORIES", &git_ceiling_dirs);
+            log::info!(
+                "[pty] Applied GIT_CEILING_DIRECTORIES for session cwd {}: {}",
+                spawn_cwd,
+                git_ceiling_dirs
+            );
+
+            #[cfg(windows)]
+            if let Some(git_guard_env) = build_git_guard_env()? {
+                command.env("PATH", &git_guard_env.path);
+                command.env("PATHEXT", &git_guard_env.pathext);
+                command.env("AC_REAL_GIT", &git_guard_env.real_git);
+                log::info!(
+                    "[pty] Enabled git guard wrapper for session cwd {}",
+                    spawn_cwd
+                );
+            }
+        }
+
+        let mut child = pair
+            .slave
+            .spawn_command(command)
+            .map_err(|e| AppError::PtyError(e.to_string()))?;
+        log::info!(
+            "[pty] Spawned session {} with child pid {:?}",
+            id,
+            child.process_id()
+        );
+
+        let job = child
+            .process_id()
+            .and_then(crate::pty::job::JobObject::for_child);
+
+        if let Some(registration) = resource_registration.as_mut() {
+            let Some(pid) = child.process_id() else {
+                let _ = child.kill();
+                return Err(AppError::PtyError(
+                    "Resource Monitor could not capture spawned child pid".to_string(),
+                ));
+            };
+            if let Err(err) = registration.register_root_pid(pid) {
+                let _ = child.kill();
+                return Err(AppError::PtyError(err));
+            }
+        }
+
+        drop(pair.slave);
+
+        let writer = match pair.master.take_writer() {
+            Ok(writer) => writer,
+            Err(e) => {
+                if let Some(registration) = resource_registration.as_ref() {
+                    registration.rollback_registered();
+                }
+                return Err(AppError::PtyError(e.to_string()));
+            }
+        };
+
+        let mut reader = match pair.master.try_clone_reader() {
+            Ok(reader) => reader,
+            Err(e) => {
+                if let Some(registration) = resource_registration.as_ref() {
+                    registration.rollback_registered();
+                }
+                return Err(AppError::PtyError(e.to_string()));
+            }
+        };
+
+        let instance = PtyInstance {
+            master: Arc::new(Mutex::new(pair.master)),
+            writer: Arc::new(Mutex::new(writer)),
+            child: Some(child),
+            job,
+        };
+
+        self.ptys.lock().unwrap().insert(id, instance);
+        self.fanout.register_session(id, idle_tuning, rows, cols);
+
+        let session_id_str = id.to_string();
+        let fanout = self.fanout.clone();
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        fanout.handle_output(&app_handle, id, &session_id_str, buf[..n].to_vec())
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Ok(())
+    }
+}
+
+impl PtyBackend for LocalProcessBackend {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn write(&self, id: Uuid, data: &[u8]) -> Result<(), AppError> {
+        let ptys = self.ptys.lock().unwrap();
+        let instance = ptys
+            .get(&id)
+            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
+
+        let mut writer = instance.writer.lock().unwrap();
+        writer
+            .write_all(data)
+            .map_err(|e| AppError::PtyError(e.to_string()))?;
+        writer
+            .flush()
+            .map_err(|e| AppError::PtyError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn has_session(&self, id: Uuid) -> bool {
+        self.ptys.lock().unwrap().contains_key(&id)
+    }
+
+    fn resize(&self, id: Uuid, cols: u16, rows: u16) -> Result<(), AppError> {
+        self.fanout.record_resize(id);
+
+        let ptys = self.ptys.lock().unwrap();
+        let instance = ptys
+            .get(&id)
+            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
+
+        let master = instance.master.lock().unwrap();
+        master
+            .resize(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| AppError::PtyError(e.to_string()))?;
+
+        self.fanout.resize_screen_and_broadcast(id, cols, rows);
+
+        Ok(())
+    }
+
+    fn kill(&self, id: Uuid) -> Result<(), AppError> {
+        let instance = {
+            let mut ptys = self.ptys.lock().unwrap();
+            ptys.remove(&id)
+        };
+
+        if let Some(mut instance) = instance {
+            if let Some(job) = instance.job.take() {
+                job.terminate();
+            }
+            if let Some(mut child) = instance.child.take() {
+                let pid = child.process_id();
+                match child.try_wait() {
+                    Ok(Some(status)) => {
+                        log::info!(
+                            "[pty] Session {} child pid {:?} already exited: {:?}",
+                            id,
+                            pid,
+                            status
+                        );
+                    }
+                    Ok(None) => {
+                        if let Err(e) = child.kill() {
+                            log::warn!(
+                                "[pty] Failed to kill session {} child pid {:?}: {}",
+                                id,
+                                pid,
+                                e
+                            );
+                        }
+                        reap_child_in_background(id, pid, child);
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "[pty] Failed to poll session {} child pid {:?}: {}",
+                            id,
+                            pid,
+                            e
+                        );
+                        if let Err(kill_err) = child.kill() {
+                            log::warn!(
+                                "[pty] Failed to kill session {} child pid {:?} after poll error: {}",
+                                id,
+                                pid,
+                                kill_err
+                            );
+                        }
+                        reap_child_in_background(id, pid, child);
+                    }
+                }
+            }
+        }
+
+        self.fanout.remove_session(id);
+        self.git_watcher.remove_session(id);
+
+        Ok(())
+    }
+
+    fn terminate_job_for_session(&self, id: Uuid) -> bool {
+        let ptys = self.ptys.lock().unwrap();
+        match ptys.get(&id).and_then(|inst| inst.job.as_ref()) {
+            Some(job) => {
+                job.terminate();
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn kill_all_jobs(&self) -> (usize, usize) {
+        let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
+        let mut terminated = 0;
+        let mut jobless = 0;
+        for (id, instance) in ptys.iter() {
+            match instance.job.as_ref() {
+                Some(job) => {
+                    job.terminate();
+                    terminated += 1;
+                    log::info!("[pty] terminated job object for session {id} at shutdown");
+                }
+                None => jobless += 1,
+            }
+        }
+        (terminated, jobless)
+    }
+
+    fn get_screen_snapshot(&self, id: Uuid) -> Option<PtyScreenSnapshot> {
+        self.fanout.get_screen_snapshot(id)
+    }
+
+    fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)> {
+        self.fanout.get_pty_size(id)
+    }
+
+    fn register_response_watcher(
+        &self,
+        session_id: Uuid,
+        request_id: String,
+        response_dir: std::path::PathBuf,
+    ) {
+        self.fanout
+            .register_response_watcher(session_id, request_id, response_dir);
+    }
+}
+
+fn reap_child_in_background(
+    session_id: Uuid,
+    pid: Option<u32>,
+    mut child: Box<dyn portable_pty::Child + Send + Sync>,
+) {
+    std::thread::spawn(move || match child.wait() {
+        Ok(status) => {
+            log::info!(
+                "[pty] Reaped session {} child pid {:?}: {:?}",
+                session_id,
+                pid,
+                status
+            );
+        }
+        Err(e) => {
+            log::warn!(
+                "[pty] Failed to reap session {} child pid {:?}: {}",
+                session_id,
+                pid,
+                e
+            );
+        }
+    });
+}

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -1,279 +1,22 @@
 use std::collections::HashMap;
-use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 
-use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
-use tauri::{AppHandle, Emitter};
+use tauri::AppHandle;
 use uuid::Uuid;
 
 use crate::errors::AppError;
+use crate::pty::backend::{PtyBackend, SessionBackendKind};
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
+use crate::pty::local_backend::LocalProcessBackend;
+use crate::pty::output::PtyScreenSnapshot;
 use crate::resource_monitor::ResourceLaunchRegistration;
 use crate::session::profile::IdleTuning;
 use crate::telegram::manager::OutputSenderMap;
 
-struct PtyInstance {
-    master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
-    writer: Arc<Mutex<Box<dyn Write + Send>>>,
-    child: Option<Box<dyn portable_pty::Child + Send + Sync>>,
-    /// #632 - Job Object the child (and its descendant tree) is assigned to, when
-    /// the OS allowed it. `None` falls back to the identity reaper for cleanup.
-    job: Option<crate::pty::job::JobObject>,
-}
-
-/// Tracks active response marker watchers per session.
-/// Key: (session_id, request_id) → accumulated output buffer.
-/// The read loop scans for %%AC_RESPONSE::<rid>::START/END%% markers.
-pub type ResponseWatcherMap = Arc<Mutex<HashMap<(Uuid, String), ResponseWatcher>>>;
-
-pub struct ResponseWatcher {
-    /// Where to write the extracted response
-    pub response_dir: std::path::PathBuf,
-    /// Buffer accumulating output between START and END markers
-    pub buffer: Option<String>,
-    /// Whether we've seen the START marker
-    pub capturing: bool,
-}
-
-#[cfg(windows)]
-struct GitGuardEnv {
-    path: String,
-    pathext: String,
-    real_git: String,
-}
-
-#[cfg(windows)]
-fn resolve_real_git_path() -> Option<String> {
-    use std::os::windows::process::CommandExt;
-
-    const CREATE_NO_WINDOW: u32 = 0x08000000;
-    let mut cmd = std::process::Command::new("where.exe");
-    crate::pty::credentials::scrub_credentials_from_std_command(&mut cmd);
-    cmd.arg("git.exe").creation_flags(CREATE_NO_WINDOW);
-    let output = cmd.output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .map(|line| line.to_string())
-}
-
-#[cfg(windows)]
-fn ensure_git_guard_wrapper() -> Result<std::path::PathBuf, AppError> {
-    let config_dir = crate::config::config_dir()
-        .ok_or_else(|| AppError::Other("Could not resolve app config directory".to_string()))?;
-    let guard_dir = config_dir.join("git-guard");
-    std::fs::create_dir_all(&guard_dir)
-        .map_err(|e| AppError::Other(format!("Failed to create git-guard dir: {}", e)))?;
-
-    let cmd_path = guard_dir.join("git.cmd");
-    let ps1_path = guard_dir.join("git-guard.ps1");
-
-    let cmd_content = "@echo off\r\npowershell.exe -NoProfile -ExecutionPolicy Bypass -File \"%~dp0git-guard.ps1\" %*\r\nexit /b %ERRORLEVEL%\r\n";
-    let ps1_content = r#"$ErrorActionPreference = 'Stop'
-$realGit = $env:AC_REAL_GIT
-if ([string]::IsNullOrWhiteSpace($realGit)) {
-  Write-Error 'AgentsCommander git guard: AC_REAL_GIT is not set.'
-  exit 1
-}
-
-$originalArgs = @($args)
-$target = (Get-Location).Path
-
-for ($i = 0; $i -lt $originalArgs.Count; $i++) {
-  $arg = [string]$originalArgs[$i]
-  if ($arg -eq '-C') {
-    if ($i + 1 -ge $originalArgs.Count) {
-      Write-Error 'AgentsCommander git guard: missing path after -C.'
-      exit 1
-    }
-
-    $next = [string]$originalArgs[$i + 1]
-    if ([System.IO.Path]::IsPathRooted($next)) {
-      $target = [System.IO.Path]::GetFullPath($next)
-    } else {
-      $target = [System.IO.Path]::GetFullPath((Join-Path -Path $target -ChildPath $next))
-    }
-    $i++
-    continue
-  }
-
-  if ($arg -eq '--git-dir' -or $arg -like '--git-dir=*' -or $arg -eq '--work-tree' -or $arg -like '--work-tree=*') {
-    Write-Error 'AgentsCommander git guard: --git-dir and --work-tree are not allowed in agent sessions.'
-    exit 1
-  }
-}
-
-function Test-AllowedGitTarget([string]$path) {
-  try {
-    $current = [System.IO.Path]::GetFullPath($path)
-  } catch {
-    return $false
-  }
-
-  while ($true) {
-    $name = [System.IO.Path]::GetFileName($current)
-    if ($name -like 'repo-*') {
-      return $true
-    }
-
-    $parent = Split-Path -Path $current -Parent
-    if ([string]::IsNullOrWhiteSpace($parent) -or $parent -eq $current) {
-      break
-    }
-    $current = $parent
-  }
-
-  return $false
-}
-
-if (-not (Test-AllowedGitTarget $target)) {
-  Write-Error ('AgentsCommander git guard: git is only allowed inside repo-* directories. Target path: ' + $target)
-  exit 1
-}
-
-& $realGit @originalArgs
-exit $LASTEXITCODE
-"#;
-
-    std::fs::write(&cmd_path, cmd_content)
-        .map_err(|e| AppError::Other(format!("Failed to write git.cmd guard: {}", e)))?;
-    std::fs::write(&ps1_path, ps1_content)
-        .map_err(|e| AppError::Other(format!("Failed to write git-guard.ps1: {}", e)))?;
-
-    Ok(guard_dir)
-}
-
-#[cfg(windows)]
-fn build_git_guard_env() -> Result<Option<GitGuardEnv>, AppError> {
-    let Some(real_git) = resolve_real_git_path() else {
-        log::warn!("[pty] git.exe not found; skipping PATH git guard wrapper");
-        return Ok(None);
-    };
-
-    let guard_dir = ensure_git_guard_wrapper()?;
-    let current_path = std::env::var_os("PATH").unwrap_or_default();
-    let mut path_entries: Vec<std::path::PathBuf> = vec![guard_dir];
-    path_entries.extend(std::env::split_paths(&current_path));
-    let path = std::env::join_paths(path_entries.iter())
-        .map_err(|e| AppError::Other(format!("Failed to join PATH for git guard: {}", e)))?
-        .to_string_lossy()
-        .to_string();
-
-    Ok(Some(GitGuardEnv {
-        path,
-        pathext: ".CMD;.BAT;.COM;.EXE".to_string(),
-        real_git,
-    }))
-}
-
 pub struct PtyManager {
-    ptys: Arc<Mutex<HashMap<Uuid, PtyInstance>>>,
-    output_senders: OutputSenderMap,
-    idle_detector: Arc<IdleDetector>,
-    git_watcher: Arc<GitWatcher>,
-    pub response_watchers: ResponseWatcherMap,
-    /// Optional WS broadcaster for remote access
-    ws_broadcaster: Option<crate::web::broadcast::WsBroadcaster>,
-    /// VT100 screen state and native output watermark per session.
-    screen_parsers: Arc<Mutex<HashMap<Uuid, ScreenReplayState>>>,
-}
-
-pub struct PtyScreenSnapshot {
-    pub data: Vec<u8>,
-    pub rows: u16,
-    pub cols: u16,
-    pub sequence: u64,
-}
-
-struct ScreenReplayState {
-    parser: vt100::Parser,
-    output_sequence: u64,
-}
-
-#[derive(Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PtyOutputPayload {
-    session_id: String,
-    data: Vec<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    sequence: Option<u64>,
-}
-
-/// Strip ANSI escape sequences so that marker detection is not fooled
-/// by terminal color/cursor codes. Handles:
-/// - CSI sequences: ESC [ ... final_byte (colors, cursor, SGR)
-/// - OSC sequences: ESC ] ... BEL/ST (title, hyperlinks, shell integration)
-/// - DCS sequences: ESC P ... ST (device control strings)
-/// - Non-CSI two-byte escapes: ESC + one byte (resets, keypad mode)
-fn strip_ansi_csi(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '\x1b' {
-            match chars.peek() {
-                Some(&'[') => {
-                    chars.next(); // skip '['
-                                  // CSI: skip parameter/intermediate bytes until final byte (0x40..=0x7E)
-                    while let Some(&next) = chars.peek() {
-                        chars.next();
-                        if ('@'..='~').contains(&next) {
-                            break;
-                        }
-                    }
-                }
-                Some(&']') => {
-                    chars.next(); // skip ']'
-                                  // OSC: consume until BEL (\x07) or ST (ESC \)
-                    while let Some(&ch) = chars.peek() {
-                        if ch == '\x07' {
-                            chars.next();
-                            break;
-                        }
-                        if ch == '\x1b' {
-                            chars.next();
-                            if chars.peek() == Some(&'\\') {
-                                chars.next();
-                                break; // proper ST terminator
-                            }
-                            // ESC not followed by \ — not ST, keep consuming
-                            continue;
-                        }
-                        chars.next();
-                    }
-                }
-                Some(&'P') => {
-                    chars.next(); // skip 'P'
-                                  // DCS: consume until ST (ESC \)
-                    while let Some(&ch) = chars.peek() {
-                        if ch == '\x1b' {
-                            chars.next();
-                            if chars.peek() == Some(&'\\') {
-                                chars.next();
-                                break; // proper ST terminator
-                            }
-                            // ESC not followed by \ — not ST, keep consuming
-                            continue;
-                        }
-                        chars.next();
-                    }
-                }
-                Some(_) => {
-                    // Non-CSI two-byte escape (e.g. ESC c, ESC M)
-                    chars.next();
-                }
-                None => {}
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    out
+    routes: Arc<Mutex<HashMap<Uuid, SessionBackendKind>>>,
+    local_backend: Arc<dyn PtyBackend>,
 }
 
 impl PtyManager {
@@ -283,23 +26,64 @@ impl PtyManager {
         git_watcher: Arc<GitWatcher>,
         ws_broadcaster: Option<crate::web::broadcast::WsBroadcaster>,
     ) -> Self {
-        Self {
-            ptys: Arc::new(Mutex::new(HashMap::new())),
+        let local_backend = Arc::new(LocalProcessBackend::new(
             output_senders,
             idle_detector,
             git_watcher,
-            response_watchers: Arc::new(Mutex::new(HashMap::new())),
             ws_broadcaster,
-            screen_parsers: Arc::new(Mutex::new(HashMap::new())),
+        ));
+        Self {
+            routes: Arc::new(Mutex::new(HashMap::new())),
+            local_backend,
         }
     }
 
-    // PTY spawn requires the full set of session knobs at once; splitting into a
-    // builder would just add ceremony for no reuse.
+    #[cfg(test)]
+    fn new_for_test(local_backend: Arc<dyn PtyBackend>) -> Self {
+        Self {
+            routes: Arc::new(Mutex::new(HashMap::new())),
+            local_backend,
+        }
+    }
+
+    pub fn backend_for_kind(&self, kind: SessionBackendKind) -> &dyn PtyBackend {
+        match kind {
+            SessionBackendKind::LocalProcess => self.local_backend.as_ref(),
+        }
+    }
+
+    pub fn record_route(&self, id: Uuid, kind: SessionBackendKind) {
+        self.routes.lock().unwrap().insert(id, kind);
+    }
+
+    pub fn remove_route_if_kind(&self, id: Uuid, kind: SessionBackendKind) {
+        let mut routes = self.routes.lock().unwrap();
+        if routes.get(&id).copied() == Some(kind) {
+            routes.remove(&id);
+        }
+    }
+
+    fn kind_for_session(&self, id: Uuid) -> Result<SessionBackendKind, AppError> {
+        self.routes
+            .lock()
+            .unwrap()
+            .get(&id)
+            .copied()
+            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))
+    }
+
+    fn local_process_backend(&self) -> Result<&LocalProcessBackend, AppError> {
+        self.local_backend
+            .as_any()
+            .downcast_ref::<LocalProcessBackend>()
+            .ok_or_else(|| AppError::PtyError("local process backend unavailable".to_string()))
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn spawn<R: tauri::Runtime>(
         &self,
         id: Uuid,
+        backend_kind: SessionBackendKind,
         cmd: &str,
         args: &[String],
         cwd: &str,
@@ -310,483 +94,83 @@ impl PtyManager {
         extra_env: &[(String, String)],
         idle_tuning: IdleTuning,
         app_handle: AppHandle<R>,
-        mut resource_registration: Option<ResourceLaunchRegistration>,
+        resource_registration: Option<ResourceLaunchRegistration>,
     ) -> Result<(), AppError> {
-        let pty_system = native_pty_system();
-        let spawn_cwd = crate::path_utils::normalize_windows_verbatim_path(cwd);
-
-        let size = PtySize {
-            rows,
-            cols,
-            pixel_width: 0,
-            pixel_height: 0,
-        };
-
-        let pair = pty_system
-            .openpty(size)
-            .map_err(|e| AppError::PtyError(e.to_string()))?;
-
-        // On Windows, non-.exe commands (like .cmd, .bat, or bare names that
-        // resolve to .cmd scripts) need to be wrapped with cmd.exe /C so the
-        // shell can resolve them from PATH.
-        let is_direct_exe = cmd.to_lowercase().ends_with(".exe")
-            || std::path::Path::new(cmd)
-                .extension()
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"));
-
-        let mut command = if cfg!(windows) && !is_direct_exe {
-            let mut c = CommandBuilder::new("cmd.exe");
-            c.arg("/C");
-            c.arg(cmd);
-            for arg in args {
-                c.arg(arg);
-            }
-            c
-        } else {
-            let mut c = CommandBuilder::new(cmd);
-            for arg in args {
-                c.arg(arg);
-            }
-            c
-        };
-        command.cwd(&spawn_cwd);
-        for key in env_remove_keys {
-            command.env_remove(key);
-        }
-        for (key, value) in configured_env {
-            command.env(key, value);
-        }
-        if !configured_env.is_empty() || !env_remove_keys.is_empty() {
-            log::info!(
-                "[pty] Applied {} configured env vars and removed {} inherited env vars for session {}",
-                configured_env.len(),
-                env_remove_keys.len(),
-                id
-            );
-        }
-        crate::pty::credentials::apply_credential_env_to_pty_command(&mut command, extra_env);
-        command.env("TERM", "xterm-256color");
-
-        if !extra_env.is_empty() {
-            log::info!(
-                "[pty] Applied {} per-process credential environment variables for session {}",
-                extra_env.len(),
-                id
-            );
-        }
-
-        if let Some(git_ceiling_dirs) =
-            crate::config::session_context::git_ceiling_directories_for_session_root(&spawn_cwd)
-        {
-            command.env("GIT_CEILING_DIRECTORIES", &git_ceiling_dirs);
-            log::info!(
-                "[pty] Applied GIT_CEILING_DIRECTORIES for session cwd {}: {}",
-                spawn_cwd,
-                git_ceiling_dirs
-            );
-
-            #[cfg(windows)]
-            if let Some(git_guard_env) = build_git_guard_env()? {
-                command.env("PATH", &git_guard_env.path);
-                command.env("PATHEXT", &git_guard_env.pathext);
-                command.env("AC_REAL_GIT", &git_guard_env.real_git);
-                log::info!(
-                    "[pty] Enabled git guard wrapper for session cwd {}",
-                    spawn_cwd
-                );
+        match backend_kind {
+            SessionBackendKind::LocalProcess => {
+                self.local_process_backend()?.spawn(
+                    id,
+                    cmd,
+                    args,
+                    cwd,
+                    cols,
+                    rows,
+                    configured_env,
+                    env_remove_keys,
+                    extra_env,
+                    idle_tuning,
+                    app_handle,
+                    resource_registration,
+                )?;
             }
         }
-
-        let mut child = pair
-            .slave
-            .spawn_command(command)
-            .map_err(|e| AppError::PtyError(e.to_string()))?;
-        log::info!(
-            "[pty] Spawned session {} with child pid {:?}",
-            id,
-            child.process_id()
-        );
-
-        // #632 - assign the child (and the descendant tree it spawns after this
-        // point) to a Job Object with KILL_ON_JOB_CLOSE, so session-destroy and
-        // app-exit can kill the whole tree atomically via the job handle. Created
-        // before the resource registration so the early-return error paths below
-        // drop `job` and let KILL_ON_JOB_CLOSE reap the child too.
-        let job = child
-            .process_id()
-            .and_then(crate::pty::job::JobObject::for_child);
-
-        if let Some(registration) = resource_registration.as_mut() {
-            let Some(pid) = child.process_id() else {
-                let _ = child.kill();
-                return Err(AppError::PtyError(
-                    "Resource Monitor could not capture spawned child pid".to_string(),
-                ));
-            };
-            if let Err(err) = registration.register_root_pid(pid) {
-                let _ = child.kill();
-                return Err(AppError::PtyError(err));
-            }
-        }
-
-        // Drop the slave side — we only need the master
-        drop(pair.slave);
-
-        let writer = match pair.master.take_writer() {
-            Ok(writer) => writer,
-            Err(e) => {
-                if let Some(registration) = resource_registration.as_ref() {
-                    registration.rollback_registered();
-                }
-                return Err(AppError::PtyError(e.to_string()));
-            }
-        };
-
-        let mut reader = match pair.master.try_clone_reader() {
-            Ok(reader) => reader,
-            Err(e) => {
-                if let Some(registration) = resource_registration.as_ref() {
-                    registration.rollback_registered();
-                }
-                return Err(AppError::PtyError(e.to_string()));
-            }
-        };
-
-        let instance = PtyInstance {
-            master: Arc::new(Mutex::new(pair.master)),
-            writer: Arc::new(Mutex::new(writer)),
-            child: Some(child),
-            job,
-        };
-
-        self.ptys.lock().unwrap().insert(id, instance);
-
-        // #260 — register with the idle detector. Seeds activity[id] (when the
-        // profile opts in) so an all-suppressed / escape-only session is still
-        // evaluated by the watcher. Must run before the read loop starts.
-        self.idle_detector.register_session(id, idle_tuning);
-
-        // Initialize vt100 screen parser and output watermark for replay.
-        {
-            let replay = ScreenReplayState {
-                parser: vt100::Parser::new(rows, cols, 0),
-                output_sequence: 0,
-            };
-            self.screen_parsers.lock().unwrap().insert(id, replay);
-        }
-
-        // Spawn read loop that emits PTY output to the frontend,
-        // feeds active Telegram bridges, WS clients, and scans for response markers
-        let session_id_str = id.to_string();
-        let output_senders = self.output_senders.clone();
-        let idle_detector = Arc::clone(&self.idle_detector);
-        let response_watchers = Arc::clone(&self.response_watchers);
-        let ws_broadcaster = self.ws_broadcaster.clone();
-        let screen_parsers = Arc::clone(&self.screen_parsers);
-        std::thread::spawn(move || {
-            let mut buf = [0u8; 4096];
-            loop {
-                match reader.read(&mut buf) {
-                    Ok(0) => break, // EOF
-                    Ok(n) => {
-                        let data = buf[..n].to_vec();
-
-                        // #552 auto-close silence clock: ANY PTY output proves the
-                        // session is alive, so it resets the silence timer. This is
-                        // DELIBERATELY broader than the idle-dot activity signal below
-                        // (which ignores escape-only spinner output per #260), so a
-                        // silent-but-spinning agent is NOT auto-closed mid-work. The
-                        // only case this does NOT cover is a foreground command that
-                        // emits literally zero terminal bytes for the whole timeout
-                        // (documented residual; see plan §7 H2).
-                        idle_detector.touch_silence(id);
-
-                        // Scan for response markers.
-                        // Use from_utf8_lossy to prevent silent detection skips
-                        // when a multi-byte UTF-8 character is split at the 4096-byte
-                        // read boundary. Response markers are pure ASCII, so
-                        // replacement chars (U+FFFD) don't affect detection.
-                        let text = String::from_utf8_lossy(&data);
-                        if text.contains('\u{FFFD}') {
-                            log::debug!(
-                                "[PTY] session {} chunk had invalid UTF-8 at buffer boundary ({} bytes, {} replacement chars)",
-                                id, n, text.matches('\u{FFFD}').count()
-                            );
-                        }
-
-                        // Record PTY activity for idle detection — but only if the
-                        // output contains meaningful visible content. Terminal escape
-                        // sequences (cursor moves, title updates, color resets, prompt
-                        // redraws) are NOT user/agent activity and must not flip the
-                        // session to busy. Strip ANSI escapes and check for printable
-                        // characters above ASCII space.
-                        let is_printable = |c: char| c > ' ' && c != '\u{FFFD}';
-                        let has_printable = if text.contains('\x1b') {
-                            strip_ansi_csi(&text).chars().any(is_printable)
-                        } else {
-                            text.chars().any(is_printable)
-                        };
-                        if has_printable {
-                            idle_detector.record_activity_with_bytes(id, n);
-                        } else {
-                            log::trace!(
-                                "[idle] SKIPPED activity for {} ({} bytes, escape-only output)",
-                                &id.to_string()[..8],
-                                n
-                            );
-                        }
-                        scan_response_markers(id, &text, &response_watchers);
-
-                        // Feed Telegram bridge if active (non-blocking)
-                        if let Ok(senders) = output_senders.lock() {
-                            if let Some(tx) = senders.get(&id) {
-                                let _ = tx.try_send(data.clone());
-                            }
-                        }
-
-                        // Feed vt100 screen parser and assign the event watermark.
-                        let sequence = if let Ok(mut parsers) = screen_parsers.lock() {
-                            if let Some(state) = parsers.get_mut(&id) {
-                                state.parser.process(&data);
-                                state.output_sequence = state.output_sequence.saturating_add(1);
-                                Some(state.output_sequence)
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        };
-
-                        // Broadcast to WebSocket clients (non-blocking).
-                        // Keep the binary WS frame unchanged: UUID prefix + raw bytes.
-                        if let Some(ref bc) = ws_broadcaster {
-                            bc.broadcast_pty_output(&session_id_str, &data);
-                        }
-
-                        let payload = PtyOutputPayload {
-                            session_id: session_id_str.clone(),
-                            data,
-                            sequence,
-                        };
-                        let _ = app_handle.emit("pty_output", payload);
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-
+        self.record_route(id, backend_kind);
         Ok(())
     }
 
     pub fn write(&self, id: Uuid, data: &[u8]) -> Result<(), AppError> {
-        let ptys = self.ptys.lock().unwrap();
-        let instance = ptys
-            .get(&id)
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
-
-        let mut writer = instance.writer.lock().unwrap();
-        writer
-            .write_all(data)
-            .map_err(|e| AppError::PtyError(e.to_string()))?;
-        writer
-            .flush()
-            .map_err(|e| AppError::PtyError(e.to_string()))?;
-
-        Ok(())
+        let kind = self.kind_for_session(id)?;
+        self.backend_for_kind(kind).write(id, data)
     }
 
-    /// Returns true if this PtyManager holds a live PtyInstance for `id`.
-    ///
-    /// Used by the mailbox router to filter out SessionManager records whose
-    /// PTY entry has gone missing (a desync that produces phantom Best-match
-    /// candidates — see issue #223). A live PtyInstance does NOT guarantee the
-    /// underlying child process is alive; it only guarantees that a subsequent
-    /// `write` will NOT fail with `AppError::SessionNotFound`. Detecting a dead
-    /// child of a live PtyInstance is out of scope for this accessor (issue #223
-    /// follow-up: state-machine PTY-exit hook).
+    /// Returns true if this manager holds a backend route whose backend has a
+    /// live session handle. A true result guarantees that the same id will not
+    /// fail `write` with `AppError::SessionNotFound` because routing is missing.
     pub fn has_session(&self, id: Uuid) -> bool {
-        self.ptys.lock().unwrap().contains_key(&id)
+        let Ok(kind) = self.kind_for_session(id) else {
+            return false;
+        };
+        self.backend_for_kind(kind).has_session(id)
     }
 
     pub fn resize(&self, id: Uuid, cols: u16, rows: u16) -> Result<(), AppError> {
-        // Tell idle detector to ignore PTY output caused by this resize
-        self.idle_detector.record_resize(id);
-
-        let ptys = self.ptys.lock().unwrap();
-        let instance = ptys
-            .get(&id)
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
-
-        let master = instance.master.lock().unwrap();
-        master
-            .resize(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|e| AppError::PtyError(e.to_string()))?;
-
-        // Keep the vt100 screen parser in sync so snapshots match the new size.
-        if let Ok(mut parsers) = self.screen_parsers.lock() {
-            if let Some(state) = parsers.get_mut(&id) {
-                state.parser.set_size(rows, cols);
-            }
-        }
-
-        // Broadcast resize to WS clients so browser mirrors can update dimensions
-        if let Some(ref bc) = self.ws_broadcaster {
-            bc.broadcast_event(
-                "pty_resized",
-                &serde_json::json!({
-                    "sessionId": id.to_string(),
-                    "cols": cols,
-                    "rows": rows,
-                }),
-            );
-        }
-
-        Ok(())
+        let kind = self.kind_for_session(id)?;
+        self.backend_for_kind(kind).resize(id, cols, rows)
     }
 
     pub fn kill(&self, id: Uuid) -> Result<(), AppError> {
-        let instance = {
-            let mut ptys = self.ptys.lock().unwrap();
-            ptys.remove(&id)
-        };
-
-        if let Some(mut instance) = instance {
-            // #632 - kill the whole descendant tree via the Job Object first. This
-            // catches descendants the identity reaper's #543 gate refuses to
-            // terminate (recycled / elevated PIDs) and any spawn-race escapee, with
-            // no snapshot walk and no 2s waits. The child handling below then reaps
-            // the (now-dead) direct child's exit status as before.
-            if let Some(job) = instance.job.take() {
-                job.terminate();
-                // job drops here -> handle closed (KILL_ON_JOB_CLOSE backstop)
-            }
-            if let Some(mut child) = instance.child.take() {
-                let pid = child.process_id();
-                match child.try_wait() {
-                    Ok(Some(status)) => {
-                        log::info!(
-                            "[pty] Session {} child pid {:?} already exited: {:?}",
-                            id,
-                            pid,
-                            status
-                        );
-                    }
-                    Ok(None) => {
-                        if let Err(e) = child.kill() {
-                            log::warn!(
-                                "[pty] Failed to kill session {} child pid {:?}: {}",
-                                id,
-                                pid,
-                                e
-                            );
-                        }
-                        reap_child_in_background(id, pid, child);
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "[pty] Failed to poll session {} child pid {:?}: {}",
-                            id,
-                            pid,
-                            e
-                        );
-                        if let Err(kill_err) = child.kill() {
-                            log::warn!(
-                                "[pty] Failed to kill session {} child pid {:?} after poll error: {}",
-                                id,
-                                pid,
-                                kill_err
-                            );
-                        }
-                        reap_child_in_background(id, pid, child);
-                    }
-                }
-            }
-        }
-
-        self.idle_detector.remove_session(id);
-        self.git_watcher.remove_session(id);
-
-        // Clean up any response watchers for this session
-        if let Ok(mut watchers) = self.response_watchers.lock() {
-            watchers.retain(|(sid, _), _| *sid != id);
-        }
-
-        // Clean up vt100 screen parser
-        if let Ok(mut parsers) = self.screen_parsers.lock() {
-            parsers.remove(&id);
-        }
-
-        Ok(())
+        let kind = self
+            .routes
+            .lock()
+            .unwrap()
+            .get(&id)
+            .copied()
+            .unwrap_or(SessionBackendKind::LocalProcess);
+        let result = self.backend_for_kind(kind).kill(id);
+        self.remove_route_if_kind(id, kind);
+        result
     }
 
-    /// #647 A: fire the Job Object tree-kill for a session WITHOUT tearing the
-    /// session down. Pure: no `ptys.remove`, no child reap, no idle/git/watcher
-    /// teardown, and the job handle is RETAINED so a Force/Retry can re-fire it.
-    /// Returns true if a live job was present and `terminate()` was called.
-    /// `TerminateJobObject` is idempotent, so repeated calls on a dead tree are safe.
-    /// On non-Windows builds the job is always `None`, so this returns false and the
-    /// caller falls back to the per-process reaper.
     pub fn terminate_job_for_session(&self, id: Uuid) -> bool {
-        let ptys = self.ptys.lock().unwrap();
-        match ptys.get(&id).and_then(|inst| inst.job.as_ref()) {
-            Some(job) => {
-                job.terminate();
-                true
-            }
-            None => false,
-        }
+        let Ok(kind) = self.kind_for_session(id) else {
+            return false;
+        };
+        self.backend_for_kind(kind).terminate_job_for_session(id)
     }
 
-    /// #632 - terminate every live agent's Job Object at app shutdown. Atomically
-    /// kills each session's whole descendant tree via the job handle (immune to PID
-    /// reuse / ACCESS_DENIED, no snapshot walking, no per-process waits). Returns
-    /// `(jobs_terminated, jobless_sessions)` so the caller can detect the MED-2
-    /// case: a session with no Job Object is reaper-only and can orphan if the
-    /// time-boxed reaper does not finish. Does NOT remove the PtyInstances; the
-    /// process is exiting and the OS reclaims the rest. No-op on non-Windows (jobs
-    /// are always `None`, so it returns `(0, live_session_count)`).
     pub fn kill_all_jobs(&self) -> (usize, usize) {
-        let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
-        let mut terminated = 0;
-        let mut jobless = 0;
-        for (id, instance) in ptys.iter() {
-            match instance.job.as_ref() {
-                Some(job) => {
-                    job.terminate();
-                    terminated += 1;
-                    log::info!("[pty] terminated job object for session {id} at shutdown");
-                }
-                None => jobless += 1,
-            }
-        }
-        (terminated, jobless)
+        self.backend_for_kind(SessionBackendKind::LocalProcess)
+            .kill_all_jobs()
     }
 
-    /// Get a screen snapshot for replay to late-joining clients.
-    /// The returned sequence is the latest PTY output sequence included in data.
     pub fn get_screen_snapshot(&self, id: Uuid) -> Option<PtyScreenSnapshot> {
-        let parsers = self.screen_parsers.lock().ok()?;
-        let state = parsers.get(&id)?;
-        let screen = state.parser.screen();
-        let (rows, cols) = screen.size();
-        Some(PtyScreenSnapshot {
-            data: screen.contents_formatted(),
-            rows,
-            cols,
-            sequence: state.output_sequence,
-        })
+        let kind = self.kind_for_session(id).ok()?;
+        self.backend_for_kind(kind).get_screen_snapshot(id)
     }
 
-    /// Get the current PTY dimensions (rows, cols) from the vt100 parser.
     pub fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)> {
-        let parsers = self.screen_parsers.lock().ok()?;
-        let state = parsers.get(&id)?;
-        Some(state.parser.screen().size())
+        let kind = self.kind_for_session(id).ok()?;
+        self.backend_for_kind(kind).get_pty_size(id)
     }
 
     pub fn register_response_watcher(
@@ -795,154 +179,155 @@ impl PtyManager {
         request_id: String,
         response_dir: std::path::PathBuf,
     ) {
-        if let Ok(mut watchers) = self.response_watchers.lock() {
-            watchers.insert(
-                (session_id, request_id),
-                ResponseWatcher {
-                    response_dir,
-                    buffer: None,
-                    capturing: false,
-                },
-            );
-        }
+        let kind = self
+            .routes
+            .lock()
+            .unwrap()
+            .get(&session_id)
+            .copied()
+            .unwrap_or(SessionBackendKind::LocalProcess);
+        self.backend_for_kind(kind)
+            .register_response_watcher(session_id, request_id, response_dir);
     }
 }
 
-fn reap_child_in_background(
-    session_id: Uuid,
-    pid: Option<u32>,
-    mut child: Box<dyn portable_pty::Child + Send + Sync>,
-) {
-    std::thread::spawn(move || match child.wait() {
-        Ok(status) => {
-            log::info!(
-                "[pty] Reaped session {} child pid {:?}: {:?}",
-                session_id,
-                pid,
-                status
-            );
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum Call {
+        Write(Uuid, Vec<u8>),
+        Resize(Uuid, u16, u16),
+        Kill(Uuid),
+        Has(Uuid),
+        Snapshot(Uuid),
+        Size(Uuid),
+        Watcher(Uuid, String),
+        TerminateJob(Uuid),
+    }
+
+    #[derive(Default)]
+    struct RecordingBackend {
+        calls: Mutex<Vec<Call>>,
+        live: Mutex<std::collections::HashSet<Uuid>>,
+    }
+
+    impl RecordingBackend {
+        fn set_live(&self, id: Uuid) {
+            self.live.lock().unwrap().insert(id);
         }
-        Err(e) => {
-            log::warn!(
-                "[pty] Failed to reap session {} child pid {:?}: {}",
-                session_id,
-                pid,
-                e
-            );
+
+        fn calls(&self) -> Vec<Call> {
+            let mut calls = self.calls.lock().unwrap();
+            std::mem::take(&mut *calls)
         }
-    });
-}
+    }
 
-/// Scan PTY output text for %%AC_RESPONSE::<rid>::START/END%% markers.
-/// This runs on the PTY read thread — must be fast and non-blocking.
-fn scan_response_markers(session_id: Uuid, text: &str, watchers: &ResponseWatcherMap) {
-    let Ok(mut watchers) = watchers.lock() else {
-        return;
-    };
-
-    // Collect keys that match this session
-    let keys: Vec<(Uuid, String)> = watchers
-        .keys()
-        .filter(|(sid, _)| *sid == session_id)
-        .cloned()
-        .collect();
-
-    for key in keys {
-        let (_, ref rid) = key;
-        let start_marker = format!("%%AC_RESPONSE::{}::START%%", rid);
-        let end_marker = format!("%%AC_RESPONSE::{}::END%%", rid);
-
-        let watcher = match watchers.get_mut(&key) {
-            Some(w) => w,
-            None => continue,
-        };
-
-        if watcher.capturing {
-            // We're between START and END — accumulate
-            if let Some(end_pos) = text.find(&end_marker) {
-                // Found END marker — extract final content
-                let chunk = &text[..end_pos];
-                if let Some(ref mut buf) = watcher.buffer {
-                    buf.push_str(chunk);
-                }
-
-                // Write the response file
-                let response_content = watcher.buffer.take().unwrap_or_default().trim().to_string();
-
-                let response_path = watcher.response_dir.join(format!("{}.json", rid));
-                if let Err(e) = std::fs::create_dir_all(&watcher.response_dir) {
-                    log::warn!("Failed to create responses dir: {}", e);
-                }
-
-                let response_json = serde_json::json!({
-                    "requestId": rid,
-                    "content": response_content,
-                    "timestamp": chrono::Utc::now().to_rfc3339(),
-                });
-
-                match serde_json::to_string_pretty(&response_json) {
-                    Ok(json) => {
-                        if let Err(e) = std::fs::write(&response_path, json) {
-                            log::warn!("Failed to write response file: {}", e);
-                        } else {
-                            log::info!(
-                                "Captured response for request {} from session {}",
-                                rid,
-                                session_id
-                            );
-                        }
-                    }
-                    Err(e) => log::warn!("Failed to serialize response: {}", e),
-                }
-
-                // Remove this watcher — response captured
-                watchers.remove(&key);
-                return; // Key removed, skip further processing
-            } else {
-                // No END yet — accumulate everything
-                if let Some(ref mut buf) = watcher.buffer {
-                    buf.push_str(text);
-                }
-            }
-        } else if let Some(start_pos) = text.find(&start_marker) {
-            // Found START marker
-            watcher.capturing = true;
-            let after_start = &text[start_pos + start_marker.len()..];
-
-            // Check if END is also in this chunk
-            if let Some(end_pos) = after_start.find(&end_marker) {
-                let content = after_start[..end_pos].trim().to_string();
-                let response_path = watcher.response_dir.join(format!("{}.json", rid));
-                if let Err(e) = std::fs::create_dir_all(&watcher.response_dir) {
-                    log::warn!("Failed to create responses dir: {}", e);
-                }
-
-                let response_json = serde_json::json!({
-                    "requestId": rid,
-                    "content": content,
-                    "timestamp": chrono::Utc::now().to_rfc3339(),
-                });
-
-                match serde_json::to_string_pretty(&response_json) {
-                    Ok(json) => {
-                        if let Err(e) = std::fs::write(&response_path, json) {
-                            log::warn!("Failed to write response file: {}", e);
-                        } else {
-                            log::info!(
-                                "Captured response for request {} from session {}",
-                                rid,
-                                session_id
-                            );
-                        }
-                    }
-                    Err(e) => log::warn!("Failed to serialize response: {}", e),
-                }
-
-                watchers.remove(&key);
-                return;
-            } else {
-                watcher.buffer = Some(after_start.to_string());
-            }
+    impl PtyBackend for RecordingBackend {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
         }
+
+        fn write(&self, id: Uuid, data: &[u8]) -> Result<(), AppError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(Call::Write(id, data.to_vec()));
+            Ok(())
+        }
+
+        fn resize(&self, id: Uuid, cols: u16, rows: u16) -> Result<(), AppError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(Call::Resize(id, cols, rows));
+            Ok(())
+        }
+
+        fn kill(&self, id: Uuid) -> Result<(), AppError> {
+            self.calls.lock().unwrap().push(Call::Kill(id));
+            self.live.lock().unwrap().remove(&id);
+            Ok(())
+        }
+
+        fn has_session(&self, id: Uuid) -> bool {
+            self.calls.lock().unwrap().push(Call::Has(id));
+            self.live.lock().unwrap().contains(&id)
+        }
+
+        fn get_screen_snapshot(&self, id: Uuid) -> Option<PtyScreenSnapshot> {
+            self.calls.lock().unwrap().push(Call::Snapshot(id));
+            None
+        }
+
+        fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)> {
+            self.calls.lock().unwrap().push(Call::Size(id));
+            Some((30, 120))
+        }
+
+        fn register_response_watcher(
+            &self,
+            session_id: Uuid,
+            request_id: String,
+            _response_dir: std::path::PathBuf,
+        ) {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(Call::Watcher(session_id, request_id));
+        }
+
+        fn terminate_job_for_session(&self, id: Uuid) -> bool {
+            self.calls.lock().unwrap().push(Call::TerminateJob(id));
+            true
+        }
+
+        fn kill_all_jobs(&self) -> (usize, usize) {
+            (1, 2)
+        }
+    }
+
+    #[test]
+    fn facade_delegates_local_route_by_session_id() {
+        let id = Uuid::new_v4();
+        let backend = Arc::new(RecordingBackend::default());
+        backend.set_live(id);
+        let manager = PtyManager::new_for_test(backend.clone());
+        manager.record_route(id, SessionBackendKind::LocalProcess);
+
+        manager.write(id, b"abc").expect("write");
+        manager.resize(id, 120, 30).expect("resize");
+        assert!(manager.has_session(id));
+        assert_eq!(manager.get_pty_size(id), Some((30, 120)));
+        assert!(manager.terminate_job_for_session(id));
+        manager.register_response_watcher(id, "r1".to_string(), std::path::PathBuf::from("x"));
+        manager.kill(id).expect("kill");
+
+        assert_eq!(
+            backend.calls(),
+            vec![
+                Call::Write(id, b"abc".to_vec()),
+                Call::Resize(id, 120, 30),
+                Call::Has(id),
+                Call::Size(id),
+                Call::TerminateJob(id),
+                Call::Watcher(id, "r1".to_string()),
+                Call::Kill(id),
+            ]
+        );
+        assert!(!manager.has_session(id));
+    }
+
+    #[test]
+    fn facade_write_without_route_returns_session_not_found() {
+        let id = Uuid::new_v4();
+        let backend = Arc::new(RecordingBackend::default());
+        let manager = PtyManager::new_for_test(backend.clone());
+
+        let err = manager.write(id, b"abc").expect_err("missing route");
+
+        assert!(matches!(err, AppError::SessionNotFound(_)));
+        assert!(backend.calls().is_empty());
     }
 }

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -1,6 +1,9 @@
+pub mod backend;
 pub mod credentials;
 pub mod git_watcher;
 pub mod idle_detector;
 pub mod inject;
 pub mod job; // #632 - per-agent Job Object for tree-kill
+pub mod local_backend;
 pub mod manager;
+pub mod output;

--- a/src-tauri/src/pty/output.rs
+++ b/src-tauri/src/pty/output.rs
@@ -1,0 +1,394 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tauri::{AppHandle, Emitter};
+use uuid::Uuid;
+
+use crate::pty::idle_detector::IdleDetector;
+use crate::session::profile::IdleTuning;
+use crate::telegram::manager::OutputSenderMap;
+
+/// Tracks active response marker watchers per session.
+/// Key: (session_id, request_id) -> accumulated output buffer.
+/// The read loop scans for %%AC_RESPONSE::<rid>::START/END%% markers.
+pub type ResponseWatcherMap = Arc<Mutex<HashMap<(Uuid, String), ResponseWatcher>>>;
+
+pub struct ResponseWatcher {
+    pub response_dir: std::path::PathBuf,
+    pub buffer: Option<String>,
+    pub capturing: bool,
+}
+
+#[derive(Clone)]
+pub struct SessionIoFanout {
+    output_senders: OutputSenderMap,
+    idle_detector: Arc<IdleDetector>,
+    response_watchers: ResponseWatcherMap,
+    ws_broadcaster: Option<crate::web::broadcast::WsBroadcaster>,
+    screen_parsers: Arc<Mutex<HashMap<Uuid, ScreenReplayState>>>,
+}
+
+pub struct PtyScreenSnapshot {
+    pub data: Vec<u8>,
+    pub rows: u16,
+    pub cols: u16,
+    pub sequence: u64,
+}
+
+struct ScreenReplayState {
+    parser: vt100::Parser,
+    output_sequence: u64,
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PtyOutputPayload {
+    session_id: String,
+    data: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sequence: Option<u64>,
+}
+
+impl SessionIoFanout {
+    pub fn new(
+        output_senders: OutputSenderMap,
+        idle_detector: Arc<IdleDetector>,
+        ws_broadcaster: Option<crate::web::broadcast::WsBroadcaster>,
+    ) -> Self {
+        Self {
+            output_senders,
+            idle_detector,
+            response_watchers: Arc::new(Mutex::new(HashMap::new())),
+            ws_broadcaster,
+            screen_parsers: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn register_session(&self, id: Uuid, idle_tuning: IdleTuning, rows: u16, cols: u16) {
+        self.idle_detector.register_session(id, idle_tuning);
+        let replay = ScreenReplayState {
+            parser: vt100::Parser::new(rows, cols, 0),
+            output_sequence: 0,
+        };
+        self.screen_parsers.lock().unwrap().insert(id, replay);
+    }
+
+    pub fn handle_output<R: tauri::Runtime>(
+        &self,
+        app_handle: &AppHandle<R>,
+        id: Uuid,
+        session_id_str: &str,
+        data: Vec<u8>,
+    ) {
+        let n = data.len();
+
+        self.idle_detector.touch_silence(id);
+
+        let text = String::from_utf8_lossy(&data);
+        if text.contains('\u{FFFD}') {
+            log::debug!(
+                "[PTY] session {} chunk had invalid UTF-8 at buffer boundary ({} bytes, {} replacement chars)",
+                id,
+                n,
+                text.matches('\u{FFFD}').count()
+            );
+        }
+
+        if output_has_printable_activity(&text) {
+            self.idle_detector.record_activity_with_bytes(id, n);
+        } else {
+            log::trace!(
+                "[idle] SKIPPED activity for {} ({} bytes, escape-only output)",
+                &id.to_string()[..8],
+                n
+            );
+        }
+
+        scan_response_markers(id, &text, &self.response_watchers);
+
+        if let Ok(senders) = self.output_senders.lock() {
+            if let Some(tx) = senders.get(&id) {
+                let _ = tx.try_send(data.clone());
+            }
+        }
+
+        let sequence = if let Ok(mut parsers) = self.screen_parsers.lock() {
+            if let Some(state) = parsers.get_mut(&id) {
+                state.parser.process(&data);
+                state.output_sequence = state.output_sequence.saturating_add(1);
+                Some(state.output_sequence)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(ref bc) = self.ws_broadcaster {
+            bc.broadcast_pty_output(session_id_str, &data);
+        }
+
+        let payload = PtyOutputPayload {
+            session_id: session_id_str.to_string(),
+            data,
+            sequence,
+        };
+        let _ = app_handle.emit("pty_output", payload);
+    }
+
+    pub fn record_resize(&self, id: Uuid) {
+        self.idle_detector.record_resize(id);
+    }
+
+    pub fn resize_screen_and_broadcast(&self, id: Uuid, cols: u16, rows: u16) {
+        if let Ok(mut parsers) = self.screen_parsers.lock() {
+            if let Some(state) = parsers.get_mut(&id) {
+                state.parser.set_size(rows, cols);
+            }
+        }
+
+        if let Some(ref bc) = self.ws_broadcaster {
+            bc.broadcast_event(
+                "pty_resized",
+                &serde_json::json!({
+                    "sessionId": id.to_string(),
+                    "cols": cols,
+                    "rows": rows,
+                }),
+            );
+        }
+    }
+
+    pub fn remove_session(&self, id: Uuid) {
+        self.idle_detector.remove_session(id);
+
+        if let Ok(mut watchers) = self.response_watchers.lock() {
+            watchers.retain(|(sid, _), _| *sid != id);
+        }
+
+        if let Ok(mut parsers) = self.screen_parsers.lock() {
+            parsers.remove(&id);
+        }
+    }
+
+    pub fn get_screen_snapshot(&self, id: Uuid) -> Option<PtyScreenSnapshot> {
+        let parsers = self.screen_parsers.lock().ok()?;
+        let state = parsers.get(&id)?;
+        let screen = state.parser.screen();
+        let (rows, cols) = screen.size();
+        Some(PtyScreenSnapshot {
+            data: screen.contents_formatted(),
+            rows,
+            cols,
+            sequence: state.output_sequence,
+        })
+    }
+
+    pub fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)> {
+        let parsers = self.screen_parsers.lock().ok()?;
+        let state = parsers.get(&id)?;
+        Some(state.parser.screen().size())
+    }
+
+    pub fn register_response_watcher(
+        &self,
+        session_id: Uuid,
+        request_id: String,
+        response_dir: std::path::PathBuf,
+    ) {
+        if let Ok(mut watchers) = self.response_watchers.lock() {
+            watchers.insert(
+                (session_id, request_id),
+                ResponseWatcher {
+                    response_dir,
+                    buffer: None,
+                    capturing: false,
+                },
+            );
+        }
+    }
+}
+
+/// Strip ANSI escape sequences so marker detection ignores color, cursor,
+/// title, hyperlink, shell-integration, and device-control noise.
+pub(crate) fn strip_ansi_csi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            match chars.peek() {
+                Some(&'[') => {
+                    chars.next();
+                    while let Some(&next) = chars.peek() {
+                        chars.next();
+                        if ('@'..='~').contains(&next) {
+                            break;
+                        }
+                    }
+                }
+                Some(&']') => {
+                    chars.next();
+                    while let Some(&ch) = chars.peek() {
+                        if ch == '\x07' {
+                            chars.next();
+                            break;
+                        }
+                        if ch == '\x1b' {
+                            chars.next();
+                            if chars.peek() == Some(&'\\') {
+                                chars.next();
+                                break;
+                            }
+                            continue;
+                        }
+                        chars.next();
+                    }
+                }
+                Some(&'P') => {
+                    chars.next();
+                    while let Some(&ch) = chars.peek() {
+                        if ch == '\x1b' {
+                            chars.next();
+                            if chars.peek() == Some(&'\\') {
+                                chars.next();
+                                break;
+                            }
+                            continue;
+                        }
+                        chars.next();
+                    }
+                }
+                Some(_) => {
+                    chars.next();
+                }
+                None => {}
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+pub(crate) fn output_has_printable_activity(text: &str) -> bool {
+    let is_printable = |c: char| c > ' ' && c != '\u{FFFD}';
+    if text.contains('\x1b') {
+        strip_ansi_csi(text).chars().any(is_printable)
+    } else {
+        text.chars().any(is_printable)
+    }
+}
+
+/// Scan PTY output text for %%AC_RESPONSE::<rid>::START/END%% markers.
+pub(crate) fn scan_response_markers(session_id: Uuid, text: &str, watchers: &ResponseWatcherMap) {
+    let Ok(mut watchers) = watchers.lock() else {
+        return;
+    };
+
+    let keys: Vec<(Uuid, String)> = watchers
+        .keys()
+        .filter(|(sid, _)| *sid == session_id)
+        .cloned()
+        .collect();
+
+    for key in keys {
+        let (_, ref rid) = key;
+        let start_marker = format!("%%AC_RESPONSE::{}::START%%", rid);
+        let end_marker = format!("%%AC_RESPONSE::{}::END%%", rid);
+
+        let watcher = match watchers.get_mut(&key) {
+            Some(w) => w,
+            None => continue,
+        };
+
+        if watcher.capturing {
+            if let Some(end_pos) = text.find(&end_marker) {
+                let chunk = &text[..end_pos];
+                if let Some(ref mut buf) = watcher.buffer {
+                    buf.push_str(chunk);
+                }
+
+                let response_content = watcher.buffer.take().unwrap_or_default().trim().to_string();
+                write_response_file(&watcher.response_dir, rid, response_content);
+                watchers.remove(&key);
+                return;
+            } else if let Some(ref mut buf) = watcher.buffer {
+                buf.push_str(text);
+            }
+        } else if let Some(start_pos) = text.find(&start_marker) {
+            watcher.capturing = true;
+            let after_start = &text[start_pos + start_marker.len()..];
+
+            if let Some(end_pos) = after_start.find(&end_marker) {
+                let content = after_start[..end_pos].trim().to_string();
+                write_response_file(&watcher.response_dir, rid, content);
+                watchers.remove(&key);
+                return;
+            } else {
+                watcher.buffer = Some(after_start.to_string());
+            }
+        }
+    }
+}
+
+fn write_response_file(response_dir: &std::path::Path, request_id: &str, content: String) {
+    let response_path = response_dir.join(format!("{}.json", request_id));
+    if let Err(e) = std::fs::create_dir_all(response_dir) {
+        log::warn!("Failed to create responses dir: {}", e);
+    }
+
+    let response_json = serde_json::json!({
+        "requestId": request_id,
+        "content": content,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    });
+
+    match serde_json::to_string_pretty(&response_json) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(&response_path, json) {
+                log::warn!("Failed to write response file: {}", e);
+            } else {
+                log::info!("Captured response for request {}", request_id);
+            }
+        }
+        Err(e) => log::warn!("Failed to serialize response: {}", e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn printable_activity_ignores_ansi_only_chunks() {
+        assert!(!output_has_printable_activity("\x1b[31m\x1b[0m"));
+        assert!(!output_has_printable_activity("\x1b]0;title\x07"));
+        assert!(output_has_printable_activity("\x1b[31mready\x1b[0m"));
+    }
+
+    #[test]
+    fn response_marker_capture_writes_trimmed_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = Uuid::new_v4();
+        let watchers: ResponseWatcherMap = Arc::new(Mutex::new(HashMap::new()));
+        watchers.lock().unwrap().insert(
+            (session_id, "r1".to_string()),
+            ResponseWatcher {
+                response_dir: dir.path().to_path_buf(),
+                buffer: None,
+                capturing: false,
+            },
+        );
+
+        scan_response_markers(
+            session_id,
+            "before %%AC_RESPONSE::r1::START%% {\"ok\": true} %%AC_RESPONSE::r1::END%% after",
+            &watchers,
+        );
+
+        let json = std::fs::read_to_string(dir.path().join("r1.json")).expect("response json");
+        assert!(json.contains("\"requestId\": \"r1\""));
+        assert!(json.contains("\"content\": \"{\\\"ok\\\": true}\""));
+        assert!(watchers.lock().unwrap().is_empty());
+    }
+}

--- a/src-tauri/src/pty/output.rs
+++ b/src-tauri/src/pty/output.rs
@@ -309,7 +309,7 @@ pub(crate) fn scan_response_markers(session_id: Uuid, text: &str, watchers: &Res
                 }
 
                 let response_content = watcher.buffer.take().unwrap_or_default().trim().to_string();
-                write_response_file(&watcher.response_dir, rid, response_content);
+                write_response_file(&watcher.response_dir, session_id, rid, response_content);
                 watchers.remove(&key);
                 return;
             } else if let Some(ref mut buf) = watcher.buffer {
@@ -321,7 +321,7 @@ pub(crate) fn scan_response_markers(session_id: Uuid, text: &str, watchers: &Res
 
             if let Some(end_pos) = after_start.find(&end_marker) {
                 let content = after_start[..end_pos].trim().to_string();
-                write_response_file(&watcher.response_dir, rid, content);
+                write_response_file(&watcher.response_dir, session_id, rid, content);
                 watchers.remove(&key);
                 return;
             } else {
@@ -331,7 +331,12 @@ pub(crate) fn scan_response_markers(session_id: Uuid, text: &str, watchers: &Res
     }
 }
 
-fn write_response_file(response_dir: &std::path::Path, request_id: &str, content: String) {
+fn write_response_file(
+    response_dir: &std::path::Path,
+    session_id: Uuid,
+    request_id: &str,
+    content: String,
+) {
     let response_path = response_dir.join(format!("{}.json", request_id));
     if let Err(e) = std::fs::create_dir_all(response_dir) {
         log::warn!("Failed to create responses dir: {}", e);
@@ -348,7 +353,11 @@ fn write_response_file(response_dir: &std::path::Path, request_id: &str, content
             if let Err(e) = std::fs::write(&response_path, json) {
                 log::warn!("Failed to write response file: {}", e);
             } else {
-                log::info!("Captured response for request {}", request_id);
+                log::info!(
+                    "Captured response for request {} from session {}",
+                    request_id,
+                    session_id
+                );
             }
         }
         Err(e) => log::warn!("Failed to serialize response: {}", e),

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -10,6 +10,7 @@ use super::session::{
 };
 use crate::config::settings::WindowGeometry;
 use crate::errors::AppError;
+use crate::pty::backend::SessionBackendKind;
 
 #[derive(Clone)]
 pub struct SessionManager {
@@ -47,6 +48,7 @@ impl SessionManager {
         agent_label: Option<String>,
         git_repos: Vec<SessionRepo>,
         is_coordinator: bool,
+        backend_kind: SessionBackendKind,
     ) -> Result<Session, AppError> {
         let id = Uuid::new_v4();
 
@@ -59,6 +61,7 @@ impl SessionManager {
             name,
             shell,
             shell_args,
+            backend_kind,
             effective_shell_args: None,
             created_at: chrono::Utc::now(),
             working_directory,
@@ -806,6 +809,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -849,6 +853,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -905,6 +910,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -948,6 +954,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -982,6 +989,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1012,6 +1020,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1040,6 +1049,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1069,6 +1079,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1108,6 +1119,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1135,6 +1147,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1163,6 +1176,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1212,6 +1226,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1236,6 +1251,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1270,6 +1286,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1319,6 +1336,7 @@ mod tests {
                 None,
                 Vec::new(),
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1352,6 +1370,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1388,6 +1407,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1419,6 +1439,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create_session should succeed");
@@ -1443,6 +1464,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create first session");
@@ -1455,6 +1477,7 @@ mod tests {
                 None,
                 Vec::new(),
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .expect("create second session");
@@ -1485,6 +1508,7 @@ mod tests {
                 None,
                 vec![],
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1515,6 +1539,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1533,6 +1558,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1576,6 +1602,7 @@ mod tests {
                 Some("Architect".into()),
                 vec![],
                 true, // is_coordinator
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1617,6 +1644,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1657,6 +1685,7 @@ mod tests {
                 None,
                 vec![],
                 true, // is_coordinator
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1669,6 +1698,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1693,6 +1723,7 @@ mod tests {
                 None,
                 vec![],
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1706,6 +1737,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1719,6 +1751,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1743,6 +1776,7 @@ mod tests {
                 None,
                 vec![],
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1756,6 +1790,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1780,6 +1815,7 @@ mod tests {
                 None,
                 vec![],
                 true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
@@ -1793,6 +1829,7 @@ mod tests {
                 None,
                 vec![],
                 false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use uuid::Uuid;
 
 use crate::config::settings::WindowGeometry;
+use crate::pty::backend::SessionBackendKind;
 use crate::session::profile::CodingAgentKind;
 
 /// Mangle a CWD path the same way Claude Code does for its project directories.
@@ -63,6 +64,8 @@ pub struct Session {
     pub name: String,
     pub shell: String,
     pub shell_args: Vec<String>,
+    #[serde(default)]
+    pub backend_kind: SessionBackendKind,
     /// Effective arg vector actually handed to portable-pty at spawn time,
     /// including dynamic provider resume injections (`--continue`,
     /// `codex resume --last`, `gemini --resume latest`). `None` until the PTY
@@ -210,6 +213,8 @@ pub struct SessionInfo {
     pub name: String,
     pub shell: String,
     pub shell_args: Vec<String>,
+    #[serde(default)]
+    pub backend_kind: SessionBackendKind,
     /// See `Session::effective_shell_args`. `None` means "not yet registered"
     /// (dormant or pre-spawn). On the wire, serializes as `null`.
     #[serde(default)]
@@ -283,6 +288,7 @@ impl From<&Session> for SessionInfo {
             name: s.name.clone(),
             shell: s.shell.clone(),
             shell_args: s.shell_args.clone(),
+            backend_kind: s.backend_kind,
             effective_shell_args: s.effective_shell_args.clone(),
             created_at: s.created_at.to_rfc3339(),
             working_directory: s.working_directory.clone(),
@@ -324,6 +330,7 @@ mod tests {
             name: "Session 1".to_string(),
             shell: "claude-mb".to_string(),
             shell_args: vec!["--dangerously-skip-permissions".to_string()],
+            backend_kind: SessionBackendKind::LocalProcess,
             effective_shell_args: effective,
             created_at: Utc::now(),
             working_directory: "C:\\tmp".to_string(),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -19,7 +19,7 @@ export interface Session {
   name: string;
   shell: string;
   shellArgs: string[];
-  backendKind: SessionBackendKind;
+  backendKind?: SessionBackendKind;
   effectiveShellArgs: string[] | null;
   createdAt: string;
   workingDirectory: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,11 +12,14 @@ export interface SessionCommunication {
   updatedAt: string;
 }
 
+export type SessionBackendKind = "localProcess";
+
 export interface Session {
   id: string;
   name: string;
   shell: string;
   shellArgs: string[];
+  backendKind: SessionBackendKind;
   effectiveShellArgs: string[] | null;
   createdAt: string;
   workingDirectory: string;


### PR DESCRIPTION
Stage 1 of #819 (Camino 2: containerized agents as first-class AC-managed sessions). **Pure refactor foundation, no user-visible change, no container/transport/Docker/DB code.**

Splits the PTY layer into a backend abstraction under the existing `PtyManager` facade so a future container backend can sit alongside the local-process backend under one uniform inject/wake path. Local-process behavior is **byte-identical** to `main`.

## What changed
- Extract output fanout into `src-tauri/src/pty/output.rs` (`SessionIoFanout`): idle silence, printable-idle detection, `scan_response_markers`, Telegram + WebSocket fanout, vt100 replay + sequence, `pty_output` emit.
- Move local PTY spawn/write/resize/kill/jobs/git-cleanup/response-watchers/screen-replay into `src-tauri/src/pty/local_backend.rs` (`LocalProcessBackend`).
- Keep `PtyManager` as the compatibility facade with a route map; same public surface (`write`, `resize`, `kill`, `has_session`, screen snapshot/size, response watchers, job methods) routing by session id.
- Add `SessionBackendKind` (default `LocalProcess`, `#[serde(default)]`) through `Session` / `SessionInfo` / `src/shared/types.ts` (optional on the TS side to mirror the Rust serde-default tolerance). Update all `create_session` callers.

## Verification
- **dev-rust**: `cargo check`, `cargo clippy --lib -- -D warnings`, `cargo test --lib` (1848 pass / 0 fail / 8 ignored, incl. new facade-routing + fanout tests), `npm run typecheck` 0 errors, `git diff --check` clean.
- **grinch (independent, adversarial)**: diffed every moved body against `main` and confirmed **moves-not-rewrites / byte-identical local behavior** (portable-pty construction, env order, job objects, resource registration, read-loop EOF, writer/resize/kill semantics, lock nesting); facade routing correct with no missed call sites and no caller reaching removed internals; scope contained (only `LocalProcess`); reproduced all gates + typecheck green. **PASS.**

Non-visual (pure refactor). No version bump. Closes #820.
