### PR TITLE
fix(sidebar): give every context-menu glyph a fixed slot so the labels line up (#987)

### DIFF
--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1829,6 +1829,7 @@ const ProjectPanel: Component = () => {
               }}
               data-ac-testid={`replica.${automationIdPart(wg.name)}.groups.trigger`}
             >
+              <span class="session-context-option-icon" aria-hidden="true" />
               <span>Add to Group</span>
               <span class="session-context-submenu-arrow">&rsaquo;</span>
             </button>
@@ -1963,16 +1964,18 @@ const ProjectPanel: Component = () => {
                       data-ac-testid={`${testIdPrefix()}.${index()}`}
                       data-ac-role="menuitem"
                     >
-                      <svg
-                        class="session-context-repo-icon"
-                        viewBox="0 0 16 16"
-                        aria-hidden="true"
-                      >
-                        <path
-                          fill="currentColor"
-                          d="M1.75 4.25A1.75 1.75 0 0 1 3.5 2.5h3.1c.46 0 .9.18 1.22.5l.9.9h3.78A1.75 1.75 0 0 1 14.25 5.65v5.1a1.75 1.75 0 0 1-1.75 1.75h-9A1.75 1.75 0 0 1 1.75 10.75v-6.5Z"
-                        />
-                      </svg>
+                      <span class="session-context-option-icon" aria-hidden="true">
+                        <svg
+                          class="session-context-repo-icon"
+                          viewBox="0 0 16 16"
+                          aria-hidden="true"
+                        >
+                          <path
+                            fill="currentColor"
+                            d="M1.75 4.25A1.75 1.75 0 0 1 3.5 2.5h3.1c.46 0 .9.18 1.22.5l.9.9h3.78A1.75 1.75 0 0 1 14.25 5.65v5.1a1.75 1.75 0 0 1-1.75 1.75h-9A1.75 1.75 0 0 1 1.75 10.75v-6.5Z"
+                          />
+                        </svg>
+                      </span>
                       <span class="session-context-repo-label">{repo.label}</span>
                       <Show when={browseItems().length > 0}>
                         <span
@@ -3770,7 +3773,7 @@ const ProjectPanel: Component = () => {
                             await restartReplicaSession(menu().sessionId);
                           }}
                         >
-                          &#x21BA; Restart Session
+                          <span class="session-context-option-icon" aria-hidden="true">&#x21BA;</span> Restart Session
                         </button>
                         <button
                           class="session-context-option"
@@ -3782,14 +3785,14 @@ const ProjectPanel: Component = () => {
                             setReplicaCodingAgentTarget({ sessionId, sessionName });
                           }}
                         >
-                          &#x1F916; Coding Agent
+                          <span class="session-context-option-icon" aria-hidden="true">&#x1F916;</span> Coding Agent
                         </button>
                         <button
                           class="session-context-option"
                           title={menu().replica.path}
                           onClick={() => void openReplicaFolder(menu().replica.path)}
                         >
-                          &#x1F4C2; Open Replica's Folder
+                          <span class="session-context-option-icon" aria-hidden="true">&#x1F4C2;</span> Open Replica's Folder
                         </button>
                         {renderRepoMenuEntries(repoEntries, () => `replica.${menu().sessionId}.menu.repo`)}
                         <Show when={matrixFolder()}>
@@ -3799,7 +3802,7 @@ const ProjectPanel: Component = () => {
                               title={path()}
                               onClick={() => void openMatrixFolder(path())}
                             >
-                              <MatrixFolderIcon /> Open Matrix folder
+                              <span class="session-context-option-icon" aria-hidden="true"><MatrixFolderIcon /></span> Open Matrix folder
                             </button>
                           )}
                         </Show>
@@ -3808,6 +3811,10 @@ const ProjectPanel: Component = () => {
                           class="session-context-option"
                           onClick={() => toggleReplicaDetach(menu().sessionId)}
                         >
+                          {/* #987 - the two glyphs the session row's detach button uses. */}
+                          <span class="session-context-option-icon" aria-hidden="true">
+                            {sessionsStore.isDetached(menu().sessionId) ? "\u2934" : "\u29C9"}
+                          </span>{" "}
                           {sessionsStore.isDetached(menu().sessionId) ? "Re-attach to main" : "Open in new window"}
                         </button>
                         {renderAddToGroupItem(menu().wg, menu().replica)}
@@ -3819,7 +3826,7 @@ const ProjectPanel: Component = () => {
                           title={broomTitle()}
                           onClick={() => void clearReplicaTaskTitle(menu().wg)}
                         >
-                          &#x1F9F9; Clear task title
+                          <span class="session-context-option-icon" aria-hidden="true">&#x1F9F9;</span> Clear task title
                         </button>
                       </>
                       );
@@ -3848,14 +3855,14 @@ const ProjectPanel: Component = () => {
                               });
                             }}
                           >
-                            &#x1F916; Coding Agent
+                            <span class="session-context-option-icon" aria-hidden="true">&#x1F916;</span> Coding Agent
                           </button>
                           <button
                             class="session-context-option"
                             title={menu().replica.path}
                             onClick={() => void openReplicaFolder(menu().replica.path)}
                           >
-                            &#x1F4C2; Open Replica's Folder
+                            <span class="session-context-option-icon" aria-hidden="true">&#x1F4C2;</span> Open Replica's Folder
                           </button>
                           {renderRepoMenuEntries(repoEntries, () => "replica.inactive.menu.repo")}
                           <Show when={matrixFolder()}>
@@ -3865,7 +3872,7 @@ const ProjectPanel: Component = () => {
                                 title={path()}
                                 onClick={() => void openMatrixFolder(path())}
                               >
-                                <MatrixFolderIcon /> Open Matrix folder
+                                <span class="session-context-option-icon" aria-hidden="true"><MatrixFolderIcon /></span> Open Matrix folder
                               </button>
                             )}
                           </Show>
@@ -3877,7 +3884,7 @@ const ProjectPanel: Component = () => {
                             title={broomTitle()}
                             onClick={() => void clearReplicaTaskTitle(menu().wg)}
                           >
-                            &#x1F9F9; Clear task title
+                            <span class="session-context-option-icon" aria-hidden="true">&#x1F9F9;</span> Clear task title
                           </button>
                         </>
                       );

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2903,9 +2903,20 @@ html.light-theme .settings-api-client-warning {
 
 /* #987 - fixed-width gutter slot for context-menu glyphs. The menu mixes 14px
    SVGs with entities and emoji, whose advance widths all differ, so an unwrapped
-   glyph starts every label at a different x. Centering each glyph in a 16px slot
-   (widest content is the 14px SVG; emoji run ~13px at this font-size) lands every
-   label on the same x. Rows with no icon (Add to Group) carry an empty slot. */
+   glyph starts every label at a different x. Centering each glyph in this slot
+   lands every label on the same x. Rows with no icon (Add to Group) carry an
+   empty slot.
+
+   The 16px box is a CENTRING ANCHOR, NOT A FIT. Measured at the 13px this slot
+   sets: the emoji (U+1F916, U+1F4C2, U+1F9F9) advance 17.86px, so they overflow
+   the box by ~0.93px per side; the SVGs are 14px, U+29C9 is 13px, U+21BA is 10px.
+   The overflow is deliberate and harmless: the box does not clip, the bleed is
+   symmetric (every glyph's centre lands on the same axis) and it spills into the
+   row's 12px padding and 8px gap, where nothing is drawn.
+
+   So there is NO spare room here. Do not add anything that clips or paints this
+   box - overflow, background, border - and do not raise its font-size, without
+   first widening it past the widest glyph. Today that means >= 18px. */
 .session-context-option-icon {
   display: inline-flex;
   align-items: center;

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -2868,8 +2868,11 @@ html.light-theme .settings-api-client-warning {
   white-space: normal;
 }
 
+/* #987 - with the icon slot this is a 3-item row (slot, label, arrow), and
+   space-between would strand the label in the middle. The arrow's own
+   margin-left: auto keeps it pinned right. */
 .session-context-submenu-trigger {
-  justify-content: space-between;
+  justify-content: flex-start;
 }
 
 .session-context-submenu-arrow {
@@ -2896,6 +2899,22 @@ html.light-theme .settings-api-client-warning {
   width: 14px;
   flex: 0 0 14px;
   color: var(--sidebar-accent);
+}
+
+/* #987 - fixed-width gutter slot for context-menu glyphs. The menu mixes 14px
+   SVGs with entities and emoji, whose advance widths all differ, so an unwrapped
+   glyph starts every label at a different x. Centering each glyph in a 16px slot
+   (widest content is the 14px SVG; emoji run ~13px at this font-size) lands every
+   label on the same x. Rows with no icon (Add to Group) carry an empty slot. */
+.session-context-option-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  font-size: 13px;
+  line-height: 1;
 }
 
 .session-context-group-option span:last-child {


### PR DESCRIPTION
Closes #987

Follow-up to #977, from the user testing the deployed build. With icons on two items, the Sidebar replica context menu read as a ragged column: the menu mixes emoji rendered as HTML entities with SVG components, every glyph has a different advance width, and the two items with no icon at all started their label at the padding edge.

## What changed

Frontend only: `src/sidebar/components/ProjectPanel.tsx` (+26/-19) and `src/sidebar/styles/sidebar.css`.

- **A fixed 16px icon slot on every row** (`.session-context-option-icon`), centring whatever glyph it holds. Rows with no icon get an empty slot of the same width, so their label lands on the same x. Measured in headless Chromium against the real stylesheets: all 8 rows now start their label at **x = 37.00, spread 0.00** (on `main`: 13 for entity rows, 35 for SVG rows, spread 22).
- **`Open in new window` gets the glyph the Sidebar already uses for that action**: `⧉` (U+29C9) when attached, `⤴` (U+2934) when detached, driven by the same ternary as the label so icon and label cannot disagree. Same codepoints and polarity as the session row's detach button.
- **`Add to Group` keeps no icon** (the user's call: it is an expander, not an action) but gets the empty slot and keeps its submenu arrow. Its `justify-content` moved from `space-between` to `flex-start`, since a third flex item would otherwise have stranded the label mid-row; the arrow stays pinned right by its own `margin-left: auto`. That class has exactly one usage.
- Both menu branches (active and inactive/grey) are covered, via the shared `renderRepoMenuEntries` / `renderAddToGroupItem` helpers.

## Review

Grinch PASSed, re-measuring everything himself rather than taking the numbers: the column, the single-use submenu-trigger class, both branches (12 slot sites, `grep -c` finds 12), the glyph pair, and the load-bearing whitespace (one test asserts a button's trimmed `textContent` verbatim, so the space between glyph and label matters; another asserts a repo row's `textContent` is exactly the repo label, so the SVG wrap must add no text node). Both hold by construction.

He raised one LOW: the stated rationale for 16px was wrong. At the slot's own `font-size: 13px` the emoji advance **17.86px**, so they overflow the box by ~0.93px per side rather than fitting it with room to spare. The rendering is unaffected (the slot is a centring anchor with no clipping, the bleed is symmetric and lands in the row's padding and gap, every glyph's ink centre falls on 21.0), but the comment would have told the next person they had room. Corrected in `bb398845`, comment-only, with the real advances recorded so nobody re-derives them: the box does not clip, and nothing that clips or paints it may be added without first widening it past 18px.

## Behavior

Unchanged. #977's pointer-leave close and its 250ms grace, `groupErrorPinned()`, the submenus, Escape and click-outside are untouched, and its 46-test regression net passes against unmodified test files. Structurally the only DOM change is child spans added inside existing buttons, and `mouseenter`/`mouseleave` do not fire on parent-child transitions.

## Gates

`npm run typecheck` clean. `npm run test`: 124 files / 1054 tests, 0 failed.

## Known, filed as #988

The Add to Group flyout (the submenu this row opens) is ragged by the same 22px on `main`: its group rows carry a 14px slot and land at x=35, while "Create new group" has no slot and lands at x=13. Pre-existing, out of scope here, and it should also unify that 14px gutter with this menu's 16px.
