### PR TITLE
feat(settings): in-app API-client mint command + Settings mint UI (#853)

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -31,6 +31,9 @@ const HOME_MARKDOWN_MAX_BYTES: usize = 256 * 1024; // 256 KB
 const HOME_MARKDOWN_TIMEOUT_SECS: u64 = 5;
 const WEB_STATUS_CONNECT_TIMEOUT_MS: u64 = 500;
 const API_SERVER_STOP_TIMEOUT_MS: u64 = 5_000;
+// Default mirrors container API token TTL; manual GUI mints get a longer cap.
+const MINT_API_CLIENT_DEFAULT_TTL_HOURS: i64 = 24;
+const MINT_API_CLIENT_MAX_TTL_DAYS: i64 = 30;
 const MINT_API_CLIENT_NOTE: &str =
     "Store this token now; it is shown only once. The registry keeps only a hash.";
 
@@ -1224,11 +1227,13 @@ pub async fn mint_api_client(
     label: Option<String>,
     expires: Option<String>,
 ) -> Result<MintApiClientResponse, String> {
+    let settings = load_settings();
     let path = crate::config::config_dir()
         .ok_or_else(|| "Cannot resolve the host config directory".to_string())?
         .join(auth::REGISTRY_FILENAME);
     mint_api_client_with_path(
         &path,
+        &settings,
         root,
         scopes,
         label,
@@ -1242,6 +1247,7 @@ pub async fn mint_api_client(
 #[allow(clippy::too_many_arguments)]
 fn mint_api_client_with_path(
     path: &Path,
+    settings: &AppSettings,
     root: String,
     scopes: Vec<String>,
     label: Option<String>,
@@ -1250,9 +1256,15 @@ fn mint_api_client_with_path(
     secret: String,
     issued_at: String,
 ) -> Result<MintApiClientResponse, String> {
-    let bound_fqn = crate::config::teams::agent_fqn_from_path(&root);
-    if crate::config::root_agent::is_root_agent_path(&root)
-        || crate::config::root_agent::is_root_agent_target(&bound_fqn)
+    if crate::config::root_agent::is_root_agent_path(&root) {
+        return Err(
+            "Cannot mint an API client bound to the Root Agent; root-agent is API-excluded"
+                .to_string(),
+        );
+    }
+
+    let (bound_root, bound_fqn) = validate_mint_api_client_root(&root, settings)?;
+    if crate::config::root_agent::is_root_agent_target(&bound_fqn)
         || bound_fqn == crate::config::root_agent::ROOT_AGENT_SENDER
     {
         return Err(
@@ -1267,6 +1279,7 @@ fn mint_api_client_with_path(
         .filter(|s| !s.is_empty())
         .collect();
     auth::validate_scopes(&scopes)?;
+    let expires_at = bounded_mint_api_client_expiry(expires, &issued_at)?;
 
     let out = auth::mint(
         path,
@@ -1274,11 +1287,11 @@ fn mint_api_client_with_path(
             client_id,
             secret,
             label: label.unwrap_or_default(),
-            bound_root: root.clone(),
+            bound_root: bound_root.clone(),
             bound_fqn: bound_fqn.clone(),
             scopes: scopes.clone(),
             issued_at,
-            expires_at: expires.clone(),
+            expires_at: Some(expires_at.clone()),
         },
     )?;
 
@@ -1287,11 +1300,68 @@ fn mint_api_client_with_path(
         client_id: out.client_id,
         token: out.secret,
         bound_fqn,
-        bound_root: root,
+        bound_root,
         scopes,
-        expires_at: expires,
+        expires_at: Some(expires_at),
         note: MINT_API_CLIENT_NOTE.to_string(),
     })
+}
+
+fn validate_mint_api_client_root(
+    root: &str,
+    settings: &AppSettings,
+) -> Result<(String, String), String> {
+    let canonical = crate::config::coding_agent_profiles::validate_profile_selection_agent_path(
+        settings,
+        Path::new(root),
+    )
+    .map_err(|_| format!("unknown or invalid root: {}", root))?
+    .launch_path;
+
+    let is_replica = canonical
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.starts_with("__agent_"))
+        .unwrap_or(false);
+    if !is_replica {
+        return Err(format!("unknown or invalid root: {}", root));
+    }
+
+    let bound_root = crate::path_utils::path_to_string_without_windows_verbatim_prefix(&canonical);
+    let bound_fqn = crate::config::teams::agent_fqn_from_path(&bound_root);
+    Ok((bound_root, bound_fqn))
+}
+
+fn bounded_mint_api_client_expiry(
+    expires: Option<String>,
+    issued_at: &str,
+) -> Result<String, String> {
+    let issued_at = chrono::DateTime::parse_from_rfc3339(issued_at)
+        .map_err(|e| format!("Invalid issuedAt timestamp: {}", e))?
+        .with_timezone(&chrono::Utc);
+    let max_expires_at = issued_at + chrono::Duration::days(MINT_API_CLIENT_MAX_TTL_DAYS);
+
+    let expires_at = match expires {
+        Some(raw) => {
+            let trimmed = raw.trim();
+            let parsed = chrono::DateTime::parse_from_rfc3339(trimmed)
+                .map_err(|e| format!("Invalid expires value; expected RFC3339: {}", e))?
+                .with_timezone(&chrono::Utc);
+            if parsed <= issued_at {
+                return Err("expires must be after the issuedAt timestamp".to_string());
+            }
+            if parsed > max_expires_at {
+                return Err(format!(
+                    "expires exceeds maximum API client lifetime of {} days",
+                    MINT_API_CLIENT_MAX_TTL_DAYS
+                ));
+            }
+            parsed
+        }
+        None => issued_at + chrono::Duration::hours(MINT_API_CLIENT_DEFAULT_TTL_HOURS),
+    };
+
+    Ok(expires_at.to_rfc3339())
 }
 
 // Tauri command: State<> injections push us over clippy's 7-arg threshold.
@@ -1688,7 +1758,8 @@ mod tests {
         persist_coding_agent_env_settings_update, persist_coding_agent_profiles_update,
         persist_narrow_settings_update_with_saver, persist_protected_settings_update_with_saver,
         persist_settings_draft_update_with_saver, RtkSweepError, RtkSweepResult,
-        WebServerOwnershipState, MINT_API_CLIENT_NOTE,
+        WebServerOwnershipState, MINT_API_CLIENT_DEFAULT_TTL_HOURS, MINT_API_CLIENT_MAX_TTL_DAYS,
+        MINT_API_CLIENT_NOTE,
     };
     use crate::api::auth;
     use crate::config::settings::{
@@ -1699,7 +1770,8 @@ mod tests {
     use crate::WebServerHandle;
     use std::collections::BTreeMap;
     #[cfg(windows)]
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
+    use std::path::PathBuf;
     use std::sync::Arc;
     use tokio::sync::RwLock;
 
@@ -1757,16 +1829,61 @@ mod tests {
         Arc::new(RwLock::new(settings))
     }
 
-    #[test]
-    fn mint_api_client_command_helper_returns_token_and_stores_hash_only() {
+    struct MintApiClientFixture {
+        _temp: tempfile::TempDir,
+        path: PathBuf,
+        project: PathBuf,
+        settings: AppSettings,
+        root: String,
+        expected_fqn: String,
+    }
+
+    fn mint_api_client_fixture() -> MintApiClientFixture {
         let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join(auth::REGISTRY_FILENAME);
-        let root = "C:/repos/proj-a/.ac/wg-1-devs/__agent_alice".to_string();
+        let project = temp.path().join("proj-a");
+        let workspace = project.join(".ac");
+        let matrix = workspace.join("_agent_alice");
+        let replica = workspace.join("wg-1-devs").join("__agent_alice");
+        std::fs::create_dir_all(&matrix).expect("create matrix");
+        std::fs::create_dir_all(&replica).expect("create replica");
+        std::fs::write(
+            replica.join("config.json"),
+            r#"{"identity":"../../_agent_alice"}"#,
+        )
+        .expect("write replica config");
+
+        let root_path = std::fs::canonicalize(&replica).expect("canonical replica");
+        let root = crate::path_utils::path_to_string_without_windows_verbatim_prefix(&root_path);
         let expected_fqn = crate::config::teams::agent_fqn_from_path(&root);
+        let settings = AppSettings {
+            project_paths: vec![project.to_string_lossy().to_string()],
+            ..AppSettings::default()
+        };
+
+        MintApiClientFixture {
+            path: temp.path().join(auth::REGISTRY_FILENAME),
+            _temp: temp,
+            project,
+            settings,
+            root,
+            expected_fqn,
+        }
+    }
+
+    #[test]
+    fn mint_api_client_command_helper_returns_token_and_stores_hash_only_with_default_expiry() {
+        let fixture = mint_api_client_fixture();
+        let issued_at = "2026-01-01T00:00:00Z";
+        let expected_expires_at = (chrono::DateTime::parse_from_rfc3339(issued_at)
+            .unwrap()
+            .with_timezone(&chrono::Utc)
+            + chrono::Duration::hours(MINT_API_CLIENT_DEFAULT_TTL_HOURS))
+        .to_rfc3339();
 
         let response = mint_api_client_with_path(
-            &path,
-            root.clone(),
+            &fixture.path,
+            &fixture.settings,
+            fixture.root.clone(),
             vec![
                 " send ".to_string(),
                 "".to_string(),
@@ -1776,33 +1893,91 @@ mod tests {
             None,
             "client-1".to_string(),
             "plain-secret".to_string(),
-            "2026-01-01T00:00:00Z".to_string(),
+            issued_at.to_string(),
         )
         .expect("mint succeeds");
 
         assert_eq!(response.client_id, "client-1");
         assert_eq!(response.token, "plain-secret");
-        assert_eq!(response.bound_root, root);
-        assert_eq!(response.bound_fqn, expected_fqn);
+        assert_eq!(response.bound_root, fixture.root);
+        assert_eq!(response.bound_fqn, fixture.expected_fqn);
         assert_eq!(response.scopes, vec!["send", "list-peers-lean"]);
-        assert_eq!(response.expires_at, None);
+        assert_eq!(
+            response.expires_at.as_deref(),
+            Some(expected_expires_at.as_str())
+        );
         assert_eq!(response.note, MINT_API_CLIENT_NOTE);
 
-        let raw = std::fs::read_to_string(&path).expect("read registry");
+        let raw = std::fs::read_to_string(&fixture.path).expect("read registry");
         assert!(raw.contains("client-1"));
         assert!(raw.contains("sha256:"));
         assert!(!raw.contains("plain-secret"));
 
-        let registry = auth::list(&path);
+        let registry = auth::list(&fixture.path);
         assert_eq!(registry.clients.len(), 1);
         let client = &registry.clients[0];
         assert_eq!(client.client_id, "client-1");
         assert_eq!(client.label, "gui mint");
-        assert_eq!(client.bound_fqn, expected_fqn);
+        assert_eq!(client.bound_fqn, fixture.expected_fqn);
         assert_eq!(client.bound_root, response.bound_root);
         assert_eq!(client.scopes, response.scopes);
-        assert_eq!(client.expires_at, None);
+        assert_eq!(client.expires_at, response.expires_at);
         assert_ne!(client.token_hash, "plain-secret");
+    }
+
+    #[test]
+    fn mint_api_client_rejects_unknown_root() {
+        let fixture = mint_api_client_fixture();
+        let unknown_root = fixture
+            .project
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_missing");
+
+        let err = mint_api_client_with_path(
+            &fixture.path,
+            &fixture.settings,
+            unknown_root.to_string_lossy().to_string(),
+            vec!["send".to_string()],
+            None,
+            None,
+            "client-1".to_string(),
+            "plain-secret".to_string(),
+            "2026-01-01T00:00:00Z".to_string(),
+        )
+        .expect_err("unknown root should fail");
+
+        assert!(err.contains("unknown or invalid root"), "{err}");
+        assert!(!fixture.path.exists());
+    }
+
+    #[test]
+    fn mint_api_client_rejects_expiry_beyond_max() {
+        let fixture = mint_api_client_fixture();
+        let issued_at = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let over_max =
+            (issued_at + chrono::Duration::days(MINT_API_CLIENT_MAX_TTL_DAYS + 1)).to_rfc3339();
+
+        let err = mint_api_client_with_path(
+            &fixture.path,
+            &fixture.settings,
+            fixture.root,
+            vec!["send".to_string()],
+            None,
+            Some(over_max),
+            "client-1".to_string(),
+            "plain-secret".to_string(),
+            issued_at.to_rfc3339(),
+        )
+        .expect_err("over-max expiry should fail");
+
+        assert!(
+            err.contains("expires exceeds maximum API client lifetime"),
+            "{err}"
+        );
+        assert!(!fixture.path.exists());
     }
 
     #[test]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, State};
+use uuid::Uuid;
 
+use crate::api::auth;
 use crate::config::claude_settings::{ensure_rtk_pretool_hook, enumerate_managed_agent_dirs};
 use crate::config::settings::{
     load_settings, merge_protected_coding_agent_settings, save_settings,
@@ -29,6 +31,8 @@ const HOME_MARKDOWN_MAX_BYTES: usize = 256 * 1024; // 256 KB
 const HOME_MARKDOWN_TIMEOUT_SECS: u64 = 5;
 const WEB_STATUS_CONNECT_TIMEOUT_MS: u64 = 500;
 const API_SERVER_STOP_TIMEOUT_MS: u64 = 5_000;
+const MINT_API_CLIENT_NOTE: &str =
+    "Store this token now; it is shown only once. The registry keeps only a hash.";
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -57,6 +61,18 @@ pub struct CodingAgentProfileResolutionResult {
     pub origin_default_profile: Option<String>,
     pub agent_default_profile: Option<String>,
     pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MintApiClientResponse {
+    pub client_id: String,
+    pub token: String,
+    pub bound_fqn: String,
+    pub bound_root: String,
+    pub scopes: Vec<String>,
+    pub expires_at: Option<String>,
+    pub note: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1201,6 +1217,83 @@ pub async fn api_server_status(settings: State<'_, SettingsState>) -> Result<boo
     Ok(is_tcp_listening(&addr).await)
 }
 
+#[tauri::command]
+pub async fn mint_api_client(
+    root: String,
+    scopes: Vec<String>,
+    label: Option<String>,
+    expires: Option<String>,
+) -> Result<MintApiClientResponse, String> {
+    let path = crate::config::config_dir()
+        .ok_or_else(|| "Cannot resolve the host config directory".to_string())?
+        .join(auth::REGISTRY_FILENAME);
+    mint_api_client_with_path(
+        &path,
+        root,
+        scopes,
+        label,
+        expires,
+        Uuid::new_v4().to_string(),
+        Uuid::new_v4().to_string(),
+        chrono::Utc::now().to_rfc3339(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn mint_api_client_with_path(
+    path: &Path,
+    root: String,
+    scopes: Vec<String>,
+    label: Option<String>,
+    expires: Option<String>,
+    client_id: String,
+    secret: String,
+    issued_at: String,
+) -> Result<MintApiClientResponse, String> {
+    let bound_fqn = crate::config::teams::agent_fqn_from_path(&root);
+    if crate::config::root_agent::is_root_agent_path(&root)
+        || crate::config::root_agent::is_root_agent_target(&bound_fqn)
+        || bound_fqn == crate::config::root_agent::ROOT_AGENT_SENDER
+    {
+        return Err(
+            "Cannot mint an API client bound to the Root Agent; root-agent is API-excluded"
+                .to_string(),
+        );
+    }
+
+    let scopes: Vec<String> = scopes
+        .into_iter()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    auth::validate_scopes(&scopes)?;
+
+    let out = auth::mint(
+        path,
+        auth::MintRequest {
+            client_id,
+            secret,
+            label: label.unwrap_or_default(),
+            bound_root: root.clone(),
+            bound_fqn: bound_fqn.clone(),
+            scopes: scopes.clone(),
+            issued_at,
+            expires_at: expires.clone(),
+        },
+    )?;
+
+    crate::api::audit::record(&out.client_id, &bound_fqn, "mint", "ok");
+    Ok(MintApiClientResponse {
+        client_id: out.client_id,
+        token: out.secret,
+        bound_fqn,
+        bound_root: root,
+        scopes,
+        expires_at: expires,
+        note: MINT_API_CLIENT_NOTE.to_string(),
+    })
+}
+
 // Tauri command: State<> injections push us over clippy's 7-arg threshold.
 #[allow(clippy::too_many_arguments)]
 #[tauri::command]
@@ -1591,12 +1684,13 @@ mod tests {
     #[cfg(windows)]
     use super::{build_profile_assignment_target, canonical_compare_key};
     use super::{
-        build_web_server_owned_status, ensure_web_remote_open_allowed,
+        build_web_server_owned_status, ensure_web_remote_open_allowed, mint_api_client_with_path,
         persist_coding_agent_env_settings_update, persist_coding_agent_profiles_update,
         persist_narrow_settings_update_with_saver, persist_protected_settings_update_with_saver,
         persist_settings_draft_update_with_saver, RtkSweepError, RtkSweepResult,
-        WebServerOwnershipState,
+        WebServerOwnershipState, MINT_API_CLIENT_NOTE,
     };
+    use crate::api::auth;
     use crate::config::settings::{
         AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ProfileCellConfig,
         SettingsState,
@@ -1661,6 +1755,54 @@ mod tests {
 
     fn state_for(settings: AppSettings) -> SettingsState {
         Arc::new(RwLock::new(settings))
+    }
+
+    #[test]
+    fn mint_api_client_command_helper_returns_token_and_stores_hash_only() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join(auth::REGISTRY_FILENAME);
+        let root = "C:/repos/proj-a/.ac/wg-1-devs/__agent_alice".to_string();
+        let expected_fqn = crate::config::teams::agent_fqn_from_path(&root);
+
+        let response = mint_api_client_with_path(
+            &path,
+            root.clone(),
+            vec![
+                " send ".to_string(),
+                "".to_string(),
+                "list-peers-lean".to_string(),
+            ],
+            Some("gui mint".to_string()),
+            None,
+            "client-1".to_string(),
+            "plain-secret".to_string(),
+            "2026-01-01T00:00:00Z".to_string(),
+        )
+        .expect("mint succeeds");
+
+        assert_eq!(response.client_id, "client-1");
+        assert_eq!(response.token, "plain-secret");
+        assert_eq!(response.bound_root, root);
+        assert_eq!(response.bound_fqn, expected_fqn);
+        assert_eq!(response.scopes, vec!["send", "list-peers-lean"]);
+        assert_eq!(response.expires_at, None);
+        assert_eq!(response.note, MINT_API_CLIENT_NOTE);
+
+        let raw = std::fs::read_to_string(&path).expect("read registry");
+        assert!(raw.contains("client-1"));
+        assert!(raw.contains("sha256:"));
+        assert!(!raw.contains("plain-secret"));
+
+        let registry = auth::list(&path);
+        assert_eq!(registry.clients.len(), 1);
+        let client = &registry.clients[0];
+        assert_eq!(client.client_id, "client-1");
+        assert_eq!(client.label, "gui mint");
+        assert_eq!(client.bound_fqn, expected_fqn);
+        assert_eq!(client.bound_root, response.bound_root);
+        assert_eq!(client.scopes, response.scopes);
+        assert_eq!(client.expires_at, None);
+        assert_ne!(client.token_hash, "plain-secret");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2197,6 +2197,7 @@ pub fn run(
             commands::config::start_api_server,
             commands::config::stop_api_server,
             commands::config::api_server_status,
+            commands::config::mint_api_client,
             commands::config::start_web_server,
             commands::config::stop_web_server,
             commands::config::get_web_server_status,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -61,7 +61,9 @@ import type {
   ScreenshotHotkeyStatus,
   WorkgroupGroupsConfig,
   NonStopReport,
-  WebServerOwnedStatus
+  WebServerOwnedStatus,
+  ApiClientMintRequest,
+  ApiClientMintResponse,
 } from "./types";
 
 export interface SessionRepoInput {
@@ -295,6 +297,13 @@ export const SettingsAPI = {
   startApiServer: () => transport.invoke<boolean>("start_api_server"),
   stopApiServer: () => transport.invoke<boolean>("stop_api_server"),
   apiServerStatus: () => transport.invoke<boolean>("api_server_status"),
+  mintApiClient: (request: ApiClientMintRequest) =>
+    transport.invoke<ApiClientMintResponse>("mint_api_client", {
+      root: request.root,
+      scopes: request.scopes,
+      label: request.label ?? null,
+      expires: request.expires ?? null,
+    }),
   getWebServerOwnedStatus: () =>
     transport.invoke<WebServerOwnedStatus>("get_web_server_owned_status"),
   // Narrow setters hold the SettingsState write lock through save_settings on

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -370,6 +370,25 @@ export interface WebServerOwnedStatus {
   state: WebServerOwnershipState;
 }
 
+export type ApiClientMintScope = "send" | "list-peers-lean" | "session-transport";
+
+export interface ApiClientMintRequest {
+  root: string;
+  scopes: ApiClientMintScope[];
+  label?: string | null;
+  expires?: string | null;
+}
+
+export interface ApiClientMintResponse {
+  clientId: string;
+  token: string;
+  boundFqn: string;
+  boundRoot: string;
+  scopes: string[];
+  expiresAt: string | null;
+  note: string;
+}
+
 export interface AppSettings {
   defaultShell: string;
   defaultShellArgs: string[];

--- a/src/sidebar/components/SettingsModal.mint.test.tsx
+++ b/src/sidebar/components/SettingsModal.mint.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import SettingsModal from "./SettingsModal";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  click,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import type { AcAgentReplica, AcWorkgroup } from "../../shared/types";
+
+const PROJECT_PATH = "C:\\Users\\Maria\\Project";
+const WORKGROUP_NAME = "wg-11-dev-v4-team";
+const WORKGROUP_PATH = `${PROJECT_PATH}\\.ac\\${WORKGROUP_NAME}`;
+const REPLICA_PATH = `${WORKGROUP_PATH}\\__agent_dev-webpage-ui`;
+
+function replica(overrides: Partial<AcAgentReplica> = {}): AcAgentReplica {
+  return {
+    name: "dev-webpage-ui",
+    path: REPLICA_PATH,
+    repoPaths: [],
+    isCoordinator: false,
+    ...overrides,
+  };
+}
+
+function workgroup(agents: AcAgentReplica[] = [replica()]): AcWorkgroup {
+  return {
+    name: WORKGROUP_NAME,
+    path: WORKGROUP_PATH,
+    task: null,
+    agents,
+  };
+}
+
+function prepareFake(fake: FakeTransport): void {
+  fake.resolve("get_settings", baseSettings());
+  fake.resolve("get_web_server_status", false);
+  fake.resolve("api_server_status", false);
+  fake.resolve("get_coding_agent_catalog", []);
+  fake.resolve("list_reseedable_agent_commands", []);
+  fake.resolve("new_project", { path: PROJECT_PATH, registered: true, created: true });
+  fake.resolve("discover_project", discovery({ workgroups: [workgroup()] }));
+}
+
+async function loadReplicaRoot(): Promise<void> {
+  await projectStore.createAndLoad(PROJECT_PATH);
+}
+
+function target<T extends Element>(root: ParentNode, testId: string): T {
+  const element = root.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`missing ${testId}`);
+  return element;
+}
+
+describe("SettingsModal API client mint UI (#853)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("sources selectable roots from discovered workgroup replicas and shows the one-time token", async () => {
+    const fake = new FakeTransport();
+    prepareFake(fake);
+    fake.resolve("mint_api_client", {
+      clientId: "client-123",
+      token: "secret-once",
+      boundFqn: `${WORKGROUP_NAME}/dev-webpage-ui`,
+      boundRoot: REPLICA_PATH,
+      scopes: ["send", "list-peers-lean"],
+      expiresAt: "2026-07-08T21:00:00Z",
+      note: "Store this token now.",
+    });
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
+    const rendered = renderWithFakeTransport(() => <SettingsModal onClose={() => {}} />, fake);
+    try {
+      await waitFor(() => expect(target(rendered.root, "settings.apiClientMint.surface")).toBeTruthy());
+      await loadReplicaRoot();
+
+      await waitFor(() => {
+        const rootSelect = target<HTMLSelectElement>(rendered.root, "settings.apiClientMint.root");
+        expect(rootSelect.tagName).toBe("SELECT");
+        expect(rootSelect.value).toBe(REPLICA_PATH);
+        expect(rootSelect.options).toHaveLength(1);
+        expect(rootSelect.options[0].textContent).toContain("dev-webpage-ui");
+      });
+
+      click(target(rendered.root, "settings.apiClientMint.submit"));
+
+      await waitFor(() =>
+        expect(target<HTMLInputElement>(rendered.root, "settings.apiClientMint.token").value).toBe(
+          "secret-once",
+        ),
+      );
+      expect(target(rendered.root, "settings.apiClientMint.clientId").textContent).toContain(
+        "client-123",
+      );
+      expect(target(rendered.root, "settings.apiClientMint.boundFqn").textContent).toContain(
+        `${WORKGROUP_NAME}/dev-webpage-ui`,
+      );
+      expect(target(rendered.root, "settings.apiClientMint.expiresAt").textContent).toContain(
+        "2026-07-08T21:00:00Z",
+      );
+
+      expect(fake.callsFor("mint_api_client")[0]?.args).toEqual({
+        root: REPLICA_PATH,
+        scopes: ["send", "list-peers-lean"],
+        label: null,
+        expires: null,
+      });
+
+      click(target(rendered.root, "settings.apiClientMint.copy"));
+      await waitFor(() => expect(writeText).toHaveBeenCalledWith("secret-once"));
+
+      click(target(rendered.root, "settings.apiClientMint.clear"));
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="settings.apiClientMint.token"]')).toBeNull(),
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("surfaces backend mint errors verbatim", async () => {
+    const fake = new FakeTransport();
+    prepareFake(fake);
+    fake.reject("mint_api_client", `unknown or invalid root: ${REPLICA_PATH}`);
+    const rendered = renderWithFakeTransport(() => <SettingsModal onClose={() => {}} />, fake);
+    try {
+      await waitFor(() => expect(target(rendered.root, "settings.apiClientMint.surface")).toBeTruthy());
+      await loadReplicaRoot();
+      await waitFor(() =>
+        expect(target<HTMLSelectElement>(rendered.root, "settings.apiClientMint.root").value).toBe(
+          REPLICA_PATH,
+        ),
+      );
+
+      click(target(rendered.root, "settings.apiClientMint.submit"));
+
+      await waitFor(() =>
+        expect(target(rendered.root, "settings.apiClientMint.error").textContent).toContain(
+          `unknown or invalid root: ${REPLICA_PATH}`,
+        ),
+      );
+      expect(rendered.root.querySelector('[data-ac-testid="settings.apiClientMint.token"]')).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, createEffect, For, Index, Show, onMount, onCleanup } from "solid-js";
+import { Component, createSignal, createEffect, createMemo, For, Index, Show, onMount, onCleanup } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import { isTauri } from "../../shared/platform";
 import type {
@@ -9,6 +9,8 @@ import type {
   LogLevel,
   TelegramBotConfig,
   ProfileCellConfig,
+  ApiClientMintResponse,
+  ApiClientMintScope,
 } from "../../shared/types";
 import { SettingsAPI, TelegramAPI, ReposAPI, CodingAgentsAPI } from "../../shared/ipc";
 import { toastStore } from "../../shared/stores/toasts";
@@ -16,6 +18,7 @@ import { validateScreenshotHotkeySyntax } from "../../shared/screenshot-hotkey";
 import { settingsStore } from "../../shared/stores/settings";
 import { setSoundsEnabled } from "../../shared/sound";
 import { sessionsStore } from "../stores/sessions";
+import { projectStore } from "../stores/project";
 import { newAgentId, definitionToSeed } from "../../shared/agent-presets";
 import { codingAgentsStore } from "../stores/coding-agents";
 import { mergeSettingsForSavePreservingProjects } from "./settings-save";
@@ -67,6 +70,27 @@ const GEMINI_MODELS = [
   { id: "gemini-1.5-pro", label: "Gemini 1.5 Pro" },
 ];
 
+const API_CLIENT_SCOPE_OPTIONS: { value: ApiClientMintScope; label: string }[] = [
+  { value: "send", label: "send" },
+  { value: "list-peers-lean", label: "list-peers-lean" },
+  { value: "session-transport", label: "session-transport" },
+];
+
+const API_CLIENT_EXPIRY_OPTIONS = [
+  { value: "default", label: "24 hours (default)" },
+  { value: "7d", label: "7 days" },
+  { value: "30d", label: "30 days" },
+] as const;
+
+type ApiClientExpiryOption = (typeof API_CLIENT_EXPIRY_OPTIONS)[number]["value"];
+
+const API_CLIENT_EXPIRY_MS: Record<Exclude<ApiClientExpiryOption, "default">, number> = {
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+const errorMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : String(err);
 
 // #526: the former "agents" + "profiles" tabs are merged into one unified
 // "Coding Agents" screen (agent list + dual comparison rails). The "profiles"
@@ -136,6 +160,19 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     seededSettings?.apiServerEnabled ?? false,
   );
   const [apiServerBusy, setApiServerBusy] = createSignal(false);
+  const [apiClientMintRoot, setApiClientMintRoot] = createSignal("");
+  const [apiClientMintScopes, setApiClientMintScopes] = createSignal<ApiClientMintScope[]>([
+    "send",
+    "list-peers-lean",
+  ]);
+  const [apiClientMintLabel, setApiClientMintLabel] = createSignal("");
+  const [apiClientMintExpiry, setApiClientMintExpiry] =
+    createSignal<ApiClientExpiryOption>("default");
+  const [apiClientMinting, setApiClientMinting] = createSignal(false);
+  const [apiClientMintError, setApiClientMintError] = createSignal("");
+  const [apiClientMintResult, setApiClientMintResult] =
+    createSignal<ApiClientMintResponse | null>(null);
+  const [apiClientSecretCopied, setApiClientSecretCopied] = createSignal(false);
   const [saveError, setSaveError] = createSignal("");
   const [profileCellText, setProfileCellText] = createStore<Record<string, string>>({});
   const [profileCellErrors, setProfileCellErrors] = createStore<Record<string, string>>({});
@@ -203,6 +240,110 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       );
     } finally {
       setApiServerBusy(false);
+    }
+  };
+
+  const apiClientRootOptions = createMemo(() => {
+    const seen = new Set<string>();
+    const options = [];
+    for (const project of projectStore.projects) {
+      for (const workgroup of project.workgroups) {
+        for (const replica of workgroup.agents) {
+          const normalized = replica.path.replace(/\\/g, "/").toLowerCase().replace(/\/+$/, "");
+          if (seen.has(normalized)) continue;
+          seen.add(normalized);
+          options.push({
+            path: replica.path,
+            label: `${project.folderName} / ${workgroup.name} / ${replica.name}${
+              replica.isCoordinator ? " (coordinator)" : ""
+            }`,
+          });
+        }
+      }
+    }
+    return options;
+  });
+
+  createEffect(() => {
+    const options = apiClientRootOptions();
+    const current = apiClientMintRoot();
+    if (options.length === 0) {
+      if (current !== "") setApiClientMintRoot("");
+      return;
+    }
+    if (!options.some((option) => option.path === current)) {
+      setApiClientMintRoot(options[0].path);
+    }
+  });
+
+  const clearApiClientSecret = () => {
+    setApiClientMintResult(null);
+    setApiClientSecretCopied(false);
+  };
+
+  const closeSettings = () => {
+    clearApiClientSecret();
+    props.onClose();
+  };
+
+  const updateApiClientScope = (scope: ApiClientMintScope, checked: boolean) => {
+    setApiClientMintError("");
+    setApiClientMintScopes((prev) => {
+      const raw = checked ? [...prev, scope] : prev.filter((s) => s !== scope);
+      return API_CLIENT_SCOPE_OPTIONS
+        .map((option) => option.value)
+        .filter((value) => raw.includes(value));
+    });
+  };
+
+  const selectedApiClientScopesValid = () => apiClientMintScopes().length > 0;
+
+  const selectedApiClientExpiry = (): string | null => {
+    const option = apiClientMintExpiry();
+    if (option === "default") return null;
+    return new Date(Date.now() + API_CLIENT_EXPIRY_MS[option]).toISOString();
+  };
+
+  const handleMintApiClient = async () => {
+    if (apiClientMinting()) return;
+    const root = apiClientMintRoot();
+    const scopes = apiClientMintScopes();
+    if (!root) {
+      setApiClientMintError("Load a project with at least one workgroup replica before minting.");
+      return;
+    }
+    if (scopes.length === 0) {
+      setApiClientMintError("Select at least one API client scope.");
+      return;
+    }
+
+    setApiClientMinting(true);
+    setApiClientMintError("");
+    clearApiClientSecret();
+    try {
+      const label = apiClientMintLabel().trim();
+      const result = await SettingsAPI.mintApiClient({
+        root,
+        scopes,
+        label: label.length > 0 ? label : null,
+        expires: selectedApiClientExpiry(),
+      });
+      setApiClientMintResult(result);
+    } catch (err: unknown) {
+      setApiClientMintError(errorMessage(err));
+    } finally {
+      setApiClientMinting(false);
+    }
+  };
+
+  const copyApiClientToken = async () => {
+    const token = apiClientMintResult()?.token;
+    if (!token) return;
+    try {
+      await navigator.clipboard.writeText(token);
+      setApiClientSecretCopied(true);
+    } catch (err: unknown) {
+      setApiClientMintError(`Copy failed: ${errorMessage(err)}`);
     }
   };
 
@@ -893,7 +1034,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
         sessionsStore.setRepos(allRepos.filter((r) => r.agents.length > 0));
       } catch {}
       setSaving(false);
-      props.onClose();
+      closeSettings();
     } catch (err: unknown) {
       setSaveError(err instanceof Error ? err.message : String(err));
       setSaving(false);
@@ -901,11 +1042,14 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") props.onClose();
+    if (e.key === "Escape") closeSettings();
   };
 
   document.addEventListener("keydown", handleKeyDown);
-  onCleanup(() => document.removeEventListener("keydown", handleKeyDown));
+  onCleanup(() => {
+    clearApiClientSecret();
+    document.removeEventListener("keydown", handleKeyDown);
+  });
 
   // ── Tab renderers ──
 
@@ -1254,6 +1398,188 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             : apiServerRunning()
               ? `Running on ${settings.data!.apiServerBind}:${settings.data!.apiServerPort}`
               : "Stopped"}
+        </div>
+        <div
+          class="settings-api-client-mint"
+          data-ac-testid="settings.apiClientMint.surface"
+          data-ac-role="region"
+        >
+          <div class="settings-subsection-title">API client credential</div>
+          <label class="settings-field">
+            <span class="settings-label">Replica root</span>
+            <select
+              class="settings-input"
+              value={apiClientMintRoot()}
+              disabled={apiClientRootOptions().length === 0 || apiClientMinting()}
+              onChange={(e) => {
+                setApiClientMintError("");
+                setApiClientMintRoot(e.currentTarget.value);
+              }}
+              data-ac-testid="settings.apiClientMint.root"
+              data-ac-role="combobox"
+              data-ac-state={apiClientRootOptions().length === 0 ? "empty" : "ready"}
+            >
+              <For each={apiClientRootOptions()}>
+                {(option) => (
+                  <option value={option.path}>
+                    {option.label}
+                  </option>
+                )}
+              </For>
+            </select>
+          </label>
+          <Show when={apiClientRootOptions().length === 0}>
+            <div
+              class="settings-hint"
+              data-ac-testid="settings.apiClientMint.noRoots"
+              data-ac-role="status"
+            >
+              Load a project with workgroup replicas before minting an API client.
+            </div>
+          </Show>
+          <div class="settings-field">
+            <span class="settings-label">Scopes</span>
+            <div class="settings-api-client-scopes">
+              <For each={API_CLIENT_SCOPE_OPTIONS}>
+                {(scope) => (
+                  <label class="settings-checkbox-field settings-api-client-scope">
+                    <input
+                      type="checkbox"
+                      class="settings-checkbox"
+                      checked={apiClientMintScopes().includes(scope.value)}
+                      disabled={apiClientMinting()}
+                      onChange={(e) => updateApiClientScope(scope.value, e.currentTarget.checked)}
+                      data-ac-testid={`settings.apiClientMint.scope.${scope.value}`}
+                      data-ac-role="checkbox"
+                      data-ac-state={
+                        apiClientMintScopes().includes(scope.value) ? "checked" : "unchecked"
+                      }
+                    />
+                    <span>{scope.label}</span>
+                  </label>
+                )}
+              </For>
+            </div>
+          </div>
+          <label class="settings-field">
+            <span class="settings-label">Label</span>
+            <input
+              class="settings-input"
+              value={apiClientMintLabel()}
+              disabled={apiClientMinting()}
+              onInput={(e) => {
+                setApiClientMintError("");
+                setApiClientMintLabel(e.currentTarget.value);
+              }}
+              placeholder="optional audit label"
+              data-ac-testid="settings.apiClientMint.label"
+              data-ac-role="textbox"
+            />
+          </label>
+          <label class="settings-field">
+            <span class="settings-label">Expiry</span>
+            <select
+              class="settings-input"
+              value={apiClientMintExpiry()}
+              disabled={apiClientMinting()}
+              onChange={(e) => {
+                setApiClientMintError("");
+                setApiClientMintExpiry(e.currentTarget.value as ApiClientExpiryOption);
+              }}
+              data-ac-testid="settings.apiClientMint.expiry"
+              data-ac-role="combobox"
+            >
+              <For each={API_CLIENT_EXPIRY_OPTIONS}>
+                {(option) => <option value={option.value}>{option.label}</option>}
+              </For>
+            </select>
+          </label>
+          <button
+            class="settings-add-btn settings-api-client-mint-btn"
+            onClick={() => void handleMintApiClient()}
+            disabled={
+              apiClientMinting() ||
+              apiClientRootOptions().length === 0 ||
+              !selectedApiClientScopesValid()
+            }
+            data-ac-testid="settings.apiClientMint.submit"
+            data-ac-role="button"
+            data-ac-state={apiClientMinting() ? "minting" : "ready"}
+          >
+            {apiClientMinting() ? "Minting..." : "Mint credential"}
+          </button>
+          <Show when={apiClientMintError()}>
+            <div
+              class="settings-api-client-error"
+              role="alert"
+              data-ac-testid="settings.apiClientMint.error"
+              data-ac-role="alert"
+            >
+              {apiClientMintError()}
+            </div>
+          </Show>
+          <Show when={apiClientMintResult()}>
+            {(result) => (
+              <div
+                class="settings-api-client-secret"
+                data-ac-testid="settings.apiClientMint.result"
+                data-ac-role="surface"
+              >
+                <div
+                  class="settings-api-client-warning"
+                  data-ac-testid="settings.apiClientMint.warning"
+                  data-ac-role="status"
+                >
+                  Shown once. Store this token now; it cannot be recovered later.
+                </div>
+                <label class="settings-field">
+                  <span class="settings-label">Token</span>
+                  <div class="settings-api-client-token-row">
+                    <input
+                      class="settings-input settings-api-client-token"
+                      readOnly
+                      value={result().token}
+                      data-ac-testid="settings.apiClientMint.token"
+                      data-ac-role="textbox"
+                    />
+                    <button
+                      class="settings-add-btn"
+                      onClick={() => void copyApiClientToken()}
+                      data-ac-testid="settings.apiClientMint.copy"
+                      data-ac-role="button"
+                      data-ac-state={apiClientSecretCopied() ? "copied" : "ready"}
+                    >
+                      {apiClientSecretCopied() ? "Copied" : "Copy"}
+                    </button>
+                  </div>
+                </label>
+                <dl class="settings-api-client-result-grid">
+                  <div>
+                    <dt>Client ID</dt>
+                    <dd data-ac-testid="settings.apiClientMint.clientId">{result().clientId}</dd>
+                  </div>
+                  <div>
+                    <dt>Bound FQN</dt>
+                    <dd data-ac-testid="settings.apiClientMint.boundFqn">{result().boundFqn}</dd>
+                  </div>
+                  <div>
+                    <dt>Expires</dt>
+                    <dd data-ac-testid="settings.apiClientMint.expiresAt">
+                      {result().expiresAt ?? "No expiry"}
+                    </dd>
+                  </div>
+                </dl>
+                <button
+                  class="settings-add-btn"
+                  onClick={clearApiClientSecret}
+                  data-ac-testid="settings.apiClientMint.clear"
+                  data-ac-role="button"
+                >
+                  Clear secret
+                </button>
+              </div>
+            )}
+          </Show>
         </div>
       </div>
 
@@ -2522,7 +2848,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           </Show>
           <button
             class="modal-btn modal-btn-cancel"
-            onClick={props.onClose}
+            onClick={closeSettings}
             data-ac-testid="settings.cancel"
             data-ac-role="button"
           >

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -1458,6 +1458,106 @@ html.light-theme .root-agent-avatar {
   color: var(--sidebar-accent);
 }
 
+.settings-add-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.settings-add-btn:disabled:hover {
+  border-color: var(--sidebar-border);
+  color: var(--sidebar-fg-dim);
+}
+
+.settings-api-client-mint {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background: var(--sidebar-hover);
+  border-radius: var(--radius-sm);
+}
+
+.settings-api-client-scopes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs) var(--spacing-sm);
+}
+
+.settings-api-client-scope {
+  padding: 0;
+}
+
+.settings-api-client-mint-btn {
+  align-self: flex-start;
+}
+
+.settings-api-client-error {
+  color: #f87171;
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.settings-api-client-secret {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-sm);
+}
+
+.settings-api-client-warning {
+  color: #fbbf24;
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.settings-api-client-token-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--spacing-xs);
+  align-items: center;
+}
+
+.settings-api-client-token {
+  font-family: var(--font-mono);
+  min-width: 0;
+}
+
+.settings-api-client-result-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--spacing-xs);
+  margin: 0;
+}
+
+.settings-api-client-result-grid div {
+  min-width: 0;
+}
+
+.settings-api-client-result-grid dt {
+  color: var(--sidebar-fg-dim);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.settings-api-client-result-grid dd {
+  margin: 1px 0 0 0;
+  color: var(--sidebar-fg);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+
+html.light-theme .settings-api-client-error {
+  color: #b91c1c;
+}
+
+html.light-theme .settings-api-client-warning {
+  color: #b45309;
+}
+
 .settings-agent-actions {
   display: flex;
   gap: var(--spacing-xs);


### PR DESCRIPTION
## Summary
Adds in-app API-client minting: a new `mint_api_client` Tauri command plus a Settings mint UI, so a user can create a scoped API-client credential from the GUI instead of the CLI. Part of #793 (increment-2b); follows #846 (the API-server toggle).

## What changed
**Backend** (`src-tauri/src/commands/config.rs`, `lib.rs`):
- New `mint_api_client(root, scopes, label, expires)` Tauri command wrapping `auth::mint`, registered in the invoke_handler.
- Binds to a caller-supplied replica root, validated to be a real `__agent_*` WG replica (rejects unknown / typo / traversal / origin-matrix / cross-identity); Root Agent rejected.
- Scopes validated against the increment-1 allowlist (`send`, `list-peers-lean`, `session-transport`); at least one required.
- Expiry bounded: omitted defaults to 24h (mirrors `CONTAINER_TOKEN_TTL_HOURS`), max 30d; over-max / malformed / `<= issuedAt` rejected.
- One-time secret returned exactly once; only the hash is persisted; never logged or in telemetry.

**Frontend** (`SettingsModal.tsx`, `types.ts`, `ipc.ts`, `sidebar.css`, `SettingsModal.mint.test.tsx`):
- Mint surface in Settings near the #846 toggle: root picker sourced from discovered WG replicas (no free-text), scope multi-select, optional label, bounded expiry control.
- Shows the returned token once with a copy button and a "shown once, store it now" warning; token held only in component state and cleared on every close path; sends `expires: null` for the default case.

## Review
- **Backend:** grinch security PASS twice (core + hardening): one-time hash-only secret with no leak/panic path, airtight Root-Agent exclusion, complete scope validation, sound root validation (traversal / symlink / cross-identity all rejected), sound expiry clamp.
- **FE:** grinch PASS: traced one-time-secret hygiene across all clear paths, the `expires: null` contract, and the root-path shape against the backend validator.
- Currency-merged latest `main` (clean auto-merge, 2 additive-overlap files); diff vs `main` is exactly the slice.

## Gates
- Backend: `cargo test --all-targets`, `cargo clippy --all-targets -- -D warnings`, `npm run version:check`, `npm run smoke:cli-release-windows` all pass.
- FE: `npm run typecheck` pass, `npm test -- --run` 794 tests pass, `npm run build` pass.

## Follow-ups (non-blocking)
- #857: FE polish (post-close in-flight-mint guard, `expires` empty-string coercion, close-path / explicit-expiry test coverage).

Closes #853
