### PR TITLE
fix(sidebar): close the replica context menu on pointer leave, add item icons (#977)

### DIFF
--- a/src/sidebar/components/ProjectPanel.context-menu-hover.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu-hover.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProjectPanel from "./ProjectPanel";
 import { FakeTransport } from "../../shared/testing/fake-transport";
 import {
+  click,
   contextMenu,
   discovery,
   installBrowserDomStubs,
@@ -13,7 +14,12 @@ import {
 } from "../../shared/testing/ui-harness";
 import { projectStore } from "../stores/project";
 import { sessionsStore } from "../stores/sessions";
-import { defaultGroupsConfig, workgroupGroupsStore } from "../stores/workgroup-groups";
+import {
+  defaultGroupsConfig,
+  exactGroupRegexForWorkgroup,
+  workgroupGroupsStore,
+} from "../stores/workgroup-groups";
+import type { WorkgroupGroupsConfig } from "../../shared/types";
 
 // #977 - the replica context menu closes when the pointer leaves it, after a
 // grace period that any re-entry cancels.
@@ -33,13 +39,18 @@ const projectPath = "C:\\Project";
 const wgPath = `${projectPath}\\.ac\\wg-1-dev-team`;
 const coordPath = `${wgPath}\\__agent_dev-webpage-ui`;
 const memberPath = `${wgPath}\\__agent_dev-rust`;
+const grayPath = `${wgPath}\\__agent_dev-docs`;
 
-// A live coordinator renders in the quick section; a non-coordinator member
-// renders under workgroups. Both open the full (active) replica menu.
+// A live coordinator renders in the quick section; the other replicas render
+// under workgroups. dev-docs has no session at all, so it opens the INACTIVE
+// (gray) branch of the menu; the other two open the active branch.
 const coordRowTestId = "replica.row.quick.wg-1-dev-team.dev-webpage-ui";
 const memberRowTestId = "replica.row.workgroups.wg-1-dev-team.dev-rust";
+const grayRowTestId = "replica.row.workgroups.wg-1-dev-team.dev-docs";
 const groupsTriggerTestId = "replica.wg-1-dev-team.groups.trigger";
 const groupsFlyoutTestId = "replica.wg-1-dev-team.groups.flyout";
+const groupsErrorTestId = "replica.groups.error";
+const groupOptionTestId = "replica.wg-1-dev-team.groups.frontend";
 
 function projectDiscovery() {
   return discovery({
@@ -61,6 +72,13 @@ function projectDiscovery() {
             name: "dev-rust",
             path: memberPath,
             identityPath: "../../_agent_dev-rust",
+            repoPaths: [],
+            isCoordinator: false,
+          },
+          {
+            name: "dev-docs",
+            path: grayPath,
+            identityPath: "../../_agent_dev-docs",
             repoPaths: [],
             isCoordinator: false,
           },
@@ -88,6 +106,21 @@ function liveSessions() {
   ];
 }
 
+/** A group the coordinator's workgroup matches by an EXACT token, so its menu
+ *  option is enabled and clicking it is a real (removing) groups write. */
+function removableGroupsConfig(): WorkgroupGroupsConfig {
+  return {
+    ...defaultGroupsConfig(),
+    groups: [
+      {
+        id: "frontend",
+        name: "Frontend",
+        regex: exactGroupRegexForWorkgroup("wg-1-dev-team"),
+      },
+    ],
+  };
+}
+
 function menu(): HTMLElement | null {
   // The menu and its flyouts render through a Portal, into document.body.
   return document.querySelector<HTMLElement>(".session-context-menu");
@@ -97,10 +130,28 @@ function target(testId: string): HTMLElement | null {
   return document.querySelector<HTMLElement>(`[data-ac-testid="${testId}"]`);
 }
 
+function menuLabels(root: HTMLElement): string[] {
+  return Array.from(root.querySelectorAll("button")).map((b) => (b.textContent ?? "").trim());
+}
+
 // Solid does not delegate mouseenter/mouseleave (they do not bubble); it binds
 // them directly, so a non-bubbling dispatch is exactly what the handler sees.
 function mouse(el: Element, type: "mouseenter" | "mouseleave"): void {
   el.dispatchEvent(new MouseEvent(type, { bubbles: false, cancelable: true }));
+}
+
+function domRect(left: number, top: number, width: number, height: number): DOMRect {
+  return {
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
 }
 
 /** Drain the macrotask queue. The menu registers its window-level dismiss
@@ -112,25 +163,28 @@ describe("ProjectPanel replica context menu - close on pointer leave (#977)", ()
   let cleanupDom: (() => void) | null = null;
   let rendered: ReturnType<typeof renderWithFakeTransport> | null = null;
 
-  async function setupPanel(): Promise<void> {
+  async function setupPanel(groups = defaultGroupsConfig()): Promise<FakeTransport> {
     const fake = new FakeTransport();
     fake.resolve("new_project", { path: projectPath, registered: true, created: false });
     fake.resolve("discover_project", projectDiscovery());
     fake.onInvoke("update_project_groups", (args) => args.config);
     sessionsStore.setSessions(liveSessions());
     rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
-    await workgroupGroupsStore.save(projectPath, defaultGroupsConfig());
+    await workgroupGroupsStore.save(projectPath, groups);
     await projectStore.createAndLoad(projectPath);
     await waitFor(() => expect(rendered!.root.textContent).toContain("dev-webpage-ui"));
+    return fake;
   }
 
-  async function openCoordinatorMenu(): Promise<HTMLElement> {
-    const row = rendered!.root.querySelector(`[data-ac-testid="${coordRowTestId}"]`);
+  async function openMenuOn(rowTestId: string): Promise<HTMLElement> {
+    const row = rendered!.root.querySelector(`[data-ac-testid="${rowTestId}"]`);
     contextMenu(row!);
     await waitFor(() => expect(menu()).not.toBeNull());
     await flush();
     return menu()!;
   }
+
+  const openCoordinatorMenu = () => openMenuOn(coordRowTestId);
 
   /** Hover the `Add to Group` trigger and wait for its portalled flyout. */
   async function openGroupFlyout(): Promise<HTMLElement> {
@@ -266,6 +320,60 @@ describe("ProjectPanel replica context menu - close on pointer leave (#977)", ()
     }
   });
 
+  // The close bails while the Add to Group flyout is showing an error, so the
+  // message stays readable (closing the menu would dispose the flyout with it).
+  // That bail is scoped to "the error is ON SCREEN", which means the flyout is
+  // open - NOT to the bare workgroupGroupsStore.error flag. The next test is why.
+  it("keeps the menu open while the Add to Group flyout is showing an error", async () => {
+    const fake = await setupPanel(removableGroupsConfig());
+    fake.reject("update_project_groups", "groups.toml changed on disk");
+
+    const open = await openCoordinatorMenu();
+    const flyout = await openGroupFlyout();
+    click(target(groupOptionTestId)!); // removes the workgroup: the write fails
+    await waitFor(() => {
+      expect(target(groupsErrorTestId)?.textContent).toContain("groups.toml changed on disk");
+    });
+
+    vi.useFakeTimers();
+    try {
+      mouse(open, "mouseleave"); // the pointer is in the flyout, which is a Portal
+      mouse(flyout, "mouseleave");
+      vi.advanceTimersByTime(GRACE * 4); // PAST the grace, not just up to it
+      await Promise.resolve();
+
+      expect(menu()).not.toBeNull();
+      expect(target(groupsFlyoutTestId)).not.toBeNull();
+      expect(target(groupsErrorTestId)).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // workgroupGroupsStore.error is a sticky PROJECT-WIDE flag: any failed groups
+  // write (another workgroup, the Edit-groups modal) or an invalid groups.toml at
+  // load sets it, and only a LATER successful save clears it. If the close bailed
+  // on that flag bare, one failed write anywhere would silently disable the
+  // pointer-leave close for every replica menu in the project - #977 all over again.
+  it("still closes after a failed groups write when the flyout was never opened", async () => {
+    const fake = await setupPanel();
+    fake.reject("update_project_groups", "groups.toml changed on disk");
+    await workgroupGroupsStore.save(projectPath, defaultGroupsConfig()).catch(() => {});
+    expect(workgroupGroupsStore.error(projectPath)).toBeTruthy();
+
+    const open = await openCoordinatorMenu(); // the flyout is never opened
+
+    vi.useFakeTimers();
+    try {
+      mouse(open, "mouseleave");
+      vi.advanceTimersByTime(GRACE * 4);
+      await Promise.resolve();
+      expect(menu()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("still closes on Escape and on an outside click", async () => {
     await setupPanel();
 
@@ -278,14 +386,60 @@ describe("ProjectPanel replica context menu - close on pointer leave (#977)", ()
     await waitFor(() => expect(menu()).toBeNull());
   });
 
+  // The close depends on the pointer's hover chain reaching the LIVE menu node:
+  // mouseleave is only delivered to the element the pointer is actually inside.
+  // positionReplicaCtxMenu writes a NEW menu object ({...current, x, y}) ~0ms after
+  // every open and again on every reclamp, so if `{replicaCtxMenu() && <Portal>}`
+  // re-created the menu on that write, the cursor would be left hovering a detached
+  // node and no mouseleave would ever fire in a real browser. It does not: Solid's
+  // wrapConditionals memoizes the `&&` on the condition's TRUTHINESS, so an identity
+  // change to the object only re-runs the fine-grained style effect. Lock that in.
+  it("does not re-create the menu element when the reposition write lands", async () => {
+    // A tall menu against jsdom's 768px viewport: the y=96 open position is clamped
+    // up to 768 - 700 - 8 = 60, so the reposition write visibly MOVES the menu. That
+    // is the control - it proves the new object really did reach the DOM.
+    const rects = vi
+      .spyOn(Element.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: Element) {
+        if (this.classList?.contains("session-context-menu")) return domRect(0, 0, 400, 700);
+        return domRect(0, 0, 0, 0);
+      });
+    try {
+      await setupPanel();
+
+      const row = rendered!.root.querySelector(`[data-ac-testid="${coordRowTestId}"]`);
+      contextMenu(row!); // the harness dispatches clientX 80 / clientY 96
+      await waitFor(() => expect(menu()).not.toBeNull());
+
+      const first = menu()!;
+      expect(first.getAttribute("style")).toContain("top: 96px");
+
+      await flush(); // runs the queued positionReplicaCtxMenu
+
+      expect(menu()!.getAttribute("style")).toContain("top: 60px"); // the write landed
+      expect(menu()).toBe(first); // ...and the element survived it
+      expect(first.isConnected).toBe(true);
+    } finally {
+      rects.mockRestore();
+    }
+  });
+
   it("renders the restart and coding agent icons", async () => {
     await setupPanel();
     const open = await openCoordinatorMenu();
 
-    const labels = Array.from(open.querySelectorAll("button")).map((b) =>
-      (b.textContent ?? "").trim()
-    );
+    const labels = menuLabels(open);
     expect(labels).toContain("↺ Restart Session");
     expect(labels).toContain("\u{1F916} Coding Agent");
+  });
+
+  it("renders the coding agent icon on the inactive (gray) branch too", async () => {
+    await setupPanel();
+    const open = await openMenuOn(grayRowTestId);
+
+    const labels = menuLabels(open);
+    expect(labels).toContain("\u{1F916} Coding Agent");
+    // The gray branch has no Restart Session at all, so this really is that menu.
+    expect(labels.some((label) => label.includes("Restart Session"))).toBe(false);
   });
 });

--- a/src/sidebar/components/ProjectPanel.context-menu-hover.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu-hover.test.tsx
@@ -1,0 +1,291 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  contextMenu,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { sessionsStore } from "../stores/sessions";
+import { defaultGroupsConfig, workgroupGroupsStore } from "../stores/workgroup-groups";
+
+// #977 - the replica context menu closes when the pointer leaves it, after a
+// grace period that any re-entry cancels.
+//
+// The load-bearing case is the submenu: `Add to Group` (and the repo Browse
+// entries, covered in ProjectPanel.repo-browse.test.tsx) render their flyout in
+// their OWN <Portal>, so it is NOT a DOM descendant of .session-context-menu.
+// Crossing from the menu into a flyout therefore fires the menu's own
+// mouseleave, and a close that ignored that would dismiss the menu exactly when
+// the user reaches for the submenu. The flyouts cancel the pending close on
+// mouseenter, which is what makes "inside a submenu" count as "inside the menu".
+//
+// GRACE is CONTEXT_MENU_CLOSE_GRACE_MS in ProjectPanel.tsx.
+const GRACE = 250;
+
+const projectPath = "C:\\Project";
+const wgPath = `${projectPath}\\.ac\\wg-1-dev-team`;
+const coordPath = `${wgPath}\\__agent_dev-webpage-ui`;
+const memberPath = `${wgPath}\\__agent_dev-rust`;
+
+// A live coordinator renders in the quick section; a non-coordinator member
+// renders under workgroups. Both open the full (active) replica menu.
+const coordRowTestId = "replica.row.quick.wg-1-dev-team.dev-webpage-ui";
+const memberRowTestId = "replica.row.workgroups.wg-1-dev-team.dev-rust";
+const groupsTriggerTestId = "replica.wg-1-dev-team.groups.trigger";
+const groupsFlyoutTestId = "replica.wg-1-dev-team.groups.flyout";
+
+function projectDiscovery() {
+  return discovery({
+    workgroups: [
+      {
+        name: "wg-1-dev-team",
+        path: wgPath,
+        task: null,
+        taskTitle: "Hover close",
+        agents: [
+          {
+            name: "dev-webpage-ui",
+            path: coordPath,
+            identityPath: "../../_agent_dev-webpage-ui",
+            repoPaths: [],
+            isCoordinator: true,
+          },
+          {
+            name: "dev-rust",
+            path: memberPath,
+            identityPath: "../../_agent_dev-rust",
+            repoPaths: [],
+            isCoordinator: false,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function liveSessions() {
+  return [
+    session({
+      id: "coord-session",
+      name: "wg-1-dev-team/dev-webpage-ui",
+      workingDirectory: coordPath,
+      status: "running",
+      isCoordinator: true,
+    }),
+    session({
+      id: "member-session",
+      name: "wg-1-dev-team/dev-rust",
+      workingDirectory: memberPath,
+      status: "running",
+    }),
+  ];
+}
+
+function menu(): HTMLElement | null {
+  // The menu and its flyouts render through a Portal, into document.body.
+  return document.querySelector<HTMLElement>(".session-context-menu");
+}
+
+function target(testId: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(`[data-ac-testid="${testId}"]`);
+}
+
+// Solid does not delegate mouseenter/mouseleave (they do not bubble); it binds
+// them directly, so a non-bubbling dispatch is exactly what the handler sees.
+function mouse(el: Element, type: "mouseenter" | "mouseleave"): void {
+  el.dispatchEvent(new MouseEvent(type, { bubbles: false, cancelable: true }));
+}
+
+/** Drain the macrotask queue. The menu registers its window-level dismiss
+ *  listeners inside a setTimeout, so a test that dispatches a dismissing event
+ *  without flushing first would hit a menu that is not yet listening. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("ProjectPanel replica context menu - close on pointer leave (#977)", () => {
+  let cleanupDom: (() => void) | null = null;
+  let rendered: ReturnType<typeof renderWithFakeTransport> | null = null;
+
+  async function setupPanel(): Promise<void> {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", projectDiscovery());
+    fake.onInvoke("update_project_groups", (args) => args.config);
+    sessionsStore.setSessions(liveSessions());
+    rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    await workgroupGroupsStore.save(projectPath, defaultGroupsConfig());
+    await projectStore.createAndLoad(projectPath);
+    await waitFor(() => expect(rendered!.root.textContent).toContain("dev-webpage-ui"));
+  }
+
+  async function openCoordinatorMenu(): Promise<HTMLElement> {
+    const row = rendered!.root.querySelector(`[data-ac-testid="${coordRowTestId}"]`);
+    contextMenu(row!);
+    await waitFor(() => expect(menu()).not.toBeNull());
+    await flush();
+    return menu()!;
+  }
+
+  /** Hover the `Add to Group` trigger and wait for its portalled flyout. */
+  async function openGroupFlyout(): Promise<HTMLElement> {
+    mouse(target(groupsTriggerTestId)!, "mouseenter");
+    await waitFor(() => expect(target(groupsFlyoutTestId)).not.toBeNull());
+    return target(groupsFlyoutTestId)!;
+  }
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    rendered?.cleanup();
+    rendered = null;
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("closes the menu once the pointer has been away for the grace period", async () => {
+    await setupPanel();
+    const open = await openCoordinatorMenu();
+
+    vi.useFakeTimers();
+    try {
+      mouse(open, "mouseleave");
+      expect(menu()).not.toBeNull(); // still open: the close is only scheduled
+
+      vi.advanceTimersByTime(GRACE - 50);
+      expect(menu()).not.toBeNull();
+
+      vi.advanceTimersByTime(100);
+      await Promise.resolve();
+      expect(menu()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels the close when the pointer comes back within the grace period", async () => {
+    await setupPanel();
+    const open = await openCoordinatorMenu();
+
+    vi.useFakeTimers();
+    try {
+      mouse(open, "mouseleave");
+      vi.advanceTimersByTime(GRACE - 50);
+      mouse(open, "mouseenter"); // a quick cursor slip, not a dismissal
+
+      vi.advanceTimersByTime(GRACE * 4);
+      await Promise.resolve();
+      expect(menu()).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the menu open when the pointer moves into the Add to Group flyout", async () => {
+    await setupPanel();
+    const open = await openCoordinatorMenu();
+    const flyout = await openGroupFlyout();
+
+    vi.useFakeTimers();
+    try {
+      // The real pointer path from the trigger into the flyout: the flyout is a
+      // sibling Portal, so the MENU sees a mouseleave on the way in.
+      mouse(target(groupsTriggerTestId)!, "mouseleave");
+      mouse(open, "mouseleave");
+      mouse(flyout, "mouseenter");
+
+      vi.advanceTimersByTime(GRACE * 4);
+      await Promise.resolve();
+      expect(menu()).not.toBeNull();
+      expect(target(groupsFlyoutTestId)).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes the menu when the pointer leaves the flyout without returning", async () => {
+    await setupPanel();
+    const open = await openCoordinatorMenu();
+    const flyout = await openGroupFlyout();
+
+    vi.useFakeTimers();
+    try {
+      mouse(open, "mouseleave");
+      mouse(flyout, "mouseenter");
+      vi.advanceTimersByTime(GRACE * 2);
+      expect(menu()).not.toBeNull();
+
+      mouse(flyout, "mouseleave");
+      vi.advanceTimersByTime(GRACE * 2);
+      await Promise.resolve();
+      expect(menu()).toBeNull();
+      expect(target(groupsFlyoutTestId)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let a pending close dismiss the NEXT menu", async () => {
+    await setupPanel();
+    const open = await openCoordinatorMenu();
+
+    vi.useFakeTimers();
+    try {
+      // Slide off the coordinator's menu and right-click another row before the
+      // grace period is up. The close was armed by the menu that is already gone.
+      mouse(open, "mouseleave");
+      vi.advanceTimersByTime(GRACE - 100);
+
+      const memberRow = rendered!.root.querySelector(`[data-ac-testid="${memberRowTestId}"]`);
+      contextMenu(memberRow!);
+      vi.advanceTimersByTime(GRACE * 4);
+      await Promise.resolve();
+
+      const reopened = menu();
+      expect(reopened).not.toBeNull();
+      // Open Replica's Folder carries the replica path, so the titles identify
+      // WHICH replica's menu survived. (A path is not usable in a CSS attribute
+      // selector here: its backslashes are escape characters.)
+      const titles = Array.from(reopened!.querySelectorAll("button")).map((b) =>
+        b.getAttribute("title")
+      );
+      expect(titles).toContain(memberPath);
+      expect(titles).not.toContain(coordPath);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still closes on Escape and on an outside click", async () => {
+    await setupPanel();
+
+    await openCoordinatorMenu();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await waitFor(() => expect(menu()).toBeNull());
+
+    await openCoordinatorMenu();
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await waitFor(() => expect(menu()).toBeNull());
+  });
+
+  it("renders the restart and coding agent icons", async () => {
+    await setupPanel();
+    const open = await openCoordinatorMenu();
+
+    const labels = Array.from(open.querySelectorAll("button")).map((b) =>
+      (b.textContent ?? "").trim()
+    );
+    expect(labels).toContain("↺ Restart Session");
+    expect(labels).toContain("\u{1F916} Coding Agent");
+  });
+});

--- a/src/sidebar/components/ProjectPanel.modal-refresh.test.tsx
+++ b/src/sidebar/components/ProjectPanel.modal-refresh.test.tsx
@@ -169,9 +169,17 @@ function seedLiveSession(): void {
   ]);
 }
 
+/** #977: replica-menu items now lead with an icon (Restart Session and Coding
+ *  Agent joined the folder/broom items), so match on the label with any leading
+ *  icon stripped - the same normalization menuButtonLabels uses in
+ *  ProjectPanel.context-menu.test.tsx. */
+function menuLabel(text: string): string {
+  return text.trim().replace(/^[^A-Za-z0-9]+/, "").trim();
+}
+
 function findButtonByText(label: string): HTMLButtonElement {
   const match = Array.from(document.body.querySelectorAll("button")).find(
-    (b) => b.textContent?.trim() === label,
+    (b) => menuLabel(b.textContent ?? "") === menuLabel(label),
   );
   if (!(match instanceof HTMLButtonElement)) throw new Error(`Button not found: ${label}`);
   return match;

--- a/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
+++ b/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
@@ -857,4 +857,41 @@ describe("ProjectPanel coordinator repo Browse submenu (#943)", () => {
     mouseEnter(repoEntries()[1]);
     expect(flyout()).toBeNull();
   });
+
+  // 18 (#977)
+  it("keeps the menu open when the pointer crosses into the Browse flyout", async () => {
+    await setupPanel(
+      [coordASession([repo(repoA1, "AgentsCommander", "feature/x")])],
+      discoveryA()
+    );
+
+    await openMenuWithArrow(rowA);
+    mouseEnter(repoEntries()[0]);
+    await waitFor(() => expect(flyout()).not.toBeNull());
+
+    vi.useFakeTimers();
+    try {
+      // The flyout is a sibling <Portal>, NOT a descendant of the menu, so the
+      // pointer crossing the 4px gap into it fires the MENU's own mouseleave.
+      // #977 arms a menu close there; the flyout's mouseenter must cancel it,
+      // or the submenu would be unreachable.
+      mouseLeave(repoEntries()[0]);
+      mouseLeave(menu()!);
+      mouseEnter(flyout()!);
+
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
+      expect(menu()).not.toBeNull();
+      expect(flyout()).not.toBeNull();
+
+      // Leaving the flyout for good takes the whole menu with it.
+      mouseLeave(flyout()!);
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
+      expect(flyout()).toBeNull();
+      expect(menu()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/sidebar/components/ProjectPanel.restart-prompt.test.tsx
+++ b/src/sidebar/components/ProjectPanel.restart-prompt.test.tsx
@@ -167,9 +167,17 @@ function seedLiveSession(): void {
   ]);
 }
 
+/** #977: replica-menu items now lead with an icon (Restart Session and Coding
+ *  Agent joined the folder/broom items), so match on the label with any leading
+ *  icon stripped - the same normalization menuButtonLabels uses in
+ *  ProjectPanel.context-menu.test.tsx. */
+function menuLabel(text: string): string {
+  return text.trim().replace(/^[^A-Za-z0-9]+/, "").trim();
+}
+
 function findButtonByText(label: string): HTMLButtonElement {
   const match = Array.from(document.body.querySelectorAll("button")).find(
-    (b) => b.textContent?.trim() === label,
+    (b) => menuLabel(b.textContent ?? "") === menuLabel(label),
   );
   if (!(match instanceof HTMLButtonElement)) throw new Error(`Button not found: ${label}`);
   return match;

--- a/src/sidebar/components/ProjectPanel.restart-toast.test.tsx
+++ b/src/sidebar/components/ProjectPanel.restart-toast.test.tsx
@@ -87,9 +87,17 @@ function seedLiveSession(): void {
   ]);
 }
 
+/** #977: replica-menu items now lead with an icon (Restart Session and Coding
+ *  Agent joined the folder/broom items), so match on the label with any leading
+ *  icon stripped - the same normalization menuButtonLabels uses in
+ *  ProjectPanel.context-menu.test.tsx. */
+function menuLabel(text: string): string {
+  return text.trim().replace(/^[^A-Za-z0-9]+/, "").trim();
+}
+
 function findButtonByText(label: string): HTMLButtonElement {
   const match = Array.from(document.body.querySelectorAll("button")).find(
-    (b) => b.textContent?.trim() === label,
+    (b) => menuLabel(b.textContent ?? "") === menuLabel(label),
   );
   if (!(match instanceof HTMLButtonElement)) throw new Error(`Button not found: ${label}`);
   return match;

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -195,6 +195,10 @@ function deriveScopeContextFromSession(
 }
 
 const CONTEXT_MENU_VIEWPORT_MARGIN = 8;
+// #977 - grace period before a pointer-leave closes the replica context menu.
+// Longer than the 180ms flyout timer: leaving the menu INTO a submenu arms both,
+// and the submenu's mouseenter must be able to cancel this one first.
+const CONTEXT_MENU_CLOSE_GRACE_MS = 250;
 
 function workgroupCollapseId(wg: AcWorkgroup, rowContext: string): string {
   return [
@@ -1294,7 +1298,31 @@ const ProjectPanel: Component = () => {
         let replicaCtxMenuEl: HTMLDivElement | undefined;
         let dismissCtx: (() => void) | null = null;
 
+        // #977 - the menu closes when the pointer leaves it, after a grace period
+        // that any re-entry cancels (a quick cursor slip must not dismiss it).
+        //
+        // BOTH SUBMENUS RENDER IN THEIR OWN <Portal>, outside .session-context-menu:
+        // crossing from a submenu trigger into its flyout therefore fires the MENU's
+        // mouseleave, and a naive close would kill the menu (and the flyout with it,
+        // since the flyout Portal is a child of the menu's render block) exactly when
+        // the user reaches for it. The flyouts cancel this timer on mouseenter, so
+        // "pointer inside the menu OR inside an open submenu" reads as still-inside.
+        // Same schedule/cancel shape the flyouts already use for themselves, one
+        // level up. Click, click-outside and Escape are untouched.
+        let replicaCtxMenuCloseTimer: number | undefined;
+        const cancelReplicaCtxMenuClose = () => {
+          if (replicaCtxMenuCloseTimer === undefined) return;
+          window.clearTimeout(replicaCtxMenuCloseTimer);
+          replicaCtxMenuCloseTimer = undefined;
+        };
+
         const cleanupCtx = () => {
+          // #977 - a pending pointer-leave close belongs to the menu that armed it.
+          // Every menu open handler and every dismiss path calls cleanupCtx() first,
+          // so cancelling here is what stops a stale timer from dismissing the NEXT
+          // menu (right-click a row, slide off, right-click another row inside the
+          // grace period) or from tearing that menu's dismiss listeners off with it.
+          cancelReplicaCtxMenuClose();
           if (dismissCtx) {
             window.removeEventListener("click", dismissCtx);
             window.removeEventListener("contextmenu", dismissCtx);
@@ -1304,6 +1332,23 @@ const ProjectPanel: Component = () => {
         };
 
         onCleanup(cleanupCtx);
+
+        const closeReplicaCtxMenu = () => {
+          setReplicaCtxMenu(null);
+          cleanupCtx();
+        };
+        const scheduleReplicaCtxMenuClose = () => {
+          cancelReplicaCtxMenuClose();
+          // A failed group action pins the Add to Group flyout open on pointer-leave
+          // (scheduleGroupFlyoutClose bails on the same predicate). Closing the menu
+          // would dispose that flyout and its error with it, so bail identically.
+          if (groupFlyoutHasError()) return;
+          replicaCtxMenuCloseTimer = window.setTimeout(() => {
+            replicaCtxMenuCloseTimer = undefined;
+            if (groupFlyoutHasError()) return;
+            closeReplicaCtxMenu();
+          }, CONTEXT_MENU_CLOSE_GRACE_MS);
+        };
 
         const positionReplicaCtxMenu = (x: number, y: number) => {
           if (!replicaCtxMenuEl) return;
@@ -1634,8 +1679,14 @@ const ProjectPanel: Component = () => {
                 class="session-context-flyout"
                 ref={groupFlyoutEl}
                 style={{ left: `${groupFlyoutPos().x}px`, top: `${groupFlyoutPos().y}px` }}
-                onMouseEnter={cancelGroupFlyoutClose}
-                onMouseLeave={scheduleGroupFlyoutClose}
+                onMouseEnter={() => {
+                  cancelGroupFlyoutClose();
+                  cancelReplicaCtxMenuClose(); // #977 - still inside the menu
+                }}
+                onMouseLeave={() => {
+                  scheduleGroupFlyoutClose();
+                  scheduleReplicaCtxMenuClose(); // #977 - re-armed; the menu cancels it on re-entry
+                }}
                 onClick={(e) => e.stopPropagation()}
                 onContextMenu={(e) => e.stopPropagation()}
                 data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.flyout`}
@@ -1815,8 +1866,14 @@ const ProjectPanel: Component = () => {
                     class="session-context-flyout"
                     ref={repoFlyoutEl}
                     style={{ left: `${repoFlyoutPos().x}px`, top: `${repoFlyoutPos().y}px` }}
-                    onMouseEnter={cancelRepoFlyoutClose}
-                    onMouseLeave={scheduleRepoFlyoutClose}
+                    onMouseEnter={() => {
+                      cancelRepoFlyoutClose();
+                      cancelReplicaCtxMenuClose(); // #977 - still inside the menu
+                    }}
+                    onMouseLeave={() => {
+                      scheduleRepoFlyoutClose();
+                      scheduleReplicaCtxMenuClose(); // #977 - re-armed; the menu cancels it on re-entry
+                    }}
                     // This Portal renders OUTSIDE .session-context-menu, so the
                     // window-level dismiss listeners (bubble phase) would
                     // otherwise see these events and kill the whole menu.
@@ -3675,11 +3732,15 @@ const ProjectPanel: Component = () => {
                   ref={replicaCtxMenuEl}
                   style={{ left: `${replicaCtxMenu()!.x}px`, top: `${replicaCtxMenu()!.y}px` }}
                   onClick={(e) => e.stopPropagation()}
+                  onMouseEnter={cancelReplicaCtxMenuClose}
                   // #943 - a <For> row re-created under a stationary cursor is a
                   // detached node and can never fire its own mouseleave. This
                   // guarantees the flyout cannot hang. The flyout's onMouseEnter
                   // cancels the 180ms timer when crossing the 4px gap.
-                  onMouseLeave={scheduleRepoFlyoutClose}
+                  onMouseLeave={() => {
+                    scheduleRepoFlyoutClose();
+                    scheduleReplicaCtxMenuClose(); // #977
+                  }}
                 >
                   <Show when={activeReplicaMenu()}>
                     {(menu) => {
@@ -3699,7 +3760,7 @@ const ProjectPanel: Component = () => {
                             await restartReplicaSession(menu().sessionId);
                           }}
                         >
-                          Restart Session
+                          &#x21BA; Restart Session
                         </button>
                         <button
                           class="session-context-option"
@@ -3711,7 +3772,7 @@ const ProjectPanel: Component = () => {
                             setReplicaCodingAgentTarget({ sessionId, sessionName });
                           }}
                         >
-                          Coding Agent
+                          &#x1F916; Coding Agent
                         </button>
                         <button
                           class="session-context-option"
@@ -3777,7 +3838,7 @@ const ProjectPanel: Component = () => {
                               });
                             }}
                           >
-                            Coding Agent
+                            &#x1F916; Coding Agent
                           </button>
                           <button
                             class="session-context-option"

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1337,15 +1337,25 @@ const ProjectPanel: Component = () => {
           setReplicaCtxMenu(null);
           cleanupCtx();
         };
+        // A failed group action pins the Add to Group flyout open on pointer-leave
+        // (scheduleGroupFlyoutClose bails so the message stays readable). Closing the
+        // MENU would dispose that flyout and its error with it, so the close bails
+        // while the error is ON SCREEN - and the flyout is the only thing that renders
+        // one, so on screen means the flyout is open.
+        //
+        // groupFlyoutHasError() ALONE IS NOT THAT CONDITION. workgroupGroupsStore.error
+        // is a sticky PROJECT-WIDE flag: any failed groups write (another workgroup, the
+        // Edit-groups modal) or an invalid groups.toml at load sets it, and only a LATER
+        // successful save clears it. Bailing on it bare disables the pointer-leave close
+        // for every replica menu in the project, with nothing on screen to explain it,
+        // which is #977 itself reintroduced through the back door.
+        const groupErrorPinned = () => groupFlyoutOpen() && groupFlyoutHasError();
         const scheduleReplicaCtxMenuClose = () => {
           cancelReplicaCtxMenuClose();
-          // A failed group action pins the Add to Group flyout open on pointer-leave
-          // (scheduleGroupFlyoutClose bails on the same predicate). Closing the menu
-          // would dispose that flyout and its error with it, so bail identically.
-          if (groupFlyoutHasError()) return;
+          if (groupErrorPinned()) return;
           replicaCtxMenuCloseTimer = window.setTimeout(() => {
             replicaCtxMenuCloseTimer = undefined;
-            if (groupFlyoutHasError()) return;
+            if (groupErrorPinned()) return;
             closeReplicaCtxMenu();
           }, CONTEXT_MENU_CLOSE_GRACE_MS);
         };


### PR DESCRIPTION
Closes #977

The Sidebar replica context menu stayed open after the pointer left it, and two of its items (`Restart Session`, `Coding Agent`) rendered without the leading icon every other item has.

## What changed

Frontend only, `src/sidebar/components/ProjectPanel.tsx` (+69/-8 net across the branch) plus test files. No Rust, `src/shared/types.ts` untouched, no new dependency.

- **Close on pointer leave.** One component-scoped timer (`CONTEXT_MENU_CLOSE_GRACE_MS = 250`), scheduled on the menu's `mouseleave` and cancelled on re-entry. Both submenus (the repo browse flyout and Add to Group) render in their own `<Portal>`, so they are not DOM descendants of the menu and crossing into one fires the menu's `mouseleave`; their `mouseenter` cancels the pending close, which is what keeps submenu navigation working. `cleanupCtx()` also cancels the timer, so a stale timer from one row cannot kill a menu freshly opened on another row (or strip its Escape / click-outside listeners). Existing dismissal paths are unchanged.
- **Icons**, using the menu's existing entity+label pattern: `↺ Restart Session` and `🤖 Coding Agent` (the robot on both the active and the inactive branch of the item).

## Review

Grinch FAILed round 1 with two HIGH findings, both real:

1. The close bailed on `groupFlyoutHasError()`, but `workgroupGroupsStore.error` is a **sticky, project-wide** flag set by any failed groups write or an invalid `groups.toml` at load, and cleared only by a later successful save. Bailing on it bare meant one failed groups write anywhere in the project silently disabled the pointer-leave close for every replica menu in that project, with no error on screen: #977 reintroduced through the back door. Fixed by gating on `groupFlyoutOpen() && groupFlyoutHasError()`, so the close only bails while the error is actually on screen.
2. A reported mutation result had not been run. The guard above had **zero** coverage (the test cited advanced 240ms against a 250ms grace, so the timer could never fire). Now covered from both sides: one test goes red if the guard is removed, another goes red if it is widened back to the sticky flag.

Grinch's round-1 concern that the reposition write re-creates the menu DOM (which would break the hover chain) was **disproved and withdrawn**: `babel-preset-solid` runs with `wrapConditionals: true`, so `{replicaCtxMenu() && <Portal>…}` memoizes on the condition's truthiness and the `{...current, x, y}` write changes identity but not truthiness. The Portal is not rebuilt, only the fine-grained `style` effect re-runs. Confirmed by reading the emitted code and by a test that asserts the element is the same connected node after a clamp that provably moved it. Round 2: **PASS**, no remaining findings.

## Gates

`npm run typecheck` clean. `npm run test`: 122 files / 1024 tests, 0 failed (+4 new cases).

## Known limitation (follow-up, not a regression)

The viewport clamp means a right-click within the 8px strip at the right or bottom edge can place the menu so the cursor is never inside it. You cannot leave what you never entered, so no `mouseleave` fires and that one menu stays open until click or Escape. It is strictly no worse than `main` (where the menu never closed on pointer-leave anywhere). The follow-up is to flip the menu around the cursor instead of clamping it under the viewport edge, which `positionGroupFlyout` already does in this same file.
