### PR TITLE
fix(ci): always report lockfile drift check (#1022)

### DIFF
--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -2,9 +2,6 @@ name: Lockfile drift check
 
 on:
   pull_request:
-    paths:
-      - 'package.json'
-      - 'package-lock.json'
   push:
     branches-ignore:
       - main
@@ -30,20 +27,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      - name: Detect lockfile inputs
+        id: changes
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --quiet HEAD^1 HEAD -- package.json package-lock.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            status=$?
+            if [[ "$status" -eq 1 ]]; then
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::Failed to detect npm manifest or lockfile changes (git diff exited $status)."
+              exit "$status"
+            fi
+          fi
 
       - name: Setup Node.js
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'
 
       - name: Pin npm version
+        if: steps.changes.outputs.changed == 'true'
         run: npm install -g npm@11.6.2
 
       - name: Regenerate lockfile in-place
+        if: steps.changes.outputs.changed == 'true'
         run: npm install --package-lock-only --ignore-scripts
 
       - name: Fail if lockfile is out of sync
+        if: steps.changes.outputs.changed == 'true'
         run: |
           if ! git diff --exit-code -- package-lock.json; then
             echo "::error::package-lock.json is out of sync with package.json. Run 'npm install --package-lock-only' locally and commit the result."


### PR DESCRIPTION
## Summary

- run the `lockfile-drift` workflow for every pull request
- detect whether `package.json` or `package-lock.json` changed before invoking Node/npm
- complete the existing exact `lockfile-drift` job successfully for non-npm PRs
- preserve the full drift-failure path for relevant PRs and qualifying pushes

## Verification

- `actionlint` 1.7.12
- detector harness: unchanged, changed, push fast path, and fail-closed error branches
- npm 11.6.2 regeneration fixtures: synchronized input passes, intentional drift fails
- `git diff --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- dev-rust-grinch exact-range review: PASS
- dev-rust-grinch post-main-merge review: PASS, deterministic merge tree and zero path overlap

## Scope

Non-visual. One workflow file. The exact required status context remains `lockfile-drift`.

Closes #1022