### PR TITLE
fix(sidebar): refresh agent list on partial-delete failure (#856)

### DIFF
--- a/src/sidebar/components/ProjectPanel.context-menu.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu.test.tsx
@@ -15,6 +15,7 @@ import {
 import { projectStore } from "../stores/project";
 import { sessionsStore } from "../stores/sessions";
 import type { AcDiscoveryResult, Session } from "../../shared/types";
+import { toastStore } from "../../shared/stores/toasts";
 import { automationIdPart } from "./replica-repo-badges";
 
 // Issue #545: gray (never launched) and red (exited) replicas could not open a
@@ -702,6 +703,87 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
       agentPath: originAgentPath,
     });
     await waitFor(() => expect(fake.callsFor("discover_project").length).toBeGreaterThan(initialDiscoveryCalls));
+  });
+
+  it("refreshes and shows a cleanup note when offline origin agent delete partially succeeds", async () => {
+    const fake = await setupPanel(
+      [],
+      discovery({
+        agents: [
+          {
+            name: "dev-docs",
+            path: originAgentPath,
+            roleExists: true,
+          },
+        ],
+      }),
+      "dev-docs"
+    );
+    fake.onInvoke("delete_agent_matrix", () => {
+      throw new Error(
+        `Agent was removed, but hidden cleanup dir(s) remain: ${originAgentPath}\\.ac-delete-cleanup`
+      );
+    });
+    const initialDiscoveryCalls = fake.callsFor("discover_project").length;
+
+    contextMenu(findAgentRow(rendered!.root, "dev-docs"));
+    await waitFor(() => expect(replicaMenu()).not.toBeNull());
+    click(findExactMenuButton(replicaMenu()!, "Delete")!);
+
+    const dialogId = `agent.delete.dialog.${automationIdPart(originAgentPath)}`;
+    const confirmId = `agent.delete.confirm.${automationIdPart(originAgentPath)}`;
+    await waitFor(() => expect(document.querySelector(`[data-ac-testid="${confirmId}"]`)).not.toBeNull());
+    click(document.querySelector(`[data-ac-testid="${confirmId}"]`)!);
+
+    await waitFor(() => expect(fake.callsFor("delete_agent_matrix")).toHaveLength(1));
+    await waitFor(() => expect(fake.callsFor("discover_project").length).toBeGreaterThan(initialDiscoveryCalls));
+    await waitFor(() => {
+      const toast = toastStore.items.find(
+        (item) => item.kind === "info" && item.message.includes("Agent was removed")
+      );
+      expect(toast).toBeTruthy();
+      expect(toast!.message).toContain("hidden cleanup folder remains");
+      expect(toast!.message).toContain(".ac-delete-cleanup");
+    });
+    await waitFor(() => expect(document.querySelector(`[data-ac-testid="${dialogId}"]`)).toBeNull());
+  });
+
+  it("keeps the modal error path and skips refresh when offline origin agent delete fails normally", async () => {
+    const fake = await setupPanel(
+      [],
+      discovery({
+        agents: [
+          {
+            name: "dev-docs",
+            path: originAgentPath,
+            roleExists: true,
+          },
+        ],
+      }),
+      "dev-docs"
+    );
+    fake.onInvoke("delete_agent_matrix", () => {
+      throw new Error("Agent has a live session. Stop it before deleting.");
+    });
+    const initialDiscoveryCalls = fake.callsFor("discover_project").length;
+
+    contextMenu(findAgentRow(rendered!.root, "dev-docs"));
+    await waitFor(() => expect(replicaMenu()).not.toBeNull());
+    click(findExactMenuButton(replicaMenu()!, "Delete")!);
+
+    const confirmId = `agent.delete.confirm.${automationIdPart(originAgentPath)}`;
+    const errorId = `agent.delete.error.${automationIdPart(originAgentPath)}`;
+    await waitFor(() => expect(document.querySelector(`[data-ac-testid="${confirmId}"]`)).not.toBeNull());
+    click(document.querySelector(`[data-ac-testid="${confirmId}"]`)!);
+
+    await waitFor(() => {
+      const error = document.querySelector<HTMLElement>(`[data-ac-testid="${errorId}"]`);
+      expect(error).not.toBeNull();
+      expect(error!.textContent).toContain("Agent has a live session");
+    });
+    expect(fake.callsFor("discover_project")).toHaveLength(initialDiscoveryCalls);
+    expect(toastStore.items.some((item) => item.message.includes("Agent was removed"))).toBe(false);
+    expect((document.querySelector(`[data-ac-testid="${confirmId}"]`) as HTMLButtonElement).disabled).toBe(false);
   });
 
   it("surfaces parsed BLOCKERS details when offline origin agent delete is blocked", async () => {

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -329,6 +329,16 @@ function TrashIcon() {
   );
 }
 
+const AGENT_DELETE_PARTIAL_REMOVAL_PREFIX =
+  "Agent was removed, but hidden cleanup dir(s) remain:";
+
+function formatAgentDeletePartialRemovalWarning(message: string): string {
+  const details = message.slice(AGENT_DELETE_PARTIAL_REMOVAL_PREFIX.length).trim();
+  return details
+    ? `Agent was removed. A hidden cleanup folder remains on disk: ${details}`
+    : "Agent was removed. A hidden cleanup folder remains on disk.";
+}
+
 function formatAgentDeleteBlockerError(report: BlockerReport): string {
   const normalized = normalizeBlockerReport(report);
   const liveSessions = normalized.liveSessions.map((session) =>
@@ -2966,6 +2976,12 @@ const ProjectPanel: Component = () => {
                                   } catch (e: any) {
                                     console.error("delete_agent_matrix failed:", e);
                                     const msg = typeof e === "string" ? e : e?.message ?? "Failed to delete agent";
+                                    if (msg.startsWith(AGENT_DELETE_PARTIAL_REMOVAL_PREFIX)) {
+                                      toastStore.info(formatAgentDeletePartialRemovalWarning(msg), { durationMs: null });
+                                      closeAgentDeleteModal();
+                                      await projectStore.reloadProject(proj.path);
+                                      return;
+                                    }
                                     if (msg.startsWith("BLOCKERS:")) {
                                       try {
                                         const report = JSON.parse(msg.slice("BLOCKERS:".length)) as BlockerReport;


### PR DESCRIPTION
Closes #856. Follow-up to #843.

## Problem
When `delete_agent_matrix` fails on the FINAL cleanup step (agent already removed from disk + team configs + settings, but a hidden `.deleting-*` dir couldn't be removed), it returns `Err`, so the delete modal's `catch` ran without refreshing the sidebar — leaving an already-removed agent still listed.

## Fix (frontend only)
In the agent-delete `catch` in `ProjectPanel.tsx`, detect the exact backend prefix for that one case — `Agent was removed, but hidden cleanup dir(s) remain:` — and treat it as removed-with-warning: close the modal, `projectStore.reloadProject(proj.path)` so the sidebar updates, and surface a sticky, non-alarming info toast. Every other error (live-session block, coordinator block, `BLOCKERS:` staging failure, staging-rollback-failed, metadata failures, not-found, path-validation) keeps its current behavior — inline modal error, no reload, confirm re-enabled — because in those cases the agent still exists.

dev-rust confirmed the prefix is emitted at exactly one place (`entity_creation.rs:2857`, final `remove_staged_agent_delete_targets`) and by no other error path, so detection is unambiguous. **No backend change.**

## Reviews & tests
- dev-rust (backend contract), dev-webpage-ui (frontend), dev-rust-grinch (adversarial): **PASS** — traced the prefix to source, confirmed no sibling error can false-match, and that tests assert the split via the key negative (a live-session error must NOT reload the sidebar).
- Frontend 49 tests + `tsc --noEmit` clean, verified on the tree merged with latest `main`.
