### PR TITLE
fix(#955): never gate live PTY output behind the snapshot round-trip (the black terminal)

### DIFF
--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -1,4 +1,6 @@
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
 use tauri::{AppHandle, Emitter, Manager, State};
 use uuid::Uuid;
 
@@ -391,19 +393,47 @@ pub fn pty_resize(
         .map_err(|e| e.to_string())
 }
 
+/// #955/#956 - the backend half of the snapshot round-trip measurement.
+///
+/// The frontend logs the whole trip (`[terminal] snapshot <id> settled in Nms`). This logs
+/// what the backend spent inside it, and between them they say WHERE the time went. Read
+/// the three numbers together:
+///
+/// - `handler_ms` - everything this function did, including waiting for both mutexes. If
+///   this is milliseconds and the frontend says seconds, the backend is not the problem.
+/// - `lock_ms` - just the wait for the `PtyManager` mutex, so backend contention cannot
+///   hide inside the total.
+/// - **the timestamp of this line.** This is a SYNC tauri command, so it runs on the main
+///   thread: a line that appears late is a request that queued before the handler ever
+///   started, which is a different bug from a response that came back late. Compare it
+///   against the session's `[pty] Spawned session ...` line.
+///
+/// Fires once per terminal attach. Never on the PTY hot path.
 #[tauri::command]
 pub fn get_screen_snapshot(
     pty_mgr: State<'_, Arc<Mutex<PtyManager>>>,
     session_id: String,
 ) -> Result<Option<PtyScreenSnapshotPayload>, String> {
     let uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+    let started = Instant::now();
 
-    let snapshot = {
+    let (snapshot, lock_ms) = {
         let pty_mgr = pty_mgr
             .lock()
             .map_err(|_| "PtyManager lock poisoned".to_string())?;
-        pty_mgr.get_screen_snapshot(uuid)
+        let lock_ms = started.elapsed().as_secs_f64() * 1000.0;
+        (pty_mgr.get_screen_snapshot(uuid), lock_ms)
     };
+
+    log::info!(
+        "[pty] screen-snapshot session={} handler_ms={:.3} lock_ms={:.3} found={} bytes={} sequence={}",
+        session_id,
+        started.elapsed().as_secs_f64() * 1000.0,
+        lock_ms,
+        snapshot.is_some(),
+        snapshot.as_ref().map(|s| s.data.len()).unwrap_or(0),
+        snapshot.as_ref().map(|s| s.sequence).unwrap_or(0)
+    );
 
     let Some(snapshot) = snapshot else {
         return Ok(None);

--- a/src/terminal/App.workflow.test.tsx
+++ b/src/terminal/App.workflow.test.tsx
@@ -17,6 +17,10 @@ interface FakeTerminalInstance {
   rows: number;
   element: HTMLElement | null;
   writes: unknown[];
+  /** What is actually visible now: reset() clears it, write() appends. */
+  screen: unknown[];
+  resets: number;
+  reset(): void;
   resizes: { cols: number; rows: number }[];
   emitData(data: string): void;
   emitResize(cols: number, rows: number): void;
@@ -38,6 +42,8 @@ vi.mock("@xterm/xterm", () => ({
     rows = 24;
     element: HTMLElement | null = null;
     writes: unknown[] = [];
+    screen: unknown[] = [];
+    resets = 0;
     resizes: { cols: number; rows: number }[] = [];
     private dataHandlers = new Set<(data: string) => void>();
     private resizeHandlers = new Set<(size: { cols: number; rows: number }) => void>();
@@ -63,6 +69,13 @@ vi.mock("@xterm/xterm", () => ({
 
     write(data: unknown): void {
       this.writes.push(data);
+      this.screen.push(data);
+    }
+
+    /** Real xterm RIS: clears the screen and the scrollback. */
+    reset(): void {
+      this.resets += 1;
+      this.screen.length = 0;
     }
 
     scrollToBottom(): void {}
@@ -358,8 +371,11 @@ describe("TerminalApp workflow", () => {
         sequence: 1,
       });
 
+      // #955: the live chunk is on screen the moment it arrives. It is NOT
+      // withheld until the snapshot round-trip settles.
       await flushPromises();
-      expect(terminal.writes).toHaveLength(0);
+      expect(terminal.writes).toHaveLength(1);
+      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
 
       snapshot.resolve({
         sessionId: "session-1",
@@ -369,9 +385,14 @@ describe("TerminalApp workflow", () => {
         sequence: 0,
       });
 
-      await waitFor(() => expect(terminal.writes).toHaveLength(2));
-      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([83, 78, 65, 80]);
-      expect(Array.from(terminal.writes[1] as Uint8Array)).toEqual(liveOutput);
+      // A snapshot is a full-screen repaint and this one predates the live
+      // chunk (sequence 0 < 1), so the screen is rebuilt rather than appended
+      // to: snapshot first, then the live output it excludes. Final state is
+      // identical to the un-raced path — nothing duplicated, nothing missing.
+      await waitFor(() => expect(terminal.resets).toBe(1));
+      expect(terminal.screen).toHaveLength(2);
+      expect(Array.from(terminal.screen[0] as Uint8Array)).toEqual([83, 78, 65, 80]);
+      expect(Array.from(terminal.screen[1] as Uint8Array)).toEqual(liveOutput);
     } finally {
       rendered.cleanup();
     }
@@ -402,8 +423,9 @@ describe("TerminalApp workflow", () => {
         sequence: 1,
       });
 
+      // #955: rendered on arrival, not withheld.
       await flushPromises();
-      expect(terminal.writes).toHaveLength(0);
+      expect(terminal.writes).toHaveLength(1);
 
       snapshot.resolve({
         sessionId: "session-1",
@@ -413,8 +435,12 @@ describe("TerminalApp workflow", () => {
         sequence: 1,
       });
 
-      await waitFor(() => expect(terminal.writes).toHaveLength(1));
-      expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([
+      // The snapshot's screen already contains the live chunk (sequence 1), so
+      // after the rebuild it appears exactly ONCE: the sequence dedup drops the
+      // replay instead of writing it a second time.
+      await waitFor(() => expect(terminal.resets).toBe(1));
+      expect(terminal.screen).toHaveLength(1);
+      expect(Array.from(terminal.screen[0] as Uint8Array)).toEqual([
         83, 78, 65, 80, 76, 73, 86, 69,
       ]);
     } finally {
@@ -584,13 +610,17 @@ describe("TerminalApp workflow", () => {
         sequence: 1,
       });
 
+      // #955: rendered on arrival, not withheld.
       await flushPromises();
-      expect(terminal.writes).toHaveLength(0);
+      expect(terminal.writes).toHaveLength(1);
 
       snapshot.resolve(null);
 
-      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+      // Nothing to seed with: the live output already on screen stands, and is
+      // not written a second time.
+      await flushPromises();
       expect(terminal.writes).toHaveLength(1);
+      expect(terminal.resets).toBe(0);
       expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
       const replayStatus = rendered.root.querySelector<HTMLDivElement>(
         '[data-ac-testid="terminal.replay-status.session-1"]'
@@ -627,13 +657,17 @@ describe("TerminalApp workflow", () => {
         sequence: 1,
       });
 
+      // #955: rendered on arrival, not withheld.
       await flushPromises();
-      expect(terminal.writes).toHaveLength(0);
+      expect(terminal.writes).toHaveLength(1);
 
       snapshot.reject("missing parser");
 
-      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+      // The round-trip failed; the live output already on screen stands, and is
+      // not written a second time.
+      await flushPromises();
       expect(terminal.writes).toHaveLength(1);
+      expect(terminal.resets).toBe(0);
       expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual(liveOutput);
       const replayStatus = rendered.root.querySelector<HTMLDivElement>(
         '[data-ac-testid="terminal.replay-status.session-1"]'

--- a/src/terminal/components/TerminalView.render-gate.test.tsx
+++ b/src/terminal/components/TerminalView.render-gate.test.tsx
@@ -1,0 +1,531 @@
+// @vitest-environment jsdom
+//
+// #955 — a new terminal rendered NOTHING until the `get_screen_snapshot` IPC
+// round-trip settled. A Trace capture proved the agent painted at 418 ms and
+// kept painting for the entire 5.4 s the user stared at a black tile: every
+// byte reached the backend, and the frontend buffered them in an array instead
+// of writing them to xterm.
+//
+// The contract these tests lock down:
+//   1. A live PTY byte is NEVER gated behind an IPC round-trip. It renders on
+//      arrival, whether the snapshot settles late, or never.
+//   2. The snapshot still restores re-attach scrollback — with no duplicated
+//      and no missing output — by reconciling AFTER the fact, not by gating.
+//
+// The xterm double models `reset()` faithfully: `writes` is the full write
+// history (proving live bytes were rendered immediately), `screen` is what is
+// actually visible now (proving the reconciled result is correct).
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TerminalApp from "../App";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import type { PtyScreenSnapshot } from "../../shared/types";
+import {
+  baseSettings,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+
+interface FakeTerminalInstance {
+  cols: number;
+  rows: number;
+  element: HTMLElement | null;
+  writes: unknown[];
+  screen: unknown[];
+  resets: number;
+  resizes: { cols: number; rows: number }[];
+  emitResize(cols: number, rows: number): void;
+  resize(cols: number, rows: number): void;
+  reset(): void;
+}
+
+const xterm = vi.hoisted(() => ({
+  instances: [] as FakeTerminalInstance[],
+}));
+
+const fitViewport = vi.hoisted(() => ({
+  cols: 88,
+  rows: 26,
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class implements FakeTerminalInstance {
+    cols = 80;
+    rows = 24;
+    element: HTMLElement | null = null;
+    writes: unknown[] = [];
+    screen: unknown[] = [];
+    resets = 0;
+    resizes: { cols: number; rows: number }[] = [];
+    private resizeHandlers = new Set<(size: { cols: number; rows: number }) => void>();
+
+    constructor() {
+      xterm.instances.push(this);
+    }
+
+    loadAddon(addon?: { activate?: (terminal: FakeTerminalInstance) => void }): void {
+      addon?.activate?.(this);
+    }
+
+    open(element: HTMLElement): void {
+      this.element = element;
+    }
+
+    focus(): void {}
+
+    dispose(): void {
+      this.resizeHandlers.clear();
+    }
+
+    write(data: unknown): void {
+      this.writes.push(data);
+      this.screen.push(data);
+    }
+
+    /** Real xterm RIS: clears the screen and scrollback. */
+    reset(): void {
+      this.resets += 1;
+      this.screen.length = 0;
+    }
+
+    scrollToBottom(): void {}
+
+    paste(): void {}
+
+    hasSelection(): boolean {
+      return false;
+    }
+
+    getSelection(): string {
+      return "";
+    }
+
+    attachCustomKeyEventHandler(): void {}
+
+    onData(): { dispose: () => void } {
+      return { dispose: () => {} };
+    }
+
+    onResize(
+      handler: (size: { cols: number; rows: number }) => void
+    ): { dispose: () => void } {
+      this.resizeHandlers.add(handler);
+      return { dispose: () => this.resizeHandlers.delete(handler) };
+    }
+
+    emitResize(cols: number, rows: number): void {
+      this.cols = cols;
+      this.rows = rows;
+      this.resizes.push({ cols, rows });
+      for (const handler of Array.from(this.resizeHandlers)) {
+        handler({ cols, rows });
+      }
+    }
+
+    resize(cols: number, rows: number): void {
+      this.emitResize(cols, rows);
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    private terminal: FakeTerminalInstance | null = null;
+
+    activate(terminal: FakeTerminalInstance): void {
+      this.terminal = terminal;
+    }
+
+    fit = vi.fn(() => {
+      this.terminal?.resize(fitViewport.cols, fitViewport.rows);
+    });
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: class {
+    onContextLoss = vi.fn();
+    dispose = vi.fn();
+  },
+}));
+
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+vi.mock("../../shared/platform", () => ({
+  isTauri: true,
+  isBrowser: false,
+}));
+
+const SNAP = [83, 78, 65, 80]; // "SNAP"
+const LIVE = [76, 73, 86, 69]; // "LIVE"
+const NEXT = [78, 69, 88, 84]; // "NEXT"
+
+function setupTerminalTransport(fake: FakeTransport, sessions = [session()]): void {
+  fake.resolve("get_settings", baseSettings());
+  fake.resolve("get_active_session", sessions[0]?.id ?? null);
+  fake.onInvoke("list_sessions", () => sessions);
+  fake.resolve("pty_write", undefined);
+  fake.resolve("pty_resize", undefined);
+  fake.resolve("get_screen_snapshot", null);
+  fake.resolve("set_last_prompt", undefined);
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function onlySession() {
+  return session({
+    id: "session-1",
+    name: "wg-1-dev-team/architect",
+    workingDirectory: "C:\\Project\\.ac\\wg-1-dev-team\\__agent_architect",
+  });
+}
+
+function bytes(writes: unknown[]): number[][] {
+  return writes.map((write) => Array.from(write as Uint8Array));
+}
+
+describe("TerminalView snapshot render gate (#955)", () => {
+  let cleanupDom: (() => void) | null = null;
+  let warn: ReturnType<typeof vi.spyOn>;
+  let debug: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+    xterm.instances.length = 0;
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    xterm.instances.length = 0;
+    warn.mockRestore();
+    debug.mockRestore();
+  });
+
+  // THE REGRESSION. Red against main: the live chunk is pushed onto
+  // pendingSnapshotEvents and never written, so `writes` stays empty forever —
+  // the black tile. Green with the gate removed.
+  it("renders live PTY output while the snapshot round-trip is still in flight", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [onlySession()]);
+    // Never settles: exactly the state the Trace capture proved.
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: LIVE,
+        sequence: 1,
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+      expect(bytes(terminal.screen)).toEqual([LIVE]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // The trace showed ~40 chunks over 5.4 s into a black tile. Every one of them
+  // must reach the screen while the round-trip is still outstanding.
+  it("keeps rendering every live chunk while the snapshot never settles", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [onlySession()]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
+      for (let index = 0; index < 5; index += 1) {
+        fake.emitFromBackend("pty_output", {
+          sessionId: "session-1",
+          data: [65 + index],
+          sequence: index + 1,
+        });
+      }
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(5));
+      expect(bytes(terminal.screen)).toEqual([[65], [66], [67], [68], [69]]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // Safety net, not a gate: a terminal that has rendered nothing at all says so
+  // instead of sitting black and silent. Red against main (no status is ever
+  // surfaced while the promise is outstanding).
+  it("surfaces the unavailable status when the snapshot stalls with nothing rendered", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [onlySession()]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+
+      await waitFor(() => {
+        const status = rendered.root.querySelector<HTMLDivElement>(
+          '[data-ac-testid="terminal.replay-status.session-1"]'
+        );
+        expect(status?.hidden).toBe(false);
+      }, 3000);
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("still pending after 500ms")
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // ...but a terminal that IS rendering live output has nothing to report.
+  it("does not surface the unavailable status while live output is rendering", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [onlySession()]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      const terminal = xterm.instances[0];
+
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: LIVE,
+        sequence: 1,
+      });
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+
+      await new Promise((resolve) => setTimeout(resolve, 700));
+
+      const status = rendered.root.querySelector<HTMLDivElement>(
+        '[data-ac-testid="terminal.replay-status.session-1"]'
+      );
+      expect(status?.hidden).toBe(true);
+      expect(bytes(terminal.screen)).toEqual([LIVE]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // RE-ATTACH, snapshot loses the race. The snapshot is a full-screen repaint,
+  // so it cannot simply be written on top of live bytes. The screen is rebuilt:
+  // reset -> snapshot (everything <= its sequence) -> live events after it.
+  // Here the snapshot already contains the live chunk (sequence 1), so the
+  // chunk must NOT be replayed on top of it: no duplication.
+  it("rebuilds from the snapshot without duplicating live output it already contains", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [onlySession()]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: LIVE,
+        sequence: 1,
+      });
+
+      // The gate is gone: it is on screen before the snapshot settles.
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+
+      snapshot.resolve({
+        sessionId: "session-1",
+        data: [...SNAP, ...LIVE],
+        rows: null,
+        cols: null,
+        sequence: 1, // the snapshot's screen already includes event #1
+      });
+
+      await waitFor(() => expect(terminal.resets).toBe(1));
+      await flushPromises();
+
+      // Visible screen: the snapshot alone. The live chunk is inside it and is
+      // dropped by the sequence dedup rather than written a second time.
+      expect(bytes(terminal.screen)).toEqual([[...SNAP, ...LIVE]]);
+      // History proves the live byte was rendered immediately, before the
+      // snapshot arrived — that is the whole point of the fix.
+      expect(bytes(terminal.writes)).toEqual([LIVE, [...SNAP, ...LIVE]]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // RE-ATTACH, snapshot loses the race and does NOT cover the newest live
+  // event. The rebuild must replay everything after the snapshot's sequence:
+  // no missing output.
+  it("replays the live output the late snapshot does not cover", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [onlySession()]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: LIVE,
+        sequence: 1,
+      });
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: NEXT,
+        sequence: 2,
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(2));
+
+      snapshot.resolve({
+        sessionId: "session-1",
+        data: SNAP,
+        rows: null,
+        cols: null,
+        sequence: 1, // covers event #1 only
+      });
+
+      await waitFor(() => expect(terminal.resets).toBe(1));
+      await flushPromises();
+
+      // Snapshot, then only the event it did not contain. Event #1 is dropped
+      // (already in the snapshot), event #2 is replayed (it was not).
+      expect(bytes(terminal.screen)).toEqual([SNAP, NEXT]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // RE-ATTACH, snapshot WINS the race (the normal, fast path). Unchanged
+  // behaviour: seed the clean terminal, never reset it.
+  it("seeds a clean terminal from the snapshot without resetting it", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [onlySession()]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
+      snapshot.resolve({
+        sessionId: "session-1",
+        data: SNAP,
+        rows: null,
+        cols: null,
+        sequence: 1,
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(1));
+
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: NEXT,
+        sequence: 2,
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(2));
+
+      expect(terminal.resets).toBe(0);
+      expect(bytes(terminal.screen)).toEqual([SNAP, NEXT]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // The retention budget bounds memory when the round-trip never settles. Once
+  // it is spent the live events after the snapshot's sequence are no longer
+  // held, so a rebuild would DROP them: the snapshot must be discarded instead,
+  // and the live screen kept.
+  it("discards a snapshot that lands after the reconcile budget is spent", async () => {
+    const fake = new FakeTransport();
+    const snapshot = deferred<PtyScreenSnapshot | null>();
+    setupTerminalTransport(fake, [onlySession()]);
+    fake.onInvoke("get_screen_snapshot", () => snapshot.promise);
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(1));
+
+      const terminal = xterm.instances[0];
+      // One chunk larger than the 2 MiB retention budget.
+      const flood = new Array<number>(2 * 1024 * 1024 + 1).fill(65);
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: flood,
+        sequence: 1,
+      });
+      fake.emitFromBackend("pty_output", {
+        sessionId: "session-1",
+        data: NEXT,
+        sequence: 2,
+      });
+
+      await waitFor(() => expect(terminal.writes).toHaveLength(2));
+
+      snapshot.resolve({
+        sessionId: "session-1",
+        data: SNAP,
+        rows: null,
+        cols: null,
+        sequence: 1,
+      });
+
+      await flushPromises();
+      await flushPromises();
+
+      // No reset: the live screen survives intact, snapshot dropped.
+      expect(terminal.resets).toBe(0);
+      expect(bytes(terminal.screen.slice(1))).toEqual([NEXT]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("outran the reconcile budget")
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../shared/ipc";
 import { isBrowser, isTauri } from "../../shared/platform";
 import { terminalStore } from "../stores/terminal";
-import type { PtyOutputEvent } from "../../shared/types";
+import type { PtyOutputEvent, PtyScreenSnapshot } from "../../shared/types";
 import type { UnlistenFn } from "../../shared/transport";
 import { updatePromptCapture } from "./prompt-input-capture";
 import { createTerminalOptions } from "./terminal-options";
@@ -23,11 +23,19 @@ interface SessionTerminal {
   fitAddon: FitAddon;
   inputBuffer: string;
   snapshotReplayRequested: boolean;
+  /**
+   * A `get_screen_snapshot` round-trip is in flight AND the screen can still be
+   * rebuilt from it. Never gates rendering (#955) — it only says whether the
+   * retained live events are still complete enough to reconcile against.
+   */
   snapshotReplayPending: boolean;
   snapshotResizeSuppressed: boolean;
+  snapshotSettleTimer: ReturnType<typeof setTimeout> | null;
   hasRenderedOutput: boolean;
   replayStatus: HTMLDivElement;
+  /** Live events already written to xterm, retained only to rebuild (#955). */
   pendingSnapshotEvents: PtyOutputEvent[];
+  pendingSnapshotBytes: number;
   lastAppliedSequence: number | null;
 }
 
@@ -38,6 +46,28 @@ interface TerminalViewProps {
    */
   lockedSessionId?: string;
 }
+
+const SNAPSHOT_UNAVAILABLE_MESSAGE =
+  "Terminal buffer unavailable. Resize the window to request a repaint.";
+
+// #955: `get_screen_snapshot` is an IPC round-trip, and it used to gate every
+// byte a new terminal rendered. On a saturated webview main thread it was
+// measured taking seconds — and, in the capture on the issue, never settling at
+// all: the agent painted continuously into a permanently black tile.
+//
+// The gate is gone. Live bytes render on arrival, and the snapshot reconciles
+// afterwards. These two bounds are what remains of the round-trip:
+//
+// 1. A settle deadline, purely diagnostic. It gates nothing; it sizes the
+//    round-trip in the log and lets a terminal that has still shown *nothing*
+//    say so instead of sitting black.
+const SNAPSHOT_SETTLE_WARN_MS = 500;
+// 2. A retention budget. Live events are held (in addition to being rendered)
+//    so the screen can be rebuilt into the snapshot's frame of reference when
+//    the snapshot loses the race. Past this many bytes the live stream has
+//    repainted the screen many times over, the snapshot is worthless, and
+//    holding more would leak if the round-trip never settles.
+const SNAPSHOT_RECONCILE_LIMIT_BYTES = 2 * 1024 * 1024;
 
 // WebGL context budget: ~16 per document. Canvas fallback activates silently
 // when the budget is exhausted (e.g. after ~16 concurrent sessions in main).
@@ -80,12 +110,20 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     });
   };
 
+  const clearSnapshotSettleTimer = (entry: SessionTerminal) => {
+    if (entry.snapshotSettleTimer !== null) {
+      clearTimeout(entry.snapshotSettleTimer);
+      entry.snapshotSettleTimer = null;
+    }
+  };
+
   const disposeSessionTerminal = (sessionId: string) => {
     const entry = terminals.get(sessionId);
     if (!entry) {
       return;
     }
 
+    clearSnapshotSettleTimer(entry);
     entry.terminal.dispose();
     entry.container.remove();
     terminals.delete(sessionId);
@@ -147,12 +185,41 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         : Math.max(entry.lastAppliedSequence, sequence);
   };
 
+  const abandonSnapshotReconcile = (entry: SessionTerminal) => {
+    entry.snapshotReplayPending = false;
+    entry.pendingSnapshotEvents = [];
+    entry.pendingSnapshotBytes = 0;
+  };
+
+  /**
+   * Retain a live event that has ALREADY been written to xterm, so the screen
+   * can be rebuilt from the snapshot's frame of reference once it lands. This
+   * buffer never withholds output (#955) — it exists only to reconcile.
+   */
+  const retainForSnapshotReconcile = (
+    entry: SessionTerminal,
+    event: PtyOutputEvent
+  ) => {
+    entry.pendingSnapshotEvents.push(event);
+    entry.pendingSnapshotBytes += event.data.length;
+
+    if (entry.pendingSnapshotBytes > SNAPSHOT_RECONCILE_LIMIT_BYTES) {
+      abandonSnapshotReconcile(entry);
+    }
+  };
+
+  /**
+   * #955: live PTY bytes are written the instant they arrive. They are NEVER
+   * gated on the snapshot round-trip — that gate was the defect: every newly
+   * created terminal stayed black for as long as `get_screen_snapshot` took to
+   * settle, which on a saturated IPC channel was forever, while the agent
+   * painted underneath and the bytes piled up in an array.
+   */
   const writeLivePtyOutput = (entry: SessionTerminal, event: PtyOutputEvent) => {
     const sequence = eventSequence(event);
 
     if (entry.snapshotReplayPending) {
-      entry.pendingSnapshotEvents.push(event);
-      return;
+      retainForSnapshotReconcile(entry, event);
     }
 
     if (shouldDropAlreadyAppliedEvent(entry, sequence)) {
@@ -161,20 +228,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
 
     writeTerminalBytes(entry, new Uint8Array(event.data));
     markAppliedSequence(entry, sequence);
-  };
-
-  const finishPendingSnapshotReplay = (
-    sessionId: string,
-    entry: SessionTerminal
-  ): PtyOutputEvent[] | null => {
-    if (terminals.get(sessionId) !== entry || !entry.snapshotReplayPending) {
-      return null;
-    }
-
-    entry.snapshotReplayPending = false;
-    const pendingEvents = entry.pendingSnapshotEvents;
-    entry.pendingSnapshotEvents = [];
-    return pendingEvents;
   };
 
   const flushPendingEvents = (
@@ -199,6 +252,130 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     }
   };
 
+  interface SnapshotSettle {
+    /** The retained live events were still complete: a rebuild is safe. */
+    reconcilable: boolean;
+    retainedEvents: PtyOutputEvent[];
+  }
+
+  /**
+   * Conclude the snapshot round-trip, whatever its outcome. Returns the live
+   * events retained while it was in flight, or null if the terminal was
+   * replaced/disposed underneath it.
+   */
+  const concludeSnapshotFetch = (
+    sessionId: string,
+    entry: SessionTerminal
+  ): SnapshotSettle | null => {
+    if (terminals.get(sessionId) !== entry) {
+      return null;
+    }
+
+    clearSnapshotSettleTimer(entry);
+
+    const settle: SnapshotSettle = {
+      reconcilable: entry.snapshotReplayPending,
+      retainedEvents: entry.pendingSnapshotEvents,
+    };
+
+    entry.snapshotReplayPending = false;
+    entry.pendingSnapshotEvents = [];
+    entry.pendingSnapshotBytes = 0;
+
+    return settle;
+  };
+
+  const logSnapshotSettle = (
+    sessionId: string,
+    requestedAt: number,
+    pendingEvents: number
+  ) => {
+    const elapsedMs = Math.round(performance.now() - requestedAt);
+    const line = `[terminal] snapshot ${sessionId} settled in ${elapsedMs}ms, pendingEvents=${pendingEvents}`;
+
+    if (elapsedMs > SNAPSHOT_SETTLE_WARN_MS) {
+      console.warn(line);
+      return;
+    }
+
+    console.debug(line);
+  };
+
+  /**
+   * Live output already painted this terminal, so the snapshot lost the race.
+   * A snapshot is a FULL-SCREEN repaint (`vt100::Screen::contents_formatted`),
+   * so writing it on top of live bytes would duplicate them. Rebuild instead:
+   * reset, lay down the snapshot (everything up to its sequence), then replay
+   * the live events that came after it. The sequence dedup drops the ones the
+   * snapshot already contains, so the result is exactly what the un-raced path
+   * renders — no duplicated and no missing output.
+   */
+  const rebuildFromSnapshot = (
+    entry: SessionTerminal,
+    snapshot: PtyScreenSnapshot,
+    retainedEvents: PtyOutputEvent[]
+  ) => {
+    entry.terminal.reset();
+    entry.hasRenderedOutput = false;
+    // Rewind, do not raise: the retained events after the snapshot's sequence
+    // must replay, and markAppliedSequence() only ever moves the watermark up.
+    entry.lastAppliedSequence = snapshot.sequence;
+
+    writeTerminalBytes(entry, new Uint8Array(snapshot.data));
+    flushPendingEvents(entry, retainedEvents);
+  };
+
+  const applySnapshot = (
+    sessionId: string,
+    entry: SessionTerminal,
+    snapshot: PtyScreenSnapshot | null,
+    settle: SnapshotSettle
+  ) => {
+    const { reconcilable, retainedEvents } = settle;
+
+    if (!snapshot || snapshot.data.length === 0) {
+      // Nothing to seed with. Whatever live output has arrived stands, and the
+      // dedup makes this flush a no-op for anything already on screen.
+      flushPendingEvents(entry, retainedEvents);
+      if (!entry.hasRenderedOutput) {
+        setReplayStatus(entry, SNAPSHOT_UNAVAILABLE_MESSAGE);
+      }
+      return;
+    }
+
+    if (entry.hasRenderedOutput && !reconcilable) {
+      // The retention budget was spent, so the live events after the snapshot's
+      // sequence are no longer held and a rebuild would drop them. The live
+      // stream has long since repainted the screen: keep it, drop the snapshot.
+      console.warn(
+        `[terminal] snapshot ${sessionId} discarded: live output outran the reconcile budget`
+      );
+      return;
+    }
+
+    if (
+      snapshot.rows !== null &&
+      snapshot.cols !== null &&
+      (entry.terminal.rows !== snapshot.rows || entry.terminal.cols !== snapshot.cols)
+    ) {
+      resizeTerminalForSnapshot(entry, snapshot.cols, snapshot.rows);
+    }
+
+    if (entry.hasRenderedOutput) {
+      rebuildFromSnapshot(entry, snapshot, retainedEvents);
+    } else {
+      // The snapshot won the race into a clean terminal: seed it and let the
+      // retained events (if any) land on top. This is the re-attach path.
+      writeTerminalBytes(entry, new Uint8Array(snapshot.data));
+      markAppliedSequence(entry, snapshot.sequence);
+      flushPendingEvents(entry, retainedEvents);
+    }
+
+    if (sessionId === activeSessionId) {
+      scheduleViewportSync(sessionId);
+    }
+  };
+
   const replayNativeSnapshot = (sessionId: string, entry: SessionTerminal) => {
     if (!isTauri || entry.snapshotReplayRequested) {
       return;
@@ -207,55 +384,52 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     entry.snapshotReplayRequested = true;
     entry.snapshotReplayPending = true;
     entry.pendingSnapshotEvents = [];
+    entry.pendingSnapshotBytes = 0;
+
+    // #955 diagnostic: size the round-trip. The gate is gone, but a slow settle
+    // still points straight at a saturated IPC channel / webview main thread.
+    const requestedAt = performance.now();
+
+    clearSnapshotSettleTimer(entry);
+    entry.snapshotSettleTimer = setTimeout(() => {
+      entry.snapshotSettleTimer = null;
+      if (terminals.get(sessionId) !== entry || !entry.snapshotReplayPending) {
+        return;
+      }
+
+      console.warn(
+        `[terminal] snapshot ${sessionId} still pending after ${SNAPSHOT_SETTLE_WARN_MS}ms, pendingEvents=${entry.pendingSnapshotEvents.length}`
+      );
+
+      // Live output keeps rendering regardless — that is the fix. Only a
+      // terminal that has shown nothing at all has anything to report.
+      if (!entry.hasRenderedOutput) {
+        setReplayStatus(entry, SNAPSHOT_UNAVAILABLE_MESSAGE);
+      }
+    }, SNAPSHOT_SETTLE_WARN_MS);
 
     void PtyAPI.getScreenSnapshot(sessionId)
       .then((snapshot) => {
-        const pendingEvents = finishPendingSnapshotReplay(sessionId, entry);
-        if (!pendingEvents) {
+        const settle = concludeSnapshotFetch(sessionId, entry);
+        if (!settle) {
           return;
         }
 
-        if (!snapshot || snapshot.data.length === 0) {
-          flushPendingEvents(entry, pendingEvents);
-          if (!entry.hasRenderedOutput) {
-            setReplayStatus(
-              entry,
-              "Terminal buffer unavailable. Resize the window to request a repaint."
-            );
-          }
-          return;
-        }
-
-        if (
-          snapshot.rows !== null &&
-          snapshot.cols !== null &&
-          (entry.terminal.rows !== snapshot.rows || entry.terminal.cols !== snapshot.cols)
-        ) {
-          resizeTerminalForSnapshot(entry, snapshot.cols, snapshot.rows);
-        }
-
-        writeTerminalBytes(entry, new Uint8Array(snapshot.data));
-        markAppliedSequence(entry, snapshot.sequence);
-        flushPendingEvents(entry, pendingEvents);
-
-        if (sessionId === activeSessionId) {
-          scheduleViewportSync(sessionId);
-        }
+        logSnapshotSettle(sessionId, requestedAt, settle.retainedEvents.length);
+        applySnapshot(sessionId, entry, snapshot, settle);
       })
       .catch((err) => {
-        const pendingEvents = finishPendingSnapshotReplay(sessionId, entry);
-        if (!pendingEvents) {
+        const settle = concludeSnapshotFetch(sessionId, entry);
+        if (!settle) {
           return;
         }
 
+        logSnapshotSettle(sessionId, requestedAt, settle.retainedEvents.length);
         console.warn("[terminal] snapshot replay failed:", err);
-        flushPendingEvents(entry, pendingEvents);
+        flushPendingEvents(entry, settle.retainedEvents);
 
         if (!entry.hasRenderedOutput) {
-          setReplayStatus(
-            entry,
-            "Terminal buffer unavailable. Resize the window to request a repaint."
-          );
+          setReplayStatus(entry, SNAPSHOT_UNAVAILABLE_MESSAGE);
         }
       });
   };
@@ -305,9 +479,11 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       snapshotReplayRequested: false,
       snapshotReplayPending: false,
       snapshotResizeSuppressed: false,
+      snapshotSettleTimer: null,
       hasRenderedOutput: false,
       replayStatus,
       pendingSnapshotEvents: [],
+      pendingSnapshotBytes: 0,
       lastAppliedSequence: null,
     };
 


### PR DESCRIPTION
## What

A newly created terminal rendered **nothing** until a `get_screen_snapshot` IPC round-trip settled. If that promise was slow or never settled, the tile stayed **black forever** while the agent ran perfectly and its bytes piled up in an unbounded array.

Closes #955.

## The bug, proven on a live capture

Session `95278d5d` (Codex), spawned 20:37:19.001, killed by the user at 20:37:24.380 after staring at a black terminal:

```
20:37:19.418  [idle] SUPPRESSED 95278d5d (1145 bytes,    4ms after resize)
20:37:19.869  [idle] SUPPRESSED 95278d5d (2264 bytes,  426ms after resize)   <- full TUI paint
   ... ~40 more printable chunks, every 30-60 ms (animation frames) ...
20:37:22.068  [idle] SUPPRESSED 95278d5d ( 366 bytes, 2625ms after resize)
```

The child painted at **418 ms** and never stopped. Every byte reached the backend and the vt100 parser. The screen showed nothing.

The defect was one `return`:

```ts
if (entry.snapshotReplayPending) { entry.pendingSnapshotEvents.push(event); return; }
writeTerminalBytes(entry, new Uint8Array(event.data));
```

Independent proof the promise never settled: the `ms after resize` counter is monotonic for 2.6 s and never resets, yet the snapshot's success path calls `scheduleViewportSync` -> `PtyAPI.resize`, which would have reset it.

## The fix

**Live PTY bytes are never gated.** They reach xterm on arrival, whether the snapshot settles late, fails, or never settles. The snapshot became a **seed, not a gate**:

- snapshot wins the race (clean terminal) -> seed it; **the re-attach path is `main` line for line**;
- live output wins (dirty terminal) -> **rebuild**: `reset()` -> write the snapshot (everything <= S) -> replay the retained events after S. Raced and un-raced end in an **identical final screen**, pinned by two tests.
- `contents_formatted()` is a full-screen repaint, so it cannot be written on top of already-painted live bytes; `reset()` is what makes the rebuild sound (verified against the vendored `@xterm/xterm` and `vt100` sources during review).
- **2 MiB retention budget** bounds the reconcile buffer and also fixes an unbounded-array leak that exists on `main` when the round-trip never settles. Past the budget the **snapshot is discarded**, not applied.
- A 500 ms settle deadline **gates nothing**: it only logs, so a terminal that has rendered nothing can say so.

## Diagnostics shipped with it

- frontend: `[terminal] snapshot <id> settled in Nms, pendingEvents=<count>` (warn > 500 ms)
- backend: `[pty] screen-snapshot session=<uuid> handler_ms=… lock_ms=… found=… bytes=… sequence=…` (INFO, once per attach)

Together they decide #956: a fast backend against a slow settle means the delay is in the IPC channel / webview main thread (`Vec<u8>` emitted as a JSON array of numbers, 4.4x inflation, measured). A **late-arriving backend line** instead means the request queued before the handler ran, which is a different bug.

## Review

The test suite had **the bug encoded as a contract**: four assertions in `App.workflow.test.tsx` read `expect(terminal.writes).toHaveLength(0)` *after a live event arrived* — asserting that an arrived byte must not be rendered. They were inverted; every final-state assertion was kept and strengthened (`screen` instead of `writes`, plus `resets === 1`).

New regression suite (8 cases) proven red against `main` and green on the branch, re-verified independently by review:

```
against main:  Tests  7 failed | 1 passed (8)
  x renders live PTY output while the snapshot round-trip is still in flight
    AssertionError: expected [] to have a length of 1 but got +0
on branch:     Tests  8 passed (8)
```

Reviewed for duplication, loss, ordering, boundedness, the re-attach path, the 2 MiB drop, and the sequence protocol end to end (TS and Rust: `parser.process()` and `output_sequence += 1` happen under the same mutex that `get_screen_snapshot` reads, so `snapshot.sequence` is exactly "the last event whose bytes are in this snapshot" — no off-by-one).

## Known, and deliberately not fixed here

- On a **raced re-attach** the user may briefly see the raw live chunk before the rebuild replaces it. A visible transient, strictly better than a black tile.
- AC's re-attach restores the visible screen, **not scrollback** (`vt100::Parser::new(rows, cols, 0)` — scrollback length zero). Unchanged from `main`; noted so nobody claims otherwise.
- AC's re-attach does not restore terminal **modes** (the snapshot carries cells, not modes). Unchanged from `main`.

## Gates

`npx tsc --noEmit` clean · `npm run test:debt` exit 0 · `cargo clippy --all-targets` no issues · `cargo test --all-targets` **2352 passed / 0 failed**.

`npx vitest run` is **flaky under pool saturation on a loaded dev box** (three consecutive no-change runs produced 5, then 3, then 2 failures; the failing specs pass solo, and they cannot touch this change — `replayNativeSnapshot` early-returns when `!isTauri`, so the browser transport never fetches a snapshot). Same class as #959. CI runs on a quiet runner; treat CI as the gate.
