### PR TITLE
docs(config-seed): document factory default seed tier (#876)

### DIFF
--- a/docs/features/config-seed.md
+++ b/docs/features/config-seed.md
@@ -8,7 +8,7 @@ When AgentsCommander spawns a replica for a coding agent, **config seed** copies
 
 For a coding agent with config seed active, at spawn AC:
 
-1. Picks the highest-precedence template folder that exists (see [Where the template comes from](#where-the-template-comes-from)).
+1. Picks the first source that qualifies, checking the [seed tiers](#seed-tiers-where-the-config-comes-from) from highest precedence to lowest.
 2. Copies it to `<replica root>/<dest>`, substituting AC path tokens in text files.
 3. For a `.claude` destination only, re-applies the RTK PreToolUse hook to match your global `injectRtkHook` setting.
 
@@ -41,27 +41,63 @@ Config seed is configured **per coding agent**, on the agent's entry in `setting
 
 Config seed is **active only when `enabled` is true and `dest` is non-empty**. Omit `configSeed` entirely (the default) and no seeding happens. `dest` is a single folder name, validated as a safe name with no path separators or traversal, both at save time and again at spawn.
 
-## Where the template comes from
+## Seed tiers: where the config comes from
 
-You do not name a source folder. AC derives candidate template locations by convention and uses the first one that exists, in this order, highest precedence first:
+You never name a source folder directly. `<dest>` is exactly the **Config folder** value you set for the coding agent in **Settings -> Coding Agents** (the `configSeed.dest` field), for example `.claude`. From that single value AC derives a fixed list of candidate sources, the **seed tiers**, and uses the **first tier that qualifies**, highest precedence first:
 
-| Rank | Location | Folder name |
+| Rank | Tier | Folder |
 |---|---|---|
 | 1 | Workspace, profile-lettered | `<workspace>/default_profile_<letter><dest>` |
 | 2 | Workspace, base | `<workspace>/default<dest>` |
 | 3 | Matrix, profile-lettered | `<matrix>/default_profile_<letter><dest>` |
 | 4 | Matrix, base | `<matrix>/default<dest>` |
+| 5 | Factory default (AC catalog) | `<config_dir>/coding-agents/_seed/<dest>` |
 
-Two rules decide the winner:
+**The first matching tier wins.** AC checks the tiers top to bottom and stops at the first one that qualifies; lower tiers are not consulted for that spawn.
+
+The path roots:
+
+- `<workspace>` is the project's `.ac` root.
+- `<matrix>` is the agent's canonical `_agent_<name>` directory.
+- `<config_dir>` is the per-binary config directory next to the AC executable (see [Portable instances](portable-instances.md#config-directory-rule)).
+- `<letter>` is the session's resolved profile letter, lowercased, so profile `B` looks for `default_profile_b<dest>`. See [Coding Agent Profiles](coding-agent-profiles.md) for how the letter is resolved.
+
+### The two kinds of tier
+
+The five tiers split into two groups with **different ownership and different overwrite behavior**.
+
+**Tiers 1-4 are your templates (user-owned).** These are workspace and matrix folders you create and maintain. When one qualifies (the folder exists and is readable) AC copies it over `<replica>/<dest>` **on every spawn**, atomically replacing whatever was there. Two rules order these four:
 
 - **Workspace beats matrix.** Every workspace-level candidate outranks every matrix-level candidate.
 - **Profile beats base.** Within a location, the folder named for the session's resolved profile letter outranks the plain `default<dest>` folder.
 
-`<letter>` is the session's resolved profile letter, lowercased, so profile `B` looks for `default_profile_b.claude`. `<workspace>` is the project's `.ac` root, and `<matrix>` is the agent's canonical `_agent_<name>` directory. See [Coding Agent Profiles](coding-agent-profiles.md) for how the profile letter is resolved.
+**Tier 5 is the AC factory default (catalog-owned).** This is the config folder AC ships for a built-in coding agent, at `<config_dir>/coding-agents/_seed/<dest>/`. It has the **lowest precedence** and behaves differently from tiers 1-4: it is **absent-only**. AC fills `<replica>/<dest>` from it **only when the destination does not already exist** (and the factory folder holds at least one file). It **never overwrites** an existing config folder, so a replica's accumulated config, credentials, and session state are safe. If the destination is already present, tier 5 is skipped and the spawn is byte-for-byte unchanged. Tier 5 is, in effect, a one-time bootstrap for a brand-new replica when you have supplied no template of your own.
 
 > **The matrix's own `<dest>` is not a template.** A folder like `_agent_<name>/.claude` is the matrix agent's live config, not a seed source. AC deliberately never copies from it, so seeding cannot clobber the agent's real config. The matrix tiers use the `default<dest>` and `default_profile_<letter><dest>` naming instead.
 
-**Example.** For a `claude` agent with `dest = ".claude"` resolving profile `A`, AC looks, in order, for `<workspace>/default_profile_a.claude`, `<workspace>/default.claude`, `<matrix>/default_profile_a.claude`, then `<matrix>/default.claude`. The first that exists is copied to `<replica>/.claude`.
+### Example: Claude, `Config folder` = `.claude`, profile `A`
+
+AC looks, in order, for:
+
+1. `<workspace>/default_profile_a.claude`
+2. `<workspace>/default.claude` - a template you own; if it exists it wins, and it is re-copied on every spawn.
+3. `<matrix>/default_profile_a.claude`
+4. `<matrix>/default.claude`
+5. `<config_dir>/coding-agents/_seed/.claude` - the AC factory fallback, used **only** when none of the above exists **and** the replica has no `.claude` yet.
+
+The first that qualifies is copied to `<replica>/.claude`. So `<workspace>/default.claude`, the user template, always wins ahead of the factory seed; `<config_dir>/coding-agents/_seed/.claude` is only the factory fallback that bootstraps a fresh replica.
+
+## The factory default and the "Re-seed" button
+
+Only the built-in **Claude**, **Codex**, and **OpenCode** agents ship a factory default (tier 5); other agents ship none, so for them tier 5 is simply absent. AC writes each shipped master into `<config_dir>/coding-agents/_seed/<dest>/` once, on first launch, then leaves it alone. The master is **yours to edit** afterward: change `_seed/.claude/settings.json` and every future absent-only bootstrap uses your edited copy.
+
+**Settings -> Coding Agents** shows a **Re-seed default configuration** button on each built-in that ships a master. It restores that master to the version AC shipped:
+
+- It first backs up your current master to `<dest>.bak-<timestamp>` (your edits are never lost), then atomically swaps AC's shipped default into place.
+- It changes **only** the tier-5 master under `<config_dir>/coding-agents/_seed/`. It does **not** touch any running session, any replica's live `<dest>`, or your workspace/matrix templates (tiers 1-4).
+- Because tier 5 is absent-only, re-seeding affects only future replicas that still have no `<dest>` and no higher-tier template; existing replicas keep their config.
+
+Use it when you have edited a factory master and want AC's original default back.
 
 ## Token substitution
 
@@ -87,7 +123,7 @@ A successful seed logs one `info`-level line. With `logLevel` at `info` (the def
 [config-seed] seeded 'C:\tools\.ac\wg-1-team\__agent_claude\.claude' into replica from WorkspaceBase source 'C:\tools\.ac\default.claude'
 ```
 
-The tier in the message (`WorkspaceProfile`, `WorkspaceBase`, `MatrixProfile`, or `MatrixBase`) tells you which template won. If you see no `[config-seed]` line at all, the seed did not run; see [Troubleshooting](#troubleshooting). See [Log filtering](../reference/log-filtering.md#where-logs-go) for where `app.log` lives and how to raise the log level.
+The tier in the message (`WorkspaceProfile`, `WorkspaceBase`, `MatrixProfile`, `MatrixBase`, or `CatalogDefault` for the factory default) tells you which source won. If you see no `[config-seed]` line at all, the seed did not run; see [Troubleshooting](#troubleshooting). See [Log filtering](../reference/log-filtering.md#where-logs-go) for where `app.log` lives and how to raise the log level.
 
 ## What it does not do
 
@@ -100,7 +136,7 @@ The only post-seed step is the RTK PreToolUse hook, and only for a `.claude` des
 
 ## Troubleshooting
 
-**"Nothing got seeded."** Config seed is active only when `enabled` is true and `dest` is non-empty. Then at least one of the four convention folders must actually exist on disk. If none exists, AC has nothing to copy and skips silently. Check the spawn logs for `[config-seed]` lines (see [Log filtering](../reference/log-filtering.md)).
+**"Nothing got seeded."** Config seed is active only when `enabled` is true and `dest` is non-empty. Then a source must qualify: one of the four workspace/matrix template folders, or, for a built-in that ships one, the tier-5 factory default (used only when the replica has no `<dest>` yet). If nothing qualifies, AC has nothing to copy and skips silently, logging that it found no source at any tier. Check the spawn logs for `[config-seed]` lines (see [Log filtering](../reference/log-filtering.md)).
 
 **"My agent's config is overwritten on every launch."** That is expected: the destination is replaced atomically on every spawn. If `dest` matches the coding agent's actual config directory, the seed overwrites that live config each time. AC logs a heuristic warning when `dest` lines up with, or exactly matches, the agent's configured config-dir env. Point `dest` at a directory you intend AC to own, or turn seeding off for that agent.
 
@@ -109,6 +145,7 @@ The only post-seed step is the RTK PreToolUse hook, and only for a `.claude` des
 ## See also
 
 - [Settings reference](../reference/settings.md#coding-agents) - the `configSeed` field on a coding agent
-- [Agent Matrix conventions, section 5](../agent-matrix-conventions.md#5-profile-path-placeholders) - the three AC path tokens
 - [Coding Agent Profiles](coding-agent-profiles.md) - how the profile letter is resolved
+- [Portable instances](portable-instances.md#config-directory-rule) - where `<config_dir>` lives
+- [Agent Matrix conventions, section 5](../agent-matrix-conventions.md#5-profile-path-placeholders) - the three AC path tokens
 - [RTK integration](rtk-integration.md) - the post-seed `.claude` hook

--- a/docs/features/config-seed.md
+++ b/docs/features/config-seed.md
@@ -39,7 +39,7 @@ Config seed is configured **per coding agent**, on the agent's entry in `setting
 | `enabled` | bool | `true` | Whether seeding runs for this agent. |
 | `dest` | string | `""` | Destination folder name under the replica root (for example `.claude`). |
 
-Config seed is **active only when `enabled` is true and `dest` is non-empty**. Omit `configSeed` entirely (the default) and no seeding happens. `dest` is a single folder name, validated as a safe name with no path separators or traversal, both at save time and again at spawn.
+Config seed is **active only when `enabled` is true and `dest` is non-empty**. Omitting `configSeed` disables seeding. Note that the built-in **Claude**, **Codex**, and **OpenCode** agents ship with `configSeed` already enabled (dest `.claude`, `.codex`, and `.opencode` respectively), so seeding is active for them out of the box. `dest` is a single folder name, validated as a safe name with no path separators or traversal, both at save time and again at spawn.
 
 ## Seed tiers: where the config comes from
 
@@ -71,7 +71,7 @@ The five tiers split into two groups with **different ownership and different ov
 - **Workspace beats matrix.** Every workspace-level candidate outranks every matrix-level candidate.
 - **Profile beats base.** Within a location, the folder named for the session's resolved profile letter outranks the plain `default<dest>` folder.
 
-**Tier 5 is the AC factory default (catalog-owned).** This is the config folder AC ships for a built-in coding agent, at `<config_dir>/coding-agents/_seed/<dest>/`. It has the **lowest precedence** and behaves differently from tiers 1-4: it is **absent-only**. AC fills `<replica>/<dest>` from it **only when the destination does not already exist** (and the factory folder holds at least one file). It **never overwrites** an existing config folder, so a replica's accumulated config, credentials, and session state are safe. If the destination is already present, tier 5 is skipped and the spawn is byte-for-byte unchanged. Tier 5 is, in effect, a one-time bootstrap for a brand-new replica when you have supplied no template of your own.
+**Tier 5 is the AC factory default (catalog-owned).** This is the config folder AC ships for a recognized `<dest>` value, at `<config_dir>/coding-agents/_seed/<dest>/`. It has the **lowest precedence** and behaves differently from tiers 1-4: it is **absent-only**. AC fills `<replica>/<dest>` from it **only when the destination does not already exist** (and the factory folder holds at least one file). It **never overwrites** an existing config folder, so a replica's accumulated config, credentials, and session state are safe. If the destination is already present, tier 5 is skipped and the spawn is byte-for-byte unchanged. Tier 5 is, in effect, a one-time bootstrap for a brand-new replica when you have supplied no template of your own.
 
 > **The matrix's own `<dest>` is not a template.** A folder like `_agent_<name>/.claude` is the matrix agent's live config, not a seed source. AC deliberately never copies from it, so seeding cannot clobber the agent's real config. The matrix tiers use the `default<dest>` and `default_profile_<letter><dest>` naming instead.
 
@@ -89,9 +89,11 @@ The first that qualifies is copied to `<replica>/.claude`. So `<workspace>/defau
 
 ## The factory default and the "Re-seed" button
 
-Only the built-in **Claude**, **Codex**, and **OpenCode** agents ship a factory default (tier 5); other agents ship none, so for them tier 5 is simply absent. AC writes each shipped master into `<config_dir>/coding-agents/_seed/<dest>/` once, on first launch, then leaves it alone. The master is **yours to edit** afterward: change `_seed/.claude/settings.json` and every future absent-only bootstrap uses your edited copy.
+AC ships factory masters for three Config folder values only: `.claude`, `.codex`, and `.opencode` (the defaults of the built-in Claude, Codex, and OpenCode agents). **Tier 5 is keyed by the Config folder value, not by agent identity.** It therefore exists for any agent whose Config folder is one of those three, including an agent you create yourself. For any other Config folder value the tier is absent.
 
-**Settings -> Coding Agents** shows a **Re-seed default configuration** button on each built-in that ships a master. It restores that master to the version AC shipped:
+AC writes each shipped master into `<config_dir>/coding-agents/_seed/<dest>/` on launch if that master is absent, and never touches one that already exists. The master is **yours to edit** afterward: change `_seed/.claude/settings.json` and every future absent-only bootstrap uses your edited copy.
+
+**Settings -> Coding Agents** shows a **Re-seed default configuration** button on any agent whose command is exactly `claude`, `codex`, or `opencode`. That button is gated on the **command's executable basename**, not on the Config folder, so a custom agent that runs `claude` shows it too. It restores the master for that command's shipped Config folder back to the version AC ships:
 
 - It first backs up your current master to `<dest>.bak-<timestamp>` (your edits are never lost), then atomically swaps AC's shipped default into place.
 - It changes **only** the tier-5 master under `<config_dir>/coding-agents/_seed/`. It does **not** touch any running session, any replica's live `<dest>`, or your workspace/matrix templates (tiers 1-4).
@@ -136,7 +138,7 @@ The only post-seed step is the RTK PreToolUse hook, and only for a `.claude` des
 
 ## Troubleshooting
 
-**"Nothing got seeded."** Config seed is active only when `enabled` is true and `dest` is non-empty. Then a source must qualify: one of the four workspace/matrix template folders, or, for a built-in that ships one, the tier-5 factory default (used only when the replica has no `<dest>` yet). If nothing qualifies, AC has nothing to copy and skips silently, logging that it found no source at any tier. Check the spawn logs for `[config-seed]` lines (see [Log filtering](../reference/log-filtering.md)).
+**"Nothing got seeded."** Config seed is active only when `enabled` is true and `dest` is non-empty. Then a source must qualify: one of the four workspace/matrix template folders, or, when `dest` is a Config folder value AC ships a master for, the tier-5 factory default (used only when the replica has no `<dest>` yet). If nothing qualifies, AC has nothing to copy and skips, logging at `info` that it found no source at any tier. Check the spawn logs for `[config-seed]` lines (see [Log filtering](../reference/log-filtering.md)).
 
 **"My agent's config is overwritten on every launch."** That is expected: the destination is replaced atomically on every spawn. If `dest` matches the coding agent's actual config directory, the seed overwrites that live config each time. AC logs a heuristic warning when `dest` lines up with, or exactly matches, the agent's configured config-dir env. Point `dest` at a directory you intend AC to own, or turn seeding off for that agent.
 


### PR DESCRIPTION
## Summary
- Document the five coding-agent config seed tiers, including the factory/catalog default tier.
- Clarify that tier 5 is keyed by Config folder value, not agent identity.
- Document built-in configSeed defaults and the re-seed button behavior.

## Verification
- technical-writer: `git diff --check`, em-dash scan, docs-only scope check.
- dev-rust-grinch: initial review failed on two doc accuracy issues; follow-up re-review PASS at `ce595aac`.
- Coordinator: branch currency check passed (`origin/main` ancestor of HEAD), docs-only diff confirmed.

## Ship status
N/A - non-visual docs-only change. No shipper build required.

Closes #876