### PR TITLE
feat(#824): async spawn routing + lock-scope cleanup (S2 of #819)

### DIFF
--- a/src-tauri/src/cli/coding_agent.rs
+++ b/src-tauri/src/cli/coding_agent.rs
@@ -475,6 +475,7 @@ fn blank_agent() -> AgentConfig {
         isolated_home: false,
         instructions_filename: None,
         config_seed: None,
+        backend: Default::default(),
     }
 }
 
@@ -491,6 +492,7 @@ fn definition_to_agent_seed(def: &CodingAgentDefinition) -> AgentConfig {
         isolated_home: def.isolated_home,
         instructions_filename: def.instructions_filename.clone(),
         config_seed: def.config_seed.clone(),
+        backend: Default::default(),
     }
 }
 

--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -157,6 +157,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            backend: Default::default(),
         }
     }
 

--- a/src-tauri/src/cli/self_switch.rs
+++ b/src-tauri/src/cli/self_switch.rs
@@ -491,6 +491,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            backend: Default::default(),
         }
     }
 

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1462,6 +1462,7 @@ mod tests {
                 isolated_home: false,
                 instructions_filename: None,
                 config_seed: None,
+                backend: Default::default(),
             }],
             ..AppSettings::default()
         }

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -2691,6 +2691,7 @@ mod tests {
                 isolated_home: false,
                 instructions_filename: None,
                 config_seed: None,
+                backend: Default::default(),
             },
             crate::config::settings::AgentConfig {
                 id: "claude".to_string(),
@@ -2701,6 +2702,7 @@ mod tests {
                 isolated_home: false,
                 instructions_filename: None,
                 config_seed: None,
+                backend: Default::default(),
             },
         ];
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -9,8 +9,9 @@ use crate::config::agent_config::{self, AgentLocalConfig};
 use crate::config::coordinator_clocks::CoordinatorClocksState;
 use crate::config::sessions_persistence::persist_current_state;
 use crate::config::settings::{AppSettings, SettingsState};
-use crate::pty::backend::SessionBackendKind;
+use crate::pty::backend::{BackendSpawnSpec, SessionBackendKind};
 use crate::pty::manager::PtyManager;
+use crate::pty::output::PtyOutputTarget;
 use crate::resource_monitor::{
     AgentLaunchPermit, ResourceLaunchMetadata, ResourceLaunchRegistration, ResourceLimits,
     ResourceMonitorState,
@@ -894,8 +895,12 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         None
     };
 
-    let mgr = session_mgr.read().await;
-    let backend_kind = SessionBackendKind::LocalProcess;
+    // Clone the manager handle so the outer RwLock guard drops before spawn awaits.
+    let mgr = session_mgr.read().await.clone();
+    let backend_kind = resolved_spawn
+        .as_ref()
+        .map(|spawn| SessionBackendKind::from(&spawn.backend))
+        .unwrap_or_default();
     let mut session = match mgr
         .create_session(
             shell.clone(),
@@ -1201,43 +1206,45 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         .as_ref()
         .map(|spawn| spawn.env_remove_keys.clone())
         .unwrap_or_default();
-    let resource_registration = resource_permit.take().map(|permit| {
-        // #516 - human-readable WG + agent identity for the Resource Monitor row,
-        // derived from the deterministic spawn cwd (not the user-renamable
-        // session.name). Root agents carry no wg-/__agent_ segments, so label them
-        // explicitly with the bare replica dir name.
-        let (workgroup, agent) = {
-            let (wg, ag) = crate::config::teams::workgroup_and_agent_from_path(&cwd);
-            if wg.is_some() {
-                (wg, ag)
-            } else if is_root_agent {
-                let bare = cwd
-                    .replace('\\', "/")
-                    .rsplit('/')
-                    .find(|s| !s.is_empty())
-                    .map(|s| s.to_string());
-                (Some("Root agent".to_string()), bare)
-            } else {
-                (None, None)
-            }
-        };
-        // #566 - project folder name for the Resource Monitor row, derived from
-        // the same deterministic spawn cwd as the (workgroup, agent) pair above.
-        let project = crate::config::teams::project_from_path(&cwd);
-        ResourceLaunchRegistration::new(
-            resource_monitor.as_ref().clone(),
-            permit,
-            ResourceLaunchMetadata {
-                session_id: id,
-                name: session.name.clone(),
-                agent_id: agent_id.clone(),
-                agent_label: agent_label.clone(),
-                workgroup,
-                agent,
-                project,
-            },
-        )
-    });
+    let resource_registration = match session.backend_kind {
+        SessionBackendKind::LocalProcess => resource_permit.take().map(|permit| {
+            // #516 - human-readable WG + agent identity for the Resource Monitor row,
+            // derived from the deterministic spawn cwd (not the user-renamable
+            // session.name). Root agents carry no wg-/__agent_ segments, so label them
+            // explicitly with the bare replica dir name.
+            let (workgroup, agent) = {
+                let (wg, ag) = crate::config::teams::workgroup_and_agent_from_path(&cwd);
+                if wg.is_some() {
+                    (wg, ag)
+                } else if is_root_agent {
+                    let bare = cwd
+                        .replace('\\', "/")
+                        .rsplit('/')
+                        .find(|s| !s.is_empty())
+                        .map(|s| s.to_string());
+                    (Some("Root agent".to_string()), bare)
+                } else {
+                    (None, None)
+                }
+            };
+            // #566 - project folder name for the Resource Monitor row, derived from
+            // the same deterministic spawn cwd as the (workgroup, agent) pair above.
+            let project = crate::config::teams::project_from_path(&cwd);
+            ResourceLaunchRegistration::new(
+                resource_monitor.as_ref().clone(),
+                permit,
+                ResourceLaunchMetadata {
+                    session_id: id,
+                    name: session.name.clone(),
+                    agent_id: agent_id.clone(),
+                    agent_label: agent_label.clone(),
+                    workgroup,
+                    agent,
+                    project,
+                },
+            )
+        }),
+    };
 
     // #598 - seed the config folder before the PTY starts so the agent sees the
     // templated config. Best-effort: never aborts the spawn. This is the single
@@ -1281,23 +1288,21 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         }
     }
 
-    let spawn_result = {
-        pty_mgr.lock().unwrap().spawn(
-            id,
-            session.backend_kind,
-            &shell,
-            &shell_args,
-            &cwd,
-            120,
-            30,
-            &configured_env,
-            &env_remove_keys,
-            &extra_env,
-            crate::session::profile::idle_tuning_for(agent_kind),
-            app.clone(),
-            resource_registration,
-        )
+    let spawn_spec = BackendSpawnSpec {
+        id,
+        cmd: shell.clone(),
+        args: shell_args.clone(),
+        cwd: cwd.clone(),
+        cols: 120,
+        rows: 30,
+        configured_env,
+        env_remove_keys,
+        extra_env,
+        idle_tuning: crate::session::profile::idle_tuning_for(agent_kind),
+        output_target: PtyOutputTarget::from_app_handle(app.clone()),
+        resource_registration,
     };
+    let spawn_result = PtyManager::spawn(pty_mgr, session.backend_kind, spawn_spec).await;
     if let Err(e) = spawn_result {
         let err = e.to_string();
         drop(mgr);
@@ -3087,6 +3092,8 @@ mod tests {
     use crate::session::session::{SessionInfo, SessionStatus};
     use std::collections::BTreeMap;
     use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+    use uuid::Uuid;
 
     #[test]
     fn count_working_members_counts_live_and_busy_only() {
@@ -3131,6 +3138,7 @@ mod tests {
                     isolated_home: false,
                     instructions_filename: None,
                     config_seed: None,
+                    backend: Default::default(),
                 },
                 AgentConfig {
                     id: "codex".to_string(),
@@ -3141,10 +3149,131 @@ mod tests {
                     isolated_home: false,
                     instructions_filename: None,
                     config_seed: None,
+                    backend: Default::default(),
                 },
             ],
             ..AppSettings::default()
         }
+    }
+
+    #[derive(Default)]
+    struct FailingSpawnBackend {
+        spawned: Mutex<Vec<Uuid>>,
+        killed: Mutex<Vec<Uuid>>,
+    }
+
+    impl FailingSpawnBackend {
+        fn spawned(&self) -> Vec<Uuid> {
+            self.spawned.lock().unwrap().clone()
+        }
+
+        fn killed(&self) -> Vec<Uuid> {
+            self.killed.lock().unwrap().clone()
+        }
+    }
+
+    impl crate::pty::backend::PtyBackend for FailingSpawnBackend {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn spawn(
+            &self,
+            spec: crate::pty::backend::BackendSpawnSpec,
+        ) -> futures::future::BoxFuture<'_, Result<(), crate::errors::AppError>> {
+            Box::pin(async move {
+                self.spawned.lock().unwrap().push(spec.id);
+                Err(crate::errors::AppError::PtyError(
+                    "synthetic spawn failure".to_string(),
+                ))
+            })
+        }
+
+        fn write(&self, _id: Uuid, _data: &[u8]) -> Result<(), crate::errors::AppError> {
+            Ok(())
+        }
+
+        fn resize(&self, _id: Uuid, _cols: u16, _rows: u16) -> Result<(), crate::errors::AppError> {
+            Ok(())
+        }
+
+        fn kill(&self, id: Uuid) -> Result<(), crate::errors::AppError> {
+            self.killed.lock().unwrap().push(id);
+            Ok(())
+        }
+
+        fn has_session(&self, _id: Uuid) -> bool {
+            false
+        }
+
+        fn get_screen_snapshot(&self, _id: Uuid) -> Option<crate::pty::output::PtyScreenSnapshot> {
+            None
+        }
+
+        fn get_pty_size(&self, _id: Uuid) -> Option<(u16, u16)> {
+            None
+        }
+
+        fn register_response_watcher(
+            &self,
+            _session_id: Uuid,
+            _request_id: String,
+            _response_dir: std::path::PathBuf,
+        ) {
+        }
+
+        fn terminate_job_for_session(&self, _id: Uuid) -> bool {
+            false
+        }
+
+        fn kill_all_jobs(&self) -> (usize, usize) {
+            (0, 0)
+        }
+    }
+
+    fn session_test_app(
+        settings: AppSettings,
+    ) -> tauri::App<tauri::test::MockRuntime> {
+        tauri::test::mock_builder()
+            .manage(Arc::new(tokio::sync::RwLock::new(settings)))
+            .manage(Arc::new(crate::resource_monitor::ResourceMonitorState::new()))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build session test app")
+    }
+
+    #[tokio::test]
+    async fn create_session_inner_rolls_back_pre_created_session_on_spawn_error() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = session_test_app(test_settings());
+        let app_handle = app.handle().clone();
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let backend = Arc::new(FailingSpawnBackend::default());
+        let pty_mgr = Arc::new(Mutex::new(crate::pty::manager::PtyManager::new_for_test(
+            backend.clone(),
+        )));
+
+        let err = super::create_session_inner(
+            &app_handle,
+            &session_mgr,
+            &pty_mgr,
+            "missing-ac-test-command".to_string(),
+            Vec::new(),
+            temp.path().to_string_lossy().to_string(),
+            None,
+            None,
+            None,
+            true,
+            Vec::new(),
+            true,
+            None,
+        )
+        .await
+        .expect_err("spawn should fail");
+
+        assert!(err.contains("synthetic spawn failure"), "{err}");
+        assert!(session_mgr.read().await.list_sessions().await.is_empty());
+        assert_eq!(backend.killed(), backend.spawned());
+        assert_eq!(backend.killed().len(), 1);
     }
 
     #[test]
@@ -3829,6 +3958,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            backend: Default::default(),
         });
 
         let resolved = resolve_actual_agent(
@@ -3906,6 +4036,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            backend: Default::default(),
         }];
 
         let resolved = resolve_agent_from_shell("codex", &[], &settings);

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -12,7 +12,8 @@ use crate::config::placeholders::{
 use crate::config::session_context::ManagedContextTarget;
 use crate::config::settings::{
     is_codex_home_key, is_opencode_config_dir_key, normalize_env_key_for_platform,
-    validate_expanded_codex_home_value, validate_user_env_key, AgentConfig, AppSettings,
+    validate_expanded_codex_home_value, validate_user_env_key, AgentBackendConfig, AgentConfig,
+    AppSettings,
 };
 use crate::session::profile::CodingAgentKind;
 use sha2::{Digest, Sha256};
@@ -39,6 +40,7 @@ pub struct AgentSpawnCommand {
     pub profile_content_hash: String,
     pub trusted_agent_id: String,
     pub trusted_agent_label: String,
+    pub backend: AgentBackendConfig,
     /// #598 - resolved config-folder seed (pure path math; executed at the
     /// session chokepoint, never here). `None` when the agent has no active seed
     /// or the launch root is not an AC replica/root-agent.
@@ -931,6 +933,7 @@ pub fn build_agent_spawn_command(
         profile_content_hash: profile_hash,
         trusted_agent_id: agent.id.clone(),
         trusted_agent_label: agent.label.clone(),
+        backend: agent.backend.clone(),
         seed,
     })
 }
@@ -1080,6 +1083,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            backend: Default::default(),
         }
     }
 

--- a/src-tauri/src/config/coding_agent_mutations.rs
+++ b/src-tauri/src/config/coding_agent_mutations.rs
@@ -539,6 +539,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            backend: Default::default(),
         }
     }
 

--- a/src-tauri/src/config/coding_agent_profiles.rs
+++ b/src-tauri/src/config/coding_agent_profiles.rs
@@ -804,6 +804,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            backend: Default::default(),
         }];
         settings
     }

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -7,7 +7,35 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::config::placeholders::AC_PLACEHOLDER_TOKENS;
+use crate::pty::backend::SessionBackendKind;
 use crate::telegram::types::TelegramBotConfig;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentBackendConfig {
+    #[serde(default)]
+    pub kind: SessionBackendKind,
+}
+
+impl Default for AgentBackendConfig {
+    fn default() -> Self {
+        Self {
+            kind: SessionBackendKind::LocalProcess,
+        }
+    }
+}
+
+impl AgentBackendConfig {
+    fn is_default(&self) -> bool {
+        self.kind == SessionBackendKind::LocalProcess
+    }
+}
+
+impl From<&AgentBackendConfig> for SessionBackendKind {
+    fn from(config: &AgentBackendConfig) -> Self {
+        config.kind
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -33,6 +61,10 @@ pub struct AgentConfig {
     /// means no seeding. Serialized as `configSeed`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config_seed: Option<ConfigSeedConfig>,
+    /// Backend used for future non-local session transports. Omitted/default
+    /// keeps today's local-process behavior.
+    #[serde(default, skip_serializing_if = "AgentBackendConfig::is_default")]
+    pub backend: AgentBackendConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2094,6 +2126,7 @@ mod tests {
                     isolated_home: false,
                     instructions_filename: None,
                     config_seed: None,
+                    backend: Default::default(),
                 })
                 .collect(),
             ..AppSettings::default()
@@ -2175,6 +2208,7 @@ mod tests {
                 enabled: true,
                 dest: ".claude".to_string(),
             }),
+            backend: Default::default(),
         };
         let json = serde_json::to_string(&agent).unwrap();
         assert!(json.contains("\"configSeed\""), "{json}");
@@ -2190,6 +2224,22 @@ mod tests {
             serde_json::from_str(r##"{"id":"x","label":"X","command":"claude","color":"#000"}"##)
                 .unwrap();
         assert!(back.config_seed.is_none());
+    }
+
+    #[test]
+    fn agent_backend_config_defaults_to_local_process_and_omits_default() {
+        use super::AgentConfig;
+
+        let agent: AgentConfig =
+            serde_json::from_str(r##"{"id":"x","label":"X","command":"codex","color":"#000"}"##)
+                .unwrap();
+
+        assert_eq!(
+            crate::pty::backend::SessionBackendKind::from(&agent.backend),
+            crate::pty::backend::SessionBackendKind::LocalProcess
+        );
+        let json = serde_json::to_string(&agent).unwrap();
+        assert!(!json.contains("backend"), "{json}");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2307,6 +2307,7 @@ mod tests {
                 isolated_home: false,
                 instructions_filename: None,
                 config_seed: None,
+                backend: Default::default(),
             }],
             ..AppSettings::default()
         }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -5472,6 +5472,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            backend: Default::default(),
         }
     }
 

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -1,11 +1,14 @@
 use std::any::Any;
 use std::path::PathBuf;
 
+use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::errors::AppError;
-use crate::pty::output::PtyScreenSnapshot;
+use crate::pty::output::{PtyOutputTarget, PtyScreenSnapshot};
+use crate::resource_monitor::ResourceLaunchRegistration;
+use crate::session::profile::IdleTuning;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -14,8 +17,25 @@ pub enum SessionBackendKind {
     LocalProcess,
 }
 
+pub struct BackendSpawnSpec {
+    pub id: Uuid,
+    pub cmd: String,
+    pub args: Vec<String>,
+    pub cwd: String,
+    pub cols: u16,
+    pub rows: u16,
+    pub configured_env: Vec<(String, String)>,
+    pub env_remove_keys: Vec<String>,
+    pub extra_env: Vec<(String, String)>,
+    pub idle_tuning: IdleTuning,
+    pub output_target: PtyOutputTarget,
+    pub resource_registration: Option<ResourceLaunchRegistration>,
+}
+
 pub trait PtyBackend: Any + Send + Sync {
     fn as_any(&self) -> &dyn Any;
+
+    fn spawn(&self, spec: BackendSpawnSpec) -> BoxFuture<'_, Result<(), AppError>>;
 
     fn write(&self, id: Uuid, data: &[u8]) -> Result<(), AppError>;
 

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -3,16 +3,13 @@ use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
-use tauri::AppHandle;
 use uuid::Uuid;
 
 use crate::errors::AppError;
-use crate::pty::backend::PtyBackend;
+use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
 use crate::pty::output::{PtyScreenSnapshot, SessionIoFanout};
-use crate::resource_monitor::ResourceLaunchRegistration;
-use crate::session::profile::IdleTuning;
 use crate::telegram::manager::OutputSenderMap;
 
 struct PtyInstance {
@@ -178,24 +175,23 @@ impl LocalProcessBackend {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub fn spawn<R: tauri::Runtime>(
-        &self,
-        id: Uuid,
-        cmd: &str,
-        args: &[String],
-        cwd: &str,
-        cols: u16,
-        rows: u16,
-        configured_env: &[(String, String)],
-        env_remove_keys: &[String],
-        extra_env: &[(String, String)],
-        idle_tuning: IdleTuning,
-        app_handle: AppHandle<R>,
-        mut resource_registration: Option<ResourceLaunchRegistration>,
-    ) -> Result<(), AppError> {
+    fn spawn_sync(&self, spec: BackendSpawnSpec) -> Result<(), AppError> {
+        let BackendSpawnSpec {
+            id,
+            cmd,
+            args,
+            cwd,
+            cols,
+            rows,
+            configured_env,
+            env_remove_keys,
+            extra_env,
+            idle_tuning,
+            output_target,
+            mut resource_registration,
+        } = spec;
         let pty_system = native_pty_system();
-        let spawn_cwd = crate::path_utils::normalize_windows_verbatim_path(cwd);
+        let spawn_cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
 
         let size = PtySize {
             rows,
@@ -209,30 +205,30 @@ impl LocalProcessBackend {
             .map_err(|e| AppError::PtyError(e.to_string()))?;
 
         let is_direct_exe = cmd.to_lowercase().ends_with(".exe")
-            || std::path::Path::new(cmd)
+            || std::path::Path::new(&cmd)
                 .extension()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"));
 
         let mut command = if cfg!(windows) && !is_direct_exe {
             let mut c = CommandBuilder::new("cmd.exe");
             c.arg("/C");
-            c.arg(cmd);
-            for arg in args {
+            c.arg(&cmd);
+            for arg in &args {
                 c.arg(arg);
             }
             c
         } else {
-            let mut c = CommandBuilder::new(cmd);
-            for arg in args {
+            let mut c = CommandBuilder::new(&cmd);
+            for arg in &args {
                 c.arg(arg);
             }
             c
         };
         command.cwd(&spawn_cwd);
-        for key in env_remove_keys {
+        for key in &env_remove_keys {
             command.env_remove(key);
         }
-        for (key, value) in configured_env {
+        for (key, value) in &configured_env {
             command.env(key, value);
         }
         if !configured_env.is_empty() || !env_remove_keys.is_empty() {
@@ -243,7 +239,7 @@ impl LocalProcessBackend {
                 id
             );
         }
-        crate::pty::credentials::apply_credential_env_to_pty_command(&mut command, extra_env);
+        crate::pty::credentials::apply_credential_env_to_pty_command(&mut command, &extra_env);
         command.env("TERM", "xterm-256color");
 
         if !extra_env.is_empty() {
@@ -343,7 +339,7 @@ impl LocalProcessBackend {
                 match reader.read(&mut buf) {
                     Ok(0) => break,
                     Ok(n) => {
-                        fanout.handle_output(&app_handle, id, &session_id_str, buf[..n].to_vec())
+                        fanout.handle_output(&output_target, id, &session_id_str, buf[..n].to_vec())
                     }
                     Err(_) => break,
                 }
@@ -357,6 +353,13 @@ impl LocalProcessBackend {
 impl PtyBackend for LocalProcessBackend {
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn spawn(
+        &self,
+        spec: BackendSpawnSpec,
+    ) -> futures::future::BoxFuture<'_, Result<(), AppError>> {
+        Box::pin(async move { self.spawn_sync(spec) })
     }
 
     fn write(&self, id: Uuid, data: &[u8]) -> Result<(), AppError> {

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -1,17 +1,14 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use tauri::AppHandle;
 use uuid::Uuid;
 
 use crate::errors::AppError;
-use crate::pty::backend::{PtyBackend, SessionBackendKind};
+use crate::pty::backend::{BackendSpawnSpec, PtyBackend, SessionBackendKind};
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
 use crate::pty::local_backend::LocalProcessBackend;
 use crate::pty::output::PtyScreenSnapshot;
-use crate::resource_monitor::ResourceLaunchRegistration;
-use crate::session::profile::IdleTuning;
 use crate::telegram::manager::OutputSenderMap;
 
 pub struct PtyManager {
@@ -39,16 +36,16 @@ impl PtyManager {
     }
 
     #[cfg(test)]
-    fn new_for_test(local_backend: Arc<dyn PtyBackend>) -> Self {
+    pub(crate) fn new_for_test(local_backend: Arc<dyn PtyBackend>) -> Self {
         Self {
             routes: Arc::new(Mutex::new(HashMap::new())),
             local_backend,
         }
     }
 
-    pub fn backend_for_kind(&self, kind: SessionBackendKind) -> &dyn PtyBackend {
+    pub fn backend_for_kind(&self, kind: SessionBackendKind) -> Arc<dyn PtyBackend> {
         match kind {
-            SessionBackendKind::LocalProcess => self.local_backend.as_ref(),
+            SessionBackendKind::LocalProcess => self.local_backend.clone(),
         }
     }
 
@@ -72,49 +69,18 @@ impl PtyManager {
             .ok_or_else(|| AppError::SessionNotFound(id.to_string()))
     }
 
-    fn local_process_backend(&self) -> Result<&LocalProcessBackend, AppError> {
-        self.local_backend
-            .as_any()
-            .downcast_ref::<LocalProcessBackend>()
-            .ok_or_else(|| AppError::PtyError("local process backend unavailable".to_string()))
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn spawn<R: tauri::Runtime>(
-        &self,
-        id: Uuid,
+    pub async fn spawn(
+        manager: &Arc<Mutex<Self>>,
         backend_kind: SessionBackendKind,
-        cmd: &str,
-        args: &[String],
-        cwd: &str,
-        cols: u16,
-        rows: u16,
-        configured_env: &[(String, String)],
-        env_remove_keys: &[String],
-        extra_env: &[(String, String)],
-        idle_tuning: IdleTuning,
-        app_handle: AppHandle<R>,
-        resource_registration: Option<ResourceLaunchRegistration>,
+        spec: BackendSpawnSpec,
     ) -> Result<(), AppError> {
-        match backend_kind {
-            SessionBackendKind::LocalProcess => {
-                self.local_process_backend()?.spawn(
-                    id,
-                    cmd,
-                    args,
-                    cwd,
-                    cols,
-                    rows,
-                    configured_env,
-                    env_remove_keys,
-                    extra_env,
-                    idle_tuning,
-                    app_handle,
-                    resource_registration,
-                )?;
-            }
-        }
-        self.record_route(id, backend_kind);
+        let id = spec.id;
+        let backend = {
+            let manager = manager.lock().unwrap();
+            manager.backend_for_kind(backend_kind)
+        };
+        backend.spawn(spec).await?;
+        manager.lock().unwrap().record_route(id, backend_kind);
         Ok(())
     }
 
@@ -229,6 +195,16 @@ mod tests {
             self
         }
 
+        fn spawn(
+            &self,
+            spec: BackendSpawnSpec,
+        ) -> futures::future::BoxFuture<'_, Result<(), AppError>> {
+            Box::pin(async move {
+                self.live.lock().unwrap().insert(spec.id);
+                Ok(())
+            })
+        }
+
         fn write(&self, id: Uuid, data: &[u8]) -> Result<(), AppError> {
             self.calls
                 .lock()
@@ -288,6 +264,108 @@ mod tests {
         }
     }
 
+    struct DelayedSpawnBackend {
+        live: Mutex<std::collections::HashSet<Uuid>>,
+        started: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        release: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+    }
+
+    impl DelayedSpawnBackend {
+        fn new(
+            started: tokio::sync::oneshot::Sender<()>,
+            release: tokio::sync::oneshot::Receiver<()>,
+        ) -> Self {
+            Self {
+                live: Mutex::new(std::collections::HashSet::new()),
+                started: Mutex::new(Some(started)),
+                release: Mutex::new(Some(release)),
+            }
+        }
+    }
+
+    impl PtyBackend for DelayedSpawnBackend {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn spawn(
+            &self,
+            spec: BackendSpawnSpec,
+        ) -> futures::future::BoxFuture<'_, Result<(), AppError>> {
+            let started = self.started.lock().unwrap().take().expect("started sender");
+            let release = self
+                .release
+                .lock()
+                .unwrap()
+                .take()
+                .expect("release receiver");
+            Box::pin(async move {
+                let _ = started.send(());
+                let _ = release.await;
+                self.live.lock().unwrap().insert(spec.id);
+                Ok(())
+            })
+        }
+
+        fn write(&self, _id: Uuid, _data: &[u8]) -> Result<(), AppError> {
+            Ok(())
+        }
+
+        fn resize(&self, _id: Uuid, _cols: u16, _rows: u16) -> Result<(), AppError> {
+            Ok(())
+        }
+
+        fn kill(&self, id: Uuid) -> Result<(), AppError> {
+            self.live.lock().unwrap().remove(&id);
+            Ok(())
+        }
+
+        fn has_session(&self, id: Uuid) -> bool {
+            self.live.lock().unwrap().contains(&id)
+        }
+
+        fn get_screen_snapshot(&self, _id: Uuid) -> Option<PtyScreenSnapshot> {
+            None
+        }
+
+        fn get_pty_size(&self, _id: Uuid) -> Option<(u16, u16)> {
+            None
+        }
+
+        fn register_response_watcher(
+            &self,
+            _session_id: Uuid,
+            _request_id: String,
+            _response_dir: std::path::PathBuf,
+        ) {
+        }
+
+        fn terminate_job_for_session(&self, _id: Uuid) -> bool {
+            false
+        }
+
+        fn kill_all_jobs(&self) -> (usize, usize) {
+            (0, 0)
+        }
+    }
+
+    fn test_spawn_spec(id: Uuid) -> BackendSpawnSpec {
+        BackendSpawnSpec {
+            id,
+            cmd: "cmd".to_string(),
+            args: Vec::new(),
+            cwd: ".".to_string(),
+            cols: 80,
+            rows: 24,
+            configured_env: Vec::new(),
+            env_remove_keys: Vec::new(),
+            extra_env: Vec::new(),
+            idle_tuning: crate::session::profile::IdleTuning::DEFAULT,
+            output_target: crate::pty::output::PtyOutputTarget::noop(),
+            resource_registration: None,
+        }
+    }
+
     #[test]
     fn facade_delegates_local_route_by_session_id() {
         let id = Uuid::new_v4();
@@ -329,5 +407,38 @@ mod tests {
 
         assert!(matches!(err, AppError::SessionNotFound(_)));
         assert!(backend.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn spawn_does_not_hold_manager_mutex_while_backend_awaits() {
+        let id = Uuid::new_v4();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let backend = Arc::new(DelayedSpawnBackend::new(started_tx, release_rx));
+        let manager = Arc::new(Mutex::new(PtyManager::new_for_test(backend)));
+
+        let spawn_task = {
+            let manager = manager.clone();
+            tokio::spawn(async move {
+                PtyManager::spawn(
+                    &manager,
+                    SessionBackendKind::LocalProcess,
+                    test_spawn_spec(id),
+                )
+                .await
+            })
+        };
+
+        started_rx.await.expect("spawn started");
+        {
+            let guard = manager
+                .try_lock()
+                .expect("manager mutex should be free while backend spawn awaits");
+            assert!(!guard.has_session(id));
+        }
+
+        release_tx.send(()).expect("release spawn");
+        spawn_task.await.expect("spawn task").expect("spawn ok");
+        assert!(manager.lock().unwrap().has_session(id));
     }
 }

--- a/src-tauri/src/pty/output.rs
+++ b/src-tauri/src/pty/output.rs
@@ -49,6 +49,31 @@ struct PtyOutputPayload {
     sequence: Option<u64>,
 }
 
+#[derive(Clone)]
+pub struct PtyOutputTarget {
+    emit_pty_output: Arc<dyn Fn(PtyOutputPayload) + Send + Sync>,
+}
+
+impl PtyOutputTarget {
+    pub fn from_app_handle<R: tauri::Runtime>(app_handle: AppHandle<R>) -> Self {
+        Self {
+            emit_pty_output: Arc::new(move |payload| {
+                let _ = app_handle.emit("pty_output", payload);
+            }),
+        }
+    }
+
+    pub fn noop() -> Self {
+        Self {
+            emit_pty_output: Arc::new(|_| {}),
+        }
+    }
+
+    fn emit_pty_output(&self, payload: PtyOutputPayload) {
+        (self.emit_pty_output)(payload);
+    }
+}
+
 impl SessionIoFanout {
     pub fn new(
         output_senders: OutputSenderMap,
@@ -73,9 +98,9 @@ impl SessionIoFanout {
         self.screen_parsers.lock().unwrap().insert(id, replay);
     }
 
-    pub fn handle_output<R: tauri::Runtime>(
+    pub fn handle_output(
         &self,
-        app_handle: &AppHandle<R>,
+        output_target: &PtyOutputTarget,
         id: Uuid,
         session_id_str: &str,
         data: Vec<u8>,
@@ -133,7 +158,7 @@ impl SessionIoFanout {
             data,
             sequence,
         };
-        let _ = app_handle.emit("pty_output", payload);
+        output_target.emit_pty_output(payload);
     }
 
     pub fn record_resize(&self, id: Uuid) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -123,6 +123,10 @@ export interface ConfigSeedConfig {
   dest: string;
 }
 
+export interface AgentBackendConfig {
+  kind?: SessionBackendKind;
+}
+
 export interface AgentConfig {
   id: string;
   label: string;
@@ -151,6 +155,7 @@ export interface AgentConfig {
    * inactive seed is never persisted as a sentinel.
    */
   configSeed?: ConfigSeedConfig;
+  backend?: AgentBackendConfig;
 }
 
 /**


### PR DESCRIPTION
Stage 2 of #819 (Camino 2, co-located). Builds on S1 (#820, `4174d28a`). **No container code, no user-visible change.**

Makes the session spawn path **async-capable** (S3's container transport registration will await network I/O) and cleans lock scopes so no `std::sync::MutexGuard` is held across an `.await`. Local-process spawn stays byte-identical.

## What changed
- `BackendSpawnSpec` + async `spawn` on the PTY backend trait. `PtyManager::spawn` becomes an async facade: clones/selects the backend while holding the manager mutex, **drops the guard before `.await`**, records the route only after spawn success. `write`/`resize`/`has_session`/snapshots/kill stay synchronous.
- `create_session_inner` clones the `SessionManager` handle so the outer read guard does not cross the spawn await.
- Defaulted `AgentBackendConfig` on `AgentConfig` (`#[serde(default, skip_serializing_if=...)]` → omit-when-default, back-compat) carried through `AgentSpawnCommand` + optional TS types; default `localProcess`.
- Backend-specific resource registration (local path keeps PID registration). `PtyOutputTarget` wrapper for trait object-safety (identical emit behavior). No new dependency (`futures` already present).

## Verification
- **dev-rust**: `cargo check`, `cargo clippy --lib -- -D warnings`, `cargo test --lib` (1851 pass / 0 fail, +3 focused tests), `npm run typecheck` 0 errors, `git diff --check` clean.
- **grinch (independent, adversarial)**: verified the crux **no std-Mutex guard across `.await`** three ways (structural — spawn is no longer a method on the guard; `create_session_inner` clones the manager handle; grep + clippy `await_holding_lock`); the new `spawn_does_not_hold_manager_mutex_while_backend_awaits` test `try_lock`s mid-await and fails if the guard were held (real proof); rollback test exercises the true spawn-error path; local spawn body byte-identical (`spawn_sync` = S1 verbatim, local trait spawn has no real await); scope contained, no new deps, both gate sets green. **PASS.**

Non-visual. No version bump. Closes #824.
