### PR TITLE
feat(#881): archive projects (context-menu action, rail button, unarchive modal)

### DIFF
--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -1,6 +1,6 @@
 use futures::future::join_all;
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -13,7 +13,7 @@ use crate::config::workspace::{
     canonical_workspace_dir_label, existing_workspace_dir, find_workspace_segment,
     has_workspace_dir, workspace_dir_for_project,
 };
-use crate::pty::manager::PtyManager;
+use crate::pty::manager::{PendingSpawn, PtyManager};
 use crate::session::manager::SessionManager;
 use crate::session::session::{SessionInfo, SessionRepo, SessionStatus};
 
@@ -2053,8 +2053,26 @@ pub(crate) async fn open_project_inner<R: tauri::Runtime>(
     settings: &SettingsState,
     path: &str,
 ) -> Result<crate::config::projects::ProjectRegistration, String> {
-    let result = open_project_inner_with_settings_path(settings, path, None).await?;
-    broadcast_project_archive_changed(app, &result.path, false, ArchiveChangeReason::Open, None);
+    open_project_inner_with_event_and_settings_path(app, settings, path, None).await
+}
+
+async fn open_project_inner_with_event_and_settings_path<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    settings: &SettingsState,
+    path: &str,
+    settings_path: Option<&Path>,
+) -> Result<crate::config::projects::ProjectRegistration, String> {
+    let (result, archived_changed) =
+        open_project_inner_with_settings_path(settings, path, settings_path).await?;
+    if archived_changed {
+        broadcast_project_archive_changed(
+            app,
+            &result.path,
+            false,
+            ArchiveChangeReason::Open,
+            None,
+        );
+    }
     Ok(result)
 }
 
@@ -2062,9 +2080,12 @@ async fn open_project_inner_with_settings_path(
     settings: &SettingsState,
     path: &str,
     settings_path: Option<&Path>,
-) -> Result<crate::config::projects::ProjectRegistration, String> {
+) -> Result<(crate::config::projects::ProjectRegistration, bool), String> {
     mutate_project_paths_with_settings_path(settings, settings_path, |s| {
-        crate::config::projects::register_existing_project(s, path).map_err(|e| e.to_string())
+        let before = s.archived_project_paths.clone();
+        let result = crate::config::projects::register_existing_project(s, path)
+            .map_err(|e| e.to_string())?;
+        Ok((result, before != s.archived_project_paths))
     })
     .await
 }
@@ -2087,8 +2108,34 @@ pub async fn new_project(
     settings: State<'_, SettingsState>,
     path: String,
 ) -> Result<crate::config::projects::ProjectRegistration, String> {
-    let result = new_project_inner_with_settings_path(settings.inner(), &path, None).await?;
-    broadcast_project_archive_changed(&app, &result.path, false, ArchiveChangeReason::Open, None);
+    new_project_inner(&app, settings.inner(), &path).await
+}
+
+pub(crate) async fn new_project_inner<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    settings: &SettingsState,
+    path: &str,
+) -> Result<crate::config::projects::ProjectRegistration, String> {
+    new_project_inner_with_event_and_settings_path(app, settings, path, None).await
+}
+
+async fn new_project_inner_with_event_and_settings_path<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    settings: &SettingsState,
+    path: &str,
+    settings_path: Option<&Path>,
+) -> Result<crate::config::projects::ProjectRegistration, String> {
+    let (result, archived_changed) =
+        new_project_inner_with_settings_path(settings, path, settings_path).await?;
+    if archived_changed {
+        broadcast_project_archive_changed(
+            app,
+            &result.path,
+            false,
+            ArchiveChangeReason::Open,
+            None,
+        );
+    }
     Ok(result)
 }
 
@@ -2096,9 +2143,12 @@ async fn new_project_inner_with_settings_path(
     settings: &SettingsState,
     path: &str,
     settings_path: Option<&Path>,
-) -> Result<crate::config::projects::ProjectRegistration, String> {
+) -> Result<(crate::config::projects::ProjectRegistration, bool), String> {
     mutate_project_paths_with_settings_path(settings, settings_path, |s| {
-        crate::config::projects::register_new_project(s, path).map_err(|e| e.to_string())
+        let before = s.archived_project_paths.clone();
+        let result =
+            crate::config::projects::register_new_project(s, path).map_err(|e| e.to_string())?;
+        Ok((result, before != s.archived_project_paths))
     })
     .await
 }
@@ -2117,8 +2167,10 @@ pub(crate) async fn remove_project_inner<R: tauri::Runtime>(
     settings: &SettingsState,
     path: &str,
 ) -> Result<(), String> {
-    remove_project_inner_with_settings_path(settings, path, None).await?;
-    broadcast_project_archive_changed(app, path, false, ArchiveChangeReason::Remove, None);
+    let archived_changed = remove_project_inner_with_settings_path(settings, path, None).await?;
+    if archived_changed {
+        broadcast_project_archive_changed(app, path, false, ArchiveChangeReason::Remove, None);
+    }
     Ok(())
 }
 
@@ -2126,10 +2178,11 @@ async fn remove_project_inner_with_settings_path(
     settings: &SettingsState,
     path: &str,
     settings_path: Option<&Path>,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     mutate_project_paths_with_settings_path(settings, settings_path, |s| {
+        let before = s.archived_project_paths.clone();
         crate::config::projects::remove_project_path(s, path);
-        Ok(())
+        Ok(before != s.archived_project_paths)
     })
     .await
 }
@@ -2143,24 +2196,40 @@ pub async fn remove_project(
     remove_project_inner(&app, settings.inner(), &path).await
 }
 
-async fn snapshot_sessions_with_liveness(
+pub(crate) struct ArchiveSnapshot {
+    sessions: Vec<(SessionInfo, bool)>,
+    pending: Vec<PendingSpawn>,
+}
+
+async fn snapshot_archive_state(
     session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
     pty_mgr: &Arc<Mutex<PtyManager>>,
-) -> Vec<(SessionInfo, bool)> {
+) -> ArchiveSnapshot {
     let sessions = {
         let mgr = session_mgr.read().await;
         mgr.list_sessions().await
     };
-    let pty = pty_mgr.lock().unwrap_or_else(|e| e.into_inner());
-    sessions
+    let session_ids = sessions
+        .iter()
+        .map(|s| Uuid::parse_str(&s.id).ok())
+        .collect::<Vec<_>>();
+    let ids = session_ids.iter().flatten().copied().collect::<Vec<_>>();
+    let (pending, live) = {
+        let pty = pty_mgr.lock().unwrap_or_else(|e| e.into_inner());
+        pty.archive_liveness(&ids)
+    };
+    let live_by_id = ids.into_iter().zip(live).collect::<HashMap<_, _>>();
+    let sessions = sessions
         .into_iter()
-        .map(|s| {
-            let has_pty = Uuid::parse_str(&s.id)
-                .map(|id| pty.has_session(id))
+        .zip(session_ids)
+        .map(|(s, id)| {
+            let has_pty = id
+                .and_then(|id| live_by_id.get(&id).copied())
                 .unwrap_or(false);
             (s, has_pty)
         })
-        .collect()
+        .collect();
+    ArchiveSnapshot { sessions, pending }
 }
 
 fn session_is_live(status: &SessionStatus, has_pty: bool) -> bool {
@@ -2170,26 +2239,45 @@ fn session_is_live(status: &SessionStatus, has_pty: bool) -> bool {
     }
 }
 
-pub(crate) fn archive_session_blockers(
-    sessions: &[(SessionInfo, bool)],
-    project_path: &str,
-) -> Vec<String> {
+fn archive_scope_contains(cwd: &str, project_path: &str) -> bool {
     let scope = [project_path.to_string()];
-    sessions
+    crate::config::sessions_persistence::working_directory_under_any_project_path(cwd, &scope)
+}
+
+fn is_root_agent_cwd(cwd: &str) -> bool {
+    crate::config::root_agent::is_root_agent_dir_name(cwd)
+        || crate::config::root_agent::is_root_agent_path(cwd)
+}
+
+pub(crate) fn archive_blockers(snapshot: &ArchiveSnapshot, project_path: &str) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut blockers = Vec::new();
+
+    for pending in &snapshot.pending {
+        if is_root_agent_cwd(&pending.cwd) {
+            continue;
+        }
+        if !archive_scope_contains(&pending.cwd, project_path) {
+            continue;
+        }
+        if seen.insert(pending.label.clone()) {
+            blockers.push(pending.label.clone());
+        }
+    }
+
+    for (session, _) in snapshot
+        .sessions
         .iter()
-        .filter(|(s, _)| {
-            !(s.is_root_agent
-                || crate::config::root_agent::is_root_agent_dir_name(&s.working_directory))
-        })
+        .filter(|(s, _)| !(s.is_root_agent || is_root_agent_cwd(&s.working_directory)))
         .filter(|(s, has_pty)| session_is_live(&s.status, *has_pty))
-        .filter(|(s, _)| {
-            crate::config::sessions_persistence::working_directory_under_any_project_path(
-                &s.working_directory,
-                &scope,
-            )
-        })
-        .map(|(s, _)| s.name.clone())
-        .collect()
+        .filter(|(s, _)| archive_scope_contains(&s.working_directory, project_path))
+    {
+        if seen.insert(session.name.clone()) {
+            blockers.push(session.name.clone());
+        }
+    }
+
+    blockers
 }
 
 fn archive_blocked_message(blockers: &[String]) -> String {
@@ -2217,30 +2305,6 @@ fn archive_blocked_message(blockers: &[String]) -> String {
     }
 }
 
-pub(crate) fn archive_late_spawn_blockers(
-    after: &[(SessionInfo, bool)],
-    exited_before: &HashSet<String>,
-    project_path: &str,
-) -> Vec<String> {
-    let scope = [project_path.to_string()];
-    after
-        .iter()
-        .filter(|(s, _)| {
-            !(s.is_root_agent
-                || crate::config::root_agent::is_root_agent_dir_name(&s.working_directory))
-        })
-        .filter(|(s, _)| !matches!(s.status, SessionStatus::Exited(_)))
-        .filter(|(s, _)| !exited_before.contains(&s.id))
-        .filter(|(s, _)| {
-            crate::config::sessions_persistence::working_directory_under_any_project_path(
-                &s.working_directory,
-                &scope,
-            )
-        })
-        .map(|(s, _)| s.name.clone())
-        .collect()
-}
-
 pub(crate) async fn archive_project_inner<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     settings: &SettingsState,
@@ -2259,33 +2323,32 @@ async fn archive_project_inner_with_settings_path<R: tauri::Runtime>(
     path: &str,
     settings_path: Option<&Path>,
 ) -> Result<(), String> {
-    let before = snapshot_sessions_with_liveness(session_mgr, pty_mgr).await;
-    let blockers = archive_session_blockers(&before, path);
+    let path = crate::config::projects::absolutise(path)
+        .map_err(|e| e.to_string())?
+        .to_string_lossy()
+        .into_owned();
+    let before = snapshot_archive_state(session_mgr, pty_mgr).await;
+    let blockers = archive_blockers(&before, &path);
     if !blockers.is_empty() {
         return Err(archive_blocked_message(&blockers));
     }
 
     mutate_project_paths_with_settings_path(settings, settings_path, |s| {
-        crate::config::projects::archive_project_path(s, path);
+        crate::config::projects::archive_project_path(s, &path);
         Ok(())
     })
     .await?;
 
-    let exited_before: HashSet<String> = before
-        .iter()
-        .filter(|(s, _)| matches!(s.status, SessionStatus::Exited(_)))
-        .map(|(s, _)| s.id.clone())
-        .collect();
-    let after = snapshot_sessions_with_liveness(session_mgr, pty_mgr).await;
-    let late = archive_late_spawn_blockers(&after, &exited_before, path);
+    let after = snapshot_archive_state(session_mgr, pty_mgr).await;
+    let late = archive_blockers(&after, &path);
     if late.is_empty() {
-        broadcast_project_archive_changed(app, path, true, ArchiveChangeReason::Archive, None);
+        broadcast_project_archive_changed(app, &path, true, ArchiveChangeReason::Archive, None);
         return Ok(());
     }
 
     let restored: Result<bool, String> =
         mutate_project_paths_with_settings_path(settings, settings_path, |s| {
-            let key = crate::config::projects::normalize_for_compare(path);
+            let key = crate::config::projects::normalize_for_compare(&path);
             let still_archived = s
                 .archived_project_paths
                 .iter()
@@ -2293,9 +2356,7 @@ async fn archive_project_inner_with_settings_path<R: tauri::Runtime>(
             if !still_archived {
                 return Ok(false);
             }
-            crate::config::projects::register_existing_project(s, path)
-                .map_err(|e| e.to_string())?;
-            Ok(true)
+            Ok(crate::config::projects::unarchive_project_path(s, &path))
         })
         .await;
 
@@ -2304,7 +2365,7 @@ async fn archive_project_inner_with_settings_path<R: tauri::Runtime>(
         Ok(true) => {
             broadcast_project_archive_changed(
                 app,
-                path,
+                &path,
                 false,
                 ArchiveChangeReason::Unarchive,
                 None,
@@ -2409,6 +2470,11 @@ fn read_task_fields(wg_path: &Path) -> TaskFields {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::settings::AppSettings;
+    use crate::pty::git_watcher::GitWatcher;
+    use crate::pty::idle_detector::IdleDetector;
+    use crate::web::broadcast::{WsBroadcaster, WsOutMsg};
+    use serde_json::{json, Value};
 
     fn archive_test_session(
         name: &str,
@@ -2472,80 +2538,219 @@ mod tests {
         )
     }
 
-    #[test]
-    fn archive_session_blockers_names_live_sessions_under_project() {
-        let (_temp, project, agent, _) = archive_scope();
-        let sessions = vec![(
-            archive_test_session("live", &agent, SessionStatus::Running, false),
-            true,
-        )];
+    type ArchiveCommandApp = (
+        tauri::App,
+        SettingsState,
+        tokio::sync::mpsc::Receiver<WsOutMsg>,
+        Arc<tokio::sync::RwLock<SessionManager>>,
+        Arc<Mutex<PtyManager>>,
+    );
 
-        assert_eq!(archive_session_blockers(&sessions, &project), vec!["live"]);
+    fn archive_command_app(settings: AppSettings) -> ArchiveCommandApp {
+        let settings_state: SettingsState = Arc::new(tokio::sync::RwLock::new(settings));
+        let broadcaster = WsBroadcaster::new();
+        let receiver = broadcaster.subscribe();
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let app = tauri::Builder::default()
+            .any_thread()
+            .manage(settings_state.clone())
+            .manage(broadcaster.clone())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build archive command test app");
+        let app_handle = app.handle().clone();
+        let idle_detector = IdleDetector::new(|_| {}, |_| {});
+        let git_watcher = GitWatcher::new(Arc::clone(&session_mgr), app_handle);
+        let pty_mgr = Arc::new(Mutex::new(PtyManager::new(
+            Arc::new(Mutex::new(HashMap::new())),
+            idle_detector,
+            git_watcher,
+            Some(broadcaster),
+            Arc::clone(&session_mgr),
+        )));
+        (app, settings_state, receiver, session_mgr, pty_mgr)
+    }
+
+    #[derive(Default)]
+    struct FlippingLiveBackend {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl crate::pty::backend::PtyBackend for FlippingLiveBackend {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn spawn(
+            &self,
+            _spec: crate::pty::backend::BackendSpawnSpec,
+        ) -> futures::future::BoxFuture<'_, Result<(), crate::errors::AppError>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn write(&self, _id: Uuid, _data: &[u8]) -> Result<(), crate::errors::AppError> {
+            Ok(())
+        }
+
+        fn resize(&self, _id: Uuid, _cols: u16, _rows: u16) -> Result<(), crate::errors::AppError> {
+            Ok(())
+        }
+
+        fn kill(&self, _id: Uuid) -> Result<(), crate::errors::AppError> {
+            Ok(())
+        }
+
+        fn has_session(&self, _id: Uuid) -> bool {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) > 0
+        }
+
+        fn get_screen_snapshot(&self, _id: Uuid) -> Option<crate::pty::output::PtyScreenSnapshot> {
+            None
+        }
+
+        fn get_pty_size(&self, _id: Uuid) -> Option<(u16, u16)> {
+            None
+        }
+
+        fn register_response_watcher(
+            &self,
+            _session_id: Uuid,
+            _request_id: String,
+            _response_dir: PathBuf,
+        ) {
+        }
+
+        fn terminate_job_for_session(&self, _id: Uuid) -> bool {
+            false
+        }
+
+        fn kill_all_jobs(&self) -> (usize, usize) {
+            (0, 0)
+        }
+    }
+
+    fn recv_ws_event(rx: &mut tokio::sync::mpsc::Receiver<WsOutMsg>) -> Value {
+        match rx.try_recv().expect("broadcast event") {
+            WsOutMsg::Text(text) => serde_json::from_str::<Value>(&text).expect("parse event"),
+            other => panic!("expected text event, got {other:?}"),
+        }
+    }
+
+    /// CWD is process-wide; serialize tests that intentionally use relative paths.
+    struct CwdGuard(PathBuf);
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
+    static CWD_MUTEX: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+
+    async fn cwd_lock() -> tokio::sync::MutexGuard<'static, ()> {
+        CWD_MUTEX
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await
+    }
+
+    fn archive_snapshot(
+        sessions: Vec<(SessionInfo, bool)>,
+        pending: Vec<PendingSpawn>,
+    ) -> ArchiveSnapshot {
+        ArchiveSnapshot { sessions, pending }
     }
 
     #[test]
-    fn archive_session_blockers_ignores_exited_session_under_project() {
+    fn archive_blockers_names_live_pty_sessions_under_project() {
         let (_temp, project, agent, _) = archive_scope();
-        let sessions = vec![(
-            archive_test_session("done", &agent, SessionStatus::Exited(0), false),
-            true,
-        )];
+        let snapshot = archive_snapshot(
+            vec![(
+                archive_test_session("live", &agent, SessionStatus::Running, false),
+                true,
+            )],
+            Vec::new(),
+        );
 
-        assert!(archive_session_blockers(&sessions, &project).is_empty());
+        assert_eq!(archive_blockers(&snapshot, &project), vec!["live"]);
     }
 
     #[test]
-    fn archive_session_blockers_ignores_running_session_with_no_pty() {
+    fn archive_blockers_ignores_exited_session_under_project() {
         let (_temp, project, agent, _) = archive_scope();
-        let sessions = vec![(
-            archive_test_session("phantom", &agent, SessionStatus::Running, false),
-            false,
-        )];
+        let snapshot = archive_snapshot(
+            vec![(
+                archive_test_session("done", &agent, SessionStatus::Exited(0), false),
+                true,
+            )],
+            Vec::new(),
+        );
 
-        assert!(archive_session_blockers(&sessions, &project).is_empty());
+        assert!(archive_blockers(&snapshot, &project).is_empty());
     }
 
     #[test]
-    fn archive_session_blockers_ignores_root_agent_session() {
+    fn archive_blockers_ignores_running_session_with_no_pty() {
         let (_temp, project, agent, _) = archive_scope();
-        let sessions = vec![(
-            archive_test_session("root", &agent, SessionStatus::Running, true),
-            true,
-        )];
+        let snapshot = archive_snapshot(
+            vec![(
+                archive_test_session("phantom", &agent, SessionStatus::Running, false),
+                false,
+            )],
+            Vec::new(),
+        );
 
-        assert!(archive_session_blockers(&sessions, &project).is_empty());
+        assert!(archive_blockers(&snapshot, &project).is_empty());
     }
 
     #[test]
-    fn archive_session_blockers_ignores_root_agent_by_dir_name_when_flag_is_false() {
+    fn archive_blockers_ignores_root_agent_session() {
+        let (_temp, project, agent, _) = archive_scope();
+        let snapshot = archive_snapshot(
+            vec![(
+                archive_test_session("root", &agent, SessionStatus::Running, true),
+                true,
+            )],
+            Vec::new(),
+        );
+
+        assert!(archive_blockers(&snapshot, &project).is_empty());
+    }
+
+    #[test]
+    fn archive_blockers_ignores_root_agent_by_dir_name_when_flag_is_false() {
         let temp = tempfile::tempdir().expect("tempdir");
         let project = temp.path().join("project");
         let root_dir = project
             .join(".ac")
             .join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
         std::fs::create_dir_all(&root_dir).expect("root dir");
-        let sessions = vec![(
-            archive_test_session(
-                "root",
-                &root_dir.to_string_lossy(),
-                SessionStatus::Running,
-                false,
-            ),
-            true,
-        )];
+        let snapshot = archive_snapshot(
+            vec![(
+                archive_test_session(
+                    "root",
+                    &root_dir.to_string_lossy(),
+                    SessionStatus::Running,
+                    false,
+                ),
+                true,
+            )],
+            Vec::new(),
+        );
 
-        assert!(archive_session_blockers(&sessions, &project.to_string_lossy()).is_empty());
+        assert!(archive_blockers(&snapshot, &project.to_string_lossy()).is_empty());
     }
 
     #[test]
-    fn archive_session_blockers_ignores_sessions_in_other_projects() {
+    fn archive_blockers_ignores_sessions_in_other_projects() {
         let (_temp, project, _, other) = archive_scope();
-        let sessions = vec![(
-            archive_test_session("other", &other, SessionStatus::Running, false),
-            true,
-        )];
+        let snapshot = archive_snapshot(
+            vec![(
+                archive_test_session("other", &other, SessionStatus::Running, false),
+                true,
+            )],
+            Vec::new(),
+        );
 
-        assert!(archive_session_blockers(&sessions, &project).is_empty());
+        assert!(archive_blockers(&snapshot, &project).is_empty());
     }
 
     #[test]
@@ -2564,49 +2769,492 @@ mod tests {
     }
 
     #[test]
-    fn archive_late_spawn_blockers_catches_record_with_no_pty_yet() {
+    fn archive_blockers_names_pending_spawn_under_project() {
         let (_temp, project, agent, _) = archive_scope();
-        let session = archive_test_session("spawning", &agent, SessionStatus::Running, false);
-        let after = vec![(session, false)];
+        let snapshot = archive_snapshot(
+            Vec::new(),
+            vec![PendingSpawn {
+                cwd: agent,
+                label: "spawning".to_string(),
+            }],
+        );
 
-        assert_eq!(
-            archive_late_spawn_blockers(&after, &HashSet::new(), &project),
-            vec!["spawning"]
+        assert_eq!(archive_blockers(&snapshot, &project), vec!["spawning"]);
+    }
+
+    #[test]
+    fn archive_blockers_ignores_pending_root_agent_by_dir_name() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        let root_dir = project
+            .join(".ac")
+            .join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
+        std::fs::create_dir_all(&root_dir).expect("root dir");
+        let snapshot = archive_snapshot(
+            Vec::new(),
+            vec![PendingSpawn {
+                cwd: root_dir.to_string_lossy().to_string(),
+                label: "root".to_string(),
+            }],
+        );
+
+        assert!(archive_blockers(&snapshot, &project.to_string_lossy()).is_empty());
+    }
+
+    #[test]
+    fn archive_blockers_dedupes_pending_mark_and_live_record_by_name() {
+        let (_temp, project, agent, _) = archive_scope();
+        let snapshot = archive_snapshot(
+            vec![(
+                archive_test_session("same", &agent, SessionStatus::Running, false),
+                true,
+            )],
+            vec![PendingSpawn {
+                cwd: agent,
+                label: "same".to_string(),
+            }],
+        );
+
+        assert_eq!(archive_blockers(&snapshot, &project), vec!["same"]);
+    }
+
+    #[test]
+    fn project_archive_changed_serializes_frontend_wire_shape() {
+        let payload = serde_json::to_value(ProjectArchiveChanged {
+            path: "C:/Projects/App".to_string(),
+            folder_name: "App".to_string(),
+            archived: false,
+            reason: ArchiveChangeReason::AutoUnarchive,
+            session_name: Some("Dev Session".to_string()),
+        })
+        .expect("serialize payload");
+
+        assert_eq!(payload["folderName"], json!("App"));
+        assert_eq!(payload["sessionName"], json!("Dev Session"));
+        assert_eq!(payload["reason"], json!("autoUnarchive"));
+        assert!(payload.get("folder_name").is_none());
+        assert!(payload.get("session_name").is_none());
+    }
+
+    #[tokio::test]
+    async fn open_project_inner_broadcasts_only_when_archived_list_changes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let settings_path = temp.path().join("settings.json");
+        let project = temp.path().join("proj-open");
+        std::fs::create_dir_all(project.join(".ac")).expect("create .ac");
+        let path = project.to_string_lossy().to_string();
+        let settings = AppSettings {
+            archived_project_paths: vec![path.clone()],
+            ..AppSettings::default()
+        };
+        let (app, state, mut rx, _, _) = archive_command_app(settings);
+        let app_handle = app.handle().clone();
+
+        open_project_inner_with_event_and_settings_path(
+            &app_handle,
+            &state,
+            &path,
+            Some(&settings_path),
+        )
+        .await
+        .expect("open archived project");
+
+        let event = recv_ws_event(&mut rx);
+        assert_eq!(event["event"], json!("project_archive_changed"));
+        assert_eq!(event["payload"]["path"], json!(path));
+        assert_eq!(event["payload"]["archived"], json!(false));
+        assert_eq!(event["payload"]["reason"], json!("open"));
+
+        open_project_inner_with_event_and_settings_path(
+            &app_handle,
+            &state,
+            &path,
+            Some(&settings_path),
+        )
+        .await
+        .expect("open already active project");
+
+        assert!(
+            rx.try_recv().is_err(),
+            "opening an already-active project must not broadcast"
         );
     }
 
-    #[test]
-    fn archive_late_spawn_blockers_ignores_record_that_was_exited_before() {
-        let (_temp, project, agent, _) = archive_scope();
-        let mut session = archive_test_session("promoted", &agent, SessionStatus::Active, false);
-        let mut exited_before = HashSet::new();
-        exited_before.insert(session.id.clone());
-        session.status = SessionStatus::Active;
-        let after = vec![(session, false)];
+    #[tokio::test]
+    async fn new_project_inner_broadcasts_only_when_archived_list_changes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let settings_path = temp.path().join("settings.json");
+        let project = temp.path().join("proj-new");
+        let path = project.to_string_lossy().to_string();
+        let settings = AppSettings {
+            archived_project_paths: vec![path.clone()],
+            ..AppSettings::default()
+        };
+        let (app, state, mut rx, _, _) = archive_command_app(settings);
+        let app_handle = app.handle().clone();
 
-        assert!(archive_late_spawn_blockers(&after, &exited_before, &project).is_empty());
+        new_project_inner_with_event_and_settings_path(
+            &app_handle,
+            &state,
+            &path,
+            Some(&settings_path),
+        )
+        .await
+        .expect("new archived project");
+
+        let event = recv_ws_event(&mut rx);
+        assert_eq!(event["event"], json!("project_archive_changed"));
+        assert_eq!(event["payload"]["path"], json!(path));
+        assert_eq!(event["payload"]["archived"], json!(false));
+        assert_eq!(event["payload"]["reason"], json!("open"));
+
+        new_project_inner_with_event_and_settings_path(
+            &app_handle,
+            &state,
+            &path,
+            Some(&settings_path),
+        )
+        .await
+        .expect("new already active project");
+
+        assert!(
+            rx.try_recv().is_err(),
+            "creating an already-active project must not broadcast"
+        );
     }
 
-    #[test]
-    fn archive_late_spawn_blockers_ignores_exited_records() {
-        let (_temp, project, agent, _) = archive_scope();
-        let after = vec![(
-            archive_test_session("done", &agent, SessionStatus::Exited(0), false),
-            false,
-        )];
+    #[tokio::test]
+    async fn archive_project_inner_absolutizes_relative_path_and_emits_archive_event() {
+        let _cwd_lock = cwd_lock().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let settings_path = temp.path().join("settings.json");
+        let project = temp.path().join("proj-archive-relative");
+        std::fs::create_dir_all(project.join(".ac")).expect("create .ac");
+        let path = project.to_string_lossy().to_string();
+        let settings = AppSettings {
+            project_paths: vec![path.clone()],
+            project_path: Some(path.clone()),
+            ..AppSettings::default()
+        };
+        let (app, state, mut rx, session_mgr, pty_mgr) = archive_command_app(settings);
+        let app_handle = app.handle().clone();
+        let prev = std::env::current_dir().expect("current dir");
+        let _guard = CwdGuard(prev);
+        std::env::set_current_dir(&project).expect("set cwd");
 
-        assert!(archive_late_spawn_blockers(&after, &HashSet::new(), &project).is_empty());
+        archive_project_inner_with_settings_path(
+            &app_handle,
+            &state,
+            &session_mgr,
+            &pty_mgr,
+            ".",
+            Some(&settings_path),
+        )
+        .await
+        .expect("archive relative project");
+
+        let stored = state.read().await.archived_project_paths.clone();
+        assert_eq!(stored, vec![path.clone()]);
+        let event = recv_ws_event(&mut rx);
+        assert_eq!(event["event"], json!("project_archive_changed"));
+        assert_eq!(event["payload"]["path"], json!(path));
+        assert_eq!(event["payload"]["archived"], json!(true));
+        assert_eq!(event["payload"]["reason"], json!("archive"));
     }
 
-    #[test]
-    fn archive_late_spawn_blockers_ignores_root_agent() {
-        let (_temp, project, agent, _) = archive_scope();
-        let after = vec![(
-            archive_test_session("root", &agent, SessionStatus::Running, true),
-            false,
-        )];
+    #[tokio::test]
+    async fn archive_project_inner_archives_vanished_registered_project() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let settings_path = temp.path().join("settings.json");
+        let project = temp.path().join("proj-vanished");
+        let path = project.to_string_lossy().to_string();
+        let settings = AppSettings {
+            project_paths: vec![path.clone()],
+            project_path: Some(path.clone()),
+            ..AppSettings::default()
+        };
+        let (app, state, mut rx, session_mgr, pty_mgr) = archive_command_app(settings);
+        let app_handle = app.handle().clone();
 
-        assert!(archive_late_spawn_blockers(&after, &HashSet::new(), &project).is_empty());
+        archive_project_inner_with_settings_path(
+            &app_handle,
+            &state,
+            &session_mgr,
+            &pty_mgr,
+            &path,
+            Some(&settings_path),
+        )
+        .await
+        .expect("archive vanished project");
+
+        let settings = state.read().await;
+        assert!(settings.project_paths.is_empty());
+        assert_eq!(settings.archived_project_paths, vec![path.clone()]);
+        drop(settings);
+        let event = recv_ws_event(&mut rx);
+        assert_eq!(event["payload"]["path"], json!(path));
+        assert_eq!(event["payload"]["archived"], json!(true));
+        assert_eq!(event["payload"]["reason"], json!("archive"));
+    }
+
+    #[tokio::test]
+    async fn archive_project_inner_allows_active_record_without_pty() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let settings_path = temp.path().join("settings.json");
+        let project = temp.path().join("proj-f1");
+        let agent = project.join(".ac").join("wg-1").join("__agent_dev");
+        std::fs::create_dir_all(&agent).expect("create agent dir");
+        let path = project.to_string_lossy().to_string();
+        let settings = AppSettings {
+            project_paths: vec![path.clone()],
+            project_path: Some(path.clone()),
+            ..AppSettings::default()
+        };
+        let (app, state, mut rx, session_mgr, pty_mgr) = archive_command_app(settings);
+        let app_handle = app.handle().clone();
+        {
+            let mgr = session_mgr.read().await;
+            mgr.create_session(
+                "shell".to_string(),
+                Vec::new(),
+                agent.to_string_lossy().to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
+            )
+            .await
+            .expect("create active record without PTY");
+        }
+
+        archive_project_inner_with_settings_path(
+            &app_handle,
+            &state,
+            &session_mgr,
+            &pty_mgr,
+            &path,
+            Some(&settings_path),
+        )
+        .await
+        .expect("active record without PTY must not block archive");
+
+        assert_eq!(
+            state.read().await.archived_project_paths,
+            vec![path.clone()]
+        );
+        let event = recv_ws_event(&mut rx);
+        assert_eq!(event["payload"]["path"], json!(path));
+        assert_eq!(event["payload"]["archived"], json!(true));
+        assert_eq!(event["payload"]["reason"], json!("archive"));
+    }
+
+    #[tokio::test]
+    async fn archive_project_inner_pending_spawn_mark_blocks_precheck() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let settings_path = temp.path().join("settings.json");
+        let project = temp.path().join("proj-pending");
+        let agent = project.join(".ac").join("wg-1").join("__agent_dev");
+        std::fs::create_dir_all(&agent).expect("create agent dir");
+        let path = project.to_string_lossy().to_string();
+        let settings = AppSettings {
+            project_paths: vec![path.clone()],
+            project_path: Some(path.clone()),
+            ..AppSettings::default()
+        };
+        let (app, state, mut rx, session_mgr, pty_mgr) = archive_command_app(settings);
+        let app_handle = app.handle().clone();
+        let _mark = {
+            let pty = pty_mgr.lock().unwrap_or_else(|e| e.into_inner());
+            pty.mark_spawning(&agent.to_string_lossy(), "spawning")
+        };
+
+        let err = archive_project_inner_with_settings_path(
+            &app_handle,
+            &state,
+            &session_mgr,
+            &pty_mgr,
+            &path,
+            Some(&settings_path),
+        )
+        .await
+        .expect_err("pending spawn should block archive before settings write");
+
+        assert!(err.contains("spawning"), "{err}");
+        let settings = state.read().await;
+        assert_eq!(settings.project_paths, vec![path]);
+        assert!(settings.archived_project_paths.is_empty());
+        drop(settings);
+        assert!(rx.try_recv().is_err(), "precheck failure must not emit");
+    }
+
+    #[tokio::test]
+    async fn archive_project_inner_rolls_back_with_unarchive_event_when_liveness_appears_after_write(
+    ) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let settings_path = temp.path().join("settings.json");
+        let project = temp.path().join("proj-rollback");
+        let agent = project.join(".ac").join("wg-1").join("__agent_dev");
+        std::fs::create_dir_all(&agent).expect("create agent dir");
+        let path = project.to_string_lossy().to_string();
+        let settings = AppSettings {
+            project_paths: vec![path.clone()],
+            project_path: Some(path.clone()),
+            ..AppSettings::default()
+        };
+        let (app, state, mut rx, session_mgr, _) = archive_command_app(settings);
+        let pty_mgr = Arc::new(Mutex::new(PtyManager::new_for_test(Arc::new(
+            FlippingLiveBackend::default(),
+        ))));
+        let app_handle = app.handle().clone();
+        let session_id = {
+            let mgr = session_mgr.read().await;
+            mgr.create_session(
+                "shell".to_string(),
+                Vec::new(),
+                agent.to_string_lossy().to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
+            )
+            .await
+            .expect("create session")
+            .id
+        };
+        pty_mgr
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .record_route(
+                session_id,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
+            );
+
+        let err = archive_project_inner_with_settings_path(
+            &app_handle,
+            &state,
+            &session_mgr,
+            &pty_mgr,
+            &path,
+            Some(&settings_path),
+        )
+        .await
+        .expect_err("late spawn should roll back archive");
+
+        assert!(err.contains("open session"), "{err}");
+        let settings = state.read().await;
+        assert_eq!(settings.project_paths, vec![path.clone()]);
+        assert!(settings.archived_project_paths.is_empty());
+        drop(settings);
+        let event = recv_ws_event(&mut rx);
+        assert_eq!(event["event"], json!("project_archive_changed"));
+        assert_eq!(event["payload"]["path"], json!(path));
+        assert_eq!(event["payload"]["archived"], json!(false));
+        assert_eq!(event["payload"]["reason"], json!("unarchive"));
+    }
+
+    #[tokio::test]
+    async fn archive_project_inner_rolls_back_vanished_project_without_validation() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let settings_path = temp.path().join("settings.json");
+        let project = temp.path().join("proj-vanished-rollback");
+        let agent = project.join(".ac").join("wg-1").join("__agent_dev");
+        let path = project.to_string_lossy().to_string();
+        let settings = AppSettings {
+            project_paths: vec![path.clone()],
+            project_path: Some(path.clone()),
+            ..AppSettings::default()
+        };
+        let (app, state, mut rx, session_mgr, _) = archive_command_app(settings);
+        let pty_mgr = Arc::new(Mutex::new(PtyManager::new_for_test(Arc::new(
+            FlippingLiveBackend::default(),
+        ))));
+        let app_handle = app.handle().clone();
+        let session_id = {
+            let mgr = session_mgr.read().await;
+            mgr.create_session(
+                "shell".to_string(),
+                Vec::new(),
+                agent.to_string_lossy().to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
+            )
+            .await
+            .expect("create session")
+            .id
+        };
+        pty_mgr
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .record_route(
+                session_id,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
+            );
+
+        let err = archive_project_inner_with_settings_path(
+            &app_handle,
+            &state,
+            &session_mgr,
+            &pty_mgr,
+            &path,
+            Some(&settings_path),
+        )
+        .await
+        .expect_err("late liveness should roll back vanished project");
+
+        assert!(err.contains("open session"), "{err}");
+        let settings = state.read().await;
+        assert_eq!(settings.project_paths, vec![path.clone()]);
+        assert!(settings.archived_project_paths.is_empty());
+        drop(settings);
+        let event = recv_ws_event(&mut rx);
+        assert_eq!(event["payload"]["path"], json!(path));
+        assert_eq!(event["payload"]["archived"], json!(false));
+        assert_eq!(event["payload"]["reason"], json!("unarchive"));
+    }
+
+    #[tokio::test]
+    async fn poll_tasks_filters_archived_session_workgroups() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("proj-task-filter");
+        let wg_root = project.join(".ac").join("wg-1");
+        let agent = wg_root.join("__agent_dev");
+        std::fs::create_dir_all(&agent).expect("create agent dir");
+        std::fs::write(wg_root.join("TASK.md"), "Task: should stay hidden").expect("write task");
+        let path = project.to_string_lossy().to_string();
+        let settings = AppSettings {
+            archived_project_paths: vec![path],
+            ..AppSettings::default()
+        };
+        let (app, _, _, session_mgr, _) = archive_command_app(settings);
+        let app_handle = app.handle().clone();
+        {
+            let mgr = session_mgr.read().await;
+            mgr.create_session(
+                "shell".to_string(),
+                Vec::new(),
+                agent.to_string_lossy().to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
+            )
+            .await
+            .expect("create archived session");
+        }
+        let watcher = DiscoveryBranchWatcher::new(app_handle, Arc::clone(&session_mgr));
+
+        watcher.poll_tasks(&[]).await.expect("poll tasks");
+
+        assert!(
+            watcher.task_cache.lock().unwrap().is_empty(),
+            "archived session workgroups must not be checked for TASK.md"
+        );
     }
 
     #[cfg(windows)]

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -1,11 +1,11 @@
 use futures::future::join_all;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 use uuid::Uuid;
 
 use crate::config::settings::SettingsState;
@@ -13,8 +13,9 @@ use crate::config::workspace::{
     canonical_workspace_dir_label, existing_workspace_dir, find_workspace_segment,
     has_workspace_dir, workspace_dir_for_project,
 };
+use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
-use crate::session::session::SessionRepo;
+use crate::session::session::{SessionInfo, SessionRepo, SessionStatus};
 
 /// Per-call monotonic ID partitioning concurrent `discover_*` invocations in the log
 /// stream. See plan §3 A0 (round-2 G5 + round-3 H1 placement-fix). Consumed only by
@@ -568,7 +569,9 @@ impl DiscoveryBranchWatcher {
                             break;
                         }
                         _ = tokio::time::sleep(BRANCH_POLL_INTERVAL) => {
-                            watcher.poll().await;
+                            if let Err(e) = watcher.poll().await {
+                                log::warn!("[DiscoveryBranchWatcher] poll failed: {}", e);
+                            }
                         }
                     }
                 }
@@ -576,7 +579,7 @@ impl DiscoveryBranchWatcher {
         });
     }
 
-    async fn poll(&self) {
+    async fn poll(&self) -> Result<(), String> {
         // Flatten per-project entries.
         let entries: Vec<ReplicaBranchEntry> = {
             let map = self.replicas.lock().unwrap();
@@ -697,13 +700,14 @@ impl DiscoveryBranchWatcher {
         // Gate C: TASK.md detection. Runs every tick whether or not Gate A/B
         // had work to do — sessions in workgroups whose project is not loaded
         // still need brief updates.
-        self.poll_tasks(&entries).await;
+        self.poll_tasks(&entries).await?;
+        Ok(())
     }
 
     /// Gate C: detect TASK.md changes per unique workgroup root and emit
     /// `workgroup_task_updated` on change. Runs on every existing 15s tick
     /// of `poll()`; no new thread, no new cadence.
-    async fn poll_tasks(&self, entries: &[ReplicaBranchEntry]) {
+    async fn poll_tasks(&self, entries: &[ReplicaBranchEntry]) -> Result<(), String> {
         // Build the union of workgroup roots to watch:
         //   1. Replicas in loaded projects (from `entries`) — covers the
         //      sidebar `ProjectPanel` surface.
@@ -726,9 +730,24 @@ impl DiscoveryBranchWatcher {
             }
         }
 
+        let archived = {
+            let settings = self.app_handle.state::<SettingsState>();
+            let cfg = settings.read().await;
+            cfg.archived_project_paths.clone()
+        };
         let sessions: Vec<(Uuid, String)> = {
             let mgr = self.session_manager.read().await;
             mgr.get_sessions_working_dirs().await
+        };
+        let sessions = if archived.is_empty() {
+            sessions
+        } else {
+            tokio::task::spawn_blocking(move || {
+                let roots = crate::config::sessions_persistence::normalize_project_roots(&archived);
+                crate::phone::mailbox::retain_unarchived_session_dirs(sessions, &roots)
+            })
+            .await
+            .map_err(|e| format!("archived task-session filter task failed: {}", e))?
         };
         for (id, cwd) in sessions {
             if let Some(task_path) = crate::session::session::find_workgroup_task_path_for_cwd(&cwd)
@@ -743,12 +762,13 @@ impl DiscoveryBranchWatcher {
         }
 
         if wg_roots.is_empty() {
-            return;
+            return Ok(());
         }
 
         for (wg_root, session_ids) in wg_roots {
             self.check_workgroup_task(wg_root, session_ids).await;
         }
+        Ok(())
     }
 
     /// Per-workgroup brief check. Stat short-circuits unchanged files; on
@@ -1954,32 +1974,6 @@ pub async fn set_replica_context_files(path: String, files: Vec<String>) -> Resu
 
 // ── #191 — shared open/new project commands ──────────────────────────────
 
-/// Validate an existing AC project at `path` and register it in
-/// `settings.project_paths`. Mirrors the ActionBar "Open Project" flow at
-/// `src/sidebar/components/ActionBar.tsx:78-94` but performs the dedup +
-/// persist atomically against `SettingsState`.
-///
-/// Holds the SettingsState write lock through `save_settings` (the same
-/// pattern as the narrow setters in `commands/config.rs`), so concurrent
-/// `update_settings` calls cannot race.
-pub(crate) async fn open_project_inner(
-    settings: &SettingsState,
-    path: &str,
-) -> Result<crate::config::projects::ProjectRegistration, String> {
-    open_project_inner_with_settings_path(settings, path, None).await
-}
-
-async fn open_project_inner_with_settings_path(
-    settings: &SettingsState,
-    path: &str,
-    settings_path: Option<&Path>,
-) -> Result<crate::config::projects::ProjectRegistration, String> {
-    mutate_project_paths_with_settings_path(settings, settings_path, |s| {
-        crate::config::projects::register_existing_project(s, path).map_err(|e| e.to_string())
-    })
-    .await
-}
-
 async fn mutate_project_paths_with_settings_path<T>(
     settings: &SettingsState,
     settings_path: Option<&Path>,
@@ -2006,12 +2000,82 @@ async fn mutate_project_paths_with_settings_path<T>(
     Ok(result)
 }
 
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum ArchiveChangeReason {
+    Archive,
+    Unarchive,
+    AutoUnarchive,
+    Open,
+    Remove,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProjectArchiveChanged {
+    pub path: String,
+    pub folder_name: String,
+    pub archived: bool,
+    pub reason: ArchiveChangeReason,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_name: Option<String>,
+}
+
+fn project_folder_name(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(path)
+        .to_string()
+}
+
+pub(crate) fn broadcast_project_archive_changed<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    path: &str,
+    archived: bool,
+    reason: ArchiveChangeReason,
+    session_name: Option<&str>,
+) {
+    let payload = serde_json::json!(ProjectArchiveChanged {
+        path: path.to_string(),
+        folder_name: project_folder_name(path),
+        archived,
+        reason,
+        session_name: session_name.map(|name| name.to_string()),
+    });
+    crate::web::commands::broadcast_all_r(app, "project_archive_changed", &payload);
+}
+
+/// Validate an existing AC project at `path` and register it in
+/// `settings.project_paths`.
+pub(crate) async fn open_project_inner<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    settings: &SettingsState,
+    path: &str,
+) -> Result<crate::config::projects::ProjectRegistration, String> {
+    let result = open_project_inner_with_settings_path(settings, path, None).await?;
+    broadcast_project_archive_changed(app, &result.path, false, ArchiveChangeReason::Open, None);
+    Ok(result)
+}
+
+async fn open_project_inner_with_settings_path(
+    settings: &SettingsState,
+    path: &str,
+    settings_path: Option<&Path>,
+) -> Result<crate::config::projects::ProjectRegistration, String> {
+    mutate_project_paths_with_settings_path(settings, settings_path, |s| {
+        crate::config::projects::register_existing_project(s, path).map_err(|e| e.to_string())
+    })
+    .await
+}
+
 #[tauri::command]
 pub async fn open_project(
+    app: tauri::AppHandle,
     settings: State<'_, SettingsState>,
     path: String,
 ) -> Result<crate::config::projects::ProjectRegistration, String> {
-    open_project_inner(settings.inner(), &path).await
+    open_project_inner(&app, settings.inner(), &path).await
 }
 
 /// Ensure an AC project at `path` (creating `.ac/` if missing) and
@@ -2019,10 +2083,13 @@ pub async fn open_project(
 /// Project" flow at `src/sidebar/components/ActionBar.tsx:58-71`.
 #[tauri::command]
 pub async fn new_project(
+    app: tauri::AppHandle,
     settings: State<'_, SettingsState>,
     path: String,
 ) -> Result<crate::config::projects::ProjectRegistration, String> {
-    new_project_inner_with_settings_path(settings.inner(), &path, None).await
+    let result = new_project_inner_with_settings_path(settings.inner(), &path, None).await?;
+    broadcast_project_archive_changed(&app, &result.path, false, ArchiveChangeReason::Open, None);
+    Ok(result)
 }
 
 async fn new_project_inner_with_settings_path(
@@ -2045,11 +2112,14 @@ async fn new_project_inner_with_settings_path(
 /// `normalize_for_compare` key matches `path`, re-derive the head, and write the
 /// deliberate list verbatim. Removing against the FRESH disk list means a
 /// CLI-appended entry the sidebar never showed is preserved, not dropped.
-pub(crate) async fn remove_project_inner(
+pub(crate) async fn remove_project_inner<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
     settings: &SettingsState,
     path: &str,
 ) -> Result<(), String> {
-    remove_project_inner_with_settings_path(settings, path, None).await
+    remove_project_inner_with_settings_path(settings, path, None).await?;
+    broadcast_project_archive_changed(app, path, false, ArchiveChangeReason::Remove, None);
+    Ok(())
 }
 
 async fn remove_project_inner_with_settings_path(
@@ -2066,10 +2136,262 @@ async fn remove_project_inner_with_settings_path(
 
 #[tauri::command]
 pub async fn remove_project(
+    app: tauri::AppHandle,
     settings: State<'_, SettingsState>,
     path: String,
 ) -> Result<(), String> {
-    remove_project_inner(settings.inner(), &path).await
+    remove_project_inner(&app, settings.inner(), &path).await
+}
+
+async fn snapshot_sessions_with_liveness(
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+    pty_mgr: &Arc<Mutex<PtyManager>>,
+) -> Vec<(SessionInfo, bool)> {
+    let sessions = {
+        let mgr = session_mgr.read().await;
+        mgr.list_sessions().await
+    };
+    let pty = pty_mgr.lock().unwrap_or_else(|e| e.into_inner());
+    sessions
+        .into_iter()
+        .map(|s| {
+            let has_pty = Uuid::parse_str(&s.id)
+                .map(|id| pty.has_session(id))
+                .unwrap_or(false);
+            (s, has_pty)
+        })
+        .collect()
+}
+
+fn session_is_live(status: &SessionStatus, has_pty: bool) -> bool {
+    match status {
+        SessionStatus::Exited(_) => false,
+        SessionStatus::Active | SessionStatus::Running | SessionStatus::Idle => has_pty,
+    }
+}
+
+pub(crate) fn archive_session_blockers(
+    sessions: &[(SessionInfo, bool)],
+    project_path: &str,
+) -> Vec<String> {
+    let scope = [project_path.to_string()];
+    sessions
+        .iter()
+        .filter(|(s, _)| {
+            !(s.is_root_agent
+                || crate::config::root_agent::is_root_agent_dir_name(&s.working_directory))
+        })
+        .filter(|(s, has_pty)| session_is_live(&s.status, *has_pty))
+        .filter(|(s, _)| {
+            crate::config::sessions_persistence::working_directory_under_any_project_path(
+                &s.working_directory,
+                &scope,
+            )
+        })
+        .map(|(s, _)| s.name.clone())
+        .collect()
+}
+
+fn archive_blocked_message(blockers: &[String]) -> String {
+    const MAX_NAMED: usize = 3;
+    let named = blockers
+        .iter()
+        .take(MAX_NAMED)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(", ");
+    let overflow = blockers.len().saturating_sub(MAX_NAMED);
+    if overflow > 0 {
+        format!(
+            "Cannot archive: {} open session(s) in this project ({}, and {} more). Close them first.",
+            blockers.len(),
+            named,
+            overflow
+        )
+    } else {
+        format!(
+            "Cannot archive: {} open session(s) in this project ({}). Close them first.",
+            blockers.len(),
+            named
+        )
+    }
+}
+
+pub(crate) fn archive_late_spawn_blockers(
+    after: &[(SessionInfo, bool)],
+    exited_before: &HashSet<String>,
+    project_path: &str,
+) -> Vec<String> {
+    let scope = [project_path.to_string()];
+    after
+        .iter()
+        .filter(|(s, _)| {
+            !(s.is_root_agent
+                || crate::config::root_agent::is_root_agent_dir_name(&s.working_directory))
+        })
+        .filter(|(s, _)| !matches!(s.status, SessionStatus::Exited(_)))
+        .filter(|(s, _)| !exited_before.contains(&s.id))
+        .filter(|(s, _)| {
+            crate::config::sessions_persistence::working_directory_under_any_project_path(
+                &s.working_directory,
+                &scope,
+            )
+        })
+        .map(|(s, _)| s.name.clone())
+        .collect()
+}
+
+pub(crate) async fn archive_project_inner<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    settings: &SettingsState,
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+    pty_mgr: &Arc<Mutex<PtyManager>>,
+    path: &str,
+) -> Result<(), String> {
+    archive_project_inner_with_settings_path(app, settings, session_mgr, pty_mgr, path, None).await
+}
+
+async fn archive_project_inner_with_settings_path<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    settings: &SettingsState,
+    session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
+    pty_mgr: &Arc<Mutex<PtyManager>>,
+    path: &str,
+    settings_path: Option<&Path>,
+) -> Result<(), String> {
+    let before = snapshot_sessions_with_liveness(session_mgr, pty_mgr).await;
+    let blockers = archive_session_blockers(&before, path);
+    if !blockers.is_empty() {
+        return Err(archive_blocked_message(&blockers));
+    }
+
+    mutate_project_paths_with_settings_path(settings, settings_path, |s| {
+        crate::config::projects::archive_project_path(s, path);
+        Ok(())
+    })
+    .await?;
+
+    let exited_before: HashSet<String> = before
+        .iter()
+        .filter(|(s, _)| matches!(s.status, SessionStatus::Exited(_)))
+        .map(|(s, _)| s.id.clone())
+        .collect();
+    let after = snapshot_sessions_with_liveness(session_mgr, pty_mgr).await;
+    let late = archive_late_spawn_blockers(&after, &exited_before, path);
+    if late.is_empty() {
+        broadcast_project_archive_changed(app, path, true, ArchiveChangeReason::Archive, None);
+        return Ok(());
+    }
+
+    let restored: Result<bool, String> =
+        mutate_project_paths_with_settings_path(settings, settings_path, |s| {
+            let key = crate::config::projects::normalize_for_compare(path);
+            let still_archived = s
+                .archived_project_paths
+                .iter()
+                .any(|p| crate::config::projects::normalize_for_compare(p) == key);
+            if !still_archived {
+                return Ok(false);
+            }
+            crate::config::projects::register_existing_project(s, path)
+                .map_err(|e| e.to_string())?;
+            Ok(true)
+        })
+        .await;
+
+    match restored {
+        Ok(false) => Err(archive_blocked_message(&late)),
+        Ok(true) => {
+            broadcast_project_archive_changed(
+                app,
+                path,
+                false,
+                ArchiveChangeReason::Unarchive,
+                None,
+            );
+            Err(archive_blocked_message(&late))
+        }
+        Err(e) => {
+            log::error!(
+                "[archive] '{}' has {} live session(s) but could not be restored: {}",
+                path,
+                late.len(),
+                e
+            );
+            Err(format!(
+                "{} The project could not be restored automatically ({}). Open Archived Projects to restore it.",
+                archive_blocked_message(&late),
+                e
+            ))
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn archive_project(
+    app: tauri::AppHandle,
+    settings: State<'_, SettingsState>,
+    session_mgr: State<'_, Arc<tokio::sync::RwLock<SessionManager>>>,
+    pty_mgr: State<'_, Arc<Mutex<PtyManager>>>,
+    path: String,
+) -> Result<(), String> {
+    archive_project_inner(
+        &app,
+        settings.inner(),
+        session_mgr.inner(),
+        pty_mgr.inner(),
+        &path,
+    )
+    .await
+}
+
+pub(crate) async fn unarchive_project_inner<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    settings: &SettingsState,
+    path: &str,
+) -> Result<crate::config::projects::ProjectRegistration, String> {
+    let result = mutate_project_paths_with_settings_path(settings, None, |s| {
+        crate::config::projects::register_existing_project(s, path).map_err(|e| e.to_string())
+    })
+    .await?;
+    broadcast_project_archive_changed(
+        app,
+        &result.path,
+        false,
+        ArchiveChangeReason::Unarchive,
+        None,
+    );
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn unarchive_project(
+    app: tauri::AppHandle,
+    settings: State<'_, SettingsState>,
+    path: String,
+) -> Result<crate::config::projects::ProjectRegistration, String> {
+    unarchive_project_inner(&app, settings.inner(), &path).await
+}
+
+pub(crate) async fn list_archived_projects_inner(
+    settings: &SettingsState,
+) -> Result<Vec<crate::config::projects::ArchivedProject>, String> {
+    let paths = {
+        let s = settings.read().await;
+        s.archived_project_paths.clone()
+    };
+    tokio::task::spawn_blocking(move || {
+        crate::config::projects::archived_projects_from_paths(&paths)
+    })
+    .await
+    .map_err(|e| format!("archived project stat task failed: {}", e))
+}
+
+#[tauri::command]
+pub async fn list_archived_projects(
+    settings: State<'_, SettingsState>,
+) -> Result<Vec<crate::config::projects::ArchivedProject>, String> {
+    list_archived_projects_inner(settings.inner()).await
 }
 
 type TaskFields = (Option<String>, Option<String>);
@@ -2087,6 +2409,205 @@ fn read_task_fields(wg_path: &Path) -> TaskFields {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn archive_test_session(
+        name: &str,
+        working_directory: &str,
+        status: SessionStatus,
+        is_root_agent: bool,
+    ) -> SessionInfo {
+        SessionInfo {
+            id: Uuid::new_v4().to_string(),
+            name: name.to_string(),
+            shell: "shell".to_string(),
+            shell_args: Vec::new(),
+            backend_kind: crate::pty::backend::SessionBackendKind::LocalProcess,
+            effective_shell_args: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            working_directory: working_directory.to_string(),
+            status,
+            waiting_for_input: false,
+            communication: None,
+            pending_review: false,
+            last_prompt: None,
+            agent_id: None,
+            agent_label: None,
+            git_repos: Vec::new(),
+            workgroup_task: None,
+            is_coordinator: false,
+            is_root_agent,
+            token: "token".to_string(),
+            agent_kind: None,
+            requested_profile: None,
+            effective_profile: None,
+            profile_fallback_chain: Vec::new(),
+            profile_fallback_applied: false,
+            effective_codex_home: None,
+            profile_content_hash: None,
+            profile_outdated: false,
+            telegram_bot_id: None,
+            was_detached: false,
+            detached_geometry: None,
+            start_fresh_on_restore: false,
+        }
+    }
+
+    fn archive_scope() -> (tempfile::TempDir, String, String, String) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        let agent = project.join(".ac").join("wg-1").join("__agent_dev");
+        let other = temp
+            .path()
+            .join("other")
+            .join(".ac")
+            .join("wg-1")
+            .join("__agent_other");
+        std::fs::create_dir_all(&agent).expect("agent");
+        std::fs::create_dir_all(&other).expect("other");
+        (
+            temp,
+            project.to_string_lossy().to_string(),
+            agent.to_string_lossy().to_string(),
+            other.to_string_lossy().to_string(),
+        )
+    }
+
+    #[test]
+    fn archive_session_blockers_names_live_sessions_under_project() {
+        let (_temp, project, agent, _) = archive_scope();
+        let sessions = vec![(
+            archive_test_session("live", &agent, SessionStatus::Running, false),
+            true,
+        )];
+
+        assert_eq!(archive_session_blockers(&sessions, &project), vec!["live"]);
+    }
+
+    #[test]
+    fn archive_session_blockers_ignores_exited_session_under_project() {
+        let (_temp, project, agent, _) = archive_scope();
+        let sessions = vec![(
+            archive_test_session("done", &agent, SessionStatus::Exited(0), false),
+            true,
+        )];
+
+        assert!(archive_session_blockers(&sessions, &project).is_empty());
+    }
+
+    #[test]
+    fn archive_session_blockers_ignores_running_session_with_no_pty() {
+        let (_temp, project, agent, _) = archive_scope();
+        let sessions = vec![(
+            archive_test_session("phantom", &agent, SessionStatus::Running, false),
+            false,
+        )];
+
+        assert!(archive_session_blockers(&sessions, &project).is_empty());
+    }
+
+    #[test]
+    fn archive_session_blockers_ignores_root_agent_session() {
+        let (_temp, project, agent, _) = archive_scope();
+        let sessions = vec![(
+            archive_test_session("root", &agent, SessionStatus::Running, true),
+            true,
+        )];
+
+        assert!(archive_session_blockers(&sessions, &project).is_empty());
+    }
+
+    #[test]
+    fn archive_session_blockers_ignores_root_agent_by_dir_name_when_flag_is_false() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        let root_dir = project
+            .join(".ac")
+            .join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
+        std::fs::create_dir_all(&root_dir).expect("root dir");
+        let sessions = vec![(
+            archive_test_session(
+                "root",
+                &root_dir.to_string_lossy(),
+                SessionStatus::Running,
+                false,
+            ),
+            true,
+        )];
+
+        assert!(archive_session_blockers(&sessions, &project.to_string_lossy()).is_empty());
+    }
+
+    #[test]
+    fn archive_session_blockers_ignores_sessions_in_other_projects() {
+        let (_temp, project, _, other) = archive_scope();
+        let sessions = vec![(
+            archive_test_session("other", &other, SessionStatus::Running, false),
+            true,
+        )];
+
+        assert!(archive_session_blockers(&sessions, &project).is_empty());
+    }
+
+    #[test]
+    fn archive_blocked_message_caps_named_sessions_at_three() {
+        let names = vec![
+            "one".to_string(),
+            "two".to_string(),
+            "three".to_string(),
+            "four".to_string(),
+        ];
+
+        let message = archive_blocked_message(&names);
+
+        assert!(message.contains("one, two, three, and 1 more"), "{message}");
+        assert!(!message.contains("four"), "{message}");
+    }
+
+    #[test]
+    fn archive_late_spawn_blockers_catches_record_with_no_pty_yet() {
+        let (_temp, project, agent, _) = archive_scope();
+        let session = archive_test_session("spawning", &agent, SessionStatus::Running, false);
+        let after = vec![(session, false)];
+
+        assert_eq!(
+            archive_late_spawn_blockers(&after, &HashSet::new(), &project),
+            vec!["spawning"]
+        );
+    }
+
+    #[test]
+    fn archive_late_spawn_blockers_ignores_record_that_was_exited_before() {
+        let (_temp, project, agent, _) = archive_scope();
+        let mut session = archive_test_session("promoted", &agent, SessionStatus::Active, false);
+        let mut exited_before = HashSet::new();
+        exited_before.insert(session.id.clone());
+        session.status = SessionStatus::Active;
+        let after = vec![(session, false)];
+
+        assert!(archive_late_spawn_blockers(&after, &exited_before, &project).is_empty());
+    }
+
+    #[test]
+    fn archive_late_spawn_blockers_ignores_exited_records() {
+        let (_temp, project, agent, _) = archive_scope();
+        let after = vec![(
+            archive_test_session("done", &agent, SessionStatus::Exited(0), false),
+            false,
+        )];
+
+        assert!(archive_late_spawn_blockers(&after, &HashSet::new(), &project).is_empty());
+    }
+
+    #[test]
+    fn archive_late_spawn_blockers_ignores_root_agent() {
+        let (_temp, project, agent, _) = archive_scope();
+        let after = vec![(
+            archive_test_session("root", &agent, SessionStatus::Running, true),
+            false,
+        )];
+
+        assert!(archive_late_spawn_blockers(&after, &HashSet::new(), &project).is_empty());
+    }
 
     #[cfg(windows)]
     #[test]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -223,6 +223,9 @@ fn build_protected_settings_candidate(
     let mut candidate = merge_protected_coding_agent_settings(current, new_settings);
     // Preserve existing root token. Frontend settings payloads cannot overwrite it.
     candidate.root_token = current.root_token.clone();
+    candidate.project_paths = current.project_paths.clone();
+    candidate.project_path = current.project_path.clone();
+    candidate.archived_project_paths = current.archived_project_paths.clone();
     validate_and_repair_settings(&mut candidate)?;
     Ok(candidate)
 }
@@ -242,6 +245,9 @@ async fn persist_settings_draft_update_with_saver(
     let mut s = settings.write().await;
     let current = s.clone();
     draft.root_token = current.root_token.clone();
+    draft.project_paths = current.project_paths.clone();
+    draft.project_path = current.project_path.clone();
+    draft.archived_project_paths = current.archived_project_paths.clone();
     validate_and_repair_settings(&mut draft)?;
     let events = settings_draft_update_events(&current, &draft);
     let written = save(&draft)?;
@@ -1758,7 +1764,9 @@ mod tests {
     #[cfg(windows)]
     use super::{build_profile_assignment_target, canonical_compare_key};
     use crate::api::auth;
-    use crate::config::sessions_persistence::PersistedSession;
+    use crate::config::sessions_persistence::{
+        session_retention_project_paths, PersistedSession,
+    };
     use crate::config::settings::{
         AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ProfileCellConfig,
         SettingsState,
@@ -1833,6 +1841,11 @@ mod tests {
         std::fs::write(dir.join("settings.json"), json).expect("write settings.json");
     }
 
+    fn write_settings_json(dir: &Path, value: serde_json::Value) {
+        let json = serde_json::to_vec_pretty(&value).expect("serialize settings json");
+        std::fs::write(dir.join("settings.json"), json).expect("write settings.json");
+    }
+
     fn write_sessions_file(dir: &Path, sessions: &[PersistedSession]) {
         let json = serde_json::to_vec_pretty(sessions).expect("serialize sessions");
         std::fs::write(dir.join("sessions.json"), json).expect("write sessions.json");
@@ -1841,6 +1854,17 @@ mod tests {
     fn read_sessions_file(dir: &Path) -> Vec<PersistedSession> {
         let json = std::fs::read_to_string(dir.join("sessions.json")).expect("read sessions.json");
         serde_json::from_str(&json).expect("parse sessions.json")
+    }
+
+    fn settings_payload_without_keys(settings: &AppSettings, keys: &[&str]) -> AppSettings {
+        let mut value = serde_json::to_value(settings).expect("serialize settings payload");
+        let object = value
+            .as_object_mut()
+            .expect("settings payload must serialize to an object");
+        for key in keys {
+            object.remove(*key);
+        }
+        serde_json::from_value(value).expect("deserialize stale settings payload")
     }
 
     fn assert_single_project(settings: &AppSettings, project: &str) {
@@ -2649,6 +2673,219 @@ mod tests {
             let live = draft_state.read().await;
             assert_single_project(&live, disk_project);
         }
+    }
+
+    #[tokio::test]
+    async fn update_settings_keeps_live_archived_list_when_disk_key_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        let live_project = "C:/live/a";
+        let archived_project = "C:/archived/b";
+        write_settings_json(
+            temp.path(),
+            serde_json::json!({
+                "projectPaths": [live_project],
+                "projectPath": live_project
+            }),
+        );
+
+        let mut current = settings_with_single_agent();
+        current.project_paths = vec![live_project.to_string()];
+        current.project_path = Some(live_project.to_string());
+        current.archived_project_paths = vec![archived_project.to_string()];
+        let state = state_for(current.clone());
+        let payload = settings_payload_without_keys(&current, &["archivedProjectPaths"]);
+
+        let saved = persist_protected_settings_update_with_saver(&state, payload, |candidate| {
+            crate::config::settings::save_settings_to_path_preserving_project_paths(
+                candidate,
+                &settings_path,
+            )
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            saved.archived_project_paths,
+            vec![archived_project.to_string()]
+        );
+        assert!(session_retention_project_paths(&saved).contains(&archived_project.to_string()));
+        {
+            let live = state.read().await;
+            assert_eq!(
+                live.archived_project_paths,
+                vec![archived_project.to_string()]
+            );
+        }
+        let disk: AppSettings =
+            serde_json::from_str(&std::fs::read_to_string(settings_path).unwrap()).unwrap();
+        assert_eq!(
+            disk.archived_project_paths,
+            vec![archived_project.to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn save_settings_draft_keeps_live_archived_list_when_disk_key_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        let live_project = "C:/live/a";
+        let archived_project = "C:/archived/b";
+        write_settings_json(
+            temp.path(),
+            serde_json::json!({
+                "projectPaths": [live_project],
+                "projectPath": live_project
+            }),
+        );
+
+        let mut current = settings_with_single_agent();
+        current.project_paths = vec![live_project.to_string()];
+        current.project_path = Some(live_project.to_string());
+        current.archived_project_paths = vec![archived_project.to_string()];
+        let state = state_for(current.clone());
+        let payload = settings_payload_without_keys(&current, &["archivedProjectPaths"]);
+
+        let (saved, _events) =
+            persist_settings_draft_update_with_saver(&state, payload, |candidate| {
+                crate::config::settings::save_settings_to_path_preserving_project_paths(
+                    candidate,
+                    &settings_path,
+                )
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            saved.archived_project_paths,
+            vec![archived_project.to_string()]
+        );
+        assert!(session_retention_project_paths(&saved).contains(&archived_project.to_string()));
+        {
+            let live = state.read().await;
+            assert_eq!(
+                live.archived_project_paths,
+                vec![archived_project.to_string()]
+            );
+        }
+        let disk: AppSettings =
+            serde_json::from_str(&std::fs::read_to_string(settings_path).unwrap()).unwrap();
+        assert_eq!(
+            disk.archived_project_paths,
+            vec![archived_project.to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn update_settings_keeps_live_project_paths_when_settings_file_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        let live_project = "C:/live/a";
+
+        let mut current = settings_with_single_agent();
+        current.project_paths = vec![live_project.to_string()];
+        current.project_path = Some(live_project.to_string());
+        let state = state_for(current.clone());
+        let payload = settings_payload_without_keys(&current, &["projectPaths", "projectPath"]);
+
+        let saved = persist_protected_settings_update_with_saver(&state, payload, |candidate| {
+            crate::config::settings::save_settings_to_path_preserving_project_paths(
+                candidate,
+                &settings_path,
+            )
+        })
+        .await
+        .unwrap();
+
+        assert_single_project(&saved, live_project);
+        assert!(session_retention_project_paths(&saved).contains(&live_project.to_string()));
+        {
+            let live = state.read().await;
+            assert_single_project(&live, live_project);
+        }
+        let disk: AppSettings =
+            serde_json::from_str(&std::fs::read_to_string(settings_path).unwrap()).unwrap();
+        assert_single_project(&disk, live_project);
+    }
+
+    #[tokio::test]
+    async fn save_settings_draft_keeps_live_project_paths_when_settings_file_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        let live_project = "C:/live/a";
+
+        let mut current = settings_with_single_agent();
+        current.project_paths = vec![live_project.to_string()];
+        current.project_path = Some(live_project.to_string());
+        let state = state_for(current.clone());
+        let payload = settings_payload_without_keys(&current, &["projectPaths", "projectPath"]);
+
+        let (saved, _events) =
+            persist_settings_draft_update_with_saver(&state, payload, |candidate| {
+                crate::config::settings::save_settings_to_path_preserving_project_paths(
+                    candidate,
+                    &settings_path,
+                )
+            })
+            .await
+            .unwrap();
+
+        assert_single_project(&saved, live_project);
+        assert!(session_retention_project_paths(&saved).contains(&live_project.to_string()));
+        {
+            let live = state.read().await;
+            assert_single_project(&live, live_project);
+        }
+        let disk: AppSettings =
+            serde_json::from_str(&std::fs::read_to_string(settings_path).unwrap()).unwrap();
+        assert_single_project(&disk, live_project);
+    }
+
+    #[tokio::test]
+    async fn update_settings_still_takes_disk_archived_list_when_key_present() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        let live_project = "C:/live/a";
+        let disk_archived = "C:/archived/a";
+        let live_archived = "C:/archived/b";
+        let payload_archived = "C:/archived/c";
+        write_settings_json(
+            temp.path(),
+            serde_json::json!({
+                "projectPaths": [live_project],
+                "projectPath": live_project,
+                "archivedProjectPaths": [disk_archived]
+            }),
+        );
+
+        let mut current = settings_with_single_agent();
+        current.project_paths = vec![live_project.to_string()];
+        current.project_path = Some(live_project.to_string());
+        current.archived_project_paths = vec![live_archived.to_string()];
+        let state = state_for(current.clone());
+        let mut payload = settings_payload_without_keys(&current, &[]);
+        payload.archived_project_paths = vec![payload_archived.to_string()];
+
+        let saved = persist_protected_settings_update_with_saver(&state, payload, |candidate| {
+            crate::config::settings::save_settings_to_path_preserving_project_paths(
+                candidate,
+                &settings_path,
+            )
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(saved.archived_project_paths, vec![disk_archived.to_string()]);
+        {
+            let live = state.read().await;
+            assert_eq!(
+                live.archived_project_paths,
+                vec![disk_archived.to_string()]
+            );
+        }
+        let disk: AppSettings =
+            serde_json::from_str(&std::fs::read_to_string(settings_path).unwrap()).unwrap();
+        assert_eq!(disk.archived_project_paths, vec![disk_archived.to_string()]);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -223,6 +223,15 @@ fn build_protected_settings_candidate(
     let mut candidate = merge_protected_coding_agent_settings(current, new_settings);
     // Preserve existing root token. Frontend settings payloads cannot overwrite it.
     candidate.root_token = current.root_token.clone();
+    // #881 A7 / R2-G1: project lists are disk-authoritative and are mutated
+    // only by dedicated project commands. A settings payload from the GUI, CLI,
+    // or API must never carry authority for them, so restore all three from
+    // live memory before repair.
+    //
+    // This is not the prohibited disk re-read. The preserving writer still
+    // overwrites all three from disk whenever disk has an opinion, so disk
+    // authority is untouched. These copies only matter on the no-disk-truth
+    // arms where a stale client would otherwise publish an empty list.
     candidate.project_paths = current.project_paths.clone();
     candidate.project_path = current.project_path.clone();
     candidate.archived_project_paths = current.archived_project_paths.clone();
@@ -245,6 +254,9 @@ async fn persist_settings_draft_update_with_saver(
     let mut s = settings.write().await;
     let current = s.clone();
     draft.root_token = current.root_token.clone();
+    // #881 A7 / R2-G1: same protected-list restore as the whole settings
+    // publisher above. This is an in-memory copy from the held settings guard,
+    // not a second disk read, and it only affects the no-disk-truth arms.
     draft.project_paths = current.project_paths.clone();
     draft.project_path = current.project_path.clone();
     draft.archived_project_paths = current.archived_project_paths.clone();
@@ -1764,9 +1776,7 @@ mod tests {
     #[cfg(windows)]
     use super::{build_profile_assignment_target, canonical_compare_key};
     use crate::api::auth;
-    use crate::config::sessions_persistence::{
-        session_retention_project_paths, PersistedSession,
-    };
+    use crate::config::sessions_persistence::{session_retention_project_paths, PersistedSession};
     use crate::config::settings::{
         AgentConfig, AppSettings, CodingAgentEnv, CodingAgentEnvSource, ProfileCellConfig,
         SettingsState,
@@ -1862,7 +1872,10 @@ mod tests {
             .as_object_mut()
             .expect("settings payload must serialize to an object");
         for key in keys {
-            object.remove(*key);
+            assert!(
+                object.remove(*key).is_some(),
+                "settings payload has no `{key}` key to strip; the A7 gate would be a no-op"
+            );
         }
         serde_json::from_value(value).expect("deserialize stale settings payload")
     }
@@ -2875,13 +2888,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(saved.archived_project_paths, vec![disk_archived.to_string()]);
+        assert_eq!(
+            saved.archived_project_paths,
+            vec![disk_archived.to_string()]
+        );
         {
             let live = state.read().await;
-            assert_eq!(
-                live.archived_project_paths,
-                vec![disk_archived.to_string()]
-            );
+            assert_eq!(live.archived_project_paths, vec![disk_archived.to_string()]);
         }
         let disk: AppSettings =
             serde_json::from_str(&std::fs::read_to_string(settings_path).unwrap()).unwrap();

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -267,9 +267,11 @@ async fn purge_sessions_after_settings_update_in_dir(
     saved: &AppSettings,
     dir: &Path,
 ) -> Result<(), String> {
+    let retention_paths =
+        crate::config::sessions_persistence::session_retention_project_paths(saved);
     crate::config::sessions_persistence::purge_sessions_outside_project_paths_in_dir(
         dir,
-        &saved.project_paths,
+        &retention_paths,
     )
     .await
     .map(|_| ())

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -935,6 +935,10 @@ pub async fn create_session_inner<R: tauri::Runtime>(
 ) -> Result<SessionInfo, String> {
     let cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
     let session_label = session_name.as_deref().unwrap_or(&shell).to_string();
+    let spawn_mark = {
+        let pty = pty_mgr.lock().unwrap_or_else(|e| e.into_inner());
+        pty.mark_spawning(&cwd, &session_label)
+    };
     crate::config::archive_gate::enforce_unarchived_for_spawn(app, &cwd, &session_label).await?;
     let (agent_id, agent_label) = {
         if let Some(spawn) = resolved_spawn.as_ref() {
@@ -1510,6 +1514,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         logical_resource_slot,
     };
     let spawn_result = PtyManager::spawn(pty_mgr, session.backend_kind, spawn_spec).await;
+    drop(spawn_mark);
     if let Err(e) = spawn_result {
         let err = e.to_string();
         drop(mgr);
@@ -3749,6 +3754,88 @@ mod tests {
         assert!(session_mgr.read().await.list_sessions().await.is_empty());
         assert_eq!(backend.killed(), backend.spawned());
         assert_eq!(backend.killed().len(), 1);
+    }
+
+    #[test]
+    fn create_session_inner_keeps_both_archive_activation_gates() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/commands/session.rs"
+        ))
+        .expect("read session.rs");
+        let production = source
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .expect("production session source");
+        let gate_call = "crate::config::archive_gate::enforce_unarchived_for_spawn(app, &cwd, &session_label).await";
+        let count = production.matches(gate_call).count();
+
+        assert_eq!(
+            count, 2,
+            "create_session_inner must keep both archive activation gates"
+        );
+    }
+
+    #[test]
+    fn create_session_inner_marks_spawning_until_spawn_returns() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/commands/session.rs"
+        ))
+        .expect("read session.rs");
+        let production = source
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .expect("production session source");
+        let mark = production
+            .find("let spawn_mark = {")
+            .expect("spawn mark before archive gate");
+        let first_gate = production
+            .find("crate::config::archive_gate::enforce_unarchived_for_spawn(app, &cwd, &session_label).await?;")
+            .expect("first archive gate");
+        let spawn = production
+            .find("let spawn_result = PtyManager::spawn(pty_mgr, session.backend_kind, spawn_spec).await;")
+            .expect("spawn call");
+        let drop_mark = production
+            .find("drop(spawn_mark);")
+            .expect("spawn mark drop");
+        let spawn_error = production
+            .find("if let Err(e) = spawn_result {")
+            .expect("spawn error handling");
+
+        assert!(mark < first_gate, "spawn mark must cover archive gate A");
+        assert!(
+            first_gate < spawn,
+            "archive gate A must run before PTY spawn"
+        );
+        assert!(
+            spawn < drop_mark,
+            "spawn mark must stay live while spawn awaits"
+        );
+        assert!(
+            drop_mark < spawn_error,
+            "spawn mark must drop immediately after spawn returns"
+        );
+    }
+
+    #[test]
+    fn restart_session_inner_probes_archive_before_destroying_session() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/commands/session.rs"
+        ))
+        .expect("read session.rs");
+        let probe = source
+            .find("crate::config::archive_gate::probe_spawn_refusal(app, &cwd).await?;")
+            .expect("restart probe call");
+        let destroy = source
+            .find("// 3. Destroy the old session")
+            .expect("destroy step marker");
+
+        assert!(
+            probe < destroy,
+            "restart must probe archive refusal before destroying the dormant row"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -934,6 +934,8 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     resolved_spawn: Option<AgentSpawnCommand>,
 ) -> Result<SessionInfo, String> {
     let cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
+    let session_label = session_name.as_deref().unwrap_or(&shell).to_string();
+    crate::config::archive_gate::enforce_unarchived_for_spawn(app, &cwd, &session_label).await?;
     let (agent_id, agent_label) = {
         if let Some(spawn) = resolved_spawn.as_ref() {
             (
@@ -1083,6 +1085,16 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             return Err(e.to_string());
         }
     };
+
+    if let Err(e) =
+        crate::config::archive_gate::enforce_unarchived_for_spawn(app, &cwd, &session_label).await
+    {
+        let err = e.to_string();
+        release_resource_launch_permit(&resource_monitor, &mut resource_permit);
+        drop(mgr);
+        rollback_pre_created_session(app, session_mgr, pty_mgr, session.id, &err).await;
+        return Err(err);
+    }
 
     // (#756) Propagate the mirror-forced intent onto the NEW record: the
     // startup-restore path reads ONLY the record, so without this an app close
@@ -2599,6 +2611,7 @@ pub async fn restart_session_inner_with_activation<R: tauri::Runtime>(
         cwd
     };
     let cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
+    crate::config::archive_gate::probe_spawn_refusal(app, &cwd).await?;
 
     // 2. Strip auto-injected args before restart so the new session starts from the saved recipe.
     let clean_args =

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -3711,6 +3711,108 @@ mod tests {
         }
     }
 
+    /// A `PtyBackend` whose `spawn` parks on a oneshot so a test can observe the
+    /// `create_session_inner` spawn mark while the PTY is still being spawned.
+    /// `fail` decides whether the parked spawn ultimately errors (exercising the
+    /// rollback path) or succeeds and records the session as live.
+    struct GatedSpawnBackend {
+        started: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        release: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+        live: Mutex<Vec<Uuid>>,
+        fail: bool,
+    }
+
+    impl GatedSpawnBackend {
+        fn new(
+            started: tokio::sync::oneshot::Sender<()>,
+            release: tokio::sync::oneshot::Receiver<()>,
+            fail: bool,
+        ) -> Self {
+            Self {
+                started: Mutex::new(Some(started)),
+                release: Mutex::new(Some(release)),
+                live: Mutex::new(Vec::new()),
+                fail,
+            }
+        }
+    }
+
+    impl crate::pty::backend::PtyBackend for GatedSpawnBackend {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn spawn(
+            &self,
+            spec: crate::pty::backend::BackendSpawnSpec,
+        ) -> futures::future::BoxFuture<'_, Result<(), crate::errors::AppError>> {
+            let started = self.started.lock().unwrap().take().expect("started sender");
+            let release = self
+                .release
+                .lock()
+                .unwrap()
+                .take()
+                .expect("release receiver");
+            let fail = self.fail;
+            Box::pin(async move {
+                // Announce that PtyManager::spawn has released the outer manager
+                // mutex and is now parked inside the backend, then wait for the
+                // test to inspect the spawn mark before the spawn resolves.
+                let _ = started.send(());
+                let _ = release.await;
+                if fail {
+                    Err(crate::errors::AppError::PtyError(
+                        "synthetic spawn failure".to_string(),
+                    ))
+                } else {
+                    self.live.lock().unwrap().push(spec.id);
+                    Ok(())
+                }
+            })
+        }
+
+        fn write(&self, _id: Uuid, _data: &[u8]) -> Result<(), crate::errors::AppError> {
+            Ok(())
+        }
+
+        fn resize(&self, _id: Uuid, _cols: u16, _rows: u16) -> Result<(), crate::errors::AppError> {
+            Ok(())
+        }
+
+        fn kill(&self, id: Uuid) -> Result<(), crate::errors::AppError> {
+            self.live.lock().unwrap().retain(|live| *live != id);
+            Ok(())
+        }
+
+        fn has_session(&self, id: Uuid) -> bool {
+            self.live.lock().unwrap().contains(&id)
+        }
+
+        fn get_screen_snapshot(&self, _id: Uuid) -> Option<crate::pty::output::PtyScreenSnapshot> {
+            None
+        }
+
+        fn get_pty_size(&self, _id: Uuid) -> Option<(u16, u16)> {
+            None
+        }
+
+        fn register_response_watcher(
+            &self,
+            _session_id: Uuid,
+            _request_id: String,
+            _response_dir: std::path::PathBuf,
+        ) {
+        }
+
+        fn terminate_job_for_session(&self, _id: Uuid) -> bool {
+            false
+        }
+
+        fn kill_all_jobs(&self) -> (usize, usize) {
+            (0, 0)
+        }
+    }
+
     fn session_test_app(settings: AppSettings) -> tauri::App<tauri::test::MockRuntime> {
         tauri::test::mock_builder()
             .manage(Arc::new(tokio::sync::RwLock::new(settings)))
@@ -3815,6 +3917,161 @@ mod tests {
         assert!(
             drop_mark < spawn_error,
             "spawn mark must drop immediately after spawn returns"
+        );
+    }
+
+    // Runtime witness for plan section 12: drive create_session_inner with a
+    // fake backend and assert archive_liveness sees the spawn mark WHILE the PTY
+    // is spawning, then sees it retired once the PTY exists. Unlike the
+    // source-scrape guards above, this executes the code, so it reds under a
+    // string-preserving runtime mutation (e.g. mark_spawning inserting nothing,
+    // or the mark dropped before PtyManager::spawn).
+    #[tokio::test]
+    async fn create_session_inner_holds_a_spawn_mark_until_the_pty_exists() {
+        use crate::pty::backend::PtyBackend;
+
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().to_string_lossy().to_string();
+        let expected_cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
+
+        let app = session_test_app(test_settings());
+        let app_handle = app.handle().clone();
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let backend = Arc::new(GatedSpawnBackend::new(started_tx, release_rx, false));
+        let pty_mgr = Arc::new(Mutex::new(crate::pty::manager::PtyManager::new_for_test(
+            backend.clone(),
+        )));
+
+        let task = {
+            let app_handle = app_handle.clone();
+            let session_mgr = session_mgr.clone();
+            let pty_mgr = pty_mgr.clone();
+            let cwd = cwd.clone();
+            tokio::spawn(async move {
+                super::create_session_inner(
+                    &app_handle,
+                    &session_mgr,
+                    &pty_mgr,
+                    "hold-mark-test-command".to_string(),
+                    Vec::new(),
+                    cwd,
+                    Some("hold-mark".to_string()),
+                    None,
+                    None,
+                    true,
+                    Vec::new(),
+                    true,
+                    None,
+                )
+                .await
+            })
+        };
+
+        // Park inside the backend's spawn. PtyManager::spawn releases the outer
+        // manager mutex before awaiting backend.spawn, so the mark is readable
+        // here without racing the spawn task.
+        started_rx.await.expect("spawn started");
+        let (pending, _) = pty_mgr.lock().unwrap().archive_liveness(&[]);
+        assert_eq!(
+            pending,
+            vec![crate::pty::manager::PendingSpawn {
+                cwd: expected_cwd.clone(),
+                label: "hold-mark".to_string(),
+            }],
+            "spawn mark must be live while the PTY is still being spawned"
+        );
+
+        let _ = release_tx.send(());
+        let info = task
+            .await
+            .expect("join create_session_inner")
+            .expect("create_session_inner should succeed");
+
+        assert!(
+            backend.has_session(Uuid::parse_str(&info.id).expect("session id is a uuid")),
+            "the PTY must exist once create_session_inner returns Ok"
+        );
+        let (pending, _) = pty_mgr.lock().unwrap().archive_liveness(&[]);
+        assert!(
+            pending.is_empty(),
+            "spawn mark must retire once the PTY exists"
+        );
+    }
+
+    // Runtime witness for plan section 12: the mark is held across a FAILING
+    // spawn exactly as across a succeeding one, and is retired on the rollback
+    // path. Holding the mark across the in-flight spawn is what makes this red
+    // under a string-preserving mutation (mark_spawning no-op / drop before
+    // spawn); the empty-afterwards assertion pins retirement on the failure arm.
+    #[tokio::test]
+    async fn create_session_inner_retires_the_spawn_mark_on_spawn_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().to_string_lossy().to_string();
+        let expected_cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
+
+        let app = session_test_app(test_settings());
+        let app_handle = app.handle().clone();
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let backend = Arc::new(GatedSpawnBackend::new(started_tx, release_rx, true));
+        let pty_mgr = Arc::new(Mutex::new(crate::pty::manager::PtyManager::new_for_test(
+            backend.clone(),
+        )));
+
+        let task = {
+            let app_handle = app_handle.clone();
+            let session_mgr = session_mgr.clone();
+            let pty_mgr = pty_mgr.clone();
+            let cwd = cwd.clone();
+            tokio::spawn(async move {
+                super::create_session_inner(
+                    &app_handle,
+                    &session_mgr,
+                    &pty_mgr,
+                    "retire-mark-test-command".to_string(),
+                    Vec::new(),
+                    cwd,
+                    Some("retire-mark".to_string()),
+                    None,
+                    None,
+                    true,
+                    Vec::new(),
+                    true,
+                    None,
+                )
+                .await
+            })
+        };
+
+        started_rx.await.expect("spawn started");
+        let (pending, _) = pty_mgr.lock().unwrap().archive_liveness(&[]);
+        assert_eq!(
+            pending,
+            vec![crate::pty::manager::PendingSpawn {
+                cwd: expected_cwd.clone(),
+                label: "retire-mark".to_string(),
+            }],
+            "spawn mark must be live while the failing spawn is in flight"
+        );
+
+        let _ = release_tx.send(());
+        let err = task
+            .await
+            .expect("join create_session_inner")
+            .expect_err("create_session_inner should fail when the spawn fails");
+        assert!(err.contains("synthetic spawn failure"), "{err}");
+
+        let (pending, _) = pty_mgr.lock().unwrap().archive_liveness(&[]);
+        assert!(
+            pending.is_empty(),
+            "spawn mark must retire after a failed spawn"
+        );
+        assert!(
+            session_mgr.read().await.list_sessions().await.is_empty(),
+            "rollback must remove the pre-created record on spawn failure"
         );
     }
 

--- a/src-tauri/src/config/archive_gate.rs
+++ b/src-tauri/src/config/archive_gate.rs
@@ -1,0 +1,242 @@
+use std::path::Path;
+use std::time::Duration;
+
+use tauri::Manager;
+
+fn folder_name(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(path)
+        .to_string()
+}
+
+fn archived_root_for_cwd(cwd: &str, archived_roots: &[String]) -> Option<String> {
+    if archived_roots.is_empty() {
+        return None;
+    }
+    let roots = crate::config::sessions_persistence::normalize_project_roots(archived_roots);
+    crate::config::sessions_persistence::first_project_path_containing(cwd, &roots)
+}
+
+fn probe_spawn_refusal_for_archived_root(root: &str) -> Result<(), String> {
+    if crate::config::workspace::has_workspace_dir(Path::new(root)) {
+        return Ok(());
+    }
+    Err(format!(
+        "Cannot start a session in archived project '{}': Project AC Root not found. Open Archived Projects to restore it, or remove it from the list.",
+        folder_name(root)
+    ))
+}
+
+fn auto_unarchive_registration(
+    settings: &mut crate::config::settings::AppSettings,
+    root: &str,
+) -> Result<
+    Option<crate::config::projects::ProjectRegistration>,
+    crate::config::projects::ProjectError,
+> {
+    let key = crate::config::projects::normalize_for_compare(root);
+    let still_archived = settings
+        .archived_project_paths
+        .iter()
+        .any(|p| crate::config::projects::normalize_for_compare(p) == key);
+    if !still_archived {
+        return Ok(None);
+    }
+
+    crate::config::projects::register_existing_project(settings, root).map(Some)
+}
+
+/// #881: read-only preflight used before restart destroys the dormant row.
+pub(crate) async fn probe_spawn_refusal<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    cwd: &str,
+) -> Result<(), String> {
+    let settings = app.state::<crate::config::settings::SettingsState>();
+    let archived = { settings.read().await.archived_project_paths.clone() };
+    if archived.is_empty() {
+        return Ok(());
+    }
+
+    let cwd_owned = cwd.to_string();
+    let root = tokio::task::spawn_blocking(move || archived_root_for_cwd(&cwd_owned, &archived))
+        .await
+        .map_err(|e| format!("archive gate probe task failed: {}", e))?;
+    let Some(root) = root else {
+        return Ok(());
+    };
+
+    probe_spawn_refusal_for_archived_root(&root)
+}
+
+/// #881: enforce that a session spawn never leaves a live PTY inside an
+/// archived project.
+pub(crate) async fn enforce_unarchived_for_spawn<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    cwd: &str,
+    session_label: &str,
+) -> Result<(), String> {
+    let settings = app.state::<crate::config::settings::SettingsState>();
+    let archived = { settings.read().await.archived_project_paths.clone() };
+    if archived.is_empty() {
+        return Ok(());
+    }
+
+    let cwd_owned = cwd.to_string();
+    let root = tokio::task::spawn_blocking(move || archived_root_for_cwd(&cwd_owned, &archived))
+        .await
+        .map_err(|e| format!("archive gate task failed: {}", e))?;
+    let Some(root) = root else {
+        return Ok(());
+    };
+
+    auto_unarchive_for_activation(app, &root, session_label).await
+}
+
+async fn auto_unarchive_for_activation<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    root: &str,
+    session_label: &str,
+) -> Result<(), String> {
+    let settings = app.state::<crate::config::settings::SettingsState>();
+    let mut s = tokio::time::timeout(Duration::from_secs(5), settings.write())
+        .await
+        .map_err(|_| {
+            format!(
+                "archive gate: timed out taking the settings write lock while un-archiving '{}'. A caller of create_session_inner is holding a SettingsState guard. That is a bug, not a slow disk.",
+                root
+            )
+        })?;
+
+    crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
+    let reg = match auto_unarchive_registration(&mut s, root).map_err(|e| {
+        format!(
+            "Cannot start a session in archived project '{}': {}. Open Archived Projects to restore it, or remove it from the list.",
+            folder_name(root),
+            e
+        )
+    })? {
+        Some(reg) => reg,
+        None => return Ok(()),
+    };
+
+    let snapshot = s.clone();
+    crate::config::settings::save_settings_with_project_paths(&snapshot)?;
+    drop(s);
+
+    log::warn!(
+        "[archive] auto-unarchived '{}': session '{}' activated inside it",
+        root,
+        session_label
+    );
+    crate::commands::ac_discovery::broadcast_project_archive_changed(
+        app,
+        &reg.path,
+        false,
+        crate::commands::ac_discovery::ArchiveChangeReason::AutoUnarchive,
+        Some(session_label),
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::AppSettings;
+
+    #[test]
+    fn first_project_path_containing_returns_the_matching_archived_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let archived = temp.path().join("archived");
+        let agent = archived.join(".ac").join("wg-1").join("__agent_dev");
+        std::fs::create_dir_all(&agent).expect("create agent dir");
+        let roots = crate::config::sessions_persistence::normalize_project_roots(&[archived
+            .to_string_lossy()
+            .to_string()]);
+
+        assert_eq!(
+            crate::config::sessions_persistence::first_project_path_containing(
+                &agent.to_string_lossy(),
+                &roots
+            ),
+            Some(roots[0].clone())
+        );
+    }
+
+    #[test]
+    fn first_project_path_containing_returns_none_for_a_cwd_outside_every_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let archived = temp.path().join("archived");
+        let other = temp.path().join("other").join(".ac").join("wg-1");
+        std::fs::create_dir_all(&archived).expect("create archived");
+        std::fs::create_dir_all(&other).expect("create other");
+        let roots = crate::config::sessions_persistence::normalize_project_roots(&[archived
+            .to_string_lossy()
+            .to_string()]);
+
+        assert_eq!(
+            crate::config::sessions_persistence::first_project_path_containing(
+                &other.to_string_lossy(),
+                &roots
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn first_project_path_containing_returns_none_on_an_empty_root_list() {
+        assert_eq!(
+            crate::config::sessions_persistence::first_project_path_containing(
+                "Z:/does/not/exist/x",
+                &[]
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn probe_spawn_refusal_rejects_an_archived_root_without_a_workspace_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("archived-project");
+        std::fs::create_dir_all(&project).expect("create project dir");
+
+        let err = probe_spawn_refusal_for_archived_root(&project.to_string_lossy())
+            .expect_err("missing workspace should reject");
+
+        assert!(err.contains("archived-project"), "{err}");
+    }
+
+    #[test]
+    fn probe_spawn_refusal_accepts_an_archived_root_that_still_has_a_workspace_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("archived-project");
+        std::fs::create_dir_all(project.join(".ac")).expect("create workspace");
+
+        probe_spawn_refusal_for_archived_root(&project.to_string_lossy())
+            .expect("workspace should accept");
+    }
+
+    #[test]
+    fn auto_unarchive_registration_coalesces_when_project_is_no_longer_archived() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("archived-project");
+        std::fs::create_dir_all(project.join(".ac")).expect("create workspace");
+        let project = project.to_string_lossy().to_string();
+        let mut settings = AppSettings {
+            archived_project_paths: vec![project.clone()],
+            ..AppSettings::default()
+        };
+
+        let first = auto_unarchive_registration(&mut settings, &project)
+            .expect("first registration")
+            .expect("first caller should unarchive");
+        assert_eq!(first.path, project);
+        assert!(settings.archived_project_paths.is_empty());
+        assert_eq!(settings.project_paths.len(), 1);
+
+        let second =
+            auto_unarchive_registration(&mut settings, &first.path).expect("second registration");
+        assert!(second.is_none(), "second caller must coalesce");
+    }
+}

--- a/src-tauri/src/config/archive_gate.rs
+++ b/src-tauri/src/config/archive_gate.rs
@@ -12,11 +12,7 @@ fn folder_name(path: &str) -> String {
 }
 
 fn archived_root_for_cwd(cwd: &str, archived_roots: &[String]) -> Option<String> {
-    if archived_roots.is_empty() {
-        return None;
-    }
-    let roots = crate::config::sessions_persistence::normalize_project_roots(archived_roots);
-    crate::config::sessions_persistence::first_project_path_containing(cwd, &roots)
+    crate::config::sessions_persistence::raw_project_path_containing(cwd, archived_roots)
 }
 
 fn probe_spawn_refusal_for_archived_root(root: &str) -> Result<(), String> {
@@ -146,53 +142,92 @@ mod tests {
     use crate::config::settings::AppSettings;
 
     #[test]
-    fn first_project_path_containing_returns_the_matching_archived_root() {
+    fn raw_project_path_containing_returns_the_matching_archived_root() {
         let temp = tempfile::tempdir().expect("tempdir");
         let archived = temp.path().join("archived");
         let agent = archived.join(".ac").join("wg-1").join("__agent_dev");
         std::fs::create_dir_all(&agent).expect("create agent dir");
-        let roots = crate::config::sessions_persistence::normalize_project_roots(&[archived
-            .to_string_lossy()
-            .to_string()]);
+        let archived = archived.to_string_lossy().to_string();
 
         assert_eq!(
-            crate::config::sessions_persistence::first_project_path_containing(
+            crate::config::sessions_persistence::raw_project_path_containing(
                 &agent.to_string_lossy(),
-                &roots
+                std::slice::from_ref(&archived)
             ),
-            Some(roots[0].clone())
+            Some(archived)
         );
     }
 
     #[test]
-    fn first_project_path_containing_returns_none_for_a_cwd_outside_every_root() {
+    fn raw_project_path_containing_returns_none_for_a_cwd_outside_every_root() {
         let temp = tempfile::tempdir().expect("tempdir");
         let archived = temp.path().join("archived");
         let other = temp.path().join("other").join(".ac").join("wg-1");
         std::fs::create_dir_all(&archived).expect("create archived");
         std::fs::create_dir_all(&other).expect("create other");
-        let roots = crate::config::sessions_persistence::normalize_project_roots(&[archived
-            .to_string_lossy()
-            .to_string()]);
+        let archived = archived.to_string_lossy().to_string();
 
         assert_eq!(
-            crate::config::sessions_persistence::first_project_path_containing(
+            crate::config::sessions_persistence::raw_project_path_containing(
                 &other.to_string_lossy(),
-                &roots
+                &[archived]
             ),
             None
         );
     }
 
     #[test]
-    fn first_project_path_containing_returns_none_on_an_empty_root_list() {
+    fn raw_project_path_containing_returns_none_on_an_empty_root_list() {
+        crate::config::sessions_persistence::reset_normalize_call_count();
         assert_eq!(
-            crate::config::sessions_persistence::first_project_path_containing(
+            crate::config::sessions_persistence::raw_project_path_containing(
                 "Z:/does/not/exist/x",
                 &[]
             ),
             None
         );
+        assert_eq!(
+            crate::config::sessions_persistence::normalize_call_count(),
+            0,
+            "empty roots must return before canonicalizing the candidate"
+        );
+    }
+
+    #[test]
+    fn archived_root_for_cwd_returns_the_raw_archived_entry() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let archived = temp.path().join("MixedCaseProject");
+        let agent = archived.join(".ac").join("wg-1").join("__agent_dev");
+        std::fs::create_dir_all(&agent).expect("create agent dir");
+        let raw = archived.to_string_lossy().replace('\\', "/");
+        let cwd = agent.to_string_lossy().to_string();
+
+        let matched = archived_root_for_cwd(&cwd, &[String::new(), raw.clone()])
+            .expect("archived root should match");
+
+        assert_eq!(matched, raw, "activation gate must preserve stored bytes");
+    }
+
+    #[test]
+    fn auto_unarchive_registration_validates_the_archived_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("missing-workspace-project");
+        std::fs::create_dir_all(&project).expect("create project dir");
+        let project = project.to_string_lossy().to_string();
+        let mut settings = AppSettings {
+            archived_project_paths: vec![project.clone()],
+            ..AppSettings::default()
+        };
+
+        let err = auto_unarchive_registration(&mut settings, &project)
+            .expect_err("missing Project AC Root must fail");
+
+        assert!(matches!(
+            err,
+            crate::config::projects::ProjectError::WorkspaceMissing(_)
+        ));
+        assert!(settings.project_paths.is_empty());
+        assert_eq!(settings.archived_project_paths, vec![project]);
     }
 
     #[test]

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_command;
 pub mod agent_config;
 pub mod agent_creation;
+pub mod archive_gate;
 pub mod coding_agent_mutations;
 pub mod coding_agent_profiles;
 pub mod coding_agents_catalog;

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -259,7 +259,7 @@ pub fn resolve_project_reference(
 
 // ── Private helpers ───────────────────────────────────────────────────────
 
-fn absolutise(raw: &str) -> Result<PathBuf, ProjectError> {
+pub(crate) fn absolutise(raw: &str) -> Result<PathBuf, ProjectError> {
     if raw.trim().is_empty() {
         return Err(ProjectError::EmptyPath(raw.to_string()));
     }
@@ -357,6 +357,33 @@ pub fn archive_project_path(settings: &mut AppSettings, abs_path: &str) -> bool 
     }
     settings.project_path = settings.project_paths.first().cloned();
     removed
+}
+
+/// Move a stored archived project back to the active list without probing the
+/// filesystem. Used only to roll back an archive operation that already passed
+/// path normalization and then discovered late liveness.
+pub fn unarchive_project_path(settings: &mut AppSettings, abs_path: &str) -> bool {
+    let key = normalize_for_compare(abs_path);
+    let matched = settings
+        .archived_project_paths
+        .iter()
+        .find(|p| normalize_for_compare(p) == key)
+        .cloned();
+    let Some(restored) = matched else {
+        return false;
+    };
+    settings
+        .archived_project_paths
+        .retain(|p| normalize_for_compare(p) != key);
+    let already_active = settings
+        .project_paths
+        .iter()
+        .any(|p| normalize_for_compare(p) == key);
+    if !already_active {
+        settings.project_paths.push(restored);
+    }
+    settings.project_path = settings.project_paths.first().cloned();
+    true
 }
 
 pub fn archived_projects_from_paths(archived_project_paths: &[String]) -> Vec<ArchivedProject> {
@@ -933,6 +960,20 @@ mod tests {
     }
 
     #[test]
+    fn unarchive_project_path_restores_archived_byte_form_without_io() {
+        let mut s = AppSettings {
+            archived_project_paths: vec!["C:/MissingProject/".to_string()],
+            ..AppSettings::default()
+        };
+
+        assert!(unarchive_project_path(&mut s, "C:/MissingProject"));
+
+        assert_eq!(s.project_paths, vec!["C:/MissingProject/".to_string()]);
+        assert!(s.archived_project_paths.is_empty());
+        assert_eq!(s.project_path.as_deref(), Some("C:/MissingProject/"));
+    }
+
+    #[test]
     fn upsert_project_path_unarchives_matching_entry() {
         let fix = FixtureRoot::new("proj-unarchive-upsert");
         std::fs::create_dir_all(fix.path().join(".ac")).expect("create .ac");
@@ -947,6 +988,29 @@ mod tests {
         assert!(result.registered);
         assert!(s.archived_project_paths.is_empty());
         assert_eq!(s.project_paths, vec![result.path]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn upsert_project_path_unarchives_windows_verbatim_variant() {
+        let mut s = AppSettings {
+            archived_project_paths: vec![r"\\?\C:\Users\maria\MixedCaseProject".to_string()],
+            ..AppSettings::default()
+        };
+
+        assert!(upsert_project_path(
+            &mut s,
+            r"C:\Users\maria\MixedCaseProject"
+        ));
+
+        assert_eq!(
+            s.project_paths,
+            vec![r"C:\Users\maria\MixedCaseProject".to_string()]
+        );
+        assert!(
+            s.archived_project_paths.is_empty(),
+            "verbatim and ordinary Windows paths must not remain in separate lists"
+        );
     }
 
     #[test]

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -30,6 +30,15 @@ pub struct ProjectRegistration {
     pub created: bool,
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchivedProject {
+    pub path: String,
+    pub folder_name: String,
+    pub exists: bool,
+    pub has_workspace: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectResolution {
     pub path: PathBuf,
@@ -267,7 +276,8 @@ fn absolutise(raw: &str) -> Result<PathBuf, ProjectError> {
 /// Mirrors the frontend `normalizePath` at
 /// `src/sidebar/stores/project.ts:17-19`. Comparison only — the persisted
 /// entry retains the original byte sequence.
-fn normalize_for_compare(s: &str) -> String {
+pub(crate) fn normalize_for_compare(s: &str) -> String {
+    let s = crate::path_utils::normalize_windows_verbatim_path(s);
     // Slashes normalised, lowercased, trailing `/` stripped. The trailing
     // strip closes Round-1 IR.3.2 (shell tab-completion appends `\` on dirs;
     // without trim, `C:\foo\` and `C:\foo` would become DIFFERENT entries).
@@ -283,6 +293,9 @@ fn normalize_for_compare(s: &str) -> String {
 /// Returns `true` if a new entry was added.
 fn upsert_project_path(settings: &mut AppSettings, abs_path: &str) -> bool {
     let key = normalize_for_compare(abs_path);
+    settings
+        .archived_project_paths
+        .retain(|p| normalize_for_compare(p) != key);
     let exists = settings
         .project_paths
         .iter()
@@ -313,9 +326,56 @@ pub fn remove_project_path(settings: &mut AppSettings, abs_path: &str) -> bool {
         .project_paths
         .retain(|p| normalize_for_compare(p) != key);
     let removed = settings.project_paths.len() != before;
+    settings
+        .archived_project_paths
+        .retain(|p| normalize_for_compare(p) != key);
     // Keep legacy `projectPath` in lockstep with the head (matches upsert).
     settings.project_path = settings.project_paths.first().cloned();
     removed
+}
+
+/// #881: move `abs_path` from the active list to the archived list.
+pub fn archive_project_path(settings: &mut AppSettings, abs_path: &str) -> bool {
+    let key = normalize_for_compare(abs_path);
+    let matched = settings
+        .project_paths
+        .iter()
+        .find(|p| normalize_for_compare(p) == key)
+        .cloned();
+    settings
+        .project_paths
+        .retain(|p| normalize_for_compare(p) != key);
+    let removed = matched.is_some();
+    let already_archived = settings
+        .archived_project_paths
+        .iter()
+        .any(|p| normalize_for_compare(p) == key);
+    if !already_archived {
+        settings
+            .archived_project_paths
+            .push(matched.unwrap_or_else(|| abs_path.to_string()));
+    }
+    settings.project_path = settings.project_paths.first().cloned();
+    removed
+}
+
+pub fn archived_projects_from_paths(archived_project_paths: &[String]) -> Vec<ArchivedProject> {
+    archived_project_paths
+        .iter()
+        .map(|raw| {
+            let path = Path::new(raw);
+            ArchivedProject {
+                path: raw.clone(),
+                folder_name: path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(raw)
+                    .to_string(),
+                exists: is_real_directory(path),
+                has_workspace: has_workspace_dir(path),
+            }
+        })
+        .collect()
 }
 
 pub fn enumerate_registered_project_candidates(project_paths: &[String]) -> Vec<ProjectResolution> {
@@ -788,6 +848,130 @@ mod tests {
         assert_eq!(s.project_path.as_deref(), Some("C:/a"));
     }
 
+    #[test]
+    fn remove_project_path_also_drops_archived_entry() {
+        let mut s = AppSettings {
+            project_paths: vec!["C:/a".to_string()],
+            project_path: Some("C:/a".to_string()),
+            archived_project_paths: vec!["c:/a/".to_string(), "C:/b".to_string()],
+            ..AppSettings::default()
+        };
+
+        assert!(remove_project_path(&mut s, "C:/a"));
+
+        assert_eq!(s.archived_project_paths, vec!["C:/b".to_string()]);
+    }
+
+    // ── #881 archive_project_path ───────────────────────────────────────
+
+    #[test]
+    fn archive_project_path_moves_entry_and_rederives_head() {
+        let mut s = AppSettings {
+            project_paths: vec!["C:/a".to_string(), "C:/b".to_string()],
+            project_path: Some("C:/a".to_string()),
+            ..AppSettings::default()
+        };
+
+        assert!(archive_project_path(&mut s, "C:/a"));
+
+        assert_eq!(s.project_paths, vec!["C:/b".to_string()]);
+        assert_eq!(s.archived_project_paths, vec!["C:/a".to_string()]);
+        assert_eq!(s.project_path.as_deref(), Some("C:/b"));
+    }
+
+    #[test]
+    fn archive_project_path_last_entry_clears_head_to_none() {
+        let mut s = AppSettings {
+            project_paths: vec!["C:/only".to_string()],
+            project_path: Some("C:/only".to_string()),
+            ..AppSettings::default()
+        };
+
+        assert!(archive_project_path(&mut s, "C:/only"));
+
+        assert!(s.project_paths.is_empty());
+        assert_eq!(s.archived_project_paths, vec!["C:/only".to_string()]);
+        assert_eq!(s.project_path, None);
+    }
+
+    #[test]
+    fn archive_project_path_is_case_slash_insensitive_and_archives_stored_byte_form() {
+        let mut s = AppSettings {
+            project_paths: vec![r"C:\Foo\".to_string(), "C:/keep".to_string()],
+            project_path: Some(r"C:\Foo\".to_string()),
+            ..AppSettings::default()
+        };
+
+        assert!(archive_project_path(&mut s, "c:/foo"));
+
+        assert_eq!(s.project_paths, vec!["C:/keep".to_string()]);
+        assert_eq!(s.archived_project_paths, vec![r"C:\Foo\".to_string()]);
+    }
+
+    #[test]
+    fn archive_project_path_is_idempotent() {
+        let mut s = AppSettings {
+            project_paths: vec!["C:/a".to_string()],
+            project_path: Some("C:/a".to_string()),
+            ..AppSettings::default()
+        };
+
+        assert!(archive_project_path(&mut s, "C:/a"));
+        assert!(!archive_project_path(&mut s, "c:/a/"));
+
+        assert_eq!(s.archived_project_paths, vec!["C:/a".to_string()]);
+    }
+
+    #[test]
+    fn archive_project_path_records_unregistered_path() {
+        let mut s = AppSettings::default();
+
+        assert!(!archive_project_path(&mut s, "C:/missing"));
+
+        assert_eq!(s.archived_project_paths, vec!["C:/missing".to_string()]);
+        assert!(s.project_paths.is_empty());
+    }
+
+    #[test]
+    fn upsert_project_path_unarchives_matching_entry() {
+        let fix = FixtureRoot::new("proj-unarchive-upsert");
+        std::fs::create_dir_all(fix.path().join(".ac")).expect("create .ac");
+        let mut s = AppSettings {
+            archived_project_paths: vec![fix.path().to_string_lossy().replace('\\', "/") + "/"],
+            ..AppSettings::default()
+        };
+
+        let result = register_existing_project(&mut s, fix.path().to_str().unwrap())
+            .expect("register existing");
+
+        assert!(result.registered);
+        assert!(s.archived_project_paths.is_empty());
+        assert_eq!(s.project_paths, vec![result.path]);
+    }
+
+    #[test]
+    fn archived_projects_reports_missing_folder_and_missing_workspace() {
+        let full = FixtureRoot::new("proj-archived-full");
+        std::fs::create_dir_all(full.path().join(".ac")).expect("full .ac");
+        let no_workspace = FixtureRoot::new("proj-archived-no-workspace");
+        let deleted = FixtureRoot::new("proj-archived-deleted");
+        let deleted_path = deleted.path().to_string_lossy().to_string();
+        std::fs::remove_dir_all(deleted.path()).expect("delete fixture");
+
+        let rows = archived_projects_from_paths(&[
+            full.path().to_string_lossy().to_string(),
+            no_workspace.path().to_string_lossy().to_string(),
+            deleted_path,
+        ]);
+
+        assert!(rows[0].exists);
+        assert!(rows[0].has_workspace);
+        assert!(rows[1].exists);
+        assert!(!rows[1].has_workspace);
+        assert!(!rows[2].exists);
+        assert!(!rows[2].has_workspace);
+    }
+
     // ── absolutise: relative + dot-dot collapse (Round-1 G4 + G13) ────────
 
     /// CWD is process-wide; restore on Drop. Any other test that mutates
@@ -984,6 +1168,22 @@ mod tests {
         assert!(matches!(err, ProjectResolveError::NotFound(_)));
     }
 
+    #[test]
+    fn enumerate_registered_project_candidates_yields_a_nested_child_of_a_registered_parent() {
+        let fix = FixtureRoot::new("proj-enumerate-nested");
+        create_ac_project(fix.path());
+        let child = fix.path().join("child");
+        create_ac_project(&child);
+        let project_paths = vec![fix.path().to_string_lossy().to_string()];
+
+        let candidates = enumerate_registered_project_candidates(&project_paths);
+
+        assert!(
+            candidates.iter().any(|c| c.path == child),
+            "nested child with .ac must remain a project candidate"
+        );
+    }
+
     // ── serde camelCase shape lock (Round-1 G14) ─────────────────────────
 
     #[test]
@@ -1014,6 +1214,29 @@ mod tests {
         assert!(
             !json.contains("workspace_dir"),
             "snake_case field name leaked: {}",
+            json
+        );
+
+        let archived = ArchivedProject {
+            path: "X".to_string(),
+            folder_name: "X".to_string(),
+            exists: true,
+            has_workspace: false,
+        };
+        let json = serde_json::to_string(&archived).unwrap();
+        assert!(
+            json.contains("\"folderName\""),
+            "missing folderName field: {}",
+            json
+        );
+        assert!(
+            json.contains("\"hasWorkspace\""),
+            "missing hasWorkspace field: {}",
+            json
+        );
+        assert!(
+            !json.contains("folder_name") && !json.contains("has_workspace"),
+            "snake_case archived field leaked: {}",
             json
         );
     }

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -309,9 +309,10 @@ fn path_is_under_or_equal(candidate: &str, root: &str) -> bool {
 /// Raw-root convenience for active project lists that are checked once, such
 /// as `archive_session_blockers`.
 ///
-/// Do not call this with `archived_project_paths` or inside a per-dir loop.
-/// In those paths, normalize roots once with `normalize_project_roots` and use
-/// the normalized helpers.
+/// Do not call this with `archived_project_paths`,
+/// `session_retention_project_paths`, or inside a per-dir loop. In those paths,
+/// normalize roots once with `normalize_project_roots` and use the normalized
+/// helpers.
 #[allow(dead_code)]
 pub(crate) fn working_directory_under_any_project_path(
     working_directory: &str,
@@ -373,6 +374,25 @@ pub(crate) fn is_under_normalized_archived_roots(
         &normalize_for_project_compare(Path::new(path)),
         normalized_archived_roots,
     )
+}
+
+/// #881: return the normalized archived root containing `path`.
+///
+/// Takes pre-normalized roots produced by `normalize_project_roots`; do not add
+/// a raw-root wrapper that hides per-root canonicalization inside a per-dir
+/// loop.
+pub(crate) fn first_project_path_containing(
+    path: &str,
+    normalized_roots: &[String],
+) -> Option<String> {
+    if normalized_roots.is_empty() {
+        return None;
+    }
+    let cwd = normalize_for_project_compare(Path::new(path));
+    normalized_roots
+        .iter()
+        .find(|root| path_is_under_or_equal(&cwd, root))
+        .cloned()
 }
 
 fn is_root_persisted_session(session: &PersistedSession) -> bool {
@@ -2590,6 +2610,17 @@ mod tests {
             NORMALIZE_CALLS.with(|calls| calls.get()),
             0,
             "empty archived roots must not canonicalize path"
+        );
+
+        NORMALIZE_CALLS.with(|calls| calls.set(0));
+        assert!(!is_under_normalized_archived_roots(
+            "Z:/does/not/exist/x",
+            &["z:/somewhere".to_string()]
+        ));
+        assert_eq!(
+            NORMALIZE_CALLS.with(|calls| calls.get()),
+            1,
+            "non-empty roots must canonicalize path exactly once"
         );
     }
 

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -279,6 +279,16 @@ thread_local! {
     static NORMALIZE_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
+#[cfg(test)]
+pub(crate) fn reset_normalize_call_count() {
+    NORMALIZE_CALLS.with(|calls| calls.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn normalize_call_count() -> usize {
+    NORMALIZE_CALLS.with(|calls| calls.get())
+}
+
 fn normalize_for_project_compare(path: &Path) -> String {
     #[cfg(test)]
     NORMALIZE_CALLS.with(|calls| calls.set(calls.get() + 1));
@@ -306,14 +316,13 @@ fn path_is_under_or_equal(candidate: &str, root: &str) -> bool {
     candidate.starts_with(&format!("{}/", root))
 }
 
-/// Raw-root convenience for active project lists that are checked once, such
-/// as `archive_session_blockers`.
+/// Raw-root convenience for active project lists where each candidate session
+/// is checked against a short per-command scope, such as `archive_blockers`.
 ///
 /// Do not call this with `archived_project_paths`,
 /// `session_retention_project_paths`, or inside a per-dir loop. In those paths,
 /// normalize roots once with `normalize_project_roots` and use the normalized
 /// helpers.
-#[allow(dead_code)]
 pub(crate) fn working_directory_under_any_project_path(
     working_directory: &str,
     project_paths: &[String],
@@ -362,7 +371,6 @@ pub(crate) fn session_retention_project_paths(
 ///
 /// Do not add a raw-root convenience wrapper. The per-root canonicalize must
 /// not hide inside a per-dir loop.
-#[allow(dead_code)]
 pub(crate) fn is_under_normalized_archived_roots(
     path: &str,
     normalized_archived_roots: &[String],
@@ -376,23 +384,25 @@ pub(crate) fn is_under_normalized_archived_roots(
     )
 }
 
-/// #881: return the normalized archived root containing `path`.
-///
-/// Takes pre-normalized roots produced by `normalize_project_roots`; do not add
-/// a raw-root wrapper that hides per-root canonicalization inside a per-dir
-/// loop.
-pub(crate) fn first_project_path_containing(
-    path: &str,
-    normalized_roots: &[String],
-) -> Option<String> {
-    if normalized_roots.is_empty() {
+/// #881: return the stored raw root containing `path`, while matching on the
+/// same normalized form used by `normalize_project_roots`.
+pub(crate) fn raw_project_path_containing(path: &str, project_paths: &[String]) -> Option<String> {
+    if project_paths.is_empty() {
         return None;
     }
     let cwd = normalize_for_project_compare(Path::new(path));
-    normalized_roots
-        .iter()
-        .find(|root| path_is_under_or_equal(&cwd, root))
-        .cloned()
+    project_paths.iter().find_map(|raw| {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let root = normalize_for_project_compare(Path::new(trimmed));
+        if path_is_under_or_equal(&cwd, &root) {
+            Some(raw.clone())
+        } else {
+            None
+        }
+    })
 }
 
 fn is_root_persisted_session(session: &PersistedSession) -> bool {

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -299,12 +299,42 @@ pub(crate) fn working_directory_under_any_project_path(
     project_paths: &[String],
 ) -> bool {
     let cwd = normalize_for_project_compare(Path::new(working_directory));
-    project_paths
+    let roots: Vec<String> = project_paths
         .iter()
         .map(|p| p.trim())
         .filter(|p| !p.is_empty())
         .map(|p| normalize_for_project_compare(Path::new(p)))
-        .any(|project| path_is_under_or_equal(&cwd, &project))
+        .collect();
+    working_directory_under_any_normalized_root(&cwd, &roots)
+}
+
+fn working_directory_under_any_normalized_root(cwd: &str, roots: &[String]) -> bool {
+    roots
+        .iter()
+        .any(|project| path_is_under_or_equal(cwd, project))
+}
+
+/// #881: paths that may retain persisted sessions. Active projects plus archived
+/// projects are both registered from the session store's point of view; only
+/// active projects should be used for discovery and background project work.
+pub(crate) fn session_retention_project_paths(
+    settings: &crate::config::settings::AppSettings,
+) -> Vec<String> {
+    let mut paths = settings.project_paths.clone();
+    paths.extend(settings.archived_project_paths.iter().cloned());
+    paths
+}
+
+/// #881: true when `path` lives under one of `archived_project_paths`.
+///
+/// The empty-list fast path lives here because callers run on poll intervals
+/// and spawn paths. Do not reimplement it upstream.
+#[allow(dead_code)]
+pub(crate) fn is_under_archived_project(path: &str, archived_project_paths: &[String]) -> bool {
+    if archived_project_paths.is_empty() {
+        return false;
+    }
+    working_directory_under_any_project_path(path, archived_project_paths)
 }
 
 fn is_root_persisted_session(session: &PersistedSession) -> bool {
@@ -317,14 +347,20 @@ fn filter_sessions_for_project_paths(
     project_paths: &[String],
 ) -> Vec<PersistedSession> {
     let total = sessions.len();
+    let roots: Vec<String> = project_paths
+        .iter()
+        .map(|p| p.trim())
+        .filter(|p| !p.is_empty())
+        .map(|p| normalize_for_project_compare(Path::new(p)))
+        .collect();
     let filtered: Vec<PersistedSession> = sessions
         .into_iter()
         .filter(|session| {
             if is_root_persisted_session(session) {
                 return true;
             }
-            let keep =
-                working_directory_under_any_project_path(&session.working_directory, project_paths);
+            let cwd = normalize_for_project_compare(Path::new(&session.working_directory));
+            let keep = working_directory_under_any_normalized_root(&cwd, &roots);
             if !keep {
                 log::warn!(
                     "[sessions] Dropping orphan persisted session '{}' at '{}' (outside current projectPaths)",
@@ -344,6 +380,16 @@ fn filter_sessions_for_project_paths(
     }
 
     filtered
+}
+
+async fn filter_sessions_for_project_paths_blocking(
+    sessions: Vec<PersistedSession>,
+    project_paths: &[String],
+) -> Result<Vec<PersistedSession>, String> {
+    let project_paths = project_paths.to_vec();
+    tokio::task::spawn_blocking(move || filter_sessions_for_project_paths(sessions, &project_paths))
+        .await
+        .map_err(|e| format!("session filter task failed: {}", e))
 }
 
 /// Remove duplicate sessions by name AND working_directory.
@@ -645,7 +691,18 @@ pub async fn load_sessions_purging_outside_project_paths(
             // Read-only fallback (no save): a stale read here cannot violate the
             // atomicity contract because nothing is written back. Restore
             // reconciles on the next persist.
-            filter_sessions_for_project_paths(load_sessions_from_dir(&dir), project_paths)
+            match filter_sessions_for_project_paths_blocking(
+                load_sessions_from_dir(&dir),
+                project_paths,
+            )
+            .await
+            {
+                Ok(filtered) => filtered,
+                Err(e) => {
+                    log::error!("Failed to filter sessions after purge failure: {}", e);
+                    vec![]
+                }
+            }
         }
     }
 }
@@ -690,7 +747,7 @@ async fn purge_sessions_outside_project_paths_in_dir_locked(
     let _guard = sessions_save_lock().lock().await;
     let before = load_sessions_from_dir(dir);
     let before_len = before.len();
-    let filtered = filter_sessions_for_project_paths(before, project_paths);
+    let filtered = filter_sessions_for_project_paths_blocking(before, project_paths).await?;
     if filtered.len() < before_len {
         save_sessions_to_dir(dir, &filtered)?;
     }
@@ -1141,7 +1198,8 @@ pub async fn persist_merging_failed_result(
     failed: &[PersistedSession],
 ) -> Result<(), String> {
     let dir = super::config_dir().ok_or("Could not determine home directory")?;
-    let project_paths = crate::config::settings::load_settings_for_cli().project_paths;
+    let settings = crate::config::settings::load_settings_for_cli();
+    let project_paths = session_retention_project_paths(&settings);
     persist_merging_failed_to_dir_for_project_paths_result(mgr, failed, &dir, Some(&project_paths))
         .await
 }
@@ -1175,7 +1233,9 @@ async fn persist_merging_failed_to_dir_for_project_paths_result(
     snapshot.extend(failed.iter().map(sanitize_failed_recoverable));
     let snapshot = deduplicate(snapshot);
     let snapshot = match project_paths {
-        Some(project_paths) => filter_sessions_for_project_paths(snapshot, project_paths),
+        Some(project_paths) => {
+            filter_sessions_for_project_paths_blocking(snapshot, project_paths).await?
+        }
         None => snapshot,
     };
     save_sessions_to_dir(dir, &snapshot)
@@ -1190,7 +1250,8 @@ pub async fn persist_merging_failed(mgr: &SessionManager, failed: &[PersistedSes
 /// Convenience: snapshot and save in one call. Logs errors but never fails.
 pub async fn persist_current_state_result(mgr: &SessionManager) -> Result<(), String> {
     let dir = super::config_dir().ok_or("Could not determine home directory")?;
-    let project_paths = crate::config::settings::load_settings_for_cli().project_paths;
+    let settings = crate::config::settings::load_settings_for_cli();
+    let project_paths = session_retention_project_paths(&settings);
     persist_current_state_to_dir_for_project_paths_result(mgr, &dir, Some(&project_paths)).await
 }
 
@@ -1219,7 +1280,9 @@ async fn snapshot_and_save_locked(
 ) -> Result<(), String> {
     let snapshot = snapshot_sessions(mgr).await;
     let snapshot = match project_paths {
-        Some(project_paths) => filter_sessions_for_project_paths(snapshot, project_paths),
+        Some(project_paths) => {
+            filter_sessions_for_project_paths_blocking(snapshot, project_paths).await?
+        }
         None => snapshot,
     };
     save_sessions_to_dir(dir, &snapshot)
@@ -1274,7 +1337,8 @@ pub async fn raise_hand_and_persist_result(
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<RaiseHandPersistOutcome, String> {
     let dir = super::config_dir().ok_or("Could not determine home directory")?;
-    let project_paths = crate::config::settings::load_settings_for_cli().project_paths;
+    let settings = crate::config::settings::load_settings_for_cli();
+    let project_paths = session_retention_project_paths(&settings);
     raise_hand_and_persist_to_dir_result(mgr, session_id, now, &dir, Some(&project_paths)).await
 }
 
@@ -1341,7 +1405,8 @@ pub async fn clear_user_input_transitions_and_persist_result(
     clear_fresh: bool,
 ) -> Result<ClearedUserInputTransitions, String> {
     let dir = super::config_dir();
-    let project_paths = crate::config::settings::load_settings_for_cli().project_paths;
+    let settings = crate::config::settings::load_settings_for_cli();
+    let project_paths = session_retention_project_paths(&settings);
     clear_user_input_transitions_and_persist_to_dir_result(
         mgr,
         session_id,
@@ -1392,7 +1457,8 @@ pub async fn set_start_fresh_and_persist_result(
     session_id: Uuid,
 ) -> Result<bool, String> {
     let dir = super::config_dir();
-    let project_paths = crate::config::settings::load_settings_for_cli().project_paths;
+    let settings = crate::config::settings::load_settings_for_cli();
+    let project_paths = session_retention_project_paths(&settings);
     write_start_fresh_and_persist_to_dir_result(
         mgr,
         session_id,
@@ -1412,7 +1478,8 @@ pub async fn clear_start_fresh_and_persist_result(
     session_id: Uuid,
 ) -> Result<bool, String> {
     let dir = super::config_dir();
-    let project_paths = crate::config::settings::load_settings_for_cli().project_paths;
+    let settings = crate::config::settings::load_settings_for_cli();
+    let project_paths = session_retention_project_paths(&settings);
     write_start_fresh_and_persist_to_dir_result(
         mgr,
         session_id,
@@ -1453,12 +1520,14 @@ mod tests {
         load_sessions_raw_from_dir_for_test, persist_current_state_result,
         persist_current_state_to_dir_result, purge_sessions_outside_project_paths_in_dir,
         raise_hand_and_persist_to_dir_result, rename_with_retry, sanitize_failed_recoverable,
-        save_sessions_to_dir, sessions_save_lock, snapshot_sessions, strip_auto_injected_args,
-        working_directory_under_any_project_path, write_start_fresh_and_persist_to_dir_result,
-        PersistedSession, RaiseHandPersistOutcome, RENAME_ATTEMPTS,
+        save_sessions_to_dir, session_retention_project_paths, sessions_save_lock,
+        snapshot_sessions, strip_auto_injected_args, working_directory_under_any_project_path,
+        write_start_fresh_and_persist_to_dir_result, PersistedSession, RaiseHandPersistOutcome,
+        RENAME_ATTEMPTS,
     };
     #[cfg(windows)]
     use super::{deduplicate, load_sessions_from_path};
+    use crate::config::settings::AppSettings;
     use crate::session::manager::SessionManager;
     use crate::session::session::{SessionCommunication, SessionCommunicationKind, SessionStatus};
     use std::time::Duration;
@@ -2416,6 +2485,85 @@ mod tests {
         assert_eq!(filtered[0].name, "kept-coordinator");
     }
 
+    #[test]
+    fn session_retention_project_paths_includes_archived_paths() {
+        let settings = AppSettings {
+            project_paths: vec!["A".to_string()],
+            archived_project_paths: vec!["B".to_string()],
+            ..AppSettings::default()
+        };
+
+        assert_eq!(
+            session_retention_project_paths(&settings),
+            vec!["A".to_string(), "B".to_string()]
+        );
+    }
+
+    #[test]
+    fn filter_sessions_for_project_paths_keeps_archived_when_called_with_retention_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let active = temp.path().join("active");
+        let archived = temp.path().join("archived");
+        let orphan = temp.path().join("orphan");
+        let active_agent = active.join(".ac").join("wg-1").join("__agent_active");
+        let archived_agent = archived.join(".ac").join("wg-1").join("__agent_archived");
+        let orphan_agent = orphan.join(".ac").join("wg-1").join("__agent_orphan");
+        std::fs::create_dir_all(&active_agent).expect("create active agent");
+        std::fs::create_dir_all(&archived_agent).expect("create archived agent");
+        std::fs::create_dir_all(&orphan_agent).expect("create orphan agent");
+        let retention_paths = vec![
+            active.to_string_lossy().to_string(),
+            archived.to_string_lossy().to_string(),
+        ];
+        let sessions = vec![
+            PersistedSession {
+                name: "active".into(),
+                working_directory: active_agent.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+            PersistedSession {
+                name: "archived".into(),
+                working_directory: archived_agent.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+            PersistedSession {
+                name: "orphan".into(),
+                working_directory: orphan_agent.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let filtered = filter_sessions_for_project_paths(sessions, &retention_paths);
+
+        let names: Vec<&str> = filtered
+            .iter()
+            .map(|session| session.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["active", "archived"]);
+    }
+
+    #[test]
+    fn filter_sessions_for_project_paths_normalizes_roots_once() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("current");
+        let agent = project.join(".ac").join("wg-1").join("__agent_keep");
+        std::fs::create_dir_all(&agent).expect("create agent");
+        let root_with_dot = project.join(".");
+        let sessions = vec![PersistedSession {
+            name: "keep".into(),
+            working_directory: agent.to_string_lossy().to_string(),
+            ..Default::default()
+        }];
+
+        let filtered = filter_sessions_for_project_paths(
+            sessions,
+            &[root_with_dot.to_string_lossy().to_string()],
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "keep");
+    }
+
     #[tokio::test]
     async fn purge_sessions_outside_project_paths_rewrites_sessions_json() {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -2455,6 +2603,58 @@ mod tests {
         let rows: Vec<PersistedSession> = serde_json::from_str(&saved).expect("parse sessions");
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].name, "keep");
+    }
+
+    #[tokio::test]
+    async fn purge_sessions_outside_project_paths_keeps_archived_session_when_retention_paths_used()
+    {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let active = temp.path().join("active");
+        let archived = temp.path().join("archived");
+        let orphan = temp.path().join("orphan");
+        let active_agent = active.join(".ac").join("wg-1").join("__agent_active");
+        let archived_agent = archived.join(".ac").join("wg-1").join("__agent_archived");
+        let orphan_agent = orphan.join(".ac").join("wg-1").join("__agent_orphan");
+        std::fs::create_dir_all(&active_agent).expect("create active agent");
+        std::fs::create_dir_all(&archived_agent).expect("create archived agent");
+        std::fs::create_dir_all(&orphan_agent).expect("create orphan agent");
+        let sessions = vec![
+            PersistedSession {
+                name: "active".into(),
+                working_directory: active_agent.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+            PersistedSession {
+                name: "archived".into(),
+                working_directory: archived_agent.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+            PersistedSession {
+                name: "orphan".into(),
+                working_directory: orphan_agent.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+        ];
+        save_sessions_to_dir(temp.path(), &sessions).expect("seed sessions");
+        let retention_paths = vec![
+            active.to_string_lossy().to_string(),
+            archived.to_string_lossy().to_string(),
+        ];
+
+        let filtered = purge_sessions_outside_project_paths_in_dir(temp.path(), &retention_paths)
+            .await
+            .expect("purge sessions");
+
+        let names: Vec<&str> = filtered
+            .iter()
+            .map(|session| session.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["active", "archived"]);
+        let saved =
+            std::fs::read_to_string(temp.path().join("sessions.json")).expect("read sessions");
+        let rows: Vec<PersistedSession> = serde_json::from_str(&saved).expect("parse sessions");
+        let saved_names: Vec<&str> = rows.iter().map(|session| session.name.as_str()).collect();
+        assert_eq!(saved_names, vec!["active", "archived"]);
     }
 
     /// #698 grinch HIGH regression — the orphan purge must take

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -269,6 +269,11 @@ fn strip_long_prefix_str(s: &str) -> String {
     crate::path_utils::normalize_windows_verbatim_path(s)
 }
 
+#[cfg(test)]
+static FILTER_PROJECT_PATHS_THREAD_ID: std::sync::OnceLock<
+    std::sync::Mutex<Option<std::thread::ThreadId>>,
+> = std::sync::OnceLock::new();
+
 fn normalize_for_project_compare(path: &Path) -> String {
     let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     let mut s = strip_long_prefix_str(&path.to_string_lossy()).replace('\\', "/");
@@ -294,18 +299,27 @@ fn path_is_under_or_equal(candidate: &str, root: &str) -> bool {
     candidate.starts_with(&format!("{}/", root))
 }
 
+#[allow(dead_code)]
 pub(crate) fn working_directory_under_any_project_path(
     working_directory: &str,
     project_paths: &[String],
 ) -> bool {
     let cwd = normalize_for_project_compare(Path::new(working_directory));
-    let roots: Vec<String> = project_paths
+    let roots = normalize_project_roots(project_paths);
+    working_directory_under_any_normalized_root(&cwd, &roots)
+}
+
+/// #881: canonicalize a project-root list once. Blocking
+/// (`std::fs::canonicalize` per root). Hoist the call out of per-session or
+/// per-dir loops, and off the async runtime when the caller is on a poll
+/// interval. Empty input yields empty output with zero syscalls.
+pub(crate) fn normalize_project_roots(project_paths: &[String]) -> Vec<String> {
+    project_paths
         .iter()
         .map(|p| p.trim())
         .filter(|p| !p.is_empty())
         .map(|p| normalize_for_project_compare(Path::new(p)))
-        .collect();
-    working_directory_under_any_normalized_root(&cwd, &roots)
+        .collect()
 }
 
 fn working_directory_under_any_normalized_root(cwd: &str, roots: &[String]) -> bool {
@@ -325,16 +339,27 @@ pub(crate) fn session_retention_project_paths(
     paths
 }
 
-/// #881: true when `path` lives under one of `archived_project_paths`.
+/// #881: true when `path` lives under one of `normalized_archived_roots`,
+/// which the caller produced with `normalize_project_roots` once per poll tick,
+/// restore loop, or resolution.
 ///
-/// The empty-list fast path lives here because callers run on poll intervals
-/// and spawn paths. Do not reimplement it upstream.
+/// The empty-list fast path lives here, before `path` itself is canonicalized,
+/// so the common case of no archived projects pays zero syscalls.
+///
+/// Do not add a raw-root convenience wrapper. The per-root canonicalize must
+/// not hide inside a per-dir loop.
 #[allow(dead_code)]
-pub(crate) fn is_under_archived_project(path: &str, archived_project_paths: &[String]) -> bool {
-    if archived_project_paths.is_empty() {
+pub(crate) fn is_under_normalized_archived_roots(
+    path: &str,
+    normalized_archived_roots: &[String],
+) -> bool {
+    if normalized_archived_roots.is_empty() {
         return false;
     }
-    working_directory_under_any_project_path(path, archived_project_paths)
+    working_directory_under_any_normalized_root(
+        &normalize_for_project_compare(Path::new(path)),
+        normalized_archived_roots,
+    )
 }
 
 fn is_root_persisted_session(session: &PersistedSession) -> bool {
@@ -346,13 +371,23 @@ fn filter_sessions_for_project_paths(
     sessions: Vec<PersistedSession>,
     project_paths: &[String],
 ) -> Vec<PersistedSession> {
-    let total = sessions.len();
-    let roots: Vec<String> = project_paths
+    let roots = normalize_project_roots(project_paths);
+    filter_sessions_for_normalized_roots(sessions, &roots)
+}
+
+fn filter_sessions_for_normalized_roots(
+    sessions: Vec<PersistedSession>,
+    roots: &[String],
+) -> Vec<PersistedSession> {
+    #[cfg(test)]
+    if sessions
         .iter()
-        .map(|p| p.trim())
-        .filter(|p| !p.is_empty())
-        .map(|p| normalize_for_project_compare(Path::new(p)))
-        .collect();
+        .any(|session| session.name == "__panic_filter_for_test__")
+    {
+        panic!("test-only session filter panic");
+    }
+
+    let total = sessions.len();
     let filtered: Vec<PersistedSession> = sessions
         .into_iter()
         .filter(|session| {
@@ -360,7 +395,7 @@ fn filter_sessions_for_project_paths(
                 return true;
             }
             let cwd = normalize_for_project_compare(Path::new(&session.working_directory));
-            let keep = working_directory_under_any_normalized_root(&cwd, &roots);
+            let keep = working_directory_under_any_normalized_root(&cwd, roots);
             if !keep {
                 log::warn!(
                     "[sessions] Dropping orphan persisted session '{}' at '{}' (outside current projectPaths)",
@@ -382,12 +417,22 @@ fn filter_sessions_for_project_paths(
     filtered
 }
 
+#[cfg(test)]
+fn record_filter_project_paths_thread_id() {
+    let slot = FILTER_PROJECT_PATHS_THREAD_ID.get_or_init(|| std::sync::Mutex::new(None));
+    *slot.lock().expect("thread id mutex poisoned") = Some(std::thread::current().id());
+}
+
 async fn filter_sessions_for_project_paths_blocking(
     sessions: Vec<PersistedSession>,
     project_paths: &[String],
 ) -> Result<Vec<PersistedSession>, String> {
     let project_paths = project_paths.to_vec();
-    tokio::task::spawn_blocking(move || filter_sessions_for_project_paths(sessions, &project_paths))
+    tokio::task::spawn_blocking(move || {
+        #[cfg(test)]
+        record_filter_project_paths_thread_id();
+        filter_sessions_for_project_paths(sessions, &project_paths)
+    })
         .await
         .map_err(|e| format!("session filter task failed: {}", e))
 }
@@ -681,7 +726,14 @@ pub async fn load_sessions_purging_outside_project_paths(
         }
     };
 
-    match purge_sessions_outside_project_paths_in_dir(&dir, project_paths).await {
+    load_sessions_purging_outside_project_paths_in_dir(&dir, project_paths).await
+}
+
+async fn load_sessions_purging_outside_project_paths_in_dir(
+    dir: &Path,
+    project_paths: &[String],
+) -> Vec<PersistedSession> {
+    match purge_sessions_outside_project_paths_in_dir(dir, project_paths).await {
         Ok(filtered) => filtered,
         Err(e) => {
             log::error!(
@@ -692,7 +744,7 @@ pub async fn load_sessions_purging_outside_project_paths(
             // atomicity contract because nothing is written back. Restore
             // reconciles on the next persist.
             match filter_sessions_for_project_paths_blocking(
-                load_sessions_from_dir(&dir),
+                load_sessions_from_dir(dir),
                 project_paths,
             )
             .await
@@ -700,7 +752,7 @@ pub async fn load_sessions_purging_outside_project_paths(
                 Ok(filtered) => filtered,
                 Err(e) => {
                     log::error!("Failed to filter sessions after purge failure: {}", e);
-                    vec![]
+                    load_sessions_from_dir(dir)
                 }
             }
         }
@@ -1517,13 +1569,15 @@ async fn write_start_fresh_and_persist_to_dir_result(
 mod tests {
     use super::{
         clear_user_input_transitions_and_persist_to_dir_result, filter_sessions_for_project_paths,
-        load_sessions_raw_from_dir_for_test, persist_current_state_result,
+        filter_sessions_for_project_paths_blocking, filter_sessions_for_normalized_roots,
+        is_under_normalized_archived_roots, load_sessions_purging_outside_project_paths_in_dir,
+        load_sessions_raw_from_dir_for_test, normalize_project_roots, persist_current_state_result,
         persist_current_state_to_dir_result, purge_sessions_outside_project_paths_in_dir,
         raise_hand_and_persist_to_dir_result, rename_with_retry, sanitize_failed_recoverable,
         save_sessions_to_dir, session_retention_project_paths, sessions_save_lock,
         snapshot_sessions, strip_auto_injected_args, working_directory_under_any_project_path,
         write_start_fresh_and_persist_to_dir_result, PersistedSession, RaiseHandPersistOutcome,
-        RENAME_ATTEMPTS,
+        FILTER_PROJECT_PATHS_THREAD_ID, RENAME_ATTEMPTS,
     };
     #[cfg(windows)]
     use super::{deduplicate, load_sessions_from_path};
@@ -2500,6 +2554,60 @@ mod tests {
     }
 
     #[test]
+    fn is_under_normalized_archived_roots_returns_false_for_empty_roots() {
+        assert!(!is_under_normalized_archived_roots(
+            "Z:/does/not/exist/.ac/wg-1/__agent_dev",
+            &[]
+        ));
+    }
+
+    #[test]
+    fn is_under_normalized_archived_roots_matches_nested_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let archived = temp.path().join("archived");
+        let agent = archived.join(".ac").join("wg-1").join("__agent_dev");
+        std::fs::create_dir_all(&agent).expect("create archived agent");
+        let roots = normalize_project_roots(&[archived.to_string_lossy().to_string()]);
+
+        assert!(is_under_normalized_archived_roots(
+            &agent.to_string_lossy(),
+            &roots
+        ));
+    }
+
+    #[test]
+    fn is_under_normalized_archived_roots_ignores_unnormalized_roots() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let archived = temp.path().join("archived");
+        let agent = archived.join(".ac").join("wg-1").join("__agent_dev");
+        std::fs::create_dir_all(&agent).expect("create archived agent");
+        let raw_root = archived.join(".").to_string_lossy().to_string();
+
+        assert!(!is_under_normalized_archived_roots(
+            &agent.to_string_lossy(),
+            &[raw_root]
+        ));
+    }
+
+    #[test]
+    fn normalize_project_roots_drops_blank_entries_and_normalizes_each() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("current");
+        std::fs::create_dir_all(&project).expect("create project");
+        let root_with_dot = project.join(".");
+        let roots = normalize_project_roots(&[
+            "".to_string(),
+            "  ".to_string(),
+            root_with_dot.to_string_lossy().to_string(),
+        ]);
+
+        assert_eq!(
+            roots,
+            vec![super::normalize_for_project_compare(project.as_path())]
+        );
+    }
+
+    #[test]
     fn filter_sessions_for_project_paths_keeps_archived_when_called_with_retention_paths() {
         let temp = tempfile::tempdir().expect("tempdir");
         let active = temp.path().join("active");
@@ -2543,7 +2651,7 @@ mod tests {
     }
 
     #[test]
-    fn filter_sessions_for_project_paths_normalizes_roots_once() {
+    fn filter_sessions_for_project_paths_matches_root_with_dot_segment() {
         let temp = tempfile::tempdir().expect("tempdir");
         let project = temp.path().join("current");
         let agent = project.join(".ac").join("wg-1").join("__agent_keep");
@@ -2562,6 +2670,121 @@ mod tests {
 
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].name, "keep");
+    }
+
+    #[test]
+    fn filter_sessions_for_normalized_roots_does_not_normalize_its_roots() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("current");
+        let agent = project.join(".ac").join("wg-1").join("__agent_drop");
+        std::fs::create_dir_all(&agent).expect("create agent");
+        let raw_root = project.join(".").to_string_lossy().to_string();
+        let sessions = vec![PersistedSession {
+            name: "drop".into(),
+            working_directory: agent.to_string_lossy().to_string(),
+            ..Default::default()
+        }];
+
+        let filtered = filter_sessions_for_normalized_roots(sessions, &[raw_root]);
+
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn filter_sessions_for_project_paths_normalizes_its_roots() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("current");
+        let agent = project.join(".ac").join("wg-1").join("__agent_keep");
+        std::fs::create_dir_all(&agent).expect("create agent");
+        let raw_root = project.join(".").to_string_lossy().to_string();
+        let sessions = vec![PersistedSession {
+            name: "keep".into(),
+            working_directory: agent.to_string_lossy().to_string(),
+            ..Default::default()
+        }];
+
+        let filtered = filter_sessions_for_project_paths(sessions, &[raw_root]);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "keep");
+    }
+
+    #[tokio::test]
+    async fn filter_sessions_for_project_paths_blocking_runs_off_the_calling_thread() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("current");
+        let agent = project.join(".ac").join("wg-1").join("__agent_keep");
+        std::fs::create_dir_all(&agent).expect("create agent");
+        let calling_thread = std::thread::current().id();
+        let slot = FILTER_PROJECT_PATHS_THREAD_ID
+            .get_or_init(|| std::sync::Mutex::new(None));
+        *slot.lock().expect("thread id mutex poisoned") = None;
+
+        let filtered = filter_sessions_for_project_paths_blocking(
+            vec![PersistedSession {
+                name: "keep".into(),
+                working_directory: agent.to_string_lossy().to_string(),
+                ..Default::default()
+            }],
+            &[project.to_string_lossy().to_string()],
+        )
+        .await
+        .expect("filter sessions");
+        let worker_thread = slot
+            .lock()
+            .expect("thread id mutex poisoned")
+            .expect("worker thread id recorded");
+
+        assert_eq!(filtered.len(), 1);
+        assert_ne!(worker_thread, calling_thread);
+    }
+
+    #[tokio::test]
+    async fn filter_sessions_for_project_paths_blocking_surfaces_join_error() {
+        let result = filter_sessions_for_project_paths_blocking(
+            vec![PersistedSession {
+                name: "__panic_filter_for_test__".into(),
+                working_directory: "C:/projects/current/.ac/wg-1/__agent_dev".into(),
+                ..Default::default()
+            }],
+            &["C:/projects/current".to_string()],
+        )
+        .await;
+
+        let Err(err) = result else {
+            panic!("worker panic must surface as JoinError");
+        };
+        assert!(err.contains("session filter task failed"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn load_sessions_purging_outside_project_paths_returns_unfiltered_on_filter_error() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let keep = PersistedSession {
+            name: "__panic_filter_for_test__".into(),
+            working_directory: "C:/projects/current/.ac/wg-1/__agent_dev".into(),
+            ..Default::default()
+        };
+        let other = PersistedSession {
+            name: "other".into(),
+            working_directory: "C:/projects/other/.ac/wg-1/__agent_other".into(),
+            ..Default::default()
+        };
+        save_sessions_to_dir(temp.path(), &[keep.clone(), other.clone()]).expect("seed sessions");
+
+        let loaded = load_sessions_purging_outside_project_paths_in_dir(
+            temp.path(),
+            &["C:/projects/current".to_string()],
+        )
+        .await;
+
+        let names: Vec<&str> = loaded
+            .iter()
+            .map(|session| session.name.as_str())
+            .collect();
+        assert_eq!(names, vec![keep.name.as_str(), other.name.as_str()]);
+        let saved = load_sessions_raw_from_dir_for_test(temp.path());
+        assert_eq!(saved.len(), 2);
     }
 
     #[tokio::test]

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -270,11 +270,18 @@ fn strip_long_prefix_str(s: &str) -> String {
 }
 
 #[cfg(test)]
-static FILTER_PROJECT_PATHS_THREAD_ID: std::sync::OnceLock<
-    std::sync::Mutex<Option<std::thread::ThreadId>>,
+static FILTER_PROJECT_PATHS_THREAD_IDS: std::sync::OnceLock<
+    std::sync::Mutex<Vec<std::thread::ThreadId>>,
 > = std::sync::OnceLock::new();
 
+#[cfg(test)]
+thread_local! {
+    static NORMALIZE_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 fn normalize_for_project_compare(path: &Path) -> String {
+    #[cfg(test)]
+    NORMALIZE_CALLS.with(|calls| calls.set(calls.get() + 1));
     let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     let mut s = strip_long_prefix_str(&path.to_string_lossy()).replace('\\', "/");
     while s.ends_with('/') && s.len() > 1 {
@@ -299,6 +306,12 @@ fn path_is_under_or_equal(candidate: &str, root: &str) -> bool {
     candidate.starts_with(&format!("{}/", root))
 }
 
+/// Raw-root convenience for active project lists that are checked once, such
+/// as `archive_session_blockers`.
+///
+/// Do not call this with `archived_project_paths` or inside a per-dir loop.
+/// In those paths, normalize roots once with `normalize_project_roots` and use
+/// the normalized helpers.
 #[allow(dead_code)]
 pub(crate) fn working_directory_under_any_project_path(
     working_directory: &str,
@@ -419,8 +432,10 @@ fn filter_sessions_for_normalized_roots(
 
 #[cfg(test)]
 fn record_filter_project_paths_thread_id() {
-    let slot = FILTER_PROJECT_PATHS_THREAD_ID.get_or_init(|| std::sync::Mutex::new(None));
-    *slot.lock().expect("thread id mutex poisoned") = Some(std::thread::current().id());
+    let slot = FILTER_PROJECT_PATHS_THREAD_IDS.get_or_init(|| std::sync::Mutex::new(Vec::new()));
+    slot.lock()
+        .expect("thread id mutex poisoned")
+        .push(std::thread::current().id());
 }
 
 async fn filter_sessions_for_project_paths_blocking(
@@ -433,8 +448,8 @@ async fn filter_sessions_for_project_paths_blocking(
         record_filter_project_paths_thread_id();
         filter_sessions_for_project_paths(sessions, &project_paths)
     })
-        .await
-        .map_err(|e| format!("session filter task failed: {}", e))
+    .await
+    .map_err(|e| format!("session filter task failed: {}", e))
 }
 
 /// Remove duplicate sessions by name AND working_directory.
@@ -1568,16 +1583,17 @@ async fn write_start_fresh_and_persist_to_dir_result(
 #[cfg(test)]
 mod tests {
     use super::{
-        clear_user_input_transitions_and_persist_to_dir_result, filter_sessions_for_project_paths,
-        filter_sessions_for_project_paths_blocking, filter_sessions_for_normalized_roots,
-        is_under_normalized_archived_roots, load_sessions_purging_outside_project_paths_in_dir,
-        load_sessions_raw_from_dir_for_test, normalize_project_roots, persist_current_state_result,
-        persist_current_state_to_dir_result, purge_sessions_outside_project_paths_in_dir,
-        raise_hand_and_persist_to_dir_result, rename_with_retry, sanitize_failed_recoverable,
-        save_sessions_to_dir, session_retention_project_paths, sessions_save_lock,
-        snapshot_sessions, strip_auto_injected_args, working_directory_under_any_project_path,
+        clear_user_input_transitions_and_persist_to_dir_result,
+        filter_sessions_for_normalized_roots, filter_sessions_for_project_paths,
+        filter_sessions_for_project_paths_blocking, is_under_normalized_archived_roots,
+        load_sessions_purging_outside_project_paths_in_dir, load_sessions_raw_from_dir_for_test,
+        normalize_project_roots, persist_current_state_result, persist_current_state_to_dir_result,
+        purge_sessions_outside_project_paths_in_dir, raise_hand_and_persist_to_dir_result,
+        rename_with_retry, sanitize_failed_recoverable, save_sessions_to_dir,
+        session_retention_project_paths, sessions_save_lock, snapshot_sessions,
+        strip_auto_injected_args, working_directory_under_any_project_path,
         write_start_fresh_and_persist_to_dir_result, PersistedSession, RaiseHandPersistOutcome,
-        FILTER_PROJECT_PATHS_THREAD_ID, RENAME_ATTEMPTS,
+        FILTER_PROJECT_PATHS_THREAD_IDS, NORMALIZE_CALLS, RENAME_ATTEMPTS,
     };
     #[cfg(windows)]
     use super::{deduplicate, load_sessions_from_path};
@@ -2562,6 +2578,22 @@ mod tests {
     }
 
     #[test]
+    fn is_under_normalized_archived_roots_short_circuits_before_canonicalizing_path() {
+        NORMALIZE_CALLS.with(|calls| calls.set(0));
+
+        assert!(!is_under_normalized_archived_roots(
+            "Z:/does/not/exist/x",
+            &[]
+        ));
+
+        assert_eq!(
+            NORMALIZE_CALLS.with(|calls| calls.get()),
+            0,
+            "empty archived roots must not canonicalize path"
+        );
+    }
+
+    #[test]
     fn is_under_normalized_archived_roots_matches_nested_dir() {
         let temp = tempfile::tempdir().expect("tempdir");
         let archived = temp.path().join("archived");
@@ -2716,9 +2748,9 @@ mod tests {
         let agent = project.join(".ac").join("wg-1").join("__agent_keep");
         std::fs::create_dir_all(&agent).expect("create agent");
         let calling_thread = std::thread::current().id();
-        let slot = FILTER_PROJECT_PATHS_THREAD_ID
-            .get_or_init(|| std::sync::Mutex::new(None));
-        *slot.lock().expect("thread id mutex poisoned") = None;
+        let slot =
+            FILTER_PROJECT_PATHS_THREAD_IDS.get_or_init(|| std::sync::Mutex::new(Vec::new()));
+        slot.lock().expect("thread id mutex poisoned").clear();
 
         let filtered = filter_sessions_for_project_paths_blocking(
             vec![PersistedSession {
@@ -2730,13 +2762,14 @@ mod tests {
         )
         .await
         .expect("filter sessions");
-        let worker_thread = slot
-            .lock()
-            .expect("thread id mutex poisoned")
-            .expect("worker thread id recorded");
+        let recorded = slot.lock().expect("thread id mutex poisoned").clone();
 
         assert_eq!(filtered.len(), 1);
-        assert_ne!(worker_thread, calling_thread);
+        assert!(!recorded.is_empty(), "filter thread id should be recorded");
+        assert!(
+            !recorded.contains(&calling_thread),
+            "filter ran on the calling thread"
+        );
     }
 
     #[tokio::test]
@@ -2778,10 +2811,7 @@ mod tests {
         )
         .await;
 
-        let names: Vec<&str> = loaded
-            .iter()
-            .map(|session| session.name.as_str())
-            .collect();
+        let names: Vec<&str> = loaded.iter().map(|session| session.name.as_str()).collect();
         assert_eq!(names, vec![keep.name.as_str(), other.name.as_str()]);
         let saved = load_sessions_raw_from_dir_for_test(temp.path());
         assert_eq!(saved.len(), 2);

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1956,6 +1956,11 @@ fn read_project_paths_from_disk(path: &Path) -> Result<Option<DiskProjectLists>,
     })?;
     let project_paths = match value.get("projectPaths") {
         None | Some(serde_json::Value::Null) => return Ok(None),
+        // #881: non-string elements are dropped here, but rejected in the
+        // archivedProjectPaths arm below. Deliberate. `projectPaths` only feeds
+        // discovery; `archivedProjectPaths` feeds session retention, where a
+        // silently-emptied list deletes sessions. Tightening this one is
+        // #888's call, not #881's.
         Some(serde_json::Value::Array(arr)) => arr
             .iter()
             .filter_map(|x| x.as_str().map(str::to_string))
@@ -1974,11 +1979,24 @@ fn read_project_paths_from_disk(path: &Path) -> Result<Option<DiskProjectLists>,
         .map(str::to_string);
     let archived_project_paths = match value.get("archivedProjectPaths") {
         None | Some(serde_json::Value::Null) => None,
-        Some(serde_json::Value::Array(arr)) => Some(
-            arr.iter()
-                .filter_map(|x| x.as_str().map(str::to_string))
-                .collect::<Vec<_>>(),
-        ),
+        Some(serde_json::Value::Array(arr)) => {
+            // #881 R2-G5: a non-string element is corruption, not an entry to
+            // skip. The `projectPaths` arm above silently drops non-strings;
+            // do not copy that here. `[123]` would read as `Some(vec![])`,
+            // meaning disk authoritatively says nothing is archived.
+            let mut archived = Vec::with_capacity(arr.len());
+            for item in arr {
+                let Some(archived_path) = item.as_str() else {
+                    return Err(format!(
+                        "{}: archivedProjectPaths contains {}, not a string (aborting save)",
+                        path.display(),
+                        item
+                    ));
+                };
+                archived.push(archived_path.to_string());
+            }
+            Some(archived)
+        }
         Some(other) => {
             return Err(format!(
                 "{}: archivedProjectPaths is {}, not an array (aborting save)",
@@ -3639,6 +3657,38 @@ mod tests {
     }
 
     #[test]
+    fn read_project_paths_from_disk_aborts_when_archived_list_has_non_string_element() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"projectPaths":["C:/a"],"archivedProjectPaths":["C:/old",123]}"#,
+        )
+        .unwrap();
+
+        assert!(super::read_project_paths_from_disk(&path).is_err());
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_drops_non_string_project_path_elements() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"projectPaths":["C:/a",123],"archivedProjectPaths":["C:/old"]}"#,
+        )
+        .unwrap();
+
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+
+        assert_eq!(lists.project_paths, vec!["C:/a".to_string()]);
+        assert_eq!(
+            lists.archived_project_paths,
+            Some(vec!["C:/old".to_string()])
+        );
+    }
+
+    #[test]
     fn read_project_paths_from_disk_aborts_on_unparseable_json() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("settings.json");
@@ -3745,10 +3795,11 @@ mod tests {
     }
 
     #[test]
-    fn save_settings_returns_candidate_archived_list_when_disk_key_absent() {
+    fn save_settings_returns_caller_archived_list_when_disk_key_absent() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("settings.json");
         std::fs::write(&path, r#"{"projectPaths":["A"],"projectPath":"A"}"#).unwrap();
+        let caller_archived = vec!["Archived".to_string()];
         let candidate = settings_with_project_and_archived_paths(&["stale"], &["Archived"]);
 
         let written =
@@ -3758,11 +3809,8 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(written.project_paths, vec!["A".to_string()]);
         assert_eq!(written.project_path.as_deref(), Some("A"));
-        assert_eq!(written.archived_project_paths, vec!["Archived".to_string()]);
-        assert_eq!(
-            reloaded.archived_project_paths,
-            vec!["Archived".to_string()]
-        );
+        assert_eq!(written.archived_project_paths, caller_archived);
+        assert_eq!(reloaded.archived_project_paths, caller_archived);
     }
 
     #[test]

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -397,6 +397,11 @@ pub struct AppSettings {
     /// Currently loaded project paths (multi-project support)
     #[serde(default)]
     pub project_paths: Vec<String>,
+    /// #881 - projects hidden from the sidebar but still registered. Disk-authoritative
+    /// under the same Design S rules as `project_paths`: the default `save_settings`
+    /// preserves the on-disk copy and only dedicated list commands mutate it.
+    #[serde(default)]
+    pub archived_project_paths: Vec<String>,
     /// Sidebar visual style: "noir-minimal", "card-sections", "command-center", "deep-space", "arctic-ops", "obsidian-mesh", "neon-circuit"
     #[serde(default = "default_sidebar_style")]
     pub sidebar_style: String,
@@ -682,6 +687,7 @@ impl Default for AppSettings {
             api_server_bind: default_api_bind(),
             project_path: None,
             project_paths: vec![],
+            archived_project_paths: vec![],
             sidebar_style: default_sidebar_style(),
             root_token: None,
             onboarding_dismissed: false,
@@ -1882,13 +1888,23 @@ pub fn read_log_level_only() -> Option<String> {
 /// counter so the two can be reasoned about independently in diagnostics.
 static SAVE_OP_ID: AtomicU64 = AtomicU64::new(0);
 
-type DiskProjectPaths = (Vec<String>, Option<String>);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiskProjectLists {
+    pub project_paths: Vec<String>,
+    pub project_path: Option<String>,
+    pub archived_project_paths: Option<Vec<String>>,
+}
 
-/// #778: side-effect-free reader of ONLY `project_paths`/`project_path` from
-/// `settings.json` on disk. Under Design S `project_paths` is disk-authoritative,
+/// #778/#881: side-effect-free reader of ONLY the project lists from
+/// `settings.json` on disk. Under Design S those lists are disk-authoritative,
 /// so the default `save_settings` uses this to preserve whatever another process
-/// (a CLI verb, a second instance) wrote, and the add/remove commands use it to
+/// (a CLI verb, a second instance) wrote, and the list commands use it to
 /// reconcile before a deliberate mutation.
+///
+/// The outer `Option` means no disk truth at all: the file is absent, or
+/// `projectPaths` is absent/null. `archived_project_paths` has its own inner
+/// `Option`: absent/null means no disk truth for that list only, while
+/// `Some(vec![])` means disk explicitly says nothing is archived.
 ///
 /// Error policy (grinch G2): a genuine `NotFound` yields `None` (fresh install:
 /// no disk truth to substitute). ANY other error (a transient os 5/32/33/1175
@@ -1904,7 +1920,7 @@ type DiskProjectPaths = (Vec<String>, Option<String>);
 /// so the later `MoveFileEx` rename cannot hit a sharing violation (os 32).
 /// MUST NOT call `load_settings` (it migrates, generates root_token, and
 /// re-saves: infinite recursion + side effects).
-fn read_project_paths_from_disk(path: &Path) -> Result<Option<DiskProjectPaths>, String> {
+fn read_project_paths_from_disk(path: &Path) -> Result<Option<DiskProjectLists>, String> {
     // 1 initial attempt + up to 2 retries on a transient (non-NotFound) read error.
     const READ_RETRY_BACKOFFS_MS: [u64; 2] = [10, 40];
     let mut attempt = 0usize;
@@ -1956,11 +1972,31 @@ fn read_project_paths_from_disk(path: &Path) -> Result<Option<DiskProjectPaths>,
         .get("projectPath")
         .and_then(|v| v.as_str())
         .map(str::to_string);
-    Ok(Some((project_paths, project_path)))
+    let archived_project_paths = match value.get("archivedProjectPaths") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::Array(arr)) => Some(
+            arr.iter()
+                .filter_map(|x| x.as_str().map(str::to_string))
+                .collect::<Vec<_>>(),
+        ),
+        Some(other) => {
+            return Err(format!(
+                "{}: archivedProjectPaths is {}, not an array (aborting save)",
+                path.display(),
+                other
+            ));
+        }
+    };
+    Ok(Some(DiskProjectLists {
+        project_paths,
+        project_path,
+        archived_project_paths,
+    }))
 }
 
-/// #778: overwrite `settings`' in-memory project list with the disk-authoritative
-/// one. The deliberate list mutators (`open_project`/`new_project`/`remove_project`)
+/// #778/#881: overwrite `settings`' in-memory project lists with the
+/// disk-authoritative ones. The deliberate list mutators
+/// (`open_project`/`new_project`/`remove_project`)
 /// call this under the `SettingsState` write lock BEFORE they add/remove, so a
 /// concurrent CLI append is reconciled into the list rather than clobbered by the
 /// following verbatim write. Aborts (propagates `Err`) on a non-`NotFound` read
@@ -1976,20 +2012,24 @@ pub(crate) fn refresh_project_paths_from_path(
     settings: &mut AppSettings,
     path: &Path,
 ) -> Result<(), String> {
-    if let Some((project_paths, project_path)) = read_project_paths_from_disk(path)? {
-        settings.project_paths = project_paths;
-        settings.project_path = project_path;
+    if let Some(lists) = read_project_paths_from_disk(path)? {
+        settings.project_paths = lists.project_paths;
+        settings.project_path = lists.project_path;
+        if let Some(archived) = lists.archived_project_paths {
+            settings.archived_project_paths = archived;
+        }
     }
     Ok(())
 }
 
 /// Save settings to the app config directory (see config_dir()).
 ///
-/// #778: this is the DEFAULT writer and treats `project_paths` as
+/// #778/#881: this is the DEFAULT writer and treats the project lists as
 /// disk-authoritative (Design S). It preserves whatever `project_paths`/
-/// `project_path` is currently on disk and discards this (possibly stale)
+/// `project_path`/`archived_project_paths` is currently on disk and discards this
+/// (possibly stale)
 /// in-memory candidate's copy, so ANY whole-object GUI save is fail-safe for the
-/// project list: a project a CLI verb registered while the GUI ran is never
+/// project lists: a project a CLI verb registered while the GUI ran is never
 /// clobbered. Deliberate list changes (the add/remove commands, the CLI verbs,
 /// the startup root_token/migration write) go through
 /// `save_settings_with_project_paths` instead.
@@ -1997,7 +2037,7 @@ pub(crate) fn refresh_project_paths_from_path(
 /// The underlying write is the #774-hardened atomic tmp+rename
 /// (`save_settings_to_path`): a per-writer unique temp plus
 /// `sessions_persistence::rename_with_retry`. The disk read that preserves
-/// `project_paths` runs first and closes its handle before that write (G4a).
+/// project lists runs first and closes its handle before that write (G4a).
 ///
 /// G4b (accepted, documented): a remove/add racing another writer within the
 /// sub-millisecond window between this preserve-read and the rename could
@@ -2010,7 +2050,8 @@ pub fn save_settings(settings: &AppSettings) -> Result<AppSettings, String> {
     save_settings_to_path_preserving_project_paths(settings, &path)
 }
 
-/// #778: EXPLICIT writer. Persists `project_paths`/`project_path` VERBATIM (the
+/// #778/#881: EXPLICIT writer. Persists `project_paths`/`project_path` and
+/// `archived_project_paths` VERBATIM (the
 /// pre-#778 `save_settings` behavior, still #774-hardened). ONLY for deliberate
 /// list mutators that have already reconciled the list against disk: the add
 /// commands (`open_project`/`new_project`), the `remove_project` command, the two
@@ -2029,8 +2070,8 @@ pub(crate) fn save_settings_with_project_paths_to_path(
     save_settings_to_path(settings, path)
 }
 
-/// #778: the preserve-disk wrapper behind the default `save_settings`. Reads the
-/// current on-disk `project_paths`/`project_path` (G2 abort policy), substitutes
+/// #778/#881: the preserve-disk wrapper behind the default `save_settings`.
+/// Reads the current on-disk project lists (G2 abort policy), substitutes
 /// them into a clone of `settings`, then hands off to the verbatim
 /// #774-hardened writer. Split out with an explicit `path` so tests can drive it
 /// against a `tempfile::tempdir()`.
@@ -2039,9 +2080,12 @@ pub(crate) fn save_settings_to_path_preserving_project_paths(
     path: &Path,
 ) -> Result<AppSettings, String> {
     let mut to_write = settings.clone();
-    if let Some((disk_paths, disk_head)) = read_project_paths_from_disk(path)? {
-        to_write.project_paths = disk_paths;
-        to_write.project_path = disk_head;
+    if let Some(lists) = read_project_paths_from_disk(path)? {
+        to_write.project_paths = lists.project_paths;
+        to_write.project_path = lists.project_path;
+        if let Some(archived) = lists.archived_project_paths {
+            to_write.archived_project_paths = archived;
+        }
     }
     save_settings_to_path(&to_write, path)?;
     Ok(to_write)
@@ -3455,15 +3499,27 @@ mod tests {
         }
     }
 
+    fn settings_with_project_and_archived_paths(paths: &[&str], archived: &[&str]) -> AppSettings {
+        AppSettings {
+            project_paths: paths.iter().map(|p| p.to_string()).collect(),
+            project_path: paths.first().map(|p| p.to_string()),
+            archived_project_paths: archived.iter().map(|p| p.to_string()).collect(),
+            ..AppSettings::default()
+        }
+    }
+
     #[test]
     fn read_project_paths_from_disk_returns_list_and_head() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("settings.json");
         super::save_settings_to_path(&settings_with_project_paths(&["C:/a", "C:/b"]), &path)
             .unwrap();
-        let (paths, head) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
-        assert_eq!(paths, vec!["C:/a".to_string(), "C:/b".to_string()]);
-        assert_eq!(head.as_deref(), Some("C:/a"));
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+        assert_eq!(
+            lists.project_paths,
+            vec!["C:/a".to_string(), "C:/b".to_string()]
+        );
+        assert_eq!(lists.project_path.as_deref(), Some("C:/a"));
     }
 
     #[test]
@@ -3503,9 +3559,83 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("settings.json");
         std::fs::write(&path, r#"{"projectPaths":[]}"#).unwrap();
-        let (paths, head) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
-        assert!(paths.is_empty());
-        assert_eq!(head, None);
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+        assert!(lists.project_paths.is_empty());
+        assert_eq!(lists.project_path, None);
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_returns_archived_list() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        super::save_settings_to_path(
+            &settings_with_project_and_archived_paths(&["C:/a"], &["C:/old"]),
+            &path,
+        )
+        .unwrap();
+
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+
+        assert_eq!(
+            lists.archived_project_paths,
+            Some(vec!["C:/old".to_string()])
+        );
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_returns_archived_none_when_key_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(&path, r#"{"projectPaths":["C:/a"],"projectPath":"C:/a"}"#).unwrap();
+
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+
+        assert_eq!(lists.project_paths, vec!["C:/a".to_string()]);
+        assert_eq!(lists.project_path.as_deref(), Some("C:/a"));
+        assert_eq!(lists.archived_project_paths, None);
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_returns_archived_none_when_key_null() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"projectPaths":["C:/a"],"archivedProjectPaths":null}"#,
+        )
+        .unwrap();
+
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+
+        assert_eq!(lists.archived_project_paths, None);
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_returns_archived_some_empty_when_key_is_empty_list() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"projectPaths":["C:/a"],"archivedProjectPaths":[]}"#,
+        )
+        .unwrap();
+
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+
+        assert_eq!(lists.archived_project_paths, Some(vec![]));
+    }
+
+    #[test]
+    fn read_project_paths_from_disk_aborts_when_archived_key_wrong_type() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"projectPaths":["C:/a"],"archivedProjectPaths":"C:/old"}"#,
+        )
+        .unwrap();
+
+        assert!(super::read_project_paths_from_disk(&path).is_err());
     }
 
     #[test]
@@ -3554,14 +3684,114 @@ mod tests {
     }
 
     #[test]
+    fn refresh_project_paths_from_path_keeps_live_archived_list_when_key_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(&path, r#"{"projectPaths":["A"],"projectPath":"A"}"#).unwrap();
+        let mut settings = settings_with_project_and_archived_paths(&["stale"], &["Archived"]);
+
+        super::refresh_project_paths_from_path(&mut settings, &path).unwrap();
+
+        assert_eq!(settings.project_paths, vec!["A".to_string()]);
+        assert_eq!(settings.project_path.as_deref(), Some("A"));
+        assert_eq!(
+            settings.archived_project_paths,
+            vec!["Archived".to_string()]
+        );
+    }
+
+    #[test]
+    fn refresh_project_paths_from_path_clears_archived_list_when_disk_says_empty() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"projectPaths":["A"],"projectPath":"A","archivedProjectPaths":[]}"#,
+        )
+        .unwrap();
+        let mut settings = settings_with_project_and_archived_paths(&["stale"], &["Archived"]);
+
+        super::refresh_project_paths_from_path(&mut settings, &path).unwrap();
+
+        assert_eq!(settings.project_paths, vec!["A".to_string()]);
+        assert_eq!(settings.project_path.as_deref(), Some("A"));
+        assert!(settings.archived_project_paths.is_empty());
+    }
+
+    #[test]
+    fn save_settings_preserves_disk_archived_list() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        super::save_settings_to_path(
+            &settings_with_project_and_archived_paths(&["A"], &["ArchivedA"]),
+            &path,
+        )
+        .unwrap();
+        let candidate = settings_with_project_and_archived_paths(&["A"], &["ArchivedB"]);
+
+        let written =
+            super::save_settings_to_path_preserving_project_paths(&candidate, &path).unwrap();
+
+        let reloaded: AppSettings =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            reloaded.archived_project_paths,
+            vec!["ArchivedA".to_string()]
+        );
+        assert_eq!(
+            written.archived_project_paths,
+            reloaded.archived_project_paths
+        );
+    }
+
+    #[test]
+    fn save_settings_returns_candidate_archived_list_when_disk_key_absent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(&path, r#"{"projectPaths":["A"],"projectPath":"A"}"#).unwrap();
+        let candidate = settings_with_project_and_archived_paths(&["stale"], &["Archived"]);
+
+        let written =
+            super::save_settings_to_path_preserving_project_paths(&candidate, &path).unwrap();
+
+        let reloaded: AppSettings =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(written.project_paths, vec!["A".to_string()]);
+        assert_eq!(written.project_path.as_deref(), Some("A"));
+        assert_eq!(written.archived_project_paths, vec!["Archived".to_string()]);
+        assert_eq!(
+            reloaded.archived_project_paths,
+            vec!["Archived".to_string()]
+        );
+    }
+
+    #[test]
     fn save_settings_with_project_paths_writes_verbatim() {
         // The explicit writer persists the in-memory list as-is (deliberate mutation).
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("settings.json");
         super::save_settings_to_path(&settings_with_project_paths(&["A"]), &path).unwrap();
         super::save_settings_to_path(&settings_with_project_paths(&["A", "Y"]), &path).unwrap();
-        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
-        assert_eq!(paths, vec!["A".to_string(), "Y".to_string()]);
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+        assert_eq!(lists.project_paths, vec!["A".to_string(), "Y".to_string()]);
+    }
+
+    #[test]
+    fn save_settings_with_project_paths_writes_archived_verbatim() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        super::save_settings_with_project_paths_to_path(
+            &settings_with_project_and_archived_paths(&["A"], &["Archived"]),
+            &path,
+        )
+        .unwrap();
+
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+
+        assert_eq!(
+            lists.archived_project_paths,
+            Some(vec!["Archived".to_string()])
+        );
     }
 
     #[test]
@@ -3582,8 +3812,8 @@ mod tests {
             &path,
         )
         .unwrap();
-        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
-        assert_eq!(paths, vec!["A".to_string()]);
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+        assert_eq!(lists.project_paths, vec!["A".to_string()]);
     }
 
     #[test]
@@ -3595,15 +3825,15 @@ mod tests {
         super::save_settings_to_path(&settings_with_project_paths(&["A", "X"]), &path).unwrap();
 
         let mut s = settings_with_project_paths(&["A"]); // stale in-memory
-        let (disk_paths, disk_head) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
-        s.project_paths = disk_paths;
-        s.project_path = disk_head; // reconciled to [A, X]
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+        s.project_paths = lists.project_paths;
+        s.project_path = lists.project_path; // reconciled to [A, X]
         assert!(crate::config::projects::remove_project_path(&mut s, "A"));
         super::save_settings_to_path(&s, &path).unwrap(); // verbatim
 
-        let (paths, head) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
-        assert_eq!(paths, vec!["X".to_string()]); // A gone, X preserved
-        assert_eq!(head.as_deref(), Some("X"));
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+        assert_eq!(lists.project_paths, vec!["X".to_string()]); // A gone, X preserved
+        assert_eq!(lists.project_path.as_deref(), Some("X"));
     }
 
     #[test]
@@ -3615,16 +3845,16 @@ mod tests {
         super::save_settings_to_path(&settings_with_project_paths(&["A", "X"]), &path).unwrap();
 
         let mut s = settings_with_project_paths(&["A"]); // stale
-        let (disk_paths, disk_head) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
-        s.project_paths = disk_paths;
-        s.project_path = disk_head; // [A, X]
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+        s.project_paths = lists.project_paths;
+        s.project_path = lists.project_path; // [A, X]
         s.project_paths.push("Y".to_string()); // stand-in for register upsert
         s.project_path = s.project_paths.first().cloned();
         super::save_settings_to_path(&s, &path).unwrap();
 
-        let (paths, _) = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
         assert_eq!(
-            paths,
+            lists.project_paths,
             vec!["A".to_string(), "X".to_string(), "Y".to_string()]
         );
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -815,9 +815,11 @@ pub fn run(
             // run-event handler. The lock is uncontended at this point (the
             // mailbox poller and other writers start below), so it returns
             // immediately.
+            let restore_session_paths =
+                sessions_persistence::session_retention_project_paths(&restore_settings_snapshot);
             let persisted = tauri::async_runtime::block_on(
                 sessions_persistence::load_sessions_purging_outside_project_paths(
-                    &restore_settings_snapshot.project_paths,
+                    &restore_session_paths,
                 ),
             );
             let restore_flag = app

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2414,6 +2414,27 @@ mod tests {
             .expect("web and api server handles must be distinct managed types");
     }
 
+    #[test]
+    fn restore_loop_normalizes_archived_roots_before_persisted_session_loop() {
+        let source = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lib.rs"))
+            .expect("read lib.rs");
+        let production = source
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .expect("production lib source");
+        let hoist = production
+            .find("let archived_roots = sessions_persistence::normalize_project_roots")
+            .expect("archived root normalization");
+        let loop_start = production
+            .find("for ps in &persisted")
+            .expect("persisted session loop");
+
+        assert!(
+            hoist < loop_start,
+            "startup restore must normalize archived roots once before the session loop"
+        );
+    }
+
     #[tokio::test]
     async fn web_server_handle_reports_owned_bind_and_port() {
         let handle = WebServerHandle::default();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -308,6 +308,22 @@ pub(crate) fn should_wake_on_restore(
     }
 }
 
+pub(crate) fn restore_session_should_wake(
+    archived_session: bool,
+    setting_on: bool,
+    is_coord: bool,
+    persisted_status: Option<&crate::session::session::SessionStatus>,
+) -> bool {
+    !archived_session && should_wake_on_restore(setting_on, is_coord, persisted_status)
+}
+
+pub(crate) fn restore_session_should_become_active(
+    was_active: bool,
+    archived_session: bool,
+) -> bool {
+    was_active && !archived_session
+}
+
 /// (#630) Resolve coordinator status for a restore decision, backstopping a
 /// transient empty `discover_teams()` with the snapshot's persisted
 /// `is_coordinator`. When live discovery returned teams we trust it. Only when
@@ -1607,6 +1623,10 @@ pub fn run(
                         failed_recoverable.push(ps.clone());
                     }
 
+                    let archived_roots = sessions_persistence::normalize_project_roots(
+                        &settings_snapshot.archived_project_paths,
+                    );
+
                     for ps in &persisted {
                         if ps.is_root_agent
                             || crate::config::root_agent::is_root_agent_path(
@@ -1636,7 +1656,17 @@ pub fn run(
                             teams.is_empty(),
                             ps.is_coordinator,
                         );
-                        let wake = should_wake_on_restore(setting_on, is_coord, ps.status.as_ref());
+                        let archived_session =
+                            sessions_persistence::is_under_normalized_archived_roots(
+                                &ps.working_directory,
+                                &archived_roots,
+                            );
+                        let wake = restore_session_should_wake(
+                            archived_session,
+                            setting_on,
+                            is_coord,
+                            ps.status.as_ref(),
+                        );
 
                         if !wake {
                             // Defer: create a dormant Session record (no PTY, status = Exited(0)).
@@ -1714,7 +1744,10 @@ pub fn run(
                                     // The post-loop branching (Fix A) ensures `set_active_only`
                                     // is used (not `switch_session`), so the dormant status
                                     // survives selection.
-                                    if ps.was_active {
+                                    if restore_session_should_become_active(
+                                        ps.was_active,
+                                        archived_session,
+                                    ) {
                                         active_id = Some(session.id.to_string());
                                     }
                                 }
@@ -2110,6 +2143,9 @@ pub fn run(
             commands::ac_discovery::open_project,
             commands::ac_discovery::new_project,
             commands::ac_discovery::remove_project,
+            commands::ac_discovery::archive_project,
+            commands::ac_discovery::unarchive_project,
+            commands::ac_discovery::list_archived_projects,
             commands::ac_discovery::discover_project,
             commands::project_settings::get_project_groups,
             commands::project_settings::update_project_groups,
@@ -2336,7 +2372,8 @@ pub fn run(
 #[cfg(test)]
 mod tests {
     use super::{
-        resolve_is_coord_for_restore, should_auto_create_root_agent_on_first_restore,
+        resolve_is_coord_for_restore, restore_session_should_become_active,
+        restore_session_should_wake, should_auto_create_root_agent_on_first_restore,
         should_wake_on_restore, should_wake_root_agent_on_restore, skip_auto_resume_for_restore,
         ApiServerHandle, ApiServerTask, WebServerHandle,
     };
@@ -2535,6 +2572,29 @@ mod tests {
     #[test]
     fn coord_unknown_status_fails_open_when_on() {
         assert!(should_wake_on_restore(true, true, None));
+    }
+
+    #[test]
+    fn archived_project_session_is_forced_dormant_on_restore_decision() {
+        assert!(!restore_session_should_wake(
+            true,
+            true,
+            true,
+            Some(&SessionStatus::Running)
+        ));
+        assert!(restore_session_should_wake(
+            false,
+            true,
+            true,
+            Some(&SessionStatus::Running)
+        ));
+    }
+
+    #[test]
+    fn archived_project_session_is_never_adopted_as_active_on_restore() {
+        assert!(!restore_session_should_become_active(true, true));
+        assert!(restore_session_should_become_active(true, false));
+        assert!(!restore_session_should_become_active(false, false));
     }
 
     #[test]

--- a/src-tauri/src/loops/scheduler.rs
+++ b/src-tauri/src/loops/scheduler.rs
@@ -12,7 +12,8 @@ use crate::config::loops::{
     write_loop_state_atomic, LoopAuditEntry, LoopAuditKind, LoopConfigDetails,
     LoopConfigRevalidation, LoopConfigToml, LoopLastResult, LoopState, LOOP_DIR_PREFIX,
 };
-use crate::config::projects::enumerate_registered_project_candidates;
+use crate::config::projects::{enumerate_registered_project_candidates, ProjectResolution};
+use crate::config::sessions_persistence;
 use crate::config::settings::SettingsState;
 use crate::config::workspace::existing_workspace_dir;
 use crate::loops::delivery::{deliver_loop_prompt, LoopDeliveryReport};
@@ -104,12 +105,14 @@ impl LoopScheduler {
 
     async fn scan_once(&self, app: AppHandle, startup: bool, pending_only: bool) {
         let _guard = self.scan_lock.lock().await;
-        let project_paths = {
+        let (project_paths, archived) = {
             let settings = app.state::<SettingsState>();
-            let project_paths = settings.read().await.project_paths.clone();
-            project_paths
+            let s = settings.read().await;
+            (s.project_paths.clone(), s.archived_project_paths.clone())
         };
         let projects = enumerate_registered_project_candidates(&project_paths);
+        let archived_roots = sessions_persistence::normalize_project_roots(&archived);
+        let projects = retain_unarchived_candidates(projects, &archived_roots);
         for project in projects {
             if let Err(e) = self
                 .scan_project(&app, &project.path, startup, pending_only)
@@ -483,6 +486,27 @@ fn loop_is_current_for_delivery(dir: &Path, expected: &LoopConfigToml) -> Result
     }
 }
 
+/// #881 A5: candidate discovery also yields immediate `.ac`-bearing children
+/// of registered paths. Subtract archived roots so nested archived projects do
+/// not keep firing loops from a registered parent.
+fn retain_unarchived_candidates(
+    candidates: Vec<ProjectResolution>,
+    normalized_archived_roots: &[String],
+) -> Vec<ProjectResolution> {
+    if normalized_archived_roots.is_empty() {
+        return candidates;
+    }
+    candidates
+        .into_iter()
+        .filter(|candidate| {
+            !sessions_persistence::is_under_normalized_archived_roots(
+                &candidate.path.to_string_lossy(),
+                normalized_archived_roots,
+            )
+        })
+        .collect()
+}
+
 fn emit_transition(
     app: &AppHandle,
     project_dir: &Path,
@@ -558,6 +582,48 @@ mod tests {
                 ..LoopPolicy::default()
             },
         }
+    }
+
+    #[test]
+    fn retain_unarchived_candidates_drops_a_candidate_under_an_archived_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let archived = temp.path().join("archived");
+        let active = temp.path().join("active");
+        std::fs::create_dir_all(&archived).expect("archived");
+        std::fs::create_dir_all(&active).expect("active");
+        let roots = sessions_persistence::normalize_project_roots(&[archived
+            .to_string_lossy()
+            .to_string()]);
+        let archived_candidate = ProjectResolution {
+            path: archived.clone(),
+            folder_name: "archived".to_string(),
+            registered: true,
+        };
+        let active_candidate = ProjectResolution {
+            path: active.clone(),
+            folder_name: "active".to_string(),
+            registered: true,
+        };
+
+        let filtered = retain_unarchived_candidates(
+            vec![archived_candidate, active_candidate.clone()],
+            &roots,
+        );
+
+        assert_eq!(filtered, vec![active_candidate]);
+    }
+
+    #[test]
+    fn retain_unarchived_candidates_returns_input_unchanged_when_archived_list_is_empty() {
+        let candidate = ProjectResolution {
+            path: PathBuf::from("Z:/does/not/exist"),
+            folder_name: "missing".to_string(),
+            registered: true,
+        };
+
+        let filtered = retain_unarchived_candidates(vec![candidate.clone()], &[]);
+
+        assert_eq!(filtered, vec![candidate]);
     }
 
     #[test]

--- a/src-tauri/src/loops/scheduler.rs
+++ b/src-tauri/src/loops/scheduler.rs
@@ -620,10 +620,43 @@ mod tests {
             folder_name: "missing".to_string(),
             registered: true,
         };
+        let input = vec![candidate.clone()];
+        let ptr = input.as_ptr();
+        let capacity = input.capacity();
 
-        let filtered = retain_unarchived_candidates(vec![candidate.clone()], &[]);
+        let filtered = retain_unarchived_candidates(input, &[]);
 
         assert_eq!(filtered, vec![candidate]);
+        assert_eq!(
+            filtered.as_ptr(),
+            ptr,
+            "empty archived roots must skip the into_iter/collect round trip"
+        );
+        assert_eq!(filtered.capacity(), capacity);
+    }
+
+    #[test]
+    fn scan_once_calls_archived_candidate_filter() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/loops/scheduler.rs"
+        ))
+        .expect("read scheduler.rs");
+        let production = source
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .expect("production scheduler source");
+        let normalize = production
+            .find("let archived_roots = sessions_persistence::normalize_project_roots(&archived);")
+            .expect("archived root normalization");
+        let retain = production
+            .find("let projects = retain_unarchived_candidates(projects, &archived_roots);")
+            .expect("retain_unarchived_candidates call");
+
+        assert!(
+            normalize < retain,
+            "scan_once must subtract archived candidates after normalizing archived roots"
+        );
     }
 
     #[test]

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -6354,10 +6354,123 @@ mod tests {
     fn retain_unarchived_session_dirs_returns_input_unchanged_when_archived_list_is_empty() {
         let id = Uuid::new_v4();
         let input = vec![(id, "Z:/does/not/exist".to_string())];
+        let ptr = input.as_ptr();
+        let capacity = input.capacity();
 
-        let filtered = retain_unarchived_session_dirs(input.clone(), &[]);
+        let filtered = retain_unarchived_session_dirs(input, &[]);
 
-        assert_eq!(filtered, input);
+        assert_eq!(filtered, vec![(id, "Z:/does/not/exist".to_string())]);
+        assert_eq!(
+            filtered.as_ptr(),
+            ptr,
+            "empty archived roots must skip the into_iter/collect round trip"
+        );
+        assert_eq!(filtered.capacity(), capacity);
+    }
+
+    #[test]
+    fn mailbox_poll_bypasses_session_dir_filter_when_archived_list_is_empty() {
+        let source =
+            std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/phone/mailbox.rs"))
+                .expect("read mailbox.rs");
+        let production = source
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .expect("production mailbox source");
+        let bypass = production
+            .find("let session_dirs = if archived.is_empty()")
+            .expect("archived-empty bypass");
+        let filter = production
+            .find("retain_unarchived_session_dirs(session_dirs, &roots)")
+            .expect("archived session filter call");
+
+        assert!(
+            bypass < filter,
+            "MailboxPoller::poll must bypass filtering before calling the archived-session filter"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_repo_path_filters_archived_session_dirs() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-a");
+        let target = project
+            .join(".ac")
+            .join("wg-1-dev-team")
+            .join("__agent_dev-rust");
+        std::fs::create_dir_all(&target).expect("create target");
+        let app = make_mailbox_app(temp.path());
+        let app_handle = app_handle(&app);
+        {
+            let settings = app_handle.state::<SettingsState>();
+            let mut cfg = settings.write().await;
+            cfg.project_paths.clear();
+            cfg.archived_project_paths = vec![project.to_string_lossy().to_string()];
+        }
+        let session_mgr = app_handle.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+        {
+            let mgr = session_mgr.read().await;
+            mgr.create_session(
+                "shell".to_string(),
+                Vec::new(),
+                target.to_string_lossy().to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                SessionBackendKind::LocalProcess,
+            )
+            .await
+            .expect("create archived session");
+        }
+        let poller = MailboxPoller::new();
+
+        let resolved = poller
+            .resolve_repo_path(CANONICAL_WAKE_TO, &app_handle)
+            .await;
+
+        assert_eq!(resolved, None);
+    }
+
+    #[tokio::test]
+    async fn resolve_wg_path_from_sessions_filters_archived_session_dirs() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj-a");
+        let wg_root = project.join(".ac").join("wg-1-dev-team");
+        let sender = wg_root.join("__agent_tech-lead");
+        let target = wg_root.join("__agent_dev-rust");
+        std::fs::create_dir_all(&sender).expect("create sender");
+        std::fs::create_dir_all(&target).expect("create target");
+        let app = make_mailbox_app(temp.path());
+        let app_handle = app_handle(&app);
+        {
+            let settings = app_handle.state::<SettingsState>();
+            let mut cfg = settings.write().await;
+            cfg.archived_project_paths = vec![project.to_string_lossy().to_string()];
+        }
+        let session_mgr = app_handle.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+        {
+            let mgr = session_mgr.read().await;
+            mgr.create_session(
+                "shell".to_string(),
+                Vec::new(),
+                sender.to_string_lossy().to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                SessionBackendKind::LocalProcess,
+            )
+            .await
+            .expect("create archived sibling session");
+        }
+        let poller = MailboxPoller::new();
+
+        let resolved = poller
+            .resolve_wg_path_from_sessions(&app_handle, LOCAL_WAKE_TO)
+            .await;
+
+        assert_eq!(resolved, None);
     }
 
     // ── §224 D.5a — wait_for_restore_or_session unit tests ──

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -38,6 +38,27 @@ fn sender_name_for_session_cwd(working_directory: &str) -> String {
     sender_name_for_session_cwd_with_root_flag(working_directory, is_root_agent)
 }
 
+/// #881: session working dirs minus those under an archived project.
+///
+/// Subtractive on purpose: root-agent and ad-hoc CWD sessions outside every
+/// project path must still be scanned.
+pub(crate) fn retain_unarchived_session_dirs(
+    dirs: Vec<(Uuid, String)>,
+    normalized_archived_roots: &[String],
+) -> Vec<(Uuid, String)> {
+    if normalized_archived_roots.is_empty() {
+        return dirs;
+    }
+    dirs.into_iter()
+        .filter(|(_, dir)| {
+            !crate::config::sessions_persistence::is_under_normalized_archived_roots(
+                dir,
+                normalized_archived_roots,
+            )
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WakeDeliveryOrigin {
     FilesystemPoller,
@@ -1735,9 +1756,12 @@ impl MailboxPoller {
     /// One poll cycle: scan all repo outbox dirs, process each message.
     async fn poll(&mut self, app: &tauri::AppHandle) -> Result<(), String> {
         let settings = app.state::<SettingsState>();
-        let repo_paths = {
+        let (repo_paths, archived) = {
             let cfg = settings.read().await;
-            cfg.project_paths.clone()
+            (
+                cfg.project_paths.clone(),
+                cfg.archived_project_paths.clone(),
+            )
         };
 
         // Also scan CWDs of active sessions for repos not in settings
@@ -1745,6 +1769,16 @@ impl MailboxPoller {
         let session_dirs = {
             let mgr = session_mgr.read().await;
             mgr.get_sessions_working_dirs().await
+        };
+        let session_dirs = if archived.is_empty() {
+            session_dirs
+        } else {
+            tokio::task::spawn_blocking(move || {
+                let roots = crate::config::sessions_persistence::normalize_project_roots(&archived);
+                retain_unarchived_session_dirs(session_dirs, &roots)
+            })
+            .await
+            .map_err(|e| format!("archived mailbox-session filter task failed: {}", e))?
         };
 
         let mut all_paths: Vec<String> = repo_paths;
@@ -5603,21 +5637,30 @@ impl MailboxPoller {
             }
         };
 
+        let settings = app.state::<SettingsState>();
+        let (project_paths, archived) = {
+            let cfg = settings.read().await;
+            (
+                cfg.project_paths.clone(),
+                cfg.archived_project_paths.clone(),
+            )
+        };
+
         // Loop 1: session CWDs
         let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
         let mgr = session_mgr.read().await;
         let dirs = mgr.get_sessions_working_dirs().await;
+        drop(mgr);
+        let roots = crate::config::sessions_persistence::normalize_project_roots(&archived);
+        let dirs = retain_unarchived_session_dirs(dirs, &roots);
         for (_, cwd) in &dirs {
             if hits_agent(cwd) {
                 record_match(cwd, &mut matches);
             }
         }
-        drop(mgr);
 
         // Loop 2: settings project_paths
-        let settings = app.state::<SettingsState>();
-        let cfg = settings.read().await;
-        for rp in &cfg.project_paths {
+        for rp in &project_paths {
             if hits_agent(rp) {
                 record_match(rp, &mut matches);
             }
@@ -5656,7 +5699,7 @@ impl MailboxPoller {
                     }
                 };
 
-                for rp in &cfg.project_paths {
+                for rp in &project_paths {
                     let base = std::path::Path::new(rp);
                     if !base.is_dir() {
                         continue;
@@ -5784,10 +5827,17 @@ impl MailboxPoller {
         app: &tauri::AppHandle<R>,
         agent_name: &str,
     ) -> Option<String> {
+        let archived = {
+            let settings = app.state::<SettingsState>();
+            let cfg = settings.read().await;
+            cfg.archived_project_paths.clone()
+        };
         let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
         let mgr = session_mgr.read().await;
         let dirs = mgr.get_sessions_working_dirs().await;
         drop(mgr);
+        let roots = crate::config::sessions_persistence::normalize_project_roots(&archived);
+        let dirs = retain_unarchived_session_dirs(dirs, &roots);
 
         resolve_wg_path_from_session_dirs(&dirs, agent_name)
     }
@@ -6245,6 +6295,69 @@ mod tests {
             backend.clone(),
         )));
         (mgr, backend)
+    }
+
+    #[test]
+    fn retain_unarchived_session_dirs_drops_dirs_under_archived_projects() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let archived = temp.path().join("archived");
+        let archived_agent = archived.join(".ac").join("wg-1").join("__agent_archived");
+        let active_agent = temp
+            .path()
+            .join("active")
+            .join(".ac")
+            .join("wg-1")
+            .join("__agent_active");
+        std::fs::create_dir_all(&archived_agent).expect("archived agent");
+        std::fs::create_dir_all(&active_agent).expect("active agent");
+        let roots = crate::config::sessions_persistence::normalize_project_roots(&[archived
+            .to_string_lossy()
+            .to_string()]);
+        let archived_id = Uuid::new_v4();
+        let active_id = Uuid::new_v4();
+
+        let filtered = retain_unarchived_session_dirs(
+            vec![
+                (archived_id, archived_agent.to_string_lossy().to_string()),
+                (active_id, active_agent.to_string_lossy().to_string()),
+            ],
+            &roots,
+        );
+
+        assert_eq!(
+            filtered,
+            vec![(active_id, active_agent.to_string_lossy().to_string())]
+        );
+    }
+
+    #[test]
+    fn retain_unarchived_session_dirs_keeps_dirs_outside_every_project_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let archived = temp.path().join("archived");
+        let ad_hoc = temp.path().join("scratch").join("__agent_ad_hoc");
+        std::fs::create_dir_all(&archived).expect("archived");
+        std::fs::create_dir_all(&ad_hoc).expect("ad hoc");
+        let roots = crate::config::sessions_persistence::normalize_project_roots(&[archived
+            .to_string_lossy()
+            .to_string()]);
+        let id = Uuid::new_v4();
+
+        let filtered = retain_unarchived_session_dirs(
+            vec![(id, ad_hoc.to_string_lossy().to_string())],
+            &roots,
+        );
+
+        assert_eq!(filtered, vec![(id, ad_hoc.to_string_lossy().to_string())]);
+    }
+
+    #[test]
+    fn retain_unarchived_session_dirs_returns_input_unchanged_when_archived_list_is_empty() {
+        let id = Uuid::new_v4();
+        let input = vec![(id, "Z:/does/not/exist".to_string())];
+
+        let filtered = retain_unarchived_session_dirs(input.clone(), &[]);
+
+        assert_eq!(filtered, input);
     }
 
     // ── §224 D.5a — wait_for_restore_or_session unit tests ──

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -14,8 +14,33 @@ use crate::pty::local_backend::LocalProcessBackend;
 use crate::pty::output::PtyScreenSnapshot;
 use crate::telegram::manager::OutputSenderMap;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PendingSpawn {
+    pub cwd: String,
+    pub label: String,
+}
+
+#[derive(Default)]
+struct SpawnRegistry {
+    routes: HashMap<Uuid, SessionBackendKind>,
+    pending: HashMap<u64, PendingSpawn>,
+    next_seq: u64,
+}
+
+pub(crate) struct SpawnMark {
+    registry: Arc<Mutex<SpawnRegistry>>,
+    seq: u64,
+}
+
+impl Drop for SpawnMark {
+    fn drop(&mut self) {
+        let mut registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
+        registry.pending.remove(&self.seq);
+    }
+}
+
 pub struct PtyManager {
-    routes: Arc<Mutex<HashMap<Uuid, SessionBackendKind>>>,
+    registry: Arc<Mutex<SpawnRegistry>>,
     local_backend: Arc<dyn PtyBackend>,
     container_backend: Arc<ContainerTransportBackend>,
 }
@@ -43,7 +68,7 @@ impl PtyManager {
             ContainerApiTokenManager::at_config_dir(),
         ));
         Self {
-            routes: Arc::new(Mutex::new(HashMap::new())),
+            registry: Arc::new(Mutex::new(SpawnRegistry::default())),
             local_backend,
             container_backend,
         }
@@ -57,7 +82,7 @@ impl PtyManager {
             crate::session::manager::SessionManager::new(),
         ));
         Self {
-            routes: Arc::new(Mutex::new(HashMap::new())),
+            registry: Arc::new(Mutex::new(SpawnRegistry::default())),
             local_backend,
             container_backend: Arc::new(ContainerTransportBackend::new(
                 output_senders,
@@ -93,27 +118,75 @@ impl PtyManager {
     }
 
     pub fn record_route(&self, id: Uuid, kind: SessionBackendKind) {
-        self.routes.lock().unwrap().insert(id, kind);
+        self.registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .routes
+            .insert(id, kind);
     }
 
     pub fn remove_route_if_kind(&self, id: Uuid, kind: SessionBackendKind) {
-        let mut routes = self.routes.lock().unwrap();
-        if routes.get(&id).copied() == Some(kind) {
-            routes.remove(&id);
+        let mut registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
+        if registry.routes.get(&id).copied() == Some(kind) {
+            registry.routes.remove(&id);
         }
     }
 
     fn kind_for_session(&self, id: Uuid) -> Result<SessionBackendKind, AppError> {
-        self.routes
+        self.registry
             .lock()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
+            .routes
             .get(&id)
             .copied()
             .ok_or_else(|| AppError::SessionNotFound(id.to_string()))
     }
 
     pub fn backend_kind(&self, id: Uuid) -> Option<SessionBackendKind> {
-        self.routes.lock().unwrap().get(&id).copied()
+        self.registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .routes
+            .get(&id)
+            .copied()
+    }
+
+    pub(crate) fn mark_spawning(&self, cwd: &str, label: &str) -> SpawnMark {
+        let mut registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
+        let seq = registry.next_seq;
+        registry.next_seq = registry.next_seq.wrapping_add(1);
+        registry.pending.insert(
+            seq,
+            PendingSpawn {
+                cwd: cwd.to_string(),
+                label: label.to_string(),
+            },
+        );
+        SpawnMark {
+            registry: Arc::clone(&self.registry),
+            seq,
+        }
+    }
+
+    pub(crate) fn archive_liveness(&self, ids: &[Uuid]) -> (Vec<PendingSpawn>, Vec<bool>) {
+        let (pending, route_kinds) = {
+            let registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
+            (
+                registry.pending.values().cloned().collect::<Vec<_>>(),
+                ids.iter()
+                    .map(|id| registry.routes.get(id).copied())
+                    .collect::<Vec<_>>(),
+            )
+        };
+        let live = ids
+            .iter()
+            .zip(route_kinds)
+            .map(|(id, kind)| {
+                kind.map(|kind| self.backend_for_kind(kind).has_session(*id))
+                    .unwrap_or(false)
+            })
+            .collect();
+        (pending, live)
     }
 
     pub async fn spawn(
@@ -153,9 +226,10 @@ impl PtyManager {
 
     pub fn kill(&self, id: Uuid) -> Result<(), AppError> {
         let kind = self
-            .routes
+            .registry
             .lock()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
+            .routes
             .get(&id)
             .copied()
             .unwrap_or(SessionBackendKind::LocalProcess);
@@ -193,9 +267,10 @@ impl PtyManager {
         response_dir: std::path::PathBuf,
     ) {
         let kind = self
-            .routes
+            .registry
             .lock()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
+            .routes
             .get(&session_id)
             .copied()
             .unwrap_or(SessionBackendKind::LocalProcess);
@@ -458,6 +533,43 @@ mod tests {
 
         assert!(matches!(err, AppError::SessionNotFound(_)));
         assert!(backend.calls().is_empty());
+    }
+
+    #[test]
+    fn archive_liveness_reports_pending_spawn_until_mark_drops() {
+        let backend = Arc::new(RecordingBackend::default());
+        let manager = PtyManager::new_for_test(backend);
+        let mark = manager.mark_spawning("C:/repo/.ac/wg-1/__agent_dev", "dev");
+
+        let (pending, live) = manager.archive_liveness(&[]);
+
+        assert_eq!(
+            pending,
+            vec![PendingSpawn {
+                cwd: "C:/repo/.ac/wg-1/__agent_dev".to_string(),
+                label: "dev".to_string(),
+            }]
+        );
+        assert!(live.is_empty());
+        drop(mark);
+
+        let (pending, _) = manager.archive_liveness(&[]);
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn archive_liveness_reports_backend_live_route() {
+        let id = Uuid::new_v4();
+        let backend = Arc::new(RecordingBackend::default());
+        backend.set_live(id);
+        let manager = PtyManager::new_for_test(backend.clone());
+        manager.record_route(id, SessionBackendKind::LocalProcess);
+
+        let (pending, live) = manager.archive_liveness(&[id]);
+
+        assert!(pending.is_empty());
+        assert_eq!(live, vec![true]);
+        assert_eq!(backend.calls(), vec![Call::Has(id)]);
     }
 
     #[tokio::test]

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -796,9 +796,8 @@ pub fn broadcast_all(
     event: &str,
     payload: &Value,
 ) {
-    if !broadcast_all_to_managed(app, event, payload) {
-        broadcaster.broadcast_event(event, payload);
-    }
+    let _ = tauri::Emitter::emit(app, event, payload.clone());
+    broadcaster.broadcast_event(event, payload);
 }
 
 // --- Arg helpers ---
@@ -899,6 +898,49 @@ mod tests {
         assert_eq!(route_web_command("new_project"), WebCommandRoute::Other);
         assert_eq!(route_web_command("open-project"), WebCommandRoute::Other);
         assert_eq!(route_web_command("new-project"), WebCommandRoute::Other);
+    }
+
+    #[test]
+    fn broadcast_all_r_sends_to_managed_websocket_broadcaster() {
+        let broadcaster = WsBroadcaster::new();
+        let mut receiver = broadcaster.subscribe();
+        let app = tauri::Builder::default()
+            .any_thread()
+            .manage(broadcaster)
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build test app");
+        let payload = json!({ "path": "C:/project", "archived": true });
+
+        broadcast_all_r(app.handle(), "project_archive_changed", &payload);
+
+        let event = match receiver.try_recv().expect("broadcast event") {
+            WsOutMsg::Text(text) => serde_json::from_str::<Value>(&text).expect("parse event"),
+            other => panic!("expected text event, got {other:?}"),
+        };
+        assert_eq!(event["event"], json!("project_archive_changed"));
+        assert_eq!(event["payload"], payload);
+    }
+
+    #[test]
+    fn broadcast_all_sends_to_explicit_websocket_broadcaster() {
+        let managed = WsBroadcaster::new();
+        let explicit = WsBroadcaster::new();
+        let mut receiver = explicit.subscribe();
+        let app = tauri::Builder::default()
+            .any_thread()
+            .manage(managed)
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build test app");
+        let payload = json!({ "path": "C:/project", "archived": false });
+
+        broadcast_all(app.handle(), &explicit, "project_archive_changed", &payload);
+
+        let event = match receiver.try_recv().expect("broadcast event") {
+            WsOutMsg::Text(text) => serde_json::from_str::<Value>(&text).expect("parse event"),
+            other => panic!("expected text event, got {other:?}"),
+        };
+        assert_eq!(event["event"], json!("project_archive_changed"));
+        assert_eq!(event["payload"], payload);
     }
 
     #[tokio::test]

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -28,6 +28,9 @@ enum BrowserProjectCommand {
     UpdateProjectGroups,
     OpenProject,
     RemoveProject,
+    ArchiveProject,
+    UnarchiveProject,
+    ListArchivedProjects,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -52,6 +55,13 @@ fn route_web_command(cmd: &str) -> WebCommandRoute {
         }
         "open_project" => WebCommandRoute::BrowserProject(BrowserProjectCommand::OpenProject),
         "remove_project" => WebCommandRoute::BrowserProject(BrowserProjectCommand::RemoveProject),
+        "archive_project" => WebCommandRoute::BrowserProject(BrowserProjectCommand::ArchiveProject),
+        "unarchive_project" => {
+            WebCommandRoute::BrowserProject(BrowserProjectCommand::UnarchiveProject)
+        }
+        "list_archived_projects" => {
+            WebCommandRoute::BrowserProject(BrowserProjectCommand::ListArchivedProjects)
+        }
         _ => WebCommandRoute::Other,
     }
 }
@@ -707,17 +717,76 @@ async fn dispatch_browser_project_command(
 
         BrowserProjectCommand::OpenProject => {
             let path = require_str(args, "path")?;
-            let result =
-                crate::commands::ac_discovery::open_project_inner(&state.settings, &path).await?;
+            let result = crate::commands::ac_discovery::open_project_inner(
+                &state.app_handle,
+                &state.settings,
+                &path,
+            )
+            .await?;
             serde_json::to_value(result).map_err(|e| e.to_string())
         }
 
         BrowserProjectCommand::RemoveProject => {
             let path = require_str(args, "path")?;
-            crate::commands::ac_discovery::remove_project_inner(&state.settings, &path).await?;
+            crate::commands::ac_discovery::remove_project_inner(
+                &state.app_handle,
+                &state.settings,
+                &path,
+            )
+            .await?;
             Ok(json!(null))
         }
+
+        BrowserProjectCommand::ArchiveProject => {
+            let path = require_str(args, "path")?;
+            crate::commands::ac_discovery::archive_project_inner(
+                &state.app_handle,
+                &state.settings,
+                &state.session_mgr,
+                &state.pty_mgr,
+                &path,
+            )
+            .await?;
+            Ok(json!(null))
+        }
+
+        BrowserProjectCommand::UnarchiveProject => {
+            let path = require_str(args, "path")?;
+            let result = crate::commands::ac_discovery::unarchive_project_inner(
+                &state.app_handle,
+                &state.settings,
+                &path,
+            )
+            .await?;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+
+        BrowserProjectCommand::ListArchivedProjects => {
+            let result =
+                crate::commands::ac_discovery::list_archived_projects_inner(&state.settings)
+                    .await?;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
     }
+}
+
+fn broadcast_all_to_managed<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    event: &str,
+    payload: &Value,
+) -> bool {
+    let _ = tauri::Emitter::emit(app, event, payload.clone());
+    if let Some(bc) = app.try_state::<WsBroadcaster>() {
+        bc.broadcast_event(event, payload);
+        true
+    } else {
+        false
+    }
+}
+
+/// Emit event to both Tauri windows and managed WebSocket clients.
+pub fn broadcast_all_r<R: tauri::Runtime>(app: &tauri::AppHandle<R>, event: &str, payload: &Value) {
+    let _ = broadcast_all_to_managed(app, event, payload);
 }
 
 /// Emit event to both Tauri windows and WebSocket clients.
@@ -727,8 +796,9 @@ pub fn broadcast_all(
     event: &str,
     payload: &Value,
 ) {
-    let _ = tauri::Emitter::emit(app, event, payload.clone());
-    broadcaster.broadcast_event(event, payload);
+    if !broadcast_all_to_managed(app, event, payload) {
+        broadcaster.broadcast_event(event, payload);
+    }
 }
 
 // --- Arg helpers ---
@@ -795,6 +865,12 @@ mod tests {
                 BrowserProjectCommand::CheckProjectPath,
             ),
             ("remove_project", BrowserProjectCommand::RemoveProject),
+            ("archive_project", BrowserProjectCommand::ArchiveProject),
+            ("unarchive_project", BrowserProjectCommand::UnarchiveProject),
+            (
+                "list_archived_projects",
+                BrowserProjectCommand::ListArchivedProjects,
+            ),
             (
                 "get_project_groups",
                 BrowserProjectCommand::GetProjectGroups,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -36,6 +36,8 @@ import type {
   TaskUpdateResult,
   WorkgroupTaskUpdatedEvent,
   ProjectRegistration,
+  ArchivedProject,
+  ProjectArchiveChanged,
   ErrorLogEntry,
   AgencyTemplatesStatus,
   AgencyTemplatesUpdateResult,
@@ -383,6 +385,12 @@ export function onSessionCreated(
   callback: (session: Session) => void
 ): Promise<UnlistenFn> {
   return transport.listen<Session>("session_created", callback);
+}
+
+export function onProjectArchiveChanged(
+  callback: (event: ProjectArchiveChanged) => void
+): Promise<UnlistenFn> {
+  return transport.listen<ProjectArchiveChanged>("project_archive_changed", callback);
 }
 
 export function onSessionDestroyed(
@@ -814,6 +822,18 @@ export const ProjectAPI = {
    * hard failure (e.g. a G2 read abort when the settings file is locked).
    */
   remove: (path: string) => transport.invoke<void>("remove_project", { path }),
+  /**
+   * #881 - hide the project at `path`. Rejects with a human-readable blocker
+   * message when the project still has live sessions, so callers must await it
+   * before mutating any local store.
+   */
+  archive: (path: string) => transport.invoke<void>("archive_project", { path }),
+  /** #881 - restore an archived project and return its backend registration. */
+  unarchive: (path: string) =>
+    transport.invoke<ProjectRegistration>("unarchive_project", { path }),
+  /** #881 - archived projects decorated with on-disk existence flags. */
+  listArchived: () =>
+    transport.invoke<ArchivedProject[]>("list_archived_projects", {}),
 };
 
 /** #777 Non-stop watchdog: frontend pushes the full disparity snapshot; the

--- a/src/shared/testing/ui-harness.archive.test.ts
+++ b/src/shared/testing/ui-harness.archive.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { autoUnarchiveStore } from "../../sidebar/stores/auto-unarchive";
+import { resetUiStoresForTests } from "./ui-harness";
+
+describe("resetUiStoresForTests archive state (#881)", () => {
+  afterEach(() => {
+    resetUiStoresForTests();
+  });
+
+  it("clears pending auto-unarchive entries", () => {
+    autoUnarchiveStore.push({
+      path: "C:\\Project",
+      folderName: "Project",
+      archived: false,
+      reason: "autoUnarchive",
+      sessionName: "wg-1/dev",
+    });
+
+    expect(autoUnarchiveStore.open).toBe(true);
+
+    resetUiStoresForTests();
+
+    expect(autoUnarchiveStore.open).toBe(false);
+    expect(autoUnarchiveStore.entries).toEqual([]);
+  });
+});

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -141,6 +141,7 @@ export function baseSettings(overrides: Partial<AppSettings> = {}): AppSettings 
     apiServerBind: "127.0.0.1",
     projectPath: null,
     projectPaths: [],
+    archivedProjectPaths: [],
     sidebarStyle: "noir-minimal",
     onboardingDismissed: true,
     coordSortByActivity: false,

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -11,6 +11,7 @@ import type {
 import { FakeTransport } from "./fake-transport";
 import { toastStore } from "../stores/toasts";
 import { projectStore } from "../../sidebar/stores/project";
+import { autoUnarchiveStore } from "../../sidebar/stores/auto-unarchive";
 import { sessionsStore } from "../../sidebar/stores/sessions";
 import { bridgesStore } from "../../sidebar/stores/bridges";
 import { workgroupGroupsStore } from "../../sidebar/stores/workgroup-groups";
@@ -242,6 +243,7 @@ export function resetUiStoresForTests(): void {
   bridgesStore.setBridges([]);
   terminalStore.setActiveSession(null, "", "", null, "", null, false);
   terminalStore.setActiveWorkgroupTask(null);
+  autoUnarchiveStore.acknowledge();
   toastStore.clear();
   __resetHomeStoreForTests();
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -448,6 +448,9 @@ export interface AppSettings {
   apiServerBind: string;
   projectPath: string | null;
   projectPaths: string[];
+  /** #881 - projects hidden from the sidebar. Disk-authoritative: the backend
+   *  preserve-writer discards whatever this field carries on a whole-object save. */
+  archivedProjectPaths: string[];
   sidebarStyle: string;
   onboardingDismissed: boolean;
   coordSortByActivity: boolean;
@@ -1181,6 +1184,33 @@ export interface ProjectRegistration {
   registered: boolean;
   /** True when this call created .ac/ on disk (always false for openProject). */
   created: boolean;
+}
+
+/** Mirrors src-tauri/src/config/projects.rs::ArchivedProject (#881). */
+export interface ArchivedProject {
+  path: string;
+  folderName: string;
+  /** The directory still exists on disk. */
+  exists: boolean;
+  /** The directory still has a `.ac/` Project AC Root. */
+  hasWorkspace: boolean;
+}
+
+export type ArchiveChangeReason =
+  | "archive"
+  | "unarchive"
+  | "autoUnarchive"
+  | "open"
+  | "remove";
+
+/** Mirrors src-tauri/src/commands/ac_discovery.rs::ProjectArchiveChanged (#881). */
+export interface ProjectArchiveChanged {
+  path: string;
+  folderName: string;
+  archived: boolean;
+  reason: ArchiveChangeReason;
+  /** Only for reason === "autoUnarchive". */
+  sessionName?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -36,6 +36,7 @@ import {
   onCodingAgentProfileSelectionUpdated,
   onLoopEvent,
   onProjectGroupsUpdated,
+  onProjectArchiveChanged,
   onNpmUpdateAvailable,
 } from "../shared/ipc";
 import { taskFirstLine } from "../shared/markdown";
@@ -57,8 +58,10 @@ import ProjectPanel from "./components/ProjectPanel";
 import WorkgroupGroupRail from "./components/WorkgroupGroupRail";
 import OnboardingModal from "./components/OnboardingModal";
 import ContextTemplateUpdateModal from "./components/ContextTemplateUpdateModal";
+import AutoUnarchiveModal from "./components/AutoUnarchiveModal";
 import ToastHost from "../shared/components/ToastHost";
 import { toastStore } from "../shared/stores/toasts";
+import { autoUnarchiveStore } from "./stores/auto-unarchive";
 import { handleProjectRefreshRequested } from "./project-refresh-handler";
 import { loopToastFromEvent, type LoopToast } from "./loop-event-toast";
 import { createUpdateToaster } from "./update-toast";
@@ -354,6 +357,16 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       })
     );
     unlisteners.push(
+      await onProjectArchiveChanged((data) => {
+        void projectStore.applyArchiveChange(data).catch((error) => {
+          console.error("[archive] Failed to apply project_archive_changed:", error);
+        });
+        if (data.reason === "autoUnarchive") {
+          autoUnarchiveStore.push(data);
+        }
+      })
+    );
+    unlisteners.push(
       await onCodingAgentProfilesUpdated(() => {
         settingsStore.refresh();
         void refreshProfileOutdated();
@@ -472,6 +485,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     await projectStore.initFromSettings(
       appSettings.projectPaths ?? [],
       appSettings.projectPath ?? null,
+      appSettings.archivedProjectPaths ?? [],
     );
 
     // Load all repos for inactive agent display
@@ -688,6 +702,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
           />
         )}
       </Show>
+      <AutoUnarchiveModal />
       <ToastHost />
     </>
   );

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -178,6 +178,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoSelfClearByAgent: {},
     logLevel: null,
     ...overrides,
+    archivedProjectPaths: overrides.archivedProjectPaths ?? [],
   };
 }
 

--- a/src/sidebar/components/ArchiveIcon.tsx
+++ b/src/sidebar/components/ArchiveIcon.tsx
@@ -1,0 +1,15 @@
+import type { Component } from "solid-js";
+
+/** #881 — monochrome Heroicons archive-box glyph for archive entry points. */
+const ArchiveIcon: Component<{ class?: string }> = (props) => (
+  <svg class={props.class} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M3.375 3C2.339 3 1.5 3.84 1.5 4.875v.75C1.5 6.66 2.34 7.5 3.375 7.5h17.25c1.035 0 1.875-.84 1.875-1.875v-.75C22.5 3.839 21.66 3 20.625 3H3.375Z" />
+    <path
+      fill-rule="evenodd"
+      d="m3.087 9 .54 9.176A3 3 0 0 0 6.62 21h10.757a3 3 0 0 0 2.995-2.824L20.913 9H3.087Zm6.163 3.75A.75.75 0 0 1 10 12h4a.75.75 0 0 1 0 1.5h-4a.75.75 0 0 1-.75-.75Z"
+      clip-rule="evenodd"
+    />
+  </svg>
+);
+
+export default ArchiveIcon;

--- a/src/sidebar/components/ArchivedProjectsModal.test.tsx
+++ b/src/sidebar/components/ArchivedProjectsModal.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  discovery,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import type { ArchivedProject } from "../../shared/types";
+import { projectStore } from "../stores/project";
+import ArchivedProjectsModal from "./ArchivedProjectsModal";
+import { automationIdPart } from "./replica-repo-badges";
+
+function row(path: string, overrides: Partial<ArchivedProject> = {}): ArchivedProject {
+  return {
+    path,
+    folderName: path.replace(/\\/g, "/").split("/").pop() ?? path,
+    exists: true,
+    hasWorkspace: true,
+    ...overrides,
+  };
+}
+
+function byTestId<T extends HTMLElement = HTMLElement>(testId: string): T {
+  const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing ${testId}`);
+  return element;
+}
+
+describe("ArchivedProjectsModal (#881)", () => {
+  beforeEach(() => {
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    resetUiStoresForTests();
+    projectStore.clear();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the empty state", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("list_archived_projects", []);
+
+    const rendered = renderWithFakeTransport(() => <ArchivedProjectsModal onClose={vi.fn()} />, fake);
+    try {
+      await waitFor(() => expect(byTestId("archivedProjects.empty")).toBeTruthy());
+      expect(byTestId("archivedProjects.empty").textContent).toContain("No archived projects");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("renders rows, unarchives through the backend, discovers, and refetches", async () => {
+    let rows = [row("C:\\Archive\\One"), row("C:\\Archive\\Two")];
+    const fake = new FakeTransport();
+    fake.onInvoke("list_archived_projects", () => rows);
+    fake.onInvoke("unarchive_project", (args) => {
+      rows = rows.filter((entry) => entry.path !== args.path);
+      return { path: args.path as string, registered: true, created: false };
+    });
+    fake.resolve("discover_project", discovery());
+
+    const rendered = renderWithFakeTransport(() => <ArchivedProjectsModal onClose={vi.fn()} />, fake);
+    try {
+      const firstId = automationIdPart("C:\\Archive\\One");
+      const secondId = automationIdPart("C:\\Archive\\Two");
+      await waitFor(() => expect(byTestId(`archivedProjects.row.${firstId}`)).toBeTruthy());
+      expect(byTestId(`archivedProjects.row.${secondId}`)).toBeTruthy();
+
+      click(byTestId(`archivedProjects.unarchive.${firstId}`));
+
+      await waitFor(() =>
+        expect(document.querySelector(`[data-ac-testid="archivedProjects.row.${firstId}"]`)).toBeNull(),
+      );
+      expect(fake.callsFor("unarchive_project")[0].args.path).toBe("C:\\Archive\\One");
+      expect(fake.callsFor("discover_project")[0].args.path).toBe("C:\\Archive\\One");
+      expect(byTestId(`archivedProjects.row.${secondId}`)).toBeTruthy();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows Remove from list for missing folders and routes it through remove_project", async () => {
+    let rows = [row("C:\\Archive\\Missing", { exists: false })];
+    const fake = new FakeTransport();
+    fake.onInvoke("list_archived_projects", () => rows);
+    fake.onInvoke("remove_project", (args) => {
+      rows = rows.filter((entry) => entry.path !== args.path);
+      return undefined;
+    });
+
+    const rendered = renderWithFakeTransport(() => <ArchivedProjectsModal onClose={vi.fn()} />, fake);
+    try {
+      const id = automationIdPart("C:\\Archive\\Missing");
+      await waitFor(() => expect(byTestId(`archivedProjects.forget.${id}`)).toBeTruthy());
+
+      click(byTestId(`archivedProjects.forget.${id}`));
+
+      await waitFor(() => expect(byTestId("archivedProjects.empty")).toBeTruthy());
+      expect(fake.callsFor("remove_project")[0].args.path).toBe("C:\\Archive\\Missing");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("renders a rejected unarchive under its own row and keeps the row present", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("list_archived_projects", [row("C:\\Archive\\Blocked")]);
+    fake.reject("unarchive_project", "Workspace missing");
+
+    const rendered = renderWithFakeTransport(() => <ArchivedProjectsModal onClose={vi.fn()} />, fake);
+    try {
+      const id = automationIdPart("C:\\Archive\\Blocked");
+      await waitFor(() => expect(byTestId(`archivedProjects.unarchive.${id}`)).toBeTruthy());
+
+      click(byTestId(`archivedProjects.unarchive.${id}`));
+
+      await waitFor(() =>
+        expect(byTestId(`archivedProjects.rowError.${id}`).textContent).toContain("Workspace missing"),
+      );
+      expect(byTestId(`archivedProjects.row.${id}`)).toBeTruthy();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("renders listArchived failures as a top-level alert, not an empty list", async () => {
+    const fake = new FakeTransport();
+    fake.reject("list_archived_projects", "settings locked");
+
+    const rendered = renderWithFakeTransport(() => <ArchivedProjectsModal onClose={vi.fn()} />, fake);
+    try {
+      await waitFor(() => expect(byTestId("archivedProjects.error")).toBeTruthy());
+      expect(byTestId("archivedProjects.error").textContent).toContain("settings locked");
+      expect(document.querySelector('[data-ac-testid="archivedProjects.empty"]')).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ArchivedProjectsModal.test.tsx
+++ b/src/sidebar/components/ArchivedProjectsModal.test.tsx
@@ -54,6 +54,36 @@ describe("ArchivedProjectsModal (#881)", () => {
     }
   });
 
+  it("exposes dialog semantics, takes focus, and restores focus on cleanup", async () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const fake = new FakeTransport();
+    fake.resolve("list_archived_projects", []);
+    const onClose = vi.fn();
+
+    const rendered = renderWithFakeTransport(() => <ArchivedProjectsModal onClose={onClose} />, fake);
+    try {
+      await waitFor(() => expect(byTestId("archivedProjects.empty")).toBeTruthy());
+      const modal = byTestId("archivedProjects.modal");
+      const closeButton = modal.querySelector<HTMLButtonElement>(".modal-close");
+
+      expect(modal.getAttribute("role")).toBe("dialog");
+      expect(modal.getAttribute("aria-modal")).toBe("true");
+      expect(modal.getAttribute("aria-labelledby")).toBe("archived-projects-title");
+      expect(document.getElementById("archived-projects-title")?.textContent).toBe("Archived projects");
+      await waitFor(() => expect(document.activeElement).toBe(closeButton));
+
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    } finally {
+      rendered.cleanup();
+    }
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
   it("renders rows, unarchives through the backend, discovers, and refetches", async () => {
     let rows = [row("C:\\Archive\\One"), row("C:\\Archive\\Two")];
     const fake = new FakeTransport();
@@ -142,6 +172,35 @@ describe("ArchivedProjectsModal (#881)", () => {
         expect(byTestId(`archivedProjects.rowError.${id}`).textContent).toContain("Workspace missing"),
       );
       expect(byTestId(`archivedProjects.row.${id}`)).toBeTruthy();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("renders a failed post-unarchive refetch as a top-level list error", async () => {
+    let listCalls = 0;
+    const fake = new FakeTransport();
+    fake.onInvoke("list_archived_projects", () => {
+      listCalls++;
+      if (listCalls === 1) return [row("C:\\Archive\\Refetch")];
+      throw "refresh failed";
+    });
+    fake.onInvoke("unarchive_project", (args) => ({
+      path: args.path as string,
+      registered: true,
+      created: false,
+    }));
+    fake.resolve("discover_project", discovery());
+
+    const rendered = renderWithFakeTransport(() => <ArchivedProjectsModal onClose={vi.fn()} />, fake);
+    try {
+      const id = automationIdPart("C:\\Archive\\Refetch");
+      await waitFor(() => expect(byTestId(`archivedProjects.unarchive.${id}`)).toBeTruthy());
+
+      click(byTestId(`archivedProjects.unarchive.${id}`));
+
+      await waitFor(() => expect(byTestId("archivedProjects.error").textContent).toContain("refresh failed"));
+      expect(document.querySelector(`[data-ac-testid="archivedProjects.rowError.${id}"]`)).toBeNull();
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/ArchivedProjectsModal.test.tsx
+++ b/src/sidebar/components/ArchivedProjectsModal.test.tsx
@@ -66,12 +66,14 @@ describe("ArchivedProjectsModal (#881)", () => {
     const rendered = renderWithFakeTransport(() => <ArchivedProjectsModal onClose={onClose} />, fake);
     try {
       await waitFor(() => expect(byTestId("archivedProjects.empty")).toBeTruthy());
-      const modal = byTestId("archivedProjects.modal");
-      const closeButton = modal.querySelector<HTMLButtonElement>(".modal-close");
+      const overlay = byTestId("archivedProjects.modal");
+      const dialog = overlay.querySelector<HTMLDivElement>(".agent-modal");
+      const closeButton = dialog?.querySelector<HTMLButtonElement>(".modal-close");
 
-      expect(modal.getAttribute("role")).toBe("dialog");
-      expect(modal.getAttribute("aria-modal")).toBe("true");
-      expect(modal.getAttribute("aria-labelledby")).toBe("archived-projects-title");
+      expect(overlay.getAttribute("role")).toBeNull();
+      expect(dialog?.getAttribute("role")).toBe("dialog");
+      expect(dialog?.getAttribute("aria-modal")).toBe("true");
+      expect(dialog?.getAttribute("aria-labelledby")).toBe("archived-projects-title");
       expect(document.getElementById("archived-projects-title")?.textContent).toBe("Archived projects");
       await waitFor(() => expect(document.activeElement).toBe(closeButton));
 
@@ -82,6 +84,40 @@ describe("ArchivedProjectsModal (#881)", () => {
     }
 
     expect(document.activeElement).toBe(trigger);
+  });
+
+  it("traps Tab focus inside the dialog", async () => {
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+
+    const fake = new FakeTransport();
+    fake.resolve("list_archived_projects", []);
+
+    const rendered = renderWithFakeTransport(() => <ArchivedProjectsModal onClose={vi.fn()} />, fake);
+    try {
+      await waitFor(() => expect(byTestId("archivedProjects.empty")).toBeTruthy());
+      const modal = byTestId("archivedProjects.modal");
+      const closeButton = modal.querySelector<HTMLButtonElement>(".modal-close");
+      const footerButton = modal.querySelector<HTMLButtonElement>(".agent-modal-footer button");
+      if (!closeButton || !footerButton) throw new Error("Missing focus trap buttons");
+      await waitFor(() => expect(document.activeElement).toBe(closeButton));
+
+      footerButton.focus();
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }));
+      expect(document.activeElement).toBe(closeButton);
+
+      closeButton.focus();
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true, cancelable: true }),
+      );
+      expect(document.activeElement).toBe(footerButton);
+
+      outside.focus();
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }));
+      expect(document.activeElement).toBe(closeButton);
+    } finally {
+      rendered.cleanup();
+    }
   });
 
   it("renders rows, unarchives through the backend, discovers, and refetches", async () => {

--- a/src/sidebar/components/ArchivedProjectsModal.test.tsx
+++ b/src/sidebar/components/ArchivedProjectsModal.test.tsx
@@ -84,6 +84,25 @@ describe("ArchivedProjectsModal (#881)", () => {
     }
   });
 
+  it("derives row automation ids from the full path when folder names collide", async () => {
+    const firstPath = "C:\\Archive\\A\\Same";
+    const secondPath = "D:\\Archive\\B\\Same";
+    const fake = new FakeTransport();
+    fake.resolve("list_archived_projects", [
+      row(firstPath, { folderName: "Same" }),
+      row(secondPath, { folderName: "Same" }),
+    ]);
+
+    const rendered = renderWithFakeTransport(() => <ArchivedProjectsModal onClose={vi.fn()} />, fake);
+    try {
+      await waitFor(() => expect(byTestId(`archivedProjects.row.${automationIdPart(firstPath)}`)).toBeTruthy());
+      expect(byTestId(`archivedProjects.row.${automationIdPart(secondPath)}`)).toBeTruthy();
+      expect(document.querySelectorAll('[data-ac-testid^="archivedProjects.row."]')).toHaveLength(2);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
   it("shows Remove from list for missing folders and routes it through remove_project", async () => {
     let rows = [row("C:\\Archive\\Missing", { exists: false })];
     const fake = new FakeTransport();

--- a/src/sidebar/components/ArchivedProjectsModal.tsx
+++ b/src/sidebar/components/ArchivedProjectsModal.tsx
@@ -112,14 +112,14 @@ const ArchivedProjectsModal: Component<ArchivedProjectsModalProps> = (props) => 
   };
 
   return (
-    <div
-      class="modal-overlay"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="archived-projects-title"
-      data-ac-testid="archivedProjects.modal"
-    >
-      <div class="agent-modal archived-projects-modal" ref={modalRef}>
+    <div class="modal-overlay" data-ac-testid="archivedProjects.modal">
+      <div
+        class="agent-modal archived-projects-modal"
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="archived-projects-title"
+      >
         <div class="agent-modal-header">
           <span class="agent-modal-title" id="archived-projects-title">
             Archived projects

--- a/src/sidebar/components/ArchivedProjectsModal.tsx
+++ b/src/sidebar/components/ArchivedProjectsModal.tsx
@@ -26,15 +26,61 @@ const ArchivedProjectsModal: Component<ArchivedProjectsModalProps> = (props) => 
   const [rows, { refetch }] = createResource(() => ProjectAPI.listArchived());
   const [busyPath, setBusyPath] = createSignal<string | null>(null);
   const [rowError, setRowError] = createSignal<{ path: string; message: string } | null>(null);
+  let modalRef: HTMLDivElement | undefined;
+  let closeButtonRef: HTMLButtonElement | undefined;
+  let previouslyFocused: HTMLElement | null = null;
+
+  const refreshRows = async () => {
+    try {
+      await refetch();
+    } catch {
+      // createResource exposes refetch failures through rows.error.
+    }
+  };
 
   onMount(() => {
+    previouslyFocused = document.activeElement as HTMLElement | null;
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      event.preventDefault();
-      props.onClose();
+      if (event.key === "Escape") {
+        event.preventDefault();
+        props.onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusables = Array.from(
+        modalRef?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        ) ?? []
+      );
+      if (focusables.length === 0) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (!active || !modalRef?.contains(active)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+        return;
+      }
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener("keydown", onKeyDown);
-    onCleanup(() => document.removeEventListener("keydown", onKeyDown));
+    queueMicrotask(() => closeButtonRef?.focus());
+    onCleanup(() => {
+      document.removeEventListener("keydown", onKeyDown);
+      try {
+        previouslyFocused?.focus();
+      } catch {
+        // Best effort only: the original target may have been removed.
+      }
+    });
   });
 
   const unarchive = async (row: ArchivedProject) => {
@@ -42,12 +88,13 @@ const ArchivedProjectsModal: Component<ArchivedProjectsModalProps> = (props) => 
     setRowError(null);
     try {
       await projectStore.unarchiveProject(row.path);
-      await refetch();
     } catch (error) {
       setRowError({ path: row.path, message: errorMessage(error) });
+      return;
     } finally {
       setBusyPath(null);
     }
+    await refreshRows();
   };
 
   const forget = async (row: ArchivedProject) => {
@@ -55,20 +102,34 @@ const ArchivedProjectsModal: Component<ArchivedProjectsModalProps> = (props) => 
     setRowError(null);
     try {
       await ProjectAPI.remove(row.path);
-      await refetch();
     } catch (error) {
       setRowError({ path: row.path, message: errorMessage(error) });
+      return;
     } finally {
       setBusyPath(null);
     }
+    await refreshRows();
   };
 
   return (
-    <div class="modal-overlay" data-ac-testid="archivedProjects.modal">
-      <div class="agent-modal archived-projects-modal">
+    <div
+      class="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="archived-projects-title"
+      data-ac-testid="archivedProjects.modal"
+    >
+      <div class="agent-modal archived-projects-modal" ref={modalRef}>
         <div class="agent-modal-header">
-          <span class="agent-modal-title">Archived projects</span>
-          <button class="modal-close" onClick={props.onClose} aria-label="Close archived projects">
+          <span class="agent-modal-title" id="archived-projects-title">
+            Archived projects
+          </span>
+          <button
+            ref={closeButtonRef}
+            class="modal-close"
+            onClick={props.onClose}
+            aria-label="Close archived projects"
+          >
             &times;
           </button>
         </div>

--- a/src/sidebar/components/ArchivedProjectsModal.tsx
+++ b/src/sidebar/components/ArchivedProjectsModal.tsx
@@ -1,0 +1,175 @@
+import {
+  Component,
+  For,
+  Show,
+  createResource,
+  createSignal,
+  onCleanup,
+  onMount,
+} from "solid-js";
+import { ProjectAPI } from "../../shared/ipc";
+import type { ArchivedProject } from "../../shared/types";
+import { projectStore } from "../stores/project";
+import { automationIdPart } from "./replica-repo-badges";
+
+interface ArchivedProjectsModalProps {
+  onClose: () => void;
+}
+
+function errorMessage(error: unknown): string {
+  return typeof error === "string" ? error : error instanceof Error ? error.message : String(error);
+}
+
+const archiveRowId = (path: string) => automationIdPart(path);
+
+const ArchivedProjectsModal: Component<ArchivedProjectsModalProps> = (props) => {
+  const [rows, { refetch }] = createResource(() => ProjectAPI.listArchived());
+  const [busyPath, setBusyPath] = createSignal<string | null>(null);
+  const [rowError, setRowError] = createSignal<{ path: string; message: string } | null>(null);
+
+  onMount(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      props.onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    onCleanup(() => document.removeEventListener("keydown", onKeyDown));
+  });
+
+  const unarchive = async (row: ArchivedProject) => {
+    setBusyPath(row.path);
+    setRowError(null);
+    try {
+      await projectStore.unarchiveProject(row.path);
+      await refetch();
+    } catch (error) {
+      setRowError({ path: row.path, message: errorMessage(error) });
+    } finally {
+      setBusyPath(null);
+    }
+  };
+
+  const forget = async (row: ArchivedProject) => {
+    setBusyPath(row.path);
+    setRowError(null);
+    try {
+      await ProjectAPI.remove(row.path);
+      await refetch();
+    } catch (error) {
+      setRowError({ path: row.path, message: errorMessage(error) });
+    } finally {
+      setBusyPath(null);
+    }
+  };
+
+  return (
+    <div class="modal-overlay" data-ac-testid="archivedProjects.modal">
+      <div class="agent-modal archived-projects-modal">
+        <div class="agent-modal-header">
+          <span class="agent-modal-title">Archived projects</span>
+          <button class="modal-close" onClick={props.onClose} aria-label="Close archived projects">
+            &times;
+          </button>
+        </div>
+
+        <div class="archived-projects-list">
+          <Show when={rows.loading}>
+            <div class="workgroup-groups-empty">Loading...</div>
+          </Show>
+
+          <Show when={!rows.loading && rows.error}>
+            <div
+              class="workgroup-groups-errors"
+              role="alert"
+              data-ac-testid="archivedProjects.error"
+            >
+              {errorMessage(rows.error)}
+            </div>
+          </Show>
+
+          <Show when={!rows.loading && !rows.error && (rows()?.length ?? 0) === 0}>
+            <div class="workgroup-groups-empty" data-ac-testid="archivedProjects.empty">
+              No archived projects
+            </div>
+          </Show>
+
+          <Show when={!rows.loading && !rows.error && (rows()?.length ?? 0) > 0}>
+            <For each={rows() ?? []}>
+              {(row) => {
+                const rowId = () => archiveRowId(row.path);
+                const busy = () => busyPath() === row.path;
+                const error = () => {
+                  const current = rowError();
+                  return current?.path === row.path ? current.message : null;
+                };
+                return (
+                  <div
+                    class="archived-projects-row"
+                    classList={{
+                      "archived-projects-row-warning": !row.exists || !row.hasWorkspace,
+                    }}
+                    data-ac-testid={`archivedProjects.row.${rowId()}`}
+                  >
+                    <div class="archived-projects-main">
+                      <div class="archived-projects-name" title={row.path}>
+                        {row.folderName}
+                      </div>
+                      <div class="archived-projects-path" title={row.path}>
+                        {row.path}
+                      </div>
+                      <Show when={!row.exists || !row.hasWorkspace}>
+                        <div class="archived-projects-warning">
+                          {!row.exists ? "Folder missing" : "Workspace missing"}
+                        </div>
+                      </Show>
+                    </div>
+                    <div class="archived-projects-actions">
+                      <button
+                        class="modal-btn modal-btn-save"
+                        disabled={busy()}
+                        onClick={() => void unarchive(row)}
+                        data-ac-testid={`archivedProjects.unarchive.${rowId()}`}
+                      >
+                        {busy() ? "Unarchiving..." : "Unarchive"}
+                      </button>
+                      <Show when={!row.exists || !row.hasWorkspace}>
+                        <button
+                          class="modal-btn modal-btn-cancel"
+                          disabled={busy()}
+                          onClick={() => void forget(row)}
+                          data-ac-testid={`archivedProjects.forget.${rowId()}`}
+                        >
+                          Remove from list
+                        </button>
+                      </Show>
+                    </div>
+                    <Show when={error()}>
+                      {(message) => (
+                        <div
+                          class="workgroup-groups-errors archived-projects-row-error"
+                          role="alert"
+                          data-ac-testid={`archivedProjects.rowError.${rowId()}`}
+                        >
+                          {message()}
+                        </div>
+                      )}
+                    </Show>
+                  </div>
+                );
+              }}
+            </For>
+          </Show>
+        </div>
+
+        <div class="agent-modal-footer">
+          <button class="modal-btn modal-btn-cancel" onClick={props.onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ArchivedProjectsModal;

--- a/src/sidebar/components/AutoUnarchiveModal.test.tsx
+++ b/src/sidebar/components/AutoUnarchiveModal.test.tsx
@@ -75,4 +75,15 @@ describe("AutoUnarchiveModal (#881)", () => {
 
     expect(document.querySelector('[data-ac-testid="autoUnarchive.modal"]')).toBeNull();
   });
+
+  it("coalesces ten simultaneous auto-unarchives into one modal with ten rows", async () => {
+    for (let index = 0; index < 10; index++) {
+      autoUnarchiveStore.push(event(`C:\\Project${index}`, `Project${index}`));
+    }
+
+    await waitFor(() =>
+      expect(document.querySelectorAll('[data-ac-testid^="autoUnarchive.row."]')).toHaveLength(10),
+    );
+    expect(document.querySelectorAll('[data-ac-testid="autoUnarchive.modal"]')).toHaveLength(1);
+  });
 });

--- a/src/sidebar/components/AutoUnarchiveModal.test.tsx
+++ b/src/sidebar/components/AutoUnarchiveModal.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { render } from "solid-js/web";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ProjectArchiveChanged } from "../../shared/types";
+import { click, waitFor } from "../../shared/testing/ui-harness";
+import { autoUnarchiveStore } from "../stores/auto-unarchive";
+import AutoUnarchiveModal from "./AutoUnarchiveModal";
+
+function event(
+  path: string,
+  folderName: string,
+  reason: ProjectArchiveChanged["reason"] = "autoUnarchive",
+): ProjectArchiveChanged {
+  return {
+    path,
+    folderName,
+    archived: false,
+    reason,
+    sessionName: `${folderName}/dev-webpage-ui`,
+  };
+}
+
+function byTestId<T extends HTMLElement = HTMLElement>(testId: string): T {
+  const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing ${testId}`);
+  return element;
+}
+
+describe("AutoUnarchiveModal (#881)", () => {
+  let dispose: (() => void) | null = null;
+
+  beforeEach(() => {
+    autoUnarchiveStore.acknowledge();
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    dispose = render(() => <AutoUnarchiveModal />, root);
+  });
+
+  afterEach(() => {
+    dispose?.();
+    dispose = null;
+    autoUnarchiveStore.acknowledge();
+    document.body.replaceChildren();
+  });
+
+  it("coalesces auto-unarchive events, dedupes by project path, and requires acknowledgement", async () => {
+    autoUnarchiveStore.push(event("C:\\ProjectA", "ProjectA"));
+
+    await waitFor(() => expect(byTestId("autoUnarchive.modal")).toBeTruthy());
+    expect(byTestId("autoUnarchive.modal").textContent).toContain("ProjectA");
+    expect(byTestId("autoUnarchive.modal").textContent).toContain("ProjectA/dev-webpage-ui");
+
+    autoUnarchiveStore.push(event("C:\\ProjectB", "ProjectB"));
+    await waitFor(() =>
+      expect(document.querySelectorAll('[data-ac-testid^="autoUnarchive.row."]')).toHaveLength(2),
+    );
+    expect(document.querySelectorAll('[data-ac-testid="autoUnarchive.modal"]')).toHaveLength(1);
+
+    autoUnarchiveStore.push(event("c:/projecta/", "ProjectA duplicate"));
+    await Promise.resolve();
+    expect(document.querySelectorAll('[data-ac-testid^="autoUnarchive.row."]')).toHaveLength(2);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(byTestId("autoUnarchive.modal")).toBeTruthy();
+
+    click(byTestId("autoUnarchive.acknowledge"));
+    await waitFor(() =>
+      expect(document.querySelector('[data-ac-testid="autoUnarchive.modal"]')).toBeNull(),
+    );
+  });
+
+  it("ignores non-auto-unarchive reasons", async () => {
+    autoUnarchiveStore.push(event("C:\\ProjectA", "ProjectA", "unarchive"));
+    await Promise.resolve();
+
+    expect(document.querySelector('[data-ac-testid="autoUnarchive.modal"]')).toBeNull();
+  });
+});

--- a/src/sidebar/components/AutoUnarchiveModal.tsx
+++ b/src/sidebar/components/AutoUnarchiveModal.tsx
@@ -67,15 +67,14 @@ const AutoUnarchiveModal: Component = () => {
   return (
     <Show when={autoUnarchiveStore.open}>
       <Portal>
-        <div
-          class="modal-overlay auto-unarchive-overlay"
-          role="alertdialog"
-          aria-modal="true"
-          aria-labelledby="auto-unarchive-title"
-          aria-describedby="auto-unarchive-description"
-          data-ac-testid="autoUnarchive.modal"
-        >
-          <div class="agent-modal auto-unarchive-modal">
+        <div class="modal-overlay auto-unarchive-overlay" data-ac-testid="autoUnarchive.modal">
+          <div
+            class="agent-modal auto-unarchive-modal"
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="auto-unarchive-title"
+            aria-describedby="auto-unarchive-description"
+          >
             <div class="agent-modal-header">
               <span class="agent-modal-title" id="auto-unarchive-title">
                 {entries().length === 1 ? "Project un-archived" : "Projects un-archived"}

--- a/src/sidebar/components/AutoUnarchiveModal.tsx
+++ b/src/sidebar/components/AutoUnarchiveModal.tsx
@@ -1,0 +1,133 @@
+import { Component, For, Show, createEffect, onCleanup, onMount } from "solid-js";
+import { Portal } from "solid-js/web";
+import { autoUnarchiveStore } from "../stores/auto-unarchive";
+import { automationIdPart } from "./replica-repo-badges";
+
+const AutoUnarchiveModal: Component = () => {
+  let messageRef: HTMLDivElement | undefined;
+  let acknowledgeRef: HTMLButtonElement | undefined;
+  let previouslyFocused: HTMLElement | null = null;
+  let wasOpen = false;
+
+  const entries = () => autoUnarchiveStore.entries;
+
+  onMount(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!autoUnarchiveStore.open) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        return;
+      }
+      if (event.key === "Tab") {
+        event.stopImmediatePropagation();
+        const focusables = [messageRef, acknowledgeRef].filter(Boolean) as HTMLElement[];
+        if (focusables.length < 2) return;
+        const index = focusables.indexOf(document.activeElement as HTMLElement);
+        if (index === -1) {
+          event.preventDefault();
+          (event.shiftKey ? focusables[focusables.length - 1] : focusables[0]).focus();
+          return;
+        }
+        if (event.shiftKey) {
+          if (index <= 0) {
+            event.preventDefault();
+            focusables[focusables.length - 1].focus();
+          }
+        } else if (index === focusables.length - 1) {
+          event.preventDefault();
+          focusables[0].focus();
+        }
+        return;
+      }
+      event.stopImmediatePropagation();
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    onCleanup(() => document.removeEventListener("keydown", onKeyDown, true));
+  });
+
+  createEffect(() => {
+    const open = autoUnarchiveStore.open;
+    if (open === wasOpen) return;
+    wasOpen = open;
+    if (open) {
+      previouslyFocused = document.activeElement as HTMLElement | null;
+      queueMicrotask(() => acknowledgeRef?.focus());
+    } else {
+      try {
+        previouslyFocused?.focus();
+      } catch {
+        // Best effort only: the original target may have been removed.
+      }
+      previouslyFocused = null;
+    }
+  });
+
+  return (
+    <Show when={autoUnarchiveStore.open}>
+      <Portal>
+        <div
+          class="modal-overlay auto-unarchive-overlay"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="auto-unarchive-title"
+          aria-describedby="auto-unarchive-description"
+          data-ac-testid="autoUnarchive.modal"
+        >
+          <div class="agent-modal auto-unarchive-modal">
+            <div class="agent-modal-header">
+              <span class="agent-modal-title" id="auto-unarchive-title">
+                {entries().length === 1 ? "Project un-archived" : "Projects un-archived"}
+              </span>
+            </div>
+
+            <div
+              class="auto-unarchive-body"
+              id="auto-unarchive-description"
+              ref={messageRef}
+              tabindex="0"
+            >
+              <p class="auto-unarchive-copy">
+                {entries().length === 1
+                  ? `${entries()[0].folderName} was restored to your project list. A session started inside it, and an archived project cannot hold a running session.`
+                  : "These projects were restored to your project list because sessions started inside them, and archived projects cannot hold running sessions."}
+              </p>
+              <div class="auto-unarchive-list">
+                <For each={entries()}>
+                  {(entry) => (
+                    <div
+                      class="auto-unarchive-row"
+                      title={entry.path}
+                      data-ac-testid={`autoUnarchive.row.${automationIdPart(entry.path)}`}
+                    >
+                      <strong>{entry.folderName}</strong>
+                      <Show when={entry.sessionName}>
+                        {(sessionName) => (
+                          <span class="auto-unarchive-session">{sessionName()}</span>
+                        )}
+                      </Show>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </div>
+
+            <div class="agent-modal-footer">
+              <button
+                ref={acknowledgeRef}
+                class="modal-btn modal-btn-save"
+                onClick={() => autoUnarchiveStore.acknowledge()}
+                data-ac-testid="autoUnarchive.acknowledge"
+              >
+                Got it
+              </button>
+            </div>
+          </div>
+        </div>
+      </Portal>
+    </Show>
+  );
+};
+
+export default AutoUnarchiveModal;

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -118,6 +118,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoSelfClearByAgent: {},
     logLevel: null,
     ...overrides,
+    archivedProjectPaths: overrides.archivedProjectPaths ?? [],
   };
 }
 

--- a/src/sidebar/components/ProjectPanel.archive.test.tsx
+++ b/src/sidebar/components/ProjectPanel.archive.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ToastHost from "../../shared/components/ToastHost";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  click,
+  contextMenu,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import ProjectPanel from "./ProjectPanel";
+import { automationIdPart } from "./replica-repo-badges";
+
+const projectPath = "C:\\Project";
+
+function setupTransport(fake: FakeTransport): void {
+  fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+  fake.resolve("discover_project", discovery());
+  fake.resolve("get_settings", baseSettings());
+}
+
+function projectHeader(): HTMLElement {
+  const header = document.querySelector<HTMLElement>(".project-header");
+  if (!header) throw new Error("project header not found");
+  return header;
+}
+
+function menuButtons(): HTMLButtonElement[] {
+  const menu = document.querySelector<HTMLElement>(".session-context-menu");
+  if (!menu) throw new Error("context menu not found");
+  return Array.from(menu.querySelectorAll<HTMLButtonElement>(".session-context-option"));
+}
+
+function buttonByText(label: string): HTMLButtonElement {
+  const button = menuButtons().find((candidate) => candidate.textContent?.trim() === label);
+  if (!button) throw new Error(`button not found: ${label}`);
+  return button;
+}
+
+function byTestId<T extends HTMLElement = HTMLElement>(testId: string): T {
+  const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing ${testId}`);
+  return element;
+}
+
+describe("ProjectPanel Archive Project action (#881)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("renders Archive Project above Remove Project without danger styling and routes clicks to archive_project", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    fake.resolve("archive_project", undefined);
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(projectHeader()).toBeTruthy());
+
+      contextMenu(projectHeader());
+      await waitFor(() => expect(buttonByText("Archive Project")).toBeTruthy());
+
+      const labels = menuButtons().map((button) => button.textContent?.trim());
+      expect(labels.indexOf("Archive Project")).toBeGreaterThan(-1);
+      expect(labels.indexOf("Archive Project")).toBeLessThan(labels.indexOf("Remove Project"));
+      expect(buttonByText("Archive Project").classList.contains("context-option-danger")).toBe(false);
+      expect(buttonByText("Remove Project").classList.contains("context-option-danger")).toBe(true);
+
+      click(byTestId(`project.action.archive.${automationIdPart(projectPath)}`));
+
+      await waitFor(() => expect(fake.callsFor("archive_project")).toHaveLength(1));
+      expect(fake.callsFor("archive_project")[0].args.path).toBe(projectPath);
+      expect(projectStore.projects).toHaveLength(0);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows the backend rejection and leaves the project rendered", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    fake.reject("archive_project", "Cannot archive: 1 open session in this project.");
+
+    const rendered = renderWithFakeTransport(
+      () => (
+        <>
+          <ProjectPanel />
+          <ToastHost />
+        </>
+      ),
+      fake,
+    );
+    try {
+      await projectStore.createAndLoad(projectPath);
+      await waitFor(() => expect(projectHeader()).toBeTruthy());
+
+      contextMenu(projectHeader());
+      await waitFor(() => expect(buttonByText("Archive Project")).toBeTruthy());
+      click(buttonByText("Archive Project"));
+
+      await waitFor(() =>
+        expect(byTestId("toast.item").textContent).toContain(
+          "Cannot archive: 1 open session in this project.",
+        ),
+      );
+      expect(projectHeader()).toBeTruthy();
+      expect(projectStore.projects).toHaveLength(1);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1820,6 +1820,15 @@ const ProjectPanel: Component = () => {
           projectStore.removeProject(proj.path);
         };
 
+        const handleArchiveProject = async () => {
+          setShowCtxMenu(false);
+          try {
+            await projectStore.archiveProject(proj.path);
+          } catch (error) {
+            toastStore.error(typeof error === "string" ? error : String(error));
+          }
+        };
+
         const handleTeamContextMenu = (e: MouseEvent, team: AcTeam) => {
           e.preventDefault();
           e.stopPropagation();
@@ -2479,6 +2488,14 @@ const ProjectPanel: Component = () => {
                     data-ac-testid={`loop.action.new.${projectAutomationId()}.projectMenu`}
                   >
                     New Loop
+                  </button>
+                  <div class="context-separator" />
+                  <button
+                    class="session-context-option"
+                    onClick={() => void handleArchiveProject()}
+                    data-ac-testid={`project.action.archive.${projectAutomationId()}`}
+                  >
+                    Archive Project
                   </button>
                   <div class="context-separator" />
                   <button

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -152,6 +152,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoSelfClearByAgent: {},
     logLevel: null,
     ...overrides,
+    archivedProjectPaths: overrides.archivedProjectPaths ?? [],
   };
 }
 

--- a/src/sidebar/components/SettingsModal.test.ts
+++ b/src/sidebar/components/SettingsModal.test.ts
@@ -79,6 +79,7 @@ function settings(overrides: Partial<AppSettings>): AppSettings {
     autoSelfClearByAgent: {},
     logLevel: null,
     ...overrides,
+    archivedProjectPaths: overrides.archivedProjectPaths ?? [],
   };
 }
 

--- a/src/sidebar/components/WorkgroupGroupRail.archive.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.archive.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AcWorkgroup } from "../../shared/types";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import type { ProjectState } from "../stores/project";
+import { defaultGroupsConfig } from "../stores/workgroup-groups";
+import WorkgroupGroupRail from "./WorkgroupGroupRail";
+
+const projectPath = "C:\\Project";
+
+function wg(name: string): AcWorkgroup {
+  return {
+    name,
+    path: `${projectPath}\\.ac\\${name}`,
+    task: null,
+    taskTitle: null,
+    agents: [],
+  };
+}
+
+function project(): ProjectState {
+  return {
+    path: projectPath,
+    folderName: "Project",
+    workgroups: [wg("wg-1-dev-team")],
+    agents: [],
+    teams: [],
+    loops: [],
+    contextTemplateUpdates: [],
+  };
+}
+
+function byTestId<T extends HTMLElement = HTMLElement>(testId: string): T {
+  const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing ${testId}`);
+  return element;
+}
+
+describe("WorkgroupGroupRail archive entry point (#881)", () => {
+  beforeEach(() => {
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("renders one archive button with zero projects and opens the archived projects modal", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("list_archived_projects", []);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[]} />, fake);
+    try {
+      expect(document.querySelectorAll('[data-ac-testid="workgroupGroups.rail.archive"]')).toHaveLength(1);
+      expect(document.querySelectorAll('[data-ac-testid^="workgroupGroups.button."]')).toHaveLength(0);
+
+      click(byTestId("workgroupGroups.rail.archive"));
+      await waitFor(() => expect(byTestId("archivedProjects.modal")).toBeTruthy());
+      expect(byTestId("archivedProjects.empty").textContent).toContain("No archived projects");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps project sections inside the scroll wrapper and the archive button outside it", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_project_groups", defaultGroupsConfig());
+    fake.resolve("list_archived_projects", []);
+
+    const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+    try {
+      await waitFor(() => expect(byTestId("workgroupGroups.rail.Project")).toBeTruthy());
+
+      const rail = byTestId("workgroupGroups.rail");
+      const scroll = rail.querySelector(".workgroup-group-rail-scroll");
+      const projectSection = byTestId("workgroupGroups.rail.Project");
+      const archiveButton = byTestId("workgroupGroups.rail.archive");
+
+      expect(scroll).toBeTruthy();
+      expect(projectSection.parentElement).toBe(scroll);
+      expect(archiveButton.parentElement).toBe(rail);
+      expect(scroll?.contains(archiveButton)).toBe(false);
+      expect(document.querySelectorAll('[data-ac-testid="workgroupGroups.rail.archive"]')).toHaveLength(1);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -20,6 +20,8 @@ import {
 } from "./workgroup-session";
 import WorkgroupGroupsModal from "./WorkgroupGroupsModal";
 import RaiseHandIcon from "./RaiseHandIcon";
+import ArchiveIcon from "./ArchiveIcon";
+import ArchivedProjectsModal from "./ArchivedProjectsModal";
 
 interface WorkgroupGroupRailProps {
   projects: ProjectState[];
@@ -597,17 +599,37 @@ const ProjectRailSection: Component<{
 };
 
 const WorkgroupGroupRail: Component<WorkgroupGroupRailProps> = (props) => {
+  const [showArchived, setShowArchived] = createSignal(false);
+
   createEffect(() => {
     workgroupGroupsStore.reconcileActiveProject(props.projects.map((project) => project.path));
   });
 
   return (
     <aside class="workgroup-group-rail" data-ac-testid="workgroupGroups.rail">
-      <For each={props.projects}>
-        {(project) => (
-          <ProjectRailSection project={project} showProjectLabel={true} />
-        )}
-      </For>
+      <div class="workgroup-group-rail-scroll">
+        <For each={props.projects}>
+          {(project) => (
+            <ProjectRailSection project={project} showProjectLabel={true} />
+          )}
+        </For>
+      </div>
+
+      <button
+        class="workgroup-group-rail-archive"
+        onClick={() => setShowArchived(true)}
+        title="Archived projects"
+        aria-label="Archived projects"
+        aria-haspopup="dialog"
+        data-ac-testid="workgroupGroups.rail.archive"
+      >
+        <ArchiveIcon class="workgroup-group-rail-archive-icon" />
+        <span class="workgroup-group-rail-archive-label">Archive</span>
+      </button>
+
+      <Show when={showArchived()}>
+        <ArchivedProjectsModal onClose={() => setShowArchived(false)} />
+      </Show>
     </aside>
   );
 };

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -93,6 +93,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoSelfClearByAgent: {},
     logLevel: null,
     ...overrides,
+    archivedProjectPaths: overrides.archivedProjectPaths ?? [],
   };
 }
 
@@ -132,13 +133,22 @@ describe("mergeSettingsForSavePreservingProjects (#529 G3 normalization)", () =>
     );
   });
 
-  it("still adopts projectPaths/projectPath from the fresh settings", () => {
-    const draft = settings({ projectPath: "C:/stale", projectPaths: ["C:/stale"] });
-    const fresh = settings({ projectPath: "C:/fresh", projectPaths: ["C:/fresh", "C:/other"] });
+  it("still adopts projectPaths/projectPath and archivedProjectPaths from the fresh settings", () => {
+    const draft = settings({
+      projectPath: "C:/stale",
+      projectPaths: ["C:/stale"],
+      archivedProjectPaths: ["C:/draft-archive"],
+    });
+    const fresh = settings({
+      projectPath: "C:/fresh",
+      projectPaths: ["C:/fresh", "C:/other"],
+      archivedProjectPaths: ["C:/fresh-archive"],
+    });
     const merged = mergeSettingsForSavePreservingProjects(draft, fresh);
 
     expect(merged.projectPath).toBe("C:/fresh");
     expect(merged.projectPaths).toEqual(["C:/fresh", "C:/other"]);
+    expect(merged.archivedProjectPaths).toEqual(["C:/fresh-archive"]);
   });
 });
 

--- a/src/sidebar/components/settings-save.ts
+++ b/src/sidebar/components/settings-save.ts
@@ -98,5 +98,6 @@ export function mergeSettingsForSavePreservingProjects(
       .map(normalizeAgentBackend),
     projectPaths: fresh.projectPaths ?? [],
     projectPath: fresh.projectPath ?? null,
+    archivedProjectPaths: fresh.archivedProjectPaths ?? [],
   };
 }

--- a/src/sidebar/stores/auto-unarchive.ts
+++ b/src/sidebar/stores/auto-unarchive.ts
@@ -1,0 +1,30 @@
+import { createSignal } from "solid-js";
+import type { ProjectArchiveChanged } from "../../shared/types";
+import { normalizeProjectPathForCompare } from "./project-refresh";
+
+const [entries, setEntries] = createSignal<ProjectArchiveChanged[]>([]);
+
+function samePath(left: string, right: string): boolean {
+  return normalizeProjectPathForCompare(left) === normalizeProjectPathForCompare(right);
+}
+
+export const autoUnarchiveStore = {
+  get entries() {
+    return entries();
+  },
+
+  get open() {
+    return entries().length > 0;
+  },
+
+  push(event: ProjectArchiveChanged) {
+    if (event.reason !== "autoUnarchive") return;
+    setEntries((prev) =>
+      prev.some((entry) => samePath(entry.path, event.path)) ? prev : [...prev, event]
+    );
+  },
+
+  acknowledge() {
+    setEntries([]);
+  },
+};

--- a/src/sidebar/stores/project.archive-event.test.ts
+++ b/src/sidebar/stores/project.archive-event.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ArchiveChangeReason, ProjectArchiveChanged } from "../../shared/types";
+
+const m = vi.hoisted(() => ({
+  open: vi.fn(),
+  newProject: vi.fn(),
+  discover: vi.fn(),
+  remove: vi.fn(),
+  archive: vi.fn(),
+  unarchive: vi.fn(),
+}));
+
+vi.mock("../../shared/ipc", () => ({
+  ProjectAPI: {
+    open: m.open,
+    new: m.newProject,
+    discover: m.discover,
+    remove: m.remove,
+    archive: m.archive,
+    unarchive: m.unarchive,
+  },
+  AgentCreatorAPI: {
+    pickFolder: vi.fn(),
+  },
+}));
+
+import { projectStore } from "./project";
+import { replicaVolatileStore } from "./replica-volatile";
+
+const PROJECT_PATH = "C:\\Users\\Maria\\Project";
+const REPLICA_PATH = `${PROJECT_PATH}\\.ac\\wg-1-dev-team\\__agent_dev-webpage-ui`;
+
+function discovery() {
+  return {
+    workgroups: [
+      {
+        name: "wg-1-dev-team",
+        path: `${PROJECT_PATH}\\.ac\\wg-1-dev-team`,
+        task: null,
+        taskTitle: null,
+        agents: [
+          {
+            name: "dev-webpage-ui",
+            path: REPLICA_PATH,
+            repoPaths: [],
+            isCoordinator: true,
+          },
+        ],
+      },
+    ],
+    agents: [],
+    teams: [],
+    loops: [],
+    contextTemplateUpdates: [],
+  };
+}
+
+function event(
+  reason: ArchiveChangeReason,
+  archived: boolean,
+  path = PROJECT_PATH,
+): ProjectArchiveChanged {
+  return {
+    path,
+    folderName: "Project",
+    archived,
+    reason,
+    sessionName: reason === "autoUnarchive" ? "wg-1-dev-team/dev-webpage-ui" : undefined,
+  };
+}
+
+describe("projectStore archive event reconciliation (#881)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectStore.clear();
+    m.open.mockResolvedValue({ path: PROJECT_PATH, registered: false, created: false });
+    m.newProject.mockResolvedValue({ path: PROJECT_PATH, registered: true, created: false });
+    m.discover.mockResolvedValue(discovery());
+    m.remove.mockResolvedValue(undefined);
+    m.archive.mockResolvedValue(undefined);
+    m.unarchive.mockResolvedValue({ path: PROJECT_PATH, registered: true, created: false });
+  });
+
+  afterEach(() => {
+    projectStore.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the archive echo idempotent after archiveProject already mutated the store", async () => {
+    const clearSpy = vi.spyOn(replicaVolatileStore, "clearForPaths");
+    await projectStore.loadProject(PROJECT_PATH);
+    clearSpy.mockClear();
+
+    await projectStore.archiveProject(PROJECT_PATH);
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+
+    await projectStore.applyArchiveChange(event("archive", true));
+    await projectStore.applyArchiveChange(event("archive", true));
+
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("is idempotent for archive, unarchive, autoUnarchive, open, and remove reasons", async () => {
+    const clearSpy = vi.spyOn(replicaVolatileStore, "clearForPaths");
+
+    await projectStore.loadProject(PROJECT_PATH);
+    clearSpy.mockClear();
+    await projectStore.applyArchiveChange(event("archive", true));
+    await projectStore.applyArchiveChange(event("archive", true));
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+
+    for (const reason of ["unarchive", "autoUnarchive", "open"] as const) {
+      projectStore.clear();
+      m.discover.mockClear();
+      await projectStore.initFromSettings([], null, [PROJECT_PATH]);
+
+      await projectStore.applyArchiveChange(event(reason, false));
+      await projectStore.applyArchiveChange(event(reason, false));
+
+      expect(projectStore.archivedPaths).toEqual([]);
+      expect(projectStore.projects).toHaveLength(1);
+      expect(projectStore.projects[0].path).toBe(PROJECT_PATH);
+      expect(m.discover).toHaveBeenCalledTimes(1);
+      expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
+    }
+
+    projectStore.clear();
+    await projectStore.initFromSettings([], null, [PROJECT_PATH]);
+    await projectStore.loadProject(PROJECT_PATH);
+    await projectStore.applyArchiveChange(event("remove", false));
+    await projectStore.applyArchiveChange(event("remove", false));
+
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([]);
+  });
+});

--- a/src/sidebar/stores/project.archive-event.test.ts
+++ b/src/sidebar/stores/project.archive-event.test.ts
@@ -155,6 +155,72 @@ describe("projectStore archive event reconciliation (#881)", () => {
     expect(projectStore.archivedPaths).toEqual([]);
   });
 
+  it("does not render a loadProject result after an archive event lands during discover", async () => {
+    const pendingDiscover = deferred<ReturnType<typeof discovery>>();
+    m.discover.mockReturnValueOnce(pendingDiscover.promise);
+
+    const load = projectStore.loadProject(PROJECT_PATH);
+    await flushArchiveQueueStart();
+    expect(m.open).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
+
+    const archiveEvent = projectStore.applyArchiveChange(event("archive", true));
+    await flushArchiveQueueStart();
+
+    pendingDiscover.resolve(discovery());
+    await Promise.all([load, archiveEvent]);
+
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+  });
+
+  it("does not append a loadProject result while the path is already archived", async () => {
+    await projectStore.initFromSettings([], null, [PROJECT_PATH]);
+
+    await projectStore.loadProject(PROJECT_PATH);
+
+    expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+  });
+
+  it("does not render a createAndLoad result after an archive event lands during discover", async () => {
+    const pendingDiscover = deferred<ReturnType<typeof discovery>>();
+    m.discover.mockReturnValueOnce(pendingDiscover.promise);
+
+    const create = projectStore.createAndLoad(PROJECT_PATH);
+    await flushArchiveQueueStart();
+    expect(m.newProject).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
+
+    const archiveEvent = projectStore.applyArchiveChange(event("archive", true));
+    await flushArchiveQueueStart();
+
+    pendingDiscover.resolve(discovery());
+    await Promise.all([create, archiveEvent]);
+
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+  });
+
+  it("does not resurrect loadProject after a remove event lands during discover", async () => {
+    const pendingDiscover = deferred<ReturnType<typeof discovery>>();
+    m.discover.mockReturnValueOnce(pendingDiscover.promise);
+
+    const load = projectStore.loadProject(PROJECT_PATH);
+    await flushArchiveQueueStart();
+    expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
+
+    const removeEvent = projectStore.applyArchiveChange(event("remove", false));
+    await flushArchiveQueueStart();
+
+    pendingDiscover.resolve(discovery());
+    await Promise.all([load, removeEvent]);
+
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([]);
+  });
+
   it("does not re-add a project when an archive event lands during an open-event discover", async () => {
     const pendingDiscover = deferred<ReturnType<typeof discovery>>();
     m.discover.mockReturnValueOnce(pendingDiscover.promise);
@@ -205,6 +271,24 @@ describe("projectStore archive event reconciliation (#881)", () => {
     expect(projectStore.archivedPaths).toEqual([]);
   });
 
+  it("keeps a concurrent archive event authoritative while direct unarchive is in flight", async () => {
+    await projectStore.initFromSettings([], null, [PROJECT_PATH]);
+    const pendingUnarchive = deferred<{ path: string; registered: boolean; created: boolean }>();
+    m.unarchive.mockReturnValueOnce(pendingUnarchive.promise);
+
+    const unarchive = projectStore.unarchiveProject(PROJECT_PATH);
+    await flushArchiveQueueStart();
+    expect(m.unarchive).toHaveBeenCalledWith(PROJECT_PATH);
+
+    const archiveEvent = projectStore.applyArchiveChange(event("archive", true));
+
+    pendingUnarchive.resolve({ path: PROJECT_PATH, registered: true, created: false });
+    await Promise.all([unarchive, archiveEvent]);
+
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+  });
+
   it("does not append after a direct archiveProject completes during an open-event discover", async () => {
     const pendingDiscover = deferred<ReturnType<typeof discovery>>();
     m.discover.mockReturnValueOnce(pendingDiscover.promise);
@@ -212,10 +296,10 @@ describe("projectStore archive event reconciliation (#881)", () => {
     const openEvent = projectStore.applyArchiveChange(event("open", false));
     await flushArchiveQueueStart();
     expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
-    await projectStore.archiveProject(PROJECT_PATH);
+    const archive = projectStore.archiveProject(PROJECT_PATH);
 
     pendingDiscover.resolve(discovery());
-    await openEvent;
+    await Promise.all([openEvent, archive]);
 
     expect(projectStore.projects).toHaveLength(0);
     expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);

--- a/src/sidebar/stores/project.archive-event.test.ts
+++ b/src/sidebar/stores/project.archive-event.test.ts
@@ -289,19 +289,91 @@ describe("projectStore archive event reconciliation (#881)", () => {
     expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
   });
 
-  it("does not append after a direct archiveProject completes during an open-event discover", async () => {
-    const pendingDiscover = deferred<ReturnType<typeof discovery>>();
-    m.discover.mockReturnValueOnce(pendingDiscover.promise);
+  it("preserves a concurrent boot-time archive when initFromSettings runs with a stale snapshot", async () => {
+    // FE-F11 (G4): a second window/CLI archived P during this window's boot -
+    // applyArchiveChange committed it before initFromSettings ran with the
+    // already-read (stale) settings snapshot. A wholesale replace would drop
+    // it, then loadProject would re-register P on disk. Reds on wholesale-replace.
+    await projectStore.applyArchiveChange(event("archive", true));
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
 
-    const openEvent = projectStore.applyArchiveChange(event("open", false));
-    await flushArchiveQueueStart();
-    expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
-    const archive = projectStore.archiveProject(PROJECT_PATH);
-
-    pendingDiscover.resolve(discovery());
-    await Promise.all([openEvent, archive]);
+    await projectStore.initFromSettings([PROJECT_PATH], null, []);
 
     expect(projectStore.projects).toHaveLength(0);
     expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+  });
+
+  it("queues a direct archiveProject behind an in-flight direct unarchiveProject", async () => {
+    // FE-F13 (G3): without archiveProject's tail (MU3), unarchive's stale
+    // continuation resumes after the archive commits and re-appends P.
+    await projectStore.initFromSettings([], null, [PROJECT_PATH]);
+    const pending = deferred<{ path: string; registered: boolean; created: boolean }>();
+    m.unarchive.mockReturnValueOnce(pending.promise);
+
+    const un = projectStore.unarchiveProject(PROJECT_PATH);
+    await flushArchiveQueueStart();
+    expect(m.unarchive).toHaveBeenCalledWith(PROJECT_PATH);
+
+    const arch = projectStore.archiveProject(PROJECT_PATH);
+    await flushArchiveQueueStart();
+    expect(m.archive).not.toHaveBeenCalled();
+
+    pending.resolve({ path: PROJECT_PATH, registered: true, created: false });
+    await Promise.all([un, arch]);
+
+    expect(m.archive).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+  });
+
+  it("keeps the tail alive for a queued event after the head archiveProject rejects", async () => {
+    // FE-F18 (G2): previous.catch(() => undefined) lets a queued task run after
+    // the head rejects - and the rejecting head is the COMMON live-sessions
+    // path. Reds on MU13 (drop the catch): the echo is silently dropped.
+    await projectStore.loadProject(PROJECT_PATH);
+    expect(projectStore.projects).toHaveLength(1);
+
+    const pendingArchive = deferred<void>();
+    m.archive.mockReturnValueOnce(pendingArchive.promise);
+
+    const archive = projectStore.archiveProject(PROJECT_PATH);
+    await flushArchiveQueueStart();
+    expect(m.archive).toHaveBeenCalledWith(PROJECT_PATH);
+
+    const archiveEvent = projectStore.applyArchiveChange(event("archive", true));
+    pendingArchive.reject("Cannot archive: 1 open session in this project.");
+    await expect(archive).rejects.toBe("Cannot archive: 1 open session in this project.");
+    await archiveEvent;
+
+    // The echo queued behind the rejected head still applied.
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+
+    // Tail not poisoned: a later change on the same key still runs.
+    await projectStore.applyArchiveChange(event("unarchive", false));
+    expect(projectStore.projects).toHaveLength(1);
+    expect(projectStore.projects[0].path).toBe(PROJECT_PATH);
+    expect(projectStore.archivedPaths).toEqual([]);
+  });
+
+  it("does not resurrect createAndLoad after a remove event lands during discover", async () => {
+    // FE-F12 (P6b): mirrors P6 for createAndLoad's tail; MU2 (createAndLoad
+    // drops the tail, keeps the belt) was previously unpinned.
+    const pendingDiscover = deferred<ReturnType<typeof discovery>>();
+    m.discover.mockReturnValueOnce(pendingDiscover.promise);
+
+    const create = projectStore.createAndLoad(PROJECT_PATH);
+    await flushArchiveQueueStart();
+    expect(m.newProject).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
+
+    const removeEvent = projectStore.applyArchiveChange(event("remove", false));
+    await flushArchiveQueueStart();
+
+    pendingDiscover.resolve(discovery());
+    await Promise.all([create, removeEvent]);
+
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([]);
   });
 });

--- a/src/sidebar/stores/project.archive-event.test.ts
+++ b/src/sidebar/stores/project.archive-event.test.ts
@@ -69,6 +69,21 @@ function event(
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushArchiveQueueStart(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe("projectStore archive event reconciliation (#881)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -138,5 +153,71 @@ describe("projectStore archive event reconciliation (#881)", () => {
 
     expect(projectStore.projects).toHaveLength(0);
     expect(projectStore.archivedPaths).toEqual([]);
+  });
+
+  it("does not re-add a project when an archive event lands during an open-event discover", async () => {
+    const pendingDiscover = deferred<ReturnType<typeof discovery>>();
+    m.discover.mockReturnValueOnce(pendingDiscover.promise);
+
+    const openEvent = projectStore.applyArchiveChange(event("open", false));
+    await flushArchiveQueueStart();
+    expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
+
+    const archiveEvent = projectStore.applyArchiveChange(event("archive", true));
+
+    pendingDiscover.resolve(discovery());
+    await Promise.all([openEvent, archiveEvent]);
+
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+  });
+
+  it("applies a queued remove event after an in-flight open-event discover", async () => {
+    const pendingDiscover = deferred<ReturnType<typeof discovery>>();
+    m.discover.mockReturnValueOnce(pendingDiscover.promise);
+
+    const openEvent = projectStore.applyArchiveChange(event("open", false));
+    await flushArchiveQueueStart();
+    expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
+    const removeEvent = projectStore.applyArchiveChange(event("remove", false));
+
+    pendingDiscover.resolve(discovery());
+    await Promise.all([openEvent, removeEvent]);
+
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([]);
+  });
+
+  it("coalesces a direct unarchive and backend unarchive event into one discover", async () => {
+    await projectStore.initFromSettings([], null, [PROJECT_PATH]);
+    let backendEvent: Promise<void> | undefined;
+    m.unarchive.mockImplementationOnce(() => {
+      backendEvent = projectStore.applyArchiveChange(event("unarchive", false));
+      return Promise.resolve({ path: PROJECT_PATH, registered: true, created: false });
+    });
+
+    await projectStore.unarchiveProject(PROJECT_PATH);
+    await backendEvent;
+
+    expect(m.discover).toHaveBeenCalledTimes(1);
+    expect(projectStore.projects).toHaveLength(1);
+    expect(projectStore.projects[0].path).toBe(PROJECT_PATH);
+    expect(projectStore.archivedPaths).toEqual([]);
+  });
+
+  it("does not append after a direct archiveProject completes during an open-event discover", async () => {
+    const pendingDiscover = deferred<ReturnType<typeof discovery>>();
+    m.discover.mockReturnValueOnce(pendingDiscover.promise);
+
+    const openEvent = projectStore.applyArchiveChange(event("open", false));
+    await flushArchiveQueueStart();
+    expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
+    await projectStore.archiveProject(PROJECT_PATH);
+
+    pendingDiscover.resolve(discovery());
+    await openEvent;
+
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
   });
 });

--- a/src/sidebar/stores/project.archive.test.ts
+++ b/src/sidebar/stores/project.archive.test.ts
@@ -63,6 +63,8 @@ describe("projectStore archive operations (#881)", () => {
     }));
 
     const archivePromise = projectStore.archiveProject(PROJECT_PATH);
+    await Promise.resolve();
+    await Promise.resolve();
     expect(m.archive).toHaveBeenCalledWith(PROJECT_PATH);
     expect(projectStore.projects).toHaveLength(1);
     expect(projectStore.archivedPaths).toEqual([]);

--- a/src/sidebar/stores/project.archive.test.ts
+++ b/src/sidebar/stores/project.archive.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const m = vi.hoisted(() => ({
+  open: vi.fn(),
+  newProject: vi.fn(),
+  discover: vi.fn(),
+  remove: vi.fn(),
+  archive: vi.fn(),
+  unarchive: vi.fn(),
+}));
+
+vi.mock("../../shared/ipc", () => ({
+  ProjectAPI: {
+    open: m.open,
+    new: m.newProject,
+    discover: m.discover,
+    remove: m.remove,
+    archive: m.archive,
+    unarchive: m.unarchive,
+  },
+  AgentCreatorAPI: {
+    pickFolder: vi.fn(),
+  },
+}));
+
+import { projectStore } from "./project";
+
+const PROJECT_PATH = "C:\\Users\\Maria\\Project";
+
+function discovery() {
+  return {
+    workgroups: [],
+    agents: [],
+    teams: [],
+    loops: [],
+    contextTemplateUpdates: [],
+  };
+}
+
+describe("projectStore archive operations (#881)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectStore.clear();
+    m.open.mockResolvedValue({ path: PROJECT_PATH, registered: false, created: false });
+    m.newProject.mockResolvedValue({ path: PROJECT_PATH, registered: true, created: false });
+    m.discover.mockResolvedValue(discovery());
+    m.remove.mockResolvedValue(undefined);
+    m.archive.mockResolvedValue(undefined);
+    m.unarchive.mockResolvedValue({ path: PROJECT_PATH, registered: true, created: false });
+  });
+
+  afterEach(() => {
+    projectStore.clear();
+  });
+
+  it("awaits archive_project before removing the project from the store", async () => {
+    await projectStore.loadProject(PROJECT_PATH);
+    expect(projectStore.projects).toHaveLength(1);
+
+    let releaseArchive!: () => void;
+    m.archive.mockReturnValueOnce(new Promise<void>((resolve) => {
+      releaseArchive = resolve;
+    }));
+
+    const archivePromise = projectStore.archiveProject(PROJECT_PATH);
+    expect(m.archive).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(projectStore.projects).toHaveLength(1);
+    expect(projectStore.archivedPaths).toEqual([]);
+
+    releaseArchive();
+    await archivePromise;
+
+    expect(projectStore.projects).toHaveLength(0);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+  });
+
+  it("leaves the project visible when archive_project rejects", async () => {
+    await projectStore.loadProject(PROJECT_PATH);
+    m.archive.mockRejectedValueOnce("Cannot archive: 1 open session in this project.");
+
+    await expect(projectStore.archiveProject(PROJECT_PATH)).rejects.toBe(
+      "Cannot archive: 1 open session in this project.",
+    );
+
+    expect(projectStore.projects).toHaveLength(1);
+    expect(projectStore.projects[0].path).toBe(PROJECT_PATH);
+    expect(projectStore.archivedPaths).toEqual([]);
+  });
+
+  it("unarchives via the backend registration path, discovers, appends, and clears archivedPaths", async () => {
+    await projectStore.initFromSettings([], null, [PROJECT_PATH]);
+    expect(projectStore.archivedPaths).toEqual([PROJECT_PATH]);
+    m.unarchive.mockResolvedValueOnce({
+      path: "C:\\Users\\Maria\\Project",
+      registered: true,
+      created: false,
+    });
+
+    await projectStore.unarchiveProject("c:/users/maria/project");
+
+    expect(m.unarchive).toHaveBeenCalledWith("c:/users/maria/project");
+    expect(m.discover).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(projectStore.archivedPaths).toEqual([]);
+    expect(projectStore.projects).toHaveLength(1);
+    expect(projectStore.projects[0].path).toBe(PROJECT_PATH);
+  });
+
+  it("initFromSettings seeds archivedPaths", async () => {
+    await projectStore.initFromSettings([], null, ["C:\\Archived"]);
+
+    expect(projectStore.archivedPaths).toEqual(["C:\\Archived"]);
+  });
+});

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -210,7 +210,16 @@ export const projectStore = {
     legacyPath: string | null,
     archivedProjectPaths: string[] = []
   ) {
-    setArchivedPaths(archivedProjectPaths);
+    // #881 (FE-F11) - union, not wholesale replace. `onProjectArchiveChanged`
+    // is registered before this boot-time call runs against an already-read
+    // settings snapshot; a concurrent archive from another window/CLI that
+    // `applyArchiveChange` committed into `archivedPaths` during that gap must
+    // survive, or the stale snapshot silently reverts it (and loadProject then
+    // re-registers the path on disk). Merge instead of clobbering.
+    setArchivedPaths((prev) => {
+      const keys = new Set(prev.map(normalizePath));
+      return [...prev, ...archivedProjectPaths.filter((p) => !keys.has(normalizePath(p)))];
+    });
     // Merge legacy single path into the array (deduplicated)
     const paths = [...projectPaths];
     if (legacyPath && !paths.some((p) => normalizePath(p) === normalizePath(legacyPath))) {

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -82,7 +82,6 @@ async function runSerializedArchiveChange(
 async function discoverAndAppendIfCurrent(path: string, key: string): Promise<void> {
   const result = await ProjectAPI.discover(path);
   if (hasArchivedPath(key)) return;
-  if (hasLoadedProject(key)) return;
   appendDiscoveredProject(path, result);
 }
 
@@ -182,8 +181,10 @@ export const projectStore = {
         // is responsible for creating it first via projectStore.createAndLoad
         // when that case is expected.
         const reg = await ProjectAPI.open(path);
-        const result = await ProjectAPI.discover(reg.path);
-        appendDiscoveredProject(reg.path, result);
+        const normalizedReg = normalizePath(reg.path);
+        await runSerializedArchiveChange(normalizedReg, () =>
+          discoverAndAppendIfCurrent(reg.path, normalizedReg)
+        );
         setLastLoadError(null);
       } catch (e) {
         // Round-1 G11: surface the failure instead of only logging it. The
@@ -227,8 +228,10 @@ export const projectStore = {
   async createAndLoad(path: string) {
     const reg = await ProjectAPI.new(path);
     // After ensuring Project AC Root exists and persistence is set, run discovery for UI.
-    const result = await ProjectAPI.discover(reg.path);
-    appendDiscoveredProject(reg.path, result);
+    const normalized = normalizePath(reg.path);
+    await runSerializedArchiveChange(normalized, () =>
+      discoverAndAppendIfCurrent(reg.path, normalized)
+    );
   },
 
   /** Full open flow: pick folder, check Project AC Root, auto-load if found */
@@ -410,25 +413,28 @@ export const projectStore = {
   /** #881 - hide a project. The backend call runs first and its rejection
    *  propagates so a blocked archive leaves the project visible. */
   async archiveProject(path: string) {
-    await ProjectAPI.archive(path);
     const normalized = normalizePath(path);
-    const archived = projects().find((p) => normalizePath(p.path) === normalized);
-    batch(() => {
-      setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== normalized));
-      setArchivedPaths((prev) =>
-        prev.some((p) => normalizePath(p) === normalized) ? prev : [...prev, path]
-      );
-      if (archived) {
-        replicaVolatileStore.clearForPaths(workgroupReplicaPaths(archived));
-      }
+    await runSerializedArchiveChange(normalized, async () => {
+      await ProjectAPI.archive(path);
+      const archived = projects().find((p) => normalizePath(p.path) === normalized);
+      batch(() => {
+        setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== normalized));
+        setArchivedPaths((prev) =>
+          prev.some((p) => normalizePath(p) === normalized) ? prev : [...prev, path]
+        );
+        if (archived) {
+          replicaVolatileStore.clearForPaths(workgroupReplicaPaths(archived));
+        }
+      });
     });
   },
 
   /** #881 - restore an archived project and load its discovery data. */
   async unarchiveProject(path: string) {
-    const reg = await ProjectAPI.unarchive(path);
-    const normalized = normalizePath(reg.path);
-    await runSerializedArchiveChange(normalized, async () => {
+    const key = normalizePath(path);
+    await runSerializedArchiveChange(key, async () => {
+      const reg = await ProjectAPI.unarchive(path);
+      const normalized = normalizePath(reg.path);
       setArchivedPaths((prev) => prev.filter((p) => normalizePath(p) !== normalized));
       if (hasLoadedProject(normalized)) return;
       await discoverAndAppendIfCurrent(reg.path, normalized);

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -41,6 +41,7 @@ const [initState, setInitState] = createSignal<{ attempted: boolean; pathCount: 
 });
 const inFlightLoads = new Map<string, Promise<void>>();
 const inFlightReloads = new Map<string, Promise<void>>();
+const archiveChangeTails = new Map<string, Promise<void>>();
 const queuedReloads = new Set<string>();
 let loadingCount = 0;
 
@@ -52,6 +53,37 @@ function normalizePath(p: string): string {
  *  set of paths whose live volatile overrides a fresh snapshot supersedes. */
 function workgroupReplicaPaths(source: { workgroups: AcWorkgroup[] }): string[] {
   return source.workgroups.flatMap((wg) => wg.agents.map((agent) => agent.path));
+}
+
+function hasArchivedPath(key: string): boolean {
+  return archivedPaths().some((p) => normalizePath(p) === key);
+}
+
+function hasLoadedProject(key: string): boolean {
+  return projects().some((p) => normalizePath(p.path) === key);
+}
+
+async function runSerializedArchiveChange(
+  key: string,
+  task: () => Promise<void> | void
+): Promise<void> {
+  const previous = archiveChangeTails.get(key) ?? Promise.resolve();
+  const next = previous.catch(() => undefined).then(task);
+  archiveChangeTails.set(key, next);
+  try {
+    await next;
+  } finally {
+    if (archiveChangeTails.get(key) === next) {
+      archiveChangeTails.delete(key);
+    }
+  }
+}
+
+async function discoverAndAppendIfCurrent(path: string, key: string): Promise<void> {
+  const result = await ProjectAPI.discover(path);
+  if (hasArchivedPath(key)) return;
+  if (hasLoadedProject(key)) return;
+  appendDiscoveredProject(path, result);
 }
 
 /** Append a freshly discovered project unless an equivalent path is already
@@ -395,11 +427,11 @@ export const projectStore = {
   /** #881 - restore an archived project and load its discovery data. */
   async unarchiveProject(path: string) {
     const reg = await ProjectAPI.unarchive(path);
-    const result = await ProjectAPI.discover(reg.path);
     const normalized = normalizePath(reg.path);
-    batch(() => {
+    await runSerializedArchiveChange(normalized, async () => {
       setArchivedPaths((prev) => prev.filter((p) => normalizePath(p) !== normalized));
-      appendDiscoveredProject(reg.path, result);
+      if (hasLoadedProject(normalized)) return;
+      await discoverAndAppendIfCurrent(reg.path, normalized);
     });
   },
 
@@ -407,36 +439,37 @@ export const projectStore = {
    *  initiating windows receive their own backend event echoes. */
   async applyArchiveChange(event: ProjectArchiveChanged) {
     const key = normalizePath(event.path);
-    if (event.archived) {
-      const archived = projects().find((p) => normalizePath(p.path) === key);
-      batch(() => {
-        setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== key));
-        setArchivedPaths((prev) =>
-          prev.some((p) => normalizePath(p) === key) ? prev : [...prev, event.path]
-        );
-        if (archived) {
-          replicaVolatileStore.clearForPaths(workgroupReplicaPaths(archived));
-        }
-      });
-      return;
-    }
+    await runSerializedArchiveChange(key, async () => {
+      if (event.archived) {
+        const archived = projects().find((p) => normalizePath(p.path) === key);
+        batch(() => {
+          setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== key));
+          setArchivedPaths((prev) =>
+            prev.some((p) => normalizePath(p) === key) ? prev : [...prev, event.path]
+          );
+          if (archived) {
+            replicaVolatileStore.clearForPaths(workgroupReplicaPaths(archived));
+          }
+        });
+        return;
+      }
 
-    if (event.reason === "remove") {
-      const removed = projects().find((p) => normalizePath(p.path) === key);
-      batch(() => {
-        setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== key));
-        setArchivedPaths((prev) => prev.filter((p) => normalizePath(p) !== key));
-        if (removed) {
-          replicaVolatileStore.clearForPaths(workgroupReplicaPaths(removed));
-        }
-      });
-      return;
-    }
+      if (event.reason === "remove") {
+        const removed = projects().find((p) => normalizePath(p.path) === key);
+        batch(() => {
+          setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== key));
+          setArchivedPaths((prev) => prev.filter((p) => normalizePath(p) !== key));
+          if (removed) {
+            replicaVolatileStore.clearForPaths(workgroupReplicaPaths(removed));
+          }
+        });
+        return;
+      }
 
-    setArchivedPaths((prev) => prev.filter((p) => normalizePath(p) !== key));
-    if (projects().some((p) => normalizePath(p.path) === key)) return;
-    const result = await ProjectAPI.discover(event.path);
-    appendDiscoveredProject(event.path, result);
+      setArchivedPaths((prev) => prev.filter((p) => normalizePath(p) !== key));
+      if (hasLoadedProject(key)) return;
+      await discoverAndAppendIfCurrent(event.path, key);
+    });
   },
 
   /** #695 — drop exactly one resolved pending context-template update. The key
@@ -481,6 +514,7 @@ export const projectStore = {
     setInitState({ attempted: false, pathCount: 0 });
     inFlightLoads.clear();
     inFlightReloads.clear();
+    archiveChangeTails.clear();
     queuedReloads.clear();
     replicaVolatileStore.clearAll();
   },

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -6,6 +6,7 @@ import type {
   AcTeam,
   AcLoopSummary,
   ContextTemplateUpdate,
+  ProjectArchiveChanged,
 } from "../../shared/types";
 import { ProjectAPI, AgentCreatorAPI } from "../../shared/ipc";
 import {
@@ -29,6 +30,9 @@ export interface ProjectState {
 }
 
 const [projects, setProjects] = createSignal<ProjectState[]>([]);
+// #881: archived projects leave `projects`, but their persisted sessions must
+// stay suppressed from the generic session list until an unarchive/open event.
+const [archivedPaths, setArchivedPaths] = createSignal<string[]>([]);
 const [loading, setLoading] = createSignal(false);
 const [lastLoadError, setLastLoadError] = createSignal<string | null>(null);
 const [initState, setInitState] = createSignal<{ attempted: boolean; pathCount: number }>({
@@ -107,6 +111,10 @@ export const projectStore = {
     return projects()[0] ?? null;
   },
 
+  get archivedPaths() {
+    return archivedPaths();
+  },
+
   get isLoading() {
     return loading();
   },
@@ -164,7 +172,12 @@ export const projectStore = {
   },
 
   /** Initialize from saved settings (call on mount) */
-  async initFromSettings(projectPaths: string[], legacyPath: string | null) {
+  async initFromSettings(
+    projectPaths: string[],
+    legacyPath: string | null,
+    archivedProjectPaths: string[] = []
+  ) {
+    setArchivedPaths(archivedProjectPaths);
     // Merge legacy single path into the array (deduplicated)
     const paths = [...projectPaths];
     if (legacyPath && !paths.some((p) => normalizePath(p) === normalizePath(legacyPath))) {
@@ -348,6 +361,7 @@ export const projectStore = {
     const removed = projects().find((p) => normalizePath(p.path) === normalized);
     batch(() => {
       setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== normalized));
+      setArchivedPaths((prev) => prev.filter((p) => normalizePath(p) !== normalized));
       // #748 — drop the removed project's live overrides so a later re-add
       // starts from its fresh discovery snapshot, not a stale live layer.
       if (removed) {
@@ -359,6 +373,70 @@ export const projectStore = {
     // Design S (it preserves the on-disk project_paths so it can't clobber
     // CLI-registered projects), so removal must go through remove_project.
     await ProjectAPI.remove(path);
+  },
+
+  /** #881 - hide a project. The backend call runs first and its rejection
+   *  propagates so a blocked archive leaves the project visible. */
+  async archiveProject(path: string) {
+    await ProjectAPI.archive(path);
+    const normalized = normalizePath(path);
+    const archived = projects().find((p) => normalizePath(p.path) === normalized);
+    batch(() => {
+      setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== normalized));
+      setArchivedPaths((prev) =>
+        prev.some((p) => normalizePath(p) === normalized) ? prev : [...prev, path]
+      );
+      if (archived) {
+        replicaVolatileStore.clearForPaths(workgroupReplicaPaths(archived));
+      }
+    });
+  },
+
+  /** #881 - restore an archived project and load its discovery data. */
+  async unarchiveProject(path: string) {
+    const reg = await ProjectAPI.unarchive(path);
+    const result = await ProjectAPI.discover(reg.path);
+    const normalized = normalizePath(reg.path);
+    batch(() => {
+      setArchivedPaths((prev) => prev.filter((p) => normalizePath(p) !== normalized));
+      appendDiscoveredProject(reg.path, result);
+    });
+  },
+
+  /** #881 - reconcile cross-window/browser archive events. Idempotent because
+   *  initiating windows receive their own backend event echoes. */
+  async applyArchiveChange(event: ProjectArchiveChanged) {
+    const key = normalizePath(event.path);
+    if (event.archived) {
+      const archived = projects().find((p) => normalizePath(p.path) === key);
+      batch(() => {
+        setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== key));
+        setArchivedPaths((prev) =>
+          prev.some((p) => normalizePath(p) === key) ? prev : [...prev, event.path]
+        );
+        if (archived) {
+          replicaVolatileStore.clearForPaths(workgroupReplicaPaths(archived));
+        }
+      });
+      return;
+    }
+
+    if (event.reason === "remove") {
+      const removed = projects().find((p) => normalizePath(p.path) === key);
+      batch(() => {
+        setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== key));
+        setArchivedPaths((prev) => prev.filter((p) => normalizePath(p) !== key));
+        if (removed) {
+          replicaVolatileStore.clearForPaths(workgroupReplicaPaths(removed));
+        }
+      });
+      return;
+    }
+
+    setArchivedPaths((prev) => prev.filter((p) => normalizePath(p) !== key));
+    if (projects().some((p) => normalizePath(p.path) === key)) return;
+    const result = await ProjectAPI.discover(event.path);
+    appendDiscoveredProject(event.path, result);
   },
 
   /** #695 — drop exactly one resolved pending context-template update. The key
@@ -396,6 +474,7 @@ export const projectStore = {
 
   clear() {
     setProjects([]);
+    setArchivedPaths([]);
     loadingCount = 0;
     setLoading(false);
     setLastLoadError(null);

--- a/src/sidebar/stores/sessions.archived.test.ts
+++ b/src/sidebar/stores/sessions.archived.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Session } from "../../shared/types";
+import { projectStore } from "./project";
+import { sessionsStore } from "./sessions";
+
+const PROJECT_PATH = "C:\\Users\\Maria\\Project";
+const OUTSIDE_PATH = "C:\\Users\\Maria\\Other\\.ac\\wg-9\\__agent_dev";
+
+function session(overrides: Partial<Session>): Session {
+  return {
+    id: "session-1",
+    name: "wg-1-dev-team/dev-webpage-ui",
+    shell: "pwsh",
+    shellArgs: [],
+    effectiveShellArgs: [],
+    createdAt: "2026-07-10T00:00:00.000Z",
+    workingDirectory: `${PROJECT_PATH}\\.ac\\wg-1-dev-team\\__agent_dev-webpage-ui`,
+    status: "running",
+    waitingForInput: false,
+    communication: null,
+    pendingReview: false,
+    lastPrompt: null,
+    agentId: null,
+    agentLabel: null,
+    gitRepos: [],
+    workgroupTask: null,
+    isCoordinator: false,
+    isRootAgent: false,
+    token: "",
+    agentKind: null,
+    requestedProfile: null,
+    effectiveProfile: null,
+    profileFallbackChain: [],
+    profileFallbackApplied: false,
+    ...overrides,
+  };
+}
+
+describe("sessionsStore archived project filtering (#881)", () => {
+  beforeEach(() => {
+    projectStore.clear();
+    sessionsStore.setSessions([]);
+    sessionsStore.setTeams([]);
+    sessionsStore.setRepos([]);
+  });
+
+  afterEach(() => {
+    projectStore.clear();
+    sessionsStore.setSessions([]);
+    sessionsStore.setTeams([]);
+    sessionsStore.setRepos([]);
+  });
+
+  it("hides both running and exited sessions under archived project roots", async () => {
+    sessionsStore.setSessions([
+      session({ id: "running", name: "wg-1/z-running", status: "running" }),
+      session({ id: "exited", name: "wg-1/a-exited", status: { exited: 0 } }),
+      session({
+        id: "outside",
+        name: "wg-9/m-outside",
+        workingDirectory: OUTSIDE_PATH,
+        status: "running",
+      }),
+    ]);
+
+    expect(sessionsStore.filteredSessions.map((s) => s.id)).toEqual([
+      "exited",
+      "outside",
+      "running",
+    ]);
+
+    await projectStore.initFromSettings([], null, [PROJECT_PATH]);
+
+    expect(sessionsStore.filteredSessions.map((s) => s.id)).toEqual(["outside"]);
+  });
+
+  it("uses the project normalizer so verbatim archived paths still suppress sessions", async () => {
+    sessionsStore.setSessions([session({ id: "verbatim" })]);
+
+    await projectStore.initFromSettings([], null, ["\\\\?\\C:\\Users\\Maria\\Project\\"]);
+
+    expect(sessionsStore.filteredSessions).toEqual([]);
+  });
+});

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -3,6 +3,7 @@ import { createStore } from "solid-js/store";
 import { NO_TEAM } from "../../shared/constants";
 import type { RepoMatch, Session, SessionCommunication, SessionRepo, SessionsState, Team, TeamSessionGroup } from "../../shared/types";
 import { projectStore } from "./project";
+import { normalizeProjectPathForCompare } from "./project-refresh";
 import { SettingsAPI } from "../../shared/ipc";
 import { settingsStore } from "../../shared/stores/settings";
 import { isRuntimeStringStatus, reconcileVisibleOrderKeys, upsertSessionList } from "./sessions-helpers";
@@ -28,6 +29,15 @@ const [state, setState] = createStore<SessionsState>({
 
 function normalizePath(p: string): string {
   return p.replace(/\\/g, "/").toLowerCase().replace(/\/+$/, "");
+}
+
+function isUnderAnyPath(path: string, roots: string[]): boolean {
+  if (roots.length === 0) return false;
+  const normalizedPath = normalizeProjectPathForCompare(path);
+  return roots.some((root) => {
+    const normalizedRoot = normalizeProjectPathForCompare(root);
+    return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}/`);
+  });
 }
 
 function stringArraysEqual(a: string[] | undefined, b: string[]): boolean {
@@ -122,12 +132,20 @@ const filteredSessionsMemo = createMemo(() => {
   const visibleSessions = wg.names.size > 0
     ? activeSessions.filter((s) => !wg.names.has(s.name))
     : activeSessions;
+  // #881: hide every session under an archived project. This relies on the
+  // backend invariant that activation inside an archived project unarchives it
+  // before a live PTY can remain hidden.
+  const archived = projectStore.archivedPaths;
+  const notArchived = (s: Session) =>
+    !s.workingDirectory || !isUnderAnyPath(s.workingDirectory, archived);
+  const projectVisibleSessions =
+    archived.length > 0 ? visibleSessions.filter(notArchived) : visibleSessions;
 
   const sortKey = (s: Session) => {
     const i = s.name.lastIndexOf("/");
     return i >= 0 ? s.name.slice(i + 1) : s.name;
   };
-  if (!state.showInactive) return [...visibleSessions].sort((a, b) => sortKey(a).localeCompare(sortKey(b), "en", { sensitivity: "base", numeric: true }));
+  if (!state.showInactive) return [...projectVisibleSessions].sort((a, b) => sortKey(a).localeCompare(sortKey(b), "en", { sensitivity: "base", numeric: true }));
 
   // Add inactive repos/members that don't have active sessions
   const activePathSet = new Set(
@@ -173,8 +191,10 @@ const filteredSessionsMemo = createMemo(() => {
   const filteredInactive = wg.paths.size > 0
     ? inactiveEntries.filter((e) => !wg.paths.has(normalizePath(e.workingDirectory)))
     : inactiveEntries;
+  const visibleInactive =
+    archived.length > 0 ? filteredInactive.filter(notArchived) : filteredInactive;
 
-  return [...visibleSessions, ...filteredInactive].sort((a, b) =>
+  return [...projectVisibleSessions, ...visibleInactive].sort((a, b) =>
     sortKey(a).localeCompare(sortKey(b), "en", { sensitivity: "base", numeric: true })
   );
 });

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -3149,16 +3149,64 @@ html.light-theme .settings-hint-warning {
   min-width: 68px;
   max-width: 68px;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.025);
+  border-left: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.workgroup-group-rail-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
   padding: 6px 4px;
-  background: rgba(255, 255, 255, 0.025);
-  border-left: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .sidebar-body[data-rail-side="left"] .workgroup-group-rail {
   border-left: none;
   border-right: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.workgroup-group-rail-archive {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  padding: 6px 2px;
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  background: transparent;
+  color: var(--sidebar-fg-dim);
+  font-family: var(--font-ui);
+  cursor: pointer;
+}
+
+.workgroup-group-rail-archive:hover {
+  color: var(--sidebar-fg);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.workgroup-group-rail-archive:focus-visible {
+  outline: 2px solid rgba(0, 212, 255, 0.65);
+  outline-offset: -2px;
+}
+
+.workgroup-group-rail-archive-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.workgroup-group-rail-archive-label {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 9px;
+  line-height: 1.2;
 }
 
 .workgroup-group-rail-project + .workgroup-group-rail-project {
@@ -4585,6 +4633,126 @@ html.light-theme .settings-hint-warning {
   color: var(--danger, #ff6b6b);
 }
 
+.archived-projects-modal {
+  width: min(620px, 92vw);
+}
+
+.archived-projects-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: var(--spacing-md);
+  overflow-y: auto;
+}
+
+.archived-projects-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.archived-projects-row-warning {
+  background: rgba(255, 184, 77, 0.09);
+}
+
+.archived-projects-main {
+  min-width: 0;
+}
+
+.archived-projects-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--sidebar-fg);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.archived-projects-path,
+.archived-projects-warning {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--sidebar-fg-dim);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.archived-projects-warning {
+  color: var(--sidebar-warning, #e0a83a);
+}
+
+.archived-projects-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.archived-projects-actions .modal-btn {
+  min-height: 26px;
+  padding: 5px 9px;
+  font-size: 11px;
+}
+
+.archived-projects-row-error {
+  grid-column: 1 / -1;
+}
+
+.auto-unarchive-modal {
+  width: min(560px, 92vw);
+}
+
+.auto-unarchive-body {
+  padding: var(--spacing-md);
+  outline: none;
+}
+
+.auto-unarchive-copy {
+  margin: 0 0 10px;
+  color: var(--sidebar-fg);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.auto-unarchive-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.auto-unarchive-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.auto-unarchive-row strong,
+.auto-unarchive-session {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.auto-unarchive-row strong {
+  color: var(--sidebar-fg);
+  font-size: 12px;
+}
+
+.auto-unarchive-session {
+  color: var(--sidebar-fg-dim);
+  font-size: 11px;
+}
+
 @media (max-width: 680px) {
   .workgroup-group-edit-row {
     grid-template-columns: 1fr;
@@ -4592,6 +4760,15 @@ html.light-theme .settings-hint-warning {
 
   .workgroup-group-delete {
     justify-self: flex-start;
+  }
+
+  .archived-projects-row {
+    grid-template-columns: 1fr;
+  }
+
+  .archived-projects-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
 }
 


### PR DESCRIPTION
## Summary

Adds **Archive Project**: hide a project from the project list and the groups rail, persistently, **without deleting it**.

- **"Archive" action** in the project context menu (next to "Remove Project", visually separated, not danger-styled).
- **Sticky "Archive" button** at the bottom of the groups rail (archive icon + small label), opening a modal that lists archived projects and lets you **unarchive** them.
- Archiving **persists across restarts**. It is **not** a delete.

Closes #881

## Locked behavior

- Archiving is **refused while the project has live sessions**.
- If a session activates in an archived project **by any route** (including a Loop), the project **auto-unarchives** and a modal informs the user; **only explicit acknowledgement dismisses it** (Escape does not).
- Opening an archived project via New/Open auto-unarchives it.

## Why this branch is large

Hiding a project means removing it from `settings.project_paths`, and that layer carried **pre-existing data-loss bugs on `main`** — none introduced by this feature. The worst was fixed and merged separately as **#888**. The feature surface itself is small (~850 lines of frontend production code); the bulk of the diff is **tests** plus the backend invariant.

## Hard invariant

**Never leave a live PTY inside an archived project, by any route.** Enforced by a cwd-keyed RAII spawn mark taken *before* the archive gate and held across `PtyManager::spawn`, plus an archive double-snapshot reconcile that rolls back if a late spawn appears. `PtyManager::spawn` has exactly **one** production caller (`create_session_inner`), so every spawn route (create / restart / startup restore / loop delivery / mailbox wake / web create) funnels through the gate.

## Review trail

Adversarially reviewed by `dev-rust-grinch` across multiple rounds. Every finding verified **by mutation**, never credited:

- **Backend** — PASS. Invariant proven by happens-before analysis + mutation; no interleave found that leaves archived + live.
- **FE store serialization + follow-up** — PASS. The 4 new witnesses (G4/G3/G2/P6b) each confirmed a **sole catcher** of its named mutant.
- **`create_session_inner` runtime witnesses** — PASS. Two-sided mutation proof. The prior source-scrape-only guards could not catch a string-preserving runtime mutation; they are kept as ordering canaries.
- **Rebase resolution** — PASS. Invariant re-proved by mutation against the new base; no behavior dropped.

Review found and closed ~10 **false witnesses** (tests whose names claimed a property their body did not check). The high test:code ratio is the point.

## Verification (rebased tree)

- `cargo test --lib`: **2119 passed**, 8 ignored
- `cargo clippy --lib --all-targets`: no issues found
- `npx tsc --noEmit`: exit 0
- `npx vitest run`: **887 passed**, 0 failed

Validated by the user on a standalone build of this branch (Archive action, rail button, unarchive modal).

## MANDATORY RELEASE NOTE — downgrade hazard

Archived projects are persisted in settings (`archived_project_paths`). **Downgrading to a version without archive support will not understand this state.** The hazard is accepted; **this note must ship with the release.**

## Accepted residual risks (not blocking)

- **F2 (LOW):** if the settings **disk write fails** during the archive rollback, the project can remain archived while a late live session exists. Compound-rare (needs a spawn inside the commit window *and* a disk-write failure); partially mitigated by the in-flight spawn's own gate.
- **H1 (LOW):** the new `create_session_inner` test harness would hang rather than fail loudly if a *future* change made the function return `Err` before reaching `backend.spawn`. Not reachable today; optional `tokio::time::timeout` hardening.
- **F3 / F4 (informational):** `archive_liveness` signature deviates from the plan (verified equivalent); pre-existing outer-mutex poison inconsistency in `PtyManager::spawn` (untouched here).

## Follow-ups NOT folded into this PR

- **#889** — `switch_session` / `destroy_session` manufacture no-PTY `Active` phantom records.
- **#907** — `open_project` / `remove_project` leave a half-applied in-memory list on save failure.
- **#917** — two load-sensitive flaky tests.

## Rebase

Rebased onto current `main`; linear, 11 commits. Three conflicts (all in the invariant commit) resolved and reviewed:

- `config/mod.rs` — dropped the `claude_settings` module decl removed by #928 (0 remaining refs).
- `commands/ac_discovery.rs` — kept the feature's generic `open_project_inner<R>`, preserving **both** main's register-and-persist behavior **and** the archive broadcast.
- `phone/mailbox.rs` — kept **both** main's #885 test helper and the feature's `retain_unarchived_session_dirs` tests.
