### PR TITLE
feat(sidebar): add reusable CodingAgentQuickConfiguration modal (#975)

### DIFF
--- a/docs/testing/02-onboarding-and-coding-agents.md
+++ b/docs/testing/02-onboarding-and-coding-agents.md
@@ -23,11 +23,11 @@ Result summary:
 - Final settings showed a Codex coding-agent row, but `onboardingDismissed = false`; the target later returned to first-run onboarding during the longer journey.
 - OCA-001 currently verifies both configured-agent persistence and dismissed-onboarding persistence before it can pass.
 - Rerun evidence from `ui-regression-baseline-rerun-20260613-202450` reproduced the baseline acceptance failure: Codex row persisted and the main UI opened, but `onboardingDismissed` remained `false` after onboarding and after relaunch.
-- Product intent is tracked as GitHub issue #505. If `onboardingDismissed` is confirmed to mean only "user skipped onboarding", adjust OCA-001/003/004/005 expectations instead of treating the setup path as a product bug.
+- Product intent is tracked as GitHub issue #505. If `onboardingDismissed` is confirmed to mean only "user cancelled onboarding", adjust OCA-001/003/004/005 expectations instead of treating the setup path as a product bug.
 
 Known automation support:
 
-- First-run onboarding has semantic selectors for `onboarding.modal`, `onboarding.agentPreset.claude`, `onboarding.agentPreset.codex`, `onboarding.agentPreset.gemini`, `onboarding.agentPreset.custom`, `onboarding.custom.label`, `onboarding.custom.command`, `onboarding.skip`, `onboarding.confirm`, `onboarding.done`, and `onboarding.done.close`.
+- First-run onboarding has semantic selectors for `onboarding.modal`, `onboarding.agentPreset.claude`, `onboarding.agentPreset.codex`, `onboarding.agentPreset.gemini`, `onboarding.agentPreset.custom`, `onboarding.custom.label`, `onboarding.custom.command`, `onboarding.cancel`, `onboarding.confirm`, `onboarding.done`, and `onboarding.done.close`.
 - Settings has semantic selectors for `actionBar.settings`, `settings.modal`, `settings.tab.agents`, `settings.agentPreset.<presetKey>`, `settings.agent.addCustom`, `settings.agentRow.<index>.*`, `settings.save`, and `settings.cancel`.
 
 Known automation gaps:
@@ -41,20 +41,20 @@ First-run onboarding controls:
 
 - Preset buttons: `Claude Code`, `Codex`, `Gemini CLI`, `Custom Agent`.
 - Custom fields: agent name and command.
-- Footer actions: `Skip`, `Set up Coding Agent`, and done-state `Get started`.
+- Footer actions: `Cancel` (optional, supplied by the consumer), `Set up Coding Agent`, and done-state `Get started`.
 
 Required clean-state slices:
 
 - OCA-001 covers Codex as the default acceptance preset.
-- OCA-002 covers Skip and verifies the app remains usable with no coding agent configured.
+- OCA-002 covers Cancel and verifies the app remains usable with no coding agent configured.
 - OCA-003 covers Claude Code.
 - OCA-004 covers Gemini CLI.
 - OCA-005 covers Custom Agent with valid fields.
 - OCA-006 and OCA-007 cover the Coding Agents settings surface after onboarding.
 
-Each slice must start from a reset testable config unless the case explicitly says it is using an existing settings state. Do not use a passing Codex run as proof that Skip, Claude, Gemini, or Custom Agent works.
+Each slice must start from a reset testable config unless the case explicitly says it is using an existing settings state. Do not use a passing Codex run as proof that Cancel, Claude, Gemini, or Custom Agent works.
 
-Dismissal semantics note: until issue #505 is resolved, setup-path cases expect `onboardingDismissed = true` after `Get started` as a conservative acceptance contract. If product intent says the flag is skip-only, replace that assertion with the intended persistence signal.
+Dismissal semantics note: until issue #505 is resolved, setup-path cases expect `onboardingDismissed = true` after `Get started` as a conservative acceptance contract. If product intent says the flag is cancel-only, replace that assertion with the intended persistence signal.
 
 ### OCA-001: First-run onboarding selects Codex
 
@@ -97,11 +97,11 @@ Pass/Fail Criteria:
 
 Pass if onboarding completes through the GUI, Codex appears in Coding Agents settings, dismissal is persisted, and onboarding does not reappear after relaunch. Fail if onboarding cannot be completed, settings do not persist the preset, dismissal remains false, or the app does not reach normal UI. Partial if the flow completes but one transient state cannot be captured.
 
-### OCA-002: First-run onboarding Skip path
+### OCA-002: First-run onboarding Cancel path
 
 Purpose:
 
-Verify that a clean first-run user can skip coding-agent setup, reach the normal app UI, and keep onboarding dismissed without adding a coding agent.
+Verify that a clean first-run user can cancel coding-agent setup, reach the normal app UI, and keep onboarding dismissed without adding a coding agent.
 
 Preconditions:
 
@@ -112,7 +112,7 @@ Preconditions:
 Steps:
 
 1. Wait for `onboarding.modal`.
-2. Click `onboarding.skip`.
+2. Click `onboarding.cancel`.
 3. Wait for `main.root` and `sidebar.root`.
 4. Open settings and inspect the Coding Agents tab.
 5. Close and relaunch the testable app.
@@ -120,19 +120,19 @@ Steps:
 
 Expected Result:
 
-The onboarding dialog closes, the main app is usable, no coding agent row is added by the skip action, `onboardingDismissed` is persisted as `true`, and onboarding does not reappear after relaunch.
+The onboarding dialog closes, the main app is usable, no coding agent row is added by the cancel action, `onboardingDismissed` is persisted as `true`, and onboarding does not reappear after relaunch.
 
 Evidence Required:
 
-- Screenshot of onboarding before Skip.
-- Semantic click result for `onboarding.skip`.
+- Screenshot of onboarding before Cancel.
+- Semantic click result for `onboarding.cancel`.
 - Screenshot or semantic result showing normal main/sidebar UI.
-- Settings snapshot proving no preset row was created by Skip and `onboardingDismissed = true`.
+- Settings snapshot proving no preset row was created by Cancel and `onboardingDismissed = true`.
 - Post-relaunch screenshot or semantic query proving onboarding did not reappear.
 
 Pass/Fail Criteria:
 
-Pass if Skip dismisses onboarding persistently without adding an agent. Fail if onboarding reappears, the app is unusable after Skip, or Skip creates an unintended coding-agent row.
+Pass if Cancel dismisses onboarding persistently without adding an agent. Fail if onboarding reappears, the app is unusable after Cancel, or Cancel creates an unintended coding-agent row.
 
 ### OCA-003: First-run onboarding selects Claude Code
 

--- a/docs/testing/semantic-ui-automation-affordance-matrix.md
+++ b/docs/testing/semantic-ui-automation-affordance-matrix.md
@@ -13,7 +13,7 @@ This matrix seeds issue #497 acceptance coverage. It tracks user-visible screen/
 | Select custom preset | `onboarding.agentPreset.custom` | `click` |
 | Enter custom label | `onboarding.custom.label` | `setValue` |
 | Enter custom command | `onboarding.custom.command` | `setValue` |
-| Skip onboarding | `onboarding.skip` | `click` |
+| Cancel onboarding | `onboarding.cancel` | `click` |
 | Confirm selected agent | `onboarding.confirm` | `query`, `click` |
 | Detect done state | `onboarding.done` | `query`, `wait` |
 | Close done dialog | `onboarding.done.close` | `click` |

--- a/src/sidebar/components/CodingAgentQuickConfiguration.test.ts
+++ b/src/sidebar/components/CodingAgentQuickConfiguration.test.ts
@@ -4,6 +4,7 @@ import { render } from "solid-js/web";
 import CodingAgentQuickConfiguration from "./CodingAgentQuickConfiguration";
 import type { AppSettings } from "../../shared/types";
 import { SettingsAPI } from "../../shared/ipc";
+import { settingsStore } from "../../shared/stores/settings";
 
 vi.mock("../../shared/ipc", () => ({
   SettingsAPI: {
@@ -134,6 +135,21 @@ function pressEscape(): void {
 
 function cancelButton(): HTMLButtonElement | null {
   return document.querySelector<HTMLButtonElement>('[data-ac-testid="onboarding.cancel"]');
+}
+
+function modalState(): string | null | undefined {
+  return document
+    .querySelector('[data-ac-testid="onboarding.modal"]')
+    ?.getAttribute("data-ac-state");
+}
+
+async function selectCodexAndConfirm(): Promise<void> {
+  document.querySelector<HTMLButtonElement>(
+    '[data-ac-testid="onboarding.agentPreset.codex"]',
+  )?.click();
+  await settle();
+  document.querySelector<HTMLButtonElement>('[data-ac-testid="onboarding.confirm"]')?.click();
+  await settle();
 }
 
 describe("CodingAgentQuickConfiguration", () => {
@@ -338,6 +354,66 @@ describe("CodingAgentQuickConfiguration", () => {
         agents: [expect.objectContaining({ label: "Codex" })],
       }),
     );
+
+    dispose();
+  });
+
+  it("closes on Escape in the success state without re-entering the cancel path (#975)", async () => {
+    const onCancel = vi.fn();
+    const onClose = vi.fn();
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () =>
+        CodingAgentQuickConfiguration({
+          title: "Add a Coding Agent",
+          message: "Pick a Coding Agent to configure.",
+          onCancel,
+          onClose,
+        }),
+      root,
+    );
+    await settle();
+
+    await selectCodexAndConfirm();
+    expect(document.querySelector('[data-ac-testid="onboarding.done"]')).toBeTruthy();
+
+    pressEscape();
+    await settle();
+
+    // #975 F1 — the success footer renders only "Get started", so Escape must
+    // resolve to onClose. Routing it to onCancel would re-run the consumer's
+    // cancel path and issue a second settings write after a completed save.
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(SettingsAPI.get).toHaveBeenCalledTimes(1);
+    expect(SettingsAPI.update).toHaveBeenCalledTimes(1);
+
+    dispose();
+  });
+
+  it("advances data-ac-state selecting -> done and refreshes the settings store", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () =>
+        CodingAgentQuickConfiguration({
+          title: "Add a Coding Agent",
+          message: "Pick a Coding Agent to configure.",
+          onClose: vi.fn(),
+        }),
+      root,
+    );
+    await settle();
+
+    expect(modalState()).toBe("selecting");
+
+    await selectCodexAndConfirm();
+
+    // Automation state contract: consumers wait on done/selecting.
+    expect(modalState()).toBe("done");
+    // Without this refresh the sidebar keeps showing zero agents after setup.
+    expect(settingsStore.refresh).toHaveBeenCalledTimes(1);
 
     dispose();
   });

--- a/src/sidebar/components/CodingAgentQuickConfiguration.test.ts
+++ b/src/sidebar/components/CodingAgentQuickConfiguration.test.ts
@@ -1,0 +1,344 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "solid-js/web";
+import CodingAgentQuickConfiguration from "./CodingAgentQuickConfiguration";
+import type { AppSettings } from "../../shared/types";
+import { SettingsAPI } from "../../shared/ipc";
+
+vi.mock("../../shared/ipc", () => ({
+  SettingsAPI: {
+    get: vi.fn(() => Promise.resolve(settings())),
+    update: vi.fn(() => Promise.resolve()),
+  },
+  // #769 — the cards are driven by codingAgentsStore, which fetches this.
+  // Resolve a catalog carrying Codex (the preset this suite selects).
+  CodingAgentsAPI: {
+    getCatalog: vi.fn(() =>
+      Promise.resolve([
+        {
+          key: "codex",
+          label: "Codex",
+          description: "Coding Agent by OpenAI",
+          color: "#10b981",
+          command: "codex",
+          instructionsFilename: "AGENTS.md",
+          envs: [],
+          isolatedHome: false,
+          removable: true,
+        },
+      ]),
+    ),
+    listReseedableCommands: vi.fn(() => Promise.resolve([])),
+    reseedDefault: vi.fn(() => Promise.resolve({ dest: "", backupPath: "" })),
+  },
+}));
+
+vi.mock("../../shared/stores/settings", () => ({
+  settingsStore: {
+    refresh: vi.fn(),
+  },
+}));
+
+function settings(overrides: Partial<AppSettings> = {}): AppSettings {
+  return {
+    defaultShell: "pwsh",
+    defaultShellArgs: [],
+    sidebarAlwaysOnTop: false,
+    sidebarStyle: "noir-minimal",
+    themeLight: true,
+    telegramNetworkPollErrorLogging: {
+      firstFailureLevel: "warn",
+      transientRepeatLevel: "debug",
+      sustainedLevel: "warn",
+      sustainedAfterSeconds: 60,
+      sustainedRepeatSeconds: 300,
+      recoveryLevel: "info",
+    },
+    raiseTerminalOnClick: true,
+    coordSortByActivity: false,
+    alwaysShowSelectedWorkgroup: true,
+    restoreCoordinatorWakeState: true,
+    soundsEnabled: true,
+    teamIdleBeepEnabled: true,
+    webServerEnabled: false,
+    webServerPort: 8765,
+    webServerBind: "127.0.0.1",
+    apiServerEnabled: false,
+    apiServerPort: 8766,
+    apiServerBind: "127.0.0.1",
+    voiceToTextEnabled: false,
+    voiceAutoExecute: false,
+    voiceAutoExecuteDelay: 15,
+    geminiApiKey: "",
+    geminiModel: "gemini-2.5-flash",
+    sidebarZoom: 1,
+    terminalZoom: 1,
+    guideZoom: 1,
+    mainZoom: 1,
+    sidebarGeometry: null,
+    terminalGeometry: null,
+    mainGeometry: null,
+    mainSidebarWidth: 360,
+    mainSidebarSide: "right",
+    mainAlwaysOnTop: false,
+    mainResourceMonitorAttached: false,
+    agents: [],
+    codingAgentProfiles: {
+      schemaVersion: 2,
+      profileSlots: { A: { label: "" } },
+      defaultProfileByAgent: {},
+      profilesByAgent: {},
+      profileLabelsByAgent: {},
+    },
+    telegramBots: [],
+    onboardingDismissed: false,
+    projectPaths: [],
+    projectPath: null,
+    autoGenerateTaskTitle: true,
+    agentTemplatesPath: null,
+    specBoardEnabled: false,
+    resourceMonitorEnabled: true,
+    maxConcurrentAgentProcesses: 3,
+    resourceWatchdogAction: "warn",
+    agentGroupWarnPrivateBytes: 8 * 1024 ** 3,
+    agentGroupKillPrivateBytes: 12 * 1024 ** 3,
+    agentProcessKillPrivateBytes: 12 * 1024 ** 3,
+    resourceKeepLastSnapshot: true,
+    resourceBackoffPolling: true,
+    coordinatorIdleBadgeYellowMinutes: 30,
+    coordinatorIdleBadgeRedMinutes: 60,
+    coordinatorAutoCloseEnabled: true,
+    coordinatorAutoCloseMinutes: 60,
+    coordinatorAutoCloseSkipTelegramAssigned: false,
+    coordinatorCascadeCloseEnabled: true,
+    npmUpdateNotificationsEnabled: true,
+    autoSelfClearEnabled: true,
+    autoSelfClearByAgent: {},
+    containerCredentialsFromHost: true,
+    logLevel: null,
+    ...overrides,
+    archivedProjectPaths: overrides.archivedProjectPaths ?? [],
+  };
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+function pressEscape(): void {
+  document
+    .querySelector('[data-ac-testid="onboarding.overlay"]')
+    ?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+}
+
+function cancelButton(): HTMLButtonElement | null {
+  return document.querySelector<HTMLButtonElement>('[data-ac-testid="onboarding.cancel"]');
+}
+
+describe("CodingAgentQuickConfiguration", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("renders the consumer-provided title and message", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () =>
+        CodingAgentQuickConfiguration({
+          title: "Add a Coding Agent",
+          message: "Pick a Coding Agent to configure.",
+          onClose: vi.fn(),
+        }),
+      root,
+    );
+    await settle();
+
+    expect(document.querySelector(".agent-modal-title")?.textContent).toBe("Add a Coding Agent");
+    expect(document.querySelector(".onboarding-welcome")?.textContent).toBe(
+      "Pick a Coding Agent to configure.",
+    );
+    // Accessible name falls back to the title when no override is supplied.
+    expect(
+      document.querySelector('[data-ac-testid="onboarding.modal"]')?.getAttribute("aria-label"),
+    ).toBe("Add a Coding Agent");
+
+    dispose();
+  });
+
+  it("renders no Cancel button when no cancel callback is supplied", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () =>
+        CodingAgentQuickConfiguration({
+          title: "Add a Coding Agent",
+          message: "Pick a Coding Agent to configure.",
+          onClose: vi.fn(),
+        }),
+      root,
+    );
+    await settle();
+
+    expect(cancelButton()).toBeNull();
+    // The confirm affordance still exists, so the modal is not a dead end.
+    expect(document.querySelector('[data-ac-testid="onboarding.confirm"]')).toBeTruthy();
+
+    dispose();
+  });
+
+  it("renders Cancel and invokes the callback when supplied", async () => {
+    const onCancel = vi.fn();
+    const onClose = vi.fn();
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () =>
+        CodingAgentQuickConfiguration({
+          title: "Add a Coding Agent",
+          message: "Pick a Coding Agent to configure.",
+          onCancel,
+          onClose,
+        }),
+      root,
+    );
+    await settle();
+
+    const cancel = cancelButton();
+    expect(cancel?.textContent).toBe("Cancel");
+
+    cancel?.click();
+    await settle();
+
+    // The callback owns closing; the component must not close on its own.
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(SettingsAPI.update).not.toHaveBeenCalled();
+
+    dispose();
+  });
+
+  it("routes Escape to the cancel callback when one is supplied", async () => {
+    const onCancel = vi.fn();
+    const onClose = vi.fn();
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () =>
+        CodingAgentQuickConfiguration({
+          title: "Add a Coding Agent",
+          message: "Pick a Coding Agent to configure.",
+          onCancel,
+          onClose,
+        }),
+      root,
+    );
+    await settle();
+
+    pressEscape();
+    await settle();
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+
+    dispose();
+  });
+
+  it("leaves Escape inert when no cancel callback is supplied", async () => {
+    const onClose = vi.fn();
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () =>
+        CodingAgentQuickConfiguration({
+          title: "Add a Coding Agent",
+          message: "Pick a Coding Agent to configure.",
+          onClose,
+        }),
+      root,
+    );
+    await settle();
+
+    pressEscape();
+    await settle();
+
+    // No back-door dismissal: Escape must not close, and must not persist.
+    expect(onClose).not.toHaveBeenCalled();
+    expect(SettingsAPI.update).not.toHaveBeenCalled();
+    expect(document.querySelector('[data-ac-testid="onboarding.modal"]')).toBeTruthy();
+
+    dispose();
+  });
+
+  it("confirms an agent without any onboarding side effect", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () =>
+        CodingAgentQuickConfiguration({
+          title: "Add a Coding Agent",
+          message: "Pick a Coding Agent to configure.",
+          onClose: vi.fn(),
+        }),
+      root,
+    );
+    await settle();
+
+    document.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="onboarding.agentPreset.codex"]',
+    )?.click();
+    await settle();
+
+    document.querySelector<HTMLButtonElement>('[data-ac-testid="onboarding.confirm"]')?.click();
+    await settle();
+
+    // #975 — the reusable component persists the agent and nothing else: it
+    // must never flip onboardingDismissed on a consumer's behalf.
+    expect(SettingsAPI.update).toHaveBeenCalledTimes(1);
+    expect(SettingsAPI.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onboardingDismissed: false,
+        agents: [expect.objectContaining({ label: "Codex", command: "codex" })],
+      }),
+    );
+    expect(document.querySelector('[data-ac-testid="onboarding.done"]')).toBeTruthy();
+
+    dispose();
+  });
+
+  it("folds onBeforeSave changes into the single agent write", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () =>
+        CodingAgentQuickConfiguration({
+          title: "Add a Coding Agent",
+          message: "Pick a Coding Agent to configure.",
+          onBeforeSave: (current) => ({ ...current, onboardingDismissed: true }),
+          onClose: vi.fn(),
+        }),
+      root,
+    );
+    await settle();
+
+    document.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="onboarding.agentPreset.codex"]',
+    )?.click();
+    await settle();
+
+    document.querySelector<HTMLButtonElement>('[data-ac-testid="onboarding.confirm"]')?.click();
+    await settle();
+
+    expect(SettingsAPI.update).toHaveBeenCalledTimes(1);
+    expect(SettingsAPI.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onboardingDismissed: true,
+        agents: [expect.objectContaining({ label: "Codex" })],
+      }),
+    );
+
+    dispose();
+  });
+});

--- a/src/sidebar/components/CodingAgentQuickConfiguration.tsx
+++ b/src/sidebar/components/CodingAgentQuickConfiguration.tsx
@@ -114,9 +114,16 @@ const CodingAgentQuickConfiguration: Component<CodingAgentQuickConfigurationProp
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Escape") {
-      // #975 — Escape mirrors the Cancel affordance exactly. With no cancel
-      // callback there is no Cancel button, so Escape must not become a
-      // back-door dismissal path.
+      // #975 — Escape resolves to whatever dismissal affordance the footer
+      // actually renders. The success state renders only "Get started", so
+      // Escape closes there and must not re-enter the consumer's cancel path:
+      // that would be a second settings write after a completed save.
+      if (done()) {
+        props.onClose();
+        return;
+      }
+      // Selecting state: Cancel renders only when the consumer supplies the
+      // callback, so without one Escape stays inert — no back-door dismissal.
       props.onCancel?.();
       return;
     }

--- a/src/sidebar/components/CodingAgentQuickConfiguration.tsx
+++ b/src/sidebar/components/CodingAgentQuickConfiguration.tsx
@@ -1,0 +1,289 @@
+import { Component, createSignal, For, onMount, Show } from "solid-js";
+import type { AgentConfig, AppSettings, CodingAgentDefinition } from "../../shared/types";
+import { SettingsAPI } from "../../shared/ipc";
+import { settingsStore } from "../../shared/stores/settings";
+import { newAgentId, definitionToSeed } from "../../shared/agent-presets";
+import { codingAgentsStore } from "../stores/coding-agents";
+
+// Custom Agent is not a catalog entry: it triggers the inline name/command
+// fields and is always offered last, so it stays a client-side definition.
+const CUSTOM_PRESET: CodingAgentDefinition = {
+  key: "custom",
+  label: "Custom Agent",
+  description: "Configure your own Coding Agent",
+  color: "#6366f1",
+  command: "",
+  envs: [],
+  isolatedHome: false,
+  removable: false,
+};
+
+export interface CodingAgentQuickConfigurationProps {
+  /** Header title, supplied by the consumer (Welcome passes "Welcome"). */
+  title: string;
+  /** Intro copy rendered above the preset cards. */
+  message: string;
+  /** Closes the modal. Fired by the success state's "Get started" action. */
+  onClose: () => void;
+  /**
+   * #975 — cancellation is opt-in. When omitted, no Cancel button renders and
+   * Escape stays inert, so a consumer can require an explicit choice. When
+   * supplied, Cancel renders and Escape invokes this same callback, keeping
+   * pointer and keyboard dismissal identical. The callback owns closing.
+   */
+  onCancel?: () => void;
+  /**
+   * #975 — consumer-owned settings changes, folded into the single atomic
+   * update that persists the new agent. This keeps consumer-specific state
+   * (such as Welcome's onboardingDismissed) out of this component while
+   * preserving the pre-existing one-write semantics.
+   */
+  onBeforeSave?: (settings: AppSettings) => AppSettings;
+  /** Overrides the dialog's accessible name. Defaults to `title`. */
+  ariaLabel?: string;
+}
+
+const CodingAgentQuickConfiguration: Component<CodingAgentQuickConfigurationProps> = (props) => {
+  const [selectedPreset, setSelectedPreset] = createSignal<string | null>(null);
+  const [saving, setSaving] = createSignal(false);
+  const [done, setDone] = createSignal(false);
+  const [addedLabel, setAddedLabel] = createSignal("");
+
+  // #769 — the catalog is backend-owned; the store is pre-seeded with the
+  // fallback so the card list (and the #768 no-scroll fit) renders immediately,
+  // with no wrong-length flash before the async fetch resolves.
+  const allPresets = () => [...codingAgentsStore.catalog(), CUSTOM_PRESET];
+
+  // Custom agent fields
+  const [customLabel, setCustomLabel] = createSignal("");
+  const [customCommand, setCustomCommand] = createSignal("");
+
+  const isCustom = () => selectedPreset() === "custom";
+  const canConfirm = () => {
+    if (!selectedPreset()) return false;
+    if (isCustom()) return customLabel().trim() !== "" && customCommand().trim() !== "";
+    return true;
+  };
+
+  const handleSelect = (key: string) => {
+    setSelectedPreset(key === selectedPreset() ? null : key);
+  };
+
+  const handleConfirm = async () => {
+    const key = selectedPreset();
+    if (!key) return;
+
+    const preset = allPresets().find((p) => p.key === key);
+    if (!preset) return;
+
+    setSaving(true);
+    try {
+      const settings = await SettingsAPI.get();
+
+      let agent: AgentConfig;
+      if (key === "custom") {
+        agent = {
+          id: newAgentId(),
+          label: customLabel().trim(),
+          command: customCommand().trim(),
+          color: preset.color,
+          envs: [],
+          isolatedHome: false,
+        };
+      } else {
+        agent = { id: newAgentId(), ...definitionToSeed(preset) };
+      }
+
+      const withAgent: AppSettings = {
+        ...settings,
+        agents: [...settings.agents, agent],
+      };
+      // #975 — the consumer decides what else rides along in this same write.
+      const updated = props.onBeforeSave ? props.onBeforeSave(withAgent) : withAgent;
+      await SettingsAPI.update(updated);
+      settingsStore.refresh();
+
+      setAddedLabel(agent.label);
+      setDone(true);
+    } catch (e) {
+      console.error("Coding Agent quick configuration save failed:", e);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      // #975 — Escape mirrors the Cancel affordance exactly. With no cancel
+      // callback there is no Cancel button, so Escape must not become a
+      // back-door dismissal path.
+      props.onCancel?.();
+      return;
+    }
+    // Focus trap: keep Tab cycling within the modal
+    if (e.key === "Tab" && modalRef) {
+      const focusable = modalRef.querySelectorAll<HTMLElement>(
+        'button:not(:disabled), input:not(:disabled), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  let overlayRef!: HTMLDivElement;
+  let modalRef!: HTMLDivElement;
+  onMount(() => {
+    overlayRef.focus();
+    void codingAgentsStore.ensureLoaded();
+  });
+
+  return (
+    <div
+      class="modal-overlay"
+      ref={overlayRef}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+      data-ac-testid="onboarding.overlay"
+      data-ac-role="overlay"
+    >
+      <div
+        class="agent-modal onboarding-modal"
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={props.ariaLabel ?? props.title}
+        data-ac-testid="onboarding.modal"
+        data-ac-role="dialog"
+        data-ac-state={done() ? "done" : "selecting"}
+      >
+        <div class="agent-modal-header">
+          <span class="agent-modal-title">{props.title}</span>
+        </div>
+
+        <div class="wizard-body onboarding-body">
+          <Show when={!done()} fallback={
+            <div
+              class="onboarding-done"
+              data-ac-testid="onboarding.done"
+              data-ac-role="status"
+            >
+              <div class="onboarding-done-icon">&#x2713;</div>
+              <div class="onboarding-done-text">
+                <strong>{addedLabel()}</strong> configured!
+              </div>
+              <div class="onboarding-done-hint">
+                You can add more Coding Agents later in Settings.
+              </div>
+            </div>
+          }>
+            <p class="onboarding-welcome">{props.message}</p>
+
+            <div class="onboarding-cards">
+              <For each={allPresets()}>
+                {(preset) => (
+                  <button
+                    class={`onboarding-card ${selectedPreset() === preset.key ? "selected" : ""}`}
+                    onClick={() => handleSelect(preset.key)}
+                    style={{ "--card-accent": preset.color }}
+                    aria-pressed={selectedPreset() === preset.key}
+                    aria-label={`Select ${preset.label}`}
+                    data-ac-testid={`onboarding.agentPreset.${preset.key}`}
+                    data-ac-role="agent-preset"
+                    data-ac-state={selectedPreset() === preset.key ? "selected" : "idle"}
+                    data-ac-agent-key={preset.key}
+                  >
+                    <div
+                      class="onboarding-card-icon"
+                      style={{ background: preset.color }}
+                    >
+                      {preset.label[0]}
+                    </div>
+                    <div class="onboarding-card-info">
+                      <div class="onboarding-card-name">{preset.label}</div>
+                      <div class="onboarding-card-desc">{preset.description}</div>
+                    </div>
+                  </button>
+                )}
+              </For>
+            </div>
+
+            <Show when={isCustom()}>
+              <div class="onboarding-custom-fields">
+                <label class="onboarding-field-label">
+                  Agent name
+                  <input
+                    class="onboarding-field-input"
+                    type="text"
+                    placeholder="My Agent"
+                    value={customLabel()}
+                    onInput={(e) => setCustomLabel(e.currentTarget.value)}
+                    data-ac-testid="onboarding.custom.label"
+                    data-ac-role="textbox"
+                  />
+                </label>
+                <label class="onboarding-field-label">
+                  Command
+                  <input
+                    class="onboarding-field-input"
+                    type="text"
+                    placeholder="my-agent --flag"
+                    value={customCommand()}
+                    onInput={(e) => setCustomCommand(e.currentTarget.value)}
+                    data-ac-testid="onboarding.custom.command"
+                    data-ac-role="textbox"
+                  />
+                </label>
+              </div>
+            </Show>
+          </Show>
+        </div>
+
+        <div class="new-agent-footer">
+          <Show when={done()} fallback={
+            <>
+              <Show when={!!props.onCancel}>
+                <button
+                  class="new-agent-cancel-btn"
+                  onClick={() => props.onCancel?.()}
+                  data-ac-testid="onboarding.cancel"
+                  data-ac-role="button"
+                >
+                  Cancel
+                </button>
+              </Show>
+              <button
+                class="new-agent-create-btn"
+                disabled={!canConfirm() || saving()}
+                onClick={handleConfirm}
+                data-ac-testid="onboarding.confirm"
+                data-ac-role="button"
+                data-ac-state={saving() ? "saving" : canConfirm() ? "ready" : "disabled"}
+              >
+                {saving() ? "Setting up..." : "Set up Coding Agent"}
+              </button>
+            </>
+          }>
+            <button
+              class="new-agent-create-btn"
+              onClick={props.onClose}
+              data-ac-testid="onboarding.done.close"
+              data-ac-role="button"
+            >
+              Get started
+            </button>
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CodingAgentQuickConfiguration;

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -150,6 +150,11 @@ describe("OnboardingModal", () => {
     expect(document.querySelector(".onboarding-welcome")?.textContent).toBe(
       "Welcome to AgentsCommander! Let's set up your first Coding Agent.",
     );
+    // #975 — Welcome overrides the accessible name; it must not silently
+    // degrade to the title.
+    expect(
+      document.querySelector('[data-ac-testid="onboarding.modal"]')?.getAttribute("aria-label"),
+    ).toBe("Set up your first Coding Agent");
 
     dispose();
   });
@@ -234,6 +239,42 @@ describe("OnboardingModal", () => {
       }),
     );
     expect(onClose).toHaveBeenCalledTimes(1);
+
+    dispose();
+  });
+
+  it("closes on Escape in the success state with no second settings write (#975)", async () => {
+    const onClose = vi.fn();
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(() => OnboardingModal({ onClose }), root);
+    await settle();
+
+    document.querySelector<HTMLButtonElement>(
+      '[data-ac-testid="onboarding.agentPreset.codex"]',
+    )?.click();
+    await settle();
+
+    document.querySelector<HTMLButtonElement>('[data-ac-testid="onboarding.confirm"]')?.click();
+    await settle();
+    expect(document.querySelector('[data-ac-testid="onboarding.done"]')).toBeTruthy();
+
+    pressEscape();
+    await settle();
+
+    // #975 F1 — Escape on the "configured!" screen closes immediately. The
+    // whole flow performs exactly one get + one update: no redundant settings
+    // rewrite, session purge or global-hotkey re-registration, and no
+    // read-modify-write clobber window after the agent was already saved.
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(SettingsAPI.get).toHaveBeenCalledTimes(1);
+    expect(SettingsAPI.update).toHaveBeenCalledTimes(1);
+    expect(SettingsAPI.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onboardingDismissed: true,
+        agents: [expect.objectContaining({ label: "Codex" })],
+      }),
+    );
 
     dispose();
   });

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -128,10 +128,30 @@ async function settle(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
+function pressEscape(): void {
+  document
+    .querySelector('[data-ac-testid="onboarding.overlay"]')
+    ?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+}
+
 describe("OnboardingModal", () => {
   afterEach(() => {
     document.body.innerHTML = "";
     vi.clearAllMocks();
+  });
+
+  it("renders the Welcome title and intro message (#975)", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(() => OnboardingModal({ onClose: vi.fn() }), root);
+    await settle();
+
+    expect(document.querySelector(".agent-modal-title")?.textContent).toBe("Welcome");
+    expect(document.querySelector(".onboarding-welcome")?.textContent).toBe(
+      "Welcome to AgentsCommander! Let's set up your first Coding Agent.",
+    );
+
+    dispose();
   });
 
   it("persists dismissal when preset setup completes", async () => {
@@ -151,6 +171,8 @@ describe("OnboardingModal", () => {
     )?.click();
     await settle();
 
+    // #975 — dismissal still rides along in the single agent-persisting write.
+    expect(SettingsAPI.update).toHaveBeenCalledTimes(1);
     expect(SettingsAPI.update).toHaveBeenCalledWith(
       expect.objectContaining({
         onboardingDismissed: true,
@@ -172,14 +194,37 @@ describe("OnboardingModal", () => {
     dispose();
   });
 
-  it("continues to persist dismissal when skipped", async () => {
+  it("continues to persist dismissal when cancelled (#975)", async () => {
     const onClose = vi.fn();
     const root = document.createElement("div");
     document.body.append(root);
     const dispose = render(() => OnboardingModal({ onClose }), root);
     await settle();
 
-    document.querySelector<HTMLButtonElement>('[data-ac-testid="onboarding.skip"]')?.click();
+    const cancel = document.querySelector<HTMLButtonElement>('[data-ac-testid="onboarding.cancel"]');
+    expect(cancel?.textContent).toBe("Cancel");
+    cancel?.click();
+    await settle();
+
+    expect(SettingsAPI.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onboardingDismissed: true,
+        agents: [],
+      }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    dispose();
+  });
+
+  it("persists dismissal when Escape cancels the Welcome flow (#975)", async () => {
+    const onClose = vi.fn();
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(() => OnboardingModal({ onClose }), root);
+    await settle();
+
+    pressEscape();
     await settle();
 
     expect(SettingsAPI.update).toHaveBeenCalledWith(

--- a/src/sidebar/components/OnboardingModal.tsx
+++ b/src/sidebar/components/OnboardingModal.tsx
@@ -1,34 +1,19 @@
-import { Component, createSignal, For, onMount, Show } from "solid-js";
-import type { AgentConfig, AppSettings, CodingAgentDefinition } from "../../shared/types";
+import { Component } from "solid-js";
+import type { AppSettings } from "../../shared/types";
 import { SettingsAPI } from "../../shared/ipc";
 import { settingsStore } from "../../shared/stores/settings";
-import { newAgentId, definitionToSeed } from "../../shared/agent-presets";
-import { codingAgentsStore } from "../stores/coding-agents";
+import CodingAgentQuickConfiguration from "./CodingAgentQuickConfiguration";
 
-// Custom Agent is not a catalog entry: it triggers the inline name/command
-// fields and is always offered last, so it stays a client-side definition.
-const CUSTOM_PRESET: CodingAgentDefinition = {
-  key: "custom",
-  label: "Custom Agent",
-  description: "Configure your own Coding Agent",
-  color: "#6366f1",
-  command: "",
-  envs: [],
-  isolatedHome: false,
-  removable: false,
-};
+// #975 — the first-run Welcome flow is now a thin wrapper over the reusable
+// CodingAgentQuickConfiguration. Every `onboardingDismissed` write lives here:
+// the reusable component never touches first-run state, so other consumers can
+// mount it without dismissing onboarding as a side effect.
+const WELCOME_TITLE = "Welcome";
+const WELCOME_MESSAGE = "Welcome to AgentsCommander! Let's set up your first Coding Agent.";
 
 const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
-  const [selectedPreset, setSelectedPreset] = createSignal<string | null>(null);
-  const [saving, setSaving] = createSignal(false);
-  const [done, setDone] = createSignal(false);
-  const [addedLabel, setAddedLabel] = createSignal("");
-
-  // #769 — the catalog is backend-owned; the store is pre-seeded with the
-  // fallback so the card list (and the #768 no-scroll fit) renders immediately,
-  // with no wrong-length flash before the async fetch resolves.
-  const allPresets = () => [...codingAgentsStore.catalog(), CUSTOM_PRESET];
-
+  // Cancel path: persist dismissal, then close. Escape resolves to this same
+  // callback, so keyboard and pointer dismissal stay identical.
   const dismissAndClose = async () => {
     try {
       const settings = await SettingsAPI.get();
@@ -38,232 +23,22 @@ const OnboardingModal: Component<{ onClose: () => void }> = (props) => {
     props.onClose();
   };
 
-  // Custom agent fields
-  const [customLabel, setCustomLabel] = createSignal("");
-  const [customCommand, setCustomCommand] = createSignal("");
-
-  const isCustom = () => selectedPreset() === "custom";
-  const canConfirm = () => {
-    if (!selectedPreset()) return false;
-    if (isCustom()) return customLabel().trim() !== "" && customCommand().trim() !== "";
-    return true;
-  };
-
-  const handleSelect = (key: string) => {
-    setSelectedPreset(key === selectedPreset() ? null : key);
-  };
-
-  const handleConfirm = async () => {
-    const key = selectedPreset();
-    if (!key) return;
-
-    const preset = allPresets().find((p) => p.key === key);
-    if (!preset) return;
-
-    setSaving(true);
-    try {
-      const settings = await SettingsAPI.get();
-
-      let agent: AgentConfig;
-      if (key === "custom") {
-        agent = {
-          id: newAgentId(),
-          label: customLabel().trim(),
-          command: customCommand().trim(),
-          color: preset.color,
-          envs: [],
-          isolatedHome: false,
-        };
-      } else {
-        agent = { id: newAgentId(), ...definitionToSeed(preset) };
-      }
-
-      const updated: AppSettings = {
-        ...settings,
-        agents: [...settings.agents, agent],
-        onboardingDismissed: true,
-      };
-      await SettingsAPI.update(updated);
-      settingsStore.refresh();
-
-      setAddedLabel(agent.label);
-      setDone(true);
-    } catch (e) {
-      console.error("Onboarding save failed:", e);
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      if (done()) props.onClose();
-      else void dismissAndClose();
-      return;
-    }
-    // Focus trap: keep Tab cycling within the modal
-    if (e.key === "Tab" && modalRef) {
-      const focusable = modalRef.querySelectorAll<HTMLElement>(
-        'button:not(:disabled), input:not(:disabled), [tabindex]:not([tabindex="-1"])'
-      );
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    }
-  };
-
-  let overlayRef!: HTMLDivElement;
-  let modalRef!: HTMLDivElement;
-  onMount(() => {
-    overlayRef.focus();
-    void codingAgentsStore.ensureLoaded();
+  // Success path: dismissal rides along in the same single settings write that
+  // persists the new agent, preserving the pre-#975 atomic update.
+  const withDismissal = (settings: AppSettings): AppSettings => ({
+    ...settings,
+    onboardingDismissed: true,
   });
 
   return (
-    <div
-      class="modal-overlay"
-      ref={overlayRef}
-      onKeyDown={handleKeyDown}
-      tabIndex={0}
-      data-ac-testid="onboarding.overlay"
-      data-ac-role="overlay"
-    >
-      <div
-        class="agent-modal onboarding-modal"
-        ref={modalRef}
-        role="dialog"
-        aria-modal="true"
-        aria-label="Set up your first Coding Agent"
-        data-ac-testid="onboarding.modal"
-        data-ac-role="dialog"
-        data-ac-state={done() ? "done" : "selecting"}
-      >
-        <div class="agent-modal-header">
-          <span class="agent-modal-title">Welcome</span>
-        </div>
-
-        <div class="wizard-body onboarding-body">
-          <Show when={!done()} fallback={
-            <div
-              class="onboarding-done"
-              data-ac-testid="onboarding.done"
-              data-ac-role="status"
-            >
-              <div class="onboarding-done-icon">&#x2713;</div>
-              <div class="onboarding-done-text">
-                <strong>{addedLabel()}</strong> configured!
-              </div>
-              <div class="onboarding-done-hint">
-                You can add more Coding Agents later in Settings.
-              </div>
-            </div>
-          }>
-            <p class="onboarding-welcome">
-              Welcome to AgentsCommander! Let's set up your first Coding Agent.
-            </p>
-
-            <div class="onboarding-cards">
-              <For each={allPresets()}>
-                {(preset) => (
-                  <button
-                    class={`onboarding-card ${selectedPreset() === preset.key ? "selected" : ""}`}
-                    onClick={() => handleSelect(preset.key)}
-                    style={{ "--card-accent": preset.color }}
-                    aria-pressed={selectedPreset() === preset.key}
-                    aria-label={`Select ${preset.label}`}
-                    data-ac-testid={`onboarding.agentPreset.${preset.key}`}
-                    data-ac-role="agent-preset"
-                    data-ac-state={selectedPreset() === preset.key ? "selected" : "idle"}
-                    data-ac-agent-key={preset.key}
-                  >
-                    <div
-                      class="onboarding-card-icon"
-                      style={{ background: preset.color }}
-                    >
-                      {preset.label[0]}
-                    </div>
-                    <div class="onboarding-card-info">
-                      <div class="onboarding-card-name">{preset.label}</div>
-                      <div class="onboarding-card-desc">{preset.description}</div>
-                    </div>
-                  </button>
-                )}
-              </For>
-            </div>
-
-            <Show when={isCustom()}>
-              <div class="onboarding-custom-fields">
-                <label class="onboarding-field-label">
-                  Agent name
-                  <input
-                    class="onboarding-field-input"
-                    type="text"
-                    placeholder="My Agent"
-                    value={customLabel()}
-                    onInput={(e) => setCustomLabel(e.currentTarget.value)}
-                    data-ac-testid="onboarding.custom.label"
-                    data-ac-role="textbox"
-                  />
-                </label>
-                <label class="onboarding-field-label">
-                  Command
-                  <input
-                    class="onboarding-field-input"
-                    type="text"
-                    placeholder="my-agent --flag"
-                    value={customCommand()}
-                    onInput={(e) => setCustomCommand(e.currentTarget.value)}
-                    data-ac-testid="onboarding.custom.command"
-                    data-ac-role="textbox"
-                  />
-                </label>
-              </div>
-            </Show>
-          </Show>
-        </div>
-
-        <div class="new-agent-footer">
-          <Show when={done()} fallback={
-            <>
-              <button
-                class="new-agent-cancel-btn"
-                onClick={() => void dismissAndClose()}
-                data-ac-testid="onboarding.skip"
-                data-ac-role="button"
-              >
-                Skip
-              </button>
-              <button
-                class="new-agent-create-btn"
-                disabled={!canConfirm() || saving()}
-                onClick={handleConfirm}
-                data-ac-testid="onboarding.confirm"
-                data-ac-role="button"
-                data-ac-state={saving() ? "saving" : canConfirm() ? "ready" : "disabled"}
-              >
-                {saving() ? "Setting up..." : "Set up Coding Agent"}
-              </button>
-            </>
-          }>
-            <button
-              class="new-agent-create-btn"
-              onClick={props.onClose}
-              data-ac-testid="onboarding.done.close"
-              data-ac-role="button"
-            >
-              Get started
-            </button>
-          </Show>
-        </div>
-      </div>
-    </div>
+    <CodingAgentQuickConfiguration
+      title={WELCOME_TITLE}
+      message={WELCOME_MESSAGE}
+      ariaLabel="Set up your first Coding Agent"
+      onCancel={() => void dismissAndClose()}
+      onBeforeSave={withDismissal}
+      onClose={props.onClose}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary

- extract the first-run Coding Agent setup into the reusable `CodingAgentQuickConfiguration` component
- accept consumer-provided title/message and optional cancellation
- keep Welcome as a thin consumer that owns `onboardingDismissed` persistence
- rename the visible Skip action and automation affordance to Cancel
- preserve the existing visual layout, configuration flow, and single-write setup behavior

## Verification

- `npm run typecheck`: PASS
- `npm run test`: PASS, 1012/1012 tests across 121 files
- `npm run test:debt`: PASS
- focused #975 + integrated-base suites: PASS, 38/38
- Grinch implementation review: PASS after one blocker fix
- Grinch integration review: PASS, synthetic merge tree and reviewed blobs verified identical
- mutation battery: 7/7 required guards killed

## Delivery

Visual change: yes, Welcome footer label changes from Skip to Cancel. Final workgroup build/deploy follows after landing.

Closes #975