### PR TITLE
fix(#993): strip Windows verbatim prefix from container repo mount sources

### DIFF
--- a/src-tauri/src/pty/container_repos.rs
+++ b/src-tauri/src/pty/container_repos.rs
@@ -181,7 +181,9 @@ pub fn resolve_repo_mounts(replica_root: &Path) -> Result<RepoMountResolution, S
                 config_entry: entry,
                 outcome: RepoOutcome::Mounted {
                     name,
-                    host_path: canonical,
+                    // #993 - dockerd rejects a verbatim \\?\ mount source. Strip it
+                    // AFTER the Sec 4.2 checks above, which run on the verbatim path.
+                    host_path: crate::path_utils::normalize_windows_verbatim_path_buf(&canonical),
                     container_path,
                 },
             });
@@ -194,7 +196,7 @@ pub fn resolve_repo_mounts(replica_root: &Path) -> Result<RepoMountResolution, S
                  admissible repo-* directory directly under the workgroup root \
                  (direct_wg_child={}, repo_prefix={}, is_dir={}, not_reserved={})",
                 entry,
-                canonical.display(),
+                crate::path_utils::path_to_string_without_windows_verbatim_prefix(&canonical),
                 parent_is_wg_root,
                 name_has_repo_prefix,
                 is_dir,
@@ -288,6 +290,25 @@ mod tests {
         let mounts: Vec<_> = resolution.mounts().collect();
         assert_eq!(mounts.len(), 1);
         assert_eq!(mounts[0].1, "/repos/repo-AgentsCommander");
+    }
+
+    #[test]
+    fn mounted_host_path_has_no_windows_verbatim_prefix() {
+        // #993 - std::fs::canonicalize yields \\?\C:\... on Windows and dockerd
+        // rejects that as a --mount source. make_workgroup canonicalizes the
+        // tempdir, so on Windows this fails without the normalize at the store.
+        let (_tmp, wg_root, replica) = make_workgroup("__agent_self");
+        mkdir(&wg_root, "repo-AgentsCommander");
+        write_repos(&replica, &["../repo-AgentsCommander"]);
+
+        let resolution = resolve_repo_mounts(&replica).expect("ok");
+        let mounts: Vec<_> = resolution.mounts().collect();
+        assert_eq!(mounts.len(), 1);
+        let host = mounts[0].0.to_string_lossy();
+        assert!(
+            !host.starts_with(r"\\?\"),
+            "mount source must not carry the verbatim prefix: {host}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/pty/docker_runtime.rs
+++ b/src-tauri/src/pty/docker_runtime.rs
@@ -708,6 +708,9 @@ mod tests {
         assert!(repo2 < image_idx, "repo mounts must precede the image");
         assert_eq!(spec.args[image_idx - 1], "--");
         assert_eq!(spec.args[image_idx + 1], DEFAULT_BRIDGE_ENTRYPOINT);
+        // #993 - the resolver strips the Windows verbatim prefix, so the
+        // rendered --mount args never carry \\?\ (dockerd rejects such a source).
+        assert!(!joined.contains(r"\\?\"), "{joined}");
         // S7 free regression guard, now exercised WITH repo mounts.
         assert!(!joined.contains("messaging"));
     }


### PR DESCRIPTION
Closes #993

## Problem

On Windows, docker-runtime sessions failed with exit 125 whenever the replica had `repos[]` entries: `resolve_repo_mounts` canonicalized repo paths into verbatim form (`\\?\C:\...`), which reached `docker run --mount source=` and was rejected by dockerd ("is not a valid Windows path"). Introduced with #935; Windows-only, so CI stayed green.

## Change

- Normalize `host_path` at the single store site in `container_repos.rs` with the existing `path_utils::normalize_windows_verbatim_path_buf` helper (same treatment the replica root mount already had). Admissibility checks keep running on the verbatim canonical path.
- Regression test `mounted_host_path_has_no_windows_verbatim_prefix` (fails without the fix on Windows; CI runs the unit suite on `windows-latest`).
- Mirror assertion on rendered `--mount` args in `docker_runtime.rs`.
- Cosmetic: refusal message renders the normalized path.

## Review

- **dev-rust**: implemented; cargo check clean, clippy clean, `container_repos` 17/17, `docker_runtime` 8/8; fail-proof verified (reverting only the store line makes the new test fail with the real-world error shape).
- **dev-rust-grinch**: adversarial review **PASS, 0 findings**. Traced all downstream consumers (none needs the verbatim form), verified UNC/NT handling and the security boundary (checks unchanged on verbatim canonical), and ran a live Docker Desktop proof on Windows: verbatim source reproduces the exact dockerd exit-125 error; normalized source mounts correctly (incl. 338-char path and trailing-dot directory).

Non-visual backend change: no shipper build required.
