### PR TITLE
perf: offload local pty spawn off the async runtime (#839)

### DIFF
--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -210,7 +210,13 @@ fn publish_git_guard_temp_with_retry(
     path: &Path,
     content: &[u8],
 ) -> Result<(), String> {
-    for attempt in 0..=GIT_GUARD_PUBLISH_RETRY_DELAYS.len() {
+    let attempts = GIT_GUARD_PUBLISH_RETRY_DELAYS
+        .iter()
+        .copied()
+        .map(Some)
+        .chain(std::iter::once(None));
+
+    for (attempt, delay) in attempts.enumerate() {
         if git_guard_file_matches(path, content) {
             let _ = std::fs::remove_file(temp);
             return Ok(());
@@ -224,7 +230,7 @@ fn publish_git_guard_temp_with_retry(
                     return Ok(());
                 }
 
-                let Some(delay) = GIT_GUARD_PUBLISH_RETRY_DELAYS.get(attempt) else {
+                let Some(delay) = delay else {
                     let _ = std::fs::remove_file(temp);
                     return Err(format!(
                         "publish {} from {} failed after {} attempts: {}",
@@ -234,12 +240,12 @@ fn publish_git_guard_temp_with_retry(
                         e
                     ));
                 };
-                std::thread::sleep(*delay);
+                std::thread::sleep(delay);
             }
         }
     }
 
-    unreachable!("retry loop always returns on final attempt")
+    unreachable!("retry loop includes a final no-delay attempt")
 }
 
 #[cfg(windows)]
@@ -361,6 +367,16 @@ pub struct LocalProcessBackend {
     ptys: Arc<Mutex<HashMap<Uuid, PtyInstance>>>,
     fanout: SessionIoFanout,
     git_watcher: Arc<GitWatcher>,
+}
+
+impl Clone for LocalProcessBackend {
+    fn clone(&self) -> Self {
+        Self {
+            ptys: Arc::clone(&self.ptys),
+            fanout: self.fanout.clone(),
+            git_watcher: Arc::clone(&self.git_watcher),
+        }
+    }
 }
 
 impl LocalProcessBackend {
@@ -562,7 +578,12 @@ impl PtyBackend for LocalProcessBackend {
         &self,
         spec: BackendSpawnSpec,
     ) -> futures::future::BoxFuture<'_, Result<(), AppError>> {
-        Box::pin(async move { self.spawn_sync(spec) })
+        let backend = self.clone();
+        Box::pin(async move {
+            tokio::task::spawn_blocking(move || backend.spawn_sync(spec))
+                .await
+                .map_err(|e| AppError::Other(format!("local process spawn task failed: {e}")))?
+        })
     }
 
     fn write(&self, id: Uuid, data: &[u8]) -> Result<(), AppError> {


### PR DESCRIPTION
## What & why

Follow-up from #836. The git-guard publish retry added there
(`publish_git_guard_temp_with_retry`) sleeps synchronously (`std::thread::sleep`,
up to ~3.175 s) and ran **inline on a tokio worker thread**, because
`LocalProcessBackend::spawn` returned `Box::pin(async move { self.spawn_sync(spec) })`
— `spawn_sync` executed on the awaiting async task. On the retry path (and for the
pre-existing blocking file I/O + `portable_pty` spawn) this tied up a runtime
worker. (Reported as MEDIUM M1 in the #836 review.)

## The fix (`src-tauri/src/pty/local_backend.rs` only, commit `aaae7bf`)

- Added `Clone` for `LocalProcessBackend` (clones its three fields — the
  `Arc<Mutex<…>>` PTY map, the `Arc<GitWatcher>`, and the `SessionIoFanout` whose
  fields are all shared `Arc` handles). Cloning is a handle-share, not a copy.
- `LocalProcessBackend::spawn` now clones the backend and runs
  `backend.spawn_sync(spec)` inside `tokio::task::spawn_blocking`, then `.await`s
  the `JoinHandle` and surfaces any `JoinError` as `AppError`. This moves the
  retry sleeps, the file I/O, and the `portable_pty` spawn off the async worker —
  no `PtyBackend` trait change, no caller ripple.
- Folded the #836 review NIT: the retry loop now derives its attempt count
  directly from `GIT_GUARD_PUBLISH_RETRY_DELAYS` (iterate delays + one final
  no-delay attempt) instead of a separate range, removing the loop/slice desync
  risk.

## Review & verification

- **dev-rust** implemented; **dev-rust-grinch** reviewed → **PASS**. Confirmed:
  the `Clone` genuinely Arc-shares the PTY map / `SessionIoFanout` / `GitWatcher`
  (so a session registered by the clone inside `spawn_blocking` is visible to the
  original backend for write/resize/kill/IO — proven by the identical
  pre-existing per-session `.clone()`); pid/job-object/tree-kill bookkeeping lands
  in shared state; `JoinError` is surfaced (bonus: a panic in `spawn_sync` is now
  caught at the blocking-task boundary instead of unwinding the async task); the
  retry refactor is behavior-identical (8 attempts / 7 sleeps); no blocking work
  remains on the async worker (M1 resolved); no double-spawn; the manager still
  drops its lock before awaiting spawn.
- `cargo check`, `cargo build`, `cargo test git_guard_writer --lib` (3 tests),
  `cargo clippy --all-targets -- -D warnings` all pass.

## Follow-up

- **#847** (latent, not reachable today): the new interior `.await` on the
  `spawn_blocking` handle means that *if* session spawn is ever wrapped in
  `tokio::time::timeout` / `tokio::select!`, a dropped future could register a
  session without its route → orphan. No current call site triggers it; tracked
  so a future cancellation wrapper doesn't silently reintroduce it.

Backend-only, no UI/visual change.

Closes #839
