### PR TITLE
feat(browser): add Sidebar left/right option, refs #840

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -1,11 +1,18 @@
-import { Component, createSignal, onCleanup, onMount } from "solid-js";
+import { Component, createSignal, onCleanup, onMount, Show } from "solid-js";
 import SidebarApp from "../sidebar/App";
 import TerminalApp from "../terminal/App";
 import type { UnlistenFn } from "../shared/transport";
+import type { MainSidebarSide } from "../shared/types";
 import { SettingsAPI, onThemeChanged } from "../shared/ipc";
 import "../sidebar/styles/sidebar.css";
 import "../terminal/styles/terminal.css";
 import "./styles/browser.css";
+
+const MIN_SIDEBAR_WIDTH = 200;
+const MAX_SIDEBAR_WIDTH = 600;
+// #840 — the web view mirrors the desktop default: sidebar on the right unless
+// the persisted `mainSidebarSide` preference says "left".
+const DEFAULT_SIDEBAR_SIDE: MainSidebarSide = "right";
 
 /**
  * Combined browser layout: sidebar + terminal with a draggable divider.
@@ -13,6 +20,7 @@ import "./styles/browser.css";
  */
 const BrowserApp: Component = () => {
   const [sidebarWidth, setSidebarWidth] = createSignal(300);
+  const [sidebarSide, setSidebarSide] = createSignal<MainSidebarSide>(DEFAULT_SIDEBAR_SIDE);
   const [dragging, setDragging] = createSignal(false);
   let disposed = false;
   let unlistenThemeChanged: UnlistenFn | null = null;
@@ -20,6 +28,9 @@ const BrowserApp: Component = () => {
   const applyTheme = (light: boolean) => {
     document.documentElement.classList.toggle("light-theme", light);
   };
+
+  const clampWidth = (raw: number) =>
+    Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, raw));
 
   onMount(async () => {
     // BrowserApp owns the document theme because its children are embedded to
@@ -38,9 +49,12 @@ const BrowserApp: Component = () => {
       const settings = await SettingsAPI.get();
       if (!disposed) {
         applyTheme(settings.themeLight);
+        // #840 — honor the shared `mainSidebarSide` preference. Default to the
+        // right for any value that isn't an explicit "left".
+        setSidebarSide(settings.mainSidebarSide === "left" ? "left" : DEFAULT_SIDEBAR_SIDE);
       }
     } catch (err) {
-      console.error("[browser] failed to load theme setting:", err);
+      console.error("[browser] failed to load settings:", err);
     }
   });
 
@@ -49,13 +63,33 @@ const BrowserApp: Component = () => {
     unlistenThemeChanged?.();
   });
 
+  // #840 — flip the sidebar side and write it through to the shared
+  // `mainSidebarSide` setting (the same preference the desktop Titlebar drives),
+  // so web and desktop stay in sync. Optimistic: update the signal first for a
+  // snappy swap, then persist; on failure we keep the UI state and just log —
+  // this mirrors the desktop side-preset handler, which also does not roll back.
+  const toggleSide = async () => {
+    const next: MainSidebarSide = sidebarSide() === "right" ? "left" : "right";
+    setSidebarSide(next);
+    try {
+      const settings = await SettingsAPI.get();
+      await SettingsAPI.update({ ...settings, mainSidebarSide: next });
+    } catch (err) {
+      console.error("[browser] failed to persist sidebar side:", err);
+    }
+  };
+
   const onMouseDown = (e: MouseEvent) => {
     e.preventDefault();
     setDragging(true);
+    // Capture the side at drag start. The divider math mirrors main/App.tsx: a
+    // left sidebar grows with clientX; a right sidebar grows as the pointer
+    // moves toward it (innerWidth - clientX).
+    const side = sidebarSide();
 
     const onMouseMove = (e: MouseEvent) => {
-      const newWidth = Math.max(200, Math.min(600, e.clientX));
-      setSidebarWidth(newWidth);
+      const raw = side === "left" ? e.clientX : window.innerWidth - e.clientX;
+      setSidebarWidth(clampWidth(raw));
     };
 
     const onMouseUp = () => {
@@ -72,11 +106,12 @@ const BrowserApp: Component = () => {
   const onTouchStart = (e: TouchEvent) => {
     e.preventDefault();
     setDragging(true);
+    const side = sidebarSide();
 
     const onTouchMove = (e: TouchEvent) => {
       const touch = e.touches[0];
-      const newWidth = Math.max(200, Math.min(600, touch.clientX));
-      setSidebarWidth(newWidth);
+      const raw = side === "left" ? touch.clientX : window.innerWidth - touch.clientX;
+      setSidebarWidth(clampWidth(raw));
     };
 
     const onTouchEnd = () => {
@@ -90,9 +125,15 @@ const BrowserApp: Component = () => {
   };
 
   return (
-    <div class="browser-layout" classList={{ "browser-dragging": dragging() }}>
+    <div
+      class="browser-layout"
+      classList={{
+        "browser-dragging": dragging(),
+        "browser-sidebar-right": sidebarSide() === "right",
+      }}
+    >
       <div class="browser-sidebar" style={{ width: `${sidebarWidth()}px` }}>
-        <SidebarApp embedded railSide="left" />
+        <SidebarApp embedded railSide={sidebarSide()} />
       </div>
       <div
         class="browser-divider"
@@ -102,6 +143,37 @@ const BrowserApp: Component = () => {
         <div class="browser-divider-handle" />
       </div>
       <div class="browser-terminal">
+        {/* #840 — the web view has no desktop titlebar to host the Left/Right
+            preset, so expose a compact toggle here. Anchored to the terminal
+            pane's top-right corner because the sidebar's ActionBar spans its
+            full top edge — floating over the sidebar would cover those buttons. */}
+        <button
+          type="button"
+          class="browser-side-toggle"
+          title={`Sidebar on the ${sidebarSide()} — move it to the ${sidebarSide() === "right" ? "left" : "right"}`}
+          aria-label={`Move sidebar to the ${sidebarSide() === "right" ? "left" : "right"}`}
+          data-ac-testid="browser.sidebarSideToggle"
+          onClick={toggleSide}
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+            <rect
+              x="1.5"
+              y="2.5"
+              width="13"
+              height="11"
+              rx="2"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.3"
+            />
+            <Show
+              when={sidebarSide() === "right"}
+              fallback={<rect x="2.4" y="3.4" width="4.2" height="9.2" rx="1" fill="currentColor" />}
+            >
+              <rect x="9.4" y="3.4" width="4.2" height="9.2" rx="1" fill="currentColor" />
+            </Show>
+          </svg>
+        </button>
         <TerminalApp embedded />
       </div>
     </div>

--- a/src/browser/App.workflow.test.tsx
+++ b/src/browser/App.workflow.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import BrowserApp from "./App";
 import { FakeTransport } from "../shared/testing/fake-transport";
 import type { WorkgroupGroupsConfig } from "../shared/types";
@@ -136,10 +136,43 @@ function setupBrowserTransport(
   fake.resolve("list_detached_sessions", []);
   fake.resolve("telegram_list_bridges", []);
   fake.resolve("pty_resize", undefined);
+  fake.resolve("update_settings", undefined);
 }
 
 describe("BrowserApp workflow", () => {
   let cleanupDom: (() => void) | null = null;
+
+  // jsdom's WebSocket is backed by the `ws` package, which throws
+  // "ws does not work in the browser" when constructed. BrowserApp's real
+  // WsTransport is created lazily (ipc.ts) and an async task can outlive a
+  // test's cleanup — after the FakeTransport override is restored — and
+  // construct it, surfacing that throw as an unhandled rejection that fails the
+  // run even though every assertion passes. Stub WebSocket with an inert no-op
+  // for the whole file so those stragglers can't crash it. File-scoped (vitest
+  // isolates per file), so no restore is needed.
+  beforeAll(() => {
+    class NoopWebSocket {
+      static readonly CONNECTING = 0;
+      static readonly OPEN = 1;
+      static readonly CLOSING = 2;
+      static readonly CLOSED = 3;
+      url: string;
+      binaryType = "blob";
+      readyState = 0;
+      onopen: ((ev?: unknown) => void) | null = null;
+      onmessage: ((ev?: unknown) => void) | null = null;
+      onclose: ((ev?: unknown) => void) | null = null;
+      onerror: ((ev?: unknown) => void) | null = null;
+      constructor(url = "") {
+        this.url = url;
+      }
+      send(): void {}
+      close(): void {}
+      addEventListener(): void {}
+      removeEventListener(): void {}
+    }
+    globalThis.WebSocket = NoopWebSocket as unknown as typeof WebSocket;
+  });
 
   beforeEach(() => {
     cleanupDom = installBrowserDomStubs();
@@ -164,7 +197,11 @@ describe("BrowserApp workflow", () => {
         expect(rendered.root.querySelector(".browser-layout")).not.toBeNull();
         expect(rendered.root.querySelector(".browser-sidebar")).not.toBeNull();
         expect(rendered.root.querySelector(".browser-terminal")).not.toBeNull();
-        expect(rendered.root.querySelector(".sidebar-body")?.getAttribute("data-rail-side")).toBe("left");
+        // #840 — web defaults to the sidebar on the right (mirrors desktop).
+        expect(rendered.root.querySelector(".sidebar-body")?.getAttribute("data-rail-side")).toBe("right");
+        expect(
+          rendered.root.querySelector(".browser-layout")?.classList.contains("browser-sidebar-right")
+        ).toBe(true);
         expect(rendered.root.querySelector(".workgroup-group-rail")).not.toBeNull();
         expect(rendered.root.textContent).toContain("wg-1-dev-team");
         expect(rendered.root.textContent).toContain("architect");
@@ -220,39 +257,105 @@ describe("BrowserApp workflow", () => {
     }
   });
 
-  it("updates sidebar width when the browser divider is dragged", async () => {
+  it("updates sidebar width when the divider is dragged (left sidebar)", async () => {
     const fake = new FakeTransport();
-    setupBrowserTransport(fake);
+    setupBrowserTransport(fake, { mainSidebarSide: "left" });
 
     const rendered = renderWithFakeTransport(() => <BrowserApp />, fake);
     try {
+      // Wait until the persisted "left" side has been applied — the divider
+      // captures the side at mousedown, so dragging before it loads would use
+      // the default ("right").
       await waitFor(() =>
-        expect(rendered.root.querySelector(".browser-divider")).not.toBeNull()
+        expect(
+          rendered.root.querySelector(".sidebar-body")?.getAttribute("data-rail-side")
+        ).toBe("left")
       );
-      await waitFor(() => {
-        expect(fake.callsFor("telegram_list_bridges").length).toBeGreaterThan(0);
-        expect(fake.callsFor("get_active_session").length).toBeGreaterThan(0);
-      });
 
       const sidebar = rendered.root.querySelector(".browser-sidebar") as HTMLElement;
       const divider = rendered.root.querySelector(".browser-divider") as HTMLElement;
       expect(sidebar.style.width).toBe("300px");
 
-      divider.dispatchEvent(
-        new MouseEvent("mousedown", { bubbles: true, cancelable: true })
-      );
+      divider.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
       document.dispatchEvent(
-        new MouseEvent("mousemove", {
-          bubbles: true,
-          cancelable: true,
-          clientX: 480,
-        })
+        new MouseEvent("mousemove", { bubbles: true, cancelable: true, clientX: 480 })
       );
-      document.dispatchEvent(
-        new MouseEvent("mouseup", { bubbles: true, cancelable: true })
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+
+      // Left sidebar grows directly with clientX.
+      expect(sidebar.style.width).toBe("480px");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("updates sidebar width with mirrored math when the divider is dragged (right sidebar)", async () => {
+    const fake = new FakeTransport();
+    setupBrowserTransport(fake); // default: right
+
+    const rendered = renderWithFakeTransport(() => <BrowserApp />, fake);
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector(".browser-layout")?.classList.contains("browser-sidebar-right")
+        ).toBe(true)
       );
 
-      expect(sidebar.style.width).toBe("480px");
+      const sidebar = rendered.root.querySelector(".browser-sidebar") as HTMLElement;
+      const divider = rendered.root.querySelector(".browser-divider") as HTMLElement;
+      expect(sidebar.style.width).toBe("300px");
+
+      divider.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+      document.dispatchEvent(
+        new MouseEvent("mousemove", { bubbles: true, cancelable: true, clientX: 480 })
+      );
+      document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+
+      // Right sidebar grows as the pointer moves toward it: innerWidth - clientX.
+      const expected = window.innerWidth - 480;
+      expect(sidebar.style.width).toBe(`${expected}px`);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("toggles the sidebar side from the web control and persists mainSidebarSide", async () => {
+    const fake = new FakeTransport();
+    setupBrowserTransport(fake); // default: right
+
+    const rendered = renderWithFakeTransport(() => <BrowserApp />, fake);
+    try {
+      // Starts on the right by default.
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector(".browser-layout")?.classList.contains("browser-sidebar-right")
+        ).toBe(true)
+      );
+
+      const toggle = rendered.root.querySelector<HTMLButtonElement>(
+        '[data-ac-testid="browser.sidebarSideToggle"]'
+      );
+      expect(toggle).not.toBeNull();
+
+      fake.clearCalls();
+      toggle!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+      // Layout + inner rail flip to the left.
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector(".browser-layout")?.classList.contains("browser-sidebar-right")
+        ).toBe(false);
+        expect(
+          rendered.root.querySelector(".sidebar-body")?.getAttribute("data-rail-side")
+        ).toBe("left");
+      });
+
+      // The new side is written through to the shared mainSidebarSide setting.
+      await waitFor(() => expect(fake.callsFor("update_settings").length).toBeGreaterThan(0));
+      const persisted = fake.lastCall("update_settings")?.args as
+        | { newSettings?: { mainSidebarSide?: string } }
+        | undefined;
+      expect(persisted?.newSettings?.mainSidebarSide).toBe("left");
     } finally {
       rendered.cleanup();
     }

--- a/src/browser/styles/browser.css
+++ b/src/browser/styles/browser.css
@@ -8,6 +8,13 @@
   background: var(--terminal-bg, #0a0a0f);
 }
 
+/* #840 — sidebar on the right (default). row-reverse flips the fixed DOM order
+   (sidebar | divider | terminal) so the sidebar renders against the right edge
+   and the terminal fills the left, without reordering the markup. */
+.browser-layout.browser-sidebar-right {
+  flex-direction: row-reverse;
+}
+
 /* Prevent text selection while dragging the divider */
 .browser-dragging {
   user-select: none;
@@ -66,6 +73,44 @@
   height: 100%;
   min-width: 0;
   overflow: hidden;
+  /* #840 — positioning context for the sidebar-side toggle. */
+  position: relative;
+}
+
+/* #840 — compact control to move the sidebar left/right in the web view
+   (no desktop titlebar here to host the existing preset). Pinned to the
+   terminal pane's top-right corner so it never overlaps the sidebar ActionBar,
+   which spans the sidebar's full top edge. */
+.browser-side-toggle {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-muted, rgba(255, 255, 255, 0.55));
+  opacity: 0.55;
+  cursor: pointer;
+  transition: opacity 150ms ease-out, background 150ms ease-out, color 150ms ease-out;
+}
+
+.browser-side-toggle:hover {
+  opacity: 1;
+  background: rgba(0, 212, 255, 0.15);
+  color: var(--text-primary, rgba(255, 255, 255, 0.92));
+}
+
+.browser-side-toggle:focus-visible {
+  opacity: 1;
+  outline: 1px solid rgba(0, 212, 255, 0.6);
+  outline-offset: 1px;
 }
 
 /* Override standalone heights — in browser layout they must fill their pane, not 100vh */
@@ -115,7 +160,12 @@
 
 /* Mobile: stack vertically with horizontal divider */
 @media (max-width: 600px) {
-  .browser-layout {
+  /* #840 — the side preference is a horizontal concept; on narrow screens both
+     sides collapse to the same vertical stack (sidebar on top). Listing the
+     higher-specificity right-side selector here keeps row-reverse from leaking
+     into the stacked layout. */
+  .browser-layout,
+  .browser-layout.browser-sidebar-right {
     flex-direction: column;
   }
 


### PR DESCRIPTION
## Summary

Closes #840.

Adds the desktop-equivalent Sidebar side option to the browser/web view:

- Browser defaults the Sidebar to the right when no saved preference exists.
- Browser can toggle Sidebar between left and right through a web-specific control.
- The implementation reuses the existing `mainSidebarSide` setting, so desktop and web share one preference.
- Divider drag math is side-aware for both mouse and touch.
- Mobile layout keeps the stacked column presentation regardless of side.

## Implementation

- `src/browser/App.tsx`: reads/persists `mainSidebarSide`, passes `railSide` to the embedded Sidebar, applies side-aware divider math, and adds the browser toggle.
- `src/browser/styles/browser.css`: adds right-side layout (`row-reverse`), mobile override, and toggle styling.
- `src/browser/App.workflow.test.tsx`: covers default-right, left/right divider math, and toggle persistence.

## Verification

Developer gates:
- `npm run typecheck` -> pass
- `npm run test` -> 95 files / 760 tests pass

Grinch review:
- Initial adversarial review PASS on `3f5dc39c`.
- Independent gates: `npm run typecheck`, focused browser vitest, full `npm test` all pass.
- Step 9.5 re-sync review PASS on merge HEAD `cda253c0`.
- Confirmed `src/browser/` is byte-identical to the previously reviewed feature commit after the merge, and backend tree is byte-identical to `origin/main`.

## Ship note

This is a visual app change. After merge, shipper should build/deploy the wg-12 standalone from landed `main`.