### PR TITLE
feat(settings): container runtime selector (UI + CLI) for coding agents (#868)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -429,6 +429,9 @@ Subcommands:
 | `--env KEY=VALUE` | Repeatable. Split on the first `=` (`FOO=a=b` -> value `a=b`). All CLI envs are `source=user`, `enabled=true`. On `update`, any `--env` REPLACES the whole env list (including `source=system` rows). |
 | `--clear-envs` | (update) Empty the env list. Conflicts with `--env`. |
 | `--isolated-home <true\|false>` | Provide an isolated CODEX_HOME at spawn (Codex). |
+| `--backend <local\|container>` | Runtime backend. `local` clears any per-agent container image; `container` uses Docker container transport. |
+| `--container-image <image>` | Per-agent Docker image override. Implies `--backend container`; conflicts with `--backend local`; rejects empty or leading-dash values. |
+| `--clear-container-image` | (update) Clear the per-agent Docker image override. Conflicts with `--container-image`; valid with `--backend container` to fall back to `AGENTSCOMMANDER_CONTAINER_IMAGE`, then the built-in default. |
 | `--instructions-filename <name.md>` | Bare `.md` filename AC writes into the agent root at launch. |
 | `--clear-instructions-filename` | (update) Clear it. Conflicts with `--instructions-filename`. |
 | `--config-seed-dest <folder>` | Config-folder seed destination NAME under the replica root. Implies enabled unless `--config-seed-enabled false`. |

--- a/src-tauri/src/cli/coding_agent.rs
+++ b/src-tauri/src/cli/coding_agent.rs
@@ -23,7 +23,7 @@
 use std::path::Path;
 use std::time::{Duration, Instant};
 
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 
 use crate::config::coding_agent_mutations::{
     self as ops, AgentPatch, CodingAgentOp, CodingAgentOpOutcome, CodingAgentRequest,
@@ -31,9 +31,10 @@ use crate::config::coding_agent_mutations::{
 };
 use crate::config::coding_agents_catalog::{load_catalog, CodingAgentDefinition};
 use crate::config::settings::{
-    load_settings_for_cli_strict, save_settings, validate_user_env_key, AgentConfig,
-    CodingAgentEnv, CodingAgentEnvSource, ConfigSeedConfig,
+    load_settings_for_cli_strict, normalize_container_image_input, save_settings,
+    validate_user_env_key, AgentConfig, CodingAgentEnv, CodingAgentEnvSource, ConfigSeedConfig,
 };
+use crate::pty::backend::SessionBackendKind;
 
 const DEFAULT_CONFIRM_TIMEOUT_SECS: u64 = 30;
 /// #786 R3: grace window (one poller interval + margin) after an ENOENT cancel.
@@ -81,6 +82,21 @@ pub struct ShowArgs {
     pub id: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CliBackendKind {
+    Local,
+    Container,
+}
+
+impl From<CliBackendKind> for SessionBackendKind {
+    fn from(kind: CliBackendKind) -> Self {
+        match kind {
+            CliBackendKind::Local => SessionBackendKind::LocalProcess,
+            CliBackendKind::Container => SessionBackendKind::ContainerTransport,
+        }
+    }
+}
+
 #[derive(Args)]
 pub struct AddArgs {
     /// Seed label/command/color/envs/isolatedHome (and optional instructions/seed)
@@ -114,6 +130,12 @@ pub struct AddArgs {
     /// Enable/disable the config-folder seed
     #[arg(long = "config-seed-enabled", value_name = "true|false", action = clap::ArgAction::Set)]
     pub config_seed_enabled: Option<bool>,
+    /// Runtime backend: local or container
+    #[arg(long = "backend", value_enum)]
+    pub backend: Option<CliBackendKind>,
+    /// Docker image for container runtime. Implies --backend container.
+    #[arg(long = "container-image", value_name = "IMAGE")]
+    pub container_image: Option<String>,
     /// Seconds to wait for the GUI to process the request (daemon path only)
     #[arg(long = "confirm-timeout", default_value_t = DEFAULT_CONFIRM_TIMEOUT_SECS)]
     pub confirm_timeout: u64,
@@ -152,6 +174,15 @@ pub struct UpdateArgs {
     /// Clear the config-folder seed (conflicts with the other seed flags)
     #[arg(long = "clear-config-seed")]
     pub clear_config_seed: bool,
+    /// Runtime backend: local or container
+    #[arg(long = "backend", value_enum)]
+    pub backend: Option<CliBackendKind>,
+    /// Docker image for container runtime. Implies --backend container.
+    #[arg(long = "container-image", value_name = "IMAGE")]
+    pub container_image: Option<String>,
+    /// Clear the per-agent Docker image override
+    #[arg(long = "clear-container-image")]
+    pub clear_container_image: bool,
     #[arg(long = "confirm-timeout", default_value_t = DEFAULT_CONFIRM_TIMEOUT_SECS)]
     pub confirm_timeout: u64,
 }
@@ -262,6 +293,7 @@ fn cmd_add(a: AddArgs, gui_running: bool) -> Result<(), String> {
         agent.instructions_filename = Some(name);
     }
     apply_seed_flags(&mut agent, a.config_seed_dest, a.config_seed_enabled);
+    apply_backend_flags(&mut agent, a.backend, a.container_image)?;
 
     // Custom (not from-catalog) requires label + command (mirrors Onboarding).
     if a.from_catalog.is_none()
@@ -297,6 +329,12 @@ fn cmd_update(a: UpdateArgs, gui_running: bool) -> Result<(), String> {
                 .to_string(),
         );
     }
+    if a.clear_container_image && a.container_image.is_some() {
+        return Err("--clear-container-image conflicts with --container-image".to_string());
+    }
+    if a.backend == Some(CliBackendKind::Local) && a.container_image.is_some() {
+        return Err("--backend local conflicts with --container-image".to_string());
+    }
     if let Some(color) = &a.color {
         ops::validate_agent_color(color)?;
     }
@@ -313,6 +351,8 @@ fn cmd_update(a: UpdateArgs, gui_running: bool) -> Result<(), String> {
     } else {
         Some(parse_env_flags(&a.env)?)
     };
+    let (backend_kind, container_image, clear_container_image) =
+        backend_patch_fields(a.backend, a.container_image, a.clear_container_image)?;
 
     let patch = AgentPatch {
         label: a.label.map(|l| l.trim().to_string()),
@@ -325,6 +365,9 @@ fn cmd_update(a: UpdateArgs, gui_running: bool) -> Result<(), String> {
         config_seed_dest: a.config_seed_dest,
         config_seed_enabled: a.config_seed_enabled,
         clear_config_seed: a.clear_config_seed,
+        backend_kind,
+        container_image,
+        clear_container_image,
     };
     dispatch_mutation(
         CodingAgentOp::Update { id: a.id, patch },
@@ -514,6 +557,58 @@ fn apply_seed_flags(agent: &mut AgentConfig, dest: Option<String>, enabled: Opti
     agent.config_seed = Some(seed);
 }
 
+fn apply_backend_flags(
+    agent: &mut AgentConfig,
+    backend: Option<CliBackendKind>,
+    container_image: Option<String>,
+) -> Result<(), String> {
+    if backend == Some(CliBackendKind::Local) && container_image.is_some() {
+        return Err("--backend local conflicts with --container-image".to_string());
+    }
+    if let Some(kind) = backend {
+        agent.backend.kind = kind.into();
+    }
+    if let Some(image) = container_image {
+        agent.backend.kind = SessionBackendKind::ContainerTransport;
+        agent.backend.image = Some(normalize_container_image_input(
+            &image,
+            "--container-image",
+        )?);
+    }
+    if agent.backend.kind == SessionBackendKind::LocalProcess {
+        agent.backend.image = None;
+    }
+    Ok(())
+}
+
+fn backend_patch_fields(
+    backend: Option<CliBackendKind>,
+    container_image: Option<String>,
+    clear_container_image: bool,
+) -> Result<(Option<SessionBackendKind>, Option<String>, bool), String> {
+    if clear_container_image && container_image.is_some() {
+        return Err("--clear-container-image conflicts with --container-image".to_string());
+    }
+    let mut backend_kind = backend.map(SessionBackendKind::from);
+    let mut clear_image = clear_container_image;
+    let image = if let Some(image) = container_image {
+        if backend == Some(CliBackendKind::Local) {
+            return Err("--backend local conflicts with --container-image".to_string());
+        }
+        backend_kind = Some(SessionBackendKind::ContainerTransport);
+        Some(normalize_container_image_input(
+            &image,
+            "--container-image",
+        )?)
+    } else {
+        None
+    };
+    if backend_kind == Some(SessionBackendKind::LocalProcess) {
+        clear_image = true;
+    }
+    Ok((backend_kind, image, clear_image))
+}
+
 /// Parse `--env KEY=VALUE` (C8): split on the FIRST `=`; missing `=` or an
 /// invalid key is a CLI error (surfaced here, not via a poller round-trip).
 fn parse_env_flags(raw: &[String]) -> Result<Vec<CodingAgentEnv>, String> {
@@ -556,6 +651,8 @@ mod tests {
             instructions_filename: None,
             config_seed_dest: None,
             config_seed_enabled: None,
+            backend: None,
+            container_image: None,
             confirm_timeout: 0,
         }
     }
@@ -574,6 +671,9 @@ mod tests {
             config_seed_dest: None,
             config_seed_enabled: None,
             clear_config_seed: false,
+            backend: None,
+            container_image: None,
+            clear_container_image: false,
             confirm_timeout: 0,
         }
     }
@@ -623,6 +723,64 @@ mod tests {
         a.clear_config_seed = true;
         a.config_seed_dest = Some(".claude".into());
         assert!(cmd_update(a, false).is_err());
+    }
+
+    #[test]
+    fn update_clear_container_image_conflicts() {
+        let mut a = update_args("x");
+        a.clear_container_image = true;
+        a.container_image = Some("image:tag".into());
+        assert!(cmd_update(a, false).is_err());
+    }
+
+    #[test]
+    fn backend_flags_apply_container_semantics() {
+        let mut agent = blank_agent();
+        apply_backend_flags(
+            &mut agent,
+            None,
+            Some(" agentscommander/ac-claude:latest ".into()),
+        )
+        .unwrap();
+        assert_eq!(agent.backend.kind, SessionBackendKind::ContainerTransport);
+        assert_eq!(
+            agent.backend.image.as_deref(),
+            Some("agentscommander/ac-claude:latest")
+        );
+
+        let mut local = blank_agent();
+        assert!(apply_backend_flags(
+            &mut local,
+            Some(CliBackendKind::Local),
+            Some("image:tag".into())
+        )
+        .is_err());
+
+        let mut bad = blank_agent();
+        assert!(apply_backend_flags(&mut bad, None, Some("--privileged".into())).is_err());
+        assert!(apply_backend_flags(&mut bad, None, Some("   ".into())).is_err());
+    }
+
+    #[test]
+    fn backend_patch_fields_follow_update_semantics() {
+        let (kind, image, clear) =
+            backend_patch_fields(None, Some(" image:tag ".into()), false).unwrap();
+        assert_eq!(kind, Some(SessionBackendKind::ContainerTransport));
+        assert_eq!(image.as_deref(), Some("image:tag"));
+        assert!(!clear);
+
+        let (kind, image, clear) =
+            backend_patch_fields(Some(CliBackendKind::Local), None, false).unwrap();
+        assert_eq!(kind, Some(SessionBackendKind::LocalProcess));
+        assert!(image.is_none());
+        assert!(clear);
+
+        assert!(
+            backend_patch_fields(Some(CliBackendKind::Local), Some("image:tag".into()), false)
+                .is_err()
+        );
+        assert!(backend_patch_fields(None, Some("image:tag".into()), true).is_err());
+        assert!(backend_patch_fields(None, Some("--volume=/:/host".into()), false).is_err());
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1308,6 +1308,9 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         cwd: cwd.clone(),
         cols: 120,
         rows: 30,
+        container_image: resolved_spawn
+            .as_ref()
+            .and_then(|spawn| spawn.backend.image.clone()),
         configured_env,
         env_remove_keys,
         extra_env,

--- a/src-tauri/src/config/coding_agent_mutations.rs
+++ b/src-tauri/src/config/coding_agent_mutations.rs
@@ -26,8 +26,10 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::config::settings::{
-    validate_and_repair_settings, AgentConfig, AppSettings, CodingAgentEnv, ConfigSeedConfig,
+    normalize_container_image_input, validate_and_repair_settings, AgentConfig, AppSettings,
+    CodingAgentEnv, ConfigSeedConfig,
 };
+use crate::pty::backend::SessionBackendKind;
 
 /// Subdirectory of the config dir holding pending coding-agent mutation requests.
 pub const CODING_AGENT_REQUESTS_DIR: &str = "coding-agent-requests";
@@ -78,6 +80,16 @@ pub struct AgentPatch {
     pub config_seed_enabled: Option<bool>,
     #[serde(default)]
     pub clear_config_seed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_kind: Option<SessionBackendKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_image: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub clear_container_image: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// Result of a successful `apply_coding_agent_op`. `op` is `"add"|"update"|"remove"`.
@@ -222,6 +234,7 @@ pub fn apply_coding_agent_op(
             warn_on_duplicate_label(settings, agent.label.trim(), None);
             let mut new_agent = agent.clone();
             new_agent.label = new_agent.label.trim().to_string();
+            ensure_backend_consistent(&mut new_agent)?;
             settings.agents.push(new_agent.clone());
             CodingAgentOpOutcome {
                 op: "add",
@@ -310,6 +323,33 @@ fn apply_patch(agent: &mut AgentConfig, patch: &AgentPatch) -> Result<(), String
         }
         ensure_seed_consistent(&Some(seed.clone()))?;
         agent.config_seed = Some(seed);
+    }
+    if let Some(kind) = patch.backend_kind {
+        agent.backend.kind = kind;
+    }
+    if patch.clear_container_image {
+        agent.backend.image = None;
+    } else if let Some(image) = &patch.container_image {
+        agent.backend.image = Some(normalize_container_image_input(image, "container image")?);
+    }
+    ensure_backend_consistent(agent)?;
+    Ok(())
+}
+
+fn ensure_backend_consistent(agent: &mut AgentConfig) -> Result<(), String> {
+    if let Some(image) = agent.backend.image.take() {
+        let trimmed = image.trim();
+        if trimmed.is_empty() {
+            agent.backend.image = None;
+        } else {
+            agent.backend.image = Some(normalize_container_image_input(
+                trimmed,
+                &format!("Agent \"{}\" container image", agent.label),
+            )?);
+        }
+    }
+    if agent.backend.kind == SessionBackendKind::LocalProcess {
+        agent.backend.image = None;
     }
     Ok(())
 }
@@ -528,6 +568,7 @@ fn write_reject(results_dir: &Path, request_id: &str, error: String) {
 mod tests {
     use super::*;
     use crate::config::settings::CodingAgentEnvSource;
+    use crate::pty::backend::SessionBackendKind;
 
     fn agent(id: &str, label: &str, command: &str) -> AgentConfig {
         AgentConfig {
@@ -677,6 +718,38 @@ mod tests {
     }
 
     #[test]
+    fn add_normalizes_backend_image() {
+        let mut s = AppSettings::default();
+        let mut a = agent("container", "Container", "claude");
+        a.backend.kind = SessionBackendKind::ContainerTransport;
+        a.backend.image = Some(" image:tag ".to_string());
+
+        apply_coding_agent_op(&mut s, &add(a)).unwrap();
+
+        assert_eq!(
+            s.agents[0].backend.kind,
+            SessionBackendKind::ContainerTransport
+        );
+        assert_eq!(s.agents[0].backend.image.as_deref(), Some("image:tag"));
+    }
+
+    #[test]
+    fn add_clears_local_backend_image_and_rejects_leading_dash() {
+        let mut local_settings = AppSettings::default();
+        let mut local = agent("local", "Local", "claude");
+        local.backend.image = Some(" image:tag ".to_string());
+        apply_coding_agent_op(&mut local_settings, &add(local)).unwrap();
+        assert!(local_settings.agents[0].backend.image.is_none());
+
+        let mut bad_settings = AppSettings::default();
+        let mut bad = agent("bad", "Bad", "claude");
+        bad.backend.kind = SessionBackendKind::ContainerTransport;
+        bad.backend.image = Some("--privileged".to_string());
+        let err = apply_coding_agent_op(&mut bad_settings, &add(bad)).unwrap_err();
+        assert!(err.contains("must not start with"), "{err}");
+    }
+
+    #[test]
     fn add_accepts_catalog_seeded_non_hex_color() {
         // §14.4 R6 carve-out: the op layer NEVER validates color (only the
         // explicit `--color` CLI flag does, in cmd_add). A catalog-seeded agent
@@ -802,6 +875,82 @@ mod tests {
         .unwrap();
         assert!(s.agents[0].instructions_filename.is_none());
         assert!(s.agents[0].config_seed.is_none());
+    }
+
+    #[test]
+    fn update_sets_and_clears_container_image() {
+        let mut s = AppSettings::default();
+        apply_coding_agent_op(&mut s, &add(agent("claude", "Claude", "claude"))).unwrap();
+
+        let patch = AgentPatch {
+            backend_kind: Some(SessionBackendKind::ContainerTransport),
+            container_image: Some(" image:tag ".into()),
+            ..Default::default()
+        };
+        apply_coding_agent_op(
+            &mut s,
+            &CodingAgentOp::Update {
+                id: "claude".into(),
+                patch,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            s.agents[0].backend.kind,
+            SessionBackendKind::ContainerTransport
+        );
+        assert_eq!(s.agents[0].backend.image.as_deref(), Some("image:tag"));
+
+        let clear = AgentPatch {
+            clear_container_image: true,
+            ..Default::default()
+        };
+        apply_coding_agent_op(
+            &mut s,
+            &CodingAgentOp::Update {
+                id: "claude".into(),
+                patch: clear,
+            },
+        )
+        .unwrap();
+        assert!(s.agents[0].backend.image.is_none());
+
+        let local = AgentPatch {
+            backend_kind: Some(SessionBackendKind::LocalProcess),
+            container_image: Some("remembered:tag".into()),
+            ..Default::default()
+        };
+        apply_coding_agent_op(
+            &mut s,
+            &CodingAgentOp::Update {
+                id: "claude".into(),
+                patch: local,
+            },
+        )
+        .unwrap();
+        assert_eq!(s.agents[0].backend.kind, SessionBackendKind::LocalProcess);
+        assert!(s.agents[0].backend.image.is_none());
+    }
+
+    #[test]
+    fn update_rejects_leading_dash_container_image() {
+        let mut s = AppSettings::default();
+        apply_coding_agent_op(&mut s, &add(agent("claude", "Claude", "claude"))).unwrap();
+
+        let patch = AgentPatch {
+            backend_kind: Some(SessionBackendKind::ContainerTransport),
+            container_image: Some("--volume=/:/host".into()),
+            ..Default::default()
+        };
+        let err = apply_coding_agent_op(
+            &mut s,
+            &CodingAgentOp::Update {
+                id: "claude".into(),
+                patch,
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("must not start with"), "{err}");
     }
 
     // ---- remove (orphan-preserve) ------------------------------------------
@@ -975,6 +1124,43 @@ mod tests {
         assert!(read_coding_agent_result(&results, "r1").unwrap().ok);
         assert!(!path.exists());
         assert!(!processing_path_for(&path).exists());
+    }
+
+    #[test]
+    fn handler_applies_backend_image_patch_from_request_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let requests = dir.path().join(CODING_AGENT_REQUESTS_DIR);
+        let results = requests.join(RESULTS_SUBDIR);
+        let mut settings = AppSettings::default();
+        apply_coding_agent_op(&mut settings, &add(agent("claude", "Claude", "claude"))).unwrap();
+        let patch = AgentPatch {
+            backend_kind: Some(SessionBackendKind::ContainerTransport),
+            container_image: Some(" image:tag ".into()),
+            ..Default::default()
+        };
+        let path = write_request_file(
+            &requests,
+            "patch",
+            100,
+            CodingAgentOp::Update {
+                id: "claude".into(),
+                patch,
+            },
+        );
+
+        let disp =
+            process_coding_agent_request(&path, &results, 200, &mut settings, &mut noop_save());
+
+        assert!(matches!(disp, RequestDisposition::Applied { .. }));
+        assert_eq!(
+            settings.agents[0].backend.kind,
+            SessionBackendKind::ContainerTransport
+        );
+        assert_eq!(
+            settings.agents[0].backend.image.as_deref(),
+            Some("image:tag")
+        );
+        assert!(read_coding_agent_result(&results, "patch").unwrap().ok);
     }
 
     #[test]

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -32,11 +32,7 @@ impl Default for AgentBackendConfig {
 
 impl AgentBackendConfig {
     fn is_default(&self) -> bool {
-        let image_blank = self
-            .image
-            .as_deref()
-            .is_none_or(|image| image.trim().is_empty());
-        self.kind == SessionBackendKind::LocalProcess && image_blank
+        self.kind == SessionBackendKind::LocalProcess
     }
 }
 
@@ -2296,6 +2292,11 @@ mod tests {
             crate::pty::backend::SessionBackendKind::LocalProcess
         );
         let json = serde_json::to_string(&agent).unwrap();
+        assert!(!json.contains("backend"), "{json}");
+
+        let mut local_with_image = agent;
+        local_with_image.backend.image = Some("hand-edited:latest".to_string());
+        let json = serde_json::to_string(&local_with_image).unwrap();
         assert!(!json.contains("backend"), "{json}");
     }
 

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -15,19 +15,28 @@ use crate::telegram::types::TelegramBotConfig;
 pub struct AgentBackendConfig {
     #[serde(default)]
     pub kind: SessionBackendKind,
+    /// #868 - optional per-agent Docker image override for container runtime.
+    /// None falls back to AGENTSCOMMANDER_CONTAINER_IMAGE, then DEFAULT_CONTAINER_IMAGE.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
 }
 
 impl Default for AgentBackendConfig {
     fn default() -> Self {
         Self {
             kind: SessionBackendKind::LocalProcess,
+            image: None,
         }
     }
 }
 
 impl AgentBackendConfig {
     fn is_default(&self) -> bool {
-        self.kind == SessionBackendKind::LocalProcess
+        let image_blank = self
+            .image
+            .as_deref()
+            .is_none_or(|image| image.trim().is_empty());
+        self.kind == SessionBackendKind::LocalProcess && image_blank
     }
 }
 
@@ -1317,7 +1326,50 @@ pub(crate) fn validate_env_rows(rows: &[CodingAgentEnv], context: &str) -> Resul
     Ok(())
 }
 
+pub fn normalize_container_image_input(value: &str, context: &str) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(format!("{context} must not be empty"));
+    }
+    if trimmed.starts_with('-') {
+        return Err(format!("{context} must not start with '-'"));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn normalize_agent_backend_config(
+    backend: &mut AgentBackendConfig,
+    context: &str,
+) -> Result<(), String> {
+    if backend.kind == SessionBackendKind::LocalProcess {
+        backend.image = None;
+        return Ok(());
+    }
+
+    let Some(raw_image) = backend.image.take() else {
+        return Ok(());
+    };
+    let trimmed = raw_image.trim();
+    if trimmed.is_empty() {
+        backend.image = None;
+        return Ok(());
+    }
+    backend.image = Some(normalize_container_image_input(trimmed, context)?);
+    Ok(())
+}
+
+fn normalize_agent_backend_configs(settings: &mut AppSettings) -> Result<(), String> {
+    for agent in &mut settings.agents {
+        normalize_agent_backend_config(
+            &mut agent.backend,
+            &format!("Agent \"{}\" container image", agent.label),
+        )?;
+    }
+    Ok(())
+}
+
 pub fn validate_and_repair_settings(settings: &mut AppSettings) -> Result<(), String> {
+    normalize_agent_backend_configs(settings)?;
     repair_coding_agent_profiles_config(&mut settings.coding_agent_profiles, &settings.agents);
     validate_agent_commands(settings)?;
     validate_screenshot_hotkey(&settings.screenshot_capture_hotkey)?;
@@ -2245,6 +2297,58 @@ mod tests {
         );
         let json = serde_json::to_string(&agent).unwrap();
         assert!(!json.contains("backend"), "{json}");
+    }
+
+    #[test]
+    fn agent_backend_config_serializes_container_image() {
+        use super::AgentConfig;
+
+        let mut settings = settings_with_agents(&[("Claude", "claude")]);
+        settings.agents[0].backend.kind =
+            crate::pty::backend::SessionBackendKind::ContainerTransport;
+        settings.agents[0].backend.image = Some("agentscommander/ac-claude:latest".to_string());
+        super::validate_and_repair_settings(&mut settings).unwrap();
+
+        let json = serde_json::to_string(&settings.agents[0]).unwrap();
+        assert!(json.contains("\"backend\""), "{json}");
+        assert!(json.contains("\"kind\":\"containerTransport\""), "{json}");
+        assert!(
+            json.contains("\"image\":\"agentscommander/ac-claude:latest\""),
+            "{json}"
+        );
+        let back: AgentConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.backend.image.as_deref(),
+            Some("agentscommander/ac-claude:latest")
+        );
+    }
+
+    #[test]
+    fn validate_and_repair_normalizes_backend_image_edges() {
+        let mut blank_container = settings_with_agents(&[("Claude", "claude")]);
+        blank_container.agents[0].backend.kind =
+            crate::pty::backend::SessionBackendKind::ContainerTransport;
+        blank_container.agents[0].backend.image = Some("   ".to_string());
+        super::validate_and_repair_settings(&mut blank_container).unwrap();
+        assert!(blank_container.agents[0].backend.image.is_none());
+
+        let mut local_with_image = settings_with_agents(&[("Codex", "codex")]);
+        local_with_image.agents[0].backend.image = Some(" custom:latest ".to_string());
+        super::validate_and_repair_settings(&mut local_with_image).unwrap();
+        assert!(local_with_image.agents[0].backend.image.is_none());
+        let json = serde_json::to_string(&local_with_image.agents[0]).unwrap();
+        assert!(!json.contains("backend"), "{json}");
+    }
+
+    #[test]
+    fn validate_and_repair_rejects_leading_dash_container_image() {
+        let mut settings = settings_with_agents(&[("Claude", "claude")]);
+        settings.agents[0].backend.kind =
+            crate::pty::backend::SessionBackendKind::ContainerTransport;
+        settings.agents[0].backend.image = Some(" --privileged".to_string());
+
+        let err = super::validate_and_repair_settings(&mut settings).unwrap_err();
+        assert!(err.contains("must not start with"), "{err}");
     }
 
     #[test]

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -25,6 +25,7 @@ pub struct BackendSpawnSpec {
     pub cwd: String,
     pub cols: u16,
     pub rows: u16,
+    pub container_image: Option<String>,
     pub configured_env: Vec<(String, String)>,
     pub env_remove_keys: Vec<String>,
     pub extra_env: Vec<(String, String)>,

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
 use crate::pty::container_runtime::{
-    api_url_for_container, container_image_from_env, ContainerRuntime, ContainerRuntimeHandle,
+    api_url_for_container, resolve_container_image, ContainerRuntime, ContainerRuntimeHandle,
     ContainerStartRequest, CONTAINER_STOP_TIMEOUT, DEFAULT_CONTAINER_WORKDIR,
 };
 use crate::pty::container_tokens::{ContainerApiToken, ContainerApiTokenManager};
@@ -556,6 +556,7 @@ impl ContainerTransportBackend {
             cwd,
             cols,
             rows,
+            container_image,
             configured_env,
             env_remove_keys,
             extra_env: _,
@@ -605,6 +606,7 @@ impl ContainerTransportBackend {
             cols,
             configured_env,
             env_remove_keys,
+            container_image,
             ticket,
             &token,
         ) {
@@ -1038,10 +1040,42 @@ fn build_start_request(
     cols: u16,
     configured_env: Vec<(String, String)>,
     env_remove_keys: Vec<String>,
+    container_image: Option<String>,
     registration_ticket: String,
     token: &ContainerApiToken,
 ) -> Result<ContainerStartRequest, AppError> {
     let settings = crate::config::settings::load_settings();
+    build_start_request_with_settings(
+        session_id,
+        cmd,
+        args,
+        cwd,
+        rows,
+        cols,
+        configured_env,
+        env_remove_keys,
+        container_image,
+        registration_ticket,
+        token,
+        &settings,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_start_request_with_settings(
+    session_id: Uuid,
+    cmd: &str,
+    args: Vec<String>,
+    cwd: &str,
+    rows: u16,
+    cols: u16,
+    configured_env: Vec<(String, String)>,
+    env_remove_keys: Vec<String>,
+    container_image: Option<String>,
+    registration_ticket: String,
+    token: &ContainerApiToken,
+    settings: &crate::config::settings::AppSettings,
+) -> Result<ContainerStartRequest, AppError> {
     if !settings.api_server_enabled {
         return Err(AppError::Other(
             "container transport requires the control-plane API server to be enabled".to_string(),
@@ -1051,7 +1085,7 @@ fn build_start_request(
     let child_env = sanitized_child_env(configured_env, env_remove_keys);
     Ok(ContainerStartRequest {
         session_id,
-        image: container_image_from_env(),
+        image: resolve_container_image(container_image.as_deref()),
         host_root: cwd.to_string(),
         container_workdir: DEFAULT_CONTAINER_WORKDIR.to_string(),
         api_url,
@@ -1176,6 +1210,7 @@ mod tests {
             cwd: root.to_string(),
             cols: 120,
             rows: 30,
+            container_image: None,
             configured_env: Vec::new(),
             env_remove_keys: Vec::new(),
             extra_env: Vec::new(),
@@ -1331,6 +1366,44 @@ mod tests {
             got,
             vec![("CODEX_HOME".to_string(), "/workspace/.codex".to_string())]
         );
+    }
+
+    fn api_enabled_settings() -> crate::config::settings::AppSettings {
+        crate::config::settings::AppSettings {
+            api_server_enabled: true,
+            api_server_bind: "0.0.0.0".to_string(),
+            api_server_port: 8765,
+            ..crate::config::settings::AppSettings::default()
+        }
+    }
+
+    fn token() -> ContainerApiToken {
+        ContainerApiToken {
+            client_id: "client".to_string(),
+            secret: "secret".to_string(),
+        }
+    }
+
+    #[test]
+    fn build_start_request_honors_container_image_override() {
+        let id = Uuid::new_v4();
+        let request = build_start_request_with_settings(
+            id,
+            "claude",
+            Vec::new(),
+            "C:/repo/.ac/wg-1/__agent_dev",
+            30,
+            120,
+            Vec::new(),
+            Vec::new(),
+            Some(" agentscommander/ac-claude:latest ".to_string()),
+            "ticket".to_string(),
+            &token(),
+            &api_enabled_settings(),
+        )
+        .unwrap();
+
+        assert_eq!(request.image, "agentscommander/ac-claude:latest");
     }
 
     #[tokio::test]

--- a/src-tauri/src/pty/container_runtime.rs
+++ b/src-tauri/src/pty/container_runtime.rs
@@ -62,6 +62,13 @@ pub fn container_image_from_env() -> String {
         .unwrap_or_else(|| DEFAULT_CONTAINER_IMAGE.to_string())
 }
 
+pub fn resolve_container_image(per_agent: Option<&str>) -> String {
+    match per_agent.map(str::trim).filter(|image| !image.is_empty()) {
+        Some(image) => image.to_string(),
+        None => container_image_from_env(),
+    }
+}
+
 pub fn api_url_for_container(bind: &str, port: u16) -> Result<String, AppError> {
     let bind = bind.trim();
     if bind.is_empty() {
@@ -86,6 +93,23 @@ pub fn api_url_for_container(bind: &str, port: u16) -> Result<String, AppError> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_container_image_env(value: Option<&str>, test: impl FnOnce()) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os("AGENTSCOMMANDER_CONTAINER_IMAGE");
+        match value {
+            Some(value) => std::env::set_var("AGENTSCOMMANDER_CONTAINER_IMAGE", value),
+            None => std::env::remove_var("AGENTSCOMMANDER_CONTAINER_IMAGE"),
+        }
+        test();
+        match previous {
+            Some(value) => std::env::set_var("AGENTSCOMMANDER_CONTAINER_IMAGE", value),
+            None => std::env::remove_var("AGENTSCOMMANDER_CONTAINER_IMAGE"),
+        }
+    }
 
     #[test]
     fn api_url_rejects_loopback_and_maps_wildcard_to_docker_host() {
@@ -98,5 +122,25 @@ mod tests {
             api_url_for_container("192.168.1.10", 8765).unwrap(),
             "http://192.168.1.10:8765"
         );
+    }
+
+    #[test]
+    fn resolve_container_image_uses_per_agent_env_then_default() {
+        with_container_image_env(Some("env/image:latest"), || {
+            assert_eq!(
+                resolve_container_image(Some(" per-agent/image:latest ")),
+                "per-agent/image:latest"
+            );
+            assert_eq!(resolve_container_image(Some("  ")), "env/image:latest");
+            assert_eq!(resolve_container_image(None), "env/image:latest");
+        });
+
+        with_container_image_env(Some("  "), || {
+            assert_eq!(resolve_container_image(None), DEFAULT_CONTAINER_IMAGE);
+        });
+
+        with_container_image_env(None, || {
+            assert_eq!(resolve_container_image(None), DEFAULT_CONTAINER_IMAGE);
+        });
     }
 }

--- a/src-tauri/src/pty/docker_runtime.rs
+++ b/src-tauri/src/pty/docker_runtime.rs
@@ -98,6 +98,7 @@ impl DockerRuntime {
             ),
             "--workdir".to_string(),
             request.container_workdir.clone(),
+            "--".to_string(),
             request.image.clone(),
             DEFAULT_BRIDGE_ENTRYPOINT.to_string(),
         ];
@@ -385,9 +386,32 @@ mod tests {
         assert!(joined.contains("AGENTSCOMMANDER_BRIDGE_COMMAND=codex"));
         assert!(joined
             .contains("type=bind,source=C:/project/.ac/wg-1-team/__agent_dev,target=/workspace"));
+        let image_idx = spec
+            .args
+            .iter()
+            .position(|arg| arg == "ac-bridge:test")
+            .expect("image arg");
+        assert_eq!(spec.args[image_idx - 1], "--");
+        assert_eq!(spec.args[image_idx + 1], DEFAULT_BRIDGE_ENTRYPOINT);
         assert!(!joined.contains("docker.sock"));
         assert!(!joined.contains("messaging"));
         assert!(!joined.contains("api-clients.json"));
+    }
+
+    #[test]
+    fn run_command_terminates_options_before_image() {
+        let runtime = DockerRuntime::with_program("docker-test");
+        let mut request = request();
+        request.image = "--privileged".to_string();
+        let spec = runtime.build_run_command(&request);
+        let image_idx = spec
+            .args
+            .iter()
+            .position(|arg| arg == "--privileged")
+            .expect("image arg");
+
+        assert_eq!(spec.args[image_idx - 1], "--");
+        assert_eq!(spec.args[image_idx + 1], DEFAULT_BRIDGE_ENTRYPOINT);
     }
 
     #[test]

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -402,6 +402,7 @@ impl LocalProcessBackend {
             cwd,
             cols,
             rows,
+            container_image: _,
             configured_env,
             env_remove_keys,
             extra_env,

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -404,6 +404,7 @@ mod tests {
             cwd: ".".to_string(),
             cols: 80,
             rows: 24,
+            container_image: None,
             configured_env: Vec::new(),
             env_remove_keys: Vec::new(),
             extra_env: Vec::new(),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -125,6 +125,8 @@ export interface ConfigSeedConfig {
 
 export interface AgentBackendConfig {
   kind?: SessionBackendKind;
+  /** #868 - per-agent Docker image override; empty/undefined falls back to env then default. */
+  image?: string;
 }
 
 export interface AgentConfig {

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -417,6 +417,88 @@ describe("SettingsModal automation hooks", () => {
     dispose();
   });
 
+  it("shows the runtime selector and reveals container-only fields with soft warnings", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    const runtime = byTestId<HTMLSelectElement>("settings.agentRow.0.runtimeKind");
+    expect(runtime.value).toBe("localProcess");
+    expect(document.querySelector('[data-ac-testid="settings.agentRow.0.containerImage"]')).toBeNull();
+    expect(
+      document.querySelector('[data-ac-testid="settings.agentRow.0.containerWarning.apiServer"]'),
+    ).toBeNull();
+    expect(
+      document.querySelector('[data-ac-testid="settings.agentRow.0.containerWarning.bind"]'),
+    ).toBeNull();
+
+    runtime.value = "containerTransport";
+    runtime.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+
+    const image = byTestId<HTMLInputElement>("settings.agentRow.0.containerImage");
+    expect(image.placeholder).toBe("agentscommander/session-bridge:latest");
+    expect(byTestId("settings.agentRow.0.containerWarning.apiServer").textContent).toContain(
+      "API server enabled",
+    );
+    expect(byTestId("settings.agentRow.0.containerWarning.bind").textContent).toContain(
+      "loopback API bind",
+    );
+
+    runtime.value = "localProcess";
+    runtime.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+
+    expect(document.querySelector('[data-ac-testid="settings.agentRow.0.containerImage"]')).toBeNull();
+    expect(
+      document.querySelector('[data-ac-testid="settings.agentRow.0.containerWarning.apiServer"]'),
+    ).toBeNull();
+    expect(
+      document.querySelector('[data-ac-testid="settings.agentRow.0.containerWarning.bind"]'),
+    ).toBeNull();
+
+    dispose();
+  });
+
+  it("saves a container runtime image through the settings draft", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    const runtime = byTestId<HTMLSelectElement>("settings.agentRow.0.runtimeKind");
+    runtime.value = "containerTransport";
+    runtime.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+
+    const image = byTestId<HTMLInputElement>("settings.agentRow.0.containerImage");
+    image.value = "  ghcr.io/ac/custom-agent:latest  ";
+    image.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.agents[0]?.backend).toEqual({
+      kind: "containerTransport",
+      image: "ghcr.io/ac/custom-agent:latest",
+    });
+
+    dispose();
+  });
+
   it("keeps an early custom agent draft when the fresh load resolves late", async () => {
     let resolveLoadedSettings: (value: AppSettings) => void = () => {};
     vi.mocked(SettingsAPI.get).mockReturnValueOnce(

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -11,6 +11,7 @@ import type {
   ProfileCellConfig,
   ApiClientMintResponse,
   ApiClientMintScope,
+  SessionBackendKind,
 } from "../../shared/types";
 import { SettingsAPI, TelegramAPI, ReposAPI, CodingAgentsAPI } from "../../shared/ipc";
 import { toastStore } from "../../shared/stores/toasts";
@@ -113,6 +114,7 @@ const resolveSettingsSection = (s: string | undefined): SettingsTab =>
       : "general";
 
 const BYTES_PER_GIB = 1024 ** 3;
+const DEFAULT_CONTAINER_IMAGE = "agentscommander/session-bridge:latest";
 
 const bytesToGiBInput = (bytes: number): string => {
   const value = bytes / BYTES_PER_GIB;
@@ -121,6 +123,16 @@ const bytesToGiBInput = (bytes: number): string => {
 
 const giBInputToBytes = (value: string): number =>
   Math.round(Number(value) * BYTES_PER_GIB);
+
+const isContainerLoopbackBind = (bind: string | undefined): boolean => {
+  const normalized = (bind ?? "").trim().toLowerCase();
+  return (
+    normalized === "" ||
+    normalized === "127.0.0.1" ||
+    normalized === "localhost" ||
+    normalized === "::1"
+  );
+};
 
 const cloneSettings = (value: AppSettings | null): AppSettings | null => {
   if (!value) return null;
@@ -480,6 +492,26 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     setSettings("data", "agents", index, "configSeed", {
       enabled: current?.enabled ?? true,
       dest,
+    });
+  };
+
+  const setAgentBackendKind = (index: number, kind: SessionBackendKind) => {
+    if (!settings.data) return;
+    setDraftDirty(true);
+    const current = settings.data.agents[index]?.backend;
+    setSettings("data", "agents", index, "backend", {
+      kind,
+      image: current?.image,
+    });
+  };
+
+  const setAgentBackendImage = (index: number, image: string) => {
+    if (!settings.data) return;
+    setDraftDirty(true);
+    const current = settings.data.agents[index]?.backend;
+    setSettings("data", "agents", index, "backend", {
+      kind: current?.kind ?? "containerTransport",
+      image,
     });
   };
 
@@ -1791,6 +1823,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     const i = () => index();
     const expanded = () => activeAgentId() === agent.id;
     const pill = () => railPillFor(agent.id);
+    const agentBackendKind = () => agent.backend?.kind ?? "localProcess";
+    const containerBindWarning = () => isContainerLoopbackBind(settings.data?.apiServerBind);
     return (
       <div
         class="settings-agent-row"
@@ -1909,6 +1943,61 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                 data-ac-role="textbox"
               />
             </label>
+            <label class="settings-field">
+              <span class="settings-label">Runtime</span>
+              <select
+                class="settings-input"
+                value={agentBackendKind()}
+                onChange={(e) =>
+                  setAgentBackendKind(i(), e.currentTarget.value as SessionBackendKind)
+                }
+                data-ac-testid={`settings.agentRow.${i()}.runtimeKind`}
+                data-ac-role="combobox"
+                data-ac-state={agentBackendKind()}
+              >
+                <option value="localProcess">Local (default)</option>
+                <option value="containerTransport">Container (Docker)</option>
+              </select>
+            </label>
+            <Show when={agentBackendKind() === "containerTransport"}>
+              <label class="settings-field">
+                <span class="settings-label">Docker image</span>
+                <input
+                  class="settings-input"
+                  value={agent.backend?.image ?? ""}
+                  onInput={(e) => setAgentBackendImage(i(), e.currentTarget.value)}
+                  placeholder={DEFAULT_CONTAINER_IMAGE}
+                  data-ac-testid={`settings.agentRow.${i()}.containerImage`}
+                  data-ac-role="textbox"
+                />
+              </label>
+              <div
+                class="settings-hint"
+                data-ac-testid={`settings.agentRow.${i()}.containerHint.image`}
+              >
+                Leave blank to use the host default. Resolution: this field, then
+                AGENTSCOMMANDER_CONTAINER_IMAGE, then {DEFAULT_CONTAINER_IMAGE}.
+              </div>
+              <Show when={!apiServerChecked()}>
+                <div
+                  class="settings-hint settings-hint-warning"
+                  data-ac-testid={`settings.agentRow.${i()}.containerWarning.apiServer`}
+                  data-ac-role="status"
+                >
+                  Container runtime needs the control-plane API server enabled.
+                </div>
+              </Show>
+              <Show when={containerBindWarning()}>
+                <div
+                  class="settings-hint settings-hint-warning"
+                  data-ac-testid={`settings.agentRow.${i()}.containerWarning.bind`}
+                  data-ac-role="status"
+                >
+                  Docker cannot reach a loopback API bind; set a Docker-reachable bind
+                  such as 0.0.0.0 with firewall rules.
+                </div>
+              </Show>
+            </Show>
             <label class="settings-field">
               <span class="settings-label">Instructions file</span>
               <input

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -188,6 +188,71 @@ describe("mergeSettingsForSavePreservingProjects (#598 configSeed normalization)
   });
 });
 
+describe("mergeSettingsForSavePreservingProjects (#868 backend normalization)", () => {
+  it("drops absent, empty, and explicit Local backend objects", () => {
+    const draft = settings({
+      agents: [
+        agent({ id: "absent" }),
+        agent({ id: "empty", backend: {} }),
+        agent({ id: "local", backend: { kind: "localProcess" } }),
+      ],
+    });
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    for (const a of merged.agents) {
+      expect("backend" in a).toBe(false);
+    }
+  });
+
+  it("keeps a container backend kind and trims the image", () => {
+    const draft = settings({
+      agents: [
+        agent({
+          backend: {
+            kind: "containerTransport",
+            image: "  agentscommander/ac-claude:latest  ",
+          },
+        }),
+      ],
+    });
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect(merged.agents[0]?.backend).toEqual({
+      kind: "containerTransport",
+      image: "agentscommander/ac-claude:latest",
+    });
+  });
+
+  it("omits empty container images while preserving the container kind", () => {
+    const draft = settings({
+      agents: [
+        agent({ id: "empty", backend: { kind: "containerTransport", image: "" } }),
+        agent({ id: "spaces", backend: { kind: "containerTransport", image: "   " } }),
+      ],
+    });
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect(merged.agents[0]?.backend).toEqual({ kind: "containerTransport" });
+    expect(merged.agents[1]?.backend).toEqual({ kind: "containerTransport" });
+  });
+
+  it("drops a Local backend even when the live draft has a hidden image", () => {
+    const draft = settings({
+      agents: [
+        agent({
+          backend: {
+            kind: "localProcess",
+            image: "agentscommander/ac-claude:latest",
+          },
+        }),
+      ],
+    });
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect(merged.agents[0]).not.toHaveProperty("backend");
+  });
+});
+
 describe("mergeSettingsForSavePreservingProjects webserver seed rebasing", () => {
   it("rebases unchanged stale modal webserver fields from fresh settings", () => {
     const modalSeed = settings({

--- a/src/sidebar/components/settings-save.ts
+++ b/src/sidebar/components/settings-save.ts
@@ -40,6 +40,25 @@ function normalizeAgentConfigSeed(agent: AgentConfig): AgentConfig {
   return rest;
 }
 
+/**
+ * #868 - normalize the optional runtime backend. The editor preserves a hidden
+ * image in the live draft while toggling Container <-> Local, but Local must
+ * persist exactly like the historical default: no `backend` object at all.
+ */
+function normalizeAgentBackend(agent: AgentConfig): AgentConfig {
+  const kind = agent.backend?.kind ?? "localProcess";
+  if (kind === "localProcess") {
+    const { backend: _drop, ...rest } = agent;
+    return rest;
+  }
+
+  const image = agent.backend?.image?.trim();
+  return {
+    ...agent,
+    backend: image ? { kind, image } : { kind },
+  };
+}
+
 export function mergeSettingsForSavePreservingProjects(
   draft: AppSettings,
   fresh: AppSettings,
@@ -64,7 +83,8 @@ export function mergeSettingsForSavePreservingProjects(
     ...webServerFields,
     agents: draft.agents
       .map(normalizeAgentInstructionsFilename)
-      .map(normalizeAgentConfigSeed),
+      .map(normalizeAgentConfigSeed)
+      .map(normalizeAgentBackend),
     projectPaths: fresh.projectPaths ?? [],
     projectPath: fresh.projectPath ?? null,
   };


### PR DESCRIPTION
## Summary
Adds a container runtime selector so launching a coding agent in Docker no longer requires hand-editing `settings.json`. Part of #819 (step b of the user-friendliness work; step a shipped the ac-claude image in #865).

## What changed
- **Model:** `AgentBackendConfig.image` (per-agent Docker image override). `is_default` is kind-only for Local, so a Local agent always omits `backend` on the wire (byte-identical), across every path including startup migration.
- **Backend:** `BackendSpawnSpec.container_image` threaded into the container start path; `resolve_container_image` with precedence per-agent > `AGENTSCOMMANDER_CONTAINER_IMAGE` > built-in default; a `--` terminator is inserted before the image in the `docker run` command and leading-dash/empty images are rejected (arg-injection guard, F2); the validation lives in the shared apply path (poller-safe, not clap-only, F4).
- **CLI:** `coding-agent add/update` gain `--backend local|container`, `--container-image`, `--clear-container-image` (`--container-image` implies container; rejects `local + image`; clear/set conflict). `docs/reference/cli.md` updated.
- **UI:** a Runtime selector (Local | Container) in the coding-agent editor; a container-only image field plus advisory warnings (API server off, loopback bind) revealed only for Container; a save normalizer drops `backend` for Local. No coupling to the #853 mint UI or the #846 toggle.
- The per-session container token mint stays automatic and unchanged; the Local resting state is unchanged.

## Review
- architect plan + 3-way enrich (dev-rust, dev-webpage-ui, grinch) converged to `READY_FOR_IMPLEMENTATION`.
- grinch security review of the slice: PASS (the F2 arg-injection guard and the F4 shared-path validation are implemented correctly with genuine tests). N1 (`is_default` kind-only for Local) folded in before landing; N2 (inline UI warning for a leading-dash image) is a follow-up.

## Gates
- Backend: `cargo test --all-targets`, `cargo clippy --all-targets -- -D warnings`, `npm run version:check`, `npm run smoke:cli-release-windows` all pass.
- FE: `npm run typecheck`, `npm test -- --run` (811 tests), `npm run build` all pass.

## Follow-ups (non-blocking)
- N2: inline UI warning for a leading-dash image (currently surfaces as a generic Rust save error; no security gap).
- F6: no API bind/port editor in the UI, so the loopback warning is advisory-only.

Closes #868
