### PR TITLE
feat(#833): DB MessageStore + inline send + dispatcher (S5 of #819, final)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "portable-pty",
  "reqwest 0.12.28",
  "rfd 0.15.4",
+ "rusqlite",
  "rust-embed",
  "serde",
  "serde_json",
@@ -49,6 +50,18 @@ dependencies = [
  "which",
  "windows-sys 0.59.0",
  "xcap",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1676,6 +1689,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,6 +2377,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2364,6 +2398,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -3134,6 +3177,17 @@ dependencies = [
  "bindgen",
  "cc",
  "system-deps 7.0.8",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4987,6 +5041,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/session-bridge/src/bin/agentscommander-api-helper.rs
+++ b/crates/session-bridge/src/bin/agentscommander-api-helper.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use uuid::Uuid;
 
 type HelperResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+const INLINE_BODY_MAX_BYTES: usize = 256 * 1024;
 
 #[tokio::main]
 async fn main() {
@@ -69,17 +70,27 @@ async fn send(args: Vec<String>) -> HelperResult<()> {
         }
     }
     let to = to.ok_or("send requires --to")?;
-    if inline.is_some() {
-        return Err("API transport v1 does not support send --message; use --send".into());
+    let body = match (file, inline) {
+        (Some(_), Some(_)) => return Err("send requires exactly one of --send or --message".into()),
+        (None, None) => return Err("send requires --send or --message".into()),
+        (Some(path), None) => std::fs::read_to_string(path)?,
+        (None, Some(text)) => text,
+    };
+    if body.len() > INLINE_BODY_MAX_BYTES {
+        return Err(format!(
+            "send body exceeds inline cap ({} bytes)",
+            INLINE_BODY_MAX_BYTES
+        )
+        .into());
     }
-    let send = file.ok_or("send requires --send")?;
 
     let request = json!({
         "apiVersion": "1",
         "opId": Uuid::new_v4().to_string(),
         "to": to,
         "message": {
-            "send": send
+            "inline": body,
+            "contentType": "text/markdown"
         }
     });
     let client = reqwest::Client::new();
@@ -97,4 +108,14 @@ async fn send(args: Vec<String>) -> HelperResult<()> {
     }
     println!("{text}");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_cap_matches_daemon_contract() {
+        assert_eq!(INLINE_BODY_MAX_BYTES, 256 * 1024);
+    }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ futures = "0.3"
 rfd = "0.15"
 tauri-plugin-dialog = "2.6.0"
 which = "7"
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 # #714 Native screenshot capture is Windows-only for this issue. Non-Windows
 # builds compile through the `screenshot::unsupported` stub and never link these.

--- a/src-tauri/src/api/README.md
+++ b/src-tauri/src/api/README.md
@@ -3,8 +3,8 @@
 A local, opt-in HTTP API hosted inside the daemon (a sibling of `web/`) that
 lets a machine client (first: a Dockerized coding agent) speak the inter-agent
 control-plane over a token instead of the filesystem outbox. The filesystem
-messaging path stays fully live; this is a strangler-fig second front door into
-the SAME actuation (`deliver_wake`).
+messaging path stays fully live. API sends are stored in the durable DB queue
+and dispatched through the SAME actuation (`deliver_wake`).
 
 ## Enabling
 
@@ -41,16 +41,21 @@ failed-auth lockout throttles unauthenticated probing.
 
 ## Endpoints (`/api/v1`)
 
-- `POST /api/v1/send` - mirrors `send --mode wake --send <file>` (no `--command`).
+- `POST /api/v1/send` - durable inline send (no `--command`).
   Body (`deny_unknown_fields`; `from`/`root`/`token`/`command`/`action` rejected):
   ```json
   { "apiVersion": "1", "opId": "<uuid>", "to": "<fqn>",
-    "message": { "send": "<bare-filename-in-messaging/>" } }
+    "message": { "inline": "message text", "contentType": "text/markdown" } }
   ```
-  `inline` is reserved and rejected with 400 in v1. `opId` is the idempotency
-  key: a replay returns the prior result and never re-delivers (persisted across
-  restarts in `api-idempotency.json`). Response: `200` delivered, `422` rejected,
-  `400/401/403/429` on client/auth/routing/lockout failures.
+  Compatibility `message.send` is also accepted as a bare filename in the
+  sender's workgroup `messaging/` directory, but the daemon reads the file once
+  and stores its content inline. It never stores or injects the host path as the
+  payload. Exactly one of `message.inline` or `message.send` is required.
+  `contentType` defaults to `text/markdown`. Inline payloads are capped at 256
+  KiB. `opId` is the idempotency key, enforced by the DB on `(senderFqn, opId)`;
+  a replay returns the same queued `messageId` and never creates a second row.
+  Response: `202` queued with `{ "status": "queued", "messageId": "..." }`;
+  `400/401/403/413/429` on client/auth/routing/size/lockout failures.
 - `GET /api/v1/peers[?peer=<fqn>...]` - `list-peers-lean` for the caller's bound
   replica; `reachable` is computed from the bound identity.
 - `GET /api/v1/healthz` - unauthenticated liveness, body exactly `{"ok":true}`.
@@ -83,3 +88,9 @@ stay in v1; a breaking change introduces `/api/v2` mounted alongside. The
 Every mint/revoke and authenticated request appends `(ts, clientId, boundFqn,
 op, outcome)` to `api-audit.log` (host-only, 10 MB cap + one rotation, never
 fails closed). Secrets and hashes are never logged.
+
+The message bus database is stored plaintext at
+`config_dir()/api-message-bus.sqlite3`. It is host-only and sensitive because it
+contains queued inline message bodies. The DB uses WAL, foreign keys, a 5s busy
+timeout, schema migrations, transactional enqueue/idempotency, retry leases, and
+delivered/poisoned retention.

--- a/src-tauri/src/api/actuation.rs
+++ b/src-tauri/src/api/actuation.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 
 use tauri::Manager;
 
+use crate::api::message_store::INLINE_BODY_MAX_BYTES;
 use crate::config::settings::SettingsState;
 use crate::phone::types::OutboxMessage;
 
@@ -47,17 +48,7 @@ pub fn reject_if_root(from: &str, to: &str) -> Result<(), ApiError> {
 /// parent confinement), and format the pointer notification. The container path
 /// is never embedded because the CLI helper canonicalizes host-side.
 pub fn build_send_body(bound_root: &str, basename: &str, from: &str) -> Result<String, ApiError> {
-    crate::phone::messaging::validate_filename_only(basename)
-        .map_err(|e| ApiError::BadRequest(format!("invalid filename: {}", e)))?;
-
-    let agent_root = Path::new(bound_root);
-    let wg_root = crate::phone::messaging::workgroup_root(agent_root).map_err(|e| {
-        ApiError::BadRequest(format!("bound replica is not under a workgroup: {}", e))
-    })?;
-    let msg_dir = crate::phone::messaging::messaging_dir(&wg_root)
-        .map_err(|e| ApiError::Internal(format!("cannot resolve messaging dir: {}", e)))?;
-    let abs = crate::phone::messaging::resolve_existing_message(&msg_dir, basename)
-        .map_err(|e| ApiError::BadRequest(format!("message file not found: {}", e)))?;
+    let abs = resolve_send_file_path(bound_root, basename)?;
 
     // UNC-strip at the single emission site, mirroring cli/send.rs.
     let abs_str = abs.to_string_lossy();
@@ -75,18 +66,57 @@ pub fn build_send_body(bound_root: &str, basename: &str, from: &str) -> Result<S
     Ok(body)
 }
 
-/// Resolve + route + actuate a `send` through the shared engine.
-///
-/// Errors returned as `Err(ApiError)` are pre-actuation failures (400 resolve,
-/// 403 root/routing). A successful resolution+route yields `Ok(DeliveryOutcome)`
-/// carrying the engine's delivered/rejected result (200 / 422).
-pub async fn deliver_wake_via_api<R: tauri::Runtime>(
+#[derive(Debug)]
+pub struct SendFileContent {
+    pub body: String,
+    pub source_ref: String,
+}
+
+pub fn read_send_file_content(
+    bound_root: &str,
+    basename: &str,
+) -> Result<SendFileContent, ApiError> {
+    let abs = resolve_send_file_path(bound_root, basename)?;
+    let bytes = std::fs::read(&abs)
+        .map_err(|e| ApiError::BadRequest(format!("message file not readable: {}", e)))?;
+    if bytes.len() > INLINE_BODY_MAX_BYTES {
+        return Err(ApiError::PayloadTooLarge(format!(
+            "message file exceeds inline cap ({} bytes)",
+            INLINE_BODY_MAX_BYTES
+        )));
+    }
+    let body = String::from_utf8(bytes)
+        .map_err(|e| ApiError::BadRequest(format!("message file is not UTF-8: {}", e)))?;
+    Ok(SendFileContent {
+        body,
+        source_ref: basename.to_string(),
+    })
+}
+
+fn resolve_send_file_path(
+    bound_root: &str,
+    basename: &str,
+) -> Result<std::path::PathBuf, ApiError> {
+    crate::phone::messaging::validate_filename_only(basename)
+        .map_err(|e| ApiError::BadRequest(format!("invalid filename: {}", e)))?;
+
+    let agent_root = Path::new(bound_root);
+    let wg_root = crate::phone::messaging::workgroup_root(agent_root).map_err(|e| {
+        ApiError::BadRequest(format!("bound replica is not under a workgroup: {}", e))
+    })?;
+    let msg_dir = crate::phone::messaging::messaging_dir(&wg_root)
+        .map_err(|e| ApiError::Internal(format!("cannot resolve messaging dir: {}", e)))?;
+    let abs = crate::phone::messaging::resolve_existing_message(&msg_dir, basename)
+        .map_err(|e| ApiError::BadRequest(format!("message file not found: {}", e)))?;
+    Ok(abs)
+}
+
+/// Resolve and authorize the API send target without delivering.
+pub async fn resolve_api_send_target<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     from: &str,
     to: &str,
-    body: String,
-    op_id: &str,
-) -> Result<DeliveryOutcome, ApiError> {
+) -> Result<String, ApiError> {
     reject_if_root(from, to)?;
 
     // Project paths: the same source `process_message` reads (SettingsState).
@@ -114,16 +144,19 @@ pub async fn deliver_wake_via_api<R: tauri::Runtime>(
             from, resolved_to
         )));
     }
+    Ok(resolved_to)
+}
 
-    // (3) construct the in-memory OutboxMessage. token = None (§0.5 open-item 4):
+pub fn build_inline_wake_message(id: &str, from: &str, to: &str, body: String) -> OutboxMessage {
+    // token = None (§0.5 open-item 4):
     // the API bypasses process_message and deliver_wake never reads the sender
     // token; the invariant is never a master/root token, never a token not owned
     // by `from`.
-    let msg = OutboxMessage {
-        id: op_id.to_string(),
+    OutboxMessage {
+        id: id.to_string(),
         token: None,
         from: from.to_string(),
-        to: resolved_to.clone(),
+        to: to.to_string(),
         body,
         mode: "wake".to_string(),
         get_output: false,
@@ -139,7 +172,23 @@ pub async fn deliver_wake_via_api<R: tauri::Runtime>(
         timeout_secs: None,
         switch_coding_agent: None,
         switch_profile: None,
-    };
+    }
+}
+
+/// Resolve + route + actuate a `send` through the shared engine.
+///
+/// Errors returned as `Err(ApiError)` are pre-actuation failures (400 resolve,
+/// 403 root/routing). A successful resolution+route yields `Ok(DeliveryOutcome)`
+/// carrying the engine's delivered/rejected result (200 / 422).
+pub async fn deliver_wake_via_api<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    from: &str,
+    to: &str,
+    body: String,
+    op_id: &str,
+) -> Result<DeliveryOutcome, ApiError> {
+    let resolved_to = resolve_api_send_target(app, from, to).await?;
+    let msg = build_inline_wake_message(op_id, from, &resolved_to, body);
 
     // (4) actuate through the SAME engine the poller uses. A throwaway
     // MailboxPoller is delivery-stateless (§0.5 HIGH-1).
@@ -207,10 +256,15 @@ mod tests {
     #[test]
     fn build_send_body_rejects_path_traversal_basename() {
         let temp = tempfile::TempDir::new().unwrap();
-        let replica = temp.path().join("proj").join(".ac").join("wg-1").join("__agent_x");
+        let replica = temp
+            .path()
+            .join("proj")
+            .join(".ac")
+            .join("wg-1")
+            .join("__agent_x");
         std::fs::create_dir_all(&replica).unwrap();
-        let err = build_send_body(replica.to_str().unwrap(), "..\\secret.md", "proj:wg-1/x")
-            .unwrap_err();
+        let err =
+            build_send_body(replica.to_str().unwrap(), "..\\secret.md", "proj:wg-1/x").unwrap_err();
         assert_eq!(err.status(), axum::http::StatusCode::BAD_REQUEST);
     }
 
@@ -221,8 +275,41 @@ mod tests {
         let replica = wg_root.join("__agent_x");
         std::fs::create_dir_all(&replica).unwrap();
         std::fs::create_dir_all(wg_root.join("messaging")).unwrap();
-        let err = build_send_body(replica.to_str().unwrap(), "nope.md", "proj:wg-1/x")
-            .unwrap_err();
+        let err = build_send_body(replica.to_str().unwrap(), "nope.md", "proj:wg-1/x").unwrap_err();
         assert_eq!(err.status(), axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn read_send_file_content_ingests_utf8_body_without_host_path() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let wg_root = temp.path().join("proj-x").join(".ac").join("wg-1-team");
+        let replica = wg_root.join("__agent_dev-rust");
+        let messaging = wg_root.join("messaging");
+        std::fs::create_dir_all(&replica).unwrap();
+        std::fs::create_dir_all(&messaging).unwrap();
+        let fname = "20260704-000000-wg1-a-to-wg1-b-hello.md";
+        std::fs::write(messaging.join(fname), "hello body").unwrap();
+
+        let got = read_send_file_content(replica.to_str().unwrap(), fname).unwrap();
+
+        assert_eq!(got.body, "hello body");
+        assert_eq!(got.source_ref, fname);
+        assert!(!got.body.contains("Process this inter-agent message:"));
+    }
+
+    #[test]
+    fn read_send_file_content_rejects_oversize_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let wg_root = temp.path().join("proj-x").join(".ac").join("wg-1-team");
+        let replica = wg_root.join("__agent_dev-rust");
+        let messaging = wg_root.join("messaging");
+        std::fs::create_dir_all(&replica).unwrap();
+        std::fs::create_dir_all(&messaging).unwrap();
+        let fname = "20260704-000000-wg1-a-to-wg1-b-large.md";
+        std::fs::write(messaging.join(fname), vec![b'x'; INLINE_BODY_MAX_BYTES + 1]).unwrap();
+
+        let err = read_send_file_content(replica.to_str().unwrap(), fname).unwrap_err();
+
+        assert_eq!(err.status(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/src-tauri/src/api/actuation.rs
+++ b/src-tauri/src/api/actuation.rs
@@ -193,7 +193,11 @@ pub async fn deliver_wake_via_api<R: tauri::Runtime>(
     // (4) actuate through the SAME engine the poller uses. A throwaway
     // MailboxPoller is delivery-stateless (§0.5 HIGH-1).
     match crate::phone::mailbox::MailboxPoller::new()
-        .deliver_wake(app, &msg)
+        .deliver_wake_with_origin(
+            app,
+            &msg,
+            crate::phone::mailbox::WakeDeliveryOrigin::DbQueue,
+        )
         .await
     {
         Ok(()) => Ok(DeliveryOutcome::Delivered { to: resolved_to }),

--- a/src-tauri/src/api/dispatcher.rs
+++ b/src-tauri/src/api/dispatcher.rs
@@ -1,0 +1,250 @@
+//! Background dispatcher for DB-backed API sends.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::Future;
+
+use crate::api::message_store::{LeasedMessage, MessageStore};
+use crate::phone::types::OutboxMessage;
+
+#[derive(Debug, Clone)]
+pub struct DispatcherConfig {
+    pub poll_interval: Duration,
+    pub lease_for: Duration,
+    pub batch_limit: usize,
+    pub max_attempts: i64,
+    pub retention: chrono::Duration,
+}
+
+impl Default for DispatcherConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_millis(500),
+            lease_for: Duration::from_secs(30),
+            batch_limit: 8,
+            max_attempts: 5,
+            retention: chrono::Duration::days(7),
+        }
+    }
+}
+
+pub fn start_dispatcher(
+    store: Arc<MessageStore>,
+    app: tauri::AppHandle,
+    shutdown: crate::shutdown::ShutdownSignal,
+    config: DispatcherConfig,
+) -> tauri::async_runtime::JoinHandle<()> {
+    tauri::async_runtime::spawn(async move {
+        let mut interval = tokio::time::interval(config.poll_interval);
+        loop {
+            tokio::select! {
+                _ = shutdown.token().cancelled() => {
+                    log::info!("[api-dispatcher] shutdown signal received, stopping");
+                    break;
+                }
+                _ = interval.tick() => {
+                    if let Err(e) = dispatch_due_with(
+                        &store,
+                        chrono::Utc::now(),
+                        &config,
+                        |msg| {
+                            let app = app.clone();
+                            async move {
+                                crate::phone::mailbox::MailboxPoller::new()
+                                    .deliver_wake(&app, &msg)
+                                    .await
+                            }
+                        },
+                    )
+                    .await
+                    {
+                        log::warn!("[api-dispatcher] dispatch tick failed: {}", e);
+                    }
+                    let cutoff = chrono::Utc::now() - config.retention;
+                    if let Err(e) = store.reap_terminal_before(cutoff) {
+                        log::warn!("[api-dispatcher] reaper failed: {}", e);
+                    }
+                }
+            }
+        }
+    })
+}
+
+pub async fn dispatch_due_with<F, Fut>(
+    store: &MessageStore,
+    now: chrono::DateTime<chrono::Utc>,
+    config: &DispatcherConfig,
+    mut deliver: F,
+) -> Result<usize, crate::api::message_store::MessageStoreError>
+where
+    F: FnMut(OutboxMessage) -> Fut,
+    Fut: Future<Output = Result<(), String>>,
+{
+    let rows = store.lease_due(now, config.batch_limit, config.lease_for, "api-dispatcher")?;
+    let mut processed = 0;
+    for row in rows {
+        let message = build_outbox_message(&row);
+        let result =
+            if crate::api::actuation::reject_if_root(&row.sender_fqn, &row.target_fqn).is_err() {
+                Err("root-agent is not reachable over DB send".to_string())
+            } else {
+                deliver(message).await
+            };
+
+        match result {
+            Ok(()) => {
+                store.mark_delivered(&row.message_id, chrono::Utc::now())?;
+                crate::api::audit::record("-", &row.sender_fqn, "send-dispatch", "delivered");
+            }
+            Err(reason) => {
+                let status = store.mark_delivery_failed(
+                    &row.message_id,
+                    &reason,
+                    chrono::Utc::now(),
+                    config.max_attempts,
+                )?;
+                crate::api::audit::record("-", &row.sender_fqn, "send-dispatch", &status);
+            }
+        }
+        processed += 1;
+    }
+    Ok(processed)
+}
+
+pub fn build_outbox_message(row: &LeasedMessage) -> OutboxMessage {
+    OutboxMessage {
+        id: row.message_id.clone(),
+        token: None,
+        from: row.sender_fqn.clone(),
+        to: row.target_fqn.clone(),
+        body: row.body.clone(),
+        mode: "wake".to_string(),
+        get_output: false,
+        request_id: None,
+        sender_agent: None,
+        preferred_agent: String::new(),
+        priority: "normal".to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        command: None,
+        action: None,
+        target: None,
+        force: None,
+        timeout_secs: None,
+        switch_coding_agent: None,
+        switch_profile: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::message_store::{EnqueueRequest, DB_FILENAME, DEFAULT_CONTENT_TYPE};
+    use std::sync::{Arc, Mutex};
+
+    fn store() -> MessageStore {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(DB_FILENAME);
+        let store = MessageStore::open(path).unwrap();
+        std::mem::forget(dir);
+        store
+    }
+
+    fn enqueue(store: &MessageStore, op_id: &str, body: &str) -> String {
+        store
+            .enqueue(EnqueueRequest {
+                sender_fqn: "proj:wg-1/a".into(),
+                target_fqn: "proj:wg-1/b".into(),
+                op_id: op_id.into(),
+                content_type: DEFAULT_CONTENT_TYPE.into(),
+                body: body.into(),
+                source_plane: "api_inline".into(),
+                source_ref: None,
+            })
+            .unwrap()
+            .message_id
+    }
+
+    #[test]
+    fn build_outbox_message_has_no_privileged_fields() {
+        let row = LeasedMessage {
+            message_id: "m1".into(),
+            sender_fqn: "proj:wg-1/a".into(),
+            target_fqn: "proj:wg-1/b".into(),
+            op_id: "op1".into(),
+            content_type: DEFAULT_CONTENT_TYPE.into(),
+            body: "hi".into(),
+            attempt: 0,
+        };
+
+        let msg = build_outbox_message(&row);
+
+        assert_eq!(msg.mode, "wake");
+        assert_eq!(msg.body, "hi");
+        assert!(msg.command.is_none());
+        assert!(msg.action.is_none());
+        assert!(msg.token.is_none());
+        assert!(msg.target.is_none());
+    }
+
+    #[tokio::test]
+    async fn dispatch_success_marks_delivered_and_calls_deliver() {
+        let store = store();
+        let message_id = enqueue(&store, "op1", "hello");
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_for_deliver = seen.clone();
+
+        let processed = dispatch_due_with(
+            &store,
+            chrono::Utc::now(),
+            &DispatcherConfig::default(),
+            move |msg| {
+                let seen = seen_for_deliver.clone();
+                async move {
+                    seen.lock().unwrap().push(msg.body);
+                    Ok(())
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(processed, 1);
+        assert_eq!(*seen.lock().unwrap(), vec!["hello".to_string()]);
+        let leased = store
+            .lease_due(
+                chrono::Utc::now() + chrono::Duration::hours(1),
+                10,
+                Duration::from_secs(1),
+                "test",
+            )
+            .unwrap();
+        assert!(leased.is_empty(), "{message_id} should be terminal");
+    }
+
+    #[tokio::test]
+    async fn dispatch_failure_retries_then_poisons() {
+        let store = store();
+        enqueue(&store, "op1", "hello");
+        let config = DispatcherConfig {
+            max_attempts: 1,
+            ..DispatcherConfig::default()
+        };
+
+        dispatch_due_with(&store, chrono::Utc::now(), &config, |_msg| async {
+            Err("no route".to_string())
+        })
+        .await
+        .unwrap();
+
+        let leased = store
+            .lease_due(
+                chrono::Utc::now() + chrono::Duration::hours(1),
+                10,
+                Duration::from_secs(1),
+                "test",
+            )
+            .unwrap();
+        assert!(leased.is_empty(), "poisoned rows must not lease again");
+    }
+}

--- a/src-tauri/src/api/dispatcher.rs
+++ b/src-tauri/src/api/dispatcher.rs
@@ -49,14 +49,18 @@ pub fn start_dispatcher(
                         chrono::Utc::now(),
                         &config,
                         |msg| {
-                            let app = app.clone();
-                            async move {
-                                crate::phone::mailbox::MailboxPoller::new()
-                                    .deliver_wake(&app, &msg)
-                                    .await
-                            }
-                        },
-                    )
+                                let app = app.clone();
+                                async move {
+                                    crate::phone::mailbox::MailboxPoller::new()
+                                        .deliver_wake_with_origin(
+                                            &app,
+                                            &msg,
+                                            crate::phone::mailbox::WakeDeliveryOrigin::DbQueue,
+                                        )
+                                        .await
+                                }
+                            },
+                        )
                     .await
                     {
                         log::warn!("[api-dispatcher] dispatch tick failed: {}", e);

--- a/src-tauri/src/api/error.rs
+++ b/src-tauri/src/api/error.rs
@@ -13,12 +13,14 @@ use super::schema::{ErrorBody, API_VERSION};
 /// A control-plane API failure with a fixed HTTP mapping.
 #[derive(Debug, Clone)]
 pub enum ApiError {
-    /// 400 - malformed body, missing/forbidden field, unsupported `inline`.
+    /// 400 - malformed body, missing/forbidden field, or invalid one-of payload.
     BadRequest(String),
     /// 401 - missing/invalid/revoked/expired token, or bound replica gone.
     Unauthorized(String),
     /// 403 - valid token but not scoped / routing denied / root-agent excluded.
     Forbidden(String),
+    /// 413 - inline payload exceeds the semantic cap.
+    PayloadTooLarge(String),
     /// 422 - the engine refused delivery (`deliver_wake` returned `Err`).
     Rejected(String),
     /// 429 - per-source failed-auth lockout or per-client rate limit.
@@ -33,6 +35,7 @@ impl ApiError {
             ApiError::BadRequest(d) => (StatusCode::BAD_REQUEST, "bad_request", d),
             ApiError::Unauthorized(d) => (StatusCode::UNAUTHORIZED, "unauthorized", d),
             ApiError::Forbidden(d) => (StatusCode::FORBIDDEN, "forbidden", d),
+            ApiError::PayloadTooLarge(d) => (StatusCode::PAYLOAD_TOO_LARGE, "payload_too_large", d),
             ApiError::Rejected(d) => (StatusCode::UNPROCESSABLE_ENTITY, "rejected", d),
             ApiError::TooManyRequests(d) => (StatusCode::TOO_MANY_REQUESTS, "rate_limited", d),
             ApiError::Internal(d) => (StatusCode::INTERNAL_SERVER_ERROR, "internal", d),
@@ -131,9 +134,22 @@ mod tests {
 
     #[test]
     fn error_status_mapping() {
-        assert_eq!(ApiError::BadRequest("x".into()).status(), StatusCode::BAD_REQUEST);
-        assert_eq!(ApiError::Unauthorized("x".into()).status(), StatusCode::UNAUTHORIZED);
-        assert_eq!(ApiError::Forbidden("x".into()).status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            ApiError::BadRequest("x".into()).status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            ApiError::Unauthorized("x".into()).status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            ApiError::Forbidden("x".into()).status(),
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            ApiError::PayloadTooLarge("x".into()).status(),
+            StatusCode::PAYLOAD_TOO_LARGE
+        );
         assert_eq!(
             ApiError::Rejected("x".into()).status(),
             StatusCode::UNPROCESSABLE_ENTITY

--- a/src-tauri/src/api/handlers/send.rs
+++ b/src-tauri/src/api/handlers/send.rs
@@ -1,6 +1,6 @@
-//! `POST /api/v1/send` (#791 §6.1). Mirrors `send --mode wake --send <file>`,
-//! MINUS `--command` (out of scope). Identity is the token's bound replica,
-//! never client input; `inline` is rejected in v1; replays are deduped.
+//! `POST /api/v1/send` (#791 + #833). Identity is the token's bound replica,
+//! never client input. The handler queues inline content durably and the
+//! dispatcher performs delivery.
 
 use std::net::SocketAddr;
 
@@ -10,16 +10,17 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 
-use crate::api::actuation::{self, DeliveryOutcome};
+use crate::api::actuation;
 use crate::api::auth::SCOPE_SEND;
-use crate::api::error::{scrub_host_paths, ApiError};
-use crate::api::idempotency::StoredResult;
-use crate::api::schema::{SendRequest, SendResponse, API_VERSION};
+use crate::api::error::ApiError;
+use crate::api::message_store::{
+    EnqueueRequest, MessageStoreError, DEFAULT_CONTENT_TYPE, INLINE_BODY_MAX_BYTES,
+};
+use crate::api::schema::{SendRequest, SendResponse};
 use crate::api::{handlers, ApiState};
 
-/// Max accepted request body (16 KB). Large content belongs in the `.md` file,
-/// referenced by basename, never inlined.
-const MAX_BODY_BYTES: usize = 16 * 1024;
+/// Max buffered JSON request body: inline cap plus envelope overhead.
+const MAX_BODY_BYTES: usize = INLINE_BODY_MAX_BYTES + (16 * 1024);
 
 /// Axum entry point. Buffers the body (bounded by a router layer), then defers
 /// to `handle_inner`, mapping its `(StatusCode, SendResponse)` or `ApiError`.
@@ -42,9 +43,10 @@ async fn handle_inner(
     body: &Bytes,
 ) -> Result<(StatusCode, SendResponse), ApiError> {
     if body.len() > MAX_BODY_BYTES {
-        return Err(ApiError::BadRequest(
-            "request body too large (>16 KB); put large content in the .md file".to_string(),
-        ));
+        return Err(ApiError::PayloadTooLarge(format!(
+            "request body too large (>{} bytes)",
+            MAX_BODY_BYTES
+        )));
     }
 
     // deny_unknown_fields rejects forbidden identity fields at parse time.
@@ -55,74 +57,90 @@ async fn handle_inner(
     let client = handlers::authenticate(state, headers, ip, SCOPE_SEND)?;
     let from = crate::api::identity::resolve_from(&client)?;
 
-    // Idempotency: a replayed opId returns the SAME stored result, never
-    // re-delivers (across restarts, since the ledger is disk-persisted).
-    if let Some(prev) = state.ledger.get(&req.op_id) {
-        return Ok(replay(prev));
-    }
+    let target = actuation::resolve_api_send_target(&state.app_handle, &from, &req.to).await?;
+    let content_type = req
+        .message
+        .content_type
+        .clone()
+        .unwrap_or_else(|| DEFAULT_CONTENT_TYPE.to_string());
+    let payload = extract_payload(&client.bound_root, &req)?;
 
-    // Message one-of: `inline` is reserved but rejected in v1; `send` required.
-    if req.message.inline.is_some() {
-        return Err(ApiError::BadRequest(
-            "inline messages are not supported in v1; write the .md into messaging/ and use `send`"
-                .to_string(),
-        ));
-    }
-    let basename = req.message.send.as_deref().ok_or_else(|| {
-        ApiError::BadRequest("message.send (a bare filename) is required".to_string())
-    })?;
+    let result = state
+        .message_store
+        .enqueue(EnqueueRequest {
+            sender_fqn: from.clone(),
+            target_fqn: target.clone(),
+            op_id: req.op_id.clone(),
+            content_type,
+            body: payload.body,
+            source_plane: payload.source_plane,
+            source_ref: payload.source_ref,
+        })
+        .map_err(store_error)?;
 
-    // Build the host-absolute notification body (path confinement inside).
-    let notif = actuation::build_send_body(&client.bound_root, basename, &from)?;
+    crate::api::audit::record(
+        &client.client_id,
+        &from,
+        "send",
+        if result.duplicate {
+            "queued_duplicate"
+        } else {
+            "queued"
+        },
+    );
+    Ok((
+        StatusCode::ACCEPTED,
+        SendResponse::queued(&result.op_id, &result.target_fqn, &result.message_id),
+    ))
+}
 
-    // Resolve + route + actuate through the shared engine.
-    let outcome =
-        actuation::deliver_wake_via_api(&state.app_handle, &from, &req.to, notif, &req.op_id)
-            .await?;
+#[derive(Debug)]
+struct Payload {
+    body: String,
+    source_plane: String,
+    source_ref: Option<String>,
+}
 
-    match outcome {
-        DeliveryOutcome::Delivered { to } => {
-            state.ledger.put(&req.op_id, "delivered", &to, None);
-            crate::api::audit::record(&client.client_id, &from, "send", "delivered");
-            Ok((StatusCode::OK, SendResponse::delivered(&req.op_id, &to)))
+fn extract_payload(bound_root: &str, req: &SendRequest) -> Result<Payload, ApiError> {
+    match (&req.message.send, &req.message.inline) {
+        (Some(_), Some(_)) => Err(ApiError::BadRequest(
+            "exactly one of message.send or message.inline is required".to_string(),
+        )),
+        (None, None) => Err(ApiError::BadRequest(
+            "exactly one of message.send or message.inline is required".to_string(),
+        )),
+        (None, Some(inline)) => {
+            if inline.len() > INLINE_BODY_MAX_BYTES {
+                return Err(ApiError::PayloadTooLarge(format!(
+                    "message.inline exceeds inline cap ({} bytes)",
+                    INLINE_BODY_MAX_BYTES
+                )));
+            }
+            Ok(Payload {
+                body: inline.clone(),
+                source_plane: "api_inline".to_string(),
+                source_ref: None,
+            })
         }
-        DeliveryOutcome::Rejected { to, reason } => {
-            let detail = scrub_host_paths(&reason);
-            state
-                .ledger
-                .put(&req.op_id, "rejected", &to, Some(detail.clone()));
-            crate::api::audit::record(&client.client_id, &from, "send", "rejected");
-            Ok((
-                StatusCode::UNPROCESSABLE_ENTITY,
-                SendResponse {
-                    api_version: API_VERSION.to_string(),
-                    op_id: req.op_id.clone(),
-                    status: "rejected".to_string(),
-                    to,
-                    detail: Some(detail),
-                },
-            ))
+        (Some(basename), None) => {
+            let content = actuation::read_send_file_content(bound_root, basename)?;
+            Ok(Payload {
+                body: content.body,
+                source_plane: "api_send_file".to_string(),
+                source_ref: Some(content.source_ref),
+            })
         }
     }
 }
 
-/// Map a stored (replayed) result back to a status + response body.
-fn replay(prev: StoredResult) -> (StatusCode, SendResponse) {
-    let status_code = if prev.status == "delivered" {
-        StatusCode::OK
-    } else {
-        StatusCode::UNPROCESSABLE_ENTITY
-    };
-    (
-        status_code,
-        SendResponse {
-            api_version: API_VERSION.to_string(),
-            op_id: prev.op_id,
-            status: prev.status,
-            to: prev.to,
-            detail: prev.detail,
-        },
-    )
+fn store_error(err: MessageStoreError) -> ApiError {
+    match err {
+        MessageStoreError::BodyTooLarge => ApiError::PayloadTooLarge(format!(
+            "message body exceeds inline cap ({} bytes)",
+            INLINE_BODY_MAX_BYTES
+        )),
+        other => ApiError::Internal(other.to_string()),
+    }
 }
 
 #[cfg(test)]
@@ -130,30 +148,46 @@ mod tests {
     use super::*;
 
     #[test]
-    fn replay_delivered_is_200() {
-        let (code, resp) = replay(StoredResult {
-            op_id: "o".into(),
-            status: "delivered".into(),
-            to: "proj/agent".into(),
-            detail: None,
-            first_seen: "2026-01-01T00:00:00Z".into(),
-        });
-        assert_eq!(code, StatusCode::OK);
-        assert_eq!(resp.status, "delivered");
-        assert!(resp.detail.is_none());
+    fn extract_payload_accepts_inline() {
+        let req: SendRequest = serde_json::from_str(
+            r#"{"apiVersion":"1","opId":"o","to":"proj/agent","message":{"inline":"hello"}}"#,
+        )
+        .unwrap();
+
+        let payload = extract_payload("unused", &req).unwrap();
+
+        assert_eq!(payload.body, "hello");
+        assert_eq!(payload.source_plane, "api_inline");
+        assert_eq!(payload.source_ref, None);
     }
 
     #[test]
-    fn replay_rejected_is_422_with_detail() {
-        let (code, resp) = replay(StoredResult {
-            op_id: "o".into(),
-            status: "rejected".into(),
-            to: "proj/agent".into(),
-            detail: Some("no route".into()),
-            first_seen: "2026-01-01T00:00:00Z".into(),
-        });
-        assert_eq!(code, StatusCode::UNPROCESSABLE_ENTITY);
-        assert_eq!(resp.status, "rejected");
-        assert_eq!(resp.detail.as_deref(), Some("no route"));
+    fn extract_payload_rejects_both_send_and_inline() {
+        let req: SendRequest = serde_json::from_str(
+            r#"{"apiVersion":"1","opId":"o","to":"proj/agent","message":{"send":"20260101-000000-wg1-a-to-wg1-b-x.md","inline":"hello"}}"#,
+        )
+        .unwrap();
+
+        let err = extract_payload("unused", &req).unwrap_err();
+
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn extract_payload_rejects_oversize_inline_with_413() {
+        let req = SendRequest {
+            api_version: crate::api::schema::API_VERSION.to_string(),
+            op_id: "o".to_string(),
+            to: "proj/agent".to_string(),
+            message: crate::api::schema::SendMessage {
+                send: None,
+                inline: Some("x".repeat(INLINE_BODY_MAX_BYTES + 1)),
+                content_type: None,
+            },
+        };
+
+        let err = extract_payload("unused", &req).unwrap_err();
+
+        assert_eq!(err.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/src-tauri/src/api/message_store.rs
+++ b/src-tauri/src/api/message_store.rs
@@ -1,0 +1,554 @@
+//! Durable DB-backed send queue for the control-plane API.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use rusqlite::params;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+pub const DB_FILENAME: &str = "api-message-bus.sqlite3";
+pub const INLINE_BODY_MAX_BYTES: usize = 256 * 1024;
+pub const DEFAULT_CONTENT_TYPE: &str = "text/markdown";
+pub const STATUS_QUEUED: &str = "queued";
+pub const STATUS_DELIVERING: &str = "delivering";
+pub const STATUS_RETRY: &str = "retry";
+pub const STATUS_DELIVERED: &str = "delivered";
+pub const STATUS_POISONED: &str = "poisoned";
+
+#[derive(Debug, Error)]
+pub enum MessageStoreError {
+    #[error("config_dir is unavailable")]
+    MissingConfigDir,
+    #[error("message body exceeds 256 KiB")]
+    BodyTooLarge,
+    #[error("sqlite: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Clone)]
+pub struct MessageStore {
+    path: PathBuf,
+    conn: Arc<Mutex<rusqlite::Connection>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnqueueRequest {
+    pub sender_fqn: String,
+    pub target_fqn: String,
+    pub op_id: String,
+    pub content_type: String,
+    pub body: String,
+    pub source_plane: String,
+    pub source_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnqueueResult {
+    pub message_id: String,
+    pub sender_fqn: String,
+    pub target_fqn: String,
+    pub op_id: String,
+    pub status: String,
+    pub duplicate: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeasedMessage {
+    pub message_id: String,
+    pub sender_fqn: String,
+    pub target_fqn: String,
+    pub op_id: String,
+    pub content_type: String,
+    pub body: String,
+    pub attempt: i64,
+}
+
+impl MessageStore {
+    pub fn at_config_dir() -> Result<Self, MessageStoreError> {
+        let dir = crate::config::config_dir().ok_or(MessageStoreError::MissingConfigDir)?;
+        Self::open(dir.join(DB_FILENAME))
+    }
+
+    pub fn open(path: PathBuf) -> Result<Self, MessageStoreError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = rusqlite::Connection::open(&path)?;
+        conn.busy_timeout(Duration::from_millis(5000))?;
+        conn.pragma_update(None, "foreign_keys", "ON")?;
+        let _: String = conn.pragma_query_value(None, "journal_mode", |row| row.get(0))?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        let store = Self {
+            path,
+            conn: Arc::new(Mutex::new(conn)),
+        };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn migrate(&self) -> Result<(), MessageStoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        tx.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS api_message_schema(
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT NOT NULL
+            );
+            "#,
+        )?;
+        let current: Option<i64> =
+            tx.query_row("SELECT MAX(version) FROM api_message_schema", [], |row| {
+                row.get::<_, Option<i64>>(0)
+            })?;
+        if current.unwrap_or(0) < 1 {
+            tx.execute_batch(
+                r#"
+                CREATE TABLE IF NOT EXISTS messages(
+                    message_id TEXT PRIMARY KEY,
+                    sender_fqn TEXT NOT NULL,
+                    target_fqn TEXT NOT NULL,
+                    op_id TEXT NOT NULL,
+                    content_type TEXT NOT NULL,
+                    body TEXT NOT NULL,
+                    body_sha256 TEXT NOT NULL,
+                    body_bytes INTEGER NOT NULL,
+                    source_plane TEXT NOT NULL,
+                    source_ref TEXT NULL,
+                    status TEXT NOT NULL,
+                    attempt INTEGER NOT NULL DEFAULT 0,
+                    next_attempt_at TEXT NOT NULL,
+                    lease_owner TEXT NULL,
+                    lease_until TEXT NULL,
+                    created_at TEXT NOT NULL,
+                    delivered_at TEXT NULL,
+                    last_error TEXT NULL,
+                    UNIQUE(sender_fqn, op_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_messages_due
+                    ON messages(status, next_attempt_at, lease_until);
+                CREATE TABLE IF NOT EXISTS message_audit(
+                    event_id TEXT PRIMARY KEY,
+                    message_id TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    detail TEXT NULL,
+                    at TEXT NOT NULL,
+                    FOREIGN KEY(message_id) REFERENCES messages(message_id) ON DELETE CASCADE
+                );
+                "#,
+            )?;
+            tx.execute(
+                "INSERT INTO api_message_schema(version, applied_at) VALUES(1, ?1)",
+                [Utc::now().to_rfc3339()],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn enqueue(&self, req: EnqueueRequest) -> Result<EnqueueResult, MessageStoreError> {
+        if req.body.len() > INLINE_BODY_MAX_BYTES {
+            return Err(MessageStoreError::BodyTooLarge);
+        }
+
+        let now = Utc::now().to_rfc3339();
+        let message_id = uuid::Uuid::new_v4().to_string();
+        let body_sha256 = sha256_hex(req.body.as_bytes());
+        let body_bytes = req.body.len() as i64;
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let inserted = tx.execute(
+            r#"
+            INSERT OR IGNORE INTO messages(
+                message_id, sender_fqn, target_fqn, op_id, content_type, body,
+                body_sha256, body_bytes, source_plane, source_ref, status,
+                attempt, next_attempt_at, created_at
+            )
+            VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 0, ?12, ?13)
+            "#,
+            params![
+                message_id,
+                req.sender_fqn,
+                req.target_fqn,
+                req.op_id,
+                req.content_type,
+                req.body,
+                body_sha256,
+                body_bytes,
+                req.source_plane,
+                req.source_ref,
+                STATUS_QUEUED,
+                now,
+                now,
+            ],
+        )?;
+
+        let result = tx.query_row(
+            r#"
+            SELECT message_id, sender_fqn, target_fqn, op_id, status
+            FROM messages
+            WHERE sender_fqn = ?1 AND op_id = ?2
+            "#,
+            params![req.sender_fqn, req.op_id],
+            |row| {
+                Ok(EnqueueResult {
+                    message_id: row.get(0)?,
+                    sender_fqn: row.get(1)?,
+                    target_fqn: row.get(2)?,
+                    op_id: row.get(3)?,
+                    status: row.get(4)?,
+                    duplicate: inserted == 0,
+                })
+            },
+        )?;
+        if inserted > 0 {
+            insert_audit(&tx, &result.message_id, STATUS_QUEUED, None, &now)?;
+        }
+        tx.commit()?;
+        Ok(result)
+    }
+
+    pub fn lease_due(
+        &self,
+        now: DateTime<Utc>,
+        limit: usize,
+        lease_for: Duration,
+        lease_owner: &str,
+    ) -> Result<Vec<LeasedMessage>, MessageStoreError> {
+        let now_s = now.to_rfc3339();
+        let lease_until =
+            (now + chrono::Duration::from_std(lease_for).unwrap_or_default()).to_rfc3339();
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let ids = {
+            let mut stmt = tx.prepare(
+                r#"
+                SELECT message_id
+                FROM messages
+                WHERE (
+                    status IN (?1, ?2) AND next_attempt_at <= ?3
+                ) OR (
+                    status = ?4 AND lease_until IS NOT NULL AND lease_until <= ?3
+                )
+                ORDER BY created_at ASC
+                LIMIT ?5
+                "#,
+            )?;
+            let rows = stmt.query_map(
+                params![
+                    STATUS_QUEUED,
+                    STATUS_RETRY,
+                    now_s,
+                    STATUS_DELIVERING,
+                    limit as i64
+                ],
+                |row| row.get::<_, String>(0),
+            )?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        };
+
+        let mut leased = Vec::with_capacity(ids.len());
+        for id in ids {
+            let changed = tx.execute(
+                r#"
+                UPDATE messages
+                SET status = ?1, lease_owner = ?2, lease_until = ?3, last_error = NULL
+                WHERE message_id = ?4
+                "#,
+                params![STATUS_DELIVERING, lease_owner, lease_until, id],
+            )?;
+            if changed == 0 {
+                continue;
+            }
+            let msg = tx.query_row(
+                r#"
+                SELECT message_id, sender_fqn, target_fqn, op_id, content_type, body, attempt
+                FROM messages
+                WHERE message_id = ?1
+                "#,
+                [id],
+                |row| {
+                    Ok(LeasedMessage {
+                        message_id: row.get(0)?,
+                        sender_fqn: row.get(1)?,
+                        target_fqn: row.get(2)?,
+                        op_id: row.get(3)?,
+                        content_type: row.get(4)?,
+                        body: row.get(5)?,
+                        attempt: row.get(6)?,
+                    })
+                },
+            )?;
+            leased.push(msg);
+        }
+        tx.commit()?;
+        Ok(leased)
+    }
+
+    pub fn mark_delivered(
+        &self,
+        message_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<(), MessageStoreError> {
+        let now_s = now.to_rfc3339();
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        tx.execute(
+            r#"
+            UPDATE messages
+            SET status = ?1, delivered_at = ?2, lease_owner = NULL, lease_until = NULL,
+                last_error = NULL
+            WHERE message_id = ?3
+            "#,
+            params![STATUS_DELIVERED, now_s, message_id],
+        )?;
+        insert_audit(&tx, message_id, STATUS_DELIVERED, None, &now_s)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn mark_delivery_failed(
+        &self,
+        message_id: &str,
+        error: &str,
+        now: DateTime<Utc>,
+        max_attempts: i64,
+    ) -> Result<String, MessageStoreError> {
+        let now_s = now.to_rfc3339();
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let current_attempt: i64 = tx.query_row(
+            "SELECT attempt FROM messages WHERE message_id = ?1",
+            [message_id],
+            |row| row.get(0),
+        )?;
+        let next_attempt = current_attempt + 1;
+        let next_status = if next_attempt >= max_attempts {
+            STATUS_POISONED
+        } else {
+            STATUS_RETRY
+        };
+        let backoff = retry_backoff_seconds(next_attempt);
+        let next_attempt_at = (now + chrono::Duration::seconds(backoff)).to_rfc3339();
+        tx.execute(
+            r#"
+            UPDATE messages
+            SET status = ?1, attempt = ?2, next_attempt_at = ?3,
+                lease_owner = NULL, lease_until = NULL, last_error = ?4
+            WHERE message_id = ?5
+            "#,
+            params![
+                next_status,
+                next_attempt,
+                next_attempt_at,
+                error,
+                message_id
+            ],
+        )?;
+        insert_audit(&tx, message_id, next_status, Some(error), &now_s)?;
+        tx.commit()?;
+        Ok(next_status.to_string())
+    }
+
+    pub fn reap_terminal_before(&self, cutoff: DateTime<Utc>) -> Result<usize, MessageStoreError> {
+        let cutoff_s = cutoff.to_rfc3339();
+        let conn = self.conn.lock().unwrap();
+        let deleted = conn.execute(
+            r#"
+            DELETE FROM messages
+            WHERE (
+                status = ?1 AND delivered_at IS NOT NULL AND delivered_at < ?2
+            ) OR (
+                status = ?3 AND next_attempt_at < ?2
+            )
+            "#,
+            params![STATUS_DELIVERED, cutoff_s, STATUS_POISONED],
+        )?;
+        Ok(deleted)
+    }
+
+    #[cfg(test)]
+    fn count_by_status(&self, status: &str) -> i64 {
+        self.conn
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE status = ?1",
+                [status],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+}
+
+pub fn retry_backoff_seconds(attempt: i64) -> i64 {
+    let exponent = attempt.saturating_sub(1).min(5) as u32;
+    5_i64.saturating_mul(2_i64.saturating_pow(exponent))
+}
+
+fn insert_audit(
+    tx: &rusqlite::Transaction<'_>,
+    message_id: &str,
+    status: &str,
+    detail: Option<&str>,
+    at: &str,
+) -> Result<(), rusqlite::Error> {
+    tx.execute(
+        r#"
+        INSERT INTO message_audit(event_id, message_id, status, detail, at)
+        VALUES(?1, ?2, ?3, ?4, ?5)
+        "#,
+        params![
+            uuid::Uuid::new_v4().to_string(),
+            message_id,
+            status,
+            detail,
+            at
+        ],
+    )?;
+    Ok(())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(64);
+    for byte in digest {
+        out.push(char::from_digit((byte >> 4) as u32, 16).unwrap());
+        out.push(char::from_digit((byte & 0x0f) as u32, 16).unwrap());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> MessageStore {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(DB_FILENAME);
+        let store = MessageStore::open(path).unwrap();
+        std::mem::forget(dir);
+        store
+    }
+
+    fn request(op: &str, body: &str) -> EnqueueRequest {
+        EnqueueRequest {
+            sender_fqn: "proj:wg-1/a".into(),
+            target_fqn: "proj:wg-1/b".into(),
+            op_id: op.into(),
+            content_type: DEFAULT_CONTENT_TYPE.into(),
+            body: body.into(),
+            source_plane: "api_inline".into(),
+            source_ref: None,
+        }
+    }
+
+    #[test]
+    fn migration_creates_schema_and_enqueue_writes_row() {
+        let store = store();
+        let result = store.enqueue(request("op1", "hello")).unwrap();
+
+        assert!(!result.message_id.is_empty());
+        assert_eq!(result.status, STATUS_QUEUED);
+        assert_eq!(store.count_by_status(STATUS_QUEUED), 1);
+    }
+
+    #[test]
+    fn duplicate_sender_op_id_returns_existing_row() {
+        let store = store();
+        let first = store.enqueue(request("op1", "hello")).unwrap();
+        let mut changed = request("op1", "changed");
+        changed.target_fqn = "proj:wg-1/other".into();
+        let second = store.enqueue(changed).unwrap();
+
+        assert_eq!(first.message_id, second.message_id);
+        assert_eq!(first.target_fqn, second.target_fqn);
+        assert!(second.duplicate);
+        assert_eq!(store.count_by_status(STATUS_QUEUED), 1);
+    }
+
+    #[test]
+    fn lease_due_hides_active_lease_until_expiry_then_redelivers() {
+        let store = store();
+        let first = store.enqueue(request("op1", "hello")).unwrap();
+        let now = Utc::now();
+
+        let leased = store
+            .lease_due(now, 10, Duration::from_secs(30), "worker")
+            .unwrap();
+        assert_eq!(leased.len(), 1);
+        assert_eq!(leased[0].message_id, first.message_id);
+
+        let none = store
+            .lease_due(
+                now + chrono::Duration::seconds(1),
+                10,
+                Duration::from_secs(30),
+                "worker",
+            )
+            .unwrap();
+        assert!(none.is_empty());
+
+        let again = store
+            .lease_due(
+                now + chrono::Duration::seconds(31),
+                10,
+                Duration::from_secs(30),
+                "worker",
+            )
+            .unwrap();
+        assert_eq!(again.len(), 1);
+        assert_eq!(again[0].message_id, first.message_id);
+    }
+
+    #[test]
+    fn delivered_retry_poison_and_reaper_transitions() {
+        let store = store();
+        let delivered = store.enqueue(request("op1", "ok")).unwrap();
+        let retry = store.enqueue(request("op2", "retry")).unwrap();
+        let now = Utc::now();
+
+        store.mark_delivered(&delivered.message_id, now).unwrap();
+        assert_eq!(store.count_by_status(STATUS_DELIVERED), 1);
+
+        let status = store
+            .mark_delivery_failed(&retry.message_id, "boom", now, 2)
+            .unwrap();
+        assert_eq!(status, STATUS_RETRY);
+        let status = store
+            .mark_delivery_failed(&retry.message_id, "boom again", now, 2)
+            .unwrap();
+        assert_eq!(status, STATUS_POISONED);
+
+        let deleted = store
+            .reap_terminal_before(now + chrono::Duration::days(2))
+            .unwrap();
+        assert_eq!(deleted, 2);
+    }
+
+    #[test]
+    fn oversize_body_rejected() {
+        let store = store();
+        let too_large = "x".repeat(INLINE_BODY_MAX_BYTES + 1);
+        let err = store.enqueue(request("op1", &too_large)).unwrap_err();
+        assert!(matches!(err, MessageStoreError::BodyTooLarge));
+    }
+
+    #[test]
+    fn backoff_is_bounded_exponential() {
+        assert_eq!(retry_backoff_seconds(1), 5);
+        assert_eq!(retry_backoff_seconds(2), 10);
+        assert_eq!(retry_backoff_seconds(6), 160);
+        assert_eq!(retry_backoff_seconds(100), 160);
+    }
+}

--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -1,7 +1,7 @@
 //! In-daemon control-plane API (#791). A sibling of `web/`: same axum stack and
 //! lifecycle, but a distinct trust model (per-client scoped tokens, not the
-//! single web token) and its own router. Increment 1 serves exactly two verbs
-//! (`send`, `list-peers-lean`) over a locally-bound TCP transport, funnelling
+//! single web token) and its own router. It exposes locally-bound send,
+//! list-peers, and container session-transport endpoints, funnelling sends
 //! through the SAME actuation the filesystem poller uses (`actuation.rs`).
 //!
 //! Auth is UNCONDITIONAL in every build profile (no `web/`-style debug bypass):
@@ -11,10 +11,12 @@
 pub mod actuation;
 pub mod audit;
 pub mod auth;
+pub mod dispatcher;
 pub mod error;
 pub mod handlers;
-pub mod identity;
 pub mod idempotency;
+pub mod identity;
+pub mod message_store;
 pub mod schema;
 
 use std::net::SocketAddr;
@@ -27,17 +29,17 @@ use axum::Router;
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
 
-/// Hard ceiling on a buffered request body (defense in depth above the send
-/// handler's 16 KB semantic cap).
-const MAX_BODY_LIMIT_BYTES: usize = 64 * 1024;
+/// Hard ceiling on a buffered request body. Inline sends allow a 256 KiB
+/// semantic body plus JSON envelope overhead.
+const MAX_BODY_LIMIT_BYTES: usize = message_store::INLINE_BODY_MAX_BYTES + (16 * 1024);
 
 /// Shared state injected into every handler.
 #[derive(Clone)]
 pub struct ApiState {
     /// Read-through client-token registry (mtime-gated).
     pub store: Arc<auth::ApiClientStore>,
-    /// Disk-persisted `send` idempotency ledger.
-    pub ledger: Arc<idempotency::IdempotencyLedger>,
+    /// Durable inline send queue and idempotency store.
+    pub message_store: Arc<message_store::MessageStore>,
     /// Per-source failed-auth lockout.
     pub lockout: Arc<auth::FailedAuthLockout>,
     /// Reach to the live daemon (SessionManager / PtyManager / SettingsState)
@@ -55,7 +57,10 @@ pub fn build_router(state: ApiState) -> Router {
     Router::new()
         .route("/api/v1/send", post(handlers::send::handle))
         .route("/api/v1/peers", get(handlers::list_peers::handle))
-        .route("/api/v1/session-transport", get(handlers::session_transport::handle))
+        .route(
+            "/api/v1/session-transport",
+            get(handlers::session_transport::handle),
+        )
         // Unauthenticated liveness; body pinned to {"ok":true} (§0.5 G9).
         .route("/api/v1/healthz", get(handlers::health))
         .layer(DefaultBodyLimit::max(MAX_BODY_LIMIT_BYTES))
@@ -82,29 +87,39 @@ pub fn start_server(
             return tauri::async_runtime::spawn(async {});
         }
     };
-    let ledger = match idempotency::IdempotencyLedger::at_config_dir() {
-        Some(l) => Arc::new(l),
-        None => {
-            log::error!("[api-server] cannot resolve config_dir for idempotency ledger; API server not started");
+    let message_store = match message_store::MessageStore::at_config_dir() {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            log::error!(
+                "[api-server] cannot initialize DB message store; API server not started: {}",
+                e
+            );
             return tauri::async_runtime::spawn(async {});
         }
     };
 
     let state = ApiState {
         store,
-        ledger,
+        message_store: message_store.clone(),
         lockout: Arc::new(auth::FailedAuthLockout::default()),
-        app_handle,
+        app_handle: app_handle.clone(),
         session_mgr,
         pty_mgr,
     };
     let router = build_router(state);
 
     tauri::async_runtime::spawn(async move {
+        let dispatcher_handle = dispatcher::start_dispatcher(
+            message_store,
+            app_handle.clone(),
+            shutdown.clone(),
+            dispatcher::DispatcherConfig::default(),
+        );
         let addr: SocketAddr = match format!("{}:{}", bind, port).parse() {
             Ok(a) => a,
             Err(e) => {
                 log::error!("[api-server] invalid bind address {}:{}: {}", bind, port, e);
+                dispatcher_handle.abort();
                 return;
             }
         };
@@ -128,6 +143,7 @@ pub fn start_server(
                     addr,
                     e
                 );
+                dispatcher_handle.abort();
                 return;
             }
         };

--- a/src-tauri/src/api/schema.rs
+++ b/src-tauri/src/api/schema.rs
@@ -23,22 +23,25 @@ pub struct SendRequest {
     pub op_id: String,
     /// Destination agent canonical FQN.
     pub to: String,
-    /// The message payload. Exactly one of `send` (increment 1) or `inline` ([H]).
+    /// The message payload. Exactly one of `send` or `inline`.
     pub message: SendMessage,
 }
 
-/// The `message` one-of. Increment 1 accepts only `send` (a bare filename that
-/// already exists in the sender's `<workgroup>/messaging/`); `inline` is
-/// reserved in the schema but rejected with 400 in v1.
+/// The `message` one-of. `send` is a bare filename that already exists in the
+/// sender's `<workgroup>/messaging/`; the handler ingests its content into the
+/// DB as inline text. `inline` carries direct message text.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SendMessage {
     /// Bare filename (no path separators) present in `<workgroup>/messaging/`.
     #[serde(default)]
     pub send: Option<String>,
-    /// Reserved [H]: inline message text. Rejected with 400 in increment 1.
+    /// Inline message text. Mutually exclusive with `send`.
     #[serde(default)]
     pub inline: Option<String>,
+    /// MIME-like content type for the inline payload.
+    #[serde(default)]
+    pub content_type: Option<String>,
 }
 
 /// `POST /api/v1/send` response.
@@ -47,22 +50,25 @@ pub struct SendMessage {
 pub struct SendResponse {
     pub api_version: String,
     pub op_id: String,
-    /// `"delivered"` on success, `"rejected"` when the engine refused delivery.
+    /// `"queued"` once the durable DB row exists.
     pub status: String,
     /// Canonical target FQN the message was routed to.
     pub to: String,
-    /// Human-readable reason on `rejected`; `null` on `delivered`.
+    /// Durable DB message id.
+    pub message_id: String,
+    /// Human-readable detail; `null` on normal queued responses.
     pub detail: Option<String>,
 }
 
 impl SendResponse {
-    /// Build the `delivered` response for a target FQN.
-    pub fn delivered(op_id: &str, to: &str) -> Self {
+    /// Build the `queued` response for a target FQN.
+    pub fn queued(op_id: &str, to: &str, message_id: &str) -> Self {
         Self {
             api_version: API_VERSION.to_string(),
             op_id: op_id.to_string(),
-            status: "delivered".to_string(),
+            status: "queued".to_string(),
             to: to.to_string(),
+            message_id: message_id.to_string(),
             detail: None,
         }
     }
@@ -121,20 +127,23 @@ mod tests {
 
     #[test]
     fn send_message_rejects_unknown_field() {
-        let json = r#"{"apiVersion":"1","opId":"o","to":"a/b","message":{"send":"f.md","bogus":1}}"#;
+        let json =
+            r#"{"apiVersion":"1","opId":"o","to":"a/b","message":{"send":"f.md","bogus":1}}"#;
         let parsed: Result<SendRequest, _> = serde_json::from_str(json);
         assert!(parsed.is_err(), "unknown message field must be rejected");
     }
 
     #[test]
     fn send_request_parses_minimal_valid_body() {
-        let json = r#"{"apiVersion":"1","opId":"o","to":"proj/agent","message":{"send":"20260101-x.md"}}"#;
+        let json =
+            r#"{"apiVersion":"1","opId":"o","to":"proj/agent","message":{"send":"20260101-x.md"}}"#;
         let req: SendRequest = serde_json::from_str(json).expect("valid body should parse");
         assert_eq!(req.api_version, "1");
         assert_eq!(req.op_id, "o");
         assert_eq!(req.to, "proj/agent");
         assert_eq!(req.message.send.as_deref(), Some("20260101-x.md"));
         assert!(req.message.inline.is_none());
+        assert!(req.message.content_type.is_none());
     }
 
     #[test]
@@ -146,12 +155,13 @@ mod tests {
     }
 
     #[test]
-    fn send_response_delivered_has_null_detail_and_camel_case() {
-        let json = serde_json::to_value(SendResponse::delivered("op1", "proj/agent")).unwrap();
+    fn send_response_queued_has_message_id_and_camel_case() {
+        let json = serde_json::to_value(SendResponse::queued("op1", "proj/agent", "msg1")).unwrap();
         assert_eq!(json["apiVersion"], "1");
         assert_eq!(json["opId"], "op1");
-        assert_eq!(json["status"], "delivered");
+        assert_eq!(json["status"], "queued");
         assert_eq!(json["to"], "proj/agent");
+        assert_eq!(json["messageId"], "msg1");
         assert!(json["detail"].is_null());
     }
 }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -14,6 +14,7 @@ use crate::config::sessions_persistence::RaiseHandPersistOutcome;
 use crate::config::settings::{AgentConfig, AppSettings, SettingsState};
 use crate::config::teams;
 use crate::phone::types::OutboxMessage;
+use crate::pty::backend::SessionBackendKind;
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
 #[cfg(test)]
@@ -35,6 +36,46 @@ fn sender_name_for_session_cwd_with_root_flag(
 fn sender_name_for_session_cwd(working_directory: &str) -> String {
     let is_root_agent = crate::config::root_agent::is_root_agent_path(working_directory);
     sender_name_for_session_cwd_with_root_flag(working_directory, is_root_agent)
+}
+
+fn inline_body_from_file_notification(body: &str) -> Result<Option<String>, String> {
+    let Some(notification_path) = crate::phone::messaging::parse_file_notification(body) else {
+        return Ok(None);
+    };
+    let filename = crate::phone::messaging::notification_filename(notification_path)
+        .ok_or_else(|| "file notification does not include a message filename".to_string())?;
+    let parent = Path::new(notification_path)
+        .parent()
+        .ok_or_else(|| "file notification does not include a parent directory".to_string())?;
+    if parent.file_name().and_then(|n| n.to_str())
+        != Some(crate::phone::messaging::MESSAGING_DIR_NAME)
+    {
+        return Err("file notification parent is not a messaging directory".to_string());
+    }
+    let abs = crate::phone::messaging::resolve_existing_message(parent, filename)
+        .map_err(|e| format!("message file not readable for container delivery: {}", e))?;
+    let bytes = std::fs::read(&abs)
+        .map_err(|e| format!("message file not readable for container delivery: {}", e))?;
+    if bytes.len() > crate::api::message_store::INLINE_BODY_MAX_BYTES {
+        return Err(format!(
+            "message file exceeds inline cap ({} bytes)",
+            crate::api::message_store::INLINE_BODY_MAX_BYTES
+        ));
+    }
+    let body = String::from_utf8(bytes)
+        .map_err(|e| format!("message file is not UTF-8 for container delivery: {}", e))?;
+    Ok(Some(body))
+}
+
+fn is_container_backend_session<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    session_id: Uuid,
+) -> Result<bool, String> {
+    let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
+    let mgr = pty_mgr
+        .lock()
+        .map_err(|e| format!("PTY lock failed: {}", e))?;
+    Ok(mgr.backend_kind(session_id) == Some(SessionBackendKind::ContainerTransport))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -2064,8 +2105,9 @@ impl MailboxPoller {
         let mut spawn_with_resume = false;
         let mut pending_exited_destroy: Option<Uuid> = None;
         let mut pending_exited_telegram_bot_id: Option<String> = None;
-        let mut pending_exited_communication: Option<crate::session::session::SessionCommunication> =
-            None;
+        let mut pending_exited_communication: Option<
+            crate::session::session::SessionCommunication,
+        > = None;
         // (#747) Set only when the deferred destroy FAILS: the orphan Exited
         // record then still holds the restored hand and must be cleared once
         // the replacement spawn succeeds (single-carrier rule, 5d).
@@ -2850,6 +2892,12 @@ impl MailboxPoller {
         // ── Standard message path ──
         // Only use response markers for non-interactive sessions
         let use_markers = msg.get_output && !interactive;
+        let body_override = if is_container_backend_session(app, session_id)? {
+            inline_body_from_file_notification(&msg.body)?
+        } else {
+            None
+        };
+        let body = body_override.as_deref().unwrap_or(&msg.body);
 
         // Interactive and marker-less paths share the minimal PTY wrap via
         // `format_pty_wrap` (single source with `PTY_WRAP_FIXED` used by the
@@ -2857,9 +2905,9 @@ impl MailboxPoller {
         // payload with response markers.
         let payload = match (use_markers, msg.request_id.as_ref()) {
             (true, Some(rid)) => {
-                crate::phone::messaging::format_pty_wrap_with_markers(&msg.from, &msg.body, rid)
+                crate::phone::messaging::format_pty_wrap_with_markers(&msg.from, body, rid)
             }
-            _ => crate::phone::messaging::format_pty_wrap(&msg.from, &msg.body),
+            _ => crate::phone::messaging::format_pty_wrap(&msg.from, body),
         };
 
         // Register response watcher only for non-interactive sessions
@@ -4269,7 +4317,8 @@ impl MailboxPoller {
                     if let Ok(new_uuid) = Uuid::parse_str(&info.id) {
                         let restored = {
                             let mgr = session_mgr.read().await;
-                            mgr.restore_communication(new_uuid, communication.clone()).await
+                            mgr.restore_communication(new_uuid, communication.clone())
+                                .await
                         };
                         if restored {
                             let _ = tauri::Emitter::emit(
@@ -5340,6 +5389,54 @@ mod tests {
     use tauri::Listener;
 
     // ── §224 D.5a — wait_for_restore_or_session unit tests ──
+
+    #[test]
+    fn container_file_notification_adapter_reads_inline_content() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let messaging = temp
+            .path()
+            .join(crate::phone::messaging::MESSAGING_DIR_NAME);
+        std::fs::create_dir_all(&messaging).unwrap();
+        let filename = "20260704-000000-wg1-a-to-wg1-b-hello.md";
+        let path = messaging.join(filename);
+        std::fs::write(&path, "inline body").unwrap();
+        let notification =
+            crate::phone::messaging::format_file_notification(&path.to_string_lossy());
+
+        let got = inline_body_from_file_notification(&notification).unwrap();
+
+        assert_eq!(got.as_deref(), Some("inline body"));
+    }
+
+    #[test]
+    fn container_file_notification_adapter_rejects_oversize_content() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let messaging = temp
+            .path()
+            .join(crate::phone::messaging::MESSAGING_DIR_NAME);
+        std::fs::create_dir_all(&messaging).unwrap();
+        let filename = "20260704-000000-wg1-a-to-wg1-b-large.md";
+        let path = messaging.join(filename);
+        std::fs::write(
+            &path,
+            vec![b'x'; crate::api::message_store::INLINE_BODY_MAX_BYTES + 1],
+        )
+        .unwrap();
+        let notification =
+            crate::phone::messaging::format_file_notification(&path.to_string_lossy());
+
+        let err = inline_body_from_file_notification(&notification).unwrap_err();
+
+        assert!(err.contains("inline cap"));
+    }
+
+    #[test]
+    fn container_file_notification_adapter_ignores_plain_body() {
+        assert_eq!(
+            inline_body_from_file_notification("plain body").unwrap(),
+            None
+        );
+    }
 
     // ── §224 D.3 — filter_sessions_by_fqn pure-predicate tests ──
 

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -38,7 +38,32 @@ fn sender_name_for_session_cwd(working_directory: &str) -> String {
     sender_name_for_session_cwd_with_root_flag(working_directory, is_root_agent)
 }
 
-fn inline_body_from_file_notification(body: &str) -> Result<Option<String>, String> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WakeDeliveryOrigin {
+    FilesystemPoller,
+    DbQueue,
+}
+
+fn container_body_override_for_delivery(
+    origin: WakeDeliveryOrigin,
+    body: &str,
+    sender_root: Option<&Path>,
+) -> Result<Option<String>, String> {
+    if origin != WakeDeliveryOrigin::FilesystemPoller {
+        return Ok(None);
+    }
+    if crate::phone::messaging::parse_file_notification(body).is_none() {
+        return Ok(None);
+    }
+    let sender_root = sender_root
+        .ok_or_else(|| "file notification sender path could not be resolved".to_string())?;
+    inline_body_from_file_notification(body, sender_root)
+}
+
+fn inline_body_from_file_notification(
+    body: &str,
+    sender_root: &Path,
+) -> Result<Option<String>, String> {
     let Some(notification_path) = crate::phone::messaging::parse_file_notification(body) else {
         return Ok(None);
     };
@@ -52,7 +77,20 @@ fn inline_body_from_file_notification(body: &str) -> Result<Option<String>, Stri
     {
         return Err("file notification parent is not a messaging directory".to_string());
     }
-    let abs = crate::phone::messaging::resolve_existing_message(parent, filename)
+
+    let wg_root = crate::phone::messaging::workgroup_root(sender_root)
+        .map_err(|e| format!("sender workgroup could not be resolved: {}", e))?;
+    let allowed_messaging_dir = crate::phone::messaging::messaging_dir(&wg_root)
+        .map_err(|e| format!("sender messaging directory could not be resolved: {}", e))?;
+    let canon_allowed = std::fs::canonicalize(&allowed_messaging_dir)
+        .map_err(|e| format!("sender messaging directory not readable: {}", e))?;
+    let canon_parent = std::fs::canonicalize(parent)
+        .map_err(|e| format!("file notification parent not readable: {}", e))?;
+    if canon_parent != canon_allowed {
+        return Err("file notification parent is outside sender messaging directory".to_string());
+    }
+
+    let abs = crate::phone::messaging::resolve_existing_message(&allowed_messaging_dir, filename)
         .map_err(|e| format!("message file not readable for container delivery: {}", e))?;
     let bytes = std::fs::read(&abs)
         .map_err(|e| format!("message file not readable for container delivery: {}", e))?;
@@ -2090,6 +2128,16 @@ impl MailboxPoller {
         app: &tauri::AppHandle<R>,
         msg: &OutboxMessage,
     ) -> Result<(), String> {
+        self.deliver_wake_with_origin(app, msg, WakeDeliveryOrigin::FilesystemPoller)
+            .await
+    }
+
+    pub(crate) async fn deliver_wake_with_origin<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        msg: &OutboxMessage,
+        origin: WakeDeliveryOrigin,
+    ) -> Result<(), String> {
         // Whether the spawn-fallback should allow provider auto-resume.
         // Default false: cold wake — no SessionManager record at this CWD.
         // Promoted to true in two paths below: (a) RespawnExited deferred-
@@ -2151,7 +2199,10 @@ impl MailboxPoller {
 
             match wake_action_for(status) {
                 WakeAction::Inject => {
-                    match self.inject_wake_into_pty(app, session_id, msg).await {
+                    match self
+                        .inject_wake_into_pty(app, session_id, msg, origin)
+                        .await
+                    {
                         Ok(()) => return Ok(()),
                         Err(e) if err_is_pty_session_missing(&e) => {
                             // Race: PTY died between `find_live_candidates`
@@ -2438,7 +2489,8 @@ impl MailboxPoller {
         self.wait_for_spawned_wake_idle(app, session_id).await?;
 
         // Inject message — interactive mode (session persists, user sees reply instructions)
-        self.inject_wake_into_pty(app, session_id, msg).await
+        self.inject_wake_into_pty(app, session_id, msg, origin)
+            .await
     }
 
     async fn has_pty_session_for_wake<R: tauri::Runtime>(
@@ -2467,6 +2519,7 @@ impl MailboxPoller {
         app: &tauri::AppHandle<R>,
         session_id: Uuid,
         msg: &OutboxMessage,
+        origin: WakeDeliveryOrigin,
     ) -> Result<(), String> {
         #[cfg(test)]
         if let Some(hooks) = &self.test_hooks {
@@ -2485,7 +2538,9 @@ impl MailboxPoller {
             return result.unwrap_or(Ok(()));
         }
 
-        let result = self.inject_into_pty(app, session_id, msg, true).await;
+        let result = self
+            .inject_into_pty(app, session_id, msg, true, origin)
+            .await;
         // #552 auto-close: a successful inter-agent wake is activity for the
         // recipient team's silence clock (NOT the badge; inter-agent is not a
         // user message). This single site covers both wake paths (deliver_wake
@@ -2744,6 +2799,7 @@ impl MailboxPoller {
         session_id: Uuid,
         msg: &OutboxMessage,
         interactive: bool,
+        origin: WakeDeliveryOrigin,
     ) -> Result<(), String> {
         let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
 
@@ -2893,7 +2949,27 @@ impl MailboxPoller {
         // Only use response markers for non-interactive sessions
         let use_markers = msg.get_output && !interactive;
         let body_override = if is_container_backend_session(app, session_id)? {
-            inline_body_from_file_notification(&msg.body)?
+            let sender_root = if origin == WakeDeliveryOrigin::FilesystemPoller
+                && crate::phone::messaging::parse_file_notification(&msg.body).is_some()
+            {
+                Some(
+                    self.resolve_repo_path(&msg.from, app)
+                        .await
+                        .ok_or_else(|| {
+                            format!(
+                        "Cannot resolve sender path for '{}' during container file delivery",
+                        msg.from
+                    )
+                        })?,
+                )
+            } else {
+                None
+            };
+            container_body_override_for_delivery(
+                origin,
+                &msg.body,
+                sender_root.as_deref().map(Path::new),
+            )?
         } else {
             None
         };
@@ -5393,9 +5469,10 @@ mod tests {
     #[test]
     fn container_file_notification_adapter_reads_inline_content() {
         let temp = tempfile::TempDir::new().unwrap();
-        let messaging = temp
-            .path()
-            .join(crate::phone::messaging::MESSAGING_DIR_NAME);
+        let wg_root = temp.path().join("proj").join(".ac").join("wg-1-team");
+        let sender_root = wg_root.join("__agent_sender");
+        let messaging = wg_root.join(crate::phone::messaging::MESSAGING_DIR_NAME);
+        std::fs::create_dir_all(&sender_root).unwrap();
         std::fs::create_dir_all(&messaging).unwrap();
         let filename = "20260704-000000-wg1-a-to-wg1-b-hello.md";
         let path = messaging.join(filename);
@@ -5403,7 +5480,7 @@ mod tests {
         let notification =
             crate::phone::messaging::format_file_notification(&path.to_string_lossy());
 
-        let got = inline_body_from_file_notification(&notification).unwrap();
+        let got = inline_body_from_file_notification(&notification, &sender_root).unwrap();
 
         assert_eq!(got.as_deref(), Some("inline body"));
     }
@@ -5411,9 +5488,10 @@ mod tests {
     #[test]
     fn container_file_notification_adapter_rejects_oversize_content() {
         let temp = tempfile::TempDir::new().unwrap();
-        let messaging = temp
-            .path()
-            .join(crate::phone::messaging::MESSAGING_DIR_NAME);
+        let wg_root = temp.path().join("proj").join(".ac").join("wg-1-team");
+        let sender_root = wg_root.join("__agent_sender");
+        let messaging = wg_root.join(crate::phone::messaging::MESSAGING_DIR_NAME);
+        std::fs::create_dir_all(&sender_root).unwrap();
         std::fs::create_dir_all(&messaging).unwrap();
         let filename = "20260704-000000-wg1-a-to-wg1-b-large.md";
         let path = messaging.join(filename);
@@ -5425,7 +5503,7 @@ mod tests {
         let notification =
             crate::phone::messaging::format_file_notification(&path.to_string_lossy());
 
-        let err = inline_body_from_file_notification(&notification).unwrap_err();
+        let err = inline_body_from_file_notification(&notification, &sender_root).unwrap_err();
 
         assert!(err.contains("inline cap"));
     }
@@ -5433,9 +5511,60 @@ mod tests {
     #[test]
     fn container_file_notification_adapter_ignores_plain_body() {
         assert_eq!(
-            inline_body_from_file_notification("plain body").unwrap(),
+            inline_body_from_file_notification("plain body", Path::new("unused")).unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn db_origin_container_adapter_does_not_read_crafted_file_notification() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let sender_wg = temp.path().join("proj").join(".ac").join("wg-1-team");
+        let sender_root = sender_wg.join("__agent_sender");
+        let victim_wg = temp.path().join("proj").join(".ac").join("wg-2-team");
+        let victim_messaging = victim_wg.join(crate::phone::messaging::MESSAGING_DIR_NAME);
+        std::fs::create_dir_all(&sender_root).unwrap();
+        std::fs::create_dir_all(&victim_messaging).unwrap();
+        let filename = "20260704-000000-wg2-a-to-wg2-b-secret.md";
+        let victim_file = victim_messaging.join(filename);
+        std::fs::write(&victim_file, "victim secret").unwrap();
+        let crafted =
+            crate::phone::messaging::format_file_notification(&victim_file.to_string_lossy());
+
+        let got = container_body_override_for_delivery(
+            WakeDeliveryOrigin::DbQueue,
+            &crafted,
+            Some(&sender_root),
+        )
+        .unwrap();
+
+        assert_eq!(got, None);
+        assert!(!crafted.contains("victim secret"));
+    }
+
+    #[test]
+    fn filesystem_origin_container_adapter_rejects_cross_workgroup_notification() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let sender_wg = temp.path().join("proj").join(".ac").join("wg-1-team");
+        let sender_root = sender_wg.join("__agent_sender");
+        let victim_wg = temp.path().join("proj").join(".ac").join("wg-2-team");
+        let victim_messaging = victim_wg.join(crate::phone::messaging::MESSAGING_DIR_NAME);
+        std::fs::create_dir_all(&sender_root).unwrap();
+        std::fs::create_dir_all(&victim_messaging).unwrap();
+        let filename = "20260704-000000-wg2-a-to-wg2-b-secret.md";
+        let victim_file = victim_messaging.join(filename);
+        std::fs::write(&victim_file, "victim secret").unwrap();
+        let crafted =
+            crate::phone::messaging::format_file_notification(&victim_file.to_string_lossy());
+
+        let err = container_body_override_for_delivery(
+            WakeDeliveryOrigin::FilesystemPoller,
+            &crafted,
+            Some(&sender_root),
+        )
+        .unwrap_err();
+
+        assert!(err.contains("outside sender messaging directory"));
     }
 
     // ── §224 D.3 — filter_sessions_by_fqn pure-predicate tests ──

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -112,6 +112,10 @@ impl PtyManager {
             .ok_or_else(|| AppError::SessionNotFound(id.to_string()))
     }
 
+    pub fn backend_kind(&self, id: Uuid) -> Option<SessionBackendKind> {
+        self.routes.lock().unwrap().get(&id).copied()
+    }
+
     pub async fn spawn(
         manager: &Arc<Mutex<Self>>,
         backend_kind: SessionBackendKind,


### PR DESCRIPTION
Stage 5 (**final**) of #819 (Camino 2, co-located). Completes increment 1: the API `send` becomes a durable **inline** send that a dispatcher injects into the recipient session (host OR container). A containerized agent can now send over **pure HTTP** (inline content, no host file) — closing the original motivation.

## What changed
- **`src-tauri/src/api/message_store.rs`** — SQLite `MessageStore` (`rusqlite` bundled) at `config_dir()/api-message-bus.sqlite3`: durable send queue, inline payload, `(sender_fqn, op_id)` idempotency (`INSERT OR IGNORE` under a UNIQUE constraint), lease/visibility-timeout, status machine `queued→delivering→(delivered | retry→…→poisoned)` with saturating backoff, 7-day retention reaper. WAL + `foreign_keys` + `busy_timeout(5s)`; schema v1 (`messages`, `message_audit`), all writes in transactions.
- **`POST /api/v1/send`** now accepts `message.inline` (+`contentType`, 256 KiB cap → 202 queued) and ingests `message.send` file content inline; DB is the sole idempotency mechanism.
- **`src-tauri/src/api/dispatcher.rs`** — background dispatcher: leases due rows, builds an in-memory wake `OutboxMessage` (`token/command/action/target = None`, `mode: "wake"`), delivers via `deliver_wake` (routes through `PtyManager` to host OR container backend), marks delivered / retries / poisons.
- **Container payload adapter** — filesystem-origin messages targeting a live ContainerTransport recipient are converted to inline body (container never receives a host path). Host↔host + local filesystem messaging unchanged.
- In-container `agentscommander-api-helper` now sends inline.

## Verification
- **dev-rust**: `cargo test --lib --bins --tests` (1894 pass / 0 fail, +25 S5 tests + 2 isolation tests), `cargo clippy --all-targets -- -D warnings`, `npm run typecheck`, **`npm run version:check`**, **`npm run smoke:cli-release-windows`** (4/0) — all green.
- **grinch (independent, adversarial SECURITY review)**: verb-escalation SECURE (parse-time `deny_unknown_fields` + verb-less schema + all-`None` dispatcher builder + dual Root exclusion), identity/anti-spoof SECURE (token-derived `from`, `can_communicate` reused, `(sender_fqn,op_id)` can't be forged), store races SECURE (parameterized SQL, idempotent enqueue, single-lease, poison+reaper, no lock across await), host↔host byte-identical.
  - **Found + fixed a MEDIUM before land**: the container payload adapter re-read an attacker-controlled `*/messaging/*` host path (container sandbox-escape). Closed with defense-in-depth — DB-origin deliveries never path-re-read (verbatim inject), and filesystem-origin re-reads are confined to the sender's own workgroup (and physically read from that dir), + 2 regression tests asserting refusal against a real cross-workgroup victim. grinch re-review **PASS**.
- 2 LOW fast-follows (blocking SQLite on async runtime; lease-UPDATE status guard) tracked in #831.

Non-visual. No version bump. **Closes #833. Completes increment 1 of Camino 2 (#819).**
