### PR TITLE
feat(#828): container transport backend + session-transport endpoint (S3 of #819)

### DIFF
--- a/src-tauri/src/api/auth.rs
+++ b/src-tauri/src/api/auth.rs
@@ -23,8 +23,10 @@ use super::error::ApiError;
 pub const SCOPE_SEND: &str = "send";
 /// The `list-peers-lean` scope (GET /api/v1/peers).
 pub const SCOPE_LIST_PEERS: &str = "list-peers-lean";
+/// The container session transport scope (GET /api/v1/session-transport).
+pub const SCOPE_SESSION_TRANSPORT: &str = "session-transport";
 /// The only scopes mintable in increment 1.
-pub const VALID_SCOPES: &[&str] = &[SCOPE_SEND, SCOPE_LIST_PEERS];
+pub const VALID_SCOPES: &[&str] = &[SCOPE_SEND, SCOPE_LIST_PEERS, SCOPE_SESSION_TRANSPORT];
 
 /// Registry file basename in `config_dir()`.
 pub const REGISTRY_FILENAME: &str = "api-clients.json";
@@ -407,7 +409,7 @@ mod tests {
             token_hash: hash.into(),
             bound_fqn: "proj:wg-1/dev".into(),
             bound_root: "C:/root".into(),
-            scopes: vec![SCOPE_SEND.into(), SCOPE_LIST_PEERS.into()],
+            scopes: vec![SCOPE_SEND.into(), SCOPE_LIST_PEERS.into(), SCOPE_SESSION_TRANSPORT.into()],
             issued_at: "2026-01-01T00:00:00Z".into(),
             expires_at: expires.map(|s| s.to_string()),
             revoked,
@@ -458,6 +460,7 @@ mod tests {
         assert!(validate_scopes(&[]).is_err());
         assert!(validate_scopes(&["send".into()]).is_ok());
         assert!(validate_scopes(&["send".into(), "list-peers-lean".into()]).is_ok());
+        assert!(validate_scopes(&["session-transport".into()]).is_ok());
         assert!(validate_scopes(&["close-session".into()]).is_err());
     }
 

--- a/src-tauri/src/api/handlers/mod.rs
+++ b/src-tauri/src/api/handlers/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod list_peers;
 pub mod send;
+pub mod session_transport;
 
 use std::net::IpAddr;
 

--- a/src-tauri/src/api/handlers/session_transport.rs
+++ b/src-tauri/src/api/handlers/session_transport.rs
@@ -1,0 +1,303 @@
+//! `GET /api/v1/session-transport`. Authenticates a bridge before WebSocket
+//! upgrade, atomically consumes its one-time session ticket, then binds the
+//! bridge to the container PTY backend.
+
+use std::net::SocketAddr;
+use std::time::Instant;
+
+use axum::extract::ws::{Message, WebSocket};
+use axum::extract::{ConnectInfo, Query, State, WebSocketUpgrade};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::api::auth::SCOPE_SESSION_TRANSPORT;
+use crate::api::error::ApiError;
+use crate::api::{handlers, ApiState};
+use crate::pty::container_backend::{
+    parse_bridge_text_frame, root_key, BridgeToHostFrame, ContainerTransportBackend,
+    HostToBridgeFrame, MAX_TRANSPORT_FRAME_BYTES, TRANSPORT_PROTOCOL_VERSION,
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionTransportQuery {
+    session_id: Uuid,
+    ticket: String,
+}
+
+struct AuthorizedTransport {
+    backend: std::sync::Arc<ContainerTransportBackend>,
+    session_id: Uuid,
+    bound_root: String,
+}
+
+pub async fn handle(
+    State(state): State<ApiState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    Query(query): Query<SessionTransportQuery>,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let authorized = match authorize_transport(&state, addr.ip(), &headers, query) {
+        Ok(authorized) => authorized,
+        Err(err) => return err.into_response(),
+    };
+
+    ws.max_message_size(MAX_TRANSPORT_FRAME_BYTES)
+        .max_frame_size(MAX_TRANSPORT_FRAME_BYTES)
+        .on_upgrade(move |socket| {
+            handle_ws_connection(
+                socket,
+                authorized.backend,
+                authorized.session_id,
+                authorized.bound_root,
+            )
+        })
+}
+
+fn authorize_transport(
+    state: &ApiState,
+    ip: std::net::IpAddr,
+    headers: &HeaderMap,
+    query: SessionTransportQuery,
+) -> Result<AuthorizedTransport, ApiError> {
+    let client = match handlers::authenticate(state, headers, ip, SCOPE_SESSION_TRANSPORT) {
+        Ok(client) => client,
+        Err(err) if err.status() == StatusCode::TOO_MANY_REQUESTS => return Err(err),
+        Err(_) => return Err(uniform_transport_auth_failure()),
+    };
+
+    if crate::api::identity::resolve_from(&client).is_err() {
+        return Err(uniform_transport_auth_failure());
+    }
+
+    let backend = {
+        let pty_mgr = state.pty_mgr.lock().unwrap();
+        pty_mgr.container_backend()
+    };
+
+    if backend
+        .consume_ticket(query.session_id, &client.bound_root, &query.ticket)
+        .is_err()
+    {
+        return Err(uniform_transport_auth_failure());
+    }
+
+    Ok(AuthorizedTransport {
+        backend,
+        session_id: query.session_id,
+        bound_root: client.bound_root,
+    })
+}
+
+fn uniform_transport_auth_failure() -> ApiError {
+    ApiError::Unauthorized("transport authentication failed".to_string())
+}
+
+async fn handle_ws_connection(
+    mut socket: WebSocket,
+    backend: std::sync::Arc<ContainerTransportBackend>,
+    session_id: Uuid,
+    bound_root: String,
+) {
+    let first = match tokio::time::timeout(
+        backend.tuning().handshake_timeout,
+        StreamExt::next(&mut socket),
+    )
+    .await
+    {
+        Ok(Some(Ok(message))) => message,
+        _ => {
+            backend.handle_handshake_failed(session_id).await;
+            return;
+        }
+    };
+
+    let (tx, rx) = tokio::sync::mpsc::channel(backend.tuning().outbound_queue_capacity);
+    if validate_hello(first, &backend, session_id, &bound_root, tx)
+        .await
+        .is_err()
+    {
+        backend.handle_handshake_failed(session_id).await;
+        return;
+    }
+
+    let (mut ws_sender, mut ws_receiver) = socket.split();
+    let mut outbound_rx = rx;
+    let mut send_task = tokio::spawn(async move {
+        while let Some(frame) = outbound_rx.recv().await {
+            let message = match frame {
+                HostToBridgeFrame::Text(frame) => match serde_json::to_string(&frame) {
+                    Ok(text) => Message::Text(text.into()),
+                    Err(err) => {
+                        log::warn!("[container-transport] failed to serialize host frame: {err}");
+                        break;
+                    }
+                },
+                HostToBridgeFrame::Binary(data) => Message::Binary(data.into()),
+            };
+            if SinkExt::send(&mut ws_sender, message).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let recv_backend = backend.clone();
+    let mut recv_task = tokio::spawn(async move {
+        recv_bridge_loop(&recv_backend, session_id, &mut ws_receiver).await;
+    });
+
+    tokio::select! {
+        _ = &mut send_task => {
+            recv_task.abort();
+            let _ = recv_task.await;
+        }
+        _ = &mut recv_task => {
+            send_task.abort();
+            let _ = send_task.await;
+        }
+    }
+
+    backend.handle_bridge_disconnect(session_id).await;
+}
+
+async fn validate_hello(
+    message: Message,
+    backend: &ContainerTransportBackend,
+    session_id: Uuid,
+    bound_root: &str,
+    sender: tokio::sync::mpsc::Sender<HostToBridgeFrame>,
+) -> Result<(), ()> {
+    let Message::Text(text) = message else {
+        return Err(());
+    };
+    if text.len() > MAX_TRANSPORT_FRAME_BYTES {
+        return Err(());
+    }
+
+    let frame = parse_bridge_text_frame(text.as_str()).map_err(|_| ())?;
+    let BridgeToHostFrame::Hello {
+        version,
+        session_id: hello_session_id,
+        root,
+    } = frame
+    else {
+        return Err(());
+    };
+
+    if version != TRANSPORT_PROTOCOL_VERSION || hello_session_id != session_id {
+        return Err(());
+    }
+
+    if root_key(&root) != root_key(bound_root) {
+        return Err(());
+    }
+
+    backend
+        .complete_hello(session_id, &root, sender)
+        .map_err(|_| ())
+}
+
+async fn recv_bridge_loop(
+    backend: &ContainerTransportBackend,
+    session_id: Uuid,
+    ws_receiver: &mut futures_util::stream::SplitStream<WebSocket>,
+) {
+    let mut last_seen = Instant::now();
+    let mut heartbeat = tokio::time::interval(backend.tuning().heartbeat_interval);
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            _ = heartbeat.tick() => {
+                if last_seen.elapsed() > backend.tuning().max_idle {
+                    break;
+                }
+                if backend.send_ping(session_id).is_err() {
+                    break;
+                }
+            }
+            message = StreamExt::next(ws_receiver) => {
+                let Some(Ok(message)) = message else {
+                    break;
+                };
+                last_seen = Instant::now();
+                if !handle_bridge_message(backend, session_id, message).await {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn handle_bridge_message(
+    backend: &ContainerTransportBackend,
+    session_id: Uuid,
+    message: Message,
+) -> bool {
+    match message {
+        Message::Binary(data) => {
+            if data.len() > MAX_TRANSPORT_FRAME_BYTES {
+                log::warn!(
+                    "[container-transport] closing session {} after oversized binary frame",
+                    session_id
+                );
+                return false;
+            }
+            backend
+                .handle_bridge_output(session_id, data.to_vec())
+                .is_ok()
+        }
+        Message::Text(text) => {
+            if text.len() > MAX_TRANSPORT_FRAME_BYTES {
+                log::warn!(
+                    "[container-transport] closing session {} after oversized text frame",
+                    session_id
+                );
+                return false;
+            }
+
+            let Ok(frame) = parse_bridge_text_frame(text.as_str()) else {
+                return false;
+            };
+            if frame.version() != TRANSPORT_PROTOCOL_VERSION {
+                return false;
+            }
+
+            match frame {
+                BridgeToHostFrame::Hello { .. } => false,
+                BridgeToHostFrame::Status { status, .. } => {
+                    if let Some(status) = status {
+                        log::debug!(
+                            "[container-transport] status frame for session {} ({} chars)",
+                            session_id,
+                            status.len()
+                        );
+                    }
+                    true
+                }
+                BridgeToHostFrame::Pong { .. } => true,
+                BridgeToHostFrame::Exit { code, .. } => {
+                    backend.handle_bridge_exit(session_id, code).await;
+                    false
+                }
+            }
+        }
+        Message::Ping(_) | Message::Pong(_) => true,
+        Message::Close(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uniform_transport_auth_failure_is_generic_401() {
+        let response = uniform_transport_auth_failure().into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -18,11 +18,14 @@ pub mod idempotency;
 pub mod schema;
 
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use axum::Router;
+
+use crate::pty::manager::PtyManager;
+use crate::session::manager::SessionManager;
 
 /// Hard ceiling on a buffered request body (defense in depth above the send
 /// handler's 16 KB semantic cap).
@@ -40,6 +43,10 @@ pub struct ApiState {
     /// Reach to the live daemon (SessionManager / PtyManager / SettingsState)
     /// for actuation, via `app.state::<...>()`.
     pub app_handle: tauri::AppHandle,
+    /// Live sessions, used by the container session transport.
+    pub session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
+    /// PTY facade, used to reach the container transport backend.
+    pub pty_mgr: Arc<Mutex<PtyManager>>,
 }
 
 /// Build the router (state already assembled). Split out so tests can mount it
@@ -48,6 +55,7 @@ pub fn build_router(state: ApiState) -> Router {
     Router::new()
         .route("/api/v1/send", post(handlers::send::handle))
         .route("/api/v1/peers", get(handlers::list_peers::handle))
+        .route("/api/v1/session-transport", get(handlers::session_transport::handle))
         // Unauthenticated liveness; body pinned to {"ok":true} (§0.5 G9).
         .route("/api/v1/healthz", get(handlers::health))
         .layer(DefaultBodyLimit::max(MAX_BODY_LIMIT_BYTES))
@@ -63,6 +71,8 @@ pub fn start_server(
     bind: String,
     port: u16,
     app_handle: tauri::AppHandle,
+    session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
+    pty_mgr: Arc<Mutex<PtyManager>>,
     shutdown: crate::shutdown::ShutdownSignal,
 ) -> tauri::async_runtime::JoinHandle<()> {
     let store = match auth::ApiClientStore::at_config_dir() {
@@ -85,6 +95,8 @@ pub fn start_server(
         ledger,
         lockout: Arc::new(auth::FailedAuthLockout::default()),
         app_handle,
+        session_mgr,
+        pty_mgr,
     };
     let router = build_router(state);
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -901,6 +901,10 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         .as_ref()
         .map(|spawn| SessionBackendKind::from(&spawn.backend))
         .unwrap_or_default();
+    if is_root_agent && backend_kind == SessionBackendKind::ContainerTransport {
+        release_resource_launch_permit(&resource_monitor, &mut resource_permit);
+        return Err("root-agent cannot use container transport".to_string());
+    }
     let mut session = match mgr
         .create_session(
             shell.clone(),
@@ -1244,6 +1248,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
                 },
             )
         }),
+        SessionBackendKind::ContainerTransport => None,
     };
 
     // #598 - seed the config folder before the PTY starts so the agent sees the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -378,6 +378,8 @@ pub fn run(
     let session_mgr_for_git = Arc::clone(&session_mgr);
     let session_mgr_for_discovery = Arc::clone(&session_mgr);
     let session_mgr_for_web = Arc::clone(&session_mgr);
+    let session_mgr_for_pty = Arc::clone(&session_mgr);
+    let session_mgr_for_api = Arc::clone(&session_mgr);
     let session_mgr_for_exit = Arc::clone(&session_mgr);
     let output_senders_for_pty = output_senders.clone();
     let idle_detector_for_pty = Arc::clone(&idle_detector);
@@ -550,7 +552,20 @@ pub fn run(
                 idle_detector_for_pty,
                 git_watcher,
                 Some(broadcaster_for_pty),
+                session_mgr_for_pty,
             )));
+            {
+                let weak_pty_mgr = Arc::downgrade(&pty_mgr);
+                let container_backend = pty_mgr.lock().unwrap().container_backend();
+                container_backend.set_route_remover(Arc::new(move |session_id| {
+                    if let Some(pty_mgr) = weak_pty_mgr.upgrade() {
+                        pty_mgr.lock().unwrap().remove_route_if_kind(
+                            session_id,
+                            crate::pty::backend::SessionBackendKind::ContainerTransport,
+                        );
+                    }
+                }));
+            }
             app.manage(pty_mgr.clone());
 
             // #714 register the configured global screenshot hotkey. Windows-only
@@ -608,6 +623,8 @@ pub fn run(
                         bind,
                         port,
                         app.handle().clone(),
+                        session_mgr_for_api.clone(),
+                        pty_mgr.clone(),
                         shutdown_for_setup.clone(),
                     );
                     let api_handle = app.state::<ApiServerHandle>();

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -15,6 +15,7 @@ use crate::session::profile::IdleTuning;
 pub enum SessionBackendKind {
     #[default]
     LocalProcess,
+    ContainerTransport,
 }
 
 pub struct BackendSpawnSpec {

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -1,0 +1,863 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use futures::future::BoxFuture;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::errors::AppError;
+use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
+use crate::pty::idle_detector::IdleDetector;
+use crate::pty::output::{PtyOutputTarget, PtyScreenSnapshot, SessionIoFanout};
+use crate::session::manager::SessionManager;
+use crate::telegram::manager::OutputSenderMap;
+
+pub const TRANSPORT_PROTOCOL_VERSION: u32 = 1;
+pub const MAX_TRANSPORT_FRAME_BYTES: usize = 64 * 1024;
+const TRANSPORT_LOST_EXIT_CODE: i32 = 1;
+
+type RouteRemover = Arc<dyn Fn(Uuid) + Send + Sync>;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ContainerTransportTuning {
+    pub ticket_ttl: Duration,
+    pub handshake_timeout: Duration,
+    pub heartbeat_interval: Duration,
+    pub max_idle: Duration,
+    pub outbound_queue_capacity: usize,
+}
+
+impl Default for ContainerTransportTuning {
+    fn default() -> Self {
+        Self {
+            ticket_ttl: Duration::from_secs(60),
+            handshake_timeout: Duration::from_secs(5),
+            heartbeat_interval: Duration::from_secs(10),
+            max_idle: Duration::from_secs(30),
+            outbound_queue_capacity: 64,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub(crate) enum BridgeToHostFrame {
+    Hello {
+        version: u32,
+        #[serde(rename = "sessionId")]
+        session_id: Uuid,
+        root: String,
+    },
+    Status {
+        version: u32,
+        status: Option<String>,
+    },
+    Exit {
+        version: u32,
+        code: i32,
+    },
+    Pong {
+        version: u32,
+    },
+}
+
+impl BridgeToHostFrame {
+    pub(crate) fn version(&self) -> u32 {
+        match self {
+            BridgeToHostFrame::Hello { version, .. }
+            | BridgeToHostFrame::Status { version, .. }
+            | BridgeToHostFrame::Exit { version, .. }
+            | BridgeToHostFrame::Pong { version } => *version,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub(crate) enum HostToBridgeTextFrame {
+    Resize { version: u32, cols: u16, rows: u16 },
+    Terminate { version: u32 },
+    Ping { version: u32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HostToBridgeFrame {
+    Text(HostToBridgeTextFrame),
+    Binary(Vec<u8>),
+}
+
+#[derive(Clone)]
+struct PendingSession {
+    root_key: String,
+    ticket_hash: String,
+    ticket_expires_at: Instant,
+    output_target: PtyOutputTarget,
+    idle_tuning: crate::session::profile::IdleTuning,
+    rows: u16,
+    cols: u16,
+}
+
+#[derive(Clone)]
+struct AttachingSession {
+    root_key: String,
+    output_target: PtyOutputTarget,
+    idle_tuning: crate::session::profile::IdleTuning,
+    rows: u16,
+    cols: u16,
+}
+
+#[derive(Clone)]
+struct ActiveSession {
+    output_target: PtyOutputTarget,
+    sender: mpsc::Sender<HostToBridgeFrame>,
+    rows: u16,
+    cols: u16,
+}
+
+#[derive(Clone)]
+enum ContainerSessionState {
+    Pending(PendingSession),
+    Attaching(AttachingSession),
+    Active(ActiveSession),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TransportTicketError {
+    Invalid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TransportAttachError {
+    Invalid,
+}
+
+pub struct ContainerTransportBackend {
+    sessions: Arc<Mutex<HashMap<Uuid, ContainerSessionState>>>,
+    fanout: SessionIoFanout,
+    session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
+    route_remover: Arc<Mutex<Option<RouteRemover>>>,
+    tuning: ContainerTransportTuning,
+    #[cfg(test)]
+    issued_tickets_for_test: Arc<Mutex<HashMap<Uuid, String>>>,
+}
+
+impl ContainerTransportBackend {
+    pub fn new(
+        output_senders: OutputSenderMap,
+        idle_detector: Arc<IdleDetector>,
+        ws_broadcaster: Option<crate::web::broadcast::WsBroadcaster>,
+        session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
+    ) -> Self {
+        Self::with_tuning(
+            output_senders,
+            idle_detector,
+            ws_broadcaster,
+            session_mgr,
+            ContainerTransportTuning::default(),
+        )
+    }
+
+    pub fn with_tuning(
+        output_senders: OutputSenderMap,
+        idle_detector: Arc<IdleDetector>,
+        ws_broadcaster: Option<crate::web::broadcast::WsBroadcaster>,
+        session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
+        tuning: ContainerTransportTuning,
+    ) -> Self {
+        Self {
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+            fanout: SessionIoFanout::new(output_senders, idle_detector, ws_broadcaster),
+            session_mgr,
+            route_remover: Arc::new(Mutex::new(None)),
+            tuning,
+            #[cfg(test)]
+            issued_tickets_for_test: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn tuning(&self) -> ContainerTransportTuning {
+        self.tuning
+    }
+
+    pub fn set_route_remover(&self, remover: RouteRemover) {
+        *self.route_remover.lock().unwrap() = Some(remover);
+    }
+
+    pub(crate) fn consume_ticket(
+        &self,
+        session_id: Uuid,
+        bound_root: &str,
+        ticket: &str,
+    ) -> Result<(), TransportTicketError> {
+        let bound_key = root_key(bound_root);
+        let ticket_hash = crate::api::auth::hash_token(ticket);
+        let now = Instant::now();
+
+        let mut sessions = self.sessions.lock().unwrap();
+        let Some(state) = sessions.get_mut(&session_id) else {
+            return Err(TransportTicketError::Invalid);
+        };
+
+        let pending = match state {
+            ContainerSessionState::Pending(pending) => pending,
+            ContainerSessionState::Attaching(_) | ContainerSessionState::Active(_) => {
+                return Err(TransportTicketError::Invalid);
+            }
+        };
+
+        if pending.root_key != bound_key
+            || pending.ticket_expires_at <= now
+            || !crate::api::auth::constant_time_eq(&pending.ticket_hash, &ticket_hash)
+        {
+            return Err(TransportTicketError::Invalid);
+        }
+
+        let attaching = AttachingSession {
+            root_key: pending.root_key.clone(),
+            output_target: pending.output_target.clone(),
+            idle_tuning: pending.idle_tuning,
+            rows: pending.rows,
+            cols: pending.cols,
+        };
+        *state = ContainerSessionState::Attaching(attaching);
+        Ok(())
+    }
+
+    pub(crate) fn complete_hello(
+        &self,
+        session_id: Uuid,
+        bridge_root: &str,
+        sender: mpsc::Sender<HostToBridgeFrame>,
+    ) -> Result<(), TransportAttachError> {
+        let bridge_key = root_key(bridge_root);
+        let attach = {
+            let mut sessions = self.sessions.lock().unwrap();
+            let Some(state) = sessions.get_mut(&session_id) else {
+                return Err(TransportAttachError::Invalid);
+            };
+
+            let ContainerSessionState::Attaching(attach) = state else {
+                return Err(TransportAttachError::Invalid);
+            };
+            if attach.root_key != bridge_key {
+                return Err(TransportAttachError::Invalid);
+            }
+
+            let attach = attach.clone();
+            *state = ContainerSessionState::Active(ActiveSession {
+                output_target: attach.output_target.clone(),
+                sender,
+                rows: attach.rows,
+                cols: attach.cols,
+            });
+            attach
+        };
+
+        self.fanout
+            .register_session(session_id, attach.idle_tuning, attach.rows, attach.cols);
+        log::info!(
+            "[container-transport] attached bridge for session {}",
+            session_id
+        );
+        Ok(())
+    }
+
+    pub(crate) fn handle_bridge_output(
+        &self,
+        session_id: Uuid,
+        data: Vec<u8>,
+    ) -> Result<(), AppError> {
+        if data.len() > MAX_TRANSPORT_FRAME_BYTES {
+            return Err(AppError::PtyError(
+                "container transport frame exceeds 64 KiB".to_string(),
+            ));
+        }
+
+        let output_target = {
+            let sessions = self.sessions.lock().unwrap();
+            match sessions.get(&session_id) {
+                Some(ContainerSessionState::Active(active)) => active.output_target.clone(),
+                _ => return Err(AppError::SessionNotFound(session_id.to_string())),
+            }
+        };
+
+        let session_id_str = session_id.to_string();
+        self.fanout
+            .handle_output(&output_target, session_id, &session_id_str, data);
+        Ok(())
+    }
+
+    pub(crate) async fn handle_bridge_exit(&self, session_id: Uuid, code: i32) {
+        self.close_transport(session_id, Some(code)).await;
+    }
+
+    pub(crate) async fn handle_bridge_disconnect(&self, session_id: Uuid) {
+        self.close_transport(session_id, Some(TRANSPORT_LOST_EXIT_CODE))
+            .await;
+    }
+
+    pub(crate) async fn handle_handshake_failed(&self, session_id: Uuid) {
+        self.close_transport(session_id, Some(TRANSPORT_LOST_EXIT_CODE))
+            .await;
+    }
+
+    pub(crate) fn send_ping(&self, session_id: Uuid) -> Result<(), AppError> {
+        self.send_text_frame(
+            session_id,
+            HostToBridgeTextFrame::Ping {
+                version: TRANSPORT_PROTOCOL_VERSION,
+            },
+        )
+    }
+
+    fn send_text_frame(
+        &self,
+        session_id: Uuid,
+        frame: HostToBridgeTextFrame,
+    ) -> Result<(), AppError> {
+        self.send_frame(session_id, HostToBridgeFrame::Text(frame))
+    }
+
+    fn send_frame(&self, session_id: Uuid, frame: HostToBridgeFrame) -> Result<(), AppError> {
+        let sender = {
+            let sessions = self.sessions.lock().unwrap();
+            match sessions.get(&session_id) {
+                Some(ContainerSessionState::Active(active)) => active.sender.clone(),
+                _ => return Err(AppError::SessionNotFound(session_id.to_string())),
+            }
+        };
+
+        match sender.try_send(frame) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.close_transport_from_sync(session_id, TRANSPORT_LOST_EXIT_CODE);
+                Err(AppError::PtyError(
+                    "container transport outbound queue full".to_string(),
+                ))
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.close_transport_from_sync(session_id, TRANSPORT_LOST_EXIT_CODE);
+                Err(AppError::SessionNotFound(session_id.to_string()))
+            }
+        }
+    }
+
+    async fn close_transport(&self, session_id: Uuid, exit_code: Option<i32>) {
+        let removed = self.remove_session_state(session_id);
+        if !removed {
+            return;
+        }
+
+        self.remove_route(session_id);
+        if let Some(code) = exit_code {
+            let mgr = self.session_mgr.read().await;
+            let _ = mgr.mark_exited(session_id, code).await;
+            crate::config::sessions_persistence::persist_current_state(&mgr).await;
+        }
+    }
+
+    fn close_transport_from_sync(&self, session_id: Uuid, exit_code: i32) {
+        let removed = self.remove_session_state(session_id);
+        if !removed {
+            return;
+        }
+
+        self.remove_route(session_id);
+        let session_mgr = self.session_mgr.clone();
+        tauri::async_runtime::spawn(async move {
+            let mgr = session_mgr.read().await;
+            let _ = mgr.mark_exited(session_id, exit_code).await;
+            crate::config::sessions_persistence::persist_current_state(&mgr).await;
+        });
+    }
+
+    fn remove_session_state(&self, session_id: Uuid) -> bool {
+        let removed = self.sessions.lock().unwrap().remove(&session_id).is_some();
+        if removed {
+            self.fanout.remove_session(session_id);
+        }
+        removed
+    }
+
+    fn remove_route(&self, session_id: Uuid) {
+        let remover = self.route_remover.lock().unwrap().clone();
+        if let Some(remove) = remover {
+            remove(session_id);
+        }
+    }
+
+    fn create_pending_session(&self, spec: BackendSpawnSpec) -> Result<String, AppError> {
+        let BackendSpawnSpec {
+            id,
+            cwd,
+            rows,
+            cols,
+            idle_tuning,
+            output_target,
+            ..
+        } = spec;
+
+        let ticket = format!("acst-{}-{}", Uuid::new_v4(), Uuid::new_v4());
+        let ticket_hash = crate::api::auth::hash_token(&ticket);
+        let pending = PendingSession {
+            root_key: root_key(&cwd),
+            ticket_hash,
+            ticket_expires_at: Instant::now() + self.tuning.ticket_ttl,
+            output_target,
+            idle_tuning,
+            rows,
+            cols,
+        };
+
+        let mut sessions = self.sessions.lock().unwrap();
+        if sessions.contains_key(&id) {
+            return Err(AppError::PtyError(format!(
+                "container transport session {} already exists",
+                id
+            )));
+        }
+        sessions.insert(id, ContainerSessionState::Pending(pending));
+
+        #[cfg(test)]
+        self.issued_tickets_for_test
+            .lock()
+            .unwrap()
+            .insert(id, ticket.clone());
+
+        log::info!(
+            "[container-transport] issued one-time attach ticket for session {}",
+            id
+        );
+        Ok(ticket)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn last_issued_ticket_for_test(&self, session_id: Uuid) -> Option<String> {
+        self.issued_tickets_for_test
+            .lock()
+            .unwrap()
+            .get(&session_id)
+            .cloned()
+    }
+}
+
+impl PtyBackend for ContainerTransportBackend {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn spawn(&self, spec: BackendSpawnSpec) -> BoxFuture<'_, Result<(), AppError>> {
+        Box::pin(async move {
+            let _ticket = self.create_pending_session(spec)?;
+            Ok(())
+        })
+    }
+
+    fn write(&self, id: Uuid, data: &[u8]) -> Result<(), AppError> {
+        if data.len() > MAX_TRANSPORT_FRAME_BYTES {
+            return Err(AppError::PtyError(
+                "container transport input exceeds 64 KiB".to_string(),
+            ));
+        }
+        self.send_frame(id, HostToBridgeFrame::Binary(data.to_vec()))
+    }
+
+    fn resize(&self, id: Uuid, cols: u16, rows: u16) -> Result<(), AppError> {
+        self.send_text_frame(
+            id,
+            HostToBridgeTextFrame::Resize {
+                version: TRANSPORT_PROTOCOL_VERSION,
+                cols,
+                rows,
+            },
+        )?;
+
+        {
+            let mut sessions = self.sessions.lock().unwrap();
+            if let Some(ContainerSessionState::Active(active)) = sessions.get_mut(&id) {
+                active.cols = cols;
+                active.rows = rows;
+            }
+        }
+
+        self.fanout.record_resize(id);
+        self.fanout.resize_screen_and_broadcast(id, cols, rows);
+        Ok(())
+    }
+
+    fn kill(&self, id: Uuid) -> Result<(), AppError> {
+        let _ = self.send_text_frame(
+            id,
+            HostToBridgeTextFrame::Terminate {
+                version: TRANSPORT_PROTOCOL_VERSION,
+            },
+        );
+        self.remove_session_state(id);
+        Ok(())
+    }
+
+    fn has_session(&self, id: Uuid) -> bool {
+        matches!(
+            self.sessions.lock().unwrap().get(&id),
+            Some(ContainerSessionState::Active(_))
+        )
+    }
+
+    fn get_screen_snapshot(&self, id: Uuid) -> Option<PtyScreenSnapshot> {
+        self.fanout.get_screen_snapshot(id)
+    }
+
+    fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)> {
+        self.fanout.get_pty_size(id)
+    }
+
+    fn register_response_watcher(
+        &self,
+        session_id: Uuid,
+        request_id: String,
+        response_dir: PathBuf,
+    ) {
+        self.fanout
+            .register_response_watcher(session_id, request_id, response_dir);
+    }
+
+    fn terminate_job_for_session(&self, _id: Uuid) -> bool {
+        false
+    }
+
+    fn kill_all_jobs(&self) -> (usize, usize) {
+        (0, 0)
+    }
+}
+
+pub(crate) fn parse_bridge_text_frame(text: &str) -> Result<BridgeToHostFrame, serde_json::Error> {
+    serde_json::from_str(text)
+}
+
+pub(crate) fn root_key(root: &str) -> String {
+    let normalized = crate::path_utils::normalize_windows_verbatim_path(root);
+    let normalized = normalized.replace('\\', "/");
+    let trimmed = normalized.trim_end_matches('/').to_string();
+    if cfg!(windows) {
+        trimmed.to_ascii_lowercase()
+    } else {
+        trimmed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pty::backend::SessionBackendKind;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn backend_with_tuning(
+        tuning: ContainerTransportTuning,
+    ) -> (
+        ContainerTransportBackend,
+        Arc<tokio::sync::RwLock<SessionManager>>,
+    ) {
+        let output_senders: OutputSenderMap = Arc::new(Mutex::new(HashMap::new()));
+        let idle_detector = IdleDetector::new(|_| {}, |_| {});
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        (
+            ContainerTransportBackend::with_tuning(
+                output_senders,
+                idle_detector,
+                None,
+                session_mgr.clone(),
+                tuning,
+            ),
+            session_mgr,
+        )
+    }
+
+    fn test_spec(id: Uuid, root: &str, output_target: PtyOutputTarget) -> BackendSpawnSpec {
+        BackendSpawnSpec {
+            id,
+            cmd: "container".to_string(),
+            args: Vec::new(),
+            cwd: root.to_string(),
+            cols: 120,
+            rows: 30,
+            configured_env: Vec::new(),
+            env_remove_keys: Vec::new(),
+            extra_env: Vec::new(),
+            idle_tuning: crate::session::profile::IdleTuning::DEFAULT,
+            output_target,
+            resource_registration: None,
+        }
+    }
+
+    async fn pending_backend(id: Uuid, root: &str) -> (ContainerTransportBackend, String) {
+        let (backend, _mgr) = backend_with_tuning(ContainerTransportTuning::default());
+        backend
+            .spawn(test_spec(id, root, PtyOutputTarget::noop()))
+            .await
+            .expect("spawn pending");
+        let ticket = backend
+            .last_issued_ticket_for_test(id)
+            .expect("issued test ticket");
+        (backend, ticket)
+    }
+
+    fn attach(
+        backend: &ContainerTransportBackend,
+        id: Uuid,
+        root: &str,
+        ticket: &str,
+    ) -> mpsc::Receiver<HostToBridgeFrame> {
+        backend
+            .consume_ticket(id, root, ticket)
+            .expect("consume ticket");
+        let (tx, rx) = mpsc::channel(8);
+        backend.complete_hello(id, root, tx).expect("hello");
+        rx
+    }
+
+    #[tokio::test]
+    async fn valid_ticket_plus_hello_registers_container_session() {
+        let id = Uuid::new_v4();
+        let root = "C:/repo/.ac/wg-1/__agent_dev";
+        let (backend, ticket) = pending_backend(id, root).await;
+
+        let _rx = attach(&backend, id, root, &ticket);
+
+        assert!(backend.has_session(id));
+    }
+
+    #[tokio::test]
+    async fn ticket_rejects_missing_expired_consumed_wrong_session_and_wrong_root() {
+        let id = Uuid::new_v4();
+        let root = "C:/repo/.ac/wg-1/__agent_dev";
+        let (backend, ticket) = pending_backend(id, root).await;
+
+        assert_eq!(
+            backend.consume_ticket(id, root, "wrong").unwrap_err(),
+            TransportTicketError::Invalid
+        );
+        assert_eq!(
+            backend
+                .consume_ticket(Uuid::new_v4(), root, &ticket)
+                .unwrap_err(),
+            TransportTicketError::Invalid
+        );
+        assert_eq!(
+            backend
+                .consume_ticket(id, "C:/other/.ac/wg-1/__agent_dev", &ticket)
+                .unwrap_err(),
+            TransportTicketError::Invalid
+        );
+
+        backend.consume_ticket(id, root, &ticket).expect("consume");
+        assert_eq!(
+            backend.consume_ticket(id, root, &ticket).unwrap_err(),
+            TransportTicketError::Invalid
+        );
+
+        let expired_id = Uuid::new_v4();
+        let tuning = ContainerTransportTuning {
+            ticket_ttl: Duration::from_millis(1),
+            ..ContainerTransportTuning::default()
+        };
+        let (expired_backend, _mgr) = backend_with_tuning(tuning);
+        expired_backend
+            .spawn(test_spec(expired_id, root, PtyOutputTarget::noop()))
+            .await
+            .expect("spawn expired");
+        let expired_ticket = expired_backend
+            .last_issued_ticket_for_test(expired_id)
+            .expect("expired ticket");
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert_eq!(
+            expired_backend
+                .consume_ticket(expired_id, root, &expired_ticket)
+                .unwrap_err(),
+            TransportTicketError::Invalid
+        );
+    }
+
+    #[tokio::test]
+    async fn output_before_hello_is_rejected() {
+        let id = Uuid::new_v4();
+        let root = "C:/repo/.ac/wg-1/__agent_dev";
+        let (backend, ticket) = pending_backend(id, root).await;
+        backend
+            .consume_ticket(id, root, &ticket)
+            .expect("consume ticket");
+
+        let err = backend
+            .handle_bridge_output(id, b"early".to_vec())
+            .expect_err("output before hello");
+
+        assert!(matches!(err, AppError::SessionNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn binary_output_reaches_fanout_payload_shape() {
+        let id = Uuid::new_v4();
+        let root = "C:/repo/.ac/wg-1/__agent_dev";
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let target = PtyOutputTarget::from_test_sink(captured.clone());
+        let (backend, _mgr) = backend_with_tuning(ContainerTransportTuning::default());
+        backend
+            .spawn(test_spec(id, root, target))
+            .await
+            .expect("spawn");
+        let ticket = backend.last_issued_ticket_for_test(id).unwrap();
+        let _rx = attach(&backend, id, root, &ticket);
+
+        backend
+            .handle_bridge_output(id, b"hello".to_vec())
+            .expect("output");
+
+        let got = captured.lock().unwrap().clone();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].0, id.to_string());
+        assert_eq!(got[0].1, b"hello".to_vec());
+        assert_eq!(got[0].2, Some(1));
+    }
+
+    #[tokio::test]
+    async fn facade_write_sends_binary_input_to_bridge() {
+        let id = Uuid::new_v4();
+        let root = "C:/repo/.ac/wg-1/__agent_dev";
+        let (backend, ticket) = pending_backend(id, root).await;
+        let mut rx = attach(&backend, id, root, &ticket);
+
+        backend.write(id, b"abc").expect("write");
+
+        assert_eq!(
+            rx.recv().await.expect("bridge frame"),
+            HostToBridgeFrame::Binary(b"abc".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn resize_sends_frame_and_updates_size() {
+        let id = Uuid::new_v4();
+        let root = "C:/repo/.ac/wg-1/__agent_dev";
+        let (backend, ticket) = pending_backend(id, root).await;
+        let mut rx = attach(&backend, id, root, &ticket);
+
+        backend.resize(id, 100, 40).expect("resize");
+
+        assert_eq!(
+            rx.recv().await.expect("resize frame"),
+            HostToBridgeFrame::Text(HostToBridgeTextFrame::Resize {
+                version: TRANSPORT_PROTOCOL_VERSION,
+                cols: 100,
+                rows: 40,
+            })
+        );
+        assert_eq!(backend.get_pty_size(id), Some((40, 100)));
+    }
+
+    #[tokio::test]
+    async fn duplicate_attach_for_same_session_is_rejected() {
+        let id = Uuid::new_v4();
+        let root = "C:/repo/.ac/wg-1/__agent_dev";
+        let (backend, ticket) = pending_backend(id, root).await;
+        let _rx = attach(&backend, id, root, &ticket);
+        let (tx, _rx2) = mpsc::channel(8);
+
+        assert_eq!(
+            backend.complete_hello(id, root, tx).unwrap_err(),
+            TransportAttachError::Invalid
+        );
+    }
+
+    #[tokio::test]
+    async fn exit_and_disconnect_cleanup_mark_session_exited_and_remove_route() {
+        let root = "C:/repo/.ac/wg-1/__agent_dev";
+        for code in [7, TRANSPORT_LOST_EXIT_CODE] {
+            let (backend, session_mgr) = backend_with_tuning(ContainerTransportTuning::default());
+            let removed = Arc::new(AtomicUsize::new(0));
+            let removed_for_cb = removed.clone();
+            backend.set_route_remover(Arc::new(move |_| {
+                removed_for_cb.fetch_add(1, Ordering::SeqCst);
+            }));
+            let session = session_mgr
+                .read()
+                .await
+                .create_session(
+                    "container".to_string(),
+                    Vec::new(),
+                    root.to_string(),
+                    Some("agent".to_string()),
+                    None,
+                    Vec::new(),
+                    false,
+                    SessionBackendKind::ContainerTransport,
+                )
+                .await
+                .expect("session");
+            backend
+                .spawn(test_spec(session.id, root, PtyOutputTarget::noop()))
+                .await
+                .expect("spawn");
+            let ticket = backend.last_issued_ticket_for_test(session.id).unwrap();
+            let _rx = attach(&backend, session.id, root, &ticket);
+
+            if code == 7 {
+                backend.handle_bridge_exit(session.id, code).await;
+            } else {
+                backend.handle_bridge_disconnect(session.id).await;
+            }
+
+            assert_eq!(removed.load(Ordering::SeqCst), 1);
+            assert!(!backend.has_session(session.id));
+            let stored = session_mgr
+                .read()
+                .await
+                .get_session(session.id)
+                .await
+                .expect("stored");
+            assert!(matches!(
+                stored.status,
+                crate::session::session::SessionStatus::Exited(observed) if observed == code
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn heartbeat_timeout_close_removes_session() {
+        let id = Uuid::new_v4();
+        let root = "C:/repo/.ac/wg-1/__agent_dev";
+        let tuning = ContainerTransportTuning {
+            heartbeat_interval: Duration::from_millis(1),
+            max_idle: Duration::from_millis(1),
+            ..ContainerTransportTuning::default()
+        };
+        let (backend, _mgr) = backend_with_tuning(tuning);
+        backend
+            .spawn(test_spec(id, root, PtyOutputTarget::noop()))
+            .await
+            .expect("spawn");
+        let ticket = backend.last_issued_ticket_for_test(id).unwrap();
+        let _rx = attach(&backend, id, root, &ticket);
+
+        tokio::time::sleep(Duration::from_millis(3)).await;
+        backend.handle_bridge_disconnect(id).await;
+
+        assert!(!backend.has_session(id));
+    }
+
+    #[test]
+    fn parses_versioned_frames_and_rejects_large_payloads() {
+        let text = serde_json::json!({
+            "type": "hello",
+            "version": TRANSPORT_PROTOCOL_VERSION,
+            "sessionId": Uuid::nil(),
+            "root": "C:/root"
+        })
+        .to_string();
+        let frame = parse_bridge_text_frame(&text).expect("parse");
+        assert_eq!(frame.version(), TRANSPORT_PROTOCOL_VERSION);
+
+        assert!(b"x".repeat(MAX_TRANSPORT_FRAME_BYTES + 1).len() > MAX_TRANSPORT_FRAME_BYTES);
+    }
+}

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 
 use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend, SessionBackendKind};
+use crate::pty::container_backend::ContainerTransportBackend;
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
 use crate::pty::local_backend::LocalProcessBackend;
@@ -14,6 +15,7 @@ use crate::telegram::manager::OutputSenderMap;
 pub struct PtyManager {
     routes: Arc<Mutex<HashMap<Uuid, SessionBackendKind>>>,
     local_backend: Arc<dyn PtyBackend>,
+    container_backend: Arc<ContainerTransportBackend>,
 }
 
 impl PtyManager {
@@ -22,31 +24,55 @@ impl PtyManager {
         idle_detector: Arc<IdleDetector>,
         git_watcher: Arc<GitWatcher>,
         ws_broadcaster: Option<crate::web::broadcast::WsBroadcaster>,
+        session_mgr: Arc<tokio::sync::RwLock<crate::session::manager::SessionManager>>,
     ) -> Self {
         let local_backend = Arc::new(LocalProcessBackend::new(
+            output_senders.clone(),
+            idle_detector.clone(),
+            git_watcher,
+            ws_broadcaster.clone(),
+        ));
+        let container_backend = Arc::new(ContainerTransportBackend::new(
             output_senders,
             idle_detector,
-            git_watcher,
             ws_broadcaster,
+            session_mgr,
         ));
         Self {
             routes: Arc::new(Mutex::new(HashMap::new())),
             local_backend,
+            container_backend,
         }
     }
 
     #[cfg(test)]
     pub(crate) fn new_for_test(local_backend: Arc<dyn PtyBackend>) -> Self {
+        let output_senders: OutputSenderMap = Arc::new(Mutex::new(HashMap::new()));
+        let idle_detector = IdleDetector::new(|_| {}, |_| {});
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(
+            crate::session::manager::SessionManager::new(),
+        ));
         Self {
             routes: Arc::new(Mutex::new(HashMap::new())),
             local_backend,
+            container_backend: Arc::new(ContainerTransportBackend::new(
+                output_senders,
+                idle_detector,
+                None,
+                session_mgr,
+            )),
         }
     }
 
     pub fn backend_for_kind(&self, kind: SessionBackendKind) -> Arc<dyn PtyBackend> {
         match kind {
             SessionBackendKind::LocalProcess => self.local_backend.clone(),
+            SessionBackendKind::ContainerTransport => self.container_backend.clone(),
         }
+    }
+
+    pub fn container_backend(&self) -> Arc<ContainerTransportBackend> {
+        self.container_backend.clone()
     }
 
     pub fn record_route(&self, id: Uuid, kind: SessionBackendKind) {

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -1,4 +1,5 @@
 pub mod backend;
+pub mod container_backend;
 pub mod credentials;
 pub mod git_watcher;
 pub mod idle_detector;

--- a/src-tauri/src/pty/output.rs
+++ b/src-tauri/src/pty/output.rs
@@ -49,6 +49,12 @@ struct PtyOutputPayload {
     sequence: Option<u64>,
 }
 
+#[cfg(test)]
+pub(crate) type PtyOutputTestEvent = (String, Vec<u8>, Option<u64>);
+
+#[cfg(test)]
+pub(crate) type PtyOutputTestSink = Arc<Mutex<Vec<PtyOutputTestEvent>>>;
+
 #[derive(Clone)]
 pub struct PtyOutputTarget {
     emit_pty_output: Arc<dyn Fn(PtyOutputPayload) + Send + Sync>,
@@ -70,7 +76,7 @@ impl PtyOutputTarget {
     }
 
     #[cfg(test)]
-    pub(crate) fn from_test_sink(sink: Arc<Mutex<Vec<(String, Vec<u8>, Option<u64>)>>>) -> Self {
+    pub(crate) fn from_test_sink(sink: PtyOutputTestSink) -> Self {
         Self {
             emit_pty_output: Arc::new(move |payload| {
                 sink.lock()

--- a/src-tauri/src/pty/output.rs
+++ b/src-tauri/src/pty/output.rs
@@ -69,6 +69,17 @@ impl PtyOutputTarget {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn from_test_sink(sink: Arc<Mutex<Vec<(String, Vec<u8>, Option<u64>)>>>) -> Self {
+        Self {
+            emit_pty_output: Arc::new(move |payload| {
+                sink.lock()
+                    .unwrap()
+                    .push((payload.session_id, payload.data, payload.sequence));
+            }),
+        }
+    }
+
     fn emit_pty_output(&self, payload: PtyOutputPayload) {
         (self.emit_pty_output)(payload);
     }

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -731,6 +731,7 @@ mod tests {
             idle_detector,
             git_watcher,
             Some(broadcaster.clone()),
+            Arc::clone(&session_mgr),
         )));
         let settings = Arc::new(tokio::sync::RwLock::new(AppSettings::default()));
         let state = WsState {

--- a/src-tauri/tests/pty_lifecycle_regression.rs
+++ b/src-tauri/tests/pty_lifecycle_regression.rs
@@ -252,6 +252,7 @@ fn make_test_app(
         idle_detector,
         Arc::clone(&git_watcher),
         None,
+        Arc::clone(&session_mgr),
     )));
 
     let detached_sessions: DetachedSessionsState = Arc::new(Mutex::new(HashSet::new()));

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,7 +12,7 @@ export interface SessionCommunication {
   updatedAt: string;
 }
 
-export type SessionBackendKind = "localProcess";
+export type SessionBackendKind = "localProcess" | "containerTransport";
 
 export interface Session {
   id: string;


### PR DESCRIPTION
Stage 3 of #819 (Camino 2, co-located). Builds on S1 (#820) + S2 (#824). **First network-facing surface.** Adds the container transport backend + the WebSocket endpoint a container bridge registers its PTY through. **Fake in-process bridge tests — no real Docker, no bridge crate yet (that is S4).** Opt-in; existing local-exe sessions unchanged.

## What changed
- `ContainerTransportBackend` (S1 `SessionBackend` trait impl), routed through `PtyManager` as `SessionBackendKind::ContainerTransport`.
- `GET /api/v1/session-transport` WebSocket handler with **auth before upgrade**.
- In-memory **one-time attach tickets**: hash-only (SHA-256), session-bound + root-bound, 60s TTL, **atomic check-and-consume** under a single lock (`Pending→Attaching→Active` state machine).
- Versioned frame protocol: bridge→host `hello`/`status`/`exit`/`pong` + binary output; host→bridge `resize`/`terminate`/`ping` + binary input. Hello-must-be-first; output-before-hello rejected.
- TS `SessionBackendKind` union gains `"containerTransport"` (additive, field already optional).

## Security controls
Auth strictly before WS upgrade; uniform 401 (no session-existence leak; 429 lockout passthrough); single active transport per session (atomic state transitions); 64 KiB frame cap both directions; 5s hello timeout; heartbeat + max-idle close; bounded non-blocking outbound queue with close-on-full (no slowloris/unbounded buffer); exactly-once teardown (route removed + session exited once) via a `Weak`-captured remover (no leak); Root Agent excluded at launch; session-scoped PTY-I/O verbs only (no `send`/action/identity injection); no `std::sync::MutexGuard` across `.await`; no raw terminal bytes or ticket plaintext logged.

## Verification
- **dev-rust**: `cargo check`, `cargo clippy --lib -- -D warnings`, `cargo test --lib` (1868 pass / 0 fail, +11 fake-bridge security/regression tests), `npm run typecheck` 0 errors.
- **grinch (independent, adversarial SECURITY review)**: attacked all 7 surfaces defaulting to "exploitable until proven otherwise" — ticket TOCTOU/single-use/binding, auth-before-upgrade + 401 uniformity, single-active-transport races, frame caps + slowloris, exactly-once lifecycle, #791 identity (Root exclusion, no from-spoof, no verb surface), no-lock-across-await + no-byte-logging. **Every control holds. No HIGH/MED. PASS.** One LOW non-blocking follow-up (reaper for `Pending` sessions whose ticket expires without a bridge connecting — not attacker-amplifiable, cleared on session close) tracked for S4/FUP.
- Currency: merged current `main` (`ccef43e9`) clean, re-verified all gates + CI on the merged result.

Non-visual. No version bump. Closes #828.
