### PR TITLE
fix: highlight only the active project's group in the groups sidebar (#860)

### DIFF
--- a/src/sidebar/components/WorkgroupGroupRail.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AcWorkgroup, Session, WorkgroupGroupsConfig } from "../../shared/types";
 import { FakeTransport } from "../../shared/testing/fake-transport";
@@ -94,6 +95,14 @@ function scopedTarget<T extends Element>(root: ParentNode, testId: string): T {
   const element = root.querySelector<T>(`[data-ac-testid="${testId}"]`);
   if (!element) throw new Error(`Missing scoped element ${testId}`);
   return element;
+}
+
+function projectRail(projectFolder: string): HTMLElement {
+  return target(`workgroupGroups.rail.${projectFolder}`);
+}
+
+function railButton(projectFolder: string, buttonKey: string): HTMLElement {
+  return scopedTarget(projectRail(projectFolder), `workgroupGroups.button.${buttonKey}`);
 }
 
 function pointer(
@@ -234,6 +243,111 @@ describe("WorkgroupGroupRail", () => {
         expect(calls[0].args.path).toBe(projectPath);
         expect(calls[0].args.path).not.toBe("C:\\OtherProject");
       });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("highlights only the active project's selected group across project rails", async () => {
+    const fake = new FakeTransport();
+    fake.onInvoke("get_project_groups", (args) =>
+      args.path === projectPath
+        ? groupsConfig()
+        : groupsConfig({ groups: [{ id: "other", name: "Other", regex: exactGroupRegexForWorkgroup("wg-9-other-team") }] })
+    );
+
+    const rendered = renderWithFakeTransport(
+      () => <WorkgroupGroupRail projects={[project(), otherProject()]} />,
+      fake
+    );
+    try {
+      await waitFor(() => {
+        expect(railButton("Project", "ui")).not.toBeNull();
+        expect(railButton("OtherProject", "other")).not.toBeNull();
+      });
+
+      const selectedButtons = () =>
+        Array.from(document.querySelectorAll<HTMLElement>(".workgroup-group-rail-button.selected"));
+      const projectAll = railButton("Project", "all");
+      const otherAll = railButton("OtherProject", "all");
+
+      await waitFor(() => {
+        expect(projectAll.classList.contains("selected")).toBe(true);
+        expect(otherAll.classList.contains("selected")).toBe(false);
+        expect(selectedButtons()).toHaveLength(1);
+      });
+
+      click(otherAll);
+
+      await waitFor(() => {
+        expect(projectAll.classList.contains("selected")).toBe(false);
+        expect(otherAll.classList.contains("selected")).toBe(true);
+        expect(selectedButtons()).toHaveLength(1);
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("remembers each project's selected group and shows it when the project becomes active again", async () => {
+    const fake = new FakeTransport();
+    fake.onInvoke("get_project_groups", (args) =>
+      args.path === projectPath
+        ? groupsConfig()
+        : groupsConfig({ groups: [{ id: "other", name: "Other", regex: exactGroupRegexForWorkgroup("wg-9-other-team") }] })
+    );
+
+    const rendered = renderWithFakeTransport(
+      () => <WorkgroupGroupRail projects={[project(), otherProject()]} />,
+      fake
+    );
+    try {
+      await waitFor(() => {
+        expect(railButton("Project", "ui")).not.toBeNull();
+        expect(railButton("OtherProject", "other")).not.toBeNull();
+      });
+      const projectUi = railButton("Project", "ui");
+      const otherGroup = railButton("OtherProject", "other");
+
+      click(projectUi);
+      await waitFor(() => expect(projectUi.classList.contains("selected")).toBe(true));
+
+      click(otherGroup);
+      await waitFor(() => {
+        expect(projectUi.classList.contains("selected")).toBe(false);
+        expect(otherGroup.classList.contains("selected")).toBe(true);
+      });
+
+      workgroupGroupsStore.setActiveProject(projectPath);
+      await waitFor(() => {
+        expect(projectUi.classList.contains("selected")).toBe(true);
+        expect(otherGroup.classList.contains("selected")).toBe(false);
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("reconciles the active project when the active project is removed", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", groupsConfig());
+    const [projects, setProjects] = createSignal<ProjectState[]>([project(), otherProject()]);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={projects()} />, fake);
+    try {
+      await waitFor(() => expect(railButton("OtherProject", "all")).not.toBeNull());
+
+      click(railButton("OtherProject", "all"));
+      await waitFor(() => expect(workgroupGroupsStore.isActiveProject("C:\\OtherProject")).toBe(true));
+
+      setProjects([project()]);
+      await waitFor(() => {
+        expect(workgroupGroupsStore.isActiveProject(projectPath)).toBe(true);
+        expect(railButton("Project", "all").classList.contains("selected")).toBe(true);
+      });
+
+      setProjects([]);
+      await waitFor(() => expect(workgroupGroupsStore.activeProjectPath()).toBe(null));
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -192,6 +192,7 @@ const ProjectRailSection: Component<{
     return result;
   });
   const selected = (button: GroupButton) => {
+    if (!workgroupGroupsStore.isActiveProject(props.project.path)) return false;
     const current = selection();
     if (current.kind !== button.selection.kind) return false;
     return current.kind !== "group" || button.selection.kind !== "group" || current.id === button.selection.id;
@@ -597,6 +598,10 @@ const ProjectRailSection: Component<{
 };
 
 const WorkgroupGroupRail: Component<WorkgroupGroupRailProps> = (props) => {
+  createEffect(() => {
+    workgroupGroupsStore.reconcileActiveProject(props.projects.map((project) => project.path));
+  });
+
   return (
     <aside class="workgroup-group-rail" data-ac-testid="workgroupGroups.rail">
       <For each={props.projects}>

--- a/src/sidebar/stores/workgroup-groups.ts
+++ b/src/sidebar/stores/workgroup-groups.ts
@@ -1,3 +1,4 @@
+import { createSignal } from "solid-js";
 import { createStore } from "solid-js/store";
 import type { AcWorkgroup, NonStopGroupConfig, WorkgroupGroup, WorkgroupGroupsConfig } from "../../shared/types";
 import { ProjectAPI } from "../../shared/ipc";
@@ -37,6 +38,7 @@ interface ProjectGroupsEntry {
 }
 
 const [entries, setEntries] = createStore<Record<string, ProjectGroupsEntry | undefined>>({});
+const [activeProjectKey, setActiveProjectKey] = createSignal<string | null>(null);
 const inFlightLoads = new Map<string, Promise<void>>();
 const saveVersions = new Map<string, number>();
 
@@ -459,9 +461,34 @@ export const workgroupGroupsStore = {
     return entryFor(projectPath).selection;
   },
 
+  activeProjectPath(): string | null {
+    return activeProjectKey();
+  },
+
+  isActiveProject(projectPath: string): boolean {
+    return activeProjectKey() === keyFor(projectPath);
+  },
+
+  setActiveProject(projectPath: string | null): void {
+    setActiveProjectKey(projectPath === null ? null : keyFor(projectPath));
+  },
+
+  reconcileActiveProject(projectPaths: string[]): void {
+    const projectKeys = projectPaths.map(keyFor);
+    if (projectKeys.length === 0) {
+      setActiveProjectKey(null);
+      return;
+    }
+
+    const current = activeProjectKey();
+    if (current !== null && projectKeys.includes(current)) return;
+    setActiveProjectKey(projectKeys[0]);
+  },
+
   select(projectPath: string, selection: WorkgroupGroupSelection): void {
     const key = keyFor(projectPath);
     const current = ensureEntry(projectPath);
+    setActiveProjectKey(key);
     setEntries(key, {
       ...current,
       selection: normalizeSelection(selection, current.config),
@@ -669,6 +696,7 @@ export const workgroupGroupsStore = {
     for (const key of Object.keys(entries)) {
       setEntries(key, undefined);
     }
+    setActiveProjectKey(null);
     inFlightLoads.clear();
     saveVersions.clear();
   },


### PR DESCRIPTION
## What

Fixes the groups sidebar highlighting one group **per open project**. With multiple projects open, the rail rendered one `.selected` group per project (each project's selection defaults to `all`), leaving a stale highlight on the non-visible project. Now only the active project's group is highlighted.

## Approach (approved by product)

UI-only `activeProjectPath` state. The visible `selected` / `aria-pressed` becomes **"project is active AND its selection matches the button"**. `select()` marks the project active (covers click + keyboard through one path). Active project is reconciled against the open projects (default to first; on close → first remaining or `null`). Per-project selection is preserved (memory). `ProjectPanel` filtering semantics are unchanged.

## Files

- `src/sidebar/stores/workgroup-groups.ts` (+28): `activeProjectKey` + accessors + `reconcileActiveProject`; `select()` sets active; `resetForTests()` clears it.
- `src/sidebar/components/WorkgroupGroupRail.tsx` (+5): highlight gated on active project + reconcile effect.
- `src/sidebar/components/WorkgroupGroupRail.test.tsx` (+114): cross-project single-highlight, per-project memory, close/reconcile.

## Verification

- **dev-webpage-ui:** 52/52 tests (WorkgroupGroupRail + workgroup-groups store + ProjectPanel groups-filter) + `tsc --noEmit` clean.
- **dev-rust-grinch: PASS** — verified the single-highlight invariant (exactly 1, never 0/2), reconciliation wiring (live, no loops / stale reads / writes-during-render), no programmatic focus-steal in `select()`, keyboard coverage, unchanged `ProjectPanel` filtering, consistent path normalization on write+compare, coherent `aria-pressed`, and genuine tests (ran 52/52 + `tsc` himself).
- **Step 9.5:** updated onto latest `origin/main` via clean merge (`318e5de`, no conflicts — disjoint files); reviewed code is byte-identical post-merge.

Visual change → a shipper visual pass on the wg-14 build follows this merge.

Closes #860
