### PR TITLE
feat(#935): mount enabled repos read-write into container agent sessions

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1094,6 +1094,26 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     } else {
         None
     };
+    // #935 - resolve the container's read-write repo bind mounts from its own
+    // per-agent config.json repos[] (plan Sec 2/4), on the CANONICAL host root.
+    // This runs BEFORE create_session below, so an inadmissible entry (an escape
+    // signature: a repos[] rewrite reaching a sibling replica or messaging/) hard-
+    // fails the spawn here with no session record, token, or container created
+    // (plan Sec 4.3/4.4). None for local-process sessions.
+    let container_repos = match container_path_context.as_ref() {
+        Some(context) => {
+            match crate::pty::container_repos::resolve_repo_mounts(std::path::Path::new(
+                &context.host_root,
+            )) {
+                Ok(resolution) => Some(resolution),
+                Err(err) => {
+                    release_resource_launch_permit(&resource_monitor, &mut resource_permit);
+                    return Err(err);
+                }
+            }
+        }
+        None => None,
+    };
     let mut session = match mgr
         .create_session(
             shell.clone(),
@@ -1417,6 +1437,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
             &managed_filenames,
             is_coordinator,
             auto_self_clear,
+            container_repos.as_ref(),
         ) {
             Ok(_) => {}
             Err(e) => {
@@ -1589,6 +1610,18 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         resource_registration,
         logical_resource_slot,
         container_credential,
+        container_repo_mounts: container_repos
+            .as_ref()
+            .map(|resolution| {
+                resolution
+                    .mounts()
+                    .map(|(host, container)| crate::pty::container_repos::ContainerRepoMount {
+                        host_path: host.to_path_buf(),
+                        container_path: container.to_string(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
     };
     let spawn_result = PtyManager::spawn(pty_mgr, session.backend_kind, spawn_spec).await;
     drop(spawn_mark);

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -17,12 +17,13 @@ static CONTEXT_TEMPLATE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 /// deterministic filename based on the agent_root to prevent races between
 /// concurrent session launches.
 pub fn ensure_session_context(agent_root: &str) -> Result<String, String> {
-    ensure_session_context_with_config(agent_root, None)
+    ensure_session_context_with_config(agent_root, None, None)
 }
 
 fn ensure_session_context_with_config(
     agent_root: &str,
     config: Option<&serde_json::Value>,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
 ) -> Result<String, String> {
     let config_dir =
         super::config_dir().ok_or_else(|| "Could not resolve app config directory".to_string())?;
@@ -60,6 +61,7 @@ fn ensure_session_context_with_config(
         &skills_section,
         Path::new(agent_root),
         config,
+        repo_mounts,
     )?;
     std::fs::write(&file_path, content)
         .map_err(|e| format!("Failed to write per-agent AgentsCommanderContext.md: {}", e))?;
@@ -1247,7 +1249,15 @@ pub fn git_ceiling_directories_for_session_root(cwd: &str) -> Option<String> {
 fn render_workspace_repos_string(
     cwd_path: &std::path::Path,
     config: Option<&serde_json::Value>,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
 ) -> String {
+    // #935 - a containerized session renders CONTAINER paths from the ONE
+    // resolution session.rs already built (plan Sec 5), so the injected context
+    // and the Docker mounts cannot disagree. A local session (repo_mounts = None)
+    // keeps today's host-path rendering, byte-for-byte.
+    if let Some(resolution) = repo_mounts {
+        return render_workspace_repos_containerized(resolution);
+    }
     let repos = config
         .and_then(|config| config.get("repos"))
         .and_then(|v| v.as_array())
@@ -1298,6 +1308,59 @@ fn render_workspace_repos_string(
     md
 }
 
+/// #935 - render the injected "Workspace Repos" block for a CONTAINER session
+/// from the resolved mounts. Container paths (/repos/repo-X) are shown, never the
+/// Windows host path, which does not resolve inside the container (defect D2). The
+/// branch is still detected host-side from the canonical host path.
+fn render_workspace_repos_containerized(
+    resolution: &crate::pty::container_repos::RepoMountResolution,
+) -> String {
+    use crate::pty::container_repos::RepoOutcome;
+
+    if resolution.entries.is_empty() {
+        return "# Workspace Repos\n\nNo repos configured for this replica.\n".to_string();
+    }
+
+    let mut md = String::from(
+        "# Workspace Repos\n\n\
+         You are working inside a workgroup replica. Your working directory is your agent dir, \
+         but your code repos are listed below. You MUST change to the appropriate repo directory \
+         before doing any code work (git, file edits, builds, etc).\n\n\
+         ## Repos\n\n",
+    );
+
+    for entry in &resolution.entries {
+        match &entry.outcome {
+            RepoOutcome::Mounted {
+                name,
+                host_path,
+                container_path,
+            } => {
+                let branch = detect_git_branch(&host_path.to_string_lossy())
+                    .unwrap_or_else(|| "unknown".to_string());
+                md.push_str(&format!(
+                    "- **{}** — Path: `{}` — Branch: `{}`\n",
+                    name, container_path, branch
+                ));
+            }
+            RepoOutcome::NotFound => {
+                let name = std::path::Path::new(&entry.config_entry)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(&entry.config_entry);
+                md.push_str(&format!(
+                    "- **{}** — Path: `{}/{}` — **(NOT FOUND)**\n",
+                    name,
+                    crate::pty::container_repos::CONTAINER_REPOS_ROOT,
+                    name
+                ));
+            }
+        }
+    }
+
+    md
+}
+
 /// Detect git branch for a given directory path.
 fn detect_git_branch(dir: &str) -> Option<String> {
     #[cfg(windows)]
@@ -1339,7 +1402,10 @@ fn detect_git_branch(dir: &str) -> Option<String> {
 ///
 /// Returns Ok(Some(path)) with the combined temp file, Ok(None) if no context[] field,
 /// or Err with details about missing files.
-pub fn build_replica_context(cwd: &str) -> Result<Option<String>, String> {
+pub fn build_replica_context(
+    cwd: &str,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
+) -> Result<Option<String>, String> {
     let cwd_path = std::path::Path::new(cwd);
     let config_path = cwd_path.join("config.json");
 
@@ -1362,12 +1428,12 @@ pub fn build_replica_context(cwd: &str) -> Result<Option<String>, String> {
         match identity {
             Some(identity) => (config, identity),
             None => {
-                return build_replica_context_from_config(cwd, cwd_path, config, None);
+                return build_replica_context_from_config(cwd, cwd_path, config, None, repo_mounts);
             }
         }
     };
 
-    build_replica_context_from_config(cwd, cwd_path, config, Some(identity))
+    build_replica_context_from_config(cwd, cwd_path, config, Some(identity), repo_mounts)
 }
 
 fn build_replica_context_from_config(
@@ -1375,6 +1441,7 @@ fn build_replica_context_from_config(
     cwd_path: &Path,
     config: serde_json::Value,
     repaired_identity: Option<crate::config::replica_identity::WgReplicaIdentity>,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
 ) -> Result<Option<String>, String> {
     // No "context" field → no replica context
     let context_array = match config.get("context").and_then(|v| v.as_array()) {
@@ -1393,7 +1460,7 @@ fn build_replica_context_from_config(
         };
 
         if raw == CONTEXT_TOKEN_GLOBAL {
-            let global_path = ensure_session_context_with_config(cwd, Some(&config))?;
+            let global_path = ensure_session_context_with_config(cwd, Some(&config), repo_mounts)?;
             resolved_paths.push((
                 "AgentsCommanderContext.md".to_string(),
                 std::path::PathBuf::from(&global_path),
@@ -1464,7 +1531,10 @@ fn build_replica_context_from_config(
     Ok(Some(file_path))
 }
 
-fn build_direct_matrix_context(cwd: &str) -> Result<String, String> {
+fn build_direct_matrix_context(
+    cwd: &str,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
+) -> Result<String, String> {
     let cwd_path = Path::new(cwd);
     let role_path = Path::new(cwd).join(ROLE_MD_FILENAME);
     let config_path = cwd_path.join("config.json");
@@ -1478,7 +1548,7 @@ fn build_direct_matrix_context(cwd: &str) -> Result<String, String> {
     } else {
         None
     };
-    let global_context = ensure_session_context_with_config(cwd, config.as_ref())?;
+    let global_context = ensure_session_context_with_config(cwd, config.as_ref(), repo_mounts)?;
     let mut resolved_paths = vec![(
         "AgentsCommanderContext.md".to_string(),
         std::path::PathBuf::from(&global_context),
@@ -1562,9 +1632,10 @@ fn resolve_session_context_content(
     cwd: &str,
     is_coordinator: bool,
     auto_self_clear: bool,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
 ) -> Result<Option<String>, String> {
     let context_path = if is_replica_agent_dir(cwd) {
-        match build_replica_context(cwd) {
+        match build_replica_context(cwd, repo_mounts) {
             Ok(Some(combined_path)) => {
                 log::info!(
                     "Using replica combined context for agent session: {}",
@@ -1572,11 +1643,11 @@ fn resolve_session_context_content(
                 );
                 combined_path
             }
-            Ok(None) => ensure_session_context(cwd)?,
+            Ok(None) => ensure_session_context_with_config(cwd, None, repo_mounts)?,
             Err(e) => return Err(e),
         }
     } else if super::root_agent::is_root_agent_dir_name(cwd) {
-        match build_replica_context(cwd) {
+        match build_replica_context(cwd, repo_mounts) {
             Ok(Some(combined_path)) => {
                 log::info!(
                     "Using root-agent combined context for agent session: {}",
@@ -1589,11 +1660,11 @@ fn resolve_session_context_content(
             // normal path; this fallback (mirroring the replica branch) makes
             // sure the Root still flows into the strip+append below even in a
             // degenerate no-context[] setup, never silently losing the directive.
-            Ok(None) => ensure_session_context(cwd)?,
+            Ok(None) => ensure_session_context_with_config(cwd, None, repo_mounts)?,
             Err(e) => return Err(e),
         }
     } else if is_canonical_agent_matrix_dir(cwd) {
-        build_direct_matrix_context(cwd)?
+        build_direct_matrix_context(cwd, repo_mounts)?
     } else {
         return Ok(None);
     };
@@ -1650,8 +1721,9 @@ pub fn materialize_agent_context_file_with_filename(
     extra_managed_filenames: &[String],
     is_coordinator: bool,
     auto_self_clear: bool,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
 ) -> Result<Option<String>, String> {
-    let content = match resolve_session_context_content(cwd, is_coordinator, auto_self_clear)? {
+    let content = match resolve_session_context_content(cwd, is_coordinator, auto_self_clear, repo_mounts)? {
         Some(content) => content,
         None => return Ok(None),
     };
@@ -1779,7 +1851,7 @@ pub fn materialize_agent_context_file(
     // materialize_agent_context_file_with_filename in session.rs, which resolves
     // and passes the real auto_self_clear flag. Pass false here so no production
     // path loses the gated directive.
-    materialize_agent_context_file_with_filename(cwd, target.filename(), &[], is_coordinator, false)
+    materialize_agent_context_file_with_filename(cwd, target.filename(), &[], is_coordinator, false, None)
 }
 
 // ── Context-cache GC (#621) ───────────────────────────────────────────────
@@ -1936,6 +2008,7 @@ fn render_agent_context_template(
     skills_section: &str,
     cwd_path: &Path,
     config: Option<&serde_json::Value>,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
 ) -> String {
     let is_root_agent = super::root_agent::is_root_agent_path(agent_root);
     render_agent_context_template_inner(
@@ -1945,10 +2018,12 @@ fn render_agent_context_template(
         skills_section,
         cwd_path,
         config,
+        repo_mounts,
         is_root_agent,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_agent_context_template_inner(
     template: &str,
     agent_root: &str,
@@ -1956,6 +2031,7 @@ fn render_agent_context_template_inner(
     skills_section: &str,
     cwd_path: &Path,
     config: Option<&serde_json::Value>,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
     is_root_agent: bool,
 ) -> String {
     let rendered =
@@ -2020,7 +2096,7 @@ fn render_agent_context_template_inner(
         )
         .replace(
             "{{WORKSPACE_REPOS}}",
-            &render_workspace_repos_string(cwd_path, config),
+            &render_workspace_repos_string(cwd_path, config, repo_mounts),
         )
         .replace(
             "{{DELEGATED_TASK_REPORTING}}",
@@ -2034,6 +2110,7 @@ fn render_default_agent_context(
     skills_section: &str,
     cwd_path: &Path,
     config: Option<&serde_json::Value>,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
 ) -> String {
     render_agent_context_template(
         get_default_agent_template(),
@@ -2042,6 +2119,7 @@ fn render_default_agent_context(
         skills_section,
         cwd_path,
         config,
+        repo_mounts,
     )
 }
 
@@ -2051,6 +2129,7 @@ fn resolve_agent_context(
     skills_section: &str,
     cwd_path: &Path,
     config: Option<&serde_json::Value>,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
 ) -> Result<String, String> {
     let template = read_or_create_context_template(
         agent_root,
@@ -2074,6 +2153,7 @@ fn resolve_agent_context(
                 skills_section,
                 cwd_path,
                 config,
+                repo_mounts,
             ))
         }
         LegacyRenderedDefaultContext::NotLegacy => Ok(render_agent_context_template(
@@ -2083,6 +2163,7 @@ fn resolve_agent_context(
             skills_section,
             cwd_path,
             config,
+            repo_mounts,
         )),
     }
 }
@@ -2792,6 +2873,7 @@ fn default_context(agent_root: &str, matrix_root: Option<&str>, skills_section: 
         skills_section,
         Path::new(agent_root),
         None,
+        None,
     )
 }
 
@@ -2807,6 +2889,7 @@ fn default_context_as_root(
         matrix_root,
         skills_section,
         Path::new(agent_root),
+        None,
         None,
         true,
     )
@@ -3412,6 +3495,7 @@ Run list-peers-lean.
             &no_skill_section(),
             Path::new(agent_root),
             None,
+            None,
             is_root_agent,
         )
     }
@@ -3599,7 +3683,7 @@ For peer discovery, the sections below (`## Inter-Agent Messaging` and `### List
                 ("{{SKILLS_SECTION}}", no_skill_section()),
                 (
                     "{{WORKSPACE_REPOS}}",
-                    render_workspace_repos_string(Path::new(agent_root), None),
+                    render_workspace_repos_string(Path::new(agent_root), None, None),
                 ),
                 (
                     "{{DELEGATED_TASK_REPORTING}}",
@@ -4303,6 +4387,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             &no_skill_section(),
             Path::new(&root),
             None,
+            None,
         );
         assert!(out.contains("Every registered AgentsCommander project folder"));
         assert!(out.contains("## Root Agent Authority and Chain of Command"));
@@ -4609,6 +4694,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             Some(&matrix_root),
             &no_skill_section(),
             &replica_root,
+            None,
             None,
         )
         .expect("resolve context");
@@ -5053,6 +5139,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             &no_skill_section(),
             &new_replica,
             None,
+            None,
         )
         .expect("resolve context");
         assert!(rendered.contains("### Incoming Message Notifications"));
@@ -5084,6 +5171,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             &no_skill_section(),
             &new_replica,
             None,
+            None,
         )
         .expect("resolve context again");
         assert_eq!(rendered_again, rendered);
@@ -5111,6 +5199,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             Some(&path_string(&matrix_root)),
             &no_skill_section(),
             &replica_root,
+            None,
             None,
         )
         .expect("resolve context");
@@ -5177,6 +5266,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             &no_skill_section(),
             &resolving_root,
             None,
+            None,
         )
         .expect("resolve context");
         let healed = std::fs::read_to_string(&template_path).expect("read healed root template");
@@ -5230,6 +5320,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             Some(&path_string(&new_matrix)),
             &no_skill_section(),
             &new_replica,
+            None,
             None,
         )
         .expect("resolve context");
@@ -5634,7 +5725,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         let cwd = path_string(&matrix_root);
 
-        let on = materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], false, true)
+        let on = materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], false, true, None)
             .expect("materialize ON")
             .expect("context path");
         let on_content = std::fs::read_to_string(&on).expect("read ON context");
@@ -5644,7 +5735,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         assert!(on_content.contains("closed background"));
 
         let off =
-            materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], false, false)
+            materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], false, false, None)
                 .expect("materialize OFF")
                 .expect("context path");
         let off_content = std::fs::read_to_string(&off).expect("read OFF context");
@@ -5670,7 +5761,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         .expect("write legacy coordinator template");
         let cwd = path_string(&matrix_root);
 
-        let on = materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], true, true)
+        let on = materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], true, true, None)
             .expect("materialize ON")
             .expect("context path");
         let on_content = std::fs::read_to_string(&on).expect("read ON context");
@@ -5692,7 +5783,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             "coordinator body preserved"
         );
 
-        let off = materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], true, false)
+        let off = materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], true, false, None)
             .expect("materialize OFF")
             .expect("context path");
         let off_content = std::fs::read_to_string(&off).expect("read OFF context");
@@ -5724,7 +5815,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         // Invariant: a Root with a non-empty context[] yields Some (the Some path
         // is the normal one; the Ok(None) fallback is defense-in-depth).
         assert!(
-            build_replica_context(&cwd)
+            build_replica_context(&cwd, None)
                 .expect("build root context")
                 .is_some(),
             "the canonical Root always has a non-empty context[]"
@@ -5732,7 +5823,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         // Sanity: the dir-name gate recognizes this as the Root.
         assert!(crate::config::root_agent::is_root_agent_dir_name(&cwd));
 
-        let on = resolve_session_context_content(&cwd, false, true)
+        let on = resolve_session_context_content(&cwd, false, true, None)
             .expect("resolve ON")
             .expect("root content");
         assert!(on.contains("## Self-Maintenance (auto self-handoff-and-clear)"));
@@ -5740,7 +5831,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         assert!(on.contains("closed background"));
         assert!(on.contains("ROOT BASE CONTEXT"), "base context preserved");
 
-        let off = resolve_session_context_content(&cwd, false, false)
+        let off = resolve_session_context_content(&cwd, false, false, None)
             .expect("resolve OFF")
             .expect("root content");
         assert!(!off.contains("## Self-Maintenance"));
@@ -6054,6 +6145,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             &["MyTeam.md".to_string()],
             false,
             false,
+            None,
         )
         .expect("materialize")
         .expect("context path");
@@ -6087,6 +6179,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             &[], // MyTeam.md intentionally not listed -> it survives.
             false,
             false,
+            None,
         )
         .expect("materialize")
         .expect("context path");
@@ -6115,6 +6208,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             &[],
             false,
             false,
+            None,
         )
         .expect_err("a filename with separators must be rejected by the writer");
         assert!(err.contains("separators"), "{err}");
@@ -6152,6 +6246,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             &[],
             false,
             false,
+            None,
         )
         .expect("materialize should succeed by replacing the link")
         .expect("context path");
@@ -6205,6 +6300,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             &[],
             false,
             false,
+            None,
         )
         .expect("materialize should replace the dir link, not brick the launch")
         .expect("context path");

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -38,6 +38,9 @@ pub struct BackendSpawnSpec {
     /// #930 - resolved host-credential copy-in for container sessions. None for
     /// local-process sessions and when copy-in is disabled/not applicable.
     pub container_credential: Option<crate::pty::container_credentials::ContainerCredentialPlan>,
+    /// #935 - read-write repo bind mounts for container sessions. Empty for
+    /// local-process sessions and when the replica has no admissible repos.
+    pub container_repo_mounts: Vec<crate::pty::container_repos::ContainerRepoMount>,
 }
 
 pub trait PtyBackend: Any + Send + Sync {

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -604,6 +604,7 @@ impl ContainerTransportBackend {
             resource_registration: _,
             logical_resource_slot,
             container_credential,
+            container_repo_mounts,
         } = spec;
 
         let attach_notify = Arc::new(Notify::new());
@@ -683,6 +684,7 @@ impl ContainerTransportBackend {
             selected_cwd.as_deref(),
             ticket,
             &token,
+            container_repo_mounts,
         ) {
             Ok(request) => request,
             Err(err) => {
@@ -1185,6 +1187,7 @@ fn build_start_request(
     selected_cwd: Option<&str>,
     registration_ticket: String,
     token: &ContainerApiToken,
+    repo_mounts: Vec<crate::pty::container_repos::ContainerRepoMount>,
 ) -> Result<ContainerStartRequest, AppError> {
     let settings = crate::config::settings::load_settings();
     build_start_request_with_settings(
@@ -1202,6 +1205,7 @@ fn build_start_request(
         registration_ticket,
         token,
         &settings,
+        repo_mounts,
     )
 }
 
@@ -1221,6 +1225,7 @@ fn build_start_request_with_settings(
     registration_ticket: String,
     token: &ContainerApiToken,
     settings: &crate::config::settings::AppSettings,
+    repo_mounts: Vec<crate::pty::container_repos::ContainerRepoMount>,
 ) -> Result<ContainerStartRequest, AppError> {
     if !settings.api_server_enabled {
         return Err(AppError::Other(
@@ -1254,6 +1259,13 @@ fn build_start_request_with_settings(
             DEFAULT_CONTAINER_WORKDIR
         ),
     }
+    for mount in &repo_mounts {
+        log::info!(
+            "[container-transport] repo mount '{}' -> '{}'",
+            mount.host_path.display(),
+            mount.container_path
+        );
+    }
     Ok(ContainerStartRequest {
         session_id,
         image: resolve_container_image(container_image.as_deref())?,
@@ -1269,6 +1281,7 @@ fn build_start_request_with_settings(
         env_unset,
         cols,
         rows,
+        repo_mounts,
     })
 }
 
@@ -1438,6 +1451,7 @@ mod tests {
             resource_registration: None,
             logical_resource_slot: None,
             container_credential: None,
+            container_repo_mounts: Vec::new(),
         }
     }
 
@@ -1801,6 +1815,7 @@ mod tests {
             "ticket".to_string(),
             &token(),
             &api_enabled_settings(),
+            Vec::new(),
         )
         .unwrap();
 

--- a/src-tauri/src/pty/container_repos.rs
+++ b/src-tauri/src/pty/container_repos.rs
@@ -1,0 +1,480 @@
+//! #935 - resolve a container replica's enabled repos into read-write bind mounts.
+//!
+//! The replica's own `config.json` `repos[]` array is already per-agent (team
+//! creation filters it, see plan Sec 2). This module turns that array into the
+//! Docker `--mount` list and the injected-context path list, from ONE ordered
+//! resolution so the two consumers cannot drift (plan Sec 5).
+//!
+//! SECURITY (plan Sec 4): `config.json` sits on the container's own read-write
+//! mount, so `repos[]` is attacker-controlled. Every admissibility check runs on
+//! the CANONICAL path (after resolving symlinks/junctions), never on the raw
+//! entry or its apparent name, and the container mount target is derived from the
+//! canonical name too. A `repo-`-named symlink whose target is a sibling
+//! `__agent_*` replica or `messaging/` must be REJECTED, and the only thing that
+//! rejects it is the canonical-name check: `container_mount_source_rejection`
+//! does not catch a sibling replica (plan Sec 7 S3).
+
+use std::path::{Path, PathBuf};
+
+use crate::pty::container_paths::{container_mount_source_rejection, root_key};
+
+/// Container-side root under which each enabled repo is mounted (plan Sec 3.2).
+pub const CONTAINER_REPOS_ROOT: &str = "/repos";
+
+/// A single admissible repo mount: the canonical host source and its container
+/// target. Both the Docker args and the injected context read from this, so they
+/// cannot disagree (plan Sec 5).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContainerRepoMount {
+    pub host_path: PathBuf,
+    pub container_path: String,
+}
+
+/// The outcome of resolving one `repos[]` entry. Two variants only: an entry that
+/// EXISTS but is not admissible never reaches here, it is the `Err` of
+/// [`resolve_repo_mounts`] and the session does not launch (plan Sec 4.3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RepoOutcome {
+    /// Admissible (plan Sec 4.2). `name` and `container_path` both derive from
+    /// `canonical.file_name()`, never from the entry string.
+    Mounted {
+        name: String,
+        host_path: PathBuf,
+        container_path: String,
+    },
+    /// Does not canonicalize (the directory is absent). No mount, the session
+    /// still launches, renders `**(NOT FOUND)**` as today (plan Sec 4.3).
+    NotFound,
+}
+
+/// One `repos[]` entry with its outcome, in `config.json` order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedRepo {
+    /// The verbatim entry, for the error/log text only.
+    pub config_entry: String,
+    pub outcome: RepoOutcome,
+}
+
+/// Every `repos[]` entry, resolved, in config order. One structure feeds BOTH the
+/// Docker mounts and the context renderer (plan Sec 5).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RepoMountResolution {
+    pub entries: Vec<ResolvedRepo>,
+}
+
+impl RepoMountResolution {
+    /// The Docker consumer: canonical host path + container target for each
+    /// mounted repo, in config order.
+    pub fn mounts(&self) -> impl Iterator<Item = (&Path, &str)> {
+        self.entries.iter().filter_map(|entry| match &entry.outcome {
+            RepoOutcome::Mounted {
+                host_path,
+                container_path,
+                ..
+            } => Some((host_path.as_path(), container_path.as_str())),
+            RepoOutcome::NotFound => None,
+        })
+    }
+}
+
+/// Read this replica's `repos[]` from `<replica_root>/config.json`. Best-effort:
+/// a missing/unreadable/unparseable config, or a non-array `repos`, yields no
+/// entries (no repo mounts), never an error. `session.rs` does not parse
+/// `config.json` on the spawn path (dev-rust plan Sec 14.5), so the resolver reads
+/// it itself rather than threading a `serde_json::Value`.
+fn read_repos_array(replica_root: &Path) -> Vec<String> {
+    let config_path = replica_root.join("config.json");
+    let Ok(text) = std::fs::read_to_string(&config_path) else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return Vec::new();
+    };
+    value
+        .get("repos")
+        .and_then(|repos| repos.as_array())
+        .map(|array| {
+            array
+                .iter()
+                .filter_map(|entry| entry.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Resolve this replica's enabled repos (its own `config.json` `repos` array,
+/// which is already per-agent: plan Sec 2) into container mounts.
+///
+/// Entries are resolved as `canonicalize(replica_root.join(entry))` - the SAME
+/// base and join `render_workspace_repos_string` uses (`session_context.rs:1275`).
+/// Do NOT change the base: a different one reintroduces D2 (the mount and the
+/// injected context disagreeing).
+///
+/// `Err` = an entry that EXISTS but is not admissible (plan Sec 4.2). Escape
+///         signature: the caller MUST refuse to launch the session (plan Sec 4.3/4.4).
+/// `Ok`  = every entry, in config order, `Mounted` or `NotFound`.
+pub fn resolve_repo_mounts(replica_root: &Path) -> Result<RepoMountResolution, String> {
+    // The workgroup root is the replica's parent. `replica_root` is already
+    // canonical (it is `container_path_context.host_root`), but do not assume the
+    // parent of a canonical path is itself canonical: canonicalize it explicitly,
+    // which is cheap and also resolves a linked workgroup dir.
+    let Some(parent) = replica_root.parent() else {
+        return Ok(RepoMountResolution::default());
+    };
+    let Ok(wg_root) = std::fs::canonicalize(parent) else {
+        return Ok(RepoMountResolution::default());
+    };
+
+    // If the session cwd is not a workgroup replica, there are no repo mounts,
+    // full stop. Same predicate `container_mount_source_rejection:285-296` uses:
+    // the parent name starts with `wg-` and a workspace ancestor exists.
+    let is_workgroup_root = wg_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.starts_with("wg-"))
+        .unwrap_or(false)
+        && crate::config::workspace::find_workspace_ancestor(&wg_root).is_some();
+    if !is_workgroup_root {
+        return Ok(RepoMountResolution::default());
+    }
+
+    let wg_key = root_key(&wg_root.to_string_lossy());
+
+    let mut entries = Vec::new();
+    for entry in read_repos_array(replica_root) {
+        // STEP 1 (plan Sec 4.3): does it exist? Resolve against the replica root,
+        // the SAME base the renderer uses.
+        let joined = replica_root.join(&entry);
+        let canonical = match std::fs::canonicalize(&joined) {
+            Ok(canonical) => canonical,
+            Err(_) => {
+                // NOT FOUND: benign, AC-produced state (a best-effort clone can
+                // leave a repos[] entry with no dir). No mount, session launches.
+                entries.push(ResolvedRepo {
+                    config_entry: entry,
+                    outcome: RepoOutcome::NotFound,
+                });
+                continue;
+            }
+        };
+
+        // STEP 2 (plan Sec 4.2): admissible? ALL four checks on the CANONICAL
+        // path. Never on `entry` or on `joined.file_name()` (the apparent name):
+        // a `repo-`-named symlink to `../__agent_other` passes a parent check and
+        // an apparent-name check but must be rejected by the canonical-name check.
+        let parent_is_wg_root = canonical
+            .parent()
+            .map(|dir| root_key(&dir.to_string_lossy()) == wg_key)
+            .unwrap_or(false);
+        let canonical_name = canonical.file_name().and_then(|name| name.to_str());
+        let name_has_repo_prefix = canonical_name
+            .map(|name| name.starts_with("repo-"))
+            .unwrap_or(false);
+        let is_dir = canonical.is_dir();
+        let not_rejected = container_mount_source_rejection(&canonical).is_none();
+
+        if parent_is_wg_root && name_has_repo_prefix && is_dir && not_rejected {
+            // Safe: `name_has_repo_prefix` implies `canonical_name` is `Some`.
+            let name = canonical_name.unwrap_or_default().to_string();
+            let container_path = format!("{}/{}", CONTAINER_REPOS_ROOT, name);
+            entries.push(ResolvedRepo {
+                config_entry: entry,
+                outcome: RepoOutcome::Mounted {
+                    name,
+                    host_path: canonical,
+                    container_path,
+                },
+            });
+        } else {
+            // An EXISTING inadmissible path is an escape signature: hard-fail the
+            // spawn, loudly, naming the entry, its canonical target and the failed
+            // check(s).
+            return Err(format!(
+                "container repo mount refused: repos[] entry '{}' resolves to '{}', which is not an \
+                 admissible repo-* directory directly under the workgroup root \
+                 (direct_wg_child={}, repo_prefix={}, is_dir={}, not_reserved={})",
+                entry,
+                canonical.display(),
+                parent_is_wg_root,
+                name_has_repo_prefix,
+                is_dir,
+                not_rejected
+            ));
+        }
+    }
+
+    // Collisions are structurally impossible under Sec 4.2 (every mount is a
+    // direct child of ONE dir, so names are unique). Assert it in debug and move
+    // on; do NOT build a suffix scheme for a case that cannot occur (plan Sec 3.3).
+    #[cfg(debug_assertions)]
+    {
+        let mut seen = std::collections::HashSet::new();
+        for entry in &entries {
+            if let RepoOutcome::Mounted { container_path, .. } = &entry.outcome {
+                debug_assert!(
+                    seen.insert(container_path.clone()),
+                    "duplicate container mount target {}",
+                    container_path
+                );
+            }
+        }
+    }
+
+    Ok(RepoMountResolution { entries })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[cfg(unix)]
+    fn try_symlink_dir(target: &Path, link: &Path) -> bool {
+        std::os::unix::fs::symlink(target, link).is_ok()
+    }
+
+    #[cfg(windows)]
+    fn try_symlink_dir(target: &Path, link: &Path) -> bool {
+        std::os::windows::fs::symlink_dir(target, link).is_ok()
+    }
+
+    /// Build `<tmp>/.ac/wg-test-team/` with the given replica name, and return
+    /// (tmp, wg_root, replica_root). `find_workspace_ancestor` keys on a `.ac`
+    /// ancestor and the wg-root name must start with `wg-`, so both are created.
+    fn make_workgroup(replica: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let wg_root = tmp.path().join(".ac").join("wg-test-team");
+        let replica_root = wg_root.join(replica);
+        std::fs::create_dir_all(&replica_root).expect("replica dir");
+        let wg_root = std::fs::canonicalize(&wg_root).expect("canonical wg root");
+        let replica_root = std::fs::canonicalize(&replica_root).expect("canonical replica");
+        (tmp, wg_root, replica_root)
+    }
+
+    fn write_repos(replica_root: &Path, repos: &[&str]) {
+        let json = serde_json::json!({ "repos": repos });
+        std::fs::write(
+            replica_root.join("config.json"),
+            serde_json::to_string(&json).unwrap(),
+        )
+        .expect("write config.json");
+    }
+
+    fn mkdir(base: &Path, name: &str) -> PathBuf {
+        let path = base.join(name);
+        std::fs::create_dir_all(&path).expect("mkdir");
+        path
+    }
+
+    #[test]
+    fn normal_sibling_repo_resolves_to_repos_container_path() {
+        let (_tmp, wg_root, replica) = make_workgroup("__agent_self");
+        mkdir(&wg_root, "repo-AgentsCommander");
+        write_repos(&replica, &["../repo-AgentsCommander"]);
+
+        let resolution = resolve_repo_mounts(&replica).expect("ok");
+        assert_eq!(resolution.entries.len(), 1);
+        match &resolution.entries[0].outcome {
+            RepoOutcome::Mounted {
+                name,
+                container_path,
+                ..
+            } => {
+                assert_eq!(name, "repo-AgentsCommander");
+                assert_eq!(container_path, "/repos/repo-AgentsCommander");
+            }
+            other => panic!("expected Mounted, got {:?}", other),
+        }
+        let mounts: Vec<_> = resolution.mounts().collect();
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].1, "/repos/repo-AgentsCommander");
+    }
+
+    #[test]
+    fn symlink_named_repo_but_targeting_sibling_replica_is_rejected() {
+        // grinch Finding 2, THE critical test. A symlink whose APPARENT name
+        // starts with `repo-` but whose CANONICAL target is a sibling replica.
+        // The parent check PASSES (the target's parent IS the wg root), so only
+        // the canonical-NAME check can reject it. Nothing else does:
+        // container_mount_source_rejection does not catch a sibling replica.
+        let (_tmp, wg_root, replica) = make_workgroup("__agent_self");
+        let other = mkdir(&wg_root, "__agent_other");
+        let trap = replica.join("repo-trap");
+        if !try_symlink_dir(&other, &trap) {
+            eprintln!("skipping: no symlink privilege on this platform");
+            return;
+        }
+        write_repos(&replica, &["./repo-trap"]);
+
+        let result = resolve_repo_mounts(&replica);
+        assert!(
+            result.is_err(),
+            "a repo-*-named symlink to a sibling replica must hard-fail, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn symlink_named_repo_but_targeting_messaging_is_rejected() {
+        // The twin: same shape, canonical target is an AC-owned NON-replica.
+        // Parent check passes again; canonical name `messaging` has no `repo-`
+        // prefix -> Err. Covers the other class of AC-owned target.
+        let (_tmp, wg_root, replica) = make_workgroup("__agent_self");
+        let messaging = mkdir(&wg_root, "messaging");
+        let trap = replica.join("repo-trap");
+        if !try_symlink_dir(&messaging, &trap) {
+            eprintln!("skipping: no symlink privilege on this platform");
+            return;
+        }
+        write_repos(&replica, &["./repo-trap"]);
+
+        assert!(
+            resolve_repo_mounts(&replica).is_err(),
+            "a repo-*-named symlink to messaging/ must hard-fail"
+        );
+    }
+
+    #[test]
+    fn plain_symlink_to_messaging_is_rejected_before_the_name_check() {
+        // Apparent name NOT `repo-`-prefixed: proves canonicalize runs before
+        // validation. Note this does NOT cover the two tests above: `messaging`
+        // fails the parent check on its own and never exercises the name rule.
+        let (_tmp, wg_root, replica) = make_workgroup("__agent_self");
+        let messaging = mkdir(&wg_root, "messaging");
+        let link = replica.join("plain-link");
+        if !try_symlink_dir(&messaging, &link) {
+            eprintln!("skipping: no symlink privilege on this platform");
+            return;
+        }
+        write_repos(&replica, &["./plain-link"]);
+
+        assert!(resolve_repo_mounts(&replica).is_err());
+    }
+
+    #[test]
+    fn messaging_sibling_is_rejected() {
+        let (_tmp, wg_root, replica) = make_workgroup("__agent_self");
+        mkdir(&wg_root, "messaging");
+        write_repos(&replica, &["../messaging"]);
+        assert!(resolve_repo_mounts(&replica).is_err());
+    }
+
+    #[test]
+    fn other_agent_replica_is_rejected() {
+        let (_tmp, wg_root, replica) = make_workgroup("__agent_self");
+        mkdir(&wg_root, "__agent_other");
+        write_repos(&replica, &["../__agent_other"]);
+        assert!(resolve_repo_mounts(&replica).is_err());
+    }
+
+    #[test]
+    fn own_replica_is_rejected() {
+        let (_tmp, _wg_root, replica) = make_workgroup("__agent_self");
+        write_repos(&replica, &["../__agent_self"]);
+        assert!(resolve_repo_mounts(&replica).is_err());
+    }
+
+    #[test]
+    fn workgroup_root_itself_is_rejected() {
+        let (_tmp, _wg_root, replica) = make_workgroup("__agent_self");
+        write_repos(&replica, &[".."]);
+        assert!(resolve_repo_mounts(&replica).is_err());
+    }
+
+    #[test]
+    fn path_at_or_above_workspace_is_rejected() {
+        let (_tmp, _wg_root, replica) = make_workgroup("__agent_self");
+        write_repos(&replica, &["../../.."]);
+        assert!(resolve_repo_mounts(&replica).is_err());
+    }
+
+    #[test]
+    fn absolute_path_to_real_dir_elsewhere_is_rejected() {
+        let (_tmp, _wg_root, replica) = make_workgroup("__agent_self");
+        let elsewhere = tempfile::tempdir().expect("elsewhere");
+        let elsewhere_repo = mkdir(elsewhere.path(), "repo-elsewhere");
+        write_repos(&replica, &[elsewhere_repo.to_str().unwrap()]);
+        assert!(
+            resolve_repo_mounts(&replica).is_err(),
+            "Q4: a repo outside the workgroup root is prohibited (post-collapse: hard-fail)"
+        );
+    }
+
+    #[test]
+    fn direct_wg_child_without_repo_prefix_is_rejected() {
+        let (_tmp, wg_root, replica) = make_workgroup("__agent_self");
+        mkdir(&wg_root, "not-repo-prefixed");
+        write_repos(&replica, &["../not-repo-prefixed"]);
+        assert!(resolve_repo_mounts(&replica).is_err());
+    }
+
+    #[test]
+    fn missing_dir_is_not_found_and_still_launches() {
+        let (_tmp, _wg_root, replica) = make_workgroup("__agent_self");
+        write_repos(&replica, &["../repo-missing"]);
+        let resolution = resolve_repo_mounts(&replica).expect("NOT FOUND must not hard-fail");
+        assert_eq!(resolution.entries.len(), 1);
+        assert_eq!(resolution.entries[0].outcome, RepoOutcome::NotFound);
+        assert_eq!(resolution.mounts().count(), 0);
+    }
+
+    #[test]
+    fn a_plain_file_named_repo_is_rejected() {
+        let (_tmp, wg_root, replica) = make_workgroup("__agent_self");
+        std::fs::write(wg_root.join("repo-file"), b"not a dir").expect("write file");
+        write_repos(&replica, &["../repo-file"]);
+        assert!(
+            resolve_repo_mounts(&replica).is_err(),
+            "an existing non-directory is inadmissible"
+        );
+    }
+
+    #[test]
+    fn two_agents_with_different_repos_resolve_to_different_mount_sets() {
+        // Per-agent enablement (plan Sec 2): each replica's own repos[] drives its
+        // own mount set.
+        let (_tmp, wg_root, replica_one) = make_workgroup("__agent_one");
+        let replica_two = wg_root.join("__agent_two");
+        std::fs::create_dir_all(&replica_two).expect("agent two");
+        let replica_two = std::fs::canonicalize(&replica_two).expect("canonical two");
+        mkdir(&wg_root, "repo-AgentsCommander");
+        mkdir(&wg_root, "repo-webpage");
+        write_repos(&replica_one, &["../repo-AgentsCommander"]);
+        write_repos(&replica_two, &["../repo-webpage"]);
+
+        let one: Vec<_> = resolve_repo_mounts(&replica_one)
+            .expect("ok")
+            .mounts()
+            .map(|(_, container)| container.to_string())
+            .collect();
+        let two: Vec<_> = resolve_repo_mounts(&replica_two)
+            .expect("ok")
+            .mounts()
+            .map(|(_, container)| container.to_string())
+            .collect();
+        assert_eq!(one, vec!["/repos/repo-AgentsCommander".to_string()]);
+        assert_eq!(two, vec!["/repos/repo-webpage".to_string()]);
+        assert_ne!(one, two);
+    }
+
+    #[test]
+    fn no_config_json_yields_no_mounts() {
+        let (_tmp, _wg_root, replica) = make_workgroup("__agent_self");
+        // No config.json written.
+        let resolution = resolve_repo_mounts(&replica).expect("ok");
+        assert!(resolution.entries.is_empty());
+    }
+
+    #[test]
+    fn not_a_workgroup_replica_yields_no_mounts() {
+        // A replica whose parent is not a `wg-` workspace child: no repo mounts,
+        // full stop (no error).
+        let tmp = tempfile::tempdir().expect("tmp");
+        let replica = tmp.path().join("some-dir");
+        std::fs::create_dir_all(&replica).expect("dir");
+        let replica = std::fs::canonicalize(&replica).expect("canonical");
+        write_repos(&replica, &["../repo-x"]);
+        let resolution = resolve_repo_mounts(&replica).expect("ok");
+        assert!(resolution.entries.is_empty());
+    }
+}

--- a/src-tauri/src/pty/container_runtime.rs
+++ b/src-tauri/src/pty/container_runtime.rs
@@ -51,6 +51,8 @@ pub struct ContainerStartRequest {
     pub env_unset: Vec<String>,
     pub cols: u16,
     pub rows: u16,
+    /// #935 - read-write repo bind mounts, each rendered as its own --mount.
+    pub repo_mounts: Vec<crate::pty::container_repos::ContainerRepoMount>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src-tauri/src/pty/docker_runtime.rs
+++ b/src-tauri/src/pty/docker_runtime.rs
@@ -199,12 +199,26 @@ impl DockerRuntime {
                 "type=bind,source={},target={}",
                 request.host_root, request.container_workdir
             ),
-            "--workdir".to_string(),
-            request.container_workdir.clone(),
-            "--".to_string(),
-            request.image.clone(),
-            DEFAULT_BRIDGE_ENTRYPOINT.to_string(),
         ];
+
+        // #935 - one read-write --mount per admissible repo, appended BEFORE the
+        // workdir/image/entrypoint tail. Pushing after the tail would place them
+        // after the image and turn them into container arguments (the image_idx
+        // assertions below guard exactly this).
+        for mount in &request.repo_mounts {
+            args.push("--mount".to_string());
+            args.push(format!(
+                "type=bind,source={},target={}",
+                mount.host_path.display(),
+                mount.container_path
+            ));
+        }
+
+        args.push("--workdir".to_string());
+        args.push(request.container_workdir.clone());
+        args.push("--".to_string());
+        args.push(request.image.clone());
+        args.push(DEFAULT_BRIDGE_ENTRYPOINT.to_string());
 
         args.retain(|arg| !arg.is_empty());
         Ok(DockerCommandSpec {
@@ -572,6 +586,7 @@ mod tests {
             env_unset: vec!["CLAUDE_CONFIG_DIR".to_string()],
             cols: 120,
             rows: 30,
+            repo_mounts: Vec::new(),
         }
     }
 
@@ -628,6 +643,73 @@ mod tests {
 
         assert_eq!(spec.args[image_idx - 1], "--");
         assert_eq!(spec.args[image_idx + 1], DEFAULT_BRIDGE_ENTRYPOINT);
+    }
+
+    #[test]
+    fn run_command_appends_read_write_repo_mounts_before_image() {
+        // #935 - each repo renders as its own --mount, AFTER the replica mount
+        // and BEFORE the -- / image / entrypoint tail. If the loop were appended
+        // after the tail, image_idx + 1 would be --mount and this test fails.
+        use crate::pty::container_repos::ContainerRepoMount;
+        let runtime = DockerRuntime::with_program("docker-test");
+        let mut req = request();
+        req.repo_mounts = vec![
+            ContainerRepoMount {
+                host_path: std::path::PathBuf::from(
+                    "C:/project/.ac/wg-1-team/repo-AgentsCommander",
+                ),
+                container_path: "/repos/repo-AgentsCommander".to_string(),
+            },
+            ContainerRepoMount {
+                host_path: std::path::PathBuf::from("C:/project/.ac/wg-1-team/repo-webpage"),
+                container_path: "/repos/repo-webpage".to_string(),
+            },
+        ];
+        let spec = runtime.build_run_command(&req).unwrap();
+        let joined = spec.args.join(" ");
+
+        // Replica mount plus the two repos = three --mount flags.
+        assert_eq!(spec.args.iter().filter(|a| *a == "--mount").count(), 3);
+        let replica = spec
+            .args
+            .iter()
+            .position(|a| a.contains("target=/workspace"))
+            .expect("replica mount");
+        let repo1 = spec
+            .args
+            .iter()
+            .position(|a| a.contains("target=/repos/repo-AgentsCommander"))
+            .expect("repo1 mount");
+        let repo2 = spec
+            .args
+            .iter()
+            .position(|a| a.contains("target=/repos/repo-webpage"))
+            .expect("repo2 mount");
+        // Order: replica first, then repos in config order.
+        assert!(replica < repo1 && repo1 < repo2);
+        assert!(joined.contains(
+            "type=bind,source=C:/project/.ac/wg-1-team/repo-AgentsCommander,target=/repos/repo-AgentsCommander"
+        ));
+        // Read-write: no readonly token on the repo mounts (Q2 = RW).
+        assert!(!joined.contains("readonly"));
+        // The workdir stays the replica.
+        let workdir_idx = spec
+            .args
+            .iter()
+            .position(|a| a == "--workdir")
+            .expect("workdir");
+        assert_eq!(spec.args[workdir_idx + 1], "/workspace");
+        // The repo mounts precede the image; the -- / entrypoint tail is intact.
+        let image_idx = spec
+            .args
+            .iter()
+            .position(|a| a == "ac-bridge:test")
+            .expect("image arg");
+        assert!(repo2 < image_idx, "repo mounts must precede the image");
+        assert_eq!(spec.args[image_idx - 1], "--");
+        assert_eq!(spec.args[image_idx + 1], DEFAULT_BRIDGE_ENTRYPOINT);
+        // S7 free regression guard, now exercised WITH repo mounts.
+        assert!(!joined.contains("messaging"));
     }
 
     #[test]

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -413,6 +413,7 @@ impl LocalProcessBackend {
             mut resource_registration,
             logical_resource_slot: _,
             container_credential: _,
+            container_repo_mounts: _,
         } = spec;
         let pty_system = native_pty_system();
         let spawn_cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -490,6 +490,7 @@ mod tests {
             resource_registration: None,
             logical_resource_slot: None,
             container_credential: None,
+            container_repo_mounts: Vec::new(),
         }
     }
 

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -2,6 +2,7 @@ pub mod backend;
 pub mod container_backend;
 pub mod container_credentials;
 pub mod container_paths;
+pub mod container_repos;
 pub mod container_runtime;
 pub mod container_tokens;
 pub mod credentials;


### PR DESCRIPTION
## Summary

Mounts each enabled `repo-*` working tree **read-write** into container agent sessions at `/repos/repo-<name>`, and fixes the injected agent context so container agents are told container paths (`/repos/...`) instead of host Windows paths.

Closes #935.

## What changed

- Each enabled repo of the workgroup is now bind-mounted RW into every container session of that workgroup, at a canonical `/repos/repo-<name>` path.
- Repo paths are canonicalized host-side before mounting; the canonical path (not the apparent one) decides the mount source and the mount target name, so a symlinked/junctioned `repo-*` entry cannot redirect a mount outside the intended tree.
- The workspace-repos block of the injected context now renders container paths for container sessions, host paths for host sessions.

## Design decision (recorded)

Q2 was resolved as **read-write with informed consent**: the repo trees mounted into containers are shared, writable working trees. The container is explicitly **not** a sandbox for those trees, and the host-RCE residual (agent-authored code executed host-side) is accepted by the owner. Container agents of a workgroup share ONE working tree per repo, so concurrent `index.lock` / checkout / build-target contention is possible by design.

## Reviews

- **Adversarial/security review (dev-rust-grinch): APPROVE.** The canonical-vs-apparent path split held on every vector probed (chained symlinks, junctions, `..` traversal, UNC, case-folding, TOCTOU) — all fail closed. Mount-string injection is not container-reachable. No path leakage in the injected context. Byte-identity of mounted content confirmed. Also confirmed AgentsCommander does not currently run any index-touching, network, diff/filter, or hook-firing git command inside a container-writable tree host-side.
- **Design conformance review (architect): INTACT.** Both implementation deviations honor the plan; single-resolution/two-consumers is one value read twice; the context cache path was checked and is safe.

## Verification

- Backend-only change; workspace build green from this commit; standalone build produced and smoke-launched.

## Follow-ups (filed separately, not in scope here)

- Windows CI does not hold `SeCreateSymbolicLinkPrivilege`, so the symlink regression tests guarding the canonical-path fix silently no-op there. Needs an elevated / Dev-Mode CI runner or an explicit privilege assertion.
- Reject canonical repo names containing docker `--mount` metacharacters (`,`, `=`) as defense in depth.
- Add a Windows junction variant of the `repo-trap` test.
- `.git/HEAD` hardening (low priority): keep the guardrail that AC must never run index-touching, network, diff/filter, or hook-firing git commands in a container-writable repo tree host-side.
- Release note: container agents of a workgroup now share one writable working tree per repo.
