### PR TITLE
fix(api): API server status false-negative on 0.0.0.0 bind + readiness await (#878)

### DIFF
--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use axum::Router;
+use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::manager::PtyManager;
@@ -33,6 +34,12 @@ use crate::session::manager::SessionManager;
 /// Hard ceiling on a buffered request body. Inline sends allow a 256 KiB
 /// semantic body plus JSON envelope overhead.
 const MAX_BODY_LIMIT_BYTES: usize = message_store::INLINE_BODY_MAX_BYTES + (16 * 1024);
+const STARTUP_READY_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub struct ApiServerStart {
+    pub join_handle: tauri::async_runtime::JoinHandle<()>,
+    pub readiness: oneshot::Receiver<Result<SocketAddr, String>>,
+}
 
 /// Shared state injected into every handler.
 #[derive(Clone)]
@@ -68,11 +75,25 @@ pub fn build_router(state: ApiState) -> Router {
         .with_state(state)
 }
 
+pub async fn wait_for_startup_ready(
+    readiness: oneshot::Receiver<Result<SocketAddr, String>>,
+) -> Result<SocketAddr, String> {
+    match tokio::time::timeout(STARTUP_READY_TIMEOUT, readiness).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(_)) => Err("API server startup task ended before reporting readiness".to_string()),
+        Err(_) => Err(format!(
+            "API server did not report bind readiness within {:?}",
+            STARTUP_READY_TIMEOUT
+        )),
+    }
+}
+
 /// Start the control-plane API server on the shared tokio runtime, mirroring
-/// `web::start_server`. Returns the join handle for the managed
-/// `ApiServerHandle`. On any startup failure (unresolvable config dir, invalid
-/// address, or `bind` error) it logs at error and the task returns cleanly: it
-/// does NOT panic (§0.5 dev-rust F7, unlike `web/mod.rs`'s `.expect()`).
+/// `web::start_server`. Returns the join handle plus a readiness receiver for
+/// the managed `ApiServerHandle`. On any startup failure (unresolvable config
+/// dir, invalid address, or `bind` error) it logs at error, sends readiness
+/// `Err`, and the task returns cleanly: it does NOT panic (§0.5 dev-rust F7,
+/// unlike `web/mod.rs`'s `.expect()`).
 pub fn start_server(
     bind: String,
     port: u16,
@@ -80,22 +101,30 @@ pub fn start_server(
     session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
     pty_mgr: Arc<Mutex<PtyManager>>,
     shutdown: CancellationToken,
-) -> tauri::async_runtime::JoinHandle<()> {
+) -> ApiServerStart {
+    let (readiness_tx, readiness) = oneshot::channel();
     let store = match auth::ApiClientStore::at_config_dir() {
         Some(s) => Arc::new(s),
         None => {
-            log::error!("[api-server] cannot resolve config_dir; API server not started");
-            return tauri::async_runtime::spawn(async {});
+            let message = "Cannot resolve config_dir for API server".to_string();
+            log::error!("[api-server] {}; API server not started", message);
+            let _ = readiness_tx.send(Err(message));
+            return ApiServerStart {
+                join_handle: tauri::async_runtime::spawn(async {}),
+                readiness,
+            };
         }
     };
     let message_store = match message_store::MessageStore::at_config_dir() {
         Ok(s) => Arc::new(s),
         Err(e) => {
-            log::error!(
-                "[api-server] cannot initialize DB message store; API server not started: {}",
-                e
-            );
-            return tauri::async_runtime::spawn(async {});
+            let message = format!("Cannot initialize API DB message store: {}", e);
+            log::error!("[api-server] {}; API server not started", message);
+            let _ = readiness_tx.send(Err(message));
+            return ApiServerStart {
+                join_handle: tauri::async_runtime::spawn(async {}),
+                readiness,
+            };
         }
     };
 
@@ -109,24 +138,29 @@ pub fn start_server(
     };
     let router = build_router(state);
 
-    tauri::async_runtime::spawn(async move {
+    let join_handle = tauri::async_runtime::spawn(async move {
+        let mut readiness_tx = Some(readiness_tx);
         let dispatcher_handle = dispatcher::start_dispatcher(
             message_store,
             app_handle.clone(),
             shutdown.clone(),
             dispatcher::DispatcherConfig::default(),
         );
-        let addr: SocketAddr = match crate::config::settings::parse_api_server_socket_addr(
-            &bind, port,
-        ) {
-            Ok(a) => a,
-            Err(e) => {
-                log::error!("[api-server] invalid bind address {}:{}: {}", bind, port, e);
-                shutdown.cancel();
-                wait_for_dispatcher(dispatcher_handle, "invalid-bind").await;
-                return;
-            }
-        };
+        let addr: SocketAddr =
+            match crate::config::settings::parse_api_server_socket_addr(&bind, port) {
+                Ok(a) => a,
+                Err(e) => {
+                    let message =
+                        format!("Invalid API server bind address {}:{}: {}", bind, port, e);
+                    log::error!("[api-server] {}", message);
+                    if let Some(tx) = readiness_tx.take() {
+                        let _ = tx.send(Err(message));
+                    }
+                    shutdown.cancel();
+                    wait_for_dispatcher(dispatcher_handle, "invalid-bind").await;
+                    return;
+                }
+            };
 
         // Loud warning on any non-loopback bind (§0.5 DESIGN DECISION).
         if !addr.ip().is_loopback() {
@@ -142,17 +176,20 @@ pub fn start_server(
         let listener = match tokio::net::TcpListener::bind(addr).await {
             Ok(l) => l,
             Err(e) => {
-                log::error!(
-                    "[api-server] bind failed on {} (port occupied?): {}; API server not started",
-                    addr,
-                    e
-                );
+                let message = format!("API server bind failed on {}: {}", addr, e);
+                log::error!("[api-server] {}; API server not started", message);
+                if let Some(tx) = readiness_tx.take() {
+                    let _ = tx.send(Err(message));
+                }
                 shutdown.cancel();
                 wait_for_dispatcher(dispatcher_handle, "bind-failure").await;
                 return;
             }
         };
 
+        if let Some(tx) = readiness_tx.take() {
+            let _ = tx.send(Ok(addr));
+        }
         log::info!("[api-server] listening on http://{}", addr);
         println!("[api-server] listening on http://{}", addr);
 
@@ -169,7 +206,12 @@ pub fn start_server(
         }
         shutdown.cancel();
         wait_for_dispatcher(dispatcher_handle, "server-stop").await;
-    })
+    });
+
+    ApiServerStart {
+        join_handle,
+        readiness,
+    }
 }
 
 const DISPATCHER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::hash::{Hash, Hasher};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -10,9 +11,9 @@ use uuid::Uuid;
 use crate::api::auth;
 use crate::config::claude_settings::{ensure_rtk_pretool_hook, enumerate_managed_agent_dirs};
 use crate::config::settings::{
-    load_settings, merge_protected_coding_agent_settings, save_settings,
-    validate_and_repair_settings, AppSettings, CodingAgentEnv, CodingAgentProfilesConfig,
-    SettingsState,
+    load_settings, merge_protected_coding_agent_settings, parse_api_server_socket_addr,
+    save_settings, validate_and_repair_settings, AppSettings, CodingAgentEnv,
+    CodingAgentProfilesConfig, SettingsState,
 };
 use crate::network::OutboundNetwork;
 use crate::pty::manager::PtyManager;
@@ -1249,8 +1250,8 @@ pub async fn start_api_server(
     let port = s.api_server_port;
     drop(s);
 
-    let addr = format!("{}:{}", bind, port);
-    if is_tcp_listening(&addr).await {
+    let probe_addr = api_server_probe_addr(&bind, port)?;
+    if is_tcp_socket_listening(probe_addr).await {
         return Ok(false);
     }
 
@@ -1284,11 +1285,19 @@ pub async fn stop_api_server(api_handle: State<'_, ApiServerHandle>) -> Result<b
 }
 
 #[tauri::command]
-pub async fn api_server_status(settings: State<'_, SettingsState>) -> Result<bool, String> {
-    let s = settings.read().await;
-    let addr = format!("{}:{}", s.api_server_bind, s.api_server_port);
-    drop(s);
-    Ok(is_tcp_listening(&addr).await)
+pub async fn api_server_status(
+    api_handle: State<'_, ApiServerHandle>,
+    settings: State<'_, SettingsState>,
+) -> Result<bool, String> {
+    if api_handle.has_running()? {
+        return Ok(true);
+    }
+
+    let probe_addr = {
+        let s = settings.read().await;
+        api_server_probe_addr(&s.api_server_bind, s.api_server_port)?
+    };
+    Ok(is_tcp_socket_listening(probe_addr).await)
 }
 
 #[tauri::command]
@@ -1525,6 +1534,27 @@ pub async fn get_web_server_owned_status(
     };
 
     Ok(build_web_server_owned_status(bind, port, owned, listening))
+}
+
+fn api_server_probe_addr(bind: &str, port: u16) -> Result<SocketAddr, String> {
+    let configured = parse_api_server_socket_addr(bind, port)?;
+    let probe_ip = match configured.ip() {
+        IpAddr::V4(ip) if ip.is_unspecified() => IpAddr::V4(Ipv4Addr::LOCALHOST),
+        IpAddr::V6(ip) if ip.is_unspecified() => IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ip => ip,
+    };
+    Ok(SocketAddr::new(probe_ip, configured.port()))
+}
+
+async fn is_tcp_socket_listening(addr: SocketAddr) -> bool {
+    matches!(
+        tokio::time::timeout(
+            Duration::from_millis(WEB_STATUS_CONNECT_TIMEOUT_MS),
+            tokio::net::TcpStream::connect(addr),
+        )
+        .await,
+        Ok(Ok(_))
+    )
 }
 
 async fn is_tcp_listening(addr: &str) -> bool {
@@ -1822,29 +1852,34 @@ pub async fn fetch_home_markdown(network: State<'_, OutboundNetwork>) -> Result<
 
 #[cfg(test)]
 mod tests {
-    #[cfg(windows)]
-    use super::{build_profile_assignment_target, canonical_compare_key};
     use super::{
-        build_web_server_owned_status, ensure_web_remote_open_allowed, mint_api_client_with_path,
+        api_server_probe_addr, api_server_status, build_web_server_owned_status,
+        ensure_web_remote_open_allowed, is_tcp_socket_listening, mint_api_client_with_path,
         persist_coding_agent_env_settings_update, persist_coding_agent_profiles_update,
         persist_narrow_settings_update_with_saver, persist_protected_settings_update_with_saver,
         persist_settings_draft_update_with_saver, RtkSweepError, RtkSweepResult,
         WebServerOwnershipState, MINT_API_CLIENT_DEFAULT_TTL_HOURS, MINT_API_CLIENT_MAX_TTL_DAYS,
         MINT_API_CLIENT_NOTE,
     };
+    #[cfg(windows)]
+    use super::{build_profile_assignment_target, canonical_compare_key};
     use crate::api::auth;
     use crate::config::settings::{
         AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ProfileCellConfig,
         SettingsState,
     };
     use crate::session::manager::SessionManager;
-    use crate::WebServerHandle;
+    use crate::{ApiServerHandle, ApiServerTask, WebServerHandle};
     use std::collections::BTreeMap;
+    use std::net::{IpAddr, Ipv4Addr};
     #[cfg(windows)]
     use std::path::Path;
     use std::path::PathBuf;
     use std::sync::Arc;
+    use std::time::Duration;
+    use tauri::Manager;
     use tokio::sync::RwLock;
+    use tokio_util::sync::CancellationToken;
 
     fn settings_with_single_agent() -> AppSettings {
         AppSettings {
@@ -1898,6 +1933,75 @@ mod tests {
 
     fn state_for(settings: AppSettings) -> SettingsState {
         Arc::new(RwLock::new(settings))
+    }
+
+    #[test]
+    fn api_server_probe_addr_maps_wildcards_to_loopback() {
+        assert_eq!(
+            api_server_probe_addr("0.0.0.0", 9906).unwrap().to_string(),
+            "127.0.0.1:9906"
+        );
+        assert_eq!(
+            api_server_probe_addr("127.0.0.1", 9906)
+                .unwrap()
+                .to_string(),
+            "127.0.0.1:9906"
+        );
+        assert_eq!(
+            api_server_probe_addr("::", 9906).unwrap().to_string(),
+            "[::1]:9906"
+        );
+        assert_eq!(
+            api_server_probe_addr("::1", 9906).unwrap().to_string(),
+            "[::1]:9906"
+        );
+    }
+
+    #[tokio::test]
+    async fn api_server_probe_addr_detects_wildcard_listener_via_loopback() {
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::UNSPECIFIED, 0))
+            .await
+            .expect("bind wildcard test listener");
+        let port = listener.local_addr().expect("listener local addr").port();
+        let probe_addr = api_server_probe_addr("0.0.0.0", port).expect("probe addr");
+
+        assert_eq!(probe_addr.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert!(is_tcp_socket_listening(probe_addr).await);
+    }
+
+    #[tokio::test]
+    async fn api_server_status_reports_running_for_managed_wildcard_server() {
+        let settings = AppSettings {
+            api_server_bind: "0.0.0.0".to_string(),
+            api_server_port: 9906,
+            ..AppSettings::default()
+        };
+        let app = tauri::test::mock_builder()
+            .manage(ApiServerHandle::default())
+            .manage(state_for(settings))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build test app");
+
+        let shutdown = CancellationToken::new();
+        let task_shutdown = shutdown.clone();
+        let join = tauri::async_runtime::spawn(async move {
+            task_shutdown.cancelled().await;
+        });
+        app.state::<ApiServerHandle>()
+            .store_if_idle(ApiServerTask::new(join, shutdown))
+            .expect("store api server task");
+
+        let running =
+            api_server_status(app.state::<ApiServerHandle>(), app.state::<SettingsState>())
+                .await
+                .expect("status succeeds");
+
+        assert!(running);
+        assert!(app
+            .state::<ApiServerHandle>()
+            .shutdown_running(Duration::from_secs(1))
+            .await
+            .expect("shutdown stored task"));
     }
 
     struct MintApiClientFixture {

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1256,7 +1256,7 @@ pub async fn start_api_server(
     }
 
     let api_shutdown = shutdown.token().child_token();
-    let join_handle = crate::api::start_server(
+    let server_start = crate::api::start_server(
         bind,
         port,
         app_handle,
@@ -1264,8 +1264,19 @@ pub async fn start_api_server(
         Arc::clone(&pty_mgr),
         api_shutdown.clone(),
     );
+    let bound_addr = match crate::api::wait_for_startup_ready(server_start.readiness).await {
+        Ok(bound_addr) => bound_addr,
+        Err(err) => {
+            api_shutdown.cancel();
+            return Err(err);
+        }
+    };
 
-    if !api_handle.store_if_idle(ApiServerTask::new(join_handle, api_shutdown))? {
+    if !api_handle.store_if_idle(ApiServerTask::new(
+        server_start.join_handle,
+        api_shutdown,
+        bound_addr,
+    ))? {
         return Ok(false);
     }
 
@@ -1857,7 +1868,7 @@ mod tests {
         ensure_web_remote_open_allowed, is_tcp_socket_listening, mint_api_client_with_path,
         persist_coding_agent_env_settings_update, persist_coding_agent_profiles_update,
         persist_narrow_settings_update_with_saver, persist_protected_settings_update_with_saver,
-        persist_settings_draft_update_with_saver, RtkSweepError, RtkSweepResult,
+        persist_settings_draft_update_with_saver, start_api_server, RtkSweepError, RtkSweepResult,
         WebServerOwnershipState, MINT_API_CLIENT_DEFAULT_TTL_HOURS, MINT_API_CLIENT_MAX_TTL_DAYS,
         MINT_API_CLIENT_NOTE,
     };
@@ -1870,12 +1881,12 @@ mod tests {
     };
     use crate::session::manager::SessionManager;
     use crate::{ApiServerHandle, ApiServerTask, WebServerHandle};
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::net::{IpAddr, Ipv4Addr};
     #[cfg(windows)]
     use std::path::Path;
     use std::path::PathBuf;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tauri::Manager;
     use tokio::sync::RwLock;
@@ -1935,6 +1946,32 @@ mod tests {
         Arc::new(RwLock::new(settings))
     }
 
+    fn api_server_command_test_app(settings: AppSettings) -> tauri::App {
+        let session_mgr = Arc::new(RwLock::new(SessionManager::new()));
+        let app = tauri::Builder::default()
+            .any_thread()
+            .manage(ApiServerHandle::default())
+            .manage(state_for(settings))
+            .manage(Arc::clone(&session_mgr))
+            .manage(crate::shutdown::ShutdownSignal::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build test app");
+        let idle_detector = crate::pty::idle_detector::IdleDetector::new(|_| {}, |_| {});
+        let git_watcher = crate::pty::git_watcher::GitWatcher::new(
+            Arc::clone(&session_mgr),
+            app.handle().clone(),
+        );
+        let pty_mgr = Arc::new(Mutex::new(crate::pty::manager::PtyManager::new(
+            Arc::new(Mutex::new(HashMap::new())),
+            idle_detector,
+            git_watcher,
+            None,
+            session_mgr,
+        )));
+        app.manage(pty_mgr);
+        app
+    }
+
     #[test]
     fn api_server_probe_addr_maps_wildcards_to_loopback() {
         assert_eq!(
@@ -1971,9 +2008,13 @@ mod tests {
 
     #[tokio::test]
     async fn api_server_status_reports_running_for_managed_wildcard_server() {
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::UNSPECIFIED, 0))
+            .await
+            .expect("bind wildcard test listener");
+        let bound_addr = listener.local_addr().expect("listener local addr");
         let settings = AppSettings {
             api_server_bind: "0.0.0.0".to_string(),
-            api_server_port: 9906,
+            api_server_port: bound_addr.port(),
             ..AppSettings::default()
         };
         let app = tauri::test::mock_builder()
@@ -1985,10 +2026,11 @@ mod tests {
         let shutdown = CancellationToken::new();
         let task_shutdown = shutdown.clone();
         let join = tauri::async_runtime::spawn(async move {
+            let _listener = listener;
             task_shutdown.cancelled().await;
         });
         app.state::<ApiServerHandle>()
-            .store_if_idle(ApiServerTask::new(join, shutdown))
+            .store_if_idle(ApiServerTask::new(join, shutdown, bound_addr))
             .expect("store api server task");
 
         let running =
@@ -2002,6 +2044,35 @@ mod tests {
             .shutdown_running(Duration::from_secs(1))
             .await
             .expect("shutdown stored task"));
+    }
+
+    #[tokio::test]
+    async fn start_api_server_bind_failure_returns_err_and_status_false() {
+        let settings = AppSettings {
+            api_server_bind: "192.0.2.1".to_string(),
+            api_server_port: 9906,
+            ..AppSettings::default()
+        };
+        let app = api_server_command_test_app(settings);
+
+        let err = start_api_server(
+            app.handle().clone(),
+            app.state::<ApiServerHandle>(),
+            app.state::<SettingsState>(),
+            app.state::<Arc<RwLock<SessionManager>>>(),
+            app.state::<Arc<Mutex<crate::pty::manager::PtyManager>>>(),
+            app.state::<crate::shutdown::ShutdownSignal>(),
+        )
+        .await
+        .expect_err("nonlocal bind should fail readiness");
+
+        assert!(err.contains("API server bind failed"), "{err}");
+        assert!(!app.state::<ApiServerHandle>().has_running().unwrap());
+        assert!(
+            !api_server_status(app.state::<ApiServerHandle>(), app.state::<SettingsState>())
+                .await
+                .expect("status succeeds")
+        );
     }
 
     struct MintApiClientFixture {

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1118,7 +1118,7 @@ pub fn repair_coding_agent_profiles_config(
         .retain(|_, letter| is_valid_profile_letter(letter));
     changed |= profiles.default_profile_by_agent.len() != original_defaults_len;
 
-    for (_agent_id, cells) in profiles.profiles_by_agent.iter_mut() {
+    for cells in profiles.profiles_by_agent.values_mut() {
         let original_cells_len = cells.len();
         cells.retain(|letter, _| is_valid_profile_letter(letter));
         changed |= cells.len() != original_cells_len;
@@ -1129,7 +1129,7 @@ pub fn repair_coding_agent_profiles_config(
     // prunes by agent id (an override for a not-yet-loaded agent is harmless and may
     // precede its agent in load order, per plan 3.7). `retain` keeps every valid key,
     // so a clean config leaves `changed` false and is not rewritten on load.
-    for (_agent_id, labels) in profiles.profile_labels_by_agent.iter_mut() {
+    for labels in profiles.profile_labels_by_agent.values_mut() {
         let original_len = labels.len();
         labels.retain(|letter, _| is_valid_profile_letter(letter));
         changed |= labels.len() != original_len;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ pub mod voice;
 pub mod web;
 
 use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -100,11 +101,20 @@ pub struct ApiServerHandle {
 pub struct ApiServerTask {
     join: tauri::async_runtime::JoinHandle<()>,
     shutdown: CancellationToken,
+    bound_addr: SocketAddr,
 }
 
 impl ApiServerTask {
-    pub fn new(join: tauri::async_runtime::JoinHandle<()>, shutdown: CancellationToken) -> Self {
-        Self { join, shutdown }
+    pub fn new(
+        join: tauri::async_runtime::JoinHandle<()>,
+        shutdown: CancellationToken,
+        bound_addr: SocketAddr,
+    ) -> Self {
+        Self {
+            join,
+            shutdown,
+            bound_addr,
+        }
     }
 }
 
@@ -115,10 +125,14 @@ impl ApiServerHandle {
             .inner
             .lock()
             .map_err(|_| "API server handle lock is poisoned".to_string())?;
-        if inner
+        if let Some(stored) = inner
             .as_ref()
-            .is_some_and(|stored| !stored.join.inner().is_finished())
+            .filter(|stored| !stored.join.inner().is_finished())
         {
+            log::debug!(
+                "[api-server] start ignored; server already running on {}",
+                stored.bound_addr
+            );
             task.shutdown.cancel();
             task.join.abort();
             return Ok(false);
@@ -128,18 +142,22 @@ impl ApiServerHandle {
     }
 
     pub fn has_running(&self) -> Result<bool, String> {
+        Ok(self.running_bound_addr()?.is_some())
+    }
+
+    pub fn running_bound_addr(&self) -> Result<Option<SocketAddr>, String> {
         let mut inner = self
             .inner
             .lock()
             .map_err(|_| "API server handle lock is poisoned".to_string())?;
-        if inner
+        if let Some(stored) = inner
             .as_ref()
-            .is_some_and(|stored| !stored.join.inner().is_finished())
+            .filter(|stored| !stored.join.inner().is_finished())
         {
-            return Ok(true);
+            return Ok(Some(stored.bound_addr));
         }
         *inner = None;
-        Ok(false)
+        Ok(None)
     }
 
     pub async fn shutdown_running(&self, timeout: std::time::Duration) -> Result<bool, String> {
@@ -731,16 +749,15 @@ pub fn run(
             }
 
             // #791 - start the control-plane API server if enabled in settings.
-            // Opt-in (default false), mirroring the web server block above. On
-            // any startup failure `api::start_server`'s task logs and returns
-            // (no panic); a listening server is stored in the managed handle.
+            // Opt-in (default false), mirroring the web server block above. The
+            // managed handle is stored only after bind readiness is confirmed.
             {
                 let api_settings = config::settings::load_settings();
                 if api_settings.api_server_enabled {
                     let bind = api_settings.api_server_bind.clone();
                     let port = api_settings.api_server_port;
                     let api_shutdown = shutdown_for_setup.token().child_token();
-                    let join_handle = api::start_server(
+                    let server_start = api::start_server(
                         bind,
                         port,
                         app.handle().clone(),
@@ -748,11 +765,23 @@ pub fn run(
                         pty_mgr.clone(),
                         api_shutdown.clone(),
                     );
-                    let api_handle = app.state::<ApiServerHandle>();
-                    if let Err(e) =
-                        api_handle.store_if_idle(ApiServerTask::new(join_handle, api_shutdown))
-                    {
-                        log::error!("[api-server] failed to store server handle: {}", e);
+                    match tauri::async_runtime::block_on(api::wait_for_startup_ready(
+                        server_start.readiness,
+                    )) {
+                        Ok(bound_addr) => {
+                            let api_handle = app.state::<ApiServerHandle>();
+                            if let Err(e) = api_handle.store_if_idle(ApiServerTask::new(
+                                server_start.join_handle,
+                                api_shutdown,
+                                bound_addr,
+                            )) {
+                                log::error!("[api-server] failed to store server handle: {}", e);
+                            }
+                        }
+                        Err(err) => {
+                            api_shutdown.cancel();
+                            log::warn!("[api-server] startup failed: {}", err);
+                        }
                     }
                 }
             }
@@ -2445,8 +2474,13 @@ mod tests {
     };
     use crate::config::settings::{AgentConfig, AppSettings};
     use crate::session::session::SessionStatus;
+    use std::net::SocketAddr;
     use std::time::Duration;
     use tokio_util::sync::CancellationToken;
+
+    fn api_test_addr(port: u16) -> SocketAddr {
+        SocketAddr::from(([127, 0, 0, 1], port))
+    }
 
     fn settings_with_agent() -> AppSettings {
         AppSettings {
@@ -2526,9 +2560,13 @@ mod tests {
         });
 
         assert!(handle
-            .store_if_idle(ApiServerTask::new(join, shutdown))
+            .store_if_idle(ApiServerTask::new(join, shutdown, api_test_addr(9906)))
             .unwrap());
         assert!(handle.has_running().unwrap());
+        assert_eq!(
+            handle.running_bound_addr().unwrap(),
+            Some(api_test_addr(9906))
+        );
         assert!(handle
             .shutdown_running(Duration::from_secs(1))
             .await
@@ -2545,7 +2583,11 @@ mod tests {
             first_task_shutdown.cancelled().await;
         });
         assert!(handle
-            .store_if_idle(ApiServerTask::new(first_join, first_shutdown))
+            .store_if_idle(ApiServerTask::new(
+                first_join,
+                first_shutdown,
+                api_test_addr(9906),
+            ))
             .unwrap());
 
         let second_shutdown = CancellationToken::new();
@@ -2555,7 +2597,11 @@ mod tests {
             second_task_shutdown.cancelled().await;
         });
         assert!(!handle
-            .store_if_idle(ApiServerTask::new(second_join, second_shutdown))
+            .store_if_idle(ApiServerTask::new(
+                second_join,
+                second_shutdown,
+                api_test_addr(9907),
+            ))
             .unwrap());
         assert!(second_observer.is_cancelled());
         assert!(handle.has_running().unwrap());

--- a/src-tauri/src/pty/credentials.rs
+++ b/src-tauri/src/pty/credentials.rs
@@ -66,11 +66,11 @@ pub fn build_credential_values(token: &Uuid, cwd: &str) -> CredentialValues {
         .and_then(|p| p.parent())
         .map(|parent| {
             parent
-                .join(format!(".{}", &binary))
+                .join(format!(".{}", binary))
                 .to_string_lossy()
                 .to_string()
         })
-        .unwrap_or_else(|| format!(".{}", &binary));
+        .unwrap_or_else(|| format!(".{}", binary));
 
     CredentialValues {
         token: token.to_string(),

--- a/src-tauri/src/testability/ui_automation.rs
+++ b/src-tauri/src/testability/ui_automation.rs
@@ -1725,10 +1725,8 @@ impl RequestFile {
 
         let (request_id, kind) = if let Some(id) = name.strip_suffix(".inflight.json") {
             (id, RequestFileKind::Inflight)
-        } else if let Some(id) = name.strip_suffix(".json") {
-            (id, RequestFileKind::Ready)
         } else {
-            return None;
+            (name.strip_suffix(".json")?, RequestFileKind::Ready)
         };
 
         if Uuid::parse_str(request_id).is_err() {


### PR DESCRIPTION
## Summary
Fixes the API server toggle reverting to OFF when the server is bound to `0.0.0.0` (found by Maria while testing the container flow). Backend only; no frontend changes.

## Root cause
`api_server_status` built the configured address verbatim (`0.0.0.0:9906`) and probed it with `TcpStream::connect`. On Windows a listener on `0.0.0.0:P` is reachable via `127.0.0.1:P`, but connecting to `0.0.0.0:P` as a destination fails. The server did start; the status check returned a false negative, so the UI showed "API server did not report running after start" and rolled the toggle back.

## What changed
- **Wildcard-to-loopback probe mapper:** `0.0.0.0:P` probes `127.0.0.1:P`, `::` probes `[::1]:P`, concrete binds probe themselves. The same parser is used for probe and bind, so they cannot diverge.
- **Readiness await:** `api::start_server` now returns `{ join_handle, readiness }`. The task sends `Ok(SocketAddr)` only after `TcpListener::bind` succeeds, and `Err` on every startup failure path (config dir, message store, invalid bind, bind failure). `start_api_server` awaits readiness (2s) before storing the managed handle and returns `Err` on bind failure, so the UI surfaces the real bind error. The app-setup auto-start does the same and fails soft.
- **`api_server_status` is handle-authoritative post-readiness** (`has_running()` now implies a successful bind), with the TCP probe kept as a fallback for a server managed by another process (CLI, second instance).
- `ApiServerTask` stores the actual bound `SocketAddr`.

## Review
- grinch FAILed the first attempt: the `has_running()` short-circuit measured "task alive", not "listener exists", so a failed bind (unassigned IP, Windows excluded port range) would report "Running" with nothing listening. That was a non-deterministic false positive the old code did not have. dev-rust then implemented grinch's readiness-await fix.
- grinch re-review: **PASS**. New invariant: `has_running() == true` implies a successful `bind()` and a live task; the start-to-status race is dead by construction. All four startup error paths report through the oneshot, and a spurious timeout leaves no orphan listener. No regression to `127.0.0.1`, the #846 toggle, or the #872 hot re-bind.

## Tests
- `start_api_server_bind_failure_returns_err_and_status_false`: binds `192.0.2.1` (TEST-NET-1, never assigned) so the bind genuinely fails; asserts start returns `Err`, the handle is not running, and status is `false`. This is exactly the test that would have caught the regression.
- The previously fake "managed wildcard server" test now holds a real `0.0.0.0:0` listener.
- Probe mapper covered for IPv4/IPv6 wildcard and concrete binds.

## Gates
`cargo test --all-targets`, `cargo clippy --all-targets -- -D warnings`, `npm run typecheck`, `npm run version:check`, `npm run smoke:cli-release-windows` all pass.

## Follow-ups (non-blocking)
- Consume the stored `bound_addr` in the UI so the status line shows the real listener address instead of the settings value.
- A bare `connect()` cannot distinguish the AC API from any other process on that port; a marked HTTP probe would close that.
- Defensive `listener.local_addr()` instead of the parsed addr, and test coverage for the readiness timeout / dropped-sender arms.

Closes #878
