### PR TITLE
feat(cli): add purge-wg verb for one-shot workgroup purge (refs #885)

### DIFF
--- a/src-tauri/src/api/actuation.rs
+++ b/src-tauri/src/api/actuation.rs
@@ -172,6 +172,8 @@ pub fn build_inline_wake_message(id: &str, from: &str, to: &str, body: String) -
         timeout_secs: None,
         switch_coding_agent: None,
         switch_profile: None,
+        dry_run: None,
+        quiet_period_ms: None,
     }
 }
 

--- a/src-tauri/src/api/dispatcher.rs
+++ b/src-tauri/src/api/dispatcher.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::Future;
+use tauri::Manager;
 use tokio_util::sync::CancellationToken;
 
 use crate::api::message_store::{LeasedMessage, MessageStore};
@@ -45,26 +46,37 @@ pub fn start_dispatcher(
                     break;
                 }
                 _ = interval.tick() => {
-                    if let Err(e) = dispatch_due_with(
-                        &store,
-                        chrono::Utc::now(),
-                        &config,
-                        |msg| {
-                                let app = app.clone();
-                                async move {
-                                    crate::phone::mailbox::MailboxPoller::new()
-                                        .deliver_wake_with_origin(
-                                            &app,
-                                            &msg,
-                                            crate::phone::mailbox::WakeDeliveryOrigin::DbQueue,
-                                        )
-                                        .await
-                                }
-                            },
-                        )
-                    .await
-                    {
-                        log::warn!("[api-dispatcher] dispatch tick failed: {}", e);
+                    // (#885 F-5) Skip DISPATCH (not the reaper) while a purge
+                    // holds a lease. Leasing a row we cannot deliver burns an
+                    // attempt against max_attempts (5) and can poison the
+                    // message permanently. A purge is bounded; the next tick
+                    // delivers.
+                    let purging = app
+                        .try_state::<std::sync::Arc<crate::session::purge_guard::PurgeGuard>>()
+                        .map(|g| g.is_active())
+                        .unwrap_or(false);
+                    if !purging {
+                        if let Err(e) = dispatch_due_with(
+                            &store,
+                            chrono::Utc::now(),
+                            &config,
+                            |msg| {
+                                    let app = app.clone();
+                                    async move {
+                                        crate::phone::mailbox::MailboxPoller::new()
+                                            .deliver_wake_with_origin(
+                                                &app,
+                                                &msg,
+                                                crate::phone::mailbox::WakeDeliveryOrigin::DbQueue,
+                                            )
+                                            .await
+                                    }
+                                },
+                            )
+                            .await
+                        {
+                            log::warn!("[api-dispatcher] dispatch tick failed: {}", e);
+                        }
                     }
                     let cutoff = chrono::Utc::now() - config.retention;
                     if let Err(e) = store.reap_terminal_before_offloaded(cutoff).await {
@@ -149,6 +161,8 @@ pub fn build_outbox_message(row: &LeasedMessage) -> OutboxMessage {
         timeout_secs: None,
         switch_coding_agent: None,
         switch_profile: None,
+        dry_run: None,
+        quiet_period_ms: None,
     }
 }
 

--- a/src-tauri/src/cli/close_session.rs
+++ b/src-tauri/src/cli/close_session.rs
@@ -198,6 +198,8 @@ pub fn execute(args: CloseSessionArgs) -> i32 {
         timeout_secs: Some(args.timeout),
         switch_coding_agent: None,
         switch_profile: None,
+        dry_run: None,
+        quiet_period_ms: None,
     };
 
     // Write to outbox — use app outbox for root/master token, else agent's outbox

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub mod list_sessions;
 pub mod loop_cmd;
 pub mod new_project;
 pub mod open_project;
+pub mod purge_wg;
 pub mod raise_hand;
 pub mod role_experiment;
 pub mod self_clear;
@@ -150,6 +151,9 @@ pub enum Commands {
     RoleExperiment(role_experiment::RoleExperimentArgs),
     /// Close all sessions for a target agent (coordinator authorization required)
     CloseSession(close_session::CloseSessionArgs),
+    /// Purge every agent in the caller's own workgroup (coordinator-only, fail-closed busy gate)
+    #[command(name = "purge-wg")]
+    PurgeWg(purge_wg::PurgeWgArgs),
     /// Set the title field in the workgroup TASK.md frontmatter (coordinator-only)
     TaskSetTitle(task_set_title::TaskSetTitleArgs),
     /// Append text to the body of the workgroup TASK.md (coordinator-only)
@@ -316,6 +320,7 @@ pub fn handle_cli(cmd: Commands) -> i32 {
         Commands::CreateAgentMatrix(args) => create_agent_matrix::execute(args),
         Commands::RoleExperiment(args) => role_experiment::execute(args),
         Commands::CloseSession(args) => close_session::execute(args),
+        Commands::PurgeWg(args) => purge_wg::execute(args),
         Commands::TaskSetTitle(args) => task_set_title::execute(args),
         Commands::TaskAppendBody(args) => task_append_body::execute(args),
         Commands::OpenProject(args) => open_project::execute(args),

--- a/src-tauri/src/cli/purge_wg.rs
+++ b/src-tauri/src/cli/purge_wg.rs
@@ -1,0 +1,350 @@
+use clap::Args;
+use std::path::PathBuf;
+use uuid::Uuid;
+
+use crate::phone::types::OutboxMessage;
+
+use super::send::agent_name_from_root;
+
+/// Pure: decide CLI exit code from the daemon's response body.
+/// Exit codes:
+///   0 - purged (or dry_run_ready)
+///   3 - gate rejected (busy/restore_in_progress/dry_run_blocked)
+///   4 - a destroy failed after the gate passed (partial_failure/failed_root_guard)
+///   2 - unparseable JSON, missing/unknown/non-string status (outcome unknown)
+///   1 - auth/IO error or rejected (handled by the rejected/ path)
+fn interpret_purge_response_exit_code(content: &str) -> i32 {
+    let resp: serde_json::Value = match serde_json::from_str(content) {
+        Ok(v) => v,
+        Err(_) => return 2,
+    };
+    let Some(status) = resp.get("status").and_then(|v| v.as_str()) else {
+        return 2;
+    };
+    match status {
+        "purged" | "dry_run_ready" => 0,
+        "rejected_busy" | "restore_in_progress" | "dry_run_blocked" => 3,
+        "partial_failure" | "failed_root_guard" => 4,
+        _ => 2,
+    }
+}
+
+/// Print a human-readable status line after the JSON response.
+fn print_status_prose(content: &str) {
+    let Ok(resp) = serde_json::from_str::<serde_json::Value>(content) else {
+        return;
+    };
+    let status = resp.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    match status {
+        "rejected_busy" => {
+            crate::cli_println!("Purge rejected: one or more peers are busy. See per-peer table above.");
+        }
+        "dry_run_ready" => {
+            crate::cli_println!("Dry-run: gate would PASS. No sessions destroyed.");
+        }
+        "dry_run_blocked" => {
+            crate::cli_println!("Dry-run: gate would REJECT. One or more peers are not purgeable.");
+        }
+        "restore_in_progress" => {
+            crate::cli_println!("Daemon is still restoring sessions; retry in a few seconds.");
+        }
+        "partial_failure" => {
+            crate::cli_println!("Purge partially failed: some sessions could not be destroyed.");
+        }
+        "failed_root_guard" => {
+            let sid = resp
+                .get("offending_session_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            let cwd = resp
+                .get("offending_working_directory")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            crate::cli_println!(
+                "Root guard tripped: session {} at '{}' appears to be a Root Agent record. \
+                 Nothing destroyed. Repair sessions.json and retry.",
+                sid,
+                cwd
+            );
+        }
+        _ => {}
+    }
+}
+
+#[derive(Args)]
+#[command(after_help = "\
+SCOPE: Purges every peer in the CALLER'S OWN workgroup. The caller itself is never \
+purged, and neither is the Root Agent. Cross-workgroup purge is not supported.\n\n\
+AUTHORIZATION: The caller must be the identity-verified coordinator of its workgroup. \
+The master/root token does NOT bypass this: a root token has no workgroup.\n\n\
+BUSY GATE: If ANY in-scope peer has produced printable output within --quiet-period-ms, \
+the command purges NOBODY and exits 3.\n\n\
+EXIT CODES: 0 purged (or dry-run would pass) | 1 auth/IO error | 2 outcome unknown \
+| 3 gate rejected (a peer is busy) | 4 a destroy failed after the gate passed.")]
+pub struct PurgeWgArgs {
+    #[arg(long)]
+    pub token: Option<String>,
+
+    #[arg(long)]
+    pub root: Option<String>,
+
+    /// Safety assertion, not a scope selector: fail unless the resolved
+    /// workgroup has exactly this name.
+    #[arg(long)]
+    pub wg: Option<String>,
+
+    /// Inject an exit command and wait, instead of killing immediately.
+    /// Off by default: OpenCode ignores exit and burns the full timeout.
+    /// WARNING: --graceful stalls ALL inter-agent messaging daemon-wide for
+    /// the duration of the purge (the message poller is sequential).
+    #[arg(long)]
+    pub graceful: bool,
+
+    /// Graceful shutdown timeout in seconds per session.
+    #[arg(long, default_value = "5")]
+    pub timeout: u32,
+
+    /// Evaluate the gate and print the per-peer table. Destroy nothing.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Printable-silence a peer must show to be purgeable.
+    /// Clamped daemon-side to a floor of 2500.
+    #[arg(long, default_value = "3000")]
+    pub quiet_period_ms: u64,
+}
+
+pub fn execute(args: PurgeWgArgs) -> i32 {
+    let root = match args.root {
+        Some(ref r) => r.clone(),
+        None => {
+            log::error!("--root is required. Specify your agent's root directory.");
+            eprintln!("Error: --root is required. Specify your agent's root directory.");
+            return 1;
+        }
+    };
+
+    if let Err(msg) = crate::cli::validate_cli_token(&args.token) {
+        log::error!("{}", msg);
+        eprintln!("{}", msg);
+        return 1;
+    }
+
+    if args.graceful {
+        eprintln!(
+            "WARNING: --graceful stalls all inter-agent messaging daemon-wide for up to \
+             {}s per peer. Consider --force (the default) for faster purges.",
+            args.timeout
+        );
+    }
+
+    let sender = agent_name_from_root(&root);
+
+    let msg_id = Uuid::new_v4().to_string();
+    let request_id = Uuid::new_v4().to_string();
+
+    let message = OutboxMessage {
+        id: msg_id.clone(),
+        token: args.token.clone(),
+        from: sender.clone(),
+        to: String::new(),
+        body: String::new(),
+        mode: String::new(),
+        get_output: false,
+        request_id: Some(request_id.clone()),
+        sender_agent: None,
+        preferred_agent: String::new(),
+        priority: "normal".to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        command: None,
+        action: Some(crate::phone::mailbox::PURGE_WG_ACTION.to_string()),
+        target: args.wg.clone(),
+        force: Some(!args.graceful),
+        timeout_secs: Some(args.timeout),
+        switch_coding_agent: None,
+        switch_profile: None,
+        dry_run: Some(args.dry_run),
+        quiet_period_ms: Some(args.quiet_period_ms),
+    };
+
+    let ac_dir = PathBuf::from(&root).join(crate::config::agent_local_dir_name());
+    let outbox_dir = ac_dir.join("outbox");
+
+    if let Err(e) = std::fs::create_dir_all(&outbox_dir) {
+        log::error!("failed to create outbox directory: {}", e);
+        eprintln!("Error: failed to create outbox directory: {}", e);
+        return 1;
+    }
+
+    let outbox_path = outbox_dir.join(format!("{}.json", msg_id));
+    let json = match serde_json::to_string_pretty(&message) {
+        Ok(j) => j,
+        Err(e) => {
+            log::error!("failed to serialize message: {}", e);
+            eprintln!("Error: failed to serialize message: {}", e);
+            return 1;
+        }
+    };
+
+    if let Err(e) = std::fs::write(&outbox_path, json) {
+        log::error!("failed to write outbox file: {}", e);
+        eprintln!("Error: failed to write outbox file: {}", e);
+        return 1;
+    }
+
+    let response_path = ac_dir.join("responses").join(format!("{}.json", request_id));
+    let rejected_reason_path = outbox_dir
+        .join("rejected")
+        .join(format!("{}.reason.txt", msg_id));
+
+    // (#885 F-6) Single deadline: collapse close-session's two poll loops
+    // into one. The 30s hardcoded confirm_timeout fires first on graceful
+    // purges. move_to_delivered runs at the END of the handler (step 14),
+    // so a separate delivery-confirmation window buys nothing and can only
+    // fire spuriously.
+    const MAX_EXPECTED_PEERS: u64 = 32;
+    let deadline = if args.graceful {
+        std::time::Duration::from_secs(args.timeout as u64 * MAX_EXPECTED_PEERS + 30)
+    } else {
+        std::time::Duration::from_secs(90)
+    };
+    let poll_interval = std::time::Duration::from_millis(500);
+    let start = std::time::Instant::now();
+
+    loop {
+        if response_path.exists() {
+            match std::fs::read_to_string(&response_path) {
+                Ok(content) => {
+                    crate::cli_println!("{}", content);
+                    print_status_prose(&content);
+                    return interpret_purge_response_exit_code(&content);
+                }
+                Err(e) => {
+                    log::error!("failed to read response: {}", e);
+                    eprintln!("Error: failed to read response: {}", e);
+                    return 1;
+                }
+            }
+        }
+        if rejected_reason_path.exists() {
+            let reason = std::fs::read_to_string(&rejected_reason_path)
+                .unwrap_or_else(|_| "unknown reason".to_string());
+            let trimmed = reason.trim();
+            log::error!("purge-wg rejected - {}", trimmed);
+            eprintln!("Error: purge-wg rejected - {}", trimmed);
+            return 1;
+        }
+        if start.elapsed() >= deadline {
+            log::error!(
+                "purge-wg response timeout after {}s (request {} may still be pending)",
+                deadline.as_secs(),
+                msg_id
+            );
+            eprintln!(
+                "Error: purge-wg response timeout after {}s (request {} may still be pending)",
+                deadline.as_secs(),
+                msg_id
+            );
+            return 2;
+        }
+        std::thread::sleep(poll_interval);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── interpret_purge_response_exit_code truth table ──
+
+    #[test]
+    fn purged_returns_zero() {
+        let resp = r#"{"status":"purged","purged":3,"failed":0}"#;
+        assert_eq!(interpret_purge_response_exit_code(resp), 0);
+    }
+
+    #[test]
+    fn dry_run_ready_returns_zero() {
+        let resp = r#"{"status":"dry_run_ready","would_purge":true}"#;
+        assert_eq!(interpret_purge_response_exit_code(resp), 0);
+    }
+
+    #[test]
+    fn dry_run_blocked_returns_three() {
+        let resp = r#"{"status":"dry_run_blocked","would_purge":false}"#;
+        assert_eq!(interpret_purge_response_exit_code(resp), 3);
+    }
+
+    #[test]
+    fn rejected_busy_returns_three() {
+        let resp = r#"{"status":"rejected_busy","peers":[]}"#;
+        assert_eq!(interpret_purge_response_exit_code(resp), 3);
+    }
+
+    #[test]
+    fn restore_in_progress_returns_three() {
+        let resp = r#"{"status":"restore_in_progress"}"#;
+        assert_eq!(interpret_purge_response_exit_code(resp), 3);
+    }
+
+    #[test]
+    fn partial_failure_returns_four() {
+        let resp = r#"{"status":"partial_failure","purged":2,"failed":1}"#;
+        assert_eq!(interpret_purge_response_exit_code(resp), 4);
+    }
+
+    #[test]
+    fn failed_root_guard_returns_four() {
+        let resp = r#"{"status":"failed_root_guard","offending_session_id":"abc"}"#;
+        assert_eq!(interpret_purge_response_exit_code(resp), 4);
+    }
+
+    #[test]
+    fn unparseable_json_returns_two() {
+        assert_eq!(interpret_purge_response_exit_code("not json"), 2);
+        assert_eq!(interpret_purge_response_exit_code(""), 2);
+    }
+
+    #[test]
+    fn missing_status_field_returns_two() {
+        let resp = r#"{"purged":0}"#;
+        assert_eq!(interpret_purge_response_exit_code(resp), 2);
+    }
+
+    #[test]
+    fn unknown_status_returns_two() {
+        let resp = r#"{"status":"weird"}"#;
+        assert_eq!(interpret_purge_response_exit_code(resp), 2);
+    }
+
+    #[test]
+    fn non_string_status_returns_two() {
+        let resp = r#"{"status":42}"#;
+        assert_eq!(interpret_purge_response_exit_code(resp), 2);
+    }
+
+    #[test]
+    fn non_object_json_returns_two() {
+        assert_eq!(interpret_purge_response_exit_code("null"), 2);
+        assert_eq!(interpret_purge_response_exit_code("[1,2,3]"), 2);
+        assert_eq!(interpret_purge_response_exit_code("\"purged\""), 2);
+        assert_eq!(interpret_purge_response_exit_code("42"), 2);
+        assert_eq!(interpret_purge_response_exit_code("true"), 2);
+    }
+
+    // (#885 F-8) The exit-code function reads ONLY `status`, never `would_purge`.
+    #[test]
+    fn exit_code_never_reads_would_purge() {
+        let resp = r#"{"status":"dry_run_blocked","would_purge":true}"#;
+        assert_eq!(interpret_purge_response_exit_code(resp), 3);
+    }
+
+    #[test]
+    fn print_status_prose_does_not_panic() {
+        print_status_prose("not json");
+        print_status_prose("");
+        print_status_prose(r#"{"status":"purged"}"#);
+        print_status_prose(r#"{"status":"rejected_busy"}"#);
+        print_status_prose(r#"{"status":"failed_root_guard","offending_session_id":"x","offending_working_directory":"y"}"#);
+    }
+}

--- a/src-tauri/src/cli/purge_wg.rs
+++ b/src-tauri/src/cli/purge_wg.rs
@@ -37,7 +37,9 @@ fn print_status_prose(content: &str) {
     let status = resp.get("status").and_then(|v| v.as_str()).unwrap_or("");
     match status {
         "rejected_busy" => {
-            crate::cli_println!("Purge rejected: one or more peers are busy. See per-peer table above.");
+            crate::cli_println!(
+                "Purge rejected: one or more peers are not purgeable. See per-peer table above."
+            );
         }
         "dry_run_ready" => {
             crate::cli_println!("Dry-run: gate would PASS. No sessions destroyed.");
@@ -192,7 +194,9 @@ pub fn execute(args: PurgeWgArgs) -> i32 {
         return 1;
     }
 
-    let response_path = ac_dir.join("responses").join(format!("{}.json", request_id));
+    let response_path = ac_dir
+        .join("responses")
+        .join(format!("{}.json", request_id));
     let rejected_reason_path = outbox_dir
         .join("rejected")
         .join(format!("{}.reason.txt", msg_id));
@@ -345,6 +349,8 @@ mod tests {
         print_status_prose("");
         print_status_prose(r#"{"status":"purged"}"#);
         print_status_prose(r#"{"status":"rejected_busy"}"#);
-        print_status_prose(r#"{"status":"failed_root_guard","offending_session_id":"x","offending_working_directory":"y"}"#);
+        print_status_prose(
+            r#"{"status":"failed_root_guard","offending_session_id":"x","offending_working_directory":"y"}"#,
+        );
     }
 }

--- a/src-tauri/src/cli/raise_hand.rs
+++ b/src-tauri/src/cli/raise_hand.rs
@@ -77,6 +77,8 @@ pub fn execute(args: RaiseHandArgs) -> i32 {
         timeout_secs: None,
         switch_coding_agent: None,
         switch_profile: None,
+        dry_run: None,
+        quiet_period_ms: None,
     };
 
     let outbox_dir = if is_root {

--- a/src-tauri/src/cli/self_clear.rs
+++ b/src-tauri/src/cli/self_clear.rs
@@ -117,6 +117,8 @@ pub fn execute(args: SelfClearArgs) -> i32 {
         timeout_secs: None,
         switch_coding_agent: None,
         switch_profile: None,
+        dry_run: None,
+        quiet_period_ms: None,
     };
 
     // Outbox selection mirrors close_session::execute (is_root -> app outbox else agent outbox).

--- a/src-tauri/src/cli/self_switch.rs
+++ b/src-tauri/src/cli/self_switch.rs
@@ -223,6 +223,8 @@ pub fn execute(args: SelfSwitchArgs) -> i32 {
         timeout_secs: None,
         switch_coding_agent: args.coding_agent,
         switch_profile,
+        dry_run: None,
+        quiet_period_ms: None,
     };
 
     let outbox_dir = if is_root {

--- a/src-tauri/src/cli/send.rs
+++ b/src-tauri/src/cli/send.rs
@@ -522,6 +522,8 @@ pub fn execute(args: SendArgs) -> i32 {
         timeout_secs: None,
         switch_coding_agent: None,
         switch_profile: None,
+        dry_run: None,
+        quiet_period_ms: None,
     };
 
     // Write to --outbox if specified, app outbox if root/master token, otherwise <root>/<local_dir>/outbox/

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -36,6 +36,15 @@ pub async fn pty_write(
 ) -> Result<(), String> {
     let uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
 
+    // (#885 J1) Keystrokes into a session being purged would flip it busy
+    // between the readiness snapshot and its destroy. Scoped to the purge's
+    // target set, so typing in unrelated sessions is unaffected.
+    if let Some(g) = app.try_state::<std::sync::Arc<crate::session::purge_guard::PurgeGuard>>() {
+        if g.blocks_session(uuid) {
+            return Err("purge-wg in progress for this session; input rejected".to_string());
+        }
+    }
+
     // Flag if user typed while voice recording is active for this session.
     // Lock scope closes before pty_mgr lock to avoid holding both.
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -606,6 +606,7 @@ pub fn run(
         .manage(settings)
         .manage(idle_detector_for_state) // #552 managed type: Arc<IdleDetector>
         .manage(coordinator_clocks) // #552 managed type: CoordinatorClocksState
+        .manage(std::sync::Arc::new(crate::session::purge_guard::PurgeGuard::default())) // #885
         .manage(detached_sessions.clone())
         .manage(spec_board_state.clone())
         .manage(loop_scheduler.clone())

--- a/src-tauri/src/loops/delivery.rs
+++ b/src-tauri/src/loops/delivery.rs
@@ -51,6 +51,30 @@ pub async fn deliver_loop_prompt(
         }
     };
     let target_fqn = target.target_fqn.clone();
+
+    // (#885 J1/J2) A purge is destroying this agent right now.
+    // `deliver_loop_prompt` both injects into a live session and SPAWNS one
+    // when none exists (`spawn_coordinator_session`), so an unguarded loop
+    // tick can resurrect a peer the purge already destroyed. Keyed on the
+    // FQN, not a session id, because the J2 case is precisely the one where
+    // the session record is already gone.
+    if let Some(g) = app.try_state::<std::sync::Arc<crate::session::purge_guard::PurgeGuard>>() {
+        if g.blocks_agent(&target_fqn) {
+            return LoopDeliveryReport {
+                kind: LoopAuditKind::SkippedBusy,
+                message: format!(
+                    "purge-wg in progress for '{}'; loop delivery skipped",
+                    target_fqn
+                ),
+                target: Some(target_fqn),
+                session_id: None,
+                error: None,
+                prompt_snapshot: None,
+                completed_at: Some(Utc::now()),
+            };
+        }
+    }
+
     let loop_storage_dir = loop_dir(&target.workspace_dir, &config.loop_def.id);
     let policy = config.policy.busy_coordinator.clone();
     let prompt = config.prompt.body.clone();

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -1575,10 +1575,7 @@ pub(crate) struct PurgePeerResult {
 ///   2. `watcher_idle` (watcher agreement)
 ///   3. `mirror_idle` (SessionManager agreement)
 ///   4. `resize_settled` (F-1: activity readings are trustworthy)
-pub(crate) fn evaluate_gate(
-    peers: &[PurgeGatePeer],
-    quiet: std::time::Duration,
-) -> PurgeDecision {
+pub(crate) fn evaluate_gate(peers: &[PurgeGatePeer], quiet: std::time::Duration) -> PurgeDecision {
     let mut passed = true;
     let mut results = Vec::with_capacity(peers.len());
 
@@ -1619,8 +1616,14 @@ pub(crate) fn evaluate_gate(
 
             if !purgeable {
                 peer_purgeable = false;
+                // (#885 E-5) Distinguish resize-unsettled from busy: an
+                // operator told their idle agent is "busy" will hunt for a
+                // working agent that does not exist. If resize is the only
+                // failing leg, the terminal was recently resized.
                 peer_outcome = if r.activity_age.is_none() {
                     "untracked"
+                } else if !r_settled && activity_ok && r.watcher_idle && m_idle {
+                    "resize_unsettled"
                 } else {
                     "busy"
                 };
@@ -2127,9 +2130,7 @@ impl MailboxPoller {
                     .reject_message(path, &msg, "purge-wg requires a session token")
                     .await;
             }
-            return self
-                .handle_purge_wg(app, path, &msg, is_app_outbox)
-                .await;
+            return self.handle_purge_wg(app, path, &msg, is_app_outbox).await;
         }
 
         if root_agent_claim {
@@ -2308,7 +2309,8 @@ impl MailboxPoller {
         //   - filesystem poller: non-permanent error, retried at the 3s poll
         //     interval up to MAX_DELIVERY_ATTEMPTS. Deferred, not lost.
         //   - inline API send: mapped to DeliveryOutcome::Rejected. No retry.
-        if let Some(g) = app.try_state::<std::sync::Arc<crate::session::purge_guard::PurgeGuard>>() {
+        if let Some(g) = app.try_state::<std::sync::Arc<crate::session::purge_guard::PurgeGuard>>()
+        {
             if g.blocks_agent(&msg.to) {
                 return Err(format!(
                     "purge-wg in progress for '{}'; wake deferred",
@@ -3884,21 +3886,23 @@ impl MailboxPoller {
             }
             paths
         };
-        let wg = match crate::config::teams::verified_wg_coordinator_target(&msg.from, &effective_paths) {
-            Some(wg) => wg,
-            None => {
-                return self
-                    .reject_message(
-                        path,
-                        msg,
-                        &format!(
+        let wg =
+            match crate::config::teams::verified_wg_coordinator_target(&msg.from, &effective_paths)
+            {
+                Some(wg) => wg,
+                None => {
+                    return self
+                        .reject_message(
+                            path,
+                            msg,
+                            &format!(
                             "Not authorized: '{}' is not the verified coordinator of its workgroup",
                             msg.from
                         ),
-                    )
-                    .await;
-            }
-        };
+                        )
+                        .await;
+                }
+            };
 
         // 3. --wg assertion (§3.6: interlock, not selector).
         if let Some(ref t) = msg.target {
@@ -3956,21 +3960,13 @@ impl MailboxPoller {
             mgr.list_sessions().await
         };
         let pty_live: std::collections::HashSet<Uuid> = {
-            // try_state: in production, PtyManager is managed. In tests where
-            // no PTY exists, this returns None and pty_live is empty, which
-            // is correct: all sessions are non-live by the F-3 predicate
-            // (!Exited && has_pty), so they are vacuously purgeable.
-            match app.try_state::<Arc<std::sync::Mutex<crate::pty::manager::PtyManager>>>() {
-                Some(pty) => {
-                    let mgr = pty.lock().unwrap();
-                    sessions
-                        .iter()
-                        .filter_map(|s| Uuid::parse_str(&s.id).ok())
-                        .filter(|id| mgr.has_session(*id))
-                        .collect()
-                }
-                None => std::collections::HashSet::new(),
-            }
+            let pty = app.state::<Arc<std::sync::Mutex<crate::pty::manager::PtyManager>>>();
+            let mgr = pty.lock().unwrap();
+            sessions
+                .iter()
+                .filter_map(|s| Uuid::parse_str(&s.id).ok())
+                .filter(|id| mgr.has_session(*id))
+                .collect()
         };
 
         // 6. Restore-in-progress guard (F-2: exit 3, not 0).
@@ -3984,9 +3980,9 @@ impl MailboxPoller {
                     "requested_by": msg.from,
                     "peers": [],
                 });
-                return self.write_purge_response_and_deliver(
-                    app, path, msg, is_app_outbox, &response,
-                ).await;
+                return self
+                    .write_purge_response_and_deliver(app, path, msg, is_app_outbox, &response)
+                    .await;
             }
         }
 
@@ -4003,8 +3999,7 @@ impl MailboxPoller {
 
         for fqn in &peer_fqns {
             let matched: Vec<&SessionInfo> = filter_sessions_by_fqn(&sessions, fqn);
-            let all_session_ids: Vec<String> =
-                matched.iter().map(|s| s.id.clone()).collect();
+            let all_session_ids: Vec<String> = matched.iter().map(|s| s.id.clone()).collect();
 
             let mut live_sessions: Vec<(Uuid, bool)> = Vec::new();
             for s in &matched {
@@ -4021,20 +4016,21 @@ impl MailboxPoller {
                         "offending_working_directory": s.working_directory,
                         "peers": [],
                     });
-                    return self.write_purge_response_and_deliver(
-                        app, path, msg, is_app_outbox, &response,
-                    ).await;
+                    return self
+                        .write_purge_response_and_deliver(app, path, msg, is_app_outbox, &response)
+                        .await;
                 }
 
                 let sid = match Uuid::parse_str(&s.id) {
                     Ok(id) => id,
                     Err(_) => continue,
                 };
-                let is_live = !matches!(s.status, SessionStatus::Exited(_))
-                    && pty_live.contains(&sid);
+                let is_live =
+                    !matches!(s.status, SessionStatus::Exited(_)) && pty_live.contains(&sid);
                 if is_live {
-                    let mirror_idle = !matches!(s.status, SessionStatus::Active | SessionStatus::Running)
-                        || s.waiting_for_input;
+                    let mirror_idle =
+                        !matches!(s.status, SessionStatus::Active | SessionStatus::Running)
+                            || s.waiting_for_input;
                     live_sessions.push((sid, mirror_idle));
                     all_live_session_ids.push(sid);
                 }
@@ -4049,11 +4045,16 @@ impl MailboxPoller {
 
         // 8. Readiness snapshot and the four-leg gate (§2.3.3, F-1).
         let quiet = std::time::Duration::from_millis(
-            msg.quiet_period_ms
-                .unwrap_or(3000)
-                .max(crate::session::profile::IdleTuning::DEFAULT.idle_threshold.as_millis() as u64),
+            msg.quiet_period_ms.unwrap_or(3000).max(
+                crate::session::profile::IdleTuning::DEFAULT
+                    .idle_threshold
+                    .as_millis() as u64,
+            ),
         );
-        let readiness_map: std::collections::HashMap<Uuid, crate::pty::idle_detector::PurgeReadiness> = {
+        let readiness_map: std::collections::HashMap<
+            Uuid,
+            crate::pty::idle_detector::PurgeReadiness,
+        > = {
             let idle = app.state::<Arc<crate::pty::idle_detector::IdleDetector>>();
             let readiness = idle.purge_readiness(&all_live_session_ids);
             readiness.into_iter().map(|r| (r.session_id, r)).collect()
@@ -4075,8 +4076,10 @@ impl MailboxPoller {
                                 activity_age: None,
                                 watcher_idle: false,
                                 last_resize_age: None,
-                                resize_grace: crate::session::profile::IdleTuning::DEFAULT.resize_grace,
-                                idle_threshold: crate::session::profile::IdleTuning::DEFAULT.idle_threshold,
+                                resize_grace: crate::session::profile::IdleTuning::DEFAULT
+                                    .resize_grace,
+                                idle_threshold: crate::session::profile::IdleTuning::DEFAULT
+                                    .idle_threshold,
                                 silence_age: None,
                             },
                         ),
@@ -4090,7 +4093,11 @@ impl MailboxPoller {
 
         // 9. Dry-run exit, BEFORE the gate rejection (F-9).
         if msg.dry_run == Some(true) {
-            let status = if decision.passed { "dry_run_ready" } else { "dry_run_blocked" };
+            let status = if decision.passed {
+                "dry_run_ready"
+            } else {
+                "dry_run_blocked"
+            };
             // (N-3) The dry-run path reports `purgeable` and the diagnostic
             // fields, NOT `outcome` (which is the gate's internal "busy"/
             // "skipped"/"untracked" vocabulary and contradicts `would_purge:
@@ -4115,9 +4122,9 @@ impl MailboxPoller {
                     "session_ids": p.session_ids,
                 })).collect::<Vec<_>>(),
             });
-            return self.write_purge_response_and_deliver(
-                app, path, msg, is_app_outbox, &response,
-            ).await;
+            return self
+                .write_purge_response_and_deliver(app, path, msg, is_app_outbox, &response)
+                .await;
         }
 
         // 10. The gate. If any peer is not purgeable: reject, destroy nothing.
@@ -4140,9 +4147,9 @@ impl MailboxPoller {
                     "session_ids": p.session_ids,
                 })).collect::<Vec<_>>(),
             });
-            return self.write_purge_response_and_deliver(
-                app, path, msg, is_app_outbox, &response,
-            ).await;
+            return self
+                .write_purge_response_and_deliver(app, path, msg, is_app_outbox, &response)
+                .await;
         }
 
         // 11. Acquire the lease (F-14: clone Arc into a named local first).
@@ -4182,22 +4189,6 @@ impl MailboxPoller {
                     Ok(id) => id,
                     Err(_) => continue,
                 };
-                // (D-2) Re-probe existence: auto-close may have destroyed the
-                // record between the gate and this point. A vanished record is
-                // success (the workgroup IS purged), not a failure. Only
-                // graceful_close_session handles this correctly today
-                // (`mailbox.rs:5469-5473`); the force path returns `false` on
-                // "session not found", which would yield a false exit 4.
-                let exists = {
-                    let session_mgr =
-                        app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
-                    let mgr = session_mgr.read().await;
-                    mgr.get_session(sid).await.is_some()
-                };
-                if !exists {
-                    already_closed_ids.push(sid_str.clone());
-                    continue;
-                }
                 let ok = if force {
                     self.force_close_session(app, sid).await
                 } else {
@@ -4206,8 +4197,25 @@ impl MailboxPoller {
                 if ok {
                     closed_ids.push(sid_str.clone());
                 } else {
-                    failed_ids.push(sid_str.clone());
-                    any_failed = true;
+                    // (#885 E-4) Post-failure re-probe: if the record is gone,
+                    // the destroy failed because auto-close raced us and the
+                    // session is already destroyed. That is success, not
+                    // failure. Sound because `destroy_session_inner` returns
+                    // Err("Session not found") ONLY from its first statement;
+                    // every other failure (notably kill_group's ??) leaves
+                    // the record present, so a genuine failure is always
+                    // distinguishable by the record still being there.
+                    let gone = {
+                        let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+                        let mgr = session_mgr.read().await;
+                        mgr.get_session(sid).await.is_none()
+                    };
+                    if gone {
+                        already_closed_ids.push(sid_str.clone());
+                    } else {
+                        failed_ids.push(sid_str.clone());
+                        any_failed = true;
+                    }
                 }
             }
         }
@@ -4216,7 +4224,11 @@ impl MailboxPoller {
         drop(lease);
 
         // 14. Response + move_to_delivered.
-        let status = if any_failed { "partial_failure" } else { "purged" };
+        let status = if any_failed {
+            "partial_failure"
+        } else {
+            "purged"
+        };
         let response = serde_json::json!({
             "action": PURGE_WG_ACTION,
             "workgroup": format!("{}:{}", wg.project, wg.wg_name),
@@ -5393,6 +5405,21 @@ impl MailboxPoller {
     ) -> bool {
         #[cfg(test)]
         {
+            // (#885 E-2) Emit a Destroy event so purge tests can assert that
+            // the destroy loop was or was not reached. Without this, the
+            // "zero Destroy events" assertions in the F-7 and root-guard
+            // tests are tautologies: the only emit site was in the wake
+            // deferred-destroy path, which the purge never reaches.
+            if let Some(hooks) = &self.test_hooks {
+                {
+                    let mut calls = hooks.destroy_calls.lock().unwrap();
+                    calls.push(sid);
+                }
+                {
+                    let mut events = hooks.events.lock().unwrap();
+                    events.push(MailboxTestEvent::Destroy(sid));
+                }
+            }
             let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
             let mgr = session_mgr.read().await;
             return mgr.destroy_session(sid).await.is_ok();
@@ -6105,6 +6132,95 @@ mod tests {
     use std::time::Duration;
     use tauri::Listener;
 
+    use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
+    use crate::pty::manager::PtyManager;
+
+    // (#885 E-3) Minimal mock PTY backend for purge-wg e2e tests. Sessions
+    // in `live` report `has_session: true`; `kill` removes them. Other
+    // methods are no-ops. This lets the purge gate exercise the F-3
+    // liveness predicate and the IdleDetector correlation end-to-end.
+    #[derive(Default)]
+    struct MailboxMockPtyBackend {
+        live: std::sync::Mutex<HashSet<Uuid>>,
+    }
+
+    impl MailboxMockPtyBackend {
+        fn set_live(&self, id: Uuid) {
+            self.live.lock().unwrap().insert(id);
+        }
+    }
+
+    impl PtyBackend for MailboxMockPtyBackend {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn spawn(
+            &self,
+            spec: BackendSpawnSpec,
+        ) -> futures::future::BoxFuture<'_, Result<(), crate::errors::AppError>> {
+            Box::pin(async move {
+                self.live.lock().unwrap().insert(spec.id);
+                Ok(())
+            })
+        }
+
+        fn write(&self, _id: Uuid, _data: &[u8]) -> Result<(), crate::errors::AppError> {
+            Ok(())
+        }
+
+        fn resize(&self, _id: Uuid, _cols: u16, _rows: u16) -> Result<(), crate::errors::AppError> {
+            Ok(())
+        }
+
+        fn kill(&self, id: Uuid) -> Result<(), crate::errors::AppError> {
+            self.live.lock().unwrap().remove(&id);
+            Ok(())
+        }
+
+        fn has_session(&self, id: Uuid) -> bool {
+            self.live.lock().unwrap().contains(&id)
+        }
+
+        fn get_screen_snapshot(&self, _id: Uuid) -> Option<crate::pty::output::PtyScreenSnapshot> {
+            None
+        }
+
+        fn get_pty_size(&self, _id: Uuid) -> Option<(u16, u16)> {
+            Some((30, 120))
+        }
+
+        fn register_response_watcher(
+            &self,
+            _session_id: Uuid,
+            _request_id: String,
+            _response_dir: std::path::PathBuf,
+        ) {
+        }
+
+        fn terminate_job_for_session(&self, id: Uuid) -> bool {
+            self.live.lock().unwrap().remove(&id)
+        }
+
+        fn kill_all_jobs(&self) -> (usize, usize) {
+            (0, 0)
+        }
+    }
+
+    /// (#885 E-3) Build a `PtyManager` with a mock backend whose live set
+    /// can be pre-populated. Sessions registered as "live" will pass the
+    /// F-3 `has_pty` liveness check in `handle_purge_wg`.
+    fn make_test_pty_manager() -> (
+        Arc<std::sync::Mutex<PtyManager>>,
+        Arc<MailboxMockPtyBackend>,
+    ) {
+        let backend = Arc::new(MailboxMockPtyBackend::default());
+        let mgr = Arc::new(std::sync::Mutex::new(PtyManager::new_for_test(
+            backend.clone(),
+        )));
+        (mgr, backend)
+    }
+
     // ── §224 D.5a — wait_for_restore_or_session unit tests ──
 
     #[test]
@@ -6376,6 +6492,7 @@ mod tests {
         };
 
         let idle_detector = crate::pty::idle_detector::IdleDetector::new(|_| {}, |_| {});
+        let (pty_mgr, _) = make_test_pty_manager();
 
         tauri::test::mock_builder()
             .manage(MasterToken::new(MAILBOX_MASTER_TOKEN.into()))
@@ -6387,6 +6504,7 @@ mod tests {
             ))
             .manage(Arc::new(tokio::sync::RwLock::new(settings)))
             .manage(session_mgr.clone())
+            .manage(pty_mgr) // #885 E-3: real PtyManager for pty_live probes
             .manage(Arc::new(tokio::sync::Mutex::new(
                 TelegramBridgeManager::new(Arc::new(Mutex::new(HashMap::new()))),
             )))
@@ -6394,7 +6512,9 @@ mod tests {
             .manage(Arc::new(crate::RestoreInProgress(AtomicBool::new(false))))
             .manage(Arc::new(crate::PendingSelfClear::default()))
             .manage(idle_detector) // #885: purge_readiness
-            .manage(std::sync::Arc::new(crate::session::purge_guard::PurgeGuard::default())) // #885
+            .manage(std::sync::Arc::new(
+                crate::session::purge_guard::PurgeGuard::default(),
+            )) // #885
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("build mailbox test app")
     }
@@ -11347,7 +11467,10 @@ mod tests {
             vec!["aaa".to_string()],
         );
         let decision = evaluate_gate(&[peer], quiet);
-        assert!(decision.passed, "a peer with no live sessions is vacuously purgeable");
+        assert!(
+            decision.passed,
+            "a peer with no live sessions is vacuously purgeable"
+        );
         assert!(decision.peers[0].purgeable);
     }
 
@@ -11510,16 +11633,15 @@ mod tests {
         message_path
     }
 
-    /// (D-3/F-7) A purge-wg message with no session token must be rejected,
-    /// even if `is_master` would be true.
-    #[tokio::test]
-    async fn process_message_purge_wg_without_token_is_rejected() {
-        let temp = tempfile::TempDir::new().unwrap();
+    /// (#885 E-3) Helper: set up a full WG fixture with a coordinator and a
+    /// peer. Returns the sender CWD and peer CWD.
+    fn setup_purge_fixture(temp: &tempfile::TempDir, wg_suffix: &str) -> (PathBuf, PathBuf) {
         let project = temp.path().join("proj-a");
         let workspace = project.join(".ac");
-        let team_dir = workspace.join("_team_dev-team");
+        let team_name = format!("_team_{}", wg_suffix);
+        let team_dir = workspace.join(&team_name);
         let origin_tl = workspace.join("_agent_tech-lead");
-        let wg_dir = workspace.join("wg-1-dev-team");
+        let wg_dir = workspace.join(format!("wg-1-{}", wg_suffix));
         let sender_cwd = wg_dir.join("__agent_tech-lead");
         let peer_cwd = wg_dir.join("__agent_dev-rust");
         for d in [&team_dir, &origin_tl, &sender_cwd, &peer_cwd] {
@@ -11535,6 +11657,45 @@ mod tests {
             r#"{"identity":"../../_agent_tech-lead"}"#,
         )
         .unwrap();
+        (sender_cwd, peer_cwd)
+    }
+
+    /// (E-3) Seed a live, busy peer session so the gate is actually exercised.
+    /// Returns the session id and the mock backend handle (to set_live).
+    async fn seed_live_busy_peer(
+        app: &tauri::AppHandle<tauri::test::MockRuntime>,
+        peer_cwd: &Path,
+    ) -> Uuid {
+        let session_id = add_mailbox_session(
+            app,
+            peer_cwd,
+            "wg-1-dev-team/dev-rust",
+            SessionStatus::Running,
+            None,
+        )
+        .await;
+        // Register the session as live in the mock PTY backend.
+        let pty_mgr = app.state::<Arc<std::sync::Mutex<crate::pty::manager::PtyManager>>>();
+        let mgr = pty_mgr.lock().unwrap();
+        mgr.record_route(
+            session_id,
+            crate::pty::backend::SessionBackendKind::LocalProcess,
+        );
+        let backend = mgr.backend_for_kind(crate::pty::backend::SessionBackendKind::LocalProcess);
+        let mock = backend
+            .as_any()
+            .downcast_ref::<MailboxMockPtyBackend>()
+            .expect("backend must be MailboxMockPtyBackend");
+        mock.set_live(session_id);
+        session_id
+    }
+
+    /// (D-3/F-7) A purge-wg message with no session token must be rejected,
+    /// even if `is_master` would be true.
+    #[tokio::test]
+    async fn process_message_purge_wg_without_token_is_rejected() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let (sender_cwd, _peer_cwd) = setup_purge_fixture(&temp, "dev-team");
 
         let app_struct = make_mailbox_app(temp.path());
         let app = app_handle(&app_struct);
@@ -11554,44 +11715,59 @@ mod tests {
         );
         let poller = MailboxPoller::new_with_test_hooks(hooks);
         let result = poller.process_message(&app, &path, false).await;
-        // reject_message still returns Ok, so process_message succeeds.
-        assert!(result.is_ok(), "process_message should not error on rejection");
+        assert!(
+            result.is_ok(),
+            "process_message should not error on rejection"
+        );
 
-        // The rejected/ directory must exist.
+        // (#885 E-1) Assert on the REASON, not just file existence. A rejection
+        // test that does not pin which guard rejected passes when the guard is
+        // deleted.
         let rejected = sender_cwd
             .join(crate::config::agent_local_dir_name())
             .join("outbox")
             .join("rejected")
             .join("msg-purge-notoken.reason.txt");
         assert!(rejected.exists(), "tokenless purge must be rejected");
+        let reason = std::fs::read_to_string(&rejected).unwrap();
+        assert!(
+            reason.contains("requires a session token"),
+            "must be rejected by the F-7 token guard, not by WG resolution: {reason}"
+        );
 
-        // No destroy events.
+        // (#885 E-2) Zero destroy events (now meaningful with the hook).
         assert_no_spawn_or_destroy_events(&hooks_clone);
     }
 
     /// (D-3/F-7) A master-token message with a forged `from` naming another
-    /// WG's coordinator must be rejected. The master path skips anti-spoof,
-    /// but `saw_session_token` is false, so the F-7 guard fires.
+    /// WG's coordinator must be rejected. The forged WG is fully constructed
+    /// on disk so `verified_wg_coordinator_target` SUCCEEDS; the F-7 token
+    /// guard is the only thing between a master token and a cross-WG purge.
     #[tokio::test]
     async fn process_message_purge_wg_with_master_token_and_forged_from_is_rejected() {
         let temp = tempfile::TempDir::new().unwrap();
+        let (sender_cwd, _peer_cwd) = setup_purge_fixture(&temp, "dev-team");
+
+        // (#885 E-1) Construct a SECOND, fully valid workgroup so
+        // `verified_wg_coordinator_target` succeeds for the forged `from`.
+        // Without this, the forged WG doesn't exist and the message is
+        // rejected by WG resolution, not by the F-7 guard.
         let project = temp.path().join("proj-a");
         let workspace = project.join(".ac");
-        let team_dir = workspace.join("_team_dev-team");
-        let origin_tl = workspace.join("_agent_tech-lead");
-        let wg_dir = workspace.join("wg-1-dev-team");
-        let sender_cwd = wg_dir.join("__agent_tech-lead");
-        let peer_cwd = wg_dir.join("__agent_dev-rust");
-        for d in [&team_dir, &origin_tl, &sender_cwd, &peer_cwd] {
+        let other_team_dir = workspace.join("_team_other-team");
+        let other_wg_dir = workspace.join("wg-1-other-team");
+        let other_sender_cwd = other_wg_dir.join("__agent_tech-lead");
+        let other_peer_cwd = other_wg_dir.join("__agent_dev-rust");
+        for d in [&other_team_dir, &other_sender_cwd, &other_peer_cwd] {
             std::fs::create_dir_all(d).unwrap();
         }
         std::fs::write(
-            team_dir.join("config.json"),
+            other_team_dir.join("config.json"),
             r#"{"agents":["../_agent_dev-rust"],"coordinator":"../_agent_tech-lead"}"#,
         )
         .unwrap();
         std::fs::write(
-            sender_cwd.join("config.json"),
+            other_sender_cwd.join("config.json"),
             r#"{"identity":"../../_agent_tech-lead"}"#,
         )
         .unwrap();
@@ -11601,19 +11777,26 @@ mod tests {
         let hooks = MailboxTestHooks::default();
         let hooks_clone = hooks.clone();
 
-        // Master token, but `from` names a DIFFERENT workgroup's coordinator.
+        // Master token, `from` names the OTHER workgroup's coordinator.
+        // `verified_wg_coordinator_target` will SUCCEED (the WG exists on disk).
+        // The F-7 guard (`!saw_session_token`) is the only thing that rejects.
+        //
+        // Process this as app-outbox traffic so the repo-outbox owner check
+        // does not reject first. That mirrors the master-token surface: with
+        // the old `is_master || saw_session_token` guard, an app-outbox
+        // message could pick any verified WG coordinator as `from`.
         let path = build_purge_wg_message(
             &sender_cwd,
             "msg-purge-forged",
             "rid-purge-forged",
-            "proj-a:wg-other-team/tech-lead", // forged
+            "proj-a:wg-1-other-team/tech-lead", // forged: a different WG
             Some(MAILBOX_MASTER_TOKEN),
             false,
             3000,
             None,
         );
         let poller = MailboxPoller::new_with_test_hooks(hooks);
-        let result = poller.process_message(&app, &path, false).await;
+        let result = poller.process_message(&app, &path, true).await;
         assert!(result.is_ok());
 
         let rejected = sender_cwd
@@ -11625,8 +11808,14 @@ mod tests {
             rejected.exists(),
             "master-token purge with forged from must be rejected"
         );
+        // (#885 E-1) Pin WHICH guard rejected.
+        let reason = std::fs::read_to_string(&rejected).unwrap();
+        assert!(
+            reason.contains("requires a session token"),
+            "must be rejected by the F-7 token guard, not by WG resolution: {reason}"
+        );
 
-        // Zero destroy events.
+        // (#885 E-2) Zero destroy events.
         assert_no_spawn_or_destroy_events(&hooks_clone);
     }
 
@@ -11635,26 +11824,7 @@ mod tests {
     #[tokio::test]
     async fn root_guard_aborts_purge() {
         let temp = tempfile::TempDir::new().unwrap();
-        let project = temp.path().join("proj-a");
-        let workspace = project.join(".ac");
-        let team_dir = workspace.join("_team_dev-team");
-        let origin_tl = workspace.join("_agent_tech-lead");
-        let wg_dir = workspace.join("wg-1-dev-team");
-        let sender_cwd = wg_dir.join("__agent_tech-lead");
-        let peer_cwd = wg_dir.join("__agent_dev-rust");
-        for d in [&team_dir, &origin_tl, &sender_cwd, &peer_cwd] {
-            std::fs::create_dir_all(d).unwrap();
-        }
-        std::fs::write(
-            team_dir.join("config.json"),
-            r#"{"agents":["../_agent_dev-rust"],"coordinator":"../_agent_tech-lead"}"#,
-        )
-        .unwrap();
-        std::fs::write(
-            sender_cwd.join("config.json"),
-            r#"{"identity":"../../_agent_tech-lead"}"#,
-        )
-        .unwrap();
+        let (sender_cwd, peer_cwd) = setup_purge_fixture(&temp, "dev-team");
 
         let app_struct = make_mailbox_app(temp.path());
         let app = app_handle(&app_struct);
@@ -11709,60 +11879,43 @@ mod tests {
         let poller = MailboxPoller::new_with_test_hooks(hooks);
         let _ = poller.process_message(&app, &path, false).await;
 
-        // The response should contain "failed_root_guard".
+        // (#885 E-6) Assert, don't hedge.
         let responses_dir = sender_cwd
             .join(crate::config::agent_local_dir_name())
             .join("responses");
         let response_path = responses_dir.join("rid-purge-rootguard.json");
-        if response_path.exists() {
-            let body = std::fs::read_to_string(&response_path).unwrap();
-            assert!(
-                body.contains("failed_root_guard"),
-                "response must contain 'failed_root_guard': {}",
-                body
-            );
-        }
+        assert!(
+            response_path.exists(),
+            "root guard response must be written"
+        );
+        let body = std::fs::read_to_string(&response_path).unwrap();
+        assert!(
+            body.contains("failed_root_guard"),
+            "response must contain 'failed_root_guard': {}",
+            body
+        );
 
-        // Zero destroy events: the root guard aborts before the destroy loop.
+        // (#885 E-2) Zero destroy events: the root guard aborts before the
+        // destroy loop.
         assert_no_spawn_or_destroy_events(&hooks_clone);
     }
 
     /// (D-3) A hand-crafted `quietPeriodMs: 0` must be clamped to >= 2500
     /// daemon-side. The clamp is inside `handle_purge_wg` and unreachable
     /// from a unit test on `evaluate_gate` alone, so this exercises the
-    /// full `process_message` path.
+    /// full `process_message` path. (E-3) Seeds a live busy peer so the
+    /// gate is actually exercised, not vacuously passed.
     #[tokio::test]
     async fn quiet_period_is_clamped_to_floor() {
-        // This test verifies the clamp logic exists by checking the code path
-        // does not panic with quiet_period_ms=0. The clamp at mailbox.rs
-        // applies `.max(IdleTuning::DEFAULT.idle_threshold.as_millis() as u64)`,
-        // which is 2500. We exercise it via a dry-run that will pass (no live
-        // sessions = vacuously purgeable) and verify the response contains
-        // quiet_period_ms >= 2500.
         let temp = tempfile::TempDir::new().unwrap();
-        let project = temp.path().join("proj-a");
-        let workspace = project.join(".ac");
-        let team_dir = workspace.join("_team_dev-team");
-        let origin_tl = workspace.join("_agent_tech-lead");
-        let wg_dir = workspace.join("wg-1-dev-team");
-        let sender_cwd = wg_dir.join("__agent_tech-lead");
-        let peer_cwd = wg_dir.join("__agent_dev-rust");
-        for d in [&team_dir, &origin_tl, &sender_cwd, &peer_cwd] {
-            std::fs::create_dir_all(d).unwrap();
-        }
-        std::fs::write(
-            team_dir.join("config.json"),
-            r#"{"agents":["../_agent_dev-rust"],"coordinator":"../_agent_tech-lead"}"#,
-        )
-        .unwrap();
-        std::fs::write(
-            sender_cwd.join("config.json"),
-            r#"{"identity":"../../_agent_tech-lead"}"#,
-        )
-        .unwrap();
+        let (sender_cwd, peer_cwd) = setup_purge_fixture(&temp, "dev-team");
 
         let app_struct = make_mailbox_app(temp.path());
         let app = app_handle(&app_struct);
+
+        // (#885 E-3) Seed a live, busy peer so the gate is exercised, not
+        // vacuously passed with an empty pty_live set.
+        let peer_sid = seed_live_busy_peer(&app, &peer_cwd).await;
 
         // Seed a sender session for the token.
         let sender_session_id = add_mailbox_session(
@@ -11801,10 +11954,7 @@ mod tests {
             .join(crate::config::agent_local_dir_name())
             .join("responses");
         let response_path = responses_dir.join("rid-purge-clamp.json");
-        assert!(
-            response_path.exists(),
-            "dry-run response must be written"
-        );
+        assert!(response_path.exists(), "dry-run response must be written");
         let body: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&response_path).unwrap()).unwrap();
         let qp = body
@@ -11815,6 +11965,40 @@ mod tests {
             qp >= 2500,
             "quiet_period_ms must be clamped to >= 2500, got {}",
             qp
+        );
+        assert_eq!(
+            body.get("status").and_then(|v| v.as_str()),
+            Some("dry_run_blocked"),
+            "live busy peer must make the dry-run gate reject: {}",
+            body
+        );
+        assert_eq!(
+            body.get("would_purge").and_then(|v| v.as_bool()),
+            Some(false),
+            "dry-run must report that purge would not proceed: {}",
+            body
+        );
+        let peer_sid_str = peer_sid.to_string();
+        let peers = body
+            .get("peers")
+            .and_then(|v| v.as_array())
+            .expect("response must contain peers");
+        let peer = peers
+            .iter()
+            .find(|p| {
+                p.get("session_ids")
+                    .and_then(|v| v.as_array())
+                    .is_some_and(|ids| {
+                        ids.iter()
+                            .any(|id| id.as_str() == Some(peer_sid_str.as_str()))
+                    })
+            })
+            .expect("seeded live peer session must appear in purge gate response");
+        assert_eq!(
+            peer.get("purgeable").and_then(|v| v.as_bool()),
+            Some(false),
+            "seeded live busy peer must be non-purgeable: {}",
+            peer
         );
     }
 }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -3956,13 +3956,21 @@ impl MailboxPoller {
             mgr.list_sessions().await
         };
         let pty_live: std::collections::HashSet<Uuid> = {
-            let pty = app.state::<Arc<std::sync::Mutex<crate::pty::manager::PtyManager>>>();
-            let mgr = pty.lock().unwrap();
-            sessions
-                .iter()
-                .filter_map(|s| Uuid::parse_str(&s.id).ok())
-                .filter(|id| mgr.has_session(*id))
-                .collect()
+            // try_state: in production, PtyManager is managed. In tests where
+            // no PTY exists, this returns None and pty_live is empty, which
+            // is correct: all sessions are non-live by the F-3 predicate
+            // (!Exited && has_pty), so they are vacuously purgeable.
+            match app.try_state::<Arc<std::sync::Mutex<crate::pty::manager::PtyManager>>>() {
+                Some(pty) => {
+                    let mgr = pty.lock().unwrap();
+                    sessions
+                        .iter()
+                        .filter_map(|s| Uuid::parse_str(&s.id).ok())
+                        .filter(|id| mgr.has_session(*id))
+                        .collect()
+                }
+                None => std::collections::HashSet::new(),
+            }
         };
 
         // 6. Restore-in-progress guard (F-2: exit 3, not 0).
@@ -4083,6 +4091,11 @@ impl MailboxPoller {
         // 9. Dry-run exit, BEFORE the gate rejection (F-9).
         if msg.dry_run == Some(true) {
             let status = if decision.passed { "dry_run_ready" } else { "dry_run_blocked" };
+            // (N-3) The dry-run path reports `purgeable` and the diagnostic
+            // fields, NOT `outcome` (which is the gate's internal "busy"/
+            // "skipped"/"untracked" vocabulary and contradicts `would_purge:
+            // true` when every peer is "skipped" because it has no live
+            // session). An operator reads `purgeable: true`, not "skipped".
             let response = serde_json::json!({
                 "action": PURGE_WG_ACTION,
                 "workgroup": format!("{}:{}", wg.project, wg.wg_name),
@@ -4093,7 +4106,6 @@ impl MailboxPoller {
                 "would_purge": decision.passed,
                 "peers": decision.peers.iter().map(|p| serde_json::json!({
                     "name": p.fqn,
-                    "outcome": p.outcome,
                     "purgeable": p.purgeable,
                     "idle_ms": p.idle_ms,
                     "silence_ms": p.silence_ms,
@@ -4161,6 +4173,7 @@ impl MailboxPoller {
         let timeout_secs = msg.timeout_secs.unwrap_or(5);
         let mut closed_ids: Vec<String> = Vec::new();
         let mut failed_ids: Vec<String> = Vec::new();
+        let mut already_closed_ids: Vec<String> = Vec::new();
         let mut any_failed = false;
 
         for peer in &gate_peers {
@@ -4169,6 +4182,22 @@ impl MailboxPoller {
                     Ok(id) => id,
                     Err(_) => continue,
                 };
+                // (D-2) Re-probe existence: auto-close may have destroyed the
+                // record between the gate and this point. A vanished record is
+                // success (the workgroup IS purged), not a failure. Only
+                // graceful_close_session handles this correctly today
+                // (`mailbox.rs:5469-5473`); the force path returns `false` on
+                // "session not found", which would yield a false exit 4.
+                let exists = {
+                    let session_mgr =
+                        app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+                    let mgr = session_mgr.read().await;
+                    mgr.get_session(sid).await.is_some()
+                };
+                if !exists {
+                    already_closed_ids.push(sid_str.clone());
+                    continue;
+                }
                 let ok = if force {
                     self.force_close_session(app, sid).await
                 } else {
@@ -4196,10 +4225,13 @@ impl MailboxPoller {
             "quiet_period_ms": quiet.as_millis() as u64,
             "dry_run": false,
             "purged": closed_ids.len(),
+            "already_closed": already_closed_ids.len(),
             "failed": failed_ids.len(),
             "peers": decision.peers.iter().map(|p| {
                 let outcome = if failed_ids.iter().any(|f| p.session_ids.contains(f)) {
                     "failed"
+                } else if already_closed_ids.iter().any(|c| p.session_ids.contains(c)) && !closed_ids.iter().any(|c| p.session_ids.contains(c)) {
+                    "already_closed"
                 } else if closed_ids.iter().any(|c| p.session_ids.contains(c)) {
                     "closed"
                 } else {
@@ -6343,6 +6375,8 @@ mod tests {
             ..Default::default()
         };
 
+        let idle_detector = crate::pty::idle_detector::IdleDetector::new(|_| {}, |_| {});
+
         tauri::test::mock_builder()
             .manage(MasterToken::new(MAILBOX_MASTER_TOKEN.into()))
             .manage(AppOutbox::new(
@@ -6359,6 +6393,8 @@ mod tests {
             .manage(Arc::new(Mutex::new(HashSet::<Uuid>::new())))
             .manage(Arc::new(crate::RestoreInProgress(AtomicBool::new(false))))
             .manage(Arc::new(crate::PendingSelfClear::default()))
+            .manage(idle_detector) // #885: purge_readiness
+            .manage(std::sync::Arc::new(crate::session::purge_guard::PurgeGuard::default())) // #885
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("build mailbox test app")
     }
@@ -11274,20 +11310,22 @@ mod tests {
     #[test]
     fn gate_rejects_when_any_peer_busy() {
         let quiet = Duration::from_millis(3000);
+        let sid_a = Uuid::new_v4();
         let peer_a = make_gate_peer(
             "proj:wg-1/devs/alice",
             vec![PurgeGateSession {
-                session_id: Uuid::new_v4(),
-                readiness: make_readiness(Uuid::new_v4(), Some(500), true, None),
+                session_id: sid_a,
+                readiness: make_readiness(sid_a, Some(500), true, None),
                 mirror_idle: true,
             }],
             vec!["aaa".to_string()],
         );
+        let sid_b = Uuid::new_v4();
         let peer_b = make_gate_peer(
             "proj:wg-1/devs/bob",
             vec![PurgeGateSession {
-                session_id: Uuid::new_v4(),
-                readiness: make_readiness(Uuid::new_v4(), Some(100), true, None),
+                session_id: sid_b,
+                readiness: make_readiness(sid_b, Some(100), true, None),
                 mirror_idle: true,
             }],
             vec!["bbb".to_string()],
@@ -11316,11 +11354,12 @@ mod tests {
     #[test]
     fn gate_reports_untracked_not_busy() {
         let quiet = Duration::from_millis(3000);
+        let sid = Uuid::new_v4();
         let peer = make_gate_peer(
             "proj:wg-1/devs/alice",
             vec![PurgeGateSession {
-                session_id: Uuid::new_v4(),
-                readiness: make_readiness(Uuid::new_v4(), None, false, None),
+                session_id: sid,
+                readiness: make_readiness(sid, None, false, None),
                 mirror_idle: true,
             }],
             vec!["aaa".to_string()],
@@ -11336,11 +11375,12 @@ mod tests {
     #[test]
     fn gate_rejects_when_mirror_disagrees() {
         let quiet = Duration::from_millis(3000);
+        let sid = Uuid::new_v4();
         let peer = make_gate_peer(
             "proj:wg-1/devs/alice",
             vec![PurgeGateSession {
-                session_id: Uuid::new_v4(),
-                readiness: make_readiness(Uuid::new_v4(), Some(5000), true, None),
+                session_id: sid,
+                readiness: make_readiness(sid, Some(5000), true, None),
                 mirror_idle: false, // disagrees
             }],
             vec!["aaa".to_string()],
@@ -11406,11 +11446,12 @@ mod tests {
         // The evaluate_gate function never produces outcome "closed"; that
         // outcome is assigned by the destroy loop, not the gate. Verify.
         let quiet = Duration::from_millis(3000);
+        let sid = Uuid::new_v4();
         let busy_peer = make_gate_peer(
             "proj:wg-1/devs/alice",
             vec![PurgeGateSession {
-                session_id: Uuid::new_v4(),
-                readiness: make_readiness(Uuid::new_v4(), Some(100), true, None),
+                session_id: sid,
+                readiness: make_readiness(sid, Some(100), true, None),
                 mirror_idle: true,
             }],
             vec!["aaa".to_string()],
@@ -11420,6 +11461,360 @@ mod tests {
         assert!(
             !decision.peers.iter().any(|p| p.outcome == "closed"),
             "evaluate_gate must never produce outcome 'closed'"
+        );
+    }
+
+    // ── (#885 D-3) handle_purge_wg end-to-end tests ──
+
+    /// Build a purge-wg outbox message file in the sender's outbox.
+    #[allow(clippy::too_many_arguments)]
+    fn build_purge_wg_message(
+        sender_cwd: &Path,
+        msg_id: &str,
+        request_id: &str,
+        from: &str,
+        token: Option<&str>,
+        dry_run: bool,
+        quiet_period_ms: u64,
+        wg_assertion: Option<&str>,
+    ) -> PathBuf {
+        let outbox_dir = sender_cwd
+            .join(crate::config::agent_local_dir_name())
+            .join("outbox");
+        std::fs::create_dir_all(&outbox_dir).unwrap();
+        let message_path = outbox_dir.join(format!("{}.json", msg_id));
+        let msg = OutboxMessage {
+            id: msg_id.into(),
+            token: token.map(String::from),
+            from: from.into(),
+            to: String::new(),
+            body: String::new(),
+            mode: String::new(),
+            get_output: false,
+            request_id: Some(request_id.into()),
+            sender_agent: None,
+            preferred_agent: String::new(),
+            priority: "normal".into(),
+            timestamp: "2026-07-09T00:00:00Z".into(),
+            command: None,
+            action: Some(PURGE_WG_ACTION.into()),
+            target: wg_assertion.map(String::from),
+            force: Some(true),
+            timeout_secs: Some(5),
+            switch_coding_agent: None,
+            switch_profile: None,
+            dry_run: Some(dry_run),
+            quiet_period_ms: Some(quiet_period_ms),
+        };
+        std::fs::write(&message_path, serde_json::to_string_pretty(&msg).unwrap()).unwrap();
+        message_path
+    }
+
+    /// (D-3/F-7) A purge-wg message with no session token must be rejected,
+    /// even if `is_master` would be true.
+    #[tokio::test]
+    async fn process_message_purge_wg_without_token_is_rejected() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-a");
+        let workspace = project.join(".ac");
+        let team_dir = workspace.join("_team_dev-team");
+        let origin_tl = workspace.join("_agent_tech-lead");
+        let wg_dir = workspace.join("wg-1-dev-team");
+        let sender_cwd = wg_dir.join("__agent_tech-lead");
+        let peer_cwd = wg_dir.join("__agent_dev-rust");
+        for d in [&team_dir, &origin_tl, &sender_cwd, &peer_cwd] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        std::fs::write(
+            team_dir.join("config.json"),
+            r#"{"agents":["../_agent_dev-rust"],"coordinator":"../_agent_tech-lead"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            sender_cwd.join("config.json"),
+            r#"{"identity":"../../_agent_tech-lead"}"#,
+        )
+        .unwrap();
+
+        let app_struct = make_mailbox_app(temp.path());
+        let app = app_handle(&app_struct);
+        let hooks = MailboxTestHooks::default();
+        let hooks_clone = hooks.clone();
+
+        // Master token but NO session token: is_master=true, saw_session_token=false.
+        let path = build_purge_wg_message(
+            &sender_cwd,
+            "msg-purge-notoken",
+            "rid-purge-notoken",
+            "proj-a:wg-1-dev-team/tech-lead",
+            Some(MAILBOX_MASTER_TOKEN),
+            false,
+            3000,
+            None,
+        );
+        let poller = MailboxPoller::new_with_test_hooks(hooks);
+        let result = poller.process_message(&app, &path, false).await;
+        // reject_message still returns Ok, so process_message succeeds.
+        assert!(result.is_ok(), "process_message should not error on rejection");
+
+        // The rejected/ directory must exist.
+        let rejected = sender_cwd
+            .join(crate::config::agent_local_dir_name())
+            .join("outbox")
+            .join("rejected")
+            .join("msg-purge-notoken.reason.txt");
+        assert!(rejected.exists(), "tokenless purge must be rejected");
+
+        // No destroy events.
+        assert_no_spawn_or_destroy_events(&hooks_clone);
+    }
+
+    /// (D-3/F-7) A master-token message with a forged `from` naming another
+    /// WG's coordinator must be rejected. The master path skips anti-spoof,
+    /// but `saw_session_token` is false, so the F-7 guard fires.
+    #[tokio::test]
+    async fn process_message_purge_wg_with_master_token_and_forged_from_is_rejected() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-a");
+        let workspace = project.join(".ac");
+        let team_dir = workspace.join("_team_dev-team");
+        let origin_tl = workspace.join("_agent_tech-lead");
+        let wg_dir = workspace.join("wg-1-dev-team");
+        let sender_cwd = wg_dir.join("__agent_tech-lead");
+        let peer_cwd = wg_dir.join("__agent_dev-rust");
+        for d in [&team_dir, &origin_tl, &sender_cwd, &peer_cwd] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        std::fs::write(
+            team_dir.join("config.json"),
+            r#"{"agents":["../_agent_dev-rust"],"coordinator":"../_agent_tech-lead"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            sender_cwd.join("config.json"),
+            r#"{"identity":"../../_agent_tech-lead"}"#,
+        )
+        .unwrap();
+
+        let app_struct = make_mailbox_app(temp.path());
+        let app = app_handle(&app_struct);
+        let hooks = MailboxTestHooks::default();
+        let hooks_clone = hooks.clone();
+
+        // Master token, but `from` names a DIFFERENT workgroup's coordinator.
+        let path = build_purge_wg_message(
+            &sender_cwd,
+            "msg-purge-forged",
+            "rid-purge-forged",
+            "proj-a:wg-other-team/tech-lead", // forged
+            Some(MAILBOX_MASTER_TOKEN),
+            false,
+            3000,
+            None,
+        );
+        let poller = MailboxPoller::new_with_test_hooks(hooks);
+        let result = poller.process_message(&app, &path, false).await;
+        assert!(result.is_ok());
+
+        let rejected = sender_cwd
+            .join(crate::config::agent_local_dir_name())
+            .join("outbox")
+            .join("rejected")
+            .join("msg-purge-forged.reason.txt");
+        assert!(
+            rejected.exists(),
+            "master-token purge with forged from must be rejected"
+        );
+
+        // Zero destroy events.
+        assert_no_spawn_or_destroy_events(&hooks_clone);
+    }
+
+    /// (D-3) Guard B: a candidate with `is_root_agent: true` must abort the
+    /// purge with `failed_root_guard` and destroy nothing.
+    #[tokio::test]
+    async fn root_guard_aborts_purge() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-a");
+        let workspace = project.join(".ac");
+        let team_dir = workspace.join("_team_dev-team");
+        let origin_tl = workspace.join("_agent_tech-lead");
+        let wg_dir = workspace.join("wg-1-dev-team");
+        let sender_cwd = wg_dir.join("__agent_tech-lead");
+        let peer_cwd = wg_dir.join("__agent_dev-rust");
+        for d in [&team_dir, &origin_tl, &sender_cwd, &peer_cwd] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        std::fs::write(
+            team_dir.join("config.json"),
+            r#"{"agents":["../_agent_dev-rust"],"coordinator":"../_agent_tech-lead"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            sender_cwd.join("config.json"),
+            r#"{"identity":"../../_agent_tech-lead"}"#,
+        )
+        .unwrap();
+
+        let app_struct = make_mailbox_app(temp.path());
+        let app = app_handle(&app_struct);
+        let hooks = MailboxTestHooks::default();
+        let hooks_clone = hooks.clone();
+
+        // Seed a session at the peer CWD that looks like a root agent record.
+        let session_id = add_mailbox_session(
+            &app,
+            &peer_cwd,
+            "wg-1-dev-team/dev-rust",
+            SessionStatus::Idle,
+            None,
+        )
+        .await;
+        {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let mgr = session_mgr.read().await;
+            mgr.set_is_root_agent(session_id, true).await;
+        }
+
+        // We need a valid session token for the sender. Seed a session at the
+        // sender CWD to get a token.
+        let sender_session_id = add_mailbox_session(
+            &app,
+            &sender_cwd,
+            "wg-1-dev-team/tech-lead",
+            SessionStatus::Idle,
+            None,
+        )
+        .await;
+        let token = {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let mgr = session_mgr.read().await;
+            mgr.get_session(sender_session_id)
+                .await
+                .expect("sender session must exist")
+                .token
+                .to_string()
+        };
+
+        let path = build_purge_wg_message(
+            &sender_cwd,
+            "msg-purge-rootguard",
+            "rid-purge-rootguard",
+            "proj-a:wg-1-dev-team/tech-lead",
+            Some(&token),
+            false,
+            3000,
+            None,
+        );
+        let poller = MailboxPoller::new_with_test_hooks(hooks);
+        let _ = poller.process_message(&app, &path, false).await;
+
+        // The response should contain "failed_root_guard".
+        let responses_dir = sender_cwd
+            .join(crate::config::agent_local_dir_name())
+            .join("responses");
+        let response_path = responses_dir.join("rid-purge-rootguard.json");
+        if response_path.exists() {
+            let body = std::fs::read_to_string(&response_path).unwrap();
+            assert!(
+                body.contains("failed_root_guard"),
+                "response must contain 'failed_root_guard': {}",
+                body
+            );
+        }
+
+        // Zero destroy events: the root guard aborts before the destroy loop.
+        assert_no_spawn_or_destroy_events(&hooks_clone);
+    }
+
+    /// (D-3) A hand-crafted `quietPeriodMs: 0` must be clamped to >= 2500
+    /// daemon-side. The clamp is inside `handle_purge_wg` and unreachable
+    /// from a unit test on `evaluate_gate` alone, so this exercises the
+    /// full `process_message` path.
+    #[tokio::test]
+    async fn quiet_period_is_clamped_to_floor() {
+        // This test verifies the clamp logic exists by checking the code path
+        // does not panic with quiet_period_ms=0. The clamp at mailbox.rs
+        // applies `.max(IdleTuning::DEFAULT.idle_threshold.as_millis() as u64)`,
+        // which is 2500. We exercise it via a dry-run that will pass (no live
+        // sessions = vacuously purgeable) and verify the response contains
+        // quiet_period_ms >= 2500.
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-a");
+        let workspace = project.join(".ac");
+        let team_dir = workspace.join("_team_dev-team");
+        let origin_tl = workspace.join("_agent_tech-lead");
+        let wg_dir = workspace.join("wg-1-dev-team");
+        let sender_cwd = wg_dir.join("__agent_tech-lead");
+        let peer_cwd = wg_dir.join("__agent_dev-rust");
+        for d in [&team_dir, &origin_tl, &sender_cwd, &peer_cwd] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        std::fs::write(
+            team_dir.join("config.json"),
+            r#"{"agents":["../_agent_dev-rust"],"coordinator":"../_agent_tech-lead"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            sender_cwd.join("config.json"),
+            r#"{"identity":"../../_agent_tech-lead"}"#,
+        )
+        .unwrap();
+
+        let app_struct = make_mailbox_app(temp.path());
+        let app = app_handle(&app_struct);
+
+        // Seed a sender session for the token.
+        let sender_session_id = add_mailbox_session(
+            &app,
+            &sender_cwd,
+            "wg-1-dev-team/tech-lead",
+            SessionStatus::Idle,
+            None,
+        )
+        .await;
+        let token = {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let mgr = session_mgr.read().await;
+            mgr.get_session(sender_session_id)
+                .await
+                .expect("sender session must exist")
+                .token
+                .to_string()
+        };
+
+        // Dry-run with quiet_period_ms=0. The clamp must raise it to >= 2500.
+        let path = build_purge_wg_message(
+            &sender_cwd,
+            "msg-purge-clamp",
+            "rid-purge-clamp",
+            "proj-a:wg-1-dev-team/tech-lead",
+            Some(&token),
+            true, // dry-run
+            0,    // below floor
+            None,
+        );
+        let poller = MailboxPoller::new();
+        let _ = poller.process_message(&app, &path, false).await;
+
+        let responses_dir = sender_cwd
+            .join(crate::config::agent_local_dir_name())
+            .join("responses");
+        let response_path = responses_dir.join("rid-purge-clamp.json");
+        assert!(
+            response_path.exists(),
+            "dry-run response must be written"
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&response_path).unwrap()).unwrap();
+        let qp = body
+            .get("quiet_period_ms")
+            .and_then(|v| v.as_u64())
+            .expect("response must contain quiet_period_ms");
+        assert!(
+            qp >= 2500,
+            "quiet_period_ms must be clamped to >= 2500, got {}",
+            qp
         );
     }
 }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -1596,7 +1596,9 @@ pub(crate) fn evaluate_gate(peers: &[PurgeGatePeer], quiet: std::time::Duration)
         }
 
         let mut peer_purgeable = true;
-        let mut peer_outcome = "skipped";
+        let mut saw_untracked_failure = false;
+        let mut saw_busy_failure = false;
+        let mut saw_resize_only_failure = false;
         let mut idle_ms: Option<u128> = None;
         let mut silence_ms: Option<u128> = None;
         let mut watcher_idle = true;
@@ -1616,17 +1618,13 @@ pub(crate) fn evaluate_gate(peers: &[PurgeGatePeer], quiet: std::time::Duration)
 
             if !purgeable {
                 peer_purgeable = false;
-                // (#885 E-5) Distinguish resize-unsettled from busy: an
-                // operator told their idle agent is "busy" will hunt for a
-                // working agent that does not exist. If resize is the only
-                // failing leg, the terminal was recently resized.
-                peer_outcome = if r.activity_age.is_none() {
-                    "untracked"
+                if r.activity_age.is_none() {
+                    saw_untracked_failure = true;
                 } else if !r_settled && activity_ok && r.watcher_idle && m_idle {
-                    "resize_unsettled"
+                    saw_resize_only_failure = true;
                 } else {
-                    "busy"
-                };
+                    saw_busy_failure = true;
+                }
             }
 
             if let Some(a) = r.activity_age {
@@ -1649,6 +1647,22 @@ pub(crate) fn evaluate_gate(peers: &[PurgeGatePeer], quiet: std::time::Duration)
         if !peer_purgeable {
             passed = false;
         }
+
+        // (#885 E-5) Distinguish resize-unsettled from busy, but aggregate
+        // across all live sessions for the peer. `resize_unsettled` is only
+        // honest when resize is the sole failing leg for every failing live
+        // session. Unknown liveness is more important than either diagnostic.
+        let peer_outcome = if peer_purgeable {
+            "skipped"
+        } else if saw_untracked_failure {
+            "untracked"
+        } else if saw_busy_failure {
+            "busy"
+        } else if saw_resize_only_failure {
+            "resize_unsettled"
+        } else {
+            "busy"
+        };
 
         results.push(PurgePeerResult {
             fqn: peer.fqn.clone(),
@@ -11540,6 +11554,37 @@ mod tests {
         assert!(
             !decision.peers[0].resize_settled,
             "resize_settled must be false"
+        );
+    }
+
+    #[test]
+    fn gate_reports_busy_when_same_peer_has_busy_and_resize_unsettled_sessions() {
+        let quiet = Duration::from_millis(3000);
+        let busy_sid = Uuid::new_v4();
+        let resize_sid = Uuid::new_v4();
+        let peer = make_gate_peer(
+            "proj:wg-1/devs/alice",
+            vec![
+                PurgeGateSession {
+                    session_id: busy_sid,
+                    readiness: make_readiness(busy_sid, Some(100), true, None),
+                    mirror_idle: true,
+                },
+                PurgeGateSession {
+                    session_id: resize_sid,
+                    readiness: make_readiness(resize_sid, Some(3000), true, Some(3100)),
+                    mirror_idle: true,
+                },
+            ],
+            vec![busy_sid.to_string(), resize_sid.to_string()],
+        );
+
+        let decision = evaluate_gate(&[peer], quiet);
+
+        assert!(!decision.passed);
+        assert_eq!(
+            decision.peers[0].outcome, "busy",
+            "resize_unsettled must not mask a busy live session on the same peer"
         );
     }
 

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -536,6 +536,10 @@ pub(crate) fn self_clear_handoff_base_prompt(handoff_path: &str) -> String {
 /// #668 - the OutboxMessage `action` value for self-handoff-and-switch.
 pub(crate) const SELF_SWITCH_ACTION: &str = "self-handoff-and-switch";
 
+/// (#885) Bulk purge of the caller's own workgroup. Dispatched pre-routing,
+/// like the other self-scoped actions: there is no single recipient to route to.
+pub(crate) const PURGE_WG_ACTION: &str = "purge-wg";
+
 /// #668/#749 - Phase-2 prompt for the switch variant; see `handoff_base_prompt`.
 pub(crate) fn self_switch_handoff_base_prompt(handoff_path: &str) -> String {
     handoff_base_prompt(
@@ -1525,6 +1529,143 @@ pub struct MailboxPoller {
     test_hooks: Option<MailboxTestHooks>,
 }
 
+// ── (#885) purge-wg gate types and pure evaluator ──────────────────────
+
+/// (#885) One peer's correlated gate input. Built from the three snapshots
+/// (mirror `Vec<SessionInfo>`, `pty_live: HashSet<Uuid>`,
+/// `Vec<PurgeReadiness>`) before `evaluate_gate` is called.
+#[derive(Debug, Clone)]
+pub(crate) struct PurgeGatePeer {
+    pub fqn: String,
+    pub all_session_ids: Vec<String>,
+    pub live: Vec<PurgeGateSession>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PurgeGateSession {
+    pub session_id: Uuid,
+    pub readiness: crate::pty::idle_detector::PurgeReadiness,
+    pub mirror_idle: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PurgeDecision {
+    pub passed: bool,
+    pub peers: Vec<PurgePeerResult>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PurgePeerResult {
+    pub fqn: String,
+    pub purgeable: bool,
+    pub outcome: &'static str,
+    pub idle_ms: Option<u128>,
+    pub silence_ms: Option<u128>,
+    pub watcher_idle: bool,
+    pub mirror_idle: bool,
+    pub resize_settled: bool,
+    pub session_ids: Vec<String>,
+}
+
+/// (#885) Pure gate evaluator. Called by both the dry-run and the real path,
+/// so a dry-run cannot lie (§3.3). A peer is purgeable iff it has no live
+/// sessions (vacuously purgeable) or ALL of its live sessions pass the
+/// four-leg test:
+///   1. `activity_age >= effective_quiet` (printable silence)
+///   2. `watcher_idle` (watcher agreement)
+///   3. `mirror_idle` (SessionManager agreement)
+///   4. `resize_settled` (F-1: activity readings are trustworthy)
+pub(crate) fn evaluate_gate(
+    peers: &[PurgeGatePeer],
+    quiet: std::time::Duration,
+) -> PurgeDecision {
+    let mut passed = true;
+    let mut results = Vec::with_capacity(peers.len());
+
+    for peer in peers {
+        if peer.live.is_empty() {
+            results.push(PurgePeerResult {
+                fqn: peer.fqn.clone(),
+                purgeable: true,
+                outcome: "skipped",
+                idle_ms: None,
+                silence_ms: None,
+                watcher_idle: false,
+                mirror_idle: true,
+                resize_settled: true,
+                session_ids: peer.all_session_ids.clone(),
+            });
+            continue;
+        }
+
+        let mut peer_purgeable = true;
+        let mut peer_outcome = "skipped";
+        let mut idle_ms: Option<u128> = None;
+        let mut silence_ms: Option<u128> = None;
+        let mut watcher_idle = true;
+        let mut mirror_idle = true;
+        let mut resize_settled = true;
+
+        for session in &peer.live {
+            let r = &session.readiness;
+            let effective_quiet = quiet.max(r.idle_threshold);
+            let m_idle = session.mirror_idle;
+            let r_settled = match r.last_resize_age {
+                None => true,
+                Some(a) => a >= r.resize_grace + effective_quiet,
+            };
+            let activity_ok = matches!(r.activity_age, Some(a) if a >= effective_quiet);
+            let purgeable = activity_ok && r.watcher_idle && m_idle && r_settled;
+
+            if !purgeable {
+                peer_purgeable = false;
+                peer_outcome = if r.activity_age.is_none() {
+                    "untracked"
+                } else {
+                    "busy"
+                };
+            }
+
+            if let Some(a) = r.activity_age {
+                idle_ms = Some(idle_ms.map_or(a.as_millis(), |m: u128| m.min(a.as_millis())));
+            }
+            if let Some(s) = r.silence_age {
+                silence_ms = Some(silence_ms.map_or(s.as_millis(), |m: u128| m.min(s.as_millis())));
+            }
+            if !r.watcher_idle {
+                watcher_idle = false;
+            }
+            if !m_idle {
+                mirror_idle = false;
+            }
+            if !r_settled {
+                resize_settled = false;
+            }
+        }
+
+        if !peer_purgeable {
+            passed = false;
+        }
+
+        results.push(PurgePeerResult {
+            fqn: peer.fqn.clone(),
+            purgeable: peer_purgeable,
+            outcome: peer_outcome,
+            idle_ms,
+            silence_ms,
+            watcher_idle,
+            mirror_idle,
+            resize_settled,
+            session_ids: peer.all_session_ids.clone(),
+        });
+    }
+
+    PurgeDecision {
+        passed,
+        peers: results,
+    }
+}
+
 impl Default for MailboxPoller {
     fn default() -> Self {
         Self::new()
@@ -1972,6 +2113,25 @@ impl MailboxPoller {
             return self.handle_raise_hand(app, path, &msg, is_app_outbox).await;
         }
 
+        // (#885 F-7) `purge-wg` dispatches pre-routing, after the anti-spoof block.
+        // `msg.from` is anti-spoof-verified ONLY inside the `if !is_master` block
+        // above, so it is unverified both for a tokenless message AND for a
+        // master-token message. `saw_session_token` is the single bit that proves
+        // `msg.from` was checked against a live session's CWD. It is NOT disjoined
+        // with `is_master`: a master-token message would sail through with an
+        // attacker-chosen `msg.from`, and `verified_wg_coordinator_target` would
+        // resolve against ANY workgroup on disk. Root has no workgroup.
+        if msg.action.as_deref() == Some(PURGE_WG_ACTION) {
+            if !saw_session_token {
+                return self
+                    .reject_message(path, &msg, "purge-wg requires a session token")
+                    .await;
+            }
+            return self
+                .handle_purge_wg(app, path, &msg, is_app_outbox)
+                .await;
+        }
+
         if root_agent_claim {
             let mut paths = {
                 let cfg = app.state::<SettingsState>();
@@ -2138,6 +2298,25 @@ impl MailboxPoller {
         msg: &OutboxMessage,
         origin: WakeDeliveryOrigin,
     ) -> Result<(), String> {
+        // (#885 J2) A purge is destroying this agent's record right now. A wake
+        // delivered into that window falls through to spawn-persistent below and
+        // would cold-spawn the agent we are purging, silently breaking the verb's
+        // postcondition. This is a BACKSTOP, not the primary defense: the DB
+        // dispatcher must skip its tick before leasing (see `api/dispatcher.rs`,
+        // #885 F-5); reaching this Err from there would burn an attempt and can
+        // POISON the message. The two callers for which this Err is safe:
+        //   - filesystem poller: non-permanent error, retried at the 3s poll
+        //     interval up to MAX_DELIVERY_ATTEMPTS. Deferred, not lost.
+        //   - inline API send: mapped to DeliveryOutcome::Rejected. No retry.
+        if let Some(g) = app.try_state::<std::sync::Arc<crate::session::purge_guard::PurgeGuard>>() {
+            if g.blocks_agent(&msg.to) {
+                return Err(format!(
+                    "purge-wg in progress for '{}'; wake deferred",
+                    msg.to
+                ));
+            }
+        }
+
         // Whether the spawn-fallback should allow provider auto-resume.
         // Default false: cold wake — no SessionManager record at this CWD.
         // Promoted to true in two paths below: (a) RespawnExited deferred-
@@ -3662,7 +3841,436 @@ impl MailboxPoller {
         self.move_to_delivered(path, msg).await
     }
 
-    /// #617 - queue a deferred self-clear for the session that owns `msg.token`.
+    // ── (#885) purge-wg ──────────────────────────────────────────────────
+
+    /// (#885) Handle `purge-wg`: purge every peer in the caller's own workgroup.
+    ///
+    /// Sequence is non-reorderable. Steps 1-14 per plan §5.5c, consensus round 1.
+    async fn handle_purge_wg<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        path: &std::path::Path,
+        msg: &OutboxMessage,
+        is_app_outbox: bool,
+    ) -> Result<(), String> {
+        // 1. Identity gate — already enforced by the caller (§5.5b).
+        debug_assert!(
+            msg.token.is_some(),
+            "purge-wg requires a session token; caller must enforce"
+        );
+
+        // 2. Resolve WG scope and authorization, one call (§3.6).
+        let effective_paths = {
+            let mut paths = {
+                let cfg = app.state::<SettingsState>();
+                let c = cfg.read().await;
+                c.project_paths.clone()
+            };
+            match derive_project_from_outbox_path(path) {
+                Ok(Some(root_project)) => {
+                    let canon = std::fs::canonicalize(&root_project).ok();
+                    let already = paths.iter().any(|p| match &canon {
+                        Some(ct) => std::fs::canonicalize(p).ok().as_ref() == Some(ct),
+                        None => p == &root_project,
+                    });
+                    if !already {
+                        paths.push(root_project);
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    return self.reject_message(path, msg, &e).await;
+                }
+            }
+            paths
+        };
+        let wg = match crate::config::teams::verified_wg_coordinator_target(&msg.from, &effective_paths) {
+            Some(wg) => wg,
+            None => {
+                return self
+                    .reject_message(
+                        path,
+                        msg,
+                        &format!(
+                            "Not authorized: '{}' is not the verified coordinator of its workgroup",
+                            msg.from
+                        ),
+                    )
+                    .await;
+            }
+        };
+
+        // 3. --wg assertion (§3.6: interlock, not selector).
+        if let Some(ref t) = msg.target {
+            if t != &wg.wg_name {
+                return self
+                    .reject_message(
+                        path,
+                        msg,
+                        &format!(
+                            "purge-wg: --wg assertion '{}' does not match resolved workgroup '{}'",
+                            t, wg.wg_name
+                        ),
+                    )
+                    .await;
+            }
+        }
+
+        // 4. Enumerate peers (Guard A). Only `__agent_*` dirs under the WG dir.
+        //    The coordinator does not purge itself.
+        let wg_dir = match wg.replica_dir.parent() {
+            Some(d) => d,
+            None => {
+                return self
+                    .reject_message(path, msg, "purge-wg: cannot resolve WG directory")
+                    .await;
+            }
+        };
+        let mut peer_fqns: Vec<String> = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(wg_dir) {
+            for entry in entries.flatten() {
+                let name = match entry.file_name().to_str() {
+                    Some(n) => n.to_string(),
+                    None => continue,
+                };
+                let agent = match name.strip_prefix("__agent_") {
+                    Some(a) => a.to_string(),
+                    None => continue,
+                };
+                if agent == wg.agent_name {
+                    continue;
+                }
+                if !entry.path().is_dir() {
+                    continue;
+                }
+                peer_fqns.push(format!("{}:{}/{}", wg.project, wg.wg_name, agent));
+            }
+        }
+        peer_fqns.sort();
+
+        // 5. Take the mirror snapshot ONCE (F-4). One list_sessions(), one
+        //    PTY-liveness pass. Per-peer filtering reuses the pure predicate.
+        let sessions: Vec<SessionInfo> = {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let mgr = session_mgr.read().await;
+            mgr.list_sessions().await
+        };
+        let pty_live: std::collections::HashSet<Uuid> = {
+            let pty = app.state::<Arc<std::sync::Mutex<crate::pty::manager::PtyManager>>>();
+            let mgr = pty.lock().unwrap();
+            sessions
+                .iter()
+                .filter_map(|s| Uuid::parse_str(&s.id).ok())
+                .filter(|id| mgr.has_session(*id))
+                .collect()
+        };
+
+        // 6. Restore-in-progress guard (F-2: exit 3, not 0).
+        {
+            let restore_flag = app.state::<Arc<crate::RestoreInProgress>>();
+            if restore_flag.0.load(std::sync::atomic::Ordering::SeqCst) {
+                let response = serde_json::json!({
+                    "action": PURGE_WG_ACTION,
+                    "workgroup": format!("{}:{}", wg.project, wg.wg_name),
+                    "status": "restore_in_progress",
+                    "requested_by": msg.from,
+                    "peers": [],
+                });
+                return self.write_purge_response_and_deliver(
+                    app, path, msg, is_app_outbox, &response,
+                ).await;
+            }
+        }
+
+        // 7. Liveness and Guard B (F-3: !Exited && has_pty; F-12: root guard).
+        //    Collect live session info; the readiness snapshot (step 8) is
+        //    correlated into gate_peers after.
+        struct PeerLiveInfo {
+            fqn: String,
+            all_session_ids: Vec<String>,
+            live_sessions: Vec<(Uuid, bool)>, // (session_id, mirror_idle)
+        }
+        let mut peer_infos: Vec<PeerLiveInfo> = Vec::with_capacity(peer_fqns.len());
+        let mut all_live_session_ids: Vec<Uuid> = Vec::new();
+
+        for fqn in &peer_fqns {
+            let matched: Vec<&SessionInfo> = filter_sessions_by_fqn(&sessions, fqn);
+            let all_session_ids: Vec<String> =
+                matched.iter().map(|s| s.id.clone()).collect();
+
+            let mut live_sessions: Vec<(Uuid, bool)> = Vec::new();
+            for s in &matched {
+                // Guard B (root): corrupted-state assertion (F-12).
+                if s.is_root_agent
+                    || crate::config::root_agent::is_root_agent_path(&s.working_directory)
+                {
+                    let response = serde_json::json!({
+                        "action": PURGE_WG_ACTION,
+                        "workgroup": format!("{}:{}", wg.project, wg.wg_name),
+                        "status": "failed_root_guard",
+                        "requested_by": msg.from,
+                        "offending_session_id": s.id,
+                        "offending_working_directory": s.working_directory,
+                        "peers": [],
+                    });
+                    return self.write_purge_response_and_deliver(
+                        app, path, msg, is_app_outbox, &response,
+                    ).await;
+                }
+
+                let sid = match Uuid::parse_str(&s.id) {
+                    Ok(id) => id,
+                    Err(_) => continue,
+                };
+                let is_live = !matches!(s.status, SessionStatus::Exited(_))
+                    && pty_live.contains(&sid);
+                if is_live {
+                    let mirror_idle = !matches!(s.status, SessionStatus::Active | SessionStatus::Running)
+                        || s.waiting_for_input;
+                    live_sessions.push((sid, mirror_idle));
+                    all_live_session_ids.push(sid);
+                }
+            }
+
+            peer_infos.push(PeerLiveInfo {
+                fqn: fqn.clone(),
+                all_session_ids,
+                live_sessions,
+            });
+        }
+
+        // 8. Readiness snapshot and the four-leg gate (§2.3.3, F-1).
+        let quiet = std::time::Duration::from_millis(
+            msg.quiet_period_ms
+                .unwrap_or(3000)
+                .max(crate::session::profile::IdleTuning::DEFAULT.idle_threshold.as_millis() as u64),
+        );
+        let readiness_map: std::collections::HashMap<Uuid, crate::pty::idle_detector::PurgeReadiness> = {
+            let idle = app.state::<Arc<crate::pty::idle_detector::IdleDetector>>();
+            let readiness = idle.purge_readiness(&all_live_session_ids);
+            readiness.into_iter().map(|r| (r.session_id, r)).collect()
+        };
+        // Correlate into gate_peers.
+        let gate_peers: Vec<PurgeGatePeer> = peer_infos
+            .iter()
+            .map(|info| PurgeGatePeer {
+                fqn: info.fqn.clone(),
+                all_session_ids: info.all_session_ids.clone(),
+                live: info
+                    .live_sessions
+                    .iter()
+                    .map(|(sid, mirror_idle)| PurgeGateSession {
+                        session_id: *sid,
+                        readiness: readiness_map.get(sid).copied().unwrap_or(
+                            crate::pty::idle_detector::PurgeReadiness {
+                                session_id: *sid,
+                                activity_age: None,
+                                watcher_idle: false,
+                                last_resize_age: None,
+                                resize_grace: crate::session::profile::IdleTuning::DEFAULT.resize_grace,
+                                idle_threshold: crate::session::profile::IdleTuning::DEFAULT.idle_threshold,
+                                silence_age: None,
+                            },
+                        ),
+                        mirror_idle: *mirror_idle,
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        let decision = evaluate_gate(&gate_peers, quiet);
+
+        // 9. Dry-run exit, BEFORE the gate rejection (F-9).
+        if msg.dry_run == Some(true) {
+            let status = if decision.passed { "dry_run_ready" } else { "dry_run_blocked" };
+            let response = serde_json::json!({
+                "action": PURGE_WG_ACTION,
+                "workgroup": format!("{}:{}", wg.project, wg.wg_name),
+                "status": status,
+                "requested_by": msg.from,
+                "quiet_period_ms": quiet.as_millis() as u64,
+                "dry_run": true,
+                "would_purge": decision.passed,
+                "peers": decision.peers.iter().map(|p| serde_json::json!({
+                    "name": p.fqn,
+                    "outcome": p.outcome,
+                    "purgeable": p.purgeable,
+                    "idle_ms": p.idle_ms,
+                    "silence_ms": p.silence_ms,
+                    "watcher_idle": p.watcher_idle,
+                    "mirror_idle": p.mirror_idle,
+                    "resize_settled": p.resize_settled,
+                    "session_ids": p.session_ids,
+                })).collect::<Vec<_>>(),
+            });
+            return self.write_purge_response_and_deliver(
+                app, path, msg, is_app_outbox, &response,
+            ).await;
+        }
+
+        // 10. The gate. If any peer is not purgeable: reject, destroy nothing.
+        if !decision.passed {
+            let response = serde_json::json!({
+                "action": PURGE_WG_ACTION,
+                "workgroup": format!("{}:{}", wg.project, wg.wg_name),
+                "status": "rejected_busy",
+                "requested_by": msg.from,
+                "quiet_period_ms": quiet.as_millis() as u64,
+                "peers": decision.peers.iter().map(|p| serde_json::json!({
+                    "name": p.fqn,
+                    "outcome": p.outcome,
+                    "purgeable": p.purgeable,
+                    "idle_ms": p.idle_ms,
+                    "silence_ms": p.silence_ms,
+                    "watcher_idle": p.watcher_idle,
+                    "mirror_idle": p.mirror_idle,
+                    "resize_settled": p.resize_settled,
+                    "session_ids": p.session_ids,
+                })).collect::<Vec<_>>(),
+            });
+            return self.write_purge_response_and_deliver(
+                app, path, msg, is_app_outbox, &response,
+            ).await;
+        }
+
+        // 11. Acquire the lease (F-14: clone Arc into a named local first).
+        let mut target_sids: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
+        let mut target_fqns: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for peer in &gate_peers {
+            for session in &peer.live {
+                target_sids.insert(session.session_id);
+            }
+            target_fqns.insert(peer.fqn.clone());
+        }
+        // Also include non-live session IDs (Exited records) for destruction.
+        for peer in &gate_peers {
+            for sid_str in &peer.all_session_ids {
+                if let Ok(sid) = Uuid::parse_str(sid_str) {
+                    target_sids.insert(sid);
+                }
+            }
+        }
+        let purge_guard: Arc<crate::session::purge_guard::PurgeGuard> = app
+            .state::<Arc<crate::session::purge_guard::PurgeGuard>>()
+            .inner()
+            .clone();
+        let lease = purge_guard.acquire(target_sids, target_fqns).await;
+
+        // 12. Destroy loop (past the commit point, §2.5; no re-check).
+        let force = msg.force.unwrap_or(true);
+        let timeout_secs = msg.timeout_secs.unwrap_or(5);
+        let mut closed_ids: Vec<String> = Vec::new();
+        let mut failed_ids: Vec<String> = Vec::new();
+        let mut any_failed = false;
+
+        for peer in &gate_peers {
+            for sid_str in &peer.all_session_ids {
+                let sid = match Uuid::parse_str(sid_str) {
+                    Ok(id) => id,
+                    Err(_) => continue,
+                };
+                let ok = if force {
+                    self.force_close_session(app, sid).await
+                } else {
+                    self.graceful_close_session(app, sid, timeout_secs).await
+                };
+                if ok {
+                    closed_ids.push(sid_str.clone());
+                } else {
+                    failed_ids.push(sid_str.clone());
+                    any_failed = true;
+                }
+            }
+        }
+
+        // 13. Drop the lease before writing the response.
+        drop(lease);
+
+        // 14. Response + move_to_delivered.
+        let status = if any_failed { "partial_failure" } else { "purged" };
+        let response = serde_json::json!({
+            "action": PURGE_WG_ACTION,
+            "workgroup": format!("{}:{}", wg.project, wg.wg_name),
+            "status": status,
+            "requested_by": msg.from,
+            "quiet_period_ms": quiet.as_millis() as u64,
+            "dry_run": false,
+            "purged": closed_ids.len(),
+            "failed": failed_ids.len(),
+            "peers": decision.peers.iter().map(|p| {
+                let outcome = if failed_ids.iter().any(|f| p.session_ids.contains(f)) {
+                    "failed"
+                } else if closed_ids.iter().any(|c| p.session_ids.contains(c)) {
+                    "closed"
+                } else {
+                    "no_match"
+                };
+                serde_json::json!({
+                    "name": p.fqn,
+                    "outcome": outcome,
+                    "session_ids": p.session_ids,
+                    "purgeable": p.purgeable,
+                })
+            }).collect::<Vec<_>>(),
+        });
+
+        self.write_purge_response_and_deliver(app, path, msg, is_app_outbox, &response)
+            .await
+    }
+
+    /// (#885) Write the purge response JSON and move the message to delivered/.
+    /// Mirrors `handle_close_session`'s dual-write block (§224 A.6, G-IMPL-2).
+    async fn write_purge_response_and_deliver<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        path: &std::path::Path,
+        msg: &OutboxMessage,
+        is_app_outbox: bool,
+        response: &serde_json::Value,
+    ) -> Result<(), String> {
+        let json = match serde_json::to_string_pretty(response) {
+            Ok(j) => j,
+            Err(e) => {
+                log::warn!("[mailbox] Failed to serialize purge-wg response: {}", e);
+                return self.move_to_delivered(path, msg).await;
+            }
+        };
+
+        if let Some(ref rid) = msg.request_id {
+            if !is_app_outbox {
+                let outbox_relative_responses_dir = path
+                    .parent()
+                    .and_then(|p| p.parent())
+                    .map(|ac_dir| ac_dir.join("responses"));
+                if let Some(responses_dir) = outbox_relative_responses_dir {
+                    let _ = std::fs::create_dir_all(&responses_dir);
+                    let response_path = responses_dir.join(format!("{}.json", rid));
+                    if let Err(e) = std::fs::write(&response_path, &json) {
+                        log::warn!(
+                            "[mailbox] Failed to write purge-wg response to outbox-relative path {:?}: {}",
+                            response_path, e
+                        );
+                    }
+                }
+            }
+
+            if let Some(sender_path) = self.resolve_repo_path(&msg.from, app).await {
+                let responses_dir = std::path::PathBuf::from(sender_path)
+                    .join(crate::config::agent_local_dir_name())
+                    .join("responses");
+                let _ = std::fs::create_dir_all(&responses_dir);
+                let response_path = responses_dir.join(format!("{}.json", rid));
+                if let Err(e) = std::fs::write(&response_path, &json) {
+                    log::warn!(
+                        "[mailbox] Failed to write purge-wg response to resolved-sender path: {}",
+                        e
+                    );
+                }
+            }
+        }
+
+        self.move_to_delivered(path, msg).await
+    }
     /// Returns fast: the 30s sustained-idle wait runs in a detached task so the
     /// poll loop is never blocked. Idempotent: a second request while one is
     /// pending is a no-op ("already_queued").
@@ -5462,6 +6070,7 @@ mod tests {
     use crate::telegram::manager::TelegramBridgeManager;
     use std::collections::HashSet;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use std::time::Duration;
     use tauri::Listener;
 
     // ── §224 D.5a — wait_for_restore_or_session unit tests ──
@@ -5685,6 +6294,8 @@ mod tests {
             timeout_secs: None,
             switch_coding_agent: None,
             switch_profile: None,
+            dry_run: None,
+            quiet_period_ms: None,
         }
     }
 
@@ -5895,6 +6506,8 @@ mod tests {
             timeout_secs: None,
             switch_coding_agent: None,
             switch_profile: None,
+            dry_run: None,
+            quiet_period_ms: None,
         };
         std::fs::write(&message_path, serde_json::to_string_pretty(&msg).unwrap()).unwrap();
         message_path
@@ -7826,6 +8439,8 @@ mod tests {
             timeout_secs: None,
             switch_coding_agent: None,
             switch_profile: None,
+            dry_run: None,
+            quiet_period_ms: None,
         };
         std::fs::write(&path, serde_json::to_string_pretty(&msg).unwrap()).unwrap();
         (path, msg)
@@ -8463,6 +9078,8 @@ mod tests {
             timeout_secs: None,
             switch_coding_agent: None,
             switch_profile: None,
+            dry_run: None,
+            quiet_period_ms: None,
         };
         std::fs::write(&path, serde_json::to_string_pretty(&msg).unwrap()).unwrap();
         (path, msg)
@@ -8571,6 +9188,8 @@ mod tests {
             timeout_secs: None,
             switch_coding_agent: coding_agent.map(str::to_string),
             switch_profile: profile.map(str::to_string),
+            dry_run: None,
+            quiet_period_ms: None,
         };
         std::fs::write(&path, serde_json::to_string_pretty(&msg).unwrap()).unwrap();
         (path, msg)
@@ -10618,6 +11237,189 @@ mod tests {
             reason.contains("Undeliverable"),
             "reason content: {}",
             reason
+        );
+    }
+
+    // ── (#885) evaluate_gate pure function tests ──
+
+    fn make_readiness(
+        session_id: Uuid,
+        activity_age_ms: Option<u64>,
+        watcher_idle: bool,
+        last_resize_age_ms: Option<u64>,
+    ) -> crate::pty::idle_detector::PurgeReadiness {
+        crate::pty::idle_detector::PurgeReadiness {
+            session_id,
+            activity_age: activity_age_ms.map(Duration::from_millis),
+            watcher_idle,
+            last_resize_age: last_resize_age_ms.map(Duration::from_millis),
+            resize_grace: Duration::from_millis(3000),
+            idle_threshold: Duration::from_millis(2500),
+            silence_age: None,
+        }
+    }
+
+    fn make_gate_peer(
+        fqn: &str,
+        live: Vec<PurgeGateSession>,
+        all_session_ids: Vec<String>,
+    ) -> PurgeGatePeer {
+        PurgeGatePeer {
+            fqn: fqn.to_string(),
+            all_session_ids,
+            live,
+        }
+    }
+
+    #[test]
+    fn gate_rejects_when_any_peer_busy() {
+        let quiet = Duration::from_millis(3000);
+        let peer_a = make_gate_peer(
+            "proj:wg-1/devs/alice",
+            vec![PurgeGateSession {
+                session_id: Uuid::new_v4(),
+                readiness: make_readiness(Uuid::new_v4(), Some(500), true, None),
+                mirror_idle: true,
+            }],
+            vec!["aaa".to_string()],
+        );
+        let peer_b = make_gate_peer(
+            "proj:wg-1/devs/bob",
+            vec![PurgeGateSession {
+                session_id: Uuid::new_v4(),
+                readiness: make_readiness(Uuid::new_v4(), Some(100), true, None),
+                mirror_idle: true,
+            }],
+            vec!["bbb".to_string()],
+        );
+        let decision = evaluate_gate(&[peer_a, peer_b], quiet);
+        assert!(!decision.passed, "gate must reject when a peer is busy");
+        assert!(
+            !decision.peers.iter().any(|p| p.outcome == "closed"),
+            "no peer should be 'closed' on a rejected gate"
+        );
+    }
+
+    #[test]
+    fn gate_treats_no_live_session_peer_as_purgeable() {
+        let quiet = Duration::from_millis(3000);
+        let peer = make_gate_peer(
+            "proj:wg-1/devs/alice",
+            vec![], // no live sessions
+            vec!["aaa".to_string()],
+        );
+        let decision = evaluate_gate(&[peer], quiet);
+        assert!(decision.passed, "a peer with no live sessions is vacuously purgeable");
+        assert!(decision.peers[0].purgeable);
+    }
+
+    #[test]
+    fn gate_reports_untracked_not_busy() {
+        let quiet = Duration::from_millis(3000);
+        let peer = make_gate_peer(
+            "proj:wg-1/devs/alice",
+            vec![PurgeGateSession {
+                session_id: Uuid::new_v4(),
+                readiness: make_readiness(Uuid::new_v4(), None, false, None),
+                mirror_idle: true,
+            }],
+            vec!["aaa".to_string()],
+        );
+        let decision = evaluate_gate(&[peer], quiet);
+        assert!(!decision.passed);
+        assert_eq!(
+            decision.peers[0].outcome, "untracked",
+            "a live record with activity_age: None must be 'untracked', not 'busy'"
+        );
+    }
+
+    #[test]
+    fn gate_rejects_when_mirror_disagrees() {
+        let quiet = Duration::from_millis(3000);
+        let peer = make_gate_peer(
+            "proj:wg-1/devs/alice",
+            vec![PurgeGateSession {
+                session_id: Uuid::new_v4(),
+                readiness: make_readiness(Uuid::new_v4(), Some(5000), true, None),
+                mirror_idle: false, // disagrees
+            }],
+            vec!["aaa".to_string()],
+        );
+        let decision = evaluate_gate(&[peer], quiet);
+        assert!(!decision.passed, "mirror disagreement must reject");
+    }
+
+    /// (#885 F-1) The acceptance test: a peer inside resize settlement must
+    /// be rejected even if activity_age, watcher_idle, and mirror_idle all
+    /// agree "idle".
+    #[test]
+    fn gate_rejects_peer_inside_resize_settlement() {
+        let quiet = Duration::from_millis(3000);
+        // activity_age = 3s (>= quiet), watcher_idle = true, mirror_idle = true.
+        // last_resize_age = 3.1s, resize_grace = 3s, effective_quiet = 3s.
+        // resize_settled requires last_resize_age >= resize_grace + effective_quiet = 6s.
+        // 3.1s < 6s => not settled => must reject.
+        let sid = Uuid::new_v4();
+        let peer = make_gate_peer(
+            "proj:wg-1/devs/alice",
+            vec![PurgeGateSession {
+                session_id: sid,
+                readiness: make_readiness(sid, Some(3000), true, Some(3100)),
+                mirror_idle: true,
+            }],
+            vec!["aaa".to_string()],
+        );
+        let decision = evaluate_gate(&[peer], quiet);
+        assert!(
+            !decision.passed,
+            "F-1: a peer inside resize settlement must be rejected"
+        );
+        assert!(
+            !decision.peers[0].resize_settled,
+            "resize_settled must be false"
+        );
+    }
+
+    #[test]
+    fn gate_accepts_peer_after_resize_settles() {
+        let quiet = Duration::from_millis(3000);
+        // last_resize_age = 6.1s >= resize_grace(3s) + effective_quiet(3s) = 6s.
+        let sid = Uuid::new_v4();
+        let peer = make_gate_peer(
+            "proj:wg-1/devs/alice",
+            vec![PurgeGateSession {
+                session_id: sid,
+                readiness: make_readiness(sid, Some(3000), true, Some(6100)),
+                mirror_idle: true,
+            }],
+            vec!["aaa".to_string()],
+        );
+        let decision = evaluate_gate(&[peer], quiet);
+        assert!(
+            decision.passed,
+            "a peer past resize settlement with all legs agreeing must pass"
+        );
+    }
+
+    #[test]
+    fn no_peer_is_closed_on_a_non_purged_status() {
+        // The evaluate_gate function never produces outcome "closed"; that
+        // outcome is assigned by the destroy loop, not the gate. Verify.
+        let quiet = Duration::from_millis(3000);
+        let busy_peer = make_gate_peer(
+            "proj:wg-1/devs/alice",
+            vec![PurgeGateSession {
+                session_id: Uuid::new_v4(),
+                readiness: make_readiness(Uuid::new_v4(), Some(100), true, None),
+                mirror_idle: true,
+            }],
+            vec!["aaa".to_string()],
+        );
+        let decision = evaluate_gate(&[busy_peer], quiet);
+        assert!(!decision.passed);
+        assert!(
+            !decision.peers.iter().any(|p| p.outcome == "closed"),
+            "evaluate_gate must never produce outcome 'closed'"
         );
     }
 }

--- a/src-tauri/src/phone/types.rs
+++ b/src-tauri/src/phone/types.rs
@@ -45,6 +45,15 @@ pub struct OutboxMessage {
     /// self-handoff-and-switch target profile slot letter A-Z.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub switch_profile: Option<String>,
+    /// (#885) purge-wg: evaluate the gate and report, destroy nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dry_run: Option<bool>,
+    /// (#885) purge-wg: printable-silence a peer must show to be purgeable.
+    /// CLAMPED daemon-side to a floor of `IdleTuning::DEFAULT.idle_threshold`
+    /// (2500 ms). The outbox is a trust boundary; a hand-crafted message must
+    /// not be able to set this to 0 and defeat the busy gate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quiet_period_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -103,6 +112,8 @@ mod tests {
             timeout_secs: None,
             switch_coding_agent: None,
             switch_profile: None,
+            dry_run: None,
+            quiet_period_ms: None,
         }
     }
 

--- a/src-tauri/src/pty/idle_detector.rs
+++ b/src-tauri/src/pty/idle_detector.rs
@@ -65,6 +65,30 @@ fn sessions_crossing_idle_threshold(
         .collect()
 }
 
+/// (#885) One peer's purge-readiness inputs, sampled at a single instant.
+#[derive(Debug, Clone, Copy)]
+pub struct PurgeReadiness {
+    pub session_id: Uuid,
+    /// Age of the last PRINTABLE output. `None` when the session is untracked.
+    pub activity_age: Option<Duration>,
+    /// The watcher has already crossed this session into the idle set.
+    pub watcher_idle: bool,
+    /// (#885 F-1) Age of the last `record_resize`, or `None` if never resized.
+    /// `activity_age` is FROZEN and untrustworthy for `resize_grace` after this
+    /// instant: `record_activity_with_bytes` early-returns without touching
+    /// `activity` inside the grace window (`:150-161`).
+    pub last_resize_age: Option<Duration>,
+    /// This session's resolved `resize_grace` and `idle_threshold`, so the
+    /// caller's gate is per-session rather than against a global constant.
+    pub resize_grace: Duration,
+    pub idle_threshold: Duration,
+    /// Age of the last output of any kind, printable or escape-only.
+    /// DIAGNOSTIC ONLY. Never gate on this: `pty/output.rs:127` resets it for
+    /// escape-only chunks, so a repainting TUI would keep it permanently fresh
+    /// and the gate could never pass.
+    pub silence_age: Option<Duration>,
+}
+
 impl IdleDetector {
     pub fn new(
         on_idle: impl Fn(Uuid) + Send + Sync + 'static,
@@ -201,6 +225,57 @@ impl IdleDetector {
             .unwrap_or_else(|e| e.into_inner())
             .get(&session_id)
             .and_then(|&t| now.checked_duration_since(t))
+    }
+
+    /// (#885) Sample readiness for `ids` under a SINGLE critical section.
+    ///
+    /// A PTY reader thread must take `activity` then `idle_set` to record activity
+    /// (`record_activity_with_bytes`), so holding both here yields a view no reader
+    /// thread can interleave. That is the strongest consistency available for the
+    /// purge busy-gate.
+    ///
+    /// LOCK ORDER. `tuning` and `resize_grace` are cloned under their own locks
+    /// and released before `activity` is taken, exactly as the watcher does with
+    /// `tuning` (`start`, `:251`). This introduces ZERO new nesting: the only
+    /// nested acquisition anywhere in this file is `activity -> idle_set`
+    /// (`:165-166`, `:252-253`), and `silence` is only ever taken alone
+    /// (`:112`, `:189`, `:199`, `:222`), so appending it at the tail cannot
+    /// deadlock.
+    ///
+    /// Reading `resize_grace` before `activity` can only MISS a resize newer than
+    /// the `activity` value we read. Such a resize begins its freeze after that
+    /// value was written, so it cannot have corrupted it. The skew is safe.
+    pub fn purge_readiness(&self, ids: &[Uuid]) -> Vec<PurgeReadiness> {
+        // Phase 1: clone the small maps, each under its own lock, then release.
+        let tuning = self.tuning.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let resizes = self
+            .resize_grace
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+
+        // Phase 2: the consistent snapshot. Nesting matches the reader thread's.
+        let now = Instant::now();
+        let activity = self.activity.lock().unwrap_or_else(|e| e.into_inner());
+        let idle_set = self.idle_set.lock().unwrap_or_else(|e| e.into_inner());
+        let silence = self.silence.lock().unwrap_or_else(|e| e.into_inner());
+
+        ids.iter()
+            .map(|id| {
+                let t = tuning.get(id).copied().unwrap_or(IdleTuning::DEFAULT);
+                PurgeReadiness {
+                    session_id: *id,
+                    activity_age: activity.get(id).and_then(|&x| now.checked_duration_since(x)),
+                    watcher_idle: idle_set.contains(id),
+                    last_resize_age: resizes
+                        .get(id)
+                        .and_then(|&x| now.checked_duration_since(x)),
+                    resize_grace: t.resize_grace,
+                    idle_threshold: t.idle_threshold,
+                    silence_age: silence.get(id).and_then(|&x| now.checked_duration_since(x)),
+                }
+            })
+            .collect()
     }
 
     /// (#580) Time since this session's PTY was registered (spawned), or None if
@@ -550,5 +625,102 @@ mod tests {
             second >= first,
             "alive age must be monotonic non-decreasing ({second:?} >= {first:?})"
         );
+    }
+
+    // ── (#885) purge_readiness tests ──
+
+    #[test]
+    fn purge_readiness_snapshot_is_consistent() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let id = Uuid::new_v4();
+        detector.register_session(id, IdleTuning::DEFAULT);
+        detector.record_activity_with_bytes(id, 42);
+
+        let readiness = detector.purge_readiness(&[id]);
+        assert_eq!(readiness.len(), 1);
+        let r = &readiness[0];
+        assert_eq!(r.session_id, id);
+        assert!(
+            r.activity_age.is_some(),
+            "activity_age must be Some after record_activity"
+        );
+        assert!(
+            r.activity_age.unwrap() < Duration::from_secs(1),
+            "activity_age must be small right after record_activity"
+        );
+        assert!(
+            !r.watcher_idle,
+            "watcher_idle must be false right after activity"
+        );
+    }
+
+    #[test]
+    fn purge_readiness_untracked_is_none() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let untracked = Uuid::new_v4();
+
+        let readiness = detector.purge_readiness(&[untracked]);
+        assert_eq!(readiness.len(), 1);
+        assert!(
+            readiness[0].activity_age.is_none(),
+            "activity_age must be None for an unregistered session"
+        );
+    }
+
+    #[test]
+    fn purge_readiness_reports_resize_age() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let id = Uuid::new_v4();
+        detector.register_session(id, IdleTuning::DEFAULT);
+        detector.record_resize(id);
+
+        let readiness = detector.purge_readiness(&[id]);
+        let r = &readiness[0];
+        assert!(
+            r.last_resize_age.is_some(),
+            "last_resize_age must be Some after record_resize"
+        );
+        assert!(
+            r.last_resize_age.unwrap() < Duration::from_secs(1),
+            "last_resize_age must be small right after record_resize"
+        );
+        assert_eq!(
+            r.resize_grace,
+            IdleTuning::DEFAULT.resize_grace,
+            "resize_grace must be the session's tuning value"
+        );
+    }
+
+    /// (#885 F-1) The core bug: inside resize grace, `record_activity_with_bytes`
+    /// early-returns WITHOUT touching `activity`, so `activity_age` grows
+    /// without bound while the child is "printing". This test pins the bug so
+    /// nobody deletes the fourth gate leg.
+    #[test]
+    fn resize_grace_freezes_activity_age() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let id = Uuid::new_v4();
+        detector.register_session(id, IdleTuning::DEFAULT);
+
+        // Record initial activity.
+        detector.record_activity_with_bytes(id, 10);
+        let first_age = detector.purge_readiness(&[id])[0].activity_age.unwrap();
+
+        // Enter resize grace.
+        detector.record_resize(id);
+
+        // Simulate the child printing during grace.
+        detector.record_activity_with_bytes(id, 99);
+
+        // activity must NOT have moved: the early-return at :159 suppressed it.
+        let second_age = detector.purge_readiness(&[id])[0].activity_age.unwrap();
+        assert!(
+            second_age >= first_age,
+            "activity_age must NOT decrease during resize grace (it is frozen). \
+             first={first_age:?}, second={second_age:?}. \
+             If this fails, record_activity_with_bytes is no longer early-returning \
+             during grace, and the F-1 fourth gate leg may be unnecessary."
+        );
+        // The age grew, which is the bug: the child printed but activity didn't
+        // refresh. This is exactly what resize_settled defends against.
     }
 }

--- a/src-tauri/src/pty/idle_detector.rs
+++ b/src-tauri/src/pty/idle_detector.rs
@@ -703,24 +703,25 @@ mod tests {
 
         // Record initial activity.
         detector.record_activity_with_bytes(id, 10);
-        let first_age = detector.purge_readiness(&[id])[0].activity_age.unwrap();
-
         // Enter resize grace.
         detector.record_resize(id);
-
+        // Sleep so a refresh would be detectable: if the early-return were
+        // removed, the next record_activity_with_bytes would reset activity
+        // to ~0ms, making age << 200ms.
+        std::thread::sleep(Duration::from_millis(200));
         // Simulate the child printing during grace.
         detector.record_activity_with_bytes(id, 99);
 
         // activity must NOT have moved: the early-return at :159 suppressed it.
-        let second_age = detector.purge_readiness(&[id])[0].activity_age.unwrap();
+        // An un-suppressed refresh would reset age to ~0, so age would be < 200ms.
+        let age = detector.purge_readiness(&[id])[0].activity_age.unwrap();
         assert!(
-            second_age >= first_age,
-            "activity_age must NOT decrease during resize grace (it is frozen). \
-             first={first_age:?}, second={second_age:?}. \
-             If this fails, record_activity_with_bytes is no longer early-returning \
-             during grace, and the F-1 fourth gate leg may be unnecessary."
+            age >= Duration::from_millis(200),
+            "activity must be FROZEN during resize grace; an un-suppressed \
+             refresh would reset age to ~0. age={age:?}. \
+             If this fails, record_activity_with_bytes is no longer \
+             early-returning during grace, and the F-1 fourth gate leg \
+             may be unnecessary."
         );
-        // The age grew, which is the bug: the child printed but activity didn't
-        // refresh. This is exactly what resize_settled defends against.
     }
 }

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -2,5 +2,6 @@ pub mod auto_close;
 pub mod manager;
 // Inner module shares the parent name; renaming would churn every import.
 pub mod profile;
+pub mod purge_guard;
 #[allow(clippy::module_inception)]
 pub mod session;

--- a/src-tauri/src/session/purge_guard.rs
+++ b/src-tauri/src/session/purge_guard.rs
@@ -1,0 +1,144 @@
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+use uuid::Uuid;
+
+/// (#885) Cross-cutting gate for `purge-wg`. Two jobs:
+///
+/// J1: no daemon-mediated input reaches a peer between the readiness snapshot
+///     and that peer's destroy.
+/// J2: no in-flight wake resurrects a peer the purge already destroyed.
+///     `deliver_wake` falls through to spawn-persistent when a peer has no
+///     SessionManager record, so a wake landing mid-loop would cold-spawn an
+///     agent we are purging and the verb would report a success it did not
+///     achieve. J2 alone justifies this type.
+///
+/// The `tokio::sync::Mutex` serializes concurrent purges. The `AtomicBool`
+/// lets the actuation choke points do a non-blocking load and refuse fast,
+/// rather than parking a Tauri command behind the destroy loop.
+///
+/// The target sets are carried so that sessions OUTSIDE the purge scope keep
+/// working. A global block held across a `--graceful --timeout 30` purge would
+/// freeze typing app-wide for 30 seconds.
+#[derive(Default)]
+pub struct PurgeGuard {
+    active: AtomicBool,
+    target_sids: std::sync::RwLock<HashSet<Uuid>>,
+    target_fqns: std::sync::RwLock<HashSet<String>>,
+    lock: tokio::sync::Mutex<()>,
+}
+
+pub struct PurgeLease<'a> {
+    guard: &'a PurgeGuard,
+    _mutex: tokio::sync::MutexGuard<'a, ()>,
+}
+
+impl PurgeGuard {
+    /// True while any purge holds a lease. Used by the #791 DB dispatcher,
+    /// which must skip its tick BEFORE leasing a row and therefore does not
+    /// yet know the row's target (§5.5e, F-5).
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+
+    /// Fast path: one atomic load when no purge is running.
+    pub fn blocks_session(&self, sid: Uuid) -> bool {
+        self.is_active()
+            && self
+                .target_sids
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .contains(&sid)
+    }
+
+    /// Wake delivery targets an FQN, and J2 is precisely the case where the
+    /// session record is already gone, so this cannot be keyed on a Uuid.
+    pub fn blocks_agent(&self, fqn: &str) -> bool {
+        self.is_active()
+            && self
+                .target_fqns
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .contains(fqn)
+    }
+
+    /// Acquire exclusive purge rights. Blocks behind any in-flight purge.
+    pub async fn acquire(&self, sids: HashSet<Uuid>, fqns: HashSet<String>) -> PurgeLease<'_> {
+        let mutex = self.lock.lock().await;
+        *self.target_sids.write().unwrap_or_else(|e| e.into_inner()) = sids;
+        *self.target_fqns.write().unwrap_or_else(|e| e.into_inner()) = fqns;
+        self.active.store(true, Ordering::SeqCst);
+        PurgeLease {
+            guard: self,
+            _mutex: mutex,
+        }
+    }
+}
+
+impl Drop for PurgeLease<'_> {
+    fn drop(&mut self) {
+        self.guard.active.store(false, Ordering::SeqCst);
+        self.guard
+            .target_sids
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+        self.guard
+            .target_fqns
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn purge_guard_blocks_only_targets() {
+        let guard = PurgeGuard::default();
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let fqn_a = "proj:wg-1-devs/alice".to_string();
+        let fqn_b = "proj:wg-1-devs/bob".to_string();
+
+        let mut sids = HashSet::new();
+        sids.insert(a);
+        let mut fqns = HashSet::new();
+        fqns.insert(fqn_a.clone());
+
+        let lease = guard.acquire(sids, fqns).await;
+
+        assert!(guard.blocks_session(a));
+        assert!(!guard.blocks_session(b));
+        assert!(guard.blocks_agent(&fqn_a));
+        assert!(!guard.blocks_agent(&fqn_b));
+
+        drop(lease);
+        assert!(!guard.blocks_session(a));
+        assert!(!guard.blocks_agent(&fqn_a));
+    }
+
+    #[tokio::test]
+    async fn purge_guard_serializes_concurrent_purges() {
+        let guard = Arc::new(PurgeGuard::default());
+        let g1 = Arc::clone(&guard);
+        let g2 = Arc::clone(&guard);
+
+        let h1 = tokio::spawn(async move {
+            let _lease = g1.acquire(HashSet::new(), HashSet::new()).await;
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        });
+        let h2 = tokio::spawn(async move {
+            // This must wait for h1's lease to drop.
+            let _lease = g2.acquire(HashSet::new(), HashSet::new()).await;
+        });
+
+        let (r1, r2) = tokio::join!(h1, h2);
+        assert!(r1.is_ok());
+        assert!(r2.is_ok());
+        // After both complete, no lease is held.
+        assert!(!guard.is_active());
+    }
+}


### PR DESCRIPTION
Closes #885.

Adds a `purge-wg` CLI verb: a coordinator destroys every agent session in its own workgroup in one command, via a `close-session` fan-out.

## Why a new verb, and why `close-session` rather than `/clear`

`send --command clear` cannot be the purge mechanism. It is rejected outright for any session whose shell is not a recognized coding-agent CLI (an OpenCode session fails with `session shell 'opencode' is not a coding-agent CLI`), it is then retried ten times and silently dropped; it cold-spawns dormant peers instead of purging them, because `deliver_wake` falls through to spawn-persistent; and it is best-effort on a busy agent. `close-session` never spawns, returns `no_match` (exit 0) for a dormant peer, has no idle gate, and destroys the record so the next wake is a cold spawn with no resume flag.

It is a new verb rather than a flag on `close-session` because the busy pre-flight gate has no home there, the response is a per-peer table rather than a single count, `close-session`'s exit-code contract is pinned by tests, and authorization is workgroup-scoped rather than per-target.

## The gate

The requirement is fail-closed: if any peer is working, the verb fails and destroys nobody.

Atomic check-then-kill is not achievable. `working` flips inside `SessionManager::mark_busy`, called from the `IdleDetector` `on_busy` callback, which runs on the PTY reader thread when a child process writes bytes. No lock the daemon holds prevents a child from writing to its own PTY. A lock freezes the daemon's bookkeeping, not the fact.

So the gate reads the **source** (`IdleDetector`'s printable-activity clock, written synchronously on the reader thread) rather than the **mirror** (`SessionManager` / `sessions.json`, which lags through a `spawn` hop and an awaited disk write), snapshots the whole workgroup in one critical section, and requires four independent legs to agree before any peer is destroyed:

1. activity quiet past `effective_quiet` (`quiet_period_ms`, floored at the session's `idle_threshold`)
2. watcher idle
3. mirror idle
4. **resize settled**

The fourth leg exists because `record_activity_with_bytes` early-returns without touching `activity` while a session is inside `resize_grace`. Since `resize_grace` (3000 ms) is asserted `>= idle_threshold` (2500 ms), a full grace window is always long enough for the watcher to cross the session idle, so without this leg all three other legs agree "idle" while a child prints continuously for three seconds. A larger quiet period cannot fix this: the quantity being thresholded is the corrupted one. The leg is therefore keyed on `t_resize`, requiring `effective_quiet` of *trustworthy* observation measured from grace expiry.

The gate is strictly stricter than the daemon's own `working: false`, so it can never purge a session the daemon reports as working.

Also included: a `PurgeGuard` lease that blocks concurrent wakes from cold-spawning a peer mid-destroy-loop (`deliver_wake_with_origin` falls through to spawn-persistent for a peer with no record, and the #791 API dispatches from independent tasks), `--dry-run`, workgroup-scoped authorization requiring a session token, an explicit root-agent guard that aborts rather than skips, and a per-peer response table (`purged` / `already_closed` / `busy` / `resize_unsettled` / `untracked` / `failed`).

`--force` is the default. Graceful close resolves its exit command by executable basename and only `claude` and `aider` map to `/exit`; everything else receives `exit\r`, which an interactive TUI ignores, so a graceful purge burns the full timeout per peer and force-kills anyway. Graceful additionally stalls the sequential mailbox poller for the duration of the destroy loop. `--graceful` remains available and prints a warning.

## Review

Full pipeline: architect plan, dev-rust enrichment, adversarial review, architect consensus (`READY_FOR_IMPLEMENTATION`, round 1), implementation, then **three rounds of adversarial review, all FAIL, before this PASS**.

The reviewer did not read the tests, it mutated them: apply the mutation, run the test, revert, verify the tree clean. That found two end-to-end tests that stayed green with their bug restored, and one change to production code (`app.state` weakened to `try_state`, whose `None` arm made "I cannot observe liveness" mean "nothing is alive, purge everything") that had been introduced so a test would run. Both are fixed, and the guards are now pinned by mutation:

- restoring `if !is_master && !saw_session_token` turns **both** F-7 tests red
- disabling the root guard turns `root_guard_aborts_purge` red with `unexpected spawn or destroy event: [Destroy(...)]`

Gates on the merged tree: `cargo test --all-targets` 18 suites, **2172 passed, 0 failed, 12 ignored**; `cargo clippy --all-targets -- -D warnings` clean; `npm run typecheck` clean (the currency merge pulled `src/shared/types.ts`).

Non-visual: the diff against `origin/main` is confined to seventeen files under `src-tauri/`.

## Known residuals

1. **Exogenous busy transition.** Between the readiness snapshot and a peer's destroy, that peer's child may spontaneously resume printing. The window is the destroy loop's wall time and is **unmeasured**; it is bounded by `--timeout × peers` under `--graceful` and by `kill_group` subtree teardown under `--force`. Closing it requires suspending child processes before the snapshot. No ratio is claimed. The safety argument does not depend on the size of this window: the gate is strictly stricter than `working: false`, so a transition inside it is one the daemon never observed.
2. **`--graceful` stalls all inter-agent messaging daemon-wide.** The mailbox poller is sequential, so for the destroy loop's duration no message to any agent in any workgroup is processed, and retry counts accrue against `MAX_DELIVERY_ATTEMPTS`.
3. **The #791 DB dispatcher's purge skip is a coarse check.** `is_active()` is read before leasing; a purge that acquires its lease mid-tick sends delivery into the `deliver_wake_with_origin` backstop, which returns `Err` and burns a delivery attempt. Closing it means skipping individual rows by target before leasing.
4. **Telegram and web inbound reach the PTY outside `pty_write`** and are not covered by `PurgeGuard`.
5. **A session record created but not yet PTY-registered bypasses the gate.** `create_session_inner` inserts the `SessionManager` record before spawning the PTY. Such a session holds no prior conversation context, so the postcondition is intact.
6. **The gate refuses to run for roughly `resize_grace + effective_quiet` (~6 s) after any terminal resize**, including resizes triggered by a tab switch or sidebar collapse that change no dimensions. This is deliberate and fail-closed. `--dry-run` reports `resize_settled`, and a resize-only rejection is now reported as `resize_unsettled` rather than `busy`.
7. **`quiet_period_ms` has a daemon-side floor (2500 ms) but no ceiling.** A large value makes the gate unsatisfiable. Fail-closed.

## Related, filed separately, not fixed here

- #884 — the inter-agent wake path ignores `start_fresh_on_restore`, so a `/clear`'d session can be resurrected with `--continue`. Found while scoping this work. `purge-wg` does not depend on the fix, because it destroys records rather than clearing them.
- #887 — `resolve_exit_command` matches the executable basename with exact equality, so `claude-amp` and other `claude-*` wrappers receive `exit\r` instead of `/exit\r` and never close gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
