### PR TITLE
feat(sidebar): coordinator repo context-menu hover submenu with Browse Main / Browse Branch (refs #943)

### DIFF
--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -358,11 +358,32 @@ struct ReplicaBranchEntry {
     session_name: String,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct DiscoveryBranchPayload {
     replica_path: String,
+    /// Single-repo shorthand, semantics unchanged: `None` for a multi-repo replica,
+    /// so the AcDiscoveryPanel chip keeps hiding the branch there.
     branch: Option<String>,
+    /// #943 B2 - per-repo branches, positionally parallel to `repo_paths` below and
+    /// therefore to `AcAgentReplica.repo_paths` (`update_replicas_for_project` maps
+    /// 1:1 over that vec and never sorts or dedupes it). `None` = branch unknown
+    /// (detached HEAD, not a work tree, git missing, detection timed out).
+    ///
+    /// This is data `poll()` already computed for every replica, multi-repo included,
+    /// and then threw away: the single-repo `branch` above was all it kept. Module B2
+    /// stops discarding it. Zero new git spawns.
+    repo_branches: Vec<Option<String>>,
+    /// #943 B2 - the repo paths those branches belong to, byte-identical to the
+    /// `AcAgentReplica.repo_paths` strings discovery already sent the frontend.
+    ///
+    /// Emitted so the consumer can key the merge by path instead of by position. The
+    /// positional guarantee holds at emit time, but the consumer stores this payload
+    /// and re-reads it against a LATER discovery result: edit a replica's config.json
+    /// `repos` (reorder, remove) and for up to one 15s tick the stored branches belong
+    /// to the previous repo list. A positional merge would then paint repo A's branch
+    /// onto repo B, silently. Matching on the path cannot.
+    repo_paths: Vec<String>,
 }
 
 #[derive(Clone, Serialize)]
@@ -408,8 +429,12 @@ pub struct DiscoveryBranchWatcher {
     /// bug (Grinch #1) and (b) the double-registration that occurs when `project_paths`
     /// contains both a parent and a child (Grinch #12).
     replicas: Mutex<HashMap<String, Vec<ReplicaBranchEntry>>>,
-    /// Single-repo branch cache — gates `ac_discovery_branch_updated` emission (panel UI).
-    discovery_cache: Mutex<HashMap<String, Option<String>>>,
+    /// Last-emitted `ac_discovery_branch_updated` payload per replica, gating that
+    /// emission (panel UI + the #943 B2 per-repo branches). Holds the whole payload,
+    /// not just the single-repo branch it held before B2, so the gate fires on
+    /// per-repo drift and on a repo-set change: the same branch text under a
+    /// different repo list is not the same event.
+    discovery_cache: Mutex<HashMap<String, DiscoveryBranchPayload>>,
     /// Full per-repo state cache — gates `session_git_repos` emission. Independent from
     /// `discovery_cache` so multi-repo replicas re-emit on per-repo drift even when the
     /// single-branch view stays None.
@@ -626,31 +651,38 @@ impl DiscoveryBranchWatcher {
                     })
                     .collect();
 
-                // Gate A: emit ac_discovery_branch_updated (single-branch UI for AcDiscoveryPanel).
-                // Only single-repo replicas surface a branch here; multi-repo = None so the panel hides it.
-                let discovery_branch: Option<String> = if entry.repos.len() == 1 {
-                    refreshed[0].branch.clone()
-                } else {
-                    None
+                // Gate A: emit ac_discovery_branch_updated (AcDiscoveryPanel's branch
+                // chip, plus #943 B2's per-repo branches for cold replicas).
+                //
+                // `branch` keeps its exact old semantics (single-repo only, None for
+                // multi-repo, so the panel chip still hides there). `repo_branches` is
+                // the vec `refreshed` already holds and Gate A used to discard, which
+                // is the whole of Module B2: a cold multi-repo coordinator learns each
+                // repo's branch without a single new git spawn.
+                let payload = DiscoveryBranchPayload {
+                    replica_path: entry.replica_path.clone(),
+                    branch: if entry.repos.len() == 1 {
+                        refreshed[0].branch.clone()
+                    } else {
+                        None
+                    },
+                    repo_branches: refreshed.iter().map(|r| r.branch.clone()).collect(),
+                    repo_paths: refreshed.iter().map(|r| r.source_path.clone()).collect(),
                 };
+                // Gate on the whole payload. Comparing only the single-repo `branch`
+                // (what this did before B2) means a multi-repo replica whose repo just
+                // changed branch compares None against None and never re-emits.
                 let discovery_changed = {
                     let mut cache = self.discovery_cache.lock().unwrap();
-                    let prev = cache.get(&entry.replica_path).cloned();
-                    if prev.as_ref() != Some(&discovery_branch) {
-                        cache.insert(entry.replica_path.clone(), discovery_branch.clone());
+                    if cache.get(&entry.replica_path) != Some(&payload) {
+                        cache.insert(entry.replica_path.clone(), payload.clone());
                         true
                     } else {
                         false
                     }
                 };
                 if discovery_changed {
-                    let _ = self.app_handle.emit(
-                        "ac_discovery_branch_updated",
-                        DiscoveryBranchPayload {
-                            replica_path: entry.replica_path.clone(),
-                            branch: discovery_branch,
-                        },
-                    );
+                    let _ = self.app_handle.emit("ac_discovery_branch_updated", payload);
                 }
 
                 // Gate B: emit session_git_repos (full per-repo state for SessionItem).
@@ -3682,5 +3714,112 @@ mod tests {
             preferred_agent_id.is_none(),
             "invalid identity must not be used to read preferred coding agent"
         );
+    }
+
+    // --- #943 Module B2: the widened ac_discovery_branch_updated payload ---
+
+    fn b2_payload(branch: Option<&str>, repos: &[(&str, Option<&str>)]) -> DiscoveryBranchPayload {
+        DiscoveryBranchPayload {
+            replica_path: "C:/proj/.ac/wg-1-team/__agent_coord".to_string(),
+            branch: branch.map(str::to_string),
+            repo_branches: repos.iter().map(|(_, b)| b.map(str::to_string)).collect(),
+            repo_paths: repos.iter().map(|(p, _)| p.to_string()).collect(),
+        }
+    }
+
+    /// The wire contract the frontend codes against. `#[serde(rename_all =
+    /// "camelCase")]` must produce exactly these four keys, `None` must serialize
+    /// as `null` (not omitted: the consumer distinguishes "unknown branch" from
+    /// "missing entry"), and `repoBranches[i]` must line up with `repoPaths[i]`.
+    #[test]
+    fn discovery_branch_payload_wire_shape_is_camel_case_with_explicit_nulls() {
+        let payload = b2_payload(
+            None,
+            &[
+                ("C:/wg/repo-AgentsCommander", Some("feature/943")),
+                ("C:/wg/repo-webpage", None),
+            ],
+        );
+
+        let value = serde_json::to_value(&payload).expect("serialize");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "replicaPath": "C:/proj/.ac/wg-1-team/__agent_coord",
+                "branch": null,
+                "repoBranches": ["feature/943", null],
+                "repoPaths": ["C:/wg/repo-AgentsCommander", "C:/wg/repo-webpage"],
+            })
+        );
+    }
+
+    /// The single-repo shorthand is untouched by B2: one repo still fills `branch`,
+    /// and `repo_branches` carries the same value so a consumer can read either.
+    #[test]
+    fn discovery_branch_payload_keeps_the_single_repo_shorthand() {
+        let payload = b2_payload(Some("main"), &[("C:/wg/repo-solo", Some("main"))]);
+        let value = serde_json::to_value(&payload).expect("serialize");
+
+        assert_eq!(value["branch"], serde_json::json!("main"));
+        assert_eq!(value["repoBranches"], serde_json::json!(["main"]));
+    }
+
+    /// The emission gate is `cache.get(path) != Some(&payload)`, so payload equality
+    /// IS the gate. This is the case B2 exists for: a multi-repo replica has
+    /// `branch: None` forever, so the pre-B2 gate (which compared only `branch`)
+    /// saw None == None and never re-emitted. A repo changing branch must now fire.
+    #[test]
+    fn discovery_branch_payload_gate_fires_on_per_repo_drift() {
+        let before = b2_payload(
+            None,
+            &[
+                ("C:/wg/repo-a", Some("main")),
+                ("C:/wg/repo-b", Some("main")),
+            ],
+        );
+        let after = b2_payload(
+            None,
+            &[
+                ("C:/wg/repo-a", Some("feature/943")),
+                ("C:/wg/repo-b", Some("main")),
+            ],
+        );
+
+        assert_eq!(before.branch, after.branch, "multi-repo: both stay None");
+        assert_ne!(before, after, "per-repo drift must re-emit");
+    }
+
+    /// A repo-set change with identical branch text must also fire: swapping a repo
+    /// for another one that happens to sit on `main` leaves the branch vec equal, and
+    /// gating on branches alone would leave the consumer holding the previous repo
+    /// list. Pinning this is why `repo_paths` is part of the payload and the gate.
+    #[test]
+    fn discovery_branch_payload_gate_fires_on_repo_set_change() {
+        let before = b2_payload(
+            None,
+            &[
+                ("C:/wg/repo-a", Some("main")),
+                ("C:/wg/repo-b", Some("main")),
+            ],
+        );
+        let swapped = b2_payload(
+            None,
+            &[
+                ("C:/wg/repo-a", Some("main")),
+                ("C:/wg/repo-c", Some("main")),
+            ],
+        );
+        let reordered = b2_payload(
+            None,
+            &[
+                ("C:/wg/repo-b", Some("main")),
+                ("C:/wg/repo-a", Some("main")),
+            ],
+        );
+
+        assert_eq!(before.repo_branches, swapped.repo_branches);
+        assert_ne!(before, swapped, "a swapped repo must re-emit");
+        assert_ne!(before, reordered, "a reordered repo list must re-emit");
     }
 }

--- a/src-tauri/src/commands/repos.rs
+++ b/src-tauri/src/commands/repos.rs
@@ -139,3 +139,256 @@ pub async fn search_repos(
 
     Ok(results)
 }
+
+/// #943 - upper bound for the `git remote get-url` call, mirroring
+/// `GitWatcher::detect_branch_with_timeout` (src-tauri/src/pty/git_watcher.rs:171).
+/// The context menu must never wait on a stalled git.
+const GIT_REMOTE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// #943 - drop `user[:password]@` from a scheme-form remote URL.
+///
+/// `git remote get-url` returns whatever `.git/config` holds, and a repo cloned
+/// with a token carries `https://<user>:<ghp_...>@github.com/o/r.git`. The caller
+/// only needs host + owner + repo, so the secret is destroyed here and never
+/// crosses the IPC boundary into the webview (nor into devtools, nor into any
+/// future console log). scp-like remotes (`git@github.com:o/r.git`) are returned
+/// untouched: that `git` is an ssh user name, not a credential, and the frontend
+/// parser ignores it.
+fn strip_userinfo(remote: &str) -> String {
+    let Some(scheme_end) = remote.find("://") else {
+        return remote.to_string();
+    };
+    let authority_start = scheme_end + 3;
+    let authority_end = remote[authority_start..]
+        .find('/')
+        .map(|i| authority_start + i)
+        .unwrap_or(remote.len());
+    let authority = &remote[authority_start..authority_end];
+    match authority.rfind('@') {
+        Some(at) => format!(
+            "{}{}{}",
+            &remote[..authority_start],
+            &authority[at + 1..],
+            &remote[authority_end..]
+        ),
+        None => remote.to_string(),
+    }
+}
+
+/// #943 - `origin`'s URL for a repo working dir, userinfo stripped, or `None`.
+///
+/// Every failure mode (path missing, not a work tree root, no `origin`, git not on
+/// PATH, timeout) collapses to `None` on purpose: the caller's only decision is
+/// "show Browse items or not". Bounded by GIT_REMOTE_TIMEOUT with
+/// `.kill_on_drop(true)` so a hung `git.exe` is reaped instead of leaked.
+pub async fn git_remote_url_inner(path: &str) -> Option<String> {
+    match tokio::time::timeout(GIT_REMOTE_TIMEOUT, run_git_remote_get_url(path)).await {
+        Ok(result) => result,
+        Err(_) => {
+            log::warn!(
+                "[repos] git_remote_url timed out for {} (>{}s)",
+                path,
+                GIT_REMOTE_TIMEOUT.as_secs()
+            );
+            None
+        }
+    }
+}
+
+async fn run_git_remote_get_url(working_dir: &str) -> Option<String> {
+    #[cfg(windows)]
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+    // #943 - require a work tree ROOT, do not let git discover a repo by walking
+    // up. `git remote get-url` climbs to the nearest ancestor `.git`, so a
+    // sourcePath that exists but is not a repo (failed clone, deleted `.git`, a
+    // plain folder the user configured) would answer with an UNRELATED
+    // repository's origin, and Browse Main would confidently open the wrong page
+    // on github.com. `.git` is checked with `metadata`, not `is_dir`: linked
+    // worktrees and submodules use a `.git` FILE.
+    //
+    // This also makes GIT_CEILING_DIRECTORIES unnecessary. Do not add it back:
+    // `git_ceiling_directories_for_session_root` returns None for any repo path
+    // (`is_agent_dir` gate, config/session_context.rs:1195-1196), i.e. it is a
+    // no-op that reads like a guard.
+    //
+    // `tokio::fs::metadata` (not `Path::is_dir`) because a sync stat inside an
+    // async fn cannot be cancelled by `tokio::time::timeout`: on a dead network
+    // share it would wedge a runtime worker for the SMB timeout and make the 2s
+    // cap a lie.
+    if tokio::fs::metadata(Path::new(working_dir).join(".git"))
+        .await
+        .is_err()
+    {
+        return None;
+    }
+
+    let mut cmd = tokio::process::Command::new("git");
+    crate::pty::credentials::scrub_credentials_from_tokio_command(&mut cmd);
+    cmd.args(["remote", "get-url", "origin"])
+        .current_dir(working_dir)
+        .kill_on_drop(true);
+
+    #[cfg(windows)]
+    cmd.creation_flags(CREATE_NO_WINDOW);
+
+    match cmd.output().await {
+        Ok(out) if out.status.success() => {
+            let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if url.is_empty() {
+                None
+            } else {
+                Some(strip_userinfo(&url))
+            }
+        }
+        // Non-zero exit: no `origin`, or git refusing the repo entirely
+        // ("detected dubious ownership", git >= 2.35.2, common on Windows after a
+        // drive move or an elevated clone). Without this arm the symptom is
+        // "Browse is silently absent forever, with nothing in app.log". Debug
+        // level and menu-driven, so it cannot flood the log the way the 5s
+        // GitWatcher poll would. stderr never contains the URL, so no leak.
+        Ok(out) => {
+            log::debug!(
+                "[repos] git remote get-url origin failed in {} (exit {:?}): {}",
+                working_dir,
+                out.status.code(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+            None
+        }
+        Err(e) => {
+            log::debug!("[repos] failed to spawn git in {}: {}", working_dir, e);
+            None
+        }
+    }
+}
+
+/// #943 - read-only. `Ok(None)` means "no Browse items"; see `git_remote_url_inner`.
+#[tauri::command]
+pub async fn git_remote_url(path: String) -> Result<Option<String>, String> {
+    if path.trim().is_empty() {
+        return Err("git_remote_url: empty path".to_string());
+    }
+    Ok(git_remote_url_inner(&path).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Run git in `dir`. `false` when git is missing OR the command failed; the
+    /// callers that need to tell those apart early-return instead of asserting.
+    /// `.output()` (not `.status()`) keeps `git init`'s chatter out of the test log.
+    fn git_in(dir: &Path, args: &[&str]) -> bool {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .map(|out| out.status.success())
+            .unwrap_or(false)
+    }
+
+    const ORIGIN: &str = "https://github.com/mblua/AgentsCommander.git";
+
+    #[test]
+    fn strip_userinfo_removes_credentials_from_scheme_urls() {
+        assert_eq!(
+            strip_userinfo("https://u:tok@github.com/o/r.git"),
+            "https://github.com/o/r.git"
+        );
+        assert_eq!(
+            strip_userinfo("ssh://git@github.com/o/r.git"),
+            "ssh://github.com/o/r.git"
+        );
+    }
+
+    #[test]
+    fn strip_userinfo_leaves_everything_else_alone() {
+        // No userinfo.
+        assert_eq!(
+            strip_userinfo("https://github.com/o/r.git"),
+            "https://github.com/o/r.git"
+        );
+        // scp-like: no `://`, and the `git@` is an ssh user name, not a secret.
+        assert_eq!(
+            strip_userinfo("git@github.com:o/r.git"),
+            "git@github.com:o/r.git"
+        );
+        // `@` in the path, none in the authority: must not be treated as userinfo.
+        assert_eq!(
+            strip_userinfo("https://github.com/o/r@2.git"),
+            "https://github.com/o/r@2.git"
+        );
+        // Degenerate inputs must not panic.
+        assert_eq!(strip_userinfo(""), "");
+        assert_eq!(strip_userinfo("https://"), "https://");
+    }
+
+    /// T1 - a path that does not exist yields None, and never spawns git: the
+    /// `.git` stat fails first.
+    #[tokio::test]
+    async fn git_remote_url_missing_path_is_none() {
+        assert_eq!(
+            git_remote_url_inner("C:/definitely/not/here/943").await,
+            None
+        );
+    }
+
+    /// T2 - real repo, real origin.
+    #[tokio::test]
+    async fn git_remote_url_reads_origin_from_a_temp_repo() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        if !git_in(dir.path(), &["init", "--quiet"]) {
+            return; // git unavailable: keep a git-less CI image green
+        }
+        assert!(git_in(dir.path(), &["remote", "add", "origin", ORIGIN]));
+
+        let url = git_remote_url_inner(&dir.path().to_string_lossy())
+            .await
+            .expect("origin");
+        // Containment, not equality: a dev with a `url.<x>.insteadOf` rewrite gets
+        // the `git@github.com:` form back, and an equality assertion would fail
+        // locally while CI stayed green.
+        assert!(
+            url.contains("mblua/AgentsCommander"),
+            "unexpected origin: {url}"
+        );
+    }
+
+    /// T3 - a work tree with no `origin` is "no browse target", not an error.
+    #[tokio::test]
+    async fn git_remote_url_without_origin_is_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        if !git_in(dir.path(), &["init", "--quiet"]) {
+            return;
+        }
+        assert_eq!(
+            git_remote_url_inner(&dir.path().to_string_lossy()).await,
+            None
+        );
+    }
+
+    /// T4 - the command's only error branch.
+    #[tokio::test]
+    async fn git_remote_url_rejects_empty_path() {
+        assert!(git_remote_url(String::new()).await.is_err());
+        assert!(git_remote_url("   ".to_string()).await.is_err());
+    }
+
+    /// T5' - pins the S5 fix. A plain dir nested inside a work tree must NOT
+    /// inherit the ancestor's origin: without the `.git` gate git walks up, and
+    /// Browse Main would confidently open an unrelated GitHub repo.
+    #[tokio::test]
+    async fn git_remote_url_nested_non_work_tree_is_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        if !git_in(dir.path(), &["init", "--quiet"]) {
+            return;
+        }
+        assert!(git_in(dir.path(), &["remote", "add", "origin", ORIGIN]));
+
+        let inner = dir.path().join("inner");
+        std::fs::create_dir_all(&inner).expect("inner dir");
+
+        assert_eq!(git_remote_url_inner(&inner.to_string_lossy()).await, None);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2084,6 +2084,7 @@ pub fn run(
             commands::config::set_log_level,
             commands::config::get_update_status,
             commands::repos::search_repos,
+            commands::repos::git_remote_url,
             commands::telegram::telegram_attach,
             commands::telegram::telegram_detach,
             commands::telegram::telegram_list_bridges,

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -589,7 +589,15 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
         | "open_in_explorer"
         | "focus_main_window"
         | "open_guide_window"
-        | "open_external_url" => Ok(json!(null)),
+        | "open_external_url"
+        // #943 - Browse is desktop-only: `open_external_url` above is already a
+        // no-op here, so the submenu is hidden in web mode (`browseSupported()`
+        // = isTauri) and this command has no consumer. A real arm would hand a
+        // network client (a) an arbitrary-path existence oracle plus a `git.exe`
+        // spawn per request, and (b) the repo's `origin`. Not worth it for a
+        // feature that cannot run here. See §9 (Module W) for what it costs to
+        // turn Browse on for web.
+        | "git_remote_url" => Ok(json!(null)),
 
         // Home screen Markdown fetch is Tauri-only for v1; browser mode is
         // out of scope (issue #164 §Constraints). The frontend renders this

--- a/src/shared/github-url.test.ts
+++ b/src/shared/github-url.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { githubBranchUrl, githubRepoUrl, parseGithubRemote } from "./github-url";
+
+const ref = { owner: "o", repo: "r" };
+
+describe("parseGithubRemote", () => {
+  it("parses https remotes, with or without .git and trailing slash", () => {
+    expect(parseGithubRemote("https://github.com/mblua/AgentsCommander")).toEqual({
+      owner: "mblua",
+      repo: "AgentsCommander",
+    });
+    expect(parseGithubRemote("https://github.com/mblua/AgentsCommander.git")).toEqual({
+      owner: "mblua",
+      repo: "AgentsCommander",
+    });
+    expect(parseGithubRemote("https://github.com/mblua/AgentsCommander/")).toEqual({
+      owner: "mblua",
+      repo: "AgentsCommander",
+    });
+  });
+
+  it("accepts http, www, and an uppercase host", () => {
+    expect(parseGithubRemote("http://github.com/o/r")).toEqual(ref);
+    expect(parseGithubRemote("https://www.github.com/o/r")).toEqual(ref);
+    expect(parseGithubRemote("https://GITHUB.com/o/r")).toEqual(ref);
+  });
+
+  it("parses scp-like remotes", () => {
+    expect(parseGithubRemote("git@github.com:mblua/AgentsCommander.git")).toEqual({
+      owner: "mblua",
+      repo: "AgentsCommander",
+    });
+    expect(parseGithubRemote("git@github.com:o/r")).toEqual(ref);
+    // The scp branch has no WHATWG normalization, so host lowercasing lives in
+    // refFromHostAndPath. Pin it.
+    expect(parseGithubRemote("git@GITHUB.com:o/r.git")).toEqual(ref);
+  });
+
+  it("parses ssh and git schemes", () => {
+    expect(parseGithubRemote("ssh://git@github.com/o/r.git")).toEqual(ref);
+    expect(parseGithubRemote("git://github.com/o/r.git")).toEqual(ref);
+  });
+
+  it("drops the port and the userinfo (defense in depth: Rust already stripped it)", () => {
+    expect(parseGithubRemote("https://github.com:443/o/r")).toEqual(ref);
+    expect(parseGithubRemote("https://user:token@github.com/o/r.git")).toEqual(ref);
+  });
+
+  it("strips .git case-insensitively (N2)", () => {
+    expect(parseGithubRemote("https://github.com/o/r.GIT")).toEqual(ref);
+    expect(parseGithubRemote("git@github.com:o/r.GIT")).toEqual(ref);
+  });
+
+  it("rejects non-github hosts", () => {
+    expect(parseGithubRemote("https://gitlab.com/o/r.git")).toBeNull();
+    expect(parseGithubRemote("https://github.example.com/o/r.git")).toBeNull();
+    expect(parseGithubRemote("git@bitbucket.org:o/r.git")).toBeNull();
+  });
+
+  it("rejects local path remotes", () => {
+    // SCP_LIKE_RE matches `C:\repos\mirror` with host "C", which is not github.
+    expect(parseGithubRemote("C:\\repos\\mirror")).toBeNull();
+    expect(parseGithubRemote("/srv/mirrors/r.git")).toBeNull();
+  });
+
+  it("rejects anything that is not exactly owner/repo", () => {
+    expect(parseGithubRemote("https://github.com/o")).toBeNull();
+    expect(parseGithubRemote("https://github.com/o/r/tree/x")).toBeNull();
+  });
+
+  it("rejects empty and nullish input", () => {
+    expect(parseGithubRemote("")).toBeNull();
+    expect(parseGithubRemote("   ")).toBeNull();
+    expect(parseGithubRemote(null)).toBeNull();
+    expect(parseGithubRemote(undefined)).toBeNull();
+  });
+
+  it("rejects traversal segments on BOTH parser branches (S7)", () => {
+    // URL branch: WHATWG normalizes `/o/../r` to `/r`, so it fails the
+    // two-segment check. (NAME_RE would NOT have caught it: `.` is in its class.)
+    expect(parseGithubRemote("https://github.com/o/../r")).toBeNull();
+    // scp branch: no normalization at all, so isSafeSegment is what rejects it.
+    // Rev 1 parsed this to {owner: "..", repo: "evil"}.
+    expect(parseGithubRemote("git@github.com:../evil")).toBeNull();
+    expect(parseGithubRemote("git@github.com:./.")).toBeNull();
+  });
+});
+
+describe("githubRepoUrl", () => {
+  it("builds the repo URL", () => {
+    expect(githubRepoUrl(ref)).toBe("https://github.com/o/r");
+  });
+});
+
+describe("githubBranchUrl", () => {
+  it("keeps slashes literal and encodes each segment", () => {
+    expect(githubBranchUrl(ref, "fix/909-agency-agents-roles-yaml-skip")).toBe(
+      "https://github.com/o/r/tree/fix/909-agency-agents-roles-yaml-skip"
+    );
+    expect(githubBranchUrl(ref, "feature/a b")).toBe("https://github.com/o/r/tree/feature/a%20b");
+    expect(githubBranchUrl(ref, "wip/#1")).toBe("https://github.com/o/r/tree/wip/%231");
+  });
+
+  it("handles a single-segment branch", () => {
+    expect(githubBranchUrl(ref, "main")).toBe("https://github.com/o/r/tree/main");
+  });
+
+  it("rejects traversal and empty refs instead of dropping segments (S8)", () => {
+    // Dropping the segments would have produced .../tree/evil/repo — a URL the
+    // browser normalizes into a DIFFERENT repository on the same host.
+    expect(githubBranchUrl(ref, "../../../../evil/repo")).toBeNull();
+    expect(githubBranchUrl(ref, "..")).toBeNull();
+    expect(githubBranchUrl(ref, ".")).toBeNull();
+    expect(githubBranchUrl(ref, "/")).toBeNull();
+    expect(githubBranchUrl(ref, "")).toBeNull();
+  });
+});

--- a/src/shared/github-url.ts
+++ b/src/shared/github-url.ts
@@ -1,0 +1,87 @@
+/// #943 - GitHub remote parsing for the coordinator repo Browse submenu.
+/// Only github.com is supported. Any other host (self-hosted GHE, GitLab,
+/// Bitbucket, a local path remote) yields null, which the caller renders as
+/// "no Browse items".
+
+export interface GithubRepoRef {
+  owner: string;
+  repo: string;
+}
+
+const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
+/// GitHub's owner/repo charset. NOTE: `.` is in this class, so it does NOT
+/// reject `.` or `..` on its own; `isSafeSegment` does that. (Rev 1 claimed the
+/// regex was an injection guard. It was not: `git@github.com:../evil` parsed to
+/// {owner: "..", repo: "evil"}.)
+const NAME_RE = /^[A-Za-z0-9._-]+$/;
+/// scp-like remote: [user@]host:owner/repo(.git)
+const SCP_LIKE_RE = /^(?:[^@/]+@)?([^:/]+):(.+)$/;
+const URL_SCHEME_RE = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//;
+const ALLOWED_SCHEMES = new Set(["http", "https", "ssh", "git"]);
+
+/// Only the URL branch gets WHATWG path normalization; the scp-like branch does
+/// not, so `.`/`..` must be rejected explicitly on both.
+function isSafeSegment(segment: string): boolean {
+  return segment.length > 0 && segment !== "." && segment !== "..";
+}
+
+function stripDotGit(value: string): string {
+  return value.replace(/\.git$/i, "");
+}
+
+function refFromHostAndPath(host: string, path: string): GithubRepoRef | null {
+  if (!GITHUB_HOSTS.has(host.toLowerCase())) return null;
+  const segments = path.split("/").filter((segment) => segment.length > 0);
+  if (segments.length !== 2) return null;
+  const owner = segments[0];
+  const repo = stripDotGit(segments[1]);
+  if (!isSafeSegment(owner) || !isSafeSegment(repo)) return null;
+  if (!NAME_RE.test(owner) || !NAME_RE.test(repo)) return null;
+  return { owner, repo };
+}
+
+export function parseGithubRemote(remote: string | null | undefined): GithubRepoRef | null {
+  const trimmed = (remote ?? "").trim();
+  if (!trimmed) return null;
+
+  if (URL_SCHEME_RE.test(trimmed)) {
+    let url: URL;
+    try {
+      url = new URL(trimmed);
+    } catch {
+      return null;
+    }
+    const scheme = url.protocol.replace(":", "").toLowerCase();
+    if (!ALLOWED_SCHEMES.has(scheme)) return null;
+    // URL.hostname already drops userinfo and port (and Rust already stripped
+    // userinfo before this ever crossed IPC; this is the second layer).
+    return refFromHostAndPath(url.hostname, url.pathname);
+  }
+
+  const scp = SCP_LIKE_RE.exec(trimmed);
+  if (!scp) return null;
+  return refFromHostAndPath(scp[1], scp[2]);
+}
+
+export function githubRepoUrl(ref: GithubRepoRef): string {
+  return `https://github.com/${ref.owner}/${ref.repo}`;
+}
+
+/// Branch names contain `/` (`fix/909-agency-agents-roles-yaml-skip`), so the
+/// separators stay literal and each segment is percent-encoded (`#`, `?`, spaces
+/// and newlines all encode; no second URL can be smuggled in).
+///
+/// Returns null for an unusable ref. `.`/`..` segments are rejected rather than
+/// dropped: git already forbids `..` in a ref name, so rejecting is lossless for
+/// real branches, and `repo.branch` is NOT always git-sourced (it also arrives
+/// from config.json `repoBranch` via configuredReplicaRepoBadges and from the
+/// volatile branch-event layer, neither of which validates). Without this,
+/// `../../../../evil/repo` produced a URL the browser normalized into a
+/// different repository.
+export function githubBranchUrl(ref: GithubRepoRef, branch: string): string | null {
+  const segments = branch.split("/").filter((segment) => segment.length > 0);
+  if (segments.length === 0) return null;
+  if (!segments.every(isSafeSegment)) return null;
+  const encoded = segments.map(encodeURIComponent).join("/");
+  return `${githubRepoUrl(ref)}/tree/${encoded}`;
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -373,6 +373,13 @@ export const SettingsAPI = {
 export const ReposAPI = {
   search: (query: string) =>
     transport.invoke<RepoMatch[]>("search_repos", { query }),
+
+  /// #943 - `origin`'s URL for a repo path, userinfo already stripped by the
+  /// backend. `null` = no origin, not a work tree root, git missing, the 2s
+  /// backend timeout fired, or a web client (the WS dispatcher no-ops this).
+  /// The caller treats all of them the same: no Browse items.
+  gitRemoteUrl: (path: string) =>
+    transport.invoke<string | null>("git_remote_url", { path }),
 };
 
 export function onPtyOutput(

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -639,10 +639,23 @@ export function onSessionCoordinatorChanged(
   );
 }
 
+/// #943 B2 - `repoBranches` and `repoPaths` are parallel arrays of equal length,
+/// 1:1 by construction (ac_discovery.rs maps over `agent.repo_paths` and never
+/// filters, sorts or dedupes), with an explicit `null` for an unknown branch.
+/// Consumers must still merge BY PATH, not by position: this payload is stored and
+/// re-read against a later discovery snapshot. `branch` is the unchanged
+/// single-repo shorthand (null for a multi-repo replica).
+interface DiscoveryBranchUpdate {
+  replicaPath: string;
+  branch: string | null;
+  repoBranches: (string | null)[];
+  repoPaths: string[];
+}
+
 export function onDiscoveryBranchUpdated(
-  callback: (data: { replicaPath: string; branch: string | null }) => void
+  callback: (data: DiscoveryBranchUpdate) => void
 ): Promise<UnlistenFn> {
-  return transport.listen<{ replicaPath: string; branch: string | null }>(
+  return transport.listen<DiscoveryBranchUpdate>(
     "ac_discovery_branch_updated",
     callback
   );

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -11,6 +11,7 @@ import type {
 import { FakeTransport } from "./fake-transport";
 import { toastStore } from "../stores/toasts";
 import { projectStore } from "../../sidebar/stores/project";
+import { replicaVolatileStore } from "../../sidebar/stores/replica-volatile";
 import { autoUnarchiveStore } from "../../sidebar/stores/auto-unarchive";
 import { sessionsStore } from "../../sidebar/stores/sessions";
 import { bridgesStore } from "../../sidebar/stores/bridges";
@@ -231,6 +232,10 @@ export function bridge(overrides: Partial<BridgeInfo> = {}): BridgeInfo {
 
 export function resetUiStoresForTests(): void {
   projectStore.clear();
+  // #943 B2 - the volatile layer outlives a render, so without this a test that
+  // lands a branch event leaks its repoBranch/repoBranchByPath into the next test
+  // in the same file (order-dependent, and silently wrong rather than red).
+  replicaVolatileStore.clearAll();
   sessionsStore.setSessions([]);
   sessionsStore.setActiveId(null);
   sessionsStore.setTeams([]);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4,6 +4,21 @@ export interface SessionRepo {
   branch: string | null;
 }
 
+/**
+ * #943 B2 - live per-repo branches, keyed by repo SOURCE PATH.
+ *
+ * A missing key = the live layer knows nothing about that repo (no event has
+ * landed yet, or it was added to `config.json` since the last watcher tick). An
+ * explicit `null` = the layer knows the repo and has no branch for it (detached
+ * HEAD, not a work tree, git missing, detection timed out).
+ *
+ * Keyed by path and NEVER by index, even though the backend emits the branches
+ * positionally: the payload is stored and re-read against a LATER discovery
+ * snapshot, so a reorder/removal in `config.json` `repos` would make a positional
+ * merge paint repo A's branch onto repo B for up to one 15s tick.
+ */
+export type RepoBranchByPath = Record<string, string | null>;
+
 export type SessionCommunicationKind = "raiseHand";
 
 export interface SessionCommunication {

--- a/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
+++ b/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
@@ -280,6 +280,33 @@ describe("ProjectPanel coordinator repo Browse submenu (#943)", () => {
     expect(flyoutLabels()).toEqual(["Browse Main"]);
   });
 
+  // 3b
+  it("offers Browse Main only when the branch is master (product rule: main AND master)", async () => {
+    await setupPanel([coordASession([repo(repoA1, "AgentsCommander", "master")])], discoveryA());
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+
+    await waitFor(() => expect(flyout()).not.toBeNull());
+    expect(flyoutLabels()).toEqual(["Browse Main"]);
+  });
+
+  // 3c
+  it("still offers Browse Branch for `Master` (the gate is exact-match, not casefolded)", async () => {
+    // Git refs are case-sensitive: `Master` is a distinct, real branch, not the
+    // default one. Guards against anyone adding a .toLowerCase() to the gate.
+    await setupPanel([coordASession([repo(repoA1, "AgentsCommander", "Master")])], discoveryA());
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+
+    await waitFor(() => expect(flyout()).not.toBeNull());
+    expect(flyoutLabels()).toEqual(["Browse Main", "Browse Branch"]);
+    expect(target("replica.coord-a.menu.repo.0.browse.branch")!.getAttribute("title")).toBe(
+      "https://github.com/mblua/AgentsCommander/tree/Master"
+    );
+  });
+
   // 4
   it("offers Browse Main only when the branch is unknown", async () => {
     await setupPanel([coordASession([repo(repoA1, "AgentsCommander", null)])], discoveryA());

--- a/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
+++ b/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
@@ -630,6 +630,49 @@ describe("ProjectPanel coordinator repo Browse submenu (#943)", () => {
     );
   });
 
+  // 18 [B2]
+  it("gives a cold multi-repo coordinator Browse Branch after a discovery branch event", async () => {
+    const fake = await setupPanel([], discoveryA([repoA1, repoA2]));
+
+    // Before the event: discovery detects a branch only for a single-repo replica,
+    // so a cold multi-repo coordinator has none and can only Browse Main. That is
+    // the up-to-15s window the user accepted when approving B2.
+    await openMenuWithArrow(rowA, 2);
+    mouseEnter(repoEntries()[0]);
+    await waitFor(() => expect(flyout()).not.toBeNull());
+    expect(flyoutLabels()).toEqual(["Browse Main"]);
+
+    keyDown(document.body, "Escape");
+    await waitFor(() => expect(menu()).toBeNull());
+
+    // The 15s watcher tick lands. repo 1's branch is an explicit null (unknown).
+    fake.emitFromBackend("ac_discovery_branch_updated", {
+      replicaPath: coordAPath,
+      branch: null, // multi-repo: the single-repo shorthand stays null
+      repoPaths: [repoA1, repoA2],
+      repoBranches: ["feature/cold", null],
+    });
+
+    await openMenuWithArrow(rowA, 2);
+    mouseEnter(repoEntries()[0]);
+
+    await waitFor(() =>
+      expect(target("replica.inactive.menu.repo.0.browse.branch")).not.toBeNull()
+    );
+    expect(flyoutLabels()).toEqual(["Browse Main", "Browse Branch"]);
+    expect(target("replica.inactive.menu.repo.0.browse.branch")!.getAttribute("title")).toBe(
+      "https://github.com/mblua/AgentsCommander/tree/feature/cold"
+    );
+
+    // repo 1: known to the watcher, no branch -> Browse Main only.
+    mouseLeave(repoEntries()[0]);
+    mouseEnter(repoEntries()[1]);
+    await waitFor(() =>
+      expect(target("replica.inactive.menu.repo.1.browse.flyout")).not.toBeNull()
+    );
+    expect(flyoutLabels()).toEqual(["Browse Main"]);
+  });
+
   // 17
   it("shows the arrow only on the repo that has a GitHub origin", async () => {
     await setupPanel(

--- a/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
+++ b/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
@@ -62,6 +62,56 @@ const keyDown = (el: Element, key: string) =>
  *  listening. */
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
+function domRect(left: number, top: number, width: number, height: number): DOMRect {
+  return {
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+/** The production reclamp prefers requestAnimationFrame, and jsdom's rAF fires on
+ *  a real ~16ms frame - long after a macrotask flush. That let a broken isConnected
+ *  guard escape unobserved (the reposition simply had not run yet when the test
+ *  asserted). Route rAF through a macrotask so the queued clamp is deterministic;
+ *  the production code takes this very path when rAF is unavailable. */
+function stubAnimationFrame(): () => void {
+  const previous = globalThis.requestAnimationFrame;
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    writable: true,
+    value: (cb: FrameRequestCallback) => window.setTimeout(() => cb(0), 0),
+  });
+  return () => {
+    Object.defineProperty(globalThis, "requestAnimationFrame", {
+      configurable: true,
+      writable: true,
+      value: previous,
+    });
+  };
+}
+
+/** jsdom reports an all-zero rect for EVERY element, which is exactly why guard 4
+ *  (`isConnected` in reclampRepoFlyout) is invisible by default: a detached anchor
+ *  looks identical to a connected one. Give connected elements a real rect and
+ *  leave detached ones at zeros - which is what a real browser reports for them. */
+function stubBoundingRects(): () => void {
+  const spy = vi
+    .spyOn(Element.prototype, "getBoundingClientRect")
+    .mockImplementation(function (this: Element) {
+      if (!this.isConnected) return domRect(0, 0, 0, 0);
+      if (this.classList?.contains("session-context-flyout")) return domRect(204, 50, 100, 20);
+      return domRect(100, 50, 100, 20); // a repo entry: right = 200, top = 50
+    });
+  return () => spy.mockRestore();
+}
+
 function coordinatorAgent(name: string, path: string, repoPaths: string[], repoBranch?: string) {
   return {
     name,
@@ -671,6 +721,106 @@ describe("ProjectPanel coordinator repo Browse submenu (#943)", () => {
       expect(target("replica.inactive.menu.repo.1.browse.flyout")).not.toBeNull()
     );
     expect(flyoutLabels()).toEqual(["Browse Main"]);
+  });
+
+  // 19 [guard 3 - the sourcePath identity check]
+  it("closes the flyout when the anchored repo is reordered out from under it", async () => {
+    await setupPanel(
+      [
+        coordASession([
+          repo(repoA1, "AgentsCommander", "feature/x"),
+          repo(repoA2, "docs", "main"),
+        ]),
+      ],
+      discoveryA([repoA1, repoA2])
+    );
+
+    await openMenuWithArrow(rowA, 2);
+    mouseEnter(repoEntries()[0]); // flyout anchored to index 0 = repoA1
+    await waitFor(() => expect(flyout()).not.toBeNull());
+
+    // config.json reorders `repos`, so index 0 is now a DIFFERENT repo. Without the
+    // `candidate.sourcePath === fly.sourcePath` check, liveRepo() would happily
+    // return docs and the open flyout would silently start offering docs' links
+    // under AgentsCommander's cursor.
+    sessionsStore.setGitRepos("coord-a", [
+      repo(repoA2, "docs", "main"),
+      repo(repoA1, "AgentsCommander", "feature/x"),
+    ]);
+
+    await waitFor(() => expect(flyout()).toBeNull());
+  });
+
+  // 20 [guard 3 - the close effect]
+  it("does not resurrect a flyout whose repo disappears and comes back", async () => {
+    await setupPanel(
+      [
+        coordASession([
+          repo(repoA1, "AgentsCommander", "feature/x"),
+          repo(repoA2, "docs", "main"),
+        ]),
+      ],
+      discoveryA([repoA1, repoA2])
+    );
+
+    await openMenuWithArrow(rowA, 2);
+    mouseEnter(repoEntries()[0]);
+    await waitFor(() => expect(flyout()).not.toBeNull());
+
+    // The repo leaves the list: <Show> hides the panel, but only the effect clears
+    // repoFlyout() itself.
+    sessionsStore.setGitRepos("coord-a", [repo(repoA2, "docs", "main")]);
+    await waitFor(() => expect(flyout()).toBeNull());
+
+    // ...and comes back on a later tick. Nobody hovered anything. Without the
+    // effect, the stale {index, sourcePath} would match again and the flyout would
+    // pop open on its own - a ghost, with no pointer anywhere near it.
+    sessionsStore.setGitRepos("coord-a", [
+      repo(repoA1, "AgentsCommander", "feature/x"),
+      repo(repoA2, "docs", "main"),
+    ]);
+    await flush();
+
+    expect(flyout()).toBeNull();
+  });
+
+  // 21 [guard 4 - isConnected in reclampRepoFlyout]
+  it("keeps the flyout anchored when the entry row is re-created under the cursor", async () => {
+    const restoreRects = stubBoundingRects();
+    const restoreRaf = stubAnimationFrame();
+    try {
+      await setupPanel(
+        [coordASession([repo(repoA1, "AgentsCommander", "feature/x")])],
+        discoveryA()
+      );
+
+      await openMenuWithArrow(rowA);
+      mouseEnter(repoEntries()[0]); // opens synchronously; the reclamp is queued
+
+      // Proves the rect stub is live: with jsdom's all-zero rects the flyout would
+      // already sit at the viewport margin and this test would be vacuous.
+      expect(flyout()).not.toBeNull();
+      const openLeft = flyout()!.style.left;
+      const openTop = flyout()!.style.top;
+      expect(openLeft).toBe("204px"); // anchor.right (200) + 4
+      expect(openTop).toBe("50px");
+
+      // <For> is reference-keyed and the cold path mints fresh objects on every
+      // evaluation, so the row - and the anchor node - is re-created while the
+      // pointer sits still. The reclamp queued at open time then runs against a
+      // DETACHED anchor, whose rect is all zeros: without the isConnected guard it
+      // flings the flyout to the top-left viewport margin.
+      sessionsStore.setGitRepos("coord-a", [repo(repoA1, "AgentsCommander", "feature/x")]);
+      await flush();
+
+      expect(flyout()).not.toBeNull();
+      expect(flyoutLabels()).toEqual(["Browse Main", "Browse Branch"]);
+      expect(flyout()!.style.left).toBe(openLeft);
+      expect(flyout()!.style.top).toBe(openTop);
+    } finally {
+      restoreRects();
+      restoreRaf();
+    }
   });
 
   // 17

--- a/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
+++ b/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
@@ -1,0 +1,640 @@
+// @vitest-environment jsdom
+import { vi } from "vitest";
+// #943 - the Browse submenu is desktop-only (`open_external_url` and
+// `git_remote_url` are both no-ops on the WS host), so it only renders when
+// isTauri is true. jsdom has no __TAURI_INTERNALS__, so isTauri is false there.
+// Mock the module for THIS FILE ONLY: vi.mock is hoisted file-wide, and flipping
+// isTauri inside ProjectPanel.context-menu.test.tsx would break its raw
+// textContent assertion (:401 would read "AgentsCommander›") and arm the
+// four isTauri-gated dynamic @tauri-apps/api/webviewWindow imports.
+// A module mock replaces the module wholesale, so all three exports are needed.
+vi.mock("../../shared/platform", () => ({
+  isTauri: true,
+  isBrowser: false,
+  isWindows: true,
+}));
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  contextMenu,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
+import type { AcDiscoveryResult, Session, SessionRepo } from "../../shared/types";
+
+const projectPath = "C:\\Project";
+
+const wgAPath = `${projectPath}\\.ac\\wg-2-dev-team`;
+const coordAPath = `${wgAPath}\\__agent_dev-webpage-ui`;
+const repoA1 = `${wgAPath}\\repo-AgentsCommander`;
+const repoA2 = `${wgAPath}\\repo-docs`;
+
+const wgBPath = `${projectPath}\\.ac\\wg-3-other-team`;
+const coordBPath = `${wgBPath}\\__agent_dev-rust`;
+const repoB1 = `${wgBPath}\\repo-webpage`;
+
+const rowA = "replica.row.quick.wg-2-dev-team.dev-webpage-ui";
+const rowB = "replica.row.quick.wg-3-other-team.dev-rust";
+
+const GITHUB_REMOTE = "https://github.com/mblua/AgentsCommander.git";
+
+// Solid does not delegate mouseenter/mouseleave (they do not bubble); it binds
+// them directly, so a non-bubbling dispatch is exactly what the handler sees.
+const mouseEnter = (el: Element) =>
+  el.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false, cancelable: true }));
+const mouseLeave = (el: Element) =>
+  el.dispatchEvent(new MouseEvent("mouseleave", { bubbles: false, cancelable: true }));
+const keyDown = (el: Element, key: string) =>
+  el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+
+/** Drain the macrotask queue. The menu registers its window-level dismiss
+ *  listeners inside a `setTimeout` (ProjectPanel :1918), so a test that dispatches
+ *  a dismissing event without flushing first would hit a menu that is not yet
+ *  listening. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function coordinatorAgent(name: string, path: string, repoPaths: string[], repoBranch?: string) {
+  return {
+    name,
+    path,
+    identityPath: `../../_agent_${name}`,
+    repoPaths,
+    ...(repoBranch === undefined ? {} : { repoBranch }),
+    isCoordinator: true,
+  };
+}
+
+function discoveryA(repoPaths: string[] = [repoA1], repoBranch?: string): AcDiscoveryResult {
+  return discovery({
+    workgroups: [
+      {
+        name: "wg-2-dev-team",
+        path: wgAPath,
+        task: null,
+        taskTitle: "Repo browse",
+        agents: [coordinatorAgent("dev-webpage-ui", coordAPath, repoPaths, repoBranch)],
+      },
+    ],
+  });
+}
+
+function discoveryAB(): AcDiscoveryResult {
+  return discovery({
+    workgroups: [
+      {
+        name: "wg-2-dev-team",
+        path: wgAPath,
+        task: null,
+        taskTitle: "Repo browse",
+        agents: [coordinatorAgent("dev-webpage-ui", coordAPath, [repoA1])],
+      },
+      {
+        name: "wg-3-other-team",
+        path: wgBPath,
+        task: null,
+        taskTitle: "Repo browse B",
+        agents: [coordinatorAgent("dev-rust", coordBPath, [repoB1])],
+      },
+    ],
+  });
+}
+
+function repo(sourcePath: string, label: string, branch: string | null): SessionRepo {
+  return { label, sourcePath, branch };
+}
+
+function coordASession(gitRepos: SessionRepo[]): Session {
+  return session({
+    id: "coord-a",
+    name: "wg-2-dev-team/dev-webpage-ui",
+    workingDirectory: coordAPath,
+    status: "running",
+    isCoordinator: true,
+    gitRepos,
+  });
+}
+
+function coordBSession(gitRepos: SessionRepo[]): Session {
+  return session({
+    id: "coord-b",
+    name: "wg-3-other-team/dev-rust",
+    workingDirectory: coordBPath,
+    status: "running",
+    isCoordinator: true,
+    gitRepos,
+  });
+}
+
+function menu(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(".session-context-menu");
+}
+
+function flyout(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('[data-ac-testid$=".browse.flyout"]');
+}
+
+function target(testId: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(`[data-ac-testid="${testId}"]`);
+}
+
+function repoEntries(): HTMLButtonElement[] {
+  const root = menu();
+  if (!root) return [];
+  return Array.from(root.querySelectorAll<HTMLButtonElement>(".session-context-repo-option"));
+}
+
+/** Arrows on REPO entries only. `Add to Group` is a submenu trigger too and
+ *  carries the same arrow span, so an unscoped selector always finds one. */
+function repoArrows(): HTMLElement[] {
+  const root = menu();
+  if (!root) return [];
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      ".session-context-repo-option .session-context-submenu-arrow"
+    )
+  );
+}
+
+function flyoutLabels(): string[] {
+  const panel = flyout();
+  if (!panel) return [];
+  return Array.from(panel.querySelectorAll("button")).map((b) => (b.textContent ?? "").trim());
+}
+
+describe("ProjectPanel coordinator repo Browse submenu (#943)", () => {
+  let cleanupDom: (() => void) | null = null;
+  let rendered: ReturnType<typeof renderWithFakeTransport> | null = null;
+
+  async function setupPanel(
+    sessions: Session[],
+    discoveryResult: AcDiscoveryResult,
+    remote: unknown | ((args: Record<string, unknown>) => unknown) = GITHUB_REMOTE
+  ): Promise<FakeTransport> {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", discoveryResult);
+    fake.resolve("task_clean", { workgroupRoot: wgAPath, task: null });
+    fake.resolve("task_clean_at", { workgroupRoot: wgAPath, task: null });
+    fake.resolve("open_in_explorer", null);
+    fake.resolve("open_external_url", null);
+    // FakeTransport throws on an unregistered invoke, so git_remote_url is always
+    // registered. Args-aware when a function is passed: fake.resolve() keys by
+    // command only and cannot vary the answer per repo path.
+    if (typeof remote === "function") {
+      fake.onInvoke("git_remote_url", remote as (args: Record<string, unknown>) => unknown);
+    } else {
+      fake.resolve("git_remote_url", remote);
+    }
+    if (sessions.length > 0) sessionsStore.setSessions(sessions);
+    rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    await projectStore.createAndLoad(projectPath);
+    await waitFor(() => expect(rendered!.root.textContent).toContain("dev-webpage-ui"));
+    return fake;
+  }
+
+  /** Right-click a row, wait until the Browse arrows have resolved, and let the
+   *  menu finish installing its window-level dismiss listeners. */
+  async function openMenuWithArrow(testId: string, expectedArrows = 1): Promise<void> {
+    contextMenu(target(testId)!);
+    await waitFor(() => {
+      expect(menu()).not.toBeNull();
+      expect(repoArrows()).toHaveLength(expectedArrows);
+    });
+    await flush();
+  }
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    rendered?.cleanup();
+    rendered = null;
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  // 1
+  it("opens Browse Main + Browse Branch on hover and navigates to the branch URL", async () => {
+    const fake = await setupPanel(
+      [coordASession([repo(repoA1, "AgentsCommander", "feature/x")])],
+      discoveryA()
+    );
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+
+    await waitFor(() => expect(flyout()).not.toBeNull());
+    expect(flyoutLabels()).toEqual(["Browse Main", "Browse Branch"]);
+
+    click(target("replica.coord-a.menu.repo.0.browse.branch")!);
+
+    await waitFor(() => {
+      expect(fake.lastCall("open_external_url")?.args).toEqual({
+        url: "https://github.com/mblua/AgentsCommander/tree/feature/x",
+      });
+      expect(menu()).toBeNull();
+    });
+  });
+
+  // 2
+  it("keeps the slashes in a branch name literal", async () => {
+    const fake = await setupPanel(
+      [coordASession([repo(repoA1, "AgentsCommander", "fix/909-agency-agents-roles-yaml-skip")])],
+      discoveryA()
+    );
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+    await waitFor(() => expect(flyout()).not.toBeNull());
+
+    click(target("replica.coord-a.menu.repo.0.browse.branch")!);
+
+    await waitFor(() =>
+      expect(fake.lastCall("open_external_url")?.args).toEqual({
+        url: "https://github.com/mblua/AgentsCommander/tree/fix/909-agency-agents-roles-yaml-skip",
+      })
+    );
+  });
+
+  // 3
+  it("offers Browse Main only when the branch is main", async () => {
+    await setupPanel([coordASession([repo(repoA1, "AgentsCommander", "main")])], discoveryA());
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+
+    await waitFor(() => expect(flyout()).not.toBeNull());
+    expect(flyoutLabels()).toEqual(["Browse Main"]);
+  });
+
+  // 4
+  it("offers Browse Main only when the branch is unknown", async () => {
+    await setupPanel([coordASession([repo(repoA1, "AgentsCommander", null)])], discoveryA());
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+
+    await waitFor(() => expect(flyout()).not.toBeNull());
+    expect(flyoutLabels()).toEqual(["Browse Main"]);
+  });
+
+  // 5
+  it("renders no arrow and no flyout for a non-GitHub remote, and still opens the folder", async () => {
+    const fake = await setupPanel(
+      [coordASession([repo(repoA1, "AgentsCommander", "feature/x")])],
+      discoveryA(),
+      "https://gitlab.com/o/r.git"
+    );
+
+    contextMenu(target(rowA)!);
+    await waitFor(() => expect(repoEntries()).toHaveLength(1));
+    // The remote resolves asynchronously; give it every chance to paint an arrow.
+    await waitFor(() => expect(fake.callsFor("git_remote_url")).toHaveLength(1));
+    await flush();
+
+    expect(repoArrows()).toHaveLength(0);
+    mouseEnter(repoEntries()[0]);
+    await flush();
+    expect(flyout()).toBeNull();
+
+    click(repoEntries()[0]);
+    await waitFor(() =>
+      expect(fake.lastCall("open_in_explorer")?.args).toEqual({ path: repoA1 })
+    );
+  });
+
+  // 6
+  it("renders no arrow when the repo has no origin", async () => {
+    const fake = await setupPanel(
+      [coordASession([repo(repoA1, "AgentsCommander", "feature/x")])],
+      discoveryA(),
+      null
+    );
+
+    contextMenu(target(rowA)!);
+    await waitFor(() => expect(repoEntries()).toHaveLength(1));
+    await waitFor(() => expect(fake.callsFor("git_remote_url")).toHaveLength(1));
+    await flush();
+
+    expect(repoArrows()).toHaveLength(0);
+    mouseEnter(repoEntries()[0]);
+    await flush();
+    expect(flyout()).toBeNull();
+  });
+
+  // 7
+  it("still opens the local folder when the entry itself is clicked (purely additive)", async () => {
+    const fake = await setupPanel(
+      [coordASession([repo(repoA1, "AgentsCommander", "feature/x")])],
+      discoveryA()
+    );
+
+    await openMenuWithArrow(rowA);
+    click(repoEntries()[0]);
+
+    await waitFor(() => {
+      expect(fake.lastCall("open_in_explorer")?.args).toEqual({ path: repoA1 });
+      expect(menu()).toBeNull();
+    });
+    expect(fake.callsFor("open_external_url")).toHaveLength(0);
+  });
+
+  // 8
+  it("renders the submenu on an inactive (gray) coordinator", async () => {
+    // Cold single-repo replica: the branch comes from discovery's repoBranch via
+    // configuredReplicaRepoBadges, not from a session.
+    await setupPanel([], discoveryA([repoA1], "feature/y"));
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+
+    await waitFor(() => expect(target("replica.inactive.menu.repo.0.browse.flyout")).not.toBeNull());
+    expect(flyoutLabels()).toEqual(["Browse Main", "Browse Branch"]);
+    expect(target("replica.inactive.menu.repo.0.browse.branch")!.getAttribute("title")).toBe(
+      "https://github.com/mblua/AgentsCommander/tree/feature/y"
+    );
+  });
+
+  // 9
+  it("is mutually exclusive with the Add to Group flyout", async () => {
+    await setupPanel([coordASession([repo(repoA1, "AgentsCommander", "feature/x")])], discoveryA());
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+    await waitFor(() => expect(flyout()).not.toBeNull());
+
+    mouseEnter(target("replica.wg-2-dev-team.groups.trigger")!);
+
+    await waitFor(() => {
+      expect(flyout()).toBeNull();
+      expect(target("replica.wg-2-dev-team.groups.flyout")).not.toBeNull();
+    });
+  });
+
+  // 10
+  it("invokes git_remote_url once per distinct repo path per menu open, never on hover", async () => {
+    const fake = await setupPanel(
+      [
+        coordASession([
+          repo(repoA1, "AgentsCommander", "feature/x"),
+          repo(repoA2, "docs", "main"),
+        ]),
+      ],
+      discoveryA([repoA1, repoA2])
+    );
+
+    await openMenuWithArrow(rowA, 2);
+    expect(fake.callsFor("git_remote_url")).toHaveLength(2);
+
+    mouseEnter(repoEntries()[0]);
+    mouseEnter(repoEntries()[0]);
+    mouseEnter(repoEntries()[0]);
+    await flush();
+
+    expect(fake.callsFor("git_remote_url")).toHaveLength(2);
+    expect(fake.callsFor("git_remote_url").map((c) => c.args.path)).toEqual([repoA1, repoA2]);
+  });
+
+  // 11
+  it("does not inherit a flyout when the menu is closed and reopened", async () => {
+    const fake = await setupPanel(
+      [coordASession([repo(repoA1, "AgentsCommander", "feature/x")])],
+      discoveryA()
+    );
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+    await waitFor(() => expect(flyout()).not.toBeNull());
+
+    // Escape at the window level is the menu's own dismiss path.
+    keyDown(document.body, "Escape");
+    await waitFor(() => expect(menu()).toBeNull());
+    expect(flyout()).toBeNull();
+
+    contextMenu(target(rowA)!);
+    await waitFor(() => expect(menu()).not.toBeNull());
+    // No stale panel before the fresh resolution lands, and the reopen re-resolved
+    // (generation bumped) rather than reusing the previous menu's answers.
+    expect(flyout()).toBeNull();
+    await waitFor(() => expect(fake.callsFor("git_remote_url")).toHaveLength(2));
+    expect(flyout()).toBeNull();
+  });
+
+  // 12 [S1 / BLOCKER 1]
+  it("renders B's repos, titles and testids after right-clicking A then B", async () => {
+    const fake = await setupPanel(
+      [
+        coordASession([repo(repoA1, "AgentsCommander", "feature/x")]),
+        coordBSession([repo(repoB1, "webpage", "feature/y")]),
+      ],
+      discoveryAB()
+    );
+
+    await openMenuWithArrow(rowA);
+    expect(repoEntries()[0].getAttribute("title")).toBe(repoA1);
+    expect(target("replica.coord-a.menu.repo.0")).not.toBeNull();
+
+    // No close in between: the handlers overwrite the signal non-null -> non-null,
+    // so nothing here goes through a null transition.
+    contextMenu(target(rowB)!);
+
+    await waitFor(() => {
+      expect(repoEntries()).toHaveLength(1);
+      expect(repoEntries()[0].getAttribute("title")).toBe(repoB1);
+    });
+    expect(target("replica.coord-b.menu.repo.0")).not.toBeNull();
+    expect(target("replica.coord-a.menu.repo.0")).toBeNull();
+    expect(repoEntries()[0].textContent).toContain("webpage");
+
+    click(repoEntries()[0]);
+    await waitFor(() =>
+      expect(fake.lastCall("open_in_explorer")?.args).toEqual({ path: repoB1 })
+    );
+  });
+
+  // 13 [S1]
+  it("leaves no stale flyout when the menu switches from A to B", async () => {
+    await setupPanel(
+      [
+        coordASession([repo(repoA1, "AgentsCommander", "feature/x")]),
+        coordBSession([repo(repoB1, "webpage", "feature/y")]),
+      ],
+      discoveryAB()
+    );
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+    await waitFor(() => expect(flyout()).not.toBeNull());
+
+    contextMenu(target(rowB)!);
+
+    await waitFor(() => expect(target("replica.coord-b.menu.repo.0")).not.toBeNull());
+    expect(flyout()).toBeNull();
+  });
+
+  // 13b [S1] - isolates the handler guard. In test 13 the flyout ALSO gets closed
+  // by the identity-check effect (B's entry 0 has a different sourcePath, so the
+  // live re-derive returns null). Here both coordinators point at the SAME repo
+  // path, so the identity check passes and cannot fire: the only thing that can
+  // close the flyout is `closeRepoFlyout()` in the context-menu handler. Delete
+  // that line and this test goes red with an empty, stale, mis-anchored panel.
+  it("closes the flyout on an A->B switch even when the repo path is identical", async () => {
+    const shared = `${projectPath}\.ac\repo-shared`;
+    const discoveryShared = discovery({
+      workgroups: [
+        {
+          name: "wg-2-dev-team",
+          path: wgAPath,
+          task: null,
+          taskTitle: "Repo browse",
+          agents: [coordinatorAgent("dev-webpage-ui", coordAPath, [shared])],
+        },
+        {
+          name: "wg-3-other-team",
+          path: wgBPath,
+          task: null,
+          taskTitle: "Repo browse B",
+          agents: [coordinatorAgent("dev-rust", coordBPath, [shared])],
+        },
+      ],
+    });
+
+    await setupPanel(
+      [
+        coordASession([repo(shared, "shared", "feature/x")]),
+        coordBSession([repo(shared, "shared", "feature/x")]),
+      ],
+      discoveryShared
+    );
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+    await waitFor(() => expect(flyout()).not.toBeNull());
+
+    contextMenu(target(rowB)!);
+
+    await waitFor(() => expect(target("replica.coord-b.menu.repo.0")).not.toBeNull());
+    expect(flyout()).toBeNull();
+  });
+
+  // 14 [S2]
+  it("closes the flyout on Escape without re-opening it, and keeps the menu", async () => {
+    await setupPanel([coordASession([repo(repoA1, "AgentsCommander", "feature/x")])], discoveryA());
+
+    await openMenuWithArrow(rowA);
+    const entry = repoEntries()[0];
+
+    keyDown(entry, "ArrowRight");
+    await waitFor(() => expect(flyout()).not.toBeNull());
+
+    keyDown(flyout()!, "Escape");
+    expect(flyout()).toBeNull();
+
+    // The refocus of the trigger fires onFocus synchronously; without the
+    // suppress latch it would re-open the flyout on the next microtask.
+    await flush();
+    expect(flyout()).toBeNull();
+    expect(menu()).not.toBeNull();
+    expect(document.activeElement).toBe(entry);
+  });
+
+  // 15
+  it("does not kill the menu when the flyout's padding is clicked", async () => {
+    const fake = await setupPanel(
+      [coordASession([repo(repoA1, "AgentsCommander", "feature/x")])],
+      discoveryA()
+    );
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+    await waitFor(() => expect(flyout()).not.toBeNull());
+
+    click(flyout()!); // the panel itself, not a button
+    await flush();
+
+    expect(menu()).not.toBeNull();
+    expect(flyout()).not.toBeNull();
+    expect(fake.callsFor("open_external_url")).toHaveLength(0);
+  });
+
+  // 16 [S3]
+  it("follows a branch change that lands while the flyout is open", async () => {
+    const fake = await setupPanel(
+      [coordASession([repo(repoA1, "AgentsCommander", "feature/x")])],
+      discoveryA()
+    );
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+    await waitFor(() => expect(flyout()).not.toBeNull());
+
+    // This is exactly what App.tsx's onSessionGitRepos listener does with the
+    // backend event (App.tsx:596-597). ProjectPanel does not own that listener,
+    // so driving the store directly is the honest way to reproduce a GitWatcher
+    // tick in a ProjectPanel-scoped test.
+    sessionsStore.setGitRepos("coord-a", [repo(repoA1, "AgentsCommander", "feature/new")]);
+
+    await waitFor(() =>
+      expect(target("replica.coord-a.menu.repo.0.browse.branch")!.getAttribute("title")).toBe(
+        "https://github.com/mblua/AgentsCommander/tree/feature/new"
+      )
+    );
+    // The entry was re-derived by index + sourcePath, so the flyout survives.
+    expect(flyout()).not.toBeNull();
+
+    click(target("replica.coord-a.menu.repo.0.browse.branch")!);
+    await waitFor(() =>
+      expect(fake.lastCall("open_external_url")?.args).toEqual({
+        url: "https://github.com/mblua/AgentsCommander/tree/feature/new",
+      })
+    );
+  });
+
+  // 17
+  it("shows the arrow only on the repo that has a GitHub origin", async () => {
+    await setupPanel(
+      [
+        coordASession([
+          repo(repoA1, "AgentsCommander", "feature/x"),
+          repo(repoA2, "docs", "feature/x"),
+        ]),
+      ],
+      discoveryA([repoA1, repoA2]),
+      (args: Record<string, unknown>) =>
+        String(args.path).endsWith("repo-AgentsCommander")
+          ? GITHUB_REMOTE
+          : "https://gitlab.com/o/r.git"
+    );
+
+    await openMenuWithArrow(rowA, 1);
+    expect(repoEntries()).toHaveLength(2);
+    expect(repoEntries()[0].querySelector(".session-context-submenu-arrow")).not.toBeNull();
+    expect(repoEntries()[1].querySelector(".session-context-submenu-arrow")).toBeNull();
+
+    mouseEnter(repoEntries()[1]);
+    await flush();
+    expect(flyout()).toBeNull();
+
+    mouseEnter(repoEntries()[0]);
+    await waitFor(() => expect(flyout()).not.toBeNull());
+    expect(flyoutLabels()).toEqual(["Browse Main", "Browse Branch"]);
+
+    // Moving onto the non-browsable entry must not leave the flyout hanging.
+    mouseLeave(repoEntries()[0]);
+    mouseEnter(repoEntries()[1]);
+    expect(flyout()).toBeNull();
+  });
+});

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -27,6 +27,7 @@ import {
   effectiveLastUserMessageAt,
   effectiveManuallyClosedAt,
   effectiveRepoBranch,
+  effectiveRepoBranchByPath,
   replicaVolatileStore,
 } from "../stores/replica-volatile";
 import { normalizeProjectPathForCompare } from "../stores/project-refresh";
@@ -222,7 +223,12 @@ function configuredReplicaRepoBadgesLive(
   workgroup: Pick<AcWorkgroup, "repoPath">
 ): SessionRepo[] {
   return configuredReplicaRepoBadges(
-    { repoPaths: replica.repoPaths, repoBranch: effectiveRepoBranch(replica) },
+    {
+      repoPaths: replica.repoPaths,
+      repoBranch: effectiveRepoBranch(replica),
+      // #943 B2 - per-repo branches for cold multi-repo replicas, keyed by path.
+      repoBranchByPath: effectiveRepoBranchByPath(replica),
+    },
     workgroup
   );
 }
@@ -403,7 +409,14 @@ const ProjectPanel: Component = () => {
   onCleanup(registerCoordinatorCloseModalHost());
   onMount(async () => {
     unlistenBranch = await onDiscoveryBranchUpdated((data) => {
-      replicaVolatileStore.setRepoBranch(data.replicaPath, data.branch);
+      // #943 B2 - one atomic write: the single-repo shorthand plus the per-repo
+      // branches, merged BY PATH (never by index - see the store).
+      replicaVolatileStore.applyDiscoveryBranchUpdate(
+        data.replicaPath,
+        data.branch,
+        data.repoPaths,
+        data.repoBranches
+      );
     });
     // #552 coordinator idle badge + auto-closed pill. Discovery reload
     // supersedes these overrides on any path miss (clearForPaths).

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1,7 +1,7 @@
-import { Component, For, Show, createEffect, createMemo, createSignal, onMount, onCleanup } from "solid-js";
+import { Component, For, Show, createEffect, createMemo, createSignal, on, onMount, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
 import type { AcWorkgroup, AcAgentReplica, AcTeam, AcLoopSummary, Session, SessionRepo, TelegramBotConfig, BlockerReport } from "../../shared/types";
-import { SessionAPI, WindowAPI, EntityAPI, LoopAPI, TelegramAPI, SettingsAPI, TaskAPI, onDiscoveryBranchUpdated, onCoordinatorClockUpdated, onCoordinatorAutoCloseChanged, onCoordinatorManualCloseChanged, emitOpenSettings } from "../../shared/ipc";
+import { SessionAPI, WindowAPI, EntityAPI, LoopAPI, TelegramAPI, SettingsAPI, TaskAPI, ReposAPI, onDiscoveryBranchUpdated, onCoordinatorClockUpdated, onCoordinatorAutoCloseChanged, onCoordinatorManualCloseChanged, emitOpenSettings } from "../../shared/ipc";
 import type { SessionRepoInput } from "../../shared/ipc";
 import {
   pendingCoordinatorClose,
@@ -11,6 +11,12 @@ import {
   registerCoordinatorCloseModalHost,
 } from "../stores/coordinator-close";
 import { isTauri } from "../../shared/platform";
+import {
+  githubBranchUrl,
+  githubRepoUrl,
+  parseGithubRemote,
+  type GithubRepoRef,
+} from "../../shared/github-url";
 import { stripFrontmatter } from "../../shared/markdown";
 import { launchErrorMessage } from "../../shared/launch-errors";
 import { focusOnMount } from "../../shared/focus-on-mount";
@@ -809,6 +815,84 @@ const ProjectPanel: Component = () => {
         let groupFlyoutEl: HTMLDivElement | undefined;
         let groupFlyoutAnchorEl: HTMLElement | undefined;
         let groupFlyoutCloseTimer: number | undefined;
+
+        // #943 - repo Browse submenu.
+        //
+        // The flyout is keyed by the repo's INDEX in the open menu plus its
+        // sourcePath, and never holds a SessionRepo object: <For> is keyed by
+        // reference and the cold path (configuredReplicaRepoBadges) maps into
+        // FRESH objects on every evaluation, so a captured entry goes stale (and
+        // its <button> gets detached) whenever GitWatcher or a discovery branch
+        // event lands. The live entry is re-derived by index, identity-checked on
+        // sourcePath. Index, not label: two repos can share a label.
+        const [repoFlyout, setRepoFlyout] = createSignal<{ index: number; sourcePath: string } | null>(null);
+        const [repoFlyoutPos, setRepoFlyoutPos] = createSignal({ x: 0, y: 0 });
+        let repoFlyoutEl: HTMLDivElement | undefined;
+        let repoFlyoutAnchorEl: HTMLElement | undefined;
+        let repoFlyoutCloseTimer: number | undefined;
+        // Set only while we programmatically return focus to the trigger after an
+        // Escape. Without it, `anchor.focus()` synchronously fires the trigger's
+        // onFocus, which re-opens the flyout we are trying to close.
+        let suppressRepoFocusOpen = false;
+
+        // #943 - GitHub remote per repo source path, resolved once when the
+        // context menu opens. Missing key = still resolving (no arrow yet);
+        // null = resolved, no GitHub remote (no arrow, ever). `repoRemotesGen`
+        // orphans in-flight results from a menu that has already been replaced,
+        // so a stale answer cannot paint an arrow on the NEXT menu.
+        const [repoRemotes, setRepoRemotes] = createSignal<Record<string, GithubRepoRef | null>>({});
+        let repoRemotesGen = 0;
+
+        // Web/WS clients: `open_external_url` is a no-op stub on the host and
+        // `git_remote_url` is too (web/commands.rs), so the whole feature is
+        // desktop-only. Hide it rather than ship dead menu items.
+        const browseSupported = () => isTauri;
+
+        const resolveRepoRemotes = (repos: SessionRepo[]) => {
+          const gen = ++repoRemotesGen;
+          setRepoRemotes({});
+          if (!browseSupported()) return;
+          const paths = Array.from(
+            new Set(repos.map((repo) => repo.sourcePath).filter((path) => !!path))
+          );
+          for (const path of paths) {
+            void ReposAPI.gitRemoteUrl(path)
+              .then((remote) => {
+                if (gen !== repoRemotesGen) return;
+                setRepoRemotes((prev) => ({ ...prev, [path]: parseGithubRemote(remote) }));
+              })
+              .catch((err) => {
+                // The command swallows every git failure into Ok(None), so a
+                // rejection here means an empty-path Err (unreachable) or a
+                // transport fault. Debug, not error: nothing is broken.
+                if (gen !== repoRemotesGen) return;
+                console.debug("[repo-browse] git_remote_url failed:", err);
+                setRepoRemotes((prev) => ({ ...prev, [path]: null }));
+              });
+          }
+        };
+
+        type RepoBrowseItem = { id: "main" | "branch"; label: string; url: string };
+
+        const repoBrowseItems = (repo: SessionRepo | null): RepoBrowseItem[] => {
+          if (!browseSupported() || !repo) return [];
+          const ref = repoRemotes()[repo.sourcePath];
+          if (!ref) return []; // undefined = resolving, null = no GitHub remote
+          const items: RepoBrowseItem[] = [
+            { id: "main", label: "Browse Main", url: githubRepoUrl(ref) },
+          ];
+          const branch = repo.branch?.trim();
+          // "HEAD" is the detached-HEAD sentinel (both git readers map it to
+          // null; this is belt for the volatile override layer).
+          if (branch && branch !== "main" && branch !== "HEAD") {
+            const url = githubBranchUrl(ref, branch);
+            // null = the branch text is not a usable ref (`..`, empty). Rather
+            // than build a URL the browser would normalize into another repo, we
+            // simply do not offer the item.
+            if (url) items.push({ id: "branch", label: "Browse Branch", url });
+          }
+          return items;
+        };
         const [agentCtxMenu, setAgentCtxMenu] = createSignal<{ agent: { name: string; path: string; preferredAgentId?: string }; x: number; y: number } | null>(null);
         const [agentsHeaderCtxMenu, setAgentsHeaderCtxMenu] = createSignal<{ x: number; y: number } | null>(null);
         const [workgroupsHeaderCtxMenu, setWorkgroupsHeaderCtxMenu] = createSignal<{ x: number; y: number } | null>(null);
@@ -1300,6 +1384,7 @@ const ProjectPanel: Component = () => {
         };
 
         const openGroupFlyout = (anchor: HTMLElement) => {
+          closeRepoFlyout(); // #943 - only one flyout at a time
           cancelGroupFlyoutClose();
           groupFlyoutAnchorEl = anchor;
           positionGroupFlyout(anchor);
@@ -1308,6 +1393,7 @@ const ProjectPanel: Component = () => {
         };
 
         const activateGroupFlyout = (anchor: HTMLElement) => {
+          closeRepoFlyout(); // #943 - the early-return path below skips openGroupFlyout
           if (groupFlyoutOpen() && groupFlyoutAnchorEl === anchor) {
             cancelGroupFlyoutClose();
             positionGroupFlyout(anchor);
@@ -1317,6 +1403,122 @@ const ProjectPanel: Component = () => {
           openGroupFlyout(anchor);
         };
         onCleanup(cancelGroupFlyoutClose);
+
+        const cancelRepoFlyoutClose = () => {
+          if (repoFlyoutCloseTimer === undefined) return;
+          window.clearTimeout(repoFlyoutCloseTimer);
+          repoFlyoutCloseTimer = undefined;
+        };
+        const closeRepoFlyout = () => {
+          cancelRepoFlyoutClose();
+          setRepoFlyout(null);
+          repoFlyoutAnchorEl = undefined;
+          repoFlyoutEl = undefined;
+        };
+        const scheduleRepoFlyoutClose = () => {
+          cancelRepoFlyoutClose();
+          repoFlyoutCloseTimer = window.setTimeout(() => {
+            repoFlyoutCloseTimer = undefined;
+            closeRepoFlyout();
+          }, 180);
+        };
+
+        const positionRepoFlyout = (anchor: HTMLElement) => {
+          const rect = anchor.getBoundingClientRect();
+          const width = repoFlyoutEl?.getBoundingClientRect().width ?? 220;
+          const height = repoFlyoutEl?.getBoundingClientRect().height ?? 88;
+          let x = rect.right + 4;
+          if (x + width + CONTEXT_MENU_VIEWPORT_MARGIN > window.innerWidth) {
+            x = rect.left - width - 4;
+          }
+          const maxX = Math.max(
+            CONTEXT_MENU_VIEWPORT_MARGIN,
+            window.innerWidth - width - CONTEXT_MENU_VIEWPORT_MARGIN
+          );
+          const maxY = Math.max(
+            CONTEXT_MENU_VIEWPORT_MARGIN,
+            window.innerHeight - height - CONTEXT_MENU_VIEWPORT_MARGIN
+          );
+          setRepoFlyoutPos({
+            x: Math.min(Math.max(CONTEXT_MENU_VIEWPORT_MARGIN, x), maxX),
+            y: Math.min(Math.max(CONTEXT_MENU_VIEWPORT_MARGIN, rect.top), maxY),
+          });
+        };
+
+        const reclampRepoFlyout = () => {
+          const anchor = repoFlyoutAnchorEl;
+          // isConnected: a <For> row can be re-created under the cursor (the cold
+          // path rebuilds entries on every evaluation). getBoundingClientRect on
+          // a detached node is all zeros, which would fling the flyout to the
+          // top-left corner.
+          if (!anchor?.isConnected || !repoFlyout()) return;
+          const clamp = () => positionRepoFlyout(anchor);
+          if (typeof window.requestAnimationFrame === "function") {
+            window.requestAnimationFrame(clamp);
+            return;
+          }
+          window.setTimeout(clamp, 0);
+        };
+
+        const openRepoFlyout = (index: number, repo: SessionRepo, anchor: HTMLElement) => {
+          closeGroupFlyout(); // mutual exclusion: both flyouts are position:fixed
+          cancelRepoFlyoutClose();
+          repoFlyoutAnchorEl = anchor;
+          positionRepoFlyout(anchor);
+          setRepoFlyout({ index, sourcePath: repo.sourcePath });
+          reclampRepoFlyout();
+        };
+
+        const focusFirstRepoFlyoutItem = () => {
+          queueMicrotask(() => repoFlyoutEl?.querySelector("button")?.focus());
+        };
+
+        /// Return focus to the trigger WITHOUT re-opening the flyout: `focus()`
+        /// fires the trigger's onFocus synchronously, and onFocus opens the
+        /// flyout. Dropping the refocus instead would strand focus on <body> and
+        /// make the menu untabbable, which is worse.
+        const focusRepoTriggerQuietly = (anchor: HTMLElement | undefined) => {
+          if (!anchor?.isConnected) return;
+          suppressRepoFocusOpen = true;
+          anchor.focus();
+          queueMicrotask(() => {
+            suppressRepoFocusOpen = false;
+          });
+        };
+
+        const openRepoBrowse = async (url: string) => {
+          closeRepoFlyout();
+          setReplicaCtxMenu(null);
+          cleanupCtx();
+          try {
+            await WindowAPI.openExternal(url);
+          } catch (e) {
+            console.error("Failed to open repo in browser:", e);
+          }
+        };
+
+        // #943 - teardown on menu CLOSE. Covers the ~20 `setReplicaCtxMenu(null)`
+        // sites plus the window-level dismiss listener with one hook, and clears
+        // stale state so a reopened menu cannot inherit a flyout.
+        //
+        // It does NOT cover the menu -> menu switch (right-click A, then
+        // right-click B): the handlers overwrite the signal non-null -> non-null
+        // and `cleanupCtx()` has already removed the dismiss listener, so there is
+        // no null transition to observe. That case is handled in the handlers
+        // themselves (F.8), exactly as the group flyout already does it
+        // (`resetGroupMenuState()`). Both are required; neither is sufficient.
+        //
+        // Do NOT rewrite this as `createEffect(on(replicaCtxMenu, ...))`:
+        // `positionReplicaCtxMenu` rewrites the menu object on every reclamp, so
+        // an identity-keyed effect would close the flyout on churn.
+        createEffect(() => {
+          if (replicaCtxMenu()) return;
+          closeRepoFlyout();
+          repoRemotesGen++;
+          setRepoRemotes({});
+        });
+
+        onCleanup(cancelRepoFlyoutClose);
 
         const restartReplicaSession = async (
           sessionId: string,
@@ -1574,6 +1776,152 @@ const ProjectPanel: Component = () => {
             </button>
             {renderAddToGroupFlyout(wg)}
           </Show>
+        );
+
+        // #943 - coordinator repo entries. Click still opens the local folder
+        // (unchanged); hover additionally opens the Browse flyout when the repo
+        // has a GitHub origin. Shared by the active and inactive menu branches.
+        //
+        // BOTH PARAMS ARE ACCESSORS, ON PURPOSE. `{helper(repoEntries(), "...")}`
+        // in JSX compiles to a tracking computation over the args, which rebuilds
+        // this entire subtree (and re-creates the <Portal>) whenever the entry
+        // list or the menu object changes identity. Passing functions gives that
+        // computation zero dependencies, so it runs once and <For> / the
+        // attribute getters do the reactive work.
+        const renderRepoBrowseFlyout = (repos: () => SessionRepo[], testIdPrefix: () => string) => {
+          // The anchored entry can be re-created (cold path) or replaced
+          // (GitWatcher) while the flyout is open. Re-derive it by index every
+          // render and identity-check the sourcePath; null = it moved or vanished.
+          const liveRepo = (): SessionRepo | null => {
+            const fly = repoFlyout();
+            if (!fly) return null;
+            const candidate = repos()[fly.index];
+            return candidate && candidate.sourcePath === fly.sourcePath ? candidate : null;
+          };
+
+          // If the identity check breaks, the anchor node is gone too: close.
+          createEffect(
+            on(
+              () => (repoFlyout() ? liveRepo() : null),
+              (repo) => {
+                if (repoFlyout() && !repo) closeRepoFlyout();
+              },
+              { defer: true }
+            )
+          );
+
+          return (
+            <Portal>
+              <Show when={repoFlyout() && liveRepo()}>
+                {(repo) => (
+                  <div
+                    class="session-context-flyout"
+                    ref={repoFlyoutEl}
+                    style={{ left: `${repoFlyoutPos().x}px`, top: `${repoFlyoutPos().y}px` }}
+                    onMouseEnter={cancelRepoFlyoutClose}
+                    onMouseLeave={scheduleRepoFlyoutClose}
+                    // This Portal renders OUTSIDE .session-context-menu, so the
+                    // window-level dismiss listeners (bubble phase) would
+                    // otherwise see these events and kill the whole menu.
+                    onClick={(e) => e.stopPropagation()}
+                    onContextMenu={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => {
+                      if (e.key !== "Escape") return;
+                      e.preventDefault();
+                      e.stopPropagation(); // close the submenu only, keep the menu
+                      const anchor = repoFlyoutAnchorEl;
+                      closeRepoFlyout();
+                      focusRepoTriggerQuietly(anchor);
+                    }}
+                    data-ac-testid={`${testIdPrefix()}.${repoFlyout()?.index ?? 0}.browse.flyout`}
+                  >
+                    <For each={repoBrowseItems(repo())}>
+                      {(item) => (
+                        <button
+                          class="session-context-option"
+                          title={item.url}
+                          onClick={() => void openRepoBrowse(item.url)}
+                          data-ac-testid={`${testIdPrefix()}.${repoFlyout()?.index ?? 0}.browse.${item.id}`}
+                          data-ac-role="menuitem"
+                        >
+                          {item.label}
+                        </button>
+                      )}
+                    </For>
+                  </div>
+                )}
+              </Show>
+            </Portal>
+          );
+        };
+
+        const renderRepoMenuEntries = (repos: () => SessionRepo[], testIdPrefix: () => string) => (
+          <>
+            <Show when={repos().length > 0}>
+              <For each={repos()}>
+                {(repo, index) => {
+                  const browseItems = () => repoBrowseItems(repo);
+                  return (
+                    <button
+                      class="session-context-option session-context-repo-option"
+                      title={repo.sourcePath}
+                      onClick={() => void openRepoFolder(repo.sourcePath)}
+                      onMouseEnter={(e) => {
+                        if (browseItems().length > 0) {
+                          openRepoFlyout(index(), repo, e.currentTarget);
+                        } else {
+                          // Moving from a browsable repo onto a non-browsable one
+                          // must not leave the previous flyout hanging.
+                          closeRepoFlyout();
+                        }
+                      }}
+                      onMouseLeave={scheduleRepoFlyoutClose}
+                      onFocus={(e) => {
+                        if (suppressRepoFocusOpen) return; // Escape refocus, see F.5
+                        if (browseItems().length > 0) openRepoFlyout(index(), repo, e.currentTarget);
+                      }}
+                      onKeyDown={(e) => {
+                        // Enter/Space keep the native button activation (open the
+                        // folder). Only ArrowRight enters the submenu.
+                        if (e.key === "ArrowRight" && browseItems().length > 0) {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          openRepoFlyout(index(), repo, e.currentTarget);
+                          focusFirstRepoFlyoutItem();
+                          return;
+                        }
+                        if (e.key === "Escape" && repoFlyout()) {
+                          e.preventDefault();
+                          e.stopPropagation(); // close the submenu only, keep the menu
+                          closeRepoFlyout();
+                        }
+                      }}
+                      data-ac-testid={`${testIdPrefix()}.${index()}`}
+                      data-ac-role="menuitem"
+                    >
+                      <svg
+                        class="session-context-repo-icon"
+                        viewBox="0 0 16 16"
+                        aria-hidden="true"
+                      >
+                        <path
+                          fill="currentColor"
+                          d="M1.75 4.25A1.75 1.75 0 0 1 3.5 2.5h3.1c.46 0 .9.18 1.22.5l.9.9h3.78A1.75 1.75 0 0 1 14.25 5.65v5.1a1.75 1.75 0 0 1-1.75 1.75h-9A1.75 1.75 0 0 1 1.75 10.75v-6.5Z"
+                        />
+                      </svg>
+                      <span class="session-context-repo-label">{repo.label}</span>
+                      <Show when={browseItems().length > 0}>
+                        <span class="session-context-submenu-arrow">&rsaquo;</span>
+                      </Show>
+                    </button>
+                  );
+                }}
+              </For>
+            </Show>
+            {/* Deliberately OUTSIDE the entry-count <Show>: a transient empty
+                list must not unmount the Portal while repoFlyout() is non-null. */}
+            {renderRepoBrowseFlyout(repos, testIdPrefix)}
+          </>
         );
 
         // Broom (clear task title) for a gray/red replica — reuses the
@@ -1897,6 +2245,7 @@ const ProjectPanel: Component = () => {
           setLoopsHeaderCtxMenu(null);
           setTeamsHeaderCtxMenu(null);
           resetGroupMenuState();
+          closeRepoFlyout(); // #943 - the A->B switch never nulls replicaCtxMenu()
           setReplicaCtxMenu({
             kind: "active",
             sessionId: session.id,
@@ -1909,6 +2258,7 @@ const ProjectPanel: Component = () => {
             x: e.clientX,
             y: e.clientY,
           });
+          resolveRepoRemotes(replicaRepoMenuEntries(wg, replica)); // #943 - one call per repo path
           const dismiss = (ev?: Event) => {
             if (ev instanceof KeyboardEvent && ev.key !== "Escape") return;
             setReplicaCtxMenu(null);
@@ -1941,7 +2291,9 @@ const ProjectPanel: Component = () => {
           setLoopsHeaderCtxMenu(null);
           setTeamsHeaderCtxMenu(null);
           resetGroupMenuState();
+          closeRepoFlyout(); // #943 - the A->B switch never nulls replicaCtxMenu()
           setReplicaCtxMenu({ kind: "inactive", wg, replica, x: e.clientX, y: e.clientY });
+          resolveRepoRemotes(replicaRepoMenuEntries(wg, replica)); // #943 - one call per repo path
           const dismiss = (ev?: Event) => {
             if (ev instanceof KeyboardEvent && ev.key !== "Escape") return;
             setReplicaCtxMenu(null);
@@ -3340,6 +3692,11 @@ const ProjectPanel: Component = () => {
                   ref={replicaCtxMenuEl}
                   style={{ left: `${replicaCtxMenu()!.x}px`, top: `${replicaCtxMenu()!.y}px` }}
                   onClick={(e) => e.stopPropagation()}
+                  // #943 - a <For> row re-created under a stationary cursor is a
+                  // detached node and can never fire its own mouseleave. This
+                  // guarantees the flyout cannot hang. The flyout's onMouseEnter
+                  // cancels the 180ms timer when crossing the 4px gap.
+                  onMouseLeave={scheduleRepoFlyoutClose}
                 >
                   <Show when={activeReplicaMenu()}>
                     {(menu) => {
@@ -3380,31 +3737,7 @@ const ProjectPanel: Component = () => {
                         >
                           &#x1F4C2; Open Replica's Folder
                         </button>
-                        <Show when={repoEntries().length > 0}>
-                          <For each={repoEntries()}>
-                            {(repo, index) => (
-                              <button
-                                class="session-context-option session-context-repo-option"
-                                title={repo.sourcePath}
-                                onClick={() => void openRepoFolder(repo.sourcePath)}
-                                data-ac-testid={`replica.${menu().sessionId}.menu.repo.${index()}`}
-                                data-ac-role="menuitem"
-                              >
-                                <svg
-                                  class="session-context-repo-icon"
-                                  viewBox="0 0 16 16"
-                                  aria-hidden="true"
-                                >
-                                  <path
-                                    fill="currentColor"
-                                    d="M1.75 4.25A1.75 1.75 0 0 1 3.5 2.5h3.1c.46 0 .9.18 1.22.5l.9.9h3.78A1.75 1.75 0 0 1 14.25 5.65v5.1a1.75 1.75 0 0 1-1.75 1.75h-9A1.75 1.75 0 0 1 1.75 10.75v-6.5Z"
-                                  />
-                                </svg>
-                                <span class="session-context-repo-label">{repo.label}</span>
-                              </button>
-                            )}
-                          </For>
-                        </Show>
+                        {renderRepoMenuEntries(repoEntries, () => `replica.${menu().sessionId}.menu.repo`)}
                         <Show when={matrixFolder()}>
                           {(path) => (
                             <button
@@ -3470,31 +3803,7 @@ const ProjectPanel: Component = () => {
                           >
                             &#x1F4C2; Open Replica's Folder
                           </button>
-                          <Show when={repoEntries().length > 0}>
-                            <For each={repoEntries()}>
-                              {(repo, index) => (
-                                <button
-                                  class="session-context-option session-context-repo-option"
-                                  title={repo.sourcePath}
-                                  onClick={() => void openRepoFolder(repo.sourcePath)}
-                                  data-ac-testid={`replica.inactive.menu.repo.${index()}`}
-                                  data-ac-role="menuitem"
-                                >
-                                  <svg
-                                    class="session-context-repo-icon"
-                                    viewBox="0 0 16 16"
-                                    aria-hidden="true"
-                                  >
-                                    <path
-                                      fill="currentColor"
-                                      d="M1.75 4.25A1.75 1.75 0 0 1 3.5 2.5h3.1c.46 0 .9.18 1.22.5l.9.9h3.78A1.75 1.75 0 0 1 14.25 5.65v5.1a1.75 1.75 0 0 1-1.75 1.75h-9A1.75 1.75 0 0 1 1.75 10.75v-6.5Z"
-                                    />
-                                  </svg>
-                                  <span class="session-context-repo-label">{repo.label}</span>
-                                </button>
-                              )}
-                            </For>
-                          </Show>
+                          {renderRepoMenuEntries(repoEntries, () => "replica.inactive.menu.repo")}
                           <Show when={matrixFolder()}>
                             {(path) => (
                               <button

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -882,9 +882,17 @@ const ProjectPanel: Component = () => {
             { id: "main", label: "Browse Main", url: githubRepoUrl(ref) },
           ];
           const branch = repo.branch?.trim();
-          // "HEAD" is the detached-HEAD sentinel (both git readers map it to
+          // PRODUCT RULE (user, #943), not an accident: tolerate BOTH `main` and
+          // `master`. A repo whose default branch is `master` already lands on
+          // `master` at the repo-root URL, so a second item pointing at the same
+          // page is noise. Everything else gets Browse Branch. Do NOT "fix" this
+          // back to a literal `!== "main"`.
+          //
+          // Exact match, no casefold: git refs are case-sensitive, so a branch
+          // literally named `Master` is a different, real branch and DOES get the
+          // item. "HEAD" is the detached-HEAD sentinel (both git readers map it to
           // null; this is belt for the volatile override layer).
-          if (branch && branch !== "main" && branch !== "HEAD") {
+          if (branch && branch !== "main" && branch !== "master" && branch !== "HEAD") {
             const url = githubBranchUrl(ref, branch);
             // null = the branch text is not a usable ref (`..`, empty). Rather
             // than build a URL the browser would normalize into another repo, we

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1468,12 +1468,19 @@ const ProjectPanel: Component = () => {
 
         const reclampRepoFlyout = () => {
           const anchor = repoFlyoutAnchorEl;
-          // isConnected: a <For> row can be re-created under the cursor (the cold
-          // path rebuilds entries on every evaluation). getBoundingClientRect on
-          // a detached node is all zeros, which would fling the flyout to the
-          // top-left corner.
           if (!anchor?.isConnected || !repoFlyout()) return;
-          const clamp = () => positionRepoFlyout(anchor);
+          // The re-check INSIDE the deferred callback is the load-bearing one, and
+          // it is not paranoia: <For> is reference-keyed and the cold path mints
+          // fresh entry objects on every evaluation, so a GitWatcher tick or a
+          // discovery refresh re-creates the row - and detaches this anchor -
+          // between scheduling the frame and running it, while the pointer has not
+          // moved. getBoundingClientRect on a detached node is all zeros, which
+          // would fling the flyout to the top-left viewport margin. Guarding only
+          // at schedule time (as this did) never fires on that path at all.
+          const clamp = () => {
+            if (anchor !== repoFlyoutAnchorEl || !anchor.isConnected || !repoFlyout()) return;
+            positionRepoFlyout(anchor);
+          };
           if (typeof window.requestAnimationFrame === "function") {
             window.requestAnimationFrame(clamp);
             return;

--- a/src/sidebar/components/replica-repo-badges.test.ts
+++ b/src/sidebar/components/replica-repo-badges.test.ts
@@ -142,6 +142,26 @@ describe("#943 B2 per-repo branches are merged BY PATH", () => {
     ]);
   });
 
+  it("survives a project reload (H1): the badges keep their per-repo branches", () => {
+    // projectStore.reloadProject() -> clearForPaths() on every loop tick, CLI
+    // refresh, entity creation... Before the fix this wiped the map, the badges
+    // fell back to the (null) single-repo shorthand, and the backend never
+    // re-emitted, so Browse Branch was gone until the app restarted.
+    replicaVolatileStore.applyDiscoveryBranchUpdate(
+      REPLICA,
+      null,
+      [REPO_A, REPO_B],
+      ["feature/943", "main"]
+    );
+
+    replicaVolatileStore.clearForPaths([REPLICA]);
+
+    expect(badgesFor([REPO_A, REPO_B]).map(formatReplicaRepoBadgeLabel)).toEqual([
+      "AgentsCommander/feature/943",
+      "webpage/main",
+    ]);
+  });
+
   it("keeps the pre-B2 fallback until the first branch event lands", () => {
     // Single repo: the discovery shorthand still drives the badge.
     expect(badgesFor([REPO_A], "feature/from-discovery").map((badge) => badge.branch)).toEqual([

--- a/src/sidebar/components/replica-repo-badges.test.ts
+++ b/src/sidebar/components/replica-repo-badges.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   automationIdPart,
   configuredReplicaRepoBadges,
   formatReplicaRepoBadgeLabel,
   repoLabelFromPath,
 } from "./replica-repo-badges";
+import {
+  effectiveRepoBranchByPath,
+  replicaVolatileStore,
+} from "../stores/replica-volatile";
 
 describe("replica repo badges", () => {
   it("renders every configured repo path for dormant coordinator rows", () => {
@@ -54,5 +58,99 @@ describe("replica repo badges", () => {
   it("normalizes labels and automation id parts", () => {
     expect(repoLabelFromPath("C:/work/repo-octocat.github.io/")).toBe("octocat.github.io");
     expect(automationIdPart("wg 1/badge main")).toBe("wg-1-badge-main");
+  });
+});
+
+// #943 B2 - a cold multi-repo replica used to report `branch: null` for every
+// repo (discovery only detects a branch when repo_paths.len() == 1), so it could
+// never show Browse Branch. The watcher already computed the per-repo branches
+// and threw them away; B2 keeps them. These tests drive the real seam the sidebar
+// uses: replicaVolatileStore <- event, then configuredReplicaRepoBadges reads it.
+describe("#943 B2 per-repo branches are merged BY PATH", () => {
+  const REPLICA = "C:\\proj\\.ac\\wg-1-team\\__agent_coord";
+  const REPO_A = "C:\\proj\\.ac\\wg-1-team\\repo-AgentsCommander";
+  const REPO_B = "C:\\proj\\.ac\\wg-1-team\\repo-webpage";
+  const REPO_C = "C:\\proj\\.ac\\wg-1-team\\repo-docs";
+
+  beforeEach(() => {
+    replicaVolatileStore.clearAll();
+  });
+
+  /** Exactly what configuredReplicaRepoBadgesLive (ProjectPanel) passes. */
+  const badgesFor = (repoPaths: string[], repoBranch?: string) =>
+    configuredReplicaRepoBadges(
+      {
+        repoPaths,
+        repoBranch,
+        repoBranchByPath: effectiveRepoBranchByPath({ path: REPLICA }),
+      },
+      { repoPath: undefined }
+    );
+
+  it("gives a cold multi-repo replica a branch per repo (the point of B2)", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(
+      REPLICA,
+      null, // multi-repo: the single-repo shorthand stays null
+      [REPO_A, REPO_B],
+      ["feature/943", "main"]
+    );
+
+    expect(badgesFor([REPO_A, REPO_B]).map(formatReplicaRepoBadgeLabel)).toEqual([
+      "AgentsCommander/feature/943",
+      "webpage/main",
+    ]);
+  });
+
+  it("follows the PATH, not the position, when config.json reorders the repos", () => {
+    // The event was emitted for [A, B]. Discovery then reports [B, A] because the
+    // user reordered `repos` in config.json. The stored payload is up to 15s old.
+    // An index-keyed merge would hand B the branch of A - silently, and Browse
+    // Branch would open a branch that does not belong to that repo.
+    replicaVolatileStore.applyDiscoveryBranchUpdate(
+      REPLICA,
+      null,
+      [REPO_A, REPO_B],
+      ["branch-a", "branch-b"]
+    );
+
+    expect(badgesFor([REPO_B, REPO_A])).toEqual([
+      { label: "webpage", sourcePath: REPO_B, branch: "branch-b" },
+      { label: "AgentsCommander", sourcePath: REPO_A, branch: "branch-a" },
+    ]);
+  });
+
+  it("yields NO branch for a repo the payload never mentioned, not a neighbour's", () => {
+    // Event covered [A, B]; the user then swapped B for C in config.json.
+    replicaVolatileStore.applyDiscoveryBranchUpdate(
+      REPLICA,
+      null,
+      [REPO_A, REPO_B],
+      ["branch-a", "branch-b"]
+    );
+
+    expect(badgesFor([REPO_A, REPO_C]).map((badge) => badge.branch)).toEqual([
+      "branch-a",
+      null, // NOT "branch-b"
+    ]);
+  });
+
+  it("masks the discovery shorthand with an explicit null (the branch went away)", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(REPLICA, null, [REPO_A], [null]);
+
+    expect(badgesFor([REPO_A], "stale-from-discovery").map((badge) => badge.branch)).toEqual([
+      null,
+    ]);
+  });
+
+  it("keeps the pre-B2 fallback until the first branch event lands", () => {
+    // Single repo: the discovery shorthand still drives the badge.
+    expect(badgesFor([REPO_A], "feature/from-discovery").map((badge) => badge.branch)).toEqual([
+      "feature/from-discovery",
+    ]);
+    // Multi-repo: no shorthand exists, so no branch - the 15s window the user
+    // accepted, and the pre-B2 behavior.
+    expect(
+      badgesFor([REPO_A, REPO_B], "feature/from-discovery").map((badge) => badge.branch)
+    ).toEqual([null, null]);
   });
 });

--- a/src/sidebar/components/replica-repo-badges.ts
+++ b/src/sidebar/components/replica-repo-badges.ts
@@ -1,4 +1,9 @@
-import type { AcAgentReplica, AcWorkgroup, SessionRepo } from "../../shared/types";
+import type {
+  AcAgentReplica,
+  AcWorkgroup,
+  RepoBranchByPath,
+  SessionRepo,
+} from "../../shared/types";
 
 export function stripRepoPrefix(name: string): string {
   return name.startsWith("repo-") ? name.slice(5) : name;
@@ -15,7 +20,11 @@ export function formatReplicaRepoBadgeLabel(repo: Pick<SessionRepo, "label" | "b
 }
 
 export function configuredReplicaRepoBadges(
-  replica: Pick<AcAgentReplica, "repoPaths" | "repoBranch">,
+  replica: Pick<AcAgentReplica, "repoPaths" | "repoBranch"> & {
+    /** #943 B2 - live per-repo branches. Optional: absent before the first branch
+     *  event, and absent for callers that do not read the volatile layer. */
+    repoBranchByPath?: RepoBranchByPath;
+  },
   workgroup: Pick<AcWorkgroup, "repoPath">
 ): SessionRepo[] {
   const repoPaths = replica.repoPaths ?? [];
@@ -24,14 +33,29 @@ export function configuredReplicaRepoBadges(
     : workgroup.repoPath
       ? [workgroup.repoPath]
       : [];
-  const branch = sourcePaths.length === 1 ? replica.repoBranch ?? null : null;
+  // Pre-B2 shorthand: discovery detects a branch only for a SINGLE-repo replica
+  // (ac_discovery.rs `repo_paths.len() == 1`), so a multi-repo replica had none.
+  // It stays as the fallback for any repo the per-repo layer has not covered: the
+  // first 15s after load, the legacy workgroup.repoPath source above, or a repo
+  // added to config.json since the last watcher tick.
+  const singleRepoBranch = sourcePaths.length === 1 ? replica.repoBranch ?? null : null;
+  const byPath = replica.repoBranchByPath;
 
   return sourcePaths
-    .map((sourcePath) => ({
-      label: repoLabelFromPath(sourcePath),
-      sourcePath,
-      branch,
-    }))
+    .map((sourcePath) => {
+      // #943 B2 - keyed BY PATH, never by position. The branch payload is stored
+      // and re-read against a LATER discovery snapshot, so if config.json `repos`
+      // is reordered or an entry removed, a positional merge would paint repo A's
+      // branch onto repo B and Browse Branch would open a branch that does not
+      // belong to that repo. A path miss yields no branch instead.
+      // `undefined` = unknown path (fall back); `null` = known, no branch (mask).
+      const live = byPath?.[sourcePath];
+      return {
+        label: repoLabelFromPath(sourcePath),
+        sourcePath,
+        branch: live === undefined ? singleRepoBranch : live,
+      };
+    })
     .filter((repo) => repo.label.length > 0);
 }
 

--- a/src/sidebar/components/replica-repo-badges.ts
+++ b/src/sidebar/components/replica-repo-badges.ts
@@ -36,8 +36,10 @@ export function configuredReplicaRepoBadges(
   // Pre-B2 shorthand: discovery detects a branch only for a SINGLE-repo replica
   // (ac_discovery.rs `repo_paths.len() == 1`), so a multi-repo replica had none.
   // It stays as the fallback for any repo the per-repo layer has not covered: the
-  // first 15s after load, the legacy workgroup.repoPath source above, or a repo
-  // added to config.json since the last watcher tick.
+  // window between project load and the first watcher tick (<=15s), the legacy
+  // workgroup.repoPath source above, or a repo added to config.json since the last
+  // tick. NOT after a reload: `clearForPaths` deliberately preserves the per-repo
+  // map, because discovery has no counterpart to re-supply it (H1).
   const singleRepoBranch = sourcePaths.length === 1 ? replica.repoBranch ?? null : null;
   const byPath = replica.repoBranchByPath;
 

--- a/src/sidebar/stores/replica-volatile.test.ts
+++ b/src/sidebar/stores/replica-volatile.test.ts
@@ -155,9 +155,45 @@ describe("replicaVolatileStore per-repo branches (#943 B2)", () => {
     expect(effectiveRepoBranch({ path: COORD_A })).toBe("feature/x");
   });
 
-  it("drops the per-repo map when discovery reclaims the replica", () => {
+  // H1 (grinch): this test used to assert the OPPOSITE - that clearForPaths drops
+  // the map - and that made it the alibi for a HIGH bug. `projectStore` calls
+  // clearForPaths on every reload (loop tick, CLI refresh, entity creation, group
+  // edit...). The other volatile fields survive that because the discovery snapshot
+  // re-supplies them; `repoBranchByPath` has NO snapshot counterpart, so the wipe
+  // installed nothing, the badge fell back to the single-repo shorthand (null for a
+  // multi-repo replica), and the backend never re-emitted (Gate A: identical payload
+  // => no event). Browse Branch died on the first reload and never came back - not
+  // for 15s, forever.
+  it("PRESERVES the per-repo map across a discovery reload (H1)", () => {
     replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [REPO_A], ["feature/943"]);
+
     replicaVolatileStore.clearForPaths([COORD_A]);
+
+    expect(effectiveRepoBranchByPath({ path: COORD_A })).toEqual({ [REPO_A]: "feature/943" });
+  });
+
+  it("still clears the snapshot-backed fields on a reload, map or no map", () => {
+    // The "discovery wins on reload" contract must keep holding for every field the
+    // snapshot actually re-supplies - preserving the B2 map must not smuggle those
+    // back in.
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, "feature/943", [REPO_A], [
+      "feature/943",
+    ]);
+    replicaVolatileStore.setAutoClosedAt(COORD_A, "2026-06-19T18:05:00Z");
+    replicaVolatileStore.setLastUserMessageAt(COORD_A, "2026-06-19T18:00:00Z");
+
+    replicaVolatileStore.clearForPaths([COORD_A]);
+
+    expect(effectiveRepoBranch({ path: COORD_A })).toBeUndefined();
+    expect(effectiveAutoClosedAt({ path: COORD_A })).toBeUndefined();
+    expect(effectiveLastUserMessageAt({ path: COORD_A })).toBeUndefined();
+    expect(effectiveRepoBranchByPath({ path: COORD_A })).toEqual({ [REPO_A]: "feature/943" });
+  });
+
+  it("clearAll DOES drop the per-repo map (the replicas themselves are gone)", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [REPO_A], ["feature/943"]);
+
+    replicaVolatileStore.clearAll();
 
     expect(effectiveRepoBranchByPath({ path: COORD_A })).toBeUndefined();
   });

--- a/src/sidebar/stores/replica-volatile.test.ts
+++ b/src/sidebar/stores/replica-volatile.test.ts
@@ -5,6 +5,7 @@ import {
   effectiveLastUserMessageAt,
   effectiveManuallyClosedAt,
   effectiveRepoBranch,
+  effectiveRepoBranchByPath,
   replicaVolatileStore,
 } from "./replica-volatile";
 
@@ -103,5 +104,67 @@ describe("replicaVolatileStore (#748)", () => {
 
       dispose();
     });
+  });
+});
+
+// #943 B2 - `ac_discovery_branch_updated` now also carries per-repo branches.
+describe("replicaVolatileStore per-repo branches (#943 B2)", () => {
+  const REPO_A = "C:\\proj\\.ac\\wg-1-team\\repo-AgentsCommander";
+  const REPO_B = "C:\\proj\\.ac\\wg-1-team\\repo-webpage";
+
+  beforeEach(() => {
+    replicaVolatileStore.clearAll();
+  });
+
+  it("keys the map by repo path and lands the shorthand in the same write", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(
+      COORD_A_EVENT, // event path: lower-cased, forward slashes (#552)
+      null,
+      [REPO_A, REPO_B],
+      ["feature/943", null]
+    );
+
+    // The REPLICA key is normalized; the REPO keys are verbatim.
+    expect(effectiveRepoBranchByPath({ path: COORD_A })).toEqual({
+      [REPO_A]: "feature/943",
+      [REPO_B]: null,
+    });
+    expect(effectiveRepoBranch({ path: COORD_A })).toBeUndefined();
+  });
+
+  it("drops the whole map when the arrays disagree in length", () => {
+    // Can only happen if a build breaks the backend's 1:1 invariant. Pairing them
+    // anyway would attach a branch to the wrong repo; no branch beats a wrong one.
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [REPO_A, REPO_B], [
+      "only-one",
+    ]);
+
+    expect(effectiveRepoBranchByPath({ path: COORD_A })).toEqual({});
+  });
+
+  it("defaults to an empty map for a replica with no repos", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [], []);
+
+    expect(effectiveRepoBranchByPath({ path: COORD_A })).toEqual({});
+  });
+
+  it("tolerates a payload from a backend that does not send the arrays", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, "feature/x");
+
+    expect(effectiveRepoBranchByPath({ path: COORD_A })).toEqual({});
+    expect(effectiveRepoBranch({ path: COORD_A })).toBe("feature/x");
+  });
+
+  it("drops the per-repo map when discovery reclaims the replica", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [REPO_A], ["feature/943"]);
+    replicaVolatileStore.clearForPaths([COORD_A]);
+
+    expect(effectiveRepoBranchByPath({ path: COORD_A })).toBeUndefined();
+  });
+
+  it("does not leak one replica's per-repo branches to another", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [REPO_A], ["feature/943"]);
+
+    expect(effectiveRepoBranchByPath({ path: COORD_B })).toBeUndefined();
   });
 });

--- a/src/sidebar/stores/replica-volatile.ts
+++ b/src/sidebar/stores/replica-volatile.ts
@@ -1,6 +1,6 @@
 import { batch } from "solid-js";
 import { createStore } from "solid-js/store";
-import type { AcAgentReplica } from "../../shared/types";
+import type { AcAgentReplica, RepoBranchByPath } from "../../shared/types";
 import { normalizeProjectPathForCompare } from "./project-refresh";
 
 /**
@@ -23,6 +23,9 @@ import { normalizeProjectPathForCompare } from "./project-refresh";
  */
 export interface ReplicaVolatileEntry {
   repoBranch?: string | null;
+  /** #943 B2 - per-repo branches keyed by repo source path. See RepoBranchByPath
+   *  (shared/types.ts) for the missing-key vs explicit-null semantics. */
+  repoBranchByPath?: RepoBranchByPath;
   lastUserMessageAt?: string;
   autoClosedAt?: string | null;
   manuallyClosedAt?: string | null;
@@ -43,9 +46,55 @@ function setField<K extends keyof ReplicaVolatileEntry>(
   setEntries(volatileKey(path), (prev) => ({ ...prev, [field]: value }));
 }
 
+/**
+ * #943 B2 - build the path -> branch map from the event's parallel arrays.
+ *
+ * A length mismatch could only come from a build that broke the backend's 1:1
+ * invariant. Pairing them anyway would attach a branch to the wrong repo, so the
+ * map is dropped instead and every repo falls back to "no branch": visible, inert,
+ * and self-healing on the next tick. No branch beats a wrong branch.
+ */
+function buildRepoBranchByPath(
+  repoPaths: string[] | undefined,
+  repoBranches: (string | null)[] | undefined
+): RepoBranchByPath {
+  const paths = repoPaths ?? [];
+  const branches = repoBranches ?? [];
+  if (paths.length !== branches.length) return {};
+  const map: RepoBranchByPath = {};
+  for (let i = 0; i < paths.length; i += 1) {
+    map[paths[i]] = branches[i] ?? null;
+  }
+  return map;
+}
+
 export const replicaVolatileStore = {
   setRepoBranch(replicaPath: string, branch: string | null) {
     setField(replicaPath, "repoBranch", branch);
+  },
+
+  /**
+   * #943 B2 - apply one `ac_discovery_branch_updated` event.
+   *
+   * Atomic on purpose: the single-repo shorthand and the path-keyed per-repo map
+   * always land together, so no reader can observe a half-updated pair (for a
+   * single-repo replica that would paint the previous branch for a frame).
+   *
+   * Repo paths are used as keys verbatim - the backend sends the same strings
+   * discovery already put on `AcAgentReplica.repoPaths` - unlike the REPLICA path,
+   * which is normalized because branch/clock events carry the session
+   * working_directory and can differ in slash/case (#552).
+   */
+  applyDiscoveryBranchUpdate(
+    replicaPath: string,
+    branch: string | null,
+    repoPaths?: string[],
+    repoBranches?: (string | null)[]
+  ) {
+    batch(() => {
+      setField(replicaPath, "repoBranch", branch);
+      setField(replicaPath, "repoBranchByPath", buildRepoBranchByPath(repoPaths, repoBranches));
+    });
   },
 
   setLastUserMessageAt(replicaPath: string, lastUserMessageAt: string) {
@@ -92,6 +141,15 @@ type ReplicaVolatileBase = Pick<AcAgentReplica, "path"> &
 export function effectiveRepoBranch(replica: ReplicaVolatileBase): string | undefined {
   const override = entries[volatileKey(replica.path)]?.repoBranch;
   return override === undefined ? replica.repoBranch : override ?? undefined;
+}
+
+/** #943 B2 - live per-repo branches for this replica, keyed by repo source path.
+ *  `undefined` when no branch event has landed yet, in which case the caller keeps
+ *  the pre-B2 single-repo `repoBranch` fallback. */
+export function effectiveRepoBranchByPath(
+  replica: ReplicaVolatileBase
+): RepoBranchByPath | undefined {
+  return entries[volatileKey(replica.path)]?.repoBranchByPath;
 }
 
 export function effectiveLastUserMessageAt(replica: ReplicaVolatileBase): string | undefined {

--- a/src/sidebar/stores/replica-volatile.ts
+++ b/src/sidebar/stores/replica-volatile.ts
@@ -110,27 +110,68 @@ export const replicaVolatileStore = {
   },
 
   /**
-   * Drop overrides for replica paths a fresh discovery snapshot now covers.
-   * Discovery fills all four fields (ac_discovery.rs reads the branch and the
-   * persisted CoordinatorClocks), so on load/reload the snapshot is the newer
-   * truth and a pre-reload live override must not mask it — the same
-   * "discovery wins on reload, events re-patch after" contract the old
-   * in-place patches had.
+   * Drop the live overrides for replica paths a fresh discovery snapshot now
+   * covers — but only the fields that snapshot actually re-supplies.
+   *
+   * `repoBranch`, `lastUserMessageAt`, `autoClosedAt` and `manuallyClosedAt` each
+   * have a counterpart on `AcAgentReplica` (ac_discovery.rs reads the branch and
+   * the persisted CoordinatorClocks), so on load/reload the snapshot is the newer
+   * truth and a pre-reload override must not mask it — the "discovery wins on
+   * reload, events re-patch after" contract the old in-place patches had.
+   *
+   * `repoBranchByPath` (#943 B2) is deliberately PRESERVED, because it has no
+   * counterpart: we did not widen `AcAgentReplica`, so wiping it installs nothing.
+   * It would fall back to the single-repo `repoBranch` shorthand — `null` for a
+   * multi-repo replica — and the backend would never re-send it: the discovery
+   * branch watcher only emits when the payload CHANGES (`ac_discovery.rs` Gate A),
+   * and an unchanged repo set with unchanged branches is an identical payload. So
+   * the map would be gone until a branch changed on disk or the app restarted, and
+   * reloads are routine (every loop tick, every CLI-driven refresh, every entity
+   * creation). "Discovery wins on reload" is meaningless for a field discovery
+   * never sends.
+   *
+   * Preserving it is safe precisely BECAUSE it is keyed by path: a repo dropped
+   * from config.json simply never matches again, a repo added since the last tick
+   * has no entry until the watcher emits one, and a real branch change re-emits.
+   *
+   * Use `clearAll` when the replicas themselves are gone.
    */
   clearForPaths(replicaPaths: Iterable<string>) {
     batch(() => {
       for (const path of replicaPaths) {
         const key = volatileKey(path);
-        if (entries[key] !== undefined) {
-          setEntries(key, undefined); // deleting the key notifies its readers
+        if (entries[key] === undefined) continue;
+        // Delete the entry, then restore ONLY the B2 map. Returning a smaller
+        // object instead would not clear anything: a Solid store setter MERGES a
+        // wrappable value into the existing node (mergeStoreNode), so the snapshot-
+        // backed fields would survive the reload and mask discovery forever - a
+        // worse bug than the one this method is fixing. The function form is used
+        // to read `prev` RAW (untracked); both writes sit inside the batch above,
+        // so readers only ever observe the final state.
+        let preserved: RepoBranchByPath | undefined;
+        setEntries(key, (prev) => {
+          preserved = prev?.repoBranchByPath;
+          return undefined; // deleting the key notifies its readers
+        });
+        if (preserved !== undefined) {
+          setEntries(key, { repoBranchByPath: preserved });
         }
       }
     });
   },
 
+  /**
+   * Full wipe, `repoBranchByPath` included. For when the replicas themselves go
+   * away (`projectStore.clear`) and for test isolation — unlike `clearForPaths`,
+   * there is no surviving replica whose per-repo branches would be worth keeping.
+   */
   clearAll() {
-    // Stored keys are already normalized, so volatileKey is a no-op on them.
-    replicaVolatileStore.clearForPaths(Object.keys(entries));
+    batch(() => {
+      // Stored keys are already normalized, so volatileKey is a no-op on them.
+      for (const key of Object.keys(entries)) {
+        setEntries(key, undefined); // deleting the key notifies its readers
+      }
+    });
   },
 };
 


### PR DESCRIPTION
Closes #943

## What

Right-clicking a **coordinator** row → each repo entry is now a **hover submenu parent**. Its click still opens the local repo folder (unchanged); the submenu adds:

- **`Browse Main`** — opens `https://github.com/<owner>/<repo>` in the system default browser.
- **`Browse Branch`** — only when the repo's checked-out branch is neither `main`, `master` nor `HEAD` — opens `https://github.com/<owner>/<repo>/tree/<branch>` (branch names containing `/` resolve correctly).

No GitHub remote → no Browse items. Hidden in web/WS mode. Coordinator menus only (active **and** inactive/gray).

Also lands **Module B2**: the discovery branch watcher already computed a per-repo branch for every replica every 15s and discarded it; it is now forwarded, so a **cold multi-repo coordinator** gets `Browse Branch` too. Zero new git spawns. Side effect (accepted by the user): cold multi-repo replicas now show branch text in their sidebar badges.

## How

- **New Rust command** `git_remote_url` (`commands/repos.rs`): `git remote get-url origin`, 2s bounded, `.git` existence gate via `tokio::fs::metadata`, `strip_userinfo` on every path, two `log::debug!` arms. **No-op (`null`) in the WS/web dispatcher.**
- **New shared util** `src/shared/github-url.ts`: parses `https://` / `ssh://` / scp-like `git@` remotes, rejects `.`/`..`/empty segments on both branches, case-insensitive `.git` strip, per-segment encoding of the ref.
- **ProjectPanel**: repo entries collapsed into one accessor-taking `renderRepoMenuEntries` (used by both menu branches), keyed repo flyout with four cooperating guards (handler close, null-transition effect, identity-break effect, deferred `isConnected` re-check), mutual exclusion with the `Add to Group` flyout, `suppressRepoFocusOpen` latch so Escape does not re-open.
- **Module B2**: `DiscoveryBranchPayload` widened with `repoBranches` + `repoPaths`; emission gate now caches the whole payload; frontend merges **by path, not by index**.

## Bugs caught before they shipped (all pre-merge)

- `git remote get-url` **walks up**: a `sourcePath` without `.git` returned the *ancestor* repo's origin → `Browse Main` would silently open a different GitHub repository. Blocked by the `.git` gate (T5' pins it). The `GIT_CEILING_DIRECTORIES` call that was supposed to prevent this was **dead code** (`is_agent_dir` is false for any repo work dir) and was deleted.
- `git remote get-url` returns credentials **verbatim** (`https://user:ghp_…@github.com/…`). `strip_userinfo` removes them before the value crosses IPC — on the desktop path too, not just web.
- Ghost flyout: right-click coordinator A → hover a repo → right-click coordinator B left A's flyout live and clickable inside B's menu.
- The `isConnected` guard was checked at rAF **schedule** time instead of inside the callback — i.e. never fired in the exact scenario it existed for.
- **Module B2 died permanently on the first project reload**: `clearForPaths` wiped `repoBranchByPath`, which — unlike every other volatile field — has no discovery-snapshot counterpart, and the backend gate would never re-emit an identical payload. Fixed; the test that had asserted the wipe was inverted.

## Review

- architect plan (rev 2) + enrichment from dev-rust, dev-webpage-ui and dev-rust-grinch; consensus verdict `READY_FOR_IMPLEMENTATION`.
- Grinch Step 9: **FAIL** (1 HIGH + 2 unpinned guards) → fixed → **PASS** on re-review, every claim re-verified by mutation (7 mutations, each guard independently red).

## Tests

`cargo clippy --all-targets` 0 lints · `cargo test -p agentscommander-new` **2314 passed / 0 failed** · `tsc --noEmit` clean · `vitest` **944 passed / 0 failed** (+40 new) · pre-existing `ProjectPanel.context-menu.test.tsx` untouched and green.

Branch merged with `origin/main` (#909) before landing: clean, zero conflicts, zero changes to the files in this PR, all four suites re-run green.

## Not automatable

`ac_cli_tester` has no `hover` action (closed TS union + closed Rust enum), so this feature's acceptance is manual QA. Follow-up filed: #944.
