### PR TITLE
fix(sidebar): reset scroll to the selected project on group/project change (#941)

### DIFF
--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -48,7 +48,6 @@ import { sessionsStore } from "./stores/sessions";
 import { bridgesStore } from "./stores/bridges";
 import { projectStore } from "./stores/project";
 import { workgroupGroupsStore } from "./stores/workgroup-groups";
-import { projectCollapseStore } from "./stores/project-collapse";
 import { normalizeProjectPathForCompare } from "./stores/project-refresh";
 import { startTeamIdleWatcher } from "./stores/team-idle-watcher";
 import { primeAudio } from "../shared/sound";
@@ -169,10 +168,6 @@ export function createSidebarSelectionScrollReset(
         // because a pinned header's rect cannot reveal its logical scroll offset.
         const projectTop = projectPanel.getBoundingClientRect().top;
         container.scrollTop = Math.max(0, container.scrollTop + projectTop - containerTop);
-      }
-
-      if (projectCollapseStore.focusTarget() === projectPath) {
-        projectCollapseStore.consumeProjectFocus();
       }
     });
   }, { defer: true }));

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, createEffect, onMount, onCleanup, Show } from "solid-js";
+import { Component, createSignal, createEffect, createMemo, on, onMount, onCleanup, Show } from "solid-js";
 import { isTauri } from "../shared/platform";
 import type { UnlistenFn } from "../shared/transport";
 import type {
@@ -47,6 +47,8 @@ import { sessionsStore } from "./stores/sessions";
 import { bridgesStore } from "./stores/bridges";
 import { projectStore } from "./stores/project";
 import { workgroupGroupsStore } from "./stores/workgroup-groups";
+import { projectCollapseStore } from "./stores/project-collapse";
+import { normalizeProjectPathForCompare } from "./stores/project-refresh";
 import { startTeamIdleWatcher } from "./stores/team-idle-watcher";
 import { primeAudio } from "../shared/sound";
 import { settingsStore } from "../shared/stores/settings";
@@ -111,6 +113,72 @@ export function blockContextMenu(e: Event): void {
   e.preventDefault();
 }
 
+function activeWorkgroupGroupSelectionKey(): string | null {
+  const projectPath = workgroupGroupsStore.activeProjectPath();
+  if (!projectPath) return null;
+  const selection = workgroupGroupsStore.selection(projectPath);
+  return JSON.stringify([
+    projectPath,
+    selection.kind,
+    selection.kind === "group" ? selection.id : null,
+  ]);
+}
+
+function projectPanelForPath(
+  scrollContainer: HTMLElement,
+  normalizedProjectPath: string,
+): HTMLElement | null {
+  const header = Array.from(
+    scrollContainer.querySelectorAll<HTMLElement>(".project-header"),
+  ).find((candidate) =>
+    normalizeProjectPathForCompare(candidate.getAttribute("title") ?? "") === normalizedProjectPath
+  );
+  return header?.closest<HTMLElement>(".project-panel") ?? null;
+}
+
+/**
+ * #941 — align the newly selected project's header with the top of the shared
+ * sidebar scrollport. The primitive semantic key deliberately suppresses raw
+ * store/config emissions and same-selection re-clicks.
+ */
+export function createSidebarSelectionScrollReset(
+  scrollContainer: () => HTMLDivElement | undefined,
+): void {
+  const selectionKey = createMemo(activeWorkgroupGroupSelectionKey);
+  let disposed = false;
+
+  createEffect(on(selectionKey, (key) => {
+    if (!key) return;
+    const projectPath = workgroupGroupsStore.activeProjectPath();
+    if (!projectPath) return;
+
+    // Collapse/expand and the filtered rows update in the same click. Position
+    // only after those Solid updates settle, and discard a superseded fast click.
+    queueMicrotask(() => {
+      if (disposed || selectionKey() !== key) return;
+      const container = scrollContainer();
+      if (!container) return;
+
+      const projectPanel = projectPanelForPath(container, projectPath);
+      if (projectPanel) {
+        const containerTop = container.getBoundingClientRect().top + container.clientTop;
+        // The header is the panel's first child. Include the panel border so
+        // bordered sidebar themes align the header itself, not the outer edge.
+        const projectTop = projectPanel.getBoundingClientRect().top + projectPanel.clientTop;
+        container.scrollTop = Math.max(0, container.scrollTop + projectTop - containerTop);
+      }
+
+      if (projectCollapseStore.focusTarget() === projectPath) {
+        projectCollapseStore.consumeProjectFocus();
+      }
+    });
+  }, { defer: true }));
+
+  onCleanup(() => {
+    disposed = true;
+  });
+}
+
 const SidebarApp: Component<SidebarAppProps> = (props) => {
   const [showOnboarding, setShowOnboarding] = createSignal(false);
   const [loopToast, setLoopToast] = createSignal<LoopToast | null>(null);
@@ -134,6 +202,8 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
   let raiseTerminalEnabled = true;
   let lastRaiseTime = 0;
   const railSide = () => props.railSide ?? settingsRailSide();
+  let sidebarScrollableEl: HTMLDivElement | undefined;
+  createSidebarSelectionScrollReset(() => sidebarScrollableEl);
   // #592 - debounce handle for the profile-drift re-list (collapses bursts).
   let profileDriftRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   const handleMainSidebarSideChange = (event: Event) => {
@@ -659,7 +729,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
           <Show when={railSide() === "left"}>
             <WorkgroupGroupRail projects={projectStore.projects} />
           </Show>
-          <div class="sidebar-scrollable">
+          <div class="sidebar-scrollable" ref={sidebarScrollableEl}>
             <ProjectPanel />
           </div>
           <Show when={railSide() === "right"}>

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -161,10 +161,10 @@ export function createSidebarSelectionScrollReset(
 
       const projectPanel = projectPanelForPath(container, projectPath);
       if (projectPanel) {
-        const containerTop = container.getBoundingClientRect().top + container.clientTop;
-        // The header is the panel's first child. Include the panel border so
-        // bordered sidebar themes align the header itself, not the outer edge.
-        const projectTop = projectPanel.getBoundingClientRect().top + projectPanel.clientTop;
+        const containerTop = container.getBoundingClientRect().top;
+        // The panel starts at its sticky header. Measure the non-sticky panel
+        // because a pinned header's rect cannot reveal its logical scroll offset.
+        const projectTop = projectPanel.getBoundingClientRect().top;
         container.scrollTop = Math.max(0, container.scrollTop + projectTop - containerTop);
       }
 

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -116,7 +116,7 @@ export function blockContextMenu(e: Event): void {
   e.preventDefault();
 }
 
-function activeWorkgroupGroupSelectionKey(): string | null {
+export function activeWorkgroupGroupSelectionKey(): string | null {
   const projectPath = workgroupGroupsStore.activeProjectPath();
   if (!projectPath) return null;
   const selection = workgroupGroupsStore.selection(projectPath);

--- a/src/sidebar/components/ProjectPanel.collapse-state.test.tsx
+++ b/src/sidebar/components/ProjectPanel.collapse-state.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import ProjectPanel from "./ProjectPanel";
 import WorkgroupGroupRail from "./WorkgroupGroupRail";
 import { FakeTransport } from "../../shared/testing/fake-transport";
@@ -202,16 +202,14 @@ describe("ProjectPanel collapse state", () => {
     }
   });
 
-  it("preserves sub-section collapse of a project collapsed by #810 rail auto-focus", async () => {
-    // #810 cross-project case: owner A is auto-focused from the rail, other
+  it("preserves sub-section collapse when a rail selection collapses another project", async () => {
+    // Cross-project case: owner A is selected from the rail, other
     // project B gets its project-level collapsed by collapseAllExceptKnown,
     // but B's "Workgroups" sub-section collapse choice must survive (sub-
     // sections stay in ProjectPanel's local collapsedByKey signal and are NOT
-    // touched by the rail's auto-focus). Two backslash Windows paths (grinch
-    // F4) so the focus lookup exercises the real production code path.
+    // touched by the rail selection). Two backslash Windows paths exercise the
+    // production collapse-key normalization.
     const otherProjectPath = "C:\\ProjectB";
-    let scrollIntoViewMock: ReturnType<typeof vi.fn>;
-    const scrollCalls: HTMLElement[] = [];
 
     const fake = new FakeTransport();
     fake.onInvoke("new_project", (args) => ({
@@ -246,11 +244,6 @@ describe("ProjectPanel collapse state", () => {
       throw new Error(`unexpected discover_project path: ${path}`);
     });
     fake.resolve("get_project_groups", { ...defaultGroupsConfig() });
-
-    scrollIntoViewMock = vi.fn(function (this: HTMLElement) {
-      scrollCalls.push(this);
-    });
-    Element.prototype.scrollIntoView = scrollIntoViewMock as any;
 
     const rendered = renderWithFakeTransport(
       () => (
@@ -293,7 +286,7 @@ describe("ProjectPanel collapse state", () => {
       if (!allButton) throw new Error("All button not found in Project rail section");
       click(allButton);
 
-      // B's project-level chevron is collapsed by auto-focus...
+      // B's project-level chevron is collapsed by the rail selection...
       await waitFor(() => {
         const chev = projectBHeader.querySelector(".ac-discovery-chevron");
         expect(chev?.classList.contains("collapsed")).toBe(true);

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -438,37 +438,6 @@ const ProjectPanel: Component = () => {
   const toggleProjectPanelCollapsed = (projectPath: string) =>
     projectCollapseStore.toggleProjectCollapsed(projectPath);
 
-  // #810 (grinch F1) - ref-Map of rendered .project-header elements keyed by
-  // the NORMALIZED project path. Lives in the stable ProjectPanel scope (not
-  // per-row) so it is not disposed mid-focus. A row's ref callback writes its
-  // header here on mount and clears it on cleanup. Replaces the original
-  // CSS-attribute-selector approach, which silently no-oped on Windows
-  // backslash paths because CSS string tokens consume `\` as an escape char.
-  const projectHeaderEls = new Map<string, HTMLElement>();
-
-  // #810 - one-shot focus: scroll the owner project header into view when
-  // the rail requests it. block:"nearest" so an already-visible owner does
-  // not jump. The target from the store is already NORMALIZED; the ref-Map
-  // is keyed on the same normalized form, so map.get(target) resolves
-  // without any CSS selector. Grinch F6: capture target before deferring to
-  // the microtask and only consume the focus if the live signal still
-  // equals the captured value, so two fast clicks (A then B) cannot have
-  // microtask-A clear B's pending target.
-  createEffect(() => {
-    const target = projectCollapseStore.focusTarget();
-    if (!target) return;
-    // Defer to next microtask so the expand (setProjectCollapsed false)
-    // applied by the rail onClick has propagated and the header/body are
-    // mounted before we scroll.
-    queueMicrotask(() => {
-      const live = projectCollapseStore.focusTarget();
-      if (live !== target) return;
-      const el = projectHeaderEls.get(target);
-      el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-      projectCollapseStore.consumeProjectFocus();
-    });
-  });
-
   // #537: post-assign "Restart now?" prompt. Hoisted to the stable ProjectPanel
   // scope (NOT inside the projects <For>) so a background replica-list refresh,
   // which replaces project object references and so re-creates each <For> row
@@ -2348,25 +2317,6 @@ const ProjectPanel: Component = () => {
               class="project-header"
               classList={{ open: filterOpen(), active: filterActive(), invalid: !!filterError() }}
               title={proj.path}
-              ref={(el) => {
-                // #810 (grinch F1 + B1) - register this header element in
-                // the stable-scope ref-Map so the focus effect can scroll it
-                // into view by normalized path key. CSS attribute selector
-                // approach was dropped: backslashes in Windows paths break
-                // the CSS string-token parser. Cleanup owns the deletion
-                // here (captures this specific el): on true project removal
-                // it frees the detached node; on a refresh re-mount the
-                // guard `get(key) === el` is false because the newer row
-                // already `set` a different element, so the fresh entry is
-                // correctly left intact.
-                const key = normalizeProjectPathForCompare(proj.path);
-                projectHeaderEls.set(key, el);
-                onCleanup(() => {
-                  if (projectHeaderEls.get(key) === el) {
-                    projectHeaderEls.delete(key);
-                  }
-                });
-              }}
               onContextMenu={handleProjectContextMenu}
             >
               <button

--- a/src/sidebar/components/WorkgroupGroupRail.autofocus.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.autofocus.test.tsx
@@ -19,7 +19,10 @@ import {
   workgroupGroupsStore,
 } from "../stores/workgroup-groups";
 import { projectCollapseStore } from "../stores/project-collapse";
-import { createSidebarSelectionScrollReset } from "../App";
+import {
+  activeWorkgroupGroupSelectionKey,
+  createSidebarSelectionScrollReset,
+} from "../App";
 import WorkgroupGroupRail from "./WorkgroupGroupRail";
 import ProjectPanel from "./ProjectPanel";
 
@@ -138,6 +141,26 @@ function installScrollableLayout(
   return scrollable;
 }
 
+function installScrollTopWriteTrap(scrollable: HTMLDivElement, initialValue: number) {
+  let currentValue = initialValue;
+  const writes: number[] = [];
+  Object.defineProperty(scrollable, "scrollTop", {
+    configurable: true,
+    get: () => currentValue,
+    set: (nextValue: number) => {
+      currentValue = nextValue;
+      writes.push(nextValue);
+    },
+  });
+  return { currentValue: () => currentValue, writes };
+}
+
+async function flushReactiveWork(): Promise<void> {
+  // Solid schedules the effect after the store update, and production adds a
+  // queueMicrotask inside it. Crossing a task boundary drains both layers.
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
 // Component that renders the production rail/panel boundary and installs the
 // same scroll-owner primitive that SidebarApp uses.
 const SidebarHarness: Component = () => {
@@ -166,6 +189,79 @@ describe("WorkgroupGroupRail selection focus (#810/#941)", () => {
     cleanupDom = null;
     resetUiStoresForTests();
     document.body.replaceChildren();
+  });
+
+  it("uses a stable primitive key for equal selections and distinct keys for real changes", () => {
+    workgroupGroupsStore.applyExternalUpdate(projectPathA, groupsConfig());
+    workgroupGroupsStore.applyExternalUpdate(projectPathB, groupsConfig());
+
+    workgroupGroupsStore.select(projectPathA, { kind: "all" });
+    const projectAAllKey = activeWorkgroupGroupSelectionKey();
+    expect(typeof projectAAllKey).toBe("string");
+
+    // Rebuild the same selection object: the semantic key stays primitive and
+    // value-equal even though the store entry emitted a new object identity.
+    workgroupGroupsStore.select(projectPathA, { kind: "all" });
+    expect(activeWorkgroupGroupSelectionKey()).toBe(projectAAllKey);
+
+    workgroupGroupsStore.select(projectPathA, { kind: "group", id: "dev" });
+    const projectAGroupKey = activeWorkgroupGroupSelectionKey();
+    expect(projectAGroupKey).not.toBe(projectAAllKey);
+
+    workgroupGroupsStore.select(projectPathA, { kind: "all" });
+    const projectAAllAgainKey = activeWorkgroupGroupSelectionKey();
+    expect(projectAAllAgainKey).toBe(projectAAllKey);
+    expect(projectAAllAgainKey).not.toBe(projectAGroupKey);
+
+    workgroupGroupsStore.select(projectPathA, { kind: "ungrouped" });
+    const projectAUngroupedKey = activeWorkgroupGroupSelectionKey();
+    expect(projectAUngroupedKey).not.toBe(projectAAllAgainKey);
+
+    workgroupGroupsStore.select(projectPathA, { kind: "nonstop" });
+    const projectANonStopKey = activeWorkgroupGroupSelectionKey();
+    expect(projectANonStopKey).not.toBe(projectAUngroupedKey);
+
+    workgroupGroupsStore.select(projectPathB, { kind: "all" });
+    const projectBAllKey = activeWorkgroupGroupSelectionKey();
+    expect(projectBAllKey).not.toBe(projectANonStopKey);
+    expect(projectBAllKey).not.toBe(projectAAllKey);
+  });
+
+  it("does not write scrollTop when an equal selection object is emitted", async () => {
+    const fake = new FakeTransport();
+    fake.onInvoke("new_project", (args) => ({
+      path: args.path as string,
+      registered: true,
+      created: false,
+    }));
+    fake.onInvoke("discover_project", (args) => {
+      const path = args.path as string;
+      if (path === projectPathA) return projectDiscovery(path);
+      throw new Error(`unexpected discover_project path: ${path}`);
+    });
+    fake.resolve("get_project_groups", groupsConfig());
+
+    const rendered = renderWithFakeTransport(() => <SidebarHarness />, fake);
+    try {
+      await projectStore.createAndLoad(projectPathA);
+      await waitFor(() => expect(railButton("ProjectA", "all")).toBeTruthy());
+
+      const scrollable = installScrollableLayout(rendered.root, [[projectPathA, 0]]);
+      await flushReactiveWork();
+
+      const priorScrollTop = 137;
+      const scrollState = installScrollTopWriteTrap(scrollable, priorScrollTop);
+
+      // This deliberately rebuilds the entry and selection objects while
+      // preserving the exact active-project/selection semantics.
+      workgroupGroupsStore.select(projectPathA, { kind: "all" });
+      await flushReactiveWork();
+
+      expect(scrollState.writes).toEqual([]);
+      expect(scrollState.currentValue()).toBe(priorScrollTop);
+    } finally {
+      rendered.cleanup();
+    }
   });
 
   it("resets every real selection kind and aligns a non-first project header", async () => {

--- a/src/sidebar/components/WorkgroupGroupRail.autofocus.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.autofocus.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Component } from "solid-js";
 import type { AcDiscoveryResult, WorkgroupGroupsConfig } from "../../shared/types";
 import { FakeTransport } from "../../shared/testing/fake-transport";
@@ -12,8 +12,14 @@ import {
   waitFor,
 } from "../../shared/testing/ui-harness";
 import { projectStore } from "../stores/project";
-import { defaultGroupsConfig, workgroupGroupsStore } from "../stores/workgroup-groups";
+import {
+  defaultGroupsConfig,
+  defaultNonStop,
+  exactGroupRegexForWorkgroup,
+  workgroupGroupsStore,
+} from "../stores/workgroup-groups";
 import { projectCollapseStore } from "../stores/project-collapse";
+import { createSidebarSelectionScrollReset } from "../App";
 import WorkgroupGroupRail from "./WorkgroupGroupRail";
 import ProjectPanel from "./ProjectPanel";
 
@@ -23,25 +29,25 @@ import ProjectPanel from "./ProjectPanel";
 const projectPathA = "C:\\ProjectA";
 const projectPathB = "C:\\ProjectB";
 
-function projectDiscovery(path: string, folderName: string): AcDiscoveryResult {
-  const wgPath = `${path}\\.ac\\wg-1-dev-team`;
+function projectDiscovery(path: string): AcDiscoveryResult {
   return discovery({
-    workgroups: [
-      {
-        name: "wg-1-dev-team",
+    workgroups: ["wg-1-dev-team", "wg-2-other-team"].map((name, index) => {
+      const wgPath = `${path}\\.ac\\${name}`;
+      return {
+        name,
         path: wgPath,
         task: null,
         taskTitle: null,
         agents: [
           {
-            name: "dev-webpage-ui",
-            path: `${wgPath}\\__agent_dev-webpage-ui`,
+            name: index === 0 ? "dev-webpage-ui" : "dev-rust",
+            path: `${wgPath}\\__agent_${index === 0 ? "dev-webpage-ui" : "dev-rust"}`,
             repoPaths: [],
             isCoordinator: true,
           },
         ],
-      },
-    ],
+      };
+    }),
     agents: [],
     teams: [],
     loops: [],
@@ -49,18 +55,26 @@ function projectDiscovery(path: string, folderName: string): AcDiscoveryResult {
 }
 
 function groupsConfig(): WorkgroupGroupsConfig {
-  return { ...defaultGroupsConfig() };
+  const groupedWorkgroup = "wg-1-dev-team";
+  return {
+    ...defaultGroupsConfig(),
+    groups: [
+      {
+        id: "dev",
+        name: "Dev",
+        regex: exactGroupRegexForWorkgroup(groupedWorkgroup),
+      },
+    ],
+    nonStop: {
+      ...defaultNonStop(),
+      show: true,
+      regex: exactGroupRegexForWorkgroup(groupedWorkgroup),
+    },
+  };
 }
 
-// #810 (grinch F1) - find the .project-header container by its title
-// ATTRIBUTE value via getAttribute, NOT via a CSS attribute selector. A CSS
-// selector like `[title="C:\ProjectA"]` would parse `\P` as `P` (CSS
-// string-token escape) and fail to match the real attribute - the exact bug
-// F1 fixed in the production code. The test must NOT use the broken pattern.
-// After main's restructure, .project-header is a <div> container holding a
-// <button class="project-header-main">. The ref-Map stores the .project-header
-// div (that's where the ref callback lives), so scrollIntoView is called on
-// it. The click-to-toggle target is the .project-header-main button inside.
+// Find the header by its raw title ATTRIBUTE value, not a CSS attribute
+// selector: Windows backslashes are CSS string escapes (#810).
 function findProjectHeader(root: ParentNode, projectPath: string): HTMLElement {
   const headers = Array.from(root.querySelectorAll<HTMLElement>(".project-header"));
   const header = headers.find((h) => h.getAttribute("title") === projectPath);
@@ -93,36 +107,58 @@ function railButton(projectFolder: string, buttonKey: string): HTMLElement {
   return btn;
 }
 
-// Component that renders both siblings the same way App.tsx does (rail +
-// scrollable ProjectPanel), so the rail's onClick can drive the shared
-// projectCollapseStore that ProjectPanel reads.
-const SidebarHarness: Component<{ projects: typeof projectStore.projects }> = () => {
+function rect(top: number, height = 40): DOMRect {
+  return {
+    x: 0,
+    y: top,
+    width: 320,
+    height,
+    top,
+    right: 320,
+    bottom: top + height,
+    left: 0,
+    toJSON: () => ({}),
+  };
+}
+
+function installScrollableLayout(
+  root: ParentNode,
+  projectTops: ReadonlyArray<readonly [string, number]>,
+): HTMLDivElement {
+  const scrollable = root.querySelector<HTMLDivElement>(".sidebar-scrollable");
+  if (!scrollable) throw new Error("sidebar-scrollable not found");
+  const viewportTop = 100;
+  scrollable.getBoundingClientRect = () => rect(viewportTop, 240);
+
+  for (const [projectPath, logicalTop] of projectTops) {
+    const panel = findProjectHeader(root, projectPath).closest<HTMLElement>(".project-panel");
+    if (!panel) throw new Error(`project-panel not found for ${projectPath}`);
+    panel.getBoundingClientRect = () => rect(viewportTop + logicalTop - scrollable.scrollTop, 180);
+  }
+  return scrollable;
+}
+
+// Component that renders the production rail/panel boundary and installs the
+// same scroll-owner primitive that SidebarApp uses.
+const SidebarHarness: Component = () => {
+  let scrollableEl: HTMLDivElement | undefined;
+  createSidebarSelectionScrollReset(() => scrollableEl);
   return (
     <div class="sidebar-body">
       <WorkgroupGroupRail projects={projectStore.projects} />
-      <div class="sidebar-scrollable">
+      <div class="sidebar-scrollable" ref={scrollableEl}>
         <ProjectPanel />
       </div>
     </div>
   );
 };
 
-describe("WorkgroupGroupRail autofocus (#810)", () => {
+describe("WorkgroupGroupRail selection focus (#810/#941)", () => {
   let cleanupDom: (() => void) | null = null;
-  let scrollIntoViewMock: ReturnType<typeof vi.fn>;
-  let scrollCalls: HTMLElement[] = [];
 
   beforeEach(() => {
     cleanupDom = installBrowserDomStubs();
     resetUiStoresForTests();
-    scrollCalls = [];
-    // #810 - jsdom throws "Not implemented: window.scrollIntoView" without a
-    // mock. Capture the `this` element of each call so we can assert the
-    // scroll targeted the owner's specific header element (grinch F4).
-    scrollIntoViewMock = vi.fn(function (this: HTMLElement, _options: ScrollIntoViewOptions) {
-      scrollCalls.push(this);
-    });
-    Element.prototype.scrollIntoView = scrollIntoViewMock as any;
   });
 
   afterEach(() => {
@@ -132,7 +168,7 @@ describe("WorkgroupGroupRail autofocus (#810)", () => {
     document.body.replaceChildren();
   });
 
-  it("collapses other projects, expands the owner, and scrolls the owner header into view", async () => {
+  it("resets every real selection kind and aligns a non-first project header", async () => {
     const fake = new FakeTransport();
     fake.onInvoke("new_project", (args) => ({
       path: args.path as string,
@@ -141,54 +177,55 @@ describe("WorkgroupGroupRail autofocus (#810)", () => {
     }));
     fake.onInvoke("discover_project", (args) => {
       const path = args.path as string;
-      if (path === projectPathA) return projectDiscovery(path, "ProjectA");
-      if (path === projectPathB) return projectDiscovery(path, "ProjectB");
+      if (path === projectPathA) return projectDiscovery(path);
+      if (path === projectPathB) return projectDiscovery(path);
       throw new Error(`unexpected discover_project path: ${path}`);
     });
     fake.resolve("get_project_groups", groupsConfig());
 
-    const rendered = renderWithFakeTransport(() => <SidebarHarness projects={projectStore.projects} />, fake);
+    const rendered = renderWithFakeTransport(() => <SidebarHarness />, fake);
     try {
       await projectStore.createAndLoad(projectPathA);
       await projectStore.createAndLoad(projectPathB);
       await waitFor(() => {
         expect(findProjectHeader(rendered.root, projectPathA)).toBeTruthy();
         expect(findProjectHeader(rendered.root, projectPathB)).toBeTruthy();
+        expect(railButton("ProjectA", "dev")).toBeTruthy();
+        expect(railButton("ProjectA", "nonstop")).toBeTruthy();
       });
 
-      // Both start expanded (default).
-      expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(false);
+      const scrollable = installScrollableLayout(rendered.root, [
+        [projectPathA, 0],
+        [projectPathB, 240],
+      ]);
+
+      // All -> custom -> All -> Ungrouped -> Alert me! are all real semantic
+      // changes and must discard a positive previous offset instantly.
+      for (const [buttonKey, oldOffset] of [
+        ["dev", 111],
+        ["all", 112],
+        ["ungrouped", 113],
+        ["nonstop", 114],
+      ] as const) {
+        scrollable.scrollTop = oldOffset;
+        click(railButton("ProjectA", buttonKey));
+        await waitFor(() => expect(scrollable.scrollTop).toBe(0));
+      }
+
+      // ProjectB remembers All, but changing the active project is still a real
+      // selection change. Its non-first panel must align to the scrollport top.
+      scrollable.scrollTop = 47;
+      click(railButton("ProjectB", "all"));
+      await waitFor(() => expect(scrollable.scrollTop).toBe(240));
+      expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(true);
       expect(headerCollapsed(findProjectHeader(rendered.root, projectPathB))).toBe(false);
-
-      // Click the "All" group button in ProjectA's rail section.
-      click(railButton("ProjectA", "all"));
-
-      // Owner (A) stays/becomes expanded; other (B) is collapsed.
-      await waitFor(() => {
-        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(false);
-      });
-      await waitFor(() => {
-        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathB))).toBe(true);
-      });
-
-      // scrollIntoView fired on ProjectA's specific .project-header element
-      // (the one whose title attr equals ProjectA's path), with the mandated
-      // options. This is the F1 regression guard: a CSS-selector-based lookup
-      // would have returned null on the backslash path and no-op'd.
-      await waitFor(() => expect(scrollCalls.length).toBeGreaterThanOrEqual(1));
-      const ownerHeader = findProjectHeader(rendered.root, projectPathA);
-      const ownerScrollCall = scrollCalls.find((el) => el === ownerHeader);
-      expect(ownerScrollCall).toBeTruthy();
-      expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest", behavior: "smooth" });
-
-      // Focus target is consumed (one-shot).
       expect(projectCollapseStore.focusTarget()).toBe(null);
     } finally {
       rendered.cleanup();
     }
   });
 
-  it("expands the owner even if it was manually collapsed beforehand (locked decision: expand owner always)", async () => {
+  it("keeps scroll fixed on a same-selection re-click while preserving collapse and expand", async () => {
     const fake = new FakeTransport();
     fake.onInvoke("new_project", (args) => ({
       path: args.path as string,
@@ -197,30 +234,40 @@ describe("WorkgroupGroupRail autofocus (#810)", () => {
     }));
     fake.onInvoke("discover_project", (args) => {
       const path = args.path as string;
-      if (path === projectPathA) return projectDiscovery(path, "ProjectA");
-      if (path === projectPathB) return projectDiscovery(path, "ProjectB");
+      if (path === projectPathA) return projectDiscovery(path);
+      if (path === projectPathB) return projectDiscovery(path);
       throw new Error(`unexpected discover_project path: ${path}`);
     });
     fake.resolve("get_project_groups", groupsConfig());
 
-    const rendered = renderWithFakeTransport(() => <SidebarHarness projects={projectStore.projects} />, fake);
+    const rendered = renderWithFakeTransport(() => <SidebarHarness />, fake);
     try {
       await projectStore.createAndLoad(projectPathA);
       await projectStore.createAndLoad(projectPathB);
       await waitFor(() => expect(findProjectHeader(rendered.root, projectPathA)).toBeTruthy());
 
-      // Manually collapse ProjectA first (click the .project-header-main
-      // button, which is the actual toggle target after main's restructure).
+      const scrollable = installScrollableLayout(rendered.root, [
+        [projectPathA, 0],
+        [projectPathB, 240],
+      ]);
+
+      // All is already the active selection. Manually collapse its owner first;
+      // ProjectB remains expanded, so the re-click has both side effects to do.
       click(findProjectHeaderButton(rendered.root, projectPathA));
       await waitFor(() =>
         expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(true)
       );
 
-      // Auto-focus from the rail must override the manual collapse.
+      scrollable.scrollTop = 137;
       click(railButton("ProjectA", "all"));
       await waitFor(() =>
         expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(false)
       );
+      await waitFor(() =>
+        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathB))).toBe(true)
+      );
+      expect(scrollable.scrollTop).toBe(137);
+      expect(projectCollapseStore.focusTarget()).toBe(null);
     } finally {
       rendered.cleanup();
     }
@@ -235,13 +282,13 @@ describe("WorkgroupGroupRail autofocus (#810)", () => {
     }));
     fake.onInvoke("discover_project", (args) => {
       const path = args.path as string;
-      if (path === projectPathA) return projectDiscovery(path, "ProjectA");
-      if (path === projectPathB) return projectDiscovery(path, "ProjectB");
+      if (path === projectPathA) return projectDiscovery(path);
+      if (path === projectPathB) return projectDiscovery(path);
       throw new Error(`unexpected discover_project path: ${path}`);
     });
     fake.resolve("get_project_groups", groupsConfig());
 
-    const rendered = renderWithFakeTransport(() => <SidebarHarness projects={projectStore.projects} />, fake);
+    const rendered = renderWithFakeTransport(() => <SidebarHarness />, fake);
     try {
       await projectStore.createAndLoad(projectPathA);
       await projectStore.createAndLoad(projectPathB);
@@ -280,7 +327,7 @@ describe("WorkgroupGroupRail autofocus (#810)", () => {
     }
   });
 
-  it("does not throw on a single-project layout and still scrolls the owner into view", async () => {
+  it("resets an actual selection change in a single-project layout", async () => {
     const fake = new FakeTransport();
     fake.onInvoke("new_project", (args) => ({
       path: args.path as string,
@@ -289,22 +336,20 @@ describe("WorkgroupGroupRail autofocus (#810)", () => {
     }));
     fake.onInvoke("discover_project", (args) => {
       const path = args.path as string;
-      if (path === projectPathA) return projectDiscovery(path, "ProjectA");
+      if (path === projectPathA) return projectDiscovery(path);
       throw new Error(`unexpected discover_project path: ${path}`);
     });
     fake.resolve("get_project_groups", groupsConfig());
 
-    const rendered = renderWithFakeTransport(() => <SidebarHarness projects={projectStore.projects} />, fake);
+    const rendered = renderWithFakeTransport(() => <SidebarHarness />, fake);
     try {
       await projectStore.createAndLoad(projectPathA);
       await waitFor(() => expect(findProjectHeader(rendered.root, projectPathA)).toBeTruthy());
 
-      // Single project: collapse-others is a no-op (only owner in the list),
-      // but the click must not throw and the owner still scrolls into view.
-      click(railButton("ProjectA", "all"));
-      await waitFor(() => expect(scrollCalls.length).toBeGreaterThanOrEqual(1));
-      const ownerHeader = findProjectHeader(rendered.root, projectPathA);
-      expect(scrollCalls.find((el) => el === ownerHeader)).toBeTruthy();
+      const scrollable = installScrollableLayout(rendered.root, [[projectPathA, 0]]);
+      scrollable.scrollTop = 83;
+      click(railButton("ProjectA", "dev"));
+      await waitFor(() => expect(scrollable.scrollTop).toBe(0));
       expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(false);
     } finally {
       rendered.cleanup();

--- a/src/sidebar/components/WorkgroupGroupRail.autofocus.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.autofocus.test.tsx
@@ -18,7 +18,6 @@ import {
   exactGroupRegexForWorkgroup,
   workgroupGroupsStore,
 } from "../stores/workgroup-groups";
-import { projectCollapseStore } from "../stores/project-collapse";
 import {
   activeWorkgroupGroupSelectionKey,
   createSidebarSelectionScrollReset,
@@ -315,7 +314,6 @@ describe("WorkgroupGroupRail selection focus (#810/#941)", () => {
       await waitFor(() => expect(scrollable.scrollTop).toBe(240));
       expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(true);
       expect(headerCollapsed(findProjectHeader(rendered.root, projectPathB))).toBe(false);
-      expect(projectCollapseStore.focusTarget()).toBe(null);
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/WorkgroupGroupRail.autofocus.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.autofocus.test.tsx
@@ -258,16 +258,16 @@ describe("WorkgroupGroupRail selection focus (#810/#941)", () => {
         expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(true)
       );
 
-      scrollable.scrollTop = 137;
+      const priorScrollTop = 137;
+      scrollable.scrollTop = priorScrollTop;
       click(railButton("ProjectA", "all"));
-      await waitFor(() =>
-        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(false)
-      );
-      await waitFor(() =>
-        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathB))).toBe(true)
-      );
-      expect(scrollable.scrollTop).toBe(137);
-      expect(projectCollapseStore.focusTarget()).toBe(null);
+      // Assert the scroll position directly after both re-click side effects
+      // settle; this behavior must not depend on the focus-target plumbing.
+      await waitFor(() => {
+        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathA))).toBe(false);
+        expect(headerCollapsed(findProjectHeader(rendered.root, projectPathB))).toBe(true);
+        expect(scrollable.scrollTop).toBe(priorScrollTop);
+      });
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -504,7 +504,6 @@ const ProjectRailSection: Component<{
                 event.stopPropagation();
                 return;
               }
-              const selectionChanged = !selected(button);
               workgroupGroupsStore.select(props.project.path, button.selection);
               // #810 - auto-focus: collapse other projects, expand owner,
               // scroll owner into view. One-shot at click time; we do NOT
@@ -517,12 +516,9 @@ const ProjectRailSection: Component<{
                 projectStore.projects.map((p) => p.path)
               );
               projectCollapseStore.setProjectCollapsed(props.project.path, false);
-              // #941 — a semantic re-click keeps the existing collapse/expand
-              // behavior but must not move scroll. Real selection/project changes
-              // are positioned instantly by SidebarApp's scroll-owner effect.
-              if (selectionChanged) {
-                projectCollapseStore.requestProjectFocus(props.project.path);
-              }
+              // #941 — scroll positioning is driven only by SidebarApp's
+              // primitive semantic-key memo. An equal re-click still performs
+              // these collapse/expand writes, but the scroll effect stays idle.
             }}
             data-ac-testid={`workgroupGroups.button.${button.key}`}
           >

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -505,20 +505,15 @@ const ProjectRailSection: Component<{
                 return;
               }
               workgroupGroupsStore.select(props.project.path, button.selection);
-              // #810 - auto-focus: collapse other projects, expand owner,
-              // scroll owner into view. One-shot at click time; we do NOT
-              // re-collapse projects the user re-expands afterwards manually.
-              // Grinch F2: feed the live projectStore.projects list to the
-              // explicit-list overload so collapse-others works on a fresh
-              // session where the collapse map is still empty.
+              // Collapse every other loaded project and expand this owner on
+              // every click. Use the live project list because a fresh session
+              // has no collapse-map entries. Scrolling is owned separately by
+              // SidebarApp's primitive semantic-key effect.
               projectCollapseStore.collapseAllExceptKnown(
                 props.project.path,
                 projectStore.projects.map((p) => p.path)
               );
               projectCollapseStore.setProjectCollapsed(props.project.path, false);
-              // #941 — scroll positioning is driven only by SidebarApp's
-              // primitive semantic-key memo. An equal re-click still performs
-              // these collapse/expand writes, but the scroll effect stays idle.
             }}
             data-ac-testid={`workgroupGroups.button.${button.key}`}
           >

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -502,6 +502,7 @@ const ProjectRailSection: Component<{
                 event.stopPropagation();
                 return;
               }
+              const selectionChanged = !selected(button);
               workgroupGroupsStore.select(props.project.path, button.selection);
               // #810 - auto-focus: collapse other projects, expand owner,
               // scroll owner into view. One-shot at click time; we do NOT
@@ -514,7 +515,12 @@ const ProjectRailSection: Component<{
                 projectStore.projects.map((p) => p.path)
               );
               projectCollapseStore.setProjectCollapsed(props.project.path, false);
-              projectCollapseStore.requestProjectFocus(props.project.path);
+              // #941 — a semantic re-click keeps the existing collapse/expand
+              // behavior but must not move scroll. Real selection/project changes
+              // are positioned instantly by SidebarApp's scroll-owner effect.
+              if (selectionChanged) {
+                projectCollapseStore.requestProjectFocus(props.project.path);
+              }
             }}
             data-ac-testid={`workgroupGroups.button.${button.key}`}
           >

--- a/src/sidebar/stores/project-collapse.test.ts
+++ b/src/sidebar/stores/project-collapse.test.ts
@@ -75,28 +75,10 @@ describe("projectCollapseStore", () => {
     expect(projectCollapseStore.isProjectCollapsed(projectB)).toBe(true);
   });
 
-  it("requestProjectFocus / focusTarget / consumeProjectFocus: consume returns once then null", () => {
-    expect(projectCollapseStore.focusTarget()).toBe(null);
-    projectCollapseStore.requestProjectFocus(projectA);
-    // Stored normalized.
-    expect(projectCollapseStore.focusTarget()).toBe("c:/projecta");
-    expect(projectCollapseStore.consumeProjectFocus()).toBe("c:/projecta");
-    expect(projectCollapseStore.focusTarget()).toBe(null);
-    // Second consume is null (already consumed).
-    expect(projectCollapseStore.consumeProjectFocus()).toBe(null);
-  });
-
-  it("requestProjectFocus normalizes the path before storing", () => {
-    projectCollapseStore.requestProjectFocus("C:\\ProjectA\\");
-    expect(projectCollapseStore.focusTarget()).toBe("c:/projecta");
-  });
-
-  it("resetForTests clears collapse state and focus target", () => {
+  it("resetForTests clears collapse state", () => {
     projectCollapseStore.setProjectCollapsed(projectA, true);
-    projectCollapseStore.requestProjectFocus(projectB);
     projectCollapseStore.resetForTests();
     expect(projectCollapseStore.isProjectCollapsed(projectA)).toBe(false);
-    expect(projectCollapseStore.focusTarget()).toBe(null);
   });
 
   it("projectPanelCollapseKey joins normalized path + section + id with the separator", () => {

--- a/src/sidebar/stores/project-collapse.ts
+++ b/src/sidebar/stores/project-collapse.ts
@@ -1,10 +1,10 @@
 import { createSignal } from "solid-js";
 import { normalizeProjectPathForCompare } from "./project-refresh";
 
-// #810 - Project-level (NOT sub-section) collapse state hoisted into a shared
-// store so WorkgroupGroupRail can drive auto-focus (collapse others, expand
-// owner, scroll owner into view) without App.tsx threading a callback prop
-// into ProjectPanel internals. Sub-section collapse (workgroups/loops/agents/
+// #810/#941 - Project-level (NOT sub-section) collapse state is hoisted into a
+// shared store so WorkgroupGroupRail can collapse others and expand the owner.
+// Its one-shot focus target coordinates the rail with App.tsx, which owns and
+// positions the shared scroll container. Sub-section collapse (workgroups/loops/agents/
 // teams/workgroup/team) STAYS in ProjectPanel's local collapsedByKey signal;
 // this store only owns the "project" section key. Session-only, no persistence
 // (consistent with Role.md: no localStorage for UI state).
@@ -36,12 +36,11 @@ export function projectPanelCollapseKey(
 // ProjectPanel used locally (projectPath-normalized + "project" + "").
 const [collapsedProjects, setCollapsedProjects] = createSignal<Record<string, boolean>>({});
 
-// #810 - one-shot focus target. Stored NORMALIZED (via
+// #810/#941 - one-shot focus target. Stored NORMALIZED (via
 // normalizeProjectPathForCompare) so the rail can pass the raw props.project.path
-// and ProjectPanel's ref-Map (keyed on the same normalized form) resolves it.
-// ProjectPanel reads focusTarget() in a createEffect, scrolls the matching
-// header element into view via its own Map<string, HTMLElement>, then consumes
-// it. Stays null when no focus is requested.
+// and SidebarApp can match it to the active semantic selection. SidebarApp
+// consumes it after positioning that project's header at the top of the shared
+// scrollport. It stays null when no focus is requested.
 const [focusTarget, setFocusTarget] = createSignal<string | null>(null);
 
 function projectKey(projectPath: string): string {
@@ -93,21 +92,18 @@ export const projectCollapseStore = {
       return next;
     });
   },
-  // #810 - focus target is stored NORMALIZED. The rail passes the raw
-  // props.project.path; ProjectPanel's ref-Map is keyed on the same
-  // normalized form, so the effect's map.get(target) resolves.
+  // #810/#941 - focus target is stored NORMALIZED. The rail passes the raw
+  // props.project.path; SidebarApp matches rendered header paths using the
+  // same normalized form.
   focusTarget(): string | null {
     return focusTarget();
   },
   requestProjectFocus(projectPath: string): void {
     setFocusTarget(normalizeProjectPathForCompare(projectPath));
   },
-  // #810 - one-shot consume: returns the current target and clears it.
-  // The focus effect in ProjectPanel captures target BEFORE deferring to a
-  // microtask (grinch F6): on two fast clicks (A then B), microtask-A must
-  // NOT clear B's pending target. The effect handles that by checking the
-  // live signal against its captured value before calling consume; this
-  // method just clears-and-returns whatever is live.
+  // #810/#941 - one-shot consume: returns the current target and clears it.
+  // SidebarApp checks its captured semantic key after deferring, so a stale
+  // microtask from click A cannot consume click B's pending target.
   consumeProjectFocus(): string | null {
     const current = focusTarget();
     if (current !== null) setFocusTarget(null);

--- a/src/sidebar/stores/project-collapse.ts
+++ b/src/sidebar/stores/project-collapse.ts
@@ -3,10 +3,9 @@ import { normalizeProjectPathForCompare } from "./project-refresh";
 
 // #810/#941 - Project-level (NOT sub-section) collapse state is hoisted into a
 // shared store so WorkgroupGroupRail can collapse others and expand the owner.
-// Its one-shot focus target coordinates the rail with App.tsx, which owns and
-// positions the shared scroll container. Sub-section collapse (workgroups/loops/agents/
-// teams/workgroup/team) STAYS in ProjectPanel's local collapsedByKey signal;
-// this store only owns the "project" section key. Session-only, no persistence
+// Sub-section collapse (workgroups/loops/agents/teams/workgroup/team) STAYS in
+// ProjectPanel's local collapsedByKey signal. This store only owns the "project"
+// section key. Session-only, no persistence
 // (consistent with Role.md: no localStorage for UI state).
 export const PROJECT_PANEL_COLLAPSE_KEY_SEP = "\u0000";
 
@@ -35,13 +34,6 @@ export function projectPanelCollapseKey(
 // Only the "project" section lives here. Keyed by the SAME composite string
 // ProjectPanel used locally (projectPath-normalized + "project" + "").
 const [collapsedProjects, setCollapsedProjects] = createSignal<Record<string, boolean>>({});
-
-// #810/#941 - one-shot focus target. Stored NORMALIZED (via
-// normalizeProjectPathForCompare) so the rail can pass the raw props.project.path
-// and SidebarApp can match it to the active semantic selection. SidebarApp
-// consumes it after positioning that project's header at the top of the shared
-// scrollport. It stays null when no focus is requested.
-const [focusTarget, setFocusTarget] = createSignal<string | null>(null);
 
 function projectKey(projectPath: string): string {
   return projectPanelCollapseKey(projectPath, "project");
@@ -92,25 +84,7 @@ export const projectCollapseStore = {
       return next;
     });
   },
-  // #810/#941 - focus target is stored NORMALIZED. The rail passes the raw
-  // props.project.path; SidebarApp matches rendered header paths using the
-  // same normalized form.
-  focusTarget(): string | null {
-    return focusTarget();
-  },
-  requestProjectFocus(projectPath: string): void {
-    setFocusTarget(normalizeProjectPathForCompare(projectPath));
-  },
-  // #810/#941 - one-shot consume: returns the current target and clears it.
-  // SidebarApp checks its captured semantic key after deferring, so a stale
-  // microtask from click A cannot consume click B's pending target.
-  consumeProjectFocus(): string | null {
-    const current = focusTarget();
-    if (current !== null) setFocusTarget(null);
-    return current;
-  },
   resetForTests(): void {
     setCollapsedProjects({});
-    setFocusTarget(null);
   },
 };


### PR DESCRIPTION
Closes #941.

## The bug

Picking another group (or project) in the sidebar's group rail re-filtered the list but left the sidebar at its **old scroll offset**, so you landed mid-list instead of at the top of the group you just asked for.

## Root cause

The scroll offset belongs to a single persistent `.sidebar-scrollable` node that is never remounted — a selection change only recomputes descendant memos and `<For>` rows *inside* it. There was **no `scrollTop` / `scrollTo` call anywhere under `src/sidebar`**: a scroll reset was simply never implemented. The old offset survived, clamped only when the new content happened to be shorter.

The one existing scroll side effect (#810's owner-focus `scrollIntoView({ block: "nearest", behavior: "smooth" })`) was a no-op in practice, because project headers are sticky and therefore already visible.

## Behavior (confirmed with the user)

- **Instant** repositioning on a *real* selection change: custom group, `All`, `Ungrouped`, `Alert me!`/`nonstop`, and active-project change.
- "Top" means **the selected project's header at the top of the scrollport**, not a literal global `scrollTop = 0`. The first project lands on exactly `0`; a lower project lands on its own header, so its coordinators are visible at first glance.
- **Same-selection re-click writes no `scrollTop`.** Collapse-others / expand-owner still run, unchanged.
- No per-group scroll memory.
- The reset keys on a *semantic* change — `(active project, selection kind, custom group id)` — never on "the store setter fired" or a raw store/config object, so config reloads cannot cause surprise resets.

#810's owner-focus is superseded by this positioning: same intent (show me the project I clicked), stronger mechanics (top-of-project, instant). Its now-dead focus plumbing (`focusTarget` / `requestProjectFocus` / `consumeProjectFocus`) is deleted.

## Review

Adversarially reviewed (`dev-rust-grinch`), **PASS**, with every claim independently re-verified rather than taken on faith:

- **The load-bearing invariant is pinned.** The whole re-click contract rests on the semantic key memo's value-dedup. Two mutations — replacing the memo with a non-deduping thunk, and returning a raw array instead of the stringified key — both turn the suite red.
- **A real test defect was found and fixed along the way.** The original re-click assertion used `waitFor`, which succeeds on its first *synchronous* evaluation — before the queued microtask runs. It went green against a broken implementation that stomped `scrollTop` a microtask later. It is now an `Object.defineProperty` **write trap** (`expect(writes).toEqual([])` — zero writes, not "the final value happens to match") plus an explicit task-boundary flush.
- **Geometry verified against the CSS**, not assumed: neither `.sidebar-scrollable` nor `.project-panel` has a border or top padding, so the first project lands on exactly `scrollTop = 0`. Anchoring on the non-sticky `.project-panel` rather than the pinned `.project-header` is deliberate — a pinned header's rect already equals the scrollport top, so a header-based delta would compute 0 and refuse to scroll.
- **Merged against `origin/main` twice** during review (#881 archive-project, then #943 Module B2 / repo browse submenu). Both audited semantically against the *merged* tree, including the project-reload path: the panel lookup re-queries live DOM inside the microtask, so it cannot measure a stale or detached node.

## Verification

- Full frontend suite: **944 passed** (`--maxWorkers=2`; see below)
- `tsc --noEmit`: clean
- Production Vite build: clean

⚠️ The frontend suite is **flaky at default worker parallelism on a loaded host** — this is **pre-existing and unrelated to this PR**, and it was proven, not assumed: with this feature's effect neutralized entirely, the suite still fails at default parallelism, with a *different* failing set each run. Tracked separately in #960. Please do not attribute those failures to this branch.

## Known consequence (documented, not introduced here)

With #881's archive broadcast, archiving a project in one window that is the *active* project in another window will reposition the other window's sidebar with no interaction in it. Inherited from #881's `broadcast_all_r`; recorded on #941 so it is not later rediscovered as a mystery bug.
