### PR TITLE
fix: route web coding-agent profile commands refs #859

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -402,17 +402,27 @@ pub async fn set_agent_default_profile(
     agent_path: String,
     profile: String,
 ) -> Result<(), String> {
+    let payload = set_agent_default_profile_inner(settings.inner(), &agent_path, &profile).await?;
+    let _ = app.emit("coding_agent_profile_selection_updated", payload);
+    Ok(())
+}
+
+/// Persist an origin agent's default profile and return the
+/// `coding_agent_profile_selection_updated` event payload for the caller to
+/// emit (desktop) or broadcast to web clients (browser transport). Shared by
+/// the desktop command and the web dispatcher.
+pub(crate) async fn set_agent_default_profile_inner(
+    settings: &SettingsState,
+    agent_path: &str,
+    profile: &str,
+) -> Result<serde_json::Value, String> {
     let snapshot = settings.read().await.clone();
     crate::config::coding_agent_profiles::set_agent_default_profile(
         &snapshot,
-        std::path::Path::new(&agent_path),
-        &profile,
+        std::path::Path::new(agent_path),
+        profile,
     )?;
-    let _ = app.emit(
-        "coding_agent_profile_selection_updated",
-        serde_json::json!({ "agentPath": agent_path, "profile": profile, "scope": "default" }),
-    );
-    Ok(())
+    Ok(serde_json::json!({ "agentPath": agent_path, "profile": profile, "scope": "default" }))
 }
 
 #[tauri::command]
@@ -422,17 +432,29 @@ pub async fn set_instance_profile_override(
     agent_path: String,
     profile: Option<String>,
 ) -> Result<(), String> {
+    let payload =
+        set_instance_profile_override_inner(settings.inner(), &agent_path, profile.as_deref())
+            .await?;
+    let _ = app.emit("coding_agent_profile_selection_updated", payload);
+    Ok(())
+}
+
+/// Persist a replica's instance-level profile override (or clear it when
+/// `profile` is `None`) and return the `coding_agent_profile_selection_updated`
+/// event payload for the caller to emit or broadcast. Shared by the desktop
+/// command and the web dispatcher.
+pub(crate) async fn set_instance_profile_override_inner(
+    settings: &SettingsState,
+    agent_path: &str,
+    profile: Option<&str>,
+) -> Result<serde_json::Value, String> {
     let snapshot = settings.read().await.clone();
     crate::config::coding_agent_profiles::set_instance_profile_override(
         &snapshot,
-        std::path::Path::new(&agent_path),
-        profile.as_deref(),
+        std::path::Path::new(agent_path),
+        profile,
     )?;
-    let _ = app.emit(
-        "coding_agent_profile_selection_updated",
-        serde_json::json!({ "agentPath": agent_path, "profile": profile, "scope": "instance" }),
-    );
-    Ok(())
+    Ok(serde_json::json!({ "agentPath": agent_path, "profile": profile, "scope": "instance" }))
 }
 
 #[tauri::command]
@@ -442,17 +464,33 @@ pub async fn resolve_coding_agent_profile(
     agent_id: String,
     requested_profile: Option<String>,
 ) -> Result<CodingAgentProfileResolutionResult, String> {
+    resolve_coding_agent_profile_inner(
+        settings.inner(),
+        agent_path.as_deref(),
+        &agent_id,
+        requested_profile.as_deref(),
+    )
+    .await
+}
+
+/// Resolve the effective coding-agent profile for an agent/replica. Shared by
+/// the desktop command and the web dispatcher; reads settings only.
+pub(crate) async fn resolve_coding_agent_profile_inner(
+    settings: &SettingsState,
+    agent_path: Option<&str>,
+    agent_id: &str,
+    requested_profile: Option<&str>,
+) -> Result<CodingAgentProfileResolutionResult, String> {
     let snapshot = settings.read().await.clone();
     let agent_path = agent_path
-        .as_deref()
         .map(str::trim)
         .filter(|path| !path.is_empty())
         .map(std::path::PathBuf::from);
     let details = crate::config::coding_agent_profiles::resolve_profile_selection(
         &snapshot,
         agent_path.as_deref(),
-        &agent_id,
-        requested_profile.as_deref(),
+        agent_id,
+        requested_profile,
     )?;
 
     Ok(CodingAgentProfileResolutionResult {
@@ -552,6 +590,18 @@ pub async fn preview_coding_agent_profile_selection(
     settings: State<'_, SettingsState>,
     request: PreviewCodingAgentProfileSelectionRequest,
 ) -> Result<PreviewCodingAgentProfileSelectionResult, String> {
+    preview_coding_agent_profile_selection_inner(session_mgr.inner(), settings.inner(), request)
+        .await
+}
+
+/// Enumerate the replicas a broad-scope profile assignment would touch and
+/// return a fingerprint the frontend echoes back on apply. Shared by the
+/// desktop command and the web dispatcher; reads settings + sessions only.
+pub(crate) async fn preview_coding_agent_profile_selection_inner(
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+    settings: &SettingsState,
+    request: PreviewCodingAgentProfileSelectionRequest,
+) -> Result<PreviewCodingAgentProfileSelectionResult, String> {
     let settings_snapshot = settings.read().await.clone();
     validate_profile_assignment_request(
         &settings_snapshot,
@@ -599,6 +649,30 @@ pub async fn apply_coding_agent_profile_selection(
     settings: State<'_, SettingsState>,
     request: ApplyCodingAgentProfileSelectionRequest,
 ) -> Result<ApplyCodingAgentProfileSelectionResult, String> {
+    let (result, payload) = apply_coding_agent_profile_selection_inner(
+        &app,
+        session_mgr.inner(),
+        pty_mgr.inner(),
+        settings.inner(),
+        request,
+    )
+    .await?;
+    let _ = app.emit("coding_agent_profile_selection_updated", payload);
+    Ok(result)
+}
+
+/// Apply a coding-agent profile assignment across the enumerated replicas
+/// (optionally restarting live sessions) and return both the result and the
+/// `coding_agent_profile_selection_updated` event payload. The caller emits the
+/// payload (desktop) or broadcasts it to web clients. Shared by the desktop
+/// command and the web dispatcher.
+pub(crate) async fn apply_coding_agent_profile_selection_inner(
+    app: &AppHandle,
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+    pty_mgr: &Arc<std::sync::Mutex<PtyManager>>,
+    settings: &SettingsState,
+    request: ApplyCodingAgentProfileSelectionRequest,
+) -> Result<(ApplyCodingAgentProfileSelectionResult, serde_json::Value), String> {
     let apply_lock = broad_profile_apply_lock().lock().await;
     let settings_snapshot = settings.read().await.clone();
     validate_profile_assignment_request(
@@ -669,10 +743,10 @@ pub async fn apply_coding_agent_profile_selection(
                     continue;
                 };
                 match crate::commands::session::restart_session_inner_with_activation(
-                    &app,
-                    session_mgr.inner(),
-                    pty_mgr.inner(),
-                    settings.inner(),
+                    app,
+                    session_mgr,
+                    pty_mgr,
+                    settings,
                     uuid,
                     Some(request.coding_agent_id.clone()),
                     Some(normalized_profile.clone()),
@@ -684,7 +758,7 @@ pub async fn apply_coding_agent_profile_selection(
                     Ok(_) => restarted_session_ids.push(session_id.clone()),
                     Err(e) => {
                         let (code, destroyed_but_not_recreated) =
-                            classify_restart_failure(session_mgr.inner(), uuid).await;
+                            classify_restart_failure(session_mgr, uuid).await;
                         errors.push(ProfileAssignmentError {
                             code: code.to_string(),
                             message: e,
@@ -711,19 +785,16 @@ pub async fn apply_coding_agent_profile_selection(
         warnings: enumeration.warnings,
         errors,
     };
-    let _ = app.emit(
-        "coding_agent_profile_selection_updated",
-        serde_json::json!({
-            "scope": request.scope,
-            "codingAgentId": request.coding_agent_id,
-            "profile": normalized_profile,
-            "updatedCount": result.updated_count,
-            "restartedCount": result.restarted_count,
-            "targetFingerprint": &result.target_fingerprint,
-            "errors": &result.errors,
-        }),
-    );
-    Ok(result)
+    let payload = serde_json::json!({
+        "scope": request.scope,
+        "codingAgentId": request.coding_agent_id,
+        "profile": normalized_profile,
+        "updatedCount": result.updated_count,
+        "restartedCount": result.restarted_count,
+        "targetFingerprint": &result.target_fingerprint,
+        "errors": &result.errors,
+    });
+    Ok((result, payload))
 }
 
 struct ProfileTargetEnumeration {

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -371,6 +371,98 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
             Ok(json!(null))
         }
 
+        // --- Coding-agent profiles (#859 web transport parity) ---
+        // Desktop registers these in the Tauri invoke_handler, but the browser
+        // websocket router did not route them, so the CODING AGENT modal hit the
+        // `Unknown command` fallback (e.g. when a closed coordinator falls
+        // through to the launch/profile path). The apply/set commands emit
+        // `coding_agent_profile_selection_updated`; we `broadcast_all` it so web
+        // clients also receive it, mirroring the `save_settings_draft` broadcast
+        // of `coding_agent_profiles_updated`.
+        "resolve_coding_agent_profile" => {
+            let agent_path = args.get("agentPath").and_then(|v| v.as_str());
+            let agent_id = require_str(args, "agentId")?;
+            let requested_profile = args.get("requestedProfile").and_then(|v| v.as_str());
+            let result = crate::commands::config::resolve_coding_agent_profile_inner(
+                &state.settings,
+                agent_path,
+                &agent_id,
+                requested_profile,
+            )
+            .await?;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+
+        "set_agent_default_profile" => {
+            let agent_path = require_str(args, "agentPath")?;
+            let profile = require_str(args, "profile")?;
+            let payload = crate::commands::config::set_agent_default_profile_inner(
+                &state.settings,
+                &agent_path,
+                &profile,
+            )
+            .await?;
+            broadcast_all(
+                &state.app_handle,
+                &state.broadcaster,
+                "coding_agent_profile_selection_updated",
+                &payload,
+            );
+            Ok(json!(null))
+        }
+
+        "set_instance_profile_override" => {
+            let agent_path = require_str(args, "agentPath")?;
+            // `profile` is `string | null`; a null clears the override.
+            let profile = args.get("profile").and_then(|v| v.as_str());
+            let payload = crate::commands::config::set_instance_profile_override_inner(
+                &state.settings,
+                &agent_path,
+                profile,
+            )
+            .await?;
+            broadcast_all(
+                &state.app_handle,
+                &state.broadcaster,
+                "coding_agent_profile_selection_updated",
+                &payload,
+            );
+            Ok(json!(null))
+        }
+
+        "preview_coding_agent_profile_selection" => {
+            let request: crate::commands::config::PreviewCodingAgentProfileSelectionRequest =
+                require_json(args, "request")?;
+            let result = crate::commands::config::preview_coding_agent_profile_selection_inner(
+                &state.session_mgr,
+                &state.settings,
+                request,
+            )
+            .await?;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+
+        "apply_coding_agent_profile_selection" => {
+            let request: crate::commands::config::ApplyCodingAgentProfileSelectionRequest =
+                require_json(args, "request")?;
+            let (result, payload) =
+                crate::commands::config::apply_coding_agent_profile_selection_inner(
+                    &state.app_handle,
+                    &state.session_mgr,
+                    &state.pty_mgr,
+                    &state.settings,
+                    request,
+                )
+                .await?;
+            broadcast_all(
+                &state.app_handle,
+                &state.broadcaster,
+                "coding_agent_profile_selection_updated",
+                &payload,
+            );
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+
         // --- Role templates ---
         "list_role_templates" => {
             let snapshot = state.settings.read().await.clone();
@@ -784,5 +876,172 @@ mod tests {
             event["payload"]["config"],
             serde_json::to_value(&config).expect("serialize config")
         );
+    }
+
+    /// Build a minimal `WsState` backed by `settings`, plus a broadcast receiver
+    /// for asserting web events emitted during dispatch.
+    fn ws_state_for(
+        settings: AppSettings,
+    ) -> (WsState, tokio::sync::mpsc::Receiver<WsOutMsg>) {
+        let app = tauri::Builder::default()
+            .any_thread()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build test app");
+        let app_handle = app.handle().clone();
+        let broadcaster = WsBroadcaster::new();
+        let receiver = broadcaster.subscribe();
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let idle_detector = IdleDetector::new(|_| {}, |_| {});
+        let git_watcher = GitWatcher::new(Arc::clone(&session_mgr), app_handle.clone());
+        let pty_mgr = Arc::new(Mutex::new(PtyManager::new(
+            Arc::new(Mutex::new(HashMap::new())),
+            idle_detector,
+            git_watcher,
+            Some(broadcaster.clone()),
+            Arc::clone(&session_mgr),
+        )));
+        let settings = Arc::new(tokio::sync::RwLock::new(settings));
+        let state = WsState {
+            session_mgr,
+            pty_mgr,
+            settings,
+            broadcaster,
+            app_handle,
+        };
+        (state, receiver)
+    }
+
+    fn test_agent(id: &str) -> crate::config::settings::AgentConfig {
+        crate::config::settings::AgentConfig {
+            id: id.to_string(),
+            label: id.to_string(),
+            command: id.to_string(),
+            color: "#10b981".to_string(),
+            envs: Vec::new(),
+            isolated_home: false,
+            instructions_filename: None,
+            config_seed: None,
+            backend: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn coding_agent_profile_commands_route_past_unknown_command() {
+        // #859 regression: before web-router parity these five commands hit the
+        // `Unknown command` fallback. Empty args make each inner fail arg
+        // validation instead, which proves the route now exists.
+        let (state, _rx) = ws_state_for(AppSettings::default());
+        for cmd in [
+            "resolve_coding_agent_profile",
+            "preview_coding_agent_profile_selection",
+            "apply_coding_agent_profile_selection",
+            "set_agent_default_profile",
+            "set_instance_profile_override",
+        ] {
+            let response = dispatch(&state, 1, cmd, &json!({})).await;
+            let error = response
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            assert!(
+                !error.contains("Unknown command"),
+                "{cmd} should be routed, got error: {error:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_coding_agent_profile_web_dispatch_returns_resolution() {
+        let settings = AppSettings {
+            agents: vec![test_agent("codex")],
+            ..AppSettings::default()
+        };
+        let (state, _rx) = ws_state_for(settings);
+
+        let response = dispatch(
+            &state,
+            2,
+            "resolve_coding_agent_profile",
+            &json!({ "agentId": "codex", "requestedProfile": "A" }),
+        )
+        .await;
+
+        assert_eq!(response["id"], json!(2));
+        assert!(
+            response.get("error").is_none(),
+            "resolve should succeed, got {response:?}"
+        );
+        assert!(
+            response["result"]["effectiveProfile"].is_string(),
+            "expected a resolved profile, got {response:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_coding_agent_profile_selection_web_dispatch_broadcasts() {
+        // Real WG replica layout so enumeration + config write succeed under the
+        // replica scope (no confirmation fingerprint required).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        let workspace = project.join(".ac");
+        let matrix = workspace.join("_agent_codex");
+        let replica = workspace.join("wg-1-team").join("__agent_codex");
+        std::fs::create_dir_all(&matrix).expect("create matrix");
+        std::fs::create_dir_all(&replica).expect("create replica");
+        std::fs::write(matrix.join("Role.md"), "# Codex\n").expect("write Role.md");
+        std::fs::write(
+            replica.join("config.json"),
+            serde_json::to_string(&json!({ "identity": "../../_agent_codex" }))
+                .expect("serialize replica config"),
+        )
+        .expect("write replica config");
+
+        let settings = AppSettings {
+            agents: vec![test_agent("codex")],
+            project_paths: vec![project.to_string_lossy().to_string()],
+            ..AppSettings::default()
+        };
+        let (state, mut rx) = ws_state_for(settings);
+
+        let request = json!({
+            "targetReplicaPath": replica.to_string_lossy(),
+            "codingAgentId": "codex",
+            "profile": "B",
+            "scope": "replica",
+            "restartSessions": false,
+            "confirmedTargetFingerprint": null,
+            "typedConfirmation": null,
+        });
+
+        let response = dispatch(
+            &state,
+            3,
+            "apply_coding_agent_profile_selection",
+            &json!({ "request": request }),
+        )
+        .await;
+
+        assert_eq!(response["id"], json!(3));
+        assert!(
+            response.get("error").is_none(),
+            "apply should succeed, got {response:?}"
+        );
+        assert_eq!(response["result"]["updatedCount"], json!(1));
+        assert_eq!(response["result"]["scope"], json!("replica"));
+
+        // The web dispatcher must broadcast the selection-updated event so
+        // browser clients refresh, mirroring the save_settings_draft pattern.
+        let event = match rx.try_recv().expect("broadcast event") {
+            WsOutMsg::Text(text) => serde_json::from_str::<Value>(&text).expect("parse event"),
+            other => panic!("expected text event, got {other:?}"),
+        };
+        assert_eq!(
+            event["event"],
+            json!("coding_agent_profile_selection_updated")
+        );
+        assert_eq!(event["payload"]["scope"], json!("replica"));
+        assert_eq!(event["payload"]["codingAgentId"], json!("codex"));
+        assert_eq!(event["payload"]["profile"], json!("B"));
+        assert_eq!(event["payload"]["updatedCount"], json!(1));
     }
 }


### PR DESCRIPTION
## Summary
- Add web transport dispatch for coding-agent profile commands used by the Coding Agent modal.
- Extract shared Rust inner helpers so desktop Tauri commands and web WS commands use the same profile logic.
- Broadcast `coding_agent_profile_selection_updated` from web apply/default/override paths.

## Review and verification
- dev-rust implemented and pushed the branch.
- dev-rust-grinch reviewed the implementation and the origin/main resync: PASS.
- `cargo test --lib web::commands::tests` passed.
- `cargo test --lib commands::config::tests` passed.
- `cargo clippy --lib --tests` passed.

## Delivery notes
- Non-visual backend Rust change; no shipper/exe build needed.

Closes #859