### PR TITLE
test(#1001): consumption-oracle measurement harness + inert verdict scaffolding (PR1/4)

### DIFF
--- a/src-tauri/src/phone/consumption.rs
+++ b/src-tauri/src/phone/consumption.rs
@@ -1,0 +1,153 @@
+//! (#1001 PR1) The wake-consumption oracle: pure decision core.
+//!
+//! Two dead oracles (dev-rust's bare `waiting_for_input` flip, §14.1's
+//! post-submit activity gate) both observed the PTY OUTPUT stream, and the echo
+//! of a pasted body IS output on that stream produced WITHOUT consuming the turn
+//! (grinch G1/G2, architect §16.1). PR1 therefore does not pick a signal on
+//! paper: it ships a GENERIC decision table and an `#[ignore]` harness that
+//! measures which candidate signal actually predicts consumption against an
+//! echo-immune, out-of-band ground truth. This module is that generic core plus
+//! the shared verdict->Result conversion.
+//!
+//! Kept in a sibling module (allowed by plan §12) so the 12k-line `mailbox.rs`
+//! is not the home for a pure, timer-free, PTY-free decision the harness and A
+//! (PR3) both import unchanged.
+
+use std::time::Duration;
+
+/// The verdict of the consumption oracle for one observation tick.
+///
+/// Signal-agnostic on purpose (grinch G1 / §16.1): the driver supplies an opaque
+/// `consumed_signal` computed from whichever candidate the PR1 harness selects;
+/// this type never names a signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConsumptionVerdict {
+    /// Idle at inject AND the chosen consumed-signal was observed within the
+    /// window: consumption confirmed.
+    Observed,
+    /// Idle at inject, no consumed-signal yet. Returned every tick the session
+    /// stays idle-without-signal; the driver converts a `Pending` that survives
+    /// to `elapsed >= window` into the not-consumed result.
+    Pending,
+    /// Not idle at inject (busy / mid-turn). Consumption cannot be attributed to
+    /// this wake, so the write-receipt (bias-to-deliver) semantics are preserved
+    /// (§F2). `wake_action_for` injects into a busy session regardless.
+    NotApplicable,
+}
+
+/// Pure per-tick decision for the consumption oracle. GENERIC: it must not
+/// reference `activity_after_submit` or any specific signal (§16.1) - the driver
+/// passes an opaque `consumed_signal`. Timer-free and PTY-free, so the whole
+/// decision table is unit-testable.
+///
+/// `elapsed` and `window` are part of the signature mandated by §16.1 so this
+/// single fn is the driver's loop primitive and A (PR3) imports it unchanged.
+/// The fn itself does not branch on them: `idle + !signal` is `Pending` whether
+/// or not the window is spent, and the DRIVER (which owns the clock) maps a
+/// terminal `Pending` (survived to `elapsed >= window`) to not-consumed via
+/// [`verdict_to_result`]. Keeping the clock in the driver, not here, is what
+/// keeps the table signal-agnostic and trivially testable.
+// PR1 lands this generic table and its enum ahead of the sole production
+// caller (the A/PR3 oracle driver). It is exercised now by the unit tests
+// below and by the `#[ignore]` measurement harness. Remove when A wires it.
+#[allow(dead_code)]
+pub(crate) fn consumption_verdict(
+    idle_at_inject: bool,
+    consumed_signal: bool,
+    elapsed: Duration,
+    window: Duration,
+) -> ConsumptionVerdict {
+    // Threaded for the mandated call-site shape; the driver, not this fn, owns
+    // the terminal test against these (see doc above).
+    let _ = (elapsed, window);
+    if !idle_at_inject {
+        ConsumptionVerdict::NotApplicable
+    } else if consumed_signal {
+        ConsumptionVerdict::Observed
+    } else {
+        ConsumptionVerdict::Pending
+    }
+}
+
+/// The SINGLE shared verdict->Result conversion (grinch G6). Called by BOTH the
+/// production path in `inject_wake_into_pty` and the `consumption_results` test
+/// hook, so the deterministic AC3 test exercises the real conversion rather than
+/// a hook-local copy. Pure, so it is unit-testable in isolation.
+pub(crate) fn verdict_to_result(verdict: ConsumptionVerdict) -> Result<(), String> {
+    match verdict {
+        // Observed: consumption confirmed. NotApplicable: busy-at-inject, keep the
+        // existing write-receipt semantics (bias-to-deliver). Both are success.
+        ConsumptionVerdict::Observed | ConsumptionVerdict::NotApplicable => Ok(()),
+        // A `Pending` that reached the driver's terminal tick means the window
+        // elapsed with no consumed signal: surface an actionable failure so the
+        // FS/DB retry machinery redelivers (A/PR3). In PR1 the production path
+        // never reaches this arm - the verdict is always `NotApplicable` until A
+        // wires a real oracle - but the hook path and A both rely on it.
+        ConsumptionVerdict::Pending => {
+            Err("wake injected but consumption was not observed within the window".to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WINDOW: Duration = Duration::from_millis(4000);
+
+    #[test]
+    fn busy_at_inject_is_not_applicable_regardless_of_signal_or_clock() {
+        // A mid-turn wake cannot attribute a flip; preserve write-receipt.
+        for signal in [false, true] {
+            for elapsed in [Duration::ZERO, WINDOW, WINDOW * 2] {
+                assert_eq!(
+                    consumption_verdict(false, signal, elapsed, WINDOW),
+                    ConsumptionVerdict::NotApplicable
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn idle_with_signal_is_observed() {
+        assert_eq!(
+            consumption_verdict(true, true, Duration::ZERO, WINDOW),
+            ConsumptionVerdict::Observed
+        );
+        // Even at/after the window, a signal this tick is Observed.
+        assert_eq!(
+            consumption_verdict(true, true, WINDOW, WINDOW),
+            ConsumptionVerdict::Observed
+        );
+    }
+
+    #[test]
+    fn idle_without_signal_is_pending_in_window_and_at_terminal() {
+        // In-window: keep waiting.
+        assert_eq!(
+            consumption_verdict(true, false, Duration::from_millis(10), WINDOW),
+            ConsumptionVerdict::Pending
+        );
+        // Terminal tick (elapsed >= window): still Pending; the driver converts
+        // this to the not-consumed Result, not the pure fn.
+        assert_eq!(
+            consumption_verdict(true, false, WINDOW, WINDOW),
+            ConsumptionVerdict::Pending
+        );
+    }
+
+    #[test]
+    fn verdict_to_result_maps_success_and_failure() {
+        assert!(verdict_to_result(ConsumptionVerdict::Observed).is_ok());
+        assert!(verdict_to_result(ConsumptionVerdict::NotApplicable).is_ok());
+        assert!(verdict_to_result(ConsumptionVerdict::Pending).is_err());
+    }
+
+    #[test]
+    fn terminal_pending_error_is_actionable() {
+        // The Err text feeds the CLI/dispatcher failure surface; keep it
+        // descriptive and free of the payload (no injected body echoed back).
+        let err = verdict_to_result(ConsumptionVerdict::Pending).unwrap_err();
+        assert!(err.contains("not observed"));
+    }
+}

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -13,6 +13,7 @@ use crate::config::agent_config::AgentLocalConfig;
 use crate::config::sessions_persistence::RaiseHandPersistOutcome;
 use crate::config::settings::{AgentConfig, AppSettings, SettingsState};
 use crate::config::teams;
+use crate::phone::consumption::{verdict_to_result, ConsumptionVerdict};
 use crate::phone::types::OutboxMessage;
 use crate::pty::backend::SessionBackendKind;
 use crate::pty::manager::PtyManager;
@@ -1507,6 +1508,11 @@ type MailboxAttachCalls = Arc<Mutex<Vec<(Uuid, Option<String>)>>>;
 struct MailboxTestHooks {
     pty_presence: Arc<Mutex<HashMap<Uuid, bool>>>,
     inject_results: Arc<Mutex<VecDeque<Result<(), String>>>>,
+    /// (#1001 PR1 / G6) Scripted consumption verdicts, mirroring
+    /// `inject_results`. When non-empty, the `inject_wake_into_pty` hook arm
+    /// pops one after a successful inject and runs the SHARED `verdict_to_result`
+    /// - so the AC3 hooked test exercises the real conversion, not a copy.
+    consumption_results: Arc<Mutex<VecDeque<ConsumptionVerdict>>>,
     inject_calls: Arc<Mutex<Vec<Uuid>>>,
     destroy_calls: Arc<Mutex<Vec<Uuid>>>,
     spawn_calls: Arc<Mutex<Vec<MailboxSpawnCall>>>,
@@ -2760,11 +2766,22 @@ impl MailboxPoller {
                 let mut events = hooks.events.lock().unwrap();
                 events.push(MailboxTestEvent::Inject(session_id));
             }
-            let result = {
+            let inject_result = {
                 let mut results = hooks.inject_results.lock().unwrap();
                 results.pop_front()
+            }
+            .unwrap_or(Ok(()));
+            // (#1001 PR1 / G6) On a successful inject, if a consumption
+            // verdict is scripted, run the SAME verdict_to_result the
+            // production path uses so AC3 covers the real conversion. No
+            // scripted verdict => Ok (existing hooked tests unchanged).
+            return match inject_result {
+                Ok(()) => match hooks.consumption_results.lock().unwrap().pop_front() {
+                    Some(verdict) => verdict_to_result(verdict),
+                    None => Ok(()),
+                },
+                Err(e) => Err(e),
             };
-            return result.unwrap_or(Ok(()));
         }
 
         let result = self
@@ -2783,7 +2800,16 @@ impl MailboxPoller {
                 idle.touch_silence(session_id);
             }
         }
-        result
+        // (#1001 PR1 / G6) Route the successful-inject return through the
+        // shared verdict_to_result so this production site runs the exact
+        // conversion the AC3 hooked test exercises. PR1 wires no oracle yet,
+        // so the verdict is NotApplicable => Ok(()): today's write-receipt
+        // semantics, unchanged. A (PR3) replaces NotApplicable with the
+        // observed verdict from the oracle driver.
+        match result {
+            Ok(()) => verdict_to_result(ConsumptionVerdict::NotApplicable),
+            Err(e) => Err(e),
+        }
     }
 
     async fn destroy_exited_wake_session<R: tauri::Runtime>(
@@ -11279,6 +11305,127 @@ mod tests {
         assert!(hooks.spawn_calls.lock().unwrap().is_empty());
         assert_no_spawn_or_destroy_events(&hooks);
         assert_inject_results_consumed(&hooks);
+    }
+
+    // ── (#1001 PR1) consumption-verdict wiring: AC3 deterministic hooked tests ──
+    //
+    // These prove the shared `verdict_to_result` (G6) is what
+    // `inject_wake_into_pty` runs, so the conversion A (PR3) changes has real,
+    // deterministic coverage instead of a hook-local copy. A live Idle candidate
+    // takes the WakeAction::Inject arm; the inject itself is scripted Ok, and the
+    // scripted ConsumptionVerdict drives the returned Result.
+
+    /// Build a well-formed wake OutboxMessage targeting the fixture's dev-rust
+    /// replica. `deliver_wake_with_origin` does not re-validate token/routing
+    /// (that is `process_message`'s job), so a direct call is the tightest way to
+    /// assert the Ok/Err the verdict produces.
+    fn wake_message_to_target() -> OutboxMessage {
+        OutboxMessage {
+            id: "consume-verdict".into(),
+            token: None,
+            from: CANONICAL_WAKE_FROM.into(),
+            to: CANONICAL_WAKE_TO.into(),
+            body: WAKE_BODY.into(),
+            mode: "wake".into(),
+            get_output: false,
+            request_id: None,
+            sender_agent: Some("codex".into()),
+            preferred_agent: "codex".into(),
+            priority: "normal".into(),
+            timestamp: "2026-07-15T00:00:00Z".into(),
+            command: None,
+            action: None,
+            target: None,
+            force: None,
+            timeout_secs: None,
+            switch_coding_agent: None,
+            switch_profile: None,
+            dry_run: None,
+            quiet_period_ms: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn deliver_wake_terminal_pending_verdict_yields_err_after_inject() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let live_id =
+            add_mailbox_session(&app, &fixture.target_cwd, "live", SessionStatus::Idle, None).await;
+        let hooks = MailboxTestHooks::default();
+        hooks.pty_presence.lock().unwrap().insert(live_id, true);
+        hooks.inject_results.lock().unwrap().push_back(Ok(()));
+        hooks
+            .consumption_results
+            .lock()
+            .unwrap()
+            .push_back(ConsumptionVerdict::Pending);
+        let poller = MailboxPoller::new_with_test_hooks(hooks.clone());
+        let msg = wake_message_to_target();
+
+        let result = poller
+            .deliver_wake_with_origin(&app, &msg, WakeDeliveryOrigin::FilesystemPoller)
+            .await;
+
+        assert!(
+            result.is_err(),
+            "a terminal Pending verdict must convert to Err (drives redelivery), got {:?}",
+            result
+        );
+        // The inject ran exactly once, against the live candidate.
+        assert_eq!(*hooks.inject_calls.lock().unwrap(), vec![live_id]);
+        assert_inject_results_consumed(&hooks);
+        assert!(
+            hooks.consumption_results.lock().unwrap().is_empty(),
+            "the scripted verdict must be consumed by the hook arm"
+        );
+    }
+
+    #[tokio::test]
+    async fn deliver_wake_observed_verdict_yields_ok_single_delivery() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let live_id =
+            add_mailbox_session(&app, &fixture.target_cwd, "live", SessionStatus::Idle, None).await;
+        let hooks = MailboxTestHooks::default();
+        hooks.pty_presence.lock().unwrap().insert(live_id, true);
+        hooks.inject_results.lock().unwrap().push_back(Ok(()));
+        hooks
+            .consumption_results
+            .lock()
+            .unwrap()
+            .push_back(ConsumptionVerdict::Observed);
+        let poller = MailboxPoller::new_with_test_hooks(hooks.clone());
+        let msg = wake_message_to_target();
+
+        let result = poller
+            .deliver_wake_with_origin(&app, &msg, WakeDeliveryOrigin::FilesystemPoller)
+            .await;
+
+        assert!(result.is_ok(), "Observed must convert to Ok, got {:?}", result);
+        assert_eq!(*hooks.inject_calls.lock().unwrap(), vec![live_id]);
+        assert_no_spawn_or_destroy_events(&hooks);
+    }
+
+    #[tokio::test]
+    async fn deliver_wake_without_scripted_verdict_stays_ok_unchanged() {
+        // Back-compat: existing hooked tests script no consumption_results, so
+        // the hook arm must default to Ok(()) (write-receipt), unchanged.
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let live_id =
+            add_mailbox_session(&app, &fixture.target_cwd, "live", SessionStatus::Idle, None).await;
+        let hooks = MailboxTestHooks::default();
+        hooks.pty_presence.lock().unwrap().insert(live_id, true);
+        hooks.inject_results.lock().unwrap().push_back(Ok(()));
+        let poller = MailboxPoller::new_with_test_hooks(hooks.clone());
+        let msg = wake_message_to_target();
+
+        let result = poller
+            .deliver_wake_with_origin(&app, &msg, WakeDeliveryOrigin::FilesystemPoller)
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(*hooks.inject_calls.lock().unwrap(), vec![live_id]);
     }
 
     #[tokio::test]

--- a/src-tauri/src/phone/mod.rs
+++ b/src-tauri/src/phone/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod consumption;
 pub mod mailbox;
 pub mod manager;
 pub mod messaging;

--- a/src-tauri/src/pty/idle_detector.rs
+++ b/src-tauri/src/pty/idle_detector.rs
@@ -227,6 +227,27 @@ impl IdleDetector {
             .and_then(|&t| now.checked_duration_since(t))
     }
 
+    /// (#1001 PR1 / grinch G7) True iff this session's last PRINTABLE-output
+    /// instant is strictly after `t`. Compares the stored `activity` stamp to
+    /// `t` directly under a single lock, with NO synthesized `now`, so it avoids
+    /// the false-positive skew of a `now - activity_age` round-trip (a driver
+    /// `now` later than the accessor `now` would inflate the reconstructed
+    /// instant and read a stale echo as fresh). This is the timestamp-gate
+    /// candidate signal the wake-consumption harness evaluates; `activity_age`
+    /// (for B) is intentionally NOT reused here.
+    ///
+    /// CAVEAT (grinch G8): `activity` is frozen during `resize_grace`
+    /// (`record_activity_with_bytes` early-returns without stamping), so a
+    /// post-resize repaint does NOT count as activity here; callers needing
+    /// resize-awareness must consult `last_resize_age` (via `purge_readiness`).
+    pub fn has_printable_activity_since(&self, session_id: Uuid, t: Instant) -> bool {
+        self.activity
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&session_id)
+            .is_some_and(|&stamp| stamp > t)
+    }
+
     /// (#885) Sample readiness for `ids` under a SINGLE critical section.
     ///
     /// A PTY reader thread must take `activity` then `idle_set` to record activity
@@ -665,6 +686,31 @@ mod tests {
             readiness[0].activity_age.is_none(),
             "activity_age must be None for an unregistered session"
         );
+    }
+
+    #[test]
+    fn has_printable_activity_since_compares_stamp_to_reference() {
+        let detector = IdleDetector::new(|_| {}, |_| {});
+        let id = Uuid::new_v4();
+        detector.register_session(id, IdleTuning::DEFAULT);
+
+        // A reference that predates the recorded stamp: activity-since is true.
+        let before = Instant::now() - Duration::from_millis(50);
+        detector.record_activity_with_bytes(id, 5);
+        assert!(
+            detector.has_printable_activity_since(id, before),
+            "a recorded stamp is strictly after an earlier reference"
+        );
+
+        // A reference strictly after the last stamp: no newer activity.
+        let after = Instant::now() + Duration::from_millis(50);
+        assert!(
+            !detector.has_printable_activity_since(id, after),
+            "no activity after a future reference"
+        );
+
+        // Untracked session: never any activity.
+        assert!(!detector.has_printable_activity_since(Uuid::new_v4(), before));
     }
 
     #[test]

--- a/src-tauri/tests/wake_consumption_measure.rs
+++ b/src-tauri/tests/wake_consumption_measure.rs
@@ -1,0 +1,506 @@
+//! (#1001 PR1) On-demand measurement harness for the wake-consumption oracle.
+//!
+//! WHY THIS EXISTS (plan section 16.1): two output-stream oracles have already
+//! died the same way - the echo/repaint of a pasted body IS output, produced
+//! WITHOUT consuming the turn, so no output-only signal is provable on paper.
+//! This harness therefore does not confirm a signal; it FALSIFIES candidates
+//! against an echo-immune, out-of-band ground truth.
+//!
+//! GROUND TRUTH (echo-immune, by construction, plan 16.1): the wake body tells
+//! the agent to run a tool that appends a unique marker line to a file in a
+//! harness-controlled dir. The harness polls the FILESYSTEM, never the PTY
+//! stream. The file gains a line iff the agent actually executed the turn; the
+//! echo of the instruction cannot create it. A per-attempt marker measures
+//! duplicate submission (F7/G4) directly as marker-count.
+//!
+//! CANDIDATE SIGNALS measured against that GT, per agent, on Windows/ConPTY:
+//!   1. bare `waiting_for_input` flip  (IdleDetector idle_set, via purge_readiness)
+//!   2. post-submit activity timestamp gate  (has_printable_activity_since, sec 14.1)
+//!   3. screen-state: body no longer in the input box AND transcript grew
+//!      (vt100 screen via get_screen_snapshot, sec 16.1 candidate #3)
+//!
+//! For each: false-positive (signal=consumed, GT=not -> masks the bug) and
+//! false-negative (signal=not, GT=consumed -> needless redeliver, couples G4).
+//!
+//! AGENT-AGNOSTIC: the agent command is read from env so the SAME instrument
+//! runs whichever agent is installed, with ZERO code change (tech-lead guidance):
+//!   AC_WAKE_HARNESS_SHELL  (default "claude")
+//!   AC_WAKE_HARNESS_ARGS   (default "--dangerously-skip-permissions"; space split)
+//!   AC_WAKE_HARNESS_AGENT  (report label; default = shell)
+//!   AC_WAKE_HARNESS_TRIALS (default "5")
+//!   AC_WAKE_HARNESS_SIGNAL_WINDOW_MS (default "6000")
+//!   AC_WAKE_HARNESS_GT_TIMEOUT_MS    (default "60000")
+//! Never fabricated: if the agent binary is absent, the harness prints a SKIP
+//! line and returns (it does not assert), so a run on a box without that agent
+//! is an honest no-op, not a fake pass.
+//!
+//! RUN (Windows, agent installed + authenticated):
+//!   cargo test --test wake_consumption_measure -- --ignored --nocapture
+//! It prints a per-signal FP/FN table, the F7 lingering answer, and the
+//! live-path fresh-idle drop rate.
+
+#![cfg(target_os = "windows")]
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use agentscommander_lib::commands::pty::get_screen_snapshot;
+use agentscommander_lib::commands::session::{create_session_inner, destroy_session_inner};
+use agentscommander_lib::config::settings::{AppSettings, SettingsState};
+use agentscommander_lib::pty::git_watcher::GitWatcher;
+use agentscommander_lib::pty::idle_detector::IdleDetector;
+use agentscommander_lib::pty::inject::inject_text_into_session;
+use agentscommander_lib::pty::manager::PtyManager;
+use agentscommander_lib::resource_monitor::ResourceMonitorState;
+use agentscommander_lib::session::manager::SessionManager;
+use agentscommander_lib::shutdown::ShutdownSignal;
+use agentscommander_lib::telegram::manager::{
+    OutputSenderMap, TelegramBridgeManager, TelegramBridgeState,
+};
+use agentscommander_lib::voice::tracker::{VoiceTracker, VoiceTrackingState};
+use agentscommander_lib::web::auth::WebAccessToken;
+use agentscommander_lib::web::broadcast::WsBroadcaster;
+use agentscommander_lib::{
+    AppOutbox, ConfigSeedLockState, DetachedSessionsState, MasterToken, RestoreInProgress,
+    SpecBoardState, WebServerHandle,
+};
+use tauri::Manager;
+use uuid::Uuid;
+
+// ─────────────────────────── env-driven config ───────────────────────────
+
+struct HarnessConfig {
+    shell: String,
+    args: Vec<String>,
+    agent_label: String,
+    trials: usize,
+    signal_window: Duration,
+    gt_timeout: Duration,
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+impl HarnessConfig {
+    fn from_env() -> Self {
+        let shell = env_or("AC_WAKE_HARNESS_SHELL", "claude");
+        let args_raw = env_or("AC_WAKE_HARNESS_ARGS", "--dangerously-skip-permissions");
+        let args = args_raw
+            .split_whitespace()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let agent_label = env_or("AC_WAKE_HARNESS_AGENT", &shell);
+        let trials = env_or("AC_WAKE_HARNESS_TRIALS", "5")
+            .parse()
+            .unwrap_or(5usize);
+        let signal_window = Duration::from_millis(
+            env_or("AC_WAKE_HARNESS_SIGNAL_WINDOW_MS", "6000")
+                .parse()
+                .unwrap_or(6000),
+        );
+        let gt_timeout = Duration::from_millis(
+            env_or("AC_WAKE_HARNESS_GT_TIMEOUT_MS", "60000")
+                .parse()
+                .unwrap_or(60000),
+        );
+        Self {
+            shell,
+            args,
+            agent_label,
+            trials,
+            signal_window,
+            gt_timeout,
+        }
+    }
+}
+
+/// Resolve the agent binary on PATH (or as an absolute path). Returns None when
+/// it is not installed, so the harness can SKIP honestly rather than fake a run.
+fn agent_available(shell: &str) -> bool {
+    if Path::new(shell).is_absolute() {
+        return Path::new(shell).exists();
+    }
+    let exts = ["", ".exe", ".cmd", ".bat"];
+    if let Ok(path) = std::env::var("PATH") {
+        for dir in path.split(';') {
+            for ext in exts {
+                if Path::new(dir).join(format!("{shell}{ext}")).exists() {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+// ───────────────────────────── app context ───────────────────────────────
+
+struct HarnessCtx {
+    app: tauri::App,
+    session_mgr: Arc<tokio::sync::RwLock<SessionManager>>,
+    pty_mgr: Arc<Mutex<PtyManager>>,
+    idle: Arc<IdleDetector>,
+    _shutdown: ShutdownSignal,
+    _temp: tempfile::TempDir,
+}
+
+/// Build a minimal but REAL app context (mirrors tests/pty_lifecycle_regression
+/// make_test_app) and START the idle watcher so the `waiting_for_input`/idle_set
+/// transition (candidate signal 1) actually fires. We hold the `Arc<IdleDetector>`
+/// so signals 1 and 2 read the real detector directly.
+fn make_ctx(repo_root: &Path) -> HarnessCtx {
+    let temp = tempfile::TempDir::new().expect("temp");
+    let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+    let output_senders: OutputSenderMap = Arc::new(Mutex::new(HashMap::new()));
+    let tg_mgr: TelegramBridgeState = Arc::new(tokio::sync::Mutex::new(
+        TelegramBridgeManager::new(Arc::clone(&output_senders)),
+    ));
+    // No-op callbacks: signal 1 is read from the detector's idle_set via
+    // purge_readiness, so we do not need to mirror into SessionManager here.
+    let idle: Arc<IdleDetector> = IdleDetector::new(|_| {}, |_| {});
+    let settings: SettingsState = Arc::new(tokio::sync::RwLock::new(AppSettings {
+        default_shell: "powershell.exe".to_string(),
+        default_shell_args: vec!["-NoLogo".to_string()],
+        project_paths: vec![repo_root.to_string_lossy().to_string()],
+        ..AppSettings::default()
+    }));
+    let git_app = Box::leak(Box::new(
+        tauri::Builder::default()
+            .any_thread()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("git handle app"),
+    ));
+    let git_watcher = GitWatcher::new(Arc::clone(&session_mgr), git_app.handle().clone());
+    let pty_mgr = Arc::new(Mutex::new(PtyManager::new(
+        output_senders,
+        Arc::clone(&idle),
+        Arc::clone(&git_watcher),
+        None,
+        Arc::clone(&session_mgr),
+    )));
+
+    let detached: DetachedSessionsState = Arc::new(Mutex::new(HashSet::new()));
+    let voice: VoiceTrackingState = Arc::new(Mutex::new(VoiceTracker::new()));
+    let spec_board: SpecBoardState = Arc::new(tokio::sync::RwLock::new(
+        agentscommander_lib::commands::spec_board::SpecBoardManager::new(),
+    ));
+    let config_seed_lock: ConfigSeedLockState = Arc::new(tokio::sync::Mutex::new(()));
+    let shutdown = ShutdownSignal::new();
+
+    let app = tauri::Builder::default()
+        .any_thread()
+        .manage(MasterToken::new("wake-consume-master".into()))
+        .manage(AppOutbox::new(
+            repo_root.join(".app-outbox").to_string_lossy().to_string(),
+        ))
+        .manage(settings)
+        .manage(Arc::clone(&session_mgr))
+        .manage(tg_mgr)
+        .manage(detached)
+        .manage(voice)
+        .manage(Arc::new(RestoreInProgress(AtomicBool::new(false))))
+        .manage(shutdown.clone())
+        .manage(Arc::new(WebAccessToken::new("wake-consume-web".into())))
+        .manage(WsBroadcaster::new())
+        .manage(WebServerHandle::default())
+        .manage(spec_board)
+        .manage(config_seed_lock)
+        .manage(Arc::clone(&git_watcher))
+        .manage(Arc::new(ResourceMonitorState::new()))
+        .manage(Arc::clone(&pty_mgr))
+        .manage(Arc::clone(&idle))
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("build harness app");
+
+    idle.start(shutdown.clone());
+
+    HarnessCtx {
+        app,
+        session_mgr,
+        pty_mgr,
+        idle,
+        _shutdown: shutdown,
+        _temp: temp,
+    }
+}
+
+// ───────────────────────────── signals + GT ──────────────────────────────
+
+/// Signal 1: is the session currently in the idle set (waiting_for_input == true
+/// equivalent)? Read from the real detector, watcher-driven.
+fn watcher_idle(idle: &Arc<IdleDetector>, id: Uuid) -> bool {
+    idle.purge_readiness(&[id])
+        .first()
+        .map(|r| r.watcher_idle)
+        .unwrap_or(false)
+}
+
+/// Strip the common SGR/CSI escapes so a plain-text screen can be scanned for the
+/// body token. Deliberately simple: the screen signal is per-agent-approximate by
+/// construction (plan 16.1), and this only needs contiguous ASCII tokens.
+fn strip_ansi(bytes: &[u8]) -> String {
+    let s = String::from_utf8_lossy(bytes);
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            // ESC: skip a CSI/OSC-ish run until a letter/terminator.
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                for d in chars.by_ref() {
+                    if d.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                // ESC + one/two byte sequence: drop next char.
+                chars.next();
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+fn screen_text(app: &tauri::App, id: Uuid) -> String {
+    let state = app.state::<Arc<Mutex<PtyManager>>>();
+    match get_screen_snapshot(state, id.to_string()) {
+        Ok(Some(snap)) => strip_ansi(&snap.data),
+        _ => String::new(),
+    }
+}
+
+fn nonblank_lines(text: &str) -> usize {
+    text.lines().filter(|l| !l.trim().is_empty()).count()
+}
+
+/// Signal 3: the body token is no longer visible in the input-box region (last
+/// few non-blank lines) AND the transcript grew vs the pre-inject snapshot.
+fn screen_consumed(pre_lines: usize, post: &str, body_token: &str) -> bool {
+    let last_region: String = post
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .rev()
+        .take(6)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let body_in_box = last_region.contains(body_token);
+    let grew = nonblank_lines(post) > pre_lines;
+    !body_in_box && grew
+}
+
+/// Ground truth: count marker lines the agent actually wrote to its side-effect
+/// file. Echo-immune: only a real tool execution creates them.
+fn gt_marker_count(file: &Path) -> usize {
+    std::fs::read_to_string(file)
+        .map(|s| s.lines().filter(|l| l.contains("AC_WAKE_MARK")).count())
+        .unwrap_or(0)
+}
+
+/// The wake body: instruct the agent to append a per-attempt marker line via a
+/// shell tool. Same string whichever agent runs it (agent-agnostic).
+fn wake_body(file: &Path, trial: usize, attempt: usize) -> String {
+    // PowerShell Add-Content is available on every Windows box the app targets.
+    let path = file.to_string_lossy().replace('\'', "''");
+    format!(
+        "Run exactly this one shell command now, then stop and do nothing else:\n\
+         powershell -NoProfile -Command \"Add-Content -LiteralPath '{path}' -Value 'AC_WAKE_MARK {trial}-{attempt}'\"\n"
+    )
+}
+
+// ───────────────────────────── per-trial record ──────────────────────────
+
+#[derive(Default, Clone, Copy)]
+struct SignalTally {
+    fp: usize, // signal said consumed, GT said not
+    fn_: usize, // signal said not-consumed, GT said consumed
+    total: usize,
+}
+
+impl SignalTally {
+    fn observe(&mut self, signal_consumed: bool, gt_consumed: bool) {
+        self.total += 1;
+        match (signal_consumed, gt_consumed) {
+            (true, false) => self.fp += 1,
+            (false, true) => self.fn_ += 1,
+            _ => {}
+        }
+    }
+}
+
+// ─────────────────────────────── the harness ─────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "on-demand real-agent measurement; needs an installed+authed coding agent on Windows/ConPTY"]
+async fn measure_wake_consumption_signals() {
+    let cfg = HarnessConfig::from_env();
+    println!("\n=== #1001 wake-consumption measurement harness ===");
+    println!(
+        "agent='{}' shell='{}' args={:?} trials={} signal_window={:?} gt_timeout={:?}",
+        cfg.agent_label, cfg.shell, cfg.args, cfg.trials, cfg.signal_window, cfg.gt_timeout
+    );
+
+    if !agent_available(&cfg.shell) {
+        println!(
+            "SKIP: agent shell '{}' not found on PATH. Set AC_WAKE_HARNESS_SHELL/ARGS to a real \
+             coding agent and re-run. No numbers produced (not fabricated).",
+            cfg.shell
+        );
+        return;
+    }
+
+    let repo_root = std::env::current_dir().expect("cwd");
+    let ctx = make_ctx(&repo_root);
+
+    let mut bare = SignalTally::default();
+    let mut ts_gate = SignalTally::default();
+    let mut screen = SignalTally::default();
+    let mut cold_drops = 0usize; // GT-not-consumed on first attempt (the raw bug)
+    let mut linger_dupes = 0usize; // redeliver produced a 2nd marker (F7/G4)
+    let mut linger_measured = 0usize;
+
+    for trial in 0..cfg.trials {
+        let trial_dir = ctx._temp.path().join(format!("trial{trial}"));
+        std::fs::create_dir_all(&trial_dir).expect("trial dir");
+        let gt_file = trial_dir.join("marks.txt");
+
+        // Cold-spawn a fresh agent session at the trial dir.
+        let info = match create_session_inner(
+            ctx.app.handle(),
+            &ctx.session_mgr,
+            &ctx.pty_mgr,
+            cfg.shell.clone(),
+            cfg.args.clone(),
+            trial_dir.to_string_lossy().to_string(),
+            Some(format!("wake-harness-{trial}")),
+            None,
+            Some(cfg.agent_label.clone()),
+            true,
+            Vec::new(),
+            true,
+            None,
+            None,
+        )
+        .await
+        {
+            Ok(info) => info,
+            Err(e) => {
+                println!("trial {trial}: spawn failed: {e}");
+                continue;
+            }
+        };
+        let id = Uuid::parse_str(&info.id).expect("uuid");
+
+        // Wait for the agent to boot to a sustained-idle, paste-ready state:
+        // watcher_idle true AND the screen has rendered content.
+        let boot_deadline = Instant::now() + Duration::from_secs(45);
+        loop {
+            let ready = watcher_idle(&ctx.idle, id)
+                && nonblank_lines(&screen_text(&ctx.app, id)) > 0;
+            if ready || Instant::now() >= boot_deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        let idle_at_inject = watcher_idle(&ctx.idle, id);
+        let pre_lines = nonblank_lines(&screen_text(&ctx.app, id));
+
+        // ── inject attempt 1 (production inject: body + double-Enter) ──
+        let body1 = wake_body(&gt_file, trial, 1);
+        let body_token = format!("AC_WAKE_MARK {trial}-1"); // the box would echo the instruction, incl. this
+        let _ = inject_text_into_session(ctx.app.handle(), id, &body1).await;
+        let submit_completed_at = Instant::now();
+
+        // ── poll the three signals over the signal window ──
+        let mut s1 = false;
+        let mut s2 = false;
+        let mut s3 = false;
+        let win_deadline = submit_completed_at + cfg.signal_window;
+        while Instant::now() < win_deadline {
+            if idle_at_inject && !watcher_idle(&ctx.idle, id) {
+                s1 = true; // bare flip: idle -> busy after inject
+            }
+            if idle_at_inject && ctx.idle.has_printable_activity_since(id, submit_completed_at) {
+                s2 = true;
+            }
+            if idle_at_inject {
+                let post = screen_text(&ctx.app, id);
+                if screen_consumed(pre_lines, &post, &body_token) {
+                    s3 = true;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        // ── ground truth: did the agent actually run the tool? ──
+        let gt_deadline = Instant::now() + cfg.gt_timeout;
+        while gt_marker_count(&gt_file) < 1 && Instant::now() < gt_deadline {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+        let gt1 = gt_marker_count(&gt_file) >= 1;
+        if !gt1 {
+            cold_drops += 1;
+        }
+
+        bare.observe(s1, gt1);
+        ts_gate.observe(s2, gt1);
+        screen.observe(s3, gt1);
+        println!(
+            "trial {trial}: idle_at_inject={idle_at_inject} GT_consumed={gt1} | \
+             bare_flip={s1} ts_gate={s2} screen={s3}"
+        );
+
+        // ── F7/G4: redeliver the SAME turn (no clear) and see if a lingering
+        // unsent body causes a duplicate submission. Only meaningful to measure
+        // when attempt 1 did NOT consume (the bug case). ──
+        if !gt1 {
+            linger_measured += 1;
+            let before = gt_marker_count(&gt_file);
+            let body2 = wake_body(&gt_file, trial, 2);
+            let _ = inject_text_into_session(ctx.app.handle(), id, &body2).await;
+            let dup_deadline = Instant::now() + cfg.gt_timeout;
+            while gt_marker_count(&gt_file) <= before && Instant::now() < dup_deadline {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            // A duplicate is >1 total markers: attempt 1 lingered and later
+            // submitted, and attempt 2 also submitted.
+            if gt_marker_count(&gt_file) > 1 {
+                linger_dupes += 1;
+            }
+        }
+
+        let _ = destroy_session_inner(ctx.app.handle(), id).await;
+    }
+
+    // ───────────────────────────── report ────────────────────────────────
+    println!("\n--- RESULTS (agent='{}') ---", cfg.agent_label);
+    let rate = |n: usize, d: usize| if d == 0 { 0.0 } else { n as f64 / d as f64 };
+    for (name, t) in [
+        ("bare waiting_for_input flip", bare),
+        ("post-submit activity gate (14.1)", ts_gate),
+        ("screen-state (16.1 #3)", screen),
+    ] {
+        println!(
+            "signal '{name}': trials={} FP={} ({:.0}%) FN={} ({:.0}%)",
+            t.total,
+            t.fp,
+            rate(t.fp, t.total) * 100.0,
+            t.fn_,
+            rate(t.fn_, t.total) * 100.0,
+        );
+    }
+    println!(
+        "cold-spawn first-attempt drop rate (raw #1001 bug): {}/{}",
+        cold_drops, cfg.trials
+    );
+    println!(
+        "F7 lingering-body duplicate on redeliver-without-clear: {}/{} measured drops",
+        linger_dupes, linger_measured
+    );
+    println!("=== end ===\n");
+}

--- a/src-tauri/tests/wake_consumption_measure.rs
+++ b/src-tauri/tests/wake_consumption_measure.rs
@@ -79,6 +79,8 @@ struct HarnessConfig {
     trials: usize,
     signal_window: Duration,
     gt_timeout: Duration,
+    inject_mode: String,
+    immediate_delay: Duration,
 }
 
 fn env_or(key: &str, default: &str) -> String {
@@ -107,6 +109,12 @@ impl HarnessConfig {
                 .parse()
                 .unwrap_or(60000),
         );
+        let inject_mode = env_or("AC_WAKE_HARNESS_INJECT_MODE", "ready");
+        let immediate_delay = Duration::from_millis(
+            env_or("AC_WAKE_HARNESS_IMMEDIATE_DELAY_MS", "1500")
+                .parse()
+                .unwrap_or(1500),
+        );
         Self {
             shell,
             args,
@@ -114,6 +122,8 @@ impl HarnessConfig {
             trials,
             signal_window,
             gt_timeout,
+            inject_mode,
+            immediate_delay,
         }
     }
 }
@@ -341,8 +351,8 @@ async fn measure_wake_consumption_signals() {
     let cfg = HarnessConfig::from_env();
     println!("\n=== #1001 wake-consumption measurement harness ===");
     println!(
-        "agent='{}' shell='{}' args={:?} trials={} signal_window={:?} gt_timeout={:?}",
-        cfg.agent_label, cfg.shell, cfg.args, cfg.trials, cfg.signal_window, cfg.gt_timeout
+        "agent='{}' shell='{}' args={:?} trials={} inject_mode='{}' signal_window={:?} gt_timeout={:?}",
+        cfg.agent_label, cfg.shell, cfg.args, cfg.trials, cfg.inject_mode, cfg.signal_window, cfg.gt_timeout
     );
 
     if !agent_available(&cfg.shell) {
@@ -396,16 +406,32 @@ async fn measure_wake_consumption_signals() {
         };
         let id = Uuid::parse_str(&info.id).expect("uuid");
 
-        // Wait for the agent to boot to a sustained-idle, paste-ready state:
-        // watcher_idle true AND the screen has rendered content.
+        // Boot/inject timing per mode. The #1001 drop lives in the fresh-idle
+        // window BEFORE the TUI is paste-ready, so "ready" (settle first) tends
+        // to consume cleanly while "first_idle"/"immediate" reproduce the race.
         let boot_deadline = Instant::now() + Duration::from_secs(45);
-        loop {
-            let ready = watcher_idle(&ctx.idle, id)
-                && nonblank_lines(&screen_text(&ctx.app, id)) > 0;
-            if ready || Instant::now() >= boot_deadline {
-                break;
+        match cfg.inject_mode.as_str() {
+            "immediate" => {
+                // Fixed short delay, then inject regardless of readiness: the
+                // most aggressive reproduction of the not-paste-ready race.
+                tokio::time::sleep(cfg.immediate_delay).await;
             }
-            tokio::time::sleep(Duration::from_millis(250)).await;
+            "first_idle" => {
+                // Inject the instant the watcher first reports idle, with no
+                // paste-ready settle (the fresh-idle danger window B targets).
+                while !watcher_idle(&ctx.idle, id) && Instant::now() < boot_deadline {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+            _ => {
+                // "ready" (default): sustained idle AND rendered content.
+                while !(watcher_idle(&ctx.idle, id)
+                    && nonblank_lines(&screen_text(&ctx.app, id)) > 0)
+                    && Instant::now() < boot_deadline
+                {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                }
+            }
         }
         let idle_at_inject = watcher_idle(&ctx.idle, id);
         let pre_lines = nonblank_lines(&screen_text(&ctx.app, id));

--- a/src-tauri/tests/wake_consumption_measure.rs
+++ b/src-tauri/tests/wake_consumption_measure.rs
@@ -30,6 +30,9 @@
 //!   AC_WAKE_HARNESS_TRIALS (default "5")
 //!   AC_WAKE_HARNESS_SIGNAL_WINDOW_MS (default "6000")
 //!   AC_WAKE_HARNESS_GT_TIMEOUT_MS    (default "60000")
+//!   AC_WAKE_HARNESS_INJECT_MODE      (ready | first_idle | immediate; default ready)
+//!   AC_WAKE_HARNESS_REDELIVER_MODE   (immediate | settled; default immediate)
+//!   AC_WAKE_HARNESS_SETTLE_HOLD_MS   (sustained paste-ready hold; default "3500")
 //! Never fabricated: if the agent binary is absent, the harness prints a SKIP
 //! line and returns (it does not assert), so a run on a box without that agent
 //! is an honest no-op, not a fake pass.
@@ -81,6 +84,8 @@ struct HarnessConfig {
     gt_timeout: Duration,
     inject_mode: String,
     immediate_delay: Duration,
+    redeliver_mode: String,
+    settle_hold: Duration,
 }
 
 fn env_or(key: &str, default: &str) -> String {
@@ -110,6 +115,12 @@ impl HarnessConfig {
                 .unwrap_or(60000),
         );
         let inject_mode = env_or("AC_WAKE_HARNESS_INJECT_MODE", "ready");
+        let redeliver_mode = env_or("AC_WAKE_HARNESS_REDELIVER_MODE", "immediate");
+        let settle_hold = Duration::from_millis(
+            env_or("AC_WAKE_HARNESS_SETTLE_HOLD_MS", "3500")
+                .parse()
+                .unwrap_or(3500),
+        );
         let immediate_delay = Duration::from_millis(
             env_or("AC_WAKE_HARNESS_IMMEDIATE_DELAY_MS", "1500")
                 .parse()
@@ -124,6 +135,8 @@ impl HarnessConfig {
             gt_timeout,
             inject_mode,
             immediate_delay,
+            redeliver_mode,
+            settle_hold,
         }
     }
 }
@@ -289,6 +302,26 @@ fn nonblank_lines(text: &str) -> usize {
     text.lines().filter(|l| !l.trim().is_empty()).count()
 }
 
+/// Wait until the session is SUSTAINED paste-ready (watcher idle AND rendered
+/// content, held continuously for `hold`), mirroring B's live-path settle.
+/// Returns true if it settled, false if `deadline` passed first.
+async fn wait_for_settle(ctx: &HarnessCtx, id: Uuid, hold: Duration, deadline: Instant) -> bool {
+    let mut ready_since: Option<Instant> = None;
+    while Instant::now() < deadline {
+        let ready = watcher_idle(&ctx.idle, id) && nonblank_lines(&screen_text(&ctx.app, id)) > 0;
+        if ready {
+            let since = *ready_since.get_or_insert_with(Instant::now);
+            if Instant::now().duration_since(since) >= hold {
+                return true;
+            }
+        } else {
+            ready_since = None;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    false
+}
+
 /// Signal 3: the body token is no longer visible in the input-box region (last
 /// few non-blank lines) AND the transcript grew vs the pre-inject snapshot.
 fn screen_consumed(pre_lines: usize, post: &str, body_token: &str) -> bool {
@@ -351,8 +384,8 @@ async fn measure_wake_consumption_signals() {
     let cfg = HarnessConfig::from_env();
     println!("\n=== #1001 wake-consumption measurement harness ===");
     println!(
-        "agent='{}' shell='{}' args={:?} trials={} inject_mode='{}' signal_window={:?} gt_timeout={:?}",
-        cfg.agent_label, cfg.shell, cfg.args, cfg.trials, cfg.inject_mode, cfg.signal_window, cfg.gt_timeout
+        "agent='{}' shell='{}' args={:?} trials={} inject_mode='{}' redeliver_mode='{}' signal_window={:?} gt_timeout={:?}",
+        cfg.agent_label, cfg.shell, cfg.args, cfg.trials, cfg.inject_mode, cfg.redeliver_mode, cfg.signal_window, cfg.gt_timeout
     );
 
     if !agent_available(&cfg.shell) {
@@ -371,8 +404,9 @@ async fn measure_wake_consumption_signals() {
     let mut ts_gate = SignalTally::default();
     let mut screen = SignalTally::default();
     let mut cold_drops = 0usize; // GT-not-consumed on first attempt (the raw bug)
-    let mut linger_dupes = 0usize; // redeliver produced a 2nd marker (F7/G4)
-    let mut linger_measured = 0usize;
+    let mut redeliver_measured = 0usize; // drops where we redelivered
+    let mut redeliver_recovered = 0usize; // GT marker appeared after redeliver
+    let mut redeliver_duplicated = 0usize; // >1 markers: body double-submitted (F7/G4)
 
     for trial in 0..cfg.trials {
         let trial_dir = ctx._temp.path().join(format!("trial{trial}"));
@@ -481,23 +515,40 @@ async fn measure_wake_consumption_signals() {
              bare_flip={s1} ts_gate={s2} screen={s3}"
         );
 
-        // ── F7/G4: redeliver the SAME turn (no clear) and see if a lingering
-        // unsent body causes a duplicate submission. Only meaningful to measure
-        // when attempt 1 did NOT consume (the bug case). ──
+        // ── F7/G4 + settled-redeliver: on a drop, redeliver and measure whether
+        // the turn RECOVERS (a GT marker appears) and whether it DUPLICATES (>1
+        // markers = a lingering body double-submitted). `immediate` (default)
+        // re-injects at once (the baseline dev-rust already measured); `settled`
+        // first waits for SUSTAINED paste-ready (mirroring B's settle), to learn
+        // whether a settled redeliver is inherently safe or still needs the
+        // Ctrl-U clear. Only meaningful when attempt 1 dropped. ──
         if !gt1 {
-            linger_measured += 1;
-            let before = gt_marker_count(&gt_file);
+            redeliver_measured += 1;
+            if cfg.redeliver_mode == "settled" {
+                let settle_deadline = Instant::now() + Duration::from_secs(30);
+                if !wait_for_settle(&ctx, id, cfg.settle_hold, settle_deadline).await {
+                    println!("trial {trial}: redeliver(settled) gave up waiting for paste-ready");
+                }
+            }
             let body2 = wake_body(&gt_file, trial, 2);
             let _ = inject_text_into_session(ctx.app.handle(), id, &body2).await;
-            let dup_deadline = Instant::now() + cfg.gt_timeout;
-            while gt_marker_count(&gt_file) <= before && Instant::now() < dup_deadline {
+            let deadline = Instant::now() + cfg.gt_timeout;
+            while gt_marker_count(&gt_file) < 1 && Instant::now() < deadline {
                 tokio::time::sleep(Duration::from_millis(500)).await;
             }
-            // A duplicate is >1 total markers: attempt 1 lingered and later
-            // submitted, and attempt 2 also submitted.
-            if gt_marker_count(&gt_file) > 1 {
-                linger_dupes += 1;
+            let count = gt_marker_count(&gt_file);
+            if count >= 1 {
+                redeliver_recovered += 1;
             }
+            if count > 1 {
+                redeliver_duplicated += 1;
+            }
+            println!(
+                "trial {trial}: redeliver({}) -> markers={count} recovered={} duplicated={}",
+                cfg.redeliver_mode,
+                count >= 1,
+                count > 1
+            );
         }
 
         let _ = destroy_session_inner(ctx.app.handle(), id).await;
@@ -525,8 +576,8 @@ async fn measure_wake_consumption_signals() {
         cold_drops, cfg.trials
     );
     println!(
-        "F7 lingering-body duplicate on redeliver-without-clear: {}/{} measured drops",
-        linger_dupes, linger_measured
+        "redeliver mode '{}': recovered {}/{} drops, duplicated {}/{} drops",
+        cfg.redeliver_mode, redeliver_recovered, redeliver_measured, redeliver_duplicated, redeliver_measured
     );
     println!("=== end ===\n");
 }


### PR DESCRIPTION
Part of #1001 (PR1 of 4). **Instrument + measurement only — no production behavior change.**

## What this is

The wake pipeline treats "PTY bytes written" as "delivered", and the submit `\r` can be dropped when the agent TUI isn't paste-ready, so a message is typed but never sent (#1001). Two plausible consumption oracles were proposed and both died the same way: the agent echoes the pasted body, and that echo is indistinguishable from real consumption on the output stream.

So PR1 does **not** pick an oracle. It builds an instrument that **empirically measures** which signal predicts consumption, against an **echo-immune, out-of-band ground truth**, and lands the pure scaffolding A and B will use.

## Contents

- `phone/consumption.rs` (new) — generic pure `consumption_verdict(idle_at_inject, consumed_signal, elapsed, window)` (bakes in no specific signal) and the shared `verdict_to_result`.
- `phone/mailbox.rs` — wires `verdict_to_result` at the delivery site; **production verdict is always `NotApplicable → Ok`**, i.e. today's write-receipt semantics, unchanged. The `consumption_results` test hook mirrors `inject_results` and drives the same shared conversion (non-vacuous AC3 tests).
- `pty/idle_detector.rs` — `has_printable_activity_since(id, t: Instant)`, a one-lock stamp compare (replaces an age round-trip that skewed false-positive). `activity_age` left intact for B.
- `tests/wake_consumption_measure.rs` (`#[ignore]`, Windows) — the measurement harness. Echo-immune ground truth: the agent runs a tool that appends a line to a per-trial file; the harness polls the **filesystem**, never the PTY. Measures per-agent false-positive/false-negative for three candidate signals and the cold-drop rate, plus a redeliver recovery/duplicate sub-measurement.

## Measured evidence (real Claude 2.1.210, Windows/ConPTY)

- **No output-stream signal is a safe positive oracle:** bare `waiting_for_input` flip and the timestamp gate both false-positive ~75% in the fresh-idle drop regime (the echo trips them while the `\r` was dropped). The naive screen-state candidate is anti-correlated for Claude.
- **Settling to paste-ready before inject takes the fresh-idle drop from 75% → 0%.** This is the basis for PR2 (B) being the primary fix.

## Review

architect → dev-rust → dev-rust-grinch (plan, 2 consensus rounds) → dev-rust (impl) → dev-rust-grinch (code review: **PASS**). Grinch verified the echo-immune ground truth holds (filesystem-scored, not stream-scored), the shared `verdict_to_result` has real deterministic coverage (neuter it → AC3 test red), the generic verdict bakes in no signal, and the production wiring is genuinely inert.

Grinch also flagged one methodology confound (`G-A1`) that does **not** affect this PR's mergeability but reshapes a later PR: the redeliver/duplicate sub-measurement over-settles (drop is only detected after the full `gt_timeout`), so its "0 duplicate" must not by itself justify PR3 (A) dropping the input-clear. Recorded; A keeps the gated clear until duplication is measured at production redeliver latency.

## Verification

- `cargo check --lib` clean; `cargo clippy --lib -- -D warnings` clean; `cargo clippy --test` clean.
- `cargo test --lib`: 2299 pass (9 new), 0 fail.
- The `#[ignore]` harness is agent-agnostic; the exact per-agent invocation for the full Claude/Codex/Gemini matrix is in the issue thread.

Non-visual (test infra + inert scaffolding). No shipper build.
