### PR TITLE
fix(settings): keep project lists disk-authoritative in memory, stop silent session deletion (refs #888)

### DIFF
--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -1966,16 +1966,42 @@ pub(crate) async fn open_project_inner(
     settings: &SettingsState,
     path: &str,
 ) -> Result<crate::config::projects::ProjectRegistration, String> {
+    open_project_inner_with_settings_path(settings, path, None).await
+}
+
+async fn open_project_inner_with_settings_path(
+    settings: &SettingsState,
+    path: &str,
+    settings_path: Option<&Path>,
+) -> Result<crate::config::projects::ProjectRegistration, String> {
+    mutate_project_paths_with_settings_path(settings, settings_path, |s| {
+        crate::config::projects::register_existing_project(s, path).map_err(|e| e.to_string())
+    })
+    .await
+}
+
+async fn mutate_project_paths_with_settings_path<T>(
+    settings: &SettingsState,
+    settings_path: Option<&Path>,
+    mutate: impl FnOnce(&mut crate::config::settings::AppSettings) -> Result<T, String>,
+) -> Result<T, String> {
     let mut s = settings.write().await;
     // #778: reconcile project_paths from disk BEFORE the upsert so a concurrent
     // CLI append is folded in, not clobbered, then write the deliberate list
     // verbatim (project_paths is disk-authoritative under Design S). Aborts on a
     // non-NotFound read error (G2) rather than registering against a stale list.
-    crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
-    let result = crate::config::projects::register_existing_project(&mut s, path)
-        .map_err(|e| e.to_string())?;
+    if let Some(path) = settings_path {
+        crate::config::settings::refresh_project_paths_from_path(&mut s, path)?;
+    } else {
+        crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
+    }
+    let result = mutate(&mut s)?;
     let snapshot = s.clone();
-    crate::config::settings::save_settings_with_project_paths(&snapshot)?;
+    if let Some(path) = settings_path {
+        crate::config::settings::save_settings_with_project_paths_to_path(&snapshot, path)?;
+    } else {
+        crate::config::settings::save_settings_with_project_paths(&snapshot)?;
+    }
     drop(s); // explicit; lock released AFTER the disk write completes
     Ok(result)
 }
@@ -1996,17 +2022,18 @@ pub async fn new_project(
     settings: State<'_, SettingsState>,
     path: String,
 ) -> Result<crate::config::projects::ProjectRegistration, String> {
-    let mut s = settings.write().await;
-    // #778: reconcile project_paths from disk BEFORE the upsert (see open_project),
-    // then write the deliberate list verbatim. Aborts on a non-NotFound read
-    // error (G2).
-    crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
-    let result =
-        crate::config::projects::register_new_project(&mut s, &path).map_err(|e| e.to_string())?;
-    let snapshot = s.clone();
-    crate::config::settings::save_settings_with_project_paths(&snapshot)?;
-    drop(s); // explicit; lock released AFTER the disk write completes
-    Ok(result)
+    new_project_inner_with_settings_path(settings.inner(), &path, None).await
+}
+
+async fn new_project_inner_with_settings_path(
+    settings: &SettingsState,
+    path: &str,
+    settings_path: Option<&Path>,
+) -> Result<crate::config::projects::ProjectRegistration, String> {
+    mutate_project_paths_with_settings_path(settings, settings_path, |s| {
+        crate::config::projects::register_new_project(s, path).map_err(|e| e.to_string())
+    })
+    .await
 }
 
 /// #778 Part 3: targeted project removal. `project_paths` is disk-authoritative
@@ -2022,13 +2049,19 @@ pub(crate) async fn remove_project_inner(
     settings: &SettingsState,
     path: &str,
 ) -> Result<(), String> {
-    let mut s = settings.write().await;
-    crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
-    crate::config::projects::remove_project_path(&mut s, path);
-    let snapshot = s.clone();
-    crate::config::settings::save_settings_with_project_paths(&snapshot)?;
-    drop(s); // explicit; lock released AFTER the disk write completes
-    Ok(())
+    remove_project_inner_with_settings_path(settings, path, None).await
+}
+
+async fn remove_project_inner_with_settings_path(
+    settings: &SettingsState,
+    path: &str,
+    settings_path: Option<&Path>,
+) -> Result<(), String> {
+    mutate_project_paths_with_settings_path(settings, settings_path, |s| {
+        crate::config::projects::remove_project_path(s, path);
+        Ok(())
+    })
+    .await
 }
 
 #[tauri::command]
@@ -2160,6 +2193,82 @@ mod tests {
         assert!(!workspace
             .join(crate::config::session_context::COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
             .exists());
+    }
+
+    #[tokio::test]
+    async fn missing_settings_file_project_mutators_preserve_live_list() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let settings_path = temp.path().join("settings.json");
+        assert!(!settings_path.exists(), "precondition: no settings.json");
+
+        fn base(paths: &[String]) -> Vec<&str> {
+            paths
+                .iter()
+                .map(|p| p.rsplit(['/', '\\']).next().unwrap())
+                .collect()
+        }
+
+        let mk = |name: &str| {
+            let path = temp.path().join(name);
+            std::fs::create_dir_all(path.join(".ac")).expect("create project .ac");
+            path.to_string_lossy().to_string()
+        };
+        let (a, b, c) = (mk("proj-a"), mk("proj-b"), mk("proj-c"));
+
+        let settings = crate::config::settings::AppSettings {
+            project_paths: vec![a.clone(), b.clone()],
+            project_path: Some(a.clone()),
+            ..Default::default()
+        };
+        let state: SettingsState = std::sync::Arc::new(tokio::sync::RwLock::new(settings));
+
+        let disk = || -> Vec<String> {
+            let value: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+            value["projectPaths"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|x| x.as_str().unwrap().to_string())
+                .collect()
+        };
+
+        remove_project_inner_with_settings_path(&state, &a, Some(&settings_path))
+            .await
+            .expect("remove");
+        let memory = state.read().await.project_paths.clone();
+        assert_eq!(
+            base(&memory),
+            vec!["proj-b"],
+            "A removed, B preserved in memory"
+        );
+        assert_eq!(
+            base(&disk()),
+            vec!["proj-b"],
+            "A removed, B preserved on disk"
+        );
+
+        open_project_inner_with_settings_path(&state, &c, Some(&settings_path))
+            .await
+            .expect("open");
+        let memory = state.read().await.project_paths.clone();
+        assert_eq!(base(&memory), vec!["proj-b", "proj-c"]);
+        assert_eq!(base(&disk()), vec!["proj-b", "proj-c"]);
+
+        std::fs::remove_file(&settings_path).expect("remove settings.json");
+        let d_path = temp.path().join("proj-d");
+        let d = d_path.to_string_lossy().to_string();
+        new_project_inner_with_settings_path(&state, &d, Some(&settings_path))
+            .await
+            .expect("new project");
+        assert!(d_path.join(".ac").is_dir());
+        let memory = state.read().await.project_paths.clone();
+        assert_eq!(base(&memory), vec!["proj-b", "proj-c", "proj-d"]);
+        assert_eq!(
+            base(&disk()),
+            vec!["proj-b", "proj-c", "proj-d"],
+            "B and C must not be lost"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -12,8 +12,8 @@ use crate::api::auth;
 use crate::config::claude_settings::{ensure_rtk_pretool_hook, enumerate_managed_agent_dirs};
 use crate::config::settings::{
     load_settings, merge_protected_coding_agent_settings, parse_api_server_socket_addr,
-    refresh_project_paths_from_disk, save_settings, validate_and_repair_settings, AppSettings,
-    CodingAgentEnv, CodingAgentProfilesConfig, SettingsState,
+    save_settings, validate_and_repair_settings, AppSettings, CodingAgentEnv,
+    CodingAgentProfilesConfig, SettingsState,
 };
 use crate::network::OutboundNetwork;
 use crate::pty::manager::PtyManager;
@@ -222,14 +222,14 @@ pub(crate) async fn persist_protected_settings_update(
 async fn persist_protected_settings_update_with_saver(
     settings: &SettingsState,
     new_settings: AppSettings,
-    save: impl FnOnce(&AppSettings) -> Result<(), String>,
+    save: impl FnOnce(&AppSettings) -> Result<AppSettings, String>,
 ) -> Result<AppSettings, String> {
     let mut s = settings.write().await;
     let current = s.clone();
     let candidate = build_protected_settings_candidate(&current, new_settings)?;
-    save(&candidate)?;
-    *s = candidate.clone();
-    Ok(candidate)
+    let written = save(&candidate)?;
+    *s = written.clone();
+    Ok(written)
 }
 
 fn build_protected_settings_candidate(
@@ -239,7 +239,6 @@ fn build_protected_settings_candidate(
     let mut candidate = merge_protected_coding_agent_settings(current, new_settings);
     // Preserve existing root token. Frontend settings payloads cannot overwrite it.
     candidate.root_token = current.root_token.clone();
-    refresh_project_paths_from_disk(&mut candidate)?;
     validate_and_repair_settings(&mut candidate)?;
     Ok(candidate)
 }
@@ -254,30 +253,42 @@ pub(crate) async fn persist_settings_draft_update(
 async fn persist_settings_draft_update_with_saver(
     settings: &SettingsState,
     mut draft: AppSettings,
-    save: impl FnOnce(&AppSettings) -> Result<(), String>,
+    save: impl FnOnce(&AppSettings) -> Result<AppSettings, String>,
 ) -> Result<(AppSettings, SettingsDraftUpdateEvents), String> {
     let mut s = settings.write().await;
     let current = s.clone();
     draft.root_token = current.root_token.clone();
-    refresh_project_paths_from_disk(&mut draft)?;
     validate_and_repair_settings(&mut draft)?;
     let events = settings_draft_update_events(&current, &draft);
-    save(&draft)?;
-    *s = draft.clone();
-    Ok((draft, events))
+    let written = save(&draft)?;
+    *s = written.clone();
+    Ok((written, events))
 }
 
 pub(crate) async fn purge_sessions_after_settings_update(saved: &AppSettings) {
-    if let Err(e) = crate::config::sessions_persistence::purge_sessions_outside_project_paths(
-        &saved.project_paths,
-    )
-    .await
-    {
+    let Some(dir) = crate::config::config_dir() else {
+        log::warn!("Could not determine home directory for session purge after settings update");
+        return;
+    };
+
+    if let Err(e) = purge_sessions_after_settings_update_in_dir(saved, &dir).await {
         log::warn!(
             "[settings] Failed to purge sessions outside current projectPaths after settings update: {}",
             e
         );
     }
+}
+
+async fn purge_sessions_after_settings_update_in_dir(
+    saved: &AppSettings,
+    dir: &Path,
+) -> Result<(), String> {
+    crate::config::sessions_persistence::purge_sessions_outside_project_paths_in_dir(
+        dir,
+        &saved.project_paths,
+    )
+    .await
+    .map(|_| ())
 }
 
 fn settings_draft_update_events(
@@ -376,8 +387,8 @@ async fn persist_coding_agent_profiles_update(
     let mut candidate = s.clone();
     candidate.coding_agent_profiles = profiles;
     validate_and_repair_settings(&mut candidate)?;
-    save_settings(&candidate)?;
-    *s = candidate;
+    let written = save_settings(&candidate)?;
+    *s = written;
     Ok(())
 }
 
@@ -414,8 +425,8 @@ async fn persist_coding_agent_env_settings_update(
     agent.envs = envs;
     agent.isolated_home = isolated_home;
     validate_and_repair_settings(&mut candidate)?;
-    save_settings(&candidate)?;
-    *s = candidate;
+    let written = save_settings(&candidate)?;
+    *s = written;
     Ok(())
 }
 
@@ -1600,13 +1611,13 @@ async fn persist_narrow_settings_update(
 async fn persist_narrow_settings_update_with_saver(
     settings: &SettingsState,
     mutate_candidate: impl FnOnce(&mut AppSettings),
-    save: impl FnOnce(&AppSettings) -> Result<(), String>,
+    save: impl FnOnce(&AppSettings) -> Result<AppSettings, String>,
 ) -> Result<(), String> {
     let mut s = settings.write().await;
     let mut candidate = s.clone();
     mutate_candidate(&mut candidate);
-    save(&candidate)?;
-    *s = candidate;
+    let written = save(&candidate)?;
+    *s = written;
     Ok(())
 }
 
@@ -1872,7 +1883,7 @@ mod tests {
         ensure_web_remote_open_allowed, is_tcp_socket_listening, mint_api_client_with_path,
         persist_coding_agent_env_settings_update, persist_coding_agent_profiles_update,
         persist_narrow_settings_update_with_saver, persist_protected_settings_update_with_saver,
-        persist_settings_draft_update_with_saver, purge_sessions_after_settings_update,
+        persist_settings_draft_update_with_saver, purge_sessions_after_settings_update_in_dir,
         start_api_server, RtkSweepError, RtkSweepResult, WebServerOwnershipState,
         MINT_API_CLIENT_DEFAULT_TTL_HOURS, MINT_API_CLIENT_MAX_TTL_DAYS, MINT_API_CLIENT_NOTE,
     };
@@ -1889,7 +1900,7 @@ mod tests {
     use std::collections::{BTreeMap, HashMap};
     use std::net::{IpAddr, Ipv4Addr};
     use std::path::{Path, PathBuf};
-    use std::sync::{Arc, Mutex, OnceLock};
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tauri::Manager;
     use tokio::sync::RwLock;
@@ -1947,79 +1958,6 @@ mod tests {
 
     fn state_for(settings: AppSettings) -> SettingsState {
         Arc::new(RwLock::new(settings))
-    }
-
-    fn config_files_test_lock() -> &'static tokio::sync::Mutex<()> {
-        static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
-    }
-
-    struct ConfigFilesFixture {
-        dir: PathBuf,
-        settings_backup: Option<Vec<u8>>,
-        sessions_backup: Option<Vec<u8>>,
-    }
-
-    impl ConfigFilesFixture {
-        fn capture() -> Self {
-            let dir = crate::config::config_dir().expect("config dir");
-            std::fs::create_dir_all(&dir).expect("create config dir");
-            let fixture = Self {
-                settings_backup: read_optional_file(&dir.join("settings.json")),
-                sessions_backup: read_optional_file(&dir.join("sessions.json")),
-                dir,
-            };
-            remove_file_if_exists(&fixture.dir.join("settings.json"));
-            remove_file_if_exists(&fixture.dir.join("sessions.json"));
-            fixture
-        }
-
-        fn dir(&self) -> &Path {
-            &self.dir
-        }
-    }
-
-    impl Drop for ConfigFilesFixture {
-        fn drop(&mut self) {
-            restore_optional_file(
-                &self.dir.join("settings.json"),
-                self.settings_backup.as_deref(),
-            );
-            restore_optional_file(
-                &self.dir.join("sessions.json"),
-                self.sessions_backup.as_deref(),
-            );
-        }
-    }
-
-    fn read_optional_file(path: &Path) -> Option<Vec<u8>> {
-        match std::fs::read(path) {
-            Ok(bytes) => Some(bytes),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
-            Err(e) => panic!("read {}: {}", path.display(), e),
-        }
-    }
-
-    fn remove_file_if_exists(path: &Path) {
-        match std::fs::remove_file(path) {
-            Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => panic!("remove {}: {}", path.display(), e),
-        }
-    }
-
-    fn restore_optional_file(path: &Path, backup: Option<&[u8]>) {
-        match backup {
-            Some(bytes) => {
-                if let Some(parent) = path.parent() {
-                    let _ = std::fs::create_dir_all(parent);
-                }
-                let _ = std::fs::write(path, bytes);
-            }
-            None => {
-                let _ = std::fs::remove_file(path);
-            }
-        }
     }
 
     fn write_settings_file(dir: &Path, settings: &AppSettings) {
@@ -2678,12 +2616,13 @@ mod tests {
                 },
             );
 
-        let err =
-            persist_settings_draft_update_with_saver(&state, draft, |_| -> Result<(), String> {
-                panic!("save must not run")
-            })
-            .await
-            .unwrap_err();
+        let err = persist_settings_draft_update_with_saver(
+            &state,
+            draft,
+            |_| -> Result<AppSettings, String> { panic!("save must not run") },
+        )
+        .await
+        .unwrap_err();
 
         assert!(err.contains("reserved by AgentsCommander"), "{err}");
         let live = state.read().await;
@@ -2803,11 +2742,11 @@ mod tests {
 
     #[tokio::test]
     async fn settings_update_does_not_clobber_in_memory_project_lists() {
-        let _lock = config_files_test_lock().lock().await;
-        let fixture = ConfigFilesFixture::capture();
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join("settings.json");
         let disk_project = "C:/disk/project-a";
         write_settings_file(
-            fixture.dir(),
+            temp.path(),
             &AppSettings {
                 project_paths: vec![disk_project.to_string()],
                 project_path: Some(disk_project.to_string()),
@@ -2828,8 +2767,10 @@ mod tests {
 
         let saved =
             persist_protected_settings_update_with_saver(&protected_state, stale, |candidate| {
-                assert_single_project(candidate, disk_project);
-                Ok(())
+                crate::config::settings::save_settings_to_path_preserving_project_paths(
+                    candidate,
+                    &settings_path,
+                )
             })
             .await
             .unwrap();
@@ -2849,8 +2790,10 @@ mod tests {
 
         let (saved, _events) =
             persist_settings_draft_update_with_saver(&draft_state, draft, |candidate| {
-                assert_single_project(candidate, disk_project);
-                Ok(())
+                crate::config::settings::save_settings_to_path_preserving_project_paths(
+                    candidate,
+                    &settings_path,
+                )
             })
             .await
             .unwrap();
@@ -2863,19 +2806,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn purge_sessions_after_settings_update_uses_disk_project_lists() {
-        let _lock = config_files_test_lock().lock().await;
-        let fixture = ConfigFilesFixture::capture();
-        let project = fixture.dir().join("project-a");
+    async fn settings_update_returns_written_project_lists_for_session_purge() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        let project = temp.path().join("project-a");
         let kept_workdir = project.join(".ac").join("wg-1").join("__agent_dev");
-        let outside = fixture.dir().join("project-b");
+        let outside = temp.path().join("project-b");
         let outside_workdir = outside.join(".ac").join("wg-1").join("__agent_dev");
         std::fs::create_dir_all(&kept_workdir).expect("create kept workdir");
         std::fs::create_dir_all(&outside_workdir).expect("create outside workdir");
 
         let project_path = project.to_string_lossy().to_string();
         write_settings_file(
-            fixture.dir(),
+            temp.path(),
             &AppSettings {
                 project_paths: vec![project_path.clone()],
                 project_path: Some(project_path.clone()),
@@ -2883,7 +2826,7 @@ mod tests {
             },
         );
         write_sessions_file(
-            fixture.dir(),
+            temp.path(),
             &[
                 PersistedSession {
                     name: "kept".to_string(),
@@ -2906,20 +2849,27 @@ mod tests {
         let state = state_for(current.clone());
         let stale = current;
 
-        let saved = persist_protected_settings_update_with_saver(&state, stale, |_| Ok(()))
+        let saved = persist_protected_settings_update_with_saver(&state, stale, |candidate| {
+            crate::config::settings::save_settings_to_path_preserving_project_paths(
+                candidate,
+                &settings_path,
+            )
+        })
+        .await
+        .unwrap();
+
+        purge_sessions_after_settings_update_in_dir(&saved, temp.path())
             .await
             .unwrap();
-        assert_single_project(&saved, &project_path);
 
-        purge_sessions_after_settings_update(&saved).await;
-
-        let remaining = read_sessions_file(fixture.dir());
+        let remaining = read_sessions_file(temp.path());
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].name, "kept");
         assert_eq!(
             remaining[0].working_directory,
             kept_workdir.to_string_lossy()
         );
+        assert_single_project(&saved, &project_path);
     }
 
     #[tokio::test]
@@ -2954,9 +2904,11 @@ mod tests {
         stale.agents[0].isolated_home = false;
         stale.coding_agent_profiles.profiles_by_agent.clear();
 
-        let saved = persist_protected_settings_update_with_saver(&state, stale, |_| Ok(()))
-            .await
-            .unwrap();
+        let saved = persist_protected_settings_update_with_saver(&state, stale, |candidate| {
+            Ok(candidate.clone())
+        })
+        .await
+        .unwrap();
 
         assert_eq!(saved.sidebar_style, "command-center");
         assert_eq!(saved.agents[0].envs, current.agents[0].envs);

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -12,8 +12,8 @@ use crate::api::auth;
 use crate::config::claude_settings::{ensure_rtk_pretool_hook, enumerate_managed_agent_dirs};
 use crate::config::settings::{
     load_settings, merge_protected_coding_agent_settings, parse_api_server_socket_addr,
-    save_settings, validate_and_repair_settings, AppSettings, CodingAgentEnv,
-    CodingAgentProfilesConfig, SettingsState,
+    refresh_project_paths_from_disk, save_settings, validate_and_repair_settings, AppSettings,
+    CodingAgentEnv, CodingAgentProfilesConfig, SettingsState,
 };
 use crate::network::OutboundNetwork;
 use crate::pty::manager::PtyManager;
@@ -127,7 +127,9 @@ pub async fn get_settings(settings: State<'_, SettingsState>) -> Result<AppSetti
 pub async fn get_coding_agent_catalog(
 ) -> Result<Vec<crate::config::coding_agents_catalog::CodingAgentDefinition>, String> {
     let config_dir = crate::config::config_dir().ok_or("No config dir")?;
-    Ok(crate::config::coding_agents_catalog::load_catalog(&config_dir))
+    Ok(crate::config::coding_agents_catalog::load_catalog(
+        &config_dir,
+    ))
 }
 
 /// #769 Phase 2 - the coding-agent command executable basenames that ship a
@@ -237,6 +239,7 @@ fn build_protected_settings_candidate(
     let mut candidate = merge_protected_coding_agent_settings(current, new_settings);
     // Preserve existing root token. Frontend settings payloads cannot overwrite it.
     candidate.root_token = current.root_token.clone();
+    refresh_project_paths_from_disk(&mut candidate)?;
     validate_and_repair_settings(&mut candidate)?;
     Ok(candidate)
 }
@@ -256,6 +259,7 @@ async fn persist_settings_draft_update_with_saver(
     let mut s = settings.write().await;
     let current = s.clone();
     draft.root_token = current.root_token.clone();
+    refresh_project_paths_from_disk(&mut draft)?;
     validate_and_repair_settings(&mut draft)?;
     let events = settings_draft_update_events(&current, &draft);
     save(&draft)?;
@@ -1868,13 +1872,14 @@ mod tests {
         ensure_web_remote_open_allowed, is_tcp_socket_listening, mint_api_client_with_path,
         persist_coding_agent_env_settings_update, persist_coding_agent_profiles_update,
         persist_narrow_settings_update_with_saver, persist_protected_settings_update_with_saver,
-        persist_settings_draft_update_with_saver, start_api_server, RtkSweepError, RtkSweepResult,
-        WebServerOwnershipState, MINT_API_CLIENT_DEFAULT_TTL_HOURS, MINT_API_CLIENT_MAX_TTL_DAYS,
-        MINT_API_CLIENT_NOTE,
+        persist_settings_draft_update_with_saver, purge_sessions_after_settings_update,
+        start_api_server, RtkSweepError, RtkSweepResult, WebServerOwnershipState,
+        MINT_API_CLIENT_DEFAULT_TTL_HOURS, MINT_API_CLIENT_MAX_TTL_DAYS, MINT_API_CLIENT_NOTE,
     };
     #[cfg(windows)]
     use super::{build_profile_assignment_target, canonical_compare_key};
     use crate::api::auth;
+    use crate::config::sessions_persistence::PersistedSession;
     use crate::config::settings::{
         AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ProfileCellConfig,
         SettingsState,
@@ -1883,10 +1888,8 @@ mod tests {
     use crate::{ApiServerHandle, ApiServerTask, WebServerHandle};
     use std::collections::{BTreeMap, HashMap};
     use std::net::{IpAddr, Ipv4Addr};
-    #[cfg(windows)]
-    use std::path::Path;
-    use std::path::PathBuf;
-    use std::sync::{Arc, Mutex};
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex, OnceLock};
     use std::time::Duration;
     use tauri::Manager;
     use tokio::sync::RwLock;
@@ -1944,6 +1947,99 @@ mod tests {
 
     fn state_for(settings: AppSettings) -> SettingsState {
         Arc::new(RwLock::new(settings))
+    }
+
+    fn config_files_test_lock() -> &'static tokio::sync::Mutex<()> {
+        static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+    }
+
+    struct ConfigFilesFixture {
+        dir: PathBuf,
+        settings_backup: Option<Vec<u8>>,
+        sessions_backup: Option<Vec<u8>>,
+    }
+
+    impl ConfigFilesFixture {
+        fn capture() -> Self {
+            let dir = crate::config::config_dir().expect("config dir");
+            std::fs::create_dir_all(&dir).expect("create config dir");
+            let fixture = Self {
+                settings_backup: read_optional_file(&dir.join("settings.json")),
+                sessions_backup: read_optional_file(&dir.join("sessions.json")),
+                dir,
+            };
+            remove_file_if_exists(&fixture.dir.join("settings.json"));
+            remove_file_if_exists(&fixture.dir.join("sessions.json"));
+            fixture
+        }
+
+        fn dir(&self) -> &Path {
+            &self.dir
+        }
+    }
+
+    impl Drop for ConfigFilesFixture {
+        fn drop(&mut self) {
+            restore_optional_file(
+                &self.dir.join("settings.json"),
+                self.settings_backup.as_deref(),
+            );
+            restore_optional_file(
+                &self.dir.join("sessions.json"),
+                self.sessions_backup.as_deref(),
+            );
+        }
+    }
+
+    fn read_optional_file(path: &Path) -> Option<Vec<u8>> {
+        match std::fs::read(path) {
+            Ok(bytes) => Some(bytes),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            Err(e) => panic!("read {}: {}", path.display(), e),
+        }
+    }
+
+    fn remove_file_if_exists(path: &Path) {
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => panic!("remove {}: {}", path.display(), e),
+        }
+    }
+
+    fn restore_optional_file(path: &Path, backup: Option<&[u8]>) {
+        match backup {
+            Some(bytes) => {
+                if let Some(parent) = path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                let _ = std::fs::write(path, bytes);
+            }
+            None => {
+                let _ = std::fs::remove_file(path);
+            }
+        }
+    }
+
+    fn write_settings_file(dir: &Path, settings: &AppSettings) {
+        let json = serde_json::to_vec_pretty(settings).expect("serialize settings");
+        std::fs::write(dir.join("settings.json"), json).expect("write settings.json");
+    }
+
+    fn write_sessions_file(dir: &Path, sessions: &[PersistedSession]) {
+        let json = serde_json::to_vec_pretty(sessions).expect("serialize sessions");
+        std::fs::write(dir.join("sessions.json"), json).expect("write sessions.json");
+    }
+
+    fn read_sessions_file(dir: &Path) -> Vec<PersistedSession> {
+        let json = std::fs::read_to_string(dir.join("sessions.json")).expect("read sessions.json");
+        serde_json::from_str(&json).expect("parse sessions.json")
+    }
+
+    fn assert_single_project(settings: &AppSettings, project: &str) {
+        assert_eq!(settings.project_paths, vec![project.to_string()]);
+        assert_eq!(settings.project_path.as_deref(), Some(project));
     }
 
     fn api_server_command_test_app(settings: AppSettings) -> tauri::App {
@@ -2703,6 +2799,127 @@ mod tests {
             |candidate| assert!(candidate.theme_light),
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn settings_update_does_not_clobber_in_memory_project_lists() {
+        let _lock = config_files_test_lock().lock().await;
+        let fixture = ConfigFilesFixture::capture();
+        let disk_project = "C:/disk/project-a";
+        write_settings_file(
+            fixture.dir(),
+            &AppSettings {
+                project_paths: vec![disk_project.to_string()],
+                project_path: Some(disk_project.to_string()),
+                ..AppSettings::default()
+            },
+        );
+
+        let mut current = settings_with_single_agent();
+        current.project_paths = vec!["C:/stale/current".to_string()];
+        current.project_path = Some("C:/stale/current".to_string());
+        current.root_token = Some("current-root-token".to_string());
+
+        let protected_state = state_for(current.clone());
+        let mut stale = current.clone();
+        stale.project_paths.clear();
+        stale.project_path = None;
+        stale.root_token = Some("frontend-root-token".to_string());
+
+        let saved =
+            persist_protected_settings_update_with_saver(&protected_state, stale, |candidate| {
+                assert_single_project(candidate, disk_project);
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        assert_single_project(&saved, disk_project);
+        assert_eq!(saved.root_token.as_deref(), Some("current-root-token"));
+        {
+            let live = protected_state.read().await;
+            assert_single_project(&live, disk_project);
+            assert_eq!(live.root_token.as_deref(), Some("current-root-token"));
+        }
+
+        let draft_state = state_for(current.clone());
+        let mut draft = current;
+        draft.project_paths.clear();
+        draft.project_path = None;
+
+        let (saved, _events) =
+            persist_settings_draft_update_with_saver(&draft_state, draft, |candidate| {
+                assert_single_project(candidate, disk_project);
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        assert_single_project(&saved, disk_project);
+        {
+            let live = draft_state.read().await;
+            assert_single_project(&live, disk_project);
+        }
+    }
+
+    #[tokio::test]
+    async fn purge_sessions_after_settings_update_uses_disk_project_lists() {
+        let _lock = config_files_test_lock().lock().await;
+        let fixture = ConfigFilesFixture::capture();
+        let project = fixture.dir().join("project-a");
+        let kept_workdir = project.join(".ac").join("wg-1").join("__agent_dev");
+        let outside = fixture.dir().join("project-b");
+        let outside_workdir = outside.join(".ac").join("wg-1").join("__agent_dev");
+        std::fs::create_dir_all(&kept_workdir).expect("create kept workdir");
+        std::fs::create_dir_all(&outside_workdir).expect("create outside workdir");
+
+        let project_path = project.to_string_lossy().to_string();
+        write_settings_file(
+            fixture.dir(),
+            &AppSettings {
+                project_paths: vec![project_path.clone()],
+                project_path: Some(project_path.clone()),
+                ..AppSettings::default()
+            },
+        );
+        write_sessions_file(
+            fixture.dir(),
+            &[
+                PersistedSession {
+                    name: "kept".to_string(),
+                    shell: "codex".to_string(),
+                    working_directory: kept_workdir.to_string_lossy().to_string(),
+                    ..Default::default()
+                },
+                PersistedSession {
+                    name: "outside".to_string(),
+                    shell: "codex".to_string(),
+                    working_directory: outside_workdir.to_string_lossy().to_string(),
+                    ..Default::default()
+                },
+            ],
+        );
+
+        let mut current = settings_with_single_agent();
+        current.project_paths.clear();
+        current.project_path = None;
+        let state = state_for(current.clone());
+        let stale = current;
+
+        let saved = persist_protected_settings_update_with_saver(&state, stale, |_| Ok(()))
+            .await
+            .unwrap();
+        assert_single_project(&saved, &project_path);
+
+        purge_sessions_after_settings_update(&saved).await;
+
+        let remaining = read_sessions_file(fixture.dir());
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].name, "kept");
+        assert_eq!(
+            remaining[0].working_directory,
+            kept_workdir.to_string_lossy()
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -2914,6 +2914,14 @@ mod tests {
             let live = state.read().await;
             assert_single_project(&live, &project_path);
         }
+        assert!(settings_path.exists(), "writer must create settings.json");
+        let disk: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+        assert_eq!(
+            disk["projectPaths"],
+            serde_json::json!([project_path.clone()])
+        );
+        assert_eq!(disk["projectPath"], serde_json::json!(project_path));
 
         purge_sessions_after_settings_update_in_dir(&saved, temp.path())
             .await

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -2873,6 +2873,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn settings_update_missing_settings_file_preserves_project_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        assert!(!settings_path.exists());
+
+        let project = temp.path().join("project-a");
+        let kept_workdir = project.join(".ac").join("wg-1").join("__agent_dev");
+        std::fs::create_dir_all(&kept_workdir).expect("create kept workdir");
+        let project_path = project.to_string_lossy().to_string();
+
+        write_sessions_file(
+            temp.path(),
+            &[PersistedSession {
+                name: "kept".to_string(),
+                shell: "codex".to_string(),
+                working_directory: kept_workdir.to_string_lossy().to_string(),
+                ..Default::default()
+            }],
+        );
+
+        let mut current = settings_with_single_agent();
+        current.project_paths = vec![project_path.clone()];
+        current.project_path = Some(project_path.clone());
+        let state = state_for(current.clone());
+
+        let mut incoming = current.clone();
+        incoming.sidebar_style = "deep-space".to_string();
+        let saved = persist_protected_settings_update_with_saver(&state, incoming, |candidate| {
+            crate::config::settings::save_settings_to_path_preserving_project_paths(
+                candidate,
+                &settings_path,
+            )
+        })
+        .await
+        .unwrap();
+
+        assert_single_project(&saved, &project_path);
+        {
+            let live = state.read().await;
+            assert_single_project(&live, &project_path);
+        }
+
+        purge_sessions_after_settings_update_in_dir(&saved, temp.path())
+            .await
+            .unwrap();
+
+        let remaining = read_sessions_file(temp.path());
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].name, "kept");
+        assert_eq!(
+            remaining[0].working_directory,
+            kept_workdir.to_string_lossy()
+        );
+    }
+
+    #[tokio::test]
     async fn protected_update_settings_transaction_preserves_current_coding_fields() {
         let mut current = settings_with_single_agent();
         current.agents[0].envs = vec![CodingAgentEnv {

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -1466,7 +1466,7 @@ async fn persist_agent_delete_metadata_with_saver<S>(
     save_settings_fn: S,
 ) -> Result<(), String>
 where
-    S: Fn(&AppSettings) -> Result<(), String>,
+    S: Fn(&AppSettings) -> Result<AppSettings, String>,
 {
     persist_agent_delete_metadata_with_writers(
         metadata,
@@ -1485,7 +1485,7 @@ async fn persist_agent_delete_metadata_with_writers<T, S>(
 ) -> Result<(), String>
 where
     T: FnMut(&Path, &[u8]) -> Result<(), String>,
-    S: Fn(&AppSettings) -> Result<(), String>,
+    S: Fn(&AppSettings) -> Result<AppSettings, String>,
 {
     metadata.settings_changed.store(false, Ordering::SeqCst);
 
@@ -1524,17 +1524,22 @@ where
                     "Failed to validate settings after agent delete: {}",
                     e
                 ))
-            } else if let Err(e) = save_settings_fn(&candidate) {
-                restore_removed_settings(
-                    &mut guard,
-                    &metadata.agent_name,
-                    removed_auto,
-                    removed_default,
-                );
-                Err(format!("Failed to save settings after agent delete: {}", e))
             } else {
-                *guard = candidate;
-                Ok(())
+                match save_settings_fn(&candidate) {
+                    Ok(written) => {
+                        *guard = written;
+                        Ok(())
+                    }
+                    Err(e) => {
+                        restore_removed_settings(
+                            &mut guard,
+                            &metadata.agent_name,
+                            removed_auto,
+                            removed_default,
+                        );
+                        Err(format!("Failed to save settings after agent delete: {}", e))
+                    }
+                }
             }
         } else {
             Ok(())
@@ -4078,8 +4083,10 @@ mod tests {
             ));
         }
 
-        if let Err(e) =
-            persist_agent_delete_metadata_with_saver(&metadata, settings, |_| Ok(())).await
+        if let Err(e) = persist_agent_delete_metadata_with_saver(&metadata, settings, |candidate| {
+            Ok(candidate.clone())
+        })
+        .await
         {
             let restore = restore_agent_delete_metadata_snapshots(&metadata, settings).await;
             let rollback = rollback_staged_agent_delete_targets(&staged);
@@ -4591,7 +4598,7 @@ mod tests {
                     write_team_config_json_atomic(path, bytes)
                 }
             },
-            |_| Ok(()),
+            |candidate| Ok(candidate.clone()),
         )
         .await
         .expect_err("team write failure");

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -659,7 +659,7 @@ pub async fn purge_sessions_outside_project_paths(
     Ok(before_len.saturating_sub(filtered.len()))
 }
 
-async fn purge_sessions_outside_project_paths_in_dir(
+pub(crate) async fn purge_sessions_outside_project_paths_in_dir(
     dir: &Path,
     project_paths: &[String],
 ) -> Result<Vec<PersistedSession>, String> {

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -681,8 +681,8 @@ pub(crate) async fn purge_sessions_outside_project_paths_in_dir(
 /// `SAVE_SESSIONS_LOCK` never re-enters this one), so there is no deadlock and
 /// no await is held across a second acquisition of this lock.
 ///
-/// Returns `(before_len, filtered)` so callers can report either the removed
-/// count or the retained snapshot.
+/// Returns `(before_len, filtered)` so callers can retain the filtered snapshot
+/// and keep the removed count available for diagnostics.
 async fn purge_sessions_outside_project_paths_in_dir_locked(
     dir: &Path,
     project_paths: &[String],

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -650,15 +650,6 @@ pub async fn load_sessions_purging_outside_project_paths(
     }
 }
 
-pub async fn purge_sessions_outside_project_paths(
-    project_paths: &[String],
-) -> Result<usize, String> {
-    let dir = super::config_dir().ok_or("Could not determine home directory")?;
-    let (before_len, filtered) =
-        purge_sessions_outside_project_paths_in_dir_locked(&dir, project_paths).await?;
-    Ok(before_len.saturating_sub(filtered.len()))
-}
-
 pub(crate) async fn purge_sessions_outside_project_paths_in_dir(
     dir: &Path,
     project_paths: &[String],
@@ -668,10 +659,10 @@ pub(crate) async fn purge_sessions_outside_project_paths_in_dir(
     Ok(filtered)
 }
 
-/// #698 HIGH fix — the lock-holding core shared by BOTH purge entry points:
-/// `purge_sessions_outside_project_paths` (settings-update path, reachable from
-/// `purge_sessions_after_settings_update`) and
-/// `purge_sessions_outside_project_paths_in_dir` (startup-restore path).
+/// #698 HIGH fix: the lock-holding core shared by both live purge callers:
+/// `commands::config::purge_sessions_after_settings_update_in_dir` (settings
+/// update path) and `load_sessions_purging_outside_project_paths` (startup
+/// restore path).
 ///
 /// The orphan purge is a load -> filter -> save sequence. Before this fix the
 /// load and save ran OUTSIDE `sessions_save_lock()`, so another locked

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -2046,7 +2046,7 @@ pub fn refresh_project_paths_from_disk(settings: &mut AppSettings) -> Result<(),
 /// momentarily resurrect an entry; orders of magnitude smaller than the prior
 /// snapshot-age window. Airtight cross-process safety would need an advisory
 /// file lock (tracked separately), deliberately not added here.
-pub fn save_settings(settings: &AppSettings) -> Result<(), String> {
+pub fn save_settings(settings: &AppSettings) -> Result<AppSettings, String> {
     let dir = super::config_dir().ok_or("Could not determine home directory")?;
     let path = dir.join("settings.json");
     save_settings_to_path_preserving_project_paths(settings, &path)
@@ -2069,15 +2069,16 @@ pub fn save_settings_with_project_paths(settings: &AppSettings) -> Result<(), St
 /// them into a clone of `settings`, then hands off to the verbatim
 /// #774-hardened writer. Split out with an explicit `path` so tests can drive it
 /// against a `tempfile::tempdir()`.
-fn save_settings_to_path_preserving_project_paths(
+pub(crate) fn save_settings_to_path_preserving_project_paths(
     settings: &AppSettings,
     path: &Path,
-) -> Result<(), String> {
+) -> Result<AppSettings, String> {
     let (disk_paths, disk_head) = read_project_paths_from_disk(path)?;
     let mut to_write = settings.clone();
     to_write.project_paths = disk_paths;
     to_write.project_path = disk_head;
-    save_settings_to_path(&to_write, path)
+    save_settings_to_path(&to_write, path)?;
+    Ok(to_write)
 }
 
 fn save_settings_to_path(settings: &AppSettings, path: &Path) -> Result<(), String> {
@@ -3540,7 +3541,8 @@ mod tests {
 
         let mut candidate = settings_with_project_paths(&["A"]); // stale, missing X
         candidate.sidebar_style = "deep-space".to_string(); // unrelated GUI field
-        super::save_settings_to_path_preserving_project_paths(&candidate, &path).unwrap();
+        let written =
+            super::save_settings_to_path_preserving_project_paths(&candidate, &path).unwrap();
 
         let contents = std::fs::read_to_string(&path).unwrap();
         let reloaded: AppSettings = serde_json::from_str(&contents).unwrap();
@@ -3550,6 +3552,8 @@ mod tests {
         ); // X preserved, not clobbered
         assert_eq!(reloaded.project_path.as_deref(), Some("A"));
         assert_eq!(reloaded.sidebar_style, "deep-space"); // unrelated field persisted
+        assert_eq!(written.project_paths, reloaded.project_paths);
+        assert_eq!(written.project_path, reloaded.project_path);
     }
 
     #[test]

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1939,14 +1939,16 @@ pub fn read_log_level_only() -> Option<String> {
 /// counter so the two can be reasoned about independently in diagnostics.
 static SAVE_OP_ID: AtomicU64 = AtomicU64::new(0);
 
+type DiskProjectPaths = (Vec<String>, Option<String>);
+
 /// #778: side-effect-free reader of ONLY `project_paths`/`project_path` from
 /// `settings.json` on disk. Under Design S `project_paths` is disk-authoritative,
 /// so the default `save_settings` uses this to preserve whatever another process
 /// (a CLI verb, a second instance) wrote, and the add/remove commands use it to
 /// reconcile before a deliberate mutation.
 ///
-/// Error policy (grinch G2): a genuine `NotFound` yields empty (fresh install:
-/// nothing on disk to preserve). ANY other error (a transient os 5/32/33/1175
+/// Error policy (grinch G2): a genuine `NotFound` yields `None` (fresh install:
+/// no disk truth to substitute). ANY other error (a transient os 5/32/33/1175
 /// lock, a permission failure, or unparseable JSON) returns `Err` so the caller
 /// ABORTS the save. The read runs BEFORE the #774 temp write, so disk is
 /// untouched and #774 is unaffected. For #778's threat model, aborting a
@@ -1959,7 +1961,7 @@ static SAVE_OP_ID: AtomicU64 = AtomicU64::new(0);
 /// so the later `MoveFileEx` rename cannot hit a sharing violation (os 32).
 /// MUST NOT call `load_settings` (it migrates, generates root_token, and
 /// re-saves: infinite recursion + side effects).
-fn read_project_paths_from_disk(path: &Path) -> Result<(Vec<String>, Option<String>), String> {
+fn read_project_paths_from_disk(path: &Path) -> Result<Option<DiskProjectPaths>, String> {
     // 1 initial attempt + up to 2 retries on a transient (non-NotFound) read error.
     const READ_RETRY_BACKOFFS_MS: [u64; 2] = [10, 40];
     let mut attempt = 0usize;
@@ -1967,8 +1969,8 @@ fn read_project_paths_from_disk(path: &Path) -> Result<(Vec<String>, Option<Stri
         match std::fs::read_to_string(path) {
             Ok(c) => break c,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // Fresh install / never-saved: nothing on disk to preserve.
-                return Ok((Vec::new(), None));
+                // Fresh install / never-saved: no disk truth to preserve.
+                return Ok(None);
             }
             Err(e) => {
                 if attempt < READ_RETRY_BACKOFFS_MS.len() {
@@ -2006,7 +2008,7 @@ fn read_project_paths_from_disk(path: &Path) -> Result<(Vec<String>, Option<Stri
         .get("projectPath")
         .and_then(|v| v.as_str())
         .map(str::to_string);
-    Ok((project_paths, project_path))
+    Ok(Some((project_paths, project_path)))
 }
 
 /// #778: overwrite `settings`' in-memory project list with the disk-authoritative
@@ -2019,9 +2021,10 @@ pub fn refresh_project_paths_from_disk(settings: &mut AppSettings) -> Result<(),
     let Some(path) = settings_path() else {
         return Ok(());
     };
-    let (project_paths, project_path) = read_project_paths_from_disk(&path)?;
-    settings.project_paths = project_paths;
-    settings.project_path = project_path;
+    if let Some((project_paths, project_path)) = read_project_paths_from_disk(&path)? {
+        settings.project_paths = project_paths;
+        settings.project_path = project_path;
+    }
     Ok(())
 }
 
@@ -2073,10 +2076,11 @@ pub(crate) fn save_settings_to_path_preserving_project_paths(
     settings: &AppSettings,
     path: &Path,
 ) -> Result<AppSettings, String> {
-    let (disk_paths, disk_head) = read_project_paths_from_disk(path)?;
     let mut to_write = settings.clone();
-    to_write.project_paths = disk_paths;
-    to_write.project_path = disk_head;
+    if let Some((disk_paths, disk_head)) = read_project_paths_from_disk(path)? {
+        to_write.project_paths = disk_paths;
+        to_write.project_path = disk_head;
+    }
     save_settings_to_path(&to_write, path)?;
     Ok(to_write)
 }
@@ -3495,20 +3499,17 @@ mod tests {
         let path = temp.path().join("settings.json");
         super::save_settings_to_path(&settings_with_project_paths(&["C:/a", "C:/b"]), &path)
             .unwrap();
-        let (paths, head) = super::read_project_paths_from_disk(&path).unwrap();
+        let (paths, head) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
         assert_eq!(paths, vec!["C:/a".to_string(), "C:/b".to_string()]);
         assert_eq!(head.as_deref(), Some("C:/a"));
     }
 
     #[test]
-    fn read_project_paths_from_disk_empty_when_file_absent() {
+    fn read_project_paths_from_disk_returns_none_when_file_absent() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("does-not-exist.json");
-        // NotFound is the ONLY error that degrades to empty (fresh install).
-        assert_eq!(
-            super::read_project_paths_from_disk(&path).unwrap(),
-            (Vec::new(), None)
-        );
+        // NotFound means there is no disk truth to substitute.
+        assert_eq!(super::read_project_paths_from_disk(&path).unwrap(), None);
     }
 
     #[test]
@@ -3563,7 +3564,7 @@ mod tests {
         let path = temp.path().join("settings.json");
         super::save_settings_to_path(&settings_with_project_paths(&["A"]), &path).unwrap();
         super::save_settings_to_path(&settings_with_project_paths(&["A", "Y"]), &path).unwrap();
-        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap();
+        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
         assert_eq!(paths, vec!["A".to_string(), "Y".to_string()]);
     }
 
@@ -3585,7 +3586,7 @@ mod tests {
             &path,
         )
         .unwrap();
-        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap();
+        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
         assert_eq!(paths, vec!["A".to_string()]);
     }
 
@@ -3598,13 +3599,13 @@ mod tests {
         super::save_settings_to_path(&settings_with_project_paths(&["A", "X"]), &path).unwrap();
 
         let mut s = settings_with_project_paths(&["A"]); // stale in-memory
-        let (disk_paths, disk_head) = super::read_project_paths_from_disk(&path).unwrap();
+        let (disk_paths, disk_head) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
         s.project_paths = disk_paths;
         s.project_path = disk_head; // reconciled to [A, X]
         assert!(crate::config::projects::remove_project_path(&mut s, "A"));
         super::save_settings_to_path(&s, &path).unwrap(); // verbatim
 
-        let (paths, head) = super::read_project_paths_from_disk(&path).unwrap();
+        let (paths, head) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
         assert_eq!(paths, vec!["X".to_string()]); // A gone, X preserved
         assert_eq!(head.as_deref(), Some("X"));
     }
@@ -3618,14 +3619,14 @@ mod tests {
         super::save_settings_to_path(&settings_with_project_paths(&["A", "X"]), &path).unwrap();
 
         let mut s = settings_with_project_paths(&["A"]); // stale
-        let (disk_paths, disk_head) = super::read_project_paths_from_disk(&path).unwrap();
+        let (disk_paths, disk_head) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
         s.project_paths = disk_paths;
         s.project_path = disk_head; // [A, X]
         s.project_paths.push("Y".to_string()); // stand-in for register upsert
         s.project_path = s.project_paths.first().cloned();
         super::save_settings_to_path(&s, &path).unwrap();
 
-        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap();
+        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
         assert_eq!(
             paths,
             vec!["A".to_string(), "X".to_string(), "Y".to_string()]

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1995,15 +1995,20 @@ fn read_project_paths_from_disk(path: &Path) -> Result<Option<DiskProjectPaths>,
             e
         )
     })?;
-    let project_paths = value
-        .get("projectPaths")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|x| x.as_str().map(str::to_string))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
+    let project_paths = match value.get("projectPaths") {
+        None | Some(serde_json::Value::Null) => return Ok(None),
+        Some(serde_json::Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|x| x.as_str().map(str::to_string))
+            .collect::<Vec<_>>(),
+        Some(other) => {
+            return Err(format!(
+                "{}: projectPaths is {}, not an array (aborting save)",
+                path.display(),
+                other
+            ));
+        }
+    };
     let project_path = value
         .get("projectPath")
         .and_then(|v| v.as_str())
@@ -2021,7 +2026,14 @@ pub fn refresh_project_paths_from_disk(settings: &mut AppSettings) -> Result<(),
     let Some(path) = settings_path() else {
         return Ok(());
     };
-    if let Some((project_paths, project_path)) = read_project_paths_from_disk(&path)? {
+    refresh_project_paths_from_path(settings, &path)
+}
+
+pub(crate) fn refresh_project_paths_from_path(
+    settings: &mut AppSettings,
+    path: &Path,
+) -> Result<(), String> {
+    if let Some((project_paths, project_path)) = read_project_paths_from_disk(path)? {
         settings.project_paths = project_paths;
         settings.project_path = project_path;
     }
@@ -2064,7 +2076,14 @@ pub fn save_settings(settings: &AppSettings) -> Result<AppSettings, String> {
 pub fn save_settings_with_project_paths(settings: &AppSettings) -> Result<(), String> {
     let dir = super::config_dir().ok_or("Could not determine home directory")?;
     let path = dir.join("settings.json");
-    save_settings_to_path(settings, &path)
+    save_settings_with_project_paths_to_path(settings, &path)
+}
+
+pub(crate) fn save_settings_with_project_paths_to_path(
+    settings: &AppSettings,
+    path: &Path,
+) -> Result<(), String> {
+    save_settings_to_path(settings, path)
 }
 
 /// #778: the preserve-disk wrapper behind the default `save_settings`. Reads the
@@ -3510,6 +3529,40 @@ mod tests {
         let path = temp.path().join("does-not-exist.json");
         // NotFound means there is no disk truth to substitute.
         assert_eq!(super::read_project_paths_from_disk(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_returns_none_when_key_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(&path, r#"{"themeLight":true}"#).unwrap();
+        assert_eq!(super::read_project_paths_from_disk(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_returns_none_when_key_null() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(&path, r#"{"projectPaths":null}"#).unwrap();
+        assert_eq!(super::read_project_paths_from_disk(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_aborts_when_key_wrong_type() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(&path, r#"{"projectPaths":"C:/a"}"#).unwrap();
+        assert!(super::read_project_paths_from_disk(&path).is_err());
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_accepts_legit_empty_list() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(&path, r#"{"projectPaths":[]}"#).unwrap();
+        let (paths, head) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+        assert!(paths.is_empty());
+        assert_eq!(head, None);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -848,10 +848,20 @@ pub fn run(
                         let mut s = settings_state.write().await;
                         s.inject_rtk_hook = false;
                         let snapshot = s.clone();
-                        if let Err(e) = crate::config::settings::save_settings(&snapshot) {
-                            log::warn!("[rtk-startup] Failed to persist auto-disable: {}", e);
-                        }
-                        let project_paths = snapshot.project_paths.clone();
+                        let project_paths =
+                            match crate::config::settings::save_settings(&snapshot) {
+                                Ok(written) => {
+                                    *s = written.clone();
+                                    written.project_paths
+                                }
+                                Err(e) => {
+                                    log::warn!(
+                                        "[rtk-startup] Failed to persist auto-disable: {}",
+                                        e
+                                    );
+                                    snapshot.project_paths.clone()
+                                }
+                            };
                         drop(s); // explicit; lock released AFTER the disk write
 
                         // M8 fix: hold RtkSweepLock through the OFF-sweep loop.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -851,8 +851,8 @@ pub fn run(
                         let project_paths =
                             match crate::config::settings::save_settings(&snapshot) {
                                 Ok(written) => {
-                                    *s = written.clone();
-                                    written.project_paths
+                                    *s = written;
+                                    s.project_paths.clone()
                                 }
                                 Err(e) => {
                                     log::warn!(

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -5399,7 +5399,7 @@ impl MailboxPoller {
                     )
                 };
                 if let ca::RequestDisposition::Applied { op, agent_id } = disposition {
-                    *s = written_settings.unwrap_or(candidate);
+                    *s = written_settings.expect("Applied implies save() succeeded");
                     Some((op, agent_id))
                 } else {
                     None

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -5383,18 +5383,23 @@ impl MailboxPoller {
             let applied = {
                 let mut s = state.write().await;
                 let mut candidate = s.clone();
-                let mut save = |st: &crate::config::settings::AppSettings| {
-                    crate::config::settings::save_settings(st)
+                let mut written_settings = None;
+                let disposition = {
+                    let mut save = |st: &crate::config::settings::AppSettings| {
+                        let written = crate::config::settings::save_settings(st)?;
+                        written_settings = Some(written);
+                        Ok(())
+                    };
+                    ca::process_coding_agent_request(
+                        &path,
+                        &results_dir,
+                        now_ms,
+                        &mut candidate,
+                        &mut save,
+                    )
                 };
-                let disposition = ca::process_coding_agent_request(
-                    &path,
-                    &results_dir,
-                    now_ms,
-                    &mut candidate,
-                    &mut save,
-                );
                 if let ca::RequestDisposition::Applied { op, agent_id } = disposition {
-                    *s = candidate;
+                    *s = written_settings.unwrap_or(candidate);
                     Some((op, agent_id))
                 } else {
                     None

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -5399,7 +5399,14 @@ impl MailboxPoller {
                     )
                 };
                 if let ca::RequestDisposition::Applied { op, agent_id } = disposition {
-                    *s = written_settings.expect("Applied implies save() succeeded");
+                    debug_assert!(
+                        written_settings.is_some(),
+                        "Applied implies save() succeeded"
+                    );
+                    *s = written_settings.unwrap_or_else(|| {
+                        log::error!("coding-agent op Applied without a save; publishing candidate");
+                        candidate
+                    });
                     Some((op, agent_id))
                 } else {
                     None


### PR DESCRIPTION
Closes #888.

## Why

`settings.project_paths` is treated as disk-authoritative. That guarantee held for the **file** and not for the **in-memory** `SettingsState`, and one destructive consumer built its allowlist from the wrong source. Both defects were live on `main` and reachable without any new feature. They were found while reviewing the design for #881 (Archive Project), which cannot be built correctly on top of them.

### Defect 1 — the in-memory settings clobber

`build_protected_settings_candidate` and `persist_settings_draft_update_with_saver` finished with `*s = candidate.clone()`, restoring only `root_token`. Disk stayed correct; memory rolled back to a stale list. The loop scheduler, mailbox poller, repo search and task validation all read the in-memory list.

### Defect 2 — silent session deletion

`purge_sessions_after_settings_update` derived its session-retention allowlist from the frontend's settings object while the six session snapshot writers derived theirs from disk. With the GUI open on `[A]`, running `ac open-project C` in a second process and then triggering any settings save (a splitter drag suffices) ran `purge_sessions_outside_project_paths(["A"])` and **deleted project C's sessions from `sessions.json`**.

## What changed

The writer now returns the object it actually wrote, and every publisher publishes that. One disk read per save, and `memory == disk == purge input` holds by construction.

- `save_settings` / `save_settings_to_path_preserving_project_paths` return the substituted `AppSettings`.
- All six in-memory publishers adopt the returned value, closing the "in-memory list may drift from disk" class at every site.
- `purge_sessions_after_settings_update` receives that same object. No second disk read was introduced.
- `read_project_paths_from_disk` now returns `Option`: `None` means *no disk truth* (file absent, key absent, or key null) and leaves the in-memory lists alone; `Some(([], None))` means *disk genuinely says empty* and is adopted; a wrong-typed `projectPaths` returns `Err` and aborts the save rather than substituting an empty list.
- `open_project` / `new_project` / `remove_project` are deduplicated behind one helper carrying the same guard. Production threads `None` at every call site; behavior, ordering, error paths and lock discipline are unchanged.
- The mailbox coding-agent publish degrades and logs instead of unwinding. A panic there would have killed the entire `MailboxPoller` — outbox delivery, wake delivery, session requests — for the app's lifetime.
- Removed the now-orphaned `purge_sessions_outside_project_paths` and corrected two stale doc comments.

## Tests

Five added, all in the default suite, each verified to be a real lock by mutating the production line it guards and watching it go red:

- `settings_update_does_not_clobber_in_memory_project_lists`
- `settings_update_returns_written_project_lists_for_session_purge`
- `settings_update_missing_settings_file_preserves_project_sessions` — asserts memory, disk, **and** purge input
- `missing_settings_file_project_mutators_preserve_live_list` — locks the guard protecting the three project mutators
- `read_project_paths_from_disk_{returns_none_when_key_absent,returns_none_when_key_null,aborts_when_key_wrong_type,accepts_legit_empty_list}`

The two regressions originally shipped ran against the shared real `config_dir()` and raced 17 `phone::mailbox` tests (measured 4/25 and 2/25 failures). They now run on `tempfile::tempdir()` through a path-injecting seam. The fixture that unconditionally deleted `settings.json` and `sessions.json` from `AGENTSCOMMANDER_TEST_CONFIG_DIR` is gone.

`cargo test --lib`: 1981 passed, 0 failed, 8 ignored. `cargo clippy --all-targets -- -D warnings`: clean.

## Review

Implemented by `dev-rust`, adversarially reviewed by `dev-rust-grinch` across four rounds: **FAIL** (the first fix still deleted sessions in a narrower window, and the regression test was flaky), **FAIL** (a missing `settings.json` blanked the project list and deleted every non-root session — a regression this PR's own earlier commits introduced), then **PASS**, then a final confirmation pass at `efe36875` reproducing every mutation proof independently.

Branch contains `origin/main` (`cb30a5e7`); the merge touched zero Rust files.

## Known unrelated flake

`pty::job::win_tests::job_terminate_kills_child_and_grandchild` is a load-sensitive 10s process-teardown deadline test that exists identically on `main`. This branch does not touch `src-tauri/src/pty/`. It may red on a loaded CI runner.

## Follow-ups filed

- #889 — `switch_session` / `destroy_session` assign `SessionStatus::Active` unconditionally, manufacturing no-PTY "desync phantom" records.
