### PR TITLE
feat(docker): ac-claude-ready container image for the Camino 2 container backend (#865)

### DIFF
--- a/docker/ac-claude/Dockerfile
+++ b/docker/ac-claude/Dockerfile
@@ -1,0 +1,23 @@
+ARG BRIDGE_IMAGE=agentscommander/session-bridge:latest
+FROM ${BRIDGE_IMAGE} AS bridge
+
+FROM node:22-bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash ca-certificates git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code \
+    && npm cache clean --force
+
+RUN mkdir -p /workspace /home/node/.claude \
+    && chown -R node:node /workspace /home/node/.claude
+
+COPY --from=bridge /usr/local/bin/session-bridge /usr/local/bin/session-bridge
+COPY --from=bridge /usr/local/bin/agentscommander-api-helper /usr/local/bin/agentscommander-api-helper
+
+ENV HOME=/home/node
+USER node
+WORKDIR /workspace
+
+ENTRYPOINT ["session-bridge"]

--- a/docker/ac-claude/Dockerfile
+++ b/docker/ac-claude/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BRIDGE_IMAGE} AS bridge
 FROM node:22-bookworm-slim
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends bash ca-certificates git \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends bash ca-certificates git \
     && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g @anthropic-ai/claude-code \
@@ -12,6 +12,8 @@ RUN npm install -g @anthropic-ai/claude-code \
 
 RUN mkdir -p /workspace /home/node/.claude \
     && chown -R node:node /workspace /home/node/.claude
+
+RUN git config --system --add safe.directory '*'
 
 COPY --from=bridge /usr/local/bin/session-bridge /usr/local/bin/session-bridge
 COPY --from=bridge /usr/local/bin/agentscommander-api-helper /usr/local/bin/agentscommander-api-helper

--- a/docker/ac-claude/README.md
+++ b/docker/ac-claude/README.md
@@ -8,6 +8,10 @@ No Anthropic credential is baked into the image. Pass authentication at runtime
 through `settings.agents[].envs`; AgentsCommander forwards enabled env rows to
 the child CLI inside the container.
 
+The image runs the bridge as the non-root `node` user. It also configures Git
+with `safe.directory=*` because AgentsCommander bind-mounts host workspaces
+whose ownership often differs from UID 1000 inside Docker.
+
 Official references:
 
 - [Claude Code IAM and authentication](https://code.claude.com/docs/en/iam)
@@ -21,7 +25,7 @@ Claude Code on top of that image.
 
 ```bash
 docker build -f crates/session-bridge/Dockerfile -t agentscommander/session-bridge:latest .
-docker build -f docker/ac-claude/Dockerfile -t agentscommander/ac-claude-ready:local .
+docker build -f docker/ac-claude/Dockerfile -t agentscommander/ac-claude:latest .
 ```
 
 To reuse a different bridge image tag:
@@ -29,7 +33,7 @@ To reuse a different bridge image tag:
 ```bash
 docker build -f docker/ac-claude/Dockerfile \
   --build-arg BRIDGE_IMAGE=agentscommander/session-bridge:my-tag \
-  -t agentscommander/ac-claude-ready:local .
+  -t agentscommander/ac-claude:latest .
 ```
 
 ## Use from AgentsCommander
@@ -37,7 +41,7 @@ docker build -f docker/ac-claude/Dockerfile \
 Set `AGENTSCOMMANDER_CONTAINER_IMAGE` before launching AgentsCommander:
 
 ```powershell
-$env:AGENTSCOMMANDER_CONTAINER_IMAGE = "agentscommander/ac-claude-ready:local"
+$env:AGENTSCOMMANDER_CONTAINER_IMAGE = "agentscommander/ac-claude:latest"
 .\agentscommander.exe
 ```
 
@@ -88,19 +92,31 @@ Do not place real tokens in this repository or in the Dockerfile. Store them in
 the local AgentsCommander settings file or inject them from your shell before
 launching AgentsCommander.
 
+## Headless mode
+
+For non-interactive smoke tests or profiles, run Claude with `-p` or `--print`:
+
+```bash
+claude -p "Reply with ok"
+```
+
+Claude Code skips the workspace trust dialog in non-interactive mode. Avoid
+`--bare` when using `CLAUDE_CODE_OAUTH_TOKEN`, because bare mode does not read
+OAuth or keychain credentials.
+
 ## Verify
 
 Check the required binaries and Claude Code:
 
 ```bash
-docker run --rm --entrypoint /bin/sh agentscommander/ac-claude-ready:local \
+docker run --rm --entrypoint /bin/sh agentscommander/ac-claude:latest \
   -lc 'test -x /usr/local/bin/session-bridge && test -x /usr/local/bin/agentscommander-api-helper && claude --version'
 ```
 
 Check that no Claude credential was baked into the image:
 
 ```bash
-docker history --no-trunc agentscommander/ac-claude-ready:local | grep -Ei 'ANTHROPIC|CLAUDE_CODE_OAUTH_TOKEN|API_KEY|AUTH_TOKEN' || true
-docker run --rm --entrypoint /bin/sh agentscommander/ac-claude-ready:local \
-  -lc 'env | grep -Ei "ANTHROPIC|CLAUDE_CODE_OAUTH_TOKEN|API_KEY|AUTH_TOKEN" || true'
+docker history --no-trunc agentscommander/ac-claude:latest | grep -Ei 'ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|CLAUDE_CODE_OAUTH_TOKEN|API_KEY=|AUTH_TOKEN=' || true
+docker run --rm --entrypoint /bin/sh agentscommander/ac-claude:latest \
+  -lc 'env | grep -Ei "ANTHROPIC_API_KEY|ANTHROPIC_AUTH_TOKEN|CLAUDE_CODE_OAUTH_TOKEN|API_KEY=|AUTH_TOKEN=" || true'
 ```

--- a/docker/ac-claude/README.md
+++ b/docker/ac-claude/README.md
@@ -1,0 +1,106 @@
+# AgentsCommander Claude-ready container
+
+This image extends the bridge-only image built from `crates/session-bridge/Dockerfile`.
+It adds Node.js and the official Claude Code npm package, then copies the existing
+`session-bridge` and `agentscommander-api-helper` binaries into `/usr/local/bin`.
+
+No Anthropic credential is baked into the image. Pass authentication at runtime
+through `settings.agents[].envs`; AgentsCommander forwards enabled env rows to
+the child CLI inside the container.
+
+Official references:
+
+- [Claude Code IAM and authentication](https://code.claude.com/docs/en/iam)
+- [Claude Code dev containers](https://code.claude.com/docs/en/devcontainer)
+
+## Build
+
+Run both commands from the repository root. The first command builds the bridge
+image by using the existing multi-stage Dockerfile. The second command layers
+Claude Code on top of that image.
+
+```bash
+docker build -f crates/session-bridge/Dockerfile -t agentscommander/session-bridge:latest .
+docker build -f docker/ac-claude/Dockerfile -t agentscommander/ac-claude-ready:local .
+```
+
+To reuse a different bridge image tag:
+
+```bash
+docker build -f docker/ac-claude/Dockerfile \
+  --build-arg BRIDGE_IMAGE=agentscommander/session-bridge:my-tag \
+  -t agentscommander/ac-claude-ready:local .
+```
+
+## Use from AgentsCommander
+
+Set `AGENTSCOMMANDER_CONTAINER_IMAGE` before launching AgentsCommander:
+
+```powershell
+$env:AGENTSCOMMANDER_CONTAINER_IMAGE = "agentscommander/ac-claude-ready:local"
+.\agentscommander.exe
+```
+
+Use the container backend for the Claude agent and keep the command as `claude`:
+
+```json
+{
+  "agents": [
+    {
+      "id": "claude",
+      "label": "Claude Code",
+      "command": "claude",
+      "color": "#E87B35",
+      "backend": { "kind": "containerTransport" },
+      "envs": [
+        {
+          "key": "CLAUDE_CODE_OAUTH_TOKEN",
+          "value": "paste-token-from-claude-setup-token",
+          "source": "user",
+          "enabled": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+Use only one primary Claude credential unless your gateway setup requires a
+different combination.
+
+- Subscription auth: run `claude setup-token` on a trusted machine, then pass
+  the output as `CLAUDE_CODE_OAUTH_TOKEN`.
+- API billing: pass `ANTHROPIC_API_KEY` instead.
+- Gateway auth: pass `ANTHROPIC_AUTH_TOKEN` and any required base URL settings.
+
+For API billing, the env row is:
+
+```json
+{
+  "key": "ANTHROPIC_API_KEY",
+  "value": "sk-ant-...",
+  "source": "user",
+  "enabled": true
+}
+```
+
+Do not place real tokens in this repository or in the Dockerfile. Store them in
+the local AgentsCommander settings file or inject them from your shell before
+launching AgentsCommander.
+
+## Verify
+
+Check the required binaries and Claude Code:
+
+```bash
+docker run --rm --entrypoint /bin/sh agentscommander/ac-claude-ready:local \
+  -lc 'test -x /usr/local/bin/session-bridge && test -x /usr/local/bin/agentscommander-api-helper && claude --version'
+```
+
+Check that no Claude credential was baked into the image:
+
+```bash
+docker history --no-trunc agentscommander/ac-claude-ready:local | grep -Ei 'ANTHROPIC|CLAUDE_CODE_OAUTH_TOKEN|API_KEY|AUTH_TOKEN' || true
+docker run --rm --entrypoint /bin/sh agentscommander/ac-claude-ready:local \
+  -lc 'env | grep -Ei "ANTHROPIC|CLAUDE_CODE_OAUTH_TOKEN|API_KEY|AUTH_TOKEN" || true'
+```


### PR DESCRIPTION
## Summary
Ships an official Claude-Code-ready Docker image for the Camino 2 container backend, so running a Claude agent in Docker no longer requires hand-building an image. Part of #819 (step a of the user-friendliness work; step b is a UI/CLI runtime selector for `backend.kind`).

## What changed
- New `docker/ac-claude/Dockerfile`: extends `agentscommander/session-bridge:latest` (via `ARG BRIDGE_IMAGE`), final stage `node:22-bookworm-slim` + `@anthropic-ai/claude-code`, copies the bridge binaries, runs non-root (`node`) at `/workspace`, `ENTRYPOINT ["session-bridge"]`.
- `git config --system --add safe.directory '*'` so git works on the bind-mounted replica root as non-root (repos live at dynamic `/workspace/repo-<name>` subpaths).
- No credentials baked; auth is provided at runtime via env (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`).
- New `docker/ac-claude/README.md`: build command, auth methods, pointing AC at the image (`AGENTSCOMMANDER_CONTAINER_IMAGE`), the `settings.agents[]` snippet, the headless (`-p`) note + `--bare` caveat, and no-secret verification commands.

## Review + verification (live Docker daemon)
- Builds: bridge base + ac-claude, both pass.
- Inside the image: bridge binaries present + executable; `claude --version` = `2.1.204 (Claude Code)`.
- F1 (non-root mount write + git): `node` writes `/workspace`; the git "dubious ownership" error is fixed via `safe.directory`; post-fix `git status` passes.
- F2 (headless): `claude -p` is non-interactive, skips the workspace trust dialog, no onboarding/theme prompt (verified with dummy tokens: fast auth error, no blocking prompt).
- No secrets in layers (`docker history` + `env` grep).
- Review: grinch static PASS + fix-delta PASS (kept `safe.directory='*'`, which is required for the dynamic `repo-<name>` subpaths since git only honors the `'*'` wildcard).
- `cargo check` / `cargo clippy` pass.

## Notes
- Non-visual change (Docker image + docs); no app UI change, so no shipper build.
- Out of scope: the UI/CLI trigger for `backend.kind` (step b, follow-up).

Closes #865
