### PR TITLE
feat(settings): API server bind/port editor, container flow fully GUI-configurable (#872)

### DIFF
--- a/src-tauri/src/api/README.md
+++ b/src-tauri/src/api/README.md
@@ -17,7 +17,8 @@ Off by default. Set in settings:
 - `apiServerPort` - profile-aware default (`profile::api_server_port`), distinct
   from the web port so dev/prod builds do not collide.
 
-A bind/port change requires a daemon restart (or a future stop/start command).
+A bind/port change can be applied by saving settings, stopping the API server,
+and starting it again. A full daemon restart is not required.
 
 ## Auth
 

--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -116,7 +116,9 @@ pub fn start_server(
             shutdown.clone(),
             dispatcher::DispatcherConfig::default(),
         );
-        let addr: SocketAddr = match format!("{}:{}", bind, port).parse() {
+        let addr: SocketAddr = match crate::config::settings::parse_api_server_socket_addr(
+            &bind, port,
+        ) {
             Ok(a) => a,
             Err(e) => {
                 log::error!("[api-server] invalid bind address {}:{}: {}", bind, port, e);

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::{BTreeMap, HashSet};
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -1369,7 +1370,34 @@ pub fn validate_and_repair_settings(settings: &mut AppSettings) -> Result<(), St
     repair_coding_agent_profiles_config(&mut settings.coding_agent_profiles, &settings.agents);
     validate_agent_commands(settings)?;
     validate_screenshot_hotkey(&settings.screenshot_capture_hotkey)?;
+    validate_api_server_settings(settings)?;
     validate_resource_settings(settings)
+}
+
+pub(crate) fn parse_api_server_socket_addr(
+    bind: &str,
+    port: u16,
+) -> Result<SocketAddr, String> {
+    let bind = bind.trim();
+    if bind.is_empty() {
+        return Err("apiServerBind must not be empty".to_string());
+    }
+    if port == 0 {
+        return Err("apiServerPort must be between 1 and 65535".to_string());
+    }
+    let ip: IpAddr = bind.parse().map_err(|e| {
+        format!(
+            "apiServerBind must be an IP address such as 127.0.0.1, 0.0.0.0, ::1, or :: ({e})"
+        )
+    })?;
+    Ok(SocketAddr::new(ip, port))
+}
+
+pub fn validate_api_server_settings(settings: &mut AppSettings) -> Result<(), String> {
+    let bind = settings.api_server_bind.trim().to_string();
+    parse_api_server_socket_addr(&bind, settings.api_server_port)?;
+    settings.api_server_bind = bind;
+    Ok(())
 }
 
 /// #714 Reject a screenshot hotkey that the native parser cannot accept. Syntax
@@ -2158,10 +2186,10 @@ mod tests {
 
     use super::{
         merge_protected_coding_agent_settings, repair_coding_agent_profiles_config,
-        validate_agent_commands, validate_resource_settings, AgentConfig, AppSettings,
-        CodingAgentEnv, CodingAgentEnvSource, MainSidebarSide, ProfileCellConfig,
-        ProfileSlotConfig, ResourceWatchdogAction, TelegramNetworkPollErrorLogging,
-        TelegramPollFailureLogLevel, TelegramPollRecoveryLogLevel,
+        validate_agent_commands, validate_api_server_settings, validate_resource_settings,
+        AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, MainSidebarSide,
+        ProfileCellConfig, ProfileSlotConfig, ResourceWatchdogAction,
+        TelegramNetworkPollErrorLogging, TelegramPollFailureLogLevel, TelegramPollRecoveryLogLevel,
     };
     use std::collections::BTreeMap;
 
@@ -3280,6 +3308,45 @@ mod tests {
                 validate_resource_settings(&s).is_ok(),
                 "expected max_concurrent_agent_processes={value} to validate"
             );
+        }
+    }
+
+    #[test]
+    fn validate_api_server_settings_rejects_invalid_bind_and_port() {
+        let mut empty_bind = AppSettings {
+            api_server_bind: "   ".to_string(),
+            ..AppSettings::default()
+        };
+        assert!(validate_api_server_settings(&mut empty_bind)
+            .unwrap_err()
+            .contains("apiServerBind"));
+
+        let mut zero_port = AppSettings {
+            api_server_port: 0,
+            ..AppSettings::default()
+        };
+        assert!(validate_api_server_settings(&mut zero_port)
+            .unwrap_err()
+            .contains("apiServerPort"));
+
+        let mut hostname = AppSettings {
+            api_server_bind: "localhost".to_string(),
+            ..AppSettings::default()
+        };
+        assert!(validate_api_server_settings(&mut hostname)
+            .unwrap_err()
+            .contains("apiServerBind"));
+    }
+
+    #[test]
+    fn validate_api_server_settings_accepts_ip_binds_and_trims() {
+        for bind in ["127.0.0.1", "0.0.0.0", "::1", "::"] {
+            let mut settings = AppSettings {
+                api_server_bind: format!(" {bind} "),
+                ..AppSettings::default()
+            };
+            validate_api_server_settings(&mut settings).unwrap();
+            assert_eq!(settings.api_server_bind, bind);
         }
     }
 

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -310,6 +310,146 @@ describe("SettingsModal automation hooks", () => {
     dispose();
   });
 
+  it("round-trips API server bind and port and warns for non-loopback binds", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {} }),
+      root,
+    );
+    await settle();
+
+    const bind = byTestId<HTMLInputElement>("settings.general.apiServerBind");
+    const port = byTestId<HTMLInputElement>("settings.general.apiServerPort");
+    expect(bind.value).toBe("127.0.0.1");
+    expect(port.value).toBe("8766");
+    expect(
+      document.querySelector('[data-ac-testid="settings.general.apiServerBind.warning"]'),
+    ).toBeNull();
+
+    bind.value = "0.0.0.0";
+    bind.dispatchEvent(new Event("input", { bubbles: true }));
+    port.value = "9000";
+    port.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+
+    expect(byTestId("settings.general.apiServerBind.warning").textContent).toContain(
+      "firewall",
+    );
+
+    bind.value = "127.0.0.1";
+    bind.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+    expect(
+      document.querySelector('[data-ac-testid="settings.general.apiServerBind.warning"]'),
+    ).toBeNull();
+
+    bind.value = "0.0.0.0";
+    bind.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.apiServerBind).toBe("0.0.0.0");
+    expect(saved?.apiServerPort).toBe(9000);
+
+    dispose();
+  });
+
+  it("blocks save for empty API bind and out-of-range API port", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {} }),
+      root,
+    );
+    await settle();
+
+    const bind = byTestId<HTMLInputElement>("settings.general.apiServerBind");
+    const port = byTestId<HTMLInputElement>("settings.general.apiServerPort");
+    const save = byTestId<HTMLButtonElement>("settings.save");
+
+    bind.value = "";
+    bind.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+    expect(save.disabled).toBe(true);
+    expect(document.querySelector(".modal-save-error")?.textContent).toContain(
+      "IP/address must not be empty",
+    );
+
+    bind.value = "127.0.0.1";
+    bind.dispatchEvent(new Event("input", { bubbles: true }));
+    port.value = "70000";
+    port.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+    expect(save.disabled).toBe(true);
+    expect(document.querySelector(".modal-save-error")?.textContent).toContain(
+      "port must be between 1 and 65535",
+    );
+
+    dispose();
+  });
+
+  it("saves changed API endpoint before restarting a running API server", async () => {
+    const runningSettings = settings({
+      apiServerEnabled: true,
+      apiServerBind: "127.0.0.1",
+      apiServerPort: 8766,
+    });
+    vi.mocked(SettingsAPI.get)
+      .mockResolvedValueOnce(runningSettings)
+      .mockResolvedValueOnce(runningSettings);
+    vi.mocked(SettingsAPI.apiServerStatus)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+    vi.mocked(SettingsAPI.stopApiServer).mockResolvedValueOnce(true);
+    vi.mocked(SettingsAPI.startApiServer).mockResolvedValueOnce(true);
+
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {} }),
+      root,
+    );
+    await settle();
+
+    expect(byTestId("settings.general.apiServerStatus").textContent).toContain(
+      "127.0.0.1:8766",
+    );
+
+    const bind = byTestId<HTMLInputElement>("settings.general.apiServerBind");
+    bind.value = "0.0.0.0";
+    bind.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle();
+
+    expect(byTestId("settings.general.apiServerStatus").textContent).toContain(
+      "127.0.0.1:8766",
+    );
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+    await settle();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.apiServerBind).toBe("0.0.0.0");
+    expect(SettingsAPI.stopApiServer).toHaveBeenCalledTimes(1);
+    expect(SettingsAPI.startApiServer).toHaveBeenCalledTimes(1);
+    expect(SettingsAPI.apiServerStatus).toHaveBeenCalledTimes(2);
+
+    const saveOrder = vi.mocked(SettingsAPI.saveDraft).mock.invocationCallOrder[0];
+    const stopOrder = vi.mocked(SettingsAPI.stopApiServer).mock.invocationCallOrder[0];
+    const startOrder = vi.mocked(SettingsAPI.startApiServer).mock.invocationCallOrder[0];
+    const restartStatusOrder = vi.mocked(SettingsAPI.apiServerStatus).mock.invocationCallOrder[1];
+    expect(saveOrder).toBeLessThan(stopOrder);
+    expect(stopOrder).toBeLessThan(startOrder);
+    expect(startOrder).toBeLessThan(restartStatusOrder);
+
+    dispose();
+  });
+
   it("surfaces API server start errors and reverts to live status", async () => {
     vi.mocked(SettingsAPI.apiServerStatus)
       .mockResolvedValueOnce(false)

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -134,6 +134,14 @@ const isContainerLoopbackBind = (bind: string | undefined): boolean => {
   );
 };
 
+const apiServerEndpointChanged = (
+  next: Pick<AppSettings, "apiServerBind" | "apiServerPort">,
+  seed: Pick<AppSettings, "apiServerBind" | "apiServerPort"> | null,
+): boolean =>
+  !!seed &&
+  (next.apiServerBind !== seed.apiServerBind ||
+    next.apiServerPort !== seed.apiServerPort);
+
 const cloneSettings = (value: AppSettings | null): AppSettings | null => {
   if (!value) return null;
   if (typeof structuredClone === "function") return structuredClone(value);
@@ -208,6 +216,28 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
 
   const apiServerChecked = () =>
     apiServerBusy() ? apiServerRunning() : settings.data?.apiServerEnabled ?? false;
+  const apiServerBindWarning = () => {
+    const bind = settings.data?.apiServerBind?.trim();
+    return !!bind && !isContainerLoopbackBind(bind);
+  };
+  const apiServerStatusAddress = () => {
+    const source = apiServerRunning() ? (modalSeed() ?? settings.data) : settings.data;
+    return source ? `${source.apiServerBind}:${source.apiServerPort}` : "";
+  };
+
+  const saveCurrentSettingsDraft = async (): Promise<AppSettings> => {
+    if (!settings.data) throw new Error("Settings are not loaded.");
+    const nextSettings = mergeSettingsForSavePreservingProjects(
+      settings.data,
+      await SettingsAPI.get(),
+      modalSeed(),
+    );
+    await SettingsAPI.saveDraft(nextSettings);
+    setSettings("data", nextSettings);
+    setModalSeed(cloneSettings(nextSettings));
+    setDraftDirty(false);
+    return nextSettings;
+  };
 
   const syncApiServerRunning = (running: boolean, markDirty: boolean) => {
     setApiServerRunning(running);
@@ -229,6 +259,14 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     setSaveError("");
     setApiServerBusy(true);
     try {
+      if (enabled && settings.data && apiServerEndpointChanged(settings.data, modalSeed())) {
+        const validationError = currentValidationError();
+        if (validationError) {
+          setSaveError(validationError);
+          return;
+        }
+        await saveCurrentSettingsDraft();
+      }
       if (enabled) {
         await SettingsAPI.startApiServer();
       } else {
@@ -250,6 +288,31 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           err instanceof Error ? err.message : String(err)
         }`,
       );
+    } finally {
+      setApiServerBusy(false);
+    }
+  };
+
+  const restartApiServerAfterEndpointSave = async (nextSettings: AppSettings) => {
+    setApiServerBusy(true);
+    try {
+      const stopped = await SettingsAPI.stopApiServer();
+      if (!stopped) {
+        throw new Error("API server did not stop for bind/port restart.");
+      }
+      setApiServerRunning(false);
+
+      if (nextSettings.apiServerEnabled) {
+        const started = await SettingsAPI.startApiServer();
+        if (!started) {
+          throw new Error("API server did not start after bind/port change.");
+        }
+        const running = await SettingsAPI.apiServerStatus();
+        syncApiServerRunning(running, false);
+        if (!running) {
+          throw new Error("API server did not report running after bind/port restart.");
+        }
+      }
     } finally {
       setApiServerBusy(false);
     }
@@ -993,6 +1056,24 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     return null;
   };
 
+  const validateApiServerSettings = (): string | null => {
+    const data = settings.data;
+    if (!data) return null;
+
+    if (!data.apiServerBind.trim()) {
+      return "API server: IP/address must not be empty";
+    }
+    if (
+      !Number.isInteger(data.apiServerPort) ||
+      data.apiServerPort < 1 ||
+      data.apiServerPort > 65535
+    ) {
+      return "API server: port must be between 1 and 65535";
+    }
+
+    return null;
+  };
+
   // #714 Lightweight pre-check mirroring the backend MVP parser (one Ctrl/Control
   // + one alphanumeric key). Backend stays the authority for OS registration.
   const validateScreenshotHotkey = (): string | null =>
@@ -1004,6 +1085,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     validateAgents() ??
     validateResources() ??
     validateCoordinatorIdle() ??
+    validateApiServerSettings() ??
     validateScreenshotHotkey();
 
   // ── Save ──
@@ -1017,15 +1099,12 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     setSaveError("");
     setSaving(true);
     try {
-      const nextSettings = mergeSettingsForSavePreservingProjects(
-        settings.data,
-        await SettingsAPI.get(),
-        modalSeed()
-      );
-      await SettingsAPI.saveDraft(nextSettings);
-      setSettings("data", nextSettings);
-      setModalSeed(cloneSettings(nextSettings));
-      setDraftDirty(false);
+      const seedBeforeSave = modalSeed();
+      const wasApiServerRunning = apiServerRunning();
+      const nextSettings = await saveCurrentSettingsDraft();
+      if (wasApiServerRunning && apiServerEndpointChanged(nextSettings, seedBeforeSave)) {
+        await restartApiServerAfterEndpointSave(nextSettings);
+      }
       // #158 — push soundsEnabled into sound.ts synchronously so the gate
       // updates before the settingsStore.refresh() roundtrip below resolves.
       // Without this, a beep emitted between this point and the next load()
@@ -1419,6 +1498,48 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           />
           <span>Enable API server</span>
         </label>
+        <label class="settings-field">
+          <span class="settings-label">IP/address</span>
+          <input
+            class="settings-input"
+            value={settings.data!.apiServerBind}
+            onInput={(e) => updateField("apiServerBind", e.currentTarget.value)}
+            placeholder="127.0.0.1"
+            data-ac-testid="settings.general.apiServerBind"
+            data-ac-role="textbox"
+          />
+        </label>
+        <label class="settings-field">
+          <span class="settings-label">Port</span>
+          <input
+            class="settings-input settings-input-sm"
+            type="number"
+            min="1"
+            max="65535"
+            step="1"
+            value={settings.data!.apiServerPort}
+            onInput={(e) => {
+              const raw = e.currentTarget.value.trim();
+              const value = raw === "" ? 0 : Number(e.currentTarget.value);
+              updateField(
+                "apiServerPort",
+                Number.isFinite(value) ? Math.trunc(value) : 0,
+              );
+            }}
+            data-ac-testid="settings.general.apiServerPort"
+            data-ac-role="spinbutton"
+          />
+        </label>
+        <Show when={apiServerBindWarning()}>
+          <div
+            class="settings-hint settings-hint-warning"
+            data-ac-testid="settings.general.apiServerBind.warning"
+            data-ac-role="status"
+          >
+            Non-loopback binds can expose the API beyond this machine. Use firewall
+            rules; API client tokens are the trust boundary.
+          </div>
+        </Show>
         <div
           class="settings-hint"
           data-ac-testid="settings.general.apiServerStatus"
@@ -1428,7 +1549,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           {apiServerBusy()
             ? "Updating..."
             : apiServerRunning()
-              ? `Running on ${settings.data!.apiServerBind}:${settings.data!.apiServerPort}`
+              ? `Running on ${apiServerStatusAddress()}`
               : "Stopped"}
         </div>
         <div

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -325,3 +325,49 @@ describe("mergeSettingsForSavePreservingProjects webserver seed rebasing", () =>
     expect(merged.webServerBind).toBe("127.0.0.1");
   });
 });
+
+describe("mergeSettingsForSavePreservingProjects api-server seed rebasing", () => {
+  it("rebases unchanged stale modal api-server fields from fresh settings", () => {
+    const modalSeed = settings({
+      apiServerPort: 8766,
+      apiServerBind: "127.0.0.1",
+      npmUpdateNotificationsEnabled: true,
+    });
+    const draft = settings({
+      apiServerPort: 8766,
+      apiServerBind: "127.0.0.1",
+      npmUpdateNotificationsEnabled: false,
+    });
+    const fresh = settings({
+      apiServerPort: 9876,
+      apiServerBind: "0.0.0.0",
+      npmUpdateNotificationsEnabled: true,
+    });
+
+    const merged = mergeSettingsForSavePreservingProjects(draft, fresh, modalSeed);
+
+    expect(merged.apiServerPort).toBe(9876);
+    expect(merged.apiServerBind).toBe("0.0.0.0");
+    expect(merged.npmUpdateNotificationsEnabled).toBe(false);
+  });
+
+  it("keeps intentional modal edits to api-server fields", () => {
+    const modalSeed = settings({
+      apiServerPort: 8766,
+      apiServerBind: "127.0.0.1",
+    });
+    const draft = settings({
+      apiServerPort: 9000,
+      apiServerBind: "0.0.0.0",
+    });
+    const fresh = settings({
+      apiServerPort: 9876,
+      apiServerBind: "::",
+    });
+
+    const merged = mergeSettingsForSavePreservingProjects(draft, fresh, modalSeed);
+
+    expect(merged.apiServerPort).toBe(9000);
+    expect(merged.apiServerBind).toBe("0.0.0.0");
+  });
+});

--- a/src/sidebar/components/settings-save.ts
+++ b/src/sidebar/components/settings-save.ts
@@ -77,10 +77,21 @@ export function mergeSettingsForSavePreservingProjects(
           : draft.webServerBind,
       }
     : {};
+  const apiServerFields = modalSeed
+    ? {
+        apiServerPort: Object.is(draft.apiServerPort, modalSeed.apiServerPort)
+          ? fresh.apiServerPort
+          : draft.apiServerPort,
+        apiServerBind: Object.is(draft.apiServerBind, modalSeed.apiServerBind)
+          ? fresh.apiServerBind
+          : draft.apiServerBind,
+      }
+    : {};
 
   return {
     ...draft,
     ...webServerFields,
+    ...apiServerFields,
     agents: draft.agents
       .map(normalizeAgentInstructionsFilename)
       .map(normalizeAgentConfigSeed)


### PR DESCRIPTION
## Summary
Adds an API-server bind/port editor to Settings, so the container flow is fully GUI-configurable: a user can set the bind to `0.0.0.0` (required for Docker to reach the host API) without editing `settings.json`. Part of #819; splits F6 out of #870. Completes the container user-friendliness work (image #865, runtime selector #868, and this).

## What changed
- **Backend:** `validate_api_server_settings` (trim bind, reject empty / port 0 / non-IP; accept `127.0.0.1`/`0.0.0.0`/`::1`/`::`) hooked into `validate_and_repair_settings` (the shared write choke point). A shared `parse_api_server_socket_addr` is reused in `api::start_server` so validation and runtime match: byte-identical for the existing v4 binds, and it fixes IPv6 (previously `::1` produced an unbracketed parse error). README notes bind/port now hot-apply via stop/start.
- **Frontend:** bind (IP/address) + port inputs in the Control Plane API section; FE validation; a non-loopback inline warning (firewall + "API client tokens are the trust boundary" wording); hot re-bind on Save (`saveDraft` -> `stopApiServer` -> `startApiServer` -> `apiServerStatus`; on failure the modal stays open with the error). The #846 toggle now saves a dirty draft before start so it never binds a stale address; the status line sources from the last saved snapshot so an unsaved bind never shows as "Running on"; modal-seed rebase for the API fields mirrors the web-server fields.

## Review
- dev-rust investigation defined the approach (hot re-bind viable with the #838 commands, no new command needed).
- grinch security review of the slice: PASS. The `start_server` change is behavior-preserving for existing binds and strictly fixes IPv6; choke-point validation, the hot re-bind half-fail path, and the toggle footgun fix are all correct and genuinely tested; exposing `0.0.0.0` has two independent warning signals and API auth is unconditional. N1 (LOW FE toggle-during-save race, bounded by the #838 Rust triple-guard, self-healing) and N2/N3 (INFO) are follow-ups.

## Gates
- Backend: `cargo test --all-targets`, `cargo clippy --all-targets -- -D warnings`, `npm run version:check`, `npm run smoke:cli-release-windows` all pass.
- FE: `npm run typecheck`, `npm test -- --run` (816 tests), `npm run build` all pass.

## Follow-ups (non-blocking)
- N1: also gate the enable/disable toggle on `saving()` (1-line, closes a transient toggle-during-save race).
- N2/N3: align the `localhost`/empty inline warning with the Rust reject; add direct tests for the restart half-fail path and an actual IPv6 bind.

Closes #872
