### PR TITLE
Container transport: translate host path env values, guard the bind mount, and surface the warnings

### DIFF
--- a/crates/session-bridge/src/lib.rs
+++ b/crates/session-bridge/src/lib.rs
@@ -14,7 +14,8 @@ use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::Message;
 use uuid::Uuid;
 
-pub const TRANSPORT_PROTOCOL_VERSION: u32 = 1;
+pub const TRANSPORT_PROTOCOL_VERSION: u32 = 2;
+const REGISTRATION_TOKEN_ENV: &str = "AGENTSCOMMANDER_SESSION_REGISTRATION_TOKEN";
 
 type BridgeResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -59,6 +60,7 @@ pub struct BridgeConfig {
     pub command: String,
     pub args: Vec<String>,
     pub child_env: Vec<(String, String)>,
+    pub env_unset: Vec<String>,
     pub cols: u16,
     pub rows: u16,
 }
@@ -75,6 +77,8 @@ impl BridgeConfig {
         let command = required_env("AGENTSCOMMANDER_BRIDGE_COMMAND")?;
         let args = parse_json_env("AGENTSCOMMANDER_BRIDGE_ARGS_JSON")?.unwrap_or_default();
         let child_env = parse_json_env("AGENTSCOMMANDER_BRIDGE_ENV_JSON")?.unwrap_or_default();
+        let env_unset =
+            parse_json_env("AGENTSCOMMANDER_BRIDGE_ENV_UNSET_JSON")?.unwrap_or_default();
         let cols = parse_u16_env("AGENTSCOMMANDER_BRIDGE_COLS", 120)?;
         let rows = parse_u16_env("AGENTSCOMMANDER_BRIDGE_ROWS", 30)?;
 
@@ -88,6 +92,7 @@ impl BridgeConfig {
             command,
             args,
             child_env,
+            env_unset,
             cols,
             rows,
         })
@@ -154,10 +159,7 @@ pub async fn run_bridge(config: BridgeConfig) -> BridgeResult<()> {
     }
     command.cwd(&config.workdir);
     command.env("TERM", "xterm-256color");
-    command.env_remove("AGENTSCOMMANDER_SESSION_REGISTRATION_TOKEN");
-    for (key, value) in &config.child_env {
-        command.env(key, value);
-    }
+    apply_bridge_env(&mut command, &config.child_env, &config.env_unset);
 
     let child = pair.slave.spawn_command(command)?;
     let child = Arc::new(Mutex::new(child));
@@ -247,6 +249,52 @@ pub async fn run_bridge(config: BridgeConfig) -> BridgeResult<()> {
     Ok(())
 }
 
+trait BridgeEnvTarget {
+    fn set_env(&mut self, key: &str, value: &str);
+    fn remove_env(&mut self, key: &str);
+}
+
+impl BridgeEnvTarget for CommandBuilder {
+    fn set_env(&mut self, key: &str, value: &str) {
+        self.env(key, value);
+    }
+
+    fn remove_env(&mut self, key: &str) {
+        self.env_remove(key);
+    }
+}
+
+fn apply_bridge_env<T: BridgeEnvTarget>(
+    target: &mut T,
+    child_env: &[(String, String)],
+    env_unset: &[String],
+) {
+    apply_bridge_env_inner(target, child_env, env_unset, true);
+}
+
+fn apply_bridge_env_inner<T: BridgeEnvTarget>(
+    target: &mut T,
+    child_env: &[(String, String)],
+    env_unset: &[String],
+    assert_disjoint: bool,
+) {
+    if assert_disjoint {
+        debug_assert!(
+            !env_unset
+                .iter()
+                .any(|unset| child_env.iter().any(|(key, _)| key == unset)),
+            "env_unset and child_env should be disjoint"
+        );
+    }
+    for (key, value) in child_env {
+        target.set_env(key, value);
+    }
+    for key in env_unset {
+        target.remove_env(key);
+    }
+    target.remove_env(REGISTRATION_TOKEN_ENV);
+}
+
 async fn handle_host_message(
     message: Message,
     master: &(dyn portable_pty::MasterPty + Send),
@@ -303,6 +351,17 @@ fn terminate_child(child: &Arc<Mutex<Box<dyn portable_pty::Child + Send + Sync>>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+
+    impl BridgeEnvTarget for BTreeMap<String, String> {
+        fn set_env(&mut self, key: &str, value: &str) {
+            self.insert(key.to_string(), value.to_string());
+        }
+
+        fn remove_env(&mut self, key: &str) {
+            self.remove(key);
+        }
+    }
 
     #[test]
     fn transport_url_maps_http_to_ws() {
@@ -316,6 +375,7 @@ mod tests {
             command: "sh".to_string(),
             args: Vec::new(),
             child_env: Vec::new(),
+            env_unset: Vec::new(),
             cols: 80,
             rows: 24,
         };
@@ -339,7 +399,7 @@ mod tests {
 
         let resize: HostToBridgeTextFrame = serde_json::from_value(serde_json::json!({
             "type": "resize",
-            "version": 1,
+            "version": TRANSPORT_PROTOCOL_VERSION,
             "cols": 100,
             "rows": 40
         }))
@@ -347,10 +407,38 @@ mod tests {
         assert_eq!(
             resize,
             HostToBridgeTextFrame::Resize {
-                version: 1,
+                version: TRANSPORT_PROTOCOL_VERSION,
                 cols: 100,
                 rows: 40
             }
         );
+    }
+
+    #[test]
+    fn env_unset_applies_after_child_env() {
+        let mut env = BTreeMap::from([("CODEX_HOME".to_string(), "/opt/codex".to_string())]);
+        apply_bridge_env_inner(
+            &mut env,
+            &[("CODEX_HOME".to_string(), "/workspace/.codex".to_string())],
+            &["CODEX_HOME".to_string()],
+            false,
+        );
+
+        assert_eq!(env.get("CODEX_HOME"), None);
+    }
+
+    #[test]
+    fn registration_token_is_removed_after_child_env() {
+        let mut env = BTreeMap::new();
+        apply_bridge_env(
+            &mut env,
+            &[(
+                REGISTRATION_TOKEN_ENV.to_string(),
+                "should-not-survive".to_string(),
+            )],
+            &[],
+        );
+
+        assert_eq!(env.get(REGISTRATION_TOKEN_ENV), None);
     }
 }

--- a/src-tauri/src/api/handlers/session_transport.rs
+++ b/src-tauri/src/api/handlers/session_transport.rs
@@ -11,7 +11,6 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
-use tauri::Emitter;
 use uuid::Uuid;
 
 use crate::api::auth::SCOPE_SESSION_TRANSPORT;
@@ -21,9 +20,10 @@ use crate::pty::container_backend::{
     parse_bridge_text_frame, root_key, BridgeToHostFrame, ContainerTransportBackend,
     HostToBridgeFrame, MAX_TRANSPORT_FRAME_BYTES, TRANSPORT_PROTOCOL_VERSION,
 };
-use crate::pty::container_paths::WARNING_KIND_PROTOCOL_MISMATCH;
-
-const PROTOCOL_WARNING_KEY: &str = "CONTAINER_TRANSPORT_PROTOCOL";
+use crate::session::warnings::{
+    emit_session_warning, SessionWarning, CONTAINER_TRANSPORT_PROTOCOL_KEY,
+    WARNING_KIND_PROTOCOL_MISMATCH,
+};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -124,13 +124,11 @@ async fn handle_ws_connection(
     };
 
     let (tx, rx) = tokio::sync::mpsc::channel(backend.tuning().outbound_queue_capacity);
-    if let Err(reason) = validate_hello(first, &backend, session_id, &bound_root, tx).await {
+    if let Err(rejection) = validate_hello(first, &backend, session_id, &bound_root, tx).await {
+        let reason = rejection.message();
         log::error!("[container-transport] {reason}");
-        if reason.starts_with("container transport protocol mismatch:") {
-            emit_session_env_warning(
-                &app_handle,
-                protocol_mismatch_session_warning_payload(session_id, &reason),
-            );
+        if let Some(warning) = rejection.session_warning(session_id) {
+            emit_session_warning(&app_handle, warning);
         }
         backend.handle_handshake_failed(session_id).await;
         return;
@@ -181,62 +179,104 @@ async fn validate_hello(
     session_id: Uuid,
     bound_root: &str,
     sender: tokio::sync::mpsc::Sender<HostToBridgeFrame>,
-) -> Result<(), String> {
+) -> Result<(), HelloRejection> {
     let Message::Text(text) = message else {
-        return Err("container transport handshake failed: first frame was not text".to_string());
+        return Err(HelloRejection::FirstFrameNotText);
     };
     if text.len() > MAX_TRANSPORT_FRAME_BYTES {
-        return Err("container transport handshake failed: first frame was too large".to_string());
+        return Err(HelloRejection::FirstFrameTooLarge);
     }
 
     let frame = parse_bridge_text_frame(text.as_str())
-        .map_err(|e| format!("container transport handshake failed: invalid hello: {e}"))?;
+        .map_err(|e| HelloRejection::InvalidHello(e.to_string()))?;
     let BridgeToHostFrame::Hello {
         version,
         session_id: hello_session_id,
         root,
     } = frame
     else {
-        return Err("container transport handshake failed: first frame was not hello".to_string());
+        return Err(HelloRejection::FirstFrameNotHello);
     };
 
     if version != TRANSPORT_PROTOCOL_VERSION {
-        return Err(format!(
-            "container transport protocol mismatch: host expects protocol {} but container image reported protocol {}. Rebuild or re-pull the AgentsCommander container image so it contains the current session-bridge.",
-            TRANSPORT_PROTOCOL_VERSION, version
-        ));
+        return Err(HelloRejection::ProtocolMismatch {
+            expected: TRANSPORT_PROTOCOL_VERSION,
+            reported: version,
+        });
     }
 
     if hello_session_id != session_id {
-        return Err(format!(
-            "container transport handshake failed: hello session id {} did not match expected {}",
-            hello_session_id, session_id
-        ));
+        return Err(HelloRejection::SessionIdMismatch {
+            expected: session_id,
+            reported: hello_session_id,
+        });
     }
 
     if root_key(&root) != root_key(bound_root) {
-        return Err(
-            "container transport handshake failed: bridge root did not match bound root"
-                .to_string(),
-        );
+        return Err(HelloRejection::RootMismatch);
     }
 
     backend
         .complete_hello(session_id, &root, sender)
-        .map_err(|_| "container transport handshake failed: session was not pending".to_string())
+        .map_err(|_| HelloRejection::SessionNotPending)
 }
 
-fn protocol_mismatch_session_warning_payload(session_id: Uuid, message: &str) -> serde_json::Value {
-    serde_json::json!({
-        "sessionId": session_id.to_string(),
-        "key": PROTOCOL_WARNING_KEY,
-        "kind": WARNING_KIND_PROTOCOL_MISMATCH,
-        "message": message,
-    })
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HelloRejection {
+    FirstFrameNotText,
+    FirstFrameTooLarge,
+    InvalidHello(String),
+    FirstFrameNotHello,
+    ProtocolMismatch { expected: u32, reported: u32 },
+    SessionIdMismatch { expected: Uuid, reported: Uuid },
+    RootMismatch,
+    SessionNotPending,
 }
 
-fn emit_session_env_warning(app_handle: &tauri::AppHandle, payload: serde_json::Value) {
-    let _ = app_handle.emit("session_env_warning", payload);
+impl HelloRejection {
+    fn message(&self) -> String {
+        match self {
+            Self::FirstFrameNotText => {
+                "container transport handshake failed: first frame was not text".to_string()
+            }
+            Self::FirstFrameTooLarge => {
+                "container transport handshake failed: first frame was too large".to_string()
+            }
+            Self::InvalidHello(err) => {
+                format!("container transport handshake failed: invalid hello: {err}")
+            }
+            Self::FirstFrameNotHello => {
+                "container transport handshake failed: first frame was not hello".to_string()
+            }
+            Self::ProtocolMismatch { expected, reported } => format!(
+                "container transport protocol mismatch: host expects protocol {} but container image reported protocol {}. Rebuild or re-pull the AgentsCommander container image so it contains the current session-bridge.",
+                expected, reported
+            ),
+            Self::SessionIdMismatch { expected, reported } => format!(
+                "container transport handshake failed: hello session id {} did not match expected {}",
+                reported, expected
+            ),
+            Self::RootMismatch => {
+                "container transport handshake failed: bridge root did not match bound root"
+                    .to_string()
+            }
+            Self::SessionNotPending => {
+                "container transport handshake failed: session was not pending".to_string()
+            }
+        }
+    }
+
+    fn session_warning(&self, session_id: Uuid) -> Option<SessionWarning> {
+        match self {
+            Self::ProtocolMismatch { .. } => Some(SessionWarning::new(
+                session_id,
+                CONTAINER_TRANSPORT_PROTOCOL_KEY,
+                WARNING_KIND_PROTOCOL_MISMATCH,
+                self.message(),
+            )),
+            _ => None,
+        }
+    }
 }
 
 async fn recv_bridge_loop(
@@ -378,8 +418,15 @@ mod tests {
         .await
         .expect_err("protocol mismatch");
 
-        assert_eq!(
+        assert!(matches!(
             err,
+            HelloRejection::ProtocolMismatch {
+                expected: TRANSPORT_PROTOCOL_VERSION,
+                reported
+            } if reported == reported_version
+        ));
+        assert_eq!(
+            err.message(),
             format!(
                 "container transport protocol mismatch: host expects protocol {} but container image reported protocol {}. Rebuild or re-pull the AgentsCommander container image so it contains the current session-bridge.",
                 TRANSPORT_PROTOCOL_VERSION, reported_version
@@ -390,13 +437,21 @@ mod tests {
     #[test]
     fn protocol_mismatch_warning_payload_uses_session_env_warning_contract() {
         let session_id = Uuid::nil();
-        let message = "container transport protocol mismatch: host expects protocol 2 but container image reported protocol 1. Rebuild or re-pull the AgentsCommander container image so it contains the current session-bridge.";
+        let rejection = HelloRejection::ProtocolMismatch {
+            expected: 2,
+            reported: 1,
+        };
 
-        let payload = protocol_mismatch_session_warning_payload(session_id, message);
+        let warning = rejection
+            .session_warning(session_id)
+            .expect("protocol mismatch warning");
 
-        assert_eq!(payload["sessionId"], session_id.to_string());
-        assert_eq!(payload["key"], PROTOCOL_WARNING_KEY);
-        assert_eq!(payload["kind"], WARNING_KIND_PROTOCOL_MISMATCH);
-        assert_eq!(payload["message"], message);
+        assert_eq!(warning.session_id, session_id.to_string());
+        assert_eq!(warning.key, CONTAINER_TRANSPORT_PROTOCOL_KEY);
+        assert_eq!(warning.kind, WARNING_KIND_PROTOCOL_MISMATCH);
+        assert_eq!(
+            warning.message,
+            "container transport protocol mismatch: host expects protocol 2 but container image reported protocol 1. Rebuild or re-pull the AgentsCommander container image so it contains the current session-bridge."
+        );
     }
 }

--- a/src-tauri/src/api/handlers/session_transport.rs
+++ b/src-tauri/src/api/handlers/session_transport.rs
@@ -117,10 +117,8 @@ async fn handle_ws_connection(
     };
 
     let (tx, rx) = tokio::sync::mpsc::channel(backend.tuning().outbound_queue_capacity);
-    if validate_hello(first, &backend, session_id, &bound_root, tx)
-        .await
-        .is_err()
-    {
+    if let Err(reason) = validate_hello(first, &backend, session_id, &bound_root, tx).await {
+        log::error!("[container-transport] {reason}");
         backend.handle_handshake_failed(session_id).await;
         return;
     }
@@ -170,35 +168,49 @@ async fn validate_hello(
     session_id: Uuid,
     bound_root: &str,
     sender: tokio::sync::mpsc::Sender<HostToBridgeFrame>,
-) -> Result<(), ()> {
+) -> Result<(), String> {
     let Message::Text(text) = message else {
-        return Err(());
+        return Err("container transport handshake failed: first frame was not text".to_string());
     };
     if text.len() > MAX_TRANSPORT_FRAME_BYTES {
-        return Err(());
+        return Err("container transport handshake failed: first frame was too large".to_string());
     }
 
-    let frame = parse_bridge_text_frame(text.as_str()).map_err(|_| ())?;
+    let frame = parse_bridge_text_frame(text.as_str())
+        .map_err(|e| format!("container transport handshake failed: invalid hello: {e}"))?;
     let BridgeToHostFrame::Hello {
         version,
         session_id: hello_session_id,
         root,
     } = frame
     else {
-        return Err(());
+        return Err("container transport handshake failed: first frame was not hello".to_string());
     };
 
-    if version != TRANSPORT_PROTOCOL_VERSION || hello_session_id != session_id {
-        return Err(());
+    if version != TRANSPORT_PROTOCOL_VERSION {
+        return Err(format!(
+            "container transport protocol mismatch: host expects protocol {} but container image reported protocol {}. Rebuild or re-pull the AgentsCommander container image so it contains the current session-bridge.",
+            TRANSPORT_PROTOCOL_VERSION, version
+        ));
+    }
+
+    if hello_session_id != session_id {
+        return Err(format!(
+            "container transport handshake failed: hello session id {} did not match expected {}",
+            hello_session_id, session_id
+        ));
     }
 
     if root_key(&root) != root_key(bound_root) {
-        return Err(());
+        return Err(
+            "container transport handshake failed: bridge root did not match bound root"
+                .to_string(),
+        );
     }
 
     backend
         .complete_hello(session_id, &root, sender)
-        .map_err(|_| ())
+        .map_err(|_| "container transport handshake failed: session was not pending".to_string())
 }
 
 async fn recv_bridge_loop(
@@ -264,6 +276,12 @@ async fn handle_bridge_message(
                 return false;
             };
             if frame.version() != TRANSPORT_PROTOCOL_VERSION {
+                log::warn!(
+                    "[container-transport] closing session {} after protocol mismatch: host expects protocol {} but bridge sent protocol {}. Rebuild or re-pull the AgentsCommander container image so it contains the current session-bridge.",
+                    session_id,
+                    TRANSPORT_PROTOCOL_VERSION,
+                    frame.version()
+                );
                 return false;
             }
 
@@ -294,10 +312,52 @@ async fn handle_bridge_message(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pty::idle_detector::IdleDetector;
+    use crate::session::manager::SessionManager;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn uniform_transport_auth_failure_is_generic_401() {
         let response = uniform_transport_auth_failure().into_response();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn validate_hello_protocol_mismatch_names_image_remedy() {
+        let output_senders: crate::telegram::manager::OutputSenderMap =
+            Arc::new(Mutex::new(HashMap::new()));
+        let idle_detector = IdleDetector::new(|_| {}, |_| {});
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let backend =
+            ContainerTransportBackend::new(output_senders, idle_detector, None, session_mgr);
+        let session_id = Uuid::new_v4();
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let reported_version = TRANSPORT_PROTOCOL_VERSION - 1;
+        let text = serde_json::json!({
+            "type": "hello",
+            "version": reported_version,
+            "sessionId": session_id,
+            "root": "C:/root"
+        })
+        .to_string();
+
+        let err = validate_hello(
+            Message::Text(text.into()),
+            &backend,
+            session_id,
+            "C:/root",
+            tx,
+        )
+        .await
+        .expect_err("protocol mismatch");
+
+        assert_eq!(
+            err,
+            format!(
+                "container transport protocol mismatch: host expects protocol {} but container image reported protocol {}. Rebuild or re-pull the AgentsCommander container image so it contains the current session-bridge.",
+                TRANSPORT_PROTOCOL_VERSION, reported_version
+            )
+        );
     }
 }

--- a/src-tauri/src/api/handlers/session_transport.rs
+++ b/src-tauri/src/api/handlers/session_transport.rs
@@ -11,6 +11,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
+use tauri::Emitter;
 use uuid::Uuid;
 
 use crate::api::auth::SCOPE_SESSION_TRANSPORT;
@@ -20,6 +21,9 @@ use crate::pty::container_backend::{
     parse_bridge_text_frame, root_key, BridgeToHostFrame, ContainerTransportBackend,
     HostToBridgeFrame, MAX_TRANSPORT_FRAME_BYTES, TRANSPORT_PROTOCOL_VERSION,
 };
+use crate::pty::container_paths::WARNING_KIND_PROTOCOL_MISMATCH;
+
+const PROTOCOL_WARNING_KEY: &str = "CONTAINER_TRANSPORT_PROTOCOL";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -46,6 +50,7 @@ pub async fn handle(
         Err(err) => return err.into_response(),
     };
 
+    let app_handle = state.app_handle.clone();
     ws.max_message_size(MAX_TRANSPORT_FRAME_BYTES)
         .max_frame_size(MAX_TRANSPORT_FRAME_BYTES)
         .on_upgrade(move |socket| {
@@ -54,6 +59,7 @@ pub async fn handle(
                 authorized.backend,
                 authorized.session_id,
                 authorized.bound_root,
+                app_handle,
             )
         })
 }
@@ -102,6 +108,7 @@ async fn handle_ws_connection(
     backend: std::sync::Arc<ContainerTransportBackend>,
     session_id: Uuid,
     bound_root: String,
+    app_handle: tauri::AppHandle,
 ) {
     let first = match tokio::time::timeout(
         backend.tuning().handshake_timeout,
@@ -119,6 +126,12 @@ async fn handle_ws_connection(
     let (tx, rx) = tokio::sync::mpsc::channel(backend.tuning().outbound_queue_capacity);
     if let Err(reason) = validate_hello(first, &backend, session_id, &bound_root, tx).await {
         log::error!("[container-transport] {reason}");
+        if reason.starts_with("container transport protocol mismatch:") {
+            emit_session_env_warning(
+                &app_handle,
+                protocol_mismatch_session_warning_payload(session_id, &reason),
+            );
+        }
         backend.handle_handshake_failed(session_id).await;
         return;
     }
@@ -211,6 +224,19 @@ async fn validate_hello(
     backend
         .complete_hello(session_id, &root, sender)
         .map_err(|_| "container transport handshake failed: session was not pending".to_string())
+}
+
+fn protocol_mismatch_session_warning_payload(session_id: Uuid, message: &str) -> serde_json::Value {
+    serde_json::json!({
+        "sessionId": session_id.to_string(),
+        "key": PROTOCOL_WARNING_KEY,
+        "kind": WARNING_KIND_PROTOCOL_MISMATCH,
+        "message": message,
+    })
+}
+
+fn emit_session_env_warning(app_handle: &tauri::AppHandle, payload: serde_json::Value) {
+    let _ = app_handle.emit("session_env_warning", payload);
 }
 
 async fn recv_bridge_loop(
@@ -359,5 +385,18 @@ mod tests {
                 TRANSPORT_PROTOCOL_VERSION, reported_version
             )
         );
+    }
+
+    #[test]
+    fn protocol_mismatch_warning_payload_uses_session_env_warning_contract() {
+        let session_id = Uuid::nil();
+        let message = "container transport protocol mismatch: host expects protocol 2 but container image reported protocol 1. Rebuild or re-pull the AgentsCommander container image so it contains the current session-bridge.";
+
+        let payload = protocol_mismatch_session_warning_payload(session_id, message);
+
+        assert_eq!(payload["sessionId"], session_id.to_string());
+        assert_eq!(payload["key"], PROTOCOL_WARNING_KEY);
+        assert_eq!(payload["kind"], WARNING_KIND_PROTOCOL_MISMATCH);
+        assert_eq!(payload["message"], message);
     }
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::OnceLock;
@@ -10,6 +11,11 @@ use crate::config::coordinator_clocks::CoordinatorClocksState;
 use crate::config::sessions_persistence::persist_current_state;
 use crate::config::settings::{AppSettings, SettingsState};
 use crate::pty::backend::{BackendSpawnSpec, SessionBackendKind};
+use crate::pty::container_paths::{
+    claude_config_dir_no_value_warning, container_config_dir, ContainerEnvWarning,
+    ContainerPathMap, CLAUDE_CONFIG_DIR_KEY,
+};
+use crate::pty::container_runtime::DEFAULT_CONTAINER_WORKDIR;
 use crate::pty::manager::PtyManager;
 use crate::pty::output::PtyOutputTarget;
 use crate::resource_monitor::{
@@ -641,6 +647,121 @@ fn claude_projects_dir_for_config_dir(config_dir: &str, cwd: &str) -> std::path:
     base.join("projects").join(mangled)
 }
 
+#[derive(Debug, Clone)]
+struct ResumeProbeTarget {
+    host_probe_path: Option<PathBuf>,
+    filesystem: &'static str,
+    warning: Option<ContainerEnvWarning>,
+}
+
+fn container_path_map_for_cwd(cwd: &str) -> Result<ContainerPathMap, String> {
+    let canonical_host_root = match std::fs::canonicalize(cwd) {
+        Ok(path) => crate::path_utils::path_to_string_without_windows_verbatim_prefix(&path),
+        Err(err) => {
+            log::warn!(
+                "[container-transport] failed to canonicalize mount source '{}': {}; using raw cwd for path comparisons",
+                cwd,
+                err
+            );
+            cwd.to_string()
+        }
+    };
+    ContainerPathMap::new(&canonical_host_root, DEFAULT_CONTAINER_WORKDIR)
+}
+
+fn resume_probe_target(
+    backend_kind: SessionBackendKind,
+    container_map: Option<&ContainerPathMap>,
+    resolved_spawn: Option<&AgentSpawnCommand>,
+    shell: &str,
+    shell_args: &[String],
+    cwd: &str,
+) -> ResumeProbeTarget {
+    let claude_config_dir_override =
+        resolved_spawn.and_then(|s| s.effective_env_value(CLAUDE_CONFIG_DIR_KEY));
+    resume_probe_target_for_config_dir(
+        backend_kind,
+        container_map,
+        claude_config_dir_override,
+        shell,
+        shell_args,
+        cwd,
+    )
+}
+
+fn resume_probe_target_for_config_dir(
+    backend_kind: SessionBackendKind,
+    container_map: Option<&ContainerPathMap>,
+    claude_config_dir_override: Option<&str>,
+    shell: &str,
+    shell_args: &[String],
+    cwd: &str,
+) -> ResumeProbeTarget {
+    match backend_kind {
+        SessionBackendKind::LocalProcess => {
+            let host_probe_path = match claude_config_dir_override {
+                Some(dir) => Some(claude_projects_dir_for_config_dir(dir, cwd)),
+                None => resolve_claude_projects_dir(shell, shell_args, cwd),
+            };
+            ResumeProbeTarget {
+                host_probe_path,
+                filesystem: "host",
+                warning: None,
+            }
+        }
+        SessionBackendKind::ContainerTransport => {
+            let Some(map) = container_map else {
+                return ResumeProbeTarget {
+                    host_probe_path: None,
+                    filesystem: "container-unreachable",
+                    warning: Some(claude_config_dir_no_value_warning()),
+                };
+            };
+            let Some(raw_config_dir) = claude_config_dir_override else {
+                return ResumeProbeTarget {
+                    host_probe_path: None,
+                    filesystem: "container-unreachable",
+                    warning: Some(claude_config_dir_no_value_warning()),
+                };
+            };
+            let Some(container_config_dir) = container_config_dir(map, raw_config_dir) else {
+                return ResumeProbeTarget {
+                    host_probe_path: None,
+                    filesystem: "container-unreachable",
+                    warning: None,
+                };
+            };
+            let container_projects_path = format!(
+                "{}/projects/{}",
+                container_config_dir.trim_end_matches('/'),
+                crate::session::session::mangle_cwd_for_claude(DEFAULT_CONTAINER_WORKDIR)
+            );
+            ResumeProbeTarget {
+                host_probe_path: map.to_host(&container_projects_path),
+                filesystem: "container-via-mount",
+                warning: None,
+            }
+        }
+    }
+}
+
+fn emit_session_env_warning<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    session_id: Uuid,
+    warning: &ContainerEnvWarning,
+) {
+    log::warn!("{}", warning.message);
+    let _ = app.emit(
+        "session_env_warning",
+        serde_json::json!({
+            "sessionId": session_id.to_string(),
+            "key": warning.key,
+            "kind": warning.kind,
+            "message": warning.message,
+        }),
+    );
+}
+
 /// Decide whether to auto-inject `--continue` for a Claude session.
 /// Pure function: no filesystem access. Caller is responsible for resolving
 /// `claude_project_exists` (typically `~/.claude/projects/<mangled-cwd>/.is_dir()`).
@@ -901,6 +1022,25 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         release_resource_launch_permit(&resource_monitor, &mut resource_permit);
         return Err("root-agent cannot use container transport".to_string());
     }
+    if backend_kind == SessionBackendKind::ContainerTransport {
+        if let Some(reason) = crate::pty::container_paths::container_mount_source_rejection(
+            std::path::Path::new(&cwd),
+        ) {
+            release_resource_launch_permit(&resource_monitor, &mut resource_permit);
+            return Err(reason);
+        }
+    }
+    let container_path_map = if backend_kind == SessionBackendKind::ContainerTransport {
+        match container_path_map_for_cwd(&cwd) {
+            Ok(map) => Some(map),
+            Err(err) => {
+                release_resource_launch_permit(&resource_monitor, &mut resource_permit);
+                return Err(err);
+            }
+        }
+    } else {
+        None
+    };
     let mut session = match mgr
         .create_session(
             shell.clone(),
@@ -1001,26 +1141,30 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     // call sites pass `skip_auto_resume = true` for fresh creates).
     // Issue #186: honor `CLAUDE_CONFIG_DIR` overrides set by `.cmd`/`.bat`/`.ps1`/`.sh`
     // wrappers (e.g. `claude-mb`) so the probe locates the real transcript store.
-    // #599 R2 - also honor the profile/agent env layer's CLAUDE_CONFIG_DIR. The env
-    // approach launches a plain `claude`, so resolve_claude_projects_dir would
-    // short-circuit to ~/.claude and miss env-relocated transcripts. When the
-    // resolved spawn carries CLAUDE_CONFIG_DIR, probe <that>/projects/<mangled>;
-    // otherwise keep the wrapper-aware default resolution.
-    let claude_config_dir_override = resolved_spawn.as_ref().and_then(|s| {
-        s.child_env
-            .iter()
-            .find(|(k, _)| k.eq_ignore_ascii_case("CLAUDE_CONFIG_DIR"))
-            .map(|(_, v)| v.clone())
-    });
-    let resolved_claude_projects_dir = match claude_config_dir_override {
-        Some(ref dir) => Some(claude_projects_dir_for_config_dir(dir, &cwd)),
-        None => resolve_claude_projects_dir(&shell, &shell_args, &cwd),
-    };
-    let claude_project_exists = resolved_claude_projects_dir
+    // #894: local sessions keep the host probe, while container sessions probe
+    // only paths reachable through the bind mount. Missing or unmappable
+    // CLAUDE_CONFIG_DIR skips resume and is surfaced as a session env warning.
+    let resume_probe = resume_probe_target(
+        session.backend_kind,
+        container_path_map.as_ref(),
+        resolved_spawn.as_ref(),
+        &shell,
+        &shell_args,
+        &cwd,
+    );
+    let resolved_claude_projects_dir = resume_probe.host_probe_path.clone();
+    let claude_project_exists = resume_probe
+        .host_probe_path
         .as_ref()
         .map(|p| p.is_dir())
         .unwrap_or(false);
     let is_claude = agent_kind == Some(CodingAgentKind::Claude);
+    let mut session_env_warnings: Vec<ContainerEnvWarning> = Vec::new();
+    if is_claude {
+        if let Some(warning) = resume_probe.warning {
+            session_env_warnings.push(warning);
+        }
+    }
     let will_inject_continue = should_inject_continue(
         is_claude,
         skip_auto_resume,
@@ -1032,11 +1176,12 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     // during the stabilization window; demote later.
     if agent_kind.is_some() {
         log::info!(
-            "[session] resume-decision {} agent={:?} cwd={:?} projects_dir={:?} exists={} skip_auto_resume={} -> inject_continue={}",
+            "[session] resume-decision {} agent={:?} cwd={:?} projects_dir={:?} filesystem={} exists={} skip_auto_resume={} -> inject_continue={}",
             &id.to_string()[..8],
             agent_kind,
             cwd,
             resolved_claude_projects_dir,
+            resume_probe.filesystem,
             claude_project_exists,
             skip_auto_resume,
             will_inject_continue
@@ -1198,7 +1343,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     } else {
         Vec::new()
     };
-    let configured_env: Vec<(String, String)> = resolved_spawn
+    let mut configured_env: Vec<(String, String)> = resolved_spawn
         .as_ref()
         .map(|spawn| spawn.child_env.clone())
         .unwrap_or_default();
@@ -1206,6 +1351,21 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         .as_ref()
         .map(|spawn| spawn.env_remove_keys.clone())
         .unwrap_or_default();
+    let mut env_unset: Vec<String> = Vec::new();
+    if session.backend_kind == SessionBackendKind::ContainerTransport {
+        if let Some(map) = container_path_map.as_ref() {
+            let translated = crate::pty::container_backend::container_child_env(
+                configured_env,
+                env_remove_keys.clone(),
+                map,
+            );
+            configured_env = translated.child_env;
+            env_unset = translated.env_unset;
+            if is_claude {
+                session_env_warnings.extend(translated.warnings);
+            }
+        }
+    }
     let (resource_registration, logical_resource_slot): (
         Option<ResourceLaunchRegistration>,
         Option<ResourceLogicalAgentSlot>,
@@ -1313,6 +1473,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             .and_then(|spawn| spawn.backend.image.clone()),
         configured_env,
         env_remove_keys,
+        env_unset,
         extra_env,
         idle_tuning: crate::session::profile::idle_tuning_for(agent_kind),
         output_target: PtyOutputTarget::from_app_handle(app.clone()),
@@ -1429,6 +1590,9 @@ pub async fn create_session_inner<R: tauri::Runtime>(
 
     let info = SessionInfo::from(&session);
     let _ = app.emit("session_created", info.clone());
+    for warning in &session_env_warnings {
+        emit_session_env_warning(app, id, warning);
+    }
 
     // 0.8.0: removed the "Show the terminal window when a session is created" branch.
     // Under the unified-window model the main window is created up-front and stays
@@ -3106,12 +3270,15 @@ pub async fn create_root_agent_session(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_existing_root, compute_profile_outdated, count_working_members,
-        effective_restart_requested_profile, inject_codex_resume, resolve_actual_agent,
-        resolve_agent_command, resolve_agent_from_shell, resolve_restart_selected_agent_id,
-        resolve_root_agent_command, should_inject_continue, ExistingRootAction,
+        classify_existing_root, claude_projects_dir_for_config_dir, compute_profile_outdated,
+        count_working_members, effective_restart_requested_profile, inject_codex_resume,
+        resolve_actual_agent, resolve_agent_command, resolve_agent_from_shell,
+        resolve_restart_selected_agent_id, resolve_root_agent_command,
+        resume_probe_target_for_config_dir, should_inject_continue, ExistingRootAction,
     };
     use crate::config::settings::{AgentConfig, AppSettings, ProfileCellConfig};
+    use crate::pty::backend::SessionBackendKind;
+    use crate::pty::container_paths::{ContainerPathMap, WARNING_KIND_NO_VALUE};
     use crate::session::manager::SessionManager;
     use crate::session::session::{SessionInfo, SessionStatus};
     use std::collections::BTreeMap;
@@ -3178,6 +3345,90 @@ mod tests {
             ],
             ..AppSettings::default()
         }
+    }
+
+    fn probe_map() -> ContainerPathMap {
+        ContainerPathMap::new(r"C:\Users\maria\repo\.ac\wg-1\__agent_x", "/workspace").unwrap()
+    }
+
+    fn norm(path: &std::path::Path) -> String {
+        path.to_string_lossy().replace('\\', "/")
+    }
+
+    #[test]
+    fn resume_probe_target_local_uses_effective_config_dir_on_host() {
+        let cwd = r"C:\Users\maria\repo\.ac\wg-1\__agent_x";
+        let config_dir = r"C:\Users\maria\.claude-work";
+        let got = resume_probe_target_for_config_dir(
+            SessionBackendKind::LocalProcess,
+            None,
+            Some(config_dir),
+            "claude",
+            &[],
+            cwd,
+        );
+
+        assert_eq!(got.filesystem, "host");
+        assert_eq!(
+            got.host_probe_path,
+            Some(claude_projects_dir_for_config_dir(config_dir, cwd))
+        );
+        assert!(got.warning.is_none());
+    }
+
+    #[test]
+    fn resume_probe_target_container_no_value_warns_and_skips_probe() {
+        let map = probe_map();
+        let got = resume_probe_target_for_config_dir(
+            SessionBackendKind::ContainerTransport,
+            Some(&map),
+            None,
+            "claude",
+            &[],
+            map.host_root(),
+        );
+
+        assert_eq!(got.filesystem, "container-unreachable");
+        assert!(got.host_probe_path.is_none());
+        assert_eq!(
+            got.warning.as_ref().map(|w| w.kind),
+            Some(WARNING_KIND_NO_VALUE)
+        );
+    }
+
+    #[test]
+    fn resume_probe_target_container_maps_bind_mounted_config_dir() {
+        let map = probe_map();
+        let got = resume_probe_target_for_config_dir(
+            SessionBackendKind::ContainerTransport,
+            Some(&map),
+            Some(r"C:\Users\maria\repo\.ac\wg-1\__agent_x\.claude"),
+            "claude",
+            &[],
+            map.host_root(),
+        );
+
+        assert_eq!(got.filesystem, "container-via-mount");
+        let host_probe = got.host_probe_path.expect("host probe");
+        assert!(norm(&host_probe).ends_with("/__agent_x/.claude/projects/-workspace"));
+        assert!(got.warning.is_none());
+    }
+
+    #[test]
+    fn resume_probe_target_container_unmappable_config_dir_skips_probe_without_duplicate_warning() {
+        let map = probe_map();
+        let got = resume_probe_target_for_config_dir(
+            SessionBackendKind::ContainerTransport,
+            Some(&map),
+            Some("/workspace/.claude"),
+            "claude",
+            &[],
+            map.host_root(),
+        );
+
+        assert_eq!(got.filesystem, "container-unreachable");
+        assert!(got.host_probe_path.is_none());
+        assert!(got.warning.is_none());
     }
 
     #[derive(Default)]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -27,6 +27,7 @@ use crate::session::profile::CodingAgentKind;
 use crate::session::session::{
     SessionCommunication, SessionCommunicationKind, SessionInfo, SessionRepo, SessionStatus,
 };
+use crate::session::warnings::{emit_session_warning, SessionWarning};
 use crate::telegram::manager::TelegramBridgeState;
 use crate::DetachedSessionsState;
 
@@ -672,13 +673,48 @@ fn container_path_context_for_cwd(cwd: &str) -> Result<ContainerPathContext, Str
     if let Some(reason) = crate::pty::container_paths::container_mount_source_rejection(
         std::path::Path::new(&canonical_host_root),
     ) {
-        return Err(reason);
+        return Err(container_mount_rejection_message(
+            cwd,
+            &canonical_host_root,
+            reason,
+        ));
     };
     let map = ContainerPathMap::new(&canonical_host_root, DEFAULT_CONTAINER_WORKDIR)?;
     Ok(ContainerPathContext {
         host_root: canonical_host_root,
         map,
     })
+}
+
+fn container_mount_rejection_message(selected: &str, canonical: &str, reason: String) -> String {
+    if selected == canonical {
+        reason
+    } else {
+        format!(
+            "{} (selected path '{}', canonical path '{}')",
+            reason, selected, canonical
+        )
+    }
+}
+
+fn effective_codex_home_for_backend(
+    backend_kind: SessionBackendKind,
+    container_map: Option<&ContainerPathMap>,
+    spawn: &AgentSpawnCommand,
+) -> Option<String> {
+    let raw_home = spawn.effective_codex_home.as_ref()?;
+    let raw_home =
+        crate::path_utils::path_to_string_without_windows_verbatim_prefix(raw_home.as_path());
+    match backend_kind {
+        SessionBackendKind::LocalProcess => Some(raw_home),
+        SessionBackendKind::ContainerTransport => {
+            let map = container_map?;
+            let container_home = container_config_dir(map, &raw_home)?;
+            map.to_host(&container_home).map(|path| {
+                crate::path_utils::path_to_string_without_windows_verbatim_prefix(path.as_path())
+            })
+        }
+    }
 }
 
 fn resume_probe_target(
@@ -755,23 +791,6 @@ fn resume_probe_target_for_config_dir(
             }
         }
     }
-}
-
-fn emit_session_env_warning<R: tauri::Runtime>(
-    app: &AppHandle<R>,
-    session_id: Uuid,
-    warning: &ContainerEnvWarning,
-) {
-    log::warn!("{}", warning.message);
-    let _ = app.emit(
-        "session_env_warning",
-        serde_json::json!({
-            "sessionId": session_id.to_string(),
-            "key": warning.key,
-            "kind": warning.kind,
-            "message": warning.message,
-        }),
-    );
 }
 
 /// Decide whether to auto-inject `--continue` for a Claude session.
@@ -1095,10 +1114,11 @@ pub async fn create_session_inner<R: tauri::Runtime>(
 
     let id = session.id;
     if let Some(spawn) = resolved_spawn.as_ref() {
-        let effective_codex_home = spawn
-            .effective_codex_home
-            .as_ref()
-            .map(|path| path.to_string_lossy().to_string());
+        let effective_codex_home = effective_codex_home_for_backend(
+            session.backend_kind,
+            container_path_context.as_ref().map(|context| &context.map),
+            spawn,
+        );
         mgr.set_profile_metadata(
             id,
             Some(spawn.profile_resolution.requested_profile.clone()),
@@ -1157,6 +1177,9 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         &cwd,
     );
     let resolved_claude_projects_dir = resume_probe.host_probe_path.clone();
+    mgr.set_resolved_claude_projects_dir(id, resolved_claude_projects_dir.clone())
+        .await;
+    session.resolved_claude_projects_dir = resolved_claude_projects_dir.clone();
     let claude_project_exists = resume_probe
         .host_probe_path
         .as_ref()
@@ -1471,7 +1494,12 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         id,
         cmd: shell.clone(),
         args: shell_args.clone(),
-        cwd: spawn_cwd,
+        cwd: spawn_cwd.clone(),
+        selected_cwd: if spawn_cwd != cwd {
+            Some(cwd.clone())
+        } else {
+            None
+        },
         cols: 120,
         rows: 30,
         container_image: resolved_spawn
@@ -1597,7 +1625,15 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     let info = SessionInfo::from(&session);
     let _ = app.emit("session_created", info.clone());
     for warning in &session_env_warnings {
-        emit_session_env_warning(app, id, warning);
+        emit_session_warning(
+            app,
+            SessionWarning::new(
+                id,
+                warning.key.clone(),
+                warning.kind,
+                warning.message.clone(),
+            ),
+        );
     }
 
     // 0.8.0: removed the "Show the terminal window when a session is created" branch.
@@ -3288,7 +3324,11 @@ mod tests {
     use crate::session::manager::SessionManager;
     use crate::session::session::{SessionInfo, SessionStatus};
     use std::collections::BTreeMap;
+    #[cfg(windows)]
+    use std::path::Path;
     use std::path::PathBuf;
+    #[cfg(windows)]
+    use std::process::Command;
     use std::sync::{Arc, Mutex};
     use uuid::Uuid;
 
@@ -3508,6 +3548,79 @@ mod tests {
 
         assert_eq!(got.host_root, canonical);
         assert_eq!(got.map.host_root(), canonical);
+    }
+
+    #[cfg(windows)]
+    fn create_junction(link: &Path, target: &Path) {
+        let output = Command::new("cmd")
+            .arg("/C")
+            .arg("mklink")
+            .arg("/J")
+            .arg(link)
+            .arg(target)
+            .output()
+            .expect("failed to invoke mklink");
+        assert!(
+            output.status.success(),
+            "failed to create junction link='{}' target='{}': stdout={} stderr={}",
+            link.display(),
+            target.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn container_path_context_refuses_junction_targeting_workgroup_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp
+            .path()
+            .join("project")
+            .join(".ac")
+            .join("wg-11-dev-v4-team");
+        std::fs::create_dir_all(&target).unwrap();
+        let link = tmp.path().join("link-to-wg");
+        create_junction(&link, &target);
+
+        let err = container_path_context_for_cwd(link.to_str().unwrap())
+            .expect_err("junction to workgroup root must be refused");
+
+        assert!(err.contains("workgroup root"), "{err}");
+        assert!(err.contains("selected path"), "{err}");
+        assert!(err.contains("canonical path"), "{err}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn container_path_context_refuses_junction_targeting_home_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = dirs::home_dir().expect("home dir required for junction guard test");
+        let link = tmp.path().join("link-to-home");
+        create_junction(&link, &home);
+
+        let err = container_path_context_for_cwd(link.to_str().unwrap())
+            .expect_err("junction to home dir must be refused");
+
+        assert!(err.contains("home directory"), "{err}");
+        assert!(err.contains("selected path"), "{err}");
+        assert!(err.contains("canonical path"), "{err}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn container_path_context_refuses_cwd_that_cannot_be_canonicalized() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("missing");
+
+        let err = container_path_context_for_cwd(missing.to_str().unwrap())
+            .expect_err("missing cwd must be refused");
+
+        assert!(
+            err.contains("failed to canonicalize container mount source"),
+            "{err}"
+        );
+        assert!(err.contains(missing.to_str().unwrap()), "{err}");
     }
 
     #[derive(Default)]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -654,19 +654,31 @@ struct ResumeProbeTarget {
     warning: Option<ContainerEnvWarning>,
 }
 
-fn container_path_map_for_cwd(cwd: &str) -> Result<ContainerPathMap, String> {
-    let canonical_host_root = match std::fs::canonicalize(cwd) {
-        Ok(path) => crate::path_utils::path_to_string_without_windows_verbatim_prefix(&path),
-        Err(err) => {
-            log::warn!(
-                "[container-transport] failed to canonicalize mount source '{}': {}; using raw cwd for path comparisons",
-                cwd,
-                err
-            );
-            cwd.to_string()
-        }
+#[derive(Debug, Clone)]
+struct ContainerPathContext {
+    host_root: String,
+    map: ContainerPathMap,
+}
+
+fn container_path_context_for_cwd(cwd: &str) -> Result<ContainerPathContext, String> {
+    let canonical_host_root = std::fs::canonicalize(cwd)
+        .map(|path| crate::path_utils::path_to_string_without_windows_verbatim_prefix(&path))
+        .map_err(|err| {
+            format!(
+                "failed to canonicalize container mount source '{}': {}",
+                cwd, err
+            )
+        })?;
+    if let Some(reason) = crate::pty::container_paths::container_mount_source_rejection(
+        std::path::Path::new(&canonical_host_root),
+    ) {
+        return Err(reason);
     };
-    ContainerPathMap::new(&canonical_host_root, DEFAULT_CONTAINER_WORKDIR)
+    let map = ContainerPathMap::new(&canonical_host_root, DEFAULT_CONTAINER_WORKDIR)?;
+    Ok(ContainerPathContext {
+        host_root: canonical_host_root,
+        map,
+    })
 }
 
 fn resume_probe_target(
@@ -1022,17 +1034,9 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         release_resource_launch_permit(&resource_monitor, &mut resource_permit);
         return Err("root-agent cannot use container transport".to_string());
     }
-    if backend_kind == SessionBackendKind::ContainerTransport {
-        if let Some(reason) = crate::pty::container_paths::container_mount_source_rejection(
-            std::path::Path::new(&cwd),
-        ) {
-            release_resource_launch_permit(&resource_monitor, &mut resource_permit);
-            return Err(reason);
-        }
-    }
-    let container_path_map = if backend_kind == SessionBackendKind::ContainerTransport {
-        match container_path_map_for_cwd(&cwd) {
-            Ok(map) => Some(map),
+    let container_path_context = if backend_kind == SessionBackendKind::ContainerTransport {
+        match container_path_context_for_cwd(&cwd) {
+            Ok(context) => Some(context),
             Err(err) => {
                 release_resource_launch_permit(&resource_monitor, &mut resource_permit);
                 return Err(err);
@@ -1146,7 +1150,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     // CLAUDE_CONFIG_DIR skips resume and is surfaced as a session env warning.
     let resume_probe = resume_probe_target(
         session.backend_kind,
-        container_path_map.as_ref(),
+        container_path_context.as_ref().map(|context| &context.map),
         resolved_spawn.as_ref(),
         &shell,
         &shell_args,
@@ -1353,17 +1357,15 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         .unwrap_or_default();
     let mut env_unset: Vec<String> = Vec::new();
     if session.backend_kind == SessionBackendKind::ContainerTransport {
-        if let Some(map) = container_path_map.as_ref() {
+        if let Some(context) = container_path_context.as_ref() {
             let translated = crate::pty::container_backend::container_child_env(
                 configured_env,
                 env_remove_keys.clone(),
-                map,
+                &context.map,
             );
             configured_env = translated.child_env;
             env_unset = translated.env_unset;
-            if is_claude {
-                session_env_warnings.extend(translated.warnings);
-            }
+            session_env_warnings.extend(translated.warnings);
         }
     }
     let (resource_registration, logical_resource_slot): (
@@ -1461,11 +1463,15 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         }
     }
 
+    let spawn_cwd = container_path_context
+        .as_ref()
+        .map(|context| context.host_root.clone())
+        .unwrap_or_else(|| cwd.clone());
     let spawn_spec = BackendSpawnSpec {
         id,
         cmd: shell.clone(),
         args: shell_args.clone(),
-        cwd: cwd.clone(),
+        cwd: spawn_cwd,
         cols: 120,
         rows: 30,
         container_image: resolved_spawn
@@ -3271,9 +3277,9 @@ pub async fn create_root_agent_session(
 mod tests {
     use super::{
         classify_existing_root, claude_projects_dir_for_config_dir, compute_profile_outdated,
-        count_working_members, effective_restart_requested_profile, inject_codex_resume,
-        resolve_actual_agent, resolve_agent_command, resolve_agent_from_shell,
-        resolve_restart_selected_agent_id, resolve_root_agent_command,
+        container_path_context_for_cwd, count_working_members, effective_restart_requested_profile,
+        inject_codex_resume, resolve_actual_agent, resolve_agent_command, resolve_agent_from_shell,
+        resolve_claude_projects_dir, resolve_restart_selected_agent_id, resolve_root_agent_command,
         resume_probe_target_for_config_dir, should_inject_continue, ExistingRootAction,
     };
     use crate::config::settings::{AgentConfig, AppSettings, ProfileCellConfig};
@@ -3377,6 +3383,58 @@ mod tests {
     }
 
     #[test]
+    fn resume_probe_target_local_bare_claude_uses_default_resolver() {
+        let cwd = r"C:\Users\Test\repo";
+        let got = resume_probe_target_for_config_dir(
+            SessionBackendKind::LocalProcess,
+            None,
+            None,
+            "claude",
+            &[],
+            cwd,
+        );
+
+        let expected = resolve_claude_projects_dir("claude", &[], cwd);
+        let Some(expected) = expected else {
+            return;
+        };
+        assert_eq!(got.filesystem, "host");
+        assert_eq!(got.host_probe_path, Some(expected));
+        assert!(got.warning.is_none());
+    }
+
+    #[test]
+    fn resume_probe_target_local_wrapper_uses_wrapper_config_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let custom_base = tmp.path().join(".claude-mb");
+        let wrapper = write_wrapper(
+            tmp.path(),
+            "claude-mb.cmd",
+            &format!(
+                "@echo off\r\nset CLAUDE_CONFIG_DIR={}\r\nclaude %*\r\n",
+                custom_base.display()
+            ),
+        );
+        let cwd = r"C:\Users\Test\repo";
+
+        let got = resume_probe_target_for_config_dir(
+            SessionBackendKind::LocalProcess,
+            None,
+            None,
+            wrapper.to_str().unwrap(),
+            &[],
+            cwd,
+        );
+
+        let expected = custom_base
+            .join("projects")
+            .join(crate::session::session::mangle_cwd_for_claude(cwd));
+        assert_eq!(got.filesystem, "host");
+        assert_eq!(got.host_probe_path, Some(expected));
+        assert!(got.warning.is_none());
+    }
+
+    #[test]
     fn resume_probe_target_container_no_value_warns_and_skips_probe() {
         let map = probe_map();
         let got = resume_probe_target_for_config_dir(
@@ -3429,6 +3487,27 @@ mod tests {
         assert_eq!(got.filesystem, "container-unreachable");
         assert!(got.host_probe_path.is_none());
         assert!(got.warning.is_none());
+    }
+
+    #[test]
+    fn container_path_context_uses_canonical_host_root_for_guard_and_map() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp
+            .path()
+            .join("project")
+            .join(".ac")
+            .join("wg-1-team")
+            .join("repo-foo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let raw = repo.join(".");
+        let canonical = crate::path_utils::path_to_string_without_windows_verbatim_prefix(
+            &std::fs::canonicalize(&repo).unwrap(),
+        );
+
+        let got = container_path_context_for_cwd(raw.to_str().unwrap()).unwrap();
+
+        assert_eq!(got.host_root, canonical);
+        assert_eq!(got.map.host_root(), canonical);
     }
 
     #[derive(Default)]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -3573,6 +3573,8 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn container_path_context_refuses_junction_targeting_workgroup_root() {
+        // B4 regression fence: before cwd canonicalization, the textual guard
+        // saw only `link-to-wg` and permitted a bind mount of the workgroup.
         let tmp = tempfile::tempdir().unwrap();
         let target = tmp
             .path()
@@ -3594,6 +3596,14 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn container_path_context_refuses_junction_targeting_home_dir() {
+        // Guard coverage, not the main B4 regression fence: the pre-B4 home
+        // rule already canonicalized both sides. This test mainly preserves the
+        // selected-vs-canonical rejection text for reparse-point inputs.
+        //
+        // Safety note: `%TEMP%` usually lives under the user's home directory,
+        // so this junction points from a tempdir back to its own ancestor.
+        // The test relies on std::fs::remove_dir_all treating the junction as a
+        // reparse point and deleting only the link, not descending into home.
         let tmp = tempfile::tempdir().unwrap();
         let home = dirs::home_dir().expect("home dir required for junction guard test");
         let link = tmp.path().join("link-to-home");
@@ -3610,6 +3620,8 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn container_path_context_refuses_cwd_that_cannot_be_canonicalized() {
+        // Pins the fail-closed DD9 behavior from 8d0d3fd5. It is not the B4
+        // junction bypass regression fence.
         let tmp = tempfile::tempdir().unwrap();
         let missing = tmp.path().join("missing");
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -4224,6 +4224,38 @@ mod tests {
         assert_eq!(resolved, expected);
     }
 
+    #[test]
+    fn local_resume_probe_env_layer_uses_config_dir_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let custom_base = tmp.path().join(".claude-env");
+        let cwd = "C:\\Users\\Test\\repo";
+
+        let resolved =
+            super::claude_projects_dir_for_config_dir(custom_base.to_str().unwrap(), cwd);
+
+        let expected = custom_base
+            .join("projects")
+            .join(crate::session::session::mangle_cwd_for_claude(cwd));
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn local_resume_probe_env_layer_expands_powershell_envvar() {
+        let var = "AC_TEST_894_CONFIG_DIR";
+        let tmp = tempfile::tempdir().unwrap();
+        let custom_base = tmp.path().join(".claude-env");
+        std::env::set_var(var, custom_base.to_str().unwrap());
+
+        let resolved =
+            super::claude_projects_dir_for_config_dir(&format!("$env:{}\\.claude", var), "C:\\x");
+
+        std::env::remove_var(var);
+        let expected = PathBuf::from(format!("{}\\.claude", custom_base.to_string_lossy()))
+            .join("projects")
+            .join(crate::session::session::mangle_cwd_for_claude("C:\\x"));
+        assert_eq!(resolved, expected);
+    }
+
     // ── should_inject_continue tests (issue #82, plan §8.1) ──
 
     #[test]

--- a/src-tauri/src/commands/telegram.rs
+++ b/src-tauri/src/commands/telegram.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use tauri::{AppHandle, Emitter, Manager, State};
@@ -8,6 +8,7 @@ use uuid::Uuid;
 use crate::config::sessions_persistence::persist_current_state_result;
 use crate::config::settings::SettingsState;
 use crate::network::OutboundNetwork;
+use crate::pty::backend::SessionBackendKind;
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
 use crate::session::profile::CodingAgentKind;
@@ -25,6 +26,9 @@ use crate::telegram::types::{BridgeInfo, TelegramBotConfig};
 ///   emits `telegram_bridge_error` + early-returns with its contractual success
 ///   value (or `Err` for `telegram_attach`).
 ///
+/// Container sessions require spawn-time memos. They never fall back to host
+/// config resolvers, because the host defaults are not the container filesystem.
+///
 /// #260: agent selection is `Option<CodingAgentKind>`. Mutual exclusion is now
 /// structural (an enum is one variant or none), so the pre-#260
 /// `debug_assert!(kinds_set <= 1, …)` guard was removed.
@@ -32,34 +36,49 @@ pub(crate) fn derive_reader(
     shell: &str,
     shell_args: &[String],
     cwd: &str,
+    backend_kind: SessionBackendKind,
     agent_kind: Option<CodingAgentKind>,
+    resolved_claude_projects_dir: Option<PathBuf>,
     effective_codex_home: Option<&str>,
 ) -> Result<Option<SessionReaderKind>, String> {
     let attach_time = chrono::Utc::now();
 
     match agent_kind {
-        Some(CodingAgentKind::Claude) => {
-            match crate::commands::session::resolve_claude_projects_dir(shell, shell_args, cwd) {
+        Some(CodingAgentKind::Claude) => match backend_kind {
+            SessionBackendKind::LocalProcess => match resolved_claude_projects_dir.or_else(|| {
+                crate::commands::session::resolve_claude_projects_dir(shell, shell_args, cwd)
+            }) {
                 Some(p) => Ok(Some(SessionReaderKind::Claude { project_dir: p })),
                 None => Err("Cannot resolve Claude projects dir".to_string()),
-            }
-        }
+            },
+            SessionBackendKind::ContainerTransport => match resolved_claude_projects_dir {
+                Some(p) => Ok(Some(SessionReaderKind::Claude { project_dir: p })),
+                None => Err("Cannot resolve Claude projects dir for container session; CLAUDE_CONFIG_DIR is not mapped into the replica mount".to_string()),
+            },
+        },
         Some(CodingAgentKind::Codex) => {
-            let effective_home = effective_codex_home.map(Path::new);
-            match crate::commands::codex_resolver::resolve_codex_sessions_root_with_effective_home(
-                effective_home,
-                shell,
-                shell_args,
-                cwd,
-            ) {
+            let root = match backend_kind {
+                SessionBackendKind::LocalProcess => {
+                    let effective_home = effective_codex_home.map(Path::new);
+                    crate::commands::codex_resolver::resolve_codex_sessions_root_with_effective_home(
+                        effective_home,
+                        shell,
+                        shell_args,
+                        cwd,
+                    )
+                }
+                SessionBackendKind::ContainerTransport => {
+                    effective_codex_home.map(|home| Path::new(home).join("sessions"))
+                }
+            };
+            match root {
                 Some(root) => Ok(Some(SessionReaderKind::Codex {
                     search_root: root,
                     cwd: cwd.to_string(),
                     attach_time,
                 })),
-                None => Err(
-                    "Cannot resolve Codex sessions root (~/.codex/sessions/ missing)".to_string(),
-                ),
+                None if backend_kind == SessionBackendKind::ContainerTransport => Err("Cannot resolve Codex sessions root for container session; CODEX_HOME is not mapped into the replica mount".to_string()),
+                None => Err("Cannot resolve Codex sessions root (~/.codex/sessions/ missing)".to_string()),
             }
         }
         Some(CodingAgentKind::Gemini) => {
@@ -94,7 +113,15 @@ pub(crate) async fn attach_telegram_bot_by_id<R: tauri::Runtime>(
     let settings = app.state::<SettingsState>();
     let network = app.state::<OutboundNetwork>().inner().clone();
 
-    let (agent_kind, shell, shell_args, working_directory, effective_codex_home) = {
+    let (
+        agent_kind,
+        shell,
+        shell_args,
+        working_directory,
+        backend_kind,
+        resolved_claude_projects_dir,
+        effective_codex_home,
+    ) = {
         let mgr = session_mgr.read().await;
         let session = mgr
             .get_session(session_id)
@@ -105,6 +132,8 @@ pub(crate) async fn attach_telegram_bot_by_id<R: tauri::Runtime>(
             session.shell.clone(),
             session.shell_args.clone(),
             session.working_directory.clone(),
+            session.backend_kind,
+            session.resolved_claude_projects_dir.clone(),
             session.effective_codex_home.clone(),
         )
     };
@@ -113,7 +142,9 @@ pub(crate) async fn attach_telegram_bot_by_id<R: tauri::Runtime>(
         &shell,
         &shell_args,
         &working_directory,
+        backend_kind,
         agent_kind,
+        resolved_claude_projects_dir,
         effective_codex_home.as_deref(),
     ) {
         Ok(r) => r,
@@ -543,6 +574,82 @@ pub async fn telegram_send_image(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn derive_reader_container_claude_requires_memo() {
+        let result = derive_reader(
+            "claude",
+            &[],
+            r"C:\Users\Test\repo",
+            SessionBackendKind::ContainerTransport,
+            Some(CodingAgentKind::Claude),
+            None,
+            None,
+        );
+
+        assert!(result
+            .expect_err("container Claude memo is required")
+            .contains("CLAUDE_CONFIG_DIR is not mapped"));
+    }
+
+    #[test]
+    fn derive_reader_container_claude_uses_memo() {
+        let project_dir = PathBuf::from(r"C:\repo\.ac\wg-1\__agent\.claude\projects\-workspace");
+        let result = derive_reader(
+            "claude",
+            &[],
+            r"C:\repo\.ac\wg-1\__agent",
+            SessionBackendKind::ContainerTransport,
+            Some(CodingAgentKind::Claude),
+            Some(project_dir.clone()),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Some(SessionReaderKind::Claude { project_dir: got }) => assert_eq!(got, project_dir),
+            other => panic!("unexpected reader: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn derive_reader_container_codex_requires_effective_home_memo() {
+        let result = derive_reader(
+            "codex",
+            &[],
+            r"C:\Users\Test\repo",
+            SessionBackendKind::ContainerTransport,
+            Some(CodingAgentKind::Codex),
+            None,
+            None,
+        );
+
+        assert!(result
+            .expect_err("container Codex memo is required")
+            .contains("CODEX_HOME is not mapped"));
+    }
+
+    #[test]
+    fn derive_reader_container_codex_uses_effective_home_memo() {
+        let home = r"C:\repo\.ac\wg-1\__agent\.codex";
+        let result = derive_reader(
+            "codex",
+            &[],
+            r"C:\repo\.ac\wg-1\__agent",
+            SessionBackendKind::ContainerTransport,
+            Some(CodingAgentKind::Codex),
+            None,
+            Some(home),
+        )
+        .unwrap();
+
+        match result {
+            Some(SessionReaderKind::Codex { search_root, .. }) => {
+                assert_eq!(search_root, Path::new(home).join("sessions"));
+            }
+            other => panic!("unexpected reader: {other:?}"),
+        }
+    }
 
     #[test]
     fn endpoint_photo_under_limit() {

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -47,6 +47,40 @@ pub struct AgentSpawnCommand {
     pub seed: Option<crate::config::config_seed::ResolvedConfigSeed>,
 }
 
+impl AgentSpawnCommand {
+    pub fn effective_child_env(&self) -> Vec<(String, String)> {
+        self.child_env
+            .iter()
+            .filter(|(key, _)| {
+                !self
+                    .env_remove_keys
+                    .iter()
+                    .any(|remove| env_key_matches_platform(remove, key))
+            })
+            .cloned()
+            .collect()
+    }
+
+    pub fn effective_env_value(&self, key: &str) -> Option<&str> {
+        let wanted = normalize_env_key_for_platform(key);
+        self.child_env
+            .iter()
+            .rev()
+            .filter(|(candidate, _)| {
+                !self
+                    .env_remove_keys
+                    .iter()
+                    .any(|remove| env_key_matches_platform(remove, candidate))
+            })
+            .find(|(candidate, _)| normalize_env_key_for_platform(candidate) == wanted)
+            .map(|(_, value)| value.as_str())
+    }
+}
+
+fn env_key_matches_platform(left: &str, right: &str) -> bool {
+    normalize_env_key_for_platform(left) == normalize_env_key_for_platform(right)
+}
+
 pub fn normalize_legacy_agent_command(command: &str) -> Result<NormalizedAgentCommand, String> {
     let input = command.trim_matches(|c: char| c.is_ascii_whitespace());
     if input.is_empty() {
@@ -947,11 +981,12 @@ mod tests {
         default_instructions_filename_for_command, ensure_opencode_config_dir,
         find_opencode_config_dir, is_safe_instructions_filename, managed_instructions_filenames,
         normalize_legacy_agent_command, profile_content_hash, resolve_instructions_filename,
-        resolve_target_filename, OpencodeConfigDirOutcome,
+        resolve_target_filename, AgentSpawnCommand, OpencodeConfigDirOutcome,
     };
+    use crate::config::coding_agent_profiles::ProfileResolution;
     use crate::config::settings::{
-        AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ConfigSeedConfig,
-        ProfileCellConfig,
+        empty_profile_cell, AgentBackendConfig, AgentConfig, AppSettings, CodingAgentEnv,
+        CodingAgentEnvSource, ConfigSeedConfig, ProfileCellConfig,
     };
     use std::collections::BTreeMap;
 
@@ -1084,6 +1119,63 @@ mod tests {
             instructions_filename: None,
             config_seed: None,
             backend: Default::default(),
+        }
+    }
+
+    fn spawn_with_env(
+        child_env: Vec<(String, String)>,
+        env_remove_keys: Vec<String>,
+    ) -> AgentSpawnCommand {
+        AgentSpawnCommand {
+            shell: "codex".to_string(),
+            shell_args: Vec::new(),
+            agent_env: BTreeMap::new(),
+            profile_env: BTreeMap::new(),
+            generated_env: BTreeMap::new(),
+            child_env,
+            env_remove_keys,
+            effective_codex_home: None,
+            profile_resolution: ProfileResolution {
+                requested_profile: "A".to_string(),
+                effective_profile: "A".to_string(),
+                fallback_chain: vec!["A".to_string()],
+                fallback_applied: false,
+                cell: empty_profile_cell(),
+                warnings: Vec::new(),
+            },
+            profile_content_hash: "0000000000000000".to_string(),
+            trusted_agent_id: "codex".to_string(),
+            trusted_agent_label: "codex".to_string(),
+            backend: AgentBackendConfig::default(),
+            seed: None,
+        }
+    }
+
+    #[test]
+    fn effective_env_helpers_apply_removals_and_last_wins() {
+        let spawn = spawn_with_env(
+            vec![
+                ("FOO".to_string(), "one".to_string()),
+                ("BAR".to_string(), "remove".to_string()),
+                ("FOO".to_string(), "last".to_string()),
+            ],
+            vec!["BAR".to_string()],
+        );
+
+        assert_eq!(
+            spawn.effective_child_env(),
+            vec![
+                ("FOO".to_string(), "one".to_string()),
+                ("FOO".to_string(), "last".to_string())
+            ]
+        );
+        assert_eq!(spawn.effective_env_value("FOO"), Some("last"));
+        assert_eq!(spawn.effective_env_value("BAR"), None);
+
+        if cfg!(windows) {
+            assert_eq!(spawn.effective_env_value("foo"), Some("last"));
+        } else {
+            assert_eq!(spawn.effective_env_value("foo"), None);
         }
     }
 

--- a/src-tauri/src/config/config_seed.rs
+++ b/src-tauri/src/config/config_seed.rs
@@ -203,13 +203,13 @@ pub fn compute_config_dir_warning(
             if matches {
                 // L1 case 2: seed overwrites the tool's ACTIVE config dir.
                 Some(format!(
-                    "config seed destination '{}' is the tool's active {}='{}'; it is overwritten on every spawn, so any credentials or session state living there are reset each launch (ensure the template is self-sufficient)",
+                    "config seed destination '{}' has the same final folder name as the tool's active {}='{}'; this heuristic does not inspect filesystem identity. The seeded folder is overwritten on every spawn, so any credentials or session state living there are reset each launch (ensure the template is self-sufficient)",
                     dest_seg, key, value
                 ))
             } else {
                 // Case 1: dest does not match the configured config-dir env.
                 Some(format!(
-                    "config seed destination '{}' does not match {}='{}'; the tool will read its config from there, not the seeded folder",
+                    "config seed destination '{}' does not match the final folder name of {}='{}'; this heuristic does not inspect filesystem identity, and the tool may read config from that path rather than the seeded folder",
                     dest_seg, key, value
                 ))
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -624,6 +624,7 @@ pub fn run(
         .manage(screenshot_capture_state) // #714
         .manage(screenshot_hotkey_state) // #714
         .manage(crate::pty::input_activity::new_state()) // #871 substantive-input tracker
+        .manage(crate::session::warnings::new_session_warning_state())
         .setup(move |app| {
             use tauri::WebviewWindowBuilder;
             use tauri::WebviewUrl;
@@ -2160,6 +2161,7 @@ pub fn run(
             commands::session::set_last_prompt,
             commands::session::list_sessions,
             commands::session::get_active_session,
+            session::warnings::drain_session_warnings,
             commands::session::create_root_agent_session,
             commands::task::task_get_title,
             commands::task::task_set_title,

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -23,6 +23,7 @@ pub struct BackendSpawnSpec {
     pub cmd: String,
     pub args: Vec<String>,
     pub cwd: String,
+    pub selected_cwd: Option<String>,
     pub cols: u16,
     pub rows: u16,
     pub container_image: Option<String>,

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -28,6 +28,7 @@ pub struct BackendSpawnSpec {
     pub container_image: Option<String>,
     pub configured_env: Vec<(String, String)>,
     pub env_remove_keys: Vec<String>,
+    pub env_unset: Vec<String>,
     pub extra_env: Vec<(String, String)>,
     pub idle_tuning: IdleTuning,
     pub output_target: PtyOutputTarget,

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -11,8 +11,8 @@ use uuid::Uuid;
 use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
 use crate::pty::container_paths::{
-    canonical_host_path_env_key, claude_config_dir_unmappable_warning, container_config_dir,
-    ContainerEnvClass, ContainerEnvWarning, ContainerPathMap, CLAUDE_CONFIG_DIR_KEY,
+    canonical_host_path_env_key, container_config_dir, host_path_env_unmappable_warning,
+    ContainerEnvClass, ContainerEnvWarning, ContainerPathMap,
 };
 use crate::pty::container_runtime::{
     api_url_for_container, resolve_container_image, ContainerDiagnostics, ContainerRuntime,
@@ -1207,11 +1207,10 @@ pub(crate) fn container_child_env(
                 if let Some(container_value) = container_config_dir(map, &value) {
                     child_env.push((canonical_key.to_string(), container_value));
                 } else {
-                    if !env_unset.iter().any(|existing| existing == canonical_key) {
+                    let already_unset = env_unset.iter().any(|existing| existing == canonical_key);
+                    if !already_unset {
                         env_unset.push(canonical_key.to_string());
-                    }
-                    if canonical_key == CLAUDE_CONFIG_DIR_KEY {
-                        warnings.push(claude_config_dir_unmappable_warning(map, &value));
+                        warnings.push(host_path_env_unmappable_warning(map, canonical_key, &value));
                     }
                 }
             }
@@ -1256,6 +1255,7 @@ fn is_reserved_container_env(key: &str) -> bool {
 mod tests {
     use super::*;
     use crate::pty::backend::SessionBackendKind;
+    use crate::pty::container_paths::CLAUDE_CONFIG_DIR_KEY;
     use crate::pty::container_runtime::ContainerCleanupReport;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -1544,10 +1544,21 @@ mod tests {
                 crate::pty::container_paths::CODEX_HOME_KEY.to_string()
             ]
         );
-        assert_eq!(got.warnings.len(), 1);
         assert_eq!(
-            got.warnings[0].kind,
-            crate::pty::container_paths::WARNING_KIND_OUTSIDE_MOUNT
+            got.warnings
+                .iter()
+                .map(|warning| (warning.key.as_str(), warning.kind))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    CLAUDE_CONFIG_DIR_KEY,
+                    crate::pty::container_paths::WARNING_KIND_OUTSIDE_MOUNT
+                ),
+                (
+                    crate::pty::container_paths::CODEX_HOME_KEY,
+                    crate::pty::container_paths::WARNING_KIND_CONTAINER_PATH_IN_HOST_FIELD
+                )
+            ]
         );
     }
 

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -28,6 +28,10 @@ const TRANSPORT_LOST_EXIT_CODE: i32 = 1;
 const CLEANUP_TASK_TIMEOUT: Duration = Duration::from_secs(10);
 const CONTAINER_DIAGNOSTIC_LOG_TAIL_LINES: usize = 80;
 
+// Keep this re-export so session_transport and container_backend continue to
+// share exactly one normalization rule.
+pub(crate) use crate::pty::container_paths::root_key;
+
 type RouteRemover = Arc<dyn Fn(Uuid) + Send + Sync>;
 
 #[derive(Debug, Clone, Copy)]
@@ -1170,17 +1174,6 @@ fn is_reserved_container_env(key: &str) -> bool {
         || key.eq_ignore_ascii_case("AGENTSCOMMANDER_SESSION_REGISTRATION_TOKEN")
         || key.eq_ignore_ascii_case("AGENTSCOMMANDER_API_TOKEN")
         || key.eq_ignore_ascii_case("AGENTSCOMMANDER_ROOT")
-}
-
-pub(crate) fn root_key(root: &str) -> String {
-    let normalized = crate::path_utils::normalize_windows_verbatim_path(root);
-    let normalized = normalized.replace('\\', "/");
-    let trimmed = normalized.trim_end_matches('/').to_string();
-    if cfg!(windows) {
-        trimmed.to_ascii_lowercase()
-    } else {
-        trimmed
-    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -564,6 +564,7 @@ impl ContainerTransportBackend {
             cmd,
             args,
             cwd,
+            selected_cwd,
             cols,
             rows,
             container_image,
@@ -619,6 +620,7 @@ impl ContainerTransportBackend {
             env_remove_keys,
             env_unset,
             container_image,
+            selected_cwd.as_deref(),
             ticket,
             &token,
         ) {
@@ -1101,6 +1103,7 @@ fn build_start_request(
     env_remove_keys: Vec<String>,
     env_unset: Vec<String>,
     container_image: Option<String>,
+    selected_cwd: Option<&str>,
     registration_ticket: String,
     token: &ContainerApiToken,
 ) -> Result<ContainerStartRequest, AppError> {
@@ -1116,6 +1119,7 @@ fn build_start_request(
         env_remove_keys,
         env_unset,
         container_image,
+        selected_cwd,
         registration_ticket,
         token,
         &settings,
@@ -1134,6 +1138,7 @@ fn build_start_request_with_settings(
     env_remove_keys: Vec<String>,
     env_unset: Vec<String>,
     container_image: Option<String>,
+    selected_cwd: Option<&str>,
     registration_ticket: String,
     token: &ContainerApiToken,
     settings: &crate::config::settings::AppSettings,
@@ -1146,15 +1151,30 @@ fn build_start_request_with_settings(
     if let Some(reason) =
         crate::pty::container_paths::container_mount_source_rejection(std::path::Path::new(cwd))
     {
-        return Err(AppError::Other(reason));
+        let message = match selected_cwd {
+            Some(selected) if selected != cwd => format!(
+                "{} (selected path '{}', canonical path '{}')",
+                reason, selected, cwd
+            ),
+            _ => reason,
+        };
+        return Err(AppError::Other(message));
     }
     let api_url = api_url_for_container(&settings.api_server_bind, settings.api_server_port)?;
     let child_env = sanitized_child_env(configured_env, env_remove_keys);
-    log::info!(
-        "[container-transport] mount source '{}' -> '{}'",
-        cwd,
-        DEFAULT_CONTAINER_WORKDIR
-    );
+    match selected_cwd {
+        Some(selected) if selected != cwd => log::info!(
+            "[container-transport] mount source selected '{}' canonical '{}' -> '{}'",
+            selected,
+            cwd,
+            DEFAULT_CONTAINER_WORKDIR
+        ),
+        _ => log::info!(
+            "[container-transport] mount source '{}' -> '{}'",
+            cwd,
+            DEFAULT_CONTAINER_WORKDIR
+        ),
+    }
     Ok(ContainerStartRequest {
         session_id,
         image: resolve_container_image(container_image.as_deref())?,
@@ -1326,6 +1346,7 @@ mod tests {
             cmd: "container".to_string(),
             args: Vec::new(),
             cwd: root.to_string(),
+            selected_cwd: None,
             cols: 120,
             rows: 30,
             container_image: None,
@@ -1608,6 +1629,7 @@ mod tests {
             Vec::new(),
             Vec::new(),
             Some(" agentscommander/ac-claude:latest ".to_string()),
+            None,
             "ticket".to_string(),
             &token(),
             &api_enabled_settings(),

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -10,6 +10,10 @@ use uuid::Uuid;
 
 use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
+use crate::pty::container_paths::{
+    canonical_host_path_env_key, claude_config_dir_unmappable_warning, container_config_dir,
+    ContainerEnvClass, ContainerEnvWarning, ContainerPathMap, CLAUDE_CONFIG_DIR_KEY,
+};
 use crate::pty::container_runtime::{
     api_url_for_container, resolve_container_image, ContainerDiagnostics, ContainerRuntime,
     ContainerRuntimeHandle, ContainerStartRequest, CONTAINER_STOP_TIMEOUT,
@@ -22,7 +26,7 @@ use crate::resource_monitor::ResourceLogicalAgentSlot;
 use crate::session::manager::SessionManager;
 use crate::telegram::manager::OutputSenderMap;
 
-pub const TRANSPORT_PROTOCOL_VERSION: u32 = 1;
+pub const TRANSPORT_PROTOCOL_VERSION: u32 = 2;
 pub const MAX_TRANSPORT_FRAME_BYTES: usize = 64 * 1024;
 const TRANSPORT_LOST_EXIT_CODE: i32 = 1;
 const CLEANUP_TASK_TIMEOUT: Duration = Duration::from_secs(10);
@@ -565,6 +569,7 @@ impl ContainerTransportBackend {
             container_image,
             configured_env,
             env_remove_keys,
+            env_unset,
             extra_env: _,
             idle_tuning,
             output_target,
@@ -612,6 +617,7 @@ impl ContainerTransportBackend {
             cols,
             configured_env,
             env_remove_keys,
+            env_unset,
             container_image,
             ticket,
             &token,
@@ -1093,6 +1099,7 @@ fn build_start_request(
     cols: u16,
     configured_env: Vec<(String, String)>,
     env_remove_keys: Vec<String>,
+    env_unset: Vec<String>,
     container_image: Option<String>,
     registration_ticket: String,
     token: &ContainerApiToken,
@@ -1107,6 +1114,7 @@ fn build_start_request(
         cols,
         configured_env,
         env_remove_keys,
+        env_unset,
         container_image,
         registration_ticket,
         token,
@@ -1124,6 +1132,7 @@ fn build_start_request_with_settings(
     cols: u16,
     configured_env: Vec<(String, String)>,
     env_remove_keys: Vec<String>,
+    env_unset: Vec<String>,
     container_image: Option<String>,
     registration_ticket: String,
     token: &ContainerApiToken,
@@ -1134,8 +1143,18 @@ fn build_start_request_with_settings(
             "container transport requires the control-plane API server to be enabled".to_string(),
         ));
     }
+    if let Some(reason) =
+        crate::pty::container_paths::container_mount_source_rejection(std::path::Path::new(cwd))
+    {
+        return Err(AppError::Other(reason));
+    }
     let api_url = api_url_for_container(&settings.api_server_bind, settings.api_server_port)?;
     let child_env = sanitized_child_env(configured_env, env_remove_keys);
+    log::info!(
+        "[container-transport] mount source '{}' -> '{}'",
+        cwd,
+        DEFAULT_CONTAINER_WORKDIR
+    );
     Ok(ContainerStartRequest {
         session_id,
         image: resolve_container_image(container_image.as_deref())?,
@@ -1148,9 +1167,66 @@ fn build_start_request_with_settings(
         command: cmd.to_string(),
         args,
         child_env,
+        env_unset,
         cols,
         rows,
     })
+}
+
+pub(crate) struct ContainerChildEnv {
+    pub child_env: Vec<(String, String)>,
+    pub env_unset: Vec<String>,
+    pub warnings: Vec<ContainerEnvWarning>,
+}
+
+pub(crate) fn container_child_env(
+    configured_env: Vec<(String, String)>,
+    env_remove_keys: Vec<String>,
+    map: &ContainerPathMap,
+) -> ContainerChildEnv {
+    let mut child_env = Vec::new();
+    let mut env_unset = Vec::new();
+    let mut warnings = Vec::new();
+    for (key, value) in configured_env {
+        if env_remove_keys
+            .iter()
+            .any(|remove| env_key_matches_platform(remove, &key))
+            || is_reserved_container_env(&key)
+        {
+            continue;
+        }
+
+        let Some(canonical_key) = canonical_host_path_env_key(&key) else {
+            child_env.push((key, value));
+            continue;
+        };
+
+        match crate::pty::container_paths::classify_container_env(&key) {
+            ContainerEnvClass::Opaque => child_env.push((key, value)),
+            ContainerEnvClass::HostPathTranslate => {
+                if let Some(container_value) = container_config_dir(map, &value) {
+                    child_env.push((canonical_key.to_string(), container_value));
+                } else {
+                    if !env_unset.iter().any(|existing| existing == canonical_key) {
+                        env_unset.push(canonical_key.to_string());
+                    }
+                    if canonical_key == CLAUDE_CONFIG_DIR_KEY {
+                        warnings.push(claude_config_dir_unmappable_warning(map, &value));
+                    }
+                }
+            }
+        }
+    }
+    ContainerChildEnv {
+        child_env,
+        env_unset,
+        warnings,
+    }
+}
+
+fn env_key_matches_platform(left: &str, right: &str) -> bool {
+    crate::config::settings::normalize_env_key_for_platform(left)
+        == crate::config::settings::normalize_env_key_for_platform(right)
 }
 
 fn sanitized_child_env(
@@ -1255,6 +1331,7 @@ mod tests {
             container_image: None,
             configured_env: Vec::new(),
             env_remove_keys: Vec::new(),
+            env_unset: Vec::new(),
             extra_env: Vec::new(),
             idle_tuning: crate::session::profile::IdleTuning::DEFAULT,
             output_target,
@@ -1410,6 +1487,86 @@ mod tests {
         );
     }
 
+    fn child_env_map() -> ContainerPathMap {
+        ContainerPathMap::new(r"C:\Users\maria\repo\.ac\wg-1\__agent_x", "/workspace").unwrap()
+    }
+
+    #[test]
+    fn container_child_env_translates_mappable_host_path_keys() {
+        let got = container_child_env(
+            vec![
+                (
+                    CLAUDE_CONFIG_DIR_KEY.to_string(),
+                    r"C:\Users\maria\repo\.ac\wg-1\__agent_x\.claude".to_string(),
+                ),
+                ("MY_VAR".to_string(), r"C:\Users\maria\.outside".to_string()),
+            ],
+            Vec::new(),
+            &child_env_map(),
+        );
+
+        assert_eq!(
+            got.child_env,
+            vec![
+                (
+                    CLAUDE_CONFIG_DIR_KEY.to_string(),
+                    "/workspace/.claude".to_string()
+                ),
+                ("MY_VAR".to_string(), r"C:\Users\maria\.outside".to_string())
+            ]
+        );
+        assert!(got.env_unset.is_empty());
+        assert!(got.warnings.is_empty());
+    }
+
+    #[test]
+    fn container_child_env_unsets_unmappable_host_path_keys() {
+        let got = container_child_env(
+            vec![
+                (
+                    CLAUDE_CONFIG_DIR_KEY.to_string(),
+                    r"C:\Users\maria\.claude".to_string(),
+                ),
+                (
+                    crate::pty::container_paths::CODEX_HOME_KEY.to_string(),
+                    "/workspace/.codex".to_string(),
+                ),
+            ],
+            Vec::new(),
+            &child_env_map(),
+        );
+
+        assert!(got.child_env.is_empty());
+        assert_eq!(
+            got.env_unset,
+            vec![
+                CLAUDE_CONFIG_DIR_KEY.to_string(),
+                crate::pty::container_paths::CODEX_HOME_KEY.to_string()
+            ]
+        );
+        assert_eq!(got.warnings.len(), 1);
+        assert_eq!(
+            got.warnings[0].kind,
+            crate::pty::container_paths::WARNING_KIND_OUTSIDE_MOUNT
+        );
+    }
+
+    #[test]
+    fn container_child_env_removal_suppresses_unset_and_warning() {
+        let got = container_child_env(
+            vec![(
+                CLAUDE_CONFIG_DIR_KEY.to_string(),
+                r"C:\Users\maria\.claude".to_string(),
+            )],
+            vec![CLAUDE_CONFIG_DIR_KEY.to_string()],
+            &child_env_map(),
+        );
+
+        assert!(got.child_env.is_empty());
+        assert!(got.env_unset.is_empty());
+        assert!(got.warnings.is_empty());
+    }
+
     fn api_enabled_settings() -> crate::config::settings::AppSettings {
         crate::config::settings::AppSettings {
             api_server_enabled: true,
@@ -1436,6 +1593,7 @@ mod tests {
             "C:/repo/.ac/wg-1/__agent_dev",
             30,
             120,
+            Vec::new(),
             Vec::new(),
             Vec::new(),
             Some(" agentscommander/ac-claude:latest ".to_string()),

--- a/src-tauri/src/pty/container_paths.rs
+++ b/src-tauri/src/pty/container_paths.rs
@@ -1,0 +1,509 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerEnvClass {
+    HostPathTranslate,
+    Opaque,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerEnvValidationRegime {
+    StrictAbsolutePath,
+    AllowsUnexpandedMarkers,
+}
+
+pub const CLAUDE_CONFIG_DIR_KEY: &str = "CLAUDE_CONFIG_DIR";
+pub const CODEX_HOME_KEY: &str = "CODEX_HOME";
+pub const OPENCODE_CONFIG_DIR_KEY: &str = "OPENCODE_CONFIG_DIR";
+
+pub const HOST_PATH_TRANSLATE_ENV_KEYS: [&str; 3] = [
+    CLAUDE_CONFIG_DIR_KEY,
+    CODEX_HOME_KEY,
+    OPENCODE_CONFIG_DIR_KEY,
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContainerPathMap {
+    host_root: String,
+    host_root_normalized: String,
+    host_root_key: String,
+    container_root: String,
+}
+
+impl ContainerPathMap {
+    pub fn new(canonical_host_root: &str, container_root: &str) -> Result<Self, String> {
+        let host_root_normalized = normalize_path_text(canonical_host_root);
+        if is_unc_path(&host_root_normalized) {
+            return Err(format!(
+                "container transport cannot bind-mount UNC host root '{}'",
+                canonical_host_root
+            ));
+        }
+        if !looks_absolute_host_path(canonical_host_root) {
+            return Err(format!(
+                "container transport host root '{}' is not absolute",
+                canonical_host_root
+            ));
+        }
+
+        let host_root_normalized = trim_trailing_separators(&host_root_normalized);
+        let container_root = normalize_container_root(container_root);
+        Ok(Self {
+            host_root: canonical_host_root.to_string(),
+            host_root_key: root_key(&host_root_normalized),
+            host_root_normalized,
+            container_root,
+        })
+    }
+
+    pub fn to_container(&self, host_path: &str) -> Option<String> {
+        if contains_unexpanded_marker(host_path) || !looks_absolute_host_path(host_path) {
+            return None;
+        }
+
+        let normalized = trim_trailing_separators(&normalize_path_text(host_path));
+        if contains_dot_segment(&normalized) {
+            return None;
+        }
+
+        let compare_key = root_key(&normalized);
+        if compare_key == self.host_root_key {
+            return Some(self.container_root.clone());
+        }
+
+        let prefix = format!("{}/", self.host_root_key);
+        if !compare_key.starts_with(&prefix) {
+            return None;
+        }
+
+        let remainder = normalized.get(self.host_root_normalized.len()..)?;
+        let remainder = remainder.strip_prefix('/')?;
+        if remainder.is_empty() {
+            Some(self.container_root.clone())
+        } else {
+            Some(format!("{}/{}", self.container_root, remainder))
+        }
+    }
+
+    pub fn to_host(&self, container_path: &str) -> Option<PathBuf> {
+        let normalized = normalize_container_path(container_path)?;
+        if normalized == self.container_root {
+            return Some(PathBuf::from(&self.host_root));
+        }
+        let prefix = format!("{}/", self.container_root);
+        let remainder = normalized.strip_prefix(&prefix)?;
+        let sep = host_separator(&self.host_root);
+        Some(PathBuf::from(format!(
+            "{}{}{}",
+            self.host_root,
+            sep,
+            remainder.replace('/', sep)
+        )))
+    }
+
+    pub fn is_container_path(&self, value: &str) -> bool {
+        normalize_container_path(value)
+            .map(|normalized| {
+                normalized == self.container_root
+                    || normalized.starts_with(&format!("{}/", self.container_root))
+            })
+            .unwrap_or(false)
+    }
+}
+
+pub fn root_key(root: &str) -> String {
+    let normalized = normalize_path_text(root);
+    let trimmed = trim_trailing_separators(&normalized);
+    if cfg!(windows) {
+        trimmed.to_ascii_lowercase()
+    } else {
+        trimmed
+    }
+}
+
+pub fn classify_container_env(key: &str) -> ContainerEnvClass {
+    if canonical_host_path_env_key(key).is_some() {
+        ContainerEnvClass::HostPathTranslate
+    } else {
+        ContainerEnvClass::Opaque
+    }
+}
+
+pub fn canonical_host_path_env_key(key: &str) -> Option<&'static str> {
+    let normalized = crate::config::settings::normalize_env_key_for_platform(key);
+    HOST_PATH_TRANSLATE_ENV_KEYS
+        .iter()
+        .copied()
+        .find(|candidate| {
+            crate::config::settings::normalize_env_key_for_platform(candidate) == normalized
+        })
+}
+
+pub fn host_path_env_validation_regime(key: &str) -> Option<ContainerEnvValidationRegime> {
+    canonical_host_path_env_key(key).map(|canonical| {
+        if canonical == CODEX_HOME_KEY {
+            ContainerEnvValidationRegime::StrictAbsolutePath
+        } else {
+            ContainerEnvValidationRegime::AllowsUnexpandedMarkers
+        }
+    })
+}
+
+pub fn container_config_dir(map: &ContainerPathMap, raw_value: &str) -> Option<String> {
+    map.to_container(raw_value)
+}
+
+pub fn container_mount_source_rejection(cwd: &Path) -> Option<String> {
+    let cwd_text = cwd.to_string_lossy();
+    if is_filesystem_or_drive_or_unc_share_root(&cwd_text) {
+        return Some(format!(
+            "container transport refuses to bind-mount filesystem root '{}'",
+            cwd.display()
+        ));
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        if same_path_or_string(cwd, &home) {
+            return Some(format!(
+                "container transport refuses to bind-mount the user's home directory '{}'",
+                cwd.display()
+            ));
+        }
+    }
+
+    if cwd
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(crate::config::workspace::is_workspace_dir_name)
+        .unwrap_or(false)
+    {
+        return Some(format!(
+            "container transport refuses to bind-mount AC workspace root '{}'",
+            cwd.display()
+        ));
+    }
+
+    if crate::config::workspace::has_workspace_dir(cwd) {
+        return Some(format!(
+            "container transport refuses to bind-mount project root '{}' because it directly contains an AC workspace",
+            cwd.display()
+        ));
+    }
+
+    let is_wg_dir = cwd
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.starts_with("wg-"))
+        .unwrap_or(false);
+    if is_wg_dir && crate::config::workspace::find_workspace_ancestor(cwd).is_some() {
+        return Some(format!(
+            "container transport refuses to bind-mount workgroup root '{}'",
+            cwd.display()
+        ));
+    }
+
+    None
+}
+
+fn same_path_or_string(a: &Path, b: &Path) -> bool {
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => root_key(&a.to_string_lossy()) == root_key(&b.to_string_lossy()),
+    }
+}
+
+fn normalize_path_text(path: &str) -> String {
+    let stripped = strip_windows_verbatim_prefix_any(path);
+    stripped.replace('\\', "/")
+}
+
+fn strip_windows_verbatim_prefix_any(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{}", rest)
+    } else if let Some(rest) = path.strip_prefix(r"\\?\") {
+        rest.to_string()
+    } else if let Some(rest) = path.strip_prefix(r"\??\UNC\") {
+        format!(r"\\{}", rest)
+    } else if let Some(rest) = path.strip_prefix(r"\??\") {
+        rest.to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+fn trim_trailing_separators(path: &str) -> String {
+    if is_drive_root_text(path) || path == "/" || is_unc_share_root_text(path) {
+        return path.to_string();
+    }
+    path.trim_end_matches('/').to_string()
+}
+
+fn normalize_container_root(root: &str) -> String {
+    let normalized = root.replace('\\', "/");
+    if normalized == "/" {
+        normalized
+    } else {
+        normalized.trim_end_matches('/').to_string()
+    }
+}
+
+fn normalize_container_path(path: &str) -> Option<String> {
+    if path.contains('\\') {
+        return None;
+    }
+    if !path.starts_with('/') || path.contains("//") || contains_dot_segment(path) {
+        return None;
+    }
+    Some(if path == "/" {
+        path.to_string()
+    } else {
+        path.trim_end_matches('/').to_string()
+    })
+}
+
+fn host_separator(host_root: &str) -> &str {
+    if host_root.contains('\\') && !host_root.contains('/') {
+        r"\"
+    } else {
+        "/"
+    }
+}
+
+fn contains_unexpanded_marker(value: &str) -> bool {
+    value.contains('%') || value.contains('$')
+}
+
+fn contains_dot_segment(path: &str) -> bool {
+    path.split('/').any(|part| part == "." || part == "..")
+}
+
+fn looks_absolute_host_path(path: &str) -> bool {
+    let normalized = normalize_path_text(path);
+    if is_unc_path(&normalized) {
+        return true;
+    }
+    if normalized.len() >= 3 {
+        let bytes = normalized.as_bytes();
+        if bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/' {
+            return true;
+        }
+    }
+    normalized.starts_with('/') && !path.starts_with('\\')
+}
+
+fn is_unc_path(normalized: &str) -> bool {
+    normalized.starts_with("//")
+}
+
+fn is_drive_root_text(normalized: &str) -> bool {
+    normalized.len() == 3
+        && normalized.as_bytes()[0].is_ascii_alphabetic()
+        && normalized.as_bytes()[1] == b':'
+        && normalized.as_bytes()[2] == b'/'
+}
+
+fn is_unc_share_root_text(normalized: &str) -> bool {
+    if !is_unc_path(normalized) {
+        return false;
+    }
+    let parts: Vec<&str> = normalized
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect();
+    parts.len() == 2
+}
+
+fn is_filesystem_or_drive_or_unc_share_root(path: &str) -> bool {
+    let normalized = normalize_path_text(path);
+    normalized == "/" || is_drive_root_text(&normalized) || is_unc_share_root_text(&normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map() -> ContainerPathMap {
+        ContainerPathMap::new(r"C:\Users\maria\repo\.ac\wg-1\__agent_x", "/workspace").unwrap()
+    }
+
+    fn norm(path: &Path) -> String {
+        path.to_string_lossy().replace('\\', "/")
+    }
+
+    #[test]
+    fn to_container_maps_windows_host_path_to_workspace_path() {
+        assert_eq!(
+            map().to_container(r"C:\Users\maria\repo\.ac\wg-1\__agent_x\.claude"),
+            Some("/workspace/.claude".to_string())
+        );
+    }
+
+    #[test]
+    fn to_container_maps_root_itself() {
+        assert_eq!(
+            map().to_container(r"C:\Users\maria\repo\.ac\wg-1\__agent_x"),
+            Some("/workspace".to_string())
+        );
+        assert_eq!(
+            map().to_container(r"C:\Users\maria\repo\.ac\wg-1\__agent_x\"),
+            Some("/workspace".to_string())
+        );
+    }
+
+    #[test]
+    fn to_container_rejects_parent_and_prefix_siblings() {
+        assert_eq!(
+            map().to_container(r"C:\Users\maria\repo\.ac\wg-1\.claude"),
+            None
+        );
+        assert_eq!(
+            map().to_container(r"C:\Users\maria\repo\.ac\wg-1\__agent_x-evil\.claude"),
+            None
+        );
+    }
+
+    #[test]
+    fn to_container_preserves_remainder_case() {
+        assert_eq!(
+            map().to_container(r"C:\Users\maria\repo\.ac\wg-1\__agent_x\MyCodex"),
+            Some("/workspace/MyCodex".to_string())
+        );
+    }
+
+    #[test]
+    fn to_container_rejects_dot_segments_markers_and_non_absolute_paths() {
+        let map = map();
+        assert_eq!(
+            map.to_container(r"C:\Users\maria\repo\.ac\wg-1\__agent_x\..\x"),
+            None
+        );
+        assert_eq!(
+            map.to_container(r"C:\Users\maria\repo\.ac\wg-1\__agent_x\.\x"),
+            None
+        );
+        assert_eq!(map.to_container(r"%AC_REPLICA_ROOT%\.claude"), None);
+        assert_eq!(map.to_container(r"$env:AC_REPLICA_ROOT\.claude"), None);
+        assert_eq!(map.to_container(r"$AC_REPLICA_ROOT/.claude"), None);
+        assert_eq!(map.to_container(r"C:.claude"), None);
+        assert_eq!(map.to_container(r"\.claude"), None);
+    }
+
+    #[test]
+    fn to_container_accepts_forward_slashes_and_strips_verbatim_prefixes_on_values() {
+        let map = map();
+        assert_eq!(
+            map.to_container("C:/Users/maria/repo/.ac/wg-1/__agent_x/.claude"),
+            Some("/workspace/.claude".to_string())
+        );
+        assert_eq!(
+            map.to_container(r"\\?\C:\Users\maria\repo\.ac\wg-1\__agent_x\.claude"),
+            Some("/workspace/.claude".to_string())
+        );
+    }
+
+    #[test]
+    fn new_rejects_unc_host_root() {
+        assert!(ContainerPathMap::new(r"\\server\share\repo", "/workspace").is_err());
+        assert!(ContainerPathMap::new(r"\\?\UNC\server\share\repo", "/workspace").is_err());
+    }
+
+    #[test]
+    fn to_host_round_trips_container_path() {
+        let got = map()
+            .to_host("/workspace/.claude/projects/-workspace")
+            .unwrap();
+        assert!(norm(&got).ends_with("/__agent_x/.claude/projects/-workspace"));
+    }
+
+    #[test]
+    fn is_container_path_identifies_workspace_paths() {
+        let map = map();
+        assert!(map.is_container_path("/workspace/.claude"));
+        assert!(map.is_container_path("/workspace"));
+        assert!(!map.is_container_path("/workspace-evil/.claude"));
+    }
+
+    #[test]
+    fn classify_container_env_matches_host_platform_key_rules() {
+        assert_eq!(
+            classify_container_env("CLAUDE_CONFIG_DIR"),
+            ContainerEnvClass::HostPathTranslate
+        );
+        assert_eq!(
+            classify_container_env("CODEX_HOME"),
+            ContainerEnvClass::HostPathTranslate
+        );
+        assert_eq!(
+            classify_container_env("OPENCODE_CONFIG_DIR"),
+            ContainerEnvClass::HostPathTranslate
+        );
+        assert_eq!(classify_container_env("MY_VAR"), ContainerEnvClass::Opaque);
+
+        if cfg!(windows) {
+            assert_eq!(
+                classify_container_env("claude_config_dir"),
+                ContainerEnvClass::HostPathTranslate
+            );
+        } else {
+            assert_eq!(
+                classify_container_env("claude_config_dir"),
+                ContainerEnvClass::Opaque
+            );
+        }
+    }
+
+    #[test]
+    fn host_path_keys_have_pinned_validation_regimes() {
+        assert_eq!(
+            host_path_env_validation_regime("CODEX_HOME"),
+            Some(ContainerEnvValidationRegime::StrictAbsolutePath)
+        );
+        assert_eq!(
+            host_path_env_validation_regime("CLAUDE_CONFIG_DIR"),
+            Some(ContainerEnvValidationRegime::AllowsUnexpandedMarkers)
+        );
+        assert_eq!(
+            host_path_env_validation_regime("OPENCODE_CONFIG_DIR"),
+            Some(ContainerEnvValidationRegime::AllowsUnexpandedMarkers)
+        );
+    }
+
+    #[test]
+    fn mount_source_rejection_refuses_pinned_sources() {
+        assert!(
+            container_mount_source_rejection(Path::new(if cfg!(windows) { r"C:\" } else { "/" }))
+                .is_some()
+        );
+        assert!(container_mount_source_rejection(Path::new(r"C:\")).is_some());
+        assert!(container_mount_source_rejection(Path::new(r"\\server\share")).is_some());
+
+        if let Some(home) = dirs::home_dir() {
+            assert!(container_mount_source_rejection(&home).is_some());
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        let workspace = project.join(".ac");
+        let wg = workspace.join("wg-1-team");
+        std::fs::create_dir_all(&wg).unwrap();
+
+        assert!(container_mount_source_rejection(&workspace).is_some());
+        assert!(container_mount_source_rejection(&project).is_some());
+        assert!(container_mount_source_rejection(&wg).is_some());
+    }
+
+    #[test]
+    fn mount_source_rejection_permits_pinned_sources() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        let workspace = project.join(".ac");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        let repo = workspace.join("wg-1-team").join("repo-foo");
+        let matrix = workspace.join("_agent_x");
+        let plain_repo = tmp.path().join("plain-repo");
+        for path in [&replica, &repo, &matrix, &plain_repo] {
+            std::fs::create_dir_all(path).unwrap();
+            assert_eq!(container_mount_source_rejection(path), None);
+        }
+    }
+}

--- a/src-tauri/src/pty/container_paths.rs
+++ b/src-tauri/src/pty/container_paths.rs
@@ -22,6 +22,17 @@ pub const HOST_PATH_TRANSLATE_ENV_KEYS: [&str; 3] = [
     OPENCODE_CONFIG_DIR_KEY,
 ];
 
+pub const WARNING_KIND_CONTAINER_PATH_IN_HOST_FIELD: &str = "container-path-in-host-field";
+pub const WARNING_KIND_OUTSIDE_MOUNT: &str = "outside-mount";
+pub const WARNING_KIND_NO_VALUE: &str = "no-value";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContainerEnvWarning {
+    pub key: String,
+    pub kind: &'static str,
+    pub message: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContainerPathMap {
     host_root: String,
@@ -109,6 +120,14 @@ impl ContainerPathMap {
             })
             .unwrap_or(false)
     }
+
+    pub fn host_root(&self) -> &str {
+        &self.host_root
+    }
+
+    pub fn container_root(&self) -> &str {
+        &self.container_root
+    }
 }
 
 pub fn root_key(root: &str) -> String {
@@ -151,6 +170,42 @@ pub fn host_path_env_validation_regime(key: &str) -> Option<ContainerEnvValidati
 
 pub fn container_config_dir(map: &ContainerPathMap, raw_value: &str) -> Option<String> {
     map.to_container(raw_value)
+}
+
+pub fn claude_config_dir_unmappable_warning(
+    map: &ContainerPathMap,
+    raw_value: &str,
+) -> ContainerEnvWarning {
+    let (kind, message) = if map.is_container_path(raw_value) {
+        (
+            WARNING_KIND_CONTAINER_PATH_IN_HOST_FIELD,
+            format!(
+                "container session: CLAUDE_CONFIG_DIR='{raw_value}' looks like a container path. Path env rows in AgentsCommander are host-side values; AgentsCommander translates them for container sessions. This value was unset in the container, so conversation state will not persist and auto-resume is skipped. Set CLAUDE_CONFIG_DIR=%AC_REPLICA_ROOT%\\.claude (it resolves to /workspace/.claude inside the container)."
+            ),
+        )
+    } else {
+        (
+            WARNING_KIND_OUTSIDE_MOUNT,
+            format!(
+                "container session: CLAUDE_CONFIG_DIR='{raw_value}' is outside the bind mount ({} -> {}); it is not visible inside the container. The variable was unset in the container environment and auto-resume is skipped. Set CLAUDE_CONFIG_DIR=%AC_REPLICA_ROOT%\\.claude to make conversation state durable and resumable.",
+                map.host_root(),
+                map.container_root()
+            ),
+        )
+    };
+    ContainerEnvWarning {
+        key: CLAUDE_CONFIG_DIR_KEY.to_string(),
+        kind,
+        message,
+    }
+}
+
+pub fn claude_config_dir_no_value_warning() -> ContainerEnvWarning {
+    ContainerEnvWarning {
+        key: CLAUDE_CONFIG_DIR_KEY.to_string(),
+        kind: WARNING_KIND_NO_VALUE,
+        message: "container session: no CLAUDE_CONFIG_DIR is set. Conversation transcripts are container-ephemeral, Telegram bridge is inactive, and auto-resume is skipped. Set CLAUDE_CONFIG_DIR=%AC_REPLICA_ROOT%\\.claude to make conversation state durable and resumable.".to_string(),
+    }
 }
 
 pub fn container_mount_source_rejection(cwd: &Path) -> Option<String> {
@@ -465,6 +520,38 @@ mod tests {
         assert_eq!(
             host_path_env_validation_regime("OPENCODE_CONFIG_DIR"),
             Some(ContainerEnvValidationRegime::AllowsUnexpandedMarkers)
+        );
+    }
+
+    #[test]
+    fn claude_config_dir_warnings_have_pinned_kinds_and_messages() {
+        let map = map();
+
+        let container_path = claude_config_dir_unmappable_warning(&map, "/workspace/.claude");
+        assert_eq!(container_path.key, CLAUDE_CONFIG_DIR_KEY);
+        assert_eq!(
+            container_path.kind,
+            WARNING_KIND_CONTAINER_PATH_IN_HOST_FIELD
+        );
+        assert_eq!(
+            container_path.message,
+            "container session: CLAUDE_CONFIG_DIR='/workspace/.claude' looks like a container path. Path env rows in AgentsCommander are host-side values; AgentsCommander translates them for container sessions. This value was unset in the container, so conversation state will not persist and auto-resume is skipped. Set CLAUDE_CONFIG_DIR=%AC_REPLICA_ROOT%\\.claude (it resolves to /workspace/.claude inside the container)."
+        );
+
+        let outside = claude_config_dir_unmappable_warning(&map, r"C:\Users\maria\.claude");
+        assert_eq!(outside.key, CLAUDE_CONFIG_DIR_KEY);
+        assert_eq!(outside.kind, WARNING_KIND_OUTSIDE_MOUNT);
+        assert_eq!(
+            outside.message,
+            "container session: CLAUDE_CONFIG_DIR='C:\\Users\\maria\\.claude' is outside the bind mount (C:\\Users\\maria\\repo\\.ac\\wg-1\\__agent_x -> /workspace); it is not visible inside the container. The variable was unset in the container environment and auto-resume is skipped. Set CLAUDE_CONFIG_DIR=%AC_REPLICA_ROOT%\\.claude to make conversation state durable and resumable."
+        );
+
+        let no_value = claude_config_dir_no_value_warning();
+        assert_eq!(no_value.key, CLAUDE_CONFIG_DIR_KEY);
+        assert_eq!(no_value.kind, WARNING_KIND_NO_VALUE);
+        assert_eq!(
+            no_value.message,
+            "container session: no CLAUDE_CONFIG_DIR is set. Conversation transcripts are container-ephemeral, Telegram bridge is inactive, and auto-resume is skipped. Set CLAUDE_CONFIG_DIR=%AC_REPLICA_ROOT%\\.claude to make conversation state durable and resumable."
         );
     }
 

--- a/src-tauri/src/pty/container_paths.rs
+++ b/src-tauri/src/pty/container_paths.rs
@@ -25,6 +25,7 @@ pub const HOST_PATH_TRANSLATE_ENV_KEYS: [&str; 3] = [
 pub const WARNING_KIND_CONTAINER_PATH_IN_HOST_FIELD: &str = "container-path-in-host-field";
 pub const WARNING_KIND_OUTSIDE_MOUNT: &str = "outside-mount";
 pub const WARNING_KIND_NO_VALUE: &str = "no-value";
+pub const WARNING_KIND_PROTOCOL_MISMATCH: &str = "protocol-mismatch";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContainerEnvWarning {
@@ -195,6 +196,42 @@ pub fn claude_config_dir_unmappable_warning(
     };
     ContainerEnvWarning {
         key: CLAUDE_CONFIG_DIR_KEY.to_string(),
+        kind,
+        message,
+    }
+}
+
+pub fn host_path_env_unmappable_warning(
+    map: &ContainerPathMap,
+    key: &str,
+    raw_value: &str,
+) -> ContainerEnvWarning {
+    if key == CLAUDE_CONFIG_DIR_KEY {
+        return claude_config_dir_unmappable_warning(map, raw_value);
+    }
+
+    let (kind, message) = if map.is_container_path(raw_value) {
+        (
+            WARNING_KIND_CONTAINER_PATH_IN_HOST_FIELD,
+            format!(
+                "container session: {key}='{raw_value}' looks like a container path. Path env rows in AgentsCommander are host-side values; AgentsCommander translates them for container sessions. This value was unset in the container. Set {key} to a host path under {} so it resolves under {} inside the container.",
+                map.host_root(),
+                map.container_root()
+            ),
+        )
+    } else {
+        (
+            WARNING_KIND_OUTSIDE_MOUNT,
+            format!(
+                "container session: {key}='{raw_value}' is outside the bind mount ({} -> {}); it is not visible inside the container. The variable was unset in the container environment. Set {key} to a host path under {} so AgentsCommander can translate it for the container.",
+                map.host_root(),
+                map.container_root(),
+                map.host_root()
+            ),
+        )
+    };
+    ContainerEnvWarning {
+        key: key.to_string(),
         kind,
         message,
     }
@@ -552,6 +589,35 @@ mod tests {
         assert_eq!(
             no_value.message,
             "container session: no CLAUDE_CONFIG_DIR is set. Conversation transcripts are container-ephemeral, Telegram bridge is inactive, and auto-resume is skipped. Set CLAUDE_CONFIG_DIR=%AC_REPLICA_ROOT%\\.claude to make conversation state durable and resumable."
+        );
+    }
+
+    #[test]
+    fn host_path_env_warnings_cover_non_claude_keys() {
+        let map = map();
+
+        let container_path =
+            host_path_env_unmappable_warning(&map, CODEX_HOME_KEY, "/workspace/.codex");
+        assert_eq!(container_path.key, CODEX_HOME_KEY);
+        assert_eq!(
+            container_path.kind,
+            WARNING_KIND_CONTAINER_PATH_IN_HOST_FIELD
+        );
+        assert_eq!(
+            container_path.message,
+            "container session: CODEX_HOME='/workspace/.codex' looks like a container path. Path env rows in AgentsCommander are host-side values; AgentsCommander translates them for container sessions. This value was unset in the container. Set CODEX_HOME to a host path under C:\\Users\\maria\\repo\\.ac\\wg-1\\__agent_x so it resolves under /workspace inside the container."
+        );
+
+        let outside = host_path_env_unmappable_warning(
+            &map,
+            OPENCODE_CONFIG_DIR_KEY,
+            r"C:\Users\maria\.opencode",
+        );
+        assert_eq!(outside.key, OPENCODE_CONFIG_DIR_KEY);
+        assert_eq!(outside.kind, WARNING_KIND_OUTSIDE_MOUNT);
+        assert_eq!(
+            outside.message,
+            "container session: OPENCODE_CONFIG_DIR='C:\\Users\\maria\\.opencode' is outside the bind mount (C:\\Users\\maria\\repo\\.ac\\wg-1\\__agent_x -> /workspace); it is not visible inside the container. The variable was unset in the container environment. Set OPENCODE_CONFIG_DIR to a host path under C:\\Users\\maria\\repo\\.ac\\wg-1\\__agent_x so AgentsCommander can translate it for the container."
         );
     }
 

--- a/src-tauri/src/pty/container_paths.rs
+++ b/src-tauri/src/pty/container_paths.rs
@@ -22,10 +22,11 @@ pub const HOST_PATH_TRANSLATE_ENV_KEYS: [&str; 3] = [
     OPENCODE_CONFIG_DIR_KEY,
 ];
 
+/// Contract: path-valued env rows are host-side values; AgentsCommander
+/// translates them for container sessions when they live under the replica mount.
 pub const WARNING_KIND_CONTAINER_PATH_IN_HOST_FIELD: &str = "container-path-in-host-field";
 pub const WARNING_KIND_OUTSIDE_MOUNT: &str = "outside-mount";
 pub const WARNING_KIND_NO_VALUE: &str = "no-value";
-pub const WARNING_KIND_PROTOCOL_MISMATCH: &str = "protocol-mismatch";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContainerEnvWarning {

--- a/src-tauri/src/pty/container_runtime.rs
+++ b/src-tauri/src/pty/container_runtime.rs
@@ -48,6 +48,7 @@ pub struct ContainerStartRequest {
     pub command: String,
     pub args: Vec<String>,
     pub child_env: Vec<(String, String)>,
+    pub env_unset: Vec<String>,
     pub cols: u16,
     pub rows: u16,
 }

--- a/src-tauri/src/pty/docker_runtime.rs
+++ b/src-tauri/src/pty/docker_runtime.rs
@@ -138,10 +138,16 @@ impl DockerRuntime {
         }
     }
 
-    pub fn build_run_command(&self, request: &ContainerStartRequest) -> DockerCommandSpec {
+    pub fn build_run_command(
+        &self,
+        request: &ContainerStartRequest,
+    ) -> Result<DockerCommandSpec, AppError> {
         let args_json = serde_json::to_string(&request.args).unwrap_or_else(|_| "[]".to_string());
         let child_env_json =
             serde_json::to_string(&request.child_env).unwrap_or_else(|_| "[]".to_string());
+        let env_unset_json = serde_json::to_string(&request.env_unset).map_err(|e| {
+            AppError::Other(format!("failed to serialize container env unset: {e}"))
+        })?;
 
         let mut args = vec![
             "run".to_string(),
@@ -179,6 +185,12 @@ impl DockerRuntime {
             "--env".to_string(),
             format!("AGENTSCOMMANDER_BRIDGE_ENV_JSON={}", child_env_json),
             "--env".to_string(),
+            // This is a flat key-name array, not key/value pairs. Do not add
+            // AGENTSCOMMANDER_BRIDGE_ENV_UNSET_JSON to SENSITIVE_LOG_KEYS:
+            // the value carries no secrets, and the redactor treats quoted
+            // sensitive key names as keys whose following array item is a value.
+            format!("AGENTSCOMMANDER_BRIDGE_ENV_UNSET_JSON={}", env_unset_json),
+            "--env".to_string(),
             format!("AGENTSCOMMANDER_BRIDGE_COLS={}", request.cols),
             "--env".to_string(),
             format!("AGENTSCOMMANDER_BRIDGE_ROWS={}", request.rows),
@@ -195,10 +207,10 @@ impl DockerRuntime {
         ];
 
         args.retain(|arg| !arg.is_empty());
-        DockerCommandSpec {
+        Ok(DockerCommandSpec {
             program: self.program.clone(),
             args,
-        }
+        })
     }
 
     pub fn build_stop_command(
@@ -435,7 +447,7 @@ fn join_command_reader(
 impl ContainerRuntime for DockerRuntime {
     fn start(&self, request: ContainerStartRequest) -> Result<ContainerRuntimeHandle, AppError> {
         let session_id = request.session_id;
-        let stdout = self.run_command(self.build_run_command(&request))?;
+        let stdout = self.run_command(self.build_run_command(&request)?)?;
         let container_id = stdout
             .lines()
             .next()
@@ -557,6 +569,7 @@ mod tests {
             command: "codex".to_string(),
             args: vec!["--version".to_string()],
             child_env: vec![("CODEX_HOME".to_string(), "/workspace/.codex".to_string())],
+            env_unset: vec!["CLAUDE_CONFIG_DIR".to_string()],
             cols: 120,
             rows: 30,
         }
@@ -565,7 +578,7 @@ mod tests {
     #[test]
     fn run_command_is_detached_labeled_and_has_expected_env_without_interactive_flags() {
         let runtime = DockerRuntime::with_program("docker-test");
-        let spec = runtime.build_run_command(&request());
+        let spec = runtime.build_run_command(&request()).unwrap();
         let joined = spec.args.join(" ");
 
         assert_eq!(spec.program, "docker-test");
@@ -586,6 +599,7 @@ mod tests {
             "AGENTSCOMMANDER_BINARY_PATH={DEFAULT_API_HELPER_PATH}"
         )));
         assert!(joined.contains("AGENTSCOMMANDER_BRIDGE_COMMAND=codex"));
+        assert!(joined.contains("AGENTSCOMMANDER_BRIDGE_ENV_UNSET_JSON=[\"CLAUDE_CONFIG_DIR\"]"));
         assert!(joined
             .contains("type=bind,source=C:/project/.ac/wg-1-team/__agent_dev,target=/workspace"));
         let image_idx = spec
@@ -605,7 +619,7 @@ mod tests {
         let runtime = DockerRuntime::with_program("docker-test");
         let mut request = request();
         request.image = "--privileged".to_string();
-        let spec = runtime.build_run_command(&request);
+        let spec = runtime.build_run_command(&request).unwrap();
         let image_idx = spec
             .args
             .iter()

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -405,6 +405,7 @@ impl LocalProcessBackend {
             container_image: _,
             configured_env,
             env_remove_keys,
+            env_unset: _,
             extra_env,
             idle_tuning,
             output_target,

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -400,6 +400,7 @@ impl LocalProcessBackend {
             cmd,
             args,
             cwd,
+            selected_cwd: _,
             cols,
             rows,
             container_image: _,

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -402,6 +402,7 @@ mod tests {
             cmd: "cmd".to_string(),
             args: Vec::new(),
             cwd: ".".to_string(),
+            selected_cwd: None,
             cols: 80,
             rows: 24,
             container_image: None,

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -407,6 +407,7 @@ mod tests {
             container_image: None,
             configured_env: Vec::new(),
             env_remove_keys: Vec::new(),
+            env_unset: Vec::new(),
             extra_env: Vec::new(),
             idle_tuning: crate::session::profile::IdleTuning::DEFAULT,
             output_target: crate::pty::output::PtyOutputTarget::noop(),

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -1,5 +1,6 @@
 pub mod backend;
 pub mod container_backend;
+pub mod container_paths;
 pub mod container_runtime;
 pub mod container_tokens;
 pub mod credentials;

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -83,6 +84,7 @@ impl SessionManager {
             profile_fallback_chain: Vec::new(),
             profile_fallback_applied: false,
             effective_codex_home: None,
+            resolved_claude_projects_dir: None,
             profile_content_hash: None,
             telegram_bot_id: None,
             was_detached: false,
@@ -621,6 +623,13 @@ impl SessionManager {
             s.profile_fallback_applied = profile_fallback_applied;
             s.effective_codex_home = effective_codex_home;
             s.profile_content_hash = profile_content_hash;
+        }
+    }
+
+    pub async fn set_resolved_claude_projects_dir(&self, id: Uuid, path: Option<PathBuf>) {
+        let mut sessions = self.sessions.write().await;
+        if let Some(s) = sessions.get_mut(&id) {
+            s.resolved_claude_projects_dir = path;
         }
     }
 

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -4,3 +4,4 @@ pub mod manager;
 pub mod profile;
 #[allow(clippy::module_inception)]
 pub mod session;
+pub mod warnings;

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 use crate::config::settings::WindowGeometry;
@@ -126,6 +126,8 @@ pub struct Session {
     pub profile_fallback_applied: bool,
     #[serde(skip)]
     pub effective_codex_home: Option<String>,
+    #[serde(skip)]
+    pub resolved_claude_projects_dir: Option<PathBuf>,
     /// #592 - 16-hex content-hash of the profile cell this session launched
     /// with. In-memory; the durable copy is `tooling.profileContentHash` in the
     /// replica config. `None` for plain-shell sessions (no resolved profile).
@@ -352,6 +354,7 @@ mod tests {
             profile_fallback_chain: Vec::new(),
             profile_fallback_applied: false,
             effective_codex_home: None,
+            resolved_claude_projects_dir: None,
             profile_content_hash: None,
             telegram_bot_id: None,
             was_detached: false,

--- a/src-tauri/src/session/warnings.rs
+++ b/src-tauri/src/session/warnings.rs
@@ -1,0 +1,132 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager, Runtime, State};
+use uuid::Uuid;
+
+pub const SESSION_ENV_WARNING_EVENT: &str = "session_env_warning";
+pub const WARNING_KIND_PROTOCOL_MISMATCH: &str = "protocol-mismatch";
+pub const CONTAINER_TRANSPORT_PROTOCOL_KEY: &str = "CONTAINER_TRANSPORT_PROTOCOL";
+
+const MAX_WARNINGS_PER_SESSION: usize = 32;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionWarning {
+    pub session_id: String,
+    pub key: String,
+    pub kind: String,
+    pub message: String,
+}
+
+impl SessionWarning {
+    pub fn new(
+        session_id: Uuid,
+        key: impl Into<String>,
+        kind: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            session_id: session_id.to_string(),
+            key: key.into(),
+            kind: kind.into(),
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SessionWarningBuffer {
+    pending: HashMap<String, Vec<SessionWarning>>,
+}
+
+impl SessionWarningBuffer {
+    pub fn push(&mut self, warning: SessionWarning) {
+        let session_warnings = self.pending.entry(warning.session_id.clone()).or_default();
+        if session_warnings.len() >= MAX_WARNINGS_PER_SESSION {
+            session_warnings.remove(0);
+        }
+        session_warnings.push(warning);
+    }
+
+    pub fn drain(&mut self, session_id: Option<&str>) -> Vec<SessionWarning> {
+        if let Some(session_id) = session_id {
+            return self.pending.remove(session_id).unwrap_or_default();
+        }
+
+        let mut drained = Vec::new();
+        for (_, mut warnings) in self.pending.drain() {
+            drained.append(&mut warnings);
+        }
+        drained
+    }
+}
+
+pub type SessionWarningState = Arc<Mutex<SessionWarningBuffer>>;
+
+pub fn new_session_warning_state() -> SessionWarningState {
+    Arc::new(Mutex::new(SessionWarningBuffer::default()))
+}
+
+pub fn emit_session_warning<R: Runtime>(app: &AppHandle<R>, warning: SessionWarning) {
+    log::warn!("{}", warning.message);
+    if let Some(state) = app.try_state::<SessionWarningState>() {
+        match state.lock() {
+            Ok(mut buffer) => buffer.push(warning.clone()),
+            Err(err) => {
+                log::warn!(
+                    "[session-warning] warning buffer lock poisoned; live emit only: {}",
+                    err
+                );
+            }
+        }
+    } else {
+        log::warn!("[session-warning] warning buffer state missing; live emit only");
+    }
+    let _ = app.emit(SESSION_ENV_WARNING_EVENT, warning);
+}
+
+#[tauri::command]
+pub fn drain_session_warnings(
+    state: State<'_, SessionWarningState>,
+    session_id: Option<String>,
+) -> Result<Vec<SessionWarning>, String> {
+    let mut buffer = state
+        .lock()
+        .map_err(|err| format!("session warning buffer lock poisoned: {err}"))?;
+    Ok(buffer.drain(session_id.as_deref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_drains_one_session_without_touching_another() {
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        let mut buffer = SessionWarningBuffer::default();
+        buffer.push(SessionWarning::new(first, "A", "kind", "first"));
+        buffer.push(SessionWarning::new(second, "B", "kind", "second"));
+
+        let drained = buffer.drain(Some(&first.to_string()));
+
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].message, "first");
+        assert_eq!(buffer.drain(Some(&second.to_string())).len(), 1);
+    }
+
+    #[test]
+    fn session_warning_serializes_frontend_contract() {
+        let session_id = Uuid::nil();
+        let warning = SessionWarning::new(session_id, "KEY", "kind", "message");
+
+        let value = serde_json::to_value(warning).unwrap();
+
+        assert_eq!(value["sessionId"], session_id.to_string());
+        assert_eq!(value["key"], "KEY");
+        assert_eq!(value["kind"], "kind");
+        assert_eq!(value["message"], "message");
+    }
+}

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -100,6 +100,20 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
             Ok(json!(active))
         }
 
+        "drain_session_warnings" => {
+            let session_id = args.get("sessionId").and_then(|v| v.as_str());
+            let drained = {
+                let warnings = state
+                    .app_handle
+                    .state::<crate::session::warnings::SessionWarningState>();
+                let mut buffer = warnings
+                    .lock()
+                    .map_err(|err| format!("session warning buffer lock poisoned: {err}"))?;
+                buffer.drain(session_id)
+            };
+            serde_json::to_value(drained).map_err(|e| e.to_string())
+        }
+
         "create_session" => {
             let cfg = state.settings.read().await;
             let cwd = str_or(
@@ -888,6 +902,7 @@ mod tests {
     fn ws_state_for(settings: AppSettings) -> (WsState, tokio::sync::mpsc::Receiver<WsOutMsg>) {
         let app = tauri::Builder::default()
             .any_thread()
+            .manage(crate::session::warnings::new_session_warning_state())
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("build test app");
         let app_handle = app.handle().clone();
@@ -926,6 +941,49 @@ mod tests {
             config_seed: None,
             backend: Default::default(),
         }
+    }
+
+    #[tokio::test]
+    async fn drain_session_warnings_web_dispatch_drains_buffer() {
+        let (state, _rx) = ws_state_for(AppSettings::default());
+        let session_id = Uuid::new_v4();
+        {
+            let warnings = state
+                .app_handle
+                .state::<crate::session::warnings::SessionWarningState>();
+            let mut buffer = warnings.lock().expect("warning buffer lock");
+            buffer.push(crate::session::warnings::SessionWarning::new(
+                session_id,
+                "CLAUDE_CONFIG_DIR",
+                "outside-mount",
+                "warning text",
+            ));
+        }
+
+        let response = dispatch(
+            &state,
+            9,
+            "drain_session_warnings",
+            &json!({ "sessionId": session_id.to_string() }),
+        )
+        .await;
+
+        assert_eq!(response["id"], json!(9));
+        assert_eq!(
+            response["result"][0]["sessionId"],
+            json!(session_id.to_string())
+        );
+        assert_eq!(response["result"][0]["key"], json!("CLAUDE_CONFIG_DIR"));
+
+        let response = dispatch(
+            &state,
+            10,
+            "drain_session_warnings",
+            &json!({ "sessionId": session_id.to_string() }),
+        )
+        .await;
+        assert_eq!(response["id"], json!(10));
+        assert_eq!(response["result"], json!([]));
     }
 
     #[tokio::test]

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -7,6 +7,7 @@ import type {
   SessionCommunication,
   SessionRepo,
   SessionEnvWarningPayload,
+  SessionWarning,
   PtyOutputEvent,
   PtyScreenSnapshot,
   AppSettings,
@@ -215,6 +216,11 @@ export const SessionAPI = {
   list: () => transport.invoke<Session[]>("list_sessions"),
 
   getActive: () => transport.invoke<string | null>("get_active_session"),
+
+  drainWarnings: (sessionId?: string | null) =>
+    transport.invoke<SessionWarning[]>("drain_session_warnings", {
+      sessionId: sessionId ?? null,
+    }),
 
   setLastPrompt: (id: string, text: string) =>
     transport.invoke<void>("set_last_prompt", { id, text }),

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -6,6 +6,7 @@ import type {
   Session,
   SessionCommunication,
   SessionRepo,
+  SessionEnvWarningPayload,
   PtyOutputEvent,
   PtyScreenSnapshot,
   AppSettings,
@@ -739,6 +740,15 @@ export function onTelegramBridgeError(
 ): Promise<UnlistenFn> {
   return transport.listen<{ sessionId: string; error: string }>(
     "telegram_bridge_error",
+    callback
+  );
+}
+
+export function onSessionEnvWarning(
+  callback: (data: SessionEnvWarningPayload) => void
+): Promise<UnlistenFn> {
+  return transport.listen<SessionEnvWarningPayload>(
+    "session_env_warning",
     callback
   );
 }

--- a/src/shared/session-warning-kind.test.ts
+++ b/src/shared/session-warning-kind.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { SESSION_WARNING_KINDS } from "./types";
 
 const BACKEND_WARNING_KIND_SOURCES = import.meta.glob<string>(
-  "../../src-tauri/src/{pty/container_paths,session/warnings}.rs",
+  "../../src-tauri/src/**/*.rs",
   {
     query: "?raw",
     import: "default",

--- a/src/shared/session-warning-kind.test.ts
+++ b/src/shared/session-warning-kind.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { SESSION_WARNING_KINDS } from "./types";
+
+const BACKEND_WARNING_KIND_SOURCES = import.meta.glob<string>(
+  "../../src-tauri/src/{pty/container_paths,session/warnings}.rs",
+  {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }
+);
+
+function backendWarningKinds(): string[] {
+  const kinds = new Set<string>();
+  const pattern = /pub const WARNING_KIND_[A-Z0-9_]+:\s*&str\s*=\s*"([^"]+)";/g;
+
+  for (const source of Object.values(BACKEND_WARNING_KIND_SOURCES)) {
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(source)) !== null) {
+      kinds.add(match[1]);
+    }
+  }
+
+  return [...kinds].sort();
+}
+
+describe("SESSION_WARNING_KINDS", () => {
+  it("matches the backend warning-kind constants", () => {
+    expect([...SESSION_WARNING_KINDS].sort()).toEqual(backendWarningKinds());
+  });
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -293,6 +293,14 @@ export interface BridgeInfo {
 
 export type BridgeStatus = "active" | { error: string } | "detaching";
 
+export interface SessionEnvWarningPayload {
+  sessionId: string;
+  key: string;
+  /** DD7 currently names container-path-in-host-field and outside-mount. */
+  kind: string;
+  message: string;
+}
+
 export interface WindowGeometry {
   x: number;
   y: number;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -293,13 +293,24 @@ export interface BridgeInfo {
 
 export type BridgeStatus = "active" | { error: string } | "detaching";
 
-export interface SessionEnvWarningPayload {
+export const SESSION_WARNING_KINDS = [
+  "container-path-in-host-field",
+  "outside-mount",
+  "no-value",
+  "protocol-mismatch",
+] as const;
+
+export type SessionWarningKind = (typeof SESSION_WARNING_KINDS)[number];
+
+export interface SessionWarning {
   sessionId: string;
+  /** Environment key, or a protocol sentinel such as CONTAINER_TRANSPORT_PROTOCOL. */
   key: string;
-  /** DD7 currently names container-path-in-host-field and outside-mount. */
-  kind: string;
+  kind: SessionWarningKind;
   message: string;
 }
+
+export type SessionEnvWarningPayload = SessionWarning;
 
 export interface WindowGeometry {
   x: number;

--- a/src/sidebar/App.session-env-warning.test.tsx
+++ b/src/sidebar/App.session-env-warning.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SidebarApp from "./App";
+import { toastStore } from "../shared/stores/toasts";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../shared/testing/ui-harness";
+
+const projectPath = "C:\\Project";
+const agentPath = `${projectPath}\\.ac\\_agent_General`;
+
+function setupTransport(fake: FakeTransport): void {
+  fake.resolve("get_settings", baseSettings({ projectPaths: [projectPath], projectPath }));
+  fake.resolve("open_project", {
+    path: projectPath,
+    registered: true,
+    created: false,
+  });
+  fake.resolve(
+    "discover_project",
+    discovery({
+      agents: [
+        {
+          name: "General",
+          path: agentPath,
+          roleExists: true,
+        },
+      ],
+      teams: [],
+      workgroups: [],
+    })
+  );
+  fake.resolve("get_project_groups", { groups: [], showAll: true, showUngrouped: true });
+  fake.resolve("search_repos", []);
+  fake.resolve("list_sessions", [
+    session({
+      id: "session-1",
+      name: "General",
+      workingDirectory: agentPath,
+      status: "active",
+    }),
+  ]);
+  fake.resolve("get_active_session", "session-1");
+  fake.resolve("list_detached_sessions", []);
+  fake.resolve("telegram_list_bridges", []);
+}
+
+describe("SidebarApp session environment warnings", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+  });
+
+  it("surfaces session_env_warning messages as sticky error toasts", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() => expect(rendered.root.textContent).toContain("General"));
+
+      const message =
+        "container session: CLAUDE_CONFIG_DIR='/workspace/.claude' looks like a container path. Set CLAUDE_CONFIG_DIR=%AC_REPLICA_ROOT%\\.claude.";
+      fake.emitFromBackend("session_env_warning", {
+        sessionId: "session-1",
+        key: "CLAUDE_CONFIG_DIR",
+        kind: "container-path-in-host-field",
+        message,
+      });
+
+      await waitFor(() => {
+        expect(toastStore.items).toHaveLength(1);
+        expect(toastStore.items[0]).toMatchObject({
+          kind: "error",
+          message,
+          exiting: false,
+        });
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/App.session-env-warning.test.tsx
+++ b/src/sidebar/App.session-env-warning.test.tsx
@@ -50,6 +50,7 @@ function setupTransport(fake: FakeTransport): void {
   fake.resolve("get_active_session", "session-1");
   fake.resolve("list_detached_sessions", []);
   fake.resolve("telegram_list_bridges", []);
+  fake.resolve("drain_session_warnings", []);
 }
 
 describe("SidebarApp session environment warnings", () => {
@@ -88,6 +89,67 @@ describe("SidebarApp session environment warnings", () => {
         expect(toastStore.items[0]).toMatchObject({
           kind: "error",
           message,
+          exiting: false,
+        });
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("drains buffered session warnings on mount", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    const message =
+      "container session: no CLAUDE_CONFIG_DIR is set. Set CLAUDE_CONFIG_DIR=%AC_REPLICA_ROOT%\\.claude.";
+    fake.resolve("drain_session_warnings", [
+      {
+        sessionId: "session-1",
+        key: "CLAUDE_CONFIG_DIR",
+        kind: "no-value",
+        message,
+      },
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() => {
+        expect(fake.lastCall("drain_session_warnings")?.args).toEqual({
+          sessionId: null,
+        });
+        expect(toastStore.items).toHaveLength(1);
+        expect(toastStore.items[0]).toMatchObject({
+          kind: "error",
+          message,
+          exiting: false,
+        });
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("dedupes a live warning that is also returned by the initial drain", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    const warning = {
+      sessionId: "session-1",
+      key: "CONTAINER_TRANSPORT_PROTOCOL",
+      kind: "protocol-mismatch" as const,
+      message: "Container image protocol is old. Rebuild the image.",
+    };
+    fake.onInvoke("drain_session_warnings", () => {
+      fake.emitFromBackend("session_env_warning", warning);
+      return [warning];
+    });
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() => {
+        expect(toastStore.items).toHaveLength(1);
+        expect(toastStore.items[0]).toMatchObject({
+          kind: "error",
+          message: warning.message,
           exiting: false,
         });
       });

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -21,6 +21,7 @@ import {
   onTelegramBridgeAttached,
   onTelegramBridgeDetached,
   onTelegramBridgeError,
+  onSessionEnvWarning,
   onTerminalDetached,
   onTerminalAttached,
   onWorkgroupTaskUpdated,
@@ -547,6 +548,15 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     unlisteners.push(
       await onTelegramBridgeError(({ sessionId, error }) => {
         console.error(`Bridge error for ${sessionId}: ${error}`);
+      })
+    );
+
+    unlisteners.push(
+      await onSessionEnvWarning((warning) => {
+        console.warn(
+          `Session environment warning for ${warning.sessionId} (${warning.key}/${warning.kind}): ${warning.message}`
+        );
+        toastStore.error(warning.message);
       })
     );
   });

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -341,7 +341,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     // #912: subscribe before the startup warning drain. The backend appends
     // before live emit, so exact live/drained duplicates are collapsed below.
     unlisteners.push(await onSessionEnvWarning(handleLiveSessionWarning));
-    await drainBufferedSessionWarnings();
+    void drainBufferedSessionWarnings();
 
     unlisteners.push(
       await onAcProjectRefreshRequested((data) => {

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -1,7 +1,12 @@
 import { Component, createSignal, createEffect, onMount, onCleanup, Show } from "solid-js";
 import { isTauri } from "../shared/platform";
 import type { UnlistenFn } from "../shared/transport";
-import type { SessionStatus, ContextTemplateUpdate, MainSidebarSide } from "../shared/types";
+import type {
+  SessionStatus,
+  ContextTemplateUpdate,
+  MainSidebarSide,
+  SessionWarning,
+} from "../shared/types";
 import {
   SessionAPI,
   SettingsAPI,
@@ -72,6 +77,32 @@ interface SidebarAppProps {
 
 function isExitedStatus(status: SessionStatus): boolean {
   return typeof status === "object" && status !== null && "exited" in status;
+}
+
+function sessionWarningIdentity(warning: SessionWarning): string {
+  return JSON.stringify([
+    warning.sessionId,
+    warning.key,
+    warning.kind,
+    warning.message,
+  ]);
+}
+
+function incrementWarningCount(counts: Map<string, number>, warning: SessionWarning): void {
+  const key = sessionWarningIdentity(warning);
+  counts.set(key, (counts.get(key) ?? 0) + 1);
+}
+
+function consumeWarningCount(counts: Map<string, number>, warning: SessionWarning): boolean {
+  const key = sessionWarningIdentity(warning);
+  const count = counts.get(key) ?? 0;
+  if (count <= 0) return false;
+  if (count === 1) {
+    counts.delete(key);
+  } else {
+    counts.set(key, count - 1);
+  }
+  return true;
 }
 
 export function blockContextMenu(e: Event): void {
@@ -265,6 +296,41 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     scheduleProfileOutdatedRefresh();
   };
 
+  const liveWarningsDuringInitialDrain = new Map<string, number>();
+  let initialWarningDrainActive = false;
+  let disposed = false;
+
+  const surfaceSessionWarning = (warning: SessionWarning) => {
+    if (disposed) return;
+    console.warn(
+      `Session warning for ${warning.sessionId} (${warning.key}/${warning.kind}): ${warning.message}`
+    );
+    toastStore.error(warning.message);
+  };
+
+  const handleLiveSessionWarning = (warning: SessionWarning) => {
+    if (initialWarningDrainActive) {
+      incrementWarningCount(liveWarningsDuringInitialDrain, warning);
+    }
+    surfaceSessionWarning(warning);
+  };
+
+  const drainBufferedSessionWarnings = async () => {
+    initialWarningDrainActive = true;
+    try {
+      const warnings = await SessionAPI.drainWarnings();
+      for (const warning of warnings) {
+        if (consumeWarningCount(liveWarningsDuringInitialDrain, warning)) continue;
+        surfaceSessionWarning(warning);
+      }
+    } catch (e) {
+      console.error("[session-warning] drain_session_warnings failed:", e);
+    } finally {
+      initialWarningDrainActive = false;
+      liveWarningsDuringInitialDrain.clear();
+    }
+  };
+
   onMount(async () => {
     // #289 / dark-default — dark is the base CSS, so first paint is dark with
     // no optimistic class; the persisted-preference check after
@@ -272,6 +338,11 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     // session. Guarded with !props.embedded because MainApp owns the
     // documentElement classList when this is mounted inside the unified layout
     // — same pattern as zoom/geometry.
+    // #912: subscribe before the startup warning drain. The backend appends
+    // before live emit, so exact live/drained duplicates are collapsed below.
+    unlisteners.push(await onSessionEnvWarning(handleLiveSessionWarning));
+    await drainBufferedSessionWarnings();
+
     unlisteners.push(
       await onAcProjectRefreshRequested((data) => {
         handleProjectRefreshRequested(data);
@@ -551,17 +622,10 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       })
     );
 
-    unlisteners.push(
-      await onSessionEnvWarning((warning) => {
-        console.warn(
-          `Session environment warning for ${warning.sessionId} (${warning.key}/${warning.kind}): ${warning.message}`
-        );
-        toastStore.error(warning.message);
-      })
-    );
   });
 
   onCleanup(() => {
+    disposed = true;
     unlisteners.forEach((unlisten) => unlisten());
     if (shortcutHandler) unregisterShortcuts(shortcutHandler);
     if (cleanupZoom) cleanupZoom();

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -580,6 +580,9 @@ describe("SettingsModal automation hooks", () => {
     expect(
       document.querySelector('[data-ac-testid="settings.agentRow.0.containerWarning.bind"]'),
     ).toBeNull();
+    expect(
+      document.querySelector('[data-ac-testid="settings.agentRow.0.containerHint.env"]'),
+    ).toBeNull();
 
     runtime.value = "containerTransport";
     runtime.dispatchEvent(new Event("change", { bubbles: true }));
@@ -596,6 +599,10 @@ describe("SettingsModal automation hooks", () => {
     expect(imageHint).toContain("AGENTSCOMMANDER_CONTAINER_IMAGE");
     expect(imageHint).toContain("no built-in image fallback");
     expect(imageHint).not.toContain("agentscommander/session-bridge:latest");
+    const envHint = byTestId("settings.agentRow.0.containerHint.env").textContent ?? "";
+    expect(envHint).toContain("Container sessions read CLAUDE_CONFIG_DIR");
+    expect(envHint).toContain("%AC_REPLICA_ROOT%\\.claude");
+    expect(envHint).toContain("auto-resume is skipped");
     expect(byTestId("settings.agentRow.0.containerWarning.image").textContent).toContain(
       "Saving this blank relies on AGENTSCOMMANDER_CONTAINER_IMAGE",
     );
@@ -619,6 +626,9 @@ describe("SettingsModal automation hooks", () => {
     ).toBeNull();
     expect(
       document.querySelector('[data-ac-testid="settings.agentRow.0.containerWarning.bind"]'),
+    ).toBeNull();
+    expect(
+      document.querySelector('[data-ac-testid="settings.agentRow.0.containerHint.env"]'),
     ).toBeNull();
 
     dispose();

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -2101,6 +2101,15 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                 blank only if the AgentsCommander process has
                 AGENTSCOMMANDER_CONTAINER_IMAGE set; there is no built-in image fallback.
               </div>
+              <div
+                class="settings-hint settings-hint-warning"
+                data-ac-testid={`settings.agentRow.${i()}.containerHint.env`}
+                data-ac-role="status"
+              >
+                Container sessions read CLAUDE_CONFIG_DIR from inside the container.
+                Set it to %AC_REPLICA_ROOT%\.claude, or conversation state will not
+                persist and auto-resume is skipped.
+              </div>
               <Show when={containerImageMissing()}>
                 <div
                   class="settings-hint settings-hint-warning"


### PR DESCRIPTION
Closes #894
Closes #906

## Why

AgentsCommander can run a coding agent inside a Docker container. When it launched one, it decided whether to auto-inject `--continue` by checking whether a prior conversation directory existed. **It made that decision against the host filesystem, then applied it to a process that reads a different one.**

The first attempt at a fix was implemented, reviewed, and stripped from #892's PR rather than shipped as dead code: the algorithm was correct but structurally unreachable, because `CLAUDE_CONFIG_DIR` is expanded to a host absolute path before the probe sees it. What the issue actually needed was **host to container environment path translation**, which is a design decision rather than a bugfix.

That design turned out to be cheaper than the alternative. Disabling auto-resume for container sessions would have left two live defects standing:

1. The unmapped Windows path was injected verbatim into a Linux container. `sanitized_child_env` filtered keys and never values, so container-side Claude received `CLAUDE_CONFIG_DIR=C:\Users\...\.claude` and tried to create a directory literally named that under `/workspace`.
2. The Telegram JSONL watcher for a container session polled a host directory the container never writes to. Silently dead.

Both are fixed by the same one-pair path map that makes the resume probe correct.

## What changed

**Translation.** A declared single-pair mount map (`ContainerPathMap { host_root, container_root }`) in a new runtime-agnostic `pty/container_paths.rs`, plus an explicit key classification table. Three keys translate (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `OPENCODE_CONFIG_DIR`); `AGENTSCOMMANDER_ROOT` is an identity key spelled as a path and translating it would break session-transport registration; everything else is opaque. No heuristics. `docker_runtime.rs` does not change, which is the proof the map stayed runtime-agnostic.

**The rule, stated as a contract:** path-valued env rows in AgentsCommander settings are **host-side values**. AgentsCommander translates them for container sessions when they live under the replica mount. The correct value is `CLAUDE_CONFIG_DIR = %AC_REPLICA_ROOT%\.claude`.

**This is a migration break and the PR owns it.** A literal `/workspace/.claude` works on `main` today, because values pass through untouched. It was the documented workaround. It now becomes unmappable, is dropped, and produces a warning that says precisely that, rather than a generic message that would read as though the user misconfigured something arbitrary.

**`drop` now means `unset`.** The bridge never called `env_clear()`, so omitting a key from `child_env` handed the agent the image's own `ENV` while `app.log` claimed the key was dropped. That is #893's failure mode reached through the fix for it. A real unset channel (`env_unset` to `AGENTSCOMMANDER_BRIDGE_ENV_UNSET_JSON` to `command.env_remove`) now exists, applied **after** `child_env` so a key in both lists fails closed. `TRANSPORT_PROTOCOL_VERSION` is bumped to 2, so an image built before this change fails loudly at registration instead of silently ignoring the unset list, and the mismatch error names the remedy.

**The bind-mount guard.** DD3 documented an invariant that nothing enforced: `build_start_request_with_settings` set `host_root: cwd` unconditionally, and nothing asserted `cwd` was a replica root. Adversarial review enumerated twelve call paths reaching `create_session_inner` with `ContainerTransport` and found the set of non-replica ones is **not empty**. A container launched at a bare workgroup directory would bind-mount every sibling agent's credentials and transcripts, plus read-write access to `messaging/`, the inter-agent command channel.

The guard that landed is a bounded deny-list, constant time, one `is_dir` probe, derived from the invariant rather than from a naming convention:

> The bind mount must not contain another agent's replica, the workgroup control surface (`messaging/`), or the user's whole home.

It refuses a filesystem, drive, or UNC share root; `dirs::home_dir()`; the `.ac` workspace dir; a directory directly containing `.ac`; and a `wg-*` dir inside a workspace. A plain repo directory containing no replica passes, which is what container transport is for. The `cwd` is canonicalized **once** and fed to both the guard and the map: an earlier textual version was walked straight through by a junction, which would have shipped the exact configuration the invariant forbids. A Windows-gated test creates a real `mklink /J` junction to a workgroup root and asserts the refusal.

**The warnings are delivered, not merely logged.** The decision not to inject a silent default was made in exchange for a warning naming the remedy. The first implementation wrote that warning to `app.log`, which the reviewer called *"a receipt, not a remedy"*. It now reaches the UI. Because Tauri does not replay events and startup restore emits before the webview mounts, warnings are buffered per session and drained on subscribe, through one shared `SessionWarning` type and one shared emit helper that both producers use. The protocol-mismatch dispatch is a typed `HelloRejection` variant rather than a string-prefix match on prose, so rewording the message cannot silently delete the warning.

**#906 falls out.** `derive_reader` now gates on `backend_kind` and consumes the memoized probe path, so a local Claude session with an env-layer `CLAUDE_CONFIG_DIR` gets its Telegram watcher on that directory instead of `~/.claude`. Two resolvers no longer give two answers. One pathological combination where the new answer is worse than the old one is recorded on #906 rather than being allowed to close silently.

## Verification

`cargo test --workspace --all-targets` from the repo root: **2061** lib passed, 0 failed, all integration binaries, and the `session-bridge` crate. `cargo clippy --workspace --all-targets` clean. `npm run typecheck` clean. Three vitest suites, 41 tests. Three Windows-gated junction tests creating real reparse points.

The workspace-member gap is worth naming: `cargo test --all-targets` run from `src-tauri/` selects the package by cwd and **never builds the bridge crate**, so two tests guarding the `env_unset` ordering were silently not executing. Found by the reviewer, not by the gate.

The merged `.manage()` chain was verified by **launching the built binary**, not by reasoning: `cargo test` never runs the Tauri builder, and this project has previously shipped a build with 1833 green tests that panicked on GUI launch because two managed states erased to the same `TypeId`. All thirty managed types were enumerated and are distinct. The currency merge against #918 was verified with `git merge-tree --write-tree`, whose output is byte-identical to the merge commit's tree.

Adversarial review by `dev-rust-grinch` across the design (two rounds) and the implementation (three rounds). It granted no free passes and I granted it none: it refused three design items outright, all of which architect accepted; it retracted two of its own findings after reading live code; it proved one of my suspicions wrong with the code; and it caught that I had scoped its final review to a range that no longer matched the branch.

## Follow-ups filed

#911, #912 (folded here), #913, #915, #919. A sequencing constraint is recorded on #919: fixing the warning-buffer hygiene by dropping entries on session destroy would remove the web client's only delivery path, because live warnings are still not broadcast to it. The broadcast lands first, or together.

Plan: `_plans/894-host-container-env-path-translation-plan.md` (gitignored, in-repo). Residuals are recorded there rather than in a green checkmark: the guard is not a complete containment proof, and a `.ac` workspace at depth two or more still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)