### PR TITLE
feat(#838): API backend hardening (N3 poison, N4 malformed-registry, N5 start/stop command)

### DIFF
--- a/src-tauri/src/api/auth.rs
+++ b/src-tauri/src/api/auth.rs
@@ -9,6 +9,7 @@
 //! truth; the in-memory copy is a cache keyed by mtime.
 
 use std::collections::{HashMap, VecDeque};
+use std::io::ErrorKind;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -83,6 +84,20 @@ impl Default for ApiClientRegistry {
     }
 }
 
+/// Diagnostic state from loading the host API client registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryLoadProblem {
+    pub status: &'static str,
+    pub message: String,
+}
+
+/// Registry plus any fail-closed load problem operators should see.
+#[derive(Debug, Clone)]
+pub struct RegistrySnapshot {
+    pub registry: ApiClientRegistry,
+    pub problem: Option<RegistryLoadProblem>,
+}
+
 /// SHA-256 the secret, formatted `"sha256:<lowercase-hex>"`.
 pub fn hash_token(secret: &str) -> String {
     let digest = Sha256::digest(secret.as_bytes());
@@ -119,19 +134,50 @@ pub fn is_expired(client: &ApiClient, now: chrono::DateTime<chrono::Utc>) -> boo
     }
 }
 
-/// Parse a registry from raw JSON, tolerating an absent/malformed file by
+/// Load the registry, tolerating an absent/malformed/unreadable file by
 /// returning an empty registry (fail-safe: no clients => everything 401).
-fn parse_registry(path: &Path) -> ApiClientRegistry {
+fn load_registry(path: &Path) -> RegistrySnapshot {
     match std::fs::read_to_string(path) {
-        Ok(raw) => serde_json::from_str(&raw).unwrap_or_else(|e| {
-            log::warn!(
-                "[api-auth] {} is malformed ({}); treating as empty registry",
+        Ok(raw) => match serde_json::from_str(&raw) {
+            Ok(registry) => RegistrySnapshot {
+                registry,
+                problem: None,
+            },
+            Err(e) => {
+                let message = format!("{} is malformed: {}", REGISTRY_FILENAME, e);
+                log::error!(
+                    "[api-auth] {} is malformed ({}); treating as empty registry",
+                    REGISTRY_FILENAME,
+                    e
+                );
+                RegistrySnapshot {
+                    registry: ApiClientRegistry::default(),
+                    problem: Some(RegistryLoadProblem {
+                        status: "malformed",
+                        message,
+                    }),
+                }
+            }
+        },
+        Err(e) if e.kind() == ErrorKind::NotFound => RegistrySnapshot {
+            registry: ApiClientRegistry::default(),
+            problem: None,
+        },
+        Err(e) => {
+            let message = format!("{} is unreadable: {}", REGISTRY_FILENAME, e);
+            log::error!(
+                "[api-auth] {} is unreadable ({}); treating as empty registry",
                 REGISTRY_FILENAME,
                 e
             );
-            ApiClientRegistry::default()
-        }),
-        Err(_) => ApiClientRegistry::default(),
+            RegistrySnapshot {
+                registry: ApiClientRegistry::default(),
+                problem: Some(RegistryLoadProblem {
+                    status: "unreadable",
+                    message,
+                }),
+            }
+        }
     }
 }
 
@@ -139,6 +185,7 @@ struct CacheInner {
     mtime: Option<SystemTime>,
     loaded: bool,
     registry: ApiClientRegistry,
+    problem: Option<RegistryLoadProblem>,
 }
 
 /// Read-through, mtime-gated registry cache. The source of truth is the file on
@@ -158,6 +205,7 @@ impl ApiClientStore {
                 mtime: None,
                 loaded: false,
                 registry: ApiClientRegistry::default(),
+                problem: None,
             }),
         }
     }
@@ -174,31 +222,36 @@ impl ApiClientStore {
 
     /// Return the current registry, reloading from disk only if the file's
     /// mtime changed since the last load (or it was never loaded).
-    fn current(&self) -> ApiClientRegistry {
+    fn current(&self) -> Result<RegistrySnapshot, ApiError> {
         let disk_mtime = std::fs::metadata(&self.path)
             .and_then(|m| m.modified())
             .ok();
-        let mut cache = self.cache.lock().unwrap();
+        let mut cache = self.cache.lock().map_err(|_| {
+            ApiError::Internal("API auth registry cache lock is poisoned".to_string())
+        })?;
         if !cache.loaded || cache.mtime != disk_mtime {
-            cache.registry = parse_registry(&self.path);
+            let snapshot = load_registry(&self.path);
+            cache.registry = snapshot.registry;
+            cache.problem = snapshot.problem;
             cache.mtime = disk_mtime;
             cache.loaded = true;
         }
-        cache.registry.clone()
+        Ok(RegistrySnapshot {
+            registry: cache.registry.clone(),
+            problem: cache.problem.clone(),
+        })
     }
 
     /// Look up the client owning `presented` (read-through). Returns the client
     /// only if it matches, is not revoked, and is not expired. The hash compare
     /// is constant-time per candidate.
-    pub fn authenticate(&self, presented: &str) -> Option<ApiClient> {
-        let registry = self.current();
+    pub fn authenticate(&self, presented: &str) -> Result<Option<ApiClient>, ApiError> {
+        let registry = self.current()?.registry;
         let presented_hash = hash_token(presented);
         let now = chrono::Utc::now();
-        registry.clients.into_iter().find(|c| {
-            !c.revoked
-                && constant_time_eq(&c.token_hash, &presented_hash)
-                && !is_expired(c, now)
-        })
+        Ok(registry.clients.into_iter().find(|c| {
+            !c.revoked && constant_time_eq(&c.token_hash, &presented_hash) && !is_expired(c, now)
+        }))
     }
 }
 
@@ -282,7 +335,12 @@ pub fn revoke(path: &Path, client_id: &str) -> Result<bool, String> {
 
 /// List clients (secrets/hashes are the caller's concern to redact).
 pub fn list(path: &Path) -> ApiClientRegistry {
-    parse_registry(path)
+    load_registry(path).registry
+}
+
+/// List clients with registry load diagnostics for operator-facing commands.
+pub fn list_with_status(path: &Path) -> RegistrySnapshot {
+    load_registry(path)
 }
 
 /// Atomic read-modify-write of the whole typed registry, reusing the process-
@@ -351,7 +409,9 @@ impl FailedAuthLockout {
     }
 
     fn check_at(&self, ip: IpAddr, now: Instant) -> Result<(), ApiError> {
-        let map = self.inner.lock().unwrap();
+        let map = self.inner.lock().map_err(|_| {
+            ApiError::Internal("API failed-auth lockout lock is poisoned".to_string())
+        })?;
         if let Some(state) = map.get(&ip) {
             if let Some(until) = state.locked_until {
                 if until > now {
@@ -365,12 +425,14 @@ impl FailedAuthLockout {
     }
 
     /// Record a failed auth; may transition the source into a lockout.
-    pub fn record_failure(&self, ip: IpAddr) {
-        self.record_failure_at(ip, Instant::now());
+    pub fn record_failure(&self, ip: IpAddr) -> Result<(), ApiError> {
+        self.record_failure_at(ip, Instant::now())
     }
 
-    fn record_failure_at(&self, ip: IpAddr, now: Instant) {
-        let mut map = self.inner.lock().unwrap();
+    fn record_failure_at(&self, ip: IpAddr, now: Instant) -> Result<(), ApiError> {
+        let mut map = self.inner.lock().map_err(|_| {
+            ApiError::Internal("API failed-auth lockout lock is poisoned".to_string())
+        })?;
         let state = map.entry(ip).or_insert_with(|| SourceState {
             failures: VecDeque::new(),
             locked_until: None,
@@ -388,12 +450,16 @@ impl FailedAuthLockout {
             state.locked_until = Some(now + self.lockout);
             state.failures.clear();
         }
+        Ok(())
     }
 
     /// Clear a source's failure history after a successful auth.
-    pub fn record_success(&self, ip: IpAddr) {
-        let mut map = self.inner.lock().unwrap();
+    pub fn record_success(&self, ip: IpAddr) -> Result<(), ApiError> {
+        let mut map = self.inner.lock().map_err(|_| {
+            ApiError::Internal("API failed-auth lockout lock is poisoned".to_string())
+        })?;
         map.remove(&ip);
+        Ok(())
     }
 }
 
@@ -490,8 +556,8 @@ mod tests {
 
         // A fresh store (empty cache) reads through to disk on first auth.
         let store = ApiClientStore::new(path.clone());
-        assert!(store.authenticate("the-secret").is_some());
-        assert!(store.authenticate("wrong-secret").is_none());
+        assert!(store.authenticate("the-secret").unwrap().is_some());
+        assert!(store.authenticate("wrong-secret").unwrap().is_none());
     }
 
     #[test]
@@ -513,13 +579,13 @@ mod tests {
         )
         .unwrap();
         let store = ApiClientStore::new(path.clone());
-        assert!(store.authenticate("s").is_some());
+        assert!(store.authenticate("s").unwrap().is_some());
 
         // Revoke via the (separate-process-equivalent) file write.
         assert!(revoke(&path, "client-1").unwrap());
         // Read-through picks up the change (mtime advanced).
         assert!(
-            store.authenticate("s").is_none(),
+            store.authenticate("s").unwrap().is_none(),
             "revocation must take effect on the next read-through"
         );
     }
@@ -537,8 +603,37 @@ mod tests {
         };
         std::fs::write(&path, serde_json::to_string_pretty(&reg).unwrap()).unwrap();
         let store = ApiClientStore::new(path);
-        assert!(store.authenticate("revoked-tok").is_none());
-        assert!(store.authenticate("expired-tok").is_none());
+        assert!(store.authenticate("revoked-tok").unwrap().is_none());
+        assert!(store.authenticate("expired-tok").unwrap().is_none());
+    }
+
+    #[test]
+    fn malformed_registry_snapshot_is_fail_closed_and_visible() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(REGISTRY_FILENAME);
+        std::fs::write(&path, "{ invalid").unwrap();
+
+        let snapshot = list_with_status(&path);
+
+        assert!(snapshot.registry.clients.is_empty());
+        let problem = snapshot.problem.expect("malformed registry is reported");
+        assert_eq!(problem.status, "malformed");
+        assert!(problem.message.contains(REGISTRY_FILENAME), "{:?}", problem);
+    }
+
+    #[test]
+    fn poisoned_registry_cache_returns_internal_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(REGISTRY_FILENAME);
+        let store = ApiClientStore::new(path);
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = store.cache.lock().unwrap();
+            panic!("poison registry cache");
+        }));
+
+        let err = store.authenticate("anything").unwrap_err();
+        assert!(matches!(err, ApiError::Internal(_)));
     }
 
     #[test]
@@ -547,10 +642,10 @@ mod tests {
         let lock = FailedAuthLockout::new(3, Duration::from_secs(10), Duration::from_secs(60));
         let t0 = Instant::now();
         assert!(lock.check_at(ip, t0).is_ok());
-        lock.record_failure_at(ip, t0);
-        lock.record_failure_at(ip, t0);
+        lock.record_failure_at(ip, t0).unwrap();
+        lock.record_failure_at(ip, t0).unwrap();
         assert!(lock.check_at(ip, t0).is_ok(), "below threshold: allowed");
-        lock.record_failure_at(ip, t0);
+        lock.record_failure_at(ip, t0).unwrap();
         assert!(
             lock.check_at(ip, t0).is_err(),
             "at threshold: source is locked"
@@ -564,14 +659,32 @@ mod tests {
         let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
         let lock = FailedAuthLockout::new(3, Duration::from_secs(10), Duration::from_secs(60));
         let t0 = Instant::now();
-        lock.record_failure_at(ip, t0);
-        lock.record_failure_at(ip, t0);
-        lock.record_success(ip);
-        lock.record_failure_at(ip, t0);
-        lock.record_failure_at(ip, t0);
+        lock.record_failure_at(ip, t0).unwrap();
+        lock.record_failure_at(ip, t0).unwrap();
+        lock.record_success(ip).unwrap();
+        lock.record_failure_at(ip, t0).unwrap();
+        lock.record_failure_at(ip, t0).unwrap();
         assert!(
             lock.check_at(ip, t0).is_ok(),
             "success reset the counter, so 2 more failures stay below threshold"
         );
+    }
+
+    #[test]
+    fn poisoned_lockout_returns_internal_error() {
+        let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let lock = FailedAuthLockout::default();
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = lock.inner.lock().unwrap();
+            panic!("poison lockout");
+        }));
+
+        let err = lock.check(ip).unwrap_err();
+        assert!(matches!(err, ApiError::Internal(_)));
+        let err = lock.record_failure(ip).unwrap_err();
+        assert!(matches!(err, ApiError::Internal(_)));
+        let err = lock.record_success(ip).unwrap_err();
+        assert!(matches!(err, ApiError::Internal(_)));
     }
 }

--- a/src-tauri/src/api/dispatcher.rs
+++ b/src-tauri/src/api/dispatcher.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::Future;
+use tokio_util::sync::CancellationToken;
 
 use crate::api::message_store::{LeasedMessage, MessageStore};
 use crate::phone::types::OutboxMessage;
@@ -32,14 +33,14 @@ impl Default for DispatcherConfig {
 pub fn start_dispatcher(
     store: Arc<MessageStore>,
     app: tauri::AppHandle,
-    shutdown: crate::shutdown::ShutdownSignal,
+    shutdown: CancellationToken,
     config: DispatcherConfig,
 ) -> tauri::async_runtime::JoinHandle<()> {
     tauri::async_runtime::spawn(async move {
         let mut interval = tokio::time::interval(config.poll_interval);
         loop {
             tokio::select! {
-                _ = shutdown.token().cancelled() => {
+                _ = shutdown.cancelled() => {
                     log::info!("[api-dispatcher] shutdown signal received, stopping");
                     break;
                 }

--- a/src-tauri/src/api/handlers/mod.rs
+++ b/src-tauri/src/api/handlers/mod.rs
@@ -47,7 +47,7 @@ pub fn authenticate(
     let token = match bearer_token(headers) {
         Some(t) => t,
         None => {
-            state.lockout.record_failure(ip);
+            state.lockout.record_failure(ip)?;
             crate::api::audit::record("-", "-", scope, "missing_token");
             return Err(ApiError::Unauthorized(
                 "missing or malformed Authorization: Bearer header".to_string(),
@@ -56,18 +56,22 @@ pub fn authenticate(
     };
 
     let client = match state.store.authenticate(&token) {
-        Some(c) => c,
-        None => {
-            state.lockout.record_failure(ip);
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            state.lockout.record_failure(ip)?;
             crate::api::audit::record("-", "-", scope, "invalid_token");
             return Err(ApiError::Unauthorized(
                 "invalid, revoked, or expired token".to_string(),
             ));
         }
+        Err(e) => {
+            crate::api::audit::record("-", "-", scope, "auth_internal_error");
+            return Err(e);
+        }
     };
 
     // A valid token proves this source is not a brute-forcer: clear its history.
-    state.lockout.record_success(ip);
+    state.lockout.record_success(ip)?;
 
     if !client.has_scope(scope) {
         crate::api::audit::record(&client.client_id, &client.bound_fqn, scope, "forbidden_scope");

--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -20,10 +20,12 @@ pub mod schema;
 
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use axum::Router;
+use tokio_util::sync::CancellationToken;
 
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
@@ -77,7 +79,7 @@ pub fn start_server(
     app_handle: tauri::AppHandle,
     session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
     pty_mgr: Arc<Mutex<PtyManager>>,
-    shutdown: crate::shutdown::ShutdownSignal,
+    shutdown: CancellationToken,
 ) -> tauri::async_runtime::JoinHandle<()> {
     let store = match auth::ApiClientStore::at_config_dir() {
         Some(s) => Arc::new(s),
@@ -118,7 +120,8 @@ pub fn start_server(
             Ok(a) => a,
             Err(e) => {
                 log::error!("[api-server] invalid bind address {}:{}: {}", bind, port, e);
-                dispatcher_handle.abort();
+                shutdown.cancel();
+                wait_for_dispatcher(dispatcher_handle, "invalid-bind").await;
                 return;
             }
         };
@@ -142,7 +145,8 @@ pub fn start_server(
                     addr,
                     e
                 );
-                dispatcher_handle.abort();
+                shutdown.cancel();
+                wait_for_dispatcher(dispatcher_handle, "bind-failure").await;
                 return;
             }
         };
@@ -151,14 +155,43 @@ pub fn start_server(
         println!("[api-server] listening on http://{}", addr);
 
         let service = router.into_make_service_with_connect_info::<SocketAddr>();
+        let server_shutdown = shutdown.clone();
         if let Err(e) = axum::serve(listener, service)
             .with_graceful_shutdown(async move {
-                shutdown.token().cancelled().await;
+                server_shutdown.cancelled().await;
                 log::info!("[api-server] shutdown signal received, stopping");
             })
             .await
         {
             log::error!("[api-server] server error: {}", e);
         }
+        shutdown.cancel();
+        wait_for_dispatcher(dispatcher_handle, "server-stop").await;
     })
+}
+
+const DISPATCHER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn wait_for_dispatcher(
+    mut dispatcher_handle: tauri::async_runtime::JoinHandle<()>,
+    reason: &'static str,
+) {
+    match tokio::time::timeout(DISPATCHER_SHUTDOWN_TIMEOUT, &mut dispatcher_handle).await {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            log::warn!(
+                "[api-server] dispatcher task failed during {} shutdown: {}",
+                reason,
+                err
+            );
+        }
+        Err(_) => {
+            log::warn!(
+                "[api-server] dispatcher did not stop within {:?} during {}; aborting",
+                DISPATCHER_SHUTDOWN_TIMEOUT,
+                reason
+            );
+            dispatcher_handle.abort();
+        }
+    }
 }

--- a/src-tauri/src/cli/api_client.rs
+++ b/src-tauri/src/cli/api_client.rs
@@ -203,9 +203,26 @@ fn list(a: ListArgs) -> i32 {
         Ok(p) => p,
         Err(code) => return code,
     };
-    let registry = auth::list(&path);
-    // Redact the hash: list shows identity + scope + status, never the digest.
-    let redacted: Vec<serde_json::Value> = registry
+    let snapshot = auth::list_with_status(&path);
+    let output = list_output(&snapshot);
+    match serde_json::to_string_pretty(&output) {
+        Ok(json) => {
+            crate::cli_println!("{}", json);
+            if snapshot.problem.is_some() {
+                1
+            } else {
+                0
+            }
+        }
+        Err(e) => {
+            eprintln!("Error: failed to serialize client list: {}", e);
+            1
+        }
+    }
+}
+
+fn redacted_clients(registry: &auth::ApiClientRegistry) -> Vec<serde_json::Value> {
+    registry
         .clients
         .iter()
         .map(|c| {
@@ -220,16 +237,19 @@ fn list(a: ListArgs) -> i32 {
                 "revoked": c.revoked,
             })
         })
-        .collect();
-    match serde_json::to_string_pretty(&redacted) {
-        Ok(json) => {
-            crate::cli_println!("{}", json);
-            0
-        }
-        Err(e) => {
-            eprintln!("Error: failed to serialize client list: {}", e);
-            1
-        }
+        .collect()
+}
+
+fn list_output(snapshot: &auth::RegistrySnapshot) -> serde_json::Value {
+    let clients = redacted_clients(&snapshot.registry);
+    if let Some(problem) = &snapshot.problem {
+        serde_json::json!({
+            "registryStatus": problem.status,
+            "error": problem.message,
+            "clients": clients,
+        })
+    } else {
+        serde_json::Value::Array(clients)
     }
 }
 
@@ -284,5 +304,22 @@ mod tests {
             })) => assert_eq!(a.client_id, "abc"),
             _ => panic!("expected api-client revoke"),
         }
+    }
+
+    #[test]
+    fn list_output_surfaces_malformed_registry_status() {
+        let snapshot = auth::RegistrySnapshot {
+            registry: auth::ApiClientRegistry::default(),
+            problem: Some(auth::RegistryLoadProblem {
+                status: "malformed",
+                message: "api-clients.json is malformed: expected value".to_string(),
+            }),
+        };
+
+        let output = list_output(&snapshot);
+
+        assert_eq!(output["registryStatus"], "malformed");
+        assert!(output["error"].as_str().unwrap().contains("malformed"));
+        assert_eq!(output["clients"].as_array().unwrap().len(), 0);
     }
 }

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -18,7 +18,9 @@ use crate::session::manager::SessionManager;
 use crate::session::session::SessionInfo;
 use crate::web::auth::WebAccessToken;
 use crate::web::broadcast::WsBroadcaster;
-use crate::{RtkStartupModeState, RtkSweepLockState, WebServerHandle};
+use crate::{
+    ApiServerHandle, ApiServerTask, RtkStartupModeState, RtkSweepLockState, WebServerHandle,
+};
 
 const HOME_MARKDOWN_URL: &str =
     "https://raw.githubusercontent.com/mblua/AgentsCommander/main/docs/home-en.md";
@@ -26,6 +28,7 @@ const HOME_MARKDOWN_URL: &str =
 const HOME_MARKDOWN_MAX_BYTES: usize = 256 * 1024; // 256 KB
 const HOME_MARKDOWN_TIMEOUT_SECS: u64 = 5;
 const WEB_STATUS_CONNECT_TIMEOUT_MS: u64 = 500;
+const API_SERVER_STOP_TIMEOUT_MS: u64 = 5_000;
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1077,6 +1080,66 @@ pub async fn open_web_remote() -> Result<(), String> {
 
     open::that(&url).map_err(|e| format!("Failed to open browser: {}", e))?;
     Ok(())
+}
+
+#[tauri::command]
+pub async fn start_api_server(
+    app_handle: tauri::AppHandle,
+    api_handle: State<'_, ApiServerHandle>,
+    settings: State<'_, SettingsState>,
+    session_mgr: State<'_, Arc<tokio::sync::RwLock<SessionManager>>>,
+    pty_mgr: State<'_, Arc<std::sync::Mutex<PtyManager>>>,
+    shutdown: State<'_, crate::shutdown::ShutdownSignal>,
+) -> Result<bool, String> {
+    if api_handle.has_running()? {
+        return Ok(false);
+    }
+
+    let s = settings.read().await;
+    let bind = s.api_server_bind.clone();
+    let port = s.api_server_port;
+    drop(s);
+
+    let addr = format!("{}:{}", bind, port);
+    if is_tcp_listening(&addr).await {
+        return Ok(false);
+    }
+
+    let api_shutdown = shutdown.token().child_token();
+    let join_handle = crate::api::start_server(
+        bind,
+        port,
+        app_handle,
+        Arc::clone(&session_mgr),
+        Arc::clone(&pty_mgr),
+        api_shutdown.clone(),
+    );
+
+    if !api_handle.store_if_idle(ApiServerTask::new(join_handle, api_shutdown))? {
+        return Ok(false);
+    }
+
+    log::info!("[api-server] Started via command");
+    Ok(true)
+}
+
+#[tauri::command]
+pub async fn stop_api_server(api_handle: State<'_, ApiServerHandle>) -> Result<bool, String> {
+    let stopped = api_handle
+        .shutdown_running(Duration::from_millis(API_SERVER_STOP_TIMEOUT_MS))
+        .await?;
+    if stopped {
+        log::info!("[api-server] Stopped via command");
+    }
+    Ok(stopped)
+}
+
+#[tauri::command]
+pub async fn api_server_status(settings: State<'_, SettingsState>) -> Result<bool, String> {
+    let s = settings.read().await;
+    let addr = format!("{}:{}", s.api_server_bind, s.api_server_port);
+    drop(s);
+    Ok(is_tcp_listening(&addr).await)
 }
 
 // Tauri command: State<> injections push us over clippy's 7-arg threshold.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ use session::manager::SessionManager;
 use shutdown::ShutdownSignal;
 use tauri::Manager;
 use telegram::manager::{OutputSenderMap, TelegramBridgeManager, TelegramBridgeState};
+use tokio_util::sync::CancellationToken;
 use voice::tracker::{VoiceTracker, VoiceTrackingState};
 use web::auth::WebAccessToken;
 use web::broadcast::WsBroadcaster;
@@ -63,13 +64,84 @@ impl WebServerHandle {
 
 #[derive(Default)]
 pub struct ApiServerHandle {
-    inner: Arc<Mutex<Option<tauri::async_runtime::JoinHandle<()>>>>,
+    inner: Arc<Mutex<Option<ApiServerTask>>>,
+}
+
+pub struct ApiServerTask {
+    join: tauri::async_runtime::JoinHandle<()>,
+    shutdown: CancellationToken,
+}
+
+impl ApiServerTask {
+    pub fn new(join: tauri::async_runtime::JoinHandle<()>, shutdown: CancellationToken) -> Self {
+        Self { join, shutdown }
+    }
 }
 
 impl ApiServerHandle {
     /// #791 - handle to the running control-plane API server task.
-    pub fn store(&self, handle: tauri::async_runtime::JoinHandle<()>) {
-        *self.inner.lock().unwrap() = Some(handle);
+    pub fn store_if_idle(&self, task: ApiServerTask) -> Result<bool, String> {
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| "API server handle lock is poisoned".to_string())?;
+        if inner
+            .as_ref()
+            .is_some_and(|stored| !stored.join.inner().is_finished())
+        {
+            task.shutdown.cancel();
+            task.join.abort();
+            return Ok(false);
+        }
+        *inner = Some(task);
+        Ok(true)
+    }
+
+    pub fn has_running(&self) -> Result<bool, String> {
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| "API server handle lock is poisoned".to_string())?;
+        if inner
+            .as_ref()
+            .is_some_and(|stored| !stored.join.inner().is_finished())
+        {
+            return Ok(true);
+        }
+        *inner = None;
+        Ok(false)
+    }
+
+    pub async fn shutdown_running(&self, timeout: std::time::Duration) -> Result<bool, String> {
+        let task = {
+            let mut inner = self
+                .inner
+                .lock()
+                .map_err(|_| "API server handle lock is poisoned".to_string())?;
+            match inner.as_ref() {
+                Some(stored) if stored.join.inner().is_finished() => {
+                    *inner = None;
+                    return Ok(false);
+                }
+                Some(_) => inner.take(),
+                None => return Ok(false),
+            }
+        };
+        let Some(task) = task else {
+            return Ok(false);
+        };
+
+        task.shutdown.cancel();
+        let mut join = task.join;
+        match tokio::time::timeout(timeout, &mut join).await {
+            Ok(Ok(())) => Ok(true),
+            Ok(Err(err)) => Err(format!("API server task failed during shutdown: {}", err)),
+            Err(_) => {
+                join.abort();
+                let _ = join.await;
+                Ok(true)
+            }
+        }
     }
 }
 
@@ -626,16 +698,21 @@ pub fn run(
                 if api_settings.api_server_enabled {
                     let bind = api_settings.api_server_bind.clone();
                     let port = api_settings.api_server_port;
+                    let api_shutdown = shutdown_for_setup.token().child_token();
                     let join_handle = api::start_server(
                         bind,
                         port,
                         app.handle().clone(),
                         session_mgr_for_api.clone(),
                         pty_mgr.clone(),
-                        shutdown_for_setup.clone(),
+                        api_shutdown.clone(),
                     );
                     let api_handle = app.state::<ApiServerHandle>();
-                    api_handle.store(join_handle);
+                    if let Err(e) =
+                        api_handle.store_if_idle(ApiServerTask::new(join_handle, api_shutdown))
+                    {
+                        log::error!("[api-server] failed to store server handle: {}", e);
+                    }
                 }
             }
 
@@ -2077,6 +2154,9 @@ pub fn run(
             commands::config::save_debug_logs,
             commands::config::drain_error_logs,
             commands::config::open_web_remote,
+            commands::config::start_api_server,
+            commands::config::stop_api_server,
+            commands::config::api_server_status,
             commands::config::start_web_server,
             commands::config::stop_web_server,
             commands::config::get_web_server_status,
@@ -2318,10 +2398,12 @@ mod tests {
     use super::{
         resolve_is_coord_for_restore, should_auto_create_root_agent_on_first_restore,
         should_wake_on_restore, should_wake_root_agent_on_restore, skip_auto_resume_for_restore,
-        ApiServerHandle, WebServerHandle,
+        ApiServerHandle, ApiServerTask, WebServerHandle,
     };
     use crate::config::settings::{AgentConfig, AppSettings};
     use crate::session::session::SessionStatus;
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
 
     fn settings_with_agent() -> AppSettings {
         AppSettings {
@@ -2348,6 +2430,56 @@ mod tests {
             .manage(ApiServerHandle::default())
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("web and api server handles must be distinct managed types");
+    }
+
+    #[tokio::test]
+    async fn api_server_handle_shutdown_cancels_running_task() {
+        let handle = ApiServerHandle::default();
+        let shutdown = CancellationToken::new();
+        let task_shutdown = shutdown.clone();
+        let join = tauri::async_runtime::spawn(async move {
+            task_shutdown.cancelled().await;
+        });
+
+        assert!(handle
+            .store_if_idle(ApiServerTask::new(join, shutdown))
+            .unwrap());
+        assert!(handle.has_running().unwrap());
+        assert!(handle
+            .shutdown_running(Duration::from_secs(1))
+            .await
+            .unwrap());
+        assert!(!handle.has_running().unwrap());
+    }
+
+    #[tokio::test]
+    async fn api_server_handle_rejects_duplicate_running_task() {
+        let handle = ApiServerHandle::default();
+        let first_shutdown = CancellationToken::new();
+        let first_task_shutdown = first_shutdown.clone();
+        let first_join = tauri::async_runtime::spawn(async move {
+            first_task_shutdown.cancelled().await;
+        });
+        assert!(handle
+            .store_if_idle(ApiServerTask::new(first_join, first_shutdown))
+            .unwrap());
+
+        let second_shutdown = CancellationToken::new();
+        let second_observer = second_shutdown.clone();
+        let second_task_shutdown = second_shutdown.clone();
+        let second_join = tauri::async_runtime::spawn(async move {
+            second_task_shutdown.cancelled().await;
+        });
+        assert!(!handle
+            .store_if_idle(ApiServerTask::new(second_join, second_shutdown))
+            .unwrap());
+        assert!(second_observer.is_cancelled());
+        assert!(handle.has_running().unwrap());
+
+        assert!(handle
+            .shutdown_running(Duration::from_secs(1))
+            .await
+            .unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Backend slice of #793 (in-daemon API #791 follow-ups). N1 was dropped (superseded by S5's DB idempotency + the module removal in #831).

## Changes
- **N3 — auth-lock poison is fail-closed.** The API auth locks (`ApiClientStore::current` registry cache + `FailedAuthLockout`) map `Mutex` poison to a handled `ApiError::Internal` instead of `.unwrap()` panicking + 500-ing until restart. `authenticate` now returns `Result<Option<ApiClient>, ApiError>`; the handler propagates every poison with `?` (never fail-open — a poisoned lockout/registry denies, never authenticates). Session-transport keeps its uniform generic 401 (no poison-vs-invalid-token oracle).
- **N4 — malformed registry deny-all + operator-visible.** A malformed/unreadable `api-clients.json` logs at ERROR + fail-closes to an empty registry (all requests 401 — never fail-open), and `api-client list` surfaces `{registryStatus, error, clients}` (hash-redacted, no token digest) so an operator can see why auth is failing.
- **N5 — API start/stop/status without a daemon restart.** New `start_api_server` / `stop_api_server` / `api_server_status` Tauri commands (mirror the web-server ones). Triple-guarded start (tracked-task check + active-TCP-listener check + atomic `store_if_idle`) prevents double-bind/leak; stop takes the task out of `ApiServerHandle` and **drops the mutex before cancelling/awaiting** (no lock across `.await`), cancels a **per-server child CancellationToken** shared by the server + DB dispatcher + reaper (leaves unrelated daemon work running), and joins the dispatcher on every exit path (no orphan; S5 lease/visibility-timeout redelivers any in-flight row on next start). Clean stop→start rebind.

## Verification
- **dev-rust**: `cargo test --lib --bins --tests` 1895 pass / 0 fail (+6 N3/N4/N5 tests), `cargo clippy --all-targets -- -D warnings`, `npm run typecheck`, `npm run version:check`, `npm run smoke:cli-release-windows` (4/0) — all green.
- **grinch (independent, adversarial)**: N5 lifecycle SECURE (no double-bind via triple guard + a duplicate-running-task test; scoped per-server cancellation that spares daemon work; dispatcher joined on every path; no lock across await — the crux); N3 fail-closed (no panic, no fail-open, no transport oracle — poison tests via `catch_unwind`); N4 deny-all + hash-redacted diagnostic (no secret leak); auth decision logic byte-identical; security model (scoped tokens, #791 identity, Root exclusion) untouched; full gate set green. **PASS.** One non-blocking INFO (the CLI diagnostic echoes a serde parse fragment — operator-local, hashes not reversible).

Non-visual. No version bump. Closes #838 (backend slice of #793; the FE toggle + mint UX remain).
