### PR TITLE
fix: decouple domain logic from UI presentation values (refs #882)

### DIFF
--- a/src/shared/coordinator-badge.test.ts
+++ b/src/shared/coordinator-badge.test.ts
@@ -40,34 +40,34 @@ describe("coordinatorIdleBadge", () => {
     expect(coordinatorIdleBadge(minsAgo(4320), NOW, thresholds(30, 60))?.label).toBe("4320m");
   });
 
-  it("applies green/yellow/red exactly at the default 30/60 boundaries", () => {
+  it("applies ok/warn/stale exactly at the default 30/60 boundaries", () => {
     const t = thresholds(30, 60);
-    expect(coordinatorIdleBadge(minsAgo(0), NOW, t)?.colorClass).toBe("green");
-    expect(coordinatorIdleBadge(minsAgo(29), NOW, t)?.colorClass).toBe("green"); // yellow - 1
-    expect(coordinatorIdleBadge(minsAgo(30), NOW, t)?.colorClass).toBe("yellow"); // == yellow
-    expect(coordinatorIdleBadge(minsAgo(59), NOW, t)?.colorClass).toBe("yellow"); // red - 1
-    expect(coordinatorIdleBadge(minsAgo(60), NOW, t)?.colorClass).toBe("red"); // == red
-    expect(coordinatorIdleBadge(minsAgo(600), NOW, t)?.colorClass).toBe("red");
+    expect(coordinatorIdleBadge(minsAgo(0), NOW, t)?.level).toBe("ok");
+    expect(coordinatorIdleBadge(minsAgo(29), NOW, t)?.level).toBe("ok"); // yellow - 1
+    expect(coordinatorIdleBadge(minsAgo(30), NOW, t)?.level).toBe("warn"); // == yellow
+    expect(coordinatorIdleBadge(minsAgo(59), NOW, t)?.level).toBe("warn"); // red - 1
+    expect(coordinatorIdleBadge(minsAgo(60), NOW, t)?.level).toBe("stale"); // == red
+    expect(coordinatorIdleBadge(minsAgo(600), NOW, t)?.level).toBe("stale");
   });
 
   it("honors custom thresholds", () => {
     const t = thresholds(5, 10);
-    expect(coordinatorIdleBadge(minsAgo(4), NOW, t)?.colorClass).toBe("green");
-    expect(coordinatorIdleBadge(minsAgo(5), NOW, t)?.colorClass).toBe("yellow");
-    expect(coordinatorIdleBadge(minsAgo(9), NOW, t)?.colorClass).toBe("yellow");
-    expect(coordinatorIdleBadge(minsAgo(10), NOW, t)?.colorClass).toBe("red");
+    expect(coordinatorIdleBadge(minsAgo(4), NOW, t)?.level).toBe("ok");
+    expect(coordinatorIdleBadge(minsAgo(5), NOW, t)?.level).toBe("warn");
+    expect(coordinatorIdleBadge(minsAgo(9), NOW, t)?.level).toBe("warn");
+    expect(coordinatorIdleBadge(minsAgo(10), NOW, t)?.level).toBe("stale");
   });
 
   it("falls back to default 30/60 thresholds when settings is null", () => {
-    expect(coordinatorIdleBadge(minsAgo(29), NOW, null)?.colorClass).toBe("green");
-    expect(coordinatorIdleBadge(minsAgo(30), NOW, null)?.colorClass).toBe("yellow");
-    expect(coordinatorIdleBadge(minsAgo(60), NOW, null)?.colorClass).toBe("red");
+    expect(coordinatorIdleBadge(minsAgo(29), NOW, null)?.level).toBe("ok");
+    expect(coordinatorIdleBadge(minsAgo(30), NOW, null)?.level).toBe("warn");
+    expect(coordinatorIdleBadge(minsAgo(60), NOW, null)?.level).toBe("stale");
   });
 
   it("floors a future-dated timestamp to 0m green (clock skew), never negative", () => {
     const future = new Date(NOW + 5 * 60_000).toISOString();
     const badge = coordinatorIdleBadge(future, NOW, thresholds(30, 60));
     expect(badge?.label).toBe("0m");
-    expect(badge?.colorClass).toBe("green");
+    expect(badge?.level).toBe("ok");
   });
 });

--- a/src/shared/coordinator-badge.ts
+++ b/src/shared/coordinator-badge.ts
@@ -1,12 +1,16 @@
 import type { AppSettings } from "./types";
 
-export type CoordinatorBadgeColor = "green" | "yellow" | "red";
+/**
+ * #882 Domain severity for the coordinator idle badge. Deliberately not a color:
+ * mapping to .green / .yellow / .red lives at the render boundary.
+ */
+export type CoordinatorIdleLevel = "ok" | "warn" | "stale";
 
 export interface CoordinatorBadge {
   /** Minutes-only label, e.g. "0m", "45m", "4320m". */
   label: string;
-  /** Threshold color class applied to the badge element. */
-  colorClass: CoordinatorBadgeColor;
+  /** Threshold severity. Mapped to a CSS class at the render boundary. */
+  level: CoordinatorIdleLevel;
 }
 
 /**
@@ -14,11 +18,13 @@ export interface CoordinatorBadge {
  * input timestamp is the unified team-idle anchor (#580): minutes since the team
  * was last truly active, not merely the user's last message (the param name is
  * retained — rename deferred). Minutes-only, raw integer, NO h/d rollover (spec):
- * 45m, 135m, 4320m. Color comes from the global thresholds: `minutes >= red ->
- * red`, else `>= yellow -> yellow`, else green (red is tested first, so an
- * inverted yellow>=red pair just collapses the yellow band rather than
- * misbehaving). The `Math.max(0, ...)` floor means clock skew / a future-dated
- * timestamp shows `0m`, never a negative value.
+ * 45m, 135m, 4320m. Severity comes from the global thresholds:
+ * `minutes >= red -> "stale"`, else `>= yellow -> "warn"`, else `"ok"` (red
+ * is tested first, so an inverted yellow>=red pair just collapses the warn band
+ * rather than misbehaving). The threshold settings keys keep their color names
+ * because they are persisted to disk and Rust config; renaming them is out of
+ * scope for #882. The `Math.max(0, ...)` floor means clock skew / a
+ * future-dated timestamp shows `0m`, never a negative value.
  *
  * Returns `null` when there is no usable timestamp (absent or unparseable), so
  * callers render nothing for a coordinator with no idle anchor yet.
@@ -37,7 +43,7 @@ export function coordinatorIdleBadge(
   const minutes = Math.max(0, Math.floor((nowMs - then) / 60_000));
   const yellow = settings?.coordinatorIdleBadgeYellowMinutes ?? 30;
   const red = settings?.coordinatorIdleBadgeRedMinutes ?? 60;
-  const colorClass: CoordinatorBadgeColor =
-    minutes >= red ? "red" : minutes >= yellow ? "yellow" : "green";
-  return { label: `${minutes}m`, colorClass };
+  const level: CoordinatorIdleLevel =
+    minutes >= red ? "stale" : minutes >= yellow ? "warn" : "ok";
+  return { label: `${minutes}m`, level };
 }

--- a/src/shared/session-activity.test.ts
+++ b/src/shared/session-activity.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { SessionStatus } from "./types";
+import {
+  isSessionWorking,
+  isWorkingActivity,
+  sessionActivity,
+  type ActivitySession,
+  type SessionActivity,
+} from "./session-activity";
+import { sessionDotClass } from "../sidebar/components/session-status";
+
+function activitySession(
+  status: SessionStatus,
+  flags: { pendingReview?: boolean; waitingForInput?: boolean } = {}
+): ActivitySession {
+  return {
+    status,
+    pendingReview: flags.pendingReview ?? false,
+    waitingForInput: flags.waitingForInput ?? false,
+  };
+}
+
+describe("sessionActivity", () => {
+  it("uses the same precedence as the visual dot classifier", () => {
+    expect(sessionActivity(activitySession({ exited: 0 }, { waitingForInput: true }))).toBe("exited");
+    expect(sessionActivity(activitySession({ exited: 0 }, { pendingReview: true }))).toBe("exited");
+    expect(sessionActivity(activitySession("running", { waitingForInput: true }))).toBe("waitingForInput");
+    expect(sessionActivity(activitySession("running", { pendingReview: true }))).toBe("pendingReview");
+    expect(sessionActivity(activitySession("running"))).toBe("running");
+    expect(sessionActivity(activitySession("active"))).toBe("active");
+    expect(sessionActivity(activitySession("idle"))).toBe("idle");
+    expect(sessionActivity(null)).toBe("offline");
+    expect(sessionActivity(activitySession("running"), { inactive: true })).toBe("offline");
+  });
+
+  it("pins pendingReview above waitingForInput when both flags are true", () => {
+    // #882/#886: sessions.ts currently lowers these flags in separate writes.
+    // Reading pendingReview first keeps pending consumers from subscribing to
+    // waitingForInput, so this order is behavioral, not visual.
+    const both = activitySession("running", {
+      pendingReview: true,
+      waitingForInput: true,
+    });
+
+    expect(sessionActivity(both)).toBe("pendingReview");
+    expect(sessionDotClass(both)).toBe("pending");
+  });
+
+  it("classifies only active and running as working", () => {
+    const expected: Record<SessionActivity, boolean> = {
+      offline: false,
+      exited: false,
+      pendingReview: false,
+      waitingForInput: false,
+      active: true,
+      running: true,
+      idle: false,
+    };
+
+    for (const [activity, working] of Object.entries(expected) as Array<[SessionActivity, boolean]>) {
+      expect(isWorkingActivity(activity)).toBe(working);
+    }
+  });
+
+  it("is equivalent to the pre-#882 dot-class working projection", () => {
+    const statuses: SessionStatus[] = ["active", "running", "idle", { exited: 0 }];
+    const flags = [false, true];
+    const workingDots = new Set(["active", "running"]);
+
+    for (const status of statuses) {
+      for (const pendingReview of flags) {
+        for (const waitingForInput of flags) {
+          const s = activitySession(status, { pendingReview, waitingForInput });
+          expect(isSessionWorking(s)).toBe(workingDots.has(sessionDotClass(s)));
+        }
+      }
+    }
+
+    expect(isSessionWorking(null)).toBe(workingDots.has(sessionDotClass(null)));
+  });
+});

--- a/src/shared/session-activity.test.ts
+++ b/src/shared/session-activity.test.ts
@@ -46,6 +46,28 @@ describe("sessionActivity", () => {
     expect(sessionDotClass(both)).toBe("pending");
   });
 
+  it("pins every domain activity to its visual dot projection", () => {
+    const cases: Record<SessionActivity, { session: ActivitySession | null; inactive?: boolean; dot: string }> = {
+      offline: { session: null, dot: "offline" },
+      exited: { session: activitySession({ exited: 0 }), dot: "exited" },
+      pendingReview: { session: activitySession("running", { pendingReview: true }), dot: "pending" },
+      waitingForInput: { session: activitySession("running", { waitingForInput: true }), dot: "waiting" },
+      active: { session: activitySession("active"), dot: "active" },
+      running: { session: activitySession("running"), dot: "running" },
+      idle: { session: activitySession("idle"), dot: "idle" },
+    };
+
+    for (const [activity, spec] of Object.entries(cases) as Array<[
+      SessionActivity,
+      { session: ActivitySession | null; inactive?: boolean; dot: string },
+    ]>) {
+      expect(sessionActivity(spec.session, { inactive: spec.inactive })).toBe(activity);
+      expect(sessionDotClass(spec.session, { inactive: spec.inactive })).toBe(spec.dot);
+    }
+
+    expect(sessionDotClass(activitySession("running"), { inactive: true })).toBe("offline");
+  });
+
   it("classifies only active and running as working", () => {
     const expected: Record<SessionActivity, boolean> = {
       offline: false,
@@ -62,7 +84,7 @@ describe("sessionActivity", () => {
     }
   });
 
-  it("is equivalent to the pre-#882 dot-class working projection", () => {
+  it("keeps the working predicate aligned with the dot-class working projection", () => {
     const statuses: SessionStatus[] = ["active", "running", "idle", { exited: 0 }];
     const flags = [false, true];
     const workingDots = new Set(["active", "running"]);

--- a/src/shared/session-activity.ts
+++ b/src/shared/session-activity.ts
@@ -1,0 +1,68 @@
+import type { Session, SessionStatus } from "./types";
+
+/**
+ * #882 Domain classification of what a session is doing. This is NOT a CSS class:
+ * sessionDotClass() is a 1:1 projection of this enum onto dot class names, and
+ * it is the only place a presentation value is produced. Behavior reads this
+ * enum, never the dot class.
+ *
+ * The precedence chain is a domain statement, not a visual one:
+ *   offline > exited > pendingReview > waitingForInput > status(active|running|idle)
+ *
+ * DO NOT REORDER pendingReview AND waitingForInput. sessions.ts lowers the two
+ * flags in separate unbatched setState calls (#886), so the store is briefly
+ * observable as waitingForInput=false, pendingReview=true. Reading pendingReview
+ * first means a pending session's consumers short-circuit before ever reading
+ * waitingForInput, never subscribe to it, and are never woken by that first
+ * write. The order is load-bearing; session-activity.test.ts pins it.
+ */
+export type SessionActivity =
+  | "offline"
+  | "exited"
+  | "pendingReview"
+  | "waitingForInput"
+  | "active"
+  | "running"
+  | "idle";
+
+/** The subset of Session the classifier reads. */
+export type ActivitySession = Pick<Session, "status" | "pendingReview" | "waitingForInput">;
+
+/** Collapse the tagged Exited(code) variant onto a flat runtime state. */
+export function sessionRuntimeState(
+  status: SessionStatus
+): "active" | "running" | "idle" | "exited" {
+  if (typeof status === "string") return status;
+  return "exited";
+}
+
+export function sessionActivity(
+  session: ActivitySession | null | undefined,
+  options: { inactive?: boolean } = {}
+): SessionActivity {
+  if (!session || options.inactive) return "offline";
+  const runtime = sessionRuntimeState(session.status);
+  if (runtime === "exited") return "exited";
+  if (session.pendingReview) return "pendingReview";
+  if (session.waitingForInput) return "waitingForInput";
+  return runtime;
+}
+
+/**
+ * #882 The load-bearing predicate. Working means a live session whose agent is
+ * currently progressing on its own. Neither waitingForInput nor pendingReview
+ * counts as working.
+ *
+ * pendingReview is not redundant with waitingForInput here. At rest it implies
+ * it, but not mid-write; dropping it breaks the existing rail pending test.
+ */
+export function isWorkingActivity(activity: SessionActivity): boolean {
+  return activity === "active" || activity === "running";
+}
+
+export function isSessionWorking(
+  session: ActivitySession | null | undefined,
+  options: { inactive?: boolean } = {}
+): boolean {
+  return isWorkingActivity(sessionActivity(session, options));
+}

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -46,6 +46,7 @@ import { voiceRecorder } from "../../shared/voice-recorder";
 import { isWgReplicaPath, profileDisplayLabel, sessionProfileBadge, shouldOfferRestartAfterAssign } from "../../shared/profile-utils";
 import { clockStore } from "../stores/clock";
 import { coordinatorIdleBadge } from "../../shared/coordinator-badge";
+import { COORD_IDLE_CLASS } from "./coordinator-badge-class";
 import SessionItem from "./SessionItem";
 import ProfileOutdatedBadge from "./ProfileOutdatedBadge";
 import NewEntityAgentModal from "./NewEntityAgentModal";
@@ -65,9 +66,10 @@ import {
   repoLabelFromPath,
 } from "./replica-repo-badges";
 import { sessionDotClass } from "./session-status";
+import { replicaDotClass } from "./replica-dot";
 import {
   findReplicaSession as replicaSession,
-  replicaDotClass,
+  isReplicaWorking,
   replicaSessionName,
 } from "./workgroup-session";
 import {
@@ -368,11 +370,9 @@ function getActiveReplicasForWg(wg: AcWorkgroup): AcAgentReplica[] {
 }
 
 function runningCoordinatorPeers(wg: AcWorkgroup, replica: AcAgentReplica): AcAgentReplica[] {
-  return (wg.agents ?? []).filter((peer) => {
-    if (peer.name === replica.name) return false;
-    const dot = replicaDotClass(wg, peer);
-    return dot === "running" || dot === "active";
-  });
+  return (wg.agents ?? []).filter(
+    (peer) => peer.name !== replica.name && isReplicaWorking(wg, peer)
+  );
 }
 
 const ProjectPanel: Component = () => {
@@ -2185,7 +2185,7 @@ const ProjectPanel: Component = () => {
                   <Show when={!autoClosed() && !manuallyClosed() && idleBadge()}>
                     {(b) => (
                       <span
-                        class={`ac-discovery-badge coord-idle ${b().colorClass}`}
+                        class={`ac-discovery-badge coord-idle ${COORD_IDLE_CLASS[b().level]}`}
                         title={idleBadgeTitle()}
                       >
                         {b().label}

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -14,10 +14,9 @@ import {
   type WorkgroupGroupSelection,
 } from "../stores/workgroup-groups";
 import {
-  isWorkingReplicaDot,
-  replicaDotClass,
+  isReplicaWorking,
+  splitWorkgroupsByWorking,
   workgroupHasRaisedHand,
-  workgroupIsWorking,
 } from "./workgroup-session";
 import WorkgroupGroupsModal from "./WorkgroupGroupsModal";
 import RaiseHandIcon from "./RaiseHandIcon";
@@ -30,8 +29,8 @@ interface GroupButton {
   key: string;
   name: string;
   counter: string;
-  /** #746 — true when the button's workgroup set has >=1 working agent
-   *  (same predicate as the counter's X: running/active, not waiting/pending). */
+  /** #746/#882: true when the button's workgroup set has >=1 working agent
+   *  (isSessionWorking: live + active/running, not waiting/pending). */
   working: boolean;
   /** #763 — true when >=1 coordinator in the button's workgroup set has a
    *  raised hand (mirrors ProjectPanel's per-row `showRaiseHand`). */
@@ -81,7 +80,7 @@ function tooltipFor(workgroups: AcWorkgroup[]): string {
   const rows = workgroups
     .flatMap((wg) =>
       wg.agents
-        .filter((replica) => isWorkingReplicaDot(replicaDotClass(wg, replica)))
+        .filter((replica) => isReplicaWorking(wg, replica))
         .map((replica) => ({ wg, replica }))
     )
     .sort((a, b) => {
@@ -97,7 +96,7 @@ function buttonContent(
   name: string,
   workgroups: AcWorkgroup[]
 ): Pick<GroupButton, "name" | "counter" | "working" | "raiseHand"> {
-  const working = workgroups.filter(workgroupIsWorking).length;
+  const working = splitWorkgroupsByWorking(workgroups).working.length;
   return {
     name,
     counter: `${working}/${workgroups.length}`,

--- a/src/sidebar/components/coordinator-badge-class.test.ts
+++ b/src/sidebar/components/coordinator-badge-class.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { AppSettings } from "../../shared/types";
+import { coordinatorIdleBadge } from "../../shared/coordinator-badge";
+import { COORD_IDLE_CLASS } from "./coordinator-badge-class";
+
+const NOW = Date.parse("2026-06-18T12:00:00.000Z");
+
+function minsAgo(mins: number): string {
+  return new Date(NOW - mins * 60_000).toISOString();
+}
+
+function thresholds(
+  yellow: number,
+  red: number
+): Pick<
+  AppSettings,
+  "coordinatorIdleBadgeYellowMinutes" | "coordinatorIdleBadgeRedMinutes"
+> {
+  return {
+    coordinatorIdleBadgeYellowMinutes: yellow,
+    coordinatorIdleBadgeRedMinutes: red,
+  };
+}
+
+describe("COORD_IDLE_CLASS", () => {
+  it("maps coordinator idle levels to the existing CSS classes", () => {
+    expect(COORD_IDLE_CLASS).toEqual({ ok: "green", warn: "yellow", stale: "red" });
+  });
+
+  it("preserves the pre-#882 minute boundary class behavior", () => {
+    const t = thresholds(30, 60);
+
+    expect(COORD_IDLE_CLASS[coordinatorIdleBadge(minsAgo(29), NOW, t)!.level]).toBe("green");
+    expect(COORD_IDLE_CLASS[coordinatorIdleBadge(minsAgo(30), NOW, t)!.level]).toBe("yellow");
+    expect(COORD_IDLE_CLASS[coordinatorIdleBadge(minsAgo(60), NOW, t)!.level]).toBe("red");
+    expect(COORD_IDLE_CLASS[coordinatorIdleBadge(minsAgo(600), NOW, t)!.level]).toBe("red");
+  });
+
+  it("is exhaustive over all coordinator idle levels", () => {
+    expect(Object.keys(COORD_IDLE_CLASS).sort()).toEqual(["ok", "stale", "warn"]);
+  });
+});

--- a/src/sidebar/components/coordinator-badge-class.ts
+++ b/src/sidebar/components/coordinator-badge-class.ts
@@ -1,0 +1,13 @@
+import type { CoordinatorIdleLevel } from "../../shared/coordinator-badge";
+
+/**
+ * #882 Render boundary: coordinator idle-badge severity -> CSS class. The value
+ * type is narrowed to the three literals so a transposed entry is a compile
+ * error rather than a silently wrong color. Classes are defined in sidebar.css.
+ * This is the only module outside sidebar.css allowed to name these colors.
+ */
+export const COORD_IDLE_CLASS: Record<CoordinatorIdleLevel, "green" | "yellow" | "red"> = {
+  ok: "green",
+  warn: "yellow",
+  stale: "red",
+};

--- a/src/sidebar/components/coordinator-badge-class.ts
+++ b/src/sidebar/components/coordinator-badge-class.ts
@@ -2,9 +2,10 @@ import type { CoordinatorIdleLevel } from "../../shared/coordinator-badge";
 
 /**
  * #882 Render boundary: coordinator idle-badge severity -> CSS class. The value
- * type is narrowed to the three literals so a transposed entry is a compile
- * error rather than a silently wrong color. Classes are defined in sidebar.css.
- * This is the only module outside sidebar.css allowed to name these colors.
+ * type is narrowed to the three literals so a misspelled color is a compile
+ * error. A transposed entry is caught by coordinator-badge-class.test.ts, which
+ * is why that test is not optional. Classes are defined in sidebar.css. This is
+ * the only module outside sidebar.css allowed to name these colors.
  */
 export const COORD_IDLE_CLASS: Record<CoordinatorIdleLevel, "green" | "yellow" | "red"> = {
   ok: "green",

--- a/src/sidebar/components/replica-dot.ts
+++ b/src/sidebar/components/replica-dot.ts
@@ -1,0 +1,12 @@
+import type { AcAgentReplica, AcWorkgroup } from "../../shared/types";
+import { sessionDotClass, type SessionDotClass } from "./session-status";
+import { findReplicaSession } from "./workgroup-session";
+
+/**
+ * #882 Render-boundary helper. Lives outside workgroup-session.ts so that the
+ * watchdog's import graph never reaches SessionDotClass. Consumers must be render
+ * code only; anything asking "is this replica working?" calls isReplicaWorking.
+ */
+export function replicaDotClass(wg: AcWorkgroup, replica: AcAgentReplica): SessionDotClass {
+  return sessionDotClass(findReplicaSession(wg, replica));
+}

--- a/src/sidebar/components/session-status.ts
+++ b/src/sidebar/components/session-status.ts
@@ -1,4 +1,4 @@
-import type { Session, SessionStatus } from "../../shared/types";
+import { sessionActivity, type ActivitySession, type SessionActivity } from "../../shared/session-activity";
 
 export type SessionDotClass =
   | "active"
@@ -9,22 +9,23 @@ export type SessionDotClass =
   | "waiting"
   | "offline";
 
-type DotSession = Pick<Session, "status" | "pendingReview" | "waitingForInput">;
-
-export function sessionStatusClass(status: SessionStatus): "active" | "running" | "idle" | "exited" {
-  if (typeof status === "string") return status;
-  return "exited";
-}
+/**
+ * #882 Presentation projection: SessionActivity -> CSS dot class. Total and 1:1.
+ * Editing a value here changes pixels only; no behavior reads a dot class.
+ */
+const DOT_CLASS: Record<SessionActivity, SessionDotClass> = {
+  offline: "offline",
+  exited: "exited",
+  pendingReview: "pending",
+  waitingForInput: "waiting",
+  active: "active",
+  running: "running",
+  idle: "idle",
+};
 
 export function sessionDotClass(
-  session: DotSession | null | undefined,
+  session: ActivitySession | null | undefined,
   options: { inactive?: boolean } = {},
 ): SessionDotClass {
-  if (!session || options.inactive) return "offline";
-
-  const status = sessionStatusClass(session.status);
-  if (status === "exited") return "exited";
-  if (session.pendingReview) return "pending";
-  if (session.waitingForInput) return "waiting";
-  return status;
+  return DOT_CLASS[sessionActivity(session, options)];
 }

--- a/src/sidebar/components/workgroup-session.test.ts
+++ b/src/sidebar/components/workgroup-session.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AcAgentReplica, AcWorkgroup, SessionStatus } from "../../shared/types";
+import { resetUiStoresForTests, session } from "../../shared/testing/ui-harness";
+import { sessionsStore } from "../stores/sessions";
+import {
+  isReplicaWorking,
+  splitWorkgroupsByWorking,
+  workgroupIsWorking,
+} from "./workgroup-session";
+
+const projectPath = "C:\\Project";
+
+function replicaPath(wgName: string): string {
+  return `${projectPath}\\.ac\\${wgName}\\__agent_dev-webpage-ui`;
+}
+
+function replica(wgName: string): AcAgentReplica {
+  return {
+    name: "dev-webpage-ui",
+    path: replicaPath(wgName),
+    repoPaths: [],
+    isCoordinator: true,
+  };
+}
+
+function wg(name: string, agents: AcAgentReplica[] = [replica(name)]): AcWorkgroup {
+  return {
+    name,
+    path: `${projectPath}\\.ac\\${name}`,
+    task: null,
+    taskTitle: null,
+    agents,
+  };
+}
+
+function replicaSession(
+  wgName: string,
+  status: SessionStatus = "running",
+  flags: { pendingReview?: boolean; waitingForInput?: boolean } = {}
+) {
+  return session({
+    id: `s-${wgName}`,
+    name: `${wgName}/dev-webpage-ui`,
+    workingDirectory: replicaPath(wgName),
+    status,
+    pendingReview: flags.pendingReview ?? false,
+    waitingForInput: flags.waitingForInput ?? false,
+  });
+}
+
+describe("workgroup-session working predicates", () => {
+  beforeEach(() => resetUiStoresForTests());
+  afterEach(() => resetUiStoresForTests());
+
+  it("classifies replicas from session state, not dot classes", () => {
+    const group = wg("wg-1-dev-team");
+    const rep = group.agents[0];
+
+    sessionsStore.setSessions([replicaSession(group.name)]);
+    expect(isReplicaWorking(group, rep)).toBe(true);
+
+    sessionsStore.setSessions([replicaSession(group.name, "running", { waitingForInput: true })]);
+    expect(isReplicaWorking(group, rep)).toBe(false);
+
+    sessionsStore.setSessions([replicaSession(group.name, "running", { pendingReview: true })]);
+    expect(isReplicaWorking(group, rep)).toBe(false);
+
+    sessionsStore.setSessions([replicaSession(group.name, { exited: 0 })]);
+    expect(isReplicaWorking(group, rep)).toBe(false);
+
+    sessionsStore.setSessions([]);
+    expect(isReplicaWorking(group, rep)).toBe(false);
+  });
+
+  it("pins running plus pendingReview as not working", () => {
+    const group = wg("wg-1-dev-team");
+    // At-rest writers pair pendingReview with waitingForInput, but #882
+    // deliberately preserves the existing constructed-state behavior too.
+    sessionsStore.setSessions([replicaSession(group.name, "running", { pendingReview: true })]);
+
+    expect(isReplicaWorking(group, group.agents[0])).toBe(false);
+    expect(workgroupIsWorking(group)).toBe(false);
+  });
+
+  it("classifies workgroups by whether any replica is working", () => {
+    const working = replica("wg-1-dev-team");
+    const waiting = { ...replica("wg-1-dev-team"), name: "dev-rust" };
+    const group = wg("wg-1-dev-team", [working, waiting]);
+
+    sessionsStore.setSessions([
+      replicaSession(group.name),
+      session({
+        id: "s-waiting",
+        name: `${group.name}/dev-rust`,
+        workingDirectory: waiting.path,
+        status: "running",
+        waitingForInput: true,
+      }),
+    ]);
+    expect(workgroupIsWorking(group)).toBe(true);
+
+    sessionsStore.setSessions([replicaSession(group.name, "idle")]);
+    expect(workgroupIsWorking(group)).toBe(false);
+    expect(workgroupIsWorking(wg("wg-empty", []))).toBe(false);
+  });
+
+  it("partitions workgroups completely and preserves order in both buckets", () => {
+    const groups = [
+      wg("wg-1-dev-team"),
+      wg("wg-2-rust-team"),
+      wg("wg-3-docs-team"),
+      wg("wg-4-qa-team"),
+    ];
+    sessionsStore.setSessions([
+      replicaSession("wg-1-dev-team"),
+      replicaSession("wg-3-docs-team", "active"),
+    ]);
+
+    const split = splitWorkgroupsByWorking(groups);
+
+    expect(split.working.length + split.notWorking.length).toBe(groups.length);
+    expect(new Set([...split.working, ...split.notWorking]).size).toBe(groups.length);
+    expect(split.working.map((group) => group.name)).toEqual(["wg-1-dev-team", "wg-3-docs-team"]);
+    expect(split.notWorking.map((group) => group.name)).toEqual(["wg-2-rust-team", "wg-4-qa-team"]);
+  });
+});

--- a/src/sidebar/components/workgroup-session.ts
+++ b/src/sidebar/components/workgroup-session.ts
@@ -1,7 +1,7 @@
 import type { AcAgentReplica, AcWorkgroup, Session } from "../../shared/types";
+import { isSessionWorking } from "../../shared/session-activity";
 import { normalizeProjectPathForCompare } from "../stores/project-refresh";
 import { sessionsStore } from "../stores/sessions";
-import { sessionDotClass, type SessionDotClass } from "./session-status";
 
 export function replicaSessionName(wg: AcWorkgroup, replica: AcAgentReplica): string {
   return `${wg.name}/${replica.name}`;
@@ -24,16 +24,35 @@ export function findReplicaSession(wg: AcWorkgroup, replica: AcAgentReplica): Se
   );
 }
 
-export function replicaDotClass(wg: AcWorkgroup, replica: AcAgentReplica): SessionDotClass {
-  return sessionDotClass(findReplicaSession(wg, replica));
-}
-
-export function isWorkingReplicaDot(dot: SessionDotClass): boolean {
-  return dot === "running" || dot === "active";
+/**
+ * #882 Domain predicate over session state. Replaces the pre-#882 dot-class
+ * predicate. Same answer for every at-rest store state.
+ */
+export function isReplicaWorking(wg: AcWorkgroup, replica: AcAgentReplica): boolean {
+  return isSessionWorking(findReplicaSession(wg, replica));
 }
 
 export function workgroupIsWorking(wg: AcWorkgroup): boolean {
-  return wg.agents.some((replica) => isWorkingReplicaDot(replicaDotClass(wg, replica)));
+  return wg.agents.some((replica) => isReplicaWorking(wg, replica));
+}
+
+/**
+ * #777/#882 parity primitive. The rail counter and the non-stop watchdog both
+ * partition their workgroup list with this one function, in one traversal,
+ * preserving input order. Do not reimplement either side with filter().
+ *
+ * Must be called inside a reactive scope. It reads sessionsStore through
+ * findReplicaSession; caching its result at module scope silently kills tracking.
+ */
+export function splitWorkgroupsByWorking(
+  workgroups: readonly AcWorkgroup[]
+): { working: AcWorkgroup[]; notWorking: AcWorkgroup[] } {
+  const working: AcWorkgroup[] = [];
+  const notWorking: AcWorkgroup[] = [];
+  for (const wg of workgroups) {
+    (workgroupIsWorking(wg) ? working : notWorking).push(wg);
+  }
+  return { working, notWorking };
 }
 
 /**

--- a/src/sidebar/watchdog/no-presentation-import.test.ts
+++ b/src/sidebar/watchdog/no-presentation-import.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+type PresentationModule = "session-status" | "replica-dot";
+
+const IMPORT_RE = /^\s*import\b[^;]*?\bfrom\s*["']([^"']+)["']/gm;
+const SELF = "sidebar/watchdog/no-presentation-import.test.ts";
+const SOURCES = import.meta.glob<string>("../../**/*.{ts,tsx}", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+});
+
+const ALLOWED: Record<PresentationModule, string[]> = {
+  "session-status": [
+    "shared/session-activity.test.ts",
+    "sidebar/components/ProjectPanel.tsx",
+    "sidebar/components/RootAgentBanner.tsx",
+    "sidebar/components/SessionItem.tsx",
+    "sidebar/components/replica-dot.ts",
+    "sidebar/components/session-status.test.ts",
+  ],
+  "replica-dot": [
+    "sidebar/components/ProjectPanel.tsx",
+  ],
+};
+
+function rel(globKey: string): string {
+  const normalized = globKey.replace(/\\/g, "/");
+  if (normalized.startsWith("../../")) return normalized.slice("../../".length);
+  if (normalized.startsWith("../")) return `sidebar/${normalized.slice("../".length)}`;
+  if (normalized.startsWith("./")) return `sidebar/watchdog/${normalized.slice("./".length)}`;
+  return normalized;
+}
+
+function presentationModule(specifier: string): PresentationModule | null {
+  const normalized = specifier.replace(/\\/g, "/").replace(/\.(ts|tsx)$/, "");
+  if (normalized.endsWith("session-status")) return "session-status";
+  if (normalized.endsWith("replica-dot")) return "replica-dot";
+  return null;
+}
+
+describe("presentation import boundary", () => {
+  it("allows session-status and replica-dot only at render/test boundaries", () => {
+    const actual: Record<PresentationModule, string[]> = {
+      "session-status": [],
+      "replica-dot": [],
+    };
+
+    for (const [file, source] of Object.entries(SOURCES)) {
+      const relativeFile = rel(file);
+      if (relativeFile === SELF) continue;
+      for (const match of source.matchAll(IMPORT_RE)) {
+        const module = presentationModule(match[1]);
+        if (module) actual[module].push(relativeFile);
+      }
+    }
+
+    expect({
+      "session-status": actual["session-status"].sort(),
+      "replica-dot": actual["replica-dot"].sort(),
+    }).toEqual({
+      "session-status": ALLOWED["session-status"].slice().sort(),
+      "replica-dot": ALLOWED["replica-dot"].slice().sort(),
+    });
+  });
+});

--- a/src/sidebar/watchdog/no-presentation-import.test.ts
+++ b/src/sidebar/watchdog/no-presentation-import.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 
 type PresentationModule = "session-status" | "replica-dot";
 
-const IMPORT_RE = /^\s*import\b[^;]*?\bfrom\s*["']([^"']+)["']/gm;
+const IMPORT_RE = /^\s*(?:import|export)\b[^;]*?\bfrom\s*["']([^"']+)["']/gm;
+const DYNAMIC_IMPORT_RE = /\bimport\s*\(\s*["']([^"']+)["']/g;
 const SELF = "sidebar/watchdog/no-presentation-import.test.ts";
 const SOURCES = import.meta.glob<string>("../../**/*.{ts,tsx}", {
   query: "?raw",
@@ -33,7 +34,7 @@ function rel(globKey: string): string {
 }
 
 function presentationModule(specifier: string): PresentationModule | null {
-  const normalized = specifier.replace(/\\/g, "/").replace(/\.(ts|tsx)$/, "");
+  const normalized = specifier.replace(/\\/g, "/").replace(/\.(ts|tsx|js|jsx|mjs)$/, "");
   if (normalized.endsWith("session-status")) return "session-status";
   if (normalized.endsWith("replica-dot")) return "replica-dot";
   return null;
@@ -41,9 +42,9 @@ function presentationModule(specifier: string): PresentationModule | null {
 
 describe("presentation import boundary", () => {
   it("allows session-status and replica-dot only at render/test boundaries", () => {
-    const actual: Record<PresentationModule, string[]> = {
-      "session-status": [],
-      "replica-dot": [],
+    const actual: Record<PresentationModule, Set<string>> = {
+      "session-status": new Set(),
+      "replica-dot": new Set(),
     };
 
     for (const [file, source] of Object.entries(SOURCES)) {
@@ -51,13 +52,17 @@ describe("presentation import boundary", () => {
       if (relativeFile === SELF) continue;
       for (const match of source.matchAll(IMPORT_RE)) {
         const module = presentationModule(match[1]);
-        if (module) actual[module].push(relativeFile);
+        if (module) actual[module].add(relativeFile);
+      }
+      for (const match of source.matchAll(DYNAMIC_IMPORT_RE)) {
+        const module = presentationModule(match[1]);
+        if (module) actual[module].add(relativeFile);
       }
     }
 
     expect({
-      "session-status": actual["session-status"].sort(),
-      "replica-dot": actual["replica-dot"].sort(),
+      "session-status": Array.from(actual["session-status"]).sort(),
+      "replica-dot": Array.from(actual["replica-dot"]).sort(),
     }).toEqual({
       "session-status": ALLOWED["session-status"].slice().sort(),
       "replica-dot": ALLOWED["replica-dot"].slice().sort(),

--- a/src/sidebar/watchdog/non-stop-watchdog-client.ts
+++ b/src/sidebar/watchdog/non-stop-watchdog-client.ts
@@ -2,16 +2,19 @@ import { createEffect, onCleanup } from "solid-js";
 import { NonStopAPI } from "../../shared/ipc";
 import type { NonStopReport } from "../../shared/types";
 import { workgroupGroupsStore, nonStopDisplayName, nonStopMatchesWorkgroup } from "../stores/workgroup-groups";
-import { workgroupIsWorking } from "../components/workgroup-session";
+import { splitWorkgroupsByWorking } from "../components/workgroup-session";
 import { projectStore } from "../stores/project";
 
 // #777 Non-stop watchdog client (hybrid design, D1). The frontend owns ONLY the
-// disparity detection, computed with the exact same code the rail counter uses
-// (workgroupIsWorking + projectStore.projects), so parity is by construction and
-// cannot drift. The backend owns the tolerance timer and actuation. Detection is
-// reactive (a Solid effect that re-runs on any session/config/project change),
-// which is immune to Chromium's hidden-window timer throttling; the keepalive
-// setInterval is only a non-critical backstop.
+// disparity detection. #882: the working/not-working partition comes from
+// splitWorkgroupsByWorking(), the same single function the rail counter calls,
+// which derives from session state and not from the dot's CSS class. So parity
+// with the rail counter is by construction and cannot drift, and a visual tweak
+// to the status dot can no longer change when this fires. The backend owns the
+// tolerance timer and actuation. Detection is reactive (a Solid effect that
+// re-runs on any session/config/project change), which is immune to Chromium's
+// hidden-window timer throttling; the keepalive setInterval is only a
+// non-critical backstop.
 
 const KEEPALIVE_MS = 10_000;
 
@@ -32,8 +35,8 @@ export function buildSnapshot(): NonStopReport[] {
     const members = project.workgroups.filter((wg) => nonStopMatchesWorkgroup(ns, wg));
     const total = members.length;
     if (total === 0) continue; // empty group, no disparity possible
-    const notWorking = members.filter((wg) => !workgroupIsWorking(wg));
-    const working = total - notWorking.length;
+    const { working: workingWgs, notWorking } = splitWorkgroupsByWorking(members);
+    const working = workingWgs.length;
     reports.push({
       projectPath: project.path,
       groupName: nonStopDisplayName(ns.name),

--- a/src/sidebar/watchdog/rail-watchdog-parity.test.tsx
+++ b/src/sidebar/watchdog/rail-watchdog-parity.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { render } from "solid-js/web";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AcWorkgroup, NonStopGroupConfig, Session } from "../../shared/types";
+import { __setTransportForTests } from "../../shared/ipc";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { settingsStore } from "../../shared/stores/settings";
+import WorkgroupGroupRail from "../components/WorkgroupGroupRail";
+import { projectStore } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
+import { defaultGroupsConfig, defaultNonStop, workgroupGroupsStore } from "../stores/workgroup-groups";
+import { buildSnapshot } from "./non-stop-watchdog-client";
+
+const projectPath = "C:\\Project";
+const wgNames = ["wg-1-dev-team", "wg-2-dev-team", "wg-3-dev-team"] as const;
+
+function wgPath(name: string): string {
+  return `${projectPath}\\.ac\\${name}`;
+}
+
+function agentPath(name: string): string {
+  return `${wgPath(name)}\\__agent_dev-webpage-ui`;
+}
+
+function wgDiscovery() {
+  return discovery({
+    workgroups: wgNames.map((name): AcWorkgroup => ({
+      name,
+      path: wgPath(name),
+      task: null,
+      taskTitle: null,
+      agents: [{ name: "dev-webpage-ui", path: agentPath(name), repoPaths: [], isCoordinator: true }],
+    })),
+  });
+}
+
+function replicaSession(wgName: string, overrides: Partial<Session> = {}): Session {
+  return session({
+    id: `s-${wgName}`,
+    name: `${wgName}/dev-webpage-ui`,
+    workingDirectory: agentPath(wgName),
+    status: "running",
+    ...overrides,
+  });
+}
+
+const activeNonStop = (): NonStopGroupConfig => ({
+  ...defaultNonStop(),
+  show: true,
+  regex: "^wg-",
+  telegram: { enabled: true, botId: null },
+});
+
+async function seed(): Promise<() => void> {
+  const fake = new FakeTransport();
+  fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+  fake.resolve("get_settings", baseSettings());
+  fake.resolve("discover_project", wgDiscovery());
+  fake.resolve("get_project_groups", { ...defaultGroupsConfig(), nonStop: activeNonStop() });
+  const restore = __setTransportForTests(fake);
+  await settingsStore.load();
+  await projectStore.createAndLoad(projectPath);
+  await workgroupGroupsStore.ensureLoaded(projectPath);
+  return restore;
+}
+
+function renderRail(): () => void {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  const dispose = render(() => <WorkgroupGroupRail projects={projectStore.projects} />, root);
+  return () => {
+    dispose();
+    root.remove();
+  };
+}
+
+function nonStopButton(): HTMLElement {
+  const button = document.querySelector<HTMLElement>('[data-ac-testid="workgroupGroups.button.nonstop"]');
+  if (!button) throw new Error("Missing non-stop rail button");
+  return button;
+}
+
+describe("#882 rail/watchdog working parity", () => {
+  let restoreTransport: (() => void) | null = null;
+  let cleanupRender: (() => void) | null = null;
+
+  beforeEach(() => {
+    resetUiStoresForTests();
+    workgroupGroupsStore.resetForTests();
+  });
+
+  afterEach(() => {
+    cleanupRender?.();
+    cleanupRender = null;
+    restoreTransport?.();
+    restoreTransport = null;
+    resetUiStoresForTests();
+    workgroupGroupsStore.resetForTests();
+  });
+
+  it.each([
+    {
+      name: "all live working",
+      sessions: [
+        replicaSession("wg-1-dev-team"),
+        replicaSession("wg-2-dev-team", { status: "active" }),
+        replicaSession("wg-3-dev-team"),
+      ],
+      expectWorking: 3,
+      expectDisparity: false,
+      expectNotWorking: [],
+    },
+    {
+      name: "absent, exited, and idle are not working",
+      sessions: [
+        replicaSession("wg-2-dev-team", { status: { exited: 0 } }),
+        replicaSession("wg-3-dev-team", { status: "idle" }),
+      ],
+      expectWorking: 0,
+      expectDisparity: true,
+      expectNotWorking: ["wg-1-dev-team", "wg-2-dev-team", "wg-3-dev-team"],
+    },
+    {
+      name: "waiting and pending are not working while active is working",
+      sessions: [
+        replicaSession("wg-1-dev-team", { waitingForInput: true }),
+        replicaSession("wg-2-dev-team", { pendingReview: true }),
+        replicaSession("wg-3-dev-team", { status: "active" }),
+      ],
+      expectWorking: 1,
+      expectDisparity: true,
+      expectNotWorking: ["wg-1-dev-team", "wg-2-dev-team"],
+    },
+    {
+      name: "running plus pendingReview is not working (#882 AC)",
+      sessions: [
+        replicaSession("wg-1-dev-team", { pendingReview: true }),
+        replicaSession("wg-2-dev-team", { pendingReview: true }),
+        replicaSession("wg-3-dev-team", { pendingReview: true }),
+      ],
+      expectWorking: 0,
+      expectDisparity: true,
+      expectNotWorking: ["wg-1-dev-team", "wg-2-dev-team", "wg-3-dev-team"],
+    },
+  ])("$name", async (row) => {
+    restoreTransport = await seed();
+    sessionsStore.setSessions(row.sessions);
+    cleanupRender = renderRail();
+
+    await waitFor(() => expect(nonStopButton().textContent).toContain(`${row.expectWorking}/3`));
+    const counter = nonStopButton().textContent?.match(/\d+\/\d+/)?.[0];
+    const snap = buildSnapshot();
+
+    expect(snap).toHaveLength(1);
+    expect(counter).toBe(`${snap[0].working}/${snap[0].total}`);
+    expect(snap[0].working).toBe(row.expectWorking);
+    expect(snap[0].disparity).toBe(row.expectDisparity);
+    expect(snap[0].notWorkingWorkgroups).toEqual(row.expectNotWorking);
+  });
+});


### PR DESCRIPTION
Closes #882

## What this is

Three frontend modules answered *"is this agent working?"* by comparing against `SessionDotClass` — the value that selects the CSS class of an 8px status dot. One of them, `non-stop-watchdog-client.ts:35`, feeds `buildSnapshot()` → `disparity` → the backend arms a tolerance timer → **Telegram notification and sound alarm**.

`sessionDotClass()` is a **lossy flattener** of orthogonal state, with a precedence chain (`offline > exited > pending > waiting > status`) chosen for visual reasons. Anything reading its output silently inherits that flattening.

This PR extracts the domain predicate into `src/shared/session-activity.ts` and makes the dot class a 1:1 projection of it, so the rail and the watchdog derive from **session state** rather than from a CSS class name — while preserving the parity guarantee documented at `non-stop-watchdog-client.ts:8-14` by construction.

Separately, `coordinator-badge.ts` modelled state as a color name (`"green" | "yellow" | "red"`). That becomes `CoordinatorIdleLevel = "ok" | "warn" | "stale"`, mapped to the existing CSS class at the render boundary. **Persisted settings keys are untouched.**

## This is a coupling fix, not a behavior fix

**No user-visible behavior changes. No alert that fires today changes.**

The issue as originally filed claimed a live false-alert bug. That claim was **wrong** and was corrected twice on the issue, in public. The invariant `pendingReview === true ⇒ waitingForInput === true` holds for every *at-rest* store state — though not for store state generally, because `setSessionWaiting` leaves a transient window between two un-batched `setState` calls. The window is invisible only because `sessionDotClass` reads `pendingReview` before `waitingForInput`, so under Solid's lazy tracking a consumer that short-circuited to `"pending"` never subscribed to `waitingForInput`.

That is exactly why reordering the precedence chain is a **real behavioral change**, and why this refactor is worth doing. The transient window itself is tracked in #886 and deliberately **not** fixed here.

## Verification

`dev-rust-grinch` reviewed the plan adversarially (returned `PLAN_NEEDS_REWORK`; `architect` accepted all ten findings), then reviewed the code twice. It did not take the equivalence claim on trust:

- **99/99 equivalence proven against `main@91016caa`.** The pre-refactor `sessionDotClass` / `isWorkingReplicaDot` were copied verbatim into a temporary test and diffed against the new implementation over the full cross product of `status × pendingReview × waitingForInput × inactive`, plus `null`/`undefined`. `isSessionWorking` agrees on all 99 cases, and `sessionDotClass` output is byte-identical on all 99 — including `{exited: n≠0}` combined with `inactive`, which no shipped test exercises together.
- **Every new pin was mutation-tested** and confirmed to fail when its target is broken. Notably, `session-activity.test.ts` is the *sole* thing standing between the repo and a silent precedence re-order: under that swap, `session-status.test.ts`, `workgroup-session.test.ts`, `rail-watchdog-parity.test.tsx` and `WorkgroupGroupRail.test.tsx` all stay green.
- **The `DOT_CLASS` projection is pinned exhaustively.** All seven entries mutation-tested individually (all red), plus compile-exhaustive: adding an eighth `SessionActivity` variant is a `tsc` error.
- The second commit closes five defects Grinch found in the first, including a guard that could be bypassed by `export * from` and by a `.js`-suffixed specifier.

`session-status.test.ts` and `non-stop-watchdog-client.test.ts` are **byte-identical to `main`** — zero edits, verified.

## Tests

```
$ npx tsc --noEmit
(exit 0, no output)

$ npx vitest run
 Test Files  103 passed (103)
      Tests  833 passed (833)
```

Run independently by both `dev-webpage-ui` and `dev-rust-grinch`. 833 = 832 + 1; the exhaustive `DOT_CLASS` pin added one test.

## Scope

Untouched: `src-tauri`, `src/sidebar/stores/sessions.ts`, `src/sidebar/stores/team-idle-watcher.ts`, `src/shared/types.ts`, `sidebar.css`, `session-status.test.ts`, and the persisted settings keys `coordinatorIdleBadgeYellowMinutes` / `coordinatorIdleBadgeRedMinutes`. Verified against the diff.

`sessionEffectiveStatusSearchText` (`ProjectPanel.tsx:127-129`) is deliberately left branching on the dot class: it produces the text the user searches against, which must mirror the dot the user can see. Reading the presentation value is the correct design there.

## Honest statement of acceptance criterion 1

AC 1 — *no module outside the render boundary imports or branches on `SessionDotClass`* — is enforced by `no-presentation-import.test.ts` **for the current tree, and against accidental regression.** It is **not** an unbreakable invariant. Grinch defeated the hardened guard three further ways in twenty minutes; one of them (re-export through an allowlisted file) is structural and no regex over source text can close it. Tracked in #890.

AC 1 also holds under the reading that **`ProjectPanel.tsx` *is* the render boundary** — see the scoping note on #882.

## Visual classification

**NON_VISUAL.** `sidebar.css` untouched; dot class output identical to `main` for all 99 cases; badge `class` attribute identical; running-peers list, coordinator search filter, rail counter/dot/tooltip all identical. No shipper build required.

## Follow-ups filed

- #883 — a fourth copy of the predicate lives in Rust (`list_peers.rs:464-474`), with stale doc anchors.
- #886 — `setSessionWaiting` leaks a transient `pendingReview`/`waitingForInput` mixed state (missing `batch()`).
- #890 — the presentation-import guard has three bypasses and two false positives.
