### PR TITLE
fix(session-bridge): enable TLS for WSS transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6485,7 +6485,9 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -6778,6 +6780,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.2",
  "sha1",
  "thiserror 2.0.18",

--- a/crates/session-bridge/Cargo.toml
+++ b/crates/session-bridge/Cargo.toml
@@ -11,7 +11,7 @@ reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-tokio-tungstenite = "0.28"
+tokio-tungstenite = { version = "0.28", features = ["native-tls"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]

--- a/crates/session-bridge/src/lib.rs
+++ b/crates/session-bridge/src/lib.rs
@@ -387,6 +387,29 @@ mod tests {
     }
 
     #[test]
+    fn transport_url_maps_https_to_wss() {
+        let config = BridgeConfig {
+            api_url: "https://api.example.test:8765/".to_string(),
+            api_token: "secret".to_string(),
+            session_id: Uuid::parse_str("11111111-1111-4111-8111-111111111111").unwrap(),
+            registration_ticket: "ticket".to_string(),
+            host_root: "C:/root".to_string(),
+            workdir: "/workspace".to_string(),
+            command: "sh".to_string(),
+            args: Vec::new(),
+            child_env: Vec::new(),
+            env_unset: Vec::new(),
+            cols: 80,
+            rows: 24,
+        };
+
+        assert_eq!(
+            config.transport_url(),
+            "wss://api.example.test:8765/api/v1/session-transport?sessionId=11111111-1111-4111-8111-111111111111&ticket=ticket"
+        );
+    }
+
+    #[test]
     fn protocol_frames_match_host_shape() {
         let hello = BridgeToHostTextFrame::Hello {
             version: TRANSPORT_PROTOCOL_VERSION,

--- a/crates/session-bridge/tests/wss_tls_backend.rs
+++ b/crates/session-bridge/tests/wss_tls_backend.rs
@@ -1,0 +1,37 @@
+use std::time::Duration;
+
+use tokio::io::AsyncReadExt;
+
+use tokio_tungstenite::connect_async;
+
+#[tokio::test]
+async fn wss_connection_starts_tls_handshake() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind local TLS probe");
+    let address = listener.local_addr().expect("local TLS probe address");
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await?;
+        let mut record_header = [0_u8; 5];
+        stream.read_exact(&mut record_header).await?;
+        Ok::<_, std::io::Error>(record_header)
+    });
+
+    let error = match connect_async(format!("wss://{address}/")).await {
+        Ok(_) => panic!("plain probe unexpectedly completed a WSS handshake"),
+        Err(error) => error,
+    };
+    let record_header = tokio::time::timeout(Duration::from_secs(5), server)
+        .await
+        .expect("TLS probe timed out")
+        .expect("TLS probe task failed")
+        .expect("read TLS record header");
+
+    assert_eq!(record_header[0], 0x16, "expected a TLS handshake record");
+    assert_eq!(record_header[1], 0x03, "expected a TLS record version");
+    assert!(
+        !format!("{error:?}").contains("TlsFeatureNotEnabled"),
+        "WSS failed before reaching the TLS backend: {error:?}"
+    );
+    println!("WSS reached the TLS backend: {error:?}");
+}

--- a/crates/session-bridge/tests/wss_tls_backend.rs
+++ b/crates/session-bridge/tests/wss_tls_backend.rs
@@ -17,9 +17,19 @@ async fn wss_connection_starts_tls_handshake() {
         Ok::<_, std::io::Error>(record_header)
     });
 
-    let error = match connect_async(format!("wss://{address}/")).await {
-        Ok(_) => panic!("plain probe unexpectedly completed a WSS handshake"),
-        Err(error) => error,
+    let error = match tokio::time::timeout(
+        Duration::from_secs(5),
+        connect_async(format!("wss://{address}/")),
+    )
+    .await
+    {
+        Ok(Ok(_)) => panic!("plain probe unexpectedly completed a WSS handshake"),
+        Ok(Err(error)) => error,
+        Err(_) => {
+            server.abort();
+            let _ = server.await;
+            panic!("WSS client TLS handshake timed out");
+        }
     };
     let record_header = tokio::time::timeout(Duration::from_secs(5), server)
         .await


### PR DESCRIPTION
## Summary

- Enable the `native-tls` backend for `tokio-tungstenite` so `wss://` session transports can perform a TLS handshake.
- Regenerate `Cargo.lock` through Cargo with only the required TLS feature dependency edges.
- Add regression coverage for HTTPS endpoint mapping and TLS-backend activation.
- Bound the loopback TLS probe on both the client handshake and server result paths, with spawned-task cleanup on timeout.

## Test credit

- `transport_url_maps_https_to_wss`: URL-scheme regression test covering the full `https://` to `wss://` transport URL.
- `wss_connection_starts_tls_handshake`: loopback TLS-backend characterization test proving a WSS connection emits a TLS handshake record and does not fail with `TlsFeatureNotEnabled`.

## Verification

All required checks pass:

- `cargo test -p session-bridge --lib --bins --tests`
- `cargo test -p session-bridge --test wss_tls_backend`
- `cargo check --locked -p session-bridge`
- `cargo test -p session-bridge --locked --lib --bins --tests`
- `cargo clippy -p session-bridge --all-targets -- -D warnings`

Independent adversarial review: PASS. This is a non-visual backend/dependency/test change.

Closes #1017