### PR TITLE
fix(#973): spawn the PTY at the real size, and never resize a child that has not rendered (the blank terminal)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -10,7 +10,7 @@ use crate::config::agent_config::{self, AgentLocalConfig};
 use crate::config::coordinator_clocks::CoordinatorClocksState;
 use crate::config::sessions_persistence::persist_current_state;
 use crate::config::settings::{AppSettings, SettingsState};
-use crate::pty::backend::{BackendSpawnSpec, SessionBackendKind};
+use crate::pty::backend::{BackendSpawnSpec, PtyViewport, SessionBackendKind};
 use crate::pty::container_paths::{
     claude_config_dir_no_value_warning, container_config_dir, ContainerEnvWarning,
     ContainerPathMap, CLAUDE_CONFIG_DIR_KEY,
@@ -956,6 +956,9 @@ pub async fn create_session_inner<R: tauri::Runtime>(
     git_repos: Vec<SessionRepo>,
     mut skip_auto_resume: bool,
     resolved_spawn: Option<AgentSpawnCommand>,
+    // #973 - the size the view has already fitted to, when the caller has a view at all.
+    // `None` keeps AC's historical 120x30. See `PtyViewport`.
+    viewport: Option<PtyViewport>,
 ) -> Result<SessionInfo, String> {
     let cwd = crate::path_utils::normalize_windows_verbatim_path(&cwd);
     let session_label = session_name.as_deref().unwrap_or(&shell).to_string();
@@ -1586,6 +1589,7 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         let _ = crate::config::config_seed::perform_config_seed(seed, &id.to_string());
     }
 
+    let viewport = viewport.unwrap_or(PtyViewport::DEFAULT);
     let spawn_spec = BackendSpawnSpec {
         id,
         agent_id: agent_id.clone(),
@@ -1602,8 +1606,12 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         } else {
             None
         },
-        cols: 120,
-        rows: 30,
+        // #973 - open the PTY at the size the terminal is actually going to be, so the
+        // frontend never has to resize a child that is still starting up. Callers with no
+        // view (restore loop, delivery loop, mailbox, CLI, tests) get PtyViewport::DEFAULT,
+        // which is the 120x30 AC always used.
+        cols: viewport.cols,
+        rows: viewport.rows,
         container_image: resolved_spawn
             .as_ref()
             .and_then(|spawn| spawn.backend.image.clone()),
@@ -1901,6 +1909,10 @@ pub async fn create_session(
     requested_profile: Option<String>,
     git_repos: Option<Vec<SessionRepo>>,
     skip_auto_resume: Option<bool>,
+    // #973 - the terminal size the view has already fitted to. Optional: an older frontend,
+    // or any caller that has no tile to measure, simply omits it and gets AC's 120x30.
+    cols: Option<u16>,
+    rows: Option<u16>,
 ) -> Result<SessionInfo, String> {
     let cfg = settings.read().await;
 
@@ -1960,6 +1972,11 @@ pub async fn create_session(
         // passes Some(false) so the prior conversation resumes.
         effective_create_skip_auto_resume(skip_auto_resume),
         resolved_spawn,
+        // #973 - the only caller that has a terminal to measure.
+        match (cols, rows) {
+            (Some(c), Some(r)) => Some(PtyViewport::from_fit(c, r)),
+            _ => None,
+        },
     )
     .await?;
 
@@ -2815,6 +2832,8 @@ pub async fn restart_session_inner_with_activation<R: tauri::Runtime>(
         git_repos,
         restart_start_fresh,
         resolved_spawn,
+        // #973 - headless caller: no terminal to measure, keep 120x30.
+        None,
     )
     .await?;
 
@@ -3395,6 +3414,8 @@ pub(crate) async fn create_root_agent_inner(
             skip_auto_resume_for_new_session
         },
         resolved_spawn,
+        // #973 - headless caller: no terminal to measure, keep 120x30.
+        None,
     )
     .await?;
 
@@ -3839,6 +3860,8 @@ mod tests {
     struct FailingSpawnBackend {
         spawned: Mutex<Vec<Uuid>>,
         killed: Mutex<Vec<Uuid>>,
+        /// #973 - every (cols, rows) a spawn was asked for.
+        sizes: Mutex<Vec<(u16, u16)>>,
     }
 
     impl FailingSpawnBackend {
@@ -3848,6 +3871,11 @@ mod tests {
 
         fn killed(&self) -> Vec<Uuid> {
             self.killed.lock().unwrap().clone()
+        }
+
+        /// #973 - the sizes the PTY would have been opened at.
+        fn sizes(&self) -> Vec<(u16, u16)> {
+            self.sizes.lock().unwrap().clone()
         }
     }
 
@@ -3862,6 +3890,8 @@ mod tests {
         ) -> futures::future::BoxFuture<'_, Result<(), crate::errors::AppError>> {
             Box::pin(async move {
                 self.spawned.lock().unwrap().push(spec.id);
+                // #973 - the size the ConPTY would have been opened at.
+                self.sizes.lock().unwrap().push((spec.cols, spec.rows));
                 Err(crate::errors::AppError::PtyError(
                     "synthetic spawn failure".to_string(),
                 ))
@@ -4047,6 +4077,8 @@ mod tests {
             Vec::new(),
             true,
             None,
+            // #973 - headless caller: no terminal to measure, keep 120x30.
+            None,
         )
         .await
         .expect_err("spawn should fail");
@@ -4055,6 +4087,137 @@ mod tests {
         assert!(session_mgr.read().await.list_sessions().await.is_empty());
         assert_eq!(backend.killed(), backend.spawned());
         assert_eq!(backend.killed().len(), 1);
+    }
+
+    /// #973 - THE REGRESSION. Red against main, which hardcodes `cols: 120, rows: 30`.
+    ///
+    /// AC used to open every ConPTY at 120x30 and let the frontend correct it 300-500 ms
+    /// later. That correction lands inside a coding agent's TUI startup, and a resize there
+    /// makes Codex redraw its still-empty viewport and lose the wakeup for the content that
+    /// becomes ready straight after: a blank terminal, alive, until any key is pressed.
+    ///
+    /// Measured outside AC, on a bare ConPTY: opened at 120x30 and then resized in the
+    /// window, Codex comes up blank 8 times in 10. Opened at the size the view actually
+    /// wants, and never resized, 0 times in 10.
+    ///
+    /// This pins the plumbing: the size the caller supplies is the size the PTY is opened
+    /// at. It does not, and cannot, prove Codex stops hanging - that needs a real child in a
+    /// real ConPTY inside a ~100 ms race. The harness is the proof of that.
+    #[tokio::test]
+    async fn create_session_opens_the_pty_at_the_size_the_view_supplied() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = session_test_app(test_settings());
+        let app_handle = app.handle().clone();
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let backend = Arc::new(FailingSpawnBackend::default());
+        let pty_mgr = Arc::new(Mutex::new(crate::pty::manager::PtyManager::new_for_test(
+            backend.clone(),
+        )));
+
+        let _ = super::create_session_inner(
+            &app_handle,
+            &session_mgr,
+            &pty_mgr,
+            "missing-ac-test-command".to_string(),
+            Vec::new(),
+            temp.path().to_string_lossy().to_string(),
+            None,
+            None,
+            None,
+            true,
+            Vec::new(),
+            true,
+            None,
+            Some(crate::pty::backend::PtyViewport::from_fit(74, 23)),
+        )
+        .await;
+
+        assert_eq!(
+            backend.sizes(),
+            vec![(74, 23)],
+            "the PTY must be opened at the size the view fitted to, not at 120x30: \
+             opening at the wrong size is what forces the startup resize that loses \
+             Codex's first render (#973)"
+        );
+    }
+
+    /// #973 - backward compatibility. Every headless caller (startup restore, the delivery
+    /// loop, the phone mailbox, the CLI, tests) has no terminal to measure and must keep
+    /// AC's historical 120x30. Those sessions are never attached to a view, so nothing
+    /// resizes them, and none of them ever hit this bug.
+    #[tokio::test]
+    async fn create_session_without_a_view_keeps_the_historical_120x30() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = session_test_app(test_settings());
+        let app_handle = app.handle().clone();
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let backend = Arc::new(FailingSpawnBackend::default());
+        let pty_mgr = Arc::new(Mutex::new(crate::pty::manager::PtyManager::new_for_test(
+            backend.clone(),
+        )));
+
+        let _ = super::create_session_inner(
+            &app_handle,
+            &session_mgr,
+            &pty_mgr,
+            "missing-ac-test-command".to_string(),
+            Vec::new(),
+            temp.path().to_string_lossy().to_string(),
+            None,
+            None,
+            None,
+            true,
+            Vec::new(),
+            true,
+            None,
+            None, // no view
+        )
+        .await;
+
+        assert_eq!(
+            backend.sizes(),
+            vec![(120, 30)],
+            "a caller with no view must behave exactly as it did before #973"
+        );
+    }
+
+    /// #973 - xterm's `fit()` really does return a zero dimension while its container is
+    /// still being laid out. Opening a 0-column ConPTY would be worse than the bug we are
+    /// fixing, so a degenerate size must fall back rather than be honoured.
+    #[tokio::test]
+    async fn a_degenerate_fitted_size_falls_back_instead_of_opening_a_zero_column_pty() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = session_test_app(test_settings());
+        let app_handle = app.handle().clone();
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let backend = Arc::new(FailingSpawnBackend::default());
+        let pty_mgr = Arc::new(Mutex::new(crate::pty::manager::PtyManager::new_for_test(
+            backend.clone(),
+        )));
+
+        let _ = super::create_session_inner(
+            &app_handle,
+            &session_mgr,
+            &pty_mgr,
+            "missing-ac-test-command".to_string(),
+            Vec::new(),
+            temp.path().to_string_lossy().to_string(),
+            None,
+            None,
+            None,
+            true,
+            Vec::new(),
+            true,
+            None,
+            Some(crate::pty::backend::PtyViewport::from_fit(0, 0)),
+        )
+        .await;
+
+        assert_eq!(
+            backend.sizes(),
+            vec![(120, 30)],
+            "a 0x0 fit must fall back to the default, never open a 0-column ConPTY"
+        );
     }
 
     #[test]
@@ -4163,6 +4326,7 @@ mod tests {
                     Vec::new(),
                     true,
                     None,
+                    None, // #973 - no view in this test: 120x30
                 )
                 .await
             })
@@ -4240,6 +4404,7 @@ mod tests {
                     Vec::new(),
                     true,
                     None,
+                    None, // #973 - no view in this test: 120x30
                 )
                 .await
             })

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -4181,9 +4181,12 @@ mod tests {
         );
     }
 
-    /// #973 - xterm's `fit()` really does return a zero dimension while its container is
-    /// still being laid out. Opening a 0-column ConPTY would be worse than the bug we are
-    /// fixing, so a degenerate size must fall back rather than be honoured.
+    /// #973 - opening a 0-column ConPTY would be worse than the bug we are fixing, so a
+    /// degenerate fitted size must fall back rather than be honoured.
+    ///
+    /// It does not come from xterm: `fit()` clamps to MINIMUM_COLS = 2 / MINIMUM_ROWS = 1. It is
+    /// guarded because this is a `u16` boundary that anything upstream can hand a 0 to, and
+    /// because the cost of being wrong is a terminal with no screen at all.
     #[tokio::test]
     async fn a_degenerate_fitted_size_falls_back_instead_of_opening_a_zero_column_pty() {
         let temp = tempfile::tempdir().unwrap();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1442,6 +1442,8 @@ pub fn run(
                                         ps.git_repos.clone(),
                                         false,
                                         resolved_spawn,
+                                        // #973 - headless caller: no terminal to measure, keep 120x30.
+                                        None,
                                     )
                                     .await
                                     {
@@ -1812,6 +1814,8 @@ pub fn run(
                             ps.git_repos.clone(),
                             skip_auto_resume_for_restore(ps.start_fresh_on_restore), // (#630/#631) resume unless restarted fresh
                             resolved_spawn,
+                            // #973 - headless caller: no terminal to measure, keep 120x30.
+                            None,
                         ).await {
                             Ok(info) => {
                                 if ps.was_active {

--- a/src-tauri/src/loops/delivery.rs
+++ b/src-tauri/src/loops/delivery.rs
@@ -377,6 +377,8 @@ async fn spawn_coordinator_session(
         Vec::<SessionRepo>::new(),
         loop_spawn_skip_auto_resume(had_existing_match),
         command.resolved_spawn,
+        // #973 - headless caller: no terminal to measure, keep 120x30.
+        None,
     )
     .await?;
     let session_id = Uuid::parse_str(&info.id)

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -2897,6 +2897,8 @@ impl MailboxPoller {
             Vec::new(),       // git_repos
             skip_auto_resume, // see deliver_wake top
             resolved_spawn,
+            // #973 - headless caller: no terminal to measure, keep 120x30.
+            None,
         )
         .await
     }
@@ -6048,6 +6050,8 @@ impl MailboxPoller {
                 Vec::new(),  // git_repos
                 true,        // skip_auto_resume = true → CLI session-request is a fresh create
                 resolved_spawn,
+                // #973 - headless caller: no terminal to measure, keep 120x30.
+                None,
             )
             .await
             {

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -18,6 +18,52 @@ pub enum SessionBackendKind {
     ContainerTransport,
 }
 
+/// #973 - the terminal size a session's PTY is opened at.
+///
+/// AC used to open every ConPTY at a hardcoded 120x30 and let the frontend correct it a few
+/// hundred milliseconds later. That correction lands in the middle of a coding agent's TUI
+/// startup, and a resize there makes Codex redraw its still-empty viewport and lose the
+/// wakeup for the content that becomes ready right after: the terminal stays blank, alive,
+/// until any key is pressed. Measured, outside AC: a resize burst at 250 ms hangs it 8/10;
+/// opening at the right size and never resizing hangs it 0/10.
+///
+/// So the size the view has already fitted to is handed down at spawn, and no resize has to
+/// happen at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PtyViewport {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+impl PtyViewport {
+    /// What AC has always opened PTYs at. Used by every caller with no view of its own:
+    /// the startup-restore loop, the delivery loop, the phone mailbox, the CLI, tests.
+    /// Those sessions are not attached to a terminal, so nothing resizes them, so they were
+    /// never exposed to this bug (18/18 of them painted in the user's production log).
+    pub const DEFAULT: Self = Self {
+        cols: 120,
+        rows: 30,
+    };
+
+    /// A size the frontend fitted before the session existed.
+    ///
+    /// A zero dimension is not hypothetical: xterm's `fit()` really does return one while
+    /// its container is still being laid out. Opening a 0-column ConPTY is worse than the
+    /// bug we are fixing, so a degenerate size warns and falls back instead of failing the
+    /// spawn.
+    pub fn from_fit(cols: u16, rows: u16) -> Self {
+        if cols == 0 || rows == 0 {
+            log::warn!(
+                "[pty] ignoring degenerate fitted viewport {cols}x{rows}, opening at {}x{}",
+                Self::DEFAULT.cols,
+                Self::DEFAULT.rows
+            );
+            return Self::DEFAULT;
+        }
+        Self { cols, rows }
+    }
+}
+
 pub struct BackendSpawnSpec {
     pub id: Uuid,
     /// #942 - the configured coding-agent PROFILE id (`settings.agents[].id`, an

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -45,16 +45,35 @@ impl PtyViewport {
         rows: 30,
     };
 
+    /// The smallest viewport that could plausibly be a terminal a human is looking at.
+    ///
+    /// A `> 0` check is not enough. xterm does not hand back a zero for a degenerate box - it
+    /// clamps to its own MINIMUM_COLS = 2 / MINIMUM_ROWS = 1 (`@xterm/addon-fit`) - so a
+    /// container that is laid out but collapsed yields a perfectly well-formed **2x1**, which
+    /// sails straight through a zero check and opens the ConPTY at 2x1. That is not a wedge: it
+    /// drifts, the view corrects it, and the drift is now warned about. But it is not a size any
+    /// real view asked for, and a TUI that comes up believing it has two columns lays itself out
+    /// around that before anyone can tell it otherwise.
+    ///
+    /// 20x5 is a floor, not a judgement about what is usable: it only has to be low enough that
+    /// no real terminal ever trips it and high enough that a collapsed box always does.
+    const PLAUSIBLE_MIN: Self = Self { cols: 20, rows: 5 };
+
     /// A size the frontend fitted before the session existed.
     ///
-    /// A zero dimension is not hypothetical: xterm's `fit()` really does return one while
-    /// its container is still being laid out. Opening a 0-column ConPTY is worse than the
-    /// bug we are fixing, so a degenerate size warns and falls back instead of failing the
-    /// spawn.
+    /// Anything below `PLAUSIBLE_MIN` warns and falls back to `DEFAULT` rather than failing the
+    /// spawn: a bad fit should cost the user a corrective resize, never a session.
+    ///
+    /// **Spawn only.** There is deliberately NO floor on the resize path. A user really can drag
+    /// a window down to a handful of columns, and refusing to follow them there would strand the
+    /// PTY at a size the terminal is not - which is the exact bug class #973 exists to close. The
+    /// resize path refuses a degenerate size and nothing else.
     pub fn from_fit(cols: u16, rows: u16) -> Self {
-        if cols == 0 || rows == 0 {
+        if cols < Self::PLAUSIBLE_MIN.cols || rows < Self::PLAUSIBLE_MIN.rows {
             log::warn!(
-                "[pty] ignoring degenerate fitted viewport {cols}x{rows}, opening at {}x{}",
+                "[pty] ignoring implausible fitted viewport {cols}x{rows} (floor {}x{}), opening at {}x{}",
+                Self::PLAUSIBLE_MIN.cols,
+                Self::PLAUSIBLE_MIN.rows,
                 Self::DEFAULT.cols,
                 Self::DEFAULT.rows
             );
@@ -131,4 +150,35 @@ pub trait PtyBackend: Any + Send + Sync {
     fn publish_stop_witness(&self, _id: Uuid, _source: &str) {}
 
     fn kill_all_jobs(&self) -> (usize, usize);
+}
+#[cfg(test)]
+mod pty_viewport_tests {
+    use super::PtyViewport;
+
+    /// #973 - the size a real view fitted is handed down untouched. That is the whole point of
+    /// the type: the PTY opens at the size the terminal already is, so nothing has to resize it
+    /// during the child's startup.
+    #[test]
+    fn a_real_fitted_size_is_handed_down_as_is() {
+        assert_eq!(
+            PtyViewport::from_fit(74, 23),
+            PtyViewport { cols: 74, rows: 23 }
+        );
+        // right on the floor, and still a real terminal
+        assert_eq!(
+            PtyViewport::from_fit(20, 5),
+            PtyViewport { cols: 20, rows: 5 }
+        );
+    }
+
+    /// #973 - the case a zero check misses. xterm clamps a collapsed container to 2x1 rather
+    /// than reporting a zero, so `2x1` is what a degenerate box actually looks like coming out
+    /// of `fit()` - well-formed, positive, and not a terminal anybody is looking at.
+    #[test]
+    fn a_collapsed_box_does_not_open_the_pty_at_two_by_one() {
+        assert_eq!(PtyViewport::from_fit(2, 1), PtyViewport::DEFAULT);
+        assert_eq!(PtyViewport::from_fit(19, 40), PtyViewport::DEFAULT);
+        assert_eq!(PtyViewport::from_fit(80, 4), PtyViewport::DEFAULT);
+        assert_eq!(PtyViewport::from_fit(0, 0), PtyViewport::DEFAULT);
+    }
 }

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -55,6 +55,24 @@ struct PtyInstance {
 /// inside the window, because the window is defined as the interval in which the child has
 /// rendered nothing. The trigger is immune to load, terminal height and frame count.
 ///
+/// **That argument only holds if the trigger actually tests rendering, so it does.** It asks the
+/// real, stateful vt100 parser - the one `handle_output` already feeds every byte of every chunk -
+/// whether the screen now holds a cell a human could see:
+/// `SessionIoFanout::has_rendered_visible_content`.
+///
+/// It is worth saying what it must NOT be, because the first version of this gate got it wrong and
+/// the mistake was invisible. It used the idle detector's text predicate
+/// (`output_has_printable_activity`), which asks whether a printable byte survives a STATELESS,
+/// per-chunk escape stripper. That is a different question, and it answers this one wrong twice:
+/// a chunk that ends mid-CSI or mid-OSC hands the tail to the next call with no leading `ESC`
+/// (`1049h`, `2J` and `cmd.exe` are all printable, and conhost really does split its writes), and
+/// a three-byte charset designator like `ESC ( B` - which ncurses and half the TUI world emit on
+/// the way up - outran a stripper that consumed `ESC` plus one char. Either one opens the gate on
+/// a child that has painted nothing, which is precisely the bug the gate exists to prevent, and
+/// it would have failed silently and intermittently inside an already intermittent bug. A parser
+/// carries state across reads and knows what an escape is, so both are closed by construction
+/// rather than by another special case.
+///
 /// **Why not #942's paint floor.** That floor is 256 bytes and the blank child sits at 345:
 /// it would fire for a child that is hung.
 ///
@@ -896,18 +914,31 @@ impl LocalProcessBackend {
                         // path: once the first byte is stamped and the head buffer is
                         // full this is two relaxed loads and one relaxed add.
                         record.note_output(&buf[..n]);
-                        // #973 (B) - has the child rendered anything yet? Once it has, this
-                        // is a single relaxed load per chunk and nothing else: no lock, no
-                        // allocation, no scan. Before it has, it is the same predicate the
-                        // idle detector runs on this chunk anyway.
+                        fanout.handle_output(
+                            &output_target,
+                            id,
+                            &session_id_str,
+                            buf[..n].to_vec(),
+                        );
+                        // #973 (B) - has the child PAINTED anything yet? Asked of the real vt100
+                        // parser that `handle_output` has just fed this chunk to, which is why it
+                        // is asked after it and not before.
+                        //
+                        // Once the child has painted, this is a single relaxed load per chunk and
+                        // nothing else: no lock, no scan, no allocation. Before it has, it is one
+                        // uncontended lock and a bounded scan of the grid - and it REPLACED a
+                        // second `from_utf8_lossy` + `strip_ansi_csi` over the whole chunk, which
+                        // `handle_output` was already paying for the idle detector on the very
+                        // same bytes. One less chunk-sized allocation per chunk, not one more.
+                        //
+                        // Locks: the query takes `screen_parsers` and RELEASES it before
+                        // `open_startup_gate` takes `ptys`. The two are sequential, never nested,
+                        // so the order stays `ptys -> startup_gate -> size -> master`.
                         if !rendered.load(Ordering::Relaxed)
-                            && crate::pty::output::output_has_printable_activity(
-                                &String::from_utf8_lossy(&buf[..n]),
-                            )
+                            && fanout.has_rendered_visible_content(id)
                         {
                             gate_backend.open_startup_gate(id);
                         }
-                        fanout.handle_output(&output_target, id, &session_id_str, buf[..n].to_vec())
                     }
                     Err(_) => break,
                 }

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -109,9 +109,12 @@ fn resize_instance(
     // child behind a 74x23 terminal. A size that must never reach the child must never be
     // allowed to displace one that must.
     //
-    // Real, not hypothetical: xterm's `fit()` returns a zero dimension while its container is
-    // still being laid out (the same hazard `PtyViewport::from_fit` guards at spawn), and
-    // `pty_resize` hands us whatever the view computed.
+    // Where a zero comes from, since we got this wrong once: NOT from xterm. `fit()` clamps to
+    // its own MINIMUM_COLS = 2 / MINIMUM_ROWS = 1 (`@xterm/addon-fit`), and `CoreTerminal.resize`
+    // rejects NaN and clamps again - the worst it can produce is NaN, which the frontend's
+    // `Number.isInteger` check catches. The zero comes off the WIRE: `pty_resize` on the web
+    // transport takes cols/rows straight from a JSON payload (`web/commands.rs`), and a client
+    // that is not xterm, or is simply broken, can put a 0 in it.
     if cols == 0 || rows == 0 {
         log::warn!("[pty] refusing degenerate resize {id} to {cols}x{rows} (#973)");
         return Ok(false);
@@ -152,11 +155,14 @@ fn send_size_to_conpty(
     cols: u16,
     rows: u16,
 ) -> Result<bool, AppError> {
-    // #973 - refuse a degenerate size. `pty_resize` hands us whatever the view computed, and
-    // xterm's `fit()` really does return a zero dimension while its container is still being
-    // laid out (the same hazard `PtyViewport::from_fit` guards at spawn). ConPTY does NOT
-    // reject it: `master.resize(0x0)` returns Ok and the child is left with no screen at all.
-    // A stale size is recoverable; a zero-column terminal is not.
+    // #973 - refuse a degenerate size. Defence in depth: the request path is guarded ahead of
+    // the gate in `resize_instance`, and this is the last line before `master.resize()`, which
+    // is also what `hand_over_held_size` calls with a size that has been sitting in the gate.
+    //
+    // It has to be refused SOMEWHERE, because ConPTY does not refuse it: `master.resize(0x0)`
+    // returns Ok and the child is left with no screen at all. A stale size is recoverable; a
+    // zero-column terminal is not. The zero itself comes off the wire, not from xterm - see
+    // `resize_instance`.
     if cols == 0 || rows == 0 {
         log::warn!("[pty] refusing degenerate resize {id} to {cols}x{rows} (#973)");
         return Ok(false);
@@ -1768,8 +1774,9 @@ mod startup_gate_tests {
             "nothing may reach a child that has not rendered yet"
         );
 
-        // ...and now a zero dimension arrives, still inside the startup window: xterm's `fit()`
-        // mid-layout, or a web client (`web/commands.rs` takes cols/rows straight off the wire).
+        // ...and now a zero dimension arrives, still inside the startup window. It comes off the
+        // wire: `web/commands.rs` takes cols/rows straight from a JSON payload. (Not from xterm -
+        // `fit()` clamps to 2x1 and cannot produce a zero.)
         assert!(
             !resize_instance(&instance, id, 0, 0).expect("must not error"),
             "a zero dimension must never be sent to the ConPTY"

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -30,6 +30,147 @@ struct PtyInstance {
     /// #973 (C) - the size the ConPTY is actually at, so a resize that changes nothing is
     /// not sent to the child. Seeded from the size the PTY was opened at.
     size: Mutex<(u16, u16)>,
+    /// #973 (B) - held closed until the child has rendered something. See `StartupGate`.
+    startup_gate: Mutex<StartupGate>,
+    /// #973 (B) - the same fact as the gate, as one relaxed atomic, so the PTY read loop
+    /// can skip the lock on every chunk once the child is up. The gate is the truth; this
+    /// is only a fast path, and a stale `false` costs one no-op call.
+    rendered: Arc<AtomicBool>,
+}
+
+/// #973 (B) - a PTY resize that lands while a coding agent's TUI is starting up makes it
+/// redraw its still-empty viewport and lose the wakeup for the content that becomes ready
+/// right after. The terminal stays blank, the process stays alive, and any keypress paints
+/// it. Measured on a bare ConPTY: a resize in that window blanks Codex 8 times in 10.
+///
+/// So AC does not resize a child that has not rendered anything yet. Resizes are held, the
+/// LAST one is kept, and it is applied the moment the child paints - which is the earliest
+/// moment it is safe to.
+///
+/// **Why the trigger is "has rendered" and not a timer.** The danger window is
+/// [TUI is up, content is ready], and both ends move with machine load: in production
+/// first-paint spans 324 ms to 2163 ms, while on an idle box the window sits at 180-300 ms.
+/// Any fixed delay is a constant fitted to one machine, and on a slower one it lands
+/// *inside* the window - a fix that reproduces the bug. A render, by contrast, cannot happen
+/// inside the window, because the window is defined as the interval in which the child has
+/// rendered nothing. The trigger is immune to load, terminal height and frame count.
+///
+/// **Why not #942's paint floor.** That floor is 256 bytes and the blank child sits at 345:
+/// it would fire for a child that is hung.
+///
+/// **Why there is no timeout escape.** A child that never renders is showing nothing, so a
+/// resize it never receives changes nothing a user can see - and the instant it does render,
+/// the size it should have had is applied. A timeout would be the very constant this design
+/// exists to avoid. Shells are unaffected: a prompt is printable, so their gate opens on the
+/// first chunk.
+enum StartupGate {
+    /// The child has not rendered yet. Resizes are held here, last one wins.
+    Holding(Option<(u16, u16)>),
+    /// The child has rendered. Resizes go straight through, forever.
+    Open,
+}
+
+/// #973 - decide what to do with a resize the view asked for, and do it. This is the whole
+/// of B and C, and it is a free function over the instance so it can be tested against a
+/// real ConPTY: the backend itself cannot be built in a unit test, because its `GitWatcher`
+/// needs a Tauri `AppHandle`, and none of that has anything to do with resizing a PTY.
+///
+/// Returns whether the ConPTY was actually resized.
+fn resize_instance(
+    instance: &PtyInstance,
+    id: Uuid,
+    cols: u16,
+    rows: u16,
+) -> Result<bool, AppError> {
+    // B - do not resize a child that has not rendered anything yet. The view fires its fit
+    // 300-500 ms after spawn, which is exactly when a coding agent's TUI is coming up, and a
+    // resize there costs it its first content render. Hold the size; the read loop hands it
+    // over the moment the child paints. See `StartupGate`.
+    {
+        let mut gate = instance
+            .startup_gate
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if gate.on_resize(cols, rows).is_none() {
+            log::debug!(
+                "[pty] resize {id} to {cols}x{rows} held: the child has not rendered yet (#973)"
+            );
+            return Ok(false);
+        }
+    }
+    send_size_to_conpty(instance, id, cols, rows)
+}
+
+/// #973 (C) - do not tell the child about a resize that is not a resize.
+///
+/// ConPTY delivers even a same-size `ResizePseudoConsole` to the client as a real event, and
+/// the view fires 5-20 identical resizes per attach (`TerminalView.tsx:85-95`, a double
+/// `requestAnimationFrame` plus a `ResizeObserver`), so today every attach shakes the child
+/// for nothing.
+///
+/// The cached size is written only AFTER the ConPTY has accepted the new one: if the resize
+/// failed and we recorded it anyway, every retry would be skipped as a no-op and the PTY
+/// would be wedged at the wrong size forever.
+fn send_size_to_conpty(
+    instance: &PtyInstance,
+    id: Uuid,
+    cols: u16,
+    rows: u16,
+) -> Result<bool, AppError> {
+    // #973 - refuse a degenerate size. `pty_resize` hands us whatever the view computed, and
+    // xterm's `fit()` really does return a zero dimension while its container is still being
+    // laid out (the same hazard `PtyViewport::from_fit` guards at spawn). ConPTY does NOT
+    // reject it: `master.resize(0x0)` returns Ok and the child is left with no screen at all.
+    // A stale size is recoverable; a zero-column terminal is not.
+    if cols == 0 || rows == 0 {
+        log::warn!("[pty] refusing degenerate resize {id} to {cols}x{rows} (#973)");
+        return Ok(false);
+    }
+
+    if !instance.size_changed(cols, rows) {
+        log::debug!("[pty] resize {id} skipped: already {cols}x{rows} (#973)");
+        return Ok(false);
+    }
+
+    {
+        let master = instance
+            .master
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        master
+            .resize(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| AppError::PtyError(e.to_string()))?;
+    }
+    instance.remember_size(cols, rows);
+    Ok(true)
+}
+
+impl StartupGate {
+    /// The view asked for a resize. Returns the size to hand the ConPTY, or `None` if the
+    /// child is still starting up and it must be held.
+    fn on_resize(&mut self, cols: u16, rows: u16) -> Option<(u16, u16)> {
+        match self {
+            StartupGate::Holding(pending) => {
+                // Only the last size matters: the frontend fires 5-20 of these per attach.
+                *pending = Some((cols, rows));
+                None
+            }
+            StartupGate::Open => Some((cols, rows)),
+        }
+    }
+
+    /// The child rendered. Open the gate for good and hand back the size that was held.
+    fn open(&mut self) -> Option<(u16, u16)> {
+        match std::mem::replace(self, StartupGate::Open) {
+            StartupGate::Holding(pending) => pending,
+            StartupGate::Open => None,
+        }
+    }
 }
 
 impl PtyInstance {
@@ -621,6 +762,8 @@ impl LocalProcessBackend {
             }
         };
 
+        // #973 (B) - the child has rendered nothing yet, so the gate starts closed.
+        let rendered = Arc::new(AtomicBool::new(false));
         let instance = PtyInstance {
             master: Arc::new(Mutex::new(pair.master)),
             writer: Arc::new(Mutex::new(writer)),
@@ -628,6 +771,8 @@ impl LocalProcessBackend {
             job,
             // #973 - the size we actually opened the ConPTY at (see PtyViewport).
             size: Mutex::new((cols, rows)),
+            startup_gate: Mutex::new(StartupGate::Holding(None)),
+            rendered: Arc::clone(&rendered),
         };
 
         self.ptys
@@ -680,6 +825,7 @@ impl LocalProcessBackend {
 
         let session_id_str = id.to_string();
         let fanout = self.fanout.clone();
+        let gate_backend = self.clone();
         std::thread::spawn(move || {
             let mut buf = [0u8; 4096];
             loop {
@@ -690,6 +836,17 @@ impl LocalProcessBackend {
                         // path: once the first byte is stamped and the head buffer is
                         // full this is two relaxed loads and one relaxed add.
                         record.note_output(&buf[..n]);
+                        // #973 (B) - has the child rendered anything yet? Once it has, this
+                        // is a single relaxed load per chunk and nothing else: no lock, no
+                        // allocation, no scan. Before it has, it is the same predicate the
+                        // idle detector runs on this chunk anyway.
+                        if !rendered.load(Ordering::Relaxed)
+                            && crate::pty::output::output_has_printable_activity(
+                                &String::from_utf8_lossy(&buf[..n]),
+                            )
+                        {
+                            gate_backend.open_startup_gate(id);
+                        }
                         fanout.handle_output(&output_target, id, &session_id_str, buf[..n].to_vec())
                     }
                     Err(_) => break,
@@ -698,6 +855,49 @@ impl LocalProcessBackend {
         });
 
         Ok(())
+    }
+
+    /// #973 (B) - the child has rendered something, so the startup window is behind us.
+    /// Open the gate for good and hand the ConPTY the size the view has been waiting to give
+    /// it. Called from the PTY read loop, once per session in practice.
+    fn open_startup_gate(&self, id: Uuid) {
+        let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(instance) = ptys.get(&id) else {
+            return;
+        };
+
+        // One lock covers both "take the held size" and "open the gate", so a resize landing
+        // at this exact instant cannot be recorded into a gate that is already open and then
+        // dropped on the floor, leaving the terminal stuck at the wrong size.
+        let pending = {
+            let mut gate = instance
+                .startup_gate
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            gate.open()
+        };
+        // Only a fast path for the read loop; the gate above is the truth. Publishing it
+        // late is safe: a stale `false` costs one extra no-op call to this function.
+        instance.rendered.store(true, Ordering::Relaxed);
+
+        let Some((cols, rows)) = pending else {
+            return;
+        };
+
+        match send_size_to_conpty(instance, id, cols, rows) {
+            Ok(true) => {
+                drop(ptys);
+                log::info!(
+                    "[pty] startup gate open for {id}: applied the held resize {cols}x{rows} (#973)"
+                );
+                self.fanout.resize_screen_and_broadcast(id, cols, rows);
+            }
+            Ok(false) => {}
+            Err(e) => {
+                // Non-critical: the child is up and painting, it is just the wrong size.
+                log::warn!("[pty] held resize {id} to {cols}x{rows} failed: {e} (#973)");
+            }
+        }
     }
 
     /// #942 - liveness of the child of a session, without disturbing it. Never blocks
@@ -894,47 +1094,16 @@ impl PtyBackend for LocalProcessBackend {
     fn resize(&self, id: Uuid, cols: u16, rows: u16) -> Result<(), AppError> {
         self.fanout.record_resize(id);
 
-        let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
-        let instance = ptys
-            .get(&id)
-            .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
-
-        // #973 (C) - do not tell the child about a resize that is not a resize.
-        //
-        // ConPTY delivers even a same-size ResizePseudoConsole to the client as a real
-        // event, and the frontend fires 5-20 identical ones per attach, so today every
-        // attach shakes the child for nothing.
-        //
-        // This does NOT fix #973 by itself: a single resize that DOES change the size,
-        // landing in the child's startup window, still loses Codex's first content render
-        // 8 times in 10 (measured). The fix for that is opening the PTY at the right size
-        // in the first place (`PtyViewport`); this is what stops the frontend's follow-up
-        // fit from undoing it.
-        //
-        // Deliberately NOT skipped: `record_resize` above and the screen broadcast below.
-        // They drive the idle grace and the vt100 screen, and changing idle semantics is
-        // #954's business, not this issue's.
-        if !instance.size_changed(cols, rows) {
-            log::debug!("[pty] resize {id} skipped: already {cols}x{rows}");
-            drop(ptys);
-            self.fanout.resize_screen_and_broadcast(id, cols, rows);
-            return Ok(());
-        }
-
         {
-            let master = instance.master.lock().unwrap_or_else(|e| e.into_inner());
-            master
-                .resize(PtySize {
-                    rows,
-                    cols,
-                    pixel_width: 0,
-                    pixel_height: 0,
-                })
-                .map_err(|e| AppError::PtyError(e.to_string()))?;
+            let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
+            let instance = ptys
+                .get(&id)
+                .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
+            resize_instance(instance, id, cols, rows)?;
         }
-        instance.remember_size(cols, rows);
-        drop(ptys);
 
+        // The screen and the idle grace see every resize the view asked for, held or not:
+        // only the ConPTY call is gated. Idle semantics are #954's, not this fix's.
         self.fanout.resize_screen_and_broadcast(id, cols, rows);
 
         Ok(())
@@ -1338,5 +1507,208 @@ mod resize_dedup_tests {
         // now it succeeds
         PtyInstance::remember_size_in(&size, 100, 40);
         assert!(!PtyInstance::size_changed_in(&size, 100, 40));
+    }
+}
+
+#[cfg(test)]
+mod startup_gate_tests {
+    use super::{resize_instance, send_size_to_conpty, PtyInstance, StartupGate};
+    use portable_pty::{native_pty_system, MasterPty, PtySize};
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{Arc, Mutex};
+    use uuid::Uuid;
+
+    /// A real ConPTY, with no child. `LocalProcessBackend` itself cannot be built here (its
+    /// `GitWatcher` needs a Tauri `AppHandle`), and it does not need to be: `PtyBackend::resize`
+    /// is a four-line wrapper - lock, delegate to `resize_instance`, broadcast - and
+    /// `resize_instance` is the whole of the decision.
+    fn conpty(cols: u16, rows: u16) -> (PtyInstance, Arc<Mutex<Box<dyn MasterPty + Send>>>) {
+        let pair = native_pty_system()
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty");
+        drop(pair.slave);
+
+        let master: Arc<Mutex<Box<dyn MasterPty + Send>>> = Arc::new(Mutex::new(pair.master));
+        let instance = PtyInstance {
+            master: Arc::clone(&master),
+            writer: Arc::new(Mutex::new(Box::new(std::io::sink()))),
+            child: None,
+            job: None,
+            size: Mutex::new((cols, rows)),
+            startup_gate: Mutex::new(StartupGate::Holding(None)),
+            rendered: Arc::new(AtomicBool::new(false)),
+        };
+        (instance, master)
+    }
+
+    /// What the CHILD would see. This is the point of these tests: not what AC believes.
+    fn size_the_child_sees(master: &Arc<Mutex<Box<dyn MasterPty + Send>>>) -> (u16, u16) {
+        let s = master.lock().unwrap().get_size().expect("get_size");
+        (s.cols, s.rows)
+    }
+
+    /// #973 - THE COLD-START CASE. This is the one the user hits every morning.
+    ///
+    /// `TerminalView` lives inside `<Show when={activeSessionId}>`, so when the app opens
+    /// with no active session there is no terminal host to measure, and the frontend cannot
+    /// supply a size. The PTY is opened at 120x30, the view then mounts, fits, and fires its
+    /// resize burst 300-500 ms later - straight into the startup window of the first coding
+    /// agent the user launches. **Option A cannot cover this. This is what covers it.**
+    ///
+    /// Red without the gate: the resize reaches the ConPTY immediately, and the child is
+    /// resized while it is still coming up, which is what costs Codex its first content
+    /// render (measured: 8 blanks in 10).
+    #[test]
+    fn a_session_opened_without_a_view_size_holds_the_burst_until_the_child_renders() {
+        let (instance, master) = conpty(120, 30);
+        let id = Uuid::new_v4();
+
+        // the view mounts and fits: 6 identical resizes inside a few milliseconds
+        for _ in 0..6 {
+            let sent = resize_instance(&instance, id, 74, 23).expect("resize");
+            assert!(!sent, "nothing may reach a child that has not rendered yet");
+        }
+
+        assert_eq!(
+            size_the_child_sees(&master),
+            (120, 30),
+            "the child has rendered nothing yet, so the ConPTY must NOT have been resized"
+        );
+
+        // the child paints
+        let held = instance
+            .startup_gate
+            .lock()
+            .unwrap()
+            .open()
+            .expect("the size the view asked for must have been kept");
+        send_size_to_conpty(&instance, id, held.0, held.1).expect("apply");
+
+        assert_eq!(
+            size_the_child_sees(&master),
+            (74, 23),
+            "once the child has rendered, the size it should have had must be applied"
+        );
+    }
+
+    /// The view fires 5-20 resizes per attach. Only the last is real; replaying all of them
+    /// at the child would be churn for nothing.
+    #[test]
+    fn only_the_last_held_size_reaches_the_child() {
+        let (instance, master) = conpty(120, 30);
+        let id = Uuid::new_v4();
+
+        resize_instance(&instance, id, 74, 23).expect("resize");
+        resize_instance(&instance, id, 90, 40).expect("resize");
+        resize_instance(&instance, id, 74, 24).expect("resize");
+        assert_eq!(size_the_child_sees(&master), (120, 30), "all of them held");
+
+        let held = instance.startup_gate.lock().unwrap().open().expect("held");
+        send_size_to_conpty(&instance, id, held.0, held.1).expect("apply");
+
+        assert_eq!(
+            size_the_child_sees(&master),
+            (74, 24),
+            "only the last size the view asked for should reach the child"
+        );
+    }
+
+    /// Once the child is up, AC gets out of the way: every later resize - the user dragging
+    /// the window - goes straight through, forever. A gate that never reopened would leave
+    /// the terminal unable to follow its window.
+    #[test]
+    fn once_the_child_has_rendered_resizes_go_straight_through() {
+        let (instance, master) = conpty(120, 30);
+        let id = Uuid::new_v4();
+
+        instance.startup_gate.lock().unwrap().open(); // the child rendered, nothing held
+
+        assert!(resize_instance(&instance, id, 74, 23).expect("resize"));
+        assert_eq!(size_the_child_sees(&master), (74, 23));
+
+        assert!(resize_instance(&instance, id, 100, 50).expect("resize"));
+        assert_eq!(
+            size_the_child_sees(&master),
+            (100, 50),
+            "the gate must not close again"
+        );
+    }
+
+    /// #973 (C) - a resize that changes nothing must not be sent. ConPTY hands even a
+    /// same-size resize to the child as a real event, and the view fires 5-20 of them.
+    #[test]
+    fn a_resize_that_changes_nothing_is_not_sent() {
+        let (instance, id) = (conpty(74, 23).0, Uuid::new_v4());
+        instance.startup_gate.lock().unwrap().open();
+
+        assert!(
+            !resize_instance(&instance, id, 74, 23).expect("resize"),
+            "the ConPTY is already 74x23: nothing should be sent"
+        );
+        assert!(
+            resize_instance(&instance, id, 74, 24).expect("resize"),
+            "one row is a real resize and must be sent"
+        );
+    }
+
+    /// #973 - a degenerate resize must be refused, and it must not be cached.
+    ///
+    /// This test caught a real one. I had assumed portable-pty would reject `0x0`. **It does
+    /// not**: `master.resize(0x0)` returns Ok and the ConPTY is genuinely set to zero, so
+    /// before the guard this test failed with `left: (0, 0)`. `pty_resize` passes the view's
+    /// numbers straight down, and xterm's `fit()` returns a zero dimension while its
+    /// container is still being laid out - the exact hazard `PtyViewport::from_fit` guards
+    /// at spawn. The resize path had no such guard.
+    ///
+    /// The cache matters as much as the refusal: if a size the ConPTY never took were
+    /// cached, every retry would be skipped as a no-op and the terminal would be wedged at
+    /// the wrong size forever.
+    #[test]
+    fn a_degenerate_resize_is_refused_and_does_not_poison_the_cache() {
+        let (instance, master) = conpty(120, 30);
+        let id = Uuid::new_v4();
+        instance.startup_gate.lock().unwrap().open();
+
+        assert!(
+            !send_size_to_conpty(&instance, id, 0, 0).expect("must not error"),
+            "a zero dimension must never be sent to the ConPTY"
+        );
+        assert_eq!(
+            size_the_child_sees(&master),
+            (120, 30),
+            "ConPTY accepts a 0x0 resize without complaint, so AC has to refuse it"
+        );
+        assert_eq!(
+            *instance.size.lock().unwrap(),
+            (120, 30),
+            "and it must not be cached, or the next real resize is skipped as a no-op"
+        );
+
+        assert!(
+            send_size_to_conpty(&instance, id, 74, 23).expect("resize"),
+            "a real resize after a refused one must still go through"
+        );
+        assert_eq!(size_the_child_sees(&master), (74, 23));
+    }
+
+    /// The gate is a two-state machine. Pin it directly, including the ordering trap: the
+    /// hand-over happens exactly once, and after it the gate is open for good.
+    #[test]
+    fn the_gate_hands_over_exactly_once() {
+        let mut gate = StartupGate::Holding(None);
+        assert_eq!(gate.on_resize(74, 23), None, "held");
+        assert_eq!(gate.on_resize(74, 24), None, "held, replacing the first");
+        assert_eq!(gate.open(), Some((74, 24)), "the last held size, handed over once");
+        assert_eq!(gate.open(), None, "a second open hands over nothing");
+        assert_eq!(
+            gate.on_resize(80, 25),
+            Some((80, 25)),
+            "the gate is open now: resizes go straight through"
+        );
     }
 }

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -82,6 +82,23 @@ fn resize_instance(
     cols: u16,
     rows: u16,
 ) -> Result<bool, AppError> {
+    // #973 - refuse a degenerate size FIRST, ahead of the gate.
+    //
+    // The gate is last-wins (`StartupGate::on_resize`), so a `0x0` reaching it OVERWRITES the
+    // real size the view is waiting to give the child. The hand-over then pops the `0x0`,
+    // `send_size_to_conpty` refuses it, the pending slot is consumed, and nothing retries: the
+    // ConPTY is wedged at the size it was opened at for good. On cold start that is a 120x30
+    // child behind a 74x23 terminal. A size that must never reach the child must never be
+    // allowed to displace one that must.
+    //
+    // Real, not hypothetical: xterm's `fit()` returns a zero dimension while its container is
+    // still being laid out (the same hazard `PtyViewport::from_fit` guards at spawn), and
+    // `pty_resize` hands us whatever the view computed.
+    if cols == 0 || rows == 0 {
+        log::warn!("[pty] refusing degenerate resize {id} to {cols}x{rows} (#973)");
+        return Ok(false);
+    }
+
     // B - do not resize a child that has not rendered anything yet. The view fires its fit
     // 300-500 ms after spawn, which is exactly when a coding agent's TUI is coming up, and a
     // resize there costs it its first content render. Hold the size; the read loop hands it
@@ -148,6 +165,49 @@ fn send_size_to_conpty(
     }
     instance.remember_size(cols, rows);
     Ok(true)
+}
+
+/// #973 (B) - the child has rendered something, so the startup window is behind us. Open the
+/// gate for good and hand the ConPTY the size the view has been waiting to give it.
+///
+/// Returns the size the ConPTY ACTUALLY took, so the caller can bring the vt100 screen along
+/// with it - and `None` if nothing was held, or the held size was refused, or it failed.
+///
+/// Free over the instance, like `resize_instance`, so the hand-over can be driven by a test
+/// against a real ConPTY: `open_startup_gate`, its only caller, needs a `LocalProcessBackend`,
+/// whose `GitWatcher` needs a Tauri `AppHandle`. A test that re-implemented these lines rather
+/// than calling them would not be testing this code.
+fn hand_over_held_size(instance: &PtyInstance, id: Uuid) -> Option<(u16, u16)> {
+    // One lock covers both "take the held size" and "open the gate", so a resize landing at
+    // this exact instant cannot be recorded into a gate that is already open and then dropped
+    // on the floor, leaving the terminal stuck at the wrong size.
+    let pending = {
+        let mut gate = instance
+            .startup_gate
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        gate.open()
+    };
+    // Only a fast path for the read loop; the gate above is the truth. Publishing it late is
+    // safe: a stale `false` costs one extra no-op call to this function.
+    instance.rendered.store(true, Ordering::Relaxed);
+
+    let (cols, rows) = pending?;
+
+    match send_size_to_conpty(instance, id, cols, rows) {
+        Ok(true) => {
+            log::info!(
+                "[pty] startup gate open for {id}: applied the held resize {cols}x{rows} (#973)"
+            );
+            Some((cols, rows))
+        }
+        Ok(false) => None,
+        Err(e) => {
+            // Non-critical: the child is up and painting, it is just the wrong size.
+            log::warn!("[pty] held resize {id} to {cols}x{rows} failed: {e} (#973)");
+            None
+        }
+    }
 }
 
 impl StartupGate {
@@ -857,46 +917,25 @@ impl LocalProcessBackend {
         Ok(())
     }
 
-    /// #973 (B) - the child has rendered something, so the startup window is behind us.
-    /// Open the gate for good and hand the ConPTY the size the view has been waiting to give
-    /// it. Called from the PTY read loop, once per session in practice.
+    /// #973 (B) - the child rendered. Hand the ConPTY the size the view has been waiting to
+    /// give it, and bring the vt100 screen with it. Called from the PTY read loop, once per
+    /// session in practice. The decision itself is `hand_over_held_size`.
     fn open_startup_gate(&self, id: Uuid) {
-        let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
-        let Some(instance) = ptys.get(&id) else {
-            return;
+        let applied = {
+            let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
+            let Some(instance) = ptys.get(&id) else {
+                return;
+            };
+            hand_over_held_size(instance, id)
         };
 
-        // One lock covers both "take the held size" and "open the gate", so a resize landing
-        // at this exact instant cannot be recorded into a gate that is already open and then
-        // dropped on the floor, leaving the terminal stuck at the wrong size.
-        let pending = {
-            let mut gate = instance
-                .startup_gate
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            gate.open()
-        };
-        // Only a fast path for the read loop; the gate above is the truth. Publishing it
-        // late is safe: a stale `false` costs one extra no-op call to this function.
-        instance.rendered.store(true, Ordering::Relaxed);
-
-        let Some((cols, rows)) = pending else {
-            return;
-        };
-
-        match send_size_to_conpty(instance, id, cols, rows) {
-            Ok(true) => {
-                drop(ptys);
-                log::info!(
-                    "[pty] startup gate open for {id}: applied the held resize {cols}x{rows} (#973)"
-                );
-                self.fanout.resize_screen_and_broadcast(id, cols, rows);
-            }
-            Ok(false) => {}
-            Err(e) => {
-                // Non-critical: the child is up and painting, it is just the wrong size.
-                log::warn!("[pty] held resize {id} to {cols}x{rows} failed: {e} (#973)");
-            }
+        // Outside the `ptys` guard: the screen and the broadcast take locks of their own, and
+        // every terminal write, resize and kill in the app queues behind that one.
+        //
+        // Only for a size the ConPTY actually took. The vt100 screen models the CHILD's
+        // screen, so it must not be moved to a size the child was never given.
+        if let Some((cols, rows)) = applied {
+            self.fanout.resize_screen_and_broadcast(id, cols, rows);
         }
     }
 
@@ -1092,19 +1131,35 @@ impl PtyBackend for LocalProcessBackend {
     }
 
     fn resize(&self, id: Uuid, cols: u16, rows: u16) -> Result<(), AppError> {
+        // The idle grace sees every resize the view ASKED for, held or refused. Idle semantics
+        // are #954's, not this fix's.
         self.fanout.record_resize(id);
 
-        {
+        let sent = {
             let ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
             let instance = ptys
                 .get(&id)
                 .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
-            resize_instance(instance, id, cols, rows)?;
-        }
+            resize_instance(instance, id, cols, rows)?
+        };
 
-        // The screen and the idle grace see every resize the view asked for, held or not:
-        // only the ConPTY call is gated. Idle semantics are #954's, not this fix's.
-        self.fanout.resize_screen_and_broadcast(id, cols, rows);
+        // #973 - the vt100 screen models the CHILD's screen, so it may only follow a size the
+        // ConPTY actually took.
+        //
+        // A refused `0x0` would otherwise set the parser to zero rows (`output.rs`), and #955's
+        // `get_screen_snapshot` reads `contents_formatted()` off that grid: an empty snapshot,
+        // and a black tile on re-attach - the exact bug #955 shipped to kill.
+        //
+        // A HELD size is not the child's size either. The child is still emitting for the size
+        // the PTY was opened at, and a screen moved ahead of it would parse that output against
+        // a geometry the child is not using. `open_startup_gate` moves the screen at the instant
+        // the ConPTY takes the size, which is the first moment the two agree.
+        //
+        // A DEDUPED size is already the screen's size: `register_session` seeds the parser with
+        // the size the PTY was opened at, and from there the two only ever move together.
+        if sent {
+            self.fanout.resize_screen_and_broadcast(id, cols, rows);
+        }
 
         Ok(())
     }
@@ -1512,7 +1567,9 @@ mod resize_dedup_tests {
 
 #[cfg(test)]
 mod startup_gate_tests {
-    use super::{resize_instance, send_size_to_conpty, PtyInstance, StartupGate};
+    use super::{
+        hand_over_held_size, resize_instance, send_size_to_conpty, PtyInstance, StartupGate,
+    };
     use portable_pty::{native_pty_system, MasterPty, PtySize};
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex};
@@ -1656,14 +1713,58 @@ mod startup_gate_tests {
         );
     }
 
-    /// #973 - a degenerate resize must be refused, and it must not be cached.
+    /// #973 - a degenerate resize that lands WHILE THE GATE IS HOLDING must not evict the
+    /// real size the view is waiting to give the child.
     ///
-    /// This test caught a real one. I had assumed portable-pty would reject `0x0`. **It does
-    /// not**: `master.resize(0x0)` returns Ok and the ConPTY is genuinely set to zero, so
-    /// before the guard this test failed with `left: (0, 0)`. `pty_resize` passes the view's
-    /// numbers straight down, and xterm's `fit()` returns a zero dimension while its
-    /// container is still being laid out - the exact hazard `PtyViewport::from_fit` guards
-    /// at spawn. The resize path had no such guard.
+    /// This walks the path `pty_resize` actually walks - `resize_instance`, gate and all -
+    /// which is the entire point of it. The guard used to sit in `send_size_to_conpty`, PAST
+    /// the gate, so nothing checked a size on its way IN: the gate took the `0x0` last-wins
+    /// over the real `74x23`, the hand-over popped it, `send_size_to_conpty` refused it, and
+    /// the pending slot was consumed and gone. **Nothing retries.** The ConPTY then stays at
+    /// the size it was OPENED at, for good - on cold start, a 120x30 child behind a 74x23
+    /// terminal, until the user drags the window.
+    ///
+    /// Red before the guard moved ahead of the gate:
+    /// `assertion failed: left: (120, 30)  right: (74, 23)`.
+    #[test]
+    fn a_degenerate_resize_cannot_evict_the_size_held_for_the_child() {
+        let (instance, master) = conpty(120, 30);
+        let id = Uuid::new_v4();
+
+        // the view mounts and fits, while the child is still starting up: held, as it should be
+        assert!(
+            !resize_instance(&instance, id, 74, 23).expect("resize"),
+            "nothing may reach a child that has not rendered yet"
+        );
+
+        // ...and now a zero dimension arrives, still inside the startup window: xterm's `fit()`
+        // mid-layout, or a web client (`web/commands.rs` takes cols/rows straight off the wire).
+        assert!(
+            !resize_instance(&instance, id, 0, 0).expect("must not error"),
+            "a zero dimension must never be sent to the ConPTY"
+        );
+
+        // the child paints. This is the read loop's hand-over itself, not a copy of it.
+        hand_over_held_size(&instance, id);
+
+        assert_eq!(
+            size_the_child_sees(&master),
+            (74, 23),
+            "the real held size must survive a degenerate resize"
+        );
+    }
+
+    /// #973 - the guard INSIDE `send_size_to_conpty`, which is defence in depth: the last line
+    /// before `master.resize()`, and the one `hand_over_held_size` relies on when it applies a
+    /// size that has been sitting in the gate. The guard that keeps a `0x0` off the request
+    /// path is in `resize_instance`, ahead of the gate - see
+    /// `a_degenerate_resize_cannot_evict_the_size_held_for_the_child`, which is the one that
+    /// walks the path `pty_resize` walks. This test calls `send_size_to_conpty` DIRECTLY and
+    /// makes no claim about the gate.
+    ///
+    /// It caught a real one. I had assumed portable-pty would reject `0x0`. **It does not**:
+    /// `master.resize(0x0)` returns Ok and the ConPTY is genuinely set to zero, so before the
+    /// guard this failed with `left: (0, 0)`.
     ///
     /// The cache matters as much as the refusal: if a size the ConPTY never took were
     /// cached, every retry would be skipped as a no-op and the terminal would be wedged at

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -27,6 +27,37 @@ struct PtyInstance {
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     child: Option<Box<dyn portable_pty::Child + Send + Sync>>,
     job: Option<crate::pty::job::JobObject>,
+    /// #973 (C) - the size the ConPTY is actually at, so a resize that changes nothing is
+    /// not sent to the child. Seeded from the size the PTY was opened at.
+    size: Mutex<(u16, u16)>,
+}
+
+impl PtyInstance {
+    /// #973 (C) - has the size actually moved?
+    ///
+    /// The frontend calls resize unconditionally (`TerminalView.tsx:85-95`, from a double
+    /// `requestAnimationFrame` plus a `ResizeObserver`), so one attach fires 5-20 identical
+    /// resizes, and ConPTY hands every one of them to the child as a real event.
+    fn size_changed(&self, cols: u16, rows: u16) -> bool {
+        Self::size_changed_in(&self.size, cols, rows)
+    }
+
+    /// Only after the ConPTY has actually accepted it: if `resize` failed, the cached size
+    /// must stay stale so the next attempt is not skipped as a no-op and the PTY is not
+    /// wedged at the wrong size forever.
+    fn remember_size(&self, cols: u16, rows: u16) {
+        Self::remember_size_in(&self.size, cols, rows);
+    }
+
+    // The two free functions above are the whole of C. Split out so they can be tested
+    // without a live ConPTY: a `PtyInstance` owns real `MasterPty` handles.
+    fn size_changed_in(size: &Mutex<(u16, u16)>, cols: u16, rows: u16) -> bool {
+        *size.lock().unwrap_or_else(|e| e.into_inner()) != (cols, rows)
+    }
+
+    fn remember_size_in(size: &Mutex<(u16, u16)>, cols: u16, rows: u16) {
+        *size.lock().unwrap_or_else(|e| e.into_inner()) = (cols, rows);
+    }
 }
 
 #[cfg(windows)]
@@ -595,6 +626,8 @@ impl LocalProcessBackend {
             writer: Arc::new(Mutex::new(writer)),
             child: Some(child),
             job,
+            // #973 - the size we actually opened the ConPTY at (see PtyViewport).
+            size: Mutex::new((cols, rows)),
         };
 
         self.ptys
@@ -866,15 +899,41 @@ impl PtyBackend for LocalProcessBackend {
             .get(&id)
             .ok_or_else(|| AppError::SessionNotFound(id.to_string()))?;
 
-        let master = instance.master.lock().unwrap();
-        master
-            .resize(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|e| AppError::PtyError(e.to_string()))?;
+        // #973 (C) - do not tell the child about a resize that is not a resize.
+        //
+        // ConPTY delivers even a same-size ResizePseudoConsole to the client as a real
+        // event, and the frontend fires 5-20 identical ones per attach, so today every
+        // attach shakes the child for nothing.
+        //
+        // This does NOT fix #973 by itself: a single resize that DOES change the size,
+        // landing in the child's startup window, still loses Codex's first content render
+        // 8 times in 10 (measured). The fix for that is opening the PTY at the right size
+        // in the first place (`PtyViewport`); this is what stops the frontend's follow-up
+        // fit from undoing it.
+        //
+        // Deliberately NOT skipped: `record_resize` above and the screen broadcast below.
+        // They drive the idle grace and the vt100 screen, and changing idle semantics is
+        // #954's business, not this issue's.
+        if !instance.size_changed(cols, rows) {
+            log::debug!("[pty] resize {id} skipped: already {cols}x{rows}");
+            drop(ptys);
+            self.fanout.resize_screen_and_broadcast(id, cols, rows);
+            return Ok(());
+        }
+
+        {
+            let master = instance.master.lock().unwrap_or_else(|e| e.into_inner());
+            master
+                .resize(PtySize {
+                    rows,
+                    cols,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                })
+                .map_err(|e| AppError::PtyError(e.to_string()))?;
+        }
+        instance.remember_size(cols, rows);
+        drop(ptys);
 
         self.fanout.resize_screen_and_broadcast(id, cols, rows);
 
@@ -1227,5 +1286,57 @@ mod cancel_tests {
             "registered state should be cleaned up after cancellation"
         );
         assert_eq!(cleanup_count.load(Ordering::SeqCst), 2);
+    }
+}
+
+#[cfg(test)]
+mod resize_dedup_tests {
+    use super::PtyInstance;
+    use std::sync::Mutex;
+
+    /// A `PtyInstance` carries real ConPTY handles, so the tests below drive the one piece
+    /// that #973 (C) actually changes: the size cache and the decision it drives.
+    fn cache(cols: u16, rows: u16) -> Mutex<(u16, u16)> {
+        Mutex::new((cols, rows))
+    }
+
+    /// #973 (C) - the frontend calls resize unconditionally from a double
+    /// `requestAnimationFrame` and a `ResizeObserver`, so a single attach fires 5-20
+    /// identical resizes and ConPTY hands every one of them to the child as a real event.
+    /// A resize that changes nothing must not reach the child.
+    #[test]
+    fn a_resize_to_the_size_it_already_has_is_not_sent_to_the_child() {
+        let size = cache(74, 23);
+        assert!(
+            !PtyInstance::size_changed_in(&size, 74, 23),
+            "an identical resize must be skipped: today AC fires 5-20 of these per attach"
+        );
+    }
+
+    /// The other half: a real resize must still get through, or the terminal would never
+    /// follow the window.
+    #[test]
+    fn a_resize_that_moves_the_size_is_sent() {
+        let size = cache(74, 23);
+        assert!(PtyInstance::size_changed_in(&size, 74, 24), "one row is a real resize");
+        assert!(PtyInstance::size_changed_in(&size, 120, 30), "a real resize");
+    }
+
+    /// The trap in the dedup: if the cache were updated BEFORE the ConPTY accepted the new
+    /// size, a failed resize would leave the cache claiming a size the PTY never took, and
+    /// every retry would then be skipped as a no-op - the terminal would be wedged at the
+    /// wrong size forever. The cache is only written after `master.resize()` returns Ok.
+    #[test]
+    fn a_failed_resize_does_not_poison_the_cache_and_the_retry_still_fires() {
+        let size = cache(74, 23);
+        // resize to 100x40 "fails": remember_size is never reached, so the cache stays put
+        assert!(PtyInstance::size_changed_in(&size, 100, 40));
+        assert!(
+            PtyInstance::size_changed_in(&size, 100, 40),
+            "after a failed resize the retry must still be issued, not skipped as a no-op"
+        );
+        // now it succeeds
+        PtyInstance::remember_size_in(&size, 100, 40);
+        assert!(!PtyInstance::size_changed_in(&size, 100, 40));
     }
 }

--- a/src-tauri/src/pty/output.rs
+++ b/src-tauri/src/pty/output.rs
@@ -182,7 +182,29 @@ impl SessionIoFanout {
         self.idle_detector.record_resize(id);
     }
 
+    /// #973 - a degenerate size must never reach the vt100 parser, and this is the boundary
+    /// where that invariant actually breaks, so this is where it is enforced.
+    ///
+    /// `vt100::grid::set_size` computes `size.rows - 1` on a `u16` (grid.rs:73). With
+    /// `rows == 0` that UNDERFLOWS: it panics in a debug build and wraps to 65535 in a release
+    /// one, leaving a zero-row grid with a scroll region of 65535. And the panic fires while
+    /// this function is HOLDING `screen_parsers`, which poisons the mutex - after which
+    /// `handle_output`, `get_screen_snapshot` and `get_pty_size` all take the `if let Ok` /
+    /// `.ok()?` branch and silently do nothing, for every session, for the life of the process.
+    /// One `cols: 0` would take #955's screen snapshot down app-wide, without a single log line.
+    ///
+    /// The callers guard too (`local_backend` only moves the screen for a size the ConPTY
+    /// actually took), but they cannot be the only guard: `container_backend:1099` calls this
+    /// with whatever `pty_resize` was given, and there is no gate on that path at all.
+    ///
+    /// A refused resize did not happen, so the broadcast is skipped with it: clients must not
+    /// be told the terminal is 0 columns wide.
     pub fn resize_screen_and_broadcast(&self, id: Uuid, cols: u16, rows: u16) {
+        if cols == 0 || rows == 0 {
+            log::warn!("[pty] refusing to resize the screen of {id} to {cols}x{rows} (#973)");
+            return;
+        }
+
         if let Ok(mut parsers) = self.screen_parsers.lock() {
             if let Some(state) = parsers.get_mut(&id) {
                 state.parser.set_size(rows, cols);
@@ -409,6 +431,60 @@ fn write_response_file(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fanout() -> SessionIoFanout {
+        SessionIoFanout::new(
+            Arc::new(Mutex::new(HashMap::new())),
+            IdleDetector::new(|_| {}, |_| {}),
+            None,
+        )
+    }
+
+    /// #973 / #955 - a degenerate size must never reach the vt100 parser.
+    ///
+    /// Red before the guard, and not with an assertion - with a **panic**:
+    ///
+    /// ```text
+    /// panicked at vt100-0.15.2/src/grid.rs:74:34: attempt to subtract with overflow
+    /// ```
+    ///
+    /// `vt100::grid::set_size` computes `size.rows - 1` on a `u16`, so `rows == 0` underflows.
+    /// Debug panics; release wraps to 65535. Worse, the panic fires while
+    /// `resize_screen_and_broadcast` holds `screen_parsers`, poisoning it - and every reader of
+    /// that mutex swallows the poison silently (`if let Ok` / `.ok()?`), so #955's snapshot,
+    /// the output sequence numbering and `get_pty_size` would go dead for EVERY session, for
+    /// the life of the process, without a log line. A black tile on re-attach is what the user
+    /// would see: exactly the bug #955 shipped to kill.
+    #[test]
+    fn a_degenerate_resize_never_reaches_the_vt100_parser() {
+        let fanout = fanout();
+        let id = Uuid::new_v4();
+        fanout.register_session(id, IdleTuning::DEFAULT, 30, 120);
+        fanout.handle_output(
+            &PtyOutputTarget::noop(),
+            id,
+            &id.to_string(),
+            b"hello".to_vec(),
+        );
+
+        fanout.resize_screen_and_broadcast(id, 0, 0);
+
+        let after = fanout.get_screen_snapshot(id).expect("snapshot");
+        assert_eq!(
+            (after.rows, after.cols),
+            (30, 120),
+            "the screen must be untouched by a size the child was never given"
+        );
+        assert!(
+            String::from_utf8_lossy(&after.data).contains("hello"),
+            "and the child's output must still be in it: an empty snapshot is #955's black tile"
+        );
+
+        // a real size still moves the screen - the guard refuses the degenerate, not the resize
+        fanout.resize_screen_and_broadcast(id, 80, 24);
+        let resized = fanout.get_screen_snapshot(id).expect("snapshot");
+        assert_eq!((resized.rows, resized.cols), (24, 80));
+    }
 
     #[test]
     fn printable_activity_ignores_ansi_only_chunks() {

--- a/src-tauri/src/pty/output.rs
+++ b/src-tauri/src/pty/output.rs
@@ -235,6 +235,42 @@ impl SessionIoFanout {
         }
     }
 
+    /// #973 (B) - has the child painted anything a human could see?
+    ///
+    /// This is the startup gate's trigger, and it asks the REAL, STATEFUL vt100 parser that
+    /// `handle_output` has already fed every byte of every chunk. Call it after `handle_output`,
+    /// so the chunk that just arrived is in the screen.
+    ///
+    /// It replaced a per-chunk text predicate (`output_has_printable_activity`, which the idle
+    /// detector still uses), and it had to, because that predicate answers a different question
+    /// and got this one wrong two ways:
+    ///
+    /// - **Chunk boundaries.** `strip_ansi_csi` is stateless and carries no residue between
+    ///   calls, but the read loop hands it raw `read()` chunks. A chunk that ends mid-CSI or
+    ///   mid-OSC delivers the tail in the next chunk with NO leading `ESC`, and `1049h`, `2J` and
+    ///   `cmd.exe` are all printable. conhost really does split its output across writes.
+    /// - **Three-byte escapes.** It consumed `ESC` plus exactly ONE char. A charset designator is
+    ///   three (`ESC ( B`, which ncurses and half the TUI world emit on the way up, plus
+    ///   `ESC ) 0` and `ESC % G`), so the third byte survived and read as printable.
+    ///
+    /// Either one opens the gate on a child that has painted nothing, which is the bug this gate
+    /// exists to prevent. A real parser carries state across reads and knows what an escape is,
+    /// so both are closed by construction rather than by another special case.
+    ///
+    /// Returns false when the parser cannot be reached: an unfed parser can never show content
+    /// anyway (`handle_output` skips the same poisoned lock), so the gate simply stays shut,
+    /// which is the safe direction. It is never resized, and a child showing nothing does not
+    /// care what size it is.
+    pub fn has_rendered_visible_content(&self, id: Uuid) -> bool {
+        let Ok(parsers) = self.screen_parsers.lock() else {
+            return false;
+        };
+        let Some(state) = parsers.get(&id) else {
+            return false;
+        };
+        screen_shows_visible_content(state.parser.screen())
+    }
+
     pub fn get_screen_snapshot(&self, id: Uuid) -> Option<PtyScreenSnapshot> {
         let parsers = self.screen_parsers.lock().ok()?;
         let state = parsers.get(&id)?;
@@ -273,8 +309,45 @@ impl SessionIoFanout {
     }
 }
 
+/// #973 (B) - is there a cell on this screen a human could see?
+///
+/// "Visible" is deliberately not "the child wrote a byte", and not even "a cell has contents":
+///
+/// - A **space is not content.** `vt100::Cell::has_contents` is true for one (it only asks
+///   whether the cell was written), and a TUI painting its still-empty viewport writes plenty.
+///   That is the exact moment the gate must stay shut, so the glyph test ignores whitespace.
+/// - A **coloured space IS content.** TUIs draw status bars, boxes and selections with nothing
+///   but a background colour, and `Cell::clear` KEEPS the attributes, so `ESC[41m ESC[2J` is a
+///   red screen holding no contents at all. A human plainly sees it.
+/// - **Reverse video** does the same thing with the default colours: a space rendered inverse is
+///   a solid block.
+///
+/// Cost: the attribute scan is allocation-free and exits at the first visible cell.
+/// `Screen::contents` is one allocation for the whole grid, where `Cell::contents` would be one
+/// per cell. It runs only until the gate opens, and after that the caller's relaxed bool skips
+/// it entirely.
+fn screen_shows_visible_content(screen: &vt100::Screen) -> bool {
+    let (rows, cols) = screen.size();
+    for row in 0..rows {
+        for col in 0..cols {
+            if let Some(cell) = screen.cell(row, col) {
+                if cell.inverse() || cell.bgcolor() != vt100::Color::Default {
+                    return true;
+                }
+            }
+        }
+    }
+
+    screen.contents().chars().any(|c| !c.is_whitespace())
+}
+
 /// Strip ANSI escape sequences so marker detection ignores color, cursor,
 /// title, hyperlink, shell-integration, and device-control noise.
+///
+/// #973 - this is the IDLE DETECTOR's predicate, and the startup gate no longer uses it. It is
+/// stateless and consumes `ESC` plus exactly one char, which is fine for deciding whether a chunk
+/// looked busy and wrong for deciding whether a child has painted. See
+/// `SessionIoFanout::has_rendered_visible_content`.
 pub(crate) fn strip_ansi_csi(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
@@ -438,6 +511,165 @@ mod tests {
             IdleDetector::new(|_| {}, |_| {}),
             None,
         )
+    }
+
+    /// A coding agent's TUI on the way up: hide the cursor, clear, switch to the alternate
+    /// screen, home, set the title, turn on mouse reporting, reset the attributes. Every byte of
+    /// it is an escape sequence. It paints NOTHING a human can see, and the gate must stay shut
+    /// through all of it.
+    ///
+    /// The charset designator a real TUI also emits here (`ESC ( B`) is deliberately NOT in this
+    /// constant: it fools the old predicate even UNSPLIT, so putting it here would let the
+    /// chunk-boundary test below pass for the wrong reason. It gets its own test.
+    const TUI_PROLOGUE: &[u8] =
+        b"\x1b[?25l\x1b[2J\x1b[?1049h\x1b[H\x1b]0;cmd.exe\x07\x1b[?1000h\x1b[?1006h\x1b[m";
+
+    fn feed(fanout: &SessionIoFanout, id: Uuid, chunks: &[&[u8]]) {
+        for chunk in chunks {
+            fanout.handle_output(
+                &PtyOutputTarget::noop(),
+                id,
+                &id.to_string(),
+                chunk.to_vec(),
+            );
+        }
+    }
+
+    fn session(fanout: &SessionIoFanout) -> Uuid {
+        let id = Uuid::new_v4();
+        fanout.register_session(id, IdleTuning::DEFAULT, 30, 120);
+        id
+    }
+
+    /// #973 (B), (a) - CHUNK BOUNDARIES. The trigger must survive the prologue arriving in two
+    /// reads, split anywhere.
+    ///
+    /// The old predicate could not. `strip_ansi_csi` is stateless and keeps no residue between
+    /// calls, but the read loop feeds it raw `read()` chunks, and conhost really does split its
+    /// output across writes. A chunk ending mid-CSI or mid-OSC hands the tail to the next call
+    /// with NO leading `ESC`, and `1049h`, `2J` and `cmd.exe` are all printable - so the gate
+    /// opened on a child that had painted nothing, which is the bug the gate exists to prevent.
+    ///
+    /// It is not an edge case. **43 of this prologue's 51 interior split points** fool the old
+    /// predicate: a boundary inside a CSI leaves the tail with no `ESC`, and the tail of nearly
+    /// every sequence here is printable - `l`, `2J`, `1049h`, `m`, and `cmd.exe` out of the OSC
+    /// title. Only a boundary that happens to land ON an `ESC` is safe.
+    ///
+    /// This asserts the hazard is REAL first (some split does fool the old predicate), or the
+    /// rest of the test would prove nothing, and then walks every interior split point through
+    /// the new trigger.
+    #[test]
+    fn the_gate_holds_a_prologue_split_at_any_chunk_boundary() {
+        let fanout = fanout();
+
+        // whole, in one chunk, the old predicate gets right
+        assert!(
+            !output_has_printable_activity(&String::from_utf8_lossy(TUI_PROLOGUE)),
+            "the prologue paints nothing, and unsplit even the old predicate saw that"
+        );
+
+        // split, it does not. These are the boundaries that would have opened the gate.
+        let fooled: Vec<usize> = (1..TUI_PROLOGUE.len())
+            .filter(|&at| {
+                let (head, tail) = TUI_PROLOGUE.split_at(at);
+                output_has_printable_activity(&String::from_utf8_lossy(head))
+                    || output_has_printable_activity(&String::from_utf8_lossy(tail))
+            })
+            .collect();
+        assert!(
+            !fooled.is_empty(),
+            "if no split fools the old predicate, this test is not testing the hazard"
+        );
+
+        // the new trigger, at every one of them
+        for at in 1..TUI_PROLOGUE.len() {
+            let id = session(&fanout);
+            let (head, tail) = TUI_PROLOGUE.split_at(at);
+            feed(&fanout, id, &[head, tail]);
+            assert!(
+                !fanout.has_rendered_visible_content(id),
+                "split at {at}: the child has painted nothing, so the gate must stay shut"
+            );
+        }
+
+        // ...and it is a gate, not a wall: the moment the child paints, it opens
+        let id = session(&fanout);
+        feed(&fanout, id, &[TUI_PROLOGUE]);
+        assert!(
+            !fanout.has_rendered_visible_content(id),
+            "still nothing to see"
+        );
+        feed(&fanout, id, &[b"> "]);
+        assert!(
+            fanout.has_rendered_visible_content(id),
+            "a glyph the user can see must open the gate"
+        );
+    }
+
+    /// #973 (B), (b) - THREE-BYTE ESCAPES. `ESC ( B` is what ncurses and half the TUI world emit
+    /// on the way up. The old stripper consumed `ESC` plus exactly ONE char, so the `B` survived
+    /// and read as printable, and the gate opened on a blank screen. Same for `ESC ) 0` (leaks
+    /// `0`) and `ESC % G` (leaks `G`).
+    ///
+    /// `ESC # 8` (DECALN) is deliberately not asserted here. It is the fourth three-byte escape
+    /// and it fools the old stripper too (leaks `8`), but it is the one that genuinely PAINTS: a
+    /// real terminal fills the screen with `E`. vt100 does not implement it, so our parser shows
+    /// nothing and this gate would stay shut - which is a limitation of the crate, not a property
+    /// worth pinning as correct. Pinning it would freeze the wrong answer.
+    #[test]
+    fn a_three_byte_charset_designator_does_not_open_the_gate() {
+        assert!(
+            output_has_printable_activity("\x1b(B"),
+            "the old predicate really is fooled by this - that is the whole defect"
+        );
+
+        let fanout = fanout();
+        let id = session(&fanout);
+        feed(&fanout, id, &[b"\x1b(B", b"\x1b)0", b"\x1b%G"]);
+
+        assert!(
+            !fanout.has_rendered_visible_content(id),
+            "a charset designator paints nothing: the gate must stay shut"
+        );
+    }
+
+    /// What "a human can see" means, pinned. A space is not content, even though the cell was
+    /// written and `Cell::has_contents` says true. A COLOURED space is - TUIs draw status bars
+    /// and boxes with nothing else, and `Cell::clear` keeps the attributes, so a cleared screen
+    /// can be solid red while holding no contents at all.
+    #[test]
+    fn a_blank_viewport_is_not_content_but_a_coloured_one_is() {
+        let fanout = fanout();
+
+        // the TUI paints its still-empty viewport: spaces, and plenty of them. This is the exact
+        // moment the gate must stay shut - it is inside the danger window.
+        let id = session(&fanout);
+        feed(&fanout, id, &[b"\x1b[2J\x1b[H", &[b' '; 240]]);
+        assert!(
+            !fanout.has_rendered_visible_content(id),
+            "a viewport of spaces is still a blank viewport"
+        );
+        feed(&fanout, id, &[b"ready"]);
+        assert!(
+            fanout.has_rendered_visible_content(id),
+            "a glyph is content"
+        );
+
+        // a red status bar: no glyph anywhere, and a human plainly sees it
+        let id = session(&fanout);
+        feed(&fanout, id, &[b"\x1b[41m", &[b' '; 20]]);
+        assert!(
+            fanout.has_rendered_visible_content(id),
+            "a coloured space is content: it is how a TUI draws a status bar"
+        );
+
+        // reverse video does it with the default colours
+        let id = session(&fanout);
+        feed(&fanout, id, &[b"\x1b[7m", &[b' '; 20]]);
+        assert!(
+            fanout.has_rendered_visible_content(id),
+            "an inverse space renders as a solid block"
+        );
     }
 
     /// #973 / #955 - a degenerate size must never reach the vt100 parser.

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -832,11 +832,18 @@ fn require_str(args: &Value, key: &str) -> Result<String, String> {
 /// contract, both transports. A value that is absent stays absent (the caller's default); only
 /// one that is PRESENT and cannot be a terminal dimension is an error.
 ///
-/// A zero is deliberately NOT an error here. It is what xterm's `fit()` genuinely returns while
-/// its container is being laid out, so a well-behaved client can send one, and the PTY backend
-/// already refuses it - once, in `resize_instance`, for every transport. Erroring here would
-/// hand a legitimate client a failure for doing nothing wrong, and would put the refusal in two
-/// places that could disagree.
+/// A zero is deliberately NOT an error here, and the reason is NOT that a legitimate client sends
+/// one - it cannot. xterm's `fit()` clamps to MINIMUM_COLS = 2 / MINIMUM_ROWS = 1, so a zero on
+/// this path means a client that is not xterm, or is broken, or is hostile. This function is what
+/// stands between such a client and the PTY.
+///
+/// It passes the zero down anyway, because refusing it HERE would be the second place that
+/// refuses it. `resize_instance` already does, once, for every transport, with a warn. Erroring
+/// here as well would make the same payload behave differently on the two transports - the Tauri
+/// command takes a typed `u16`, where serde accepts a 0 and passes it down exactly like this -
+/// and would put one rule in two places that can drift apart. One refusal, in the backend, shared.
+/// What this boundary is for is the value that cannot be a dimension at all, which is the one the
+/// old `as u16` cast turned into a plausible-looking lie.
 fn terminal_dimension(args: &Value, key: &str, default: u16) -> Result<u16, String> {
     let Some(value) = args.get(key) else {
         return Ok(default);
@@ -939,8 +946,9 @@ mod tests {
         );
 
         // ...and a zero passes through to the ONE guard that refuses it, in `resize_instance`,
-        // shared by both transports. xterm's `fit()` really does emit one mid-layout, and a
-        // client doing nothing wrong must not get an error for it.
+        // shared by both transports. Not because a zero is legitimate - xterm cannot produce one -
+        // but because refusing it twice, in two places that can drift apart, is worse than
+        // refusing it once where both transports meet.
         assert_eq!(
             dim(json!(0)).expect("a zero is refused downstream, not here"),
             0

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -307,8 +307,8 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
         // --- PTY commands ---
         "pty_resize" => {
             let session_id = require_str(args, "sessionId")?;
-            let cols = args.get("cols").and_then(|v| v.as_u64()).unwrap_or(120) as u16;
-            let rows = args.get("rows").and_then(|v| v.as_u64()).unwrap_or(30) as u16;
+            let cols = terminal_dimension(args, "cols", 120)?;
+            let rows = terminal_dimension(args, "rows", 30)?;
             let uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
 
             state
@@ -820,6 +820,36 @@ fn require_str(args: &Value, key: &str) -> Result<String, String> {
         .ok_or_else(|| format!("Missing required field: {}", key))
 }
 
+/// #973 - a terminal dimension off the wire, for `pty_resize`.
+///
+/// This is a network-facing input path, and `as u16` SILENTLY TRUNCATES: `cols: 65536` arrives
+/// at the PTY as **0**, and `cols: 65537` as **1**. A zero-column ConPTY is precisely what #973
+/// exists to keep out, and a one-column one is not much better - both from a number that looked
+/// perfectly plausible on the wire.
+///
+/// `u16` is exactly what the Tauri `pty_resize` command takes, where serde rejects an
+/// out-of-range number for us. The web transport has no such boundary, so this is it: same
+/// contract, both transports. A value that is absent stays absent (the caller's default); only
+/// one that is PRESENT and cannot be a terminal dimension is an error.
+///
+/// A zero is deliberately NOT an error here. It is what xterm's `fit()` genuinely returns while
+/// its container is being laid out, so a well-behaved client can send one, and the PTY backend
+/// already refuses it - once, in `resize_instance`, for every transport. Erroring here would
+/// hand a legitimate client a failure for doing nothing wrong, and would put the refusal in two
+/// places that could disagree.
+fn terminal_dimension(args: &Value, key: &str, default: u16) -> Result<u16, String> {
+    let Some(value) = args.get(key) else {
+        return Ok(default);
+    };
+    if value.is_null() {
+        return Ok(default);
+    }
+    value
+        .as_u64()
+        .and_then(|n| u16::try_from(n).ok())
+        .ok_or_else(|| format!("Invalid field {}: not a terminal dimension: {}", key, value))
+}
+
 fn require_json<T>(args: &Value, key: &str) -> Result<T, String>
 where
     T: serde::de::DeserializeOwned,
@@ -864,6 +894,58 @@ mod tests {
     use crate::web::broadcast::{WsBroadcaster, WsOutMsg};
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
+
+    /// #973 - `pty_resize` is network-facing, and the old `as u16` cast SILENTLY TRUNCATED.
+    /// `cols: 65536` reached the PTY as **0** and `cols: 65537` as **1**: a zero-column ConPTY
+    /// (the very thing #973 exists to keep out) conjured from a number that looked fine on the
+    /// wire. Rejected at the boundary now, exactly as serde rejects it for the Tauri command.
+    #[test]
+    fn a_terminal_dimension_off_the_wire_is_never_truncated_into_a_degenerate_one() {
+        let dim = |v: serde_json::Value| terminal_dimension(&json!({ "cols": v }), "cols", 120);
+
+        assert_eq!(dim(json!(74)).expect("a plain size"), 74);
+        assert_eq!(dim(json!(65535)).expect("the largest there is"), 65535);
+
+        // 65536 -> 0 and 65537 -> 1 under `as u16`. This is the whole point.
+        assert!(
+            dim(json!(65536)).is_err(),
+            "65536 must not become a 0-column terminal"
+        );
+        assert!(
+            dim(json!(65537)).is_err(),
+            "65537 must not become a 1-column terminal"
+        );
+        assert!(
+            dim(json!(-1)).is_err(),
+            "a negative is not a terminal dimension"
+        );
+        assert!(
+            dim(json!("74")).is_err(),
+            "a string is not a terminal dimension"
+        );
+        assert!(
+            dim(json!(74.5)).is_err(),
+            "a float is not a terminal dimension"
+        );
+
+        // absent stays absent: the caller's default, unchanged
+        assert_eq!(
+            terminal_dimension(&json!({}), "cols", 120).expect("absent"),
+            120
+        );
+        assert_eq!(
+            terminal_dimension(&json!({ "cols": null }), "cols", 120).expect("null"),
+            120
+        );
+
+        // ...and a zero passes through to the ONE guard that refuses it, in `resize_instance`,
+        // shared by both transports. xterm's `fit()` really does emit one mid-layout, and a
+        // client doing nothing wrong must not get an error for it.
+        assert_eq!(
+            dim(json!(0)).expect("a zero is refused downstream, not here"),
+            0
+        );
+    }
 
     #[test]
     fn browser_project_commands_route_before_unknown_fallback() {

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -185,6 +185,9 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
                 Vec::new(),  // git_repos
                 true,        // skip_auto_resume = true → fresh create, no `--continue` injection
                 resolved_spawn,
+                // #973 - browser-mode create. The browser client pushes its fitted size after
+                // attach, not at create time, so this keeps AC's 120x30 for now.
+                None,
             )
             .await?;
 

--- a/src-tauri/tests/pty_lifecycle_regression.rs
+++ b/src-tauri/tests/pty_lifecycle_regression.rs
@@ -754,6 +754,7 @@ fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup()
             persisted_row.git_repos,
             false,
             None,
+            None, // #973 - no view in this test: 120x30
         )
         .await
         .unwrap_or_else(|e| {
@@ -852,6 +853,7 @@ fn claude_launch_materializes_context_without_prompt_file_arg() {
             Vec::new(),
             true,
             None,
+            None, // #973 - no view in this test: 120x30
         )
         .await
         .unwrap_or_else(|e| panic!("Claude launch failed: {e}"));
@@ -916,6 +918,7 @@ impl LifecycleFixture {
             Vec::new(),
             true,
             None,
+            None, // #973 - no view in this test: 120x30
         )
         .await
     }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,4 +1,8 @@
-import { isTauri } from "./platform";
+import { isBrowser, isTauri } from "./platform";
+import {
+  measurePtyViewport,
+  rememberSpawnViewport,
+} from "./terminal-viewport";
 import type { Transport, UnlistenFn } from "./transport";
 import { TauriTransport } from "./transport-tauri";
 import { WsTransport } from "./transport-ws";
@@ -170,8 +174,26 @@ export interface CodingAgentProfileSelectionUpdatedPayload {
 }
 
 export const SessionAPI = {
-  create: (opts?: CreateSessionOptions) =>
-    transport.invoke<Session>("create_session", {
+  /**
+   * #973 — the ONLY create path with a terminal tile to measure, and so the only
+   * one that hands the backend a size. Every other caller (startup restore, the
+   * delivery loop, the phone mailbox, the root agent, the CLI, tests) has no view
+   * and keeps AC's historical 120x30.
+   *
+   * The size is measured, not predicted: {@link measurePtyViewport} runs the same
+   * `FitAddon.proposeDimensions()` the terminal's own post-mount fit will run,
+   * against the tile already on screen. Null when there is nothing to measure —
+   * then no size is sent, and a wrong size is worse than no size.
+   */
+  create: async (opts?: CreateSessionOptions): Promise<Session> => {
+    // Browser mode is deliberately excluded. The web-mode `create_session`
+    // handler parses its args by hand and ignores cols/rows entirely: it always
+    // spawns at the 120x30 default. Recording a spawn size the PTY was never
+    // opened at would make the terminal's dedup skip the corrective resize and
+    // wedge that PTY at 120x30 forever.
+    const viewport = isBrowser ? null : measurePtyViewport();
+
+    const session = await transport.invoke<Session>("create_session", {
       shell: opts?.shell ?? null,
       shellArgs: opts?.shellArgs ?? null,
       cwd: opts?.cwd ?? null,
@@ -180,7 +202,17 @@ export const SessionAPI = {
       requestedProfile: opts?.requestedProfile ?? null,
       gitRepos: opts?.gitRepos ?? null,
       skipAutoResume: opts?.skipAutoResume ?? null,
-    }),
+      // Both or neither: the backend builds a viewport only when both arrive.
+      cols: viewport?.cols ?? null,
+      rows: viewport?.rows ?? null,
+    });
+
+    if (viewport) {
+      rememberSpawnViewport(session.id, viewport);
+    }
+
+    return session;
+  },
 
   destroy: (id: string) => transport.invoke<void>("destroy_session", { id }),
 

--- a/src/shared/terminal-viewport.test.ts
+++ b/src/shared/terminal-viewport.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+//
+// #973 — the guard rails around the size we hand to `create_session`.
+//
+// dev-rust measured the fix as it will actually ship: opening the PTY at the
+// fitted size and letting the view's redundant same-size burst land is 0/10
+// blank, but letting it land ONE ROW off is 6/10 blank. So the only thing worse
+// than not sending a size is sending a wrong one, and every rule below exists to
+// make sure a wrong one can never be sent or — just as bad — recorded.
+//
+// Recording matters as much as sending: `TerminalView` dedups resizes against
+// the size it believes the PTY was opened at. Record a size the backend did not
+// honour and the corrective resize is skipped as a no-op, wedging that PTY at
+// the wrong size for its whole life.
+//
+// This file runs WITHOUT a platform mock, so `isTauri` is false and `isBrowser`
+// is true — which is exactly the environment the browser-mode test needs.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionAPI, __setTransportForTests } from "./ipc";
+import { FakeTransport } from "./testing/fake-transport";
+import { session } from "./testing/ui-harness";
+import {
+  measurePtyViewport,
+  registerPtyViewportProbe,
+  rememberSpawnViewport,
+  resetPtyViewportForTests,
+  takeSpawnViewport,
+} from "./terminal-viewport";
+
+describe("pty spawn viewport (#973)", () => {
+  let restoreTransport: (() => void) | null = null;
+
+  beforeEach(() => {
+    resetPtyViewportForTests();
+  });
+
+  afterEach(() => {
+    restoreTransport?.();
+    restoreTransport = null;
+    resetPtyViewportForTests();
+    vi.restoreAllMocks();
+  });
+
+  describe("measurePtyViewport", () => {
+    it("returns null when no terminal has registered a probe", () => {
+      expect(measurePtyViewport()).toBeNull();
+    });
+
+    it("returns the probed size when a terminal is on screen to measure", () => {
+      registerPtyViewportProbe(() => ({ cols: 74, rows: 23 }));
+      expect(measurePtyViewport()).toEqual({ cols: 74, rows: 23 });
+    });
+
+    it("returns null once the terminal that registered the probe is gone", () => {
+      const unregister = registerPtyViewportProbe(() => ({ cols: 74, rows: 23 }));
+      unregister();
+      expect(measurePtyViewport()).toBeNull();
+    });
+
+    // xterm's fit genuinely returns a zero dimension while its container is still
+    // being laid out. The backend's `PtyViewport::from_fit` SILENTLY falls back to
+    // 120x30 on a zero — so sending one would open the PTY at a size we then
+    // recorded as 0xN and deduped every corrective resize against. Never send it.
+    it.each([
+      ["zero cols", { cols: 0, rows: 23 }],
+      ["zero rows", { cols: 74, rows: 0 }],
+      ["negative", { cols: -1, rows: 23 }],
+      ["fractional", { cols: 74.5, rows: 23 }],
+      ["NaN", { cols: Number.NaN, rows: 23 }],
+      ["beyond u16", { cols: 70000, rows: 23 }],
+    ])("returns null for a degenerate fit: %s", (_label, viewport) => {
+      registerPtyViewportProbe(() => viewport);
+      expect(measurePtyViewport()).toBeNull();
+    });
+
+    it("returns null, and does not throw, when the probe itself throws", () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      registerPtyViewportProbe(() => {
+        throw new Error("not laid out");
+      });
+
+      // A DOM read must never be able to fail a session create.
+      expect(measurePtyViewport()).toBeNull();
+    });
+  });
+
+  describe("spawn viewport memory", () => {
+    it("hands the recorded size to the first terminal built for the session", () => {
+      rememberSpawnViewport("session-1", { cols: 74, rows: 23 });
+      expect(takeSpawnViewport("session-1")).toEqual({ cols: 74, rows: 23 });
+    });
+
+    // Consumed on read: it is only true for the FIRST terminal. A re-attach — a
+    // detached window, a re-created tile — must fit and resize normally, because
+    // the child has long since started and the tile may be a different size now.
+    it("does not hand the same spawn size to a re-attach", () => {
+      rememberSpawnViewport("session-1", { cols: 74, rows: 23 });
+      takeSpawnViewport("session-1");
+      expect(takeSpawnViewport("session-1")).toBeNull();
+    });
+
+    it("returns null for a session that was never given a size", () => {
+      expect(takeSpawnViewport("never-created")).toBeNull();
+    });
+
+    it("refuses to record a size the backend would not have honoured", () => {
+      rememberSpawnViewport("session-1", { cols: 0, rows: 23 });
+      expect(takeSpawnViewport("session-1")).toBeNull();
+    });
+  });
+
+  describe("SessionAPI.create", () => {
+    const mountTransport = (): FakeTransport => {
+      const fake = new FakeTransport();
+      fake.resolve("create_session", session({ id: "created" }));
+      restoreTransport = __setTransportForTests(fake);
+      return fake;
+    };
+
+    // Browser mode: the web-mode `create_session` handler parses its args by hand
+    // and ignores cols/rows entirely — it always spawns at 120x30. Sending a size
+    // it will not honour, and then recording it, would make the terminal dedup the
+    // corrective resize away and strand that PTY at 120x30 forever.
+    it("sends no size in browser mode, even with a terminal on screen to measure", async () => {
+      const fake = mountTransport();
+      registerPtyViewportProbe(() => ({ cols: 74, rows: 23 }));
+
+      await SessionAPI.create({ cwd: "C:\\Project" });
+
+      const args = fake.lastCall("create_session")!.args;
+      expect(args.cols).toBeNull();
+      expect(args.rows).toBeNull();
+    });
+
+    it("records nothing for a session it sent no size for", async () => {
+      mountTransport();
+      registerPtyViewportProbe(() => ({ cols: 74, rows: 23 }));
+
+      await SessionAPI.create({ cwd: "C:\\Project" });
+
+      // Browser mode measured nothing, so the terminal must be free to fit and
+      // resize this PTY normally.
+      expect(takeSpawnViewport("created")).toBeNull();
+    });
+  });
+});

--- a/src/shared/terminal-viewport.test.ts
+++ b/src/shared/terminal-viewport.test.ts
@@ -20,12 +20,20 @@ import { SessionAPI, __setTransportForTests } from "./ipc";
 import { FakeTransport } from "./testing/fake-transport";
 import { session } from "./testing/ui-harness";
 import {
+  BACKEND_SPAWN_FLOOR,
   measurePtyViewport,
   registerPtyViewportProbe,
   rememberSpawnViewport,
   resetPtyViewportForTests,
   takeSpawnViewport,
 } from "./terminal-viewport";
+
+/** The Rust half of the floor, read from source. See the drift guard below. */
+const BACKEND_SOURCES = import.meta.glob<string>("../../src-tauri/src/**/*.rs", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+});
 
 describe("pty spawn viewport (#973)", () => {
   let restoreTransport: (() => void) | null = null;
@@ -57,10 +65,16 @@ describe("pty spawn viewport (#973)", () => {
       expect(measurePtyViewport()).toBeNull();
     });
 
-    // xterm's fit genuinely returns a zero dimension while its container is still
-    // being laid out. The backend's `PtyViewport::from_fit` SILENTLY falls back to
-    // 120x30 on a zero — so sending one would open the PTY at a size we then
-    // recorded as 0xN and deduped every corrective resize against. Never send it.
+    // A size the backend will not open the PTY at must never be sent, because we
+    // would then RECORD it and dedup the corrective resize away against it.
+    //
+    // Two different hazards live in this list. The malformed ones (NaN, fractional,
+    // out of u16 range) are what a broken probe could produce — xterm itself cannot
+    // hand back a zero, it clamps to MINIMUM_COLS = 2 / MINIMUM_ROWS = 1, and the
+    // worst it can propagate is NaN. The BELOW-FLOOR ones are the dangerous ones,
+    // because they are perfectly well-formed: a collapsed-but-laid-out container
+    // measures a real, honest 2x1, which sails straight through a `> 0` check while
+    // `PtyViewport::from_fit` quietly opens the PTY at 120x30 instead.
     it.each([
       ["zero cols", { cols: 0, rows: 23 }],
       ["zero rows", { cols: 74, rows: 0 }],
@@ -68,9 +82,20 @@ describe("pty spawn viewport (#973)", () => {
       ["fractional", { cols: 74.5, rows: 23 }],
       ["NaN", { cols: Number.NaN, rows: 23 }],
       ["beyond u16", { cols: 70000, rows: 23 }],
-    ])("returns null for a degenerate fit: %s", (_label, viewport) => {
+      ["a collapsed box: xterm's own 2x1 clamp", { cols: 2, rows: 1 }],
+      ["one column below the floor", { cols: 19, rows: 40 }],
+      ["one row below the floor", { cols: 80, rows: 4 }],
+    ])("returns null for a fit the backend would not honour: %s", (_label, viewport) => {
       registerPtyViewportProbe(() => viewport);
       expect(measurePtyViewport()).toBeNull();
+    });
+
+    // The floor is a floor, not a preference: a fit sitting exactly on it is a real
+    // size the backend opens the PTY at, and refusing it would cost that session the
+    // whole fix for nothing.
+    it("returns a fit that sits exactly on the floor", () => {
+      registerPtyViewportProbe(() => ({ ...BACKEND_SPAWN_FLOOR }));
+      expect(measurePtyViewport()).toEqual(BACKEND_SPAWN_FLOOR);
     });
 
     it("returns null, and does not throw, when the probe itself throws", () => {
@@ -106,6 +131,43 @@ describe("pty spawn viewport (#973)", () => {
     it("refuses to record a size the backend would not have honoured", () => {
       rememberSpawnViewport("session-1", { cols: 0, rows: 23 });
       expect(takeSpawnViewport("session-1")).toBeNull();
+    });
+
+    // The second door into the wedge, and the one that is NOT hypothetical. The
+    // backend floors this to 120x30 without failing the spawn. Record the 2x1 and
+    // the terminal starts at 2x1, its fit finds nothing to do, and the resize that
+    // would have corrected the PTY is deduped away — leaving the PTY at 120x30
+    // behind a terminal that is not that size, forever.
+    it("refuses to record a below-floor size the backend silently opens at 120x30", () => {
+      rememberSpawnViewport("session-1", { cols: 2, rows: 1 });
+      expect(takeSpawnViewport("session-1")).toBeNull();
+    });
+  });
+
+  // The two floors are one rule living in two languages, and a comment cannot keep
+  // them honest. This reads the Rust and fails the moment they disagree: drift here
+  // does not produce a type error or a failed call, it produces a stranded PTY.
+  describe("the floor mirrors the backend", () => {
+    it("matches PtyViewport::PLAUSIBLE_MIN in src-tauri/src/pty/backend.rs", () => {
+      const pattern =
+        /const PLAUSIBLE_MIN:\s*Self\s*=\s*Self\s*\{\s*cols:\s*(\d+)\s*,\s*rows:\s*(\d+)\s*,?\s*\}/g;
+
+      const found: { cols: number; rows: number }[] = [];
+      for (const source of Object.values(BACKEND_SOURCES)) {
+        let match: RegExpExecArray | null;
+        while ((match = pattern.exec(source)) !== null) {
+          found.push({ cols: Number(match[1]), rows: Number(match[2]) });
+        }
+      }
+
+      // Not found means the backend renamed or restructured the constant. Do not
+      // paper over it: find the new floor and mirror it here, or this whole guard
+      // is decoration.
+      expect(found, "PtyViewport::PLAUSIBLE_MIN not found in the Rust sources").toHaveLength(1);
+      expect(found[0]).toEqual({
+        cols: BACKEND_SPAWN_FLOOR.cols,
+        rows: BACKEND_SPAWN_FLOOR.rows,
+      });
     });
   });
 

--- a/src/shared/terminal-viewport.ts
+++ b/src/shared/terminal-viewport.ts
@@ -55,27 +55,52 @@ const spawnViewports = new Map<string, PtyViewport>();
 const MAX_TRACKED_SPAWN_VIEWPORTS = 32;
 
 /**
+ * The smallest viewport the backend will actually open a PTY at.
+ *
+ * MIRRORS `PtyViewport::PLAUSIBLE_MIN` in `src-tauri/src/pty/backend.rs`. The two
+ * are not allowed to drift, and a comment cannot enforce that: `terminal-viewport
+ * .test.ts` reads the Rust source and fails if this constant stops matching it.
+ *
+ * Below the floor the backend does not fail the spawn — it opens the PTY at
+ * 120x30 and warns. So this side must never SEND a below-floor size, and above
+ * all never RECORD one. See `isHonouredByBackend`.
+ */
+export const BACKEND_SPAWN_FLOOR: PtyViewport = { cols: 20, rows: 5 };
+
+/** `u16` on the Rust side: a bigger number is not a viewport, it is a bug. */
+const MAX_VIEWPORT_DIMENSION = 65535;
+
+/**
  * True only when the backend will genuinely open the PTY at this size.
  *
  * This gate is load-bearing, not hygiene. Recording a size the PTY was NOT
  * opened at is the one way this fix can wedge a terminal: the dedup would treat
  * the corrective resize as a no-op and skip it, leaving the PTY at a size the
- * view never agreed to, forever. Two backend rules decide it:
+ * view never agreed to, forever. Three backend rules decide it:
  *
  *   - `create_session` builds a viewport only when BOTH cols and rows arrive.
- *   - `PtyViewport::from_fit` silently falls back to 120x30 on a zero dimension
- *     (xterm's fit really does return one while its container is being laid
- *     out), so a zero must never be sent, let alone recorded.
+ *   - `PtyViewport::from_fit` opens at 120x30 instead, for anything below
+ *     `BACKEND_SPAWN_FLOOR`. A collapsed-but-laid-out box does NOT measure zero:
+ *     xterm's fit clamps to its own MINIMUM_COLS = 2 / MINIMUM_ROWS = 1, so it
+ *     hands back a perfectly well-formed 2x1 that sails through a `> 0` check
+ *     and that the backend then silently declines to use. Recorded, that 2x1 is
+ *     the wedge — and it is not a corner case: the probe is exact by
+ *     construction, so a box that is collapsed at create time is still collapsed
+ *     at attach time, the fit finds the terminal already at 2x1, and the
+ *     corrective resize is deduped away before it is ever sent.
+ *   - `u16` on the Rust side, so the range is checked here too.
  *
- * `u16` on the Rust side, so the range is checked here too.
+ * The worst xterm itself can hand back is NaN (`CoreTerminal.resize` rejects it,
+ * `FitAddon` can propagate it), which `Number.isInteger` catches. A zero can only
+ * come off the WIRE, from a web-transport client that is not xterm.
  */
 const isHonouredByBackend = (viewport: PtyViewport): boolean =>
   Number.isInteger(viewport.cols) &&
   Number.isInteger(viewport.rows) &&
-  viewport.cols > 0 &&
-  viewport.rows > 0 &&
-  viewport.cols <= 65535 &&
-  viewport.rows <= 65535;
+  viewport.cols >= BACKEND_SPAWN_FLOOR.cols &&
+  viewport.rows >= BACKEND_SPAWN_FLOOR.rows &&
+  viewport.cols <= MAX_VIEWPORT_DIMENSION &&
+  viewport.rows <= MAX_VIEWPORT_DIMENSION;
 
 /** `TerminalView` publishes how it measures its own tile. Returns the unregister. */
 export const registerPtyViewportProbe = (next: PtyViewportProbe): (() => void) => {

--- a/src/shared/terminal-viewport.ts
+++ b/src/shared/terminal-viewport.ts
@@ -1,0 +1,156 @@
+import type { PtyViewport } from "./types";
+
+/**
+ * #973 — the size the PTY is opened at.
+ *
+ * AC opened every ConPTY at a hardcoded 120x30 and let the terminal correct it
+ * a few hundred milliseconds later. dev-rust measured what that correction does
+ * when it lands inside a coding agent's TUI startup: the child redraws its
+ * still-empty viewport, loses the wakeup for the content that becomes ready
+ * right after, and the tile stays blank. 8/10 on a bare ConPTY, no Tauri and no
+ * webview.
+ *
+ * The fix is to open the PTY at the size the view has ALREADY fitted to, so no
+ * resize has to reach a starting child at all. That only works if the size
+ * handed to `create_session` is byte-exact with the size the terminal's own
+ * post-mount fit produces:
+ *
+ *   - a redundant SAME-size resize is harmless ......... 0/10 blank
+ *   - ONE ROW of drift puts the bug back at ............ 6/10 blank
+ *
+ * So this module does not PREDICT the fit, because a prediction that is one row
+ * off is worse than no prediction at all. `TerminalView` registers a probe that
+ * runs the SAME computation the post-mount fit runs — `FitAddon
+ * .proposeDimensions()` — against a terminal that is already on screen in the
+ * same host. Every `.terminal-instance` is `position: absolute; inset: 0` inside
+ * one shared `.terminal-host`, so they all have the identical box, the same
+ * `.terminal-host .xterm` padding, the same `createTerminalOptions`, and the
+ * same (already resolved) font metrics. The answer is exact by construction.
+ *
+ * When there is nothing on screen to measure — no session is active, so
+ * `TerminalView` is not even mounted — the probe returns null, the caller sends
+ * no size, and the backend keeps its historical 120x30. That case is not
+ * covered by this fix; it is covered by the backend's startup-resize guard.
+ */
+
+type PtyViewportProbe = () => PtyViewport | null;
+
+let probe: PtyViewportProbe | null = null;
+
+/**
+ * The size each session's PTY was actually OPENED at, recorded at create time
+ * and consumed when the terminal for it is built.
+ *
+ * `TerminalView` needs this for two things: it starts xterm at that exact size
+ * (so the first fit finds the size it already has and resizes nothing), and it
+ * seeds the resize dedup with it (so the post-mount `syncViewport` does not send
+ * the size the PTY is already open at).
+ *
+ * Bounded: an entry is consumed the moment the session is attached to a
+ * terminal, so this holds at most the handful of sessions created but not yet
+ * shown. The cap is a backstop against a caller that creates sessions it never
+ * attaches.
+ */
+const spawnViewports = new Map<string, PtyViewport>();
+const MAX_TRACKED_SPAWN_VIEWPORTS = 32;
+
+/**
+ * True only when the backend will genuinely open the PTY at this size.
+ *
+ * This gate is load-bearing, not hygiene. Recording a size the PTY was NOT
+ * opened at is the one way this fix can wedge a terminal: the dedup would treat
+ * the corrective resize as a no-op and skip it, leaving the PTY at a size the
+ * view never agreed to, forever. Two backend rules decide it:
+ *
+ *   - `create_session` builds a viewport only when BOTH cols and rows arrive.
+ *   - `PtyViewport::from_fit` silently falls back to 120x30 on a zero dimension
+ *     (xterm's fit really does return one while its container is being laid
+ *     out), so a zero must never be sent, let alone recorded.
+ *
+ * `u16` on the Rust side, so the range is checked here too.
+ */
+const isHonouredByBackend = (viewport: PtyViewport): boolean =>
+  Number.isInteger(viewport.cols) &&
+  Number.isInteger(viewport.rows) &&
+  viewport.cols > 0 &&
+  viewport.rows > 0 &&
+  viewport.cols <= 65535 &&
+  viewport.rows <= 65535;
+
+/** `TerminalView` publishes how it measures its own tile. Returns the unregister. */
+export const registerPtyViewportProbe = (next: PtyViewportProbe): (() => void) => {
+  probe = next;
+  return () => {
+    if (probe === next) {
+      probe = null;
+    }
+  };
+};
+
+/**
+ * The size a terminal created right now would fit to, or null when there is
+ * nothing on screen to measure. Never throws: a DOM read must not be able to
+ * fail a session create.
+ */
+export const measurePtyViewport = (): PtyViewport | null => {
+  if (!probe) {
+    return null;
+  }
+
+  let measured: PtyViewport | null;
+  try {
+    measured = probe();
+  } catch (err) {
+    console.warn("[terminal] viewport probe failed:", err);
+    return null;
+  }
+
+  if (!measured || !isHonouredByBackend(measured)) {
+    return null;
+  }
+
+  return measured;
+};
+
+/** Record the size the backend just opened this session's PTY at. */
+export const rememberSpawnViewport = (
+  sessionId: string,
+  viewport: PtyViewport
+): void => {
+  if (!isHonouredByBackend(viewport)) {
+    return;
+  }
+
+  if (spawnViewports.size >= MAX_TRACKED_SPAWN_VIEWPORTS) {
+    const oldest = spawnViewports.keys().next();
+    if (!oldest.done) {
+      spawnViewports.delete(oldest.value);
+    }
+  }
+
+  spawnViewports.set(sessionId, { cols: viewport.cols, rows: viewport.rows });
+};
+
+/**
+ * The size this session's PTY was opened at, consumed on read.
+ *
+ * Consumed, because it is only true for the FIRST terminal built for the
+ * session. A later re-attach (a detached window, a re-created tile) must fit and
+ * resize normally: by then the child has long since started, the resize is safe,
+ * and the tile may genuinely be a different size.
+ */
+export const takeSpawnViewport = (sessionId: string): PtyViewport | null => {
+  const viewport = spawnViewports.get(sessionId);
+  if (!viewport) {
+    return null;
+  }
+
+  spawnViewports.delete(sessionId);
+  return viewport;
+};
+
+/** Test seam: drop the probe and every recorded spawn size. */
+export const resetPtyViewportForTests = (): void => {
+  probe = null;
+  spawnViewports.clear();
+};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -119,6 +119,18 @@ export interface PtyOutputEvent {
   sequence?: number;
 }
 
+/**
+ * #973 — the terminal size the view has already fitted to, handed to
+ * `create_session` so the PTY is OPENED at it and no resize has to reach a
+ * child that is still starting up. Mirrors the Rust `PtyViewport`
+ * (`pty/backend.rs`), which the command takes as two flat optional fields:
+ * both must arrive, and a zero dimension falls back to 120x30.
+ */
+export interface PtyViewport {
+  cols: number;
+  rows: number;
+}
+
 export interface PtyScreenSnapshot {
   sessionId: string;
   data: number[];

--- a/src/terminal/App.workflow.test.tsx
+++ b/src/terminal/App.workflow.test.tsx
@@ -337,9 +337,24 @@ describe("TerminalApp workflow", () => {
       expect(terminal.resizes).toContainEqual({ cols: 120, rows: 30 });
       expect(Array.from(terminal.writes[0] as Uint8Array)).toEqual([83, 78, 65, 80]);
       expect(hasPtyResizeCall(fake, "session-1", 120, 30)).toBe(false);
+
+      // #973. The snapshot resized xterm to the PTY's size in order to paint it,
+      // and the re-fit then puts xterm back to the tile's size. But the PTY was
+      // ALREADY told that size — by the mount fit, before `fake.clearCalls()` —
+      // and it never moved since. Re-sending it is exactly the redundant resize
+      // #973 removed: land one of those inside a coding agent's TUI startup and
+      // the tile stays blank (0/10 blank without it, 8/10 with).
+      //
+      // This assertion used to require that redundant call. It now requires the
+      // end state it was standing in for, which is the stronger claim: xterm is
+      // back at the fitted size, and the PTY was not spoken to for nothing.
       await waitFor(() =>
-        expect(hasPtyResizeCall(fake, "session-1", fitViewport.cols, fitViewport.rows)).toBe(true)
+        expect({ cols: terminal.cols, rows: terminal.rows }).toEqual({
+          cols: fitViewport.cols,
+          rows: fitViewport.rows,
+        })
       );
+      expect(fake.callsFor("pty_resize")).toHaveLength(0);
       expect(terminal.writes).toHaveLength(1);
     } finally {
       rendered.cleanup();

--- a/src/terminal/components/TerminalView.spawn-size.test.tsx
+++ b/src/terminal/components/TerminalView.spawn-size.test.tsx
@@ -340,18 +340,76 @@ describe("TerminalView PTY spawn size (#973)", () => {
     }
   });
 
-  it("retries a failed resize instead of deduping it away", async () => {
+  // The backend's plausibility floor (`PtyViewport::PLAUSIBLE_MIN`, 20x5). Below it,
+  // `from_fit` does NOT fail the spawn — it opens the PTY at 120x30 and warns. So a
+  // below-floor fit that this side sent AND recorded is the wedge: the PTY is at
+  // 120x30, the view believes it is at 2x1, and the resize that would correct it is
+  // deduped away as a no-op.
+  //
+  // And it is not a corner case. The probe is exact by construction — the same
+  // `proposeDimensions()`, against the same box — so a container that is collapsed
+  // at create time is still collapsed at attach time. The fit finds the terminal
+  // already at 2x1, never reflows, never fires onResize, and nothing ever tells the
+  // PTY the truth. Refusing to record is what keeps the resize path free.
+  it("sends no size for a collapsed tile, and still corrects the PTY afterwards", async () => {
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake);
+
+    // A laid-out but collapsed box. xterm does not report a zero for this — it
+    // clamps to its own MINIMUM_COLS = 2 / MINIMUM_ROWS = 1 — so the fit is a
+    // perfectly well-formed 2x1 that a `> 0` check waves straight through.
+    fitViewport.cols = 2;
+    fitViewport.rows = 1;
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+
+    try {
+      const args = await createWhileOnScreen(fake);
+
+      // Below the floor: not sent, so the backend opens at its own 120x30 default —
+      // and, crucially, nothing is recorded on this side.
+      expect(args.cols).toBeNull();
+      expect(args.rows).toBeNull();
+
+      const spawned = await attachSpawnedSession();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Nothing recorded, so the terminal starts at xterm's default, fits to the
+      // collapsed 2x1, and TELLS the PTY. The corrective resize goes out normally:
+      // the resize path has no floor, deliberately (a user really can drag a window
+      // down this far), and only the spawn path does.
+      expect({ cols: spawned.cols, rows: spawned.rows }).toEqual({ cols: 2, rows: 1 });
+
+      const resizes = resizesFor(fake, SPAWNED);
+      expect(resizes.length).toBeGreaterThan(0);
+      expect(resizes[0].args).toEqual({ sessionId: SPAWNED, cols: 2, rows: 1 });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // A failed resize rolls `lastSentViewport` back so that a SUBSEQUENT identical
+  // resize is not deduped away — but after the dedup, there usually is no subsequent
+  // one. The burst collapses to a single call, and when that one is the one that
+  // failed, the PTY just stays at the wrong size.
+  //
+  // So this test gives the failure nothing to hide behind. The terminal is fully
+  // settled — no pending rAF, no pending fit, no burst left — and then ONE resize is
+  // driven through xterm's onResize, exactly as a user dragging the window would.
+  // That one fails. Nothing else in this system will ever call `sendPtyResize` for
+  // this session again. A rollback that is not a real retry leaves it at one call.
+  it("re-sends a failed resize that is the only one of its burst", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const fake = new FakeTransport();
     setupTerminalTransport(fake);
 
-    // The trap dev-rust hit in the backend's own dedup: if a FAILED resize is
-    // cached as "sent", the retry is skipped as a no-op and the PTY stays at the
-    // wrong size forever.
-    let attempts = 0;
-    fake.onInvoke("pty_resize", () => {
-      attempts += 1;
-      if (attempts === 1) {
+    let spawnedAttempts = 0;
+    fake.onInvoke("pty_resize", (args) => {
+      if (args.sessionId !== SPAWNED) {
+        return undefined;
+      }
+      spawnedAttempts += 1;
+      if (spawnedAttempts === 1) {
         throw new Error("pty_resize failed");
       }
       return undefined;
@@ -360,18 +418,68 @@ describe("TerminalView PTY spawn size (#973)", () => {
     const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
 
     try {
-      await waitFor(() => expect(xterm.instances).toHaveLength(1));
-      await waitFor(() =>
-        expect(resizesFor(fake, ON_SCREEN).length).toBeGreaterThanOrEqual(2)
+      await createWhileOnScreen(fake);
+      const spawned = await attachSpawnedSession();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Opened at the size the tile was already fitted to, so the attach sent
+      // nothing at all. There is no burst.
+      expect(resizesFor(fake, SPAWNED)).toHaveLength(0);
+
+      // The user drags the window. xterm reflows and fires onResize: one resize,
+      // long after every scheduled fit has run. It fails.
+      spawned.emitResize(74, 24);
+
+      await waitFor(
+        () => expect(resizesFor(fake, SPAWNED).length).toBeGreaterThanOrEqual(2),
+        2000
       );
 
-      // The retry carries the same size the failed attempt did — it was not
-      // suppressed as already-sent.
-      expect(resizesFor(fake, ON_SCREEN)[1].args).toEqual({
-        sessionId: ON_SCREEN,
-        cols: 74,
-        rows: 23,
-      });
+      // The attempt and the re-send both carry the size the terminal is actually at.
+      // Nothing but the retry could have produced that second call.
+      const resizes = resizesFor(fake, SPAWNED);
+      expect(resizes[0].args).toEqual({ sessionId: SPAWNED, cols: 74, rows: 24 });
+      expect(resizes[1].args).toEqual({ sessionId: SPAWNED, cols: 74, rows: 24 });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("gives up loudly, and boundedly, when the resize can never land", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake);
+
+    fake.onInvoke("pty_resize", (args) => {
+      if (args.sessionId !== SPAWNED) {
+        return undefined;
+      }
+      throw new Error("pty_resize failed");
+    });
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+
+    try {
+      await createWhileOnScreen(fake);
+      const spawned = await attachSpawnedSession();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      spawned.emitResize(74, 24);
+
+      // A PTY stranded at a size the terminal is not must never be mistaken for a
+      // PTY that was resized. When the budget runs out, it says so.
+      await waitFor(
+        () =>
+          expect(
+            error.mock.calls.some((call) => String(call[0]).includes("giving up"))
+          ).toBe(true),
+        3000
+      );
+
+      // And the budget is a budget: the first attempt plus a fixed number of
+      // re-sends, not an endless loop against a backend that is gone.
+      expect(resizesFor(fake, SPAWNED).length).toBeLessThanOrEqual(4);
     } finally {
       rendered.cleanup();
     }

--- a/src/terminal/components/TerminalView.spawn-size.test.tsx
+++ b/src/terminal/components/TerminalView.spawn-size.test.tsx
@@ -1,0 +1,379 @@
+// @vitest-environment jsdom
+//
+// #973 — a coding agent's tile stays blank on spawn.
+//
+// AC opened every ConPTY at a hardcoded 120x30 and let the view correct it a few
+// hundred milliseconds later. That correction lands inside the agent's TUI
+// startup: the child redraws its still-empty viewport, loses the wakeup for the
+// content that becomes ready right after, and the tile stays blank while the
+// process runs on. dev-rust measured it on a bare ConPTY — 8/10 blank with the
+// resize burst, 0/10 without — and on the user's production logs (p = 0.0103).
+//
+// The frontend half is this: hand `create_session` the size the view has ALREADY
+// fitted to, and then do not resize the PTY to a size it is already at. Both
+// halves are load-bearing, and dev-rust measured why:
+//
+//   R8  open at 74x23, redundant same-size burst still fires ..... 0/10 blank
+//   R9  open at 74x23, the fit lands on 74x24 — one row of drift .. 6/10 blank
+//
+// So the size handed over at create time must be BYTE-EXACT with the size the
+// post-mount fit produces. These tests pin that, and pin the failure modes that
+// would silently un-fix it: a resize that still fires for nothing, a terminal
+// that starts at xterm's 80x24 default and reflows, and a failed resize that
+// poisons the dedup so the retry is skipped and the PTY is wedged forever.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TerminalApp from "../App";
+import { SessionAPI } from "../../shared/ipc";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import { resetPtyViewportForTests } from "../../shared/terminal-viewport";
+import { terminalStore } from "../stores/terminal";
+import {
+  baseSettings,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+
+interface FakeTerminalInstance {
+  cols: number;
+  rows: number;
+  resizes: { cols: number; rows: number }[];
+  emitResize(cols: number, rows: number): void;
+  resize(cols: number, rows: number): void;
+}
+
+const xterm = vi.hoisted(() => ({
+  instances: [] as FakeTerminalInstance[],
+}));
+
+/** What the tile currently fits to. Mutable: drift is simulated by moving it
+ *  between the create and the attach. */
+const fitViewport = vi.hoisted(() => ({ cols: 74, rows: 23 }));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class implements FakeTerminalInstance {
+    cols: number;
+    rows: number;
+    element: HTMLElement | null = null;
+    writes: unknown[] = [];
+    resizes: { cols: number; rows: number }[] = [];
+    private resizeHandlers = new Set<(size: { cols: number; rows: number }) => void>();
+
+    // Real xterm honours cols/rows from the constructor and defaults to 80x24.
+    // That default is the thing #973 must stop relying on.
+    constructor(options?: { cols?: number; rows?: number }) {
+      this.cols = options?.cols ?? 80;
+      this.rows = options?.rows ?? 24;
+      xterm.instances.push(this);
+    }
+
+    loadAddon(addon?: { activate?: (terminal: FakeTerminalInstance) => void }): void {
+      addon?.activate?.(this);
+    }
+
+    open(element: HTMLElement): void {
+      this.element = element;
+    }
+
+    focus(): void {}
+    dispose(): void {
+      this.resizeHandlers.clear();
+    }
+    write(data: unknown): void {
+      this.writes.push(data);
+    }
+    reset(): void {}
+    scrollToBottom(): void {}
+    paste(): void {}
+    hasSelection(): boolean {
+      return false;
+    }
+    getSelection(): string {
+      return "";
+    }
+    attachCustomKeyEventHandler(): void {}
+    onData(): { dispose: () => void } {
+      return { dispose: () => {} };
+    }
+
+    onResize(
+      handler: (size: { cols: number; rows: number }) => void
+    ): { dispose: () => void } {
+      this.resizeHandlers.add(handler);
+      return { dispose: () => this.resizeHandlers.delete(handler) };
+    }
+
+    emitResize(cols: number, rows: number): void {
+      this.cols = cols;
+      this.rows = rows;
+      this.resizes.push({ cols, rows });
+      for (const handler of Array.from(this.resizeHandlers)) {
+        handler({ cols, rows });
+      }
+    }
+
+    resize(cols: number, rows: number): void {
+      this.emitResize(cols, rows);
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    private terminal: FakeTerminalInstance | null = null;
+
+    activate(terminal: FakeTerminalInstance): void {
+      this.terminal = terminal;
+    }
+
+    /** The computation `TerminalView` probes at create time — and the one `fit()`
+     *  runs at attach time. Same function, which is the entire point. */
+    proposeDimensions(): { cols: number; rows: number } {
+      return { cols: fitViewport.cols, rows: fitViewport.rows };
+    }
+
+    /** Faithful to the real FitAddon: it resizes the terminal ONLY when the
+     *  proposal differs from what the terminal already is. A terminal started at
+     *  the size the PTY was opened at therefore never reflows and never fires
+     *  `onResize` — which is exactly what has to be true for the resize to stop
+     *  reaching the child. */
+    fit = vi.fn(() => {
+      const terminal = this.terminal;
+      if (!terminal) return;
+      if (terminal.cols === fitViewport.cols && terminal.rows === fitViewport.rows) {
+        return;
+      }
+      terminal.resize(fitViewport.cols, fitViewport.rows);
+    });
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: class {
+    onContextLoss = vi.fn();
+    dispose = vi.fn();
+  },
+}));
+
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+vi.mock("../../shared/platform", () => ({
+  isTauri: true,
+  isBrowser: false,
+}));
+
+const ON_SCREEN = "session-on-screen";
+const SPAWNED = "session-spawned";
+
+function setupTerminalTransport(fake: FakeTransport): void {
+  fake.resolve("get_settings", baseSettings());
+  fake.resolve("get_active_session", ON_SCREEN);
+  fake.onInvoke("list_sessions", () => [
+    session({ id: ON_SCREEN }),
+    session({ id: SPAWNED }),
+  ]);
+  fake.resolve("pty_write", undefined);
+  fake.resolve("pty_resize", undefined);
+  fake.resolve("get_screen_snapshot", null);
+  fake.resolve("set_last_prompt", undefined);
+  fake.resolve("create_session", session({ id: SPAWNED }));
+}
+
+function resizesFor(fake: FakeTransport, sessionId: string) {
+  return fake
+    .callsFor("pty_resize")
+    .filter((call) => call.args.sessionId === sessionId);
+}
+
+/** The real sequence: a tile is on screen, the sidebar creates a session, and the
+ *  view switches to it. Returns the args `create_session` was invoked with. */
+async function createWhileOnScreen(fake: FakeTransport) {
+  await waitFor(() => expect(xterm.instances).toHaveLength(1));
+  await SessionAPI.create({ cwd: "C:\\Project" });
+  return fake.lastCall("create_session")!.args;
+}
+
+async function attachSpawnedSession() {
+  terminalStore.setActiveSession(SPAWNED);
+  await waitFor(() => expect(xterm.instances).toHaveLength(2));
+  return xterm.instances[1];
+}
+
+describe("TerminalView PTY spawn size (#973)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+    resetPtyViewportForTests();
+    xterm.instances.length = 0;
+    fitViewport.cols = 74;
+    fitViewport.rows = 23;
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    resetPtyViewportForTests();
+    terminalStore.setActiveSession(null);
+    vi.restoreAllMocks();
+  });
+
+  it("opens the PTY at the size the tile on screen is already fitted to", async () => {
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake);
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+
+    try {
+      const args = await createWhileOnScreen(fake);
+
+      // Not a guess: this is `FitAddon.proposeDimensions()` — the same computation
+      // the new terminal's own post-mount fit will run — measured against the tile
+      // already on screen in the same host.
+      expect(args.cols).toBe(74);
+      expect(args.rows).toBe(23);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("issues no resize at all when the fitted size already equals the spawn size", async () => {
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake);
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+
+    try {
+      await createWhileOnScreen(fake);
+      await attachSpawnedSession();
+
+      // Let every resize path have its turn: the double requestAnimationFrame in
+      // scheduleViewportSync, the ResizeObserver, and xterm's own onResize.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // The session that was opened at the fitted size is never resized. This is
+      // the whole fix: no resize reaches the child while it is starting up.
+      expect(resizesFor(fake, SPAWNED)).toHaveLength(0);
+
+      // ...and the resize path is not simply gone. The session already on screen
+      // was created with no size (it predates this view), so it still fits and
+      // resizes exactly as before.
+      expect(resizesFor(fake, ON_SCREEN).length).toBeGreaterThan(0);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("starts xterm at the size the PTY was opened at, so the fit finds nothing to do", async () => {
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake);
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+
+    try {
+      await createWhileOnScreen(fake);
+      const spawned = await attachSpawnedSession();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Started at 74x23, not at xterm's 80x24 default...
+      expect({ cols: spawned.cols, rows: spawned.rows }).toEqual({ cols: 74, rows: 23 });
+      // ...so it never reflowed, and never fired onResize.
+      expect(spawned.resizes).toHaveLength(0);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("resizes exactly once, and says so, when the fit drifts from the spawn size", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake);
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+
+    try {
+      await createWhileOnScreen(fake);
+
+      // The tile measured 74x23 at create time and fits to 74x24 at attach time:
+      // one row of drift — a scrollbar, a late font metric, an extra layout pass.
+      // dev-rust measured this exact case at 6/10 blank, so it must not pass
+      // silently.
+      fitViewport.rows = 24;
+
+      await attachSpawnedSession();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Correctness first: the PTY is told the truth. But exactly once — the
+      // burst of identical resizes is gone.
+      const resizes = resizesFor(fake, SPAWNED);
+      expect(resizes).toHaveLength(1);
+      expect(resizes[0].args).toEqual({ sessionId: SPAWNED, cols: 74, rows: 24 });
+
+      // And it is reported, because a silent drift is a silent 6/10 blank.
+      expect(
+        warn.mock.calls.some((call) => String(call[0]).includes("spawn-size drift"))
+      ).toBe(true);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("still fits and resizes a session that was opened without a spawn size", async () => {
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake);
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+
+      // No size was ever handed over for this one (startup restore, the delivery
+      // loop, a session from a previous run). It must behave exactly as it always
+      // has: start at 80x24, fit, and tell the PTY.
+      await waitFor(() => expect(resizesFor(fake, ON_SCREEN).length).toBeGreaterThan(0));
+      expect(resizesFor(fake, ON_SCREEN)[0].args).toEqual({
+        sessionId: ON_SCREEN,
+        cols: 74,
+        rows: 23,
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("retries a failed resize instead of deduping it away", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fake = new FakeTransport();
+    setupTerminalTransport(fake);
+
+    // The trap dev-rust hit in the backend's own dedup: if a FAILED resize is
+    // cached as "sent", the retry is skipped as a no-op and the PTY stays at the
+    // wrong size forever.
+    let attempts = 0;
+    fake.onInvoke("pty_resize", () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("pty_resize failed");
+      }
+      return undefined;
+    });
+
+    const rendered = renderWithFakeTransport(() => <TerminalApp embedded />, fake);
+
+    try {
+      await waitFor(() => expect(xterm.instances).toHaveLength(1));
+      await waitFor(() =>
+        expect(resizesFor(fake, ON_SCREEN).length).toBeGreaterThanOrEqual(2)
+      );
+
+      // The retry carries the same size the failed attempt did — it was not
+      // suppressed as already-sent.
+      expect(resizesFor(fake, ON_SCREEN)[1].args).toEqual({
+        sessionId: ON_SCREEN,
+        cols: 74,
+        rows: 23,
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -10,8 +10,16 @@ import {
   onTerminalDetached,
 } from "../../shared/ipc";
 import { isBrowser, isTauri } from "../../shared/platform";
+import {
+  registerPtyViewportProbe,
+  takeSpawnViewport,
+} from "../../shared/terminal-viewport";
 import { terminalStore } from "../stores/terminal";
-import type { PtyOutputEvent, PtyScreenSnapshot } from "../../shared/types";
+import type {
+  PtyOutputEvent,
+  PtyScreenSnapshot,
+  PtyViewport,
+} from "../../shared/types";
 import type { UnlistenFn } from "../../shared/transport";
 import { updatePromptCapture } from "./prompt-input-capture";
 import { createTerminalOptions } from "./terminal-options";
@@ -37,6 +45,20 @@ interface SessionTerminal {
   pendingSnapshotEvents: PtyOutputEvent[];
   pendingSnapshotBytes: number;
   lastAppliedSequence: number | null;
+  /**
+   * #973. The size the PTY was OPENED at, when this is the first terminal built
+   * for a session the view sized itself. Null for a re-attach, and for every
+   * session created with no tile to measure.
+   */
+  spawnViewport: PtyViewport | null;
+  /**
+   * #973. The size the PTY is at, as far as this view knows: the size it was
+   * opened at, then whatever resize we last sent. Null means "unknown", and the
+   * next resize is always sent.
+   */
+  lastSentViewport: PtyViewport | null;
+  /** #973. One drift warning per terminal, not one per resize. */
+  spawnDriftReported: boolean;
 }
 
 interface TerminalViewProps {
@@ -82,6 +104,73 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
 
   const terminals = new Map<string, SessionTerminal>();
 
+  /**
+   * #973 diagnostic. The PTY was opened at the size the view had already fitted
+   * to, so a later fit that disagrees means the two measurements drifted apart —
+   * a scrollbar, a font metric settling late, an extra layout pass, a DPI quirk.
+   * The resize still goes out (correctness first), but it lands inside the
+   * child's startup, which is the whole bug. This is the line that says it
+   * happened, on a real box, instead of us assuming it never does.
+   */
+  const reportSpawnSizeDrift = (
+    sessionId: string,
+    entry: SessionTerminal,
+    cols: number,
+    rows: number
+  ) => {
+    const spawn = entry.spawnViewport;
+    if (!spawn || entry.spawnDriftReported) {
+      return;
+    }
+    if (spawn.cols === cols && spawn.rows === rows) {
+      return;
+    }
+
+    entry.spawnDriftReported = true;
+    console.warn(
+      `[terminal] spawn-size drift ${sessionId}: PTY opened at ${spawn.cols}x${spawn.rows}, ` +
+        `view fitted to ${cols}x${rows} — a resize will reach the child during startup (#973)`
+    );
+  };
+
+  /**
+   * #973 — the ONE place a resize reaches the PTY, and it only does so when the
+   * size actually moved.
+   *
+   * A single attach used to fire 5-20 `pty_resize` calls: `syncViewport` sent one
+   * unconditionally, from a double `requestAnimationFrame` AND a `ResizeObserver`,
+   * and xterm's own `onResize` sent another. dev-rust measured that a redundant
+   * SAME-size burst is harmless (0/10 blank) while one row of real drift is not
+   * (6/10) — so both halves matter: send nothing when nothing changed, and when
+   * something did change, say it exactly once.
+   */
+  const sendPtyResize = (
+    sessionId: string,
+    entry: SessionTerminal,
+    cols: number,
+    rows: number
+  ) => {
+    const previous = entry.lastSentViewport;
+    if (previous && previous.cols === cols && previous.rows === rows) {
+      return;
+    }
+
+    reportSpawnSizeDrift(sessionId, entry, cols, rows);
+
+    const sent: PtyViewport = { cols, rows };
+    entry.lastSentViewport = sent;
+
+    void PtyAPI.resize(sessionId, cols, rows).catch((err: unknown) => {
+      // A FAILED resize must not poison the cache: if it did, the retry would be
+      // deduped away as a no-op and the PTY would sit at the wrong size forever.
+      // (dev-rust hit exactly this trap in the backend's own dedup.)
+      if (entry.lastSentViewport === sent) {
+        entry.lastSentViewport = previous;
+      }
+      console.warn(`[terminal] pty_resize ${sessionId} failed:`, err);
+    });
+  };
+
   const syncViewport = (sessionId: string, skipPtyResize = false) => {
     const entry = terminals.get(sessionId);
     if (!entry) {
@@ -90,9 +179,47 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
 
     entry.fitAddon.fit();
     if (!skipPtyResize) {
-      void PtyAPI.resize(sessionId, entry.terminal.cols, entry.terminal.rows);
+      sendPtyResize(sessionId, entry, entry.terminal.cols, entry.terminal.rows);
     }
   };
+
+  /**
+   * #973 — the size a terminal created RIGHT NOW would fit to, handed to
+   * `create_session` so the PTY is opened at it and nothing has to resize a child
+   * that is still starting up.
+   *
+   * This is not a prediction. `proposeDimensions()` is the exact computation the
+   * new terminal's own post-mount `fit()` will run, and it is run here against a
+   * tile that is already on screen in the same `.terminal-host`: every
+   * `.terminal-instance` is `position: absolute; inset: 0`, so a new one gets the
+   * identical box; `createTerminalOptions` is the same for all of them; and the
+   * font metrics are already resolved, because this terminal has been rendering
+   * with them. Same inputs, same computation, same answer.
+   *
+   * Null whenever any of that stops being true — nothing is active, the tile is
+   * `display: none` (a pre-warmed or backgrounded session measures a 0 box), or
+   * xterm itself reports it has not been laid out yet. The caller then sends no
+   * size, which is strictly better than sending a wrong one.
+   */
+  const measureFittedViewport = (): PtyViewport | null => {
+    if (!activeSessionId) {
+      return null;
+    }
+
+    const entry = terminals.get(activeSessionId);
+    if (!entry || entry.container.hidden) {
+      return null;
+    }
+
+    const proposed = entry.fitAddon.proposeDimensions();
+    if (!proposed) {
+      return null;
+    }
+
+    return { cols: proposed.cols, rows: proposed.rows };
+  };
+
+  onCleanup(registerPtyViewportProbe(measureFittedViewport));
 
   const scheduleViewportSync = (sessionId: string) => {
     requestAnimationFrame(() => {
@@ -449,7 +576,17 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     container.hidden = true;
     hostRef.appendChild(container);
 
-    const terminal = new Terminal(createTerminalOptions(isTauri));
+    // #973. The PTY was opened at the size this view fitted to, so start xterm AT
+    // that size. Without this it would start at xterm's 80x24 default and the very
+    // first fit would resize it — firing, through `onResize`, exactly the resize
+    // into the child's startup that opening at the right size exists to avoid.
+    const spawnViewport = takeSpawnViewport(sessionId);
+    const terminal = new Terminal({
+      ...createTerminalOptions(isTauri),
+      ...(spawnViewport
+        ? { cols: spawnViewport.cols, rows: spawnViewport.rows }
+        : {}),
+    });
 
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
@@ -485,6 +622,11 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       pendingSnapshotEvents: [],
       pendingSnapshotBytes: 0,
       lastAppliedSequence: null,
+      spawnViewport,
+      // The PTY is already at the size it was opened at. That is the baseline the
+      // post-mount fit is deduped against, and the reason it sends nothing at all.
+      lastSentViewport: spawnViewport,
+      spawnDriftReported: false,
     };
 
     // Per-terminal keyboard shortcuts. Match keys via event.key (layout-aware,
@@ -574,7 +716,7 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         return;
       }
 
-      void PtyAPI.resize(sessionId, cols, rows);
+      sendPtyResize(sessionId, entry, cols, rows);
     });
 
     terminals.set(sessionId, entry);

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -59,6 +59,14 @@ interface SessionTerminal {
   lastSentViewport: PtyViewport | null;
   /** #973. One drift warning per terminal, not one per resize. */
   spawnDriftReported: boolean;
+  /**
+   * #973. The pending re-send of a resize the PTY never got, and how many times
+   * we have tried. Rolling the dedup back on failure is not enough on its own:
+   * after the dedup, the failed call is usually the ONLY one of its burst, so
+   * there is no subsequent resize for the rollback to un-suppress.
+   */
+  resizeRetryTimer: ReturnType<typeof setTimeout> | null;
+  resizeRetryAttempts: number;
 }
 
 interface TerminalViewProps {
@@ -90,6 +98,15 @@ const SNAPSHOT_SETTLE_WARN_MS = 500;
 //    repainted the screen many times over, the snapshot is worthless, and
 //    holding more would leak if the round-trip never settles.
 const SNAPSHOT_RECONCILE_LIMIT_BYTES = 2 * 1024 * 1024;
+
+// #973. A `pty_resize` that fails leaves the PTY at a size the terminal is not —
+// the exact bug class this issue exists to close, arrived at from the other end.
+// So a failed resize is re-sent, with a linear back-off, and bounded: a resize
+// that can never succeed (the session is gone, the backend is gone) must not
+// retry forever. Exhausting the budget is reported at error level, because a PTY
+// stranded at the wrong size must not look like a PTY that was resized.
+const PTY_RESIZE_RETRY_DELAY_MS = 120;
+const PTY_RESIZE_MAX_RETRIES = 3;
 
 // WebGL context budget: ~16 per document. Canvas fallback activates silently
 // when the budget is exhausted (e.g. after ~16 concurrent sessions in main).
@@ -133,6 +150,51 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     );
   };
 
+  const clearResizeRetryTimer = (entry: SessionTerminal) => {
+    if (entry.resizeRetryTimer !== null) {
+      clearTimeout(entry.resizeRetryTimer);
+      entry.resizeRetryTimer = null;
+    }
+  };
+
+  /**
+   * #973 — re-send a resize the PTY never got.
+   *
+   * It re-sends the size the terminal IS when the timer fires, not the size that
+   * failed. The view may have moved on in the meantime, and what has to be true at
+   * the end is that the PTY is where the terminal is now. That also makes the retry
+   * self-cancelling: if a later resize already landed on that size, `sendPtyResize`
+   * dedups this one away and nothing is sent.
+   */
+  const scheduleResizeRetry = (sessionId: string, entry: SessionTerminal) => {
+    if (entry.resizeRetryTimer !== null) {
+      return;
+    }
+
+    if (entry.resizeRetryAttempts >= PTY_RESIZE_MAX_RETRIES) {
+      console.error(
+        `[terminal] pty_resize ${sessionId} failed ${entry.resizeRetryAttempts} times: ` +
+          `giving up with the PTY at a size this terminal is not (#973)`
+      );
+      return;
+    }
+
+    entry.resizeRetryAttempts += 1;
+    const attempt = entry.resizeRetryAttempts;
+
+    entry.resizeRetryTimer = setTimeout(() => {
+      entry.resizeRetryTimer = null;
+
+      // Disposed, or replaced by a re-attach: that terminal's size is not this
+      // terminal's business any more.
+      if (terminals.get(sessionId) !== entry) {
+        return;
+      }
+
+      sendPtyResize(sessionId, entry, entry.terminal.cols, entry.terminal.rows);
+    }, PTY_RESIZE_RETRY_DELAY_MS * attempt);
+  };
+
   /**
    * #973 — the ONE place a resize reaches the PTY, and it only does so when the
    * size actually moved.
@@ -160,15 +222,24 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     const sent: PtyViewport = { cols, rows };
     entry.lastSentViewport = sent;
 
-    void PtyAPI.resize(sessionId, cols, rows).catch((err: unknown) => {
-      // A FAILED resize must not poison the cache: if it did, the retry would be
-      // deduped away as a no-op and the PTY would sit at the wrong size forever.
-      // (dev-rust hit exactly this trap in the backend's own dedup.)
-      if (entry.lastSentViewport === sent) {
-        entry.lastSentViewport = previous;
-      }
-      console.warn(`[terminal] pty_resize ${sessionId} failed:`, err);
-    });
+    void PtyAPI.resize(sessionId, cols, rows)
+      .then(() => {
+        // The channel works. Whatever budget an earlier failure burned is returned.
+        entry.resizeRetryAttempts = 0;
+      })
+      .catch((err: unknown) => {
+        // A FAILED resize must not poison the cache: if it did, the retry below
+        // would be deduped away as a no-op and the PTY would sit at the wrong size
+        // forever. (dev-rust hit exactly this trap in the backend's own dedup.)
+        if (entry.lastSentViewport === sent) {
+          entry.lastSentViewport = previous;
+        }
+        console.warn(`[terminal] pty_resize ${sessionId} failed:`, err);
+
+        // ...and un-suppressing a resize nobody is going to send again is not a
+        // retry. Send it again.
+        scheduleResizeRetry(sessionId, entry);
+      });
   };
 
   const syncViewport = (sessionId: string, skipPtyResize = false) => {
@@ -251,6 +322,7 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     }
 
     clearSnapshotSettleTimer(entry);
+    clearResizeRetryTimer(entry);
     entry.terminal.dispose();
     entry.container.remove();
     terminals.delete(sessionId);
@@ -627,6 +699,8 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       // post-mount fit is deduped against, and the reason it sends nothing at all.
       lastSentViewport: spawnViewport,
       spawnDriftReported: false,
+      resizeRetryTimer: null,
+      resizeRetryAttempts: 0,
     };
 
     // Per-terminal keyboard shortcuts. Match keys via event.key (layout-aware,


### PR DESCRIPTION
## What

A new coding-agent session comes up as a **blank terminal** while the agent process is alive and healthy. Pressing any key paints it instantly. This is the other half of the "Codex hangs on launch" report — the first half was the render gate (#955).

**Root cause: AgentsCommander opens every ConPTY at a hardcoded `120x30`, then the frontend fires 5-20 unconditional resizes at 279-543 ms — straight through the window in which Codex's TUI is starting. A resize inside that window makes Codex redraw its still-empty viewport and lose the wakeup for the content that becomes ready immediately after. AC then goes silent forever, and so does Codex.**

Closes #973.

## Reproduced outside AC, byte-identical to production

Bare ConPTY, `cmd.exe /C codex --yolo ...`, opened at AC's real `120x30`, then AC's real fit to `74x23`. **No Tauri, no webview, no xterm.js.** n=10 per arm; every "cure" arm induces the hang first.

| Arm | What | SILENT |
|---|---|---|
| R0 | control: spawn, send nothing | **0/10** |
| **R5** | **AC today: 6 resizes in the window** | **8/10** |
| R7 | open the PTY at the fitted size, never resize | **0/10** |
| **R9** | **A only, drifted ONE ROW** | **6/10** |
| **R10** | **B: open 120x30, suppress until the child renders** | **0/10** |
| **R11** | **A + B, drifted one row** | **0/10** |
| R1 / R2 / R4 / R6 | cure with a resize (different size / same size / honouring the child's XTWINOPS / late) | 7-8/10 — **a resize cannot cure it** |
| R3 | cure with **one keystroke** | **0/10** |

The two rows that explain it, same child, same hang, sitting at exactly 345 bytes:

```
resize    -> wake_ms=0   -> +133 bytes    (one more EMPTY frame)  *** STILL BLANK ***
keystroke -> wake_ms=16  -> +14,803 bytes (the entire UI)         painted
```

Codex's renderer is not stuck. It is alive, it handles resizes perfectly, and it repaints on demand — it repaints *the empty viewport*. Only an **input** event makes it re-render content. That is a lost wakeup inside Codex (reported upstream separately).

**On the user's production logs:** resized during startup → **4 silent / 10 (40%)**. Never resized → **0 / 18 (0%)**. Fisher exact, two-sided: **p = 0.0103**.

## The fix

- **A** — spawn the ConPTY at the size the view will actually use. The frontend runs `FitAddon.proposeDimensions()` (the same function the post-mount fit calls) against the tile already on screen, so the size is exact by construction, and constructs xterm at that size so the first fit does not reflow and `onResize` never fires. The resize is not suppressed; **it is never generated.**
- **B** — never resize a child that has not rendered anything. Resizes are **held**, the last size is kept, and it is handed to the ConPTY the moment the child paints. **This is the load-bearing fix**: it covers the cold-start case (no active session ⇒ no tile to measure ⇒ no spawn size ⇒ `120x30`), which is the first agent the user launches every day.
- **C** — skip `master.resize()` when the size has not changed (free; AC was firing 5-20 redundant ConPTY resizes per session for nothing).

**The trigger for B is not a timer and not a byte count.** Production first-paint spans 324-2163 ms, so any constant fitted to one machine lands *inside* the window on a slower one. It asks the **real, stateful vt100 parser** AC already feeds on every chunk: *does the screen hold a cell a human can see?* A space is not content (a TUI paints its empty viewport with spaces — the exact moment the gate must stay shut); a **coloured or reverse-video** space is (`Cell::clear` keeps attributes, so `ESC[41m ESC[2J` is a solid red screen with no "contents").

## Found in review, and fixed here

- **A `0x0` resize panics `vt100::grid::set_size`** (`size.rows - 1` underflows a `u16`: panic in debug, **wrap to 65535 in release**) **while holding `screen_parsers`, poisoning that mutex.** Every reader swallows the poison silently, so **one `cols: 0` off the web transport killed the #955 screen snapshot, the output sequence numbering and `get_pty_size` for every session, for the life of the process, with no log line.** Live on `main` before this branch. The guard now sits where the invariant breaks, so it covers every transport.
- The degenerate guard originally sat **behind** the startup gate, so a `0x0` could evict the real held size and strand the PTY at `120x30` permanently.
- `web/commands.rs` parsed dimensions with `as u16`, which **silently truncated**: `cols: 65536` became `0`.
- The gate's first trigger used a **stateless** per-chunk byte stripper. Measured: **43 of 51** chunk-boundary splits of a real TUI prologue falsely reported printable, and a 3-byte escape (`ESC ( B` — what ncurses emits) leaked its third byte. Replaced by the stateful parser above.
- The frontend could record a below-floor spawn size the backend refused, which would strand the PTY at `120x30` **guaranteed** for a collapsed tile. Both floors are now pinned by a test that reads the Rust constant out of `backend.rs`, so they cannot drift.
- Seven comments claimed xterm's `fit()` returns a zero. **It cannot** (it clamps to `2x1` and can only propagate NaN). The zero comes off the wire. Corrected.

## What the tests prove, and what they do not

The unit tests pin the **plumbing**: that the ConPTY is opened at the size the view asked for, that a child which has not rendered is not resized, that a degenerate size cannot evict a held one, and that the gate is immune to chunk boundaries. Backend tests assert on `MasterPty::get_size()` — the size the child would actually see.

They do **not** prove Codex stops hanging. That needs a real child in a real ConPTY inside a ~100 ms race window, and no unit test can honestly claim it. **The harness is the proof.**

## Gates

`cargo test --all-targets` **2402 passed / 0 failed** · `cargo clippy --all-targets` clean · `npx tsc --noEmit` clean · `npx vitest run` **1042 / 0** · `npm run test:debt` exit 0.

## Related

#955 (the render gate — the other half of the black terminal). #942 / PR #951 (the diagnostics that made this visible). #978 (`cmd.exe /D /C`: a printing `AutoRun` can open B's gate early — worth landing soon). #980 (the container backend still forwards a degenerate size). #956 (the IPC firehose — measured, and **not** the cause of this bug).
