### PR TITLE
feat: add titlebar zoom (%) stepper control (#863)

### DIFF
--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -194,7 +194,7 @@ pub(crate) async fn detach_terminal_inner(
         .map_err(|e| e.to_string())?
         .min_inner_size(400.0, 300.0)
         .decorations(false)
-        .zoom_hotkeys_enabled(true);
+        .zoom_hotkeys_enabled(false);
     if let Some(ref geo) = geometry {
         builder = builder
             .inner_size(geo.width, geo.height)
@@ -474,7 +474,7 @@ pub async fn focus_main_window(app: AppHandle) -> Result<(), String> {
     .map_err(|e| e.to_string())?
     .min_inner_size(800.0, 500.0)
     .decorations(false)
-    .zoom_hotkeys_enabled(true);
+    .zoom_hotkeys_enabled(false);
 
     if let Some(geo) = &saved.main_geometry {
         builder = builder
@@ -518,7 +518,7 @@ pub async fn open_guide_window(app: AppHandle) -> Result<(), String> {
     .inner_size(720.0, 560.0)
     .min_inner_size(480.0, 380.0)
     .decorations(false)
-    .zoom_hotkeys_enabled(true)
+    .zoom_hotkeys_enabled(false)
     .build()
     .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1279,7 +1279,7 @@ pub fn run(
             .expect("Failed to set main window icon")
             .min_inner_size(800.0, 500.0)
             .decorations(false)
-            .zoom_hotkeys_enabled(true)
+            .zoom_hotkeys_enabled(false)
             .inner_size(main_geo.width, main_geo.height)
             .position(main_geo.x, main_geo.y)
             .build()?;

--- a/src/shared/zoom.ts
+++ b/src/shared/zoom.ts
@@ -3,16 +3,16 @@ import type { AppSettings } from "./types";
 import { isTauri } from "./platform";
 
 // NOTE: main window is the only zoom initializer for the unified app. Embedded
-// Sidebar + Terminal MUST skip initZoom() — otherwise Ctrl+= registers two
-// wheel/keydown handlers with independent currentZoom closures and the values
-// race. Detached windows use "detached" (mapped to terminalZoom). See plan
-// §A2.11.N1 and DW.2 embedded-mode contract.
+// Sidebar + Terminal MUST skip initZoom() so Ctrl+= does not register two
+// wheel/keydown handlers with independent currentZoom values. Detached windows
+// use "detached" (mapped to terminalZoom). See plan §A2.11.N1 and DW.2
+// embedded-mode contract.
 
-const ZOOM_STEP = 0.1;
-const ZOOM_MIN = 0.5;
-const ZOOM_MAX = 3.0;
+export const ZOOM_STEP = 0.1;
+export const ZOOM_MIN = 0.5;
+export const ZOOM_MAX = 3.0;
 
-type WindowType = "sidebar" | "terminal" | "main" | "detached" | "guide";
+export type WindowType = "sidebar" | "terminal" | "main" | "detached" | "guide";
 
 const zoomKeyMap: Record<WindowType, keyof AppSettings> = {
   sidebar: "sidebarZoom",
@@ -22,55 +22,86 @@ const zoomKeyMap: Record<WindowType, keyof AppSettings> = {
   guide: "guideZoom",
 };
 
+export interface ZoomState {
+  zoom: number;
+  windowType: WindowType | null;
+}
+
+type ZoomListener = (state: ZoomState) => void;
+
+let currentZoom = 1.0;
+let activeWindowType: WindowType | null = null;
+let saveTimeout: ReturnType<typeof setTimeout> | null = null;
+const zoomListeners = new Set<ZoomListener>();
+
+export function getZoomState(): ZoomState {
+  return { zoom: currentZoom, windowType: activeWindowType };
+}
+
+export function onZoomChange(listener: ZoomListener): () => void {
+  zoomListeners.add(listener);
+  return () => zoomListeners.delete(listener);
+}
+
+function notifyZoomChange() {
+  const state = getZoomState();
+  for (const listener of Array.from(zoomListeners)) listener(state);
+}
+
 function clampZoom(value: number): number {
   return Math.round(Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, value)) * 100) / 100;
 }
 
+async function applyZoom(zoom: number) {
+  currentZoom = clampZoom(zoom);
+  if (isTauri) {
+    const { getCurrentWebview } = await import("@tauri-apps/api/webview");
+    await getCurrentWebview().setZoom(currentZoom);
+  } else {
+    // Browser mode: apply zoom to #root, not <html>.
+    // Zooming <html> breaks xterm FitAddon measurements because it calculates
+    // cell counts against pre-zoom container dimensions, producing content
+    // that overflows when rendered at the zoomed scale.
+    document.documentElement.style.zoom = "";
+    const root = document.getElementById("root");
+    if (root) root.style.zoom = String(currentZoom);
+  }
+  notifyZoomChange();
+}
+
+function debouncedSave(windowType: WindowType) {
+  if (saveTimeout) clearTimeout(saveTimeout);
+  saveTimeout = setTimeout(async () => {
+    try {
+      const settings = await SettingsAPI.get();
+      const key = zoomKeyMap[windowType];
+      if (settings[key] !== currentZoom) {
+        await SettingsAPI.update({ ...settings, [key]: currentZoom });
+      }
+    } catch (e) {
+      console.error("Failed to save zoom:", e);
+    }
+  }, 500);
+}
+
+export async function setUiZoom(zoom: number): Promise<void> {
+  const windowType = activeWindowType;
+  await applyZoom(zoom);
+  if (windowType) debouncedSave(windowType);
+}
+
 /**
  * Initialize zoom: restore saved level and attach keyboard/wheel listeners.
- * All mutable state is closure-local so multiple calls (BrowserApp) don't conflict.
  * Returns a cleanup function for onCleanup.
  */
 export async function initZoom(windowType: WindowType): Promise<() => void> {
-  let currentZoom = 1.0;
-  let saveTimeout: ReturnType<typeof setTimeout> | null = null;
-
-  async function applyZoom(zoom: number) {
-    currentZoom = clampZoom(zoom);
-    if (isTauri) {
-      const { getCurrentWebview } = await import("@tauri-apps/api/webview");
-      await getCurrentWebview().setZoom(currentZoom);
-    } else {
-      // Browser mode: apply zoom to #root, not <html>.
-      // Zooming <html> breaks xterm FitAddon measurements — it calculates
-      // cell counts against pre-zoom container dimensions, producing content
-      // that overflows when rendered at the zoomed scale.
-      document.documentElement.style.zoom = "";
-      const root = document.getElementById("root");
-      if (root) root.style.zoom = String(currentZoom);
-    }
-  }
-
-  function debouncedSave() {
-    if (saveTimeout) clearTimeout(saveTimeout);
-    saveTimeout = setTimeout(async () => {
-      try {
-        const settings = await SettingsAPI.get();
-        const key = zoomKeyMap[windowType];
-        if (settings[key] !== currentZoom) {
-          await SettingsAPI.update({ ...settings, [key]: currentZoom });
-        }
-      } catch (e) {
-        console.error("Failed to save zoom:", e);
-      }
-    }, 500);
-  }
+  activeWindowType = windowType;
 
   // Restore saved zoom
   try {
     const settings = await SettingsAPI.get();
     const saved = settings[zoomKeyMap[windowType]] as number;
-    if (saved && saved !== 1.0) {
+    if (typeof saved === "number") {
       await applyZoom(saved);
     }
   } catch (e) {
@@ -81,24 +112,20 @@ export async function initZoom(windowType: WindowType): Promise<() => void> {
     if (!e.ctrlKey) return;
     e.preventDefault();
     const delta = e.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP;
-    applyZoom(currentZoom + delta);
-    debouncedSave();
+    void setUiZoom(currentZoom + delta);
   };
 
   const onKeydown = (e: KeyboardEvent) => {
-    if (!e.ctrlKey || e.shiftKey || e.altKey) return;
+    if (!(e.ctrlKey || e.metaKey) || e.shiftKey || e.altKey) return;
     if (e.key === "=" || e.key === "+") {
       e.preventDefault();
-      applyZoom(currentZoom + ZOOM_STEP);
-      debouncedSave();
+      void setUiZoom(currentZoom + ZOOM_STEP);
     } else if (e.key === "-") {
       e.preventDefault();
-      applyZoom(currentZoom - ZOOM_STEP);
-      debouncedSave();
+      void setUiZoom(currentZoom - ZOOM_STEP);
     } else if (e.key === "0") {
       e.preventDefault();
-      applyZoom(1.0);
-      debouncedSave();
+      void setUiZoom(1.0);
     }
   };
 
@@ -109,5 +136,6 @@ export async function initZoom(windowType: WindowType): Promise<() => void> {
     document.removeEventListener("wheel", onWheel);
     document.removeEventListener("keydown", onKeydown);
     if (saveTimeout) clearTimeout(saveTimeout);
+    if (activeWindowType === windowType) activeWindowType = null;
   };
 }

--- a/src/sidebar/components/Titlebar.tsx
+++ b/src/sidebar/components/Titlebar.tsx
@@ -6,6 +6,7 @@ import { extractWorkgroupName, computeTrailingText } from "../../shared/path-ext
 import { terminalStore } from "../../terminal/stores/terminal";
 import type { MainSidebarSide } from "../../shared/types";
 import WebServerMenu from "./WebServerMenu";
+import ZoomStepper from "./ZoomStepper";
 import {
   DEFAULT_MAIN_SIDEBAR_WIDTH,
   MAIN_SIDEBAR_MAX_WIDTH,
@@ -146,6 +147,7 @@ const Titlebar: Component = () => {
             onOpenChange={setWebServerMenuOpen}
           />
         </Show>
+        <ZoomStepper />
         <div class="layout-dropdown-wrapper">
           <button
             class={`titlebar-btn titlebar-btn-layout ${layoutOpen() ? "open" : ""}`}

--- a/src/sidebar/components/Titlebar.zoom.test.tsx
+++ b/src/sidebar/components/Titlebar.zoom.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Component, JSX } from "solid-js";
+import type { AppSettings, WebServerOwnedStatus } from "../../shared/types";
+import type { FakeTransport } from "../../shared/testing/fake-transport";
+
+const tauriMocks = vi.hoisted(() => ({
+  invoke: vi.fn(() => Promise.resolve("")),
+  setZoom: vi.fn(() => Promise.resolve()),
+  minimize: vi.fn(),
+  isMaximized: vi.fn(() => Promise.resolve(false)),
+  maximize: vi.fn(),
+  unmaximize: vi.fn(),
+  close: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: tauriMocks.invoke,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    minimize: tauriMocks.minimize,
+    isMaximized: tauriMocks.isMaximized,
+    maximize: tauriMocks.maximize,
+    unmaximize: tauriMocks.unmaximize,
+    close: tauriMocks.close,
+  }),
+}));
+
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    setZoom: tauriMocks.setZoom,
+  }),
+}));
+
+type InitZoom = typeof import("../../shared/zoom").initZoom;
+
+type HarnessModules = {
+  Titlebar: Component;
+  FakeTransport: typeof FakeTransport;
+  baseSettings: (overrides?: Partial<AppSettings>) => AppSettings;
+  renderWithFakeTransport: (
+    component: () => JSX.Element,
+    fake?: FakeTransport,
+  ) => { fake: FakeTransport; root: HTMLDivElement; cleanup: () => void };
+  click: (el: Element) => void;
+  waitFor: (assertion: () => void | Promise<void>, timeoutMs?: number) => Promise<void>;
+  initZoom: InitZoom;
+};
+
+interface MountedTitlebar {
+  fake: FakeTransport;
+  root: HTMLDivElement;
+  modules: HarnessModules;
+  getSettings: () => AppSettings;
+}
+
+const cleanups: Array<() => void> = [];
+
+const stoppedStatus = (port = 8765): WebServerOwnedStatus => ({
+  listening: false,
+  owned: false,
+  externalListening: false,
+  openAllowed: false,
+  bind: "127.0.0.1",
+  port,
+  state: "stopped",
+});
+
+async function loadModules(): Promise<HarnessModules> {
+  const [{ default: Titlebar }, testing, fakeTransport, zoom] = await Promise.all([
+    import("./Titlebar"),
+    import("../../shared/testing/ui-harness"),
+    import("../../shared/testing/fake-transport"),
+    import("../../shared/zoom"),
+  ]);
+  return {
+    Titlebar,
+    FakeTransport: fakeTransport.FakeTransport,
+    baseSettings: testing.baseSettings,
+    renderWithFakeTransport: testing.renderWithFakeTransport,
+    click: testing.click,
+    waitFor: testing.waitFor,
+    initZoom: zoom.initZoom,
+  };
+}
+
+async function mountTitlebar(settings: Partial<AppSettings> = {}): Promise<MountedTitlebar> {
+  const modules = await loadModules();
+  const fake = new modules.FakeTransport();
+  let currentSettings = modules.baseSettings(settings);
+
+  fake.onInvoke("get_settings", () => currentSettings);
+  fake.onInvoke("update_settings", ({ newSettings }) => {
+    currentSettings = newSettings as AppSettings;
+  });
+  fake.onInvoke("save_settings_draft", ({ draft }) => {
+    currentSettings = draft as AppSettings;
+  });
+  fake.onInvoke("get_web_server_owned_status", () => stoppedStatus(currentSettings.webServerPort));
+  fake.onInvoke("start_web_server", () => true);
+  fake.onInvoke("stop_web_server", () => true);
+  fake.onInvoke("open_web_remote", () => undefined);
+
+  const rendered = modules.renderWithFakeTransport(() => <modules.Titlebar />, fake);
+  cleanups.push(rendered.cleanup);
+
+  return {
+    fake,
+    root: rendered.root,
+    modules,
+    getSettings: () => currentSettings,
+  };
+}
+
+function byTestId<T extends Element = Element>(testId: string): T {
+  const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`missing selector ${testId}`);
+  return element;
+}
+
+async function initMainZoom(mounted: MountedTitlebar): Promise<void> {
+  const cleanupZoom = await mounted.modules.initZoom("main");
+  cleanups.push(cleanupZoom);
+}
+
+describe("Titlebar zoom stepper", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    vi.resetModules();
+    vi.clearAllMocks();
+    tauriMocks.setZoom.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    while (cleanups.length > 0) cleanups.pop()?.();
+    document.body.innerHTML = "";
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("renders between the webserver menu and layout button", async () => {
+    await mountTitlebar();
+
+    const controls = document.querySelector(".titlebar-controls");
+    expect(controls).toBeTruthy();
+    const children = Array.from(controls?.children ?? []);
+
+    expect(children[0]?.querySelector('[data-ac-testid="titlebar.webserver.button"]')).toBeTruthy();
+    expect(children[1]?.getAttribute("data-ac-testid")).toBe("titlebar.zoom");
+    expect(children[2]?.querySelector('[data-ac-testid="titlebar.layout.button"]')).toBeTruthy();
+  });
+
+  it("clicking plus updates the live display and persists main zoom", async () => {
+    const mounted = await mountTitlebar({ mainZoom: 1 });
+    await initMainZoom(mounted);
+
+    mounted.modules.click(byTestId("titlebar.zoom.in"));
+
+    await mounted.modules.waitFor(() => {
+      expect(tauriMocks.setZoom).toHaveBeenLastCalledWith(1.1);
+      expect(byTestId("titlebar.zoom.value").textContent).toBe("110%");
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 550));
+
+    await mounted.modules.waitFor(() => {
+      expect(mounted.fake.callsFor("update_settings")).toHaveLength(1);
+      expect(mounted.fake.lastCall("update_settings")?.args.newSettings).toMatchObject({
+        mainZoom: 1.1,
+      });
+      expect(mounted.getSettings().mainZoom).toBe(1.1);
+    });
+  });
+
+  it("ctrl plus wheel updates the display live", async () => {
+    const mounted = await mountTitlebar({ mainZoom: 1 });
+    await initMainZoom(mounted);
+
+    document.dispatchEvent(
+      new WheelEvent("wheel", {
+        ctrlKey: true,
+        deltaY: -1,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    await mounted.modules.waitFor(() => {
+      expect(byTestId("titlebar.zoom.value").textContent).toBe("110%");
+    });
+  });
+
+  it("meta plus keydown updates the display live", async () => {
+    const mounted = await mountTitlebar({ mainZoom: 1 });
+    await initMainZoom(mounted);
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        metaKey: true,
+        key: "=",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    await mounted.modules.waitFor(() => {
+      expect(byTestId("titlebar.zoom.value").textContent).toBe("110%");
+    });
+  });
+
+  it("disables zoom out at the minimum", async () => {
+    const mounted = await mountTitlebar({ mainZoom: 0.5 });
+    await initMainZoom(mounted);
+
+    await mounted.modules.waitFor(() => {
+      expect(byTestId("titlebar.zoom.value").textContent).toBe("50%");
+      expect(byTestId<HTMLButtonElement>("titlebar.zoom.out").disabled).toBe(true);
+    });
+  });
+
+  it("disables zoom in at the maximum", async () => {
+    const mounted = await mountTitlebar({ mainZoom: 3.0 });
+    await initMainZoom(mounted);
+
+    await mounted.modules.waitFor(() => {
+      expect(byTestId("titlebar.zoom.value").textContent).toBe("300%");
+      expect(byTestId<HTMLButtonElement>("titlebar.zoom.in").disabled).toBe(true);
+    });
+  });
+});

--- a/src/sidebar/components/ZoomStepper.tsx
+++ b/src/sidebar/components/ZoomStepper.tsx
@@ -1,0 +1,57 @@
+import { Component, createMemo, createSignal, onCleanup } from "solid-js";
+import {
+  ZOOM_MAX,
+  ZOOM_MIN,
+  ZOOM_STEP,
+  getZoomState,
+  onZoomChange,
+  setUiZoom,
+} from "../../shared/zoom";
+
+const ZoomStepper: Component = () => {
+  const [zoom, setZoom] = createSignal(getZoomState().zoom);
+  const unsubscribe = onZoomChange((state) => setZoom(state.zoom));
+  onCleanup(unsubscribe);
+
+  const percent = createMemo(() => `${Math.round(zoom() * 100)}%`);
+  const canZoomOut = createMemo(() => zoom() > ZOOM_MIN);
+  const canZoomIn = createMemo(() => zoom() < ZOOM_MAX);
+
+  const changeZoom = (delta: number) => {
+    void setUiZoom(zoom() + delta).catch((err) => {
+      console.error("Failed to change zoom:", err);
+    });
+  };
+
+  return (
+    <div class="titlebar-zoom-stepper" role="group" aria-label="UI zoom" data-ac-testid="titlebar.zoom">
+      <button
+        class="titlebar-zoom-btn"
+        type="button"
+        title="Zoom out"
+        aria-label="Zoom out"
+        disabled={!canZoomOut()}
+        onClick={() => changeZoom(-ZOOM_STEP)}
+        data-ac-testid="titlebar.zoom.out"
+      >
+        -
+      </button>
+      <span class="titlebar-zoom-value" aria-live="polite" data-ac-testid="titlebar.zoom.value">
+        {percent()}
+      </span>
+      <button
+        class="titlebar-zoom-btn"
+        type="button"
+        title="Zoom in"
+        aria-label="Zoom in"
+        disabled={!canZoomIn()}
+        onClick={() => changeZoom(ZOOM_STEP)}
+        data-ac-testid="titlebar.zoom.in"
+      >
+        +
+      </button>
+    </div>
+  );
+};
+
+export default ZoomStepper;

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -117,6 +117,51 @@ html, body, #root {
   background: var(--titlebar-btn-hover);
 }
 
+.titlebar-zoom-stepper {
+  display: flex;
+  align-items: center;
+  height: 32px;
+  margin: 0 2px;
+  -webkit-app-region: no-drag;
+}
+
+.titlebar-zoom-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  color: var(--titlebar-fg);
+  cursor: pointer;
+  font-size: 13px;
+  transition: background var(--transition-fast), color var(--transition-fast), opacity var(--transition-fast);
+}
+
+.titlebar-zoom-btn:hover:not(:disabled) {
+  background: rgba(0, 212, 255, 0.15);
+  color: var(--sidebar-accent);
+}
+
+.titlebar-zoom-btn:disabled {
+  cursor: default;
+  opacity: 0.35;
+}
+
+.titlebar-zoom-value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 32px;
+  color: var(--titlebar-fg);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.75;
+  user-select: none;
+}
+
 .titlebar-btn-close:hover {
   background: var(--titlebar-btn-close-hover);
   color: white;


### PR DESCRIPTION
## Summary

Adds a compact browser-style zoom control — `−  100%  +` — to the Titlebar, positioned between the webserver controls and the Sidebar Layout toggle. `+` / `−` step the UI zoom by 10% within 50%–300% bounds, and the displayed percentage stays in sync (both directions) with the existing Ctrl+scroll / Ctrl+key zoom.

Closes #863.

## What changed

- **`src/shared/zoom.ts`** — centralized live zoom state as the single source of truth: exported `ZOOM_STEP`/`ZOOM_MIN`/`ZOOM_MAX`, `getZoomState`, `onZoomChange`, and `setUiZoom`. Button clicks, Ctrl+wheel, and Ctrl/Cmd+key all route through the same apply+save path and notify subscribers immediately. Restore path notifies subscribers; listener/save cleanup preserved.
- **`src/sidebar/components/ZoomStepper.tsx`** (new) — compact inline `−  <pct>%  +` control; disables `−`/`+` at min/max; all writes via `setUiZoom`.
- **`src/sidebar/components/Titlebar.tsx`** — inserts `<ZoomStepper />` between `WebServerMenu` and the layout dropdown.
- **`src/sidebar/styles/sidebar.css`** — fixed-width zoom styles so the % never shifts neighboring controls.
- **`src-tauri/src/lib.rs`, `src-tauri/src/commands/window.rs`** — disabled native Tauri `zoom_hotkeys_enabled` on the `initZoom`-controlled windows (main / detached terminal / recreated main / guide) so no unobservable native zoom path can desync the displayed %.
- **macOS:** keydown zoom handler now accepts `ctrlKey || metaKey` so disabling native hotkeys doesn't regress Cmd+zoom.
- **`src/sidebar/components/Titlebar.zoom.test.tsx`** (new) — covers control order/placement, click persistence, Ctrl+wheel live sync, meta-key live sync, and min/max disabled bounds.

## Review & verification

- **dev-rust** implemented; **architect** reviewed the executed diff against the plan → **PASS**, no blocking findings.
- Checks green on both the original commit and the post-merge tree:
  - `npm test -- src/sidebar/components/Titlebar.zoom.test.tsx` → 6/6 pass
  - `npm run typecheck` → pass
  - `cargo check --manifest-path src-tauri/Cargo.toml` → pass
  - `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` → pass
- Plan: `_plans/863-titlebar-zoom-stepper.md`. No new npm/Rust/Tauri dependencies.
