### PR TITLE
Container transport: surface real startup failures, require an explicit image, redact secrets from diagnostics

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -431,7 +431,7 @@ Subcommands:
 | `--isolated-home <true\|false>` | Provide an isolated CODEX_HOME at spawn (Codex). |
 | `--backend <local\|container>` | Runtime backend. `local` clears any per-agent container image; `container` uses Docker container transport. |
 | `--container-image <image>` | Per-agent Docker image override. Implies `--backend container`; conflicts with `--backend local`; rejects empty or leading-dash values. |
-| `--clear-container-image` | (update) Clear the per-agent Docker image override. Conflicts with `--container-image`; valid with `--backend container` to fall back to `AGENTSCOMMANDER_CONTAINER_IMAGE`, then the built-in default. |
+| `--clear-container-image` | (update) Clear the per-agent Docker image override. Conflicts with `--container-image`; with `--backend container`, launch succeeds only if the AgentsCommander process has `AGENTSCOMMANDER_CONTAINER_IMAGE` set. There is no built-in image default. |
 | `--instructions-filename <name.md>` | Bare `.md` filename AC writes into the agent root at launch. |
 | `--clear-instructions-filename` | (update) Clear it. Conflicts with `--instructions-filename`. |
 | `--config-seed-dest <folder>` | Config-folder seed destination NAME under the replica root. Implies enabled unless `--config-seed-enabled false`. |

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -10,7 +10,6 @@ use crate::config::coordinator_clocks::CoordinatorClocksState;
 use crate::config::sessions_persistence::persist_current_state;
 use crate::config::settings::{AppSettings, SettingsState};
 use crate::pty::backend::{BackendSpawnSpec, SessionBackendKind};
-use crate::pty::container_runtime::DEFAULT_CONTAINER_WORKDIR;
 use crate::pty::manager::PtyManager;
 use crate::pty::output::PtyOutputTarget;
 use crate::resource_monitor::{
@@ -642,128 +641,6 @@ fn claude_projects_dir_for_config_dir(config_dir: &str, cwd: &str) -> std::path:
     base.join("projects").join(mangled)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ClaudeResumeProbe {
-    projects_dir: Option<std::path::PathBuf>,
-    exists: bool,
-    filesystem: &'static str,
-    detail: String,
-}
-
-fn looks_like_windows_absolute_path(value: &str) -> bool {
-    let bytes = value.as_bytes();
-    bytes.len() >= 3
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':'
-        && (bytes[2] == b'/' || bytes[2] == b'\\')
-}
-
-fn map_container_workspace_path_to_host(
-    container_path: &str,
-    host_root: &str,
-) -> Option<std::path::PathBuf> {
-    let expanded = expand_env_var_refs(container_path);
-    let trimmed = expanded.trim();
-    if trimmed.is_empty()
-        || trimmed.starts_with('~')
-        || trimmed.contains('$')
-        || trimmed.contains('%')
-        || looks_like_windows_absolute_path(trimmed)
-    {
-        return None;
-    }
-
-    let normalized = trimmed.replace('\\', "/");
-    let normalized = if normalized.starts_with('/') {
-        normalized
-    } else {
-        format!(
-            "{}/{}",
-            DEFAULT_CONTAINER_WORKDIR.trim_end_matches('/'),
-            normalized.trim_start_matches("./")
-        )
-    };
-    let workdir = DEFAULT_CONTAINER_WORKDIR.trim_end_matches('/');
-    let relative = if normalized == workdir {
-        ""
-    } else {
-        normalized.strip_prefix(&format!("{workdir}/"))?
-    };
-
-    let mut host_path = std::path::PathBuf::from(host_root);
-    for segment in relative.split('/').filter(|segment| !segment.is_empty()) {
-        if segment == "." || segment == ".." {
-            return None;
-        }
-        host_path.push(segment);
-    }
-    Some(host_path)
-}
-
-fn claude_projects_dir_for_container_config_dir(
-    config_dir: &str,
-    host_root: &str,
-) -> Option<std::path::PathBuf> {
-    let host_config_dir = map_container_workspace_path_to_host(config_dir, host_root)?;
-    let mangled = crate::session::session::mangle_cwd_for_claude(DEFAULT_CONTAINER_WORKDIR);
-    Some(host_config_dir.join("projects").join(mangled))
-}
-
-fn resolve_claude_resume_probe(
-    backend_kind: SessionBackendKind,
-    claude_config_dir_override: Option<&str>,
-    shell: &str,
-    shell_args: &[String],
-    cwd: &str,
-) -> ClaudeResumeProbe {
-    if backend_kind == SessionBackendKind::ContainerTransport {
-        return match claude_config_dir_override {
-            Some(config_dir) => {
-                match claude_projects_dir_for_container_config_dir(config_dir, cwd) {
-                    Some(projects_dir) => {
-                        let exists = projects_dir.is_dir();
-                        ClaudeResumeProbe {
-                            projects_dir: Some(projects_dir),
-                            exists,
-                            filesystem: "container-workspace",
-                            detail: format!(
-                                "container_config_dir={config_dir:?} container_cwd={DEFAULT_CONTAINER_WORKDIR:?}"
-                            ),
-                        }
-                    }
-                    None => ClaudeResumeProbe {
-                        projects_dir: None,
-                        exists: false,
-                        filesystem: "container-unmapped",
-                        detail: format!(
-                            "container_config_dir={config_dir:?} is not reachable through {DEFAULT_CONTAINER_WORKDIR}"
-                        ),
-                    },
-                }
-            }
-            None => ClaudeResumeProbe {
-                projects_dir: None,
-                exists: false,
-                filesystem: "container-unresolved",
-                detail: "no CLAUDE_CONFIG_DIR in resolved child env; container auto-resume skipped"
-                    .to_string(),
-            },
-        };
-    }
-
-    let projects_dir = match claude_config_dir_override {
-        Some(dir) => Some(claude_projects_dir_for_config_dir(dir, cwd)),
-        None => resolve_claude_projects_dir(shell, shell_args, cwd),
-    };
-    let exists = projects_dir.as_ref().map(|p| p.is_dir()).unwrap_or(false);
-    ClaudeResumeProbe {
-        projects_dir,
-        exists,
-        filesystem: "host",
-        detail: "host filesystem".to_string(),
-    }
-}
-
 /// Decide whether to auto-inject `--continue` for a Claude session.
 /// Pure function: no filesystem access. Caller is responsible for resolving
 /// `claude_project_exists` (typically `~/.claude/projects/<mangled-cwd>/.is_dir()`).
@@ -1135,15 +1012,14 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             .find(|(k, _)| k.eq_ignore_ascii_case("CLAUDE_CONFIG_DIR"))
             .map(|(_, v)| v.clone())
     });
-    let claude_resume_probe = resolve_claude_resume_probe(
-        backend_kind,
-        claude_config_dir_override.as_deref(),
-        &shell,
-        &shell_args,
-        &cwd,
-    );
-    let resolved_claude_projects_dir = claude_resume_probe.projects_dir.clone();
-    let claude_project_exists = claude_resume_probe.exists;
+    let resolved_claude_projects_dir = match claude_config_dir_override {
+        Some(ref dir) => Some(claude_projects_dir_for_config_dir(dir, &cwd)),
+        None => resolve_claude_projects_dir(&shell, &shell_args, &cwd),
+    };
+    let claude_project_exists = resolved_claude_projects_dir
+        .as_ref()
+        .map(|p| p.is_dir())
+        .unwrap_or(false);
     let is_claude = agent_kind == Some(CodingAgentKind::Claude);
     let will_inject_continue = should_inject_continue(
         is_claude,
@@ -1156,12 +1032,10 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     // during the stabilization window; demote later.
     if agent_kind.is_some() {
         log::info!(
-            "[session] resume-decision {} agent={:?} cwd={:?} resume_fs={} resume_detail={} projects_dir={:?} exists={} skip_auto_resume={} -> inject_continue={}",
+            "[session] resume-decision {} agent={:?} cwd={:?} projects_dir={:?} exists={} skip_auto_resume={} -> inject_continue={}",
             &id.to_string()[..8],
             agent_kind,
             cwd,
-            claude_resume_probe.filesystem,
-            claude_resume_probe.detail,
             resolved_claude_projects_dir,
             claude_project_exists,
             skip_auto_resume,
@@ -4348,62 +4222,6 @@ mod tests {
             .join("projects")
             .join(crate::session::session::mangle_cwd_for_claude("C:\\x"));
         assert_eq!(resolved, expected);
-    }
-
-    #[test]
-    fn container_claude_resume_probe_maps_workspace_config_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let host_root = tmp.path().join("__agent_dev-rust");
-        let expected = host_root.join(".claude").join("projects").join(
-            crate::session::session::mangle_cwd_for_claude(
-                crate::pty::container_runtime::DEFAULT_CONTAINER_WORKDIR,
-            ),
-        );
-        std::fs::create_dir_all(&expected).unwrap();
-
-        let probe = super::resolve_claude_resume_probe(
-            crate::pty::backend::SessionBackendKind::ContainerTransport,
-            Some("/workspace/.claude"),
-            "claude",
-            &[],
-            host_root.to_str().unwrap(),
-        );
-
-        assert_eq!(probe.projects_dir.as_deref(), Some(expected.as_path()));
-        assert!(probe.exists);
-        assert_eq!(probe.filesystem, "container-workspace");
-    }
-
-    #[test]
-    fn container_claude_resume_probe_skips_unmapped_config_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let probe = super::resolve_claude_resume_probe(
-            crate::pty::backend::SessionBackendKind::ContainerTransport,
-            Some("C:\\Users\\maria\\.claude"),
-            "claude",
-            &[],
-            tmp.path().to_str().unwrap(),
-        );
-
-        assert!(probe.projects_dir.is_none());
-        assert!(!probe.exists);
-        assert_eq!(probe.filesystem, "container-unmapped");
-    }
-
-    #[test]
-    fn container_claude_resume_probe_skips_without_config_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let probe = super::resolve_claude_resume_probe(
-            crate::pty::backend::SessionBackendKind::ContainerTransport,
-            None,
-            "claude",
-            &[],
-            tmp.path().to_str().unwrap(),
-        );
-
-        assert!(probe.projects_dir.is_none());
-        assert!(!probe.exists);
-        assert_eq!(probe.filesystem, "container-unresolved");
     }
 
     // ── should_inject_continue tests (issue #82, plan §8.1) ──

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -10,6 +10,7 @@ use crate::config::coordinator_clocks::CoordinatorClocksState;
 use crate::config::sessions_persistence::persist_current_state;
 use crate::config::settings::{AppSettings, SettingsState};
 use crate::pty::backend::{BackendSpawnSpec, SessionBackendKind};
+use crate::pty::container_runtime::DEFAULT_CONTAINER_WORKDIR;
 use crate::pty::manager::PtyManager;
 use crate::pty::output::PtyOutputTarget;
 use crate::resource_monitor::{
@@ -641,6 +642,128 @@ fn claude_projects_dir_for_config_dir(config_dir: &str, cwd: &str) -> std::path:
     base.join("projects").join(mangled)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ClaudeResumeProbe {
+    projects_dir: Option<std::path::PathBuf>,
+    exists: bool,
+    filesystem: &'static str,
+    detail: String,
+}
+
+fn looks_like_windows_absolute_path(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'/' || bytes[2] == b'\\')
+}
+
+fn map_container_workspace_path_to_host(
+    container_path: &str,
+    host_root: &str,
+) -> Option<std::path::PathBuf> {
+    let expanded = expand_env_var_refs(container_path);
+    let trimmed = expanded.trim();
+    if trimmed.is_empty()
+        || trimmed.starts_with('~')
+        || trimmed.contains('$')
+        || trimmed.contains('%')
+        || looks_like_windows_absolute_path(trimmed)
+    {
+        return None;
+    }
+
+    let normalized = trimmed.replace('\\', "/");
+    let normalized = if normalized.starts_with('/') {
+        normalized
+    } else {
+        format!(
+            "{}/{}",
+            DEFAULT_CONTAINER_WORKDIR.trim_end_matches('/'),
+            normalized.trim_start_matches("./")
+        )
+    };
+    let workdir = DEFAULT_CONTAINER_WORKDIR.trim_end_matches('/');
+    let relative = if normalized == workdir {
+        ""
+    } else {
+        normalized.strip_prefix(&format!("{workdir}/"))?
+    };
+
+    let mut host_path = std::path::PathBuf::from(host_root);
+    for segment in relative.split('/').filter(|segment| !segment.is_empty()) {
+        if segment == "." || segment == ".." {
+            return None;
+        }
+        host_path.push(segment);
+    }
+    Some(host_path)
+}
+
+fn claude_projects_dir_for_container_config_dir(
+    config_dir: &str,
+    host_root: &str,
+) -> Option<std::path::PathBuf> {
+    let host_config_dir = map_container_workspace_path_to_host(config_dir, host_root)?;
+    let mangled = crate::session::session::mangle_cwd_for_claude(DEFAULT_CONTAINER_WORKDIR);
+    Some(host_config_dir.join("projects").join(mangled))
+}
+
+fn resolve_claude_resume_probe(
+    backend_kind: SessionBackendKind,
+    claude_config_dir_override: Option<&str>,
+    shell: &str,
+    shell_args: &[String],
+    cwd: &str,
+) -> ClaudeResumeProbe {
+    if backend_kind == SessionBackendKind::ContainerTransport {
+        return match claude_config_dir_override {
+            Some(config_dir) => {
+                match claude_projects_dir_for_container_config_dir(config_dir, cwd) {
+                    Some(projects_dir) => {
+                        let exists = projects_dir.is_dir();
+                        ClaudeResumeProbe {
+                            projects_dir: Some(projects_dir),
+                            exists,
+                            filesystem: "container-workspace",
+                            detail: format!(
+                                "container_config_dir={config_dir:?} container_cwd={DEFAULT_CONTAINER_WORKDIR:?}"
+                            ),
+                        }
+                    }
+                    None => ClaudeResumeProbe {
+                        projects_dir: None,
+                        exists: false,
+                        filesystem: "container-unmapped",
+                        detail: format!(
+                            "container_config_dir={config_dir:?} is not reachable through {DEFAULT_CONTAINER_WORKDIR}"
+                        ),
+                    },
+                }
+            }
+            None => ClaudeResumeProbe {
+                projects_dir: None,
+                exists: false,
+                filesystem: "container-unresolved",
+                detail: "no CLAUDE_CONFIG_DIR in resolved child env; container auto-resume skipped"
+                    .to_string(),
+            },
+        };
+    }
+
+    let projects_dir = match claude_config_dir_override {
+        Some(dir) => Some(claude_projects_dir_for_config_dir(dir, cwd)),
+        None => resolve_claude_projects_dir(shell, shell_args, cwd),
+    };
+    let exists = projects_dir.as_ref().map(|p| p.is_dir()).unwrap_or(false);
+    ClaudeResumeProbe {
+        projects_dir,
+        exists,
+        filesystem: "host",
+        detail: "host filesystem".to_string(),
+    }
+}
+
 /// Decide whether to auto-inject `--continue` for a Claude session.
 /// Pure function: no filesystem access. Caller is responsible for resolving
 /// `claude_project_exists` (typically `~/.claude/projects/<mangled-cwd>/.is_dir()`).
@@ -1012,14 +1135,15 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             .find(|(k, _)| k.eq_ignore_ascii_case("CLAUDE_CONFIG_DIR"))
             .map(|(_, v)| v.clone())
     });
-    let resolved_claude_projects_dir = match claude_config_dir_override {
-        Some(ref dir) => Some(claude_projects_dir_for_config_dir(dir, &cwd)),
-        None => resolve_claude_projects_dir(&shell, &shell_args, &cwd),
-    };
-    let claude_project_exists = resolved_claude_projects_dir
-        .as_ref()
-        .map(|p| p.is_dir())
-        .unwrap_or(false);
+    let claude_resume_probe = resolve_claude_resume_probe(
+        backend_kind,
+        claude_config_dir_override.as_deref(),
+        &shell,
+        &shell_args,
+        &cwd,
+    );
+    let resolved_claude_projects_dir = claude_resume_probe.projects_dir.clone();
+    let claude_project_exists = claude_resume_probe.exists;
     let is_claude = agent_kind == Some(CodingAgentKind::Claude);
     let will_inject_continue = should_inject_continue(
         is_claude,
@@ -1032,10 +1156,12 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     // during the stabilization window; demote later.
     if agent_kind.is_some() {
         log::info!(
-            "[session] resume-decision {} agent={:?} cwd={:?} projects_dir={:?} exists={} skip_auto_resume={} -> inject_continue={}",
+            "[session] resume-decision {} agent={:?} cwd={:?} resume_fs={} resume_detail={} projects_dir={:?} exists={} skip_auto_resume={} -> inject_continue={}",
             &id.to_string()[..8],
             agent_kind,
             cwd,
+            claude_resume_probe.filesystem,
+            claude_resume_probe.detail,
             resolved_claude_projects_dir,
             claude_project_exists,
             skip_auto_resume,
@@ -4222,6 +4348,62 @@ mod tests {
             .join("projects")
             .join(crate::session::session::mangle_cwd_for_claude("C:\\x"));
         assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn container_claude_resume_probe_maps_workspace_config_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let host_root = tmp.path().join("__agent_dev-rust");
+        let expected = host_root.join(".claude").join("projects").join(
+            crate::session::session::mangle_cwd_for_claude(
+                crate::pty::container_runtime::DEFAULT_CONTAINER_WORKDIR,
+            ),
+        );
+        std::fs::create_dir_all(&expected).unwrap();
+
+        let probe = super::resolve_claude_resume_probe(
+            crate::pty::backend::SessionBackendKind::ContainerTransport,
+            Some("/workspace/.claude"),
+            "claude",
+            &[],
+            host_root.to_str().unwrap(),
+        );
+
+        assert_eq!(probe.projects_dir.as_deref(), Some(expected.as_path()));
+        assert!(probe.exists);
+        assert_eq!(probe.filesystem, "container-workspace");
+    }
+
+    #[test]
+    fn container_claude_resume_probe_skips_unmapped_config_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let probe = super::resolve_claude_resume_probe(
+            crate::pty::backend::SessionBackendKind::ContainerTransport,
+            Some("C:\\Users\\maria\\.claude"),
+            "claude",
+            &[],
+            tmp.path().to_str().unwrap(),
+        );
+
+        assert!(probe.projects_dir.is_none());
+        assert!(!probe.exists);
+        assert_eq!(probe.filesystem, "container-unmapped");
+    }
+
+    #[test]
+    fn container_claude_resume_probe_skips_without_config_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let probe = super::resolve_claude_resume_probe(
+            crate::pty::backend::SessionBackendKind::ContainerTransport,
+            None,
+            "claude",
+            &[],
+            tmp.path().to_str().unwrap(),
+        );
+
+        assert!(probe.projects_dir.is_none());
+        assert!(!probe.exists);
+        assert_eq!(probe.filesystem, "container-unresolved");
     }
 
     // ── should_inject_continue tests (issue #82, plan §8.1) ──

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -17,7 +17,7 @@ pub struct AgentBackendConfig {
     #[serde(default)]
     pub kind: SessionBackendKind,
     /// #868 - optional per-agent Docker image override for container runtime.
-    /// None falls back to AGENTSCOMMANDER_CONTAINER_IMAGE, then DEFAULT_CONTAINER_IMAGE.
+    /// None falls back to AGENTSCOMMANDER_CONTAINER_IMAGE at launch.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 }

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -11,8 +11,9 @@ use uuid::Uuid;
 use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
 use crate::pty::container_runtime::{
-    api_url_for_container, resolve_container_image, ContainerRuntime, ContainerRuntimeHandle,
-    ContainerStartRequest, CONTAINER_STOP_TIMEOUT, DEFAULT_CONTAINER_WORKDIR,
+    api_url_for_container, resolve_container_image, ContainerDiagnostics, ContainerRuntime,
+    ContainerRuntimeHandle, ContainerStartRequest, CONTAINER_STOP_TIMEOUT,
+    DEFAULT_CONTAINER_WORKDIR,
 };
 use crate::pty::container_tokens::{ContainerApiToken, ContainerApiTokenManager};
 use crate::pty::idle_detector::IdleDetector;
@@ -25,6 +26,7 @@ pub const TRANSPORT_PROTOCOL_VERSION: u32 = 1;
 pub const MAX_TRANSPORT_FRAME_BYTES: usize = 64 * 1024;
 const TRANSPORT_LOST_EXIT_CODE: i32 = 1;
 const CLEANUP_TASK_TIMEOUT: Duration = Duration::from_secs(10);
+const CONTAINER_DIAGNOSTIC_LOG_TAIL_LINES: usize = 80;
 
 type RouteRemover = Arc<dyn Fn(Uuid) + Send + Sync>;
 
@@ -658,15 +660,62 @@ impl ContainerTransportBackend {
             Ok(_) if self.has_session(id) => Ok(()),
             _ => {
                 if let Some(resources) = self.remove_session_state(id) {
+                    let diagnostics = if let (Some(runtime), Some(handle)) =
+                        (self.runtime.clone(), resources.runtime_handle.clone())
+                    {
+                        Some(Self::collect_container_diagnostics(runtime, handle).await)
+                    } else {
+                        None
+                    };
+                    if let Some(diagnostics) = diagnostics.as_ref() {
+                        log::error!(
+                            "[container-transport] attach timeout diagnostics for session {}:\n{}",
+                            id,
+                            diagnostics.log_summary()
+                        );
+                    }
                     self.cleanup_removed_resources_offloaded(resources, "handshake-timeout")
                         .await;
+                    return Err(Self::handshake_timeout_error(
+                        self.tuning.handshake_timeout,
+                        diagnostics.as_ref(),
+                    ));
                 }
-                Err(AppError::PtyError(format!(
-                    "container bridge did not attach within {:?}",
-                    self.tuning.handshake_timeout
-                )))
+                Err(Self::handshake_timeout_error(
+                    self.tuning.handshake_timeout,
+                    None,
+                ))
             }
         }
+    }
+
+    async fn collect_container_diagnostics(
+        runtime: Arc<dyn ContainerRuntime>,
+        handle: ContainerRuntimeHandle,
+    ) -> ContainerDiagnostics {
+        let fallback_handle = handle.clone();
+        let task = tokio::task::spawn_blocking(move || {
+            runtime.diagnostics(&handle, CONTAINER_DIAGNOSTIC_LOG_TAIL_LINES)
+        });
+        match task.await {
+            Ok(diagnostics) => diagnostics,
+            Err(err) => ContainerDiagnostics::unavailable(
+                &fallback_handle,
+                format!("container diagnostics task failed: {err}"),
+            ),
+        }
+    }
+
+    fn handshake_timeout_error(
+        timeout: Duration,
+        diagnostics: Option<&ContainerDiagnostics>,
+    ) -> AppError {
+        let mut message = format!("container bridge did not attach within {timeout:?}");
+        if let Some(diagnostics) = diagnostics {
+            message.push_str("; ");
+            message.push_str(&diagnostics.ui_summary());
+        }
+        AppError::PtyError(message)
     }
 
     fn cleanup_removed_resources_async(
@@ -1085,7 +1134,7 @@ fn build_start_request_with_settings(
     let child_env = sanitized_child_env(configured_env, env_remove_keys);
     Ok(ContainerStartRequest {
         session_id,
-        image: resolve_container_image(container_image.as_deref()),
+        image: resolve_container_image(container_image.as_deref())?,
         host_root: cwd.to_string(),
         container_workdir: DEFAULT_CONTAINER_WORKDIR.to_string(),
         api_url,
@@ -1404,6 +1453,36 @@ mod tests {
         .unwrap();
 
         assert_eq!(request.image, "agentscommander/ac-claude:latest");
+    }
+
+    #[test]
+    fn handshake_timeout_error_includes_container_diagnostics() {
+        let diagnostics = ContainerDiagnostics {
+            container_id: "container-123".to_string(),
+            state: Some(crate::pty::container_runtime::ContainerStateSnapshot {
+                status: Some("exited".to_string()),
+                running: Some(false),
+                exit_code: Some(127),
+                error: None,
+            }),
+            inspect_error: None,
+            log_tail: Some("session-bridge error: command not found: claude".to_string()),
+            logs_error: None,
+        };
+
+        let err = ContainerTransportBackend::handshake_timeout_error(
+            Duration::from_secs(5),
+            Some(&diagnostics),
+        )
+        .to_string();
+
+        assert!(
+            err.contains("container bridge did not attach within 5s"),
+            "{err}"
+        );
+        assert!(err.contains("container id container-123"), "{err}");
+        assert!(err.contains("exitCode=127"), "{err}");
+        assert!(err.contains("command not found: claude"), "{err}");
     }
 
     #[tokio::test]

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -1193,11 +1193,16 @@ mod tests {
     #[derive(Default)]
     struct RecordingRuntime {
         stopped: Arc<Mutex<Vec<Uuid>>>,
+        removed: Arc<Mutex<Vec<Uuid>>>,
     }
 
     impl RecordingRuntime {
         fn stopped(&self) -> Vec<Uuid> {
             self.stopped.lock().unwrap().clone()
+        }
+
+        fn removed(&self) -> Vec<Uuid> {
+            self.removed.lock().unwrap().clone()
         }
     }
 
@@ -1218,6 +1223,7 @@ mod tests {
             _timeout: Duration,
         ) -> Result<(), AppError> {
             self.stopped.lock().unwrap().push(handle.session_id);
+            self.removed.lock().unwrap().push(handle.session_id);
             Ok(())
         }
 
@@ -1387,12 +1393,12 @@ mod tests {
                 .revoked
         );
         for _ in 0..20 {
-            if runtime.stopped().contains(&id) {
+            if runtime.stopped().contains(&id) && runtime.removed().contains(&id) {
                 return;
             }
             std::thread::sleep(Duration::from_millis(10));
         }
-        panic!("runtime stop was not called");
+        panic!("runtime cleanup was not called");
     }
 
     #[test]
@@ -1483,6 +1489,30 @@ mod tests {
         assert!(err.contains("container id container-123"), "{err}");
         assert!(err.contains("exitCode=127"), "{err}");
         assert!(err.contains("command not found: claude"), "{err}");
+    }
+
+    #[test]
+    fn handshake_timeout_error_leads_when_diagnostics_fail() {
+        let diagnostics = ContainerDiagnostics {
+            container_id: "container-123".to_string(),
+            state: None,
+            inspect_error: Some("inspect failed".to_string()),
+            log_tail: None,
+            logs_error: Some("logs failed".to_string()),
+        };
+
+        let err = ContainerTransportBackend::handshake_timeout_error(
+            Duration::from_secs(5),
+            Some(&diagnostics),
+        )
+        .to_string();
+
+        assert!(
+            err.starts_with("PTY error: container bridge did not attach within 5s"),
+            "{err}"
+        );
+        assert!(err.contains("container id container-123"), "{err}");
+        assert!(err.contains("logs unavailable: logs failed"), "{err}");
     }
 
     #[tokio::test]

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -1193,16 +1193,11 @@ mod tests {
     #[derive(Default)]
     struct RecordingRuntime {
         stopped: Arc<Mutex<Vec<Uuid>>>,
-        removed: Arc<Mutex<Vec<Uuid>>>,
     }
 
     impl RecordingRuntime {
         fn stopped(&self) -> Vec<Uuid> {
             self.stopped.lock().unwrap().clone()
-        }
-
-        fn removed(&self) -> Vec<Uuid> {
-            self.removed.lock().unwrap().clone()
         }
     }
 
@@ -1223,7 +1218,6 @@ mod tests {
             _timeout: Duration,
         ) -> Result<(), AppError> {
             self.stopped.lock().unwrap().push(handle.session_id);
-            self.removed.lock().unwrap().push(handle.session_id);
             Ok(())
         }
 
@@ -1393,12 +1387,12 @@ mod tests {
                 .revoked
         );
         for _ in 0..20 {
-            if runtime.stopped().contains(&id) && runtime.removed().contains(&id) {
+            if runtime.stopped().contains(&id) {
                 return;
             }
             std::thread::sleep(Duration::from_millis(10));
         }
-        panic!("runtime cleanup was not called");
+        panic!("runtime stop was not called");
     }
 
     #[test]

--- a/src-tauri/src/pty/container_runtime.rs
+++ b/src-tauri/src/pty/container_runtime.rs
@@ -12,7 +12,7 @@ pub const DEFAULT_API_HELPER_PATH: &str = "/usr/local/bin/agentscommander-api-he
 pub const CONTAINER_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 const DIAGNOSTIC_UI_LOG_LIMIT: usize = 500;
 const REDACTED_SECRET: &str = "[REDACTED]";
-// Keep AGENTSCOMMANDER_* entries in sync with container_backend::is_reserved_container_env.
+// Keep AGENTSCOMMANDER_* entries in sync with DockerRuntime::build_run_command.
 // This list is separate because diagnostics must also scrub valid provider env keys.
 const SENSITIVE_LOG_KEYS: &[&str] = &[
     "AGENTSCOMMANDER_API_TOKEN",
@@ -26,7 +26,14 @@ const SENSITIVE_LOG_KEYS: &[&str] = &[
     "GITHUB_TOKEN",
     "OPENAI_API_KEY",
 ];
-const SENSITIVE_TOKEN_PREFIXES: &[&str] = &["ac-container-", "acst-", "sk-ant-"];
+const SENSITIVE_TOKEN_PREFIXES: &[&str] = &[
+    "ac-container-",
+    "acst-",
+    "AIza",
+    "ghp_",
+    "sk-ant-",
+    "sk-proj-",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContainerStartRequest {
@@ -287,19 +294,31 @@ fn redact_key_values(input: &str, key: &str) -> String {
         while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
             cursor += 1;
         }
+        let mut quoted_key = false;
         if cursor < bytes.len() && (bytes[cursor] == b'"' || bytes[cursor] == b'\'') {
+            quoted_key = true;
             cursor += 1;
             while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
                 cursor += 1;
             }
         }
-        if cursor >= bytes.len() || !matches!(bytes[cursor], b'=' | b':') {
+        if quoted_key && cursor < bytes.len() && bytes[cursor] == b',' {
+            cursor += 1;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+            if cursor >= bytes.len() || !matches!(bytes[cursor], b'"' | b'\'') {
+                search_start = key_start + key.len();
+                continue;
+            }
+        } else if cursor < bytes.len() && matches!(bytes[cursor], b'=' | b':') {
+            cursor += 1;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+        } else {
             search_start = key_start + key.len();
             continue;
-        }
-        cursor += 1;
-        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
-            cursor += 1;
         }
 
         let (value_start, value_end) =
@@ -477,6 +496,23 @@ mod tests {
         let openai_key = "openai-secret-without-sensitive-prefix";
         let gemini_key = "gemini-secret-without-sensitive-prefix";
         let github_token = "github-token-without-sensitive-prefix";
+        let bare_openai_key = "sk-proj-bare-openai-secret";
+        let bare_gemini_key = "AIzaBareGeminiSecret";
+        let bare_github_token = "ghp_bare_github_secret";
+        let child_env = vec![
+            ("OPENAI_API_KEY".to_string(), openai_key.to_string()),
+            ("GEMINI_API_KEY".to_string(), gemini_key.to_string()),
+            ("GITHUB_TOKEN".to_string(), github_token.to_string()),
+            ("PATH".to_string(), "/usr/local/bin".to_string()),
+        ];
+        let child_env_json = serde_json::to_string(&child_env).expect("serialize child env");
+        let bridge_args = vec![
+            bare_openai_key,
+            bare_gemini_key,
+            bare_github_token,
+            "--verbose",
+        ];
+        let bridge_args_json = serde_json::to_string(&bridge_args).expect("serialize bridge args");
         let diagnostics = ContainerDiagnostics {
             container_id: "abc123".to_string(),
             state: None,
@@ -484,9 +520,8 @@ mod tests {
             log_tail: Some(format!(
                 "AGENTSCOMMANDER_API_TOKEN={api_token}\n\
                  AGENTSCOMMANDER_SESSION_REGISTRATION_TOKEN={registration_ticket}\n\
-                 OPENAI_API_KEY={openai_key}\n\
-                 GEMINI_API_KEY='{gemini_key}'\n\
-                 GITHUB_TOKEN: \"{github_token}\""
+                 AGENTSCOMMANDER_BRIDGE_ARGS_JSON={bridge_args_json}\n\
+                 AGENTSCOMMANDER_BRIDGE_ENV_JSON={child_env_json}"
             )),
             logs_error: Some(format!(
                 "failed after token {api_token} and ticket {registration_ticket}"
@@ -502,12 +537,21 @@ mod tests {
             openai_key,
             gemini_key,
             github_token,
+            bare_openai_key,
+            bare_gemini_key,
+            bare_github_token,
         ] {
             assert!(!ui.contains(secret), "{ui}");
             assert!(!full.contains(secret), "{full}");
         }
         assert!(ui.contains(REDACTED_SECRET), "{ui}");
         assert!(full.contains(REDACTED_SECRET), "{full}");
+        assert!(ui.contains("PATH"), "{ui}");
+        assert!(ui.contains("/usr/local/bin"), "{ui}");
+        assert!(full.contains("PATH"), "{full}");
+        assert!(full.contains("/usr/local/bin"), "{full}");
+        assert!(ui.contains("--verbose"), "{ui}");
+        assert!(full.contains("--verbose"), "{full}");
     }
 
     #[test]

--- a/src-tauri/src/pty/container_runtime.rs
+++ b/src-tauri/src/pty/container_runtime.rs
@@ -12,14 +12,21 @@ pub const DEFAULT_API_HELPER_PATH: &str = "/usr/local/bin/agentscommander-api-he
 pub const CONTAINER_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 const DIAGNOSTIC_UI_LOG_LIMIT: usize = 500;
 const REDACTED_SECRET: &str = "[REDACTED]";
+// Keep AGENTSCOMMANDER_* entries in sync with container_backend::is_reserved_container_env.
+// This list is separate because diagnostics must also scrub valid provider env keys.
 const SENSITIVE_LOG_KEYS: &[&str] = &[
+    "AGENTSCOMMANDER_API_TOKEN",
+    "AGENTSCOMMANDER_SESSION_REGISTRATION_TOKEN",
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_TOKEN",
     "CLAUDE_API_KEY",
     "CLAUDE_CODE_OAUTH_TOKEN",
+    "GEMINI_API_KEY",
+    "GITHUB_TOKEN",
+    "OPENAI_API_KEY",
 ];
-const SENSITIVE_TOKEN_PREFIXES: &[&str] = &["sk-ant-"];
+const SENSITIVE_TOKEN_PREFIXES: &[&str] = &["ac-container-", "acst-", "sk-ant-"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContainerStartRequest {
@@ -463,22 +470,42 @@ mod tests {
 
     #[test]
     fn container_diagnostics_redacts_tokens_from_ui_and_log_summary() {
-        let token = "sk-ant-oat01-abcdefghijklmnopqrstuvwxyz0123456789";
+        let api_token =
+            "ac-container-11111111-1111-4111-8111-111111111111-22222222-2222-4222-8222-222222222222";
+        let registration_ticket =
+            "acst-33333333-3333-4333-8333-333333333333-44444444-4444-4444-8444-444444444444";
+        let openai_key = "openai-secret-without-sensitive-prefix";
+        let gemini_key = "gemini-secret-without-sensitive-prefix";
+        let github_token = "github-token-without-sensitive-prefix";
         let diagnostics = ContainerDiagnostics {
             container_id: "abc123".to_string(),
             state: None,
             inspect_error: Some("inspect failed".to_string()),
             log_tail: Some(format!(
-                "CLAUDE_CODE_OAUTH_TOKEN={token}\nANTHROPIC_API_KEY=\"{token}\""
+                "AGENTSCOMMANDER_API_TOKEN={api_token}\n\
+                 AGENTSCOMMANDER_SESSION_REGISTRATION_TOKEN={registration_ticket}\n\
+                 OPENAI_API_KEY={openai_key}\n\
+                 GEMINI_API_KEY='{gemini_key}'\n\
+                 GITHUB_TOKEN: \"{github_token}\""
             )),
-            logs_error: Some(format!("failed after token {token}")),
+            logs_error: Some(format!(
+                "failed after token {api_token} and ticket {registration_ticket}"
+            )),
         };
 
         let ui = diagnostics.ui_summary();
         let full = diagnostics.log_summary();
 
-        assert!(!ui.contains(token), "{ui}");
-        assert!(!full.contains(token), "{full}");
+        for secret in [
+            api_token,
+            registration_ticket,
+            openai_key,
+            gemini_key,
+            github_token,
+        ] {
+            assert!(!ui.contains(secret), "{ui}");
+            assert!(!full.contains(secret), "{full}");
+        }
         assert!(ui.contains(REDACTED_SECRET), "{ui}");
         assert!(full.contains(REDACTED_SECRET), "{full}");
     }

--- a/src-tauri/src/pty/container_runtime.rs
+++ b/src-tauri/src/pty/container_runtime.rs
@@ -11,6 +11,15 @@ pub const DEFAULT_BRIDGE_ENTRYPOINT: &str = "session-bridge";
 pub const DEFAULT_API_HELPER_PATH: &str = "/usr/local/bin/agentscommander-api-helper";
 pub const CONTAINER_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 const DIAGNOSTIC_UI_LOG_LIMIT: usize = 500;
+const REDACTED_SECRET: &str = "[REDACTED]";
+const SENSITIVE_LOG_KEYS: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_TOKEN",
+    "CLAUDE_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+];
+const SENSITIVE_TOKEN_PREFIXES: &[&str] = &["sk-ant-"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContainerStartRequest {
@@ -75,14 +84,26 @@ impl ContainerDiagnostics {
 
     pub fn ui_summary(&self) -> String {
         let mut summary = self.state_summary();
-        if let Some(log_tail) = self.log_tail.as_deref().map(compact_log_tail) {
-            if !log_tail.is_empty() {
-                summary.push_str("; logs: ");
-                summary.push_str(&truncate_chars(&log_tail, DIAGNOSTIC_UI_LOG_LIMIT));
+        match self.log_tail.as_deref() {
+            Some(log_tail) => {
+                let redacted = redact_container_diagnostic_text(log_tail);
+                let compact = compact_log_tail_bounded(&redacted, DIAGNOSTIC_UI_LOG_LIMIT);
+                if !compact.is_empty() {
+                    summary.push_str("; logs: ");
+                    summary.push_str(&compact);
+                } else if let Some(err) = self.logs_error.as_deref() {
+                    summary.push_str("; logs unavailable: ");
+                    summary.push_str(&redact_and_truncate(err, DIAGNOSTIC_UI_LOG_LIMIT));
+                } else {
+                    summary.push_str("; logs: <empty>");
+                }
             }
-        } else if let Some(err) = self.logs_error.as_deref() {
-            summary.push_str("; logs unavailable: ");
-            summary.push_str(err);
+            None => {
+                if let Some(err) = self.logs_error.as_deref() {
+                    summary.push_str("; logs unavailable: ");
+                    summary.push_str(&redact_and_truncate(err, DIAGNOSTIC_UI_LOG_LIMIT));
+                }
+            }
         }
         summary
     }
@@ -95,8 +116,9 @@ impl ContainerDiagnostics {
         }
         match self.log_tail.as_deref() {
             Some(log_tail) if !log_tail.trim().is_empty() => {
+                let redacted = redact_container_diagnostic_text(log_tail);
                 summary.push_str("\ncontainer log tail:\n");
-                summary.push_str(log_tail.trim_end());
+                summary.push_str(redacted.trim_end());
             }
             _ => {
                 summary.push_str("\ncontainer log tail: <empty>");
@@ -104,7 +126,7 @@ impl ContainerDiagnostics {
         }
         if let Some(err) = self.logs_error.as_deref() {
             summary.push_str("\nlogs error: ");
-            summary.push_str(err);
+            summary.push_str(&redact_container_diagnostic_text(err));
         }
         summary
     }
@@ -190,8 +212,35 @@ pub fn api_url_for_container(bind: &str, port: u16) -> Result<String, AppError> 
     Ok(format!("http://{}:{}", host, port))
 }
 
-fn compact_log_tail(log_tail: &str) -> String {
-    log_tail.split_whitespace().collect::<Vec<_>>().join(" ")
+fn compact_log_tail_bounded(log_tail: &str, max_chars: usize) -> String {
+    let mut out = String::new();
+    let mut count = 0;
+    let mut truncated = false;
+    for token in log_tail.split_whitespace() {
+        if !out.is_empty() && !push_chars_bounded(&mut out, &mut count, " ", max_chars) {
+            truncated = true;
+            break;
+        }
+        if !push_chars_bounded(&mut out, &mut count, token, max_chars) {
+            truncated = true;
+            break;
+        }
+    }
+    if truncated {
+        out.push_str("...");
+    }
+    out
+}
+
+fn push_chars_bounded(out: &mut String, count: &mut usize, text: &str, max_chars: usize) -> bool {
+    for ch in text.chars() {
+        if *count >= max_chars {
+            return false;
+        }
+        out.push(ch);
+        *count += 1;
+    }
+    true
 }
 
 fn truncate_chars(value: &str, max_chars: usize) -> String {
@@ -201,6 +250,125 @@ fn truncate_chars(value: &str, max_chars: usize) -> String {
     let mut out = value.chars().take(max_chars).collect::<String>();
     out.push_str("...");
     out
+}
+
+fn redact_and_truncate(value: &str, max_chars: usize) -> String {
+    truncate_chars(&redact_container_diagnostic_text(value), max_chars)
+}
+
+fn redact_container_diagnostic_text(input: &str) -> String {
+    let mut redacted = input.to_string();
+    for key in SENSITIVE_LOG_KEYS {
+        redacted = redact_key_values(&redacted, key);
+    }
+    for prefix in SENSITIVE_TOKEN_PREFIXES {
+        redacted = redact_token_prefix(&redacted, prefix);
+    }
+    redacted
+}
+
+fn redact_key_values(input: &str, key: &str) -> String {
+    let lower = input.to_ascii_lowercase();
+    let key_lower = key.to_ascii_lowercase();
+    let bytes = input.as_bytes();
+    let mut ranges = Vec::new();
+    let mut search_start = 0;
+
+    while let Some(relative) = lower[search_start..].find(&key_lower) {
+        let key_start = search_start + relative;
+        let mut cursor = key_start + key.len();
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if cursor < bytes.len() && (bytes[cursor] == b'"' || bytes[cursor] == b'\'') {
+            cursor += 1;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+                cursor += 1;
+            }
+        }
+        if cursor >= bytes.len() || !matches!(bytes[cursor], b'=' | b':') {
+            search_start = key_start + key.len();
+            continue;
+        }
+        cursor += 1;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+
+        let (value_start, value_end) =
+            if cursor < bytes.len() && (bytes[cursor] == b'"' || bytes[cursor] == b'\'') {
+                let quote = bytes[cursor];
+                let value_start = cursor + 1;
+                let mut value_end = value_start;
+                while value_end < bytes.len() && bytes[value_end] != quote {
+                    value_end += 1;
+                }
+                (value_start, value_end)
+            } else {
+                let value_start = cursor;
+                let mut value_end = value_start;
+                while value_end < bytes.len() {
+                    if is_unquoted_secret_delimiter(bytes[value_end]) {
+                        break;
+                    }
+                    let ch = input[value_end..]
+                        .chars()
+                        .next()
+                        .expect("valid char boundary");
+                    value_end += ch.len_utf8();
+                }
+                (value_start, value_end)
+            };
+
+        if value_end > value_start {
+            ranges.push((value_start, value_end));
+        }
+        search_start = value_end.max(key_start + key.len());
+    }
+
+    if ranges.is_empty() {
+        return input.to_string();
+    }
+
+    let mut out = input.to_string();
+    for (start, end) in ranges.into_iter().rev() {
+        out.replace_range(start..end, REDACTED_SECRET);
+    }
+    out
+}
+
+fn is_unquoted_secret_delimiter(byte: u8) -> bool {
+    byte.is_ascii_whitespace() || matches!(byte, b',' | b';' | b'}' | b']')
+}
+
+fn redact_token_prefix(input: &str, prefix: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(input.len());
+    let mut cursor = 0;
+
+    while cursor < input.len() {
+        if input[cursor..].starts_with(prefix) {
+            let mut end = cursor + prefix.len();
+            while end < bytes.len() && is_token_char(bytes[end]) {
+                end += 1;
+            }
+            if end > cursor + prefix.len() {
+                out.push_str(REDACTED_SECRET);
+                cursor = end;
+                continue;
+            }
+        }
+
+        let ch = input[cursor..].chars().next().expect("valid char boundary");
+        out.push(ch);
+        cursor += ch.len_utf8();
+    }
+
+    out
+}
+
+fn is_token_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')
 }
 
 #[cfg(test)]
@@ -264,6 +432,7 @@ mod tests {
 
     #[test]
     fn container_diagnostics_formats_bounded_ui_and_full_log() {
+        let long_tail = "x".repeat(DIAGNOSTIC_UI_LOG_LIMIT + 25);
         let diagnostics = ContainerDiagnostics {
             container_id: "abc123".to_string(),
             state: Some(ContainerStateSnapshot {
@@ -273,7 +442,7 @@ mod tests {
                 error: None,
             }),
             inspect_error: None,
-            log_tail: Some("line one\nline two".to_string()),
+            log_tail: Some(format!("line one\n{long_tail}")),
             logs_error: None,
         };
 
@@ -281,12 +450,62 @@ mod tests {
         assert!(ui.contains("container id abc123"), "{ui}");
         assert!(ui.contains("status=exited"), "{ui}");
         assert!(ui.contains("exitCode=127"), "{ui}");
-        assert!(ui.contains("logs: line one line two"), "{ui}");
+        let ui_logs = ui.split("logs: ").nth(1).expect("ui logs");
+        assert!(ui_logs.ends_with("..."), "{ui}");
+        assert!(
+            ui_logs.chars().count() <= DIAGNOSTIC_UI_LOG_LIMIT + 3,
+            "{ui}"
+        );
 
         let full = diagnostics.log_summary();
+        assert!(full.contains(&long_tail), "{full}");
+    }
+
+    #[test]
+    fn container_diagnostics_redacts_tokens_from_ui_and_log_summary() {
+        let token = "sk-ant-oat01-abcdefghijklmnopqrstuvwxyz0123456789";
+        let diagnostics = ContainerDiagnostics {
+            container_id: "abc123".to_string(),
+            state: None,
+            inspect_error: Some("inspect failed".to_string()),
+            log_tail: Some(format!(
+                "CLAUDE_CODE_OAUTH_TOKEN={token}\nANTHROPIC_API_KEY=\"{token}\""
+            )),
+            logs_error: Some(format!("failed after token {token}")),
+        };
+
+        let ui = diagnostics.ui_summary();
+        let full = diagnostics.log_summary();
+
+        assert!(!ui.contains(token), "{ui}");
+        assert!(!full.contains(token), "{full}");
+        assert!(ui.contains(REDACTED_SECRET), "{ui}");
+        assert!(full.contains(REDACTED_SECRET), "{full}");
+    }
+
+    #[test]
+    fn ui_summary_reports_empty_tail_logs_error_bounded() {
+        let token = "sk-ant-oat01-abcdefghijklmnopqrstuvwxyz0123456789";
+        let diagnostics = ContainerDiagnostics {
+            container_id: "abc123".to_string(),
+            state: None,
+            inspect_error: None,
+            log_tail: Some(String::new()),
+            logs_error: Some(format!(
+                "docker logs failed CLAUDE_CODE_OAUTH_TOKEN={token} {}",
+                "e".repeat(DIAGNOSTIC_UI_LOG_LIMIT + 25)
+            )),
+        };
+
+        let ui = diagnostics.ui_summary();
+        let ui_error = ui.split("logs unavailable: ").nth(1).expect("logs error");
+
+        assert!(ui.contains("logs unavailable"), "{ui}");
+        assert!(!ui.contains(token), "{ui}");
+        assert!(ui.contains(REDACTED_SECRET), "{ui}");
         assert!(
-            full.contains("container log tail:\nline one\nline two"),
-            "{full}"
+            ui_error.chars().count() <= DIAGNOSTIC_UI_LOG_LIMIT + 3,
+            "{ui}"
         );
     }
 }

--- a/src-tauri/src/pty/container_runtime.rs
+++ b/src-tauri/src/pty/container_runtime.rs
@@ -6,11 +6,11 @@ use uuid::Uuid;
 use crate::errors::AppError;
 
 pub const SESSION_LABEL: &str = "com.agentscommander.session";
-pub const DEFAULT_CONTAINER_IMAGE: &str = "agentscommander/session-bridge:latest";
 pub const DEFAULT_CONTAINER_WORKDIR: &str = "/workspace";
 pub const DEFAULT_BRIDGE_ENTRYPOINT: &str = "session-bridge";
 pub const DEFAULT_API_HELPER_PATH: &str = "/usr/local/bin/agentscommander-api-helper";
 pub const CONTAINER_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+const DIAGNOSTIC_UI_LOG_LIMIT: usize = 500;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContainerStartRequest {
@@ -42,10 +42,107 @@ pub struct ContainerCleanupReport {
     pub invalid_labels: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ContainerStateSnapshot {
+    pub status: Option<String>,
+    pub running: Option<bool>,
+    pub exit_code: Option<i64>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContainerDiagnostics {
+    pub container_id: String,
+    pub state: Option<ContainerStateSnapshot>,
+    pub inspect_error: Option<String>,
+    pub log_tail: Option<String>,
+    pub logs_error: Option<String>,
+}
+
+impl ContainerDiagnostics {
+    pub fn unavailable(
+        handle: &ContainerRuntimeHandle,
+        error: impl Into<String>,
+    ) -> ContainerDiagnostics {
+        ContainerDiagnostics {
+            container_id: handle.container_id.clone(),
+            state: None,
+            inspect_error: Some(error.into()),
+            log_tail: None,
+            logs_error: None,
+        }
+    }
+
+    pub fn ui_summary(&self) -> String {
+        let mut summary = self.state_summary();
+        if let Some(log_tail) = self.log_tail.as_deref().map(compact_log_tail) {
+            if !log_tail.is_empty() {
+                summary.push_str("; logs: ");
+                summary.push_str(&truncate_chars(&log_tail, DIAGNOSTIC_UI_LOG_LIMIT));
+            }
+        } else if let Some(err) = self.logs_error.as_deref() {
+            summary.push_str("; logs unavailable: ");
+            summary.push_str(err);
+        }
+        summary
+    }
+
+    pub fn log_summary(&self) -> String {
+        let mut summary = self.state_summary();
+        if let Some(err) = self.inspect_error.as_deref() {
+            summary.push_str("\ninspect error: ");
+            summary.push_str(err);
+        }
+        match self.log_tail.as_deref() {
+            Some(log_tail) if !log_tail.trim().is_empty() => {
+                summary.push_str("\ncontainer log tail:\n");
+                summary.push_str(log_tail.trim_end());
+            }
+            _ => {
+                summary.push_str("\ncontainer log tail: <empty>");
+            }
+        }
+        if let Some(err) = self.logs_error.as_deref() {
+            summary.push_str("\nlogs error: ");
+            summary.push_str(err);
+        }
+        summary
+    }
+
+    fn state_summary(&self) -> String {
+        let mut parts = vec![format!("container id {}", self.container_id)];
+        if let Some(state) = &self.state {
+            if let Some(status) = state.status.as_deref().filter(|value| !value.is_empty()) {
+                parts.push(format!("status={status}"));
+            }
+            if let Some(running) = state.running {
+                parts.push(format!("running={running}"));
+            }
+            if let Some(exit_code) = state.exit_code {
+                parts.push(format!("exitCode={exit_code}"));
+            }
+            if let Some(error) = state.error.as_deref().filter(|value| !value.is_empty()) {
+                parts.push(format!("stateError={error}"));
+            }
+        } else if self.inspect_error.is_some() {
+            parts.push("state unavailable".to_string());
+        }
+        parts.join(", ")
+    }
+}
+
 pub trait ContainerRuntime: Send + Sync {
     fn start(&self, request: ContainerStartRequest) -> Result<ContainerRuntimeHandle, AppError>;
 
     fn stop(&self, handle: &ContainerRuntimeHandle, timeout: Duration) -> Result<(), AppError>;
+
+    fn diagnostics(
+        &self,
+        handle: &ContainerRuntimeHandle,
+        _log_tail_lines: usize,
+    ) -> ContainerDiagnostics {
+        ContainerDiagnostics::unavailable(handle, "container runtime diagnostics are not supported")
+    }
 
     fn cleanup_labeled_orphans(
         &self,
@@ -54,18 +151,21 @@ pub trait ContainerRuntime: Send + Sync {
     ) -> Result<ContainerCleanupReport, AppError>;
 }
 
-pub fn container_image_from_env() -> String {
+pub fn container_image_from_env() -> Option<String> {
     std::env::var("AGENTSCOMMANDER_CONTAINER_IMAGE")
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| DEFAULT_CONTAINER_IMAGE.to_string())
 }
 
-pub fn resolve_container_image(per_agent: Option<&str>) -> String {
+pub fn resolve_container_image(per_agent: Option<&str>) -> Result<String, AppError> {
     match per_agent.map(str::trim).filter(|image| !image.is_empty()) {
-        Some(image) => image.to_string(),
-        None => container_image_from_env(),
+        Some(image) => Ok(image.to_string()),
+        None => container_image_from_env().ok_or_else(|| {
+            AppError::Other(
+                "containerTransport requires backend.image (container image); set the agent's backend.image field or AGENTSCOMMANDER_CONTAINER_IMAGE before launch".to_string(),
+            )
+        }),
     }
 }
 
@@ -88,6 +188,19 @@ pub fn api_url_for_container(bind: &str, port: u16) -> Result<String, AppError> 
         other => other,
     };
     Ok(format!("http://{}:{}", host, port))
+}
+
+fn compact_log_tail(log_tail: &str) -> String {
+    log_tail.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut out = value.chars().take(max_chars).collect::<String>();
+    out.push_str("...");
+    out
 }
 
 #[cfg(test)]
@@ -125,22 +238,55 @@ mod tests {
     }
 
     #[test]
-    fn resolve_container_image_uses_per_agent_env_then_default() {
+    fn resolve_container_image_uses_per_agent_then_env() {
         with_container_image_env(Some("env/image:latest"), || {
             assert_eq!(
-                resolve_container_image(Some(" per-agent/image:latest ")),
+                resolve_container_image(Some(" per-agent/image:latest ")).unwrap(),
                 "per-agent/image:latest"
             );
-            assert_eq!(resolve_container_image(Some("  ")), "env/image:latest");
-            assert_eq!(resolve_container_image(None), "env/image:latest");
+            assert_eq!(
+                resolve_container_image(Some("  ")).unwrap(),
+                "env/image:latest"
+            );
+            assert_eq!(resolve_container_image(None).unwrap(), "env/image:latest");
         });
 
         with_container_image_env(Some("  "), || {
-            assert_eq!(resolve_container_image(None), DEFAULT_CONTAINER_IMAGE);
+            let err = resolve_container_image(None).unwrap_err().to_string();
+            assert!(err.contains("backend.image"), "{err}");
         });
 
         with_container_image_env(None, || {
-            assert_eq!(resolve_container_image(None), DEFAULT_CONTAINER_IMAGE);
+            let err = resolve_container_image(None).unwrap_err().to_string();
+            assert!(err.contains("AGENTSCOMMANDER_CONTAINER_IMAGE"), "{err}");
         });
+    }
+
+    #[test]
+    fn container_diagnostics_formats_bounded_ui_and_full_log() {
+        let diagnostics = ContainerDiagnostics {
+            container_id: "abc123".to_string(),
+            state: Some(ContainerStateSnapshot {
+                status: Some("exited".to_string()),
+                running: Some(false),
+                exit_code: Some(127),
+                error: None,
+            }),
+            inspect_error: None,
+            log_tail: Some("line one\nline two".to_string()),
+            logs_error: None,
+        };
+
+        let ui = diagnostics.ui_summary();
+        assert!(ui.contains("container id abc123"), "{ui}");
+        assert!(ui.contains("status=exited"), "{ui}");
+        assert!(ui.contains("exitCode=127"), "{ui}");
+        assert!(ui.contains("logs: line one line two"), "{ui}");
+
+        let full = diagnostics.log_summary();
+        assert!(
+            full.contains("container log tail:\nline one\nline two"),
+            "{full}"
+        );
     }
 }

--- a/src-tauri/src/pty/docker_runtime.rs
+++ b/src-tauri/src/pty/docker_runtime.rs
@@ -15,6 +15,7 @@ use crate::pty::container_runtime::{
 
 const DOCKER_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 const DOCKER_COMMAND_POLL: Duration = Duration::from_millis(50);
+const DOCKER_COMMAND_OUTPUT_BYTE_LIMIT: usize = 64 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DockerCommandSpec {
@@ -22,14 +23,85 @@ pub struct DockerCommandSpec {
     pub args: Vec<String>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct CappedCommandStream {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
 struct DockerCommandOutput {
-    stdout: Vec<u8>,
-    stderr: Vec<u8>,
+    stdout: CappedCommandStream,
+    stderr: CappedCommandStream,
+}
+
+impl DockerCommandOutput {
+    #[cfg(test)]
+    fn empty() -> Self {
+        Self {
+            stdout: CappedCommandStream::default(),
+            stderr: CappedCommandStream::default(),
+        }
+    }
+}
+
+impl CappedCommandStream {
+    fn trimmed_text(&self) -> String {
+        let mut text = String::from_utf8_lossy(&self.bytes).trim().to_string();
+        if self.truncated {
+            append_truncation_marker(&mut text);
+        }
+        text
+    }
+
+    fn trim_end_text(&self) -> String {
+        let mut text = String::from_utf8_lossy(&self.bytes).trim_end().to_string();
+        if self.truncated {
+            append_truncation_marker(&mut text);
+        }
+        text
+    }
+}
+
+fn append_truncation_marker(text: &mut String) {
+    if !text.is_empty() {
+        text.push('\n');
+    }
+    text.push_str("[output truncated]");
+}
+
+fn read_capped_to_end<R: Read>(
+    mut reader: R,
+    limit: usize,
+) -> std::io::Result<CappedCommandStream> {
+    let mut output = CappedCommandStream {
+        bytes: Vec::with_capacity(limit.min(8 * 1024)),
+        truncated: false,
+    };
+    let mut chunk = [0_u8; 8 * 1024];
+    loop {
+        let n = reader.read(&mut chunk)?;
+        if n == 0 {
+            break;
+        }
+        let remaining = limit.saturating_sub(output.bytes.len());
+        if remaining > 0 {
+            let keep = n.min(remaining);
+            output.bytes.extend_from_slice(&chunk[..keep]);
+            if keep < n {
+                output.truncated = true;
+            }
+        } else {
+            output.truncated = true;
+        }
+    }
+    Ok(output)
 }
 
 #[derive(Debug, Clone)]
 pub struct DockerRuntime {
     program: String,
+    #[cfg(test)]
+    recorded_commands: Option<std::sync::Arc<std::sync::Mutex<Vec<DockerCommandSpec>>>>,
 }
 
 impl Default for DockerRuntime {
@@ -42,6 +114,8 @@ impl DockerRuntime {
     pub fn new() -> Self {
         Self {
             program: "docker".to_string(),
+            #[cfg(test)]
+            recorded_commands: None,
         }
     }
 
@@ -49,6 +123,18 @@ impl DockerRuntime {
     pub(crate) fn with_program(program: impl Into<String>) -> Self {
         Self {
             program: program.into(),
+            recorded_commands: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_recorded_commands(
+        program: impl Into<String>,
+        recorded_commands: std::sync::Arc<std::sync::Mutex<Vec<DockerCommandSpec>>>,
+    ) -> Self {
+        Self {
+            program: program.into(),
+            recorded_commands: Some(recorded_commands),
         }
     }
 
@@ -188,6 +274,12 @@ impl DockerRuntime {
     }
 
     fn run_command_output(&self, spec: DockerCommandSpec) -> Result<DockerCommandOutput, AppError> {
+        #[cfg(test)]
+        if let Some(recorded_commands) = &self.recorded_commands {
+            recorded_commands.lock().unwrap().push(spec);
+            return Ok(DockerCommandOutput::empty());
+        }
+
         let mut child = Command::new(&spec.program)
             .args(&spec.args)
             .stdout(Stdio::piped())
@@ -210,12 +302,10 @@ impl DockerRuntime {
             ));
         };
         let stdout_reader = std::thread::spawn(move || {
-            let mut buf = Vec::new();
-            stdout.read_to_end(&mut buf).map(|_| buf)
+            read_capped_to_end(&mut stdout, DOCKER_COMMAND_OUTPUT_BYTE_LIMIT)
         });
         let stderr_reader = std::thread::spawn(move || {
-            let mut buf = Vec::new();
-            stderr.read_to_end(&mut buf).map(|_| buf)
+            read_capped_to_end(&mut stderr, DOCKER_COMMAND_OUTPUT_BYTE_LIMIT)
         });
 
         let deadline = Instant::now() + DOCKER_COMMAND_TIMEOUT;
@@ -250,8 +340,8 @@ impl DockerRuntime {
         let stdout = join_command_reader(stdout_reader, "stdout")?;
         let stderr = join_command_reader(stderr_reader, "stderr")?;
         if !status.success() {
-            let stderr_text = String::from_utf8_lossy(&stderr);
-            let stdout_text = String::from_utf8_lossy(&stdout);
+            let stderr_text = stderr.trimmed_text();
+            let stdout_text = stdout.trimmed_text();
             let detail = if stderr_text.trim().is_empty() {
                 stdout_text.trim()
             } else {
@@ -267,7 +357,9 @@ impl DockerRuntime {
 
     fn run_command(&self, spec: DockerCommandSpec) -> Result<String, AppError> {
         let output = self.run_command_output(spec)?;
-        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        Ok(String::from_utf8_lossy(&output.stdout.bytes)
+            .trim()
+            .to_string())
     }
 
     fn parse_labeled_containers(raw: &str) -> Vec<(String, String)> {
@@ -309,8 +401,8 @@ impl DockerRuntime {
     }
 
     fn combined_output_text(output: DockerCommandOutput) -> Option<String> {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = output.stdout.trim_end_text();
+        let stderr = output.stderr.trim_end_text();
         let stdout = stdout.trim_end();
         let stderr = stderr.trim_end();
         match (stdout.is_empty(), stderr.is_empty()) {
@@ -323,9 +415,9 @@ impl DockerRuntime {
 }
 
 fn join_command_reader(
-    reader: JoinHandle<std::io::Result<Vec<u8>>>,
+    reader: JoinHandle<std::io::Result<CappedCommandStream>>,
     stream_name: &'static str,
-) -> Result<Vec<u8>, AppError> {
+) -> Result<CappedCommandStream, AppError> {
     reader
         .join()
         .map_err(|_| {
@@ -446,8 +538,11 @@ impl ContainerRuntime for DockerRuntime {
 mod tests {
     use super::*;
     use crate::pty::container_runtime::{
-        ContainerStartRequest, DEFAULT_API_HELPER_PATH, DEFAULT_CONTAINER_WORKDIR, SESSION_LABEL,
+        ContainerRuntime, ContainerStartRequest, DEFAULT_API_HELPER_PATH,
+        DEFAULT_CONTAINER_WORKDIR, SESSION_LABEL,
     };
+    use std::io::Cursor;
+    use std::sync::{Arc, Mutex};
 
     fn request() -> ContainerStartRequest {
         ContainerStartRequest {
@@ -543,6 +638,38 @@ mod tests {
         let list = runtime.build_list_labeled_command();
         assert_eq!(list.args[0], "ps");
         assert!(list.args.contains(&format!("label={}", SESSION_LABEL)));
+    }
+
+    #[test]
+    fn stop_runs_force_remove_after_successful_stop() {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let runtime = DockerRuntime::with_recorded_commands("docker-test", recorded.clone());
+        let handle = ContainerRuntimeHandle {
+            session_id: Uuid::nil(),
+            container_id: "abc123".to_string(),
+        };
+
+        runtime.stop(&handle, Duration::from_secs(5)).unwrap();
+
+        let commands = recorded.lock().unwrap().clone();
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0].args, vec!["stop", "--time", "5", "abc123"]);
+        assert_eq!(commands[1].args, vec!["rm", "-f", "abc123"]);
+    }
+
+    #[test]
+    fn read_capped_to_end_retains_limit_and_reports_truncation() {
+        let oversized = vec![b'x'; DOCKER_COMMAND_OUTPUT_BYTE_LIMIT + 17];
+        let capped =
+            read_capped_to_end(Cursor::new(oversized), DOCKER_COMMAND_OUTPUT_BYTE_LIMIT).unwrap();
+        assert_eq!(capped.bytes.len(), DOCKER_COMMAND_OUTPUT_BYTE_LIMIT);
+        assert!(capped.truncated);
+
+        let exact = vec![b'y'; DOCKER_COMMAND_OUTPUT_BYTE_LIMIT];
+        let uncapped =
+            read_capped_to_end(Cursor::new(exact), DOCKER_COMMAND_OUTPUT_BYTE_LIMIT).unwrap();
+        assert_eq!(uncapped.bytes.len(), DOCKER_COMMAND_OUTPUT_BYTE_LIMIT);
+        assert!(!uncapped.truncated);
     }
 
     #[test]

--- a/src-tauri/src/pty/docker_runtime.rs
+++ b/src-tauri/src/pty/docker_runtime.rs
@@ -8,8 +8,9 @@ use uuid::Uuid;
 
 use crate::errors::AppError;
 use crate::pty::container_runtime::{
-    ContainerCleanupReport, ContainerRuntime, ContainerRuntimeHandle, ContainerStartRequest,
-    DEFAULT_API_HELPER_PATH, DEFAULT_BRIDGE_ENTRYPOINT, SESSION_LABEL,
+    ContainerCleanupReport, ContainerDiagnostics, ContainerRuntime, ContainerRuntimeHandle,
+    ContainerStartRequest, ContainerStateSnapshot, DEFAULT_API_HELPER_PATH,
+    DEFAULT_BRIDGE_ENTRYPOINT, SESSION_LABEL,
 };
 
 const DOCKER_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
@@ -19,6 +20,11 @@ const DOCKER_COMMAND_POLL: Duration = Duration::from_millis(50);
 pub struct DockerCommandSpec {
     pub program: String,
     pub args: Vec<String>,
+}
+
+struct DockerCommandOutput {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
 }
 
 #[derive(Debug, Clone)]
@@ -53,7 +59,6 @@ impl DockerRuntime {
 
         let mut args = vec![
             "run".to_string(),
-            "--rm".to_string(),
             "-d".to_string(),
             "--label".to_string(),
             format!("{}={}", SESSION_LABEL, request.session_id),
@@ -137,6 +142,37 @@ impl DockerRuntime {
         }
     }
 
+    pub fn build_inspect_state_command(
+        &self,
+        handle: &ContainerRuntimeHandle,
+    ) -> DockerCommandSpec {
+        DockerCommandSpec {
+            program: self.program.clone(),
+            args: vec![
+                "inspect".to_string(),
+                "--format".to_string(),
+                "{{json .State}}".to_string(),
+                handle.container_id.clone(),
+            ],
+        }
+    }
+
+    pub fn build_logs_command(
+        &self,
+        handle: &ContainerRuntimeHandle,
+        tail_lines: usize,
+    ) -> DockerCommandSpec {
+        DockerCommandSpec {
+            program: self.program.clone(),
+            args: vec![
+                "logs".to_string(),
+                "--tail".to_string(),
+                tail_lines.to_string(),
+                handle.container_id.clone(),
+            ],
+        }
+    }
+
     pub fn build_list_labeled_command(&self) -> DockerCommandSpec {
         DockerCommandSpec {
             program: self.program.clone(),
@@ -151,7 +187,7 @@ impl DockerRuntime {
         }
     }
 
-    fn run_command(&self, spec: DockerCommandSpec) -> Result<String, AppError> {
+    fn run_command_output(&self, spec: DockerCommandSpec) -> Result<DockerCommandOutput, AppError> {
         let mut child = Command::new(&spec.program)
             .args(&spec.args)
             .stdout(Stdio::piped())
@@ -214,14 +250,24 @@ impl DockerRuntime {
         let stdout = join_command_reader(stdout_reader, "stdout")?;
         let stderr = join_command_reader(stderr_reader, "stderr")?;
         if !status.success() {
-            let stderr = String::from_utf8_lossy(&stderr);
+            let stderr_text = String::from_utf8_lossy(&stderr);
+            let stdout_text = String::from_utf8_lossy(&stdout);
+            let detail = if stderr_text.trim().is_empty() {
+                stdout_text.trim()
+            } else {
+                stderr_text.trim()
+            };
             return Err(AppError::PtyError(format!(
                 "container runtime command exited {}: {}",
-                status,
-                stderr.trim()
+                status, detail
             )));
         }
-        Ok(String::from_utf8_lossy(&stdout).trim().to_string())
+        Ok(DockerCommandOutput { stdout, stderr })
+    }
+
+    fn run_command(&self, spec: DockerCommandSpec) -> Result<String, AppError> {
+        let output = self.run_command_output(spec)?;
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
     fn parse_labeled_containers(raw: &str) -> Vec<(String, String)> {
@@ -237,6 +283,42 @@ impl DockerRuntime {
                 }
             })
             .collect()
+    }
+
+    fn parse_container_state(raw: &str) -> Result<ContainerStateSnapshot, AppError> {
+        #[derive(serde::Deserialize)]
+        struct DockerState {
+            #[serde(rename = "Status")]
+            status: Option<String>,
+            #[serde(rename = "Running")]
+            running: Option<bool>,
+            #[serde(rename = "ExitCode")]
+            exit_code: Option<i64>,
+            #[serde(rename = "Error")]
+            error: Option<String>,
+        }
+
+        let state: DockerState = serde_json::from_str(raw)
+            .map_err(|e| AppError::PtyError(format!("container state JSON parse failed: {e}")))?;
+        Ok(ContainerStateSnapshot {
+            status: state.status,
+            running: state.running,
+            exit_code: state.exit_code,
+            error: state.error,
+        })
+    }
+
+    fn combined_output_text(output: DockerCommandOutput) -> Option<String> {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = stdout.trim_end();
+        let stderr = stderr.trim_end();
+        match (stdout.is_empty(), stderr.is_empty()) {
+            (true, true) => None,
+            (false, true) => Some(stdout.to_string()),
+            (true, false) => Some(stderr.to_string()),
+            (false, false) => Some(format!("{stdout}\n{stderr}")),
+        }
     }
 }
 
@@ -278,17 +360,41 @@ impl ContainerRuntime for DockerRuntime {
     }
 
     fn stop(&self, handle: &ContainerRuntimeHandle, timeout: Duration) -> Result<(), AppError> {
-        match self.run_command(self.build_stop_command(handle, timeout)) {
-            Ok(_) => Ok(()),
-            Err(stop_err) => {
-                log::warn!(
-                    "[container-runtime] graceful stop failed for session {}: {}",
-                    handle.session_id,
-                    stop_err
-                );
-                self.run_command(self.build_force_remove_command(handle))
-                    .map(|_| ())
-            }
+        if let Err(stop_err) = self.run_command(self.build_stop_command(handle, timeout)) {
+            log::warn!(
+                "[container-runtime] graceful stop failed for session {}: {}",
+                handle.session_id,
+                stop_err
+            );
+        }
+        self.run_command(self.build_force_remove_command(handle))
+            .map(|_| ())
+    }
+
+    fn diagnostics(
+        &self,
+        handle: &ContainerRuntimeHandle,
+        log_tail_lines: usize,
+    ) -> ContainerDiagnostics {
+        let (state, inspect_error) =
+            match self.run_command(self.build_inspect_state_command(handle)) {
+                Ok(raw) => match Self::parse_container_state(&raw) {
+                    Ok(state) => (Some(state), None),
+                    Err(err) => (None, Some(err.to_string())),
+                },
+                Err(err) => (None, Some(err.to_string())),
+            };
+        let (log_tail, logs_error) =
+            match self.run_command_output(self.build_logs_command(handle, log_tail_lines)) {
+                Ok(output) => (Self::combined_output_text(output), None),
+                Err(err) => (None, Some(err.to_string())),
+            };
+        ContainerDiagnostics {
+            container_id: handle.container_id.clone(),
+            state,
+            inspect_error,
+            log_tail,
+            logs_error,
         }
     }
 
@@ -369,6 +475,7 @@ mod tests {
 
         assert_eq!(spec.program, "docker-test");
         assert!(spec.args.iter().any(|arg| arg == "-d"));
+        assert!(!spec.args.iter().any(|arg| arg == "--rm"));
         assert!(!spec
             .args
             .iter()
@@ -424,6 +531,15 @@ mod tests {
         let stop = runtime.build_stop_command(&handle, Duration::from_secs(5));
         assert_eq!(stop.args, vec!["stop", "--time", "5", "abc123"]);
 
+        let inspect = runtime.build_inspect_state_command(&handle);
+        assert_eq!(
+            inspect.args,
+            vec!["inspect", "--format", "{{json .State}}", "abc123"]
+        );
+
+        let logs = runtime.build_logs_command(&handle, 80);
+        assert_eq!(logs.args, vec!["logs", "--tail", "80", "abc123"]);
+
         let list = runtime.build_list_labeled_command();
         assert_eq!(list.args[0], "ps");
         assert!(list.args.contains(&format!("label={}", SESSION_LABEL)));
@@ -439,5 +555,16 @@ mod tests {
                 "11111111-1111-4111-8111-111111111111".to_string()
             )]
         );
+    }
+
+    #[test]
+    fn parse_container_state_reads_docker_inspect_state_json() {
+        let raw = r#"{"Status":"exited","Running":false,"ExitCode":127,"Error":""}"#;
+        let state = DockerRuntime::parse_container_state(raw).unwrap();
+
+        assert_eq!(state.status.as_deref(), Some("exited"));
+        assert_eq!(state.running, Some(false));
+        assert_eq!(state.exit_code, Some(127));
+        assert_eq!(state.error.as_deref(), Some(""));
     }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -125,7 +125,7 @@ export interface ConfigSeedConfig {
 
 export interface AgentBackendConfig {
   kind?: SessionBackendKind;
-  /** #868 - per-agent Docker image override; empty/undefined falls back to env then default. */
+  /** #868 - per-agent Docker image; empty/undefined requires AGENTSCOMMANDER_CONTAINER_IMAGE at launch. */
   image?: string;
 }
 

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -572,6 +572,9 @@ describe("SettingsModal automation hooks", () => {
     expect(runtime.value).toBe("localProcess");
     expect(document.querySelector('[data-ac-testid="settings.agentRow.0.containerImage"]')).toBeNull();
     expect(
+      document.querySelector('[data-ac-testid="settings.agentRow.0.containerWarning.image"]'),
+    ).toBeNull();
+    expect(
       document.querySelector('[data-ac-testid="settings.agentRow.0.containerWarning.apiServer"]'),
     ).toBeNull();
     expect(
@@ -583,7 +586,19 @@ describe("SettingsModal automation hooks", () => {
     await settle();
 
     const image = byTestId<HTMLInputElement>("settings.agentRow.0.containerImage");
-    expect(image.placeholder).toBe("agentscommander/session-bridge:latest");
+    expect(image.placeholder).toBe(
+      "Required unless AGENTSCOMMANDER_CONTAINER_IMAGE is set",
+    );
+    const imageHint = byTestId("settings.agentRow.0.containerHint.image").textContent ?? "";
+    expect(imageHint).toContain(
+      "Set a Docker image here, for example agentscommander/ac-claude:latest.",
+    );
+    expect(imageHint).toContain("AGENTSCOMMANDER_CONTAINER_IMAGE");
+    expect(imageHint).toContain("no built-in image fallback");
+    expect(imageHint).not.toContain("agentscommander/session-bridge:latest");
+    expect(byTestId("settings.agentRow.0.containerWarning.image").textContent).toContain(
+      "Saving this blank relies on AGENTSCOMMANDER_CONTAINER_IMAGE",
+    );
     expect(byTestId("settings.agentRow.0.containerWarning.apiServer").textContent).toContain(
       "API server enabled",
     );
@@ -597,11 +612,47 @@ describe("SettingsModal automation hooks", () => {
 
     expect(document.querySelector('[data-ac-testid="settings.agentRow.0.containerImage"]')).toBeNull();
     expect(
+      document.querySelector('[data-ac-testid="settings.agentRow.0.containerWarning.image"]'),
+    ).toBeNull();
+    expect(
       document.querySelector('[data-ac-testid="settings.agentRow.0.containerWarning.apiServer"]'),
     ).toBeNull();
     expect(
       document.querySelector('[data-ac-testid="settings.agentRow.0.containerWarning.bind"]'),
     ).toBeNull();
+
+    dispose();
+  });
+
+  it("does not synthesize a container image when the field is left blank", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    const runtime = byTestId<HTMLSelectElement>("settings.agentRow.0.runtimeKind");
+    runtime.value = "containerTransport";
+    runtime.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+
+    expect(document.body.textContent).not.toContain(
+      "agentscommander/session-bridge:latest",
+    );
+    expect(byTestId<HTMLInputElement>("settings.agentRow.0.containerImage").value).toBe("");
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.agents[0]?.backend).toEqual({
+      kind: "containerTransport",
+    });
+    expect(saved?.agents[0]?.backend?.image).toBeUndefined();
 
     dispose();
   });

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -114,7 +114,7 @@ const resolveSettingsSection = (s: string | undefined): SettingsTab =>
       : "general";
 
 const BYTES_PER_GIB = 1024 ** 3;
-const DEFAULT_CONTAINER_IMAGE = "agentscommander/session-bridge:latest";
+const CONTAINER_IMAGE_EXAMPLE = "agentscommander/ac-claude:latest";
 
 const bytesToGiBInput = (bytes: number): string => {
   const value = bytes / BYTES_PER_GIB;
@@ -1945,6 +1945,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     const expanded = () => activeAgentId() === agent.id;
     const pill = () => railPillFor(agent.id);
     const agentBackendKind = () => agent.backend?.kind ?? "localProcess";
+    const containerImageMissing = () => !agent.backend?.image?.trim();
     const containerBindWarning = () => isContainerLoopbackBind(settings.data?.apiServerBind);
     return (
       <div
@@ -2087,7 +2088,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                   class="settings-input"
                   value={agent.backend?.image ?? ""}
                   onInput={(e) => setAgentBackendImage(i(), e.currentTarget.value)}
-                  placeholder={DEFAULT_CONTAINER_IMAGE}
+                  placeholder="Required unless AGENTSCOMMANDER_CONTAINER_IMAGE is set"
                   data-ac-testid={`settings.agentRow.${i()}.containerImage`}
                   data-ac-role="textbox"
                 />
@@ -2096,9 +2097,20 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                 class="settings-hint"
                 data-ac-testid={`settings.agentRow.${i()}.containerHint.image`}
               >
-                Leave blank to use the host default. Resolution: this field, then
-                AGENTSCOMMANDER_CONTAINER_IMAGE, then {DEFAULT_CONTAINER_IMAGE}.
+                Set a Docker image here, for example {CONTAINER_IMAGE_EXAMPLE}. Leave
+                blank only if the AgentsCommander process has
+                AGENTSCOMMANDER_CONTAINER_IMAGE set; there is no built-in image fallback.
               </div>
+              <Show when={containerImageMissing()}>
+                <div
+                  class="settings-hint settings-hint-warning"
+                  data-ac-testid={`settings.agentRow.${i()}.containerWarning.image`}
+                  data-ac-role="status"
+                >
+                  Saving this blank relies on AGENTSCOMMANDER_CONTAINER_IMAGE; launch
+                  will fail if it is not set.
+                </div>
+              </Show>
               <Show when={!apiServerChecked()}>
                 <div
                   class="settings-hint settings-hint-warning"


### PR DESCRIPTION
Closes #892
Closes #893

## Why

A user configured a coding agent with `backend.kind = "containerTransport"` and got exactly one line back:

```
PTY error: container bridge did not attach within 5s
```

The real cause: no `backend.image` was set, so image resolution fell through to the default `agentscommander/session-bridge:latest`, which is the bridge base layer and contains **no coding agent binary at all**. Verified directly:

```
$ docker run --rm --entrypoint sh agentscommander/session-bridge:latest -c "command -v claude || echo NO_CLAUDE"
NO_CLAUDE
```

The container started, could not spawn `claude`, died, and was auto-removed before AgentsCommander could inspect it. Diagnosing it required a human to reason about image resolution and then run `docker run` by hand.

## What changed

**#892, surface the real failure.** On attach timeout, capture `docker inspect` state and a bounded `docker logs` tail **before** cleanup destroys the container. Container id, running flag, exit code and a compact log excerpt now reach the UI error and `app.log`. Containers are no longer started with `--rm`; cleanup runs `docker stop` then `docker rm -f`, so evidence survives long enough to be read.

**#893, no more guaranteed-failure default.** `resolve_container_image` requires either the per-agent `backend.image` or the `AGENTSCOMMANDER_CONTAINER_IMAGE` env override, and fails fast naming both. The Settings UI, its tests, and `docs/reference/cli.md` no longer advertise a built-in fallback that does not exist; a blank image field now shows an inline warning instead of a placeholder promising a default.

**Secret redaction, the reason this took four rounds.** Piping container stdout into `app.log` and a UI toast is a channel `main` never had. Three separate leaks were found and closed by adversarial review, each with a working reproduction:

1. The `docker logs` tail was passed through verbatim. An image that prints its environment on a startup crash would write a live `CLAUDE_CODE_OAUTH_TOKEN` into a toast and into `app.log`.
2. The first scrubber covered Anthropic keys only. It missed `AGENTSCOMMANDER_API_TOKEN` (24h TTL, scopes `send` / `list-peers` / `session-transport`), the `acst-` session registration ticket, and `OPENAI_API_KEY` / `GEMINI_API_KEY` / `GITHUB_TOKEN`, which nothing revokes.
3. `ContainerStartRequest::child_env` is a `Vec<(String, String)>`, so `serde_json::to_string` emits an **array of pairs**, not an object. `AGENTSCOMMANDER_BRIDGE_ENV_JSON` therefore carried every `child_env` secret in the one serialization the key-name scrubber could not parse. Because Docker `--env` only injects the `AGENTSCOMMANDER_*` set (the bridge applies `child_env` to the agent process itself), that blob was the **only** place those keys appeared, so the key list added in round 2 was protecting a shape that cannot occur.

The scrubber now handles `KEY=value`, `KEY: "value"`, `KEY='value'` and the `["KEY","VALUE"]` tuple-array shape, redacts only the value span so key names and non-secret env survive in the diagnostic, and backs the key net with value prefixes (`ac-container-`, `acst-`, `sk-ant-`, `sk-proj-`, `ghp_`, `AIza`) to cover bare values in `AGENTSCOMMANDER_BRIDGE_ARGS_JSON`, which is an array with no keys. `docker inspect` is scoped to `--format '{{json .State}}'` and never fetches `Config.Env`. Reads are byte-capped at 64 KiB per stream (`--tail` bounds lines, not bytes) while still draining the pipe, so a container printing one enormous line cannot balloon memory or block on a full pipe.

## Not in this PR

#894 (auto `--continue` resume decision reads the host projects dir) was implemented, reviewed, and then **stripped**. The algorithm was correct but structurally unreachable: `CLAUDE_CONFIG_DIR` is already expanded to a host absolute path before the probe sees it, and `AC_WORKSPACE_ROOT` is the parent of the bind-mount source, so no configuration can produce a value that maps. The real requirement is host-to-container env path translation, which touches `claude_watcher`, `config_seed::compute_config_dir_warning` and `resolve_claude_projects_dir`. That is a design decision, not a bugfix. `src-tauri/src/commands/session.rs` is byte-identical to `main` in this branch (verified by blob SHA), so the local-process resume path is provably untouched. #894 stays open and goes to architect.

## Verification

`cargo test --all-targets`: 1981 lib passed, 0 failed, 8 ignored; all 16 integration suites pass; zero warnings. `cargo check`, `cargo clippy`, `git diff --check` clean. `npm run typecheck` clean. `npx vitest run SettingsModal.automation.test.ts`: 37 passed.

Adversarial review by `dev-rust-grinch` across four rounds. It compiled the scrubber standalone and ran real dying-container log tails through it, attacked the tuple-array parser with fourteen inputs (nested arrays, empty values, unterminated quotes, keys at buffer end, multibyte before and inside values, sensitive pair not first), proved memory safety and termination, and mutated the code to confirm the regression fixture actually goes red when the array-pair branch is reverted. It also verified against real Docker 29.2.1 that `docker rm -f <missing>` exits 0 and that `docker ps -a` keeps exited containers visible to the orphan sweep.

## Follow-ups filed

#896 (diagnostics and shutdown time budgets), #897 (dropping `--rm` can leak `Exited` containers when the sweep never runs), #898 (`docker stop --time` deprecated on Docker 29), #899 (resume probe reads `child_env` before `env_remove_keys` is applied), #900 (CLI `--clear-container-image` gives no feedback when the env var is unset), #901 (`run_command` drops the truncation flag, compounds with #897), #902 (`inspect_error` bypasses the scrubber that `logs_error` goes through).

Also filed from the final review: escaped quotes defeat the value scan (same acceptable-residual class as base64 env dumps), a sensitive key in value position over-redacts one adjacent token (cosmetic, not a leak), `AIza` should be tightened to `AIzaSy`, and the scalar-shape redaction fixtures should be restored alongside the new JSON ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)