### PR TITLE
feat(#1028): colour the sidebar repo badge letters red when the worktree is dirty

### DIFF
--- a/plans/1028-sidebar-dirty-repo-badge.md
+++ b/plans/1028-sidebar-dirty-repo-badge.md
@@ -1,0 +1,634 @@
+# Plan #1028: Sidebar repo badge letters go red when the worktree is dirty
+
+Author: architect (wg-25). Base: `main` @ `4acadfe5b22e67dff40cd20eda87b23eca4a7cbe`. Branch: `feature/1028-sidebar-dirty-repo-badge`. Issue: mblua/AgentsCommander#1028.
+
+Status: READY_FOR_IMPLEMENTATION
+
+Certified by architect after consensus round 2. This plan is the sole implementation specification; it carries no TBD, no competing alternative, and no choice left to the implementer. Verify the `Plan-SHA256` in the architect's round-2 report before touching code.
+
+Consensus applied 2026-07-16. Round 1: dev-rust (Step 5), dev-webpage-ui (Step 5), grinch G1-G8 (Step 6). Round 2: dev-rust and grinch cleared §4.4's mechanism (grinch PASS on all five attack axes) and contributed R1-R7. Resolution map in §10.
+
+---
+
+## 1. Issue and objective
+
+Colour the Sidebar repo badge **letters only** red (background unchanged) when that repo's working tree is dirty: untracked files, unstaged modifications, or staged-but-uncommitted changes. Clean stays violet.
+
+The badge is `<label>/<branch>`, rendered at `ProjectPanel.tsx:2659-2671` inside `renderReplicaItem`. **It renders on coordinator rows only**: the render is gated `<Show when={isCoord() && repoBadges().length > 0}>` with `isCoord = () => replica.isCoordinator` (`:2392`), and `replicaSearchText` (`:1149`) documents the same gate as "Repo/branch badges render only for coordinators" (G8). Every statement in this plan about "rows" means coordinator rows.
+
+The backend already spawns `git` against every one of these repo paths on a timer and discards everything except the branch name. This change stops discarding the dirty bit.
+
+Dormant (no running session) coordinator rows are **in scope**: the user decided this, and `DiscoveryBranchWatcher` already polls every replica every 15s regardless of any session, so a dormant row's dirtiness is known and thrown away, not unknown.
+
+---
+
+## 2. Evidence and current-state gap
+
+### 2.1 Three emitters write this struct to the UI (G4)
+
+`SessionRepo` (`src-tauri/src/session/session.rs:36-44`) is the badge. Three code paths put it in front of the user:
+
+| Emitter | Location | Cadence | Emits |
+|---|---|---|---|
+| `GitWatcher::poll` | `pty/git_watcher.rs:97-165` | **5s** | `session_git_repos` (`:148`) |
+| `DiscoveryBranchWatcher::poll` | `commands/ac_discovery.rs:607-730` | **15s** | **Gate A** `ac_discovery_branch_updated` (`:685`), **Gate B** `session_git_repos` (`:711`) |
+| `sync_workgroup_repos_inner` | `commands/entity_creation.rs:2336-2346` | **one-shot, on user action** | `session_git_repos` (`:2340`), hand-rolled `serde_json::json!` |
+
+The first two are the badge writers this change modifies. The third is a hand-rolled emit of `build_session_repo` output (`entity_creation.rs:2128-2144`), i.e. `branch: None` and, after this change, `dirty: None`, straight to the frontend. Its conclusion is benign and bounded: it is one-shot on a user-initiated sync, and `git_watcher.invalidate_session_cache(session_id)` at `:2338` forces `GitWatcher` to re-emit within 5s. So it is a <=5s violet flash on a rare user action, exactly matching what `branch` already does there. It is listed because §2.1 is the section the feature rests on and a two-emitter census is wrong.
+
+Both badge writers bound each detection with a 2s `DETECT_TIMEOUT` + `kill_on_drop(true)`, parallelise per repo with `join_all`, and commit through the `set_git_repos_if_gen` CAS (`session/manager.rs:701-716`), which exists to arbitrate these racing writers.
+
+Gate A covers **every replica, session or not** (the cold feed): registration walks `wg.agents` with no session lookup (`ac_discovery.rs:499-524`), a missing session is explicitly tolerated (`:622-631`), and the git spawn is unconditional (`:635-641`). Gate B is gated on `if let Some(session_id)` (`:702`), so it is live-only.
+
+**Consequence, non-negotiable:** if only one writer computes `dirty`, the other writes the `Option` default every 15s. Both gates compare with `PartialEq` over the whole value (`git_watcher.rs:132-135`; `ac_discovery.rs:675-683`, `:691-700`), so `Some(true)` -> `None` -> `Some(true)` is a *genuine* change every tick: the machinery that normally suppresses no-op emits would instead **guarantee** a violet flash twice per 15s cycle, on both events. Both writers must compute `dirty`.
+
+### 2.2 The cold path is already plumbed end to end
+
+`DiscoveryBranchPayload` (`ac_discovery.rs:361-387`) already carries `repo_branches: Vec<Option<String>>` and `repo_paths: Vec<String>`, populated at `:669-670`. Frontend: `DiscoveryBranchUpdate` (`ipc.ts:685-690`), listener `onDiscoveryBranchUpdated` (`:692-699`), wired at `ProjectPanel.tsx:415-424`, zipped into `repoBranchByPath` at `replica-volatile.ts:88-98`. A third parallel array rides all of it. No new event, no new spawn, no new cadence, no new thread.
+
+### 2.3 `clearForPaths` is the highest "quietly does not work" risk
+
+`replica-volatile.ts:139-161` deliberately preserves `repoBranchByPath` across a reload, for the reason documented at `:122-136`: it has no counterpart on `AcAgentReplica`, and Gate A only emits when the payload **changed**, so a wiped map is never re-sent. `repoDirtyByPath` inherits that exactly. Miss it and dirty silently vanishes on every reload (every loop tick, every CLI refresh, every entity creation).
+
+This is not hypothetical. The test at `replica-volatile.test.ts:157-166` **used to assert the opposite**, and its own comment records that this made it "the alibi for a HIGH bug": `Browse Branch` died on the first reload and stayed dead "not for 15s, forever", because Gate A never re-emits an identical payload. `repoDirtyByPath` inherits that failure mode exactly.
+
+### 2.4 The ancestor-repo trap is real, self-perpetuating, and reproduced
+
+The replica tree sits inside a parent git repo. Measured in a synthetic dirty parent with a child at `parent/.ac/wg-25/repo-X`:
+
+```
+no .git                          -> ## main /  M f.txt    metadata guard CATCHES   (CASE A)
+empty .git dir                   -> ## main /  M f.txt    metadata guard MISSES    (CASE B)
+.git dir, config, no HEAD        -> ## main /  M f.txt    metadata guard MISSES    (interrupted clone)
+.git dir, HEAD only, no objects  -> ## main /  M f.txt    metadata guard MISSES
+.git FILE, dangling gitdir       -> fatal: not a git repository    SAFE, does not walk up
+```
+
+**And the parent is permanently dirty by AC's own operation.** Verified in `AgentsCommander_ac`: `git check-ignore -v .ac` exits 1 (**`.ac/` is NOT gitignored**), `git ls-files .ac` returns **312 tracked files**, and `git status` reports **12 dirty `.ac/` entries right now**. So a false red from the ancestor there would never self-clear.
+
+**The existing ceiling guard cannot fire.** `git_watcher.rs:202-206` sets `GIT_CEILING_DIRECTORIES` from `git_ceiling_directories_for_session_root`, which returns `None` unless `is_agent_dir(cwd)` (`config/session_context.rs:1233-1236`; `is_agent_dir` = replica agent dir | canonical matrix dir | root agent dir, `:1224-1228`). A `repo-*` path is none of those, so **it is a proven no-op for every path the watcher passes it**, as `commands/repos.rs:206-213` documents ("a no-op that reads like a guard"). `DiscoveryBranchWatcher::detect_branch` (`ac_discovery.rs:931-956`) sets no ceiling at all. Today this only mis-reports a *branch*; with dirty it becomes a false red driven by an unrelated repository, on a timer, on a passively-read surface.
+
+### 2.5 `check_workgroup_repos_dirty` is not reusable
+
+`commands/entity_creation.rs:2422-2509` already runs `git status --porcelain` (`:2462`), but it is sync/blocking with no timeout, iterates workgroup dirs rather than a given path, and uses a **broader** definition that also counts `unpushed commits` (`:2482`) and `no remote upstream` (`:2501`). A clean-but-unpushed repo is "dirty" under that function and must **not** be under ours. Reuse the pattern, not the function.
+
+### 2.6 Corrections to the Step 1 reports
+
+1. **`skip_serializing_if = "Option::is_none"` does not solve the stale-red problem it was proposed for.** It omits the key only when the value is *already* `None`; a stale `Some(true)` still serializes and still restores. Proven by compiling both variants (§4.1).
+2. **There is a fifth header shape**, not four: `## No commits yet on master...origin/master [gone]`. Issue AC 7 says "(4)"; it is 5. §4.3.
+3. **The `.git` metadata guard is necessary but not sufficient** (§2.4, CASE B). Closed by the ceiling in §4.2, not accepted as a residual (G3).
+4. **Hold-last-known does not "kill the blink at the source."** With the single call a timeout loses branch *and* dirty. `branch` keeps today's no-hold behaviour, so it still flips to `None`, the gate still sees a genuine change, and the array is still re-emitted. Hold-last-known protects the `dirty` **field**, not the emit. The user-facing benefit survives: the re-emitted array carries the held `dirty`, so the recreated span recomputes `dirty === true` and **the colour does not move**.
+5. **`dirty: detected.unwrap_or(r.dirty)` works for `GitWatcher` only.** `DiscoveryBranchWatcher::poll` iterates `entry.repos`, a `Vec<(String, String)>` (`ac_discovery.rs:352-359`, `:643-652`), with no previous `dirty` in hand. Superseded by §4.4, which removes the need for a per-watcher previous value entirely.
+
+---
+
+## 3. Scope
+
+### 3.1 In scope
+
+- `dirty` on `SessionRepo`, computed by **both** badge writers from a **single** shared git call returning branch and dirty together.
+- Hold last-known `dirty` across a failed detection (§4.4).
+- Ancestor-repo guard: `.git` metadata check **and** a ceiling that actually fires (§4.2).
+- `repo_dirty` on the Gate A payload plus the frontend `repoDirtyByPath` volatile layer, so dormant coordinator rows are covered.
+- Red letters via an additive CSS variant class; badge `title` carries the third state.
+
+### 3.2 Out of scope
+
+- **Dedupe by `source_path`.** Filed as #1029. Measured and refuted as a timeout mitigation (8 concurrent same-path calls finish in 424ms, ~2x *faster* than sequential, sharing the page cache). Efficiency only. Do not fold it in.
+- **`SessionItem`'s `.session-item-branch` chips** (`SessionItem.tsx:393-405`). Dim gray, not violet. User decision: out.
+- **Light-theme `.branch` contrast.** No light-theme override, so it keeps its dark-theme violet and reads 1.94:1 there today, a hard WCAG fail. Pre-existing; needs its own issue.
+- **Timeout decay** (N consecutive failures -> `None`). **Not justified as "speculative" (G2).** §7.3 establishes a *measured* path to a permanent timeout on a bulk-stat-dirty repo, where `branch` (which has no hold) would go `None` on every tick indefinitely. The omission is kept for two reasons that are not "we have not seen it": the trigger is a rare compound condition (bulk stat-dirty *and* a repo large enough to exceed 2s, measured at 6000 tracked files but not at 654), and decay is a distinct feature with its own state and policy that would need its own issue. **This is the known, measured cost of the decision, recorded as a decision.**
+- **Cross-watcher emit-cache coherence** (§6.6). Pre-existing, ships today for `branch`, not introduced here.
+- **`branch` hold-last-known.** `branch` keeps today's exact behaviour.
+
+---
+
+## 4. Decided solution
+
+### 4.1 Persisted `dirty`: `#[serde(default, skip_deserializing)]`
+
+**Decision.** It satisfies both devs' stated goals at once; there is no trade.
+
+The mechanism the reports debated (`skip_serializing_if`) is the wrong tool for both. Proven by compiling both candidates against serde 1.0.228 / serde_json 1.0.149:
+
+```
+--- OPTION B: skip_serializing_if = Option::is_none ---     (what the reports debated)
+serialize Some(true) -> {"label":"A","dirty":true}          << stale value IS persisted
+restore from that    -> OptB { dirty: Some(true) }          << STALE RED SURVIVES
+serialize None       -> {"label":"A"}                       << key omitted from the WIRE too
+
+--- OPTION C: skip_deserializing ---                        (decided)
+serialize Some(true) -> {"label":"A","dirty":true}          << wire ALWAYS self-describing
+restore from that    -> OptC { dirty: None }                << restores as None: no stale red
+serialize None       -> {"label":"A","dirty":null}          << key present as null
+old JSON (no key)    -> OptC { dirty: None }                << back-compat OK
+input claims dirty   -> OptC { dirty: None }                << backend-authoritative
+```
+
+Option B fails **both** goals: the stale `true` gets through, and the key is stripped from the wire on `None`. Option C gives an always-present key and a guaranteed `None` on restore.
+
+Safe because nothing needs to read `dirty` back. **Five** deserialize entry points, all audited:
+
+- `sessions_persistence.rs:188` (`PersistedSession.git_repos`) - the intended target. Restore yields `None`.
+- `commands/session.rs:1910` - `create_session` is a `#[tauri::command]` and genuinely deserializes `Vec<SessionRepo>` from frontend input. The frontend sends `SessionRepoInput` = `{label, sourcePath}` (`ipc.ts:77-80`) and never sends `dirty`, so nothing is lost. Making it un-settable is correct: `dirty` is backend-authoritative and now un-spoofable from a command payload.
+- `SessionInfo` (`session/session.rs:238`) derives `Deserialize`, but no Rust-side `from_str`/`from_value`/`from_slice`/`from_reader` on it exists. Confirmed by grep.
+- `load_sessions_raw` (`sessions_persistence.rs:598-604`) - production, used by the CLI (`cli/list_peers.rs:7`, `cli/list_sessions.rs:4`). Read-only listing; never reads `dirty`; never writes `sessions.json` back. Harmless.
+- `commands/config.rs:1930` `read_sessions_file` - inside `#[cfg(test)]`, paired with `write_sessions_file` at `:1925`. Harmless today. **Note for the implementer: a future test that round-trips `dirty` through this helper will silently get `None` back and will look like a serde bug rather than the intended design.**
+
+Old `sessions.json` has no `dirty` key; `skip_deserializing` uses `Default::default()` = `None`. `#[serde(default)]` is redundant next to `skip_deserializing` (serde already falls back to `Default::default()`) but is kept: the issue text specifies it, it is harmless, and it states intent at the field. The `PartialEq`/`Eq` derives are unaffected: `manager.rs:766`'s `if &s.git_repos != repos` gate is already dominated by `branch: None` vs a detected branch, so it reports changed today and after.
+
+Cost: the on-disk file still writes a `dirty` key that is ignored on read. Dead data, useful in a bug report. Accepted.
+
+### 4.2 One shared detection, replacing two diverged copies
+
+`GitWatcher::detect_branch` (`git_watcher.rs:193-224`) and `DiscoveryBranchWatcher::detect_branch` (`ac_discovery.rs:931-956`) are near-identical copies that have **already diverged**: one sets the (no-op) ceiling env, the other does not. The plan's own non-negotiable is that both writers compute `dirty` identically. Duplicating a new 5-shape parse into both is how that guarantee gets lost.
+
+**Decision:** one shared `pub(crate)` guard + spawn + parse in `pty/git_watcher.rs`. Each watcher keeps its **own timeout wrapper**, which is **required, not stylistic**: each owns its per-path counter and log tag (`note_timeout` / `note_discovery_timeout`, `[GitWatcher]` / `[DiscoveryBranchWatcher]`), and merging them would collapse the two tags that keep the watchers distinguishable in `app.log`.
+
+Placement in `pty/git_watcher.rs` rather than a new module: no module restructuring, and `commands/ac_discovery.rs` already depends on `crate::pty::*` (`crate::pty::credentials::scrub_credentials_from_tokio_command`, `ac_discovery.rs:937`, inside the very function being deleted). Tests live next to the parser.
+
+The call:
+
+```
+git --no-optional-locks status --porcelain --branch
+```
+
+**`--no-optional-locks` is load-bearing, not hygiene (G7).** It is what keeps the 2s `kill_on_drop` from orphaning `.git/index.lock` in the user's repo. Measured: plain `status` takes the lock (a ~13ms window at ~99% of the run) and rewrites `.git/index`; `--no-optional-locks` does neither; a hard kill (`TerminateProcess`, which is what `kill_on_drop` does) inside that window orphaned the lock **8/8**. An orphaned `index.lock` leaves `git status` at exit 0 and silent while `git add` and `git commit` **hard-fail**, so the agent's commits break while the badge keeps painting normally. The bound is narrow (the kill must land within ~13ms of the 2s deadline; killing at 30-170ms orphaned 0/12), but the blast radius is severe and the mechanism is proven. It also stops the poll writing `.git/index` every tick. **This flag has a cost too, in §7.3; the plan owns both halves.** Do not remove it in a later cleanup.
+
+The prior note that "`git status` exits 0 with `index.lock` held either way" is true and about the **wrong direction**: it establishes the watcher tolerates someone else's lock, not that it will not orphan one on everyone else.
+
+**Ancestor guard: both halves (G3).**
+
+1. **`.git` metadata check.** `tokio::fs::metadata(Path::new(working_dir).join(".git"))`, return `None` on error, before spawning. Use `metadata` not `is_dir` (linked worktrees and submodules use a `.git` **file**) and `tokio::fs` not `std` (a sync stat inside an async fn cannot be cancelled by `tokio::time::timeout`; on a dead share it would wedge a runtime worker and make the 2s cap a lie). Precedent: `commands/repos.rs:218-224`.
+2. **`GIT_CEILING_DIRECTORIES` set to the repo path's parent**, via one `cmd.env()` call. This closes CASE B (§2.4), which the metadata check misses.
+
+The earlier draft kept CASE B open citing `commands/repos.rs` precedent. **That argument is withdrawn.** `repos.rs`'s comment enumerates "a failed clone, deleted `.git`, a plain folder the user configured" - all CASE A. Corrupt-but-present `.git` appears nowhere in it, so the "identical residual" was an absence of consideration, not a considered acceptance. And `repos.rs`'s "do not add it back" forbids `git_ceiling_directories_for_session_root`, "a no-op that reads like a guard" - a *different mechanism*. Computing the ceiling from the repo path's parent is not re-adding the no-op helper, and only the helper is forbidden. Blast radius differs too: `repos.rs` is menu-driven and one-shot, and its failure is a wrong GitHub page on a click; the badge's is a persistent false red on a 5s/15s timer on a passively-read surface.
+
+Measured. The first line closes CASE B; the rest are the "does the ceiling break a legitimate repo" cases, and nothing was harmed:
+
+```
+CASE B (corrupt .git) + GIT_CEILING_DIRECTORIES=<parent-of-repo>
+                                          -> fatal: not a git repository, exit 128   (closes it)
+HEALTHY repo + same ceiling               -> ## No commits yet on feat               (unharmed)
+LINKED WORKTREE (.git is a FILE)          -> ## wt / ?? w.txt                        (unharmed)
+  ... whose MAIN repo lives ABOVE the ceiling -> ## wt2 / ?? w.txt                   (unharmed)
+SUBMODULE superproject, clean             -> ## main                                 (unharmed)
+SUBMODULE dirty, WITHOUT ceiling          -> ## main /  M sub
+SUBMODULE dirty, WITH ceiling             -> ## main /  M sub                        (IDENTICAL)
+```
+
+The ceiling constrains only the **discovery ascent**; it does not constrain **gitdir resolution** through a `.git` file. That is why a linked worktree still resolves correctly even when its main repo lives above the ceiling, and why the issue's submodule decision (§6.2: default behaviour, a moved or dirty submodule turns the superproject red) is preserved byte-for-byte: ` M sub` appears identically with and without the ceiling. Implementation notes: build the value from the repo path's parent with `std::env::join_paths` (which emits the platform separator, `;` on Windows, matching what the existing ceiling code does); if the path has no parent, skip the env entirely rather than setting an empty value.
+
+**This removes the `git_ceiling_directories_for_session_root` call from `GitWatcher::detect_branch`.** Deliberate and behaviour-neutral: it returns `None` for every path the watcher passes it (§2.4). Replacing a guard that cannot fire with one that does is strictly better.
+
+Keep, from the current copies: `scrub_credentials_from_tokio_command`, `kill_on_drop(true)`, `CREATE_NO_WINDOW`, and **the `out.status.success()` gate** (`git_watcher.rs:214`, `ac_discovery.rs:946`). Dropping the success gate would not open a correctness hole (a failed git writes `fatal:` to stderr, leaving stdout empty, so the parser's "no `## ` first line" rule returns `None` anyway) but it would be an unintended silent behaviour change.
+
+Name the function for worktree dirty and comment the distinction from `check_workgroup_repos_dirty` (§2.5).
+
+### 4.3 Parse contract: 5 shapes, enumeration provably closed
+
+| # | State | Header |
+|---|---|---|
+| 1 | born, no upstream | `## master` |
+| 2 | born, upstream in sync | `## master...origin/master` |
+| 3 | born, upstream diverged | `## master...origin/master [ahead 1, behind 2]` |
+| 4 | detached / mid-rebase | `## HEAD (no branch)` |
+| 5 | unborn, no upstream | `## No commits yet on master` |
+| 5b | **unborn with upstream** | `## No commits yet on master...origin/master [gone]` |
+
+Tracking markers observed: `[ahead 1]`, `[behind 2]`, `[ahead 1, behind 2]`, `[gone]`.
+
+**The enumeration is closed, not merely "what we found".** Git builds the header as `## ` + (`No commits yet on ` if unborn) + branch + (`...` + upstream + optional ` [...]` if an upstream is configured), so unborn and upstream are orthogonal and the matrix is enumerable. The closing measurement: with a **real, existing** `origin/master` fetched, an unborn branch **still** prints `[gone]`, because an unborn branch has no commit so `stat_tracking_info` cannot compute ahead/behind and falls through to the gone marker. **There is therefore no "unborn + upstream + no bracket" shape**, and both variants of 5b produce the identical string form.
+
+**Splitting on `...` is unambiguous**, and step (d) is safe, because git's refname rules forbid both sequences:
+
+```
+git branch "feat..bad" -> fatal: 'feat..bad' is not a valid branch name    (so `...` split is safe)
+git branch "feat[x]"   -> fatal: 'feat[x]' is not a valid branch name      (so step (d) cannot eat a real name)
+git branch HEAD        -> fatal: 'HEAD' is not a valid branch name         (so step (e) is unreachable)
+## feat/a.b-c                                                              (single dots and slashes survive)
+```
+
+Required parse order:
+
+1. If the first line does not start with `## `, return `None` (output we do not understand; do not guess).
+2. `dirty` = **any** non-empty line after the first. Filter empty lines; output ends with a trailing newline.
+3. Branch, from the first line with `## ` stripped:
+   a. If it equals `HEAD (no branch)`, branch = `None`. **Must short-circuit before (b).**
+   b. Strip a leading `No commits yet on ` if present. **Then continue to (c); do not return here.** This is what makes 5b work.
+   c. Take everything before the first `...` if present, else the whole remainder.
+   d. Defensively trim a trailing ` [...]` tracking suffix. Unreachable after (c) with today's git (a marker implies an upstream implies `...`), and safe because `[` is forbidden in refnames.
+   e. Trim. If empty or equal to `HEAD`, branch = `None`. Unreachable per the refname rule above; kept for parity with today's `git_watcher.rs:216`.
+
+Dirty lines are any porcelain v1 entry: ` M tracked.txt` (unstaged), `A  staged.txt` (staged-but-uncommitted), `?? untracked.txt` (untracked). All three verified together in one run, and all three are exactly the definition the issue names.
+
+### 4.4 Hold last-known: a path-keyed memory of successful detections only
+
+**This section replaces the round-1 mechanism entirely. It is the fix for G1, and it cleared consensus round 2: grinch PASSed it on write-reordering, two runtimes, poisoning, the bound, and sharing, and withdrew its own competing fix.**
+
+Convert transient false-cleans into transient false-reds. The errors are asymmetric: a false-clean means shipping uncommitted work (silent, costly); a false-red self-corrects on the next tick (cheap). `branch` keeps today's behaviour exactly: `None` on failure, no hold.
+
+**Why the round-1 mechanism failed.** It sourced GitWatcher's previous value from the manager (`r.dirty`, via `get_sessions_repos` -> `s.git_repos`, `manager.rs:781`) and discovery's from `repos_cache`. Both are stores whose lifecycle is governed by *emit gating* and *race arbitration*, reused for a *value memory* purpose. Their resets have nothing to do with whether we still know a repo's dirty state, and they fire for reasons correlated with the very failures the hold exists to absorb:
+
+| Source | Reset / poisoning | Correlated with a timeout cluster? |
+|---|---|---|
+| Manager `r.dirty` | Gate B writes `s.git_repos` (`ac_discovery.rs:704-708`), so a discovery failure writes `None` into GitWatcher's hold source | **Yes** (G1's 6-step chain) |
+| Manager `r.dirty` | `refresh_git_repos_for_sessions` (`manager.rs:756-770`) wholesale-replaces `s.git_repos` with `build_session_repo` output (`dirty: None`) | No (user sync) |
+| `repos_cache` | CAS gen mismatch -> `remove` (`ac_discovery.rs:723`) | **Yes** (a GitWatcher timeout bumps the gen, failing discovery's CAS) |
+| `repos_cache` | `invalidate_replicas` (`ac_discovery.rs:557-576`) | No (user sync) |
+| GitWatcher's own cache | `invalidate_session_cache` (`entity_creation.rs:2338`) | No (user sync) |
+| GitWatcher's own cache | CAS gen mismatch -> `remove` (`git_watcher.rs:161`) | **Yes** |
+
+Grinch's proposed fix (GitWatcher holds from `self.cache`) removes the *correlated* poisoning of row 1, which is a real improvement, but rows 5 and 6 show its source has resets of its own, and grinch states the remaining residual himself: "a cluster that outlives a `repos_cache` reset still degrades **discovery** to `None`." Since the feature's whole promise is never to assert a confident clean, a fix that knowingly leaves a false-clean path is not the right resolution when a complete one is smaller.
+
+**The decided mechanism.** A process-local map keyed by repo `source_path`, written **only on a successful detection**, read on failure. This is a structural twin of `note_timeout` (`git_watcher.rs:15-28`) which sits ~100 lines above it in the same file: same `OnceLock<Mutex<HashMap<String, _>>>` shape, same lock-poisoning idiom, same "process-local, resets on restart" semantics, and the same documented bound ("bounded by the number of distinct repo paths (~150 in production observations), so no GC is needed").
+
+```rust
+/// #1028 - last SUCCESSFULLY detected worktree-dirty state per repo path, so a
+/// transient detection failure holds the previous answer instead of asserting a
+/// confident "clean". Only successful detections are ever written, so a failure
+/// can never poison the memory. Keyed by repo path, not by session or replica:
+/// dirty is a property of the worktree, and several replicas legitimately share
+/// one repo dir. Process-local: resets on restart, which is correct (an unknown
+/// repo is `None` = violet until its first answer). Bounded by the number of
+/// distinct repo paths (~150 in production observations), so no GC is needed.
+/// NOTE: unlike `note_timeout`, this map is deliberately SHARED by both watchers.
+/// See the sharing rationale below: separate maps would re-admit the flicker
+/// that §2.1 calls broken by design.
+///
+/// `pub(crate)` because the hold must be applied where a FAILURE is observed,
+/// which is each watcher's timeout wrapper, and one of those lives in
+/// `commands/ac_discovery.rs`. See §5.1.
+///
+/// INVARIANT, and it is NOT enforced here: this function remembers whatever it
+/// is handed. "Never remembers an ancestor's dirt" is enforced by the caller,
+/// `detect_git_status`, via its three gates (`.git` metadata check, ceiling,
+/// `out.status.success()`). Only feed this from `detect_git_status`. A caller
+/// like `detect_git_branch_sync` (`ac_discovery.rs:305-331`), which has no
+/// `.git` guard and no ceiling, would silently violate it. Nothing does today.
+pub(crate) fn remember_dirty(path: &str, detected: Option<bool>) -> Option<bool> {
+    use std::sync::OnceLock;
+    static LAST_DIRTY: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
+    let map = LAST_DIRTY.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut g = map.lock().unwrap_or_else(|e| e.into_inner());
+    match detected {
+        Some(d) => {
+            g.insert(path.to_string(), d);
+            Some(d)
+        }
+        None => g.get(path).copied(),
+    }
+}
+```
+
+Call site, **identical in shape in both watchers**, at each `SessionRepo` construction. The path argument must come from the **source binding**, not the field being initialised: inside a `SessionRepo { .. }` literal, `source_path` is a field name and not a variable in scope.
+
+```rust
+// GitWatcher::poll (git_watcher.rs:122-130), iterating `repos.iter().zip(statuses)` as `(r, status)`:
+branch: status.as_ref().and_then(|s| s.branch.clone()),
+dirty: remember_dirty(&r.source_path, status.as_ref().map(|s| s.dirty)),
+
+// DiscoveryBranchWatcher::poll (ac_discovery.rs:643-652), whose closure destructures `((label, path), status)`:
+branch: status.as_ref().and_then(|s| s.branch.clone()),
+dirty: crate::pty::git_watcher::remember_dirty(path, status.as_ref().map(|s| s.dirty)),
+```
+
+Compiled and behaviour-tested standalone, including the case that defeats both reviewed alternatives:
+
+```
+cold start + failure        -> None         (unknown, violet - never detected)
+detect true                 -> Some(true)   (red)
+5-tick timeout CLUSTER      -> Some(true)   (still red, cluster survived)
+detect false                -> Some(false)  (violet)
+independent path            -> None         (unaffected by the other path)
+```
+
+**Why this resolves G1 completely, and why it is smaller than what it replaces.** The invariant is one line: *only successful detections are ever written*, so no failure of either watcher can poison it, and there is nothing to reset. Concretely it closes every row of the table above, and it deletes from the round-1 plan: the `repos_cache` snapshot, dev-rust's owned-keys compile fix, the "snapshot before `:643`" timing constraint, the four reset points, and the asymmetry between the two watchers. A held value is always "the last successful detection of this path by anyone", and the 8 replicas sharing 2 repo dirs measured in wg-25 all get the same answer.
+
+Two properties fall out of the shape and are worth naming, because both were attacked in round 2 and neither is a discipline the implementer must maintain. `remember_dirty` is a **sync fn**, so the guard cannot outlive it and no `.await` can appear inside: that is a guarantee from the signature, and it is what *deletes* round 1's owned-keys borrow problem rather than fixing it. And `.unwrap_or_else(|e| e.into_inner())` is required, not stylistic: `.unwrap()` would be the bug, since a single panic would take both watchers down permanently. Poisoning needs a panic while the guard is held, and the section is a `HashMap` insert/get over `String`/`bool` with no user code and no unwinding panic point.
+
+**Sharing is REQUIRED by §2.1, not merely the best estimate. Do not "fix" it back to the `note_timeout` precedent.** With **separate** per-watcher maps, a cluster hitting both watchers leaves their holds sourced from successes up to 5s and up to 15s old respectively; if the repo changed in between, **the two watchers hold different values**, both write divergent `dirty` into `s.git_repos`, and **both emit**, because each compares against its own differing cache. The CAS is not a backstop: it only suppresses discovery when GitWatcher's write lands inside discovery's detection window. The result is the red/violet flicker §2.1 calls "broken by design", gated behind a cluster instead of arriving every tick. Sharing makes the two watchers agree by construction. Verified by dev-rust: `probe_shared_keeps_watchers_in_agreement ... ok`.
+
+The scan sets also cut *for* sharing: on the paths only one watcher touches, shared behaves exactly like private; on the overlap, both get the freshest observation. Neutral where they differ, better where they meet.
+
+**Deliberate divergence from the cited precedent, stated so it is a decision:** `note_timeout` and `note_discovery_timeout` are deliberately **separate** statics so "the two watchers track their own paths independently (different scan sets)" (`ac_discovery.rs:338-340`). That is the right call for a **throttle counter** (sharing would make "1st + every 50th" fire at wrong times for both watchers) and irrelevant for **a fact about a worktree**. The `~150 distinct repo paths, no GC` bound transfers **exactly and not by analogy**, because `note_timeout`'s comment bounds by *distinct repo paths*, not by timeouts, and that is the same key space (~20 KB). The one real difference is fill *rate*: `note_timeout` gains an entry only on a timeout, `remember_dirty` on nearly every path, so the map goes from a handful to ~150, with *smaller* entries (`bool` vs `u64`). The leak-on-churn case (`invalidate_replicas` re-registering with new paths, `ac_discovery.rs:554-556`) needs ~85,000 distinct repo paths in one process lifetime to reach 10 MB. Accepted.
+
+**A remembered value cannot be an ancestor's via repo discovery, which is the property the mechanism rests on.** `remember_dirty` writes only when `detect_git_status` returns `Some`, so the question is whether a *success* can carry a wrong `dirty`. Not through discovery: three independent gates each turn the ancestor-walk cases into `None` before a value exists. The `.git` metadata check rejects CASE A; the ceiling makes CASE B exit 128 (measured, §4.2); the retained `out.status.success()` gate rejects any non-zero exit. Measured end to end: corrupt `.git` + ceiling gives `exit=128`, so the success gate rejects it, so `parse_status_porcelain_branch` is never reached, so nothing is remembered. The pre-§4.2 ancestor cases that *did* return `Some` with the ancestor's dirt (§2.4) are exactly what §4.2 closes, which is why §4.2 and §4.4 are one change and not two.
+
+**The claim is scoped to discovery on purpose.** All three gates govern how git *discovers* a repo by walking directories. **`GIT_DIR`/`GIT_WORK_TREE` bypass discovery entirely**, and `detect_git_status` inherits the app process environment (`scrub_credentials_from_tokio_command` touches credential helpers only; the `env_remove_keys` machinery in `config/agent_command.rs` is for agent PTY sessions, not this spawn). Measured, valid `.git`, ceiling set exactly as §4.2 specifies:
+
+```
+repo-X alone, ceiling set                              -> ## feat                 exit=0   (correct)
+repo-X + GIT_DIR/GIT_WORK_TREE -> dirty parent,
+        ceiling STILL set                              -> ## main /  M file.txt   exit=0   (ancestor's dirt)
+today's rev-parse, same GIT_DIR                        -> main                             (pre-existing)
+```
+
+**This is a sentence, not a code change, and deliberately so.** There is no realistic vector: a desktop app would need the user to have exported `GIT_DIR` in the launching shell. It is **pre-existing** and identical for today's `rev-parse` spawn (third line above), so it is not introduced here. It belongs to §4.2's spawn rather than §4.4's memory. And **§4.4 does not amplify it**: an env var set for the process lifetime means every detection is wrong and the map is continuously overwritten with the same wrong value, so the memory adds no persistence the process did not already have; a restart clears both. `env_remove` is explicitly **not** wanted here: it would be code for a threat nobody faces.
+
+**Residual: a stale success can overwrite a fresher one, bounded to ~21ms.** The invariant "only successful detections are ever written" closes everything about *failures*, and is silent about *stale successes*, which are a different axis from the ancestor question above. The map write **bypasses the CAS**: `remember_dirty` fires at construction (`git_watcher.rs:122`, `ac_discovery.rs:643`), ~60 lines before the CAS (`:142`, `:706`), so a value the CAS rejects as stale **has already been committed to the map**. The map is last-writer-wins, so an earlier observer completing last can overwrite a fresher value with no failure involved. Verified by dev-rust: `probe_stale_success_overwrites_fresher ... ok`.
+
+**It is inherent, not fixable, and the plan accepts it.** The call cannot move after the CAS: the construction site *needs* the held value to build `refreshed`, which is what the CAS receives, so the dependency is circular. And discovery's CAS runs only inside `if let Some(session_id)` (`ac_discovery.rs:702`), so **dormant replicas never reach it**; moving the call there would mean dormant paths are never remembered, destroying the cold-path hold this section exists to buy.
+
+**Bounded by measurement.** An inversion needs the start stagger between the two watchers to be smaller than the difference in their detections' durations, and both watchers run the *identical command on the identical path*, so durations match and start order is completion order. Grinch measured: 6000-file repo at 1s stagger, **0/4 inversions**; 654-file repo, **max staleness injectable 21 ms**, self-correcting on the next success. #1029's "8 concurrent same-path calls are ~2x faster, sharing the page cache" **does not transfer** as a counter-argument, because `status` is lstat-and-rehash bound rather than page-cache bound. These figures are local SSD, warm cache, synthetic repos, and they **bound a race window, not a production rate**. The residual surfaces only if a *later* detection fails, and it errs to a **false-red**, which is the direction §4.4 deliberately chooses and the direction every reviewed alternative failed to hold.
+
+**Residuals, accepted and stated:**
+- A repo whose `.git` is deleted mid-session holds its last red until restart, because `detect_git_status` cannot distinguish "not a work tree" from "timed out". This is the same "hold indefinitely" edge already accepted under timeout decay (§3.2). For a path that was *never* detected, the value is `None` and stays `None`, which is correct.
+- Entries for repos removed from config persist until restart. Same property, same bound, and the same explicit acceptance as `note_timeout`'s counters.
+- Tests must use unique-per-test path strings, exactly as `note_timeout_counts_per_path` already documents ("Process-global state: use unique-per-test path strings to avoid collisions").
+
+### 4.5 Frontend
+
+- **Type contract:** Rust `dirty: Option<bool>`; TS **`dirty: boolean | null` (required, no `?`)** (G6). Badge keyed strictly off **`dirty === true`**, collapsing `{false, null}` to violet. Pin `=== true` rather than a truthy check: behaviourally identical today, correct if the field widens, and it reads as deliberate.
+
+  **Why required, reversing the round-1 draft.** §5.1's safety argument is that `SessionRepo` has no `Default`, so every Rust construction site is compile-forced; a `?` throws that away on the TS side for test convenience. The precedent cuts the same way: `types.ts:1-5` already has `branch: string | null` **required** against a Rust `#[serde(default)] Option<String>`. The site that matters is `replica-repo-badges.ts:55-59`, the one production builder of `SessionRepo[]` on the cold path: with `?`, an implementer who adds `repoDirtyByPath` to the signature and forgets the `dirty:` line gets **no `tsc` error and a permanently violet cold feed** - the exact silent failure the type is there to prevent. dev-webpage-ui's own correction concedes that literal will always set `dirty`, removing the only production reason for the `?`. Cost: the ~6 test literals §7.1 already counts.
+- **Additive variant class, not an edit to the existing rule.** `.ac-discovery-badge.branch` is also used by `AcDiscoveryPanel.tsx:294`, so editing its `color` repaints that too. `.ac-discovery-badge.branch.dirty` is (0,3,0) and beats the (0,2,0) rule at `sidebar.css:5511`. This is the repo's established idiom, with the specificity rationale already documented at `sidebar.css:5534-5538` for `.coord-idle.red` (`:5553`). Setting `color` only leaves `background` untouched by construction, satisfying "letters only" literally.
+- **Red = `var(--status-exited)`** (`variables.css:16` `#ff3b5c` dark, `:67` `#dc2626` light). No new hex. Contrast, measured by compositing the badge's `rgba(139,92,246,0.15)` over the real row backgrounds: **4.97:1** base, 4.57 hover, 4.31 active. Within 0.01 of `.coord-idle.red` (4.89 / 4.51 / 4.32), a red badge already shipping on the same row.
+- **Wire naming.** `SessionRepo` carries `#[serde(rename_all = "camelCase")]` and `dirty` is one lowercase word, so it round-trips unchanged. The Gate A field `repo_dirty` -> `repoDirty` does transform, but `DiscoveryBranchPayload` **already carries `rename_all = "camelCase"`** (`ac_discovery.rs:361-362`) and the identical `repo_branches` -> `repoBranches` mapping is load-bearing in production today (all of #943 B2 depends on it). **Risk: low**, not "the highest quietly-does-not-work risk" as the round-1 draft claimed. The residual is only "did someone name the two sides inconsistently", and §5.1/§5.2 pin both names so they agree by construction. The genuine highest risk is `clearForPaths` (§2.3).
+- **Reactivity needs no work.** Both feeds replace the whole array; `<For>` is reference-keyed and the cold path maps into fresh objects on every evaluation (`ProjectPanel.tsx:805-812`). The `<For>` callback param `repo` is a plain value, not an accessor, so the class is computed once per item identity: the dirty signal **must** arrive as a full re-emit of the repos array, which is what all three emitters already do. No scalar "dirty changed" event, no in-place mutation. Verified there is no hole: dirty-flips-branch-same, timeout-branch-None-dirty-held, and detached-HEAD-dirty-flips all differ in the array and emit; a timeout on a repo whose branch was *already* `None` with dirty held is byte-identical and correctly stays silent, because nothing about the badge changed.
+- **No entrance animation replays.** `.ac-discovery-badge` (`sidebar.css:5487-5494`) sets only `font-size`, `font-weight`, `letter-spacing`, `padding`, `border-radius`, `text-transform`; no `animation`, no `transition`, and no keyframes target it. Span recreation costs a DOM node, not a visible flash.
+- **Cold cannot clobber live.** `repoBadges()` (`ProjectPanel.tsx:2405-2410`) is strictly either/or, never a merge: live wins unconditionally whenever `s.gitRepos` is non-empty. The fallback is dynamic, so if a session exits and `s.gitRepos` goes empty the row falls back to the cold feed mid-life; with the cold path dirty-aware it stays correct there, a second independent reason the cold path is in scope.
+
+### 4.6 Tooltip
+
+The badge already carries `title={repo.sourcePath}` (`ProjectPanel.tsx:2664`). Extend it so colour stays a binary alarm at 8px while the tooltip carries the third state:
+
+| `dirty` | `title` |
+|---|---|
+| `true` | `` `${repo.sourcePath} (uncommitted changes)` `` |
+| `false` | `repo.sourcePath` (unchanged) |
+| `null` | `` `${repo.sourcePath} (status unknown)` `` |
+
+**"(status unknown)" is the normal startup state, not an error state**, and the wording is chosen for that: a cold row shows it until the first Gate A tick (<=15s) and a live row until the first `GitWatcher` tick (<=5s), because `effectiveRepoDirtyByPath` returns `undefined` before any event lands and `configuredReplicaRepoBadges` maps that to `null`. It is the first thing a user sees on every launch, so it must read as "not yet known" rather than "something is broken". Deliberate.
+
+**On a timeout the badge shows the label without its `/branch` suffix while staying red** (`AgentsCommander` in red, not `AgentsCommander/main`). That is correct on both axes independently and reads as "something is off, and there is still uncommitted work". Named here because it is a visible state and nobody should be surprised by it.
+
+Reject a third badge colour. The codebase renders unknown as **absence**, never a distinct colour (`replica-repo-badges.ts:19` degrades to no suffix; `coordinator-badge.ts:30-40` returns `null`), there is no room at 8px/600, the user asked for one thing, and a third colour would advertise a transient internal failure the user can do nothing about.
+
+---
+
+## 5. Affected surfaces
+
+Line numbers are from base `4acadfe` and will shift. Symbols are authoritative.
+
+### 5.1 Rust
+
+| File | Symbol | Change |
+|---|---|---|
+| `session/session.rs` | `SessionRepo` (`:36-44`) | Add `dirty: Option<bool>` with `#[serde(default, skip_deserializing)]` + doc. Keep `PartialEq`/`Eq`: they are what make both gates re-emit on a dirty flip. |
+| `pty/git_watcher.rs` | new `pub(crate) struct GitStatus { branch: Option<String>, dirty: bool }` | Detection result. |
+| `pty/git_watcher.rs` | new `pub(crate) fn parse_status_porcelain_branch(stdout: &str) -> Option<GitStatus>` | Pure parser, §4.3. |
+| `pty/git_watcher.rs` | new `pub(crate) fn remember_dirty(path, Option<bool>) -> Option<bool>` | §4.4. **`pub(crate)`, not module-private, and this is forced rather than preferred:** on a timeout `tokio::time::timeout` **drops** the `detect_git_status` future, so it never returns and cannot remember anything. The hold must therefore be applied where the failure is observed, which is each watcher's own timeout wrapper or call site, and one of each lives in `commands/ac_discovery.rs`. There is no arrangement that keeps the map module-private and still holds on the failure path, which is the only path it exists for; the alternative would be merging the two timeout wrappers, collapsing `note_timeout`/`note_discovery_timeout` and the `[GitWatcher]`/`[DiscoveryBranchWatcher]` log tags that §4.2 establishes are load-bearing. A plain `fn` here is a reproduced **`error[E0603]: function 'remember_dirty' is private`**. |
+| `pty/git_watcher.rs` | new `pub(crate) async fn detect_git_status(working_dir: &str) -> Option<GitStatus>` | `.git` metadata guard + ceiling env + spawn + `out.status.success()` gate + parse. Replaces both `detect_branch` copies. Keeps `scrub_credentials_from_tokio_command`, `kill_on_drop(true)`, `CREATE_NO_WINDOW`. Drops the no-op ceiling helper call (§4.2). Name it for worktree dirty; comment the distinction from `check_workgroup_repos_dirty`. |
+| `pty/git_watcher.rs` | `GitWatcher::detect_branch` (`:193-224`) | Delete; superseded. |
+| `pty/git_watcher.rs` | `GitWatcher::detect_branch_with_timeout` (`:170-191`) | Retarget to `detect_git_status`, return `Option<GitStatus>`. Keep `note_timeout`, the `[GitWatcher]` tag, and the 1st+every-50th dampening verbatim. |
+| `pty/git_watcher.rs` | `GitWatcher::poll` (`:122-130`) | Build `SessionRepo` with the §4.4 call-site shape. |
+| `commands/ac_discovery.rs` | `DiscoveryBranchWatcher::detect_branch` (`:931-956`) | Delete; superseded. |
+| `commands/ac_discovery.rs` | `DiscoveryBranchWatcher::detect_branch_with_timeout` (`:910-929`) | Retarget to `crate::pty::git_watcher::detect_git_status`. Keep `note_discovery_timeout` and the `[DiscoveryBranchWatcher]` tag. |
+| `commands/ac_discovery.rs` | `DiscoveryBranchWatcher::poll` (`:643-652`) | Build `SessionRepo` with the §4.4 call-site shape. **No `repos_cache` snapshot is needed**; §4.4 removed it. |
+| `commands/ac_discovery.rs` | `DiscoveryBranchPayload` (`:361-387`) | Add `repo_dirty: Vec<Option<bool>>` + doc. Already derives `PartialEq`, so Gate A re-emits on a dirty flip with no gate change. |
+| `commands/ac_discovery.rs` | Gate A payload construction (`:662-671`) | `repo_dirty: refreshed.iter().map(\|r\| r.dirty).collect(),` beside the existing two. |
+| `commands/entity_creation.rs` | `build_session_repo` (`:2139`) | Add `dirty: None`. **Note: this literal is emitted straight to the UI at `:2340`** (§2.1), so it is a <=5s violet flash on a user-initiated sync, bounded by `invalidate_session_cache` at `:2338`. Intended. |
+| `config/sessions_persistence.rs` | `:690`, `:711` | Add `dirty: None` to the two legacy-upgrade literals. |
+
+`detect_git_branch_sync` (`ac_discovery.rs:305-331`) is **not** a badge writer and is not touched.
+
+**Compile-forced sites: 11, not 10.** `SessionRepo` has no `Default` derive and no site uses `..Default::default()`, so every construction site must add `dirty` or the crate will not build. `grep -rn "SessionRepo {" src-tauri/src --include=*.rs` returns 12 hits minus the struct definition at `session.rs:36` = **11**:
+
+- **Production (5):** `ac_discovery.rs:647`, `entity_creation.rs:2139`, `sessions_persistence.rs:690`, `:711`, `git_watcher.rs:125`.
+- **Test (6):** `git_watcher.rs:242`, `:259`, `:271`, `:289`, `sessions_persistence.rs:3461`, `:3600` (the last two inside `#[cfg(test)]`, nearest preceding at `:1613`).
+
+Also verified: no `SessionRepo{` without a space that the grep would miss, and `src-tauri/tests/` (~11 integration files) contains **zero** `SessionRepo` references, so there are no hidden sites in the `cargo test` build.
+
+The report line "the 4 restore sites already default" is wrong twice: they do not default, and they are the *legacy upgrade* path, not the main restore. `PersistedSession.git_repos` restores through plain serde at `sessions_persistence.rs:188`, which is not one of them; `skip_deserializing` is what guarantees restore-as-`None`.
+
+### 5.2 TypeScript / CSS
+
+| File | Symbol | Change |
+|---|---|---|
+| `shared/types.ts` | `SessionRepo` (`:1-5`) | Add `dirty: boolean \| null;` (**required**, G6) + doc. |
+| `shared/types.ts` | new `RepoDirtyByPath` | `Record<string, boolean \| null>`. Mirror the `RepoBranchByPath` doc (`:7-20`) on missing-key vs explicit-null. |
+| `shared/ipc.ts` | `DiscoveryBranchUpdate` (`:685-690`) | Add `repoDirty: (boolean \| null)[];`. |
+| `stores/replica-volatile.ts` | `ReplicaVolatileEntry` (`:24-32`) | Add `repoDirtyByPath?: RepoDirtyByPath;`. |
+| `stores/replica-volatile.ts` | `buildRepoBranchByPath` (`:57-69`) | Generalise to `zipByPath<T>(repoPaths, values): Record<string, T \| null>`, keeping the existing length-mismatch guard **per call**, so a malformed `repoDirty` cannot drop the branch map. `T = string` -> `RepoBranchByPath`; `T = boolean` -> `RepoDirtyByPath`. **The body's `?? null` must not become `\|\|`**: with `T = string` it is a no-op that looks like dead syntax, but with `T = boolean`, `false ?? null` is `false` (correct) while `false \|\| null` is `null` (wrong), and the difference is invisible on the badge. Pinned by a test (§9.2). |
+| `stores/replica-volatile.ts` | `applyDiscoveryBranchUpdate` (`:88-98`) | +1 optional param `repoDirty?: (boolean \| null)[]`, +1 `setField` inside the **existing** `batch()`. Atomicity is the point. Keeping the param optional preserves the existing 2-arg test call at `:151-156`. |
+| `stores/replica-volatile.ts` | `clearForPaths` (`:139-161`) | **Preserve `repoDirtyByPath` alongside `repoBranchByPath`** (§2.3). Both captures in the **one** existing `setEntries(key, prev => ...)` callback that reads `prev` raw; restore stays inside the existing `batch`. **The restore guard must become `if (preservedBranch !== undefined \|\| preservedDirty !== undefined)`** - an `&&`, or keeping the single-map condition, silently drops the dirty map. |
+| `stores/replica-volatile.ts` | new `effectiveRepoDirtyByPath(replica)` | Mirror `effectiveRepoBranchByPath` (`:190-194`). Needs no change to `ReplicaVolatileBase` (`:178-179`); it reads only `path`. |
+| `stores/replica-volatile.ts` | `clearAll` (`:168-175`) | No change: it deletes whole entries. |
+| `components/replica-repo-badges.ts` | `configuredReplicaRepoBadges` (`:22-62`) | Accept `repoDirtyByPath?: RepoDirtyByPath`; set `dirty: dirtyByPath?.[sourcePath] ?? null` in the literal at `:55-59`. There is no single-repo shorthand for dirty, so a path miss is `null` (violet), not a fallback. |
+| `components/ProjectPanel.tsx` | `configuredReplicaRepoBadgesLive` (`:225-238`) | Pass `repoDirtyByPath: effectiveRepoDirtyByPath(replica)`. |
+| `components/ProjectPanel.tsx` | `onDiscoveryBranchUpdated` listener (`:415-424`) | Pass `data.repoDirty`. |
+| `components/ProjectPanel.tsx` | badge render (`:2659-2671`) | `` class={`ac-discovery-badge branch${repo.dirty === true ? " dirty" : ""}`} `` and the `title` from §4.6. |
+| `styles/sidebar.css` | after `.ac-discovery-badge.branch` (`:5511-5515`) | Add `.ac-discovery-badge.branch.dirty { color: var(--status-exited); }` + a comment naming the (0,3,0) reason and the `AcDiscoveryPanel` blast-radius reason. |
+
+**Correctly not listed**, verified: `ProjectPanel.tsx:142` and `AcDiscoveryPanel.tsx:23` build `SessionRepoInput[]` = `{label, sourcePath}`, not `SessionRepo[]`. `replicaRepoMenuEntries` (`:240`) and `replicaSearchText` (`:1143`) are further `configuredReplicaRepoBadges`/`...Live` callers that need no change: they reach only `label`/`branch` via `formatReplicaRepoBadgeLabel`. `AcDiscoveryPanel.tsx:294` is not touched.
+
+---
+
+## 6. Required behaviour, edge cases, failure behaviour
+
+### 6.1 State table
+
+| Rust `dirty` | Wire | Meaning | Badge |
+|---|---|---|---|
+| `Some(true)` | `true` | Backend says dirty | **red letters, background unchanged** |
+| `Some(false)` | `false` | Backend says clean | violet |
+| `None` | `null` | Never successfully detected for this path since process start | violet |
+
+With §4.4, `None` means "never got a first answer", not "flaked once". That is defensible to render violet; rendering the *common* case violet would not be.
+
+### 6.2 Definition of dirty
+
+Exactly the three the issue names: untracked, unstaged, staged-but-uncommitted. All verified in one run.
+
+- **`.gitignore`d files: excluded** (default). Do not pass `--ignored`, or every built repo is permanently red from `target/`.
+- **ahead/behind: excluded**, free. With `-b` they appear only inside the `## ` header, and dirty is "any line after the header".
+- **Submodules: default behaviour.** A submodule with a moved or dirty HEAD reports ` M <path>` and turns the superproject red. Do **not** pass `--ignore-submodules=dirty`: a moved submodule pointer genuinely is uncommitted work. User decision.
+
+### 6.3 Both writers, or it is broken by design
+
+§2.1. A correctness requirement, not polish.
+
+### 6.4 Failure behaviour
+
+| Case | Detection | `branch` | `dirty` |
+|---|---|---|---|
+| Success | `Some(GitStatus)` | from header | `Some(scan result)`, and remembered |
+| 2s timeout | `None` | `None` (as today) | **held** (§4.4) |
+| Not a work tree (`.git` absent) | `None` | `None` (as today) | held; `None` if never detected |
+| Ancestor blocked by the ceiling | `None` | `None` | held; `None` if never detected |
+| Not a git repo (exit 128) | `None` | `None` (as today) | held |
+| Unparseable output (no `## ` first line) | `None` | `None` | held |
+| Detached HEAD / mid-rebase | `Some` | `None` | answered normally |
+| Unborn branch | `Some` | branch name | answered normally |
+| `index.lock` held by someone else | `Some` | normal | normal. `git status` exits 0 either way. |
+
+### 6.5 Ancestor repos
+
+Both halves of the guard, and the measurements, are in §4.2. CASE B is **closed**, not accepted.
+
+### 6.6 Cross-watcher emit-cache coherence (pre-existing, out of scope)
+
+`GitWatcher`'s cache is "last **emitted** by GitWatcher", keyed by session id (`git_watcher.rs:33-35`); Gate B's `repos_cache` is keyed by replica_path (`ac_discovery.rs:438-441`). They do not share. `set_git_repos_if_gen` bumps `git_repos_gen` but touches neither (`manager.rs:701-716`). So the gates compare against **the emitter's own last emit**, while the manager and the UI are **last-writer-wins across three emitters**: a watcher's cache can certify "already sent" for a value the UI is no longer showing.
+
+**The bound (G5).** A degraded value is corrected in <=15s (discovery) or <=5s (GitWatcher) **only if that emitter's next detection succeeds**. If detection **keeps failing**, the emitter recomputes the same degraded value, its own cache matches, `changed == false`, and it never re-emits, while the other watcher stays muted by its own cache even when it knows the truth. So the honest bound is: **<=15s for a transient degradation, unbounded for as long as detection keeps failing.** The round-1 claim of "bounded, not sticky" was false.
+
+This ships today for `branch` and is out of scope. **§4.4 does not mitigate it** and this plan does not claim it does: §4.4 keeps `dirty` correct at the source in the common case, but a permanently-failing path degrades `branch` regardless. The round-1 draft had §6.6 and §4.4 pointing at each other as the mitigation, which was circular.
+
+### 6.7 Performance
+
+No new spawns, threads, dependencies, events, or cadences. `GitWatcher::start` runs a dedicated `std::thread` with its own tokio runtime (`git_watcher.rs:66-69`), so git never occupies the main Tauri runtime's workers; repos are parallel via `join_all`, sessions sequential, and `select!` sleeps then polls so ticks drift rather than pile up. Badge staleness degrades under mass stall; the app does not. See §7.3 for the cost of the `status` call itself, which is **not** uniformly small.
+
+---
+
+## 7. Compatibility, security, and confidence
+
+### 7.1 Compatibility
+
+- **Old `sessions.json`**: no `dirty` key -> `None`. Verified (§4.1).
+- **Persisted stale `dirty: true`**: ignored on read -> `None`. That is the decision, verified.
+- **The ~6 TS test literals** must add `dirty: null` (G6, a deliberate trade: a compile error in tests buys a compile guard on the one production cold-path builder).
+- **Old frontend + new backend**: extra keys ignored by the TS cast.
+- **New frontend + old backend**: `dirty` absent -> `undefined` at runtime -> `=== true` is false -> violet. Fails safe. Only reachable in dev/hot-reload, since backend and frontend ship in one bundle.
+
+### 7.2 Security
+
+No new attack surface. The spawn keeps `scrub_credentials_from_tokio_command`, `kill_on_drop(true)`, `CREATE_NO_WINDOW`, and the 2s bound. `--no-optional-locks` **reduces** side effects: the poll no longer writes `.git/index`, and per §4.2 it is what prevents the watcher orphaning `.git/index.lock` in the user's repo. `GIT_CEILING_DIRECTORIES` **reduces** reach: git can no longer walk up into an unrelated ancestor repository. `skip_deserializing` makes `dirty` un-settable from the frontend via `create_session`, so the badge cannot be spoofed by a command payload. No new dependency. No path is logged that is not logged today.
+
+### 7.3 Numbers, at their real confidence
+
+**The `+45 to +62 ms` figure holds only for a stat-refreshed index, and `--no-optional-locks` is what stops the watcher from ever refreshing one (G2).** `git status` normally persists a refreshed `.git/index` so the next run is fast; `--no-optional-locks` forbids that write. So once a repo's index goes **stat-dirty**, the watcher is stuck in the slow path **on every tick, indefinitely**, because it can never persist the refresh that would make it fast. Measured, local SSD, warm cache, git 2.52.0.windows.1:
+
+| tracked | `rev-parse` (today) | nol status, **refreshed** | nol status, **stat-dirty** | plain status, stat-dirty |
+|---|---|---|---|---|
+| 654 | 78.8 ms | 78.6 ms (**+0**) | 290-323 ms, never recovers | 278 / 273 / **75** recovers on run 2 |
+| 3000 | 60.7 ms | 80.1 ms (**+19**) | 1216-1509 ms, never recovers | 1364 / **141** / 115 recovers |
+| 6000 | 73.3 ms | 117.8 ms (**+44**) | **2073-2704 ms, over the 2s cap, never recovers** | 2346 / **177** / 110 recovers |
+
+The refreshed column reproduces the original `+45-62ms` measurement exactly, so that measurement is sound and its **generalisation** was not. **Do not claim "the scan is the cheap part"**: that is true only in the refreshed state.
+
+**Bounds, which are why this is not a blocker.** Only files that are **stat-dirty but content-identical** pay this; genuinely-modified files cost the same either way (79/82/76 ms nol vs 83/104/89 ms plain, 50 modified files). At this repo's size the realistic cases are noise: at 654 tracked files, baseline 101.8 ms, 10 touched-but-identical -> 68-71 ms, 50 -> 96-119 ms, 200 -> 164-179 ms (modest but persistent), 6000 -> fatal. Bulk stat-dirty is not an everyday event (`git stash pop`, a formatter or codegen rewriting the tree identically, a OneDrive/Dropbox/backup/AV restore, archive extraction). **`repo-AgentsCommander` is 655 tracked files, so its worst case is ~4x, not a timeout.**
+
+**The interaction with the dormant-rows decision, stated plainly.** In a **live** replica the agent's own `git` commands refresh the index, so a stat-dirty repo self-heals. In a **dormant** replica the watcher is the only git caller, so **there is no self-heal**: a dormant, bulk-stat-dirty, large repo stays in the slow path until something else runs git there. At >=6000 tracked files that means `detect_git_status` times out every tick permanently, the badge never gets a first answer (`dirty` stays `None`, violet, honest), and because `branch` has no hold **it also loses today's working branch suffix indefinitely** - a regression to a shipped feature, in that corner. §3.2 records this as the measured cost of omitting timeout decay.
+
+The other two qualifiers still apply and are not the main variable: the measurements are local-SSD and warm-cache, and they are blind to the network/OneDrive paths that plausibly generate the production timeouts, where `status` (which lstats the whole worktree) versus `rev-parse` (which reads one ref) could be 10-100x rather than 1.4x.
+
+**`~120 detect_branch timeouts/day/path`** (`git_watcher.rs:15-28`) is a **code comment recording someone else's production observation** (#280 §3.3). No telemetry, not reproduced; local runs produce **zero** timeouts, worst case 424ms, 4.7x under the bound. Order of magnitude, not a figure. Any arithmetic on it inherits that.
+
+The false-clean is **correlated with dirtiness, not random**: `git status` is heaviest exactly when the worktree is being written to, which is exactly when the repo is dirty. Timeouts also cluster (I/O spikes, AV scans), so exposure is contiguous multi-tick windows. This is the real argument for §4.4, more than the raw rate - **and §4.4's mechanism must survive a cluster**, which is precisely what the round-1 mechanism failed to do (G1) and what the decided one is tested against.
+
+---
+
+## 8. Implementation order
+
+Each step compiles and is independently reviewable. Steps 1-4 backend, 5-7 frontend, 8 tests.
+
+1. **`SessionRepo.dirty`** + `#[serde(default, skip_deserializing)]` + doc. Add `dirty: None` to all **11** construction sites (§5.1) to restore the build. No behaviour change yet.
+2. **Shared detection** in `pty/git_watcher.rs`: `GitStatus`, `parse_status_porcelain_branch`, `remember_dirty`, `detect_git_status` (guard + ceiling + spawn + success gate + parse). Add the parse and `remember_dirty` unit tests here, before any caller uses it.
+3. **`GitWatcher`**: retarget its timeout wrapper to `detect_git_status`, delete its `detect_branch`, wire `branch` + the §4.4 call-site shape in `poll`. Live badge now goes red.
+4. **`DiscoveryBranchWatcher`**: retarget its timeout wrapper, delete its `detect_branch`, wire `poll` with the same §4.4 shape. Then `DiscoveryBranchPayload.repo_dirty` + populate at Gate A. **After this step the 15s violet flash is impossible**; between steps 3 and 4 it is expected, which is why 3 and 4 must land together in one PR.
+5. **Types and wire**: `types.ts` (`SessionRepo.dirty` required, `RepoDirtyByPath`), `ipc.ts` (`DiscoveryBranchUpdate.repoDirty`). This step breaks the ~6 test literals; fix them here.
+6. **Volatile layer**: `zipByPath`, entry field, `applyDiscoveryBranchUpdate` param, **`clearForPaths` preserve**, `effectiveRepoDirtyByPath`.
+7. **Render**: `replica-repo-badges.ts` literal, `ProjectPanel.tsx` (live wiring, listener arg, class, title), `sidebar.css` variant rule.
+8. **Tests** (§9), then `npm run typecheck`, `npm test`, `cargo test`.
+
+---
+
+## 9. Tests and acceptance criteria
+
+### 9.1 Rust unit tests (`src-tauri/src/pty/git_watcher.rs`)
+
+`parse_status_porcelain_branch`, one test per header shape (§4.3):
+
+1. `## master` -> `Some("master")`, `dirty = false`
+2. `## master...origin/master` -> `Some("master")`
+3. `## master...origin/master [ahead 1, behind 2]` -> `Some("master")`
+4. `## HEAD (no branch)` -> `None`
+5. `## No commits yet on master` -> `Some("master")`
+6. `## No commits yet on master...origin/master [gone]` -> `Some("master")` **(the regression guard for the shape both round-1 reports missed)**
+
+Plus:
+
+7. Dirty scan: header + ` M tracked.txt` / `A  staged.txt` / `?? untracked.txt`, each and together -> `dirty = true`.
+8. Clean: header only, trailing newline -> `dirty = false`.
+9. Garbage: stdout with no `## ` first line -> `None`.
+10. `## feat/a.b-c` -> `Some("feat/a.b-c")`.
+
+`remember_dirty` (§4.4), using **unique-per-test path strings** per the `note_timeout_counts_per_path` precedent:
+
+11. Never detected -> `None`; a failure does not invent a value.
+12. `Some(true)` then a **5-tick failure cluster** -> `Some(true)` throughout. **This is G1's regression guard: the mechanism must survive a cluster, not just a blip.**
+13. `Some(true)` -> `Some(false)` -> failure -> `Some(false)`. A later success overwrites the memory.
+14. Two distinct paths keep independent memories.
+
+Existing `set_git_repos_if_gen_rejects_stale_gen` and `note_timeout_counts_per_path` must still pass.
+
+### 9.2 Frontend tests
+
+- `stores/replica-volatile.test.ts`: **`clearForPaths` preserves `repoDirtyByPath`** as it does `repoBranchByPath`. This is AC 6 and, per §2.3, the highest-risk item in the change, with a HIGH bug already in its history.
+- `stores/replica-volatile.test.ts`: **`repoDirty: [false]` yields `{ [REPO_A]: false }`, not `null`.** Not pedantry: `false` and `null` both render violet, so a `||`-for-`??` slip produces a byte-identical badge and only the §4.6 tooltip exposes it (it would say "(status unknown)" on every clean repo in the app). Without this test and the tooltip test, nothing catches it.
+- `stores/replica-volatile.test.ts`: `applyDiscoveryBranchUpdate` zips `repoDirty` by path; a length mismatch drops **only** the dirty map and leaves the branch map intact. The two existing tests (`:135-142` drops-on-mismatch, `:151-156` two-arg call) must still pass unchanged.
+- `components/replica-repo-badges.test.ts`: `dirty` resolves from `repoDirtyByPath` by path; a path miss yields `null`; reordered `repoPaths` do not transpose dirty onto the wrong repo.
+- Badge class: `dirty === true` -> `dirty` class present; `false` / `null` -> absent. `coordinator-badge-class.test.ts` is the precedent for why this is not optional.
+- **Badge `title` (§4.6), currently untested:** `true` -> `` `${sourcePath} (uncommitted changes)` ``; `false` -> `sourcePath` unchanged; `null` -> `` `${sourcePath} (status unknown)` ``. This is the assertion that makes the `false`-vs-`null` test observable and the only place the three states are distinguishable.
+
+**No test claims to catch a `repoDirty` name mismatch, and none can.** A frontend test's payload is written to match the TS interface, so it is not evidence about Rust's payload: if Rust emitted `repo_dirty`, the test still passes and production goes permanently violet. **Do not add a Rust wire-shape test either**: `rename_all` is already on `DiscoveryBranchPayload` (`:361-362`), `repo_branches` -> `repoBranches` proves the mapping in production, §5.1/§5.2 pin both names, and no wire-shape test exists anywhere in `ac_discovery.rs` today. Both devs and grinch converge here. The risk does not earn a new test genre.
+
+### 9.3 Acceptance criteria
+
+1. A repo with untracked files, unstaged modifications, or staged-but-uncommitted changes renders its badge **letters** red; background unchanged.
+2. A clean repo stays violet.
+3. `AcDiscoveryPanel`'s badge is unaffected.
+4. Dormant (no running session) **coordinator** rows go red on the same terms (G8: the badge is coordinator-only; a non-coordinator row has no badge at all).
+5. No violet flash on the 15s discovery tick.
+6. `dirty` survives a replica reload (`clearForPaths`).
+7. Unit test per header shape: **6 tests covering 5 shapes plus the unborn-with-upstream variant**.
+8. `npm run typecheck` (`tsc --noEmit`) clean; baseline confirmed clean before this work.
+9. `npm test` (vitest) and `cargo test` green.
+10. A repo path with no `.git`, **or with a corrupt `.git`**, inside a dirty parent repo does **not** render red (§4.2 CASE A and CASE B).
+11. A restored session whose persisted `dirty` was `true` does not render red before the first watcher tick (§4.1).
+12. A repo that is dirty, then suffers a multi-tick detection failure, **stays red** (§4.4 / §9.1 test 12).
+
+**AC 1 and AC 2 require a real visual check, not green tests.** The class-present test asserts `class="ac-discovery-badge branch dirty"`; it does not assert the letters are red. jsdom does not evaluate the stylesheet, so a misspelled rule, wrong specificity, or wrong property leaves **every test passing and the badge violet**. Check against §4.5: letters `#ff3b5c`, background `rgba(139,92,246,0.15)` unchanged.
+
+---
+
+## 10. Round-1 resolution map and verdict
+
+| # | Finding | Resolution |
+|---|---|---|
+| **G1** | GitWatcher holds from the shared manager; a cluster kills both holds | **Accepted, fixed differently, and the fix cleared review in round 2.** §4.4 replaced wholesale: a path-keyed memory written only on success. Closes every reset/poisoning row, including the residual grinch's own fix leaves. Grinch withdrew its own proposed fix unprompted ("I have no defence of my version") and PASSed this one on write-reordering, two runtimes, poisoning, the bound, and sharing. |
+| **G2** | +45-62ms holds only for a refreshed index | **Accepted.** §7.3 rewritten with the real condition and the full measured table; "the scan is the cheap part" deleted; §3.2 no longer calls timeout decay speculative and records the measured cost instead. |
+| **G3** | The `repos.rs` CASE B precedent is an oversight, not a decision | **Accepted, fix adopted.** CASE B closed via `GIT_CEILING_DIRECTORIES` in §4.2; precedent claim withdrawn; moved out of §3.2. I re-verified `.ac/` is not gitignored (312 tracked, 12 dirty now) and added a measurement nobody had: the ceiling also leaves a **linked worktree** (`.git` as a file) unharmed. |
+| **G4** | Three emitters, not two | **Accepted.** §2.1 table has the third row with its cadence and bound; §5.1's `:2139` row annotated. |
+| **G5** | "Bounded, not sticky" false under sustained failure | **Accepted.** §6.6 restated as "<=15s transient, unbounded while detection keeps failing"; the circular §4.4/§6.6 cross-reference removed. |
+| **G6** | `dirty?:` discards the compile-forcing | **Accepted, dev-webpage-ui overruled.** `dirty: boolean \| null` required, matching the `branch` precedent. Cost is ~6 test literals (§7.1). |
+| **G7** | `--no-optional-locks` is load-bearing | **Accepted.** §4.2 relabelled with the 8/8 measurement and cross-referenced to its cost in §7.3. |
+| **G8** | Badge is coordinator-only | **Accepted.** §1, §3.1, AC 4 fixed. |
+| dev-rust | §4.4 compile error; snapshot before `:643`; 4 reset points | **Moot.** §4.4's new mechanism has no snapshot, no borrowed keys, no timing constraint, no reset points. |
+| dev-rust | 11 sites not 10; `[` refname rule; `out.status.success()`; five deserialize consumers + `read_sessions_file` note; cite `:937` | **All adopted** (§5.1, §4.3, §4.2, §4.1). |
+| dev-webpage-ui | Delete the false §9.2 claim; no Rust wire test; add `false`-survives and tooltip tests; AC 1/2 visual; `clearForPaths` `\|\|` guard; downgrade the camelCase risk | **All adopted** (§9.2, §4.5, §5.2). |
+
+### Round 2 (§4.4 only)
+
+| # | Finding | Resolution |
+|---|---|---|
+| **R1** | `fn remember_dirty` is private; the cross-module call is `error[E0603]`. Reproduced by building the real module structure | **Fixed.** `pub(crate) fn`. Both reviewers flagged it independently; this is what the round bought. |
+| **R2** | §5.1 left visibility as an open branch, and the plan was self-inconsistent (code block private, call site cross-module) | **Closed to `pub(crate)`, forced not preferred.** `tokio::time::timeout` **drops** the `detect_git_status` future on timeout, so it never returns and cannot remember. The hold must live where the failure is observed: each watcher's wrapper, one of which is in `ac_discovery.rs`. No arrangement keeps the map private and still holds on the failure path. |
+| **R3** | `&source_path` is not in scope inside the `SessionRepo { .. }` literal | **Fixed.** `&r.source_path` in `GitWatcher::poll`, `path` in `DiscoveryBranchWatcher::poll`. |
+| **R4** | `pub(crate)` widens who can violate the invariant, which `remember_dirty` does not enforce | **Adopted.** Doc comment names `detect_git_status`'s three gates as the enforcer and `detect_git_branch_sync` (no guard, no ceiling) as the shape of a caller that would break it. Nothing reachable today. |
+| **R5** | The sharing rationale was weaker than the real one | **Adopted.** §2.1 *requires* sharing: separate maps let the two watchers hold different values during a cluster, both write and both emit, re-admitting the flicker §2.1 calls broken by design. The CAS is not a backstop. Also settled: `note_timeout`'s "~150, no GC" bound transfers **exactly** (its comment bounds by distinct repo paths, the same key space), and separating the counters is right for a throttle and irrelevant for a fact about a worktree. |
+| **R6** | Stale-success residual: the map write bypasses the CAS, so a CAS-rejected value is already committed | **Adopted as an accepted residual.** Inherent, not fixable (the construction site needs the held value to build `refreshed`, so the dependency is circular; and discovery's CAS is inside `if let Some(session_id)`, so moving the call there would never remember dormant paths). Bounded by measurement: 0/4 inversions at 6000 files / 1s stagger, max 21ms injectable at 654 files, because both watchers run the identical command on the identical path so start order is completion order. Errs to a **false-red**, the direction §4.4 chooses. |
+| **R7** | "Can never be an ancestor's" is absolute over an incomplete gate list; `GIT_DIR`/`GIT_WORK_TREE` bypass discovery | **Adopted, scoped to discovery.** I reproduced it, including that it is **pre-existing**: today's `rev-parse` with `GIT_DIR` set returns the ancestor's branch identically. A sentence, not a code change; §4.4 does not amplify it; `env_remove` explicitly not wanted. |
+
+### Verdict: READY_FOR_IMPLEMENTATION
+
+Every finding from both rounds is integrated. Every section is closed. The plan carries no TBD, no competing alternative, and no choice left to the implementer.
+
+§4.4 was the section every party had got wrong, and spending round 2 on it was right: it found a reproduced compile error (R1), a self-inconsistency between the code block and the call site (R2), a scope error at both call sites (R3), and two claim-precision defects (R6, R7) that no amount of my own re-reading would have surfaced. Both reviewers cleared the mechanism itself, and grinch withdrew its own competing fix without being asked.
+
+The three things a cold-start implementer must not "simplify", each with its reason recorded at the site: `pub(crate)` on `remember_dirty` (R2: the hold cannot work on the failure path otherwise), the **shared** map (R5: separate maps re-admit the §2.1 flicker), and `--no-optional-locks` (§4.2/G7: it is what stops the 2s `kill_on_drop` orphaning `index.lock` and breaking the agent's commits).
+
+**Two claims in this plan are scoped rather than absolute, and the scoping is load-bearing.** §4.4's "cannot be an ancestor's" covers repo *discovery* and not `GIT_DIR`/`GIT_WORK_TREE` (R7, pre-existing, no realistic vector). §6.6's bound is "<=15s transient, unbounded while detection keeps failing" (G5), and §4.4 does **not** mitigate it. Neither was scoped to be safe; both were absolute in an earlier draft and measurement showed the absolute form was false.
+
+**Numbers carry their conditions, per the tech-lead's constraint.** The `+45-62ms` holds only for a stat-refreshed index (§7.3). The `~120 timeouts/day/path` is an unreproduced code comment, an order of magnitude and not a figure (§7.3). Grinch's stagger and duration figures bound a **race window, not a production rate**, on local SSD with a warm cache and synthetic repos (§4.4). #1029 (dedupe) stays out.

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -335,9 +335,15 @@ fn detect_git_branch_sync(dir: &str) -> Option<String> {
 const BRANCH_POLL_INTERVAL: Duration = Duration::from_secs(15);
 const DETECT_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// #280 §3.3 — per-path counter for `detect_branch` timeouts. Mirrors the
+/// #280 §3.3 - per-path counter for `detect_git_status` timeouts (#1028 renamed
+/// the detection; the counter and its policy are unchanged). Mirrors the
 /// `git_watcher.rs` helper but lives in a separate module-local map so the
 /// two watchers track their own paths independently (different scan sets).
+///
+/// #1028 note: this counter stays per-watcher on purpose, unlike
+/// `git_watcher::remember_dirty`'s SHARED map. Sharing would make "1st + every 50th"
+/// fire at the wrong times for both watchers; that reasoning is about a throttle
+/// counter and does not transfer to a fact about a worktree.
 fn note_discovery_timeout(path: &str) -> u64 {
     use std::sync::OnceLock;
     static TIMEOUT_COUNTS: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
@@ -384,6 +390,19 @@ struct DiscoveryBranchPayload {
     /// to the previous repo list. A positional merge would then paint repo A's branch
     /// onto repo B, silently. Matching on the path cannot.
     repo_paths: Vec<String>,
+    /// #1028 - per-repo worktree-dirty, positionally parallel to `repo_paths` exactly as
+    /// `repo_branches` is, and keyed by path by the consumer for the same reason.
+    /// `Some(true)` paints the badge letters red; `None` = never successfully detected
+    /// for that path (rendered violet, like clean).
+    ///
+    /// This rides the feed `repo_branches` already established, which is what covers
+    /// DORMANT coordinator rows: Gate A runs for every replica whether or not a session
+    /// exists, so a dormant row's dirtiness was already being computed and thrown away.
+    /// Gate B below cannot cover them (it is inside `if let Some(session_id)`).
+    ///
+    /// This struct's `PartialEq` gates the emit, so adding the field is also what makes
+    /// a dirty flip re-emit with no gate change.
+    repo_dirty: Vec<Option<bool>>,
 }
 
 #[derive(Clone, Serialize)]
@@ -631,23 +650,34 @@ impl DiscoveryBranchWatcher {
                 };
 
                 // Parallelize per-repo detection (Grinch #16). Each call individually bounded by
-                // detect_branch_with_timeout (2s). Without join_all this was M*N*2s worst case.
-                let branches: Vec<Option<String>> = join_all(
+                // detect_status_with_timeout (2s). Without join_all this was M*N*2s worst case.
+                let statuses: Vec<Option<crate::pty::git_watcher::GitStatus>> = join_all(
                     entry
                         .repos
                         .iter()
-                        .map(|(_, path)| Self::detect_branch_with_timeout(path)),
+                        .map(|(_, path)| Self::detect_status_with_timeout(path)),
                 )
                 .await;
 
                 let refreshed: Vec<SessionRepo> = entry
                     .repos
                     .iter()
-                    .zip(branches)
-                    .map(|((label, path), branch)| SessionRepo {
+                    .zip(statuses)
+                    .map(|((label, path), status)| SessionRepo {
                         label: label.clone(),
                         source_path: path.clone(),
-                        branch,
+                        // #1028 - `branch` keeps its old behaviour exactly: a failed
+                        // detection reports `None`, with no hold.
+                        branch: status.as_ref().and_then(|s| s.branch.clone()),
+                        // #1028 - identical shape to GitWatcher::poll, over the SAME
+                        // shared map. Both badge writers must compute `dirty` the same
+                        // way: they take turns writing this vec, and if only one of them
+                        // computed it the other would write `None` every 15s and flicker
+                        // the badge violet twice a cycle.
+                        dirty: crate::pty::git_watcher::remember_dirty(
+                            path,
+                            status.as_ref().map(|s| s.dirty),
+                        ),
                     })
                     .collect();
 
@@ -668,6 +698,7 @@ impl DiscoveryBranchWatcher {
                     },
                     repo_branches: refreshed.iter().map(|r| r.branch.clone()).collect(),
                     repo_paths: refreshed.iter().map(|r| r.source_path.clone()).collect(),
+                    repo_dirty: refreshed.iter().map(|r| r.dirty).collect(),
                 };
                 // Gate on the whole payload. Comparing only the single-repo `branch`
                 // (what this did before B2) means a multi-repo replica whose repo just
@@ -907,8 +938,26 @@ impl DiscoveryBranchWatcher {
         }
     }
 
-    async fn detect_branch_with_timeout(working_dir: &str) -> Option<String> {
-        match tokio::time::timeout(DETECT_TIMEOUT, Self::detect_branch(working_dir)).await {
+    /// #1028 - detection is the shared `git_watcher::detect_git_status`, which replaced
+    /// this watcher's own near-identical `detect_branch` copy. The two copies had already
+    /// diverged (one set a ceiling env, this one did not), and both badge writers must
+    /// compute `dirty` identically.
+    ///
+    /// The timeout wrapper stays here rather than merging with GitWatcher's: this one
+    /// owns `note_discovery_timeout` and the `[DiscoveryBranchWatcher]` tag, which is
+    /// what keeps the two watchers distinguishable in app.log.
+    ///
+    /// Because `timeout` DROPS the future on expiry, `detect_git_status` never returns
+    /// here and cannot remember anything itself: `poll` applies the dirty hold.
+    async fn detect_status_with_timeout(
+        working_dir: &str,
+    ) -> Option<crate::pty::git_watcher::GitStatus> {
+        match tokio::time::timeout(
+            DETECT_TIMEOUT,
+            crate::pty::git_watcher::detect_git_status(working_dir),
+        )
+        .await
+        {
             Ok(result) => result,
             Err(_) => {
                 let n = note_discovery_timeout(working_dir);
@@ -918,7 +967,7 @@ impl DiscoveryBranchWatcher {
                 // distinguishable in app.log.
                 if n == 1 || n.is_multiple_of(50) {
                     log::warn!(
-                        "[DiscoveryBranchWatcher] detect_branch timed out for {} (>{}s); occurrence={} (logging 1st + every 50th)",
+                        "[DiscoveryBranchWatcher] detect_git_status timed out for {} (>{}s); occurrence={} (logging 1st + every 50th)",
                         working_dir,
                         DETECT_TIMEOUT.as_secs(),
                         n
@@ -926,32 +975,6 @@ impl DiscoveryBranchWatcher {
                 }
                 None
             }
-        }
-    }
-
-    async fn detect_branch(dir: &str) -> Option<String> {
-        #[cfg(windows)]
-        const CREATE_NO_WINDOW: u32 = 0x08000000;
-
-        let mut cmd = tokio::process::Command::new("git");
-        crate::pty::credentials::scrub_credentials_from_tokio_command(&mut cmd);
-        cmd.args(["rev-parse", "--abbrev-ref", "HEAD"])
-            .current_dir(dir)
-            .kill_on_drop(true);
-
-        #[cfg(windows)]
-        cmd.creation_flags(CREATE_NO_WINDOW);
-
-        match cmd.output().await {
-            Ok(out) if out.status.success() => {
-                let branch = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                if branch.is_empty() || branch == "HEAD" {
-                    None
-                } else {
-                    Some(branch)
-                }
-            }
-            _ => None,
         }
     }
 }
@@ -3718,26 +3741,44 @@ mod tests {
 
     // --- #943 Module B2: the widened ac_discovery_branch_updated payload ---
 
-    fn b2_payload(branch: Option<&str>, repos: &[(&str, Option<&str>)]) -> DiscoveryBranchPayload {
+    /// Repo tuple: (path, branch, dirty). #1028 added the third column.
+    fn b2_payload(
+        branch: Option<&str>,
+        repos: &[(&str, Option<&str>, Option<bool>)],
+    ) -> DiscoveryBranchPayload {
         DiscoveryBranchPayload {
             replica_path: "C:/proj/.ac/wg-1-team/__agent_coord".to_string(),
             branch: branch.map(str::to_string),
-            repo_branches: repos.iter().map(|(_, b)| b.map(str::to_string)).collect(),
-            repo_paths: repos.iter().map(|(p, _)| p.to_string()).collect(),
+            repo_branches: repos
+                .iter()
+                .map(|(_, b, _)| b.map(str::to_string))
+                .collect(),
+            repo_paths: repos.iter().map(|(p, _, _)| p.to_string()).collect(),
+            repo_dirty: repos.iter().map(|(_, _, d)| *d).collect(),
         }
     }
 
     /// The wire contract the frontend codes against. `#[serde(rename_all =
-    /// "camelCase")]` must produce exactly these four keys, `None` must serialize
+    /// "camelCase")]` must produce exactly these five keys, `None` must serialize
     /// as `null` (not omitted: the consumer distinguishes "unknown branch" from
-    /// "missing entry"), and `repoBranches[i]` must line up with `repoPaths[i]`.
+    /// "missing entry"), and `repoBranches[i]` / `repoDirty[i]` must line up with
+    /// `repoPaths[i]`.
+    ///
+    /// #1028: this is the one test that can catch a `repo_dirty` vs `repoDirty` wire
+    /// name mismatch. A frontend test cannot: its payload is written to match the TS
+    /// interface, so if Rust emitted `repo_dirty` the frontend test would still pass
+    /// and every badge in production would go permanently violet.
     #[test]
     fn discovery_branch_payload_wire_shape_is_camel_case_with_explicit_nulls() {
         let payload = b2_payload(
             None,
             &[
-                ("C:/wg/repo-AgentsCommander", Some("feature/943")),
-                ("C:/wg/repo-webpage", None),
+                (
+                    "C:/wg/repo-AgentsCommander",
+                    Some("feature/943"),
+                    Some(true),
+                ),
+                ("C:/wg/repo-webpage", None, None),
             ],
         );
 
@@ -3750,6 +3791,7 @@ mod tests {
                 "branch": null,
                 "repoBranches": ["feature/943", null],
                 "repoPaths": ["C:/wg/repo-AgentsCommander", "C:/wg/repo-webpage"],
+                "repoDirty": [true, null],
             })
         );
     }
@@ -3758,7 +3800,7 @@ mod tests {
     /// and `repo_branches` carries the same value so a consumer can read either.
     #[test]
     fn discovery_branch_payload_keeps_the_single_repo_shorthand() {
-        let payload = b2_payload(Some("main"), &[("C:/wg/repo-solo", Some("main"))]);
+        let payload = b2_payload(Some("main"), &[("C:/wg/repo-solo", Some("main"), None)]);
         let value = serde_json::to_value(&payload).expect("serialize");
 
         assert_eq!(value["branch"], serde_json::json!("main"));
@@ -3774,20 +3816,58 @@ mod tests {
         let before = b2_payload(
             None,
             &[
-                ("C:/wg/repo-a", Some("main")),
-                ("C:/wg/repo-b", Some("main")),
+                ("C:/wg/repo-a", Some("main"), None),
+                ("C:/wg/repo-b", Some("main"), None),
             ],
         );
         let after = b2_payload(
             None,
             &[
-                ("C:/wg/repo-a", Some("feature/943")),
-                ("C:/wg/repo-b", Some("main")),
+                ("C:/wg/repo-a", Some("feature/943"), None),
+                ("C:/wg/repo-b", Some("main"), None),
             ],
         );
 
         assert_eq!(before.branch, after.branch, "multi-repo: both stay None");
         assert_ne!(before, after, "per-repo drift must re-emit");
+    }
+
+    /// #1028 - a dirty flip with every branch identical must re-emit, or the badge
+    /// never turns red on a cold row. `PartialEq` over the whole payload is what
+    /// delivers this, which is why `repo_dirty` had to join the payload rather than
+    /// ride a separate event: no gate change was needed, but the field must be IN the
+    /// compared value.
+    #[test]
+    fn discovery_branch_payload_gate_fires_on_dirty_flip() {
+        let clean = b2_payload(
+            None,
+            &[
+                ("C:/wg/repo-a", Some("main"), Some(false)),
+                ("C:/wg/repo-b", Some("main"), Some(false)),
+            ],
+        );
+        let dirtied = b2_payload(
+            None,
+            &[
+                ("C:/wg/repo-a", Some("main"), Some(true)),
+                ("C:/wg/repo-b", Some("main"), Some(false)),
+            ],
+        );
+        let unknown = b2_payload(
+            None,
+            &[
+                ("C:/wg/repo-a", Some("main"), None),
+                ("C:/wg/repo-b", Some("main"), Some(false)),
+            ],
+        );
+
+        assert_eq!(
+            clean.repo_branches, dirtied.repo_branches,
+            "only dirty moved"
+        );
+        assert_ne!(clean, dirtied, "clean -> dirty must re-emit");
+        assert_ne!(dirtied, unknown, "dirty -> unknown must re-emit");
+        assert_ne!(clean, unknown, "false and null are distinct on the wire");
     }
 
     /// A repo-set change with identical branch text must also fire: swapping a repo
@@ -3799,22 +3879,22 @@ mod tests {
         let before = b2_payload(
             None,
             &[
-                ("C:/wg/repo-a", Some("main")),
-                ("C:/wg/repo-b", Some("main")),
+                ("C:/wg/repo-a", Some("main"), None),
+                ("C:/wg/repo-b", Some("main"), None),
             ],
         );
         let swapped = b2_payload(
             None,
             &[
-                ("C:/wg/repo-a", Some("main")),
-                ("C:/wg/repo-c", Some("main")),
+                ("C:/wg/repo-a", Some("main"), None),
+                ("C:/wg/repo-c", Some("main"), None),
             ],
         );
         let reordered = b2_payload(
             None,
             &[
-                ("C:/wg/repo-b", Some("main")),
-                ("C:/wg/repo-a", Some("main")),
+                ("C:/wg/repo-b", Some("main"), None),
+                ("C:/wg/repo-a", Some("main"), None),
             ],
         );
 

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -2139,7 +2139,13 @@ fn build_session_repo(replica_dir: &Path, rel: &str) -> Option<SessionRepo> {
     Some(SessionRepo {
         label,
         source_path,
+        // #1028 - undetected, like `branch` above. This literal is emitted straight to
+        // the UI by `sync_workgroup_repos_inner`, so a user-initiated sync shows a
+        // violet badge until the next GitWatcher tick (<=5s, forced by the
+        // `invalidate_session_cache` call beside that emit). Same bound `branch`
+        // already has there.
         branch: None,
+        dirty: None,
     })
 }
 

--- a/src-tauri/src/commands/repos.rs
+++ b/src-tauri/src/commands/repos.rs
@@ -141,7 +141,7 @@ pub async fn search_repos(
 }
 
 /// #943 - upper bound for the `git remote get-url` call, mirroring
-/// `GitWatcher::detect_branch_with_timeout` (src-tauri/src/pty/git_watcher.rs:171).
+/// `GitWatcher::detect_status_with_timeout` (src-tauri/src/pty/git_watcher.rs).
 /// The context menu must never wait on a stalled git.
 const GIT_REMOTE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -691,6 +691,7 @@ fn load_sessions_from_path(path: &Path) -> Vec<PersistedSession> {
                                 label: prefix,
                                 source_path: source,
                                 branch: None,
+                                dirty: None,
                             });
                         }
                         (Some(source), None) => {
@@ -712,6 +713,7 @@ fn load_sessions_from_path(path: &Path) -> Vec<PersistedSession> {
                                 label,
                                 source_path: source,
                                 branch: None,
+                                dirty: None,
                             });
                         }
                         (None, Some(prefix)) if prefix == "multi-repo" => {
@@ -3462,6 +3464,7 @@ mod tests {
                         label: prefix,
                         source_path: source,
                         branch: None,
+                        dirty: None,
                     });
                 }
                 _ => {}
@@ -3601,6 +3604,7 @@ mod tests {
                         label: prefix,
                         source_path: source,
                         branch: None,
+                        dirty: None,
                     });
                 }
                 _ => {}

--- a/src-tauri/src/pty/git_watcher.rs
+++ b/src-tauri/src/pty/git_watcher.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -12,7 +13,8 @@ use crate::session::session::SessionRepo;
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 const DETECT_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// #280 §3.3 — per-path counter for `detect_branch` timeouts. Used to dampen
+/// #280 §3.3 - per-path counter for `detect_git_status` timeouts (#1028 renamed
+/// the detection; the counter and its policy are unchanged). Used to dampen
 /// the WARN storm by logging only the first occurrence per path plus every
 /// 50th thereafter. Process-local: counts reset on restart. Bounded by the
 /// number of distinct repo paths (~150 in production observations), so no
@@ -25,6 +27,228 @@ fn note_timeout(path: &str) -> u64 {
     let count = g.entry(path.to_string()).or_insert(0);
     *count += 1;
     *count
+}
+
+/// #1028 - one worktree status detection: the branch from the `## ` header plus
+/// whether the worktree holds any uncommitted work.
+///
+/// `dirty` is strictly the WORKTREE definition #1028 names: untracked, unstaged,
+/// or staged-but-uncommitted. It is deliberately NARROWER than
+/// `check_workgroup_repos_dirty` (`commands/entity_creation.rs`), which also counts
+/// unpushed commits and a missing upstream. A clean-but-unpushed repo is dirty
+/// there and clean here, on purpose. Reuse that pattern, never that function.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct GitStatus {
+    /// `None` for a detached HEAD or a mid-rebase, matching what
+    /// `rev-parse --abbrev-ref` reported before this replaced it.
+    pub(crate) branch: Option<String>,
+    pub(crate) dirty: bool,
+}
+
+/// #1028 - last SUCCESSFULLY detected worktree-dirty state per repo path, so a
+/// transient detection failure holds the previous answer instead of asserting a
+/// confident "clean". The errors are asymmetric: a false clean means shipping
+/// uncommitted work (silent, costly), a false red self-corrects on the next tick
+/// (cheap). `branch` deliberately keeps its old no-hold behaviour.
+///
+/// Only successful detections are ever written, so no failure can poison the map
+/// and there is nothing to reset. Keyed by repo path, not by session or replica:
+/// dirty is a property of the worktree, and several replicas legitimately share one
+/// repo dir. Process-local, so it resets on restart, which is correct: an unknown
+/// repo is `None` (violet) until its first answer. Bounded by the number of distinct
+/// repo paths (~150 in production observations), so no GC is needed.
+///
+/// `pub(crate)`, and that is FORCED, not preferred: on a timeout `tokio::time::timeout`
+/// DROPS the `detect_git_status` future, so it never returns and cannot remember
+/// anything. The hold must therefore be applied where the failure is observed, which is
+/// each watcher's own timeout wrapper, and one of those lives in
+/// `commands/ac_discovery.rs`. No arrangement keeps this map module-private and still
+/// holds on the failure path, which is the only path it exists for.
+///
+/// Deliberately SHARED by both watchers, diverging from `note_timeout` above, which is
+/// deliberately per-watcher. That split is right for a throttle counter and irrelevant
+/// for a fact about a worktree. Sharing is REQUIRED here: with separate maps, a timeout
+/// cluster hitting both watchers leaves their holds sourced from successes up to 5s and
+/// up to 15s old, so if the repo changed in between the two watchers hold DIFFERENT
+/// values, both write divergent `dirty` into `git_repos`, and both emit (each compares
+/// against its own cache). That is a red/violet badge flicker. The CAS is not a backstop:
+/// it only suppresses discovery when GitWatcher's write lands inside discovery's
+/// detection window. Sharing makes the two watchers agree by construction.
+///
+/// `.unwrap_or_else(|e| e.into_inner())` is required, not stylistic: `.unwrap()` would
+/// take BOTH watchers down permanently on a single poisoning.
+///
+/// INVARIANT, and it is NOT enforced here: this function remembers whatever it is
+/// handed. "Never remembers an ancestor's dirt" is enforced by the caller,
+/// `detect_git_status`, through its three gates (`.git` metadata check, ceiling,
+/// `status.success()`). Only ever feed this from `detect_git_status`. A caller shaped
+/// like `detect_git_branch_sync` (`commands/ac_discovery.rs`), which has no `.git` guard
+/// and no ceiling, would silently violate it. Nothing does today.
+pub(crate) fn remember_dirty(path: &str, detected: Option<bool>) -> Option<bool> {
+    use std::sync::OnceLock;
+    static LAST_DIRTY: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
+    let map = LAST_DIRTY.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut g = map.lock().unwrap_or_else(|e| e.into_inner());
+    match detected {
+        Some(d) => {
+            g.insert(path.to_string(), d);
+            Some(d)
+        }
+        None => g.get(path).copied(),
+    }
+}
+
+/// #1028 - parse `git status --porcelain --branch` output.
+///
+/// Git builds the header as `## ` + (`No commits yet on ` if unborn) + branch +
+/// (`...` + upstream + optional ` [...]` if an upstream is configured), so unborn and
+/// upstream are orthogonal and the shape matrix is closed, not merely "what we found":
+///
+/// | State                     | Header                                          |
+/// |---------------------------|-------------------------------------------------|
+/// | born, no upstream         | `## master`                                      |
+/// | born, upstream in sync    | `## master...origin/master`                      |
+/// | born, upstream diverged   | `## master...origin/master [ahead 1, behind 2]`  |
+/// | detached / mid-rebase     | `## HEAD (no branch)`                            |
+/// | unborn, no upstream       | `## No commits yet on master`                    |
+/// | unborn, with upstream     | `## No commits yet on master...origin/master [gone]` |
+///
+/// An unborn branch prints `[gone]` even against a real, fetched upstream, because it
+/// has no commit and so ahead/behind cannot be computed. There is therefore no
+/// "unborn + upstream + no bracket" shape.
+///
+/// Splitting on `...` and trimming ` [...]` are both safe because git's refname rules
+/// reject `feat..bad` and `feat[x]`, so neither sequence can occur inside a real branch
+/// name. Single dots and slashes (`feat/a.b-c`) survive.
+pub(crate) fn parse_status_porcelain_branch(stdout: &str) -> Option<GitStatus> {
+    let mut lines = stdout.lines();
+    // Output we do not understand: do not guess.
+    let header = lines.next()?.strip_prefix("## ")?;
+
+    // Any entry after the header is a dirty entry: ` M tracked`, `A  staged`,
+    // `?? untracked`. Ahead/behind live inside the header, so they cost nothing here.
+    let dirty = lines.any(|l| !l.trim().is_empty());
+
+    // (a) detached / mid-rebase. Must short-circuit before (b).
+    let branch = if header == "HEAD (no branch)" {
+        None
+    } else {
+        // (b) unborn: strip the prefix and CONTINUE, which is what makes the
+        // unborn-with-upstream shape parse.
+        let rest = header.strip_prefix("No commits yet on ").unwrap_or(header);
+        // (c) drop the upstream.
+        let rest = rest.split_once("...").map_or(rest, |(b, _)| b);
+        // (d) defensively drop a tracking suffix. Unreachable after (c) with today's
+        // git (a marker implies an upstream implies `...`), and safe: `[` is forbidden
+        // in refnames, so this cannot eat a real name.
+        let rest = rest.split_once(" [").map_or(rest, |(b, _)| b);
+        // (e) unreachable per the refname rule (git rejects a branch named `HEAD`);
+        // kept for parity with the `rev-parse` implementation this replaced.
+        let rest = rest.trim();
+        if rest.is_empty() || rest == "HEAD" {
+            None
+        } else {
+            Some(rest.to_string())
+        }
+    };
+
+    Some(GitStatus { branch, dirty })
+}
+
+/// #1028 - detect branch AND worktree-dirty for `working_dir` in ONE git call. Shared
+/// by both badge writers (`GitWatcher` and `DiscoveryBranchWatcher`), which previously
+/// kept near-identical `detect_branch` copies that had already diverged: one set the
+/// ceiling env, the other did not. Both writers must compute `dirty` identically or the
+/// badge flickers, and duplicating the parse is how that guarantee gets lost.
+///
+/// Each caller keeps its OWN timeout wrapper. That is required, not stylistic: each owns
+/// its per-path counter and log tag (`note_timeout` / `note_discovery_timeout`,
+/// `[GitWatcher]` / `[DiscoveryBranchWatcher]`), and merging them would collapse the two
+/// tags that keep the watchers distinguishable in app.log.
+///
+/// `--no-optional-locks` is LOAD-BEARING, not hygiene. Do not drop it in a cleanup. A
+/// plain `status` takes `.git/index.lock` (a ~13ms window) and rewrites `.git/index`;
+/// with the caller's 2s timeout dropping this future, `kill_on_drop` TerminateProcess-es
+/// git, and a kill inside that window orphaned the lock 8/8 in measurement. An orphaned
+/// `index.lock` leaves `git status` at exit 0 and silent while the user's own `git add`
+/// and `git commit` hard-fail: the badge keeps painting while their commits break. The
+/// flag also stops the poll writing `.git/index` every tick. Its cost is that a
+/// stat-dirty index can never be refreshed by us, so such a repo stays on the slow
+/// status path; that is measured and accepted.
+///
+/// Two gates keep git from answering with an UNRELATED ancestor repository's status. The
+/// replica tree sits inside a parent repo that AC's own operation keeps permanently
+/// dirty, so a false red from up there would never self-clear:
+/// 1. `.git` metadata check: rejects a path with no `.git` at all. `metadata`, not
+///    `is_dir`, because linked worktrees and submodules use a `.git` FILE. `tokio::fs`,
+///    not `std::fs`, because a sync stat inside an async fn cannot be cancelled by
+///    `tokio::time::timeout`: on a dead share it would wedge a runtime worker and make
+///    the caller's 2s cap a lie.
+/// 2. `GIT_CEILING_DIRECTORIES` = the repo path's parent: rejects a path whose `.git`
+///    EXISTS but is corrupt or empty (an interrupted clone), which the metadata check
+///    passes and which otherwise walks up and reports the ancestor's dirt. Measured:
+///    corrupt `.git` + this ceiling gives `fatal: not a git repository`, exit 128, while
+///    a healthy repo, a linked worktree whose main repo lives above the ceiling, and a
+///    dirty submodule superproject are all unharmed. The ceiling constrains the
+///    discovery ascent only, not gitdir resolution through a `.git` file.
+///
+/// This deliberately does NOT call `git_ceiling_directories_for_session_root`: that
+/// helper returns `None` for every path a watcher passes it (its `is_agent_dir` gate
+/// rejects `repo-*` paths), i.e. it is a no-op that reads like a guard. Replacing a
+/// guard that cannot fire with one that does is not re-adding it.
+///
+/// Returns `None` on every failure path, which the callers turn into "hold the last
+/// known dirty" via `remember_dirty` and "branch unknown" for `branch`.
+pub(crate) async fn detect_git_status(working_dir: &str) -> Option<GitStatus> {
+    #[cfg(windows)]
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+    // Gate 1: require a work tree ROOT; do not let git discover a repo by walking up.
+    if tokio::fs::metadata(Path::new(working_dir).join(".git"))
+        .await
+        .is_err()
+    {
+        return None;
+    }
+
+    let mut cmd = tokio::process::Command::new("git");
+    crate::pty::credentials::scrub_credentials_from_tokio_command(&mut cmd);
+    cmd.args(["--no-optional-locks", "status", "--porcelain", "--branch"])
+        .current_dir(working_dir)
+        .kill_on_drop(true);
+
+    // Gate 2: no ancestor ascent. `join_paths` emits the platform separator, matching
+    // the existing ceiling code. With no parent (a filesystem root), skip the env
+    // entirely rather than set an empty value.
+    if let Some(parent) = Path::new(working_dir).parent() {
+        match std::env::join_paths(std::iter::once(parent)) {
+            Ok(ceiling) => {
+                cmd.env("GIT_CEILING_DIRECTORIES", ceiling);
+            }
+            Err(e) => {
+                // Only reachable if the path contains the path separator itself.
+                // Gate 1 still stands; log rather than abort the detection.
+                log::debug!(
+                    "[git] Could not build GIT_CEILING_DIRECTORIES for {}: {}",
+                    working_dir,
+                    e
+                );
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    cmd.creation_flags(CREATE_NO_WINDOW);
+
+    match cmd.output().await {
+        // Gate 3: retained from the two `detect_branch` copies. A failed git writes
+        // `fatal:` to stderr and leaves stdout empty, so the parser would return `None`
+        // anyway; dropping the gate would be a silent behaviour change, not a fix.
+        Ok(out) if out.status.success() => {
+            parse_status_porcelain_branch(&String::from_utf8_lossy(&out.stdout))
+        }
+        _ => None,
+    }
 }
 
 pub struct GitWatcher {
@@ -110,22 +334,29 @@ impl GitWatcher {
             }
 
             // Parallelize per-repo detection (Grinch #16). Each call bounded by 2s
-            // (detect_branch_with_timeout). Without join_all, worst-case per poll is
+            // (detect_status_with_timeout). Without join_all, worst-case per poll is
             // M*N*2s under simultaneous stalls.
-            let branches: Vec<Option<String>> = join_all(
+            let statuses: Vec<Option<GitStatus>> = join_all(
                 repos
                     .iter()
-                    .map(|r| Self::detect_branch_with_timeout(&r.source_path)),
+                    .map(|r| Self::detect_status_with_timeout(&r.source_path)),
             )
             .await;
 
             let refreshed: Vec<SessionRepo> = repos
                 .iter()
-                .zip(branches)
-                .map(|(r, branch)| SessionRepo {
+                .zip(statuses)
+                .map(|(r, status)| SessionRepo {
                     label: r.label.clone(),
                     source_path: r.source_path.clone(),
-                    branch,
+                    // #1028 - `branch` keeps its old behaviour exactly: a failed
+                    // detection reports `None`, with no hold.
+                    branch: status.as_ref().and_then(|s| s.branch.clone()),
+                    // #1028 - `dirty` DOES hold across a failure, because asserting a
+                    // confident "clean" while the worktree has uncommitted work is the
+                    // one error this feature must not make. Same shape in
+                    // DiscoveryBranchWatcher::poll; the map behind it is shared.
+                    dirty: remember_dirty(&r.source_path, status.as_ref().map(|s| s.dirty)),
                 })
                 .collect();
 
@@ -164,11 +395,19 @@ impl GitWatcher {
         }
     }
 
-    /// Detect branch via `git rev-parse`, bounded by a 2s timeout. On timeout the
-    /// pending future is dropped; `.kill_on_drop(true)` ensures the child `git.exe`
-    /// is terminated so repeated polls can't leak processes.
-    async fn detect_branch_with_timeout(working_dir: &str) -> Option<String> {
-        match tokio::time::timeout(DETECT_TIMEOUT, Self::detect_branch(working_dir)).await {
+    /// Detect branch + worktree-dirty via the shared `detect_git_status`, bounded by a
+    /// 2s timeout. On timeout the pending future is dropped; `.kill_on_drop(true)`
+    /// ensures the child `git.exe` is terminated so repeated polls can't leak processes.
+    ///
+    /// #1028 - this wrapper stays private to GitWatcher rather than merging with
+    /// DiscoveryBranchWatcher's: each owns its per-path counter and log tag, and merging
+    /// them would collapse `note_timeout`/`note_discovery_timeout` and the two tags that
+    /// keep the watchers distinguishable in app.log.
+    ///
+    /// Because `timeout` DROPS the future here, `detect_git_status` never returns on this
+    /// path and cannot remember anything itself: the caller applies the dirty hold.
+    async fn detect_status_with_timeout(working_dir: &str) -> Option<GitStatus> {
+        match tokio::time::timeout(DETECT_TIMEOUT, detect_git_status(working_dir)).await {
             Ok(result) => result,
             Err(_) => {
                 let n = note_timeout(working_dir);
@@ -179,7 +418,7 @@ impl GitWatcher {
                 // notice persistent slowness without spamming.
                 if n == 1 || n.is_multiple_of(50) {
                     log::warn!(
-                        "[GitWatcher] detect_branch timed out for {} (>{}s); occurrence={} (logging 1st + every 50th)",
+                        "[GitWatcher] detect_git_status timed out for {} (>{}s); occurrence={} (logging 1st + every 50th)",
                         working_dir,
                         DETECT_TIMEOUT.as_secs(),
                         n
@@ -187,39 +426,6 @@ impl GitWatcher {
                 }
                 None
             }
-        }
-    }
-
-    async fn detect_branch(working_dir: &str) -> Option<String> {
-        #[cfg(windows)]
-        const CREATE_NO_WINDOW: u32 = 0x08000000;
-
-        let mut cmd = tokio::process::Command::new("git");
-        crate::pty::credentials::scrub_credentials_from_tokio_command(&mut cmd);
-        cmd.args(["rev-parse", "--abbrev-ref", "HEAD"])
-            .current_dir(working_dir)
-            .kill_on_drop(true);
-        if let Some(git_ceiling_dirs) =
-            crate::config::session_context::git_ceiling_directories_for_session_root(working_dir)
-        {
-            cmd.env("GIT_CEILING_DIRECTORIES", git_ceiling_dirs);
-        }
-
-        #[cfg(windows)]
-        cmd.creation_flags(CREATE_NO_WINDOW);
-
-        let output = cmd.output().await;
-
-        match output {
-            Ok(out) if out.status.success() => {
-                let branch = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                if branch.is_empty() || branch == "HEAD" {
-                    None
-                } else {
-                    Some(branch)
-                }
-            }
-            _ => None,
         }
     }
 }
@@ -243,6 +449,7 @@ mod tests {
                     label: "A".into(),
                     source_path: "C:/a".into(),
                     branch: None,
+                    dirty: None,
                 }],
                 false,
                 crate::pty::backend::SessionBackendKind::LocalProcess,
@@ -260,6 +467,7 @@ mod tests {
                 label: "A2".into(),
                 source_path: "C:/a2".into(),
                 branch: None,
+                dirty: None,
             }],
         )
         .await;
@@ -272,6 +480,7 @@ mod tests {
                     label: "A-stale".into(),
                     source_path: "C:/a-stale".into(),
                     branch: Some("main".into()),
+                    dirty: None,
                 }],
                 gen0,
             )
@@ -290,6 +499,7 @@ mod tests {
                     label: "A2".into(),
                     source_path: "C:/a2".into(),
                     branch: Some("feature".into()),
+                    dirty: None,
                 }],
                 gen_now,
             )
@@ -312,5 +522,227 @@ mod tests {
         // Independent counter for a different path.
         assert_eq!(note_timeout(p2), 1);
         assert_eq!(note_timeout(p1), 4);
+    }
+
+    // --- #1028: parse_status_porcelain_branch, one test per header shape ---
+
+    fn parse(stdout: &str) -> GitStatus {
+        parse_status_porcelain_branch(stdout).expect("header should parse")
+    }
+
+    /// Shape 1: born, no upstream.
+    #[test]
+    fn parse_born_no_upstream() {
+        let s = parse("## master\n");
+        assert_eq!(s.branch.as_deref(), Some("master"));
+        assert!(!s.dirty);
+    }
+
+    /// Shape 2: born, upstream in sync. The upstream must not leak into the branch.
+    #[test]
+    fn parse_born_upstream_in_sync() {
+        assert_eq!(
+            parse("## master...origin/master\n").branch.as_deref(),
+            Some("master")
+        );
+    }
+
+    /// Shape 3: born, upstream diverged. Ahead/behind live in the header, so they must
+    /// not be read as dirty entries either.
+    #[test]
+    fn parse_born_upstream_diverged() {
+        let s = parse("## master...origin/master [ahead 1, behind 2]\n");
+        assert_eq!(s.branch.as_deref(), Some("master"));
+        assert!(!s.dirty, "ahead/behind is not worktree dirt");
+    }
+
+    /// Shape 4: detached HEAD or mid-rebase. Parses fine; the BRANCH is what is unknown.
+    #[test]
+    fn parse_detached_head() {
+        let s = parse("## HEAD (no branch)\n");
+        assert_eq!(s.branch, None);
+        assert!(!s.dirty);
+    }
+
+    /// Shape 5: unborn, no upstream.
+    #[test]
+    fn parse_unborn_no_upstream() {
+        assert_eq!(
+            parse("## No commits yet on master\n").branch.as_deref(),
+            Some("master")
+        );
+    }
+
+    /// Shape 5b: unborn WITH an upstream. Regression guard for the shape both round-1
+    /// reports missed: step (b) must strip `No commits yet on ` and then CONTINUE into
+    /// the `...` split rather than returning. An unborn branch prints `[gone]` even
+    /// against a real fetched upstream, so this is the only unborn-with-upstream form.
+    #[test]
+    fn parse_unborn_with_upstream() {
+        assert_eq!(
+            parse("## No commits yet on master...origin/master [gone]\n")
+                .branch
+                .as_deref(),
+            Some("master")
+        );
+    }
+
+    /// A detached HEAD is checked before the unborn prefix strip, and a branch may not
+    /// be named `HEAD`, so nothing here can resolve to a `HEAD` branch.
+    #[test]
+    fn parse_detached_head_beats_unborn_prefix() {
+        assert_eq!(parse("## HEAD (no branch)\n").branch, None);
+        assert_eq!(parse("## HEAD\n").branch, None);
+    }
+
+    /// All three dirty kinds #1028 names, each alone and then together.
+    #[test]
+    fn parse_dirty_kinds() {
+        assert!(parse("## main\n M tracked.txt\n").dirty, "unstaged");
+        assert!(parse("## main\nA  staged.txt\n").dirty, "staged");
+        assert!(parse("## main\n?? untracked.txt\n").dirty, "untracked");
+
+        let all = parse("## main\n M tracked.txt\nA  staged.txt\n?? untracked.txt\n");
+        assert!(all.dirty);
+        assert_eq!(all.branch.as_deref(), Some("main"));
+    }
+
+    /// Clean: header only. The trailing newline must not read as a dirty entry.
+    #[test]
+    fn parse_clean_is_not_dirty() {
+        assert!(!parse("## main\n").dirty);
+        assert!(!parse("## main").dirty, "no trailing newline");
+        assert!(!parse("## main\n\n").dirty, "blank lines are not entries");
+    }
+
+    /// Output we do not understand: return None rather than guess. Only a first line
+    /// that is not a `## ` header does this; a header we CAN read but whose branch is
+    /// unknowable still answers, with `branch: None` (see the detached-HEAD shape).
+    #[test]
+    fn parse_garbage_returns_none() {
+        assert_eq!(parse_status_porcelain_branch(""), None, "no first line");
+        assert_eq!(
+            parse_status_porcelain_branch("fatal: not a git repository\n"),
+            None,
+            "stderr text on stdout"
+        );
+        assert_eq!(
+            parse_status_porcelain_branch("##main\n"),
+            None,
+            "`## ` prefix requires the space"
+        );
+        assert_eq!(
+            parse_status_porcelain_branch(" ## main\n"),
+            None,
+            "header must be at the line start"
+        );
+    }
+
+    /// A `## ` header with an empty branch is a HEADER, not garbage: it answers
+    /// `branch: None` like a detached HEAD rather than discarding the dirty scan. Git
+    /// does not emit this today; pinned so the two "unknown" paths stay distinct.
+    #[test]
+    fn parse_empty_branch_answers_with_none_branch() {
+        assert_eq!(
+            parse_status_porcelain_branch("## \n"),
+            Some(GitStatus {
+                branch: None,
+                dirty: false
+            })
+        );
+        assert_eq!(
+            parse_status_porcelain_branch("## \n?? untracked.txt\n"),
+            Some(GitStatus {
+                branch: None,
+                dirty: true
+            }),
+            "dirty is still observable without a branch"
+        );
+    }
+
+    /// Single dots and slashes are legal in refnames and must survive: only `...` splits.
+    #[test]
+    fn parse_branch_with_dots_and_slashes() {
+        assert_eq!(
+            parse("## feat/a.b-c\n").branch.as_deref(),
+            Some("feat/a.b-c")
+        );
+        assert_eq!(
+            parse("## feat/a.b-c...origin/feat/a.b-c [ahead 1]\n")
+                .branch
+                .as_deref(),
+            Some("feat/a.b-c")
+        );
+    }
+
+    // --- #1028: remember_dirty ---
+    // Process-global state: use unique-per-test path strings to avoid collisions,
+    // exactly as `note_timeout_counts_per_path` above documents.
+
+    /// A failure with nothing remembered must not invent a value. `None` = "never got a
+    /// first answer", which renders violet, and that is honest.
+    #[test]
+    fn remember_dirty_never_detected_stays_none() {
+        let p = "/test-1028/remember/never-detected";
+        assert_eq!(remember_dirty(p, None), None);
+        assert_eq!(remember_dirty(p, None), None);
+    }
+
+    /// G1's regression guard: the hold must survive a CLUSTER, not just a single blip.
+    /// Timeouts cluster (I/O spikes, AV scans) and `git status` is heaviest exactly when
+    /// the worktree is being written to, i.e. exactly when the repo is dirty.
+    #[test]
+    fn remember_dirty_survives_failure_cluster() {
+        let p = "/test-1028/remember/cluster";
+        assert_eq!(remember_dirty(p, Some(true)), Some(true));
+        for tick in 0..5 {
+            assert_eq!(
+                remember_dirty(p, None),
+                Some(true),
+                "tick {tick} of a 5-tick cluster must still hold red"
+            );
+        }
+    }
+
+    /// A later success overwrites the memory; the hold is last-known, not sticky-red.
+    #[test]
+    fn remember_dirty_success_overwrites_then_holds() {
+        let p = "/test-1028/remember/overwrite";
+        assert_eq!(remember_dirty(p, Some(true)), Some(true));
+        assert_eq!(remember_dirty(p, Some(false)), Some(false));
+        assert_eq!(
+            remember_dirty(p, None),
+            Some(false),
+            "holds the newer answer"
+        );
+    }
+
+    /// Keyed by path: one repo's memory never leaks onto another.
+    #[test]
+    fn remember_dirty_keeps_paths_independent() {
+        let p1 = "/test-1028/remember/path-a";
+        let p2 = "/test-1028/remember/path-b";
+        assert_eq!(remember_dirty(p1, Some(true)), Some(true));
+        assert_eq!(remember_dirty(p2, None), None, "p2 never detected");
+        assert_eq!(remember_dirty(p2, Some(false)), Some(false));
+        assert_eq!(remember_dirty(p1, None), Some(true), "p1 unaffected by p2");
+    }
+
+    /// The map is SHARED by both watchers on purpose: during a timeout cluster separate
+    /// maps would let the two watchers hold different-age values, write divergent
+    /// `dirty`, and both emit, flickering the badge. Sharing makes them agree by
+    /// construction. This asserts the shape that guarantees it: a read from "the other
+    /// watcher" sees the freshest successful observation of that path, whoever made it.
+    #[test]
+    fn remember_dirty_is_shared_across_watchers() {
+        let p = "/test-1028/remember/shared";
+        // GitWatcher (5s) observes dirty.
+        assert_eq!(remember_dirty(p, Some(true)), Some(true));
+        // DiscoveryBranchWatcher (15s) fails on the same path and holds GitWatcher's
+        // answer rather than its own older one or a confident clean.
+        assert_eq!(remember_dirty(p, None), Some(true));
+        // Discovery then observes clean; GitWatcher's next failure holds THAT.
+        assert_eq!(remember_dirty(p, Some(false)), Some(false));
+        assert_eq!(remember_dirty(p, None), Some(false));
     }
 }

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -41,6 +41,23 @@ pub struct SessionRepo {
     /// Current branch. `None` until first watcher tick, or when detection fails.
     #[serde(default)]
     pub branch: Option<String>,
+    /// #1028 - worktree dirty: untracked, unstaged, or staged-but-uncommitted changes.
+    /// `Some(true)` paints the badge letters red. `None` = never successfully detected
+    /// for this path since process start, rendered violet like clean; a failed detection
+    /// holds the last known answer instead (`git_watcher::remember_dirty`), so `None`
+    /// means "no first answer yet", not "flaked once".
+    ///
+    /// `skip_deserializing`, not merely `default`: `dirty` is backend-authoritative and
+    /// must never be restored. A persisted `true` would otherwise paint a red badge at
+    /// launch from a worktree state that may be long gone, and `create_session` (a
+    /// `#[tauri::command]`, `commands/session.rs`) genuinely deserializes this struct
+    /// from frontend input, which would make the badge spoofable from a command payload.
+    /// Serializing is kept so the on-disk value stays self-describing in a bug report;
+    /// it is written and then ignored on read. NOTE: a test that round-trips `dirty`
+    /// through a write/read helper will get `None` back. That is this attribute, by
+    /// design, not a serde bug.
+    #[serde(default, skip_deserializing)]
+    pub dirty: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -476,5 +493,76 @@ mod tests {
         assert!(p.is_some());
         let p = p.unwrap().to_string_lossy().to_string();
         assert!(p.ends_with(r"\wg-3-team\TASK.md"));
+    }
+
+    // --- #1028: SessionRepo.dirty is backend-authoritative and never restored ---
+
+    /// The whole point of `skip_deserializing`. A `sessions.json` written before the app
+    /// closed can hold `dirty: true` from a worktree state that is long gone; restoring
+    /// it would paint a red badge at launch that no watcher tick asked for. It must come
+    /// back `None` (violet, "not yet known") and wait for a real detection.
+    ///
+    /// This also covers `create_session`, a `#[tauri::command]` that genuinely
+    /// deserializes `Vec<SessionRepo>` from frontend input: `dirty` is un-settable from a
+    /// command payload, so the badge cannot be spoofed. The frontend sends only
+    /// `{label, sourcePath}` today, so nothing is lost.
+    #[test]
+    fn session_repo_dirty_is_never_deserialized() {
+        let stale = r#"{"label":"A","sourcePath":"C:/a","branch":"main","dirty":true}"#;
+        let restored: SessionRepo = serde_json::from_str(stale).expect("deserialize");
+
+        assert_eq!(
+            restored.dirty, None,
+            "a persisted `true` must NOT restore red"
+        );
+        assert_eq!(
+            restored.branch.as_deref(),
+            Some("main"),
+            "branch still restores; only dirty is skipped"
+        );
+    }
+
+    /// Back-compat: `sessions.json` from before #1028 has no `dirty` key at all.
+    #[test]
+    fn session_repo_without_dirty_key_restores_as_none() {
+        let old = r#"{"label":"A","sourcePath":"C:/a","branch":"main"}"#;
+        let restored: SessionRepo = serde_json::from_str(old).expect("deserialize");
+        assert_eq!(restored.dirty, None);
+    }
+
+    /// Serialization is deliberately KEPT, so the wire and the on-disk file stay
+    /// self-describing: the key is always present, `None` as an explicit `null` rather
+    /// than an omitted key. The frontend reads `dirty === true`, and `skip_serializing_if`
+    /// would have stripped the key here while STILL letting a stale `true` through on
+    /// read, which is why it was rejected.
+    #[test]
+    fn session_repo_dirty_always_serializes_with_an_explicit_null() {
+        let dirty = SessionRepo {
+            label: "A".into(),
+            source_path: "C:/a".into(),
+            branch: Some("main".into()),
+            dirty: Some(true),
+        };
+        assert_eq!(
+            serde_json::to_value(&dirty).expect("serialize"),
+            serde_json::json!({
+                "label": "A",
+                "sourcePath": "C:/a",
+                "branch": "main",
+                "dirty": true,
+            })
+        );
+
+        let unknown = SessionRepo {
+            label: "A".into(),
+            source_path: "C:/a".into(),
+            branch: None,
+            dirty: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&unknown).expect("serialize")["dirty"],
+            serde_json::json!(null),
+            "key present as null, not omitted"
+        );
     }
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -687,6 +687,11 @@ interface DiscoveryBranchUpdate {
   branch: string | null;
   repoBranches: (string | null)[];
   repoPaths: string[];
+  /** #1028 - per-repo worktree-dirty, parallel to `repoPaths` exactly as
+   *  `repoBranches` is, and merged BY PATH for the same reason. `null` = the backend
+   *  has never successfully detected that path. Gate A emits for every replica,
+   *  session or not, which is what carries dirty to DORMANT coordinator rows. */
+  repoDirty: (boolean | null)[];
 }
 
 export function onDiscoveryBranchUpdated(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2,6 +2,23 @@ export interface SessionRepo {
   label: string;
   sourcePath: string;
   branch: string | null;
+  /**
+   * #1028 - worktree dirty: untracked, unstaged, or staged-but-uncommitted changes.
+   * `true` paints the badge letters red; `false` = backend says clean; `null` = never
+   * successfully detected for this path since the backend process started. A failed
+   * detection HOLDS the last known answer (git_watcher::remember_dirty), so `null`
+   * means "no first answer yet", not "flaked once". Both `false` and `null` render
+   * violet - only the badge `title` distinguishes them.
+   *
+   * REQUIRED, not `dirty?:`, deliberately. `SessionRepo` has no `Default` in Rust, so
+   * every backend construction site is compile-forced to state a value; a `?` throws
+   * that guarantee away on the TS side at `configuredReplicaRepoBadges`
+   * (components/replica-repo-badges.ts), the one production builder of this type on
+   * the cold path, where omitting the `dirty:` line would raise no tsc error and ship
+   * a permanently violet feed. `branch` above is the same shape against a Rust
+   * `Option<String>`. Cost is a `dirty: null` in test literals; that is the trade.
+   */
+  dirty: boolean | null;
 }
 
 /**
@@ -18,6 +35,27 @@ export interface SessionRepo {
  * merge paint repo A's branch onto repo B for up to one 15s tick.
  */
 export type RepoBranchByPath = Record<string, string | null>;
+
+/**
+ * #1028 - live per-repo worktree-dirty, keyed by repo SOURCE PATH.
+ *
+ * A missing key = the live layer knows nothing about that repo (no event has
+ * landed yet, or it was added to `config.json` since the last watcher tick), and
+ * the caller resolves it to `null`: there is no single-repo shorthand for dirty to
+ * fall back to, unlike `RepoBranchByPath`. An explicit `null` = the layer knows the
+ * repo and the backend has never successfully detected its dirty state. Both miss
+ * and explicit-null render violet, so the two collapse on screen by design.
+ *
+ * `false` is a THIRD, distinct value and must survive the trip: it means "detected,
+ * clean". It renders identically to `null`, so a `??`-to-`||` slip that turns it
+ * into `null` is invisible on the badge and only the `title` exposes it.
+ *
+ * Keyed by path and NEVER by index, for the same reason as `RepoBranchByPath`: the
+ * payload is stored and re-read against a LATER discovery snapshot, so a
+ * reorder/removal in `config.json` `repos` would make a positional merge paint repo
+ * A's dirty state onto repo B for up to one 15s tick.
+ */
+export type RepoDirtyByPath = Record<string, boolean | null>;
 
 export type SessionCommunicationKind = "raiseHand";
 

--- a/src/sidebar/components/ProjectPanel.context-menu.test.tsx
+++ b/src/sidebar/components/ProjectPanel.context-menu.test.tsx
@@ -447,7 +447,7 @@ describe("ProjectPanel replica context menu — gray/red (#545)", () => {
       coordSession({
         id: "same-name-other-project",
         workingDirectory: coordPath,
-        gitRepos: [{ label: "wrong-live", sourcePath: wrongLiveRepo, branch: "main" }],
+        gitRepos: [{ label: "wrong-live", sourcePath: wrongLiveRepo, branch: "main", dirty: null }],
       }),
     ]);
     rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);

--- a/src/sidebar/components/ProjectPanel.dirty-repo-badge.test.tsx
+++ b/src/sidebar/components/ProjectPanel.dirty-repo-badge.test.tsx
@@ -1,0 +1,278 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import ProjectPanel from "./ProjectPanel";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { projectStore } from "../stores/project";
+import { replicaVolatileStore } from "../stores/replica-volatile";
+
+// #1028 - the repo badge's letters go red when that repo's worktree is dirty.
+//
+// These render the real ProjectPanel through the FakeTransport harness and assert
+// the DOM, per the frontend-visual-verification discipline. They cover the CLASS and
+// the TITLE; they deliberately do NOT claim to cover the COLOUR. jsdom does not
+// evaluate the stylesheet, so a misspelled rule, a wrong property, or losing the
+// specificity contest would leave every assertion in this file green and the badge
+// violet on screen. AC 1 and AC 2 are closed by a real visual check, not by this file.
+//
+// The rows here are DORMANT - nothing in this file creates a session - which is AC 4:
+// Gate A polls every replica whether or not a session exists, so a dormant row's
+// dirtiness was already being computed and thrown away.
+
+const projectPath = "C:\\Project";
+const workgroupPath = `${projectPath}\\.ac\\wg-2-dev-team`;
+const coordPath = `${workgroupPath}\\__agent_dev-webpage-ui`;
+const memberPath = `${workgroupPath}\\__agent_dev-rust`;
+const REPO_A = `${workgroupPath}\\repo-AgentsCommander`;
+const REPO_B = `${workgroupPath}\\repo-webpage`;
+
+/** A coordinator row renders TWICE: once in the workgroup tree (rowContext
+ *  "workgroups") and once in the coord-quick-access strip (rowContext "quick"). Both
+ *  go through the same renderReplicaItem, so tests target one context explicitly
+ *  rather than counting badges document-wide. */
+const TREE = "workgroups";
+const QUICK = "quick";
+
+/** The badge's own data-ac-testid: replica.repoBadge.<ctx>.<wg>.<replica>.<i>.<label> */
+function badgeIn(
+  root: Element,
+  ctx: string,
+  replicaName: string,
+  index: number,
+  label: string
+): HTMLElement | null {
+  return root.querySelector<HTMLElement>(
+    `[data-ac-testid="replica.repoBadge.${ctx}.wg-2-dev-team.${replicaName}.${index}.${label}"]`
+  );
+}
+
+/** A dormant coordinator plus a dormant non-coordinator, both carrying repo paths. */
+function repoDiscovery(repoPaths: string[]) {
+  return discovery({
+    workgroups: [
+      {
+        name: "wg-2-dev-team",
+        path: workgroupPath,
+        task: null,
+        taskTitle: "Dirty badge",
+        agents: [
+          {
+            name: "dev-webpage-ui",
+            path: coordPath,
+            repoPaths,
+            isCoordinator: true,
+          },
+          {
+            name: "dev-rust",
+            path: memberPath,
+            repoPaths,
+            isCoordinator: false,
+          },
+        ],
+      },
+    ],
+  });
+}
+
+async function renderDormantRepoRow(fake: FakeTransport, repoPaths: string[]) {
+  fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+  fake.resolve("get_settings", baseSettings());
+  fake.resolve("discover_project", repoDiscovery(repoPaths));
+
+  const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+  await projectStore.createAndLoad(projectPath);
+  await waitFor(() => expect(rendered.root.textContent).toContain("dev-webpage-ui"));
+  return rendered;
+}
+
+describe("ProjectPanel dirty repo badge (#1028)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("adds the dirty class to a DORMANT coordinator's badge when the repo is dirty (AC 4)", async () => {
+    const fake = new FakeTransport();
+    const rendered = await renderDormantRepoRow(fake, [REPO_A]);
+    try {
+      // Before any event lands: no dirty class, and the tooltip says why.
+      await waitFor(() =>
+        expect(badgeIn(rendered.root, TREE, "dev-webpage-ui", 0, "AgentsCommander")).not.toBeNull()
+      );
+      const before = badgeIn(rendered.root, TREE, "dev-webpage-ui", 0, "AgentsCommander")!;
+      expect(before.classList.contains("dirty")).toBe(false);
+      expect(before.title).toBe(`${REPO_A} (status unknown)`);
+
+      // A Gate A tick for a replica with NO session: the badge still goes red.
+      replicaVolatileStore.applyDiscoveryBranchUpdate(coordPath, "main", [REPO_A], ["main"], [
+        true,
+      ]);
+
+      await waitFor(() => {
+        const badge = badgeIn(rendered.root, TREE, "dev-webpage-ui", 0, "AgentsCommander")!;
+        expect(badge.classList.contains("dirty")).toBe(true);
+        // ADDITIVE variant: `.branch` must survive alongside it, or the badge loses
+        // its background and the `.branch.dirty` rule stops matching at all.
+        expect(badge.className).toBe("ac-discovery-badge branch dirty");
+        expect(badge.title).toBe(`${REPO_A} (uncommitted changes)`);
+        expect(badge.textContent).toBe("AgentsCommander/main");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("reddens the coordinator's quick-access copy from the same event", async () => {
+    // The coordinator row renders in two places off one code path. Pinned so a future
+    // refactor that splits them cannot redden one and leave the other violet.
+    const fake = new FakeTransport();
+    const rendered = await renderDormantRepoRow(fake, [REPO_A]);
+    try {
+      replicaVolatileStore.applyDiscoveryBranchUpdate(coordPath, "main", [REPO_A], ["main"], [
+        true,
+      ]);
+
+      await waitFor(() => {
+        const quick = badgeIn(rendered.root, QUICK, "dev-webpage-ui", 0, "AgentsCommander");
+        expect(quick).not.toBeNull();
+        expect(quick!.classList.contains("dirty")).toBe(true);
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("leaves a clean repo without the dirty class, and its title untouched (AC 2)", async () => {
+    const fake = new FakeTransport();
+    const rendered = await renderDormantRepoRow(fake, [REPO_A]);
+    try {
+      replicaVolatileStore.applyDiscoveryBranchUpdate(coordPath, "main", [REPO_A], ["main"], [
+        false,
+      ]);
+
+      await waitFor(() => {
+        const badge = badgeIn(rendered.root, TREE, "dev-webpage-ui", 0, "AgentsCommander")!;
+        expect(badge.textContent).toBe("AgentsCommander/main");
+        expect(badge.classList.contains("dirty")).toBe(false);
+        expect(badge.className).toBe("ac-discovery-badge branch");
+        // A detected-clean repo keeps the bare path, exactly as before #1028.
+        expect(badge.title).toBe(REPO_A);
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keys the class off `=== true`, so an unknown state stays violet", async () => {
+    const fake = new FakeTransport();
+    const rendered = await renderDormantRepoRow(fake, [REPO_A]);
+    try {
+      replicaVolatileStore.applyDiscoveryBranchUpdate(coordPath, "main", [REPO_A], ["main"], [
+        null,
+      ]);
+
+      await waitFor(() => {
+        const badge = badgeIn(rendered.root, TREE, "dev-webpage-ui", 0, "AgentsCommander")!;
+        expect(badge.classList.contains("dirty")).toBe(false);
+        expect(badge.title).toBe(`${REPO_A} (status unknown)`);
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("reddens only the dirty repo of a multi-repo row, keyed by path", async () => {
+    const fake = new FakeTransport();
+    const rendered = await renderDormantRepoRow(fake, [REPO_A, REPO_B]);
+    try {
+      await waitFor(() =>
+        expect(badgeIn(rendered.root, TREE, "dev-webpage-ui", 1, "webpage")).not.toBeNull()
+      );
+
+      replicaVolatileStore.applyDiscoveryBranchUpdate(
+        coordPath,
+        null, // multi-repo: the single-repo shorthand stays null
+        [REPO_A, REPO_B],
+        ["main", "main"],
+        [false, true]
+      );
+
+      await waitFor(() => {
+        const a = badgeIn(rendered.root, TREE, "dev-webpage-ui", 0, "AgentsCommander")!;
+        const b = badgeIn(rendered.root, TREE, "dev-webpage-ui", 1, "webpage")!;
+        expect(a.classList.contains("dirty")).toBe(false);
+        expect(b.classList.contains("dirty")).toBe(true);
+        expect(a.title).toBe(REPO_A);
+        expect(b.title).toBe(`${REPO_B} (uncommitted changes)`);
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps the red across a discovery reload (AC 6, end to end)", async () => {
+    const fake = new FakeTransport();
+    const rendered = await renderDormantRepoRow(fake, [REPO_A]);
+    try {
+      replicaVolatileStore.applyDiscoveryBranchUpdate(coordPath, "main", [REPO_A], ["main"], [
+        true,
+      ]);
+      await waitFor(() =>
+        expect(
+          badgeIn(rendered.root, TREE, "dev-webpage-ui", 0, "AgentsCommander")!.classList.contains(
+            "dirty"
+          )
+        ).toBe(true)
+      );
+
+      // What every reload does (loop tick, CLI refresh, entity creation). Gate A will
+      // NOT re-emit afterwards, because the payload has not changed - so if the map
+      // were wiped here the red would be gone until the worktree changed on disk.
+      replicaVolatileStore.clearForPaths([coordPath]);
+
+      await waitFor(() => {
+        const badge = badgeIn(rendered.root, TREE, "dev-webpage-ui", 0, "AgentsCommander")!;
+        expect(badge.classList.contains("dirty")).toBe(true);
+        expect(badge.title).toBe(`${REPO_A} (uncommitted changes)`);
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("renders no repo badge at all on a non-coordinator row (G8)", async () => {
+    const fake = new FakeTransport();
+    const rendered = await renderDormantRepoRow(fake, [REPO_A]);
+    try {
+      await waitFor(() => expect(rendered.root.textContent).toContain("dev-rust"));
+
+      // The badge render is gated on isCoordinator, so the member row has no badge to
+      // redden: the dirty feed reaches it and changes nothing on screen.
+      replicaVolatileStore.applyDiscoveryBranchUpdate(memberPath, "main", [REPO_A], ["main"], [
+        true,
+      ]);
+
+      expect(badgeIn(rendered.root, TREE, "dev-rust", 0, "AgentsCommander")).toBeNull();
+      // ...while the coordinator in the same workgroup still has one.
+      expect(badgeIn(rendered.root, TREE, "dev-webpage-ui", 0, "AgentsCommander")).not.toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.regex-filter.test.tsx
@@ -502,7 +502,7 @@ describe("ProjectPanel regex filter", () => {
         workingDirectory: `${workgroupPath}\\__agent_dev-webpage-ui`,
         status: "running",
         isCoordinator: true,
-        gitRepos: [{ label: "uirepo", sourcePath: "C:\\repo-ui", branch: "coordbranch" }],
+        gitRepos: [{ label: "uirepo", sourcePath: "C:\\repo-ui", branch: "coordbranch", dirty: null }],
       }),
       session({
         id: "peer-session",
@@ -510,7 +510,7 @@ describe("ProjectPanel regex filter", () => {
         workingDirectory: `${workgroupPath}\\__agent_dev-rust`,
         status: "running",
         isCoordinator: false,
-        gitRepos: [{ label: "rustrepo", sourcePath: "C:\\repo-rust", branch: "peerbranch" }],
+        gitRepos: [{ label: "rustrepo", sourcePath: "C:\\repo-rust", branch: "peerbranch", dirty: null }],
       }),
     ]);
     sessionsStore.setActiveId("coord-session");
@@ -745,7 +745,7 @@ describe("ProjectPanel regex filter", () => {
         isCoordinator: true,
         agentId: null,
         agentLabel: null,
-        gitRepos: [{ label: "shownrepo", sourcePath: "C:\\repo-shown", branch: "x" }],
+        gitRepos: [{ label: "shownrepo", sourcePath: "C:\\repo-shown", branch: "x", dirty: null }],
         requestedProfile: "C",
         effectiveProfile: "D",
         profileFallbackApplied: true,

--- a/src/sidebar/components/ProjectPanel.repo-browse.automation.test.tsx
+++ b/src/sidebar/components/ProjectPanel.repo-browse.automation.test.tsx
@@ -191,7 +191,7 @@ function discoveryShared(shared: string): AcDiscoveryResult {
 }
 
 function repo(sourcePath: string, label: string, branch: string | null): SessionRepo {
-  return { label, sourcePath, branch };
+  return { label, sourcePath, branch, dirty: null };
 }
 
 function coordASession(gitRepos: SessionRepo[]): Session {

--- a/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
+++ b/src/sidebar/components/ProjectPanel.repo-browse.test.tsx
@@ -159,7 +159,7 @@ function discoveryAB(): AcDiscoveryResult {
 }
 
 function repo(sourcePath: string, label: string, branch: string | null): SessionRepo {
-  return { label, sourcePath, branch };
+  return { label, sourcePath, branch, dirty: null };
 }
 
 function coordASession(gitRepos: SessionRepo[]): Session {

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -28,6 +28,7 @@ import {
   effectiveManuallyClosedAt,
   effectiveRepoBranch,
   effectiveRepoBranchByPath,
+  effectiveRepoDirtyByPath,
   replicaVolatileStore,
 } from "../stores/replica-volatile";
 import { normalizeProjectPathForCompare } from "../stores/project-refresh";
@@ -70,6 +71,7 @@ import {
   automationIdPart,
   configuredReplicaRepoBadges,
   formatReplicaRepoBadgeLabel,
+  formatReplicaRepoBadgeTitle,
   repoLabelFromPath,
 } from "./replica-repo-badges";
 import { sessionDotClass } from "./session-status";
@@ -232,6 +234,10 @@ function configuredReplicaRepoBadgesLive(
       repoBranch: effectiveRepoBranch(replica),
       // #943 B2 - per-repo branches for cold multi-repo replicas, keyed by path.
       repoBranchByPath: effectiveRepoBranchByPath(replica),
+      // #1028 - per-repo worktree-dirty on the same cold feed. This is what turns a
+      // DORMANT coordinator row red: Gate A polls every replica whether or not a
+      // session exists.
+      repoDirtyByPath: effectiveRepoDirtyByPath(replica),
     },
     workgroup
   );
@@ -415,11 +421,13 @@ const ProjectPanel: Component = () => {
     unlistenBranch = await onDiscoveryBranchUpdated((data) => {
       // #943 B2 - one atomic write: the single-repo shorthand plus the per-repo
       // branches, merged BY PATH (never by index - see the store).
+      // #1028 - per-repo dirty rides the same payload and the same atomic write.
       replicaVolatileStore.applyDiscoveryBranchUpdate(
         data.replicaPath,
         data.branch,
         data.repoPaths,
-        data.repoBranches
+        data.repoBranches,
+        data.repoDirty
       );
     });
     // #552 coordinator idle badge + auto-closed pill. Discovery reload
@@ -2660,8 +2668,10 @@ const ProjectPanel: Component = () => {
                     <For each={repoBadges()}>
                       {(repo, index) => (
                         <span
-                          class="ac-discovery-badge branch"
-                          title={repo.sourcePath}
+                          // #1028 - `=== true`, not a truthy check: `false` (clean)
+                          // and `null` (not yet detected) must both stay violet.
+                          class={`ac-discovery-badge branch${repo.dirty === true ? " dirty" : ""}`}
+                          title={formatReplicaRepoBadgeTitle(repo)}
                           data-ac-testid={repoBadgeTestId(repo.label, index())}
                         >
                           {formatReplicaRepoBadgeLabel(repo)}

--- a/src/sidebar/components/SessionItem.test.tsx
+++ b/src/sidebar/components/SessionItem.test.tsx
@@ -241,11 +241,11 @@ describe("SessionItem coordinator repo folder menu (#708)", () => {
 
   it("renders one folder action per valid coordinator repo and opens duplicate labels by index", async () => {
     const repos = [
-      { label: "AgentsCommander", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-AgentsCommander", branch: "feature/x" },
-      { label: "docs", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-docs-primary", branch: null },
-      { label: "docs", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-docs-secondary", branch: "docs-alt" },
-      { label: "cli", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-cli", branch: null },
-      { label: "mobile", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-mobile", branch: "main" },
+      { label: "AgentsCommander", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-AgentsCommander", branch: "feature/x", dirty: null },
+      { label: "docs", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-docs-primary", branch: null, dirty: null },
+      { label: "docs", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-docs-secondary", branch: "docs-alt", dirty: null },
+      { label: "cli", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-cli", branch: null, dirty: null },
+      { label: "mobile", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-mobile", branch: "main", dirty: null },
     ];
     const fake = new FakeTransport();
     fake.resolve("open_in_explorer", null);
@@ -347,7 +347,7 @@ describe("SessionItem coordinator repo folder menu (#708)", () => {
             id: "member-1",
             isCoordinator: false,
             gitRepos: [
-              { label: "AgentsCommander", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-AgentsCommander", branch: null },
+              { label: "AgentsCommander", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-AgentsCommander", branch: null, dirty: null },
             ],
           })}
           isActive={false}
@@ -449,7 +449,7 @@ describe("SessionItem coordinator repo folder menu (#708)", () => {
             name: "wg-7-dev-team/architect",
             isCoordinator: true,
             gitRepos: [
-              { label: "AgentsCommander", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-AgentsCommander", branch: null },
+              { label: "AgentsCommander", sourcePath: "C:\\Project\\.ac\\wg-7-dev-team\\repo-AgentsCommander", branch: null, dirty: null },
             ],
           })}
           isActive={false}

--- a/src/sidebar/components/replica-repo-badges.test.ts
+++ b/src/sidebar/components/replica-repo-badges.test.ts
@@ -3,10 +3,12 @@ import {
   automationIdPart,
   configuredReplicaRepoBadges,
   formatReplicaRepoBadgeLabel,
+  formatReplicaRepoBadgeTitle,
   repoLabelFromPath,
 } from "./replica-repo-badges";
 import {
   effectiveRepoBranchByPath,
+  effectiveRepoDirtyByPath,
   replicaVolatileStore,
 } from "../stores/replica-volatile";
 
@@ -114,8 +116,10 @@ describe("#943 B2 per-repo branches are merged BY PATH", () => {
     );
 
     expect(badgesFor([REPO_B, REPO_A])).toEqual([
-      { label: "webpage", sourcePath: REPO_B, branch: "branch-b" },
-      { label: "AgentsCommander", sourcePath: REPO_A, branch: "branch-a" },
+      // #1028: `dirty` is null here because badgesFor() passes no dirty map - this
+      // test is about branch/path transposition and says nothing about dirty.
+      { label: "webpage", sourcePath: REPO_B, branch: "branch-b", dirty: null },
+      { label: "AgentsCommander", sourcePath: REPO_A, branch: "branch-a", dirty: null },
     ]);
   });
 
@@ -172,5 +176,138 @@ describe("#943 B2 per-repo branches are merged BY PATH", () => {
     expect(
       badgesFor([REPO_A, REPO_B], "feature/from-discovery").map((badge) => badge.branch)
     ).toEqual([null, null]);
+  });
+});
+
+// #1028 - worktree-dirty rides the B2 feed and is merged by path for the same
+// reason. The stake is different though: a transposed BRANCH opens the wrong
+// Browse Branch page, a transposed DIRTY accuses a clean repo of holding
+// uncommitted work (or, worse, clears the accusation from one that does).
+describe("#1028 per-repo dirty is merged BY PATH", () => {
+  const REPLICA = "C:\\proj\\.ac\\wg-1-team\\__agent_coord";
+  const REPO_A = "C:\\proj\\.ac\\wg-1-team\\repo-AgentsCommander";
+  const REPO_B = "C:\\proj\\.ac\\wg-1-team\\repo-webpage";
+  const REPO_C = "C:\\proj\\.ac\\wg-1-team\\repo-docs";
+
+  beforeEach(() => {
+    replicaVolatileStore.clearAll();
+  });
+
+  /** Exactly what configuredReplicaRepoBadgesLive (ProjectPanel) passes. */
+  const badgesFor = (repoPaths: string[]) =>
+    configuredReplicaRepoBadges(
+      {
+        repoPaths,
+        repoBranch: undefined,
+        repoBranchByPath: effectiveRepoBranchByPath({ path: REPLICA }),
+        repoDirtyByPath: effectiveRepoDirtyByPath({ path: REPLICA }),
+      },
+      { repoPath: undefined }
+    );
+
+  it("resolves each repo's dirty from the map by path", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(
+      REPLICA,
+      null,
+      [REPO_A, REPO_B],
+      ["main", "main"],
+      [true, false]
+    );
+
+    expect(badgesFor([REPO_A, REPO_B]).map((badge) => badge.dirty)).toEqual([true, false]);
+  });
+
+  it("follows the PATH, not the position, when config.json reorders the repos", () => {
+    // The event was emitted for [A, B]; discovery then reports [B, A] because the
+    // user reordered `repos`. An index-keyed merge would paint A's red onto B.
+    replicaVolatileStore.applyDiscoveryBranchUpdate(
+      REPLICA,
+      null,
+      [REPO_A, REPO_B],
+      ["main", "main"],
+      [true, false]
+    );
+
+    expect(badgesFor([REPO_B, REPO_A]).map((badge) => badge.dirty)).toEqual([false, true]);
+  });
+
+  it("yields null for a repo the payload never mentioned, not a neighbour's dirty", () => {
+    // Event covered [A, B]; the user then swapped B for C in config.json.
+    replicaVolatileStore.applyDiscoveryBranchUpdate(
+      REPLICA,
+      null,
+      [REPO_A, REPO_B],
+      ["main", "main"],
+      [true, true]
+    );
+
+    expect(badgesFor([REPO_A, REPO_C]).map((badge) => badge.dirty)).toEqual([
+      true,
+      null, // NOT true
+    ]);
+  });
+
+  it("yields null before any event lands: there is no single-repo shorthand for dirty", () => {
+    // Unlike `branch`, which falls back to the discovery shorthand here, dirty has no
+    // scalar counterpart on AcAgentReplica. This is the <=15s post-launch state.
+    expect(badgesFor([REPO_A]).map((badge) => badge.dirty)).toEqual([null]);
+  });
+
+  it("keeps a detected `false` distinct from an unknown `null` all the way to the badge", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(REPLICA, null, [REPO_A], ["main"], [false]);
+
+    const [clean, unknown] = badgesFor([REPO_A, REPO_C]);
+    expect(clean.dirty).toBe(false);
+    expect(unknown.dirty).toBe(null);
+    // Both render violet, so the ONLY user-visible difference is the tooltip. This
+    // pair is what makes a `?? null` -> `|| null` regression observable at all.
+    expect(formatReplicaRepoBadgeTitle(clean)).toBe(REPO_A);
+    expect(formatReplicaRepoBadgeTitle(unknown)).toBe(`${REPO_C} (status unknown)`);
+  });
+
+  it("survives a project reload (AC 6): the badges keep their dirty state", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(REPLICA, null, [REPO_A], ["main"], [true]);
+
+    replicaVolatileStore.clearForPaths([REPLICA]);
+
+    expect(badgesFor([REPO_A]).map((badge) => badge.dirty)).toEqual([true]);
+  });
+
+  it("leaves dirty null for callers that do not read the volatile layer", () => {
+    // `replicaRepoMenuEntries` / `replicaSearchText` pass no dirty map: they reach
+    // only label/branch, and must keep compiling and behaving unchanged.
+    replicaVolatileStore.applyDiscoveryBranchUpdate(REPLICA, null, [REPO_A], ["main"], [true]);
+
+    const badges = configuredReplicaRepoBadges(
+      { repoPaths: [REPO_A], repoBranch: "main" },
+      { repoPath: undefined }
+    );
+    expect(badges.map((badge) => badge.dirty)).toEqual([null]);
+    expect(badges.map(formatReplicaRepoBadgeLabel)).toEqual(["AgentsCommander/main"]);
+  });
+});
+
+// #1028 - the tooltip is the only surface that distinguishes all three states, so
+// the colour can stay a binary alarm at 8px.
+describe("#1028 badge title carries the third state", () => {
+  const REPO = "C:\\proj\\.ac\\wg-1-team\\repo-AgentsCommander";
+
+  it("names the uncommitted work when the repo is dirty", () => {
+    expect(formatReplicaRepoBadgeTitle({ sourcePath: REPO, dirty: true })).toBe(
+      `${REPO} (uncommitted changes)`
+    );
+  });
+
+  it("leaves the title exactly as it was when the repo is known clean", () => {
+    // The pre-#1028 title, unchanged: a clean repo must not gain tooltip noise.
+    expect(formatReplicaRepoBadgeTitle({ sourcePath: REPO, dirty: false })).toBe(REPO);
+  });
+
+  it("says status unknown - the normal state for the first <=15s after launch", () => {
+    // Deliberately worded as "not yet known", not as a fault: it is the first thing
+    // a user sees on every launch, before the first watcher tick lands.
+    expect(formatReplicaRepoBadgeTitle({ sourcePath: REPO, dirty: null })).toBe(
+      `${REPO} (status unknown)`
+    );
   });
 });

--- a/src/sidebar/components/replica-repo-badges.ts
+++ b/src/sidebar/components/replica-repo-badges.ts
@@ -2,6 +2,7 @@ import type {
   AcAgentReplica,
   AcWorkgroup,
   RepoBranchByPath,
+  RepoDirtyByPath,
   SessionRepo,
 } from "../../shared/types";
 
@@ -19,11 +20,37 @@ export function formatReplicaRepoBadgeLabel(repo: Pick<SessionRepo, "label" | "b
   return `${repo.label}${repo.branch ? `/${repo.branch}` : ""}`;
 }
 
+/**
+ * #1028 - the badge tooltip, and the ONLY surface where all three dirty states are
+ * distinguishable. Colour is a binary alarm at 8px (red = uncommitted work, violet =
+ * everything else), so `false` ("detected clean") and `null` ("no answer yet") are
+ * byte-identical on screen; this is what tells them apart, and what makes a
+ * `?? null` -> `|| null` slip in the store observable at all.
+ *
+ * "(status unknown)" is the NORMAL startup state, not an error: a cold row shows it
+ * until the first Gate A tick (<=15s) and a live row until the first GitWatcher tick
+ * (<=5s). It is the first thing a user sees on every launch, so the wording says "not
+ * yet known" rather than implying a fault.
+ *
+ * A third badge COLOUR was rejected: this codebase renders unknown as absence, never
+ * as its own colour, and a third colour would advertise a transient internal failure
+ * the user can do nothing about.
+ */
+export function formatReplicaRepoBadgeTitle(repo: Pick<SessionRepo, "sourcePath" | "dirty">): string {
+  if (repo.dirty === true) return `${repo.sourcePath} (uncommitted changes)`;
+  if (repo.dirty === false) return repo.sourcePath;
+  return `${repo.sourcePath} (status unknown)`;
+}
+
 export function configuredReplicaRepoBadges(
   replica: Pick<AcAgentReplica, "repoPaths" | "repoBranch"> & {
     /** #943 B2 - live per-repo branches. Optional: absent before the first branch
      *  event, and absent for callers that do not read the volatile layer. */
     repoBranchByPath?: RepoBranchByPath;
+    /** #1028 - live per-repo worktree-dirty. Optional for the same two reasons: the
+     *  callers that only read `label`/`branch` (menu entries, search text) pass
+     *  nothing and every repo resolves to `dirty: null`, which they ignore. */
+    repoDirtyByPath?: RepoDirtyByPath;
   },
   workgroup: Pick<AcWorkgroup, "repoPath">
 ): SessionRepo[] {
@@ -42,6 +69,7 @@ export function configuredReplicaRepoBadges(
   // map, because discovery has no counterpart to re-supply it (H1).
   const singleRepoBranch = sourcePaths.length === 1 ? replica.repoBranch ?? null : null;
   const byPath = replica.repoBranchByPath;
+  const dirtyByPath = replica.repoDirtyByPath;
 
   return sourcePaths
     .map((sourcePath) => {
@@ -56,6 +84,12 @@ export function configuredReplicaRepoBadges(
         label: repoLabelFromPath(sourcePath),
         sourcePath,
         branch: live === undefined ? singleRepoBranch : live,
+        // #1028 - there is NO single-repo shorthand for dirty (discovery never had a
+        // scalar dirty the way it had `repoBranch`), so a path miss resolves to
+        // `null` = "never detected" = violet, never to a fallback. `?? null` maps
+        // only the miss; a detected `false` passes through as `false`, which the
+        // badge title reports differently from `null`.
+        dirty: dirtyByPath?.[sourcePath] ?? null,
       };
     })
     .filter((repo) => repo.label.length > 0);

--- a/src/sidebar/stores/replica-volatile.test.ts
+++ b/src/sidebar/stores/replica-volatile.test.ts
@@ -6,6 +6,7 @@ import {
   effectiveManuallyClosedAt,
   effectiveRepoBranch,
   effectiveRepoBranchByPath,
+  effectiveRepoDirtyByPath,
   replicaVolatileStore,
 } from "./replica-volatile";
 
@@ -202,5 +203,141 @@ describe("replicaVolatileStore per-repo branches (#943 B2)", () => {
     replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [REPO_A], ["feature/943"]);
 
     expect(effectiveRepoBranchByPath({ path: COORD_B })).toBeUndefined();
+  });
+});
+
+// #1028 - the same `ac_discovery_branch_updated` event now also carries per-repo
+// worktree-dirty. It rides the B2 feed exactly, so it inherits B2's by-path merge
+// and, critically, B2's clearForPaths PRESERVE.
+describe("replicaVolatileStore per-repo dirty (#1028)", () => {
+  const REPO_A = "C:\\proj\\.ac\\wg-1-team\\repo-AgentsCommander";
+  const REPO_B = "C:\\proj\\.ac\\wg-1-team\\repo-webpage";
+
+  beforeEach(() => {
+    replicaVolatileStore.clearAll();
+  });
+
+  it("keys dirty by repo path and lands it in the same write as the branches", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(
+      COORD_A_EVENT, // event path: lower-cased, forward slashes (#552)
+      null,
+      [REPO_A, REPO_B],
+      ["feature/1028", null],
+      [true, null]
+    );
+
+    // The REPLICA key is normalized; the REPO keys are verbatim.
+    expect(effectiveRepoDirtyByPath({ path: COORD_A })).toEqual({
+      [REPO_A]: true,
+      [REPO_B]: null,
+    });
+  });
+
+  // The `?? null` vs `|| null` guard in zipByPath, and the ONLY reason this test can
+  // exist as a distinct case: `false` and `null` are byte-identical on the badge
+  // (both violet). If `false` collapsed to `null` here, nothing on screen would move
+  // and the only symptom would be every clean repo's tooltip reading "(status
+  // unknown)". Nothing else in the suite would notice.
+  it("preserves an explicit `false` (detected clean) instead of collapsing it to null", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [REPO_A], [null], [false]);
+
+    const map = effectiveRepoDirtyByPath({ path: COORD_A });
+    expect(map).toEqual({ [REPO_A]: false });
+    // toEqual would pass on `undefined` too; pin the exact value.
+    expect(map?.[REPO_A]).toBe(false);
+  });
+
+  it("drops ONLY the dirty map when the dirty array disagrees in length", () => {
+    // The length guard is applied PER call, so a malformed `repoDirty` from a build
+    // that broke the backend's 1:1 invariant cannot take the branch map down with it.
+    replicaVolatileStore.applyDiscoveryBranchUpdate(
+      COORD_A,
+      null,
+      [REPO_A, REPO_B],
+      ["branch-a", "branch-b"],
+      [true] // 1 dirty for 2 repos
+    );
+
+    expect(effectiveRepoDirtyByPath({ path: COORD_A })).toEqual({});
+    expect(effectiveRepoBranchByPath({ path: COORD_A })).toEqual({
+      [REPO_A]: "branch-a",
+      [REPO_B]: "branch-b",
+    });
+  });
+
+  it("tolerates a payload from a backend that does not send the dirty array", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [REPO_A], ["feature/x"]);
+
+    expect(effectiveRepoDirtyByPath({ path: COORD_A })).toEqual({});
+    expect(effectiveRepoBranchByPath({ path: COORD_A })).toEqual({ [REPO_A]: "feature/x" });
+  });
+
+  // AC 6, and the highest-risk item in the change. Same failure mode the B2 map has a
+  // HIGH bug on record for: `projectStore` calls clearForPaths on EVERY reload (loop
+  // tick, CLI refresh, entity creation), `repoDirtyByPath` has no `AcAgentReplica`
+  // counterpart to re-supply it, and Gate A only emits on a CHANGED payload - so a
+  // wiped map is never re-sent. The red would vanish on the first reload and not come
+  // back until the worktree changed on disk or the app restarted.
+  it("PRESERVES the dirty map across a discovery reload (AC 6)", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [REPO_A], ["main"], [true]);
+
+    replicaVolatileStore.clearForPaths([COORD_A]);
+
+    expect(effectiveRepoDirtyByPath({ path: COORD_A })).toEqual({ [REPO_A]: true });
+  });
+
+  it("preserves BOTH maps across a reload, without smuggling back the snapshot fields", () => {
+    // The "discovery wins on reload" contract must keep holding for every field the
+    // snapshot re-supplies; preserving two maps must not resurrect a third field.
+    replicaVolatileStore.applyDiscoveryBranchUpdate(
+      COORD_A,
+      "feature/1028",
+      [REPO_A],
+      ["feature/1028"],
+      [false]
+    );
+    replicaVolatileStore.setAutoClosedAt(COORD_A, "2026-07-16T18:05:00Z");
+
+    replicaVolatileStore.clearForPaths([COORD_A]);
+
+    expect(effectiveRepoBranchByPath({ path: COORD_A })).toEqual({ [REPO_A]: "feature/1028" });
+    // A preserved `false` must stay `false`, not decay to "never detected".
+    expect(effectiveRepoDirtyByPath({ path: COORD_A })).toEqual({ [REPO_A]: false });
+    expect(effectiveRepoBranch({ path: COORD_A })).toBeUndefined();
+    expect(effectiveAutoClosedAt({ path: COORD_A })).toBeUndefined();
+  });
+
+  it("clearAll DOES drop the dirty map (the replicas themselves are gone)", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [REPO_A], ["main"], [true]);
+
+    replicaVolatileStore.clearAll();
+
+    expect(effectiveRepoDirtyByPath({ path: COORD_A })).toBeUndefined();
+  });
+
+  it("does not leak one replica's dirty map to another", () => {
+    replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A, null, [REPO_A], ["main"], [true]);
+
+    expect(effectiveRepoDirtyByPath({ path: COORD_B })).toBeUndefined();
+  });
+
+  it("reads are reactive: a memo re-evaluates when dirty flips, without a row re-creation", () => {
+    createRoot((dispose) => {
+      const replica = { path: COORD_A };
+      const dirty = createMemo(() => effectiveRepoDirtyByPath(replica)?.[REPO_A]);
+      expect(dirty()).toBeUndefined();
+
+      replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A_EVENT, null, [REPO_A], ["main"], [
+        true,
+      ]);
+      expect(dirty()).toBe(true);
+
+      replicaVolatileStore.applyDiscoveryBranchUpdate(COORD_A_EVENT, null, [REPO_A], ["main"], [
+        false,
+      ]);
+      expect(dirty()).toBe(false);
+
+      dispose();
+    });
   });
 });

--- a/src/sidebar/stores/replica-volatile.ts
+++ b/src/sidebar/stores/replica-volatile.ts
@@ -1,6 +1,6 @@
 import { batch } from "solid-js";
 import { createStore } from "solid-js/store";
-import type { AcAgentReplica, RepoBranchByPath } from "../../shared/types";
+import type { AcAgentReplica, RepoBranchByPath, RepoDirtyByPath } from "../../shared/types";
 import { normalizeProjectPathForCompare } from "./project-refresh";
 
 /**
@@ -26,6 +26,10 @@ export interface ReplicaVolatileEntry {
   /** #943 B2 - per-repo branches keyed by repo source path. See RepoBranchByPath
    *  (shared/types.ts) for the missing-key vs explicit-null semantics. */
   repoBranchByPath?: RepoBranchByPath;
+  /** #1028 - per-repo worktree-dirty keyed by repo source path. Same missing-key vs
+   *  explicit-null semantics as `repoBranchByPath` above; see RepoDirtyByPath
+   *  (shared/types.ts). Like that map, this one is PRESERVED by `clearForPaths`. */
+  repoDirtyByPath?: RepoDirtyByPath;
   lastUserMessageAt?: string;
   autoClosedAt?: string | null;
   manuallyClosedAt?: string | null;
@@ -47,23 +51,35 @@ function setField<K extends keyof ReplicaVolatileEntry>(
 }
 
 /**
- * #943 B2 - build the path -> branch map from the event's parallel arrays.
+ * #943 B2 - build a path -> value map from the event's parallel arrays.
+ * #1028 - generalised over the value type: `T = string` gives RepoBranchByPath,
+ * `T = boolean` gives RepoDirtyByPath.
  *
  * A length mismatch could only come from a build that broke the backend's 1:1
- * invariant. Pairing them anyway would attach a branch to the wrong repo, so the
- * map is dropped instead and every repo falls back to "no branch": visible, inert,
- * and self-healing on the next tick. No branch beats a wrong branch.
+ * invariant. Pairing them anyway would attach a value to the wrong repo, so the
+ * map is dropped instead and every repo falls back to "unknown": visible, inert,
+ * and self-healing on the next tick. No branch beats a wrong branch, and an
+ * unknown-dirty (violet) beats a red badge on the wrong repo.
+ *
+ * The guard is applied PER CALL, not once for both arrays: a malformed `repoDirty`
+ * must not be able to drop the branch map with it.
  */
-function buildRepoBranchByPath(
+function zipByPath<T>(
   repoPaths: string[] | undefined,
-  repoBranches: (string | null)[] | undefined
-): RepoBranchByPath {
+  values: (T | null)[] | undefined
+): Record<string, T | null> {
   const paths = repoPaths ?? [];
-  const branches = repoBranches ?? [];
-  if (paths.length !== branches.length) return {};
-  const map: RepoBranchByPath = {};
+  const vals = values ?? [];
+  if (paths.length !== vals.length) return {};
+  const map: Record<string, T | null> = {};
   for (let i = 0; i < paths.length; i += 1) {
-    map[paths[i]] = branches[i] ?? null;
+    // `?? null`, NEVER `|| null`. With T = string this looks like dead syntax an
+    // implementer would "simplify". With T = boolean it is load-bearing and the
+    // difference is INVISIBLE on the badge: `false ?? null` is `false` (detected
+    // clean, correct), but `false || null` is `null` ("never detected"), and both
+    // render violet. Only the badge title exposes the slip, which is why
+    // `repoDirty: [false]` has its own test.
+    map[paths[i]] = vals[i] ?? null;
   }
   return map;
 }
@@ -89,11 +105,16 @@ export const replicaVolatileStore = {
     replicaPath: string,
     branch: string | null,
     repoPaths?: string[],
-    repoBranches?: (string | null)[]
+    repoBranches?: (string | null)[],
+    repoDirty?: (boolean | null)[]
   ) {
     batch(() => {
       setField(replicaPath, "repoBranch", branch);
-      setField(replicaPath, "repoBranchByPath", buildRepoBranchByPath(repoPaths, repoBranches));
+      setField(replicaPath, "repoBranchByPath", zipByPath<string>(repoPaths, repoBranches));
+      // #1028 - inside the SAME batch: dirty and branch come from one payload and
+      // must land together, or a reader observes a row whose branch has ticked and
+      // whose colour has not.
+      setField(replicaPath, "repoDirtyByPath", zipByPath<boolean>(repoPaths, repoDirty));
     });
   },
 
@@ -119,20 +140,29 @@ export const replicaVolatileStore = {
    * truth and a pre-reload override must not mask it — the "discovery wins on
    * reload, events re-patch after" contract the old in-place patches had.
    *
-   * `repoBranchByPath` (#943 B2) is deliberately PRESERVED, because it has no
-   * counterpart: we did not widen `AcAgentReplica`, so wiping it installs nothing.
-   * It would fall back to the single-repo `repoBranch` shorthand — `null` for a
-   * multi-repo replica — and the backend would never re-send it: the discovery
-   * branch watcher only emits when the payload CHANGES (`ac_discovery.rs` Gate A),
-   * and an unchanged repo set with unchanged branches is an identical payload. So
-   * the map would be gone until a branch changed on disk or the app restarted, and
-   * reloads are routine (every loop tick, every CLI-driven refresh, every entity
-   * creation). "Discovery wins on reload" is meaningless for a field discovery
-   * never sends.
+   * `repoBranchByPath` (#943 B2) and `repoDirtyByPath` (#1028) are deliberately
+   * PRESERVED, because neither has a counterpart: we did not widen
+   * `AcAgentReplica`, so wiping either installs nothing. The backend would never
+   * re-send it either: the discovery branch watcher only emits when the payload
+   * CHANGES (`ac_discovery.rs` Gate A), and an unchanged repo set with unchanged
+   * branches and unchanged dirty is an identical payload. So a wiped map would be
+   * gone until something changed on disk or the app restarted, and reloads are
+   * routine (every loop tick, every CLI-driven refresh, every entity creation).
+   * "Discovery wins on reload" is meaningless for a field discovery never sends.
    *
-   * Preserving it is safe precisely BECAUSE it is keyed by path: a repo dropped
-   * from config.json simply never matches again, a repo added since the last tick
-   * has no entry until the watcher emits one, and a real branch change re-emits.
+   * What each map falls back to when wiped is NOT the same, and the dirty half is
+   * the worse one:
+   *   - `repoBranchByPath` degrades to the single-repo `repoBranch` shorthand —
+   *     `null` for a multi-repo replica — which is how Browse Branch died on the
+   *     first reload and stayed dead, "not for 15s, forever" (H1, a HIGH bug).
+   *   - `repoDirtyByPath` has NO shorthand to degrade to (discovery never sent a
+   *     scalar dirty), so every repo silently reverts to `null` = violet = "clean,
+   *     as far as you can see" — a false CLEAN on a passively-read surface, which is
+   *     the one direction #1028 is built never to assert.
+   *
+   * Preserving them is safe precisely BECAUSE they are keyed by path: a repo
+   * dropped from config.json simply never matches again, a repo added since the last
+   * tick has no entry until the watcher emits one, and a real change re-emits.
    *
    * Use `clearAll` when the replicas themselves are gone.
    */
@@ -141,20 +171,31 @@ export const replicaVolatileStore = {
       for (const path of replicaPaths) {
         const key = volatileKey(path);
         if (entries[key] === undefined) continue;
-        // Delete the entry, then restore ONLY the B2 map. Returning a smaller
+        // Delete the entry, then restore ONLY the two by-path maps. Returning a smaller
         // object instead would not clear anything: a Solid store setter MERGES a
         // wrappable value into the existing node (mergeStoreNode), so the snapshot-
         // backed fields would survive the reload and mask discovery forever - a
         // worse bug than the one this method is fixing. The function form is used
         // to read `prev` RAW (untracked); both writes sit inside the batch above,
         // so readers only ever observe the final state.
-        let preserved: RepoBranchByPath | undefined;
+        let preservedBranch: RepoBranchByPath | undefined;
+        let preservedDirty: RepoDirtyByPath | undefined;
         setEntries(key, (prev) => {
-          preserved = prev?.repoBranchByPath;
+          preservedBranch = prev?.repoBranchByPath;
+          preservedDirty = prev?.repoDirtyByPath;
           return undefined; // deleting the key notifies its readers
         });
-        if (preserved !== undefined) {
-          setEntries(key, { repoBranchByPath: preserved });
+        // `||`, not `&&`. Today the two are always written together (the only
+        // writer is applyDiscoveryBranchUpdate, whose batch sets both, and a
+        // length-mismatch stores `{}` rather than leaving the field undefined), so
+        // `&&` would behave identically and no test can tell them apart. It is `||`
+        // because it is the condition that stays CORRECT if that ever stops holding:
+        // with `&&`, a single one-sided entry silently drops the map that IS there,
+        // and the symptom would be a badge quietly losing its red on reload - the
+        // exact failure this preserve exists to prevent, re-entering by the back
+        // door. The cost of the safe operator here is zero.
+        if (preservedBranch !== undefined || preservedDirty !== undefined) {
+          setEntries(key, { repoBranchByPath: preservedBranch, repoDirtyByPath: preservedDirty });
         }
       }
     });
@@ -191,6 +232,16 @@ export function effectiveRepoBranchByPath(
   replica: ReplicaVolatileBase
 ): RepoBranchByPath | undefined {
   return entries[volatileKey(replica.path)]?.repoBranchByPath;
+}
+
+/** #1028 - live per-repo worktree-dirty for this replica, keyed by repo source path.
+ *  `undefined` until the first discovery branch event lands, which the caller maps to
+ *  `dirty: null` (violet, "status unknown"): the normal state for the first <=15s
+ *  after launch, not an error. There is no single-repo shorthand to fall back to. */
+export function effectiveRepoDirtyByPath(
+  replica: ReplicaVolatileBase
+): RepoDirtyByPath | undefined {
+  return entries[volatileKey(replica.path)]?.repoDirtyByPath;
 }
 
 export function effectiveLastUserMessageAt(replica: ReplicaVolatileBase): string | undefined {

--- a/src/sidebar/stores/replica-volatile.ts
+++ b/src/sidebar/stores/replica-volatile.ts
@@ -202,9 +202,11 @@ export const replicaVolatileStore = {
   },
 
   /**
-   * Full wipe, `repoBranchByPath` included. For when the replicas themselves go
-   * away (`projectStore.clear`) and for test isolation — unlike `clearForPaths`,
-   * there is no surviving replica whose per-repo branches would be worth keeping.
+   * Full wipe, both by-path maps included (`repoBranchByPath` #943 B2 and
+   * `repoDirtyByPath` #1028). For when the replicas themselves go away
+   * (`projectStore.clear`) and for test isolation — unlike `clearForPaths`, there is
+   * no surviving replica whose per-repo branches or dirty state would be worth
+   * keeping, so the argument for preserving them there does not apply here.
    */
   clearAll() {
     batch(() => {

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -5514,6 +5514,33 @@ html.light-theme .settings-hint-warning {
   text-transform: none;
 }
 
+/* #1028 worktree-dirty repo badge — LETTERS ONLY go red; the violet background is
+   inherited untouched from `.branch` above, which is what "letters only" means and
+   why this rule sets `color` and nothing else.
+
+   ADDITIVE variant, deliberately not an edit to `.branch`: that rule also paints
+   AcDiscoveryPanel's chip, so recolouring it in place would repaint a surface this
+   issue does not touch (AC 3).
+
+   Three-class specificity (0,3,0) beats `.ac-discovery-badge.branch` (0,2,0) above,
+   so source order is not what carries it — the same rationale already documented for
+   `.coord-idle.red`, a red badge that ships on this very row.
+
+   `--status-exited` reuses the app's existing alarm red (#ff3b5c dark / #dc2626
+   light), no new hex.
+
+   Contrast, re-measured for this change (WCAG 2.x, #ff3b5c over the badge's own
+   rgba(139,92,246,0.15) composited on each real row background): 4.97:1 base,
+   4.57:1 hover, 4.35:1 active. The active row is under the 4.5:1 AA floor for text
+   this size — but `.coord-idle.red`, a red badge ALREADY SHIPPING on this same row,
+   measures 4.89 / 4.51 / 4.32 by the identical method, so the dirty badge is equal
+   or better in every state and introduces no new contrast debt. Raising the floor
+   for both is a separate concern, and light-theme `.branch` is worse still (no
+   light override exists) — see the issue's out-of-scope list. */
+.ac-discovery-badge.branch.dirty {
+  color: var(--status-exited);
+}
+
 .ac-discovery-badge.agent {
   background: rgba(16, 185, 129, 0.14);
   color: #34d399;


### PR DESCRIPTION
Closes #1028.

Colours the Sidebar repo badge **letters only** red (`--status-exited`) when that repo's worktree is dirty — untracked files, unstaged modifications, or staged-but-uncommitted changes. Background and geometry are unchanged.

## How

The backend already spawned `git rev-parse` against every watched repo path on a timer and threw the rest away. This replaces that with a single `git --no-optional-locks status --porcelain --branch`, which yields **branch and dirty from the spawn already being paid for** — no new dependency, no new event, no new thread, no new git process. Measured marginal cost: +45–62 ms per repo per tick on a stat-refreshed index.

- **Backend** (`93481d0`): `SessionRepo.dirty: Option<bool>` with `#[serde(default, skip_deserializing)]`; a shared `detect_git_status` replacing the two drifted `detect_branch` copies; `remember_dirty`, a path-keyed map written **only on successful detection**; `DiscoveryBranchPayload.repo_dirty` at Gate A. Both watchers compute `dirty` — if only one did, the badge would flash violet every 15s.
- **Frontend** (`8e84c73`): `SessionRepo.dirty: boolean | null` (required, not optional); `repoDirtyByPath` volatile layer mirroring `repoBranchByPath`, preserved across `clearForPaths`; additive `.ac-discovery-badge.branch.dirty` variant at (0,3,0); badge `title` carrying the three states. Class keyed strictly off `dirty === true`.
- **Plan** (`fde3d40`): the architect's certified plan, committed unmodified.
- **F1** (`f687b3e`): comment-only follow-up from review.

Dormant (no running session) coordinator rows are covered — `DiscoveryBranchWatcher` already polls every replica every 15s regardless of any session, so their dirtiness was known and discarded.

## Review

**dev-rust** backend, **dev-webpage-ui** frontend, **architect** plan (certified `A0EB1978…19C`, verified by every implementer before touching code and again at review), **dev-rust-grinch** adversarial review at plan and implementation.

Grinch **PASS**, no FAIL findings, no code defect, plan unchanged. It reproduced every reported number under its own hand rather than accepting them, including the four mutation results (8/4/4/4) proving the guards actually guard, and re-derived the contrast figures analytically as a cross-check on the headless-Chromium rig.

Consensus took two rounds. `§4.4`'s hold mechanism was rebuilt **four times** — the first three were each broken by a different reviewer (the plan sourced it from a store both watchers write; dev-rust's fix covered one of two watchers; grinch's own fix left a false-clean path it named itself). The fourth writes only on success, so no failure can poison it and there is nothing to reset; it survived attacks on write-reordering, two runtimes, poisoning, the bound, and sharing.

## Tests

```
cargo clippy --all-targets      exit 0, 0 warnings
cargo test --lib --bins --tests exit 0, 2502 passed, 0 failed   (22 new)
tsc --noEmit                    No errors found
npx vitest run                  PASS (1080) FAIL (0)             (13 new)
npm run test:debt               exit 0
```

**AC 1/2/3 are not closeable by tests** — jsdom does not evaluate the stylesheet, so a misspelled rule leaves every test green and the badge violet. Verified instead in headless Chromium against the real stylesheets: `.branch.dirty` resolves to `rgb(255,59,92)`, `.branch` clean stays `rgb(167,139,250)`, backgrounds byte-identical, geometry identical (108.69×11 both). Light theme resolves to `#dc2626`, so the variable tracks the theme. Final on-screen check by the user after deploy.

Two known-good deviations from the plan, both ruled in scope by review: `detect_branch_with_timeout` → `detect_status_with_timeout` (leaving a name saying "branch" on a function returning status would reinstate the exact drift the change exists to kill), and extracting `formatReplicaRepoBadgeTitle` (which is what makes a plan-mandated title test possible).

## Corrections found along the way

The plan's `4.31:1` active-row contrast figure was wrong (`4.34–4.35`, measured twice by independent methods); its claim that no test could catch a `repoDirty` name mismatch was wrong (one existed and now asserts it); its "~6 test literals" undercounted (9 sites), and the compile-forcing argument does not extend to `toEqual` assertion literals, which take `any`. Two acceptance criteria in the issue were also wrong and are corrected in its comments.

## Out of scope, filed

- **#1029** — dedupe `GitWatcher` polling by `source_path` (16 spawns/tick for 2 distinct repos). Efficiency only: the theory that concurrent spawns drive timeouts was **measured and refuted**.
- **#1036** — no test coverage for `detect_git_status`'s three ancestor-walk gates, which is what AC 10 rests on.
- Light-theme `.branch` reads 1.94:1 today (pre-existing, no light override). Untouched.
