### PR TITLE
fix: preserve Restart Session fresh intent against non-substantive PTY writes (#871)

### DIFF
--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -15,6 +15,17 @@ pub struct PtyScreenSnapshotPayload {
     pub sequence: u64,
 }
 
+/// (#871) Classifies user-input notifications so fresh-intent clearing can be
+/// gated on substantive post-boundary submissions.
+pub(crate) enum UserInputSource<'a> {
+    /// xterm terminal keystrokes from the Tauri `pty_write` command.
+    Terminal(&'a [u8]),
+    /// Web UI raw keystrokes from binary frames or the web command path.
+    Web(&'a [u8]),
+    /// A complete submitted message, always substantive.
+    CompleteMessage,
+}
+
 #[tauri::command]
 pub async fn pty_write(
     app: AppHandle,
@@ -44,7 +55,7 @@ pub async fn pty_write(
 
     // #552 user input -> silence touch (+ badge reset if coordinator). Resolves
     // all state from `app`, so the same helper serves Telegram and web.
-    note_user_message_to_session(&app, uuid).await;
+    note_user_message_to_session(&app, uuid, UserInputSource::Terminal(&data)).await;
 
     Ok(())
 }
@@ -52,28 +63,37 @@ pub async fn pty_write(
 /// #552 Record a real user message to `session_id`: always reset the auto-close
 /// silence clock; if the session is a coordinator, reset its badge clock and
 /// emit `coordinator_clock_updated` (and clear any "auto-closed" marker).
-/// Resolves all state from `app`, so every user-input surface (xterm `pty_write`,
-/// Telegram inbound, web UI) can call it with just (app, uuid). Injection /
-/// auto-resume MUST NOT call this (they are not user messages).
+/// Resolves all state from `app`, so every user-input surface (xterm
+/// `pty_write`, Telegram inbound, web UI) can call it with its source tag.
+/// Injection / auto-resume MUST NOT call this (they are not user messages).
 ///
 /// Generic over the Tauri runtime so callers holding either a concrete
 /// `AppHandle` or a generic `AppHandle<R>` (e.g. the Telegram bridge) can reuse it.
 pub(crate) async fn note_user_message_to_session<R: tauri::Runtime>(
     app: &AppHandle<R>,
     session_id: Uuid,
+    source: UserInputSource<'_>,
 ) {
+    let (substantive, source_class): (bool, &'static str) = match source {
+        UserInputSource::Terminal(data) => {
+            (classify_substantive(app, session_id, data), "terminal")
+        }
+        UserInputSource::Web(data) => (classify_substantive(app, session_id, data), "web"),
+        UserInputSource::CompleteMessage => (true, "message"),
+    };
+
     // (a) auto-close silence: any user message keeps the team alive.
     if let Some(idle) = app.try_state::<Arc<crate::pty::idle_detector::IdleDetector>>() {
         idle.touch_silence(session_id);
     }
 
     // (#630/#631 + #698) Apply both user-input state transitions and persist them
-    // atomically. On the FIRST real user message we re-arm the resume intent (so a
-    // restarted-fresh session stays fresh until the user actually engages) and
-    // clear any visible raise-hand communication. This is the unified user-input
-    // choke point (xterm/Telegram/web); injection and auto-resume never call it,
-    // and it runs before the coordinator-only early return below so non-
-    // coordinator members re-arm too.
+    // atomically. On the FIRST substantive post-boundary submission we re-arm the
+    // resume intent, and every user write still lowers any visible raise-hand
+    // communication. This is the unified user-input choke point
+    // (xterm/Telegram/web); injection and auto-resume never call it, and it runs
+    // before the coordinator-only early return below so non-coordinator members
+    // re-arm too when the write is substantive.
     //
     // `clear_user_input_transitions_and_persist_result` flips BOTH fields in one
     // SessionManager critical section and runs the mutation + snapshot + save
@@ -86,13 +106,15 @@ pub(crate) async fn note_user_message_to_session<R: tauri::Runtime>(
         let guard = mgr.read().await;
         guard.clone()
     };
-    let cleared_raise_hand =
+    let cleared =
         match crate::config::sessions_persistence::clear_user_input_transitions_and_persist_result(
-            &manager, session_id,
+            &manager,
+            session_id,
+            substantive,
         )
         .await
         {
-            Ok(cleared) => cleared.cleared_raise_hand,
+            Ok(cleared) => cleared,
             Err(e) => {
                 log::error!(
                     "Failed to persist user-input session state transitions: {}",
@@ -101,11 +123,25 @@ pub(crate) async fn note_user_message_to_session<R: tauri::Runtime>(
                 // The in-memory clear still applied; only the snapshot failed.
                 // Suppress the clear event so the live UI does not diverge from the
                 // durable file (the next persist will reconcile disk).
-                false
+                crate::config::sessions_persistence::ClearedUserInputTransitions::default()
             }
         };
 
-    if cleared_raise_hand {
+    if cleared.cleared_start_fresh {
+        log::info!(
+            "[session-state] {} fresh intent cleared: substantive {} input (#871)",
+            &session_id.to_string()[..8],
+            source_class
+        );
+    } else if !substantive {
+        log::debug!(
+            "[session-state] {} non-substantive {} write; fresh intent preserved (#871)",
+            &session_id.to_string()[..8],
+            source_class
+        );
+    }
+
+    if cleared.cleared_raise_hand {
         let _ = app.emit(
             "session_communication_changed",
             serde_json::json!({ "sessionId": session_id.to_string(), "communication": null }),
@@ -127,18 +163,21 @@ pub(crate) async fn note_user_message_to_session<R: tauri::Runtime>(
     // agent_fqn_from_path returns String (teams.rs:80), not Option.
     let fqn = crate::config::teams::agent_fqn_from_path(&cwd);
     let now = chrono::Utc::now();
-    let (changed, cleared, cleared_fresh) = {
+    let (changed, cleared_auto, cleared_fresh) = {
         let mut guard = clocks.lock().unwrap_or_else(|e| e.into_inner());
         let changed = guard.note_user_message(&fqn, now);
         // #552 a real user message reopens the coordinator -> clear any
         // "auto-closed" marker (idempotent; no-op if not marked).
-        let cleared = guard.clear_auto_closed(&fqn);
-        // (#756) typed input creates a post-boundary transcript: drop the
-        // fresh-intent mirror. The record half is re-armed above via
-        // clear_user_input_transitions; without this the destroyed-record
-        // reopen would force an ENGAGED coordinator fresh.
-        let cleared_fresh = guard.clear_start_fresh(&fqn);
-        (changed, cleared, cleared_fresh)
+        let cleared_auto = guard.clear_auto_closed(&fqn);
+        // (#871/#756) Drop the fresh-intent mirror only on a substantive
+        // post-boundary submission. Non-substantive terminal writes leave it set
+        // so an app restart still restores fresh.
+        let cleared_fresh = if substantive {
+            guard.clear_start_fresh(&fqn)
+        } else {
+            false
+        };
+        (changed, cleared_auto, cleared_fresh)
     };
     if changed {
         let _ = app.emit(
@@ -146,7 +185,7 @@ pub(crate) async fn note_user_message_to_session<R: tauri::Runtime>(
             serde_json::json!({ "replicaPath": cwd, "lastUserMessageAt": now.to_rfc3339() }),
         );
     }
-    if cleared {
+    if cleared_auto {
         let _ = app.emit(
             "coordinator_auto_close_changed",
             serde_json::json!({ "replicaPath": cwd, "autoClosedAt": null }),
@@ -161,6 +200,21 @@ pub(crate) async fn note_user_message_to_session<R: tauri::Runtime>(
             log::warn!("[coordinator-clocks] fresh-intent clear save failed: {}", e);
         }
     }
+}
+
+/// (#871) Run the substantive-submission classifier for a raw keystroke chunk.
+/// Locks the managed tracker briefly with no await held. Fail-open to true if
+/// the tracker state is absent, preserving the historical clear contract.
+fn classify_substantive<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    session_id: Uuid,
+    data: &[u8],
+) -> bool {
+    let Some(state) = app.try_state::<crate::pty::input_activity::SubstantiveInputState>() else {
+        return true;
+    };
+    let mut tracker = state.lock().unwrap_or_else(|e| e.into_inner());
+    tracker.feed(session_id, data)
 }
 
 /// (#756) Record an AC-driven fresh-conversation boundary for `session_id`:
@@ -186,6 +240,12 @@ pub(crate) async fn stamp_fresh_boundary_to_session<R: tauri::Runtime>(
     // a later record destroy resurrect the pre-boundary conversation: the
     // exact #756 bug.
     write_start_fresh_mirror_for_session(app, session_id, true).await;
+    if let Some(state) = app.try_state::<crate::pty::input_activity::SubstantiveInputState>() {
+        state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .reset(session_id);
+    }
     let manager = {
         let mgr = app.state::<Arc<tokio::sync::RwLock<crate::session::manager::SessionManager>>>();
         let guard = mgr.read().await;
@@ -197,8 +257,7 @@ pub(crate) async fn stamp_fresh_boundary_to_session<R: tauri::Runtime>(
         .get_session(session_id)
         .await
         .map(|s| {
-            s.is_root_agent
-                || crate::config::root_agent::is_root_agent_path(&s.working_directory)
+            s.is_root_agent || crate::config::root_agent::is_root_agent_path(&s.working_directory)
         })
         .unwrap_or(false);
     if !is_root {
@@ -348,4 +407,162 @@ pub fn get_screen_snapshot(
         cols: Some(snapshot.cols),
         sequence: snapshot.sequence,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use crate::config::coordinator_clocks::{CoordinatorClocks, CoordinatorClocksState};
+    use crate::session::manager::SessionManager;
+    use crate::session::session::SessionRepo;
+
+    struct FreshIntentFixture {
+        app: tauri::App<tauri::test::MockRuntime>,
+        session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
+        clocks: CoordinatorClocksState,
+        session_id: Uuid,
+        fqn: String,
+    }
+
+    fn user_input_test_app(
+        session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
+        clocks: CoordinatorClocksState,
+    ) -> tauri::App<tauri::test::MockRuntime> {
+        tauri::test::mock_builder()
+            .manage(session_mgr)
+            .manage(clocks)
+            .manage(crate::pty::input_activity::new_state())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build user input test app")
+    }
+
+    async fn fresh_intent_fixture() -> FreshIntentFixture {
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let clocks = Arc::new(Mutex::new(CoordinatorClocks::default()));
+        let app = user_input_test_app(session_mgr.clone(), clocks.clone());
+        let cwd = "C:/ac-test/project/.ac/wg-871-dev-team/__agent_tech-lead".to_string();
+        let fqn = crate::config::teams::agent_fqn_from_path(&cwd);
+        let session = {
+            let mgr = session_mgr.read().await;
+            mgr.create_session(
+                "codex".to_string(),
+                Vec::new(),
+                cwd,
+                None,
+                None,
+                Vec::<SessionRepo>::new(),
+                true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
+            )
+            .await
+            .expect("create coordinator session")
+        };
+
+        {
+            let mgr = session_mgr.read().await;
+            mgr.set_start_fresh_on_restore(session.id, true).await;
+        }
+        {
+            let mut guard = clocks.lock().unwrap_or_else(|e| e.into_inner());
+            assert!(guard.mark_start_fresh(&fqn, chrono::Utc::now()));
+        }
+
+        FreshIntentFixture {
+            app,
+            session_mgr,
+            clocks,
+            session_id: session.id,
+            fqn,
+        }
+    }
+
+    async fn record_fresh(f: &FreshIntentFixture) -> bool {
+        let mgr = f.session_mgr.read().await;
+        mgr.get_session(f.session_id)
+            .await
+            .expect("session should exist")
+            .start_fresh_on_restore
+    }
+
+    fn mirror_fresh(f: &FreshIntentFixture) -> bool {
+        f.clocks
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .start_fresh_at(&f.fqn)
+            .is_some()
+    }
+
+    fn inject_continue_after_restore(start_fresh_on_restore: bool) -> bool {
+        !start_fresh_on_restore
+    }
+
+    #[tokio::test]
+    async fn restart_non_substantive_terminal_writes_keep_restore_fresh() {
+        let f = fresh_intent_fixture().await;
+        for chunk in [
+            b"\x1b[I".as_slice(),
+            b"\x1b[A".as_slice(),
+            b"\x1b]11;rgb:1234/5678/9abc\x07".as_slice(),
+            b"\r".as_slice(),
+        ] {
+            note_user_message_to_session(
+                f.app.handle(),
+                f.session_id,
+                UserInputSource::Terminal(chunk),
+            )
+            .await;
+            assert!(record_fresh(&f).await);
+            assert!(mirror_fresh(&f));
+        }
+
+        assert!(!inject_continue_after_restore(record_fresh(&f).await));
+    }
+
+    #[tokio::test]
+    async fn restart_substantive_terminal_prompt_allows_resume_on_restore() {
+        let f = fresh_intent_fixture().await;
+        note_user_message_to_session(
+            f.app.handle(),
+            f.session_id,
+            UserInputSource::Terminal(b"do the thing\r"),
+        )
+        .await;
+
+        assert!(!record_fresh(&f).await);
+        assert!(!mirror_fresh(&f));
+        assert!(inject_continue_after_restore(record_fresh(&f).await));
+    }
+
+    #[tokio::test]
+    async fn restart_injected_body_allows_resume_on_restore() {
+        let f = fresh_intent_fixture().await;
+        note_post_boundary_content_to_session(f.app.handle(), f.session_id).await;
+
+        assert!(!record_fresh(&f).await);
+        assert!(!mirror_fresh(&f));
+        assert!(inject_continue_after_restore(record_fresh(&f).await));
+    }
+
+    #[tokio::test]
+    async fn ctrl_c_cancelled_terminal_line_keeps_restore_fresh() {
+        let f = fresh_intent_fixture().await;
+        for chunk in [
+            b"do the thing".as_slice(),
+            b"\x03".as_slice(),
+            b"\r".as_slice(),
+        ] {
+            note_user_message_to_session(
+                f.app.handle(),
+                f.session_id,
+                UserInputSource::Terminal(chunk),
+            )
+            .await;
+        }
+
+        assert!(record_fresh(&f).await);
+        assert!(mirror_fresh(&f));
+        assert!(!inject_continue_after_restore(record_fresh(&f).await));
+    }
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1959,6 +1959,13 @@ async fn destroy_session_inner_with_options<R: tauri::Runtime>(
     // Persist after destruction
     persist_current_state(&mgr).await;
 
+    // (#871) Drop the substantive-input tracker entry for this uuid so the
+    // per-session map does not grow monotonically. Dormant roots keep their
+    // uuid, so the early-return branch above intentionally does not reset.
+    if let Some(state) = app.try_state::<crate::pty::input_activity::SubstantiveInputState>() {
+        state.lock().unwrap_or_else(|e| e.into_inner()).reset(uuid);
+    }
+
     let _ = app.emit("session_destroyed", serde_json::json!({ "id": id }));
 
     // Close any detached terminal window for this session.

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -1314,10 +1314,10 @@ async fn raise_hand_and_persist_to_dir_result(
     Ok(RaiseHandPersistOutcome::Raised(communication))
 }
 
-/// #698 — the user-input session-state transitions cleared by
+/// #698: the user-input session-state transitions cleared by
 /// `clear_user_input_transitions_and_persist_result`, reported so the caller can
 /// decide whether to emit the raise-hand clear event.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct ClearedUserInputTransitions {
     /// `start_fresh_on_restore` flipped `true -> false` (#630/#631 re-arm).
     pub cleared_start_fresh: bool,
@@ -1325,9 +1325,10 @@ pub struct ClearedUserInputTransitions {
     pub cleared_raise_hand: bool,
 }
 
-/// #698 — clear the user-input session-state transitions (re-arm
-/// `start_fresh_on_restore`, lower any visible raise-hand) and persist the
-/// result atomically with respect to all session persistence.
+/// #698: clear the user-input session-state transitions and persist the result
+/// atomically with respect to all session persistence. `clear_fresh` gates the
+/// `start_fresh_on_restore` re-arm to substantive post-boundary submissions
+/// (#871); lowering any visible raise-hand remains unconditional.
 ///
 /// Fix for the MEDIUM grinch finding: the two field clears previously ran in two
 /// separate critical sections with an await between them, so a concurrent persist
@@ -1346,12 +1347,14 @@ pub struct ClearedUserInputTransitions {
 pub async fn clear_user_input_transitions_and_persist_result(
     mgr: &SessionManager,
     session_id: Uuid,
+    clear_fresh: bool,
 ) -> Result<ClearedUserInputTransitions, String> {
     let dir = super::config_dir();
     let project_paths = crate::config::settings::load_settings_for_cli().project_paths;
     clear_user_input_transitions_and_persist_to_dir_result(
         mgr,
         session_id,
+        clear_fresh,
         dir.as_deref(),
         Some(&project_paths),
     )
@@ -1361,16 +1364,19 @@ pub async fn clear_user_input_transitions_and_persist_result(
 async fn clear_user_input_transitions_and_persist_to_dir_result(
     mgr: &SessionManager,
     session_id: Uuid,
+    clear_fresh: bool,
     dir: Option<&Path>,
     project_paths: Option<&[String]>,
 ) -> Result<ClearedUserInputTransitions, String> {
     let _guard = sessions_save_lock().lock().await;
 
     // Mutate FIRST and unconditionally: the user typed, so the hand is lowered
-    // and the fresh intent re-armed even if we cannot persist. Both fields flip
-    // in one critical section, so no snapshot can capture a half-applied state.
-    let (cleared_start_fresh, cleared_raise_hand) =
-        mgr.clear_user_input_transitions(session_id).await;
+    // and, when gated, the fresh intent is re-armed even if we cannot persist.
+    // Both fields flip in one critical section, so no snapshot can capture a
+    // half-applied state.
+    let (cleared_start_fresh, cleared_raise_hand) = mgr
+        .clear_user_input_transitions(session_id, clear_fresh)
+        .await;
     let cleared = ClearedUserInputTransitions {
         cleared_start_fresh,
         cleared_raise_hand,
@@ -2021,10 +2027,15 @@ mod tests {
         let raise_time = chrono::DateTime::parse_from_rfc3339("2026-06-30T11:00:00+00:00")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        let outcome =
-            raise_hand_and_persist_to_dir_result(&mgr_a, session_a.id, raise_time, temp.path(), None)
-                .await
-                .expect("raise+persist should succeed");
+        let outcome = raise_hand_and_persist_to_dir_result(
+            &mgr_a,
+            session_a.id,
+            raise_time,
+            temp.path(),
+            None,
+        )
+        .await
+        .expect("raise+persist should succeed");
         assert!(matches!(outcome, RaiseHandPersistOutcome::Raised(_)));
 
         let rows = load_sessions_raw_from_dir_for_test(temp.path());
@@ -2112,6 +2123,7 @@ mod tests {
         let cleared = clear_user_input_transitions_and_persist_to_dir_result(
             &mgr,
             session.id,
+            true,
             Some(temp.path()),
             None,
         )
@@ -2165,6 +2177,7 @@ mod tests {
         let result = clear_user_input_transitions_and_persist_to_dir_result(
             &mgr,
             session.id,
+            true,
             Some(&file_as_dir),
             None,
         )
@@ -2206,6 +2219,7 @@ mod tests {
         let mut fut = Box::pin(clear_user_input_transitions_and_persist_to_dir_result(
             &mgr,
             session.id,
+            true,
             Some(temp.path()),
             None,
         ));
@@ -2265,13 +2279,19 @@ mod tests {
         )
         .await
         .expect("stamp+persist should succeed");
-        assert!(stamped, "first stamp must report the false -> true transition");
+        assert!(
+            stamped,
+            "first stamp must report the false -> true transition"
+        );
 
         let saved =
             std::fs::read_to_string(temp.path().join("sessions.json")).expect("read sessions.json");
         let rows: Vec<PersistedSession> = serde_json::from_str(&saved).expect("deserialize");
         assert_eq!(rows.len(), 1);
-        assert!(rows[0].start_fresh_on_restore, "stamp must reach the snapshot");
+        assert!(
+            rows[0].start_fresh_on_restore,
+            "stamp must reach the snapshot"
+        );
 
         // Second stamp is a no-op: Ok(false), and the file is not rewritten.
         std::fs::remove_file(temp.path().join("sessions.json")).expect("remove snapshot");
@@ -2328,7 +2348,10 @@ mod tests {
             std::fs::read_to_string(temp.path().join("sessions.json")).expect("read sessions.json");
         let rows: Vec<PersistedSession> = serde_json::from_str(&saved).expect("deserialize");
         assert_eq!(rows.len(), 1);
-        assert!(!rows[0].start_fresh_on_restore, "drop must reach the snapshot");
+        assert!(
+            !rows[0].start_fresh_on_restore,
+            "drop must reach the snapshot"
+        );
     }
 
     /// (#756) Dropping an unset record is Ok(false) and does not save.
@@ -2744,10 +2767,7 @@ mod tests {
                     .to_string(),
             ],
         );
-        assert_eq!(
-            stripped,
-            vec!["/C".to_string(), "npx claude".to_string()]
-        );
+        assert_eq!(stripped, vec!["/C".to_string(), "npx claude".to_string()]);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -605,6 +605,7 @@ pub fn run(
         .manage(Arc::new(PendingSelfClear::default()))
         .manage(screenshot_capture_state) // #714
         .manage(screenshot_hotkey_state) // #714
+        .manage(crate::pty::input_activity::new_state()) // #871 substantive-input tracker
         .setup(move |app| {
             use tauri::WebviewWindowBuilder;
             use tauri::WebviewUrl;

--- a/src-tauri/src/pty/input_activity.rs
+++ b/src-tauri/src/pty/input_activity.rs
@@ -1,0 +1,247 @@
+//! (#871) Substantive-submission classifier for raw PTY keystroke input.
+//!
+//! Restart Session stamps a durable "start fresh on restore" intent. That intent
+//! must survive an app restart when the user has not actually engaged. The bug:
+//! `pty_write` cleared the intent on any byte, including non-substantive terminal
+//! writes such as focus/CSI sequences, terminal init, and empty Enter. This
+//! module distinguishes a real prompt submission (CR/LF with pending
+//! non-whitespace content since the last submit) from those control writes, so
+//! only substantive engagement clears the fresh intent.
+//!
+//! `pty_write` carries user-to-PTY input only; terminal output flows the other
+//! way via the `pty_output` event and never reaches here. So we classify the
+//! user's own keystrokes plus xterm-generated input, all ESC-introduced and
+//! skipped below. We do not reconstruct the child agent's rendered line.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+/// Per-session tracker of whether non-whitespace printable input is pending
+/// since the last submit or fresh boundary.
+#[derive(Default)]
+pub struct SubstantiveInputTracker {
+    pending_nonspace: HashMap<Uuid, bool>,
+}
+
+/// Tauri-managed shared state alias.
+pub type SubstantiveInputState = Arc<Mutex<SubstantiveInputTracker>>;
+
+/// Build a fresh managed state value.
+pub fn new_state() -> SubstantiveInputState {
+    Arc::new(Mutex::new(SubstantiveInputTracker::default()))
+}
+
+impl SubstantiveInputTracker {
+    /// Feed one raw keystroke chunk for `id`. Returns true iff the chunk
+    /// completed a substantive submission: a CR/LF encountered while
+    /// non-whitespace printable content was pending since the last submit.
+    pub fn feed(&mut self, id: Uuid, data: &[u8]) -> bool {
+        let pending = self.pending_nonspace.entry(id).or_insert(false);
+        classify_chunk(pending, data)
+    }
+
+    /// Reset the pending flag for `id`. Call when a fresh boundary is stamped so
+    /// pre-boundary keystrokes cannot leak into a post-boundary submit decision.
+    pub fn reset(&mut self, id: Uuid) {
+        self.pending_nonspace.remove(&id);
+    }
+}
+
+/// Pure classifier. `pending` persists across chunks, while the ESC parse state
+/// is local to this chunk so it can never swallow a later chunk's content.
+fn classify_chunk(pending: &mut bool, data: &[u8]) -> bool {
+    let mut submitted = false;
+    let mut i = 0;
+    while i < data.len() {
+        let b = data[i];
+        match b {
+            0x1b => {
+                i += 1;
+                if i >= data.len() {
+                    break;
+                }
+                match data[i] {
+                    b'[' | b'O' => {
+                        i += 1;
+                        while i < data.len() && !(0x40..=0x7e).contains(&data[i]) {
+                            i += 1;
+                        }
+                    }
+                    b']' | b'P' | b'_' | b'^' | b'X' => {
+                        i += 1;
+                        while i < data.len() {
+                            if data[i] == 0x07 {
+                                break;
+                            }
+                            if data[i] == 0x1b {
+                                if i + 1 < data.len() && data[i + 1] == 0x5c {
+                                    i += 1;
+                                }
+                                break;
+                            }
+                            i += 1;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            0x0d | 0x0a => {
+                if *pending {
+                    submitted = true;
+                    *pending = false;
+                }
+            }
+            0x03 | 0x15 => {
+                *pending = false;
+            }
+            0x08 | 0x7f | 0x09 | 0x20 => {}
+            _ if b < 0x20 => {}
+            _ => {
+                *pending = true;
+            }
+        }
+        i += 1;
+    }
+    submitted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tracker() -> SubstantiveInputTracker {
+        SubstantiveInputTracker::default()
+    }
+
+    #[test]
+    fn typed_prompt_then_enter_is_substantive() {
+        let mut t = tracker();
+        let id = Uuid::new_v4();
+        assert!(!t.feed(id, b"hello"));
+        assert!(t.feed(id, b"\r"));
+    }
+
+    #[test]
+    fn single_chunk_prompt_is_substantive() {
+        let mut t = tracker();
+        assert!(t.feed(Uuid::new_v4(), b"hello world\r"));
+    }
+
+    #[test]
+    fn empty_enter_is_not_substantive() {
+        let mut t = tracker();
+        assert!(!t.feed(Uuid::new_v4(), b"\r"));
+    }
+
+    #[test]
+    fn focus_in_out_is_not_substantive() {
+        let mut t = tracker();
+        let id = Uuid::new_v4();
+        assert!(!t.feed(id, b"\x1b[I"));
+        assert!(!t.feed(id, b"\x1b[O"));
+    }
+
+    #[test]
+    fn cursor_keys_are_not_substantive() {
+        let mut t = tracker();
+        let id = Uuid::new_v4();
+        assert!(!t.feed(id, b"\x1b[A\x1b[B\x1b[C\x1b[D"));
+    }
+
+    #[test]
+    fn dsr_response_is_not_substantive() {
+        let mut t = tracker();
+        assert!(!t.feed(Uuid::new_v4(), b"\x1b[24;80R"));
+    }
+
+    #[test]
+    fn bracketed_paste_then_enter_is_substantive() {
+        let mut t = tracker();
+        assert!(t.feed(Uuid::new_v4(), b"\x1b[200~hi\x1b[201~\r"));
+    }
+
+    #[test]
+    fn content_spanning_chunks_then_enter_is_substantive() {
+        let mut t = tracker();
+        let id = Uuid::new_v4();
+        assert!(!t.feed(id, b"hel"));
+        assert!(!t.feed(id, b"lo"));
+        assert!(t.feed(id, b"\r"));
+    }
+
+    #[test]
+    fn non_ascii_content_is_substantive() {
+        let mut t = tracker();
+        assert!(t.feed(Uuid::new_v4(), "\u{00e9}\r".as_bytes()));
+    }
+
+    #[test]
+    fn reset_forgets_pending_content() {
+        let mut t = tracker();
+        let id = Uuid::new_v4();
+        assert!(!t.feed(id, b"hello"));
+        t.reset(id);
+        assert!(!t.feed(id, b"\r"));
+    }
+
+    #[test]
+    fn osc_color_reply_then_enter_is_not_substantive() {
+        let mut t = tracker();
+        let id = Uuid::new_v4();
+        assert!(!t.feed(id, b"\x1b]11;rgb:1234/5678/9abc\x07"));
+        assert!(!t.feed(id, b"\r"));
+    }
+
+    #[test]
+    fn dcs_reply_then_enter_is_not_substantive() {
+        let mut t = tracker();
+        let id = Uuid::new_v4();
+        assert!(!t.feed(id, b"\x1bP1$r0m\x1b\\"));
+        assert!(!t.feed(id, b"\r"));
+    }
+
+    #[test]
+    fn osc_reply_and_enter_in_one_chunk_is_not_substantive() {
+        let mut t = tracker();
+        assert!(!t.feed(Uuid::new_v4(), b"\x1b]11;rgb:1234/5678/9abc\x07\r"));
+    }
+
+    #[test]
+    fn control_only_bytes_are_not_substantive() {
+        let mut t = tracker();
+        let id = Uuid::new_v4();
+        assert!(!t.feed(id, b"\x03"));
+        assert!(!t.feed(id, b"\x04"));
+        assert!(!t.feed(id, b"\x15"));
+        assert!(!t.feed(id, b"\r"));
+    }
+
+    #[test]
+    fn ctrl_c_cancels_pending_line_so_enter_is_not_substantive() {
+        let mut t = tracker();
+        let id = Uuid::new_v4();
+        assert!(!t.feed(id, b"do the thing"));
+        assert!(!t.feed(id, b"\x03"));
+        assert!(!t.feed(id, b"\r"));
+    }
+
+    #[test]
+    fn ctrl_u_cancels_pending_line_so_enter_is_not_substantive() {
+        let mut t = tracker();
+        let id = Uuid::new_v4();
+        assert!(!t.feed(id, b"partial"));
+        assert!(!t.feed(id, b"\x15"));
+        assert!(!t.feed(id, b"\r"));
+    }
+
+    #[test]
+    fn real_line_after_ctrl_c_then_enter_is_substantive() {
+        let mut t = tracker();
+        let id = Uuid::new_v4();
+        assert!(!t.feed(id, b"oops"));
+        assert!(!t.feed(id, b"\x03"));
+        assert!(!t.feed(id, b"real prompt"));
+        assert!(t.feed(id, b"\r"));
+    }
+}

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -7,6 +7,7 @@ pub mod docker_runtime;
 pub mod git_watcher;
 pub mod idle_detector;
 pub mod inject;
+pub mod input_activity;
 pub mod job; // #632 - per-agent Job Object for tree-kill
 pub mod local_backend;
 pub mod manager;

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -553,26 +553,26 @@ impl SessionManager {
         false
     }
 
-    /// #698 — clear BOTH user-input session-state transitions in a SINGLE
-    /// critical section: re-arm the durable resume intent
-    /// (`start_fresh_on_restore` true -> false, #630/#631) and lower any visible
-    /// raise-hand. Returns `(cleared_start_fresh, cleared_raise_hand)` so the
-    /// caller can persist once and emit the raise-hand clear event only when a
-    /// hand was actually lowered.
+    /// #698: clear BOTH user-input session-state transitions in a SINGLE
+    /// critical section. `clear_fresh` gates re-arming the durable resume intent
+    /// (`start_fresh_on_restore` true -> false, #871); lowering any visible
+    /// raise-hand remains unconditional. Returns
+    /// `(cleared_start_fresh, cleared_raise_hand)` so the caller can persist once
+    /// and emit the raise-hand clear event only when a hand was actually lowered.
     ///
     /// Doing both under one `sessions.write()` acquisition is the MEDIUM grinch
     /// fix: with the previous two-call shape a concurrent snapshot could observe a
     /// half-applied state (`start_fresh_on_restore` already cleared while the hand
     /// was still raised). Mutating both fields atomically removes that window.
-    pub async fn clear_user_input_transitions(&self, id: Uuid) -> (bool, bool) {
+    pub async fn clear_user_input_transitions(&self, id: Uuid, clear_fresh: bool) -> (bool, bool) {
         let mut sessions = self.sessions.write().await;
         let Some(s) = sessions.get_mut(&id) else {
             return (false, false);
         };
 
-        let cleared_start_fresh = if s.start_fresh_on_restore {
-            log::info!(
-                "[session-state] {} '{}': start_fresh_on_restore true -> false (user message, re-armed)",
+        let cleared_start_fresh = if clear_fresh && s.start_fresh_on_restore {
+            log::debug!(
+                "[session-state] {} '{}': start_fresh_on_restore true -> false (substantive user message, re-armed)",
                 &id.to_string()[..8],
                 s.name
             );
@@ -948,7 +948,10 @@ mod tests {
     #[tokio::test]
     async fn set_start_fresh_on_restore_if_unset_no_op_on_missing_session() {
         let mgr = SessionManager::new();
-        assert!(!mgr.set_start_fresh_on_restore_if_unset(Uuid::new_v4()).await);
+        assert!(
+            !mgr.set_start_fresh_on_restore_if_unset(Uuid::new_v4())
+                .await
+        );
     }
 
     #[tokio::test]
@@ -1277,12 +1280,16 @@ mod tests {
             .is_none());
 
         // Unknown id: rejected.
-        assert!(!mgr.restore_communication(Uuid::new_v4(), visible_hand).await);
+        assert!(
+            !mgr.restore_communication(Uuid::new_v4(), visible_hand)
+                .await
+        );
     }
 
     /// #698 MEDIUM fix: `clear_user_input_transitions` lowers a visible raise-hand
-    /// AND re-arms the fresh intent in ONE critical section, reporting which fields
-    /// transitioned. A second call is a no-op, and an unknown id is a no-op.
+    /// and, when gated, re-arms the fresh intent in ONE critical section,
+    /// reporting which fields transitioned. A second call is a no-op, and an
+    /// unknown id is a no-op.
     #[tokio::test]
     async fn clear_user_input_transitions_clears_both_fields_atomically() {
         let mgr = SessionManager::new();
@@ -1306,7 +1313,7 @@ mod tests {
 
         // Both transitions happen together and are reported.
         let (cleared_start_fresh, cleared_raise_hand) =
-            mgr.clear_user_input_transitions(session.id).await;
+            mgr.clear_user_input_transitions(session.id, true).await;
         assert!(cleared_start_fresh);
         assert!(cleared_raise_hand);
 
@@ -1319,18 +1326,18 @@ mod tests {
 
         // Idempotent: a second call transitions nothing.
         assert_eq!(
-            mgr.clear_user_input_transitions(session.id).await,
+            mgr.clear_user_input_transitions(session.id, true).await,
             (false, false)
         );
 
         // Unknown id is a no-op.
         assert_eq!(
-            mgr.clear_user_input_transitions(Uuid::new_v4()).await,
+            mgr.clear_user_input_transitions(Uuid::new_v4(), true).await,
             (false, false)
         );
     }
 
-    /// #698: the two transitions are independent — `clear_user_input_transitions`
+    /// #698: the two transitions are independent. `clear_user_input_transitions`
     /// reports each field's own true/false, so a session with only one set re-arms
     /// only that one.
     #[tokio::test]
@@ -1353,7 +1360,7 @@ mod tests {
         // Only the fresh intent is set -> (true, false).
         mgr.set_start_fresh_on_restore(session.id, true).await;
         assert_eq!(
-            mgr.clear_user_input_transitions(session.id).await,
+            mgr.clear_user_input_transitions(session.id, true).await,
             (true, false)
         );
 
@@ -1362,9 +1369,43 @@ mod tests {
             .await
             .expect("raise_hand should succeed");
         assert_eq!(
-            mgr.clear_user_input_transitions(session.id).await,
+            mgr.clear_user_input_transitions(session.id, true).await,
             (false, true)
         );
+    }
+
+    #[tokio::test]
+    async fn clear_user_input_transitions_preserves_fresh_when_gate_is_false() {
+        let mgr = SessionManager::new();
+        let session = mgr
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                "C:\\tmp".to_string(),
+                None,
+                None,
+                Vec::new(),
+                true,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
+            )
+            .await
+            .expect("create_session should succeed");
+        mgr.set_start_fresh_on_restore(session.id, true).await;
+        mgr.raise_hand(session.id, chrono::Utc::now())
+            .await
+            .expect("raise_hand should succeed");
+
+        assert_eq!(
+            mgr.clear_user_input_transitions(session.id, false).await,
+            (false, true)
+        );
+
+        let stored = mgr
+            .get_session(session.id)
+            .await
+            .expect("session should still exist");
+        assert!(stored.start_fresh_on_restore);
+        assert!(stored.communication.is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/telegram/bridge.rs
+++ b/src-tauri/src/telegram/bridge.rs
@@ -1181,7 +1181,12 @@ async fn poll_task<R: tauri::Runtime>(
                             // #552 a Telegram message is a real user message to this
                             // coordinator: reset the badge clock + auto-close silence
                             // (covers text and transcribed-voice inbound; both converge here).
-                            crate::commands::pty::note_user_message_to_session(&app, session_id).await;
+                            crate::commands::pty::note_user_message_to_session(
+                                &app,
+                                session_id,
+                                crate::commands::pty::UserInputSource::CompleteMessage,
+                            )
+                            .await;
 
                             let _ = app.emit(
                                 "telegram_incoming",

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -316,7 +316,12 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
                 .map_err(|e| e.to_string())?;
 
             // #552 web UI input is a real user message (resets badge + silence).
-            crate::commands::pty::note_user_message_to_session(&state.app_handle, uuid).await;
+            crate::commands::pty::note_user_message_to_session(
+                &state.app_handle,
+                uuid,
+                crate::commands::pty::UserInputSource::Web(&data),
+            )
+            .await;
 
             Ok(json!(null))
         }
@@ -880,9 +885,7 @@ mod tests {
 
     /// Build a minimal `WsState` backed by `settings`, plus a broadcast receiver
     /// for asserting web events emitted during dispatch.
-    fn ws_state_for(
-        settings: AppSettings,
-    ) -> (WsState, tokio::sync::mpsc::Receiver<WsOutMsg>) {
+    fn ws_state_for(settings: AppSettings) -> (WsState, tokio::sync::mpsc::Receiver<WsOutMsg>) {
         let app = tauri::Builder::default()
             .any_thread()
             .build(tauri::test::mock_context(tauri::test::noop_assets()))

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -325,7 +325,12 @@ async fn handle_binary_message(state: &WsState, data: &[u8]) {
 
     // #552 web UI keystrokes (binary frame) are the real web input path and a
     // genuine user message: reset the badge clock + auto-close silence.
-    crate::commands::pty::note_user_message_to_session(&state.app_handle, uuid).await;
+    crate::commands::pty::note_user_message_to_session(
+        &state.app_handle,
+        uuid,
+        crate::commands::pty::UserInputSource::Web(pty_data),
+    )
+    .await;
 }
 
 fn binary_pty_write_succeeded(


### PR DESCRIPTION
## What & why

Applying **Restart Session** to a coordinator, then closing and reopening the app, was resurrecting the pre-restart conversation (Claude `--continue` injected). This is the documented **residual 1** of #756 — not a regression of #756's durable-intent mechanics, which work correctly.

**Root cause:** `pty_write` → `note_user_message_to_session` re-armed the durable fresh intent (`start_fresh_on_restore` + coordinator-clock `start_fresh_at`) to false on **any** bytes written to the PTY — including non-substantive terminal writes (control/focus sequences, terminal init, xterm auto-replies to OSC/DCS queries, empty Enter). Live logs showed the intent re-armed ~3s after a restart with the coordinator untouched, so the later restore injected `--continue`.

## The fix

Split "terminal/user activity" from "substantive post-boundary content" via a byte-level classifier at the `pty_write` choke point (new module `pty/input_activity.rs`):
- Per-uuid `pending_nonspace` bit; a CR/LF submit while the bit is set ⇒ **substantive**. Focus/CSI/SS3/init and empty Enter never set it.
- **String escapes (OSC/DCS/APC/PM/SOS `] P _ ^ X`)** consume their payload to BEL/ST within-chunk, so xterm's color/capability auto-replies don't false-set `pending` (would otherwise reproduce the bug silently for TUI providers).
- **Ctrl-C (`0x03`) / Ctrl-U (`0x15`)** reset `pending` (cancelled line ⇒ no post-boundary content); Ctrl-D does not.
- Both durable fresh-intent clears are gated behind the single `substantive` flag → record and mirror halves can't diverge. Silence/badge/auto-close/raise-hand lowering stay **unconditional** in the same atomic `sessions.write()` (#698 intact).
- `UserInputSource` plumbed through the 4 keystroke surfaces (terminal, web-binary, web-command, Telegram `CompleteMessage`). Tracker reset in `destroy_session_inner_with_options`. Fresh-clear log demoted to DEBUG; a single source-tagged INFO per real clear (no message content logged).

Loop/mailbox injected content (`note_post_boundary_content_to_session`) is untouched → a genuinely engaged (typed or dispatched) session still resumes on reopen. Provider-agnostic (Claude/Codex/Gemini).

## Review trail (FULL pipeline)

architect plan → dev-rust enrich → grinch enrich → architect consensus **READY_FOR_IMPLEMENTATION** → dev-rust implement → grinch review **PASS** (traced the diff line-by-line, could not construct a false-negative regression; every residual hole is false-positive-only / safe-degrading).

## Gates

- `cargo build` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test --lib --bins --tests` = **2118 passed / 0 failed / 12 ignored** ✅ · `cargo check` ✅
- Grinch independent re-run: `input_activity` 17/0, fresh-intent mock-app + gate tests 10/0.

Non-visual backend change (no FE/IPC/event/schema surface).

Closes #871.
