### PR TITLE
feat(#942): spawn diagnostics — instrument PTY startup to capture the intermittent blank-terminal hang

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1568,6 +1568,11 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     let spawn_spec = BackendSpawnSpec {
         id,
         agent_id: agent_id.clone(),
+        // #942 - the CLI identity from the canonical detector (`agent_kind`, resolved
+        // at the top of this function). The profile id above cannot stand in for it:
+        // it is opaque, several profiles can drive the same CLI, and a coding-agent
+        // launch can carry no profile id at all.
+        coding_agent: agent_kind,
         cmd: shell.clone(),
         args: shell_args.clone(),
         cwd: spawn_cwd.clone(),

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -2150,6 +2150,17 @@ async fn destroy_session_inner_with_options<R: tauri::Runtime>(
     {
         let resource_monitor = app.state::<Arc<ResourceMonitorState>>().inner().clone();
         if resource_monitor.has_registered_group(uuid) {
+            // #942 - the resource monitor kills the process tree by pid, without going
+            // through the PTY layer, and that cleanup can take seconds. Publish the
+            // pre-stop witness first: without it, a child that had ALREADY died on its
+            // own (the #942 symptom) would be observed dead during the cleanup, charged
+            // to our kill, and its head bytes dropped. The guard is scoped: no std Mutex
+            // is held across the await below.
+            {
+                let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
+                let pty = pty_mgr.lock().unwrap_or_else(|e| e.into_inner());
+                pty.publish_stop_witness(uuid, "session-destroy");
+            }
             let cleanup_started = std::time::Instant::now();
             let monitor = Arc::clone(&resource_monitor);
             let result = tokio::task::spawn_blocking(move || {

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1567,6 +1567,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
 
     let spawn_spec = BackendSpawnSpec {
         id,
+        agent_id: agent_id.clone(),
         cmd: shell.clone(),
         args: shell_args.clone(),
         cwd: spawn_cwd.clone(),

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use crate::errors::AppError;
 use crate::pty::output::{PtyOutputTarget, PtyScreenSnapshot};
 use crate::resource_monitor::{ResourceLaunchRegistration, ResourceLogicalAgentSlot};
-use crate::session::profile::IdleTuning;
+use crate::session::profile::{CodingAgentKind, IdleTuning};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -20,10 +20,15 @@ pub enum SessionBackendKind {
 
 pub struct BackendSpawnSpec {
     pub id: Uuid,
-    /// #942 - configured coding-agent id (e.g. "codex"), None for a plain shell.
-    /// Diagnostics only: it identifies the spawn in `[pty] spawn-record` and keys
-    /// the per-agent concurrency counter.
+    /// #942 - the configured coding-agent PROFILE id (`settings.agents[].id`, an
+    /// opaque string like `agent_1782513272568_0`), or None. It is NOT the CLI:
+    /// several profiles can run the same `codex` binary, and a coding agent can be
+    /// launched with no profile id at all. Diagnostics log it, and never key on it.
     pub agent_id: Option<String>,
+    /// #942 - the CLI actually being launched, from the canonical detector
+    /// (`CodingAgentKind::detect`). This is the identity the diagnostics key on: the
+    /// stall predicate and the "concurrent startups on the shared ~/.codex" counter.
+    pub coding_agent: Option<CodingAgentKind>,
     pub cmd: String,
     pub args: Vec<String>,
     pub cwd: String,

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -75,5 +75,11 @@ pub trait PtyBackend: Any + Send + Sync {
 
     fn terminate_job_for_session(&self, id: Uuid) -> bool;
 
+    /// #942 - tag an imminent AC stop with the liveness of the child BEFORE any process
+    /// is touched, for callers that are about to kill outside the PTY layer (the resource
+    /// monitor kills a process tree by pid). Diagnostics only; the default no-op covers
+    /// backends with no local child (container transport).
+    fn publish_stop_witness(&self, _id: Uuid, _source: &str) {}
+
     fn kill_all_jobs(&self) -> (usize, usize);
 }

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -20,6 +20,10 @@ pub enum SessionBackendKind {
 
 pub struct BackendSpawnSpec {
     pub id: Uuid,
+    /// #942 - configured coding-agent id (e.g. "codex"), None for a plain shell.
+    /// Diagnostics only: it identifies the spawn in `[pty] spawn-record` and keys
+    /// the per-agent concurrency counter.
+    pub agent_id: Option<String>,
     pub cmd: String,
     pub args: Vec<String>,
     pub cwd: String,

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -589,6 +589,7 @@ impl ContainerTransportBackend {
         let BackendSpawnSpec {
             id,
             agent_id: _,
+            coding_agent: _,
             cmd,
             args,
             cwd,
@@ -1424,6 +1425,7 @@ mod tests {
         BackendSpawnSpec {
             id,
             agent_id: None,
+            coding_agent: None,
             cmd: "container".to_string(),
             args: Vec::new(),
             cwd: root.to_string(),

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -588,6 +588,7 @@ impl ContainerTransportBackend {
         })?;
         let BackendSpawnSpec {
             id,
+            agent_id: _,
             cmd,
             args,
             cwd,
@@ -1422,6 +1423,7 @@ mod tests {
     fn test_spec(id: Uuid, root: &str, output_target: PtyOutputTarget) -> BackendSpawnSpec {
         BackendSpawnSpec {
             id,
+            agent_id: None,
             cmd: "container".to_string(),
             args: Vec::new(),
             cwd: root.to_string(),

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use uuid::Uuid;
@@ -18,6 +19,7 @@ use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
 use crate::pty::output::{PtyScreenSnapshot, SessionIoFanout};
+use crate::pty::spawn_diagnostics::{self, ChildLiveness, ExitCause, SpawnRecord, SpawnRecordInit};
 use crate::telegram::manager::OutputSenderMap;
 
 struct PtyInstance {
@@ -397,6 +399,7 @@ impl LocalProcessBackend {
     fn spawn_sync(&self, spec: BackendSpawnSpec) -> Result<(), AppError> {
         let BackendSpawnSpec {
             id,
+            agent_id,
             cmd,
             args,
             cwd,
@@ -414,6 +417,11 @@ impl LocalProcessBackend {
             logical_resource_slot: _,
             container_credential: _,
         } = spec;
+        // #942 - how many sessions were spawned in the window just before this one.
+        // Concurrent startups against shared agent state (the global ~/.codex) are a
+        // prime suspect for the intermittent blank terminal, so every spawn record
+        // carries its own concurrency context. Counting only, no behavior change.
+        let spawn_window = spawn_diagnostics::note_spawn_attempt(agent_id.as_deref());
         let pty_system = native_pty_system();
         let spawn_cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
 
@@ -449,6 +457,39 @@ impl LocalProcessBackend {
             c
         };
         command.cwd(&spawn_cwd);
+
+        // #942 - the argv exactly as executed, cmd.exe wrapper included. Mirrors the
+        // branch above instead of reshaping the CommandBuilder, so the spawn stays
+        // byte-for-byte what it was.
+        let exec_argv: Vec<String> = if cfg!(windows) && !is_direct_exe {
+            let mut argv = vec!["cmd.exe".to_string(), "/C".to_string(), cmd.clone()];
+            argv.extend(args.iter().cloned());
+            argv
+        } else {
+            let mut argv = vec![cmd.clone()];
+            argv.extend(args.iter().cloned());
+            argv
+        };
+
+        // #942 - what the child will really see for CODEX_HOME: an explicit configured
+        // value wins, then an explicit removal, then the AC environment the child
+        // inherits. None here means this Codex shares the global ~/.codex with every
+        // other one.
+        let codex_home = configured_env
+            .iter()
+            .find(|(key, _)| key.eq_ignore_ascii_case("CODEX_HOME"))
+            .map(|(_, value)| value.clone())
+            .or_else(|| {
+                if env_remove_keys
+                    .iter()
+                    .any(|key| key.eq_ignore_ascii_case("CODEX_HOME"))
+                {
+                    None
+                } else {
+                    std::env::var("CODEX_HOME").ok()
+                }
+            });
+
         for key in &env_remove_keys {
             command.env_remove(key);
         }
@@ -496,15 +537,14 @@ impl LocalProcessBackend {
             }
         }
 
+        // #942 - time zero for time-to-first-output.
+        let spawn_started = Instant::now();
         let mut child = pair
             .slave
             .spawn_command(command)
             .map_err(|e| AppError::PtyError(e.to_string()))?;
-        log::info!(
-            "[pty] Spawned session {} with child pid {:?}",
-            id,
-            child.process_id()
-        );
+        let child_pid = child.process_id();
+        log::info!("[pty] Spawned session {} with child pid {:?}", id, child_pid);
 
         let job = child
             .process_id()
@@ -555,6 +595,29 @@ impl LocalProcessBackend {
         self.ptys.lock().unwrap().insert(id, instance);
         self.fanout.register_session(id, idle_tuning, rows, cols);
 
+        // #942 - emits `[pty] spawn-record` (argv, cwd, agent, CODEX_HOME, concurrency).
+        let record = spawn_diagnostics::register(SpawnRecordInit {
+            session_id: id,
+            pid: child_pid,
+            argv: exec_argv,
+            cwd: spawn_cwd,
+            agent_id,
+            codex_home,
+            configured_env_count: configured_env.len(),
+            removed_env_count: env_remove_keys.len(),
+            window: spawn_window,
+            started: spawn_started,
+        });
+
+        // #942 - startup-stall WARN and exit attribution. The PTY reader alone cannot
+        // carry this: ConPTY holds the pipe open past the death of the child, so a
+        // child that dies on its own would stay invisible until the session is torn
+        // down. The monitor polls the child handle instead and ends with the session.
+        let monitor_backend = self.clone();
+        spawn_diagnostics::watch_child(Arc::clone(&record), move || {
+            monitor_backend.probe_child(id)
+        });
+
         let session_id_str = id.to_string();
         let fanout = self.fanout.clone();
         std::thread::spawn(move || {
@@ -563,6 +626,10 @@ impl LocalProcessBackend {
                 match reader.read(&mut buf) {
                     Ok(0) => break,
                     Ok(n) => {
+                        // #942 - time-to-first-output and the retained head bytes. Hot
+                        // path: once the first byte is stamped and the head buffer is
+                        // full this is two relaxed loads and one relaxed add.
+                        record.note_output(&buf[..n]);
                         fanout.handle_output(&output_target, id, &session_id_str, buf[..n].to_vec())
                     }
                     Err(_) => break,
@@ -571,6 +638,24 @@ impl LocalProcessBackend {
         });
 
         Ok(())
+    }
+
+    /// #942 - liveness of the child of a session, without disturbing it. `try_wait`
+    /// caches the exit status, so the monitor poll and the kill path always agree on
+    /// what happened.
+    fn probe_child(&self, id: Uuid) -> ChildLiveness {
+        let mut ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(instance) = ptys.get_mut(&id) else {
+            return ChildLiveness::Gone;
+        };
+        let Some(child) = instance.child.as_mut() else {
+            return ChildLiveness::Gone;
+        };
+        match child.try_wait() {
+            Ok(Some(status)) => ChildLiveness::from(&status),
+            Ok(None) => ChildLiveness::Alive,
+            Err(e) => ChildLiveness::Unknown(e.to_string()),
+        }
     }
 }
 
@@ -705,6 +790,13 @@ impl PtyBackend for LocalProcessBackend {
     }
 
     fn kill(&self, id: Uuid) -> Result<(), AppError> {
+        // #942 - tag the stop as ours and snapshot the child BEFORE we terminate
+        // anything. The old "already exited" line fired both for a child that had died
+        // on its own and for one our own job/kill had just taken down; the pre-stop
+        // probe is what tells the two apart.
+        let record = spawn_diagnostics::mark_ac_stop(id, "session-kill");
+        let child_at_stop = self.probe_child(id);
+
         let instance = {
             let mut ptys = self.ptys.lock().unwrap();
             ptys.remove(&id)
@@ -716,14 +808,34 @@ impl PtyBackend for LocalProcessBackend {
             }
             if let Some(mut child) = instance.child.take() {
                 let pid = child.process_id();
+                log::info!(
+                    "[pty] session-stop session={} pid={:?} source=session-kill child_at_stop={}",
+                    id,
+                    pid,
+                    child_at_stop.as_log()
+                );
                 match child.try_wait() {
                     Ok(Some(status)) => {
-                        log::info!(
-                            "[pty] Session {} child pid {:?} already exited: {:?}",
-                            id,
-                            pid,
-                            status
-                        );
+                        // Dead by the time we removed it. Already dead BEFORE we touched
+                        // the job means the child ended itself; otherwise our stop did.
+                        let cause = if matches!(child_at_stop, ChildLiveness::Exited { .. }) {
+                            ExitCause::ChildInitiated
+                        } else {
+                            ExitCause::AcRequested
+                        };
+                        let liveness = ChildLiveness::from(&status);
+                        match record.as_ref() {
+                            Some(record) => {
+                                record.log_child_exit(cause, &liveness, "observed-at-stop");
+                            }
+                            None => log::info!(
+                                "[pty] child-exit session={} pid={:?} cause={} detail=observed-at-stop child={}",
+                                id,
+                                pid,
+                                cause.as_log(),
+                                liveness.as_log()
+                            ),
+                        }
                     }
                     Ok(None) => {
                         if let Err(e) = child.kill() {
@@ -734,7 +846,7 @@ impl PtyBackend for LocalProcessBackend {
                                 e
                             );
                         }
-                        reap_child_in_background(id, pid, child);
+                        reap_child_in_background(id, pid, child, record);
                     }
                     Err(e) => {
                         log::warn!(
@@ -751,7 +863,7 @@ impl PtyBackend for LocalProcessBackend {
                                 kill_err
                             );
                         }
-                        reap_child_in_background(id, pid, child);
+                        reap_child_in_background(id, pid, child, record);
                     }
                 }
             }
@@ -759,11 +871,14 @@ impl PtyBackend for LocalProcessBackend {
 
         self.fanout.remove_session(id);
         self.git_watcher.remove_session(id);
+        spawn_diagnostics::forget(id);
 
         Ok(())
     }
 
     fn terminate_job_for_session(&self, id: Uuid) -> bool {
+        // #942 - AC asked for this stop; tag it so the exit is attributed to us.
+        spawn_diagnostics::mark_ac_stop(id, "job-terminate");
         let ptys = self.ptys.lock().unwrap();
         match ptys.get(&id).and_then(|inst| inst.job.as_ref()) {
             Some(job) => {
@@ -779,6 +894,8 @@ impl PtyBackend for LocalProcessBackend {
         let mut terminated = 0;
         let mut jobless = 0;
         for (id, instance) in ptys.iter() {
+            // #942 - shutdown stops every live session; tag them all as ours.
+            spawn_diagnostics::mark_ac_stop(*id, "app-shutdown");
             match instance.job.as_ref() {
                 Some(job) => {
                     job.terminate();
@@ -814,15 +931,36 @@ fn reap_child_in_background(
     session_id: Uuid,
     pid: Option<u32>,
     mut child: Box<dyn portable_pty::Child + Send + Sync>,
+    record: Option<Arc<SpawnRecord>>,
 ) {
     std::thread::spawn(move || match child.wait() {
         Ok(status) => {
-            log::info!(
-                "[pty] Reaped session {} child pid {:?}: {:?}",
-                session_id,
-                pid,
-                status
-            );
+            // #942 - the exit AC asked for. The monitor may have reported this child
+            // first (it died a hair before our stop); then the event is already on
+            // record with the right cause and we only leave a reap crumb.
+            let liveness = ChildLiveness::from(&status);
+            match record.as_ref() {
+                Some(record) => {
+                    if !record.log_child_exit(
+                        ExitCause::AcRequested,
+                        &liveness,
+                        "reaped-after-stop",
+                    ) {
+                        log::debug!(
+                            "[pty] Reaped session {} child pid {:?}: {:?} (exit already reported)",
+                            session_id,
+                            pid,
+                            status
+                        );
+                    }
+                }
+                None => log::info!(
+                    "[pty] child-exit session={} pid={:?} cause=ac-requested detail=reaped-after-stop child={}",
+                    session_id,
+                    pid,
+                    liveness.as_log()
+                ),
+            }
         }
         Err(e) => {
             log::warn!(

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -400,6 +400,7 @@ impl LocalProcessBackend {
         let BackendSpawnSpec {
             id,
             agent_id,
+            coding_agent,
             cmd,
             args,
             cwd,
@@ -417,11 +418,14 @@ impl LocalProcessBackend {
             logical_resource_slot: _,
             container_credential: _,
         } = spec;
-        // #942 - how many sessions were spawned in the window just before this one.
-        // Concurrent startups against shared agent state (the global ~/.codex) are a
-        // prime suspect for the intermittent blank terminal, so every spawn record
-        // carries its own concurrency context. Counting only, no behavior change.
-        let spawn_window = spawn_diagnostics::note_spawn_attempt(agent_id.as_deref());
+        // #942 - how many sessions were spawned in the window just before this one,
+        // and how many of them were the same CLI. Concurrent startups against shared
+        // agent state (the global ~/.codex) are a prime suspect for the intermittent
+        // blank terminal, so every spawn record carries its own concurrency context.
+        // Keyed on the CLI, never on the profile id: several profiles run the same
+        // codex binary against the same ~/.codex. Counting only, no behavior change.
+        let diag_thresholds = spawn_diagnostics::Thresholds::from_env();
+        let spawn_window = spawn_diagnostics::note_spawn_attempt(coding_agent, diag_thresholds);
         let pty_system = native_pty_system();
         let spawn_cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
 
@@ -595,26 +599,40 @@ impl LocalProcessBackend {
         self.ptys.lock().unwrap().insert(id, instance);
         self.fanout.register_session(id, idle_tuning, rows, cols);
 
-        // #942 - emits `[pty] spawn-record` (argv, cwd, agent, CODEX_HOME, concurrency).
+        // #942 - app.log is what users paste into issues, so never echo AC credentials
+        // or configured env values (the rows where AC tells users to keep API keys) back
+        // out through the child output or the argv we log.
+        let redact: Vec<String> = extra_env
+            .iter()
+            .chain(configured_env.iter())
+            .map(|(_, value)| value.clone())
+            .collect();
+
+        // #942 - emits `[pty] spawn-record` (argv, cwd, CLI, profile, CODEX_HOME,
+        // concurrency).
         let record = spawn_diagnostics::register(SpawnRecordInit {
             session_id: id,
             pid: child_pid,
             argv: exec_argv,
             cwd: spawn_cwd,
-            agent_id,
+            cli: coding_agent,
+            agent_profile_id: agent_id,
             codex_home,
             configured_env_count: configured_env.len(),
             removed_env_count: env_remove_keys.len(),
+            redact,
             window: spawn_window,
             started: spawn_started,
+            thresholds: diag_thresholds,
         });
 
-        // #942 - startup-stall WARN and exit attribution. The PTY reader alone cannot
-        // carry this: ConPTY holds the pipe open past the death of the child, so a
-        // child that dies on its own would stay invisible until the session is torn
-        // down. The monitor polls the child handle instead and ends with the session.
+        // #942 - the startup verdict at the deadline and exit attribution. The PTY
+        // reader alone cannot carry either: ConPTY holds the pipe open past the death of
+        // the child, so a child that dies on its own would stay invisible until the
+        // session is torn down. The monitor polls the child handle instead and ends with
+        // the session (detached on purpose; the handle is only useful to tests).
         let monitor_backend = self.clone();
-        spawn_diagnostics::watch_child(Arc::clone(&record), move || {
+        let _monitor = spawn_diagnostics::watch_child(Arc::clone(&record), move || {
             monitor_backend.probe_child(id)
         });
 
@@ -640,9 +658,8 @@ impl LocalProcessBackend {
         Ok(())
     }
 
-    /// #942 - liveness of the child of a session, without disturbing it. `try_wait`
-    /// caches the exit status, so the monitor poll and the kill path always agree on
-    /// what happened.
+    /// #942 - liveness of the child of a session, without disturbing it. Never blocks
+    /// (zero timeout) and never reports a child it could not query as running.
     fn probe_child(&self, id: Uuid) -> ChildLiveness {
         let mut ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
         let Some(instance) = ptys.get_mut(&id) else {
@@ -651,11 +668,57 @@ impl LocalProcessBackend {
         let Some(child) = instance.child.as_mut() else {
             return ChildLiveness::Gone;
         };
-        match child.try_wait() {
-            Ok(Some(status)) => ChildLiveness::from(&status),
-            Ok(None) => ChildLiveness::Alive,
-            Err(e) => ChildLiveness::Unknown(e.to_string()),
+        probe_child_liveness(child)
+    }
+}
+
+/// #942 - ask Windows directly instead of going through `portable_pty::Child::try_wait`.
+/// `WinChild::is_complete` cannot answer honestly: it swallows a failed
+/// `GetExitCodeProcess` and returns "not exited" (so a handle whose query rights were
+/// stripped by AV/EDR, a known scenario here, reads as ALIVE), and its `STILL_ACTIVE`
+/// sentinel is 259, which is also a legal exit code. The process handle is signalled if
+/// and only if the child is gone, whatever it exited with, and a handle we cannot wait
+/// on fails loudly instead of pretending.
+#[cfg(windows)]
+fn probe_child_liveness(child: &mut Box<dyn portable_pty::Child + Send + Sync>) -> ChildLiveness {
+    use windows_sys::Win32::Foundation::{GetLastError, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
+    use windows_sys::Win32::System::Threading::{GetExitCodeProcess, WaitForSingleObject};
+
+    let Some(handle) = child.as_raw_handle() else {
+        return ChildLiveness::Unqueryable("child exposes no process handle".to_string());
+    };
+
+    match unsafe { WaitForSingleObject(handle as _, 0) } {
+        WAIT_TIMEOUT => ChildLiveness::Alive,
+        WAIT_OBJECT_0 => {
+            let mut code: u32 = 0;
+            if unsafe { GetExitCodeProcess(handle as _, &mut code) } == 0 {
+                let os_error = unsafe { GetLastError() };
+                return ChildLiveness::Unqueryable(format!(
+                    "GetExitCodeProcess failed (os error {os_error})"
+                ));
+            }
+            ChildLiveness::Exited {
+                code,
+                success: code == 0,
+            }
         }
+        WAIT_FAILED => {
+            let os_error = unsafe { GetLastError() };
+            ChildLiveness::Unqueryable(format!("WaitForSingleObject failed (os error {os_error})"))
+        }
+        other => ChildLiveness::Unqueryable(format!("WaitForSingleObject returned {other}")),
+    }
+}
+
+/// #942 - on Unix `try_wait` is `waitpid(WNOHANG)`: it reports a failed poll as `Err`,
+/// so it can be trusted to tell "running" from "we could not ask".
+#[cfg(not(windows))]
+fn probe_child_liveness(child: &mut Box<dyn portable_pty::Child + Send + Sync>) -> ChildLiveness {
+    match child.try_wait() {
+        Ok(Some(status)) => ChildLiveness::from(&status),
+        Ok(None) => ChildLiveness::Alive,
+        Err(e) => ChildLiveness::Unqueryable(e.to_string()),
     }
 }
 
@@ -790,12 +853,15 @@ impl PtyBackend for LocalProcessBackend {
     }
 
     fn kill(&self, id: Uuid) -> Result<(), AppError> {
-        // #942 - tag the stop as ours and snapshot the child BEFORE we terminate
-        // anything. The old "already exited" line fired both for a child that had died
-        // on its own and for one our own job/kill had just taken down; the pre-stop
-        // probe is what tells the two apart.
-        let record = spawn_diagnostics::mark_ac_stop(id, "session-kill");
+        // #942 - probe the child BEFORE we tag the stop and BEFORE we touch job or
+        // child. That ordering is the whole trick: nothing AC does can have killed a
+        // child this probe already finds dead, so "was it already gone when we asked?"
+        // has a witness that no race can flip. The old "already exited" line fired both
+        // for a child that had died on its own and for one our own job kill had just
+        // taken down; this is what tells the two apart.
         let child_at_stop = self.probe_child(id);
+        let record =
+            spawn_diagnostics::mark_ac_stop(id, "session-kill", Some(child_at_stop.clone()));
 
         let instance = {
             let mut ptys = self.ptys.lock().unwrap();
@@ -816,25 +882,30 @@ impl PtyBackend for LocalProcessBackend {
                 );
                 match child.try_wait() {
                     Ok(Some(status)) => {
-                        // Dead by the time we removed it. Already dead BEFORE we touched
-                        // the job means the child ended itself; otherwise our stop did.
-                        let cause = if matches!(child_at_stop, ChildLiveness::Exited { .. }) {
-                            ExitCause::ChildInitiated
-                        } else {
-                            ExitCause::AcRequested
-                        };
+                        // Dead by the time we removed it. The pre-stop probe decides
+                        // whose kill this was: already dead before we touched anything
+                        // means the child ended itself.
                         let liveness = ChildLiveness::from(&status);
                         match record.as_ref() {
                             Some(record) => {
+                                let cause = record.attribute_exit(record.stop_snapshot());
                                 record.log_child_exit(cause, &liveness, "observed-at-stop");
                             }
-                            None => log::info!(
-                                "[pty] child-exit session={} pid={:?} cause={} detail=observed-at-stop child={}",
-                                id,
-                                pid,
-                                cause.as_log(),
-                                liveness.as_log()
-                            ),
+                            None => {
+                                let cause =
+                                    if matches!(child_at_stop, ChildLiveness::Exited { .. }) {
+                                        ExitCause::ChildInitiated
+                                    } else {
+                                        ExitCause::AcRequested
+                                    };
+                                log::info!(
+                                    "[pty] child-exit session={} pid={:?} cause={} detail=observed-at-stop child={}",
+                                    id,
+                                    pid,
+                                    cause.as_log(),
+                                    liveness.as_log()
+                                );
+                            }
                         }
                     }
                     Ok(None) => {
@@ -877,8 +948,12 @@ impl PtyBackend for LocalProcessBackend {
     }
 
     fn terminate_job_for_session(&self, id: Uuid) -> bool {
-        // #942 - AC asked for this stop; tag it so the exit is attributed to us.
-        spawn_diagnostics::mark_ac_stop(id, "job-terminate");
+        // #942 - AC asked for this stop. Probe first (same reason as `kill`), then tag,
+        // so a child that was already dead is never charged to us. This stop can also
+        // FAIL (a Quarantined resource-monitor kill leaves the instance intact), which
+        // is why the tag only owns exits that follow it inside the attribution window.
+        let child_at_stop = self.probe_child(id);
+        spawn_diagnostics::mark_ac_stop(id, "job-terminate", Some(child_at_stop));
         let ptys = self.ptys.lock().unwrap();
         match ptys.get(&id).and_then(|inst| inst.job.as_ref()) {
             Some(job) => {
@@ -894,8 +969,10 @@ impl PtyBackend for LocalProcessBackend {
         let mut terminated = 0;
         let mut jobless = 0;
         for (id, instance) in ptys.iter() {
-            // #942 - shutdown stops every live session; tag them all as ours.
-            spawn_diagnostics::mark_ac_stop(*id, "app-shutdown");
+            // #942 - shutdown stops every live session; tag them all as ours. Lock order
+            // here is ptys -> diagnostics registry; nothing ever takes them the other way
+            // round (the monitor holds no registry lock while it probes under ptys).
+            spawn_diagnostics::mark_ac_stop(*id, "app-shutdown", None);
             match instance.job.as_ref() {
                 Some(job) => {
                     job.terminate();
@@ -941,11 +1018,8 @@ fn reap_child_in_background(
             let liveness = ChildLiveness::from(&status);
             match record.as_ref() {
                 Some(record) => {
-                    if !record.log_child_exit(
-                        ExitCause::AcRequested,
-                        &liveness,
-                        "reaped-after-stop",
-                    ) {
+                    let cause = record.attribute_exit(record.stop_snapshot());
+                    if !record.log_child_exit(cause, &liveness, "reaped-after-stop") {
                         log::debug!(
                             "[pty] Reaped session {} child pid {:?}: {:?} (exit already reported)",
                             session_id,

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -596,15 +596,23 @@ impl LocalProcessBackend {
             job,
         };
 
-        self.ptys.lock().unwrap().insert(id, instance);
+        self.ptys
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(id, instance);
         self.fanout.register_session(id, idle_tuning, rows, cols);
 
-        // #942 - app.log is what users paste into issues, so never echo AC credentials
-        // or configured env values (the rows where AC tells users to keep API keys) back
-        // out through the child output or the argv we log.
+        // #942 - app.log is what users paste into issues, so a secret must never be
+        // echoed back out through the child output or the argv we log. Keyed on the env
+        // NAME (token / key / secret / password / credential), across both AC's own
+        // credential env and the configured rows where AC tells users to keep their API
+        // keys. Deliberately not a sweep of every value: a Codex profile legitimately
+        // carries `MODEL=gpt-5.6-sol`, and blanking that would shred the very argv this
+        // instrumentation exists to record.
         let redact: Vec<String> = extra_env
             .iter()
             .chain(configured_env.iter())
+            .filter(|(key, _)| spawn_diagnostics::is_secret_env_key(key))
             .map(|(_, value)| value.clone())
             .collect();
 
@@ -668,8 +676,23 @@ impl LocalProcessBackend {
         let Some(child) = instance.child.as_mut() else {
             return ChildLiveness::Gone;
         };
-        probe_child_liveness(child)
+        probe_child_contained(child)
     }
+}
+
+/// #942 - probe a child while the caller holds the `ptys` guard, and CONTAIN any panic.
+///
+/// portable-pty locks a mutex of its own inside the child and unwraps it (`try_wait`,
+/// `do_kill`, `process_id` and `as_raw_handle` all do). If that mutex is ever poisoned,
+/// an unwind from the probe would escape while the `ptys` guard is held and poison the
+/// PTY map itself, which every terminal write, resize and kill locks on: a diagnostics
+/// probe would silently take the terminal subsystem down with it. Catching AT the call
+/// means the guard above us is released normally and the map stays usable.
+fn probe_child_contained(child: &mut Box<dyn portable_pty::Child + Send + Sync>) -> ChildLiveness {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| probe_child_liveness(child)))
+        .unwrap_or_else(|_| {
+            ChildLiveness::Unqueryable("portable-pty child lock is poisoned".to_string())
+        })
 }
 
 /// #942 - ask Windows directly instead of going through `portable_pty::Child::try_wait`.
@@ -809,7 +832,9 @@ impl PtyBackend for LocalProcessBackend {
     }
 
     fn write(&self, id: Uuid, data: &[u8]) -> Result<(), AppError> {
-        let ptys = self.ptys.lock().unwrap();
+        // #942 - poison-tolerant: a panic anywhere under this guard (portable-pty unwraps
+        // inside its own child polling) must not brick every terminal write that follows.
+        let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
         let instance = ptys
             .get(&id)
             .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
@@ -826,13 +851,16 @@ impl PtyBackend for LocalProcessBackend {
     }
 
     fn has_session(&self, id: Uuid) -> bool {
-        self.ptys.lock().unwrap().contains_key(&id)
+        self.ptys
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(&id)
     }
 
     fn resize(&self, id: Uuid, cols: u16, rows: u16) -> Result<(), AppError> {
         self.fanout.record_resize(id);
 
-        let ptys = self.ptys.lock().unwrap();
+        let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
         let instance = ptys
             .get(&id)
             .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
@@ -864,7 +892,7 @@ impl PtyBackend for LocalProcessBackend {
             spawn_diagnostics::mark_ac_stop(id, "session-kill", Some(child_at_stop.clone()));
 
         let instance = {
-            let mut ptys = self.ptys.lock().unwrap();
+            let mut ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
             ptys.remove(&id)
         };
 
@@ -947,6 +975,16 @@ impl PtyBackend for LocalProcessBackend {
         Ok(())
     }
 
+    /// #942 - record who asked for the stop and what the child looked like BEFORE any
+    /// process is touched. The resource monitor kills a process tree without going through
+    /// the PTY layer, so a caller that is about to do that publishes the witness here
+    /// first; without it, a child that had already died on its own would be logged as our
+    /// kill and its evidence dropped.
+    fn publish_stop_witness(&self, id: Uuid, source: &str) {
+        let child_at_stop = self.probe_child(id);
+        spawn_diagnostics::mark_ac_stop(id, source, Some(child_at_stop));
+    }
+
     fn terminate_job_for_session(&self, id: Uuid) -> bool {
         // #942 - AC asked for this stop. Probe first (same reason as `kill`), then tag,
         // so a child that was already dead is never charged to us. This stop can also
@@ -954,7 +992,7 @@ impl PtyBackend for LocalProcessBackend {
         // is why the tag only owns exits that follow it inside the attribution window.
         let child_at_stop = self.probe_child(id);
         spawn_diagnostics::mark_ac_stop(id, "job-terminate", Some(child_at_stop));
-        let ptys = self.ptys.lock().unwrap();
+        let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
         match ptys.get(&id).and_then(|inst| inst.job.as_ref()) {
             Some(job) => {
                 job.terminate();
@@ -965,14 +1003,19 @@ impl PtyBackend for LocalProcessBackend {
     }
 
     fn kill_all_jobs(&self) -> (usize, usize) {
-        let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
+        let mut ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
         let mut terminated = 0;
         let mut jobless = 0;
-        for (id, instance) in ptys.iter() {
-            // #942 - shutdown stops every live session; tag them all as ours. Lock order
-            // here is ptys -> diagnostics registry; nothing ever takes them the other way
-            // round (the monitor holds no registry lock while it probes under ptys).
-            spawn_diagnostics::mark_ac_stop(*id, "app-shutdown", None);
+        for (id, instance) in ptys.iter_mut() {
+            // #942 - shutdown stops every live session; tag them all as ours, with the
+            // same pre-stop witness every other stop path publishes. Lock order here is
+            // ptys -> diagnostics registry; nothing ever takes them the other way round
+            // (the monitor holds no registry lock while it probes under ptys).
+            let child_at_stop = match instance.child.as_mut() {
+                Some(child) => probe_child_contained(child),
+                None => ChildLiveness::Gone,
+            };
+            spawn_diagnostics::mark_ac_stop(*id, "app-shutdown", Some(child_at_stop));
             match instance.job.as_ref() {
                 Some(job) => {
                     job.terminate();
@@ -1045,6 +1088,79 @@ fn reap_child_in_background(
             );
         }
     });
+}
+
+#[cfg(test)]
+mod probe_containment_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// A child that panics exactly where portable-pty does when its inner mutex is
+    /// poisoned: inside the accessor, with the caller holding the PTY map guard.
+    #[derive(Debug)]
+    struct PoisonedChild;
+
+    impl portable_pty::ChildKiller for PoisonedChild {
+        fn kill(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn clone_killer(&self) -> Box<dyn portable_pty::ChildKiller + Send + Sync> {
+            Box::new(PoisonedChild)
+        }
+    }
+
+    impl portable_pty::Child for PoisonedChild {
+        fn try_wait(&mut self) -> std::io::Result<Option<portable_pty::ExitStatus>> {
+            panic!("called `Result::unwrap()` on a poisoned mutex");
+        }
+
+        fn wait(&mut self) -> std::io::Result<portable_pty::ExitStatus> {
+            panic!("called `Result::unwrap()` on a poisoned mutex");
+        }
+
+        fn process_id(&self) -> Option<u32> {
+            None
+        }
+
+        #[cfg(windows)]
+        fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle> {
+            panic!("called `Result::unwrap()` on a poisoned mutex");
+        }
+    }
+
+    /// grinch D4: the probe runs while the global `ptys` guard is held. A panic inside
+    /// portable-pty must not unwind through that guard, because a poisoned `ptys` map
+    /// makes the next terminal write panic, with nothing in the log tying it back here.
+    #[test]
+    fn a_panicking_child_probe_never_poisons_the_pty_map() {
+        let ptys: Mutex<HashMap<Uuid, Box<dyn portable_pty::Child + Send + Sync>>> =
+            Mutex::new(HashMap::new());
+        let id = Uuid::new_v4();
+        ptys.lock()
+            .unwrap()
+            .insert(id, Box::new(PoisonedChild) as Box<dyn portable_pty::Child + Send + Sync>);
+
+        {
+            // Exactly the shape of `probe_child`: guard held, probe called under it.
+            let mut guard = ptys.lock().unwrap();
+            let child = guard.get_mut(&id).expect("child");
+            let liveness = probe_child_contained(child);
+            assert!(
+                matches!(liveness, ChildLiveness::Unqueryable(_)),
+                "a probe that could not ask must never claim the child is alive"
+            );
+        }
+
+        assert!(
+            !ptys.is_poisoned(),
+            "the ptys guard must be released normally, not unwound through"
+        );
+        assert!(
+            ptys.lock().is_ok(),
+            "the next terminal write still gets the lock"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -245,6 +245,15 @@ impl PtyManager {
         self.backend_for_kind(kind).terminate_job_for_session(id)
     }
 
+    /// #942 - publish the pre-stop witness for a session AC is about to kill outside the
+    /// PTY layer (resource-monitor tree kill). No-op when the session has no route.
+    pub fn publish_stop_witness(&self, id: Uuid, source: &str) {
+        let Ok(kind) = self.kind_for_session(id) else {
+            return;
+        };
+        self.backend_for_kind(kind).publish_stop_witness(id, source);
+    }
+
     pub fn kill_all_jobs(&self) -> (usize, usize) {
         self.backend_for_kind(SessionBackendKind::LocalProcess)
             .kill_all_jobs()

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -475,6 +475,7 @@ mod tests {
         BackendSpawnSpec {
             id,
             agent_id: None,
+            coding_agent: None,
             cmd: "cmd".to_string(),
             args: Vec::new(),
             cwd: ".".to_string(),

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -474,6 +474,7 @@ mod tests {
     fn test_spawn_spec(id: Uuid) -> BackendSpawnSpec {
         BackendSpawnSpec {
             id,
+            agent_id: None,
             cmd: "cmd".to_string(),
             args: Vec::new(),
             cwd: ".".to_string(),

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -14,3 +14,4 @@ pub mod job; // #632 - per-agent Job Object for tree-kill
 pub mod local_backend;
 pub mod manager;
 pub mod output;
+pub mod spawn_diagnostics; // #942 - spawn/first-output/exit evidence for hang triage

--- a/src-tauri/src/pty/spawn_diagnostics.rs
+++ b/src-tauri/src/pty/spawn_diagnostics.rs
@@ -70,6 +70,14 @@
 //! by construction; the residue is a microsecond-wide race, and it is stated here rather
 //! than papered over.
 //!
+//! One more residual, stated rather than "fixed": an exit inside the attribution window
+//! that follows a stop which FAILED (a Quarantined kill leaves the agent running) is
+//! attributed to AC. We err this way deliberately. The alternative mislabels a
+//! slow-but-successful kill as a spontaneous death, which is the fabrication this module
+//! exists to prevent, and `Quarantined` means "AC could not verify the termination", not
+//! "the kill failed". `stop_source` and `stop_age_ms` are printed on every exit event, so
+//! a human can see a 30-second gap for what it is.
+//!
 //! ## Lock order
 //!
 //! `ptys` -> diagnostics registry (`kill_all_jobs` holds the PTY map while tagging

--- a/src-tauri/src/pty/spawn_diagnostics.rs
+++ b/src-tauri/src/pty/spawn_diagnostics.rs
@@ -48,6 +48,28 @@
 //!   with code 259 stays invisible to it: an upstream limitation, documented here
 //!   rather than asserted away.
 //!
+//! ## Accepted gap: container transport
+//!
+//! Container sessions produce **nothing** here: no spawn record, no deadline report, no
+//! exit event (`container_backend` registers no record, so `mark_ac_stop` is a genuine
+//! no-op for them). A containerised coding-agent hang leaves zero evidence. That is an
+//! accepted gap: #942 is a local-spawn bug. It never MISreports a container session, it
+//! simply says nothing about one.
+//!
+//! ## Exit attribution: where the witness comes from, and the one path without it
+//!
+//! Every AC stop publishes a **pre-stop witness**: the liveness of the child probed
+//! before anything is touched. `kill`, `terminate_job_for_session`, `kill_all_jobs` and
+//! the session-destroy path all publish one, so a child that was already dead when AC
+//! asked can never be charged to us. The resource-monitor **watchdog** is the exception:
+//! it calls `kill_group` straight from `resource_monitor/watchdog.rs` with no access to
+//! the PTY child, so it publishes no witness. There the monitor falls back to the stop
+//! flag as read before the probe, which means a child that died on its own in the
+//! microseconds before the watchdog fired is attributed `ac-requested`. The watchdog
+//! only fires on a group that is measurably burning CPU or memory, so the child is alive
+//! by construction; the residue is a microsecond-wide race, and it is stated here rather
+//! than papered over.
+//!
 //! ## Lock order
 //!
 //! `ptys` -> diagnostics registry (`kill_all_jobs` holds the PTY map while tagging
@@ -94,6 +116,20 @@ const MAX_STOP_ATTRIBUTION_MS: u64 = 60 * 60 * 1_000;
 const RECENT_SPAWNS_CAP: usize = 128;
 /// Values shorter than this are not secrets, they are flags like `1` or `true`.
 const MIN_REDACTED_LEN: usize = 8;
+/// Env keys whose VALUE is a secret and must never reach the log. Keyed on the name, not
+/// swept over every value: a coding-agent profile legitimately carries rows like
+/// `MODEL=gpt-5.6-sol`, and blanking those would shred the argv this module exists to
+/// record, and the Codex error text inside `head=`.
+const SECRET_KEY_MARKERS: &[&str] = &["token", "key", "secret", "password", "passwd", "credential"];
+
+/// True when an env row's value must be redacted out of anything we echo into the log.
+/// AC's own credential env is covered by this: the only secret it carries is
+/// `AGENTSCOMMANDER_TOKEN` (the other rows are paths and a binary name, which are not
+/// secrets and which we deliberately print in `cwd=` / `argv=`).
+pub fn is_secret_env_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    SECRET_KEY_MARKERS.iter().any(|marker| key.contains(marker))
+}
 
 /// Everything the diagnostics need to be told, resolved once from the environment and
 /// then carried by each record, so no code path (and no test) reads a process-global.
@@ -105,6 +141,11 @@ pub struct Thresholds {
     pub head_bytes: usize,
     pub concurrency_window: Duration,
     pub stop_attribution: Duration,
+    /// How long after a stop request ConPTY's teardown repaint can still arrive. Only
+    /// the startup TIMING stamps are suppressed during it; bytes keep counting, and the
+    /// stall verdict is byte-based, so a stop that fails to kill the child cannot fake a
+    /// stall on a session that is painting normally.
+    pub teardown_suppression: Duration,
     pub startup_poll: Duration,
     pub steady_poll: Duration,
 }
@@ -116,6 +157,7 @@ impl Thresholds {
         head_bytes: DEFAULT_HEAD_BYTES as usize,
         concurrency_window: Duration::from_millis(DEFAULT_CONCURRENCY_WINDOW_MS),
         stop_attribution: Duration::from_millis(DEFAULT_STOP_ATTRIBUTION_MS),
+        teardown_suppression: Duration::from_secs(2),
         startup_poll: Duration::from_millis(250),
         steady_poll: Duration::from_secs(2),
     };
@@ -376,10 +418,20 @@ impl SpawnRecord {
         }
     }
 
-    /// Mask AC credentials and configured env values out of anything we echo into the
-    /// log. `app.log` is what users paste into issues.
-    fn scrub(&self, text: String) -> String {
-        let mut text = text;
+    /// Mask secrets out of anything we echo into the log. `app.log` is what users paste
+    /// into issues.
+    ///
+    /// ALWAYS runs on the RAW text, never on escaped text. Escaping first and matching
+    /// second is a silent no-op for any secret containing a backslash, a quote, a control
+    /// character or non-ASCII (the haystack has been rewritten, the needle has not), and
+    /// a redaction that silently fails is worse than none, because it invites the log to
+    /// be pasted in public.
+    fn scrub(&self, text: &str) -> String {
+        // Exact needles first (the secret-keyed env values this child was given), then
+        // the URL-shape redactor AC already applies to error text, so a key smuggled
+        // inside a URL the child printed (`?key=...`, `/bot<token>/`) does not walk out
+        // through `head=` either.
+        let mut text = crate::telegram::redact::redact(text);
         for secret in &self.redact {
             if text.contains(secret.as_str()) {
                 text = text.replace(secret.as_str(), "<redacted>");
@@ -389,7 +441,9 @@ impl SpawnRecord {
     }
 
     fn argv_log(&self) -> String {
-        self.scrub(format!("{:?}", self.argv))
+        // Scrub each raw argument, THEN let Debug do the escaping.
+        let argv: Vec<String> = self.argv.iter().map(|arg| self.scrub(arg)).collect();
+        format!("{argv:?}")
     }
 
     fn head_log(&self) -> String {
@@ -397,8 +451,9 @@ impl SpawnRecord {
         if head.is_empty() {
             return "<empty>".to_string();
         }
-        let text = String::from_utf8_lossy(&head).escape_debug().to_string();
-        format!("\"{}\"", self.scrub(text))
+        // Scrub the raw child output, THEN escape it for the log line.
+        let scrubbed = self.scrub(&String::from_utf8_lossy(&head));
+        format!("\"{}\"", scrubbed.escape_debug())
     }
 
     pub fn saw_output(&self) -> bool {
@@ -487,39 +542,43 @@ impl SpawnRecord {
         !self.startup_reported.load(Ordering::Relaxed)
     }
 
+    /// LAST-wins, deliberately. AC supports a stop that FAILS (a Quarantined kill leaves
+    /// the agent running), and a first-wins anchor would let that stale stop own the
+    /// attribution of the real one minutes later: the user closes the session, we kill it,
+    /// and the window measured from the dead stop calls our own kill `child-initiated`.
+    /// That is a fabricated smoking gun, which is exactly what #942 exists to remove. The
+    /// window is therefore measured from the MOST RECENT stop request.
+    ///
+    /// The witness is upgraded, never downgraded: a fresher probe replaces an older one,
+    /// and a witness-less stop (the resource-monitor watchdog) leaves a witness that a
+    /// real probe already established. A witness that said `Exited` stays true forever: a
+    /// dead child does not come back.
     fn mark_ac_stop(&self, source: &str, pre_stop: Option<ChildLiveness>) {
-        {
-            let mut current = self.ac_stop_source.lock().unwrap_or_else(|e| e.into_inner());
-            if current.is_none() {
-                *current = Some(source.to_string());
-            }
-        }
+        *self.ac_stop_source.lock().unwrap_or_else(|e| e.into_inner()) = Some(source.to_string());
         if let Some(pre_stop) = pre_stop {
-            let mut current = self
+            *self
                 .pre_stop_liveness
                 .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            if current.is_none() {
-                *current = Some(pre_stop);
-            }
+                .unwrap_or_else(|e| e.into_inner()) = Some(pre_stop);
         }
         let stamp = (self.started.elapsed().as_micros().min(u64::MAX as u128) as u64).max(1);
-        let _ = self
-            .ac_stop_at_us
-            .compare_exchange(0, stamp, Ordering::SeqCst, Ordering::Relaxed);
+        self.ac_stop_at_us.store(stamp, Ordering::SeqCst);
         // Published last: any thread that sees this flag also sees the source, the
         // timestamp and the pre-stop liveness written above.
         self.ac_stop.store(true, Ordering::SeqCst);
     }
 
     /// A stop AC asked for, recent enough that the teardown it triggers is still in
-    /// flight. Keeps ConPTY's teardown repaint out of the startup timings without
-    /// going permanently blind on a session whose kill was blocked.
+    /// flight. ConPTY repaints the master when the session is torn down (milliseconds
+    /// after the kill), and that repaint is not the child painting. Deliberately a short
+    /// window of its own, NOT the 60s attribution window: a stop that fails to kill the
+    /// child must not blind the startup timings of a session that keeps running.
     fn stop_in_flight(&self, elapsed: Duration) -> bool {
         match self.ac_stop_at_us.load(Ordering::SeqCst) {
             0 => false,
             at => {
-                elapsed.saturating_sub(Duration::from_micros(at)) <= self.thresholds.stop_attribution
+                elapsed.saturating_sub(Duration::from_micros(at))
+                    <= self.thresholds.teardown_suppression
             }
         }
     }
@@ -625,9 +684,13 @@ impl SpawnRecord {
     /// The child never painted a screen: nothing at all, or nothing past the ConPTY
     /// handshake for a coding agent (which always paints a TUI immediately). A plain
     /// shell whose prompt is legitimately tiny is not stalled, it is just quiet.
+    ///
+    /// Keyed on the BYTES, not on the paint stamp: the stamp can be suppressed while a
+    /// stop is in flight, and a suppressed stamp must never be able to fake a stall on a
+    /// session that is painting normally.
     fn is_stalled(&self) -> bool {
         let bytes = self.bytes_read.load(Ordering::Relaxed);
-        bytes == 0 || (self.cli.is_some() && !self.painted())
+        bytes == 0 || (self.cli.is_some() && bytes < self.thresholds.paint_floor)
     }
 
     /// True once the startup window has elapsed and the verdict is still unwritten.
@@ -697,12 +760,17 @@ impl SpawnRecord {
         // A child that ends itself without ever painting a screen, or with a failing
         // status, is the #942 smoking gun. A clean exit from a session that did come up
         // is just someone quitting.
-        let unexpected =
-            cause == ExitCause::ChildInitiated && (!self.painted() || !liveness.exited_ok());
+        let never_came_up = self.is_stalled();
+        let unexpected = cause == ExitCause::ChildInitiated && (never_came_up || !liveness.exited_ok());
+        // The head bytes and the argv go out whenever the session never came up, whoever
+        // ended it. The user who kills a blank terminal at t=3s (before the deadline
+        // report can fire) is reporting THIS bug, and we must not answer with a one-line
+        // shrug just because the kill was ours.
+        let with_evidence = unexpected || never_came_up;
 
-        if unexpected {
-            log::warn!(
-                "[pty] child-exit session={} pid={} cli={} agent_profile={} cause={} detail={} child={} uptime_ms={} first_output_ms={} first_paint_ms={} bytes_read={} stop_source={} stop_age_ms={} argv={} cwd={} codex_home={} recent_spawns={} recent_same_cli={} window_ms={} head={}",
+        if with_evidence {
+            let line = format!(
+                "[pty] child-exit session={} pid={} cli={} agent_profile={} cause={} detail={} child={} came_up={} uptime_ms={} first_output_ms={} first_paint_ms={} bytes_read={} stop_source={} stop_age_ms={} argv={} cwd={} codex_home={} recent_spawns={} recent_same_cli={} window_ms={} head={}",
                 self.session_id,
                 self.pid_log(),
                 self.cli_log(),
@@ -710,6 +778,7 @@ impl SpawnRecord {
                 cause.as_log(),
                 detail,
                 liveness.as_log(),
+                !never_came_up,
                 uptime.as_millis(),
                 Self::ms_log(&self.first_output_us),
                 Self::ms_log(&self.first_paint_us),
@@ -724,6 +793,11 @@ impl SpawnRecord {
                 self.window.window_ms,
                 self.head_log()
             );
+            if unexpected {
+                log::warn!("{}", line);
+            } else {
+                log::info!("{}", line);
+            }
         } else {
             log::info!(
                 "[pty] child-exit session={} pid={} cli={} agent_profile={} cause={} detail={} child={} uptime_ms={} first_output_ms={} first_paint_ms={} bytes_read={} stop_source={} stop_age_ms={}",
@@ -918,6 +992,7 @@ mod tests {
             head_bytes: 512,
             concurrency_window: Duration::from_millis(10_000),
             stop_attribution: Duration::from_millis(500),
+            teardown_suppression: Duration::from_millis(50),
             startup_poll: Duration::from_millis(5),
             steady_poll: Duration::from_millis(10),
         }
@@ -1167,19 +1242,216 @@ mod tests {
     }
 
     #[test]
-    fn ac_stop_keeps_the_first_source_and_flags_the_record() {
+    fn ac_stop_takes_the_most_recent_source_timestamp_and_witness() {
+        // grinch D2: first-wins let a stale, failed stop own every later stop.
         let record = test_record(Some(CodingAgentKind::Codex));
         assert!(!record.stop_requested());
 
-        record.mark_ac_stop("watchdog", None);
-        record.mark_ac_stop("session-kill", None);
+        record.mark_ac_stop("job-terminate", Some(ChildLiveness::Alive));
+        let first_stamp = record.ac_stop_at_us.load(Ordering::SeqCst);
+        std::thread::sleep(Duration::from_millis(5));
+        record.mark_ac_stop(
+            "session-kill",
+            Some(ChildLiveness::Exited {
+                code: 0,
+                success: true,
+            }),
+        );
 
         assert!(record.stop_requested());
-        assert_eq!(record.stop_source(), "watchdog");
+        assert_eq!(record.stop_source(), "session-kill");
+        assert!(
+            record.ac_stop_at_us.load(Ordering::SeqCst) > first_stamp,
+            "the attribution window is measured from the most recent stop"
+        );
+        assert!(
+            matches!(
+                record.pre_stop_liveness(),
+                Some(ChildLiveness::Exited { .. })
+            ),
+            "the fresher witness replaces the older one"
+        );
     }
 
     #[test]
-    fn credentials_and_configured_env_values_are_scrubbed_from_echoed_output() {
+    fn a_witness_less_stop_never_erases_a_witness_we_already_have() {
+        let record = test_record(Some(CodingAgentKind::Codex));
+        record.mark_ac_stop(
+            "session-kill",
+            Some(ChildLiveness::Exited {
+                code: 1,
+                success: false,
+            }),
+        );
+        // The resource monitor publishes no witness; it must not blank the real one.
+        record.mark_ac_stop("watchdog", None);
+
+        assert_eq!(
+            record.attribute_exit(record.stop_snapshot()),
+            ExitCause::ChildInitiated,
+            "it was already dead when AC asked, and a witness-less stop cannot rewrite that"
+        );
+    }
+
+    #[test]
+    fn a_stale_failed_stop_does_not_poison_the_stop_that_finally_lands() {
+        // grinch D2, the real run: RM Kill is blocked by AV/EDR (Quarantined leaves the
+        // agent running), the user closes the session minutes later, we kill it. With a
+        // first-wins anchor our own kill came out as `child-initiated` with a WARN and a
+        // head dump: a fabricated smoking gun, the exact lie #942 exists to remove.
+        let record = SpawnRecord {
+            thresholds: Thresholds {
+                stop_attribution: Duration::from_millis(30),
+                ..test_thresholds()
+            },
+            ..test_record(Some(CodingAgentKind::Codex))
+        };
+
+        record.mark_ac_stop("job-terminate", Some(ChildLiveness::Alive));
+        std::thread::sleep(Duration::from_millis(45));
+        assert_eq!(
+            record.attribute_exit(record.stop_snapshot()),
+            ExitCause::ChildInitiated,
+            "a stop that evidently failed does not own a death long after it"
+        );
+
+        record.mark_ac_stop("session-kill", Some(ChildLiveness::Alive));
+        assert_eq!(
+            record.attribute_exit(record.stop_snapshot()),
+            ExitCause::AcRequested,
+            "the window is measured from the stop that actually killed it"
+        );
+        assert_eq!(record.stop_source(), "session-kill");
+    }
+
+    #[test]
+    fn a_blocked_stop_cannot_fake_a_stall_on_a_session_that_keeps_painting() {
+        // Same anchor, second consequence: the timing stamps are suppressed while a stop
+        // is in flight, so the stall verdict must not depend on them.
+        let record = SpawnRecord {
+            thresholds: Thresholds {
+                teardown_suppression: Duration::from_millis(10),
+                ..test_thresholds()
+            },
+            ..aged_record(Some(CodingAgentKind::Codex))
+        };
+        record.mark_ac_stop("job-terminate", Some(ChildLiveness::Alive));
+        record.note_output(&[b'x'; 200]);
+
+        assert!(
+            !record.painted(),
+            "the paint stamp is suppressed while a stop is in flight"
+        );
+        assert!(
+            !record.is_stalled(),
+            "but the bytes are on record, so a blocked kill cannot fake a stall"
+        );
+    }
+
+    #[test]
+    fn a_blank_session_killed_by_ac_still_dumps_its_evidence() {
+        // The user who kills a blank terminal at t=3s, before the deadline report can
+        // fire, is reporting THIS bug. An ac-requested exit must not answer with a
+        // one-line shrug just because the kill was ours.
+        let record = test_record(Some(CodingAgentKind::Codex));
+        record.note_output(CONPTY_PROLOGUE);
+        record.mark_ac_stop("session-kill", Some(ChildLiveness::Alive));
+
+        assert!(
+            record.is_stalled(),
+            "16 bytes of ConPTY handshake is not a painted screen"
+        );
+        assert!(record.log_child_exit(
+            ExitCause::AcRequested,
+            &ChildLiveness::Exited {
+                code: 1,
+                success: false,
+            },
+            "observed-at-stop"
+        ));
+        assert_eq!(
+            *record.exit_cause.lock().unwrap(),
+            Some(ExitCause::AcRequested)
+        );
+    }
+
+    #[test]
+    fn secrets_are_scrubbed_before_the_text_is_escaped() {
+        // grinch D1: escaping first and matching second is a SILENT no-op for any secret
+        // holding a backslash, a quote, a control character or non-ASCII, because the
+        // haystack has been rewritten and the needle has not. A redaction that fails
+        // quietly is worse than none: the feature invites people to paste the log.
+        let windows_path = r"C:\Users\maria\.codex\auth.json";
+        let quoted = "a\"b\\c-secret-value";
+        let control = "tok\tsecret\r\n1234";
+        let unicode = "p\u{e4}ssw\u{f6}rd-\u{fc}-9876";
+        let record = SpawnRecord::new(SpawnRecordInit {
+            argv: vec![
+                "codex".to_string(),
+                format!("--config={windows_path}"),
+                format!("--auth={quoted}"),
+            ],
+            redact: vec![
+                windows_path.to_string(),
+                quoted.to_string(),
+                control.to_string(),
+                unicode.to_string(),
+            ],
+            ..test_init(Some(CodingAgentKind::Codex))
+        });
+        record.note_output(
+            format!("loading {windows_path} with {quoted} {control} {unicode}\r\n").as_bytes(),
+        );
+
+        let head = record.head_log();
+        let argv = record.argv_log();
+        for secret in [windows_path, quoted, control, unicode] {
+            assert!(!head.contains(secret), "raw secret survived in head: {head}");
+            assert!(!argv.contains(secret), "raw secret survived in argv: {argv}");
+        }
+        // The escaped shapes must not survive either: escaping happens after the scrub.
+        assert!(!head.contains("auth.json"), "escaped path survived: {head}");
+        assert!(!argv.contains("auth.json"), "escaped path survived: {argv}");
+        assert!(!head.contains("9876"), "escaped non-ASCII secret survived: {head}");
+        assert!(head.contains("<redacted>"));
+        assert!(argv.contains("<redacted>"));
+        assert!(
+            head.contains("loading"),
+            "the rest of the line still has to be readable: {head}"
+        );
+    }
+
+    #[test]
+    fn a_key_smuggled_inside_a_url_in_the_child_output_is_redacted_too() {
+        let record = test_record(Some(CodingAgentKind::Codex));
+        record.note_output(b"error: GET https://generativelanguage.googleapis.com/v1beta/models?key=AIzaSyFAKE_KEY_VALUE failed
+");
+
+        let head = record.head_log();
+        assert!(!head.contains("AIzaSyFAKE_KEY_VALUE"), "url key survived: {head}");
+        assert!(head.contains("error: GET"), "the error text still has to be readable");
+    }
+
+    #[test]
+    fn only_secret_keyed_env_rows_are_redacted() {
+        // grinch D1 (second half): sweeping every configured env value blanked
+        // `MODEL=gpt-5.6-sol` inside our own argv, the argv requirement 1 exists to
+        // record, and could shred the Codex error text inside `head=`.
+        assert!(is_secret_env_key("AGENTSCOMMANDER_TOKEN"));
+        assert!(is_secret_env_key("OPENAI_API_KEY"));
+        assert!(is_secret_env_key("DB_PASSWORD"));
+        assert!(is_secret_env_key("gh_secret"));
+        assert!(is_secret_env_key("SERVICE_CREDENTIAL"));
+
+        assert!(!is_secret_env_key("MODEL"));
+        assert!(!is_secret_env_key("CODEX_HOME"));
+        assert!(!is_secret_env_key("AGENTSCOMMANDER_ROOT"));
+        assert!(!is_secret_env_key("AGENTSCOMMANDER_BINARY_PATH"));
+        assert!(!is_secret_env_key("NODE_ENV"));
+    }
+
+    #[test]
+    fn credentials_are_scrubbed_from_echoed_output() {
         let token = "3f1c9d2e-7a4b-4c8d-9e1f-2b3c4d5e6f70";
         let record = SpawnRecord::new(SpawnRecordInit {
             argv: vec!["codex".to_string(), format!("--token={token}")],

--- a/src-tauri/src/pty/spawn_diagnostics.rs
+++ b/src-tauri/src/pty/spawn_diagnostics.rs
@@ -1,0 +1,839 @@
+//! #942 - spawn diagnostics for local PTY sessions.
+//!
+//! Diagnostics only. Nothing in this module changes how a session is spawned,
+//! killed or read; it only records evidence so an intermittent coding-agent
+//! blank-terminal hang explains itself after the fact:
+//!
+//! 1. `[pty] spawn-record` - the argv AC actually executed, the resolved cwd,
+//!    the coding-agent id, the effective `CODEX_HOME`, and how many other
+//!    sessions were spawned in the preceding window (shared `~/.codex` contention).
+//! 2. `[pty] first-output` (DEBUG) - time from spawn to the first byte read off
+//!    the PTY, and `[pty] first-paint` (INFO) - time until the child produced
+//!    real output. Both are needed on Windows: ConPTY writes its own 16-byte
+//!    handshake (`ESC[?9001h ESC[?1004h`) into the PTY within ~20ms of every
+//!    spawn, child or no child, so the first byte is never evidence that the
+//!    child came up. Crossing the paint floor is.
+//! 3. `[pty] startup-stall` - WARN when the child produced nothing (or nothing
+//!    past the ConPTY handshake) within the threshold, with child liveness at
+//!    that moment.
+//! 4. `[pty] child-exit` - every child exit, tagged with an unambiguous cause:
+//!    `ac-requested` (we asked: session kill, job terminate, resource-monitor
+//!    kill_group) vs `child-initiated` (it died on its own).
+//! 5. The first N bytes the child ever wrote, replayed into the stall and the
+//!    unexpected-exit events, so an error message that never reached the screen
+//!    is still on record.
+//!
+//! Tunables (env vars, read once):
+//! - `AC_SPAWN_STALL_TIMEOUT_MS` (default 5000, `0` disables the stall check)
+//! - `AC_SPAWN_PAINT_FLOOR_BYTES` (default 64)
+//! - `AC_SPAWN_HEAD_BYTES` (default 512)
+//! - `AC_SPAWN_CONCURRENCY_WINDOW_MS` (default 10000)
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use portable_pty::ExitStatus;
+use uuid::Uuid;
+
+/// No output within this window after spawn is a startup stall.
+const DEFAULT_STALL_TIMEOUT_MS: u64 = 5_000;
+/// Output below this many bytes is not a painted screen; it is the ConPTY handshake
+/// (16 bytes) and nothing else. A coding agent paints a full TUI immediately, so a
+/// coding-agent session still under the floor at the stall deadline is the
+/// blank-terminal symptom. Plain shells are exempt from the stall check: a bare
+/// prompt is legitimately tiny.
+const DEFAULT_PAINT_FLOOR_BYTES: u64 = 64;
+/// How much of the child's first output we retain for stall / early-exit reports.
+const DEFAULT_HEAD_BYTES: u64 = 512;
+/// Window used to correlate a hang with concurrent startups on shared agent state.
+const DEFAULT_CONCURRENCY_WINDOW_MS: u64 = 10_000;
+/// Safety net on the recent-spawn ring; only the time window is load-bearing.
+const RECENT_SPAWNS_CAP: usize = 128;
+
+/// Child poll cadence while we are still waiting for a painted screen.
+const STARTUP_POLL: Duration = Duration::from_millis(250);
+/// Child poll cadence once the session is up (exit attribution only).
+const STEADY_POLL: Duration = Duration::from_secs(2);
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    match std::env::var(key) {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(value) => value,
+            Err(_) => {
+                log::warn!("[pty] ignoring non-numeric {key}='{raw}', using {default}");
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+pub fn stall_timeout() -> Duration {
+    static VALUE: OnceLock<Duration> = OnceLock::new();
+    *VALUE.get_or_init(|| {
+        Duration::from_millis(env_u64(
+            "AC_SPAWN_STALL_TIMEOUT_MS",
+            DEFAULT_STALL_TIMEOUT_MS,
+        ))
+    })
+}
+
+fn paint_floor() -> u64 {
+    static VALUE: OnceLock<u64> = OnceLock::new();
+    *VALUE.get_or_init(|| env_u64("AC_SPAWN_PAINT_FLOOR_BYTES", DEFAULT_PAINT_FLOOR_BYTES))
+}
+
+fn head_bytes() -> usize {
+    static VALUE: OnceLock<usize> = OnceLock::new();
+    *VALUE.get_or_init(|| env_u64("AC_SPAWN_HEAD_BYTES", DEFAULT_HEAD_BYTES) as usize)
+}
+
+fn concurrency_window() -> Duration {
+    static VALUE: OnceLock<Duration> = OnceLock::new();
+    *VALUE.get_or_init(|| {
+        Duration::from_millis(env_u64(
+            "AC_SPAWN_CONCURRENCY_WINDOW_MS",
+            DEFAULT_CONCURRENCY_WINDOW_MS,
+        ))
+    })
+}
+
+/// What AC knows about a child process at the instant we ask.
+#[derive(Debug, Clone)]
+pub enum ChildLiveness {
+    /// The child is running.
+    Alive,
+    /// The child has exited; we hold its status.
+    Exited {
+        code: u32,
+        success: bool,
+        status: String,
+    },
+    /// The poll itself failed.
+    Unknown(String),
+    /// No PTY instance for this session anymore (killed, or never inserted).
+    Gone,
+}
+
+impl ChildLiveness {
+    pub fn as_log(&self) -> String {
+        match self {
+            ChildLiveness::Alive => "alive".to_string(),
+            ChildLiveness::Exited { code, .. } => format!("exited({code})"),
+            ChildLiveness::Unknown(err) => format!("unknown({err})"),
+            ChildLiveness::Gone => "gone".to_string(),
+        }
+    }
+
+    fn exited_ok(&self) -> bool {
+        matches!(self, ChildLiveness::Exited { success: true, .. })
+    }
+}
+
+impl From<&ExitStatus> for ChildLiveness {
+    fn from(status: &ExitStatus) -> Self {
+        ChildLiveness::Exited {
+            code: status.exit_code(),
+            success: status.success(),
+            status: format!("{status:?}"),
+        }
+    }
+}
+
+/// Who ended the child. The whole point of #942's requirement 3: an AC-initiated
+/// stop (session destroy, job terminate, resource-monitor kill_group) can never be
+/// confused with a child that died on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitCause {
+    AcRequested,
+    ChildInitiated,
+}
+
+impl ExitCause {
+    pub fn as_log(self) -> &'static str {
+        match self {
+            ExitCause::AcRequested => "ac-requested",
+            ExitCause::ChildInitiated => "child-initiated",
+        }
+    }
+}
+
+/// How busy the spawner was just before this spawn. Correlates a hang with
+/// concurrent startups against the same shared agent state (e.g. `~/.codex`).
+#[derive(Debug, Clone, Copy)]
+pub struct SpawnWindow {
+    pub window_ms: u64,
+    pub total: usize,
+    pub same_agent: usize,
+}
+
+pub struct SpawnRecordInit {
+    pub session_id: Uuid,
+    pub pid: Option<u32>,
+    /// The argv as executed, including any `cmd.exe /C` wrapper AC added.
+    pub argv: Vec<String>,
+    pub cwd: String,
+    pub agent_id: Option<String>,
+    /// Effective `CODEX_HOME` for the child (configured, inherited, or removed).
+    pub codex_home: Option<String>,
+    pub configured_env_count: usize,
+    pub removed_env_count: usize,
+    pub window: SpawnWindow,
+    /// Taken immediately before the child was spawned; time zero for first-output.
+    pub started: Instant,
+}
+
+pub struct SpawnRecord {
+    session_id: Uuid,
+    pid: Option<u32>,
+    argv: Vec<String>,
+    cwd: String,
+    agent_id: Option<String>,
+    codex_home: Option<String>,
+    configured_env_count: usize,
+    removed_env_count: usize,
+    window: SpawnWindow,
+    started: Instant,
+    /// Microseconds from spawn to the first byte; 0 means nothing read yet.
+    first_output_us: AtomicU64,
+    /// Microseconds from spawn to the first real output (past the paint floor);
+    /// 0 means the child has still painted nothing.
+    first_paint_us: AtomicU64,
+    bytes_read: AtomicU64,
+    head: Mutex<Vec<u8>>,
+    head_full: AtomicBool,
+    ac_stop: AtomicBool,
+    ac_stop_source: Mutex<Option<String>>,
+    stall_reported: AtomicBool,
+    exit_reported: AtomicBool,
+}
+
+impl SpawnRecord {
+    fn new(init: SpawnRecordInit) -> Self {
+        Self {
+            session_id: init.session_id,
+            pid: init.pid,
+            argv: init.argv,
+            cwd: init.cwd,
+            agent_id: init.agent_id,
+            codex_home: init.codex_home,
+            configured_env_count: init.configured_env_count,
+            removed_env_count: init.removed_env_count,
+            window: init.window,
+            started: init.started,
+            first_output_us: AtomicU64::new(0),
+            first_paint_us: AtomicU64::new(0),
+            bytes_read: AtomicU64::new(0),
+            head: Mutex::new(Vec::new()),
+            head_full: AtomicBool::new(false),
+            ac_stop: AtomicBool::new(false),
+            ac_stop_source: Mutex::new(None),
+            stall_reported: AtomicBool::new(false),
+            exit_reported: AtomicBool::new(false),
+        }
+    }
+
+    pub fn session_id(&self) -> Uuid {
+        self.session_id
+    }
+
+    fn agent_log(&self) -> &str {
+        self.agent_id.as_deref().unwrap_or("none")
+    }
+
+    fn codex_home_log(&self) -> &str {
+        self.codex_home.as_deref().unwrap_or("unset")
+    }
+
+    fn pid_log(&self) -> String {
+        match self.pid {
+            Some(pid) => pid.to_string(),
+            None => "unknown".to_string(),
+        }
+    }
+
+    pub fn saw_output(&self) -> bool {
+        self.first_output_us.load(Ordering::Relaxed) != 0
+    }
+
+    pub fn painted(&self) -> bool {
+        self.first_paint_us.load(Ordering::Relaxed) != 0
+    }
+
+    fn ms_log(stamp_us: &AtomicU64) -> String {
+        match stamp_us.load(Ordering::Relaxed) {
+            0 => "none".to_string(),
+            us => (us / 1_000).to_string(),
+        }
+    }
+
+    pub fn stop_requested(&self) -> bool {
+        self.ac_stop.load(Ordering::Relaxed)
+    }
+
+    fn stop_source(&self) -> String {
+        self.ac_stop_source
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .unwrap_or_else(|| "none".to_string())
+    }
+
+    /// Poll fast while the child still owes us a painted screen, slowly afterwards.
+    pub fn in_startup_phase(&self) -> bool {
+        !self.painted() && !self.stall_reported.load(Ordering::Relaxed)
+    }
+
+    fn mark_ac_stop(&self, source: &str) {
+        {
+            let mut current = self.ac_stop_source.lock().unwrap_or_else(|e| e.into_inner());
+            if current.is_none() {
+                *current = Some(source.to_string());
+            }
+        }
+        self.ac_stop.store(true, Ordering::SeqCst);
+    }
+
+    /// The child is dead or on its way out. ConPTY repaints the master while a
+    /// session is torn down, so anything read past this point belongs to the teardown,
+    /// not to the child, and must not land in the record.
+    fn torn_down(&self) -> bool {
+        self.exit_reported.load(Ordering::Relaxed) || self.stop_requested()
+    }
+
+    /// Hot path: called for every chunk read off the PTY. After the first paint and
+    /// a full head buffer it costs one relaxed add plus a handful of relaxed loads.
+    pub fn note_output(&self, chunk: &[u8]) {
+        if chunk.is_empty() || self.torn_down() {
+            return;
+        }
+        let total = self
+            .bytes_read
+            .fetch_add(chunk.len() as u64, Ordering::Relaxed)
+            + chunk.len() as u64;
+
+        // Both stamps are one-shot, so a settled session never reads the clock here.
+        let needs_first = self.first_output_us.load(Ordering::Relaxed) == 0;
+        let needs_paint =
+            self.first_paint_us.load(Ordering::Relaxed) == 0 && total >= paint_floor();
+
+        if needs_first || needs_paint {
+            let elapsed = self.started.elapsed();
+            // 0 is the "nothing yet" sentinel for both stamps, so never store it.
+            let stamp = (elapsed.as_micros().min(u64::MAX as u128) as u64).max(1);
+
+            // The first byte off the PTY. On Windows this is ConPTY greeting us, not
+            // the child, which is why it is DEBUG and never taken as proof of life.
+            if needs_first
+                && self
+                    .first_output_us
+                    .compare_exchange(0, stamp, Ordering::SeqCst, Ordering::Relaxed)
+                    .is_ok()
+            {
+                log::debug!(
+                    "[pty] first-output session={} pid={} agent={} after_ms={} bytes={}",
+                    self.session_id,
+                    self.pid_log(),
+                    self.agent_log(),
+                    elapsed.as_millis(),
+                    total
+                );
+            }
+
+            // The first real output: the child actually painted something. This is the
+            // healthy-startup signal, and its absence is the hang.
+            if needs_paint
+                && self
+                    .first_paint_us
+                    .compare_exchange(0, stamp, Ordering::SeqCst, Ordering::Relaxed)
+                    .is_ok()
+            {
+                // Only a stall we actually reported can be recovered from.
+                if self.stall_reported.load(Ordering::Relaxed) {
+                    log::warn!(
+                        "[pty] first-paint session={} pid={} agent={} after_ms={} bytes={} late=true (startup stall recovered)",
+                        self.session_id,
+                        self.pid_log(),
+                        self.agent_log(),
+                        elapsed.as_millis(),
+                        total
+                    );
+                } else {
+                    log::info!(
+                        "[pty] first-paint session={} pid={} agent={} after_ms={} bytes={}",
+                        self.session_id,
+                        self.pid_log(),
+                        self.agent_log(),
+                        elapsed.as_millis(),
+                        total
+                    );
+                }
+            }
+        }
+
+        if !self.head_full.load(Ordering::Relaxed) {
+            self.capture_head(chunk);
+        }
+    }
+
+    fn capture_head(&self, chunk: &[u8]) {
+        let cap = head_bytes();
+        let mut head = self.head.lock().unwrap_or_else(|e| e.into_inner());
+        if head.len() >= cap {
+            self.head_full.store(true, Ordering::Relaxed);
+            return;
+        }
+        let take = (cap - head.len()).min(chunk.len());
+        head.extend_from_slice(&chunk[..take]);
+        if head.len() >= cap {
+            self.head_full.store(true, Ordering::Relaxed);
+        }
+    }
+
+    fn head_log(&self) -> String {
+        let head = self.head.lock().unwrap_or_else(|e| e.into_inner());
+        if head.is_empty() {
+            return "<empty>".to_string();
+        }
+        format!("\"{}\"", String::from_utf8_lossy(&head).escape_debug())
+    }
+
+    /// True once the child has had its whole startup window and still produced no
+    /// output at all (any session), or nothing past the ConPTY handshake (coding-agent
+    /// sessions, which always paint a TUI). Never fires when the check is disabled.
+    pub fn startup_stalled(&self) -> bool {
+        let timeout = stall_timeout();
+        if timeout.is_zero() || self.stall_reported.load(Ordering::Relaxed) {
+            return false;
+        }
+        if self.started.elapsed() < timeout {
+            return false;
+        }
+        let bytes = self.bytes_read.load(Ordering::Relaxed);
+        bytes == 0 || (self.agent_id.is_some() && !self.painted())
+    }
+
+    /// Requirement 2 + 4: the startup stall event. Emitted at most once.
+    pub fn log_startup_stall(&self, liveness: &ChildLiveness) {
+        if self.stall_reported.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        log::warn!(
+            "[pty] startup-stall session={} pid={} agent={} backend=local child={} elapsed_ms={} threshold_ms={} bytes_read={} paint_floor={} first_output_ms={} argv={:?} cwd={} codex_home={} recent_spawns={} recent_same_agent={} window_ms={} head={}",
+            self.session_id,
+            self.pid_log(),
+            self.agent_log(),
+            liveness.as_log(),
+            self.started.elapsed().as_millis(),
+            stall_timeout().as_millis(),
+            self.bytes_read.load(Ordering::Relaxed),
+            paint_floor(),
+            Self::ms_log(&self.first_output_us),
+            self.argv,
+            self.cwd,
+            self.codex_home_log(),
+            self.window.total,
+            self.window.same_agent,
+            self.window.window_ms,
+            self.head_log()
+        );
+    }
+
+    /// Requirement 3 + 4: the one exit event for this session. Returns false when
+    /// another path already reported the exit (the caller may log a debug crumb).
+    pub fn log_child_exit(&self, cause: ExitCause, liveness: &ChildLiveness, detail: &str) -> bool {
+        if self.exit_reported.swap(true, Ordering::SeqCst) {
+            return false;
+        }
+        let uptime = self.started.elapsed();
+        let first_output_ms = Self::ms_log(&self.first_output_us);
+        let first_paint_ms = Self::ms_log(&self.first_paint_us);
+        let bytes = self.bytes_read.load(Ordering::Relaxed);
+        // A child that ends itself without ever painting a screen, or with a failing
+        // status, is the #942 smoking gun. A clean exit from a session that did come up
+        // is just someone quitting.
+        let unexpected =
+            cause == ExitCause::ChildInitiated && (!self.painted() || !liveness.exited_ok());
+
+        if unexpected {
+            log::warn!(
+                "[pty] child-exit session={} pid={} agent={} cause={} detail={} child={} uptime_ms={} first_output_ms={} first_paint_ms={} bytes_read={} argv={:?} cwd={} codex_home={} recent_spawns={} recent_same_agent={} window_ms={} head={}",
+                self.session_id,
+                self.pid_log(),
+                self.agent_log(),
+                cause.as_log(),
+                detail,
+                liveness.as_log(),
+                uptime.as_millis(),
+                first_output_ms,
+                first_paint_ms,
+                bytes,
+                self.argv,
+                self.cwd,
+                self.codex_home_log(),
+                self.window.total,
+                self.window.same_agent,
+                self.window.window_ms,
+                self.head_log()
+            );
+        } else {
+            log::info!(
+                "[pty] child-exit session={} pid={} agent={} cause={} detail={} child={} stop_source={} uptime_ms={} first_output_ms={} first_paint_ms={} bytes_read={}",
+                self.session_id,
+                self.pid_log(),
+                self.agent_log(),
+                cause.as_log(),
+                detail,
+                liveness.as_log(),
+                self.stop_source(),
+                uptime.as_millis(),
+                first_output_ms,
+                first_paint_ms,
+                bytes
+            );
+        }
+        true
+    }
+
+    /// Requirement 1: the full spawn record, one line, on every local spawn.
+    fn log_spawn(&self) {
+        log::info!(
+            "[pty] spawn-record session={} pid={} agent={} backend=local argv={:?} cwd={} codex_home={} env_configured={} env_removed={} recent_spawns={} recent_same_agent={} window_ms={}",
+            self.session_id,
+            self.pid_log(),
+            self.agent_log(),
+            self.argv,
+            self.cwd,
+            self.codex_home_log(),
+            self.configured_env_count,
+            self.removed_env_count,
+            self.window.total,
+            self.window.same_agent,
+            self.window.window_ms
+        );
+    }
+}
+
+#[derive(Default)]
+struct Registry {
+    records: HashMap<Uuid, Arc<SpawnRecord>>,
+    recent: VecDeque<(Instant, Option<String>)>,
+}
+
+fn registry() -> &'static Mutex<Registry> {
+    static REGISTRY: OnceLock<Mutex<Registry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(Registry::default()))
+}
+
+/// Requirement 5: count the spawns that happened in the window BEFORE this one,
+/// then record this attempt. Call once per spawn, at the top of the spawn path.
+pub fn note_spawn_attempt(agent_id: Option<&str>) -> SpawnWindow {
+    let window = concurrency_window();
+    let now = Instant::now();
+    let mut registry = registry().lock().unwrap_or_else(|e| e.into_inner());
+
+    while let Some((at, _)) = registry.recent.front() {
+        if now.duration_since(*at) > window {
+            registry.recent.pop_front();
+        } else {
+            break;
+        }
+    }
+
+    let total = registry.recent.len();
+    let same_agent = match agent_id {
+        Some(id) => registry
+            .recent
+            .iter()
+            .filter(|(_, recent_agent)| recent_agent.as_deref() == Some(id))
+            .count(),
+        None => 0,
+    };
+
+    registry
+        .recent
+        .push_back((now, agent_id.map(|id| id.to_string())));
+    if registry.recent.len() > RECENT_SPAWNS_CAP {
+        registry.recent.pop_front();
+    }
+
+    SpawnWindow {
+        window_ms: window.as_millis().min(u64::MAX as u128) as u64,
+        total,
+        same_agent,
+    }
+}
+
+/// Register a spawned child and emit its spawn record.
+pub fn register(init: SpawnRecordInit) -> Arc<SpawnRecord> {
+    let record = Arc::new(SpawnRecord::new(init));
+    record.log_spawn();
+    registry()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .records
+        .insert(record.session_id, Arc::clone(&record));
+    record
+}
+
+/// Tag a session's child as stopped by AC (session kill, job terminate,
+/// resource-monitor kill_group) BEFORE any process is touched, so its exit can
+/// never be misread as a spontaneous death. No-op for unknown sessions.
+pub fn mark_ac_stop(session_id: Uuid, source: &str) -> Option<Arc<SpawnRecord>> {
+    let record = registry()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .records
+        .get(&session_id)
+        .cloned()?;
+    record.mark_ac_stop(source);
+    Some(record)
+}
+
+pub fn forget(session_id: Uuid) {
+    registry()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .records
+        .remove(&session_id);
+}
+
+/// One monitor thread per local session. It owns two signals: the startup stall
+/// WARN, and exit attribution for a child that dies without AC asking (the PTY
+/// reader cannot be trusted for that on ConPTY, which keeps the pipe open).
+/// It ends when the child exits or the session's PTY instance is gone.
+pub fn watch_child<P>(record: Arc<SpawnRecord>, probe: P)
+where
+    P: Fn() -> ChildLiveness + Send + 'static,
+{
+    std::thread::spawn(move || loop {
+        let tick = if record.in_startup_phase() {
+            STARTUP_POLL
+        } else {
+            STEADY_POLL
+        };
+        std::thread::sleep(tick);
+
+        let liveness = probe();
+        match liveness {
+            ChildLiveness::Gone => return,
+            ChildLiveness::Exited { .. } => {
+                let cause = if record.stop_requested() {
+                    ExitCause::AcRequested
+                } else {
+                    ExitCause::ChildInitiated
+                };
+                record.log_child_exit(cause, &liveness, "observed-by-monitor");
+                return;
+            }
+            ChildLiveness::Alive | ChildLiveness::Unknown(_) => {
+                if record.startup_stalled() {
+                    record.log_startup_stall(&liveness);
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_record(agent_id: Option<&str>) -> SpawnRecord {
+        SpawnRecord::new(SpawnRecordInit {
+            session_id: Uuid::new_v4(),
+            pid: Some(4242),
+            argv: vec!["codex".to_string(), "resume".to_string()],
+            cwd: "C:/repo".to_string(),
+            agent_id: agent_id.map(|id| id.to_string()),
+            codex_home: None,
+            configured_env_count: 0,
+            removed_env_count: 0,
+            window: SpawnWindow {
+                window_ms: 10_000,
+                total: 0,
+                same_agent: 0,
+            },
+            started: Instant::now(),
+        })
+    }
+
+    #[test]
+    fn head_capture_is_capped_and_stops_after_full() {
+        let record = test_record(Some("codex"));
+        let cap = head_bytes();
+        record.note_output(&vec![b'a'; cap + 64]);
+        record.note_output(b"ignored");
+
+        let head = record.head.lock().unwrap();
+        assert_eq!(head.len(), cap);
+        assert!(head.iter().all(|b| *b == b'a'));
+        assert!(record.head_full.load(Ordering::Relaxed));
+        assert_eq!(
+            record.bytes_read.load(Ordering::Relaxed),
+            (cap + 64 + 7) as u64
+        );
+    }
+
+    #[test]
+    fn first_output_stamp_is_recorded_once() {
+        let record = test_record(None);
+        assert!(!record.saw_output());
+
+        record.note_output(b"hello");
+        let first = record.first_output_us.load(Ordering::Relaxed);
+        record.note_output(b" world");
+
+        assert!(record.saw_output());
+        assert_eq!(record.first_output_us.load(Ordering::Relaxed), first);
+        assert_eq!(record.bytes_read.load(Ordering::Relaxed), 11);
+    }
+
+    #[test]
+    fn paint_is_stamped_once_the_output_passes_the_floor() {
+        let record = test_record(Some("codex"));
+
+        // The ConPTY handshake alone is not a paint.
+        record.note_output(b"\x1b[?9001h\x1b[?1004h");
+        assert!(record.saw_output());
+        assert!(!record.painted());
+
+        record.note_output(&vec![b'x'; paint_floor() as usize]);
+        assert!(record.painted());
+        let painted_at = record.first_paint_us.load(Ordering::Relaxed);
+
+        record.note_output(b"more");
+        assert_eq!(
+            record.first_paint_us.load(Ordering::Relaxed),
+            painted_at,
+            "the paint stamp is taken once"
+        );
+    }
+
+    #[test]
+    fn silent_child_stalls_only_after_the_threshold() {
+        let record = test_record(Some("codex"));
+        assert!(!record.startup_stalled(), "not yet past the threshold");
+
+        let record = SpawnRecord {
+            started: Instant::now() - stall_timeout() - Duration::from_millis(1),
+            ..test_record(Some("codex"))
+        };
+        assert!(record.startup_stalled());
+
+        record.log_startup_stall(&ChildLiveness::Alive);
+        assert!(
+            !record.startup_stalled(),
+            "the stall event is emitted at most once"
+        );
+    }
+
+    #[test]
+    fn plain_shell_prompt_is_not_a_stall_but_a_silent_agent_is() {
+        let shell = SpawnRecord {
+            started: Instant::now() - stall_timeout() - Duration::from_millis(1),
+            ..test_record(None)
+        };
+        shell.note_output(b"C:\\repo>");
+        assert!(
+            !shell.startup_stalled(),
+            "a tiny shell prompt is a healthy start"
+        );
+
+        // Exactly what a hung Codex leaves behind on Windows: the ConPTY handshake
+        // and not one byte more.
+        let agent = SpawnRecord {
+            started: Instant::now() - stall_timeout() - Duration::from_millis(1),
+            ..test_record(Some("codex"))
+        };
+        agent.note_output(b"\x1b[?9001h\x1b[?1004h");
+        assert!(
+            agent.saw_output(),
+            "ConPTY greets us even when the child never does"
+        );
+        assert!(
+            agent.startup_stalled(),
+            "a coding agent that never paints its TUI is stalled"
+        );
+
+        let painted = SpawnRecord {
+            started: Instant::now() - stall_timeout() - Duration::from_millis(1),
+            ..test_record(Some("codex"))
+        };
+        painted.note_output(&vec![b'x'; paint_floor() as usize]);
+        assert!(
+            !painted.startup_stalled(),
+            "a coding agent that painted its TUI is healthy"
+        );
+    }
+
+    #[test]
+    fn exit_is_reported_once_and_carries_its_cause() {
+        let record = test_record(Some("codex"));
+        let liveness = ChildLiveness::Exited {
+            code: 1,
+            success: false,
+            status: "ExitStatus { code: 1 }".to_string(),
+        };
+
+        assert!(record.log_child_exit(ExitCause::ChildInitiated, &liveness, "observed-by-monitor"));
+        assert!(
+            !record.log_child_exit(ExitCause::AcRequested, &liveness, "reaped-after-stop"),
+            "a second exit report must be suppressed"
+        );
+    }
+
+    #[test]
+    fn ac_stop_keeps_the_first_source_and_flags_the_record() {
+        let record = test_record(Some("codex"));
+        assert!(!record.stop_requested());
+
+        record.mark_ac_stop("watchdog");
+        record.mark_ac_stop("session-kill");
+
+        assert!(record.stop_requested());
+        assert_eq!(record.stop_source(), "watchdog");
+    }
+
+    #[test]
+    fn spawn_window_counts_only_the_preceding_spawns() {
+        let agent = format!("codex-{}", Uuid::new_v4());
+        let first = note_spawn_attempt(Some(&agent));
+        let second = note_spawn_attempt(Some(&agent));
+        let third = note_spawn_attempt(Some("other-agent"));
+
+        assert_eq!(first.same_agent, 0);
+        assert_eq!(second.same_agent, 1);
+        assert_eq!(third.same_agent, 0);
+        assert!(second.total >= 1);
+        assert!(third.total >= 2);
+        assert_eq!(first.window_ms, concurrency_window().as_millis() as u64);
+    }
+
+    #[test]
+    fn registry_forgets_a_session() {
+        let record = register(SpawnRecordInit {
+            session_id: Uuid::new_v4(),
+            pid: None,
+            argv: vec!["cmd.exe".to_string()],
+            cwd: "C:/repo".to_string(),
+            agent_id: None,
+            codex_home: None,
+            configured_env_count: 0,
+            removed_env_count: 0,
+            window: SpawnWindow {
+                window_ms: 10_000,
+                total: 0,
+                same_agent: 0,
+            },
+            started: Instant::now(),
+        });
+        let id = record.session_id();
+
+        assert!(mark_ac_stop(id, "session-kill").is_some());
+        forget(id);
+        assert!(mark_ac_stop(id, "session-kill").is_none());
+    }
+}

--- a/src-tauri/src/pty/spawn_diagnostics.rs
+++ b/src-tauri/src/pty/spawn_diagnostics.rs
@@ -114,13 +114,21 @@ const DEFAULT_STOP_ATTRIBUTION_MS: u64 = 60_000;
 const MAX_STOP_ATTRIBUTION_MS: u64 = 60 * 60 * 1_000;
 /// Safety net on the recent-spawn ring; only the time window is load-bearing.
 const RECENT_SPAWNS_CAP: usize = 128;
-/// Values shorter than this are not secrets, they are flags like `1` or `true`.
-const MIN_REDACTED_LEN: usize = 8;
 /// Env keys whose VALUE is a secret and must never reach the log. Keyed on the name, not
 /// swept over every value: a coding-agent profile legitimately carries rows like
 /// `MODEL=gpt-5.6-sol`, and blanking those would shred the argv this module exists to
 /// record, and the Codex error text inside `head=`.
-const SECRET_KEY_MARKERS: &[&str] = &["token", "key", "secret", "password", "passwd", "credential"];
+const SECRET_KEY_MARKERS: &[&str] = &[
+    "token",
+    "key",
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+    // `AUTHORIZATION=Bearer sk-...` is a secret and neither the other markers nor the
+    // URL-shape redactor catches it.
+    "auth",
+];
 
 /// True when an env row's value must be redacted out of anything we echo into the log.
 /// AC's own credential env is covered by this: the only secret it carries is
@@ -128,7 +136,23 @@ const SECRET_KEY_MARKERS: &[&str] = &["token", "key", "secret", "password", "pas
 /// secrets and which we deliberately print in `cwd=` / `argv=`).
 pub fn is_secret_env_key(key: &str) -> bool {
     let key = key.to_ascii_lowercase();
-    SECRET_KEY_MARKERS.iter().any(|marker| key.contains(marker))
+    if SECRET_KEY_MARKERS.iter().any(|marker| key.contains(marker)) {
+        return true;
+    }
+    // A personal access token (`GH_PAT`). Matched as a whole segment, never as a
+    // substring: `PATH`, `PATHEXT` and `COMPATIBILITY` all contain "pat", and blanking a
+    // PATH across the log would shred every path in the evidence.
+    key.split(|c: char| !c.is_ascii_alphanumeric())
+        .any(|segment| segment == "pat")
+}
+
+/// A value from a secret-named row is redacted whatever its length: an explicitly named
+/// `*_TOKEN` row is a secret even when it is short. The one exclusion is a purely numeric
+/// value, because `MAX_TOKENS=8192` and `TOKEN_LIMIT=4096` are real config rows, and
+/// blanking `8192` everywhere it appears would corrupt the evidence while protecting
+/// nothing.
+fn is_redactable_value(value: &str) -> bool {
+    !value.trim().is_empty() && !value.chars().all(|c| c.is_ascii_digit())
 }
 
 /// Everything the diagnostics need to be told, resolved once from the environment and
@@ -360,7 +384,7 @@ impl SpawnRecord {
             redact: init
                 .redact
                 .into_iter()
-                .filter(|value| value.len() >= MIN_REDACTED_LEN)
+                .filter(|value| is_redactable_value(value))
                 .collect(),
             window: init.window,
             started: init.started,
@@ -542,30 +566,61 @@ impl SpawnRecord {
         !self.startup_reported.load(Ordering::Relaxed)
     }
 
-    /// LAST-wins, deliberately. AC supports a stop that FAILS (a Quarantined kill leaves
-    /// the agent running), and a first-wins anchor would let that stale stop own the
-    /// attribution of the real one minutes later: the user closes the session, we kill it,
-    /// and the window measured from the dead stop calls our own kill `child-initiated`.
-    /// That is a fabricated smoking gun, which is exactly what #942 exists to remove. The
-    /// window is therefore measured from the MOST RECENT stop request.
+    /// A stop AC asked for that still owns the child: the flag is set and it is inside
+    /// the attribution window. A stop older than that evidently failed (a Quarantined kill
+    /// leaves the agent running), so the next stop opens a NEW episode.
+    fn stop_episode_open(&self) -> bool {
+        self.stop_requested() && self.stop_cause() == ExitCause::AcRequested
+    }
+
+    /// Timestamp and source are LAST-wins: the attribution window must be measured from
+    /// the stop that actually landed, not from a stale one that failed. The WITNESS is the
+    /// opposite: it is the EARLIEST probe of the current stop episode, never the latest.
     ///
-    /// The witness is upgraded, never downgraded: a fresher probe replaces an older one,
-    /// and a witness-less stop (the resource-monitor watchdog) leaves a witness that a
-    /// real probe already established. A witness that said `Exited` stays true forever: a
-    /// dead child does not come back.
+    /// Once AC has begun stopping a child, a probe is not a witness, it is a photograph of
+    /// our own kill. On the destroy path the resource monitor `TerminateProcess`es the PTY
+    /// child (its process tree includes the root) BEFORE `PtyBackend::kill` ever probes it,
+    /// so a "latest wins" witness would see `Exited(1)`, conclude the child died on its
+    /// own, and stamp a WARN with the full evidence dump on **every closed coding-agent
+    /// tab**. That is requirement 3 inverted on the most common path in the app.
+    ///
+    /// So: a stop already in flight keeps the witness it published (or the absence of one:
+    /// the watchdog publishes none, and a later probe of the corpse it made is no better).
+    /// A new episode takes a fresh probe, because the child may have survived the last stop
+    /// and its state now is genuinely unknown. And a witness that saw the child dead is
+    /// sticky forever, because a dead child does not come back and no later `Gone` or
+    /// `Unqueryable` from a racing second kill can improve on it.
     fn mark_ac_stop(&self, source: &str, pre_stop: Option<ChildLiveness>) {
+        // Read the episode state BEFORE the timestamp below refreshes it.
+        let episode_open = self.stop_episode_open();
+        self.record_witness(pre_stop, episode_open);
+
         *self.ac_stop_source.lock().unwrap_or_else(|e| e.into_inner()) = Some(source.to_string());
-        if let Some(pre_stop) = pre_stop {
-            *self
-                .pre_stop_liveness
-                .lock()
-                .unwrap_or_else(|e| e.into_inner()) = Some(pre_stop);
-        }
         let stamp = (self.started.elapsed().as_micros().min(u64::MAX as u128) as u64).max(1);
         self.ac_stop_at_us.store(stamp, Ordering::SeqCst);
         // Published last: any thread that sees this flag also sees the source, the
         // timestamp and the pre-stop liveness written above.
         self.ac_stop.store(true, Ordering::SeqCst);
+    }
+
+    fn record_witness(&self, pre_stop: Option<ChildLiveness>, episode_open: bool) {
+        let Some(pre_stop) = pre_stop else {
+            // A witness-less stop (the resource-monitor watchdog) never blanks a witness a
+            // real probe already established.
+            return;
+        };
+        let mut current = self
+            .pre_stop_liveness
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        match current.as_ref() {
+            // Sticky: a dead child does not come back.
+            Some(ChildLiveness::Exited { .. }) => {}
+            // An open episode keeps what it has, including nothing at all.
+            _ if episode_open => {}
+            // A new episode: the child may have outlived the last stop, so ask again.
+            _ => *current = Some(pre_stop),
+        }
     }
 
     /// A stop AC asked for, recent enough that the teardown it triggers is still in
@@ -1242,14 +1297,81 @@ mod tests {
     }
 
     #[test]
-    fn ac_stop_takes_the_most_recent_source_timestamp_and_witness() {
-        // grinch D2: first-wins let a stale, failed stop own every later stop.
+    fn closing_a_coding_agent_tab_is_never_reported_as_a_spontaneous_death() {
+        // grinch B1, the chain that ships on EVERY closed Codex tab:
+        //   1. destroy_session publishes the witness: the child is Alive.
+        //   2. kill_group TerminateProcess()es the process tree. Its root IS the PTY
+        //      child, so the child is now dead with exit code 1.
+        //   3. PtyBackend::kill probes that corpse and marks the stop again.
+        // A "latest wins" witness takes the corpse as evidence that the child died on its
+        // own, and log_child_exit then stamps WARN + argv + head on it, because
+        // `exited(1)` is not a clean exit. That is requirement 3 inverted on the most
+        // common path in the app, and `exited(1)` is literally the ExitStatus string from
+        // the log trap this issue exists to kill.
+        let record = test_record(Some(CodingAgentKind::Codex));
+        record.note_output(&[b'x'; 200]); // it came up fine
+
+        record.mark_ac_stop("session-destroy", Some(ChildLiveness::Alive));
+        record.mark_ac_stop(
+            "session-kill",
+            Some(ChildLiveness::Exited {
+                code: 1,
+                success: false,
+            }),
+        );
+
+        assert_eq!(
+            record.attribute_exit(record.stop_snapshot()),
+            ExitCause::AcRequested,
+            "a probe taken after AC has begun killing is not a witness, it is a photograph of our own kill"
+        );
+        assert!(
+            matches!(record.pre_stop_liveness(), Some(ChildLiveness::Alive)),
+            "the earliest probe of the stop episode is the witness"
+        );
+        assert_eq!(
+            record.stop_source(),
+            "session-kill",
+            "source and timestamp stay last-wins; only the witness is first-wins"
+        );
+    }
+
+    #[test]
+    fn ac_stop_takes_the_most_recent_source_and_timestamp() {
+        // grinch D2: first-wins timestamps let a stale, failed stop own every later stop.
         let record = test_record(Some(CodingAgentKind::Codex));
         assert!(!record.stop_requested());
 
         record.mark_ac_stop("job-terminate", Some(ChildLiveness::Alive));
         let first_stamp = record.ac_stop_at_us.load(Ordering::SeqCst);
         std::thread::sleep(Duration::from_millis(5));
+        record.mark_ac_stop("session-kill", None);
+
+        assert!(record.stop_requested());
+        assert_eq!(record.stop_source(), "session-kill");
+        assert!(
+            record.ac_stop_at_us.load(Ordering::SeqCst) > first_stamp,
+            "the attribution window is measured from the most recent stop"
+        );
+    }
+
+    #[test]
+    fn a_new_stop_episode_takes_a_fresh_witness() {
+        // The counterpart to B1: the witness is first-wins WITHIN an episode, not forever.
+        // A stop that failed leaves the child running, so the next stop must look again.
+        let record = SpawnRecord {
+            thresholds: Thresholds {
+                stop_attribution: Duration::from_millis(30),
+                ..test_thresholds()
+            },
+            ..test_record(Some(CodingAgentKind::Codex))
+        };
+
+        // A blocked RM kill: the agent keeps running.
+        record.mark_ac_stop("job-terminate", Some(ChildLiveness::Alive));
+        std::thread::sleep(Duration::from_millis(45));
+
+        // Much later the child dies on its own, and only then does the user close the tab.
         record.mark_ac_stop(
             "session-kill",
             Some(ChildLiveness::Exited {
@@ -1258,18 +1380,49 @@ mod tests {
             }),
         );
 
-        assert!(record.stop_requested());
-        assert_eq!(record.stop_source(), "session-kill");
-        assert!(
-            record.ac_stop_at_us.load(Ordering::SeqCst) > first_stamp,
-            "the attribution window is measured from the most recent stop"
+        assert_eq!(
+            record.attribute_exit(record.stop_snapshot()),
+            ExitCause::ChildInitiated,
+            "the stale stop did not kill it, and it was already dead when we asked again"
         );
+    }
+
+    #[test]
+    fn a_witness_that_saw_the_child_dead_can_never_be_downgraded() {
+        // grinch B2: `LocalProcessBackend::kill` is reachable twice concurrently (the
+        // blocking-spawn cancel guard fires it directly), and the second probe lands after
+        // `ptys.remove` and returns `Gone`. A real death must not be blanked by it.
+        let record = SpawnRecord {
+            thresholds: Thresholds {
+                stop_attribution: Duration::from_millis(1),
+                ..test_thresholds()
+            },
+            ..test_record(Some(CodingAgentKind::Codex))
+        };
+        record.mark_ac_stop(
+            "session-kill",
+            Some(ChildLiveness::Exited {
+                code: 1,
+                success: false,
+            }),
+        );
+        std::thread::sleep(Duration::from_millis(5)); // even once the episode has expired
+        record.mark_ac_stop("session-kill", Some(ChildLiveness::Gone));
+        record.mark_ac_stop(
+            "session-kill",
+            Some(ChildLiveness::Unqueryable("os error 5".to_string())),
+        );
+
         assert!(
             matches!(
                 record.pre_stop_liveness(),
                 Some(ChildLiveness::Exited { .. })
             ),
-            "the fresher witness replaces the older one"
+            "a dead child does not come back"
+        );
+        assert_eq!(
+            record.attribute_exit(record.stop_snapshot()),
+            ExitCause::ChildInitiated
         );
     }
 
@@ -1442,12 +1595,50 @@ mod tests {
         assert!(is_secret_env_key("DB_PASSWORD"));
         assert!(is_secret_env_key("gh_secret"));
         assert!(is_secret_env_key("SERVICE_CREDENTIAL"));
+        assert!(is_secret_env_key("AUTHORIZATION"));
+        assert!(is_secret_env_key("CODEX_AUTH"));
+        assert!(is_secret_env_key("GH_PAT"));
+        assert!(is_secret_env_key("pat"));
 
         assert!(!is_secret_env_key("MODEL"));
         assert!(!is_secret_env_key("CODEX_HOME"));
         assert!(!is_secret_env_key("AGENTSCOMMANDER_ROOT"));
-        assert!(!is_secret_env_key("AGENTSCOMMANDER_BINARY_PATH"));
         assert!(!is_secret_env_key("NODE_ENV"));
+        // "pat" is a segment, never a substring: blanking a PATH across the log would
+        // shred every path in the evidence.
+        assert!(!is_secret_env_key("PATH"));
+        assert!(!is_secret_env_key("PATHEXT"));
+        assert!(!is_secret_env_key("AGENTSCOMMANDER_BINARY_PATH"));
+    }
+
+    #[test]
+    fn a_short_secret_from_a_secret_named_row_is_still_redacted() {
+        // The 8-char floor used to gate rows whose NAME already declares them a secret.
+        let record = SpawnRecord::new(SpawnRecordInit {
+            redact: vec!["sk-ab".to_string()],
+            ..test_init(Some(CodingAgentKind::Codex))
+        });
+        record.note_output(b"AUTHORIZATION=Bearer sk-ab\r\n");
+
+        let head = record.head_log();
+        assert!(!head.contains("sk-ab"), "short secret survived: {head}");
+        assert!(head.contains("<redacted>"));
+    }
+
+    #[test]
+    fn a_numeric_value_from_a_secret_named_row_is_a_config_knob_not_a_secret() {
+        // `MAX_TOKENS=8192` and `TOKEN_LIMIT=4096` are real rows whose NAME matches the
+        // secret markers. Blanking `8192` everywhere would corrupt the evidence and
+        // protect nothing.
+        let record = SpawnRecord::new(SpawnRecordInit {
+            argv: vec!["codex".to_string(), "--max-tokens=8192".to_string()],
+            redact: vec!["8192".to_string()],
+            ..test_init(Some(CodingAgentKind::Codex))
+        });
+        record.note_output(b"max_tokens=8192 loading\r\n");
+
+        assert!(record.head_log().contains("8192"));
+        assert!(record.argv_log().contains("8192"));
     }
 
     #[test]
@@ -1455,7 +1646,7 @@ mod tests {
         let token = "3f1c9d2e-7a4b-4c8d-9e1f-2b3c4d5e6f70";
         let record = SpawnRecord::new(SpawnRecordInit {
             argv: vec!["codex".to_string(), format!("--token={token}")],
-            redact: vec![token.to_string(), "x".to_string()],
+            redact: vec![token.to_string()],
             ..test_init(Some(CodingAgentKind::Codex))
         });
         record.note_output(format!("AGENTSCOMMANDER_TOKEN={token}\r\n").as_bytes());
@@ -1466,7 +1657,7 @@ mod tests {
         assert!(!record.argv_log().contains(token));
         assert!(
             record.head_log().contains("AGENTSCOMMANDER_TOKEN"),
-            "a one-character redaction entry must not shred the whole line"
+            "the rest of the line still has to be readable"
         );
     }
 

--- a/src-tauri/src/pty/spawn_diagnostics.rs
+++ b/src-tauri/src/pty/spawn_diagnostics.rs
@@ -2,117 +2,181 @@
 //!
 //! Diagnostics only. Nothing in this module changes how a session is spawned,
 //! killed or read; it only records evidence so an intermittent coding-agent
-//! blank-terminal hang explains itself after the fact:
+//! blank-terminal hang explains itself after the fact.
 //!
-//! 1. `[pty] spawn-record` - the argv AC actually executed, the resolved cwd,
-//!    the coding-agent id, the effective `CODEX_HOME`, and how many other
-//!    sessions were spawned in the preceding window (shared `~/.codex` contention).
-//! 2. `[pty] first-output` (DEBUG) - time from spawn to the first byte read off
-//!    the PTY, and `[pty] first-paint` (INFO) - time until the child produced
-//!    real output. Both are needed on Windows: ConPTY writes its own 16-byte
-//!    handshake (`ESC[?9001h ESC[?1004h`) into the PTY within ~20ms of every
-//!    spawn, child or no child, so the first byte is never evidence that the
-//!    child came up. Crossing the paint floor is.
-//! 3. `[pty] startup-stall` - WARN when the child produced nothing (or nothing
-//!    past the ConPTY handshake) within the threshold, with child liveness at
-//!    that moment.
-//! 4. `[pty] child-exit` - every child exit, tagged with an unambiguous cause:
-//!    `ac-requested` (we asked: session kill, job terminate, resource-monitor
-//!    kill_group) vs `child-initiated` (it died on its own).
-//! 5. The first N bytes the child ever wrote, replayed into the stall and the
-//!    unexpected-exit events, so an error message that never reached the screen
-//!    is still on record.
+//! ## Events
 //!
-//! Tunables (env vars, read once):
-//! - `AC_SPAWN_STALL_TIMEOUT_MS` (default 5000, `0` disables the stall check)
-//! - `AC_SPAWN_PAINT_FLOOR_BYTES` (default 64)
-//! - `AC_SPAWN_HEAD_BYTES` (default 512)
-//! - `AC_SPAWN_CONCURRENCY_WINDOW_MS` (default 10000)
+//! | Event | Level | When |
+//! |---|---|---|
+//! | `[pty] spawn-record` | INFO | once, at spawn: argv as executed, cwd, CLI, profile, `CODEX_HOME`, concurrency |
+//! | `[pty] first-output` | DEBUG | first byte off the PTY |
+//! | `[pty] first-paint` | INFO (WARN if it recovers a stall) | output passes the paint floor |
+//! | `[pty] startup-stall` | WARN | at the deadline, when the child never painted |
+//! | `[pty] startup-checkpoint` | INFO | at the deadline otherwise |
+//! | `[pty] child-exit` | INFO (WARN when unexpected) | once, when the child ends |
+//!
+//! The startup report (`startup-stall` / `startup-checkpoint`) fires for **every**
+//! session at the deadline, whatever it painted and whoever launched it, and it always
+//! carries the retained head bytes. A hang that gets as far as entering the alt screen
+//! and clearing it (easily past the paint floor) would otherwise leave no trace at
+//! all, and "alt screen entered, nothing drawn" is exactly what a blank terminal looks
+//! like.
+//!
+//! ## Two identities, and why the CLI one is load-bearing
+//!
+//! `cli=` is [`CodingAgentKind`], detected from the argv by the canonical detector
+//! (`session/profile.rs`). `agent_profile=` is the configured coding-agent profile id
+//! (`settings.agents[].id`), an opaque string like `agent_1782513272568_0`. They are
+//! not interchangeable: a Codex launch can carry no profile id at all
+//! (`commands/session.rs`, `is_agent_owned_launch`), and several distinct profiles can
+//! all run the `codex` CLI against the same global `~/.codex`. The stall predicate and
+//! the concurrency counter therefore key on the **CLI**; the profile id is logged
+//! beside it, never used as the identity.
+//!
+//! ## Windows caveats this module refuses to paper over
+//!
+//! - ConPTY writes its own 16-byte handshake (`ESC[?9001h ESC[?1004h`) into every PTY
+//!   within ~20ms of the spawn, child or no child. The first byte is therefore never
+//!   evidence that the child came up; crossing the paint floor is.
+//! - `portable_pty::Child::try_wait` cannot tell "running" from "we cannot query this
+//!   handle": `WinChild::is_complete` swallows a failed `GetExitCodeProcess` and
+//!   returns `Ok(None)`, and its `STILL_ACTIVE` sentinel (259) is also a legal exit
+//!   code. AV/EDR stripping query rights off our handles is a known scenario here
+//!   (#647). The Windows probe in `local_backend` therefore calls
+//!   `WaitForSingleObject` directly and reports [`ChildLiveness::Unqueryable`] when the
+//!   OS refuses to answer. The kill path still uses `try_wait`, so a child that exits
+//!   with code 259 stays invisible to it: an upstream limitation, documented here
+//!   rather than asserted away.
+//!
+//! ## Lock order
+//!
+//! `ptys` -> diagnostics registry (`kill_all_jobs` holds the PTY map while tagging
+//! records). Never the reverse: the monitor thread probes under `ptys` but only ever
+//! touches its own `Arc<SpawnRecord>`, never the registry.
+//!
+//! ## Tunables (env vars, read once, clamped)
+//!
+//! | Var | Default | Ceiling |
+//! |---|---|---|
+//! | `AC_SPAWN_STALL_TIMEOUT_MS` | 5000 (`0` disables the startup report) | 600000 |
+//! | `AC_SPAWN_PAINT_FLOOR_BYTES` | 64 | 65536 |
+//! | `AC_SPAWN_HEAD_BYTES` | 512 | 65536 |
+//! | `AC_SPAWN_CONCURRENCY_WINDOW_MS` | 10000 | 3600000 |
+//! | `AC_SPAWN_STOP_ATTRIBUTION_MS` | 60000 | 3600000 |
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use portable_pty::ExitStatus;
 use uuid::Uuid;
 
-/// No output within this window after spawn is a startup stall.
+use crate::session::profile::CodingAgentKind;
+
 const DEFAULT_STALL_TIMEOUT_MS: u64 = 5_000;
+const MAX_STALL_TIMEOUT_MS: u64 = 10 * 60 * 1_000;
 /// Output below this many bytes is not a painted screen; it is the ConPTY handshake
-/// (16 bytes) and nothing else. A coding agent paints a full TUI immediately, so a
-/// coding-agent session still under the floor at the stall deadline is the
-/// blank-terminal symptom. Plain shells are exempt from the stall check: a bare
-/// prompt is legitimately tiny.
+/// (16 bytes) and nothing else. A coding agent paints a full TUI immediately.
 const DEFAULT_PAINT_FLOOR_BYTES: u64 = 64;
-/// How much of the child's first output we retain for stall / early-exit reports.
+const MAX_PAINT_FLOOR_BYTES: u64 = 64 * 1024;
 const DEFAULT_HEAD_BYTES: u64 = 512;
-/// Window used to correlate a hang with concurrent startups on shared agent state.
+const MAX_HEAD_BYTES: u64 = 64 * 1024;
 const DEFAULT_CONCURRENCY_WINDOW_MS: u64 = 10_000;
+const MAX_CONCURRENCY_WINDOW_MS: u64 = 60 * 60 * 1_000;
+/// How long an AC stop request owns the exit that follows it. A resource-monitor kill
+/// can be blocked (a Quarantined result leaves the child running); a child that dies
+/// half an hour later died on its own, whatever we asked for back then.
+const DEFAULT_STOP_ATTRIBUTION_MS: u64 = 60_000;
+const MAX_STOP_ATTRIBUTION_MS: u64 = 60 * 60 * 1_000;
 /// Safety net on the recent-spawn ring; only the time window is load-bearing.
 const RECENT_SPAWNS_CAP: usize = 128;
+/// Values shorter than this are not secrets, they are flags like `1` or `true`.
+const MIN_REDACTED_LEN: usize = 8;
 
-/// Child poll cadence while we are still waiting for a painted screen.
-const STARTUP_POLL: Duration = Duration::from_millis(250);
-/// Child poll cadence once the session is up (exit attribution only).
-const STEADY_POLL: Duration = Duration::from_secs(2);
+/// Everything the diagnostics need to be told, resolved once from the environment and
+/// then carried by each record, so no code path (and no test) reads a process-global.
+#[derive(Debug, Clone, Copy)]
+pub struct Thresholds {
+    /// Deadline for the startup report. Zero disables it.
+    pub stall_timeout: Duration,
+    pub paint_floor: u64,
+    pub head_bytes: usize,
+    pub concurrency_window: Duration,
+    pub stop_attribution: Duration,
+    pub startup_poll: Duration,
+    pub steady_poll: Duration,
+}
 
-fn env_u64(key: &str, default: u64) -> u64 {
-    match std::env::var(key) {
-        Ok(raw) => match raw.trim().parse::<u64>() {
-            Ok(value) => value,
-            Err(_) => {
-                log::warn!("[pty] ignoring non-numeric {key}='{raw}', using {default}");
-                default
-            }
-        },
-        Err(_) => default,
+impl Thresholds {
+    pub const DEFAULT: Self = Self {
+        stall_timeout: Duration::from_millis(DEFAULT_STALL_TIMEOUT_MS),
+        paint_floor: DEFAULT_PAINT_FLOOR_BYTES,
+        head_bytes: DEFAULT_HEAD_BYTES as usize,
+        concurrency_window: Duration::from_millis(DEFAULT_CONCURRENCY_WINDOW_MS),
+        stop_attribution: Duration::from_millis(DEFAULT_STOP_ATTRIBUTION_MS),
+        startup_poll: Duration::from_millis(250),
+        steady_poll: Duration::from_secs(2),
+    };
+
+    /// Read once per process. Every value is clamped: a fat-fingered
+    /// `AC_SPAWN_HEAD_BYTES=1000000000` must not buy a 1 GB buffer per session.
+    pub fn from_env() -> Self {
+        static VALUE: OnceLock<Thresholds> = OnceLock::new();
+        *VALUE.get_or_init(|| Thresholds {
+            stall_timeout: Duration::from_millis(env_u64(
+                "AC_SPAWN_STALL_TIMEOUT_MS",
+                DEFAULT_STALL_TIMEOUT_MS,
+                MAX_STALL_TIMEOUT_MS,
+            )),
+            paint_floor: env_u64(
+                "AC_SPAWN_PAINT_FLOOR_BYTES",
+                DEFAULT_PAINT_FLOOR_BYTES,
+                MAX_PAINT_FLOOR_BYTES,
+            ),
+            head_bytes: env_u64("AC_SPAWN_HEAD_BYTES", DEFAULT_HEAD_BYTES, MAX_HEAD_BYTES) as usize,
+            concurrency_window: Duration::from_millis(env_u64(
+                "AC_SPAWN_CONCURRENCY_WINDOW_MS",
+                DEFAULT_CONCURRENCY_WINDOW_MS,
+                MAX_CONCURRENCY_WINDOW_MS,
+            )),
+            stop_attribution: Duration::from_millis(env_u64(
+                "AC_SPAWN_STOP_ATTRIBUTION_MS",
+                DEFAULT_STOP_ATTRIBUTION_MS,
+                MAX_STOP_ATTRIBUTION_MS,
+            )),
+            ..Thresholds::DEFAULT
+        })
     }
 }
 
-pub fn stall_timeout() -> Duration {
-    static VALUE: OnceLock<Duration> = OnceLock::new();
-    *VALUE.get_or_init(|| {
-        Duration::from_millis(env_u64(
-            "AC_SPAWN_STALL_TIMEOUT_MS",
-            DEFAULT_STALL_TIMEOUT_MS,
-        ))
-    })
-}
-
-fn paint_floor() -> u64 {
-    static VALUE: OnceLock<u64> = OnceLock::new();
-    *VALUE.get_or_init(|| env_u64("AC_SPAWN_PAINT_FLOOR_BYTES", DEFAULT_PAINT_FLOOR_BYTES))
-}
-
-fn head_bytes() -> usize {
-    static VALUE: OnceLock<usize> = OnceLock::new();
-    *VALUE.get_or_init(|| env_u64("AC_SPAWN_HEAD_BYTES", DEFAULT_HEAD_BYTES) as usize)
-}
-
-fn concurrency_window() -> Duration {
-    static VALUE: OnceLock<Duration> = OnceLock::new();
-    *VALUE.get_or_init(|| {
-        Duration::from_millis(env_u64(
-            "AC_SPAWN_CONCURRENCY_WINDOW_MS",
-            DEFAULT_CONCURRENCY_WINDOW_MS,
-        ))
-    })
+fn env_u64(key: &str, default: u64, max: u64) -> u64 {
+    let Ok(raw) = std::env::var(key) else {
+        return default;
+    };
+    match raw.trim().parse::<u64>() {
+        Ok(value) if value <= max => value,
+        Ok(value) => {
+            log::warn!("[pty] {key}={value} exceeds the {max} ceiling; clamping to {max}");
+            max
+        }
+        Err(_) => {
+            log::warn!("[pty] ignoring non-numeric {key}='{raw}'; using {default}");
+            default
+        }
+    }
 }
 
 /// What AC knows about a child process at the instant we ask.
 #[derive(Debug, Clone)]
 pub enum ChildLiveness {
-    /// The child is running.
     Alive,
-    /// The child has exited; we hold its status.
-    Exited {
-        code: u32,
-        success: bool,
-        status: String,
-    },
-    /// The poll itself failed.
-    Unknown(String),
+    Exited { code: u32, success: bool },
+    /// The OS would not tell us. Distinct from `Alive` on purpose: reporting an
+    /// unanswerable handle as "running" is the same ambiguity class as the
+    /// `ExitStatus { code: 1 }` trap this module exists to kill.
+    Unqueryable(String),
     /// No PTY instance for this session anymore (killed, or never inserted).
     Gone,
 }
@@ -122,13 +186,17 @@ impl ChildLiveness {
         match self {
             ChildLiveness::Alive => "alive".to_string(),
             ChildLiveness::Exited { code, .. } => format!("exited({code})"),
-            ChildLiveness::Unknown(err) => format!("unknown({err})"),
+            ChildLiveness::Unqueryable(detail) => format!("unqueryable({detail})"),
             ChildLiveness::Gone => "gone".to_string(),
         }
     }
 
     fn exited_ok(&self) -> bool {
         matches!(self, ChildLiveness::Exited { success: true, .. })
+    }
+
+    fn is_exited(&self) -> bool {
+        matches!(self, ChildLiveness::Exited { .. })
     }
 }
 
@@ -137,14 +205,13 @@ impl From<&ExitStatus> for ChildLiveness {
         ChildLiveness::Exited {
             code: status.exit_code(),
             success: status.success(),
-            status: format!("{status:?}"),
         }
     }
 }
 
-/// Who ended the child. The whole point of #942's requirement 3: an AC-initiated
-/// stop (session destroy, job terminate, resource-monitor kill_group) can never be
-/// confused with a child that died on its own.
+/// Who ended the child. An AC-initiated stop (session destroy, job terminate,
+/// resource-monitor `kill_group`, shutdown) can never be confused with a child that
+/// died on its own: that confusion is the bug #942 was filed against.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExitCause {
     AcRequested,
@@ -160,13 +227,21 @@ impl ExitCause {
     }
 }
 
-/// How busy the spawner was just before this spawn. Correlates a hang with
-/// concurrent startups against the same shared agent state (e.g. `~/.codex`).
+/// The stop state as it was **before** a liveness probe. Read it first, probe second:
+/// a stop that lands after the read cannot have caused an exit the probe then sees.
+#[derive(Debug, Clone, Copy)]
+pub struct StopSnapshot {
+    requested: bool,
+}
+
+/// How busy the spawner was just before this spawn. `same_cli` is keyed on the CLI
+/// identity, because the suspect is contention between concurrent Codex startups on
+/// the shared `~/.codex`, not between AC profiles.
 #[derive(Debug, Clone, Copy)]
 pub struct SpawnWindow {
     pub window_ms: u64,
     pub total: usize,
-    pub same_agent: usize,
+    pub same_cli: usize,
 }
 
 pub struct SpawnRecordInit {
@@ -175,14 +250,22 @@ pub struct SpawnRecordInit {
     /// The argv as executed, including any `cmd.exe /C` wrapper AC added.
     pub argv: Vec<String>,
     pub cwd: String,
-    pub agent_id: Option<String>,
+    /// CLI identity from the canonical detector. Keys the stall predicate.
+    pub cli: Option<CodingAgentKind>,
+    /// Configured coding-agent profile id (opaque). Logged, never used as identity.
+    pub agent_profile_id: Option<String>,
     /// Effective `CODEX_HOME` for the child (configured, inherited, or removed).
     pub codex_home: Option<String>,
     pub configured_env_count: usize,
     pub removed_env_count: usize,
+    /// Values to mask out of anything we echo into the log (child output, argv): AC's
+    /// own credentials plus every configured env value, which is where AC tells users
+    /// to keep their API keys.
+    pub redact: Vec<String>,
     pub window: SpawnWindow,
     /// Taken immediately before the child was spawned; time zero for first-output.
     pub started: Instant,
+    pub thresholds: Thresholds,
 }
 
 pub struct SpawnRecord {
@@ -190,12 +273,15 @@ pub struct SpawnRecord {
     pid: Option<u32>,
     argv: Vec<String>,
     cwd: String,
-    agent_id: Option<String>,
+    cli: Option<CodingAgentKind>,
+    agent_profile_id: Option<String>,
     codex_home: Option<String>,
     configured_env_count: usize,
     removed_env_count: usize,
+    redact: Vec<String>,
     window: SpawnWindow,
     started: Instant,
+    thresholds: Thresholds,
     /// Microseconds from spawn to the first byte; 0 means nothing read yet.
     first_output_us: AtomicU64,
     /// Microseconds from spawn to the first real output (past the paint floor);
@@ -205,9 +291,16 @@ pub struct SpawnRecord {
     head: Mutex<Vec<u8>>,
     head_full: AtomicBool,
     ac_stop: AtomicBool,
+    /// Microseconds from spawn to the stop request; 0 means none.
+    ac_stop_at_us: AtomicU64,
     ac_stop_source: Mutex<Option<String>>,
+    /// Liveness observed by the kill path **before** it touched job or child: the
+    /// authoritative answer to "was it already dead when we asked?".
+    pre_stop_liveness: Mutex<Option<ChildLiveness>>,
+    startup_reported: AtomicBool,
     stall_reported: AtomicBool,
     exit_reported: AtomicBool,
+    exit_cause: Mutex<Option<ExitCause>>,
 }
 
 impl SpawnRecord {
@@ -217,21 +310,32 @@ impl SpawnRecord {
             pid: init.pid,
             argv: init.argv,
             cwd: init.cwd,
-            agent_id: init.agent_id,
+            cli: init.cli,
+            agent_profile_id: init.agent_profile_id,
             codex_home: init.codex_home,
             configured_env_count: init.configured_env_count,
             removed_env_count: init.removed_env_count,
+            redact: init
+                .redact
+                .into_iter()
+                .filter(|value| value.len() >= MIN_REDACTED_LEN)
+                .collect(),
             window: init.window,
             started: init.started,
+            thresholds: init.thresholds,
             first_output_us: AtomicU64::new(0),
             first_paint_us: AtomicU64::new(0),
             bytes_read: AtomicU64::new(0),
             head: Mutex::new(Vec::new()),
             head_full: AtomicBool::new(false),
             ac_stop: AtomicBool::new(false),
+            ac_stop_at_us: AtomicU64::new(0),
             ac_stop_source: Mutex::new(None),
+            pre_stop_liveness: Mutex::new(None),
+            startup_reported: AtomicBool::new(false),
             stall_reported: AtomicBool::new(false),
             exit_reported: AtomicBool::new(false),
+            exit_cause: Mutex::new(None),
         }
     }
 
@@ -239,8 +343,19 @@ impl SpawnRecord {
         self.session_id
     }
 
-    fn agent_log(&self) -> &str {
-        self.agent_id.as_deref().unwrap_or("none")
+    pub fn thresholds(&self) -> Thresholds {
+        self.thresholds
+    }
+
+    fn cli_log(&self) -> &'static str {
+        match self.cli {
+            Some(kind) => kind.as_str(),
+            None => "none",
+        }
+    }
+
+    fn profile_log(&self) -> &str {
+        self.agent_profile_id.as_deref().unwrap_or("none")
     }
 
     fn codex_home_log(&self) -> &str {
@@ -254,6 +369,38 @@ impl SpawnRecord {
         }
     }
 
+    fn ms_log(stamp_us: &AtomicU64) -> String {
+        match stamp_us.load(Ordering::Relaxed) {
+            0 => "none".to_string(),
+            us => (us / 1_000).to_string(),
+        }
+    }
+
+    /// Mask AC credentials and configured env values out of anything we echo into the
+    /// log. `app.log` is what users paste into issues.
+    fn scrub(&self, text: String) -> String {
+        let mut text = text;
+        for secret in &self.redact {
+            if text.contains(secret.as_str()) {
+                text = text.replace(secret.as_str(), "<redacted>");
+            }
+        }
+        text
+    }
+
+    fn argv_log(&self) -> String {
+        self.scrub(format!("{:?}", self.argv))
+    }
+
+    fn head_log(&self) -> String {
+        let head = self.head.lock().unwrap_or_else(|e| e.into_inner());
+        if head.is_empty() {
+            return "<empty>".to_string();
+        }
+        let text = String::from_utf8_lossy(&head).escape_debug().to_string();
+        format!("\"{}\"", self.scrub(text))
+    }
+
     pub fn saw_output(&self) -> bool {
         self.first_output_us.load(Ordering::Relaxed) != 0
     }
@@ -262,15 +409,14 @@ impl SpawnRecord {
         self.first_paint_us.load(Ordering::Relaxed) != 0
     }
 
-    fn ms_log(stamp_us: &AtomicU64) -> String {
-        match stamp_us.load(Ordering::Relaxed) {
-            0 => "none".to_string(),
-            us => (us / 1_000).to_string(),
-        }
+    pub fn stop_requested(&self) -> bool {
+        self.ac_stop.load(Ordering::SeqCst)
     }
 
-    pub fn stop_requested(&self) -> bool {
-        self.ac_stop.load(Ordering::Relaxed)
+    pub fn stop_snapshot(&self) -> StopSnapshot {
+        StopSnapshot {
+            requested: self.stop_requested(),
+        }
     }
 
     fn stop_source(&self) -> String {
@@ -281,32 +427,111 @@ impl SpawnRecord {
             .unwrap_or_else(|| "none".to_string())
     }
 
-    /// Poll fast while the child still owes us a painted screen, slowly afterwards.
-    pub fn in_startup_phase(&self) -> bool {
-        !self.painted() && !self.stall_reported.load(Ordering::Relaxed)
+    fn pre_stop_liveness(&self) -> Option<ChildLiveness> {
+        self.pre_stop_liveness
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
-    fn mark_ac_stop(&self, source: &str) {
+    /// Age of the stop request, or `None` when AC never asked.
+    fn stop_age(&self) -> Option<Duration> {
+        match self.ac_stop_at_us.load(Ordering::SeqCst) {
+            0 => None,
+            at => Some(
+                self.started
+                    .elapsed()
+                    .saturating_sub(Duration::from_micros(at)),
+            ),
+        }
+    }
+
+    fn stop_age_log(&self) -> String {
+        match self.stop_age() {
+            Some(age) => age.as_millis().to_string(),
+            None => "none".to_string(),
+        }
+    }
+
+    /// A stop request only owns the exits that follow it closely. AC has a documented
+    /// path where the kill is blocked and the agent keeps running (a Quarantined
+    /// resource-monitor kill leaves the instance intact); a child that dies an hour
+    /// later died on its own, whatever we asked for back then.
+    fn stop_cause(&self) -> ExitCause {
+        match self.stop_age() {
+            Some(age) if age <= self.thresholds.stop_attribution => ExitCause::AcRequested,
+            _ => ExitCause::ChildInitiated,
+        }
+    }
+
+    /// Cause for an observed exit. `before` is the stop state read BEFORE the liveness
+    /// probe. The pre-stop liveness always wins when present: the kill path probes the
+    /// child before it touches anything, so it is the one witness that cannot be racy.
+    pub fn attribute_exit(&self, before: StopSnapshot) -> ExitCause {
+        if let Some(pre_stop) = self.pre_stop_liveness() {
+            if pre_stop.is_exited() {
+                // It was already dead when AC asked. Our stop did not do this.
+                return ExitCause::ChildInitiated;
+            }
+            return self.stop_cause();
+        }
+        if before.requested {
+            self.stop_cause()
+        } else {
+            ExitCause::ChildInitiated
+        }
+    }
+
+    /// Poll fast until the startup verdict is in, slowly afterwards.
+    pub fn in_startup_phase(&self) -> bool {
+        !self.startup_reported.load(Ordering::Relaxed)
+    }
+
+    fn mark_ac_stop(&self, source: &str, pre_stop: Option<ChildLiveness>) {
         {
             let mut current = self.ac_stop_source.lock().unwrap_or_else(|e| e.into_inner());
             if current.is_none() {
                 *current = Some(source.to_string());
             }
         }
+        if let Some(pre_stop) = pre_stop {
+            let mut current = self
+                .pre_stop_liveness
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if current.is_none() {
+                *current = Some(pre_stop);
+            }
+        }
+        let stamp = (self.started.elapsed().as_micros().min(u64::MAX as u128) as u64).max(1);
+        let _ = self
+            .ac_stop_at_us
+            .compare_exchange(0, stamp, Ordering::SeqCst, Ordering::Relaxed);
+        // Published last: any thread that sees this flag also sees the source, the
+        // timestamp and the pre-stop liveness written above.
         self.ac_stop.store(true, Ordering::SeqCst);
     }
 
-    /// The child is dead or on its way out. ConPTY repaints the master while a
-    /// session is torn down, so anything read past this point belongs to the teardown,
-    /// not to the child, and must not land in the record.
-    fn torn_down(&self) -> bool {
-        self.exit_reported.load(Ordering::Relaxed) || self.stop_requested()
+    /// A stop AC asked for, recent enough that the teardown it triggers is still in
+    /// flight. Keeps ConPTY's teardown repaint out of the startup timings without
+    /// going permanently blind on a session whose kill was blocked.
+    fn stop_in_flight(&self, elapsed: Duration) -> bool {
+        match self.ac_stop_at_us.load(Ordering::SeqCst) {
+            0 => false,
+            at => {
+                elapsed.saturating_sub(Duration::from_micros(at)) <= self.thresholds.stop_attribution
+            }
+        }
     }
 
-    /// Hot path: called for every chunk read off the PTY. After the first paint and
-    /// a full head buffer it costs one relaxed add plus a handful of relaxed loads.
+    /// Hot path: called for every chunk read off the PTY. Once the stamps are taken and
+    /// the head buffer is full it costs one relaxed add and a few relaxed loads: no
+    /// clock, no lock, no allocation.
     pub fn note_output(&self, chunk: &[u8]) {
-        if chunk.is_empty() || self.torn_down() {
+        // Only a reported exit closes the record. A stop request must NOT: AC has a
+        // path where the kill is blocked and the session keeps running, and going blind
+        // on a live agent is exactly the evidence loss this module exists to prevent.
+        if chunk.is_empty() || self.exit_reported.load(Ordering::Relaxed) {
             return;
         }
         let total = self
@@ -314,72 +539,77 @@ impl SpawnRecord {
             .fetch_add(chunk.len() as u64, Ordering::Relaxed)
             + chunk.len() as u64;
 
-        // Both stamps are one-shot, so a settled session never reads the clock here.
         let needs_first = self.first_output_us.load(Ordering::Relaxed) == 0;
         let needs_paint =
-            self.first_paint_us.load(Ordering::Relaxed) == 0 && total >= paint_floor();
+            self.first_paint_us.load(Ordering::Relaxed) == 0 && total >= self.thresholds.paint_floor;
 
         if needs_first || needs_paint {
             let elapsed = self.started.elapsed();
-            // 0 is the "nothing yet" sentinel for both stamps, so never store it.
-            let stamp = (elapsed.as_micros().min(u64::MAX as u128) as u64).max(1);
+            // ConPTY repaints the master while a session is being torn down. That is
+            // the teardown talking, not the child starting up.
+            if !self.stop_in_flight(elapsed) {
+                // 0 is the "nothing yet" sentinel for both stamps, so never store it.
+                let stamp = (elapsed.as_micros().min(u64::MAX as u128) as u64).max(1);
 
-            // The first byte off the PTY. On Windows this is ConPTY greeting us, not
-            // the child, which is why it is DEBUG and never taken as proof of life.
-            if needs_first
-                && self
-                    .first_output_us
-                    .compare_exchange(0, stamp, Ordering::SeqCst, Ordering::Relaxed)
-                    .is_ok()
-            {
-                log::debug!(
-                    "[pty] first-output session={} pid={} agent={} after_ms={} bytes={}",
-                    self.session_id,
-                    self.pid_log(),
-                    self.agent_log(),
-                    elapsed.as_millis(),
-                    total
-                );
-            }
-
-            // The first real output: the child actually painted something. This is the
-            // healthy-startup signal, and its absence is the hang.
-            if needs_paint
-                && self
-                    .first_paint_us
-                    .compare_exchange(0, stamp, Ordering::SeqCst, Ordering::Relaxed)
-                    .is_ok()
-            {
-                // Only a stall we actually reported can be recovered from.
-                if self.stall_reported.load(Ordering::Relaxed) {
-                    log::warn!(
-                        "[pty] first-paint session={} pid={} agent={} after_ms={} bytes={} late=true (startup stall recovered)",
+                // The first byte off the PTY. On Windows this is ConPTY greeting us,
+                // not the child, which is why it is DEBUG and never proof of life.
+                if needs_first
+                    && self
+                        .first_output_us
+                        .compare_exchange(0, stamp, Ordering::SeqCst, Ordering::Relaxed)
+                        .is_ok()
+                {
+                    log::debug!(
+                        "[pty] first-output session={} pid={} cli={} after_ms={} bytes={}",
                         self.session_id,
                         self.pid_log(),
-                        self.agent_log(),
-                        elapsed.as_millis(),
-                        total
-                    );
-                } else {
-                    log::info!(
-                        "[pty] first-paint session={} pid={} agent={} after_ms={} bytes={}",
-                        self.session_id,
-                        self.pid_log(),
-                        self.agent_log(),
+                        self.cli_log(),
                         elapsed.as_millis(),
                         total
                     );
                 }
+
+                // The first real output: the child actually painted something. This is
+                // the healthy-startup signal, and its absence is the hang.
+                if needs_paint
+                    && self
+                        .first_paint_us
+                        .compare_exchange(0, stamp, Ordering::SeqCst, Ordering::Relaxed)
+                        .is_ok()
+                {
+                    // Only a stall we actually reported can be recovered from.
+                    if self.stall_reported.load(Ordering::Relaxed) {
+                        log::warn!(
+                            "[pty] first-paint session={} pid={} cli={} after_ms={} bytes={} late=true (startup stall recovered)",
+                            self.session_id,
+                            self.pid_log(),
+                            self.cli_log(),
+                            elapsed.as_millis(),
+                            total
+                        );
+                    } else {
+                        log::info!(
+                            "[pty] first-paint session={} pid={} cli={} after_ms={} bytes={}",
+                            self.session_id,
+                            self.pid_log(),
+                            self.cli_log(),
+                            elapsed.as_millis(),
+                            total
+                        );
+                    }
+                }
             }
         }
 
-        if !self.head_full.load(Ordering::Relaxed) {
+        // The head is the child's opening bytes. Once AC has asked for a stop, what
+        // arrives is teardown, so freeze it rather than pollute the evidence.
+        if !self.head_full.load(Ordering::Relaxed) && !self.stop_requested() {
             self.capture_head(chunk);
         }
     }
 
     fn capture_head(&self, chunk: &[u8]) {
-        let cap = head_bytes();
+        let cap = self.thresholds.head_bytes;
         let mut head = self.head.lock().unwrap_or_else(|e| e.into_inner());
         if head.len() >= cap {
             self.head_full.store(true, Ordering::Relaxed);
@@ -392,64 +622,77 @@ impl SpawnRecord {
         }
     }
 
-    fn head_log(&self) -> String {
-        let head = self.head.lock().unwrap_or_else(|e| e.into_inner());
-        if head.is_empty() {
-            return "<empty>".to_string();
-        }
-        format!("\"{}\"", String::from_utf8_lossy(&head).escape_debug())
-    }
-
-    /// True once the child has had its whole startup window and still produced no
-    /// output at all (any session), or nothing past the ConPTY handshake (coding-agent
-    /// sessions, which always paint a TUI). Never fires when the check is disabled.
-    pub fn startup_stalled(&self) -> bool {
-        let timeout = stall_timeout();
-        if timeout.is_zero() || self.stall_reported.load(Ordering::Relaxed) {
-            return false;
-        }
-        if self.started.elapsed() < timeout {
-            return false;
-        }
+    /// The child never painted a screen: nothing at all, or nothing past the ConPTY
+    /// handshake for a coding agent (which always paints a TUI immediately). A plain
+    /// shell whose prompt is legitimately tiny is not stalled, it is just quiet.
+    fn is_stalled(&self) -> bool {
         let bytes = self.bytes_read.load(Ordering::Relaxed);
-        bytes == 0 || (self.agent_id.is_some() && !self.painted())
+        bytes == 0 || (self.cli.is_some() && !self.painted())
     }
 
-    /// Requirement 2 + 4: the startup stall event. Emitted at most once.
-    pub fn log_startup_stall(&self, liveness: &ChildLiveness) {
-        if self.stall_reported.swap(true, Ordering::SeqCst) {
-            return;
+    /// True once the startup window has elapsed and the verdict is still unwritten.
+    pub fn startup_deadline_reached(&self) -> bool {
+        let timeout = self.thresholds.stall_timeout;
+        !timeout.is_zero()
+            && !self.startup_reported.load(Ordering::Relaxed)
+            && self.started.elapsed() >= timeout
+    }
+
+    /// The startup verdict, emitted at most once, for EVERY session at the deadline:
+    /// WARN when the child never painted, INFO otherwise. It always carries the head
+    /// bytes, so a hang that painted past the floor still leaves its output on record.
+    pub fn log_startup_report(&self, liveness: &ChildLiveness) -> bool {
+        if self.startup_reported.swap(true, Ordering::SeqCst) {
+            return false;
         }
-        log::warn!(
-            "[pty] startup-stall session={} pid={} agent={} backend=local child={} elapsed_ms={} threshold_ms={} bytes_read={} paint_floor={} first_output_ms={} argv={:?} cwd={} codex_home={} recent_spawns={} recent_same_agent={} window_ms={} head={}",
+        let stalled = self.is_stalled();
+        self.stall_reported.store(stalled, Ordering::SeqCst);
+
+        let event = if stalled {
+            "startup-stall"
+        } else {
+            "startup-checkpoint"
+        };
+        let line = format!(
+            "[pty] {} session={} pid={} cli={} agent_profile={} backend=local child={} stalled={} elapsed_ms={} threshold_ms={} bytes_read={} paint_floor={} first_output_ms={} first_paint_ms={} argv={} cwd={} codex_home={} recent_spawns={} recent_same_cli={} window_ms={} head={}",
+            event,
             self.session_id,
             self.pid_log(),
-            self.agent_log(),
+            self.cli_log(),
+            self.profile_log(),
             liveness.as_log(),
+            stalled,
             self.started.elapsed().as_millis(),
-            stall_timeout().as_millis(),
+            self.thresholds.stall_timeout.as_millis(),
             self.bytes_read.load(Ordering::Relaxed),
-            paint_floor(),
+            self.thresholds.paint_floor,
             Self::ms_log(&self.first_output_us),
-            self.argv,
+            Self::ms_log(&self.first_paint_us),
+            self.argv_log(),
             self.cwd,
             self.codex_home_log(),
             self.window.total,
-            self.window.same_agent,
+            self.window.same_cli,
             self.window.window_ms,
             self.head_log()
         );
+        if stalled {
+            log::warn!("{}", line);
+        } else {
+            log::info!("{}", line);
+        }
+        true
     }
 
-    /// Requirement 3 + 4: the one exit event for this session. Returns false when
-    /// another path already reported the exit (the caller may log a debug crumb).
+    /// The one exit event for this session. Returns false when another path already
+    /// reported it (the caller may then leave a debug crumb instead).
     pub fn log_child_exit(&self, cause: ExitCause, liveness: &ChildLiveness, detail: &str) -> bool {
         if self.exit_reported.swap(true, Ordering::SeqCst) {
             return false;
         }
+        *self.exit_cause.lock().unwrap_or_else(|e| e.into_inner()) = Some(cause);
+
         let uptime = self.started.elapsed();
-        let first_output_ms = Self::ms_log(&self.first_output_us);
-        let first_paint_ms = Self::ms_log(&self.first_paint_us);
         let bytes = self.bytes_read.load(Ordering::Relaxed);
         // A child that ends itself without ever painting a screen, or with a failing
         // status, is the #942 smoking gun. A clean exit from a session that did come up
@@ -459,58 +702,64 @@ impl SpawnRecord {
 
         if unexpected {
             log::warn!(
-                "[pty] child-exit session={} pid={} agent={} cause={} detail={} child={} uptime_ms={} first_output_ms={} first_paint_ms={} bytes_read={} argv={:?} cwd={} codex_home={} recent_spawns={} recent_same_agent={} window_ms={} head={}",
+                "[pty] child-exit session={} pid={} cli={} agent_profile={} cause={} detail={} child={} uptime_ms={} first_output_ms={} first_paint_ms={} bytes_read={} stop_source={} stop_age_ms={} argv={} cwd={} codex_home={} recent_spawns={} recent_same_cli={} window_ms={} head={}",
                 self.session_id,
                 self.pid_log(),
-                self.agent_log(),
+                self.cli_log(),
+                self.profile_log(),
                 cause.as_log(),
                 detail,
                 liveness.as_log(),
                 uptime.as_millis(),
-                first_output_ms,
-                first_paint_ms,
+                Self::ms_log(&self.first_output_us),
+                Self::ms_log(&self.first_paint_us),
                 bytes,
-                self.argv,
+                self.stop_source(),
+                self.stop_age_log(),
+                self.argv_log(),
                 self.cwd,
                 self.codex_home_log(),
                 self.window.total,
-                self.window.same_agent,
+                self.window.same_cli,
                 self.window.window_ms,
                 self.head_log()
             );
         } else {
             log::info!(
-                "[pty] child-exit session={} pid={} agent={} cause={} detail={} child={} stop_source={} uptime_ms={} first_output_ms={} first_paint_ms={} bytes_read={}",
+                "[pty] child-exit session={} pid={} cli={} agent_profile={} cause={} detail={} child={} uptime_ms={} first_output_ms={} first_paint_ms={} bytes_read={} stop_source={} stop_age_ms={}",
                 self.session_id,
                 self.pid_log(),
-                self.agent_log(),
+                self.cli_log(),
+                self.profile_log(),
                 cause.as_log(),
                 detail,
                 liveness.as_log(),
-                self.stop_source(),
                 uptime.as_millis(),
-                first_output_ms,
-                first_paint_ms,
-                bytes
+                Self::ms_log(&self.first_output_us),
+                Self::ms_log(&self.first_paint_us),
+                bytes,
+                self.stop_source(),
+                self.stop_age_log()
             );
         }
         true
     }
 
-    /// Requirement 1: the full spawn record, one line, on every local spawn.
+    /// The full spawn record, one line, on every local spawn.
     fn log_spawn(&self) {
         log::info!(
-            "[pty] spawn-record session={} pid={} agent={} backend=local argv={:?} cwd={} codex_home={} env_configured={} env_removed={} recent_spawns={} recent_same_agent={} window_ms={}",
+            "[pty] spawn-record session={} pid={} cli={} agent_profile={} backend=local argv={} cwd={} codex_home={} env_configured={} env_removed={} recent_spawns={} recent_same_cli={} window_ms={}",
             self.session_id,
             self.pid_log(),
-            self.agent_log(),
-            self.argv,
+            self.cli_log(),
+            self.profile_log(),
+            self.argv_log(),
             self.cwd,
             self.codex_home_log(),
             self.configured_env_count,
             self.removed_env_count,
             self.window.total,
-            self.window.same_agent,
+            self.window.same_cli,
             self.window.window_ms
         );
     }
@@ -519,7 +768,7 @@ impl SpawnRecord {
 #[derive(Default)]
 struct Registry {
     records: HashMap<Uuid, Arc<SpawnRecord>>,
-    recent: VecDeque<(Instant, Option<String>)>,
+    recent: VecDeque<(Instant, Option<CodingAgentKind>)>,
 }
 
 fn registry() -> &'static Mutex<Registry> {
@@ -527,10 +776,10 @@ fn registry() -> &'static Mutex<Registry> {
     REGISTRY.get_or_init(|| Mutex::new(Registry::default()))
 }
 
-/// Requirement 5: count the spawns that happened in the window BEFORE this one,
-/// then record this attempt. Call once per spawn, at the top of the spawn path.
-pub fn note_spawn_attempt(agent_id: Option<&str>) -> SpawnWindow {
-    let window = concurrency_window();
+/// Count the spawns that happened in the window BEFORE this one, then record this
+/// attempt. Call once per spawn, at the top of the spawn path.
+pub fn note_spawn_attempt(cli: Option<CodingAgentKind>, thresholds: Thresholds) -> SpawnWindow {
+    let window = thresholds.concurrency_window;
     let now = Instant::now();
     let mut registry = registry().lock().unwrap_or_else(|e| e.into_inner());
 
@@ -543,18 +792,16 @@ pub fn note_spawn_attempt(agent_id: Option<&str>) -> SpawnWindow {
     }
 
     let total = registry.recent.len();
-    let same_agent = match agent_id {
-        Some(id) => registry
+    let same_cli = match cli {
+        Some(kind) => registry
             .recent
             .iter()
-            .filter(|(_, recent_agent)| recent_agent.as_deref() == Some(id))
+            .filter(|(_, recent_cli)| *recent_cli == Some(kind))
             .count(),
         None => 0,
     };
 
-    registry
-        .recent
-        .push_back((now, agent_id.map(|id| id.to_string())));
+    registry.recent.push_back((now, cli));
     if registry.recent.len() > RECENT_SPAWNS_CAP {
         registry.recent.pop_front();
     }
@@ -562,7 +809,7 @@ pub fn note_spawn_attempt(agent_id: Option<&str>) -> SpawnWindow {
     SpawnWindow {
         window_ms: window.as_millis().min(u64::MAX as u128) as u64,
         total,
-        same_agent,
+        same_cli,
     }
 }
 
@@ -579,16 +826,23 @@ pub fn register(init: SpawnRecordInit) -> Arc<SpawnRecord> {
 }
 
 /// Tag a session's child as stopped by AC (session kill, job terminate,
-/// resource-monitor kill_group) BEFORE any process is touched, so its exit can
-/// never be misread as a spontaneous death. No-op for unknown sessions.
-pub fn mark_ac_stop(session_id: Uuid, source: &str) -> Option<Arc<SpawnRecord>> {
+/// resource-monitor `kill_group`, shutdown) BEFORE any process is touched, so its exit
+/// can never be misread as a spontaneous death. `pre_stop` is the liveness the caller
+/// observed before touching anything: pass it whenever you have it, it is the only
+/// non-racy witness of "was it already dead when we asked?". No-op for unknown sessions
+/// (container transport, or a session with no local spawn record).
+pub fn mark_ac_stop(
+    session_id: Uuid,
+    source: &str,
+    pre_stop: Option<ChildLiveness>,
+) -> Option<Arc<SpawnRecord>> {
     let record = registry()
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .records
         .get(&session_id)
         .cloned()?;
-    record.mark_ac_stop(source);
+    record.mark_ac_stop(source, pre_stop);
     Some(record)
 }
 
@@ -600,70 +854,127 @@ pub fn forget(session_id: Uuid) {
         .remove(&session_id);
 }
 
-/// One monitor thread per local session. It owns two signals: the startup stall
-/// WARN, and exit attribution for a child that dies without AC asking (the PTY
-/// reader cannot be trusted for that on ConPTY, which keeps the pipe open).
-/// It ends when the child exits or the session's PTY instance is gone.
-pub fn watch_child<P>(record: Arc<SpawnRecord>, probe: P)
+/// One monitor thread per local session. It owns two signals the PTY reader cannot
+/// carry: the startup verdict at the deadline, and the exit of a child that dies
+/// without AC asking (ConPTY keeps the pipe open past the death of the child, so reader
+/// EOF is not a reliable witness). It ends when the child exits, when the session is
+/// gone, or when the probe itself panics.
+pub fn watch_child<P>(record: Arc<SpawnRecord>, probe: P) -> JoinHandle<()>
 where
     P: Fn() -> ChildLiveness + Send + 'static,
 {
     std::thread::spawn(move || loop {
         let tick = if record.in_startup_phase() {
-            STARTUP_POLL
+            record.thresholds.startup_poll
         } else {
-            STEADY_POLL
+            record.thresholds.steady_poll
         };
         std::thread::sleep(tick);
 
-        let liveness = probe();
+        // Read the stop state BEFORE looking at the child: a stop that lands after this
+        // point cannot be what killed a child the probe is about to find already dead.
+        let stop_before = record.stop_snapshot();
+
+        // portable-pty unwraps its own internals while polling a child. A poisoned
+        // mutex in there must not take this thread down silently.
+        let liveness = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(&probe)) {
+            Ok(liveness) => liveness,
+            Err(_) => {
+                log::warn!(
+                    "[pty] child-probe panicked for session {}; stopping its monitor",
+                    record.session_id()
+                );
+                return;
+            }
+        };
+
         match liveness {
             ChildLiveness::Gone => return,
             ChildLiveness::Exited { .. } => {
-                let cause = if record.stop_requested() {
-                    ExitCause::AcRequested
-                } else {
-                    ExitCause::ChildInitiated
-                };
+                let cause = record.attribute_exit(stop_before);
                 record.log_child_exit(cause, &liveness, "observed-by-monitor");
                 return;
             }
-            ChildLiveness::Alive | ChildLiveness::Unknown(_) => {
-                if record.startup_stalled() {
-                    record.log_startup_stall(&liveness);
+            ChildLiveness::Alive | ChildLiveness::Unqueryable(_) => {
+                if record.startup_deadline_reached() {
+                    record.log_startup_report(&liveness);
                 }
             }
         }
-    });
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicUsize;
 
-    fn test_record(agent_id: Option<&str>) -> SpawnRecord {
-        SpawnRecord::new(SpawnRecordInit {
+    /// Fast, deterministic, and above all NOT read from the process environment: a test
+    /// must not change its verdict because someone exported a tunable.
+    fn test_thresholds() -> Thresholds {
+        Thresholds {
+            stall_timeout: Duration::from_millis(120),
+            paint_floor: 64,
+            head_bytes: 512,
+            concurrency_window: Duration::from_millis(10_000),
+            stop_attribution: Duration::from_millis(500),
+            startup_poll: Duration::from_millis(5),
+            steady_poll: Duration::from_millis(10),
+        }
+    }
+
+    fn test_init(cli: Option<CodingAgentKind>) -> SpawnRecordInit {
+        SpawnRecordInit {
             session_id: Uuid::new_v4(),
             pid: Some(4242),
             argv: vec!["codex".to_string(), "resume".to_string()],
             cwd: "C:/repo".to_string(),
-            agent_id: agent_id.map(|id| id.to_string()),
+            cli,
+            agent_profile_id: cli.map(|_| "agent_1782513272568_0".to_string()),
             codex_home: None,
             configured_env_count: 0,
             removed_env_count: 0,
+            redact: Vec::new(),
             window: SpawnWindow {
                 window_ms: 10_000,
                 total: 0,
-                same_agent: 0,
+                same_cli: 0,
             },
             started: Instant::now(),
-        })
+            thresholds: test_thresholds(),
+        }
+    }
+
+    fn test_record(cli: Option<CodingAgentKind>) -> SpawnRecord {
+        SpawnRecord::new(test_init(cli))
+    }
+
+    /// A record whose startup deadline is already in the past.
+    fn aged_record(cli: Option<CodingAgentKind>) -> SpawnRecord {
+        let thresholds = test_thresholds();
+        SpawnRecord {
+            started: Instant::now() - thresholds.stall_timeout - Duration::from_millis(1),
+            ..test_record(cli)
+        }
+    }
+
+    const CONPTY_PROLOGUE: &[u8] = b"\x1b[?9001h\x1b[?1004h";
+
+    fn wait_until(deadline: Duration, mut done: impl FnMut() -> bool) -> bool {
+        let start = Instant::now();
+        while start.elapsed() < deadline {
+            if done() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        done()
     }
 
     #[test]
     fn head_capture_is_capped_and_stops_after_full() {
-        let record = test_record(Some("codex"));
-        let cap = head_bytes();
+        let record = test_record(Some(CodingAgentKind::Codex));
+        let cap = record.thresholds.head_bytes;
         record.note_output(&vec![b'a'; cap + 64]);
         record.note_output(b"ignored");
 
@@ -693,14 +1004,14 @@ mod tests {
 
     #[test]
     fn paint_is_stamped_once_the_output_passes_the_floor() {
-        let record = test_record(Some("codex"));
+        let record = test_record(Some(CodingAgentKind::Codex));
 
         // The ConPTY handshake alone is not a paint.
-        record.note_output(b"\x1b[?9001h\x1b[?1004h");
+        record.note_output(CONPTY_PROLOGUE);
         assert!(record.saw_output());
         assert!(!record.painted());
 
-        record.note_output(&vec![b'x'; paint_floor() as usize]);
+        record.note_output(&vec![b'x'; record.thresholds.paint_floor as usize]);
         assert!(record.painted());
         let painted_at = record.first_paint_us.load(Ordering::Relaxed);
 
@@ -713,69 +1024,73 @@ mod tests {
     }
 
     #[test]
-    fn silent_child_stalls_only_after_the_threshold() {
-        let record = test_record(Some("codex"));
-        assert!(!record.startup_stalled(), "not yet past the threshold");
-
-        let record = SpawnRecord {
-            started: Instant::now() - stall_timeout() - Duration::from_millis(1),
-            ..test_record(Some("codex"))
-        };
-        assert!(record.startup_stalled());
-
-        record.log_startup_stall(&ChildLiveness::Alive);
-        assert!(
-            !record.startup_stalled(),
-            "the stall event is emitted at most once"
-        );
-    }
-
-    #[test]
-    fn plain_shell_prompt_is_not_a_stall_but_a_silent_agent_is() {
-        let shell = SpawnRecord {
-            started: Instant::now() - stall_timeout() - Duration::from_millis(1),
-            ..test_record(None)
-        };
-        shell.note_output(b"C:\\repo>");
-        assert!(
-            !shell.startup_stalled(),
-            "a tiny shell prompt is a healthy start"
-        );
-
-        // Exactly what a hung Codex leaves behind on Windows: the ConPTY handshake
-        // and not one byte more.
-        let agent = SpawnRecord {
-            started: Instant::now() - stall_timeout() - Duration::from_millis(1),
-            ..test_record(Some("codex"))
-        };
-        agent.note_output(b"\x1b[?9001h\x1b[?1004h");
+    fn a_coding_agent_that_never_paints_is_stalled_and_a_quiet_shell_is_not() {
+        // Exactly what a hung Codex leaves behind on Windows: the ConPTY handshake and
+        // not one byte more.
+        let agent = aged_record(Some(CodingAgentKind::Codex));
+        agent.note_output(CONPTY_PROLOGUE);
         assert!(
             agent.saw_output(),
             "ConPTY greets us even when the child never does"
         );
-        assert!(
-            agent.startup_stalled(),
-            "a coding agent that never paints its TUI is stalled"
-        );
+        assert!(agent.is_stalled());
+        assert!(agent.startup_deadline_reached());
 
-        let painted = SpawnRecord {
-            started: Instant::now() - stall_timeout() - Duration::from_millis(1),
-            ..test_record(Some("codex"))
-        };
-        painted.note_output(&vec![b'x'; paint_floor() as usize]);
+        let shell = aged_record(None);
+        shell.note_output(b"C:\\repo>");
+        assert!(!shell.is_stalled(), "a tiny shell prompt is a healthy start");
+
+        let painted = aged_record(Some(CodingAgentKind::Codex));
+        painted.note_output(&vec![b'x'; painted.thresholds.paint_floor as usize]);
         assert!(
-            !painted.startup_stalled(),
+            !painted.is_stalled(),
             "a coding agent that painted its TUI is healthy"
         );
     }
 
     #[test]
+    fn the_startup_report_fires_once_for_every_session_whatever_it_painted() {
+        // grinch F2: a hang that paints past the floor must still leave its bytes on
+        // record, and so must a session with no coding-agent identity at all.
+        let painted = aged_record(None);
+        painted.note_output(&[b'x'; 200]);
+
+        assert!(painted.startup_deadline_reached());
+        assert!(painted.log_startup_report(&ChildLiveness::Alive));
+        assert!(
+            !painted.stall_reported.load(Ordering::Relaxed),
+            "a painted session is a checkpoint, not a stall"
+        );
+        assert!(
+            !painted.log_startup_report(&ChildLiveness::Alive),
+            "the startup verdict is written once"
+        );
+        assert!(!painted.startup_deadline_reached());
+
+        let stalled = aged_record(Some(CodingAgentKind::Codex));
+        stalled.note_output(CONPTY_PROLOGUE);
+        assert!(stalled.log_startup_report(&ChildLiveness::Alive));
+        assert!(stalled.stall_reported.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn a_disabled_stall_timeout_disables_the_startup_report() {
+        let record = SpawnRecord {
+            thresholds: Thresholds {
+                stall_timeout: Duration::ZERO,
+                ..test_thresholds()
+            },
+            ..aged_record(Some(CodingAgentKind::Codex))
+        };
+        assert!(!record.startup_deadline_reached());
+    }
+
+    #[test]
     fn exit_is_reported_once_and_carries_its_cause() {
-        let record = test_record(Some("codex"));
+        let record = test_record(Some(CodingAgentKind::Codex));
         let liveness = ChildLiveness::Exited {
             code: 1,
             success: false,
-            status: "ExitStatus { code: 1 }".to_string(),
         };
 
         assert!(record.log_child_exit(ExitCause::ChildInitiated, &liveness, "observed-by-monitor"));
@@ -783,57 +1098,316 @@ mod tests {
             !record.log_child_exit(ExitCause::AcRequested, &liveness, "reaped-after-stop"),
             "a second exit report must be suppressed"
         );
+        assert_eq!(
+            *record.exit_cause.lock().unwrap(),
+            Some(ExitCause::ChildInitiated)
+        );
+    }
+
+    #[test]
+    fn output_keeps_flowing_after_a_stop_that_did_not_kill_the_child() {
+        // grinch F5: a Quarantined resource-monitor kill leaves the agent running. The
+        // record must not go blind, and a much later death is the child's own.
+        let record = test_record(Some(CodingAgentKind::Codex));
+        record.mark_ac_stop("watchdog", Some(ChildLiveness::Alive));
+
+        record.note_output(&[b'x'; 128]);
+        assert_eq!(record.bytes_read.load(Ordering::Relaxed), 128);
+        assert_eq!(
+            record.attribute_exit(record.stop_snapshot()),
+            ExitCause::AcRequested,
+            "inside the attribution window the exit is ours"
+        );
+
+        let stale = test_record(Some(CodingAgentKind::Codex));
+        stale.mark_ac_stop("watchdog", Some(ChildLiveness::Alive));
+        // Rewind the clock: the stop request is now older than the attribution window.
+        let long_ago = stale.thresholds.stop_attribution + Duration::from_secs(1);
+        let stale = SpawnRecord {
+            started: Instant::now() - long_ago,
+            ..stale
+        };
+        assert_eq!(
+            stale.attribute_exit(stale.stop_snapshot()),
+            ExitCause::ChildInitiated,
+            "a kill that evidently failed does not own a death an hour later"
+        );
+    }
+
+    #[test]
+    fn a_child_already_dead_at_the_stop_is_never_attributed_to_ac() {
+        // grinch F6: the kill path probes before it touches anything, and that witness
+        // outranks any flag the monitor reads afterwards.
+        let record = test_record(Some(CodingAgentKind::Codex));
+        record.mark_ac_stop(
+            "session-kill",
+            Some(ChildLiveness::Exited {
+                code: 1,
+                success: false,
+            }),
+        );
+
+        assert_eq!(
+            record.attribute_exit(record.stop_snapshot()),
+            ExitCause::ChildInitiated,
+            "it was already dead when AC asked"
+        );
+    }
+
+    #[test]
+    fn an_exit_seen_before_the_stop_flag_is_the_child_s_own() {
+        let record = test_record(Some(CodingAgentKind::Codex));
+        let before = record.stop_snapshot(); // no stop yet
+
+        // The stop lands after the snapshot, with no pre-stop witness (the
+        // resource-monitor path). The exit we already saw cannot be ours.
+        record.mark_ac_stop("watchdog", None);
+
+        assert_eq!(record.attribute_exit(before), ExitCause::ChildInitiated);
     }
 
     #[test]
     fn ac_stop_keeps_the_first_source_and_flags_the_record() {
-        let record = test_record(Some("codex"));
+        let record = test_record(Some(CodingAgentKind::Codex));
         assert!(!record.stop_requested());
 
-        record.mark_ac_stop("watchdog");
-        record.mark_ac_stop("session-kill");
+        record.mark_ac_stop("watchdog", None);
+        record.mark_ac_stop("session-kill", None);
 
         assert!(record.stop_requested());
         assert_eq!(record.stop_source(), "watchdog");
     }
 
     #[test]
-    fn spawn_window_counts_only_the_preceding_spawns() {
-        let agent = format!("codex-{}", Uuid::new_v4());
-        let first = note_spawn_attempt(Some(&agent));
-        let second = note_spawn_attempt(Some(&agent));
-        let third = note_spawn_attempt(Some("other-agent"));
+    fn credentials_and_configured_env_values_are_scrubbed_from_echoed_output() {
+        let token = "3f1c9d2e-7a4b-4c8d-9e1f-2b3c4d5e6f70";
+        let record = SpawnRecord::new(SpawnRecordInit {
+            argv: vec!["codex".to_string(), format!("--token={token}")],
+            redact: vec![token.to_string(), "x".to_string()],
+            ..test_init(Some(CodingAgentKind::Codex))
+        });
+        record.note_output(format!("AGENTSCOMMANDER_TOKEN={token}\r\n").as_bytes());
 
-        assert_eq!(first.same_agent, 0);
-        assert_eq!(second.same_agent, 1);
-        assert_eq!(third.same_agent, 0);
+        assert!(record.head_log().contains("<redacted>"));
+        assert!(!record.head_log().contains(token));
+        assert!(record.argv_log().contains("<redacted>"));
+        assert!(!record.argv_log().contains(token));
+        assert!(
+            record.head_log().contains("AGENTSCOMMANDER_TOKEN"),
+            "a one-character redaction entry must not shred the whole line"
+        );
+    }
+
+    #[test]
+    fn thresholds_from_env_are_clamped() {
+        assert_eq!(env_u64("AC_SPAWN_TEST_MISSING_KEY", 7, 100), 7);
+        std::env::set_var("AC_SPAWN_TEST_CLAMP", "1000000000");
+        assert_eq!(env_u64("AC_SPAWN_TEST_CLAMP", 512, 65_536), 65_536);
+        std::env::set_var("AC_SPAWN_TEST_CLAMP", "not-a-number");
+        assert_eq!(env_u64("AC_SPAWN_TEST_CLAMP", 512, 65_536), 512);
+        std::env::remove_var("AC_SPAWN_TEST_CLAMP");
+    }
+
+    #[test]
+    fn spawn_window_counts_the_preceding_spawns_by_cli() {
+        let thresholds = test_thresholds();
+        let first = note_spawn_attempt(Some(CodingAgentKind::Gemini), thresholds);
+        let second = note_spawn_attempt(Some(CodingAgentKind::Gemini), thresholds);
+        let third = note_spawn_attempt(Some(CodingAgentKind::Claude), thresholds);
+
+        assert_eq!(first.same_cli, 0);
+        assert_eq!(second.same_cli, 1, "two Geminis in the window");
+        assert_eq!(third.same_cli, 0, "a Claude is not a Gemini");
         assert!(second.total >= 1);
         assert!(third.total >= 2);
-        assert_eq!(first.window_ms, concurrency_window().as_millis() as u64);
+        assert_eq!(
+            first.window_ms,
+            thresholds.concurrency_window.as_millis() as u64
+        );
     }
 
     #[test]
     fn registry_forgets_a_session() {
-        let record = register(SpawnRecordInit {
-            session_id: Uuid::new_v4(),
-            pid: None,
-            argv: vec!["cmd.exe".to_string()],
-            cwd: "C:/repo".to_string(),
-            agent_id: None,
-            codex_home: None,
-            configured_env_count: 0,
-            removed_env_count: 0,
-            window: SpawnWindow {
-                window_ms: 10_000,
-                total: 0,
-                same_agent: 0,
-            },
-            started: Instant::now(),
-        });
+        let record = register(test_init(None));
         let id = record.session_id();
 
-        assert!(mark_ac_stop(id, "session-kill").is_some());
+        assert!(mark_ac_stop(id, "session-kill", None).is_some());
         forget(id);
-        assert!(mark_ac_stop(id, "session-kill").is_none());
+        assert!(mark_ac_stop(id, "session-kill", None).is_none());
+    }
+
+    // ---- the monitor thread (grinch N1) ----
+
+    struct FakeProbe {
+        answers: Mutex<Vec<ChildLiveness>>,
+        calls: AtomicUsize,
+    }
+
+    impl FakeProbe {
+        /// Answers are consumed in order; the last one repeats forever.
+        fn new(answers: Vec<ChildLiveness>) -> Arc<Self> {
+            Arc::new(Self {
+                answers: Mutex::new(answers),
+                calls: AtomicUsize::new(0),
+            })
+        }
+
+        fn probe(self: &Arc<Self>) -> impl Fn() -> ChildLiveness + Send + 'static {
+            let probe = Arc::clone(self);
+            move || {
+                probe.calls.fetch_add(1, Ordering::SeqCst);
+                let mut answers = probe.answers.lock().unwrap();
+                if answers.len() > 1 {
+                    answers.remove(0)
+                } else {
+                    answers.first().cloned().unwrap_or(ChildLiveness::Gone)
+                }
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[test]
+    fn monitor_reports_a_child_that_dies_on_its_own_and_then_ends() {
+        let record = Arc::new(test_record(Some(CodingAgentKind::Codex)));
+        let probe = FakeProbe::new(vec![
+            ChildLiveness::Alive,
+            ChildLiveness::Alive,
+            ChildLiveness::Exited {
+                code: 1,
+                success: false,
+            },
+        ]);
+
+        let handle = watch_child(Arc::clone(&record), probe.probe());
+        assert!(
+            wait_until(Duration::from_secs(2), || handle.is_finished()),
+            "the monitor must end with the child"
+        );
+        handle.join().expect("monitor thread");
+
+        assert_eq!(
+            *record.exit_cause.lock().unwrap(),
+            Some(ExitCause::ChildInitiated)
+        );
+        let calls = probe.calls();
+        std::thread::sleep(Duration::from_millis(40));
+        assert_eq!(calls, probe.calls(), "no polling after the exit");
+    }
+
+    #[test]
+    fn monitor_attributes_an_exit_after_an_ac_stop_to_ac() {
+        let record = Arc::new(test_record(Some(CodingAgentKind::Codex)));
+        record.mark_ac_stop("session-kill", Some(ChildLiveness::Alive));
+        let probe = FakeProbe::new(vec![ChildLiveness::Exited {
+            code: 1,
+            success: false,
+        }]);
+
+        let handle = watch_child(Arc::clone(&record), probe.probe());
+        handle.join().expect("monitor thread");
+
+        assert_eq!(
+            *record.exit_cause.lock().unwrap(),
+            Some(ExitCause::AcRequested)
+        );
+    }
+
+    #[test]
+    fn monitor_keeps_child_initiated_when_the_child_was_dead_before_the_stop() {
+        let record = Arc::new(test_record(Some(CodingAgentKind::Codex)));
+        record.mark_ac_stop(
+            "session-kill",
+            Some(ChildLiveness::Exited {
+                code: 0,
+                success: true,
+            }),
+        );
+        let probe = FakeProbe::new(vec![ChildLiveness::Exited {
+            code: 0,
+            success: true,
+        }]);
+
+        let handle = watch_child(Arc::clone(&record), probe.probe());
+        handle.join().expect("monitor thread");
+
+        assert_eq!(
+            *record.exit_cause.lock().unwrap(),
+            Some(ExitCause::ChildInitiated),
+            "AC asked, but it was already dead: the stop did not cause this"
+        );
+    }
+
+    #[test]
+    fn monitor_ends_when_the_session_is_gone_without_reporting_an_exit() {
+        let record = Arc::new(test_record(None));
+        let probe = FakeProbe::new(vec![ChildLiveness::Gone]);
+
+        let handle = watch_child(Arc::clone(&record), probe.probe());
+        handle.join().expect("monitor thread");
+
+        assert!(!record.exit_reported.load(Ordering::Relaxed));
+        assert!(record.exit_cause.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn monitor_writes_the_startup_verdict_for_a_silent_child_and_keeps_watching() {
+        let record = Arc::new(test_record(Some(CodingAgentKind::Codex)));
+        record.note_output(CONPTY_PROLOGUE);
+        let probe = FakeProbe::new(vec![ChildLiveness::Alive]);
+
+        let handle = watch_child(Arc::clone(&record), probe.probe());
+        assert!(
+            wait_until(Duration::from_secs(2), || record
+                .startup_reported
+                .load(Ordering::Relaxed)),
+            "the startup verdict must land at the deadline"
+        );
+        assert!(record.stall_reported.load(Ordering::Relaxed));
+        assert!(
+            !handle.is_finished(),
+            "a stalled but living child stays under watch"
+        );
+
+        // The monitor still ends when the session goes away.
+        *probe.answers.lock().unwrap() = vec![ChildLiveness::Gone];
+        assert!(wait_until(Duration::from_secs(2), || handle.is_finished()));
+        handle.join().expect("monitor thread");
+    }
+
+    #[test]
+    fn monitor_survives_a_panicking_probe() {
+        let record = Arc::new(test_record(Some(CodingAgentKind::Codex)));
+        let handle = watch_child(Arc::clone(&record), || panic!("poisoned child mutex"));
+
+        assert!(
+            wait_until(Duration::from_secs(2), || handle.is_finished()),
+            "a panicking probe must end the monitor, not the app"
+        );
+        handle.join().expect("the panic is caught inside the thread");
+        assert!(!record.exit_reported.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn monitor_reports_an_unqueryable_child_without_calling_it_alive() {
+        let record = Arc::new(test_record(Some(CodingAgentKind::Codex)));
+        record.note_output(CONPTY_PROLOGUE);
+        let probe = FakeProbe::new(vec![ChildLiveness::Unqueryable("os error 5".to_string())]);
+
+        let handle = watch_child(Arc::clone(&record), probe.probe());
+        assert!(
+            wait_until(Duration::from_secs(2), || record
+                .startup_reported
+                .load(Ordering::Relaxed)),
+            "an unqueryable child still gets its startup verdict"
+        );
+        assert!(!record.exit_reported.load(Ordering::Relaxed));
+
+        *probe.answers.lock().unwrap() = vec![ChildLiveness::Gone];
+        assert!(wait_until(Duration::from_secs(2), || handle.is_finished()));
+        handle.join().expect("monitor thread");
     }
 }

--- a/src-tauri/src/pty/spawn_diagnostics.rs
+++ b/src-tauri/src/pty/spawn_diagnostics.rs
@@ -35,9 +35,14 @@
 //!
 //! ## Windows caveats this module refuses to paper over
 //!
-//! - ConPTY writes its own 16-byte handshake (`ESC[?9001h ESC[?1004h`) into every PTY
-//!   within ~20ms of the spawn, child or no child. The first byte is therefore never
-//!   evidence that the child came up; crossing the paint floor is.
+//! - The first bytes off the PTY are never the child. Measured on the shipping spawn
+//!   shape (`cmd.exe /C codex ...`, which is what AC does for every npm-installed agent
+//!   CLI), **71 bytes arrive within ~45ms with the child still doing nothing**: ConPTY's
+//!   own handshake (`ESC[?9001h ESC[?1004h`), its screen setup (`ESC[?25l ESC[2J ESC[m
+//!   ESC[H`), and the npm shim's own `title %COMSPEC%` line, which ConPTY renders as an
+//!   OSC title sequence. The paint floor has to sit ABOVE that band or a hung agent
+//!   reads as painted: 64 did not, 256 does. A real coding-agent TUI crosses 256 bytes in
+//!   ~350ms when healthy (measured, fresh codex) and takes seconds when it is hanging.
 //! - `portable_pty::Child::try_wait` cannot tell "running" from "we cannot query this
 //!   handle": `WinChild::is_complete` swallows a failed `GetExitCodeProcess` and
 //!   returns `Ok(None)`, and its `STILL_ACTIVE` sentinel (259) is also a legal exit
@@ -107,9 +112,14 @@ use crate::session::profile::CodingAgentKind;
 
 const DEFAULT_STALL_TIMEOUT_MS: u64 = 5_000;
 const MAX_STALL_TIMEOUT_MS: u64 = 10 * 60 * 1_000;
-/// Output below this many bytes is not a painted screen; it is the ConPTY handshake
-/// (16 bytes) and nothing else. A coding agent paints a full TUI immediately.
-const DEFAULT_PAINT_FLOOR_BYTES: u64 = 64;
+/// Output below this many bytes is not a painted screen; it is the shell saying hello.
+/// Measured on the real spawn shape (`cmd.exe /C codex ...`): ConPTY's handshake and
+/// screen setup plus the npm shim's `title %COMSPEC%` put **71 bytes** on the PTY within
+/// ~45ms while the agent itself has written nothing. A floor of 64 was therefore crossed
+/// by noise alone, which made every hung coding agent read as "painted" and silently
+/// disabled the stall detector this module exists for. A healthy codex TUI crosses 256
+/// bytes in ~350ms; a hanging one takes seconds.
+const DEFAULT_PAINT_FLOOR_BYTES: u64 = 256;
 const MAX_PAINT_FLOOR_BYTES: u64 = 64 * 1024;
 const DEFAULT_HEAD_BYTES: u64 = 512;
 const MAX_HEAD_BYTES: u64 = 64 * 1024;
@@ -1051,7 +1061,7 @@ mod tests {
     fn test_thresholds() -> Thresholds {
         Thresholds {
             stall_timeout: Duration::from_millis(120),
-            paint_floor: 64,
+            paint_floor: DEFAULT_PAINT_FLOOR_BYTES,
             head_bytes: 512,
             concurrency_window: Duration::from_millis(10_000),
             stop_attribution: Duration::from_millis(500),
@@ -1097,6 +1107,12 @@ mod tests {
     }
 
     const CONPTY_PROLOGUE: &[u8] = b"\x1b[?9001h\x1b[?1004h";
+
+    /// The real thing, captured off a live `cmd.exe /C codex ...` spawn: ConPTY handshake,
+    /// ConPTY screen setup, and the npm shim's own `title %COMSPEC%`. 71 bytes, ~45ms, and
+    /// the agent has not written a thing.
+    const AC_SHELL_PROLOGUE: &[u8] =
+        b"\x1b[?9001h\x1b[?1004h\x1b[?25l\x1b[2J\x1b[m\x1b[H\x1b]0;C:\\WINDOWS\\system32\\cmd.exe \x07\x1b[?25h";
 
     fn wait_until(deadline: Duration, mut done: impl FnMut() -> bool) -> bool {
         let start = Instant::now();
@@ -1159,6 +1175,26 @@ mod tests {
             painted_at,
             "the paint stamp is taken once"
         );
+    }
+
+    #[test]
+    fn the_shell_prologue_alone_is_not_a_painted_screen() {
+        // Measured, not assumed: 71 bytes of ConPTY + npm-shim noise land on the PTY of
+        // EVERY codex spawn within ~45ms. With the old 64-byte floor they crossed it on
+        // their own, so a codex that painted nothing at all read as "painted", the stall
+        // detector never fired, and the deadline report called the hang healthy.
+        assert_eq!(AC_SHELL_PROLOGUE.len(), 71);
+        assert!(
+            (AC_SHELL_PROLOGUE.len() as u64) < Thresholds::DEFAULT.paint_floor,
+            "the paint floor must sit above the shell noise band"
+        );
+
+        let agent = aged_record(Some(CodingAgentKind::Codex));
+        agent.note_output(AC_SHELL_PROLOGUE);
+
+        assert!(agent.saw_output(), "the shell greeted us");
+        assert!(!agent.painted(), "but the agent painted nothing");
+        assert!(agent.is_stalled());
     }
 
     #[test]
@@ -1317,7 +1353,7 @@ mod tests {
         // common path in the app, and `exited(1)` is literally the ExitStatus string from
         // the log trap this issue exists to kill.
         let record = test_record(Some(CodingAgentKind::Codex));
-        record.note_output(&[b'x'; 200]); // it came up fine
+        record.note_output(&[b'x'; 300]); // it came up fine (past the paint floor)
 
         record.mark_ac_stop("session-destroy", Some(ChildLiveness::Alive));
         record.mark_ac_stop(
@@ -1497,7 +1533,7 @@ mod tests {
             ..aged_record(Some(CodingAgentKind::Codex))
         };
         record.mark_ac_stop("job-terminate", Some(ChildLiveness::Alive));
-        record.note_output(&[b'x'; 200]);
+        record.note_output(&[b'x'; 300]);
 
         assert!(
             !record.painted(),

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -412,10 +412,6 @@ impl ResourceMonitorState {
         reason: ResourceKillReason,
         fresh_targets_only: bool,
     ) -> Result<ResourceKillResult, String> {
-        // #942 - tag the stop as AC-initiated BEFORE any process is touched, so the
-        // PTY child-exit event can never read one of our kills as a child that died
-        // on its own. No-op for sessions with no local spawn record.
-        crate::pty::spawn_diagnostics::mark_ac_stop(session_id, reason.as_log_reason());
         let kill_started = Instant::now();
         let (root_identity, previous_targets) = {
             let mut inner = self
@@ -476,6 +472,14 @@ impl ResourceMonitorState {
                 },
             )
         };
+
+        // #942 - we are committed to killing and have touched no process yet: tag the
+        // stop as AC-initiated so the PTY child-exit event can never read it as a child
+        // that died on its own. Deliberately AFTER the early returns above (a group that
+        // is not registered, already terminating or already terminated kills nothing, so
+        // it must not latch an attribution). No-op for sessions with no local spawn
+        // record. Taken with no resource-monitor lock held.
+        crate::pty::spawn_diagnostics::mark_ac_stop(session_id, reason.as_log_reason(), None);
 
         let mut targets = previous_targets;
         let mut current_cleanup_identities = BTreeSet::new();

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -412,6 +412,10 @@ impl ResourceMonitorState {
         reason: ResourceKillReason,
         fresh_targets_only: bool,
     ) -> Result<ResourceKillResult, String> {
+        // #942 - tag the stop as AC-initiated BEFORE any process is touched, so the
+        // PTY child-exit event can never read one of our kills as a child that died
+        // on its own. No-op for sessions with no local spawn record.
+        crate::pty::spawn_diagnostics::mark_ac_stop(session_id, reason.as_log_reason());
         let kill_started = Instant::now();
         let (root_identity, previous_targets) = {
             let mut inner = self

--- a/src-tauri/src/session/profile.rs
+++ b/src-tauri/src/session/profile.rs
@@ -75,6 +75,16 @@ impl CodingAgentKind {
         }
     }
 
+    /// Stable lowercase name of the CLI, for logs and for keying diagnostics by the
+    /// coding agent that is actually running (#942). Not the configured profile id.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            CodingAgentKind::Claude => "claude",
+            CodingAgentKind::Codex => "codex",
+            CodingAgentKind::Gemini => "gemini",
+        }
+    }
+
     /// Resolve the full behavior profile for this kind.
     pub const fn profile(self) -> CodingAgentProfile {
         match self {


### PR DESCRIPTION
## What

Instrumentation to make the intermittent Codex blank-terminal hang self-explaining from `app.log`. **Diagnostics only: no spawn, kill, or teardown behaviour change.**

Closes #942.

## The five signals (all land in `app.log`)

| Event | What it answers |
|---|---|
| `[pty] spawn-record` | the **argv as executed**, cwd, coding-agent CLI, whether `CODEX_HOME` is set, and how many sessions (and how many of the same CLI) spawned in the preceding 10s |
| `[pty] first-paint` / `first-output` | did the child actually come up, and when |
| `[pty] startup-stall` (WARN) / `startup-checkpoint` (INFO) | fires for **every** session at the deadline, always carrying `bytes_read`, `first_paint_ms`, `child=alive\|exited(N)\|unqueryable`, argv, cwd, concurrency and the first 512 bytes off the PTY |
| `[pty] child-exit` | `cause=child-initiated` vs `cause=ac-requested` + `stop_source=` — kills the pre-existing log trap where AC's own tree-kill and a genuine child death both printed `ExitStatus { code: 1 }` |
| `came_up=false` | a session that never painted dumps its evidence **whoever** ended it — i.e. the user who stares at a blank terminal for three seconds and closes it |

Secrets are scrubbed from `argv=` and `head=` **before** the text is escaped, keyed on the env name (`token`, `key`, `secret`, `password`, `credential`, `auth`, `pat`).

## Review

Four adversarial rounds (dev-rust ↔ dev-rust-grinch). Defects found and fixed **in review, before landing**:

- the stall predicate keyed on the wrong identity (AC profile id, not the coding-agent CLI) → a Codex with no profile id was invisible, and the concurrency counter would have argued *against* the leading hypothesis;
- a hang that painted ≥64 bytes produced **zero** evidence (head bytes were only emitted inside the WARN branch);
- the redaction escaped the text *before* scrubbing it, so any secret containing `\` or `"` (i.e. every Windows path) printed **in clear**;
- the stop timestamp was first-wins, so a stale failed kill fabricated `cause=child-initiated` on a child AC had just killed;
- a probe panic could poison the global `ptys` mutex and brick the terminal subsystem;
- **the paint floor (64 B) sat below the shell-noise prologue (71 B: ConPTY handshake + screen setup + the npm shim's own `title %COMSPEC%`)**, so `startup-stall` could never fire for the bug this branch exists to catch. Raised to 256 B, with a test that fails against 64.

Each fix ships with a regression test proven to fail against the prior commit.

## Gate

`cargo test --all-targets`: **2341 passed / 12 ignored / 0 failed** (18 suites). `cargo clippy --all-targets`: no issues.

Note: bare `cargo test` cannot pass on this machine — `rustdoc.exe` is absent from the toolchain, so the doctest target dies; it only ever looked green on a stale cached fingerprint. `--all-targets` is the correct local gate. Follow-up filed.

## Already paying for itself

With this instrumentation the team measured, and **refuted**, two hypotheses (contention on the shared global `~/.codex`: +70 ms; `resume` being inherently slow: +280 ms), and measured a real defect instead: `codex resume --last` in a cwd Codex has never seen costs **3625 ms median / 6011 ms worst** vs 368 ms fresh, and AC injects it with no resumability check while it already gates the equivalent Claude injection on a filesystem probe (#950).
