### PR TITLE
fix: sync project group changes live between web and desktop views

### DIFF
--- a/src-tauri/src/commands/project_settings.rs
+++ b/src-tauri/src/commands/project_settings.rs
@@ -3,6 +3,18 @@ use std::path::Path;
 use crate::config::project_settings::{
     load_workgroup_groups, save_workgroup_groups, WorkgroupGroupsConfig,
 };
+use crate::web::broadcast::WsBroadcaster;
+use serde_json::{json, Value};
+use tauri::{AppHandle, State};
+
+pub(crate) const PROJECT_GROUPS_UPDATED_EVENT: &str = "project_groups_updated";
+
+pub(crate) fn project_groups_updated_payload(
+    project_path: &str,
+    config: &WorkgroupGroupsConfig,
+) -> Value {
+    json!({ "projectPath": project_path, "config": config })
+}
 
 pub(crate) fn get_project_groups_inner(path: &str) -> Result<WorkgroupGroupsConfig, String> {
     load_workgroup_groups(Path::new(path))
@@ -22,10 +34,20 @@ pub(crate) fn update_project_groups_inner(
 
 #[tauri::command]
 pub async fn update_project_groups(
+    app: AppHandle,
+    broadcaster: State<'_, WsBroadcaster>,
     path: String,
     config: WorkgroupGroupsConfig,
 ) -> Result<WorkgroupGroupsConfig, String> {
-    update_project_groups_inner(&path, config)
+    let result = update_project_groups_inner(&path, config)?;
+    let payload = project_groups_updated_payload(&path, &result);
+    crate::web::commands::broadcast_all(
+        &app,
+        broadcaster.inner(),
+        PROJECT_GROUPS_UPDATED_EVENT,
+        &payload,
+    );
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -69,9 +91,7 @@ mod tests {
         let path = project.path().to_string_lossy().to_string();
         let config = sample_config();
 
-        let saved = update_project_groups(path.clone(), config.clone())
-            .await
-            .expect("update groups");
+        let saved = update_project_groups_inner(&path, config.clone()).expect("update groups");
         let loaded = get_project_groups(path).await.expect("get groups");
 
         assert_eq!(saved, config);

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -583,6 +583,14 @@ async fn dispatch_browser_project_command(
                 require_json(args, "config")?;
             let result =
                 crate::commands::project_settings::update_project_groups_inner(&path, config)?;
+            let payload =
+                crate::commands::project_settings::project_groups_updated_payload(&path, &result);
+            broadcast_all(
+                &state.app_handle,
+                &state.broadcaster,
+                crate::commands::project_settings::PROJECT_GROUPS_UPDATED_EVENT,
+                &payload,
+            );
             serde_json::to_value(result).map_err(|e| e.to_string())
         }
 
@@ -653,6 +661,18 @@ fn str_vec_or(args: &Value, key: &str, default: &[String]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::project_settings::{
+        get_project_groups_inner, PROJECT_GROUPS_UPDATED_EVENT,
+    };
+    use crate::config::project_settings::{WorkgroupGroup, WorkgroupGroupsConfig};
+    use crate::config::settings::AppSettings;
+    use crate::pty::git_watcher::GitWatcher;
+    use crate::pty::idle_detector::IdleDetector;
+    use crate::pty::manager::PtyManager;
+    use crate::session::manager::SessionManager;
+    use crate::web::broadcast::{WsBroadcaster, WsOutMsg};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn browser_project_commands_route_before_unknown_fallback() {
@@ -692,5 +712,76 @@ mod tests {
         assert_eq!(route_web_command("new_project"), WebCommandRoute::Other);
         assert_eq!(route_web_command("open-project"), WebCommandRoute::Other);
         assert_eq!(route_web_command("new-project"), WebCommandRoute::Other);
+    }
+
+    #[tokio::test]
+    async fn update_project_groups_web_dispatch_broadcasts_saved_config() {
+        let app = tauri::Builder::default()
+            .any_thread()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build test app");
+        let app_handle = app.handle().clone();
+        let broadcaster = WsBroadcaster::new();
+        let mut receiver = broadcaster.subscribe();
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let idle_detector = IdleDetector::new(|_| {}, |_| {});
+        let git_watcher = GitWatcher::new(Arc::clone(&session_mgr), app_handle.clone());
+        let pty_mgr = Arc::new(Mutex::new(PtyManager::new(
+            Arc::new(Mutex::new(HashMap::new())),
+            idle_detector,
+            git_watcher,
+            Some(broadcaster.clone()),
+        )));
+        let settings = Arc::new(tokio::sync::RwLock::new(AppSettings::default()));
+        let state = WsState {
+            session_mgr,
+            pty_mgr,
+            settings,
+            broadcaster: broadcaster.clone(),
+            app_handle,
+        };
+
+        let project = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(project.path().join(".ac")).expect("create .ac");
+        let path = project.path().to_string_lossy().to_string();
+        let config = WorkgroupGroupsConfig {
+            groups: vec![WorkgroupGroup {
+                id: "core".to_string(),
+                name: "Core".to_string(),
+                regex: "^wg-14$".to_string(),
+            }],
+            show_all: false,
+            show_ungrouped: true,
+            non_stop: None,
+        };
+
+        let response = dispatch(
+            &state,
+            7,
+            "update_project_groups",
+            &json!({ "path": path, "config": config.clone() }),
+        )
+        .await;
+
+        assert_eq!(response["id"], json!(7));
+        assert_eq!(
+            response["result"],
+            serde_json::to_value(&config).expect("serialize config")
+        );
+        assert_eq!(
+            get_project_groups_inner(&path).expect("load saved groups"),
+            config
+        );
+
+        let event = match receiver.try_recv().expect("broadcast event") {
+            WsOutMsg::Text(text) => serde_json::from_str::<Value>(&text).expect("parse event"),
+            other => panic!("expected text event, got {other:?}"),
+        };
+        assert_eq!(event["event"], json!(PROJECT_GROUPS_UPDATED_EVENT));
+        assert_eq!(event["payload"]["projectPath"], json!(path));
+        assert_eq!(
+            event["payload"]["config"],
+            serde_json::to_value(&config).expect("serialize config")
+        );
     }
 }

--- a/src/browser/App.workflow.test.tsx
+++ b/src/browser/App.workflow.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import BrowserApp from "./App";
 import { FakeTransport } from "../shared/testing/fake-transport";
+import type { WorkgroupGroupsConfig } from "../shared/types";
 import {
   baseSettings,
   discovery,
@@ -100,6 +101,15 @@ function browserDiscovery() {
   });
 }
 
+function groupsConfig(overrides: Partial<WorkgroupGroupsConfig> = {}): WorkgroupGroupsConfig {
+  return {
+    groups: overrides.groups ?? [],
+    showAll: overrides.showAll ?? true,
+    showUngrouped: overrides.showUngrouped ?? true,
+    nonStop: overrides.nonStop ?? null,
+  };
+}
+
 function setupBrowserTransport(
   fake: FakeTransport,
   settingsOverrides: Parameters<typeof baseSettings>[0] = {}
@@ -119,7 +129,7 @@ function setupBrowserTransport(
     created: false,
   });
   fake.resolve("discover_project", browserDiscovery());
-  fake.resolve("get_project_groups", { groups: [], showAll: true, showUngrouped: true });
+  fake.resolve("get_project_groups", groupsConfig());
   fake.resolve("search_repos", []);
   fake.resolve("list_sessions", [architectSession]);
   fake.resolve("get_active_session", architectSession.id);
@@ -166,6 +176,45 @@ describe("BrowserApp workflow", () => {
       expect(fake.callsFor("list_sessions").length).toBeGreaterThan(0);
       expect(fake.callsFor("get_active_session").length).toBeGreaterThan(0);
       expect(fake.callsFor("list_detached_sessions").length).toBeGreaterThan(0);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("applies project_groups_updated events to the groups rail without reloading", async () => {
+    const fake = new FakeTransport();
+    setupBrowserTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <BrowserApp />, fake);
+    try {
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector('[data-ac-testid="workgroupGroups.button.all"]')
+        ).not.toBeNull();
+        expect(fake.callsFor("discover_project")).toHaveLength(1);
+        expect(fake.callsFor("get_project_groups")).toHaveLength(1);
+      });
+      fake.clearCalls();
+
+      fake.emitFromBackend("project_groups_updated", {
+        projectPath,
+        config: groupsConfig({
+          showUngrouped: false,
+          groups: [{ id: "live", name: "Live synced", regex: "^wg-1-dev-team$" }],
+        }),
+      });
+
+      await waitFor(() => {
+        const liveButton = rendered.root.querySelector<HTMLElement>(
+          '[data-ac-testid="workgroupGroups.button.live"]'
+        );
+        expect(liveButton).not.toBeNull();
+        expect(liveButton?.textContent).toContain("Live synced");
+        expect(liveButton?.textContent).toContain("1/1");
+      });
+
+      expect(fake.callsFor("discover_project")).toHaveLength(0);
+      expect(fake.callsFor("get_project_groups")).toHaveLength(0);
     } finally {
       rendered.cleanup();
     }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -23,6 +23,7 @@ import type {
   ContextTemplateOverwriteResult,
   ContextTemplateUpdate,
   AcProjectRefreshRequestedPayload,
+  ProjectGroupsUpdatedPayload,
   LoopConfigDetails,
   LoopCreateInput,
   LoopCronPreview,
@@ -672,6 +673,15 @@ export function onAcProjectRefreshRequested(
 ): Promise<UnlistenFn> {
   return transport.listen<AcProjectRefreshRequestedPayload>(
     "ac_project_refresh_requested",
+    callback
+  );
+}
+
+export function onProjectGroupsUpdated(
+  callback: (data: ProjectGroupsUpdatedPayload) => void
+): Promise<UnlistenFn> {
+  return transport.listen<ProjectGroupsUpdatedPayload>(
+    "project_groups_updated",
     callback
   );
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -802,6 +802,11 @@ export interface WorkgroupGroupsConfig {
   nonStop?: NonStopGroupConfig | null;
 }
 
+export interface ProjectGroupsUpdatedPayload {
+  projectPath: string;
+  config: WorkgroupGroupsConfig;
+}
+
 /** #777 frontend -> backend watchdog signal; one entry per project with an ACTIVE Non-stop group. */
 export interface NonStopReport {
   projectPath: string;

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -29,6 +29,7 @@ import {
   onCodingAgentEnvSettingsUpdated,
   onCodingAgentProfileSelectionUpdated,
   onLoopEvent,
+  onProjectGroupsUpdated,
   onNpmUpdateAvailable,
 } from "../shared/ipc";
 import { taskFirstLine } from "../shared/markdown";
@@ -39,6 +40,7 @@ import { applyWindowLayout } from "../shared/window-layout";
 import { sessionsStore } from "./stores/sessions";
 import { bridgesStore } from "./stores/bridges";
 import { projectStore } from "./stores/project";
+import { workgroupGroupsStore } from "./stores/workgroup-groups";
 import { startTeamIdleWatcher } from "./stores/team-idle-watcher";
 import { primeAudio } from "../shared/sound";
 import { settingsStore } from "../shared/stores/settings";
@@ -272,6 +274,11 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     unlisteners.push(
       await onAcProjectRefreshRequested((data) => {
         handleProjectRefreshRequested(data);
+      })
+    );
+    unlisteners.push(
+      await onProjectGroupsUpdated((data) => {
+        workgroupGroupsStore.applyExternalUpdate(data.projectPath, data.config);
       })
     );
     unlisteners.push(

--- a/src/sidebar/stores/workgroup-groups.test.ts
+++ b/src/sidebar/stores/workgroup-groups.test.ts
@@ -117,6 +117,73 @@ describe("workgroupGroupsStore", () => {
     ]);
   });
 
+  it("applies external project group updates", () => {
+    workgroupGroupsStore.applyExternalUpdate(
+      projectPath,
+      config({
+        groups: [{ id: "live", name: "Live", regex: "^wg-2-" }],
+        showAll: false,
+        showUngrouped: true,
+      })
+    );
+
+    expect(workgroupGroupsStore.config(projectPath)).toMatchObject({
+      groups: [{ id: "live", name: "Live", regex: "^wg-2-" }],
+      showAll: false,
+      showUngrouped: true,
+    });
+    expect(workgroupGroupsStore.error(projectPath)).toBeNull();
+    expect(workgroupGroupsStore.loading(projectPath)).toBe(false);
+  });
+
+  it("does not let a stale initial load overwrite an external update", async () => {
+    const fake = new FakeTransport();
+    restoreTransport?.();
+    restoreTransport = __setTransportForTests(fake);
+
+    let resolveLoad!: (value: WorkgroupGroupsConfig) => void;
+    const loadPromise = new Promise<WorkgroupGroupsConfig>((resolve) => {
+      resolveLoad = resolve;
+    });
+    fake.onInvoke("get_project_groups", () => loadPromise);
+
+    const load = workgroupGroupsStore.ensureLoaded(projectPath);
+    expect(fake.callsFor("get_project_groups")).toHaveLength(1);
+
+    workgroupGroupsStore.applyExternalUpdate(
+      projectPath,
+      config({ groups: [{ id: "external", name: "External", regex: "^wg-9-" }] })
+    );
+
+    resolveLoad(config({ groups: [{ id: "stale", name: "Stale", regex: "^wg-1-" }] }));
+    await load;
+
+    expect(workgroupGroupsStore.config(projectPath).groups).toEqual([
+      { id: "external", name: "External", regex: "^wg-9-" },
+    ]);
+    expect(workgroupGroupsStore.loading(projectPath)).toBe(false);
+  });
+
+  it("keys external updates by project path", () => {
+    const otherProject = "C:\\OtherProject";
+
+    workgroupGroupsStore.applyExternalUpdate(
+      projectPath,
+      config({ groups: [{ id: "primary", name: "Primary", regex: "^wg-1-" }] })
+    );
+    workgroupGroupsStore.applyExternalUpdate(
+      otherProject,
+      config({ groups: [{ id: "other", name: "Other", regex: "^wg-2-" }] })
+    );
+
+    expect(workgroupGroupsStore.config(projectPath).groups).toEqual([
+      { id: "primary", name: "Primary", regex: "^wg-1-" },
+    ]);
+    expect(workgroupGroupsStore.config(otherProject).groups).toEqual([
+      { id: "other", name: "Other", regex: "^wg-2-" },
+    ]);
+  });
+
   it("reorders groups by final insertion index and clamps to the list bounds", () => {
     const groups = [
       { id: "a", name: "A", regex: "a" },

--- a/src/sidebar/stores/workgroup-groups.ts
+++ b/src/sidebar/stores/workgroup-groups.ts
@@ -480,6 +480,29 @@ export const workgroupGroupsStore = {
     return entryFor(projectPath).saving;
   },
 
+  applyExternalUpdate(projectPath: string, config: WorkgroupGroupsConfig): void {
+    const key = keyFor(projectPath);
+    saveVersions.set(key, (saveVersions.get(key) ?? 0) + 1);
+
+    const structuralErrors = validateGroupsConfig(config, { validateRegexSyntax: false });
+    if (structuralErrors.length > 0) {
+      setConfig(projectPath, defaultGroupsConfig(), {
+        loaded: true,
+        loading: false,
+        saving: false,
+        error: structuralErrors.join(" "),
+      });
+      return;
+    }
+
+    setConfig(projectPath, config, {
+      loaded: true,
+      loading: false,
+      saving: false,
+      error: null,
+    });
+  },
+
   async save(projectPath: string, config: WorkgroupGroupsConfig): Promise<void> {
     const key = keyFor(projectPath);
     const current = ensureEntry(projectPath);


### PR DESCRIPTION
## Summary

Closes #822. Project group changes now sync **live** between the web and desktop views. Previously a group change in one frontend didn't reach the other until reload — newly observable after #807 enabled web-side group read/write.

## Changes

- **Backend (`56fb09b`):** after a successful `update_project_groups` save (both desktop IPC and web dispatch paths), emit `project_groups_updated` `{ projectPath, config }` via `broadcast_all`, so the event reaches **both** Tauri (desktop) and WebSocket (browser) clients.
- **Frontend (`4082eb6`):** `SidebarApp` subscribes to the event; `workgroupGroupsStore.applyExternalUpdate` applies the pushed config, bumping `saveVersions` so a stale in-flight `get_project_groups` load can't overwrite the pushed update; keyed by normalized `projectPath` (no cross-project clobber).

## Review

- **Backend:** `cargo build` / `clippy -D warnings` pass; web-dispatch broadcast test + `project_settings` tests pass.
- **Frontend:** typecheck / build pass; 26 tests pass; live-update verified (groups rail updates without reload, no `discover_project` / `get_project_groups` re-call).
- **Grinch (adversarial) full-diff review: PASS.** `saveVersions` race guard confirmed correct and genuinely tested (stalled load resolves stale → discarded); cross-transport delivery confirmed; `projectPath` keying correct; echo harmless (no re-broadcast loop); no behavior drift; camelCase marshaling correct. One INFO note (narrow save-vs-concurrent-peer-event last-write-wins window — strictly better than the pre-change no-sync state, self-healing; non-blocking).

## Out of scope (follow-up)

Project-list open/remove has the same cross-frontend propagation gap (confirmed by investigation) — tracked as a separate follow-up issue.

Closes #822
