### PR TITLE
feat(#965): sidebar rail favorites + collapsible categories

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1696,10 +1696,33 @@ pub(crate) async fn set_rail_collapse_inner(
     collapsed_projects: Vec<String>,
     favorites_collapsed: bool,
 ) -> Result<(), String> {
-    persist_narrow_settings_update(settings, |candidate| {
-        candidate.rail_collapsed_projects = collapsed_projects;
-        candidate.rail_favorites_collapsed = favorites_collapsed;
-    })
+    set_rail_collapse_inner_with_saver(
+        settings,
+        collapsed_projects,
+        favorites_collapsed,
+        save_settings,
+    )
+    .await
+}
+
+/// Saver seam for `set_rail_collapse_inner`, mirroring the three existing
+/// `*_with_saver` pairs in this module. It exists so a unit test can drive the REAL
+/// mutation without reaching `save_settings` -> `config::config_dir()`, a `OnceLock`
+/// that no test redirects and that would overwrite the developer's own settings.json.
+async fn set_rail_collapse_inner_with_saver(
+    settings: &SettingsState,
+    collapsed_projects: Vec<String>,
+    favorites_collapsed: bool,
+    save: impl FnOnce(&AppSettings) -> Result<AppSettings, String>,
+) -> Result<(), String> {
+    persist_narrow_settings_update_with_saver(
+        settings,
+        |candidate| {
+            candidate.rail_collapsed_projects = collapsed_projects;
+            candidate.rail_favorites_collapsed = favorites_collapsed;
+        },
+        save,
+    )
     .await
 }
 
@@ -1813,7 +1836,7 @@ mod tests {
         persist_coding_agent_env_settings_update, persist_coding_agent_profiles_update,
         persist_narrow_settings_update_with_saver, persist_protected_settings_update_with_saver,
         persist_settings_draft_update_with_saver, purge_sessions_after_settings_update_in_dir,
-        start_api_server, WebServerOwnershipState,
+        set_rail_collapse_inner_with_saver, start_api_server, WebServerOwnershipState,
         MINT_API_CLIENT_DEFAULT_TTL_HOURS, MINT_API_CLIENT_MAX_TTL_DAYS, MINT_API_CLIENT_NOTE,
     };
     #[cfg(windows)]
@@ -3082,18 +3105,15 @@ mod tests {
         original.rail_favorites_collapsed = false;
         let state = state_for(original);
 
-        // The mutation `set_rail_collapse_inner` applies, exercised through the
-        // fake-saver hook. Calling the inner fn directly would reach the real
-        // `save_settings` -> `config::config_dir()`, a `OnceLock` that no test
-        // redirects, and would overwrite the developer's real settings.json.
+        // Drives the REAL `set_rail_collapse_inner` mutation through its saver seam, so
+        // dropping or swapping a field assignment inside that fn fails this test. The fake
+        // saver keeps it off disk: the real `save_settings` resolves `config::config_dir()`,
+        // a `OnceLock` no test redirects, which would overwrite the developer's settings.json.
         let captured: Mutex<Option<AppSettings>> = Mutex::new(None);
-        persist_narrow_settings_update_with_saver(
+        set_rail_collapse_inner_with_saver(
             &state,
-            |candidate| {
-                candidate.rail_collapsed_projects =
-                    vec!["c:/foo".to_string(), "d:/bar".to_string()];
-                candidate.rail_favorites_collapsed = true;
-            },
+            vec!["c:/foo".to_string(), "d:/bar".to_string()],
+            true,
             |candidate| {
                 *captured.lock().expect("capture lock") = Some(candidate.clone());
                 Ok(candidate.clone())

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -235,6 +235,12 @@ fn build_protected_settings_candidate(
     candidate.project_paths = current.project_paths.clone();
     candidate.project_path = current.project_path.clone();
     candidate.archived_project_paths = current.archived_project_paths.clone();
+    // #965: rail collapse is mutated only by `set_rail_collapse`. A settings payload
+    // from the GUI, CLI, or API must never carry authority for it, so restore both
+    // fields from live memory. Same rule and same mechanism as the project lists
+    // above; this is not the prohibited disk re-read.
+    candidate.rail_collapsed_projects = current.rail_collapsed_projects.clone();
+    candidate.rail_favorites_collapsed = current.rail_favorites_collapsed;
     validate_and_repair_settings(&mut candidate)?;
     Ok(candidate)
 }
@@ -260,6 +266,12 @@ async fn persist_settings_draft_update_with_saver(
     draft.project_paths = current.project_paths.clone();
     draft.project_path = current.project_path.clone();
     draft.archived_project_paths = current.archived_project_paths.clone();
+    // #965: same protect as `build_protected_settings_candidate`. The SettingsModal
+    // Save path lands here, and so does every whole-object writer that reads
+    // `settingsStore.current` first (window geometry, zoom, titlebar...). Rail
+    // collapse is owned by `set_rail_collapse`; restore it from live memory.
+    draft.rail_collapsed_projects = current.rail_collapsed_projects.clone();
+    draft.rail_favorites_collapsed = current.rail_favorites_collapsed;
     validate_and_repair_settings(&mut draft)?;
     let events = settings_draft_update_events(&current, &draft);
     let written = save(&draft)?;
@@ -1669,6 +1681,37 @@ pub async fn set_main_resource_monitor_attached(
     .await
 }
 
+/// #965 narrow setter for the rail collapse snapshot. Same candidate-save-publish
+/// pattern as `set_theme_light`: holds the `SettingsState` write lock across
+/// `save_settings`, so it cannot lose an interleaved `update_settings`.
+/// ONE command for both fields: the rail always persists its whole snapshot, so a
+/// per-field setter would just double the writes. Called once per explicit header
+/// click (no auto-focus path writes here), so it is cold by construction.
+///
+/// The `_inner` split exists so the web/WS route (`web/commands.rs`) reaches the
+/// same read-modify-save instead of duplicating it; the browser client mounts the
+/// rail too. Precedent: `set_agent_default_profile_inner`.
+pub(crate) async fn set_rail_collapse_inner(
+    settings: &SettingsState,
+    collapsed_projects: Vec<String>,
+    favorites_collapsed: bool,
+) -> Result<(), String> {
+    persist_narrow_settings_update(settings, |candidate| {
+        candidate.rail_collapsed_projects = collapsed_projects;
+        candidate.rail_favorites_collapsed = favorites_collapsed;
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn set_rail_collapse(
+    settings: State<'_, SettingsState>,
+    collapsed_projects: Vec<String>,
+    favorites_collapsed: bool,
+) -> Result<(), String> {
+    set_rail_collapse_inner(settings.inner(), collapsed_projects, favorites_collapsed).await
+}
+
 /// #612 apply the runtime log level (no-op under RUST_LOG) and broadcast so
 /// every webview re-applies its own console gate. Single point that both the
 /// dedicated `set_log_level` command and the SettingsModal Save path reuse.
@@ -3030,6 +3073,103 @@ mod tests {
             remaining[0].working_directory,
             kept_workdir.to_string_lossy()
         );
+    }
+
+    #[tokio::test]
+    async fn set_rail_collapse_persists_both_fields_and_publishes_to_live_state() {
+        let mut original = settings_with_single_agent();
+        original.rail_collapsed_projects = vec!["c:/stale".to_string()];
+        original.rail_favorites_collapsed = false;
+        let state = state_for(original);
+
+        // The mutation `set_rail_collapse_inner` applies, exercised through the
+        // fake-saver hook. Calling the inner fn directly would reach the real
+        // `save_settings` -> `config::config_dir()`, a `OnceLock` that no test
+        // redirects, and would overwrite the developer's real settings.json.
+        let captured: Mutex<Option<AppSettings>> = Mutex::new(None);
+        persist_narrow_settings_update_with_saver(
+            &state,
+            |candidate| {
+                candidate.rail_collapsed_projects =
+                    vec!["c:/foo".to_string(), "d:/bar".to_string()];
+                candidate.rail_favorites_collapsed = true;
+            },
+            |candidate| {
+                *captured.lock().expect("capture lock") = Some(candidate.clone());
+                Ok(candidate.clone())
+            },
+        )
+        .await
+        .expect("persist rail collapse");
+
+        let written = captured
+            .lock()
+            .expect("capture lock")
+            .clone()
+            .expect("saver ran");
+        assert_eq!(
+            written.rail_collapsed_projects,
+            vec!["c:/foo".to_string(), "d:/bar".to_string()]
+        );
+        assert!(written.rail_favorites_collapsed);
+
+        let live = state.read().await;
+        assert_eq!(
+            live.rail_collapsed_projects,
+            vec!["c:/foo".to_string(), "d:/bar".to_string()]
+        );
+        assert!(live.rail_favorites_collapsed);
+    }
+
+    // (#965 F1) The two whole-object writers must not let a stale client payload
+    // revert the rail snapshot. Without these, `window-geometry.ts` alone (which
+    // fires a whole-object write on every window move/resize) would silently wipe
+    // a header click, and nothing re-persists it: the in-memory signal is never
+    // invalidated, so it does NOT self-heal.
+    #[tokio::test]
+    async fn update_settings_keeps_live_rail_collapse_when_payload_is_stale() {
+        let mut current = settings_with_single_agent();
+        current.rail_collapsed_projects = vec!["c:/foo".to_string()];
+        current.rail_favorites_collapsed = true;
+        let state = state_for(current);
+
+        let mut stale = settings_with_single_agent();
+        stale.rail_collapsed_projects = Vec::new();
+        stale.rail_favorites_collapsed = false;
+
+        let saved =
+            persist_protected_settings_update_with_saver(&state, stale, |c| Ok(c.clone()))
+                .await
+                .expect("persist");
+
+        assert_eq!(saved.rail_collapsed_projects, vec!["c:/foo".to_string()]);
+        assert!(saved.rail_favorites_collapsed);
+        let live = state.read().await;
+        assert_eq!(live.rail_collapsed_projects, vec!["c:/foo".to_string()]);
+        assert!(live.rail_favorites_collapsed);
+    }
+
+    #[tokio::test]
+    async fn save_settings_draft_keeps_live_rail_collapse_when_draft_is_stale() {
+        let mut current = settings_with_single_agent();
+        current.rail_collapsed_projects = vec!["c:/foo".to_string()];
+        current.rail_favorites_collapsed = true;
+        let state = state_for(current);
+
+        let mut draft = settings_with_single_agent();
+        draft.rail_collapsed_projects = Vec::new();
+        draft.rail_favorites_collapsed = false;
+
+        let (saved, _events) =
+            persist_settings_draft_update_with_saver(&state, draft, |c| Ok(c.clone()))
+                .await
+                .expect("persist");
+
+        assert_eq!(saved.rail_collapsed_projects, vec!["c:/foo".to_string()]);
+        assert!(saved.rail_favorites_collapsed);
+        let live = state.read().await;
+        assert_eq!(live.rail_collapsed_projects, vec!["c:/foo".to_string()]);
+        assert!(live.rail_favorites_collapsed);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/project_settings.rs
+++ b/src-tauri/src/commands/project_settings.rs
@@ -67,6 +67,7 @@ mod tests {
                 id: "bots".to_string(),
                 name: "BOTS".to_string(),
                 regex: "^(wg-9)$".to_string(),
+                favorite: false,
             }],
             show_all: true,
             show_ungrouped: true,

--- a/src-tauri/src/config/project_settings.rs
+++ b/src-tauri/src/config/project_settings.rs
@@ -21,6 +21,11 @@ pub struct WorkgroupGroup {
     pub id: String,
     pub name: String,
     pub regex: String,
+    /// (#965) Pinned into the rail's cross-project `Favorites` section. Absent on
+    /// legacy configs => false. Lives on the group record so it survives rename
+    /// (`id` is a stable UUID), travels with reorder, and dies with the group.
+    #[serde(default)]
+    pub favorite: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -286,6 +291,7 @@ mod tests {
             id: id.to_string(),
             name: name.to_string(),
             regex: regex.to_string(),
+            favorite: false,
         }
     }
 
@@ -296,6 +302,37 @@ mod tests {
             show_ungrouped: true,
             non_stop: None,
         }
+    }
+
+    #[test]
+    fn legacy_group_json_defaults_favorite_false() {
+        let legacy = r#"{"groups":[{"id":"bots","name":"BOTS","regex":"^(wg-9)$"}]}"#;
+        let config: WorkgroupGroupsConfig = serde_json::from_str(legacy).expect("parse legacy");
+        assert!(!config.groups[0].favorite);
+    }
+
+    #[test]
+    fn favorite_flag_round_trips_through_save_load() {
+        let project = project_with_workspace();
+        let mut config = config_with_groups(vec![
+            group("bots", "BOTS", "^(wg-9)$"),
+            group("ui", "UI", "^(wg-1)$"),
+        ]);
+        config.groups[0].favorite = true;
+
+        save_workgroup_groups(project.path(), config.clone()).expect("save");
+        let reloaded = load_workgroup_groups(project.path()).expect("reload");
+
+        assert_eq!(reloaded, config);
+        let persisted: Value = serde_json::from_str(
+            &std::fs::read_to_string(settings_path(project.path())).expect("read"),
+        )
+        .expect("parse");
+        assert_eq!(persisted["groups"][0]["favorite"], true);
+        // (#965) A NON-favorited group must still emit `false` on disk. Guard against a
+        // `skip_serializing_if` creeping in later and handing the frontend `undefined`
+        // where it expects a concrete boolean.
+        assert_eq!(persisted["groups"][1]["favorite"], false);
     }
 
     fn populated_non_stop() -> NonStopGroupConfig {

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -440,6 +440,22 @@ pub struct AppSettings {
     /// Defaults to `false` so fresh and missing values use dark mode.
     #[serde(default)]
     pub theme_light: bool,
+    /// #965 - rail project sections the user has explicitly collapsed by clicking
+    /// their header. This is the RAIL's own state; it is deliberately NOT the
+    /// ProjectPanel's collapse (which stays session-only and auto-focus driven).
+    /// Entries are FRONTEND-NORMALIZED project paths (lowercase, forward slashes,
+    /// no trailing slash: `normalizeProjectPathForCompare` in
+    /// `src/sidebar/stores/project-refresh.ts`).
+    /// WRITTEN ONLY BY `set_rail_collapse`. A whole-object settings payload from the
+    /// GUI/CLI/API carries no authority for this field: both whole-object writers
+    /// restore it from live memory (see `build_protected_settings_candidate`).
+    #[serde(default)]
+    pub rail_collapsed_projects: Vec<String>,
+    /// #965 - collapsed state of the rail's cross-project `Favorites` section.
+    /// Belongs to no project, which is why collapse cannot live in project-settings.json.
+    /// Same protection as `rail_collapsed_projects`.
+    #[serde(default)]
+    pub rail_favorites_collapsed: bool,
     /// When true, show the Spec Board toolbar button. Defaults off because the
     /// board is an opt-in feature enabled manually from settings.json.
     #[serde(default)]
@@ -703,6 +719,8 @@ impl Default for AppSettings {
             auto_generate_task_title: true,
             agent_templates_path: None,
             theme_light: false,
+            rail_collapsed_projects: Vec::new(),
+            rail_favorites_collapsed: false,
             spec_board_enabled: false,
             resource_monitor_enabled: default_resource_monitor_enabled(),
             max_concurrent_agent_processes: default_max_concurrent_agent_processes(),
@@ -3057,6 +3075,46 @@ mod tests {
         assert!(s.sounds_enabled);
         // Existing per-feature toggle is honored as-is.
         assert!(!s.team_idle_beep_enabled);
+    }
+
+    #[test]
+    fn rail_collapse_fields_round_trip_through_serde() {
+        let mut s = AppSettings::default();
+        assert!(s.rail_collapsed_projects.is_empty());
+        assert!(!s.rail_favorites_collapsed);
+
+        s.rail_collapsed_projects = vec!["c:/foo/bar".to_string(), "d:/baz".to_string()];
+        s.rail_favorites_collapsed = true;
+
+        let json = serde_json::to_string(&s).expect("serialize");
+        // (#965) camelCase guard. A broken `rename_all` would otherwise surface only as a
+        // silently dead frontend, since the TS side reads `railCollapsedProjects` /
+        // `railFavoritesCollapsed`.
+        assert!(
+            json.contains("\"railCollapsedProjects\":[\"c:/foo/bar\",\"d:/baz\"]"),
+            "{json}"
+        );
+        assert!(json.contains("\"railFavoritesCollapsed\":true"), "{json}");
+
+        let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.rail_collapsed_projects, s.rail_collapsed_projects);
+        assert!(back.rail_favorites_collapsed);
+    }
+
+    #[test]
+    fn rail_collapse_fields_default_when_missing_from_json() {
+        // A legacy settings.json carries neither key. Build one by round-tripping a
+        // default and deleting them, so every other field stays present and the test
+        // isolates exactly the `#[serde(default)]` behavior.
+        let mut value = serde_json::to_value(AppSettings::default()).expect("to_value");
+        let obj = value.as_object_mut().expect("settings object");
+        obj.remove("railCollapsedProjects");
+        obj.remove("railFavoritesCollapsed");
+
+        let s: AppSettings = serde_json::from_value(value).expect("deserialize legacy");
+
+        assert!(s.rail_collapsed_projects.is_empty());
+        assert!(!s.rail_favorites_collapsed);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2081,6 +2081,7 @@ pub fn run(
             commands::config::set_sounds_enabled,
             commands::config::set_theme_light,
             commands::config::set_main_resource_monitor_attached,
+            commands::config::set_rail_collapse,
             commands::config::set_log_level,
             commands::config::get_update_status,
             commands::repos::search_repos,

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -400,6 +400,35 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
             Ok(json!(null))
         }
 
+        // #965 - the rail is live in the browser client (`src/browser/App.tsx`
+        // mounts `<SidebarApp embedded>`), so its collapse setter must be routed
+        // or every rail header click hits the `Unknown command` fallback at the
+        // bottom of this match. Same omission #859 had to fix for the profile
+        // commands below. Symptom if unrouted: SILENT non-persistence, not a
+        // console error - the frontend catch swallows the rejection.
+        "set_rail_collapse" => {
+            let collapsed_projects: Vec<String> = args
+                .get("collapsedProjects")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let favorites_collapsed = args
+                .get("favoritesCollapsed")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            crate::commands::config::set_rail_collapse_inner(
+                &state.settings,
+                collapsed_projects,
+                favorites_collapsed,
+            )
+            .await?;
+            Ok(json!(null))
+        }
+
         // --- Coding-agent profiles (#859 web transport parity) ---
         // Desktop registers these in the Tauri invoke_handler, but the browser
         // websocket router did not route them, so the CODING AGENT modal hit the
@@ -987,6 +1016,7 @@ mod tests {
                 id: "core".to_string(),
                 name: "Core".to_string(),
                 regex: "^wg-14$".to_string(),
+                favorite: false,
             }],
             show_all: false,
             show_ungrouped: true,

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -407,19 +407,17 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
         // commands below. Symptom if unrouted: SILENT non-persistence, not a
         // console error - the frontend catch swallows the rejection.
         "set_rail_collapse" => {
-            let collapsed_projects: Vec<String> = args
-                .get("collapsedProjects")
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(str::to_string))
-                        .collect()
-                })
-                .unwrap_or_default();
-            let favorites_collapsed = args
-                .get("favoritesCollapsed")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
+            // (#965) STRICT parse. Deliberately NOT `unwrap_or_default()` / `unwrap_or(false)`:
+            // this setter writes a FULL snapshot, so a payload that is missing or malforms
+            // either half is not a partial update, it is a WIPE. A defaulted
+            // `collapsedProjects` erases every collapsed section; a defaulted
+            // `favoritesCollapsed` re-expands a section the user explicitly folded. BOTH args
+            // are therefore required: the desktop path takes them as non-Option typed args and
+            // errors when one is absent, and the two transports must not disagree about the
+            // same payload. `require_json` additionally rejects a non-string element instead of
+            // silently dropping it, which the previous `filter_map` did.
+            let collapsed_projects: Vec<String> = require_json(args, "collapsedProjects")?;
+            let favorites_collapsed: bool = require_json(args, "favoritesCollapsed")?;
             crate::commands::config::set_rail_collapse_inner(
                 &state.settings,
                 collapsed_projects,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -316,6 +316,11 @@ export const SettingsAPI = {
   // round-trip racing SettingsModal.
   setMainResourceMonitorAttached: (value: boolean) =>
     transport.invoke<void>("set_main_resource_monitor_attached", { value }),
+  // #965 — one narrow setter for the whole rail-collapse snapshot (explicitly
+  // collapsed project paths + the Favorites section bit). Same write-lock pattern.
+  // Called once per header click; no debounce (plan §0.2).
+  setRailCollapse: (collapsedProjects: string[], favoritesCollapsed: boolean) =>
+    transport.invoke<void>("set_rail_collapse", { collapsedProjects, favoritesCollapsed }),
   // #612 — canonical command to change ONLY the log level: validates, persists
   // logLevel, applies live + broadcasts `log_level_changed`. The SettingsModal
   // uses the form Save path (save_settings_draft) instead; this is for

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -17,6 +17,7 @@ import { sessionsStore } from "../../sidebar/stores/sessions";
 import { bridgesStore } from "../../sidebar/stores/bridges";
 import { workgroupGroupsStore } from "../../sidebar/stores/workgroup-groups";
 import { projectCollapseStore } from "../../sidebar/stores/project-collapse";
+import { railCollapseStore } from "../../sidebar/stores/rail-collapse";
 import { codingAgentsStore } from "../../sidebar/stores/coding-agents";
 import { terminalStore } from "../../terminal/stores/terminal";
 import { __resetHomeStoreForTests } from "../../main/stores/home";
@@ -245,6 +246,10 @@ export function resetUiStoresForTests(): void {
   sessionsStore.clearDetached();
   workgroupGroupsStore.resetForTests();
   projectCollapseStore.resetForTests();
+  // #965 - the rail's own collapse state is a module-level signal, so it outlives a
+  // render exactly like the stores above. Without this, a test that collapses a
+  // header leaks a folded rail into the next test in the same file.
+  railCollapseStore.resetForTests();
   codingAgentsStore.resetForTests();
   bridgesStore.setBridges([]);
   terminalStore.setActiveSession(null, "", "", null, "", null, false);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -473,6 +473,14 @@ export interface AppSettings {
   autoGenerateTaskTitle: boolean;
   agentTemplatesPath: string | null;
   themeLight: boolean;
+  /** #965 - rail project sections the user explicitly collapsed (header click).
+   *  NOT the ProjectPanel's collapse. Normalized project paths (see
+   *  `normalizeProjectPathForCompare`). Written only by `setRailCollapse`; a
+   *  whole-object save cannot change it (Rust restores it from live memory).
+   *  Optional so existing partial-AppSettings fixtures keep compiling. */
+  railCollapsedProjects?: string[];
+  /** #965 - collapsed state of the rail's cross-project Favorites section. */
+  railFavoritesCollapsed?: boolean;
   specBoardEnabled: boolean;
   resourceMonitorEnabled: boolean;
   maxConcurrentAgentProcesses: number;
@@ -870,6 +878,9 @@ export interface WorkgroupGroup {
   id: string;
   name: string;
   regex: string;
+  /** #965 - pinned into the rail's cross-project Favorites section. Absent on
+   *  legacy configs (Rust `#[serde(default)]`). */
+  favorite?: boolean;
 }
 
 export interface NonStopTelegramConfig {

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -52,6 +52,7 @@ import { normalizeProjectPathForCompare } from "./stores/project-refresh";
 import { startTeamIdleWatcher } from "./stores/team-idle-watcher";
 import { primeAudio } from "../shared/sound";
 import { settingsStore } from "../shared/stores/settings";
+import { railCollapseStore } from "./stores/rail-collapse";
 import Titlebar from "./components/Titlebar";
 import ActionBar from "./components/ActionBar";
 import RootAgentBanner from "./components/RootAgentBanner";
@@ -504,6 +505,12 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     raiseTerminalEnabled = appSettings.raiseTerminalOnClick;
     sessionsStore.setCoordSortByActivity(appSettings.coordSortByActivity ?? false);
     sessionsStore.setAlwaysShowSelectedWorkgroup(appSettings.alwaysShowSelectedWorkgroup ?? true);
+    // #965 (RC-3) — restore the rail's collapse snapshot. MUST run before
+    // projectStore.initFromSettings() populates the rail: that ordering is the only
+    // thing preventing an expand-then-collapse flash, because onMount runs AFTER the
+    // first paint. Deliberately NOT inside the `!props.embedded` guard above — the
+    // rail is live in the browser client and in the unified main window too.
+    railCollapseStore.hydrateFromSettings(appSettings);
     // Apply sidebar style from settings (remap removed themes to default)
     const style = appSettings.sidebarStyle;
     const removedThemes = ["classic", "signal-grid"];

--- a/src/sidebar/components/WorkgroupGroupRail.favorites.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.favorites.test.tsx
@@ -1,0 +1,666 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AcWorkgroup, Session, WorkgroupGroupsConfig } from "../../shared/types";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  contextMenu,
+  discovery,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore, type ProjectState } from "../stores/project";
+import { projectCollapseStore } from "../stores/project-collapse";
+import { sessionsStore } from "../stores/sessions";
+import {
+  defaultGroupsConfig,
+  defaultNonStop,
+  exactGroupRegexForWorkgroup,
+} from "../stores/workgroup-groups";
+import WorkgroupGroupRail from "./WorkgroupGroupRail";
+
+const projectPath = "C:\\Project";
+const otherProjectPath = "C:\\OtherProject";
+
+function wg(name: string, root = projectPath): AcWorkgroup {
+  return {
+    name,
+    path: `${root}\\.ac\\${name}`,
+    task: null,
+    taskTitle: null,
+    agents: [
+      {
+        name: "dev-webpage-ui",
+        path: `${root}\\.ac\\${name}\\__agent_dev-webpage-ui`,
+        repoPaths: [],
+        isCoordinator: true,
+      },
+    ],
+  };
+}
+
+function project(): ProjectState {
+  return {
+    path: projectPath,
+    folderName: "Project",
+    workgroups: [wg("wg-1-dev-team"), wg("wg-2-rust-team"), wg("wg-3-docs-team")],
+    agents: [],
+    teams: [],
+    loops: [],
+    contextTemplateUpdates: [],
+  };
+}
+
+function otherProject(): ProjectState {
+  return {
+    path: otherProjectPath,
+    folderName: "OtherProject",
+    workgroups: [wg("wg-9-ops-team", otherProjectPath)],
+    agents: [],
+    teams: [],
+    loops: [],
+    contextTemplateUpdates: [],
+  };
+}
+
+/** A session that makes the given workgroup "working" (running dot). */
+function replicaSession(wgName: string): Session {
+  return session({
+    id: `session-${wgName}`,
+    name: `${wgName}/dev-webpage-ui`,
+    workingDirectory: `${projectPath}\\.ac\\${wgName}\\__agent_dev-webpage-ui`,
+    status: "running",
+  });
+}
+
+function groupsConfig(overrides: Partial<WorkgroupGroupsConfig> = {}): WorkgroupGroupsConfig {
+  return {
+    ...defaultGroupsConfig(),
+    ...overrides,
+    groups: overrides.groups ?? [
+      { id: "ui", name: "UI", regex: exactGroupRegexForWorkgroup("wg-1-dev-team") },
+      { id: "rust", name: "Rust", regex: exactGroupRegexForWorkgroup("wg-2-rust-team") },
+      { id: "docs", name: "Docs", regex: exactGroupRegexForWorkgroup("wg-3-docs-team") },
+    ],
+  };
+}
+
+function target<T extends Element>(testId: string): T {
+  const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing element ${testId}`);
+  return element;
+}
+
+function maybeTarget<T extends Element>(testId: string): T | null {
+  return document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+}
+
+function railButtonOrder(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-ac-testid^="workgroupGroups.button."]')
+  ).map((button) => button.dataset.acTestid!.replace("workgroupGroups.button.", ""));
+}
+
+function railDotKeys(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-ac-testid^="workgroupGroups.dot."]')
+  ).map((dot) => dot.dataset.acTestid!.replace("workgroupGroups.dot.", ""));
+}
+
+function favoriteButtonKeys(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-ac-testid^="workgroupGroups.favoriteButton."]')
+  ).map((button) => button.dataset.acTestid!.replace("workgroupGroups.favoriteButton.", ""));
+}
+
+function lastUpdatedGroupIds(fake: FakeTransport): string[] | undefined {
+  const config = fake.lastCall("update_project_groups")?.args.config as WorkgroupGroupsConfig | undefined;
+  return config?.groups.map((group) => group.id);
+}
+
+function pointer(
+  el: Element | Window,
+  type: "pointerdown" | "pointermove" | "pointerup",
+  init: { clientY?: number; pointerId?: number } = {}
+): void {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: 10,
+    clientY: init.clientY ?? 10,
+    button: 0,
+  });
+  Object.defineProperty(event, "pointerId", { value: init.pointerId ?? 1 });
+  Object.defineProperty(event, "pointerType", { value: "mouse" });
+  Object.defineProperty(event, "isPrimary", { value: true });
+  el.dispatchEvent(event);
+}
+
+function mockRect(el: HTMLElement, top: number, height = 30): void {
+  vi.spyOn(el, "getBoundingClientRect").mockReturnValue({
+    x: 0,
+    y: top,
+    top,
+    left: 0,
+    right: 68,
+    bottom: top + height,
+    width: 68,
+    height,
+    toJSON: () => ({}),
+  } as DOMRect);
+}
+
+/** Right-click `el` and wait for the hoisted rail context menu to render. */
+async function openMenuOn(el: Element): Promise<void> {
+  contextMenu(el);
+  await waitFor(() => expect(target("workgroupGroups.contextMenu")).toBeTruthy());
+}
+
+/** `get_project_groups` is invoked per project path, so a flat `resolve()` would
+ *  hand OtherProject the SAME groups (and the same favorites) as Project. Key the
+ *  handler on `args.path`; every project other than the main one gets the empty
+ *  default config. */
+function railFake(mainConfig: WorkgroupGroupsConfig = groupsConfig()): FakeTransport {
+  const fake = new FakeTransport();
+  fake.onInvoke("get_project_groups", (args) =>
+    args.path === projectPath ? mainConfig : defaultGroupsConfig()
+  );
+  fake.onInvoke("update_project_groups", (args) => args.config);
+  fake.resolve("set_rail_collapse", null);
+  fake.resolve("list_archived_projects", []);
+  return fake;
+}
+
+/** Seed `projectStore`, which is what `selectFromRail` reads for the #810
+ *  auto-focus (`collapseAllExceptKnown(owner, projectStore.projects…)`) — NOT the
+ *  `projects` prop. Without this the auto-focus list is empty and collapse-others
+ *  silently no-ops. */
+async function seedProjectStore(fake: FakeTransport, paths: string[]): Promise<void> {
+  fake.onInvoke("new_project", (args) => ({ path: args.path as string }));
+  fake.onInvoke("discover_project", (args) => {
+    const path = args.path as string;
+    return discovery({
+      workgroups:
+        path === projectPath
+          ? [wg("wg-1-dev-team"), wg("wg-2-rust-team"), wg("wg-3-docs-team")]
+          : [wg("wg-9-ops-team", path)],
+    });
+  });
+  for (const path of paths) await projectStore.createAndLoad(path);
+}
+
+describe("WorkgroupGroupRail favorites + collapsible rail (#965)", () => {
+  beforeEach(() => {
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("Option B: a group click never touches rail collapse (RC-2)", () => {
+    // THE B REGRESSION TEST. Never delete it. This is the user's ruling, encoded:
+    // the rail folds ONLY on an explicit header click, while the #810 auto-focus
+    // keeps driving the ProjectPanel exactly as before.
+    it("issues no set_rail_collapse and leaves every header expanded, while the ProjectPanel auto-focus still fires", async () => {
+      const fake = railFake();
+      const rendered = renderWithFakeTransport(
+        () => <WorkgroupGroupRail projects={projectStore.projects} />,
+        fake
+      );
+      try {
+        await seedProjectStore(fake, [projectPath, otherProjectPath]);
+        await waitFor(() => expect(target("workgroupGroups.button.ui")).toBeTruthy());
+
+        click(target("workgroupGroups.button.ui"));
+
+        // The rail did not fold, and nothing was persisted.
+        expect(fake.callsFor("set_rail_collapse")).toEqual([]);
+        expect(target("workgroupGroups.projectLabel.Project").getAttribute("aria-expanded")).toBe("true");
+        expect(target("workgroupGroups.projectLabel.OtherProject").getAttribute("aria-expanded")).toBe(
+          "true"
+        );
+        expect(target("workgroupGroups.button.ui")).toBeTruthy();
+
+        // ...but the ProjectPanel's #810 auto-focus is untouched: it still collapses
+        // the other project's CARD and expands the owner's.
+        expect(projectCollapseStore.isProjectCollapsed(otherProjectPath)).toBe(true);
+        expect(projectCollapseStore.isProjectCollapsed(projectPath)).toBe(false);
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  });
+
+  describe("collapsible headers", () => {
+    it("folds a project section on header click, persists the snapshot, and restores aria-expanded", async () => {
+      const fake = railFake();
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(target("workgroupGroups.button.ui")).toBeTruthy());
+        const header = target<HTMLElement>("workgroupGroups.projectLabel.Project");
+        expect(header.getAttribute("aria-expanded")).toBe("true");
+
+        click(header);
+
+        await waitFor(() => expect(maybeTarget("workgroupGroups.button.ui")).toBeNull());
+        expect(header.getAttribute("aria-expanded")).toBe("false");
+        expect(fake.lastCall("set_rail_collapse")?.args).toEqual({
+          collapsedProjects: ["c:/project"],
+          favoritesCollapsed: false,
+        });
+
+        click(header);
+
+        await waitFor(() => expect(maybeTarget("workgroupGroups.button.ui")).toBeTruthy());
+        expect(header.getAttribute("aria-expanded")).toBe("true");
+        expect(fake.lastCall("set_rail_collapse")?.args).toEqual({
+          collapsedProjects: [],
+          favoritesCollapsed: false,
+        });
+      } finally {
+        rendered.cleanup();
+      }
+    });
+
+    it("keeps the config error badge visible while the section is collapsed", async () => {
+      const fake = railFake();
+      fake.reject("get_project_groups", "disk denied");
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() =>
+          expect(document.querySelector(".workgroup-group-rail-error")).toBeTruthy()
+        );
+
+        click(target("workgroupGroups.projectLabel.Project"));
+
+        // An error badge that hides itself is a bug.
+        await waitFor(() =>
+          expect(target("workgroupGroups.projectLabel.Project").getAttribute("aria-expanded")).toBe(
+            "false"
+          )
+        );
+        expect(document.querySelector(".workgroup-group-rail-error")).toBeTruthy();
+      } finally {
+        rendered.cleanup();
+      }
+    });
+
+    it("folds the Favorites section on its header click and persists the bit", async () => {
+      const fake = railFake(
+        groupsConfig({
+          groups: [
+            { id: "ui", name: "UI", regex: exactGroupRegexForWorkgroup("wg-1-dev-team"), favorite: true },
+            { id: "rust", name: "Rust", regex: exactGroupRegexForWorkgroup("wg-2-rust-team") },
+          ],
+        })
+      );
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(favoriteButtonKeys()).toEqual(["Project.ui"]));
+        const header = target<HTMLElement>("workgroupGroups.favorites.header");
+        expect(header.getAttribute("aria-expanded")).toBe("true");
+
+        click(header);
+
+        await waitFor(() => expect(favoriteButtonKeys()).toEqual([]));
+        expect(header.getAttribute("aria-expanded")).toBe("false");
+        // The section header stays, so the user can unfold it again.
+        expect(target("workgroupGroups.favorites")).toBeTruthy();
+        expect(fake.lastCall("set_rail_collapse")?.args).toEqual({
+          collapsedProjects: [],
+          favoritesCollapsed: true,
+        });
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  });
+
+  describe("favorite / unfavorite via the context menu", () => {
+    it("offers Favorite on a user group, renders it in Favorites, and KEEPS it in its project section", async () => {
+      const fake = railFake();
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(target("workgroupGroups.button.rust")).toBeTruthy());
+        expect(maybeTarget("workgroupGroups.favorites")).toBeNull();
+
+        await openMenuOn(target("workgroupGroups.button.rust"));
+        expect(target("workgroupGroups.contextMenu.favorite").textContent).toContain("Favorite");
+
+        click(target("workgroupGroups.contextMenu.favorite"));
+
+        await waitFor(() => expect(favoriteButtonKeys()).toEqual(["Project.rust"]));
+        // The duplication is the point: a favorite shows in BOTH places. Filtering it
+        // out of the project section would desync the reorder index math (§4.7).
+        expect(target("workgroupGroups.button.rust")).toBeTruthy();
+        expect(lastUpdatedGroupIds(fake)).toEqual(["ui", "rust", "docs"]);
+        const saved = fake.lastCall("update_project_groups")?.args.config as WorkgroupGroupsConfig;
+        expect(saved.groups.find((group) => group.id === "rust")?.favorite).toBe(true);
+      } finally {
+        rendered.cleanup();
+      }
+    });
+
+    it("offers Unfavorite on a favorited group and removes it from Favorites", async () => {
+      const fake = railFake(
+        groupsConfig({
+          groups: [
+            { id: "ui", name: "UI", regex: exactGroupRegexForWorkgroup("wg-1-dev-team"), favorite: true },
+            { id: "rust", name: "Rust", regex: exactGroupRegexForWorkgroup("wg-2-rust-team") },
+          ],
+        })
+      );
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(favoriteButtonKeys()).toEqual(["Project.ui"]));
+
+        await openMenuOn(target("workgroupGroups.button.ui"));
+        expect(target("workgroupGroups.contextMenu.favorite").textContent).toContain("Unfavorite");
+
+        click(target("workgroupGroups.contextMenu.favorite"));
+
+        await waitFor(() => expect(maybeTarget("workgroupGroups.favorites")).toBeNull());
+        const saved = fake.lastCall("update_project_groups")?.args.config as WorkgroupGroupsConfig;
+        expect(saved.groups.find((group) => group.id === "ui")?.favorite).toBe(false);
+      } finally {
+        rendered.cleanup();
+      }
+    });
+
+    it("can unfavorite from the Favorites entry itself", async () => {
+      const fake = railFake(
+        groupsConfig({
+          groups: [
+            { id: "ui", name: "UI", regex: exactGroupRegexForWorkgroup("wg-1-dev-team"), favorite: true },
+          ],
+        })
+      );
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(favoriteButtonKeys()).toEqual(["Project.ui"]));
+
+        await openMenuOn(target("workgroupGroups.favoriteButton.Project.ui"));
+        expect(target("workgroupGroups.contextMenu.favorite").textContent).toContain("Unfavorite");
+
+        click(target("workgroupGroups.contextMenu.favorite"));
+
+        await waitFor(() => expect(maybeTarget("workgroupGroups.favorites")).toBeNull());
+      } finally {
+        rendered.cleanup();
+      }
+    });
+
+    it("exposes no favorite option on the pseudo-entries (All / Ungrouped / Alert me!)", async () => {
+      const fake = railFake(groupsConfig({ nonStop: { ...defaultNonStop(), show: true } }));
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(target("workgroupGroups.button.nonstop")).toBeTruthy());
+
+        for (const key of ["all", "ungrouped", "nonstop"]) {
+          await openMenuOn(target(`workgroupGroups.button.${key}`));
+          expect(target("workgroupGroups.contextMenu.edit")).toBeTruthy();
+          expect(maybeTarget("workgroupGroups.contextMenu.favorite")).toBeNull();
+        }
+
+        // ...and the project header is a project target too: Edit only.
+        await openMenuOn(target("workgroupGroups.projectLabel.Project"));
+        expect(maybeTarget("workgroupGroups.contextMenu.favorite")).toBeNull();
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  });
+
+  describe("a favorite of a collapsed project", () => {
+    it("stays visible and stays clickable while its project section is folded", async () => {
+      const fake = railFake(
+        groupsConfig({
+          groups: [
+            { id: "ui", name: "UI", regex: exactGroupRegexForWorkgroup("wg-1-dev-team"), favorite: true },
+            { id: "rust", name: "Rust", regex: exactGroupRegexForWorkgroup("wg-2-rust-team") },
+          ],
+        })
+      );
+      const rendered = renderWithFakeTransport(
+        () => <WorkgroupGroupRail projects={projectStore.projects} />,
+        fake
+      );
+      try {
+        await seedProjectStore(fake, [projectPath, otherProjectPath]);
+        await waitFor(() => expect(favoriteButtonKeys()).toEqual(["Project.ui"]));
+
+        click(target("workgroupGroups.projectLabel.Project"));
+        await waitFor(() => expect(maybeTarget("workgroupGroups.button.ui")).toBeNull());
+
+        // This is the whole point of Option B plus Favorites: the group is reachable
+        // in one click even though its project section is folded.
+        const favorite = target<HTMLElement>("workgroupGroups.favoriteButton.Project.ui");
+        expect(favorite).toBeTruthy();
+
+        click(favorite);
+
+        expect(projectCollapseStore.isProjectCollapsed(otherProjectPath)).toBe(true);
+        expect(favorite.getAttribute("aria-pressed")).toBe("true");
+        // Clicking a favorite does NOT unfold the rail section (RC-2).
+        expect(maybeTarget("workgroupGroups.button.ui")).toBeNull();
+        expect(target("workgroupGroups.projectLabel.Project").getAttribute("aria-expanded")).toBe(
+          "false"
+        );
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  });
+
+  describe("testid namespaces (the automation bridge THROWS on duplicates)", () => {
+    it("keeps the project-section testid namespaces byte-identical when a group is favorited", async () => {
+      const fake = railFake();
+      sessionsStore.setSessions([replicaSession("wg-1-dev-team")]);
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(target("workgroupGroups.button.ui")).toBeTruthy());
+        const orderBefore = railButtonOrder();
+        const dotsBefore = railDotKeys();
+        expect(orderBefore).toEqual(["all", "ungrouped", "ui", "rust", "docs"]);
+        expect(dotsBefore).toContain("ui");
+
+        await openMenuOn(target("workgroupGroups.button.ui"));
+        click(target("workgroupGroups.contextMenu.favorite"));
+        await waitFor(() => expect(favoriteButtonKeys()).toEqual(["Project.ui"]));
+
+        // The favorited group now renders TWICE, but the project-section prefixes are
+        // untouched: no duplicate ids leak into `^workgroupGroups.button.` or
+        // `^workgroupGroups.dot.`, which is what `railButtonOrder()` / `railDots()`
+        // scan and what the automation bridge resolves against.
+        expect(railButtonOrder()).toEqual(orderBefore);
+        expect(railDotKeys()).toEqual(dotsBefore);
+        expect(document.querySelectorAll('[data-ac-testid="workgroupGroups.button.ui"]')).toHaveLength(1);
+        expect(
+          document.querySelectorAll('[data-ac-testid="workgroupGroups.favoriteDot.Project.ui"]')
+        ).toHaveLength(1);
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  });
+
+  describe("reorder safety", () => {
+    // THE F2 CORRUPTION TEST. Never delete it. `targetIndexForPointer` ends
+    // `return candidates.length`, so with every candidate gone it returns 0 — "drop
+    // at the top", not "nowhere". A drag in flight whose buttons unmount would splice
+    // the group to the front and PERSIST it.
+    it("does not reorder when the header is clicked mid-drag (G3 cancels the gesture)", async () => {
+      const fake = railFake();
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust", "docs"]));
+        const rail = target<HTMLElement>("workgroupGroups.rail.Project");
+        const ui = target<HTMLElement>("workgroupGroups.button.ui");
+        const rust = target<HTMLElement>("workgroupGroups.button.rust");
+        const docs = target<HTMLElement>("workgroupGroups.button.docs");
+        mockRect(rail, 0, 200);
+        mockRect(ui, 80);
+        mockRect(rust, 114);
+        mockRect(docs, 148);
+
+        vi.useFakeTimers();
+        pointer(docs, "pointerdown", { clientY: 158 });
+        vi.advanceTimersByTime(2000); // past REORDER_HOLD_MS -> dragging
+        click(target("workgroupGroups.projectLabel.Project")); // fold mid-gesture
+        pointer(window, "pointerup", { clientY: 84 });
+        vi.useRealTimers();
+
+        await waitFor(() =>
+          expect(target("workgroupGroups.projectLabel.Project").getAttribute("aria-expanded")).toBe(
+            "false"
+          )
+        );
+        expect(fake.callsFor("update_project_groups")).toEqual([]);
+      } finally {
+        rendered.cleanup();
+      }
+    });
+
+    // G1 in isolation: candidates empty while the section is still expanded (every
+    // sibling button measures zero-height, exactly as a detached ref does). Without
+    // `if (candidates.length === 0) return null`, this reorders `docs` to index 0.
+    it("does not reorder when every drop candidate has collapsed away (G1)", async () => {
+      const fake = railFake();
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust", "docs"]));
+        const rail = target<HTMLElement>("workgroupGroups.rail.Project");
+        const ui = target<HTMLElement>("workgroupGroups.button.ui");
+        const rust = target<HTMLElement>("workgroupGroups.button.rust");
+        const docs = target<HTMLElement>("workgroupGroups.button.docs");
+        mockRect(rail, 0, 200);
+        mockRect(ui, 80, 0); // zero-height == detached, filtered out of the candidates
+        mockRect(rust, 114, 0);
+        mockRect(docs, 148);
+
+        vi.useFakeTimers();
+        pointer(docs, "pointerdown", { clientY: 158 });
+        vi.advanceTimersByTime(2000);
+        pointer(window, "pointermove", { clientY: 84 });
+        pointer(window, "pointerup", { clientY: 84 });
+        vi.useRealTimers();
+
+        expect(fake.callsFor("update_project_groups")).toEqual([]);
+        expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust", "docs"]);
+      } finally {
+        rendered.cleanup();
+      }
+    });
+
+    // F9: the project section must NOT filter favorites out. The drop-target math
+    // counts RENDERED buttons while `reorderGroup` writes into the UNFILTERED
+    // `config.groups`; filtering would desync them and scramble the order.
+    it("persists the rendered order when a middle group is favorited", async () => {
+      const fake = railFake(
+        groupsConfig({
+          groups: [
+            { id: "ui", name: "UI", regex: exactGroupRegexForWorkgroup("wg-1-dev-team") },
+            { id: "rust", name: "Rust", regex: exactGroupRegexForWorkgroup("wg-2-rust-team"), favorite: true },
+            { id: "docs", name: "Docs", regex: exactGroupRegexForWorkgroup("wg-3-docs-team") },
+          ],
+        })
+      );
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(favoriteButtonKeys()).toEqual(["Project.rust"]));
+        expect(railButtonOrder()).toEqual(["all", "ungrouped", "ui", "rust", "docs"]);
+
+        const rail = target<HTMLElement>("workgroupGroups.rail.Project");
+        const ui = target<HTMLElement>("workgroupGroups.button.ui");
+        const rust = target<HTMLElement>("workgroupGroups.button.rust");
+        const docs = target<HTMLElement>("workgroupGroups.button.docs");
+        mockRect(rail, 0, 200);
+        mockRect(ui, 80);
+        mockRect(rust, 114);
+        mockRect(docs, 148);
+
+        vi.useFakeTimers();
+        pointer(docs, "pointerdown", { clientY: 158 });
+        vi.advanceTimersByTime(2000);
+        pointer(window, "pointermove", { clientY: 84 });
+        pointer(window, "pointerup", { clientY: 84 });
+        vi.useRealTimers();
+
+        // Rendered order and persisted order agree, despite `rust` also rendering
+        // up in Favorites.
+        await waitFor(() => expect(lastUpdatedGroupIds(fake)).toEqual(["docs", "ui", "rust"]));
+        await waitFor(() => expect(railButtonOrder()).toEqual(["all", "ungrouped", "docs", "ui", "rust"]));
+      } finally {
+        rendered.cleanup();
+      }
+    });
+
+    it("never arms a drag on a Favorites entry", async () => {
+      const fake = railFake(
+        groupsConfig({
+          groups: [
+            { id: "ui", name: "UI", regex: exactGroupRegexForWorkgroup("wg-1-dev-team"), favorite: true },
+            { id: "rust", name: "Rust", regex: exactGroupRegexForWorkgroup("wg-2-rust-team") },
+          ],
+        })
+      );
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(favoriteButtonKeys()).toEqual(["Project.ui"]));
+        const favorite = target<HTMLElement>("workgroupGroups.favoriteButton.Project.ui");
+        expect(favorite.classList.contains("reorderable")).toBe(false);
+
+        vi.useFakeTimers();
+        pointer(favorite, "pointerdown", { clientY: 20 });
+        vi.advanceTimersByTime(2000);
+        vi.useRealTimers();
+
+        // No pointer handlers are bound at all, so the hold cannot arm a gesture.
+        expect(favorite.classList.contains("reorder-arming")).toBe(false);
+        expect(favorite.classList.contains("reorder-dragging")).toBe(false);
+        expect(fake.callsFor("update_project_groups")).toEqual([]);
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  });
+
+  describe("tooltip", () => {
+    it("puts the owning project's folderName on the first line of every rail button", async () => {
+      const fake = railFake(
+        groupsConfig({
+          groups: [
+            { id: "ui", name: "UI", regex: exactGroupRegexForWorkgroup("wg-1-dev-team"), favorite: true },
+          ],
+        })
+      );
+      sessionsStore.setSessions([replicaSession("wg-1-dev-team")]);
+      const rendered = renderWithFakeTransport(() => <WorkgroupGroupRail projects={[project()]} />, fake);
+      try {
+        await waitFor(() => expect(favoriteButtonKeys()).toEqual(["Project.ui"]));
+
+        const projectButton = target<HTMLElement>("workgroupGroups.button.ui");
+        const favoriteButton = target<HTMLElement>("workgroupGroups.favoriteButton.Project.ui");
+
+        // The rail is 68px and the header ellipsizes, so the tooltip is the only place
+        // the full project identity can live — and it is what identifies a favorite's
+        // owning project without a visible label.
+        expect(projectButton.title.split("\n")[0]).toBe("Project");
+        expect(favoriteButton.title.split("\n")[0]).toBe("Project");
+        // The running-agent lines are preserved beneath it.
+        expect(favoriteButton.title).toContain("WG1:(dev-webpage-ui)");
+        expect(target<HTMLElement>("workgroupGroups.button.all").title).toBe(
+          "Project\nWG1:(dev-webpage-ui)"
+        );
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  });
+});

--- a/src/sidebar/components/WorkgroupGroupRail.favorites.test.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.favorites.test.tsx
@@ -512,7 +512,21 @@ describe("WorkgroupGroupRail favorites + collapsible rail (#965)", () => {
         vi.useFakeTimers();
         pointer(docs, "pointerdown", { clientY: 158 });
         vi.advanceTimersByTime(2000); // past REORDER_HOLD_MS -> dragging
+        expect(rail.classList.contains("reorder-active")).toBe(true);
+
         click(target("workgroupGroups.projectLabel.Project")); // fold mid-gesture
+
+        // ISOLATES G3, and it has to be asserted HERE, before the pointerup.
+        // `reorder-active` is bound to phase === "dragging" || "saving", so it is
+        // false only if cancelReorder() actually ran in the header's onClick.
+        //
+        // Without this line the test does NOT pin G3: `mockRect` installs its spy on
+        // the element OBJECT, so the folded-away siblings keep reporting height 30,
+        // the candidate list never empties, G1 cannot fire, and G2 silently catches
+        // the drop instead — the test stays green with G3 deleted. Same mirage the
+        // G1 test below sidesteps by mocking the siblings to zero height.
+        expect(rail.classList.contains("reorder-active")).toBe(false);
+
         pointer(window, "pointerup", { clientY: 84 });
         vi.useRealTimers();
 

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -4,6 +4,7 @@ import type { AcWorkgroup, WorkgroupGroup } from "../../shared/types";
 import type { ProjectState } from "../stores/project";
 import { projectStore } from "../stores/project";
 import { projectCollapseStore } from "../stores/project-collapse";
+import { railCollapseStore } from "../stores/rail-collapse";
 import {
   MAX_GROUP_MATCH_ID_LENGTH,
   compileGroupRegex,
@@ -45,6 +46,15 @@ interface GroupButton {
   groupIndex: number | null;
 }
 
+/** #965 — the context menu and the groups modal live at the rail root (they are
+ *  shared by the project sections and the cross-project Favorites section), so a
+ *  target must be stored as IDENTITY, never as a captured `ProjectState` /
+ *  `WorkgroupGroup` object: `projectStore` replaces those objects on every reload,
+ *  and a capture goes stale the moment discovery refreshes. */
+type RailContextTarget =
+  | { kind: "project"; projectPath: string }
+  | { kind: "group"; projectPath: string; groupId: string };
+
 const REORDER_HOLD_MS = 2000;
 const REORDER_MOVE_CANCEL_PX = 6;
 const CONTEXT_MENU_VIEWPORT_MARGIN = 8;
@@ -78,7 +88,7 @@ function groupMatches(group: WorkgroupGroup, wg: AcWorkgroup): boolean {
   return !!regex?.test(id);
 }
 
-function tooltipFor(workgroups: AcWorkgroup[]): string {
+function tooltipFor(folderName: string, workgroups: AcWorkgroup[]): string {
   const rows = workgroups
     .flatMap((wg) =>
       wg.agents
@@ -91,7 +101,11 @@ function tooltipFor(workgroups: AcWorkgroup[]): string {
       return a.replica.name.localeCompare(b.replica.name, "en", { sensitivity: "base", numeric: true });
     })
     .map(({ wg, replica }) => `${wgTooltipLabel(wg.name)}:(${replica.name})`);
-  return rows.length > 0 ? rows.join("\n") : "No running agents";
+  const body = rows.length > 0 ? rows.join("\n") : "No running agents";
+  // #965 — the rail is 68px and the project header ellipsizes, so the native
+  // multi-line `title` is the only place the full project identity can live. It
+  // is what identifies a Favorites entry's owning project without a visible label.
+  return `${folderName}\n${body}`;
 }
 
 function buttonContent(
@@ -107,18 +121,238 @@ function buttonContent(
   };
 }
 
+/** #965 — the rail button markup carries THREE testids, all keyed on the group id.
+ *  A favorited group renders twice (Favorites + its project section), so all three
+ *  would duplicate. That is a hard break, not a wart: `automation-bridge.ts` THROWS
+ *  on a duplicate `data-ac-testid` rather than taking the first match, and the
+ *  suites' `railButtonOrder()` / `railDots()` do document-wide PREFIX scans
+ *  (`^workgroupGroups.button.` / `^workgroupGroups.dot.`) that a suffixed id would
+ *  still double. Hence a DISTINCT prefix for Favorites, not a namespaced suffix. */
+type RailButtonTestIds = { button: string; raiseHand: string; dot: string };
+
+function projectRailTestIds(key: string): RailButtonTestIds {
+  return {
+    button: `workgroupGroups.button.${key}`,
+    raiseHand: `workgroupGroups.raiseHand.${key}`,
+    dot: `workgroupGroups.dot.${key}`,
+  };
+}
+
+function favoriteRailTestIds(folderName: string, groupId: string): RailButtonTestIds {
+  const key = `${folderName}.${groupId}`;
+  return {
+    button: `workgroupGroups.favoriteButton.${key}`,
+    raiseHand: `workgroupGroups.favoriteRaiseHand.${key}`,
+    dot: `workgroupGroups.favoriteDot.${key}`,
+  };
+}
+
+/** #965 — lifted out of the `buttons` memo so the cross-project Favorites section
+ *  can build an identical button for a group it does not own. `reorderable` is a
+ *  parameter, and Favorites MUST pass `false` (see the reorder invariants). */
+function groupButtonFor(
+  project: ProjectState,
+  group: WorkgroupGroup,
+  groupIndex: number | null,
+  reorderable: boolean
+): GroupButton {
+  const workgroups = project.workgroups.filter((wg) => groupMatches(group, wg));
+  return {
+    key: group.id,
+    ...buttonContent(group.name, workgroups),
+    selection: { kind: "group", id: group.id },
+    workgroups,
+    title: tooltipFor(project.folderName, workgroups),
+    reorderable,
+    groupId: group.id,
+    groupIndex,
+  };
+}
+
+/** #965 — was a closure inside `ProjectRailSection`; both sections need it now.
+ *  Both copies of a favorited group highlight simultaneously, which is correct:
+ *  it is one group. */
+function isSelected(projectPath: string, button: GroupButton): boolean {
+  if (!workgroupGroupsStore.isActiveProject(projectPath)) return false;
+  const current = workgroupGroupsStore.selection(projectPath);
+  if (current.kind !== button.selection.kind) return false;
+  return current.kind !== "group" || button.selection.kind !== "group" || current.id === button.selection.id;
+}
+
+/** #965 — the existing group-button onClick body, parameterized by project so a
+ *  Favorites click behaves identically (you clicked a group of project B, so the
+ *  main panel focuses B).
+ *
+ *  RC-2: the two `projectCollapseStore` calls drive the **ProjectPanel** (#810
+ *  auto-focus) and are unchanged. They must NEVER touch `railCollapseStore`: the
+ *  rail folds only on an explicit header click. */
+function selectFromRail(project: ProjectState, selection: WorkgroupGroupSelection): void {
+  workgroupGroupsStore.select(project.path, selection);
+  // Collapse every other loaded project and expand this owner on every click. Use
+  // the live project list because a fresh session has no collapse-map entries.
+  // Scrolling is owned separately by SidebarApp's primitive semantic-key effect.
+  projectCollapseStore.collapseAllExceptKnown(
+    project.path,
+    projectStore.projects.map((p) => p.path)
+  );
+  projectCollapseStore.setProjectCollapsed(project.path, false);
+}
+
+/** #965 — the rail button markup, extracted verbatim so Favorites renders an
+ *  identical button. The pointer handlers and `onRef` are OPTIONAL: Favorites
+ *  passes none, so a favorite never enters a `groupButtonEls` map, never arms a
+ *  drag, and never gets the `reorderable` class (and its `cursor: grab`). */
+const RailButton: Component<{
+  button: GroupButton;
+  testIds: RailButtonTestIds;
+  selected: boolean;
+  reorderState?: ReorderState | null;
+  onRef?: (el: HTMLButtonElement) => void;
+  onPointerDown?: (event: PointerEvent & { currentTarget: HTMLButtonElement }) => void;
+  onPointerMove?: (event: PointerEvent) => void;
+  onPointerUp?: (event: PointerEvent) => void;
+  onPointerCancel?: (event: PointerEvent) => void;
+  onContextMenu: (event: MouseEvent) => void;
+  onClick: (event: MouseEvent) => void;
+}> = (props) => (
+  <button
+    ref={(el) => props.onRef?.(el)}
+    class="workgroup-group-rail-button"
+    classList={{
+      selected: props.selected,
+      reorderable: props.button.reorderable,
+      "reorder-arming":
+        props.reorderState?.phase === "arming" && props.reorderState?.groupId === props.button.groupId,
+      "reorder-dragging":
+        (props.reorderState?.phase === "dragging" || props.reorderState?.phase === "saving") &&
+        props.reorderState?.groupId === props.button.groupId,
+      "reorder-invalid":
+        props.reorderState?.phase === "dragging" &&
+        props.reorderState?.groupId === props.button.groupId &&
+        props.reorderState?.targetIndex === null,
+    }}
+    aria-pressed={props.selected}
+    aria-grabbed={
+      props.button.reorderable ? props.reorderState?.groupId === props.button.groupId : undefined
+    }
+    title={props.button.title}
+    onPointerDown={props.onPointerDown}
+    onPointerMove={props.onPointerMove}
+    onPointerUp={props.onPointerUp}
+    onPointerCancel={props.onPointerCancel}
+    onContextMenu={props.onContextMenu}
+    onClick={props.onClick}
+    data-ac-testid={props.testIds.button}
+  >
+    <span class="workgroup-group-rail-title-line">
+      <Show when={props.button.raiseHand}>
+        <span
+          class="workgroup-group-rail-raise-hand"
+          data-ac-testid={props.testIds.raiseHand}
+          title="A coordinator raised its hand"
+          aria-label="A coordinator raised its hand"
+        >
+          <RaiseHandIcon class="workgroup-group-rail-raise-hand-icon" />
+        </span>
+      </Show>
+      <span
+        class="workgroup-group-rail-title"
+        classList={{
+          // #775 — built-in/system groups (All, Ungrouped, …) render bold to stand
+          // out from user-created groups. Gated on the selection kind, not the
+          // display name, so a user group named "All" stays normal weight.
+          "workgroup-group-rail-title-system": props.button.selection.kind !== "group",
+        }}
+      >
+        {props.button.name}
+      </span>
+    </span>
+    <span class="workgroup-group-rail-counter-line">
+      <Show when={props.button.working}>
+        <span
+          class="session-item-status running workgroup-group-rail-dot"
+          data-ac-testid={props.testIds.dot}
+        />
+      </Show>
+      {props.button.counter}
+    </span>
+  </button>
+);
+
+/** #965 — the cross-project Favorites section. Pinned OUTSIDE
+ *  `.workgroup-group-rail-scroll` at the top, mirroring how #881 pinned Archive at
+ *  the bottom: that is what makes it permanently visible. */
+const FavoritesRailSection: Component<{
+  projects: ProjectState[];
+  onOpenContextMenu: (event: MouseEvent, target: RailContextTarget) => void;
+}> = (props) => {
+  const collapsed = () => railCollapseStore.isFavoritesCollapsed();
+
+  // Iterate `props.projects`, never a global list: an archived/hidden project has
+  // no rail section and must not contribute favorites. A project whose rail section
+  // is COLLAPSED still contributes, because `ensureLoaded` lives outside the
+  // collapse `<Show>` — that is what makes a collapsed project's favorites visible.
+  const entries = createMemo(() =>
+    props.projects.flatMap((project) =>
+      workgroupGroupsStore
+        .config(project.path)
+        .groups.filter((group) => group.favorite)
+        .map((group) => ({ project, group, button: groupButtonFor(project, group, null, false) }))
+    )
+  );
+
+  return (
+    <Show when={entries().length > 0}>
+      <div class="workgroup-group-rail-favorites" data-ac-testid="workgroupGroups.favorites">
+        <button
+          type="button"
+          class="workgroup-group-rail-project-label workgroup-group-rail-header"
+          aria-expanded={!collapsed()}
+          onClick={() => railCollapseStore.toggleFavoritesCollapsed()}
+          data-ac-testid="workgroupGroups.favorites.header"
+        >
+          Favorites
+        </button>
+        <Show when={!collapsed()}>
+          <div class="workgroup-group-rail-favorites-scroll">
+            <For each={entries()}>
+              {(entry) => (
+                <RailButton
+                  button={entry.button}
+                  testIds={favoriteRailTestIds(entry.project.folderName, entry.group.id)}
+                  selected={isSelected(entry.project.path, entry.button)}
+                  onContextMenu={(event) =>
+                    props.onOpenContextMenu(event, {
+                      kind: "group",
+                      projectPath: entry.project.path,
+                      groupId: entry.group.id,
+                    })
+                  }
+                  onClick={() => selectFromRail(entry.project, entry.button.selection)}
+                />
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </Show>
+  );
+};
+
 const ProjectRailSection: Component<{
   project: ProjectState;
   showProjectLabel: boolean;
+  onOpenContextMenu: (event: MouseEvent, target: RailContextTarget) => void;
 }> = (props) => {
-  const [editing, setEditing] = createSignal(false);
-
   createEffect(() => {
     void workgroupGroupsStore.ensureLoaded(props.project.path);
   });
 
   const config = () => workgroupGroupsStore.config(props.project.path);
-  const selection = () => workgroupGroupsStore.selection(props.project.path);
+  // #965 — the RAIL's own collapse (RC-1), never the ProjectPanel's. The only
+  // `projectCollapseStore` reference left in this file is the #810 auto-focus pair
+  // inside `selectFromRail`, which drives the ProjectPanel and is unchanged.
+  const collapsed = () => railCollapseStore.isProjectCollapsed(props.project.path);
   const ungroupedWorkgroups = createMemo(() =>
     props.project.workgroups.filter(
       (wg) => !config().groups.some((group) => groupMatches(group, wg))
@@ -138,7 +372,7 @@ const ProjectRailSection: Component<{
         raiseHand: false,
         selection: { kind: "all" },
         workgroups: props.project.workgroups,
-        title: tooltipFor(props.project.workgroups),
+        title: tooltipFor(props.project.folderName, props.project.workgroups),
         reorderable: false,
         groupId: null,
         groupIndex: null,
@@ -151,7 +385,7 @@ const ProjectRailSection: Component<{
         ...buttonContent("Ungrouped", workgroups),
         selection: { kind: "ungrouped" },
         workgroups,
-        title: tooltipFor(workgroups),
+        title: tooltipFor(props.project.folderName, workgroups),
         reorderable: false,
         groupId: null,
         groupIndex: null,
@@ -171,41 +405,21 @@ const ProjectRailSection: Component<{
         ...buttonContent(nonStopDisplayName(nonStop.name), workgroups),
         selection: { kind: "nonstop" },
         workgroups,
-        title: tooltipFor(workgroups),
+        title: tooltipFor(props.project.folderName, workgroups),
         reorderable: false,
         groupId: null,
         groupIndex: null,
       });
     }
     for (const [groupIndex, group] of config().groups.entries()) {
-      const workgroups = props.project.workgroups.filter((wg) => groupMatches(group, wg));
-      result.push({
-        key: group.id,
-        ...buttonContent(group.name, workgroups),
-        selection: { kind: "group", id: group.id },
-        workgroups,
-        title: tooltipFor(workgroups),
-        reorderable: true,
-        groupId: group.id,
-        groupIndex,
-      });
+      result.push(groupButtonFor(props.project, group, groupIndex, true));
     }
     return result;
   });
-  const selected = (button: GroupButton) => {
-    if (!workgroupGroupsStore.isActiveProject(props.project.path)) return false;
-    const current = selection();
-    if (current.kind !== button.selection.kind) return false;
-    return current.kind !== "group" || button.selection.kind !== "group" || current.id === button.selection.id;
-  };
   const [reorderState, setReorderState] = createSignal<ReorderState | null>(null);
-  const [showContextMenu, setShowContextMenu] = createSignal(false);
-  const [contextMenuPos, setContextMenuPos] = createSignal({ x: 0, y: 0 });
   let holdTimer: number | null = null;
   let suppressClickGroupId: string | null = null;
   let projectEl: HTMLDivElement | undefined;
-  let contextMenuEl: HTMLDivElement | undefined;
-  let dismissContextMenu: ((ev?: Event) => void) | null = null;
   const groupButtonEls = new Map<string, HTMLButtonElement>();
 
   const clearHoldTimer = () => {
@@ -226,56 +440,12 @@ const ProjectRailSection: Component<{
     setReorderState(null);
   };
 
-  const cleanupContextMenu = () => {
-    if (!dismissContextMenu) return;
-    window.removeEventListener("click", dismissContextMenu);
-    window.removeEventListener("contextmenu", dismissContextMenu);
-    window.removeEventListener("keydown", dismissContextMenu as EventListener);
-    dismissContextMenu = null;
-  };
-
-  const positionContextMenu = (x: number, y: number) => {
-    if (!contextMenuEl) return;
-    const { width, height } = contextMenuEl.getBoundingClientRect();
-    const maxX = Math.max(
-      CONTEXT_MENU_VIEWPORT_MARGIN,
-      window.innerWidth - width - CONTEXT_MENU_VIEWPORT_MARGIN
-    );
-    const maxY = Math.max(
-      CONTEXT_MENU_VIEWPORT_MARGIN,
-      window.innerHeight - height - CONTEXT_MENU_VIEWPORT_MARGIN
-    );
-    setContextMenuPos({
-      x: Math.min(Math.max(CONTEXT_MENU_VIEWPORT_MARGIN, x), maxX),
-      y: Math.min(Math.max(CONTEXT_MENU_VIEWPORT_MARGIN, y), maxY),
-    });
-  };
-
-  const openContextMenu = (event: MouseEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
+  // #965 — this section owns the reorder gesture, so it cancels the drag before
+  // delegating to the rail root (which owns the menu). preventDefault /
+  // stopPropagation live in the root's handler.
+  const openContextMenu = (event: MouseEvent, target: RailContextTarget) => {
     cancelReorder(true);
-    cleanupContextMenu();
-    setContextMenuPos({ x: event.clientX, y: event.clientY });
-    setShowContextMenu(true);
-    const dismiss = (ev?: Event) => {
-      if (ev instanceof KeyboardEvent && ev.key !== "Escape") return;
-      setShowContextMenu(false);
-      cleanupContextMenu();
-    };
-    dismissContextMenu = dismiss;
-    setTimeout(() => {
-      positionContextMenu(event.clientX, event.clientY);
-      window.addEventListener("click", dismiss);
-      window.addEventListener("contextmenu", dismiss);
-      window.addEventListener("keydown", dismiss as EventListener);
-    });
-  };
-
-  const openEditorFromContextMenu = () => {
-    setShowContextMenu(false);
-    cleanupContextMenu();
-    setEditing(true);
+    props.onOpenContextMenu(event, target);
   };
 
   createEffect(() => {
@@ -287,14 +457,30 @@ const ProjectRailSection: Component<{
 
   const targetIndexForPointer = (clientY: number, groupId: string): number | null => {
     if (!projectEl) return null;
+    // #965 G2 — a collapsed section has no drop targets at all. Redundant given G1
+    // below, kept because it states the intent at the collapse site and covers a
+    // partially-unmounted frame.
+    if (collapsed()) return null;
     const projectRect = projectEl.getBoundingClientRect();
     if (clientY < projectRect.top || clientY > projectRect.bottom) return null;
 
     const candidates = Array.from(groupButtonEls.entries())
       .filter(([id]) => id !== groupId)
+      // Solid does not null out `ref` callbacks on disposal, so this map retains
+      // detached elements whose getBoundingClientRect() is all zeros. Necessary,
+      // but NOT sufficient — see G1. Do not remove it.
       .map(([id, el]) => ({ id, rect: el.getBoundingClientRect() }))
       .filter(({ rect }) => rect.height > 0)
       .sort((a, b) => a.rect.top - b.rect.top);
+
+    // #965 G1 (root fix) — "no candidates" means "nothing to drop onto", NOT "drop
+    // at index 0". Falling through to `return candidates.length` (= 0) here would
+    // splice the dragged group to the front and PERSIST it: a drag in flight whose
+    // buttons unmount mid-gesture (a header click) would silently reorder the
+    // project. The only pre-existing empty case is a single-group project, where
+    // sourceIndex is 0 anyway and the reorder was already a no-op, so null is
+    // equally correct there.
+    if (candidates.length === 0) return null;
 
     for (let index = 0; index < candidates.length; index++) {
       const rect = candidates[index].rect;
@@ -428,7 +614,6 @@ const ProjectRailSection: Component<{
     window.removeEventListener("pointerup", onWindowPointerUp);
     window.removeEventListener("pointercancel", onWindowPointerCancel);
     clearHoldTimer();
-    cleanupContextMenu();
     suppressClickGroupId = null;
     groupButtonEls.clear();
   });
@@ -460,100 +645,70 @@ const ProjectRailSection: Component<{
       data-ac-testid={`workgroupGroups.rail.${props.project.folderName}`}
     >
       <Show when={props.showProjectLabel}>
-        <div
-          class="workgroup-group-rail-project-label"
+        <button
+          type="button"
+          class="workgroup-group-rail-project-label workgroup-group-rail-header"
           title={props.project.path}
-          onContextMenu={openContextMenu}
+          aria-expanded={!collapsed()}
+          onClick={() => {
+            // #965 G3 — cancel any in-flight drag BEFORE the toggle unmounts the
+            // buttons, so the trailing pointerup cannot resolve a drop against an
+            // empty candidate list. Same one-liner the context menu already uses.
+            // suppressClick=true is correct: the gesture was a drag, not a click.
+            cancelReorder(true);
+            railCollapseStore.toggleProjectCollapsed(props.project.path);
+          }}
+          onContextMenu={(event) =>
+            openContextMenu(event, { kind: "project", projectPath: props.project.path })
+          }
           data-ac-testid={`workgroupGroups.projectLabel.${props.project.folderName}`}
         >
           {props.project.folderName}
-        </div>
+        </button>
       </Show>
 
-      <For each={previewButtons()}>
-        {(button) => (
-          <button
-            ref={(el) => {
-              if (button.groupId) groupButtonEls.set(button.groupId, el);
-            }}
-            class="workgroup-group-rail-button"
-            classList={{
-              selected: selected(button),
-              reorderable: button.reorderable,
-              "reorder-arming": reorderState()?.phase === "arming" && reorderState()?.groupId === button.groupId,
-              "reorder-dragging":
-                (reorderState()?.phase === "dragging" || reorderState()?.phase === "saving") &&
-                reorderState()?.groupId === button.groupId,
-              "reorder-invalid":
-                reorderState()?.phase === "dragging" &&
-                reorderState()?.groupId === button.groupId &&
-                reorderState()?.targetIndex === null,
-            }}
-            aria-pressed={selected(button)}
-            aria-grabbed={button.reorderable ? reorderState()?.groupId === button.groupId : undefined}
-            title={button.title}
-            onPointerDown={(event) => startPress(event, button)}
-            onPointerMove={movePress}
-            onPointerUp={finishPress}
-            onPointerCancel={cancelPress}
-            onContextMenu={openContextMenu}
-            onClick={(event) => {
-              if (button.groupId && suppressClickGroupId === button.groupId) {
-                suppressClickGroupId = null;
-                event.preventDefault();
-                event.stopPropagation();
-                return;
+      <Show when={!collapsed()}>
+        <For each={previewButtons()}>
+          {(button) => (
+            <RailButton
+              button={button}
+              testIds={projectRailTestIds(button.key)}
+              selected={isSelected(props.project.path, button)}
+              reorderState={reorderState()}
+              onRef={(el) => {
+                if (button.groupId) groupButtonEls.set(button.groupId, el);
+              }}
+              onPointerDown={(event) => startPress(event, button)}
+              onPointerMove={movePress}
+              onPointerUp={finishPress}
+              onPointerCancel={cancelPress}
+              onContextMenu={(event) =>
+                openContextMenu(
+                  event,
+                  // Pseudo-entries (All / Ungrouped / Alert me!) have `groupId: null`
+                  // and cannot be favorited, so they open the project menu (Edit only).
+                  // Gated on the id, never on the display name.
+                  button.groupId
+                    ? { kind: "group", projectPath: props.project.path, groupId: button.groupId }
+                    : { kind: "project", projectPath: props.project.path }
+                )
               }
-              workgroupGroupsStore.select(props.project.path, button.selection);
-              // Collapse every other loaded project and expand this owner on
-              // every click. Use the live project list because a fresh session
-              // has no collapse-map entries. Scrolling is owned separately by
-              // SidebarApp's primitive semantic-key effect.
-              projectCollapseStore.collapseAllExceptKnown(
-                props.project.path,
-                projectStore.projects.map((p) => p.path)
-              );
-              projectCollapseStore.setProjectCollapsed(props.project.path, false);
-            }}
-            data-ac-testid={`workgroupGroups.button.${button.key}`}
-          >
-            <span class="workgroup-group-rail-title-line">
-              <Show when={button.raiseHand}>
-                <span
-                  class="workgroup-group-rail-raise-hand"
-                  data-ac-testid={`workgroupGroups.raiseHand.${button.key}`}
-                  title="A coordinator raised its hand"
-                  aria-label="A coordinator raised its hand"
-                >
-                  <RaiseHandIcon class="workgroup-group-rail-raise-hand-icon" />
-                </span>
-              </Show>
-              <span
-                class="workgroup-group-rail-title"
-                classList={{
-                  // #775 — built-in/system groups (All, Ungrouped, …) render bold
-                  // to stand out from user-created groups. Gated on the selection
-                  // kind, not the display name, so a user group named "All" stays
-                  // normal weight.
-                  "workgroup-group-rail-title-system": button.selection.kind !== "group",
-                }}
-              >
-                {button.name}
-              </span>
-            </span>
-            <span class="workgroup-group-rail-counter-line">
-              <Show when={button.working}>
-                <span
-                  class="session-item-status running workgroup-group-rail-dot"
-                  data-ac-testid={`workgroupGroups.dot.${button.key}`}
-                />
-              </Show>
-              {button.counter}
-            </span>
-          </button>
-        )}
-      </For>
+              onClick={(event) => {
+                if (button.groupId && suppressClickGroupId === button.groupId) {
+                  suppressClickGroupId = null;
+                  event.preventDefault();
+                  event.stopPropagation();
+                  return;
+                }
+                selectFromRail(props.project, button.selection);
+              }}
+            />
+          )}
+        </For>
+      </Show>
 
+      {/* Deliberately OUTSIDE the collapse Show: a collapsed project must still
+          surface its config error. An error badge that hides itself is a bug. */}
       <Show when={workgroupGroupsStore.error(props.project.path)}>
         {(error) => (
           <div class="workgroup-group-rail-error" title={error()}>
@@ -561,53 +716,154 @@ const ProjectRailSection: Component<{
           </div>
         )}
       </Show>
-
-      <Show when={showContextMenu()}>
-        <Portal>
-          <div
-            ref={contextMenuEl}
-            class="session-context-menu"
-            style={{ left: `${contextMenuPos().x}px`, top: `${contextMenuPos().y}px` }}
-            onClick={(event) => event.stopPropagation()}
-            data-ac-testid="workgroupGroups.contextMenu"
-            data-ac-role="menu"
-          >
-            <button
-              class="session-context-option"
-              onClick={openEditorFromContextMenu}
-              data-ac-testid="workgroupGroups.contextMenu.edit"
-              data-ac-role="menuitem"
-            >
-              Edit
-            </button>
-          </div>
-        </Portal>
-      </Show>
-
-      <Show when={editing()}>
-        <WorkgroupGroupsModal
-          projectPath={props.project.path}
-          projectName={props.project.folderName}
-          onClose={() => setEditing(false)}
-        />
-      </Show>
     </div>
   );
 };
 
 const WorkgroupGroupRail: Component<WorkgroupGroupRailProps> = (props) => {
   const [showArchived, setShowArchived] = createSignal(false);
+  // #965 — the menu and the groups modal are hoisted here from ProjectRailSection:
+  // Favorites is cross-project and needs the same menu, and one <Portal> + one set
+  // of window dismiss listeners beats N of them.
+  const [contextTarget, setContextTarget] = createSignal<RailContextTarget | null>(null);
+  const [contextMenuPos, setContextMenuPos] = createSignal({ x: 0, y: 0 });
+  const [editingProjectPath, setEditingProjectPath] = createSignal<string | null>(null);
+  let contextMenuEl: HTMLDivElement | undefined;
+  let dismissContextMenu: ((ev?: Event) => void) | null = null;
 
   createEffect(() => {
     workgroupGroupsStore.reconcileActiveProject(props.projects.map((project) => project.path));
   });
 
+  // Resolved LIVE from props.projects, never from a capture, so the modal header
+  // cannot go stale after a discovery refresh (and it closes if the project dies).
+  const editingProject = createMemo(() => {
+    const path = editingProjectPath();
+    return path ? (props.projects.find((project) => project.path === path) ?? null) : null;
+  });
+
+  const cleanupContextMenu = () => {
+    if (!dismissContextMenu) return;
+    window.removeEventListener("click", dismissContextMenu);
+    window.removeEventListener("contextmenu", dismissContextMenu);
+    window.removeEventListener("keydown", dismissContextMenu as EventListener);
+    dismissContextMenu = null;
+  };
+
+  const positionContextMenu = (x: number, y: number) => {
+    if (!contextMenuEl) return;
+    const { width, height } = contextMenuEl.getBoundingClientRect();
+    const maxX = Math.max(
+      CONTEXT_MENU_VIEWPORT_MARGIN,
+      window.innerWidth - width - CONTEXT_MENU_VIEWPORT_MARGIN
+    );
+    const maxY = Math.max(
+      CONTEXT_MENU_VIEWPORT_MARGIN,
+      window.innerHeight - height - CONTEXT_MENU_VIEWPORT_MARGIN
+    );
+    setContextMenuPos({
+      x: Math.min(Math.max(CONTEXT_MENU_VIEWPORT_MARGIN, x), maxX),
+      y: Math.min(Math.max(CONTEXT_MENU_VIEWPORT_MARGIN, y), maxY),
+    });
+  };
+
+  const openContextMenu = (event: MouseEvent, target: RailContextTarget) => {
+    event.preventDefault();
+    event.stopPropagation();
+    cleanupContextMenu();
+    setContextMenuPos({ x: event.clientX, y: event.clientY });
+    setContextTarget(target);
+    const dismiss = (ev?: Event) => {
+      if (ev instanceof KeyboardEvent && ev.key !== "Escape") return;
+      setContextTarget(null);
+      cleanupContextMenu();
+    };
+    dismissContextMenu = dismiss;
+    // Deferred so the opening `contextmenu` event does not dismiss its own menu.
+    setTimeout(() => {
+      positionContextMenu(event.clientX, event.clientY);
+      window.addEventListener("click", dismiss);
+      window.addEventListener("contextmenu", dismiss);
+      window.addEventListener("keydown", dismiss as EventListener);
+    });
+  };
+
+  const closeContextMenu = () => {
+    setContextTarget(null);
+    cleanupContextMenu();
+  };
+
+  // #965 — the menu/modal now outlive the section that opened them (they live at the
+  // rail root). Drop a target whose project has left `props.projects`, OR whose group
+  // has left that project's config — a cross-window delete kills the group while the
+  // project lives, and that is the commoner case. Without this the menu offers
+  // "Favorite" on a dead group and the click is a silent no-op (the throw precedes
+  // any setEntries, so no `!` indicator ever appears). Mirrors the groupButtonEls
+  // prune effect in ProjectRailSection.
+  //
+  // NOT a write barrier: a `WorkgroupGroupsModal.save()` already in flight still
+  // lands. That is harmless (the store never evicts entries, so the modal seeded from
+  // the real config and rewrites the same groups), but nobody should believe otherwise.
+  createEffect(() => {
+    const live = new Set(props.projects.map((project) => project.path));
+    const target = contextTarget();
+    if (target) {
+      const projectGone = !live.has(target.projectPath);
+      const groupGone =
+        target.kind === "group" &&
+        !workgroupGroupsStore
+          .config(target.projectPath)
+          .groups.some((group) => group.id === target.groupId);
+      if (projectGone || groupGone) closeContextMenu();
+    }
+    const editing = editingProjectPath();
+    if (editing && !live.has(editing)) setEditingProjectPath(null);
+  });
+
+  onCleanup(cleanupContextMenu);
+
+  // Read from the store at render, never from a capture, so the label is correct
+  // after an external update (another window favoriting the same group).
+  const favoriteTargetIsFavorited = () => {
+    const target = contextTarget();
+    if (target?.kind !== "group") return false;
+    return !!workgroupGroupsStore
+      .config(target.projectPath)
+      .groups.find((group) => group.id === target.groupId)?.favorite;
+  };
+
+  const openEditorFromContextMenu = () => {
+    const target = contextTarget();
+    if (!target) return;
+    closeContextMenu();
+    setEditingProjectPath(target.projectPath);
+  };
+
+  const toggleFavoriteFromContextMenu = () => {
+    const target = contextTarget();
+    if (target?.kind !== "group") return;
+    const next = !favoriteTargetIsFavorited();
+    closeContextMenu();
+    void workgroupGroupsStore
+      .setGroupFavorite(target.projectPath, target.groupId, next)
+      .catch(() => {
+        // A save failure surfaces through workgroupGroupsStore.error(path), which the
+        // project section renders as the `!` badge.
+      });
+  };
+
   return (
     <aside class="workgroup-group-rail" data-ac-testid="workgroupGroups.rail">
+      <FavoritesRailSection projects={props.projects} onOpenContextMenu={openContextMenu} />
+
       <div class="workgroup-group-rail-scroll">
         <For each={props.projects}>
           {(project) => (
-            <ProjectRailSection project={project} showProjectLabel={true} />
+            <ProjectRailSection
+              project={project}
+              showProjectLabel={true}
+              onOpenContextMenu={openContextMenu}
+            />
           )}
         </For>
       </div>
@@ -626,6 +882,48 @@ const WorkgroupGroupRail: Component<WorkgroupGroupRailProps> = (props) => {
 
       <Show when={showArchived()}>
         <ArchivedProjectsModal onClose={() => setShowArchived(false)} />
+      </Show>
+
+      <Show when={contextTarget()}>
+        <Portal>
+          <div
+            ref={contextMenuEl}
+            class="session-context-menu"
+            style={{ left: `${contextMenuPos().x}px`, top: `${contextMenuPos().y}px` }}
+            onClick={(event) => event.stopPropagation()}
+            data-ac-testid="workgroupGroups.contextMenu"
+            data-ac-role="menu"
+          >
+            <button
+              class="session-context-option"
+              onClick={openEditorFromContextMenu}
+              data-ac-testid="workgroupGroups.contextMenu.edit"
+              data-ac-role="menuitem"
+            >
+              Edit
+            </button>
+            <Show when={contextTarget()?.kind === "group"}>
+              <button
+                class="session-context-option"
+                onClick={toggleFavoriteFromContextMenu}
+                data-ac-testid="workgroupGroups.contextMenu.favorite"
+                data-ac-role="menuitem"
+              >
+                {favoriteTargetIsFavorited() ? "Unfavorite" : "Favorite"}
+              </button>
+            </Show>
+          </div>
+        </Portal>
+      </Show>
+
+      <Show when={editingProject()}>
+        {(project) => (
+          <WorkgroupGroupsModal
+            projectPath={project().path}
+            projectName={project().folderName}
+            onClose={() => setEditingProjectPath(null)}
+          />
+        )}
       </Show>
     </aside>
   );

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -457,9 +457,17 @@ const ProjectRailSection: Component<{
 
   const targetIndexForPointer = (clientY: number, groupId: string): number | null => {
     if (!projectEl) return null;
-    // #965 G2 — a collapsed section has no drop targets at all. Redundant given G1
-    // below, kept because it states the intent at the collapse site and covers a
-    // partially-unmounted frame.
+    // #965 G2 — a collapsed section has no drop targets at all.
+    //
+    // UNREACHABLE today, deliberately: RC-1 makes the header's onClick the only
+    // mutator of rail collapse, and G3 cancels the drag there BEFORE the toggle, so
+    // `collapsed()` is never true while a reorder is in flight. Nor is there a
+    // partially-unmounted frame in between — Solid disposes the <Show> synchronously
+    // inside the click task. G1 below is the guard that actually fires in production.
+    //
+    // Kept as the backstop for a future mutator that folds outside the header path.
+    // Deliberately pinned by NO test: reaching it requires manufacturing a state the
+    // design forbids, and a test for that would calcify it.
     if (collapsed()) return null;
     const projectRect = projectEl.getBoundingClientRect();
     if (clientY < projectRect.top || clientY > projectRect.bottom) return null;

--- a/src/sidebar/stores/rail-collapse.test.ts
+++ b/src/sidebar/stores/rail-collapse.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AppSettings } from "../../shared/types";
+import { __setTransportForTests } from "../../shared/ipc";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import { railCollapseStore } from "./rail-collapse";
+
+const projectA = "C:\\Foo\\Bar";
+const projectB = "C:\\Other\\Project";
+
+function settings(overrides: Partial<AppSettings> = {}): AppSettings {
+  return overrides as AppSettings;
+}
+
+function railCollapseCalls(fake: FakeTransport) {
+  return fake.callsFor("set_rail_collapse").map((call) => call.args);
+}
+
+describe("railCollapseStore (#965)", () => {
+  let fake: FakeTransport;
+  let restoreTransport: (() => void) | undefined;
+
+  beforeEach(() => {
+    fake = new FakeTransport();
+    fake.resolve("set_rail_collapse", null);
+    restoreTransport = __setTransportForTests(fake);
+    railCollapseStore.resetForTests();
+  });
+
+  afterEach(() => {
+    railCollapseStore.resetForTests();
+    restoreTransport?.();
+    restoreTransport = undefined;
+  });
+
+  describe("hydration (RC-3)", () => {
+    it("restores collapsed project paths and the Favorites bit without writing back", () => {
+      railCollapseStore.hydrateFromSettings(
+        settings({ railCollapsedProjects: ["c:/foo/bar"], railFavoritesCollapsed: true })
+      );
+
+      expect(railCollapseStore.isProjectCollapsed(projectA)).toBe(true);
+      expect(railCollapseStore.isFavoritesCollapsed()).toBe(true);
+      // Hydration sets the signals directly, never through the toggles. A write-back
+      // here would persist the snapshot we just read, and (worse) invite someone to
+      // make hydration reactive.
+      expect(railCollapseCalls(fake)).toEqual([]);
+    });
+
+    it("treats null settings and missing fields as nothing-collapsed", () => {
+      railCollapseStore.hydrateFromSettings(null);
+      expect(railCollapseStore.isProjectCollapsed(projectA)).toBe(false);
+      expect(railCollapseStore.isFavoritesCollapsed()).toBe(false);
+
+      railCollapseStore.hydrateFromSettings(settings());
+      expect(railCollapseStore.isProjectCollapsed(projectA)).toBe(false);
+      expect(railCollapseStore.isFavoritesCollapsed()).toBe(false);
+      expect(railCollapseCalls(fake)).toEqual([]);
+    });
+
+    it("normalizes paths on both hydrate and query", () => {
+      // Persisted entries are frontend-normalized, but a caller passes the raw
+      // ProjectState.path. Both ends must agree or restore silently no-ops.
+      railCollapseStore.hydrateFromSettings(settings({ railCollapsedProjects: ["C:\\Foo\\Bar"] }));
+
+      expect(railCollapseStore.isProjectCollapsed("c:/foo/bar/")).toBe(true);
+      expect(railCollapseStore.isProjectCollapsed("C:\\Foo\\Bar")).toBe(true);
+    });
+
+    it("replaces prior state rather than merging into it", () => {
+      railCollapseStore.hydrateFromSettings(settings({ railCollapsedProjects: [projectA] }));
+      railCollapseStore.hydrateFromSettings(settings({ railCollapsedProjects: [projectB] }));
+
+      expect(railCollapseStore.isProjectCollapsed(projectA)).toBe(false);
+      expect(railCollapseStore.isProjectCollapsed(projectB)).toBe(true);
+    });
+  });
+
+  describe("toggles persist the full snapshot", () => {
+    it("toggleProjectCollapsed flips the bit and issues exactly one write", () => {
+      railCollapseStore.toggleProjectCollapsed(projectA);
+
+      expect(railCollapseStore.isProjectCollapsed(projectA)).toBe(true);
+      expect(railCollapseCalls(fake)).toEqual([
+        { collapsedProjects: ["c:/foo/bar"], favoritesCollapsed: false },
+      ]);
+    });
+
+    it("toggling back drops the path from the persisted snapshot", () => {
+      railCollapseStore.toggleProjectCollapsed(projectA);
+      railCollapseStore.toggleProjectCollapsed(projectA);
+
+      expect(railCollapseStore.isProjectCollapsed(projectA)).toBe(false);
+      expect(railCollapseCalls(fake)).toEqual([
+        { collapsedProjects: ["c:/foo/bar"], favoritesCollapsed: false },
+        { collapsedProjects: [], favoritesCollapsed: false },
+      ]);
+    });
+
+    it("toggleFavoritesCollapsed flips the bit and carries the collapsed paths along", () => {
+      railCollapseStore.toggleProjectCollapsed(projectA);
+      fake.clearCalls();
+
+      railCollapseStore.toggleFavoritesCollapsed();
+
+      expect(railCollapseStore.isFavoritesCollapsed()).toBe(true);
+      // Every payload is a FULL snapshot, not a delta. That is what makes an
+      // out-of-order write self-healing rather than corrupting (plan §0.5).
+      expect(railCollapseCalls(fake)).toEqual([
+        { collapsedProjects: ["c:/foo/bar"], favoritesCollapsed: true },
+      ]);
+    });
+
+    it("persists collapsed paths sorted and normalized", () => {
+      railCollapseStore.toggleProjectCollapsed(projectB);
+      railCollapseStore.toggleProjectCollapsed(projectA);
+
+      expect(fake.lastCall("set_rail_collapse")?.args).toEqual({
+        collapsedProjects: ["c:/foo/bar", "c:/other/project"],
+        favoritesCollapsed: false,
+      });
+    });
+
+    it("does not throw when the settings write fails", async () => {
+      // A header click CAN genuinely fail: the backend save is read+serialize+tmp+
+      // rename, so a transiently unreadable settings.json aborts it. Fire-and-forget
+      // is the right call for cosmetic UI state, but it must not break the rail.
+      fake.reject("set_rail_collapse", "settings.json is locked");
+
+      expect(() => railCollapseStore.toggleProjectCollapsed(projectA)).not.toThrow();
+      // The in-memory signal is the source of truth and stays correct regardless.
+      expect(railCollapseStore.isProjectCollapsed(projectA)).toBe(true);
+      await Promise.resolve();
+    });
+  });
+});

--- a/src/sidebar/stores/rail-collapse.ts
+++ b/src/sidebar/stores/rail-collapse.ts
@@ -1,0 +1,90 @@
+import { createSignal } from "solid-js";
+import { normalizeProjectPathForCompare } from "./project-refresh";
+import { SettingsAPI } from "../../shared/ipc";
+import type { AppSettings } from "../../shared/types";
+
+// #965 - collapse state for the WorkgroupGroupRail's category headers.
+//
+// DELIBERATELY SEPARATE from `project-collapse.ts` (the ProjectPanel's card
+// collapse). The user's ruling: the rail folds ONLY on an explicit header click.
+// The #810 auto-focus (`collapseAllExceptKnown`, fired on every rail group click)
+// keeps driving the ProjectPanel exactly as before and must have ZERO effect here.
+// That is why this is its own module with its own signals and only two mutators,
+// both bound to a header click. Do not add a `collapseAllExcept*` here, and do not
+// import this store from `project-collapse.ts`. (Plan RC-1 / RC-2.)
+//
+// Persisted (unlike the ProjectPanel store) via the `set_rail_collapse` narrow
+// setter, written straight through on each toggle - no debounce, no dedupe: a
+// header click is a human-rate event, and a trailing debounce would lose the last
+// toggle if the user quits inside the window.
+
+// Keyed by the normalized project path directly. No composite section key: this
+// map holds exactly one notion. The persisted `railCollapsedProjects` is this key
+// set verbatim, so restore is exact and idempotent.
+const [collapsedProjects, setCollapsedProjects] = createSignal<Record<string, boolean>>({});
+const [favoritesCollapsed, setFavoritesCollapsed] = createSignal(false);
+
+function key(projectPath: string): string {
+  return normalizeProjectPathForCompare(projectPath);
+}
+
+function snapshot(): { collapsedProjects: string[]; favoritesCollapsed: boolean } {
+  const map = collapsedProjects();
+  return {
+    collapsedProjects: Object.keys(map)
+      .filter((k) => map[k])
+      .sort(),
+    favoritesCollapsed: favoritesCollapsed(),
+  };
+}
+
+function persist(): void {
+  const next = snapshot();
+  // Fire-and-forget: this is cosmetic UI state, and a settings-write failure must
+  // never surface as a broken rail. But it is NOT silent: the backend save is
+  // read+serialize+tmp+rename, so a transiently unreadable settings.json aborts it
+  // (plan §0.5). Warn so that class is debuggable instead of invisible.
+  void SettingsAPI.setRailCollapse(next.collapsedProjects, next.favoritesCollapsed).catch((err) => {
+    console.warn("[rail-collapse] failed to persist rail collapse:", err);
+  });
+}
+
+export const railCollapseStore = {
+  isProjectCollapsed(projectPath: string): boolean {
+    return collapsedProjects()[key(projectPath)] ?? false;
+  },
+  isFavoritesCollapsed(): boolean {
+    return favoritesCollapsed();
+  },
+
+  // The ONLY two mutators. Both are an explicit header click. See RC-1 before
+  // adding a third.
+  toggleProjectCollapsed(projectPath: string): void {
+    const k = key(projectPath);
+    setCollapsedProjects((prev) => ({ ...prev, [k]: !(prev[k] ?? false) }));
+    persist();
+  },
+  toggleFavoritesCollapsed(): void {
+    setFavoritesCollapsed((prev) => !prev);
+    persist();
+  },
+
+  // #965 - single hydration point (RC-3). Sets the signals directly, never through
+  // the toggles, so it never writes back.
+  //
+  // DO NOT wrap this in a createEffect over `settingsStore.current`. That store
+  // re-fetches on `coding_agent_settings_updated` (`shared/stores/settings.ts:28-32`),
+  // and a reactive hydrate would clobber the user's in-session rail collapse with
+  // the on-disk snapshot, mid-session. One-shot call only.
+  hydrateFromSettings(settings: AppSettings | null): void {
+    const next: Record<string, boolean> = {};
+    for (const path of settings?.railCollapsedProjects ?? []) next[key(path)] = true;
+    setCollapsedProjects(next);
+    setFavoritesCollapsed(!!settings?.railFavoritesCollapsed);
+  },
+
+  resetForTests(): void {
+    setCollapsedProjects({});
+    setFavoritesCollapsed(false);
+  },
+};

--- a/src/sidebar/stores/workgroup-groups.ts
+++ b/src/sidebar/stores/workgroup-groups.ts
@@ -571,6 +571,24 @@ export const workgroupGroupsStore = {
     await this.save(projectPath, { ...config, groups });
   },
 
+  // #965 - pin/unpin a group into the rail's cross-project Favorites section. The
+  // flag lives on the group record, so it survives rename (`id` is stable), travels
+  // with reorder, and dies with the group. `save()` re-seeds the store from the
+  // SAVED config, so the flag is authoritative from the backend on the same tick
+  // and the toggle cannot visually revert.
+  async setGroupFavorite(projectPath: string, groupId: string, favorite: boolean): Promise<void> {
+    const config = this.config(projectPath);
+    const group = config.groups.find((candidate) => candidate.id === groupId);
+    if (!group) throw new Error("Group no longer exists.");
+    if (!!group.favorite === favorite) return;
+    await this.save(projectPath, {
+      ...config,
+      groups: config.groups.map((candidate) =>
+        candidate.id === groupId ? { ...candidate, favorite } : candidate
+      ),
+    });
+  },
+
   async addWorkgroupToGroup(projectPath: string, groupId: string, wgName: string): Promise<void> {
     if (charLength(wgName) > MAX_GROUP_MATCH_ID_LENGTH) {
       const message = `Workgroup id cannot exceed ${MAX_GROUP_MATCH_ID_LENGTH} characters.`;

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -3225,6 +3225,60 @@ html.light-theme .settings-hint-warning {
   white-space: nowrap;
 }
 
+/* #965 - the project header and the Favorites header are now click-to-collapse.
+   They are <button>s, so reset the UA chrome and re-inherit the label's type;
+   the label class alone no longer supplies font/box on a button element. */
+.workgroup-group-rail-header {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 9px;
+  line-height: 1.2;
+  text-align: left;
+  cursor: pointer;
+  user-select: none;
+  transition: color var(--transition-fast), text-shadow var(--transition-fast);
+}
+
+/* Hover glow: the rail's established accent idiom, so the header reads as
+   clickable. The glow is `currentColor`, NOT a hardcoded cyan: `--sidebar-accent`
+   is #00d4ff in dark and #0066cc under `html.light-theme` (variables.css:6, :58),
+   so a literal rgba(0, 212, 255, .) glow would fight the accent in light mode. */
+.workgroup-group-rail-header:hover {
+  color: var(--sidebar-accent);
+  text-shadow: 0 0 6px currentColor;
+}
+
+.workgroup-group-rail-header:focus-visible {
+  outline: 2px solid rgba(0, 212, 255, 0.65);
+  outline-offset: -2px;
+}
+
+/* #965 - Favorites is pinned OUTSIDE `.workgroup-group-rail-scroll`, at the TOP,
+   exactly mirroring how #881 pinned Archive at the bottom (`flex: 0 0 auto`).
+   That is what makes it permanently visible. `max-height` + its own scroll keeps a
+   long favorites list from eating the rail; the % resolves against the rail's
+   definite height (it is a flex column with `overflow: hidden`). */
+.workgroup-group-rail-favorites {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  max-height: 40%;
+  padding: 6px 4px 4px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.workgroup-group-rail-favorites-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 .workgroup-group-rail-button {
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
Closes #965.

## What this adds

The left project/group rail gets favorites and collapsible categories:

- **`Favorites` section pinned at the top of the rail**, mirroring the existing pinned `Archive` structure (`flex: 0 0 auto`, outside the scroll container), with `max-height: 40%` + its own inner scroll. It renders nothing at all when there are no favorites.
- **`Favorite` / `Unfavorite` in the rail's right-click context menu.** The existing menu was project-scoped and offered only `Edit`; it is now target-aware, and it was hoisted (with `WorkgroupGroupsModal`) to the rail root so a group can be unfavorited **from** the Favorites section.
- **Collapsible category headers** — project headers and the `Favorites` header — folded by a left-click on the header name, which now has a hover glow and `cursor: pointer` (it previously had neither, so it did not look interactive).
- **Favorites and rail collapse both persist across restarts.**
- **Rail tooltips now lead with the project name** (the header is ellipsized at 68px, so the full project name was previously visible nowhere), followed by the existing running-agent lines.

Only real user groups are favoritable — `All` / `Ungrouped` / `Alert me!` are not. A favorited group is duplicated: it appears in `Favorites` **and** stays listed under its own project.

## Design decision (user ruling)

The rail owns its **own** collapse state (`src/sidebar/stores/rail-collapse.ts`, new): it folds **only** on an explicit header click. A group-button click mutates rail collapse in neither direction. `project-collapse.ts` has a **zero-line diff**, so the #810 auto-focus keeps driving the ProjectPanel exactly as before — the rail simply stops reading that store. This also removed the write-amplification problem entirely, so there is no debounce (a trailing debounce would have *lost* a toggle if the window closed inside its window, contradicting "reopens exactly as I left it").

## Backend (5 touchpoints)

- `favorite: bool` + `#[serde(default)]` on `WorkgroupGroup` — without it the flag was silently dropped at the Tauri boundary and the toggle would have visibly reverted in the same tick.
- Two new `AppSettings` fields + a narrow `set_rail_collapse` setter holding the Rust-side write lock (house pattern; not a get+update round-trip, which races `SettingsModal`).
- **The WS route in `web/commands.rs`** — the rail runs in the browser client too (`<SidebarApp embedded>`), and without the arm every rail click there would have silently failed to persist.
- **A clobber protect** in `build_protected_settings_candidate` + `persist_settings_draft_update_with_saver`: every whole-object `AppSettings` writer is a read-modify-write over a fresh `get()`, including `window-geometry.ts`, which fires **on every window move/resize**. Without the protect, moving the window could silently revert the persisted rail collapse — and it would not self-heal, because the rail's in-memory signal is never invalidated.

## Review

- **architect** produced the plan (`_plans/965-...`, revision 3) and took the consensus verdict `READY_FOR_IMPLEMENTATION` after one round.
- **dev-rust** (backend) + **dev-webpage-ui** (frontend) implemented and enriched.
- **dev-rust-grinch** reviewed the plan (1 blocker + 3 medium) and then the implementation: **PASS**.
- The blocker was the clobber protect above; grinch's premise-breaking evidence is what reversed the architect's original decision to accept the clobber.
- **Three reorder-corruption guards** were added after grinch found that `targetIndexForPointer` returned `0` (not `null`) when every drop candidate was filtered out, conflating "nothing to drop onto" with "drop at the top" — a drag in flight plus a header click would have spliced the group to the front and persisted it.
- Never-delete regression tests were **mutation-verified**: each was checked to actually fail when its guard is removed.

## Gates

- `cargo clippy --all-targets` clean; `cargo test --lib --bins --tests` → **2382 passed, 0 failed**. (Bare `cargo check` is not a valid gate here: all three `WorkgroupGroup` literals are `#[cfg(test)]`, so it compiles clean over the E0063.)
- `npx tsc --noEmit` → 0 errors; `npx vitest run` → **1000 passed, 0 failed**; `npm run build` OK.
- All 54 existing rail tests pass with **zero edits** — every existing `data-ac-testid` is byte-identical.

## Known gaps (deliberate)

- No Rust test proves the WS arm is *routed*: that test would have written the developer's real `settings.json` (`AGENTSCOMMANDER_TEST_CONFIG_DIR` has exactly one occurrence in the repo — its own definition). Needs a manual browser check.
- No visual verification (the repo has no screenshot harness): the hover glow, the pinning and the 40% cap scroll need eyes.

## Follow-ups filed

- #970 — three narrow setters are unrouted in the WS dispatcher (silent non-persistence in the browser today, on `main`).
- #971 — `cargo fmt` reformats ~30 untouched files (drifted baseline, no CI fmt gate).
- #972 — cross-process CLI whole-object saves can still revert narrow-setter fields (`ac open-project` / `new-project` have no GUI-running guard).
