### PR TITLE
feat(config): expand %USER_HOME% in seeded file content (refs #924)

### DIFF
--- a/src-tauri/src/config/config_seed.rs
+++ b/src-tauri/src/config/config_seed.rs
@@ -1058,6 +1058,117 @@ mod tests {
         assert!(out.starts_with(b"%AC_REPLICA_ROOT%"));
     }
 
+    // ---- %USER_HOME% in seeded content (#924) ------------------------------
+
+    /// `dirs::home_dir()` forward-slashed. `None` on a machine without a home,
+    /// where the token is expected to stay literal.
+    fn home_fwd() -> Option<String> {
+        dirs::home_dir().map(|home| home.to_string_lossy().replace('\\', "/"))
+    }
+
+    #[test]
+    fn copy_file_substitutes_user_home() {
+        let temp = tempfile::tempdir().unwrap();
+        let ctx = ctx_with(&abs(r"C:\r", "/r"), Some(&abs(r"C:\ws", "/ws")), None);
+
+        let src = temp.path().join("s.json");
+        std::fs::write(&src, b"excl=%USER_HOME%/.claude/CLAUDE.md").unwrap();
+        let dst = temp.path().join("s.out");
+        copy_file_substituted(&src, &dst, Some(&ctx), true).unwrap();
+
+        let out = std::fs::read_to_string(&dst).unwrap();
+        match home_fwd() {
+            Some(home) => assert_eq!(out, format!("excl={}/.claude/CLAUDE.md", home)),
+            None => assert_eq!(out, "excl=%USER_HOME%/.claude/CLAUDE.md"),
+        }
+    }
+
+    #[test]
+    fn copy_file_over_cap_does_not_substitute_user_home() {
+        let temp = tempfile::tempdir().unwrap();
+        let ctx = ctx_with(&abs(r"C:\r", "/r"), Some(&abs(r"C:\ws", "/ws")), None);
+
+        let src = temp.path().join("big.json");
+        let mut content = vec![b'a'; (CONTENT_SUBSTITUTION_CAP as usize) + 16];
+        content[..12].copy_from_slice(b"%USER_HOME%\n");
+        std::fs::write(&src, &content).unwrap();
+        let dst = temp.path().join("big.out");
+        copy_file_substituted(&src, &dst, Some(&ctx), true).unwrap();
+
+        let out = std::fs::read(&dst).unwrap();
+        assert_eq!(out.len(), content.len());
+        // Over the cap: streamed verbatim, the token is NOT substituted.
+        assert!(out.starts_with(b"%USER_HOME%"));
+    }
+
+    #[test]
+    fn copy_file_binary_with_user_home_bytes_is_verbatim() {
+        let temp = tempfile::tempdir().unwrap();
+        let ctx = ctx_with(&abs(r"C:\r", "/r"), Some(&abs(r"C:\ws", "/ws")), None);
+
+        let src = temp.path().join("b.bin");
+        let raw: &[u8] = b"%USER_HOME%\x00binary";
+        std::fs::write(&src, raw).unwrap();
+        let dst = temp.path().join("b.out");
+        copy_file_substituted(&src, &dst, Some(&ctx), true).unwrap();
+        // NUL in the leading window -> verbatim, no substitution.
+        assert_eq!(std::fs::read(&dst).unwrap(), raw);
+    }
+
+    #[test]
+    fn copy_tree_verbatim_preserves_user_home_when_substitute_false() {
+        // embedded -> master copies raw templates: the token must survive so the
+        // later replica seed can expand it.
+        let temp = tempfile::tempdir().unwrap();
+        let src = temp.path().join("src");
+        write_file(&src.join("a.json"), b"excl=%USER_HOME%/.claude/CLAUDE.md");
+        let dst = temp.path().join("dst");
+        copy_tree(&src, &dst, 0, None, false).unwrap();
+        assert_eq!(
+            std::fs::read(dst.join("a.json")).unwrap(),
+            b"excl=%USER_HOME%/.claude/CLAUDE.md"
+        );
+    }
+
+    #[test]
+    fn seed_settings_local_expands_user_home_but_not_hook_markers() {
+        // Realistic settings.local.json: `claudeMdExcludes` uses %USER_HOME% (must
+        // expand), while a PreToolUse hook command uses %TEMP% (must NOT).
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("ws");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        std::fs::create_dir_all(&replica).unwrap();
+        let template = concat!(
+            "{\n",
+            "  \"claudeMdExcludes\": [\"%USER_HOME%/.claude/CLAUDE.md\"],\n",
+            "  \"hooks\": { \"PreToolUse\": [{ \"command\": \"echo %TEMP%/log.txt\" }] }\n",
+            "}\n"
+        );
+        write_file(
+            &workspace.join("default.claude").join("settings.local.json"),
+            template.as_bytes(),
+        );
+
+        let ctx = ctx_with(&replica, Some(&workspace), None);
+        let resolved = resolve_config_seed(&seed_cfg(".claude"), "A", Some(&ctx)).unwrap();
+        assert_eq!(
+            perform_config_seed(&resolved, "sfx924"),
+            ConfigSeedReport::Seeded
+        );
+
+        let out =
+            std::fs::read_to_string(replica.join(".claude").join("settings.local.json")).unwrap();
+        if let Some(home) = home_fwd() {
+            assert!(
+                out.contains(&format!("\"{}/.claude/CLAUDE.md\"", home)),
+                "{out}"
+            );
+            assert!(!out.contains("%USER_HOME%"), "{out}");
+        }
+        // The unknown marker inside the hook command survives verbatim.
+        assert!(out.contains("echo %TEMP%/log.txt"), "{out}");
+    }
+
     // ---- copy_tree (reparse skip + depth bound) ----------------------------
 
     #[test]

--- a/src-tauri/src/config/config_seed.rs
+++ b/src-tauri/src/config/config_seed.rs
@@ -1158,12 +1158,16 @@ mod tests {
 
         let out =
             std::fs::read_to_string(replica.join(".claude").join("settings.local.json")).unwrap();
-        if let Some(home) = home_fwd() {
-            assert!(
-                out.contains(&format!("\"{}/.claude/CLAUDE.md\"", home)),
-                "{out}"
-            );
-            assert!(!out.contains("%USER_HOME%"), "{out}");
+        match home_fwd() {
+            Some(home) => {
+                assert!(
+                    out.contains(&format!("\"{}/.claude/CLAUDE.md\"", home)),
+                    "{out}"
+                );
+                assert!(!out.contains("%USER_HOME%"), "{out}");
+            }
+            // No home: the seed still succeeds, the token is written literally.
+            None => assert!(out.contains("\"%USER_HOME%/.claude/CLAUDE.md\""), "{out}"),
         }
         // The unknown marker inside the hook command survives verbatim.
         assert!(out.contains("echo %TEMP%/log.txt"), "{out}");

--- a/src-tauri/src/config/placeholders.rs
+++ b/src-tauri/src/config/placeholders.rs
@@ -1,8 +1,16 @@
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 pub const AC_REPLICA_ROOT_PLACEHOLDER: &str = "%AC_REPLICA_ROOT%";
 pub const AC_WORKSPACE_ROOT_PLACEHOLDER: &str = "%AC_WORKSPACE_ROOT%";
 pub const AC_MATRIX_ROOT_PLACEHOLDER: &str = "%AC_MATRIX_ROOT%";
+
+/// The current user's home directory (#924). Deliberately NOT a member of
+/// [`AC_PLACEHOLDER_TOKENS`]: that array is the launch-root GATE, and this token
+/// needs no AC context (it resolves from `dirs::home_dir()`, which is
+/// process-global). It is expanded in seeded file CONTENT only, never in the
+/// strict env/arg path.
+pub const USER_HOME_PLACEHOLDER: &str = "%USER_HOME%";
 
 /// Single source of truth for the AC path-placeholder token set. Every site that
 /// gates on, validates, or scans these tokens MUST iterate this list, so adding a
@@ -138,7 +146,26 @@ pub fn expand_placeholders_in_args(
         .collect()
 }
 
-/// Expand the 3 known AC tokens inside file CONTENT (#598 config-folder seed).
+/// Process-global home directory, resolved once. `None` when `dirs::home_dir()`
+/// cannot determine it (no HOME / USERPROFILE); callers leave the token literal.
+fn user_home() -> Option<&'static Path> {
+    static USER_HOME: OnceLock<Option<PathBuf>> = OnceLock::new();
+    USER_HOME
+        .get_or_init(|| {
+            let home = dirs::home_dir();
+            if home.is_none() {
+                log::warn!(
+                    "[placeholders] home directory is undeterminable; {} stays literal in seeded content",
+                    USER_HOME_PLACEHOLDER
+                );
+            }
+            home
+        })
+        .as_deref()
+}
+
+/// Expand the 3 known AC tokens plus `%USER_HOME%` inside file CONTENT
+/// (#598 config-folder seed, #924 user home).
 /// Unlike [`expand_placeholders`] this does NOT fail-closed on unknown `%...%`:
 /// a seeded template may legitimately contain other `%VAR%` text the tool reads
 /// at runtime, so unknown markers are left literal. Substituted paths are
@@ -154,6 +181,14 @@ pub fn expand_placeholders_in_content(value: &str, context: &PlaceholderContext)
     }
     if let Some(mx) = &context.matrix_root {
         out = out.replace(AC_MATRIX_ROOT_PLACEHOLDER, &fwd(mx));
+    }
+    // #924: best-effort, exactly like the AC tokens above. An undeterminable home
+    // leaves the token literal (already warned once by `user_home`) and NEVER
+    // aborts the spawn.
+    if out.contains(USER_HOME_PLACEHOLDER) {
+        if let Some(home) = user_home() {
+            out = out.replace(USER_HOME_PLACEHOLDER, &fwd(home));
+        }
     }
     out
 }
@@ -433,6 +468,85 @@ mod tests {
             out,
             "%AC_REPLICA_ROOT% %AC_WORKSPACE_ROOT% %AC_MATRIX_ROOT%"
         );
+    }
+
+    // ---- %USER_HOME% (#924) ------------------------------------------------
+
+    /// `dirs::home_dir()` forward-slashed, or `None` on a machine without a home.
+    /// Tests derive the expectation instead of hardcoding a literal, so they stay
+    /// deterministic across OSes and CI users.
+    fn expected_home_fwd() -> Option<String> {
+        dirs::home_dir().map(|home| home.to_string_lossy().replace('\\', "/"))
+    }
+
+    #[test]
+    fn content_expands_user_home_forward_slashed() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = make_replica(temp.path());
+        let ctx = placeholder_context_for_launch_root(&replica).unwrap();
+
+        let out = expand_placeholders_in_content("excl=%USER_HOME%/.claude/CLAUDE.md", &ctx);
+        match expected_home_fwd() {
+            Some(home) => {
+                assert_eq!(out, format!("excl={}/.claude/CLAUDE.md", home));
+                assert!(!out.contains('\\'), "{out}");
+                assert!(!out.contains(USER_HOME_PLACEHOLDER), "{out}");
+            }
+            // No home on this machine: the token stays literal, the spawn never aborts.
+            None => assert_eq!(out, "excl=%USER_HOME%/.claude/CLAUDE.md"),
+        }
+    }
+
+    #[test]
+    fn content_leaves_unknown_percent_markers_literal() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = make_replica(temp.path());
+        let ctx = placeholder_context_for_launch_root(&replica).unwrap();
+        // %USER_HOME% is the ONLY new token: sibling %VAR% markers that a tool reads
+        // at runtime (hook commands, shell vars) must survive verbatim.
+        let out = expand_placeholders_in_content("%TEMP% %CD% %USERPROFILE%", &ctx);
+        assert_eq!(out, "%TEMP% %CD% %USERPROFILE%");
+    }
+
+    #[test]
+    fn content_expands_user_home_alongside_ac_tokens() {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = make_replica(temp.path());
+        let ctx = placeholder_context_for_launch_root(&replica).unwrap();
+
+        let out = expand_placeholders_in_content(
+            "%AC_REPLICA_ROOT% %AC_WORKSPACE_ROOT% %AC_MATRIX_ROOT% %USER_HOME%",
+            &ctx,
+        );
+        let expected_replica = canonical_stripped(&replica)
+            .to_string_lossy()
+            .replace('\\', "/");
+        assert!(out.starts_with(&expected_replica), "{out}");
+        assert!(!out.contains("%AC_"), "{out}");
+        if let Some(home) = expected_home_fwd() {
+            assert!(out.ends_with(&home), "{out}");
+            assert!(!out.contains('\\'), "{out}");
+        }
+    }
+
+    #[test]
+    fn user_home_is_not_an_ac_placeholder_token() {
+        // GATE, not catalog: `value_contains_ac_placeholder` drives the "this spawn
+        // requires an AC launch root" decision (agent_command.rs) and the CODEX_HOME
+        // validators. %USER_HOME% needs no AC context, so it must stay out.
+        assert!(!AC_PLACEHOLDER_TOKENS.contains(&USER_HOME_PLACEHOLDER));
+        assert!(!value_contains_ac_placeholder("%USER_HOME%/.claude"));
+    }
+
+    #[test]
+    fn strict_expand_still_rejects_user_home() {
+        // v1 scope: env values and command args keep their fail-closed contract,
+        // because `home_dir()` can return None and strict mode cannot degrade.
+        let temp = tempfile::tempdir().unwrap();
+        let replica = make_replica(temp.path());
+        let ctx = placeholder_context_for_launch_root(&replica).unwrap();
+        let err = expand_placeholders("%USER_HOME%/x", &ctx).unwrap_err();
+        assert!(err.contains("unknown placeholder"), "{err}");
     }
 
     #[test]

--- a/src-tauri/src/config/placeholders.rs
+++ b/src-tauri/src/config/placeholders.rs
@@ -523,9 +523,16 @@ mod tests {
             .replace('\\', "/");
         assert!(out.starts_with(&expected_replica), "{out}");
         assert!(!out.contains("%AC_"), "{out}");
-        if let Some(home) = expected_home_fwd() {
-            assert!(out.ends_with(&home), "{out}");
-            assert!(!out.contains('\\'), "{out}");
+        match expected_home_fwd() {
+            Some(home) => {
+                assert!(out.ends_with(&home), "{out}");
+                assert!(!out.contains('\\'), "{out}");
+            }
+            // No home: the AC tokens still expand, %USER_HOME% stays literal.
+            None => {
+                assert!(out.ends_with(USER_HOME_PLACEHOLDER), "{out}");
+                assert!(out.contains("%USER_HOME%"), "{out}");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds the `%USER_HOME%` placeholder to the content-expansion pass that already runs over every file the config seeder copies into `__agent_<name>/<dest>`.

Seed templates previously had to hardcode absolute, machine- and OS-specific paths. Now a template can say:

```json
"claudeMdExcludes": ["%USER_HOME%/.claude/CLAUDE.md"]
```

and it resolves to `C:/Users/maria/.claude/CLAUDE.md` on Windows, `/home/maria/...` on Linux, `/Users/maria/...` on macOS.

No new engine was written. `expand_placeholders_in_content` (`placeholders.rs:146`) already existed, already ran on seeded content, and already had the right semantics: exact-token `str::replace`, unknown `%MARKERS%` left literal, output forward-slash normalized.

## Changes

- `src-tauri/src/config/placeholders.rs` — `USER_HOME_PLACEHOLDER` const, a `OnceLock<Option<PathBuf>>` cache over `dirs::home_dir()`, and the expansion inside `expand_placeholders_in_content`. If `home_dir()` returns `None`: token left literal, one `log::warn!` per process, spawn never aborts.
- `src-tauri/src/config/config_seed.rs` — tests only, no production changes.

`+226 / −1` across 2 files.

## Deliberately out of scope

- **`USER_HOME_PLACEHOLDER` is NOT in `AC_PLACEHOLDER_TOKENS`.** That array is a launch-root **gate**, not a catalog: `value_contains_ac_placeholder` feeds `agent_command.rs:852`, which decides whether a spawn *requires* an AC replica root. `%USER_HOME%` needs no AC context. Test `user_home_is_not_an_ac_placeholder_token` asserts against both the array and the gate function.
- Strict mode (`expand_placeholders`, env values and command args) still rejects `%USER_HOME%`. Pinned by `strict_expand_still_rejects_user_home`.
- No escape syntax, no additional tokens, no change to the content-based substitution filter in `copy_file_substituted`.

## Backward compatibility

Total. Templates with hardcoded absolute paths contain no tokens, so `str::replace` finds nothing and files are copied byte-for-byte identical. No migration performed or required.

## Tests

10 new tests. `cargo test --lib config::` → **737 passed, 0 failed, 1 ignored**. `cargo clippy --all-targets` → 0 warnings.

Notably `seed_settings_local_expands_user_home_but_not_hook_markers` drives the real pipeline (`resolve_config_seed` + `perform_config_seed`, not `copy_file_substituted` in isolation) with a realistic `settings.local.json`, and asserts that `%USER_HOME%` inside `claudeMdExcludes` expands while `%TEMP%` inside a `hooks.PreToolUse` command survives untouched.

Every `%USER_HOME%` test uses `match` on `dirs::home_dir()` with a `None` arm asserting the literal fallback, so no test can pass vacuously in a home-less environment.

## Review

Adversarial review by `dev-rust-grinch`: **PASS**. It re-ran the suite independently, audited the gate and all five consumers of `AC_PLACEHOLDER_TOKENS`, traced the real seed chain (`session.rs:1470 → config_seed.rs:329 → :487 → :526`) to confirm no `home_dir() == None` path can abort a spawn, and separated pre-existing `cargo fmt` diffs from new ones (12 in `main`, 12 on the branch — none new).

Review also established that the forward-slash normalization is load-bearing rather than cosmetic: an un-normalized Windows home would inject `C:\Users\...` into a JSON string, where `\U` is an invalid escape, breaking `serde_json` in `ensure_rtk_pretool_hook` downstream.

Two LOW findings. One (vacuous `if let` in two tests) is fixed in `f1a7364`. The other is filed below.

## Known limitations

- **Sequential replacement.** The four token replacements are sequential passes over one buffer, with `%USER_HOME%` last. An AC root whose literal path contains the text `%USER_HOME%` would be re-expanded by the final pass. This bug class predates this PR (it already exists among the three AC tokens since #598); `%USER_HOME%` widens it rather than creating it. It requires a directory literally named `%USER_HOME%`. Not fixed here.
- **Containers.** `%USER_HOME%` expands to the *host* home, which generally does not exist inside a container. The existing `%AC_*%` tokens share this property. Not a regression.
- **Fail-soft branches are untestable in practice.** On Windows `dirs::home_dir()` calls `SHGetKnownFolderPath`, so `None` cannot be forced by unsetting an env var, and the `OnceLock` cache is process-wide. The `None` arms are correct by inspection but never execute in a CI that has a home.

Closes #924
