### PR TITLE
feat(#1032): per-session context-usage scrape off the vt100 mirror (backend engine)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "mime_guess",
  "open",
  "portable-pty",
+ "regex",
  "reqwest 0.12.28",
  "rfd 0.15.4",
  "rusqlite",

--- a/plans/1032-context-scrape-vt100-mirror.md
+++ b/plans/1032-context-scrape-vt100-mirror.md
@@ -1,0 +1,761 @@
+# Plan Contract: #1032 - context % scrape off the vt100 session mirror (backend engine)
+
+**Status: READY_FOR_IMPLEMENTATION**
+**Issue:** #1032, child of epic #1031
+**Branch:** `feature/1032-context-scrape-vt100-mirror`, cut from `main` = `4acadfe5b22e67dff40cd20eda87b23eca4a7cbe`
+**Revision:** 4, certified at round 3 of 3. Integrates `dev-rust` round 3 (verdict: implement cold, no open decision) and `dev-rust-grinch` round 3 (H1/H2/H3, acceptance condition met by §6.4.1).
+
+> **Retracted-in-place** is kept: both reviewers said it let them check the delta rather than re-derive it. Revision 4 retracts: §6.4's `Unqueryable` disposition (**H1**), §6.4's map-growth claim (**H3**), §6.1.1's guard corollary, §2.13's count, and §6.4's lock-order citation.
+>
+> **Every mechanism in this plan has now been run against the real thing by someone other than its author.** That is the only thing that has ever caught a defect here (§10.4), and it is why revision 4 is certifiable where revisions 1-3 were not.
+
+---
+
+## 1. Issue and objective
+
+Produce a per-session, best-effort reading of a coding agent's context-window usage (`0..=100`, or unavailable), by running a **per-agent, user-configured regex** over the plain de-ANSI'd rows of the `vt100` screen mirror AC already maintains for every session.
+
+Deliver **only the backend engine**. The badge and every TypeScript surface are #1033. The move of the config to `.ac/project-settings.json` is #1034.
+
+**The percentage is a signal for a human. It never drives an action.**
+
+---
+
+## 2. Evidence and current-state gap
+
+### 2.1 The issue's coordinates are 130 commits stale (holds)
+
+Evidence copied from `dev-rust`'s memo, written at **`f123b03`**, 130 commits behind the `4acadfe` the issue claims. `git show f123b03:src-tauri/src/pty/output.rs` puts `get_screen_snapshot` at `216`, exactly what the issue cites; at `4acadfe` it is at `274`. Claims survive; coordinates do not. Both reviewers re-checked the corrected map across three rounds and it lands.
+
+#### 2.1.1 Corrections to revision 1's own coordinates (all fixed, re-verified)
+
+`Cargo.toml:28` not `:29`; insert the settings field **before `:72`** (`:72` is the `#[serde]` attribute, `:73` is `pub backend:` - inserting at `:73` splits them and does not compile); `instructions_filename` is attribute `:63`, field `:64`; `pty/mod.rs:8` (alphabetical); mock impl `:3882`; the scroll clear is `grid.rs:549` → `:47` → `row.rs:13`, not `grid.rs:534`/`:570`.
+
+### 2.2 "12 impls" is a grep count, not an impl count (holds)
+
+12 `fn get_screen_snapshot` lines; **8** are `PtyBackend` impls. See §2.13 for why this section aged badly.
+
+### 2.3 What already exists (verified)
+
+Key entries: `screen_parsers` `output.rs:28`; `register_session` `:109-116` (`Parser::new(rows, cols, 0)`, no scrollback); fed `:157-167`; `remove_session` `:226-236`; `get_screen_snapshot` `:274-285`; `get_pty_size` `:287-291`; `git_watcher.rs` sampler precedent (`:12`, `:64-84`, `:132-154`); `create_session_inner` `session.rs:945`, spawn `:1640`, Err arm `:1642-1647`; `SettingsState` `settings.rs:2184`, built `lib.rs:526`, managed `lib.rs:604`; `vt100 = "0.15"` at `Cargo.toml:28`.
+
+**Load-bearing for §6.4:**
+
+| Piece | Location |
+|---|---|
+| Per-session child-liveness oracle | `LocalProcessBackend::probe_child`, `local_backend.rs:981-993` |
+| Its Windows implementation | `probe_child_liveness`, `local_backend.rs:1016-1045` |
+| `ChildLiveness { Alive, Exited{code,success}, Unqueryable(String), Gone }` | `spawn_diagnostics.rs:257-266` |
+| A per-session poller that already calls it | `spawn_diagnostics::watch_child`, `:1009-1049`, spawned at `local_backend.rs:906-908` |
+| Container teardown on natural exit | `handle_bridge_exit` `:380` → `close_transport` `:435-448` → `remove_session_state` `:436`/`:466-472` (**drops the parser at `:469`**) + `mark_exited` `:445` |
+| **The test seam for a real ConPTY + real `PtyInstance`** | `startup_gate_tests`, `local_backend.rs:1605-1641` (`openpty` `:1620-1627`, instance `:1631-1639`, `child: None` `:1634`) |
+| Free-function-over-fields precedent | `resize_instance` `local_backend.rs:97`; `hand_over_held_size` `:200` |
+
+### 2.4 `vt100::Screen::row_wrapped()` is real, and it is nowhere in production
+
+The find holds: public at `screen.rs:604-611`, set only at `grid.rs:679`, cleared by `Grid::set_size` via the unconditional `row.resize` (`grid.rs:79` → `row.rs:73-76`).
+
+**RETRACTED (rev 1): the design built on it.** The capture measured twelve widths: the statusline never hard-wraps. The join it enabled produced a wrong number (grinch's F1). Deleted in revision 2.
+
+**RETRACTED (rev 2): the reason for keeping the flags exposed.** §2.4 kept them *"because the §9.2 tests pin the crate's behavior"* while §9.2's drop list removed the only test that read one, *"because no production path reads them (§2.4)"* - the two sections cited each other for opposite conclusions (G6). They were not free either: `row_wrapped(r)` is `visible_rows().nth(r)` over a `skip`/`take`/`chain` iterator (`grid.rs:119-125`, `:138-140`), so building the vector is **O(N²)** - ~465 iterator steps per sample at 30 rows, for a field with no reader and no test. Grinch reproduced the consequence (`clippy -D warnings`: `fields wrapped and cols are never read`, halting step 4) and notes that §2.4 found the **cause** its own finding was only the symptom of.
+
+**Decided (rev 3): `wrapped`, `cols` and the `ScreenRows` struct are all gone.** `row_wrapped` appears nowhere in production; both reviewers confirmed.
+
+**The whole arc is the plan's most useful record and is kept deliberately:** a real find, correctly read, verified against the crate, praised - and every line of code it motivated is now deleted, because nobody checked whether the hazard it addressed existed.
+
+### 2.5 The two backends do not share a fanout (holds)
+
+`SessionIoFanout::new` builds `screen_parsers` fresh per call (`output.rs:105`), called twice in production: `local_backend.rs:650`, `container_backend.rs:211`. Disjoint. The trait method is necessary.
+
+### 2.6 RETRACTED (rev 1). `AppSettings` is in managed state, and **both** whole-settings writers write through
+
+Revision 1's *"no `AppSettings` in Tauri managed state... a settings disk read per tick... the only affordable option"* was false in every clause. `SettingsState = Arc<tokio::sync::RwLock<AppSettings>>` (`settings.rs:8`, `:2184`), built `lib.rs:526`, managed `lib.rs:604`, read by `create_session_inner` itself at `session.rs:977`/`:1073`/`:1239`/`:1411`. **A grep for a type name is not a search for a managed state** - it is reached through the alias.
+
+**Corrected in revision 3:**
+
+- Revision 2 cited `persist_protected_settings_update_with_saver` (`config.rs:205-216`) as "the shape" of a function it was not. The real draft path is `save_settings_draft` (`:169`) → `persist_settings_draft_update` (`:248`) → `persist_settings_draft_update_with_saver` (`:255-280`): `settings.write().await` (`:260`), `let written = save(&draft)?` (`:277`), `*s = written.clone()` (`:278`).
+- **Both whole-settings writers write through**, so the plan predicts nothing about #1033's choice: `update_settings` → `persist_protected_settings_update_with_saver` (`config.rs:206-217`) does `*s = written.clone()` at `:211-215`. **`agents` is not in the protected-restore list** (`:262-274`), so `agents[].context_regex` survives to both `save` and `*s`. The agent-config surface uses `SettingsAPI.update` **today** (`CodingAgentQuickConfiguration.test.ts:315`, `:350`, `:390`).
+
+### 2.7 `Session.agent_id` exists; keying by `id` is the codebase's existing rule (`session.rs:3099`)
+
+### 2.8 `regex` adds no supply chain; `Cargo.lock` gains exactly one line
+
+788 `[[package]]` before and after; `regex 1.12.3` already vendored. **RETRACTED (rev 1): "`Cargo.lock` does not change".** It gains `"regex",` on the `agentscommander-new` dependency array, so revision 1's `git diff --exit-code` gate halted step 1 on the correct outcome. Gate corrected in §8.
+
+### 2.9 The gap
+
+No context signal exists today.
+
+### 2.10 Facts inherited from the epic
+
+The row is **claude-hud**, hard-pinned to an absolute path ending `…/0.0.10/dist/index.js`; the cache also holds an orphaned `0.3.0`. "claude-hud's format" means **0.0.10's** format and changes silently if the pin is rewritten. The `statusLine` hook approach was rejected by the epic; not reopened.
+
+### 2.11 The round-1 live capture (real bytes)
+
+Probe reproduces AC's mirror exactly (`portable-pty 0.8.1` + `vt100 0.15.2`, `Parser::new(rows,cols,0)`, `process()` on raw ConPTY chunks) against real `claude.exe` v2.1.211 and `codex.exe` 0.144.4.
+
+**The capture's bytes are literally this accessor's bytes**, verified independently by both reviewers: `contents_between` with `start_row == end_row` and `start_col < end_col` **is implemented as** `self.rows(start_col, end_col-start_col).nth(start_row)` (`screen.rs:222-227`). Same call, same code path.
+
+1. **The narrow-wrap hazard does not exist.** Measured at 120, 80, 60, 40, 30, 24, 23, 22, 21, 20, 19, 18 cols. claude-hud pre-wraps *itself* at ` | ` / ` │ ` segment boundaries only; `Context <bar> <pct>` is one segment and is never split. The issue's "real design work" is not real.
+2. **Truncation is the real hazard.** Overflow truncates with `…`, never wraps. At a true 100%, cols=20 renders `  Context ████ 10…`; `Context [░█]+ (\d+)` returns **10**. **Live at cols=120 too**, because Claude's render budget is narrower than `cols`. **Mitigation: require the literal `%` after the digits.** Truncation eats right-to-left, so removing any digit necessarily removed `%` first - grinch confirms this is structural, not lucky.
+3. **The glyph anchor is refuted.** Reproduced by *typing into the input box*: `❯ The row says Context ██████████ 99% right now` matches while the truth is `0%`. **`▓` never occurs** - only `░` and `█`; the issue's own probe fixtures use `▓` and test fiction.
+4. **`null != 0` confirmed on real bytes.** Fresh session sends `used_percentage: null` with a real `context_window_size: 1000000`; claude-hud computes `0/1000000` and prints `0%`, **byte-identical** to a true 0%.
+5. **Row position is not stable and the row is never last.** `09 → 11 → 14 → 18` on width alone; `⏸ manual mode on` always below it. Absolute-index, "last row" and "second-to-last" anchoring all refuted. `Context` starts at **column 2**, always.
+6. **Codex is real and worse than described.** `  Ready · Context 0% used · weekly 83% left`. Glyphless; **a second `%` on the row**; `Ready · ` is a mutable prefix.
+7. **Absence states:** `/help`, slash autocomplete, `@` autocomplete, `disableAllHooks` all remove the row (verified live). Untrusted workspace: untested, not refuted. **Permission prompts: NOT VERIFIED LIVE.** Two user-config lines delete the anchor (`lineLayout: "compact"`; `showContextBar: false`) - source-read only.
+
+### 2.12 The round-2 exit-grid capture. **The row survives, and nothing signals the death**
+
+| Exit | Provider | Status | Context row on the frozen grid |
+|---|---|---|---|
+| `/exit` clean | Claude | `code: 0` | **survives verbatim** |
+| external kill (crash surrogate) | Claude | `code: 1` | **survives verbatim** |
+| `Ctrl+D` | Claude | `code: 129` | absent - **not** an exit-time clear |
+| external kill | Codex | `code: 1` | **survives verbatim** |
+| `/quit` | Codex | `0xC000013A` | **survives verbatim** |
+
+Clean `/exit`: child gone at t=16098 ms; grid sampled at 16.5/17.5/19/22/24 s, **every sample identical, ~8 s after the process died**. Claude Code never uses the alternate screen, does not clear, and does not restore.
+
+**The `Ctrl+D` result is not an exit clear.** Ctrl+D swaps the statusline for `  Press Ctrl-D again to exit` *before* exiting - §2.11.7's absence class, inherited incidentally. **The killed path can only ever preserve the row, because a killed process cannot repaint.**
+
+**PTY EOF never arrives either.** `eof_at=None` in **every** run, 8 s past a confirmed `code: 0`. The rig matches AC where it counts (master held alive `local_backend.rs:852`, reader cloned `:839`, break on `Ok(0)` `:916-917`). **Nothing signals the death from any direction, so any mechanism must poll.** `dev-rust` retracted its own round-1 *"the read thread just ends on EOF"* on this evidence, unprompted: *"an inference from `:917`'s `Ok(0) => break` without checking whether ConPTY ever delivers the `Ok(0)`. It does not."*
+
+*Caveat, stated: ~8 s observed, not minutes; Windows/ConPTY only. Unix PTY EOF semantics differ and are untested by anyone.*
+
+**A frozen grid presents a perfectly well-formed row** - glyph present, `%` present, column 2, last match on the grid - that passes **every** defence in §4.5. Those rules separate prose from statusline; **none separates live from dead. Liveness is not a regex problem.**
+
+#### 2.12.1 Q2: column 2 is reachable, via the input box's wrapped continuation lines
+
+The round-1 capture asserted *"Claude indents transcript output by 2 as well"* with no capture. Measured: **the conclusion holds, the stated mechanism does not.**
+
+```
+[06]|❯ aaaaaaaaaa bbbbbbbbbb … kkkkkk|
+[07]|  Context ██████████ 99% tail|
+[10]|  Context ░░░░░░░░░░ 0% │ Usage ██░░░░░░░░ 16% …|
+```
+
+Row 07 is a wrapped continuation, starts with exactly two spaces, and matches `^ {2}Context [░█]+ (\d+)%`; truth is row 10 = `0%`. `❯` decorates only the **first** visual row. Two bounds that survive: the *single-row* input case does **not** defeat the anchor (`❯` at column 0), and tool output is gutter-indented (content at column 5). Assistant transcript prose: **not verified live**; it cannot change the answer, since input wrapping needs no model turn.
+
+**The expert retracted its own round-1 advice:** persistence does not defend against this, because a wrapped input line persists as long as the user leaves it in the box. That independently confirms §4.6's rejection from a third angle.
+
+### 2.13 RETRACTED: my round-1 report's "`mark_exited` has exactly two production callers". **No count is stated here**
+
+I ran `grep ... | head -20` and read the truncated output as the complete list. **That is precisely §2.2's error** - reading a grep count as an enumeration - committed by me, four sections later, in the report that told the tech-lead a peer's disposition was falsified.
+
+**The count is now dropped entirely, on the tech-lead's call, and he is right.** Three parties have produced three numbers for it (mine: 2; `dev-rust`: 20 `.mark_exited(` sites, noting *"§2.13 is itself the retraction of a miscount, and it miscounts by one"*; grinch: 29 grep lines, ~9 production sites, *"not 2, not 21"*). **It is not load-bearing, and it has been wrong three times in a section whose subject is a wrong count.** State the scoped claim, cite the mechanism, cite no total.
+
+**The scoped claim, verified independently by both reviewers, and it is stronger than revision 3 stated:**
+
+> **Nothing observes a *local* session's natural exit.**
+
+`dev-rust` corrected two of revision 3's own rows: `phone/mailbox.rs:7176` and `:9367` are **test fixture builders**, not startup restore (both sit in helpers that create a session, force it to a requested status, `.unwrap()` throughout, and return `(session.id, session.token)`; `mailbox.rs`'s real `#[cfg(test)]` is at `:6510`, above both). So the production non-container surface is **only** the two explicit stops that `kill()` first (`resource_monitor.rs:82`, `session.rs:2252` → `kill` at `:2246`) and the two startup-restore sites (`lib.rs:1592`, `:1720`). Grinch reached the same place from its own enumeration: *"every one replays a status AC already recorded, observes a container, or kills first. **None observes a local child dying.**"*
+
+*(A trap for the next reader, from `dev-rust`: `mailbox.rs` contains `#[cfg(test)]` inside a **string literal** at `:6686` as part of a source-scrape guard, so a naive grep for scope markers in this file misleads.)*
+
+**The general claim *"AC is blind to natural exits"* is false: the container backend is not blind.** `close_transport` (`:435-448`) drops the parser (`:436` → `:469`) and calls `mark_exited` (`:445`). **This is why §6.4's fix is small** - the gap is local-only, and the container backend is the reference behaviour, not a second site to change. §5.3's bare container delegation is right, and both reviewers confirmed it.
+
+---
+
+## 3. Scope
+
+### In
+
+1. A rows accessor on `SessionIoFanout`.
+2. One `PtyBackend` trait method returning `ScreenRowsRead`, its 8 impls, and one `PtyManager` forwarder. **The local impl gates on child liveness (§6.4).**
+3. `pty/context_scrape/`: three narrow source/sink traits, pattern resolution and compile cache, matching, per-session state, timer sampler.
+4. A `context_regex` field on `AgentConfig`, `#[serde(default)]`.
+5. Registration at the spawn chokepoint.
+6. One typed IPC event (`session_context`) and one snapshot command (`get_session_context`).
+
+### Out
+
+- **Every TypeScript surface**: **#1033** (tech-lead's role-boundary call). §5.5 is normative so it can be mirrored without a decision.
+- The Settings field and the sidebar badge: **#1033**. `.ac/project-settings.json`: **#1034**.
+- Any automatic action at any threshold. Ever.
+- **The general product gap: AC does not notice that a local agent died.** #1032 does not fix it, does not depend on it, and does not make it worse. See §10.3.
+
+---
+
+## 4. The decided solution
+
+### 4.1 Shape
+
+```
+create_session_inner (commands/session.rs:945)
+  after a successful PtyManager::spawn, for a session with Some(agent_id):
+    scraper.register_session(id, agent_id)         [try_state; absent scraper = feature off]
+                                                   [fresh entry: last_emitted = None]
+
+ContextScraper (new, pty/context_scrape/)
+  holds: Arc<dyn ScreenRowsSource>, Arc<dyn ContextPatternSource>, Arc<dyn ContextEventSink>
+         and NOTHING else. No AppHandle.           [§6.1]
+  own thread + own tokio runtime + shutdown token  [GitWatcher shape, git_watcher.rs:64-84]
+
+  every SAMPLE_INTERVAL (5s):
+    if registered.is_empty() { return }            [§6.1.1 - before patterns()]
+    patterns = source.patterns().await             [ONE RwLock read; BoxFuture, §6.1]
+
+    // Snapshot ids first: the loop must not mutate `registered` while iterating it,
+    // and must not write last_emitted to an entry it is about to remove (dev-rust).
+    let ids: Vec<(Uuid, String)> = registered snapshot;
+    let mut over: Vec<Uuid> = vec![];
+
+    for (id, agent_id) in ids {
+      let (reading, session_over): (Option<u8>, bool) = match patterns.get(&agent_id) {
+        None                         => (None, false),   [not configured: no lock, no rows, no compile]
+        Some(p) if compile_failed(p) => (None, false),   [no lock, no rows]
+        Some(p) => {                                     [recompile ONLY if p changed since last tick]
+          match source.get_screen_rows(id) {             [short lock, rows cloned out, released]
+            ScreenRowsRead::Rows(rows)  => (extract(&regex, &rows), false),
+            ScreenRowsRead::Unavailable => (None, false),   [NOT a statement about the session - H1]
+            ScreenRowsRead::SessionOver => (None, true),    [the session is over - prune]
+          }
+        }
+      };
+      if reading != last_emitted[id] {               [ONE gate for every state - §4.1.1]
+        sink.emit(ContextUsagePayload { id, reading });
+        last_emitted[id] = reading;
+      }
+      if session_over { over.push(id); }
+    }
+    registered.retain(|id, _| !over.contains(id));   [prune AFTER the loop]
+```
+
+#### 4.1.1 One equality gate covers every state
+
+**RETRACTED (rev 2): "pattern = None -> skip entirely".** Grinch (G3): skip means no emit, so clearing the regex left the badge showing `42` **forever**, for a feature the user had just turned off - the exact class this plan calls unshippable, on a path marked decided, landing on the very journey §4.2 was rewritten to fix (typing a regex passes **through** empty and invalid states).
+
+**Decided:** there is no skip. Every state produces a `reading: Option<u8>`, and **one** gate decides the emit. `last_emitted: Option<u8>` starts at `None` on registration, because `None` **is** what the badge already shows.
+
+`dev-rust` on why this is the right shape: it makes §6.1.1's "no event when unconfigured" hold **by construction** rather than by a special case - `None != None` is false - *"exactly the property revision 2's `skip entirely` tried to get and broke G3 getting."*
+
+| Case | reading | last_emitted | Emit? | Prune? |
+|---|---|---|---|---|
+| Never configured, forever | `None` | `None` | **no** | no |
+| Configured, matches 42 | `Some(42)` | `None` | yes, `42` | no |
+| Pattern cleared | `None` | `Some(42)` | **yes, `null`** | no |
+| Pattern edited to something invalid | `None` | `Some(42)` | **yes, `null`** | no |
+| Row stops matching (`/help`) | `None` | `Some(42)` | yes, `null` | no |
+| **Child alive but unqueryable** | `None` | `Some(42)` | **yes, `null`** | **no - H1** |
+| **Child `Exited`/`Gone`, session unknown** | `None` | `Some(42)` | **yes, `null`** | **yes** |
+| Unchanged | `Some(42)` | `Some(42)` | no | no |
+| Decrease | `Some(12)` | `Some(80)` | yes, `12` | no |
+
+### 4.2 Pattern resolution: a compile cache keyed by the pattern string
+
+**Revision 1 decided resolve-at-spawn on a false premise (§2.6); the tech-lead acked it citing that same premise and explicitly unbound me from the ack.** The property worth protecting was never a disk read - settings are in memory. It is **no `Regex::new` per tick per session**.
+
+**Decided: register the `agent_id` at spawn; resolve the pattern *string* per tick from `SettingsState`; compile only when that string changes.** The decisive fact is **the respawn requirement**: under resolve-at-spawn, first contact is *paste the regex, see nothing*, because every watched session is already running. The counter-argument (every other `AgentConfig` field is spawn-time-resolved) fails because those are **inherently** spawn-time - you cannot change a running child's env. The regex is a read-side concern.
+
+**The registration point survives §2.6's collapse.** `create_session_inner` (`session.rs:945`) sits above the backend split and calls `PtyManager::spawn` for both backends (`:1640`), so one registration covers local and container with **zero backend plumbing**. Both reviewers confirmed the chokepoint (7 production callers) and no register-before-parser race. `dev-rust`'s sharpening, adopted: **the correct claim is "the parser exists before the first sample", and the proof is the 5s gap, not the ordering** (`notify_waiters()` fires at `container_backend.rs:341` before `register_session` at `:346-347`).
+
+**`try_state`, not `state` (F5).** Tauri 2.10.3's `state::<T>()` panics when unmanaged; `session_test_app` (`session.rs:4045-4053`) manages two types and `create_session_inner_holds_a_spawn_mark_until_the_pty_exists` (`:4295`) reaches the registration on a successful spawn. `commands/pty.rs:97` is the exact idiom (one of 25 sites). **Absent scraper = feature off.**
+
+**Wording (`dev-rust`):** there is **no `settings` binding in scope at `session.rs:1648`**. Registration needs only `agent_id`, which is in scope (`:1549`, `:1595`).
+
+#### 4.2.1 RETRACTED (rev 2): the F7 registration-reset paragraph. **AC never respawns with the same `Uuid`**
+
+`SessionManager::create_session` (`manager.rs:43-53`) is the **only** creation path, takes **no id parameter**, and mints `let id = Uuid::new_v4();` (`:54`). The wake path (`lib.rs:1803-1819`) never passes `ps.id` and reads the new id back at `:1822`. AC says it out loud at `lib.rs:1912-1913`: `// PB-4: pass &info.id (the newly-live session's UUID), NOT ps.id (the stale prior-run UUID).`
+
+**`register_session` can never meet an existing entry.** The `GitWatcher::invalidate_session_cache` precedent does not transfer (`git_repos` **is** rewritten on a live id; nothing rewrites a context reading on a live id).
+
+**Decided: the paragraph and its test are deleted, not re-justified.** Keeping the reset as "insurance" would preserve a mechanism with no verified problem, which is the precise habit this plan exists to record. **Three of us moved an unverified claim forward** - grinch inferred it, the tech-lead relayed it as a requirement, I adopted it as fact and built a test on it. Grinch retracted its own premise unprompted, in the lead position of its own report.
+
+### 4.3 A per-session accessor, not a batch (holds)
+
+The scraper iterates its own map, so "zero cost when unconfigured" is satisfied before any lock. `dev-rust` confirmed the lock discipline is **compiler-enforced**: `get_screen_rows` is a **sync** `fn` over a `std::sync::Mutex` returning owned data, and a sync fn has no `await` to hold a guard across.
+
+**Implementer watch-item (grinch), in the contract:** write `let rows = { source.get_screen_rows(id) };` so the guard drops. The natural `if let Some(rows) = ....lock().unwrap().get_screen_rows(id) { ...await... }` holds the temporary to the end of the block; `MutexGuard` is `!Send` but the tick runs under `rt.block_on`, which does not require `Send`, **so it would compile.** `clippy::await_holding_lock` catches it (§9.5.7); do not rely on the gate alone. **The §6.4 gate itself is structurally immune to this trap - see §6.4.2.**
+
+### 4.4 Scan physical rows, bottom-up, first match wins
+
+**RETRACTED (rev 1): wrap-joined logical rows.** Grinch re-ran its F1 screen under revision 2's rules and got `Some(42)`: **the deletion is verified clean, not conceded**, and grinch agrees deletion beat its own verified rightmost-match fix.
+
+**Decided:**
+- **Physical rows only.** No join. `wrapped[]` gone (§2.4).
+- **Bottom-up; first match from the bottom wins.** The capture's "last match on the grid". Measured, not inferred: prose and transcript always render above the statusline; only `⏸ manual mode on` and blanks render below it (§2.11.5).
+- **Extraction:** capture group 1, parsed as `u8`, rejected unless `0..=100`. No capture group 1 → rejected at compile time.
+
+### 4.5 Anchoring: the rules live in the user's regex, and the engine ships none of them
+
+**RETRACTED (rev 1): "the regex is a complete defense for Claude".** Refuted on real bytes (§2.11.3).
+
+**The structural fact that keeps this section short:** the regex is **per-agent user configuration**. `%`-required, column-2-anchored and glyph-required are all expressible *in the pattern*. The engine implements **none** of them. The capture's rules are **documentation for #1033's placeholder** and cost this issue nothing.
+
+| Agent | Pattern | Every element load-bearing |
+|---|---|---|
+| Claude (claude-hud 0.0.10, `lineLayout: expanded`) | `^ {2}Context [░█]+ (\d{1,3})%` | `^ {2}` rejects single-row input prose (`❯ ` at col 0); `[░█]` only (never `▓`); trailing `%` fails truncation closed |
+| Codex 0.144.4 | `^ {2}.*· Context (\d{1,3})% used` | ` used` excludes the second `%` (`weekly 83% left`); no anchor on the mutable `Ready · ` |
+
+Do not anchor `$` after `%`: `write_contents` (`row.rs:98-135`) strips trailing blank cells, but a submitted-prompt row was observed padded to column 120.
+
+**The residual, measured (§2.12.1):** when the statusline is **suppressed** and a column-2 row carrying a matching bar is on the grid, the engine reads it. The reachable route is the **input box's wrapped continuation lines**, fully user-controlled, needing no model turn. It self-corrects on the next tick once the statusline returns.
+
+Accepted rather than defended against: the epic already accepted this class (*"a stale or wrong number, not an error"*); it is transient and self-correcting, unlike §6.4's defect; and with the statusline absent **the grid carries no information that distinguishes it from prose**, so every mechanism against it is undecidable from the input available.
+
+### 4.6 What I rejected, and why
+
+**RETRACTED (rev 1): the row-budget contingency.** Refuted (§2.11.5).
+
+**Cross-sample persistence: rejected, confirmed from three independent angles.** The reproduced false positive sits *in the input box* and is not transient, so a stability gate accepts it exactly as it accepts the statusline. Grinch reached the same place from the other side and reproduced it. **The expert retracted its own round-1 recommendation** for the same reason. Persistence separates *scrolling* prose, which bottom-up already handles.
+
+**`────`-border anchoring: rejected for #1032, recorded for a successor.** It would close the residual, but it is **Claude-shaped** (Codex has no `────`), so it needs a second config field against the epic's single-field opt-in - **and the capture observed the border without testing an anchored scan against it.** Grinch endorses rejecting it on **"untested"** rather than "unwanted", from the agent that reproduced what building on an observation costs.
+
+### 4.7 Sampling interval: 5s (holds, measured twice)
+
+Matches `git_watcher.rs:12`. Grinch measured a full sample at **203 µs** on AC's default 30×120: fifty sessions at 5s is **0.2% of one core**. The `probe_child` gate adds **~0.9 µs** per configured session per tick (§6.4.3). Both reviewers endorse keeping the honest "argued by comparison" label for the sampler CPU itself; `dev-rust` would decline a benchmark for it.
+
+---
+
+## 5. Affected surfaces
+
+### 5.1 New files
+
+| File | Contents |
+|---|---|
+| `pty/context_scrape/mod.rs` | `ContextScraper`, `ScreenRowsSource`, `ContextPatternSource`, `ContextEventSink`, `ScreenRowsRead`, `SAMPLE_INTERVAL`, `ContextUsagePayload` |
+| `pty/context_scrape/pattern.rs` | `ContextPattern` (compiled + source string), `compile(&str) -> Result<ContextPattern, String>`, 1 MiB size limit, capture-group-1 validation |
+| `pty/context_scrape/rows.rs` | `extract(&ContextPattern, rows: &[String]) -> Option<u8>`. **Pure: no locks, no vt100, no Tauri** |
+
+### 5.2 Modified
+
+| File:line at `4acadfe` | Change |
+|---|---|
+| `Cargo.toml:28` | add `regex = "1"` after `vt100` |
+| `pty/mod.rs:8` | `pub mod context_scrape;` (alphabetical) |
+| `pty/output.rs:285` | after `get_screen_snapshot`: `pub fn get_screen_rows(&self, id) -> Option<Vec<String>>`. `let (_rows, cols) = screen.size();` (the call `get_pty_size:290` makes), then `screen.rows(0, cols).collect()`. `.ok()?` on the mutex, matching `:275`. Sync; clones out; releases. **The fanout stays 2-state: it knows nothing about children. The 3-state mapping is the backend's job (§6.4.1)** |
+| `pty/local_backend.rs` (new free fn, beside `resize_instance:97`) | `fn screen_rows_if_child_alive(ptys: &Mutex<HashMap<Uuid, PtyInstance>>, fanout: &SessionIoFanout, id: Uuid) -> ScreenRowsRead`. **Free over the fields so a test can drive it against a real ConPTY child** (`dev-rust`; precedent `resize_instance:97`, `hand_over_held_size:200`) |
+| `pty/backend.rs:135` | `fn get_screen_rows(&self, id: Uuid) -> ScreenRowsRead;` after `get_pty_size`. **Doc: the three states and what each means for the caller (§6.4.1)** |
+| `pty/manager.rs:270` | inherent forwarder. **`kind_for_session(id)` failing means the route is gone ⇒ `ScreenRowsRead::SessionOver`**, not `Unavailable` (grinch verified every route removal is preceded by parser removal) |
+| `config/settings.rs:**72**` | **insert BEFORE `:72`**: `#[serde(default, skip_serializing_if = "Option::is_none")] pub context_regex: Option<String>` |
+| `commands/session.rs:1648` | after the Err arm (`:1642-1647`): if `agent_id.is_some()`, `app.try_state::<Arc<ContextScraper>>()` → `register_session(id, agent_id)` |
+| `commands/pty.rs:440` | `#[tauri::command] pub fn get_session_context(...) -> Result<Option<u8>, String>`, `try_state` |
+| `lib.rs:696` | after `app.manage(pty_mgr.clone())`: build the **three** adapters, `ContextScraper::new(...)`, `.start(shutdown_for_setup.clone())`, `app.manage(...)`. Mirrors `GitWatcher` `:656-661`. **Must be after `lib.rs:604`'s `.manage(settings)`** |
+| `lib.rs:2069` | register `get_session_context` |
+
+### 5.3 The 8 `PtyBackend::get_screen_rows` impls (complete; confirmed across three rounds)
+
+| File:line | Impl | Body |
+|---|---|---|
+| `pty/local_backend.rs:1358` | `LocalProcessBackend` (`:1120`) | one call to `screen_rows_if_child_alive(&self.ptys, &self.fanout, id)` |
+| `pty/container_backend.rs:1182` | `ContainerTransportBackend` (`:1088`) | `match self.fanout.get_screen_rows(id) { Some(r) => Rows(r), None => SessionOver }`. **No liveness gate: `close_transport` drops the parser before anyone could read it (§2.13), so parser-absent IS the container's liveness oracle** |
+| `pty/manager.rs:371` | `RecordingBackend` (`:324`) | `SessionOver` |
+| `pty/manager.rs:462` | `DelayedSpawnBackend` (`:417`) | `SessionOver` |
+| `commands/session.rs:3922` | `FailingSpawnBackend` (`:3882`) | `SessionOver` |
+| `commands/session.rs:4024` | `GatedSpawnBackend` (`:3969`) | `SessionOver` |
+| `commands/ac_discovery.rs:2642` | `FlippingLiveBackend` (`:2610`) | `SessionOver` |
+| `phone/mailbox.rs:6574` | `MailboxMockPtyBackend` (`:6538`) | `SessionOver` |
+
+`session_test_app` (`session.rs:4045-4053`) needs **no** change, because §4.2 uses `try_state`.
+
+### 5.4 (removed - TypeScript is #1033)
+
+### 5.5 The IPC contract, normative for #1033
+
+```rust
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextUsagePayload {
+    pub session_id: String,
+    /// 0..=100, or None when unavailable. NEVER 0 for "unknown" (§6.3).
+    /// Deliberately NO `skip_serializing_if`: `None` MUST serialize as an
+    /// explicit `"percent": null`, not as an absent key.
+    pub percent: Option<u8>,
+}
+```
+
+- **Event:** `session_context`. **Command:** `get_session_context`, args `{ sessionId: string }`, returns `Option<u8>`.
+- **`Some`:** `{"sessionId":"3f2a…","percent":42}` · **`None`:** `{"sessionId":"3f2a…","percent":null}` · **Command:** `42` or `null`
+- **TS #1033 must write:** `interface SessionContext { sessionId: string; percent: number | null }`; `getSessionContext: (sessionId: string) => Promise<number | null>`; `onSessionContext(cb)`
+
+**Why `skip_serializing_if` is forbidden here:** with it, `None` omits the key and TS must type `percent?: number`, silently re-introducing *absent* as a third state beside `null` and `0`, in a feature whose one hard rule is that unavailable is exactly one thing. The codebase distinguishes these deliberately: `Session.agent_id` has no skip and surfaces as `agentId: string | null` (`types.ts:46`); `PtyOutputPayload.sequence` (`output.rs:48-49`) has the skip and is optional. `AgentConfig.context_regex` (§5.2) **does** take the skip - a settings field where an absent key is correct.
+
+**Known and frozen (grinch):** the engine gives #1033 **no way to distinguish "invalid regex" from "no match"** - both are `percent: null`. Bounded, but the user-visible result is "I pasted a regex and nothing happened, with no error anywhere but `app.log`". #1033 may want to surface compile errors from Settings; that is its call and this contract does not block it.
+
+---
+
+## 6. Required behavior, edge cases, failure behavior
+
+### 6.1 Required
+
+- **The value never drives an action.** No `/clear`, `/compact`, restart, PTY write, or process destruction, at any threshold, ever.
+
+  **RETRACTED (rev 1): "enforced by construction, not by discipline"** - it was discipline; the scraper held `Arc<Mutex<PtyManager>>`. **RETRACTED (rev 2): "two narrow trait objects and nothing else"** - §4.1 listed `AppHandle` as a third field, and `AppHandle` is the universal capability handle: the repo does `app.state::<Arc<Mutex<PtyManager>>>()` in **19 places** (count verified exact by `dev-rust`), including `session.rs:2242` which calls `.kill(uuid)` four lines later at `:2246`, `pty/inject.rs:79`/`:104`/`:115` (writes to PTYs), and `session/auto_close.rs:197` (kills sessions). I narrowed two fields of three and re-made the same absolute claim one level up, about #1031's one hard rule.
+
+  **Decided (rev 3), and grinch confirms it is now true:**
+
+  ```rust
+  pub trait ScreenRowsSource: Send + Sync {
+      /// Three states, because the oracle behind it has three (§6.4.1).
+      fn get_screen_rows(&self, id: Uuid) -> ScreenRowsRead;
+  }
+  pub trait ContextPatternSource: Send + Sync {
+      /// BoxFuture, not a sync fn: `blocking_read` panics in a runtime (G2, reproduced).
+      fn patterns(&self) -> BoxFuture<'_, HashMap<String, String>>;
+  }
+  pub trait ContextEventSink: Send + Sync {
+      fn emit(&self, payload: ContextUsagePayload);
+  }
+
+  pub enum ScreenRowsRead {
+      /// The live grid's rows.
+      Rows(Vec<String>),
+      /// No reading this tick. Says NOTHING about whether the session is over.
+      /// Retry next tick, keep the entry. (H1: child alive but unqueryable; parser poisoned.)
+      Unavailable,
+      /// The session is over. Emit null once, then stop sampling it.
+      SessionOver,
+  }
+  ```
+
+  All three traits implemented in `lib.rs` over `Arc<Mutex<PtyManager>>`, `SettingsState` and `AppHandle`. The scraper holds **three trait objects and no `AppHandle`**. **Grinch went looking for the escape and it is not there:** all three are `Send + Sync` **only**, with **no `Any` supertrait and no `as_any`**, so a `dyn` handle cannot be downcast back to its implementation - contrast `PtyBackend: Any + Send + Sync` with `fn as_any(&self)` (`backend.rs:120-121`), which **is** downcastable. Its verdict: *"G1's fix is real, and it's the first mechanism in this plan to earn its own claim. I falsified it twice; it's now true."* **#1031's one hard rule is structurally enforced.**
+
+  Precedent: `PtyOutputTarget` (`output.rs:58-92`) already wraps `AppHandle` behind `Arc<dyn Fn(PtyOutputPayload) + Send + Sync>` **in the file the accessor goes into**, and ships `noop()` (`:72`) and `from_test_sink()` (`:79`). `GitWatcher` holding an `AppHandle` (`git_watcher.rs:32`, `:147`) is a fine *shape* precedent and not a precedent for the *claim*, because it never claimed to be read-only.
+
+- **`ContextPatternSource` must be async (G2, reproduced).** Revision 2 specified a **sync** `fn patterns(&self)` over `SettingsState`, which is a **tokio** `RwLock` (§2.6 says so itself). A sync fn can only read it via `blocking_read()`, which **panics inside an async context**; §4.1's tick is one (`rt.block_on`). Grinch reproduced: `PANIC: Cannot block the current thread from within a runtime.` `GitWatcher` survives only because its `poll()` is an `async fn` that awaits (`git_watcher.rs:97-98`). **The scraper would have died on tick 1, silently, permanently, for every session**, with §6.5's "silent and inert" holding in its most useless possible sense. **Decided: `BoxFuture`**, the repo's own idiom (`PtyBackend::spawn`, `backend.rs:123`), one file over. `async_trait` is in the lock but used nowhere in `src`. (`dev-rust`, unprompted: *"grinch was right and I was not."*)
+- **Accept decreases.** No monotonicity. **Sample on a timer, never in `handle_output`. Key by agent `id`, never `command`. Emit only on change**, through §4.1.1's single gate.
+
+#### 6.1.1 The cost when unconfigured, stated completely, and the leak it does not close
+
+The issue's criterion is *"No regex configured → no event, no state, no cost."*
+
+**Restated:** *no regex configured → no event, no reading, no PTY lock taken, no rows cloned, no regex compiled.* Sessions with `agent_id: None` (plain shells) are never registered. `dev-rust` confirms §4.1.1's single gate makes the "no event" half hold **by construction**, and that the `None` arm never calls `get_screen_rows`, so the rest holds too.
+
+**RETRACTED (rev 3): the guard corollary.** Revision 3 adopted `dev-rust`'s empty-map guard and claimed it restores *"literal zero cost for users running no agent sessions"*. **Grinch reproduced that it does not**, because `prune` lives only in the `Some(p)` arm, so **no pattern ⇒ no `get_screen_rows` ⇒ no prune**:
+
+```
+=== C. agent registered, NO regex configured, children EXITED ===
+  tick 0..3: registered.len() = 5, 5, 5, 5   --> entries never leave
+=== C2. same, WITH a regex configured ===
+  after 1 tick: registered.len() = 0         (prune fired)
+```
+
+So `registered` **never returns to empty** after the first agent session of the app run. The guard fires only in the window before that, and never again.
+
+**Decided, and the tension is decided rather than left open (grinch: "a decision, not a defect"):**
+
+1. **The guard stays, scoped honestly:** it covers the window from app start until the first agent session. That window is real and the guard is two lines; it is simply not the general property revision 3 claimed.
+2. **Entries for unconfigured agents persist until app exit.** ~100 bytes each (`Uuid` + agent id + `Option<u8>` + map overhead), bounded by agent sessions spawned per app run. A week-long run at 100 sessions/day is ~70 KB.
+3. **I am not pruning them, and the reason is this plan's own lesson.** Reaching them costs either a `ptys` probe **or** a discarded 30-row clone for every registered session on every tick - purely to reclaim ~100 bytes for a feature that is switched off. Grinch is right that it would break "no PTY lock taken when unconfigured", and it would need a second method on the source trait to avoid the clone. **Building a mechanism to solve a problem measured at ~70 KB is exactly what §10.4 is a record of.** The honest bound is cheaper and true.
+
+**Flagged as a scope decision, not hidden:** this rewrites an acceptance criterion from the issue body. It is the price of deleting the respawn requirement (§4.2). The fallback is resolve-at-spawn plus a named respawn requirement.
+
+### 6.2 Edge cases
+
+| Case | Behavior | Why |
+|---|---|---|
+| Chunk splits, SGR interleaved | Non-problem | The grid normalizes before any regex runs |
+| **Narrow width** | **Matches; the segment becomes its own row** | claude-hud pre-wraps at segment boundaries (§2.11.1) |
+| **Truncation (`Context ████ 10…`)** | **N/A** | Only if the pattern requires the trailing `%` (§2.11.2) |
+| Alt-screen | Live grid; no match → N/A | `Screen::grid()` returns `alternate_grid` when active (`screen.rs:744`); `Screen::set_size` (`:113-118`) resizes **both** grids |
+| Scrolled-off rows | Unreadable | Scrollback is `0` |
+| Prose FP, single-row input box | Rejected | Column-2 anchor; `❯` at column 0 |
+| Prose FP, column 2, statusline present | Rejected | Bottom-up (§4.4). **Tested by §9.1.4** |
+| **Prose FP, wrapped input continuation** | **Wrong number, self-corrects next tick** | Accepted residual (§4.5, §2.12.1). **Pinned by §9.1.6** |
+| Statusline suppressed (`/help`, autocomplete, `disableAllHooks`) | N/A | §2.11.7 |
+| **Local agent exits naturally** | **`null` once, then pruned** | §6.4 |
+| **Local child alive but unqueryable** | **`null`, entry KEPT, retry next tick** | **§6.4.1 - H1** |
+| **Container agent exits naturally** | **`null` once, then pruned** | `close_transport` drops the parser (§2.13) |
+| **Pattern cleared or made invalid** | **`null` once** | §4.1.1 |
+| Two concurrent sessions | Never cross | Mirror keyed by `Uuid`; scraper map likewise. `Regex` is `Sync` and stateless across matches |
+| Session never mounted in a terminal | Still produces a reading | `register_session` runs at `local_backend.rs:866` before any frontend involvement |
+| Match outside `0..=100` | Rejected, N/A | §4.4 |
+
+**RETRACTED (rev 1): "sample inside the resize window → `null`, never a wrong number".** Grinch reproduced the opposite (`EXTRACT = Some(87)` where revision 1 predicted `null`): the wrap splits wherever the column boundary falls, and claude-hud's real format has a long suffix after the percent, so the first fragment still matches alone. The *mechanism* was right; the *inference* was wrong, and §9.1.3 was cited as pinning it while its fixture split the number. Moot now that the join is gone; recorded because **the reasoning error is the transferable part** and it recurred three more times.
+
+### 6.3 The one place `null != 0` stops (holds; confirmed on real bytes)
+
+**The engine never synthesizes `0`.** Absent row, no match, unparseable, out of range, session over, unqueryable child, poisoned lock: all `null`.
+
+**If the row literally renders `0%`, the engine reports `Some(0)`.** The capture proves this is unavoidable: on a fresh session `used_percentage` is `null` but `context_window_size` is a real 1000000, so claude-hud computes `Math.round(0/1000000*100)` and prints `0%`, byte-identical to a true 0%. Inferring `null` from `Some(0)` would erase a genuine low reading. The epic accepted this; this plan pins where the line falls.
+
+### 6.4 Liveness: gated in the one backend that has the gap
+
+The probe (§2.12) closed §10.1's blocker against "accept and document": the row survives every path that matters, PTY EOF never arrives, and a frozen grid passes every §4.5 defence.
+
+**Three facts, reconciled:** any mechanism must **poll** (§2.12); `watch_child` (`spawn_diagnostics.rs:1009-1049`) **already polls `probe_child` per session** and already sees `Exited` (`:1040-1043`) and only logs; and **the gap is local-only** (§2.13). So revision 2's costing of "a liveness trait method plus 8 impls" was wrong twice: the oracle already exists **and** only one backend needs it.
+
+**Decided: `LocalProcessBackend` gates its rows read on `probe_child`, as a free function so a test can drive it.**
+
+```rust
+/// Free over the map and the fanout, like `resize_instance` (`:97`), so the liveness gate
+/// can be driven by a test against a real ConPTY child (§9.2).
+fn screen_rows_if_child_alive(
+    ptys: &Mutex<HashMap<Uuid, PtyInstance>>,
+    fanout: &SessionIoFanout,
+    id: Uuid,
+) -> ScreenRowsRead {
+    match probe_child_in(ptys, id) {
+        ChildLiveness::Alive => match fanout.get_screen_rows(id) {
+            Some(rows) => ScreenRowsRead::Rows(rows),
+            // The child is alive, so the session is NOT over. A missing/poisoned parser
+            // here is a desync or a poisoned lock, never a statement about the session.
+            None => ScreenRowsRead::Unavailable,
+        },
+        ChildLiveness::Exited { .. } | ChildLiveness::Gone => ScreenRowsRead::SessionOver,
+        // H1: "we could not ask" is NOT "the child is dead". Keep the entry, retry.
+        ChildLiveness::Unqueryable(_) => ScreenRowsRead::Unavailable,
+    }
+}
+```
+
+#### 6.4.1 RETRACTED (rev 3): `Unqueryable → None → prune`. **H1, reproduced twice**
+
+Revision 3 priced `Unqueryable` as *"a possible flicker to N/A"* and mapped it to the same `None` as a dead child. §4.1's pseudocode then pruned on `None`, and **`prune` removes the entry from `registered`, which only `create_session_inner` ever writes.** The pseudocode wins. Grinch reproduced it (`tickprobe`, §4.1 verbatim):
+
+```
+t=0  alive                             registered=[1]  emitted=[(1,Some(42))]
+t=10 AV strips rights -> Unqueryable   registered=[]   emitted=[(1,Some(42)), (1,None)]
+t=15 alive again, child never died     registered=[]   emitted=[…unchanged]
+--> child ALIVE, row says 42%. Badge: None. Still registered? false
+```
+
+**A flicker is 5 seconds. This is the rest of the session's life, on a child that never died.** And it is reachable on a **live** child, reproduced against real Windows processes (`gateprobe`): the same running process, two handles - full rights → `Alive`; no `SYNCHRONIZE` → `Unqueryable("WaitForSingleObject failed (os error 5)")`.
+
+*Grinch's bound, stated as it stated it:* **"No lo validé"** that AV/EDR strips `SYNCHRONIZE` in production; it proved the mechanism, not its frequency. It also notes #942's rights-stripping comment is about `GetExitCodeProcess`, which the gate reaches only **after** the child is gone. **That does not soften it:** revision 3 already conceded reachability and priced it, so the dispute is the price, and the price was wrong by the difference between 5 seconds and forever.
+
+**The codebase already made this argument and I overrode it.** `spawn_diagnostics.rs:260-263`: `Unqueryable` is *"**Distinct from `Alive` on purpose**: reporting an unanswerable handle as 'running' is the same ambiguity class as the `ExitStatus { code: 1 }` trap this module exists to kill."* **#942 built a three-valued oracle precisely so "could not ask" is never confused with a definite answer.** Revision 3 collapsed it to two and read the merged value as a definite *dead*, while saying so out loud: *"`watch_child` treats `Unqueryable` as 'keep polling', which is right for diagnostics and wrong here."* **That sentence is the defect. `watch_child` is the one that has it right**, and it is the only consumer that kept the third state third.
+
+**H2 (grinch) is the cause: `Option<Vec<String>>` is a two-state channel for a three-state oracle**, and `None` came to mean four things - session unknown, parser poisoned, child dead, child unqueryable - of which prune is correct for three and destructive for the fourth. **The oracle was never wrong; the seam was too narrow to carry what it knows.** And the same narrowness made the defect **unrepresentable in §9.4 by construction**, because the fake implements `ScreenRowsSource` and so was two-state too. Grinch calls that a new F6 mutation: not a test pinning a fiction, but **a fake whose type makes the failure unsayable**.
+
+**Fixed by `ScreenRowsRead` (§6.1), which closes H1, H2 and my own §10.2 item 4 together:** three states in, three states out, no collapse, and the fake becomes three-state so `a_live_child_that_cannot_be_queried_is_not_pruned` (§9.4) is writable. It is the same move §6.1 made three times this revision: **give the type the shape of the truth.**
+
+*Naming, since the shape was mine to choose:* grinch proposed `RowsResult { Rows, Unavailable, Gone }`. I kept its structure and renamed `Gone` → `SessionOver`, because `ChildLiveness::Gone` already means something narrower (no PTY instance) and both enums sit in the same five lines; and `SessionOver` names what the caller must **do**, which is the distinction the enum exists to carry.
+
+#### 6.4.2 Lock order: verified, and structurally immune to §4.3's own trap
+
+`probe_child` takes the `ptys` guard as a **local inside its own body** and returns `ChildLiveness` **by value**, so the guard drops at the function's return. The `match` scrutinee is an owned value holding no borrow of the map, so no temporary-lifetime extension can carry the guard into an arm. `screen_parsers` is therefore taken strictly after `ptys` is released.
+
+`dev-rust`'s point, adopted verbatim because it is the difference that matters: **this is not "we were careful", it is "it cannot be written wrong here".** §4.3 warns about `if let Some(x) = lock().foo() { ...await... }` holding the temporary to the end of the block; the gate **cannot** have that bug, because the lock is taken inside the callee and the callee returns an owned value rather than a guard.
+
+The wider chain adds no edge: `PtyManager` → (`kind_for_session`) → `ptys` → *released* → `screen_parsers`. `PtyManager` → `ptys` is pre-existing (`commands/session.rs:70` → `kill` → `local_backend.rs:1217`).
+
+**RETRACTED (rev 3): the citation.** Revision 3 cited `local_backend.rs:940-943` as precedent for *"the order stays `ptys → screen_parsers`"*. **That comment documents the opposite order** (*"the query takes `screen_parsers` and RELEASES it before `open_startup_gate` takes `ptys`"*). Both are safe for the reason the comment actually gives - **never nested** - so the conclusion stands and the citation supported it by analogy, not directly. Cited here for the discipline, not the direction.
+
+#### 6.4.3 Cost: measured independently, twice
+
+Revision 3 listed this as a belief I could not check (*"I believe this is free - which is precisely the kind of belief that has been wrong twice"*). It is now a number.
+
+| | `dev-rust` (`ptysbench`, n=20000, release) | grinch (`gateprobe`, n=200000, release) |
+|---|---|---|
+| **full `probe_child` `ptys` hold** | **729 ns** (p50 700, p95 1000, p99 1200-1300) | **897 ns** |
+| `WaitForSingleObject(h, 0)` alone | - | 788 ns |
+| lock + `HashMap::get_mut` only | 94 ns (empty write) | in the noise |
+| **one keystroke `write` `ptys` hold** | **1868-2350 ns** (p50 1300-1500) | - |
+| `probe_child` on an exited child | 1661 ns (adds `GetExitCodeProcess`) | - |
+
+**A single keystroke holds `ptys` 2.6 to 3.2 times longer than the entire probe.** Duty cycle 1.5 × 10⁻⁷ (`dev-rust`) / 0.0009% at 50 sessions (grinch). **Contention was unmeasurable:** `dev-rust` ran keystrokes against a sampler at **1000 Hz, 5000× production**, and *the ordering inverted between runs* (the real-rate row was worst in one and best in the other); grinch hot-looped at ~5,000,000× and moved the write-lock mean only 0.154 → 1.793 µs. **Both refused to dress noise as a delta**, and grinch discarded its own worst-case figures after finding the no-scraper baseline already showed 377 µs outliers. `WaitForSingleObject(handle, 0)` makes it free. **Confirmed.**
+
+#### 6.4.4 Why this shape, and not the alternatives
+
+- **The oracle is inherent to the backend with the gap.** No trait method for liveness, no 8 impls, no container change. Both reviewers confirmed the oracle choice: `probe_child_liveness` (`local_backend.rs:1016-1045`) deliberately does **not** use `try_wait`, because #942 found `WinChild::is_complete` *"swallows a failed `GetExitCodeProcess` and returns 'not exited'"* and its `STILL_ACTIVE` sentinel 259 is a legal exit code. It calls `WaitForSingleObject(handle, 0)` directly. Grinch confirmed both halves against real processes (live → `Alive`, exited → `Exited{code:0}`). **The expert's probe reached the same conclusion from the other end when it abandoned EOF for polling; AC's oracle is the stronger of the two and it was already here.**
+- **It does not touch `get_screen_snapshot`, and that is the point.** The obvious general fix - drop the parser when the child dies - would change what `get_screen_snapshot` returns for an exited local session, and that accessor is #955's screen replay, fired on every terminal attach (`commands/pty.rs:413`). Whether a user re-attaching to a dead agent should see its final screen or a black tile is **a product question this issue must not answer by accident**. See §10.3.
+
+**With the gate, the prune fires on natural exit** for configured sessions, §4.1.1 emits `null` once, and the entry leaves the map. Grinch reproduced it (`tickprobe` scenario B): frozen 42% → `null` exactly once → silence → entry gone. **§10.1's blocker is genuinely closed for `Exited`/`Gone`.** (The map-growth corollary for *unconfigured* sessions is **not** closed: §6.1.1.)
+
+**What this does NOT fix, deliberately (§3, §10.3):** AC still does not notice that a local agent died. `SessionStatus` stays stale, the parser still leaks, the sidebar still shows the session as it was. **#1032 makes none of that worse and depends on none of it.**
+
+### 6.5 Failure behavior
+
+Every failure is silent and inert: never breaks a session, never writes to the PTY, never blocks a launch, never raises a dialog.
+
+| Failure | Behavior |
+|---|---|
+| Pattern does not compile | `reading = None` → §4.1.1 emits `null` if the badge showed a number. Logged **once per pattern change**, not once per tick (the cache makes the failure sticky, so the log keys on the change). No prune |
+| Pattern has no capture group 1 | Same; rejected in `pattern.rs::compile` |
+| Pattern compiles but never matches | `null`. No log spam |
+| `screen_parsers` mutex poisoned | `.ok()?` → fanout `None`; with a live child that is `Unavailable` → `null`, **no prune** (§6.4.1) |
+| `ptys` mutex poisoned | `probe_child` uses `unwrap_or_else(|e| e.into_inner())` (`local_backend.rs:982`), so it still answers |
+| `PtyManager` mutex poisoned | Tick logs once, returns. Next tick retries |
+| `kind_for_session` fails (route gone) | `SessionOver` → `null` once → pruned (grinch: route removal is always preceded by parser removal) |
+| Scraper not managed (`try_state` → `None`) | Feature off. No panic (F5) |
+| Session killed, or child exited | `SessionOver` → `null` once → pruned |
+| **Child alive, liveness unqueryable** | **`Unavailable` → `null`, entry kept, retried every tick until it answers** |
+
+**Catastrophic-regex note:** `regex` 1.x has no backtracking and is linear-time by construction. `RegexBuilder::size_limit` fixed at 1 MiB so a hostile pattern fails compile rather than allocating unboundedly. With the cache, compilation happens once per pattern change.
+
+---
+
+## 7. Compatibility and security impact
+
+### Compatibility
+
+- **Existing settings files deserialize unchanged** (`#[serde(default)]` + `Option` + skip, identical to `instructions_filename`).
+- **`Cargo.lock` gains exactly one line**; 788 packages before and after; no new crate.
+- **No IPC breaking change.**
+- **`PtyBackend` gains a method.** Private in-crate trait, 8 impls, all enumerated.
+- **`cargo test --lib` unaffected** (`try_state`).
+- **`get_screen_snapshot` is untouched** (§6.4.4), so screen replay behaves exactly as it does today for every session, live or exited.
+
+### Security
+
+- **Read-only by type** (§6.1), and grinch verified the escape is closed: no `Any` supertrait, no `as_any`, so the `dyn` handles cannot be downcast back. Total capability is read rows, read patterns, emit a payload.
+- **The reading is never persisted.**
+- **The regex is user-supplied and executed as a regex**, never as a command, path, or format string.
+- **No captured text is logged.** Only capture group 1, parsed as `u8` and range-checked, leaves `rows.rs`. Agent output cannot reach `app.log` through this path - deliberate, since `app.log` is what users paste into issues.
+- **Out of scope, re-confirmed by the capture (`env_has_AC_TOKEN = true`), already routed by the epic:** `AGENTSCOMMANDER_TOKEN` is inherited by the `statusLine` subprocess, today the hard-pinned third-party claude-hud, which makes network calls. Neither worsened nor addressed here.
+
+---
+
+## 8. Implementation order
+
+1. **`Cargo.toml:28`**: `regex = "1"`.
+   **Gate (corrected; revision 1's halted on the correct outcome):** `Cargo.lock` gains **exactly one line**, `"regex",` in `agentscommander-new`'s `dependencies`, and the `[[package]]` count is **unchanged at 788**. **If any new `[[package]]` block appears, stop and report.** Do **not** use `git diff --exit-code Cargo.lock`; it returns 1 on a correct run.
+2. **`context_scrape/rows.rs`**: `extract`, pure, plus §9.1.
+3. **`context_scrape/pattern.rs`**: `ContextPattern`, `compile`, size limit, capture-group validation, plus tests.
+4. **`output.rs`**: `get_screen_rows -> Option<Vec<String>>`, plus §9.2's first block.
+5. **`backend.rs` + `ScreenRowsRead` + the 8 impls + `manager.rs` forwarder + `screen_rows_if_child_alive`**, plus §9.2's real-ConPTY block.
+6. **`settings.rs`**: the field, **before `:72`**, plus §9.3.
+7. **`context_scrape/mod.rs`**: the three traits, `ContextScraper`, thread, tick, compile cache, prune-after-loop, emit, plus §9.4.
+8. **`lib.rs` + `commands/pty.rs` + `commands/session.rs`**: adapters, construct, manage, start, register, command.
+
+Steps 1-6 are inert. The feature first becomes live at step 8.
+
+---
+
+## 9. Tests and objective acceptance criteria
+
+**Fixture discipline.** §9.1's fixtures are **copied from the capture**, never hand-written: `Row::write_contents` (`row.rs:98-135`) strips trailing blank cells and pads interior gaps, so an invented `"% "` is not what the parser emits. **No fixture may contain `▓`** (§2.11.3). *(Revision 2 wrote this rule and violated its spirit twice on the same page; see §9.6.)*
+
+### 9.1 `rows.rs`, pure
+
+| Test | Asserts |
+|---|---|
+| `the_real_120_col_row_extracts` | `  Context ░░░░░░░░░░ 0% │ Usage …` → `Some(0)` |
+| `truncation_fails_closed_when_the_pattern_requires_percent` | `  Context ████ 10…` (truth 100) → **`None`**. The highest-value test here |
+| `truncation_without_the_percent_rule_returns_a_wrong_number` | Same row against `Context [░█]+ (\d+)` → `Some(10)`. **Pins *why* the rule exists**, so a careless pattern edit cannot silently drop it. Grinch: the one test here that survives a careless edit |
+| **`the_lowest_matching_row_wins`** | **REWRITTEN (G4).** `["  Context ██████████ 99% (pasted)", "", <capture row 09>]` → bottom-up `Some(0)`; the same fixture top-down gives `Some(99)`. **The only test that distinguishes scan order** |
+| `input_box_prose_is_rejected_by_the_column_two_anchor` | Capture row 06 (`❯ ` at col 0) → `None` |
+| `a_wrapped_input_continuation_defeats_the_column_two_anchor` | §2.12.1's row 07 → `Some(99)`. **Pins the accepted residual as measured, not as a surprise** |
+| `the_85_percent_breakdown_still_extracts` | `  Context █████████░ 87% (in: 12k, cache: 40k) │ …` → `Some(87)`. Catches an end-anchored pattern |
+| `all_three_bar_widths_extract` | 10/6/4-block real rows (cols 120/80/40) |
+| `zero_and_hundred_extract_despite_a_missing_glyph` | `Context ░░░░░░░░░░ 0%` (no `█`) and `Context ██████████ 100%` (no `░`) |
+| `codex_row_extracts_context_not_weekly` | `  Ready · Context 0% used · weekly 83% left` → `Some(0)`, **never `Some(83)`** |
+| `an_out_of_range_match_is_rejected` | `Context 999%` → `None` |
+| `a_zero_percent_row_reports_zero_not_null` | Pins §6.3 |
+
+### 9.2 `output.rs` and the gate, against the real parser and a real child
+
+Harness: `fanout()` (`output.rs:508-514`), `feed()` (`:527-536`), `session()` (`:538-542`). **`session()` registers at 30×120 (`:540`)**, so a test needing another size must call `register_session` directly or resize first, or it silently tests nothing (`dev-rust`).
+
+| Test | Asserts |
+|---|---|
+| `get_screen_rows_matches_contents_between` | `rows(0, cols)[r] == contents_between(r, 0, r, cols)` **for valid `r` only** - the `Equal` branch ends in `.unwrap_or_default()`, so an out-of-range row yields `""` where `rows()` has no index (grinch). Pins §2.11's transfer claim |
+| `leading_spaces_survive_so_the_column_two_anchor_works` | A row painted at column 2 reads back with both leading spaces. **The column-2 anchor rests on `write_contents`'s gap-padding** |
+| `two_sessions_never_cross_rows` | Criterion 1 |
+| `get_screen_rows_is_none_for_an_unknown_session` | The fanout's 2-state contract |
+| `rows_are_readable_for_a_session_with_no_terminal` | `PtyOutputTarget::noop()`, never resized. Criterion 2 |
+
+**The gate, against a real ConPTY child** (`dev-rust`'s seam, adopted - see §10.2). Extend `startup_gate_tests`' existing helper (`local_backend.rs:1605-1641`, which already opens a real ConPTY at `:1620-1627` and builds a real `PtyInstance` at `:1631-1639`) with a `conpty_with_child()` variant filling the `child: None` gap at `:1634`, plus the real `fanout()`:
+
+| Test | Asserts |
+|---|---|
+| `rows_are_readable_while_the_child_is_alive` | Real ConPTY + real child + real fanout, feed bytes → `ScreenRowsRead::Rows(..)` |
+| `session_over_once_the_child_actually_exits` | Kill the child, await exit → `ScreenRowsRead::SessionOver`. **Red if the probe call is deleted** |
+
+This pins the **real wiring against the real oracle and the real parser**, which the §9.4 fake structurally cannot, since a fake `ScreenRowsSource` sits *above* the gate. It is §10.4's own conclusion applied to the one new mechanism. **Cost, stated:** it spawns a real process, so it is slower and carries the usual real-process flake surface; `startup_gate_tests` already pays that, so it is settled precedent rather than a new argument.
+
+**Not testable in-repo, and stated rather than faked:** the `Unqueryable → Unavailable` arm needs a rights-stripped handle inside a `PtyInstance`. Its *behaviour* is pinned by §9.4's three-state fake; the *real-handle* proof is grinch's `gateprobe`, which reproduced it against live Windows processes and is not a repo test.
+
+**Dropped:** `a_hard_wrapped_statusline_joins_into_one_logical_row`, `a_wrap_between_context_and_the_number_still_matches` (tested the deleted join against a shape that cannot occur), `a_resize_clears_the_wrap_flags` (the flags no longer exist - §2.4).
+
+### 9.3 `settings.rs`
+
+`settings_without_context_regex_deserialize_unchanged` (criterion 6); `context_regex_round_trips_as_camel_case`.
+
+### 9.4 `context_scrape/mod.rs` - pure, with a **three-state** rows fake
+
+Fake `ScreenRowsSource` / `ContextPatternSource` / `ContextEventSink`. No Tauri, no `PtyManager`, no `SettingsState`. The sink is a recording fake holding `Vec<ContextUsagePayload>` (`PtyOutputTarget::from_test_sink`'s shape). **The rows fake returns `ScreenRowsRead`, so H1 is now expressible** - under revision 3's `Option` it was unrepresentable by construction (§6.4.1).
+
+| Test | Asserts |
+|---|---|
+| `a_session_whose_agent_has_no_pattern_takes_no_lock_and_emits_nothing` | The rows fake records calls: **zero**. Sink: **empty**. Criterion 5 |
+| `an_empty_registered_map_never_reads_patterns` | The pattern fake records calls: **zero**. §6.1.1's guard, in the only window it covers |
+| `clearing_a_pattern_emits_null_once` | **G3.** 42, then pattern gone → **one** `null`, then silence. Entry kept |
+| `a_pattern_edited_to_something_invalid_emits_null_once` | **G3**, second half |
+| `an_uncompilable_pattern_logs_once_per_change_not_once_per_tick` | §6.5's sticky-failure rule |
+| `a_changed_pattern_is_recompiled_within_one_tick` | The compile cache; the deleted respawn requirement |
+| `an_unchanged_pattern_is_not_recompiled` | Compile count stays 1 across 3 ticks |
+| `session_over_emits_null_once_and_prunes` | Rows fake → `SessionOver`: one `null`, entry gone, no further reads |
+| **`a_live_child_that_cannot_be_queried_is_not_pruned`** | **NEW - H1.** Rows fake: `Rows(42)` → `Unavailable` → `Rows(42)`. Asserts `null` then `42`, **and that the entry survives the `Unavailable` tick.** Red against revision 3's design. **This is the test the old fake's type made impossible to write** |
+| `an_unchanged_value_emits_once` | The gate |
+| `a_decrease_is_emitted` | 80 then 12 emits 12 |
+| `a_second_session_for_the_same_agent_gets_its_own_entry_and_first_emit` | Replaces `re_registering_an_id_re_emits` (§4.2.1). Exercises a thing production does |
+
+### 9.5 Objective acceptance criteria
+
+1. Two concurrent sessions never cross samples. **9.2.3.**
+2. A session whose terminal was never mounted still produces a reading. **9.2.5.**
+3. Absent/no-match/truncated/out-of-range/session-over/unqueryable renders unavailable, never `0`, and triggers no action. **9.1.2, 9.1.11, 9.1.12, 9.4.8, 9.4.9**; "no action" holds **by type** (§6.1, escape verified closed).
+4. A prose line containing `Context 99%` does not move the badge **in the two configurations that are tested by two different tests**: single-row input-box prose (**9.1.5**, the column-2 anchor) and **column-2 prose with the statusline present (9.1.4, bottom-up)**. **Not** when the statusline is suppressed, and **not** for a wrapped input continuation (**9.1.6** pins that as known and measured). The residual is stated in §4.5.
+5. No regex configured: no event, no reading, no lock, no compile. **9.4.1**, per §6.1.1 (which also states what *is* paid).
+6. Existing settings files without the new field deserialize unchanged. **9.3.1.**
+7. **A live child that cannot be queried is never deregistered. 9.4.9.**
+8. `cargo clippy --all-targets -- -D warnings` clean for touched files. Catches `await_holding_lock` (§4.3). `ScreenRows` is gone, so G5's `fields never read` cannot recur.
+9. `cargo fmt` clean **for touched files only** (the repo is not `rustfmt`-clean at baseline).
+10. `cargo test --lib` green. **Not `cargo test`**: it fails at baseline (`rustdoc.exe` missing), pre-existing.
+
+**CPU:** the sampler is argued by comparison, corroborated at 203 µs per sample at 30×120 (50 sessions at 5s = 0.2% of one core). **The gate is measured, not argued: ~0.9 µs `ptys` hold, against a keystroke's own 1.9-2.4 µs** (§6.4.3).
+
+### 9.6 RETRACTED (rev 2): §9.1.4, and the rule it broke
+
+Revision 2's `the_lowest_matching_row_wins` used *"capture's rows 06 and 09 verbatim"*. Grinch ran it against the plan's own pattern: **bottom-up `Some(0)`, top-down `Some(0)`** - row 06 is `❯ The row says…`, so `❯ ` puts `Context` at column 16 and it **never matches**. The test passed under **any** scan order, pinning only the column-2 anchor that §9.1.5 already pinned **with the same fixture**. **§9.5's criterion 4 then named those two as different configurations, counting one configuration twice**, while column-2-prose-with-statusline-present - the case bottom-up is the **sole** defence for - had **no test at all**. Both fixed above.
+
+---
+
+## 10. Verdict
+
+### Status: READY_FOR_IMPLEMENTATION
+
+Round 3 of 3. `dev-rust`: *"Yes. I would implement revision 3 cold, from the plan alone, with no open decision."* Grinch's acceptance condition, stated verbatim in its own verdict: *"If `Unqueryable` stops pruning - via H2's `RowsResult` or any equivalent - then on my evidence this mechanism is sound, and it is the first in this plan that a probe could not break."* **§6.4.1 does exactly that**, and §9.4.9 is the test its type finally permits.
+
+### 10.1 What round 3 changed
+
+| Item | Disposition |
+|---|---|
+| **H1** (`Unqueryable` prunes a live session, permanently) | **Fixed.** `ScreenRowsRead::Unavailable` never prunes (§6.4.1). New test §9.4.9 |
+| **H2** (the seam is 2-state for a 3-state oracle; the fake cannot express H1) | **Fixed by the same enum.** Closes my own §10.2 item 4 with it |
+| **H3** (prune unreachable without a pattern; §6.1.1's guard never fires again) | **Guard corollary retracted; the leak is bounded honestly and the tension decided** (§6.1.1). Not pruning ~100 bytes is cheaper than the mechanism to reclaim it |
+| §2.13's count | **Dropped.** Three parties, three numbers, in a section about a wrong count. Scoped claim kept and strengthened |
+| §6.4's lock-order citation | **Retracted** (it documents the opposite order); the conclusion holds on "never nested" (§6.4.2) |
+| `dev-rust`'s §9.2 seam | **Adopted** (§9.2). Real ConPTY child, red if the probe call is deleted |
+
+### 10.2 My five unanswerable questions, answered
+
+Revision 3 listed five things I could not check about my own work. Round 3 answered all five, and this is the reason the plan is certifiable now rather than a round ago.
+
+1. **Can the gate false-prune a live session?** **Yes, permanently.** Reproduced twice. Fixed (§6.4.1).
+2. **Does `probe_child` cost the keystroke path anything?** **No, and it is now a number.** 729 ns / 897 ns against a keystroke's own 1868-2350 ns, measured independently by both reviewers, with contention unmeasurable at 5000× and ~5,000,000× production rates (§6.4.3). **My belief was right; it should not have shipped as a belief.**
+3. **Is the lock order sound?** **Yes, and it is structurally immune to my own §4.3 trap** (§6.4.2).
+4. **Is the gate pinned by any test?** It was not, and it was worse than "only a mock" - the fake's *type* made the failure unsayable. **Now it has a real-ConPTY seam the repo already built for #973** (§9.2), and a three-state fake.
+5. **Is gating a general-sounding accessor on liveness the right seam?** **The oracle was right; the seam was too narrow.** `ScreenRowsRead` is the answer.
+
+**Asking them was worth more than any answer I could have given.** Every one came back with a probe attached, and two of them (1 and 4) were defects I would have shipped.
+
+### 10.3 Scope: option 3, as recommended and endorsed
+
+**#1032 gates its own read; a new issue owns the general gap.** `dev-rust` concurs.
+
+- **Option 1 (absorb the liveness fix) is more dangerous than it looks, and §2.13 is why.** The obvious general fix is "remove the parser when the child dies" - exactly what the container backend already does. For local sessions that changes what `get_screen_snapshot` returns for an exited session, and that accessor is #955's screen replay, fired on every terminal attach. **The two backends already disagree about this today**, which is itself worth an issue and not one to settle by picking a side inside a badge issue.
+- **Option 2 buys correctness we do not need.** #1032 does not need AC to *notice* the death; it needs to not *report* a dead reading. The second is ~5 lines.
+
+**File the general gap separately.** It is unusually well-specified already: the target behaviour is **what the container backend already does** (`close_transport`: drop state, then `mark_exited`), the oracle exists (`probe_child`), the poller exists (`watch_child`, which detects the exit and discards it), and there is exactly one real design question (what `get_screen_snapshot` should return for an exited session).
+
+### 10.4 The record, which is the thing that freezes
+
+Six retracted mechanisms, one mistake: **a claim nobody verified, plus a test that pins the resulting fiction.**
+
+| # | Mechanism | Justified by | Found by |
+|---|---|---|---|
+| 1 | `row_wrapped` join (rev 1) | the issue's "genuine hazard" | capture (never wraps) + grinch (wrong number) |
+| 2 | §9.1.3 pinning the resize window (rev 1) | an inference about where a wrap splits | grinch (reproduced the opposite) |
+| 3 | `a_pruned_session_stops_emitting` (rev 1) | a mock returning `None` | `dev-rust` (production never reaches `None`) |
+| 4 | `re_registering_an_id_re_emits` (rev 2) | grinch's F7, relayed by the tech-lead, adopted by me | grinch (retracted its own premise) |
+| 5 | §9.1.4 pinning bottom-up (rev 2) | a fixture where the decoy never matches | grinch (passes under any scan order) |
+| 6 | **`Unqueryable → prune` (rev 3)** | **my own inference that it was "a flicker"** | **grinch (`tickprobe`: the rest of the session's life)** |
+
+**4 and 5 were added by revision 2, in a §9 whose opening sentence convicts revision 1 of exactly this.** 6 was added by revision 3, in a document whose §10.4 already said all of the above - **while the codebase's own comment (`spawn_diagnostics.rs:260-263`) argued against me in advance, and revision 3 quoted that comment and overrode it in the same paragraph.** Writing the rule down has never once stopped me from breaking it.
+
+And §2.13 is the same reflex in the evidence rather than the design: I convicted the issue of reading a grep count as an enumeration (§2.2), then did it myself four sections later. **Then §2.13's own replacement count was wrong too**, which is why no count survives in it.
+
+**What actually worked, every single time, is a probe that runs the mechanism against the real thing.** Reading the crate carefully caught none of the six, and I read it very carefully. Six were caught by `vt100probe`, `tickprobe`, `gateprobe`, `ptysbench` and a real ConPTY rig. **That is why §9.2 now spawns a real child, and it is the one design decision in this plan I would defend without evidence.**

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { version = "0.12", features = ["json", "blocking", "multipart"] }
 base64 = "0.22"
 tokio-util = "0.7"
 vt100 = "0.15"
+regex = "1"
 toml = "0.8"
 open = "5"
 axum = { version = "0.8", features = ["ws"] }

--- a/src-tauri/src/cli/coding_agent.rs
+++ b/src-tauri/src/cli/coding_agent.rs
@@ -518,6 +518,7 @@ fn blank_agent() -> AgentConfig {
         isolated_home: false,
         instructions_filename: None,
         config_seed: None,
+        context_regex: None,
         backend: Default::default(),
     }
 }
@@ -535,6 +536,9 @@ fn definition_to_agent_seed(def: &CodingAgentDefinition) -> AgentConfig {
         isolated_home: def.isolated_home,
         instructions_filename: def.instructions_filename.clone(),
         config_seed: def.config_seed.clone(),
+        // #1032 - presets carry no context regex: it is per-agent user config with no
+        // counterpart in a definition, so a seeded agent starts with the feature off.
+        context_regex: None,
         backend: Default::default(),
     }
 }

--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -157,6 +157,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            context_regex: None,
             backend: Default::default(),
         }
     }

--- a/src-tauri/src/cli/self_switch.rs
+++ b/src-tauri/src/cli/self_switch.rs
@@ -493,6 +493,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            context_regex: None,
             backend: Default::default(),
         }
     }

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -2643,6 +2643,10 @@ mod tests {
             None
         }
 
+        fn get_screen_rows(&self, _id: Uuid) -> crate::pty::context_scrape::ScreenRowsRead {
+            crate::pty::context_scrape::ScreenRowsRead::SessionOver
+        }
+
         fn register_response_watcher(
             &self,
             _session_id: Uuid,

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1869,6 +1869,7 @@ mod tests {
                 isolated_home: false,
                 instructions_filename: None,
                 config_seed: None,
+                context_regex: None,
                 backend: Default::default(),
             }],
             ..AppSettings::default()

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -448,6 +448,20 @@ pub fn get_screen_snapshot(
     }))
 }
 
+/// #1032 - the last context reading for a session, for a frontend that just mounted and
+/// missed the `session_context` event.
+///
+/// `None` covers every unavailable case there is - no regex, no match, a truncated row, a
+/// session that is over, a scraper that is not managed - and NEVER means 0.
+#[tauri::command]
+pub fn get_session_context(app: AppHandle, session_id: String) -> Result<Option<u8>, String> {
+    let uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+    let Some(scraper) = app.try_state::<Arc<crate::pty::context_scrape::ContextScraper>>() else {
+        return Ok(None);
+    };
+    Ok(scraper.last_reading(uuid))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -3923,6 +3923,10 @@ mod tests {
             None
         }
 
+        fn get_screen_rows(&self, _id: Uuid) -> crate::pty::context_scrape::ScreenRowsRead {
+            crate::pty::context_scrape::ScreenRowsRead::SessionOver
+        }
+
         fn register_response_watcher(
             &self,
             _session_id: Uuid,
@@ -4023,6 +4027,10 @@ mod tests {
 
         fn get_pty_size(&self, _id: Uuid) -> Option<(u16, u16)> {
             None
+        }
+
+        fn get_screen_rows(&self, _id: Uuid) -> crate::pty::context_scrape::ScreenRowsRead {
+            crate::pty::context_scrape::ScreenRowsRead::SessionOver
         }
 
         fn register_response_watcher(

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -3529,6 +3529,7 @@ mod tests {
                     isolated_home: false,
                     instructions_filename: None,
                     config_seed: None,
+                    context_regex: None,
                     backend: Default::default(),
                 },
                 AgentConfig {
@@ -3540,6 +3541,7 @@ mod tests {
                     isolated_home: false,
                     instructions_filename: None,
                     config_seed: None,
+                    context_regex: None,
                     backend: Default::default(),
                 },
             ],
@@ -5152,6 +5154,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            context_regex: None,
             backend: Default::default(),
         });
 
@@ -5230,6 +5233,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            context_regex: None,
             backend: Default::default(),
         }];
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1646,6 +1646,19 @@ pub async fn create_session_inner<R: tauri::Runtime>(
         return Err(err);
     }
 
+    // #1032 - start sampling this session's context reading. This sits above the backend
+    // split and covers local and container alike, with no backend plumbing. `try_state`,
+    // not `state`: `state` panics when unmanaged, and test apps do not manage the scraper.
+    // An absent scraper is simply the feature being off.
+    //
+    // Sessions with no agent are never registered, so a plain shell costs nothing. There is
+    // no race with the parser here: the first sample is 5s away.
+    if let Some(agent_id) = agent_id.clone() {
+        if let Some(scraper) = app.try_state::<Arc<crate::pty::context_scrape::ContextScraper>>() {
+            scraper.register_session(id, agent_id);
+        }
+    }
+
     // Auto-inject optional non-credential bootstrap text for agent sessions
     // after PTY spawn. Credentials are already present in child environment
     // variables; no credentials are written through PTY.

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -1092,6 +1092,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            context_regex: None,
             backend: Default::default(),
         }
     }

--- a/src-tauri/src/config/coding_agent_mutations.rs
+++ b/src-tauri/src/config/coding_agent_mutations.rs
@@ -580,6 +580,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            context_regex: None,
             backend: Default::default(),
         }
     }

--- a/src-tauri/src/config/coding_agent_profiles.rs
+++ b/src-tauri/src/config/coding_agent_profiles.rs
@@ -804,6 +804,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            context_regex: None,
             backend: Default::default(),
         }];
         settings

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -67,6 +67,17 @@ pub struct AgentConfig {
     /// means no seeding. Serialized as `configSeed`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config_seed: Option<ConfigSeedConfig>,
+    /// #1032 - per-agent regex run over this agent's screen rows to read its
+    /// context-window usage. Capture group 1 is the percentage. `None`/absent means
+    /// the feature is off for this agent: no event, no reading, no PTY lock, no
+    /// compile. Serialized as `contextRegex`.
+    ///
+    /// The engine ships no anchoring rules of its own; every rule that makes a
+    /// pattern trustworthy lives in the pattern, because only the user knows what
+    /// their agent renders. The reading is a signal for a human and never drives an
+    /// action.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_regex: Option<String>,
     /// Backend used for future non-local session transports. Omitted/default
     /// keeps today's local-process behavior.
     #[serde(default, skip_serializing_if = "AgentBackendConfig::is_default")]
@@ -2261,6 +2272,7 @@ mod tests {
                     isolated_home: false,
                     instructions_filename: None,
                     config_seed: None,
+                    context_regex: None,
                     backend: Default::default(),
                 })
                 .collect(),
@@ -2343,6 +2355,7 @@ mod tests {
                 enabled: true,
                 dest: ".claude".to_string(),
             }),
+            context_regex: None,
             backend: Default::default(),
         };
         let json = serde_json::to_string(&agent).unwrap();
@@ -4346,5 +4359,48 @@ mod tests {
         assert_eq!(s.max_concurrent_agent_processes, 32);
         assert_eq!(s.resource_watchdog_action, ResourceWatchdogAction::Warn);
         assert!(validate_resource_settings(&s).is_ok());
+    }
+
+    // ---- #1032: the per-agent context regex ---------------------------------------
+
+    /// Criterion 6. Every settings file that exists today predates this field, so the one
+    /// thing this field must never do is make an existing config fail to load.
+    #[test]
+    fn settings_without_context_regex_deserialize_unchanged() {
+        let json = r##"{ "id": "claude", "label": "Claude", "command": "claude",
+                         "color": "#10b981" }"##;
+        let agent: super::AgentConfig = serde_json::from_str(json).expect("deserializes");
+        assert_eq!(agent.label, "Claude");
+        assert_eq!(agent.context_regex, None, "absent must mean off, not empty");
+    }
+
+    /// The field is an agent-config field, where an absent key is the correct way to say
+    /// "off" - unlike the IPC payload, where `percent` must serialize as an explicit null.
+    #[test]
+    fn context_regex_round_trips_as_camel_case() {
+        let json = r##"{ "id": "claude", "label": "Claude", "command": "claude",
+                         "color": "#10b981",
+                         "contextRegex": "^ {2}Context [\u2591\u2588]+ (\\d{1,3})%" }"##;
+        let agent: super::AgentConfig = serde_json::from_str(json).expect("deserializes");
+        assert_eq!(
+            agent.context_regex.as_deref(),
+            Some("^ {2}Context [\u{2591}\u{2588}]+ (\\d{1,3})%")
+        );
+
+        let back = serde_json::to_string(&agent).expect("serializes");
+        assert!(
+            back.contains("\"contextRegex\""),
+            "the frontend contract is camelCase: {back}"
+        );
+
+        let cleared = super::AgentConfig {
+            context_regex: None,
+            ..agent
+        };
+        let back = serde_json::to_string(&cleared).expect("serializes");
+        assert!(
+            !back.contains("contextRegex"),
+            "None must omit the key here, so an untouched config stays untouched: {back}"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -425,10 +425,20 @@ impl ContextPatternSource for ScraperPatterns {
                 .agents
                 .iter()
                 .filter_map(|agent| {
-                    let regex = agent.context_regex.as_deref()?.trim();
-                    // An empty string is a cleared field, not a pattern that matches
-                    // everything.
-                    (!regex.is_empty()).then(|| (agent.id.clone(), regex.to_string()))
+                    let regex = agent.context_regex.as_deref()?;
+                    // A blank field is the field being blank, and skipping it here is a
+                    // LOG-HYGIENE choice and nothing more: `pattern::compile` already
+                    // refuses "" and "   " for having no capture group 1, so this can never
+                    // become a pattern that matches everything - it would only warn on every
+                    // change while a user is still typing.
+                    //
+                    // Note what is trimmed and what is not: the emptiness TEST looks at a
+                    // trimmed view, the VALUE handed over is the user's string, byte for
+                    // byte. The pattern is the only defence this feature has - the engine
+                    // ships no anchoring rules of its own - so editing it can only weaken
+                    // it. Trimming would eat the leading spaces of `  Context ...`, which
+                    // ARE the column-2 anchor, and the reading would fail open.
+                    (!regex.trim().is_empty()).then(|| (agent.id.clone(), regex.to_string()))
                 })
                 .collect()
         })
@@ -2476,7 +2486,8 @@ mod tests {
         resolve_is_coord_for_restore, restore_session_should_become_active,
         restore_session_should_wake, should_auto_create_root_agent_on_first_restore,
         should_wake_on_restore, should_wake_root_agent_on_restore, skip_auto_resume_for_restore,
-        ApiServerHandle, ApiServerTask, WebServerHandle,
+        ApiServerHandle, ApiServerTask, ContextPatternSource, ScraperPatterns, SettingsState,
+        WebServerHandle,
     };
     use crate::config::settings::{AgentConfig, AppSettings};
     use crate::session::session::SessionStatus;
@@ -2504,6 +2515,95 @@ mod tests {
             }],
             ..AppSettings::default()
         }
+    }
+
+    fn settings_with_context_regex(regex: &str) -> AppSettings {
+        let mut settings = settings_with_agent();
+        settings.agents[0].context_regex = Some(regex.to_string());
+        settings
+    }
+
+    fn resolved(settings: AppSettings) -> std::collections::HashMap<String, String> {
+        let source = ScraperPatterns {
+            settings: std::sync::Arc::new(tokio::sync::RwLock::new(settings)) as SettingsState,
+        };
+        futures::executor::block_on(source.patterns())
+    }
+
+    /// #1032 - the adapter must hand `compile` the string the user wrote, byte for byte.
+    ///
+    /// The pattern is the ONLY defence this feature has: the engine deliberately ships no
+    /// anchoring rules of its own, so every rule that makes a reading trustworthy lives in
+    /// the user's text. An engine that edits that text can only weaken it, and it does so
+    /// silently, in the one place nobody thinks to look.
+    ///
+    /// The concrete loss this pins: `  Context [\u{2591}\u{2588}]+ (\d{1,3})%` is the natural
+    /// transcription of a row the plan says ALWAYS starts at column 2 - copy the row, swap
+    /// the bar and the number for classes. Trimming it deletes the column-2 anchor, and with
+    /// the statusline suppressed the pattern then matches input-box prose and reports a
+    /// confident 99% that is a lie. Failing open, in a design where everything else fails
+    /// closed.
+    #[test]
+    fn the_adapter_hands_over_the_users_pattern_verbatim() {
+        let user_wrote = "  Context [\u{2591}\u{2588}]+ (\\d{1,3})%";
+        let patterns = resolved(settings_with_context_regex(user_wrote));
+
+        assert_eq!(
+            patterns.get("codex").map(String::as_str),
+            Some(user_wrote),
+            "the engine must not rewrite the user's regex, and leading spaces ARE the anchor"
+        );
+    }
+
+    /// The consequence, end to end through the real adapter: what the user configured is
+    /// what gets read, and it reports NO number rather than a wrong one.
+    ///
+    /// The grid here is the statusline-suppressed case (`/help`, autocomplete, a hook turned
+    /// off), where the only `Context ... %` on screen is prose the user typed themselves.
+    /// The column-2 anchor is the single thing that rejects it. Resolve the pattern through
+    /// the adapter, compile it, run it: `None`. With the adapter trimming, this same row
+    /// read `Some(99)` - a confident lie - which is why the string identity above matters.
+    #[test]
+    fn a_pattern_resolved_through_the_adapter_still_rejects_input_box_prose() {
+        let user_wrote = "  Context [\u{2591}\u{2588}]+ (\\d{1,3})%";
+        let patterns = resolved(settings_with_context_regex(user_wrote));
+        let resolved_source = patterns.get("codex").expect("configured");
+
+        let pattern = crate::pty::context_scrape::pattern::compile(resolved_source)
+            .expect("the user's pattern compiles");
+        let grid = vec![
+            "\u{276f} The row says Context \u{2588}\u{2588}\u{2588}\u{2588}\u{2588} 99% right now"
+                .to_string(),
+        ];
+
+        assert_eq!(
+            crate::pty::context_scrape::rows::extract(&pattern, &grid),
+            None,
+            "no number beats a wrong number: the engine must not edit the only defence there is"
+        );
+    }
+
+    /// Trailing whitespace is just as much the user's business: `%` then a space is a
+    /// pattern that requires a space, and only the user knows whether their row has one.
+    #[test]
+    fn trailing_whitespace_in_a_pattern_is_the_users_business_too() {
+        let user_wrote = "Context (\\d{1,3})% ";
+        let patterns = resolved(settings_with_context_regex(user_wrote));
+
+        assert_eq!(patterns.get("codex").map(String::as_str), Some(user_wrote));
+    }
+
+    /// A blank field is the field being blank, not a pattern. Skipped for log hygiene ONLY:
+    /// `pattern::compile` already refuses "" and "   " (no capture group 1), so this cannot
+    /// become "a pattern that matches everything" - it would merely warn on every change.
+    #[test]
+    fn a_blank_context_regex_is_treated_as_unconfigured() {
+        assert!(resolved(settings_with_context_regex("")).is_empty());
+        assert!(resolved(settings_with_context_regex("   ")).is_empty());
+        assert!(
+            resolved(settings_with_agent()).is_empty(),
+            "None is unconfigured"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,12 +27,16 @@ use std::sync::{Arc, Mutex, OnceLock};
 use commands::ac_discovery::DiscoveryBranchWatcher;
 use config::sessions_persistence;
 use config::settings::SettingsState;
+use pty::context_scrape::{
+    ContextEventSink, ContextPatternSource, ContextScraper, ContextUsagePayload, ScreenRowsRead,
+    ScreenRowsSource,
+};
 use pty::git_watcher::GitWatcher;
 use pty::idle_detector::IdleDetector;
 use pty::manager::PtyManager;
 use session::manager::SessionManager;
 use shutdown::ShutdownSignal;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 use telegram::manager::{OutputSenderMap, TelegramBridgeManager, TelegramBridgeState};
 use tokio_util::sync::CancellationToken;
 use voice::tracker::{VoiceTracker, VoiceTrackingState};
@@ -370,6 +374,79 @@ pub(crate) fn should_auto_create_root_agent_on_first_restore(
     commands::session::resolve_root_agent_command(settings, None, last_coding_agent).is_ok()
 }
 
+// ---- #1032: the three adapters ----------------------------------------------------
+//
+// This is the boundary. Everything above it holds an `AppHandle` and a `PtyManager` and
+// can do anything to a session; the `ContextScraper` below it holds these three trait
+// objects and can do exactly three things. The narrowing is the feature's one hard rule
+// ("the value never drives an action") made structural instead of remembered.
+
+/// Rows, via the routed backend. The three states come from the backend, which is the only
+/// thing that holds a liveness oracle.
+struct ScraperRows {
+    pty_mgr: Arc<Mutex<PtyManager>>,
+    /// A poisoned `PtyManager` is app-wide and permanent, so the warning is worth exactly
+    /// one line, not one per configured session every 5 seconds.
+    poison_logged: AtomicBool,
+}
+
+impl ScreenRowsSource for ScraperRows {
+    fn get_screen_rows(&self, id: uuid::Uuid) -> ScreenRowsRead {
+        match self.pty_mgr.lock() {
+            Ok(mgr) => mgr.get_screen_rows(id),
+            Err(_) => {
+                if !self
+                    .poison_logged
+                    .swap(true, std::sync::atomic::Ordering::Relaxed)
+                {
+                    log::warn!(
+                        "[context] PtyManager lock is poisoned; context readings are unavailable"
+                    );
+                }
+                // NOT SessionOver: a poisoned lock says nothing about whether the session
+                // is alive, and guessing would deregister live sessions.
+                ScreenRowsRead::Unavailable
+            }
+        }
+    }
+}
+
+/// Every agent's configured pattern string, read fresh from settings each tick. One
+/// `RwLock` read per tick for all sessions, not one per session.
+struct ScraperPatterns {
+    settings: SettingsState,
+}
+
+impl ContextPatternSource for ScraperPatterns {
+    fn patterns(&self) -> futures::future::BoxFuture<'_, HashMap<String, String>> {
+        Box::pin(async move {
+            let settings = self.settings.read().await;
+            settings
+                .agents
+                .iter()
+                .filter_map(|agent| {
+                    let regex = agent.context_regex.as_deref()?.trim();
+                    // An empty string is a cleared field, not a pattern that matches
+                    // everything.
+                    (!regex.is_empty()).then(|| (agent.id.clone(), regex.to_string()))
+                })
+                .collect()
+        })
+    }
+}
+
+/// The sink. `PtyOutputTarget` (`output.rs`) already wraps an `AppHandle` behind a plain
+/// `Fn` for the same reason.
+struct ScraperSink {
+    app_handle: tauri::AppHandle,
+}
+
+impl ContextEventSink for ScraperSink {
+    fn emit(&self, payload: ContextUsagePayload) {
+        let _ = self.app_handle.emit("session_context", payload);
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run(
     test_window_placement: Option<crate::testability::window_placement::TestWindowPlacement>,
@@ -694,6 +771,23 @@ pub fn run(
                 guard.start_container_pending_reaper(shutdown_for_setup.clone());
             }
             app.manage(pty_mgr.clone());
+
+            // #1032 context scrape. Must be after `.manage(settings)` above, since the
+            // pattern adapter reads settings back out of managed state. Mirrors GitWatcher.
+            let context_scraper = ContextScraper::new(
+                Arc::new(ScraperRows {
+                    pty_mgr: pty_mgr.clone(),
+                    poison_logged: AtomicBool::new(false),
+                }),
+                Arc::new(ScraperPatterns {
+                    settings: app.state::<SettingsState>().inner().clone(),
+                }),
+                Arc::new(ScraperSink {
+                    app_handle: app.handle().clone(),
+                }),
+            );
+            context_scraper.start(shutdown_for_setup.clone());
+            app.manage(Arc::clone(&context_scraper));
 
             // #714 register the configured global screenshot hotkey. Windows-only
             // effect; on other targets register_configured_hotkey records an
@@ -2067,6 +2161,7 @@ pub fn run(
                         commands::pty::pty_write,
             commands::pty::pty_resize,
             commands::pty::get_screen_snapshot,
+            commands::pty::get_session_context,
             commands::config::get_settings,
             commands::config::get_coding_agent_catalog,
             commands::config::list_reseedable_agent_commands,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2404,6 +2404,7 @@ mod tests {
                 isolated_home: false,
                 instructions_filename: None,
                 config_seed: None,
+                context_regex: None,
                 backend: Default::default(),
             }],
             ..AppSettings::default()

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -7022,6 +7022,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            context_regex: None,
             backend: Default::default(),
         }
     }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -6575,6 +6575,10 @@ mod tests {
             Some((30, 120))
         }
 
+        fn get_screen_rows(&self, _id: Uuid) -> crate::pty::context_scrape::ScreenRowsRead {
+            crate::pty::context_scrape::ScreenRowsRead::SessionOver
+        }
+
         fn register_response_watcher(
             &self,
             _session_id: Uuid,

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::errors::AppError;
+use crate::pty::context_scrape::ScreenRowsRead;
 use crate::pty::output::{PtyOutputTarget, PtyScreenSnapshot};
 use crate::resource_monitor::{ResourceLaunchRegistration, ResourceLogicalAgentSlot};
 use crate::session::profile::{CodingAgentKind, IdleTuning};
@@ -133,6 +134,17 @@ pub trait PtyBackend: Any + Send + Sync {
     fn get_screen_snapshot(&self, id: Uuid) -> Option<PtyScreenSnapshot>;
 
     fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)>;
+
+    /// #1032 - the session's screen rows for the context scrape, plus what this backend
+    /// knows about whether there is still a session behind the id.
+    ///
+    /// - `Rows`: the live grid.
+    /// - `Unavailable`: no reading this tick, and NO claim about the session. Keep
+    ///   sampling it. A child that is alive but whose handle cannot be queried lands
+    ///   here, and calling that "over" would strand a live session forever.
+    /// - `SessionOver`: there is no session here any more. Report unavailable once, then
+    ///   stop sampling it.
+    fn get_screen_rows(&self, id: Uuid) -> ScreenRowsRead;
 
     fn register_response_watcher(
         &self,

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
+use crate::pty::context_scrape::ScreenRowsRead;
 use crate::pty::container_credentials::CopyOutcome;
 use crate::pty::container_paths::{
     canonical_host_path_env_key, container_config_dir, host_path_env_unmappable_warning,
@@ -1179,6 +1180,16 @@ impl PtyBackend for ContainerTransportBackend {
 
     fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)> {
         self.fanout.get_pty_size(id)
+    }
+
+    fn get_screen_rows(&self, id: Uuid) -> ScreenRowsRead {
+        // No liveness gate here, and none is needed: this backend already tears down on a
+        // natural exit, and `close_transport` drops the parser before anyone could read it.
+        // Parser-absent IS the container's liveness oracle.
+        match self.fanout.get_screen_rows(id) {
+            Some(rows) => ScreenRowsRead::Rows(rows),
+            None => ScreenRowsRead::SessionOver,
+        }
     }
 
     fn register_response_watcher(

--- a/src-tauri/src/pty/context_scrape/mod.rs
+++ b/src-tauri/src/pty/context_scrape/mod.rs
@@ -10,6 +10,21 @@
 pub mod pattern;
 pub mod rows;
 
+use futures::future::BoxFuture;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use uuid::Uuid;
+
+use pattern::ContextPattern;
+
+/// Matches `GitWatcher`'s poll interval. A full sample is ~200 us at AC's default 30x120,
+/// so fifty sessions at 5s is ~0.2% of one core, and the liveness gate adds ~0.9 us per
+/// configured session per tick - against the ~1.9-2.4 us a single keystroke already holds
+/// the same `ptys` lock for.
+pub const SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
+
 /// What a backend can say about one session's rows.
 ///
 /// THREE states, because the oracle behind it has three. A two-state channel here would
@@ -27,4 +42,704 @@ pub enum ScreenRowsRead {
     Unavailable,
     /// The session is over. Emit null once, then stop sampling it.
     SessionOver,
+}
+
+/// The rows of one session's screen. Three states in, three states out.
+pub trait ScreenRowsSource: Send + Sync {
+    fn get_screen_rows(&self, id: Uuid) -> ScreenRowsRead;
+}
+
+/// Every agent's configured pattern STRING, resolved fresh each tick.
+///
+/// `BoxFuture` and not a sync fn: the settings live behind a `tokio::sync::RwLock`, whose
+/// `blocking_read` panics inside a runtime - and the tick is inside one. A sync signature
+/// here would kill the scraper on tick 1, silently and permanently, for every session.
+pub trait ContextPatternSource: Send + Sync {
+    fn patterns(&self) -> BoxFuture<'_, HashMap<String, String>>;
+}
+
+/// Where a reading goes. The ONLY thing this module can do to the outside world.
+pub trait ContextEventSink: Send + Sync {
+    fn emit(&self, payload: ContextUsagePayload);
+}
+
+/// The IPC contract, normative for #1033.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContextUsagePayload {
+    pub session_id: String,
+    /// 0..=100, or None when unavailable. NEVER 0 for "unknown".
+    ///
+    /// Deliberately NO `skip_serializing_if`: `None` MUST serialize as an explicit
+    /// `"percent": null` rather than an absent key. With the skip, TS would have to type
+    /// this `percent?: number`, which re-introduces *absent* as a third state beside `null`
+    /// and `0` - in a feature whose one hard rule is that unavailable is exactly one thing.
+    pub percent: Option<u8>,
+}
+
+/// One registered session: which agent's pattern applies to it, and the last thing the
+/// badge was told.
+struct Registered {
+    agent_id: String,
+    /// Starts as `None` because `None` IS what the badge already shows, so an unconfigured
+    /// session never emits: `None != None` is false. The "no event when unconfigured"
+    /// requirement holds by construction rather than by a special case.
+    last_emitted: Option<u8>,
+}
+
+/// A compiled pattern, kept against the source string it came from.
+///
+/// Keyed by agent rather than by pattern text so the map is bounded by the number of
+/// configured agents: a user typing a regex passes through a new string on every keystroke,
+/// and none of those may accumulate. The source string is what decides a recompile, which
+/// is the property the plan asks for.
+enum Cached {
+    Ok(Arc<ContextPattern>),
+    /// The pattern does not compile. Kept so the failure is sticky: we neither recompile it
+    /// nor log it again until the user changes it.
+    Failed {
+        source: String,
+    },
+}
+
+impl Cached {
+    fn source(&self) -> &str {
+        match self {
+            Cached::Ok(pattern) => pattern.source(),
+            Cached::Failed { source } => source,
+        }
+    }
+
+    fn pattern(&self) -> Option<Arc<ContextPattern>> {
+        match self {
+            Cached::Ok(pattern) => Some(Arc::clone(pattern)),
+            Cached::Failed { .. } => None,
+        }
+    }
+}
+
+/// Samples every registered session on a timer and emits a reading when it changes.
+///
+/// Holds three trait objects and NOTHING else. No `AppHandle`: an `AppHandle` reaches
+/// `PtyManager` through managed state, and from there `kill`, `write` and session
+/// destruction - so "this never drives an action" would be a promise instead of a fact.
+/// None of the three traits is downcastable back to its implementation (no `Any`
+/// supertrait, no `as_any`), so the total capability of this type is: read rows, read
+/// patterns, emit a payload.
+pub struct ContextScraper {
+    rows: Arc<dyn ScreenRowsSource>,
+    patterns: Arc<dyn ContextPatternSource>,
+    sink: Arc<dyn ContextEventSink>,
+    registered: Mutex<HashMap<Uuid, Registered>>,
+    compiled: Mutex<HashMap<String, Cached>>,
+    /// Test-visible: the number of `pattern::compile` calls. The compile site is also the
+    /// log site, so this is what "logged once per change, not once per tick" is measured by.
+    compiles: AtomicUsize,
+}
+
+impl ContextScraper {
+    pub fn new(
+        rows: Arc<dyn ScreenRowsSource>,
+        patterns: Arc<dyn ContextPatternSource>,
+        sink: Arc<dyn ContextEventSink>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            rows,
+            patterns,
+            sink,
+            registered: Mutex::new(HashMap::new()),
+            compiled: Mutex::new(HashMap::new()),
+            compiles: AtomicUsize::new(0),
+        })
+    }
+
+    /// Own thread, own runtime, shutdown token: `GitWatcher`'s shape.
+    pub fn start(self: &Arc<Self>, shutdown: crate::shutdown::ShutdownSignal) {
+        let scraper = Arc::clone(self);
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new()
+                .expect("Failed to create tokio runtime for ContextScraper");
+            rt.block_on(async move {
+                loop {
+                    tokio::select! {
+                        biased;
+                        _ = shutdown.token().cancelled() => {
+                            log::info!("[context] Shutdown signal received, stopping");
+                            break;
+                        }
+                        _ = tokio::time::sleep(SAMPLE_INTERVAL) => {
+                            scraper.tick().await;
+                        }
+                    }
+                }
+            });
+        });
+    }
+
+    /// Start sampling a session. Called once per agent session at the spawn chokepoint;
+    /// sessions with no agent are never registered, so a plain shell costs nothing.
+    ///
+    /// A fresh entry always starts at `last_emitted: None`. It can never meet an existing
+    /// entry: session ids are minted per spawn and AC never reuses one, not even on respawn.
+    pub fn register_session(&self, id: Uuid, agent_id: String) {
+        let mut registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
+        registered.insert(
+            id,
+            Registered {
+                agent_id,
+                last_emitted: None,
+            },
+        );
+    }
+
+    /// The last reading emitted for a session, for the snapshot command. `None` covers both
+    /// "no reading" and "not registered", which are the same thing to the badge.
+    pub fn last_reading(&self, id: Uuid) -> Option<u8> {
+        self.registered
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&id)
+            .and_then(|entry| entry.last_emitted)
+    }
+
+    /// Resolve an agent's pattern, compiling only when its source string changed.
+    ///
+    /// The guard is a local and an owned `Arc` comes back, so the cache lock is never held
+    /// across the rows read below it.
+    fn resolve(&self, agent_id: &str, source: &str) -> Option<Arc<ContextPattern>> {
+        let mut cache = self.compiled.lock().unwrap_or_else(|e| e.into_inner());
+
+        if let Some(cached) = cache.get(agent_id) {
+            if cached.source() == source {
+                return cached.pattern();
+            }
+        }
+
+        self.compiles.fetch_add(1, Ordering::Relaxed);
+        let cached = match pattern::compile(source) {
+            Ok(pattern) => Cached::Ok(Arc::new(pattern)),
+            Err(err) => {
+                // Once per change, not once per tick: the cache below makes it sticky.
+                log::warn!("[context] agent {agent_id} has an unusable context regex: {err}");
+                Cached::Failed {
+                    source: source.to_string(),
+                }
+            }
+        };
+        let pattern = cached.pattern();
+        cache.insert(agent_id.to_string(), cached);
+        pattern
+    }
+
+    async fn tick(&self) {
+        // Before `patterns()`, so an app with no agent session running reads nothing at all.
+        // Honest bound: this window is app start until the first agent session, and no
+        // longer - entries for unconfigured agents are never pruned, because reaching them
+        // would cost either a PTY probe or a discarded 30-row clone per session per tick,
+        // purely to reclaim ~100 bytes for a feature that is switched off.
+        if self
+            .registered
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_empty()
+        {
+            return;
+        }
+
+        let patterns = self.patterns.patterns().await;
+
+        // Snapshot first: the loop must not mutate `registered` while iterating it.
+        let ids: Vec<(Uuid, String)> = {
+            let registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
+            registered
+                .iter()
+                .map(|(id, entry)| (*id, entry.agent_id.clone()))
+                .collect()
+        };
+
+        let mut over: Vec<Uuid> = Vec::new();
+
+        for (id, agent_id) in ids {
+            let (reading, session_over): (Option<u8>, bool) = match patterns.get(&agent_id) {
+                // Not configured: no lock, no rows, no compile.
+                None => (None, false),
+                Some(source) => match self.resolve(&agent_id, source) {
+                    // Does not compile: no lock, no rows either.
+                    None => (None, false),
+                    Some(pattern) => match self.rows.get_screen_rows(id) {
+                        ScreenRowsRead::Rows(rows) => (rows::extract(&pattern, &rows), false),
+                        ScreenRowsRead::Unavailable => (None, false),
+                        ScreenRowsRead::SessionOver => (None, true),
+                    },
+                },
+            };
+
+            // ONE gate, for every state there is. Clearing a pattern, an invalid pattern, a
+            // suppressed statusline, a dead session and a real decrease all arrive here, and
+            // all of them emit exactly when the value changed.
+            let changed = {
+                let mut registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
+                match registered.get_mut(&id) {
+                    Some(entry) if entry.last_emitted != reading => {
+                        entry.last_emitted = reading;
+                        true
+                    }
+                    _ => false,
+                }
+            };
+            if changed {
+                self.sink.emit(ContextUsagePayload {
+                    session_id: id.to_string(),
+                    percent: reading,
+                });
+            }
+
+            if session_over {
+                over.push(id);
+            }
+        }
+
+        // After the loop, never during it.
+        if !over.is_empty() {
+            let mut registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
+            registered.retain(|id, _| !over.contains(id));
+        }
+    }
+
+    #[cfg(test)]
+    fn compile_count(&self) -> usize {
+        self.compiles.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    fn is_registered(&self, id: Uuid) -> bool {
+        self.registered
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(&id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    const CLAUDE: &str = r"^ {2}Context [\u{2591}\u{2588}]+ (\d{1,3})%";
+    const AGENT: &str = "claude";
+
+    fn row(percent: u8) -> String {
+        format!("  Context \u{2591}\u{2591}\u{2588} {percent}%")
+    }
+
+    /// A THREE-state rows fake, because the seam is three-state. Under a two-state
+    /// `Option<Vec<String>>` the H1 defect was not merely untested, it was unsayable: the
+    /// fake had no way to express "a live child we could not ask", so no test could have
+    /// caught the design pruning it forever.
+    #[derive(Default)]
+    struct RowsFake {
+        script: StdMutex<Vec<ScreenRowsRead>>,
+        calls: StdMutex<Vec<Uuid>>,
+    }
+
+    impl RowsFake {
+        fn scripted(reads: Vec<ScreenRowsRead>) -> Arc<Self> {
+            Arc::new(Self {
+                script: StdMutex::new(reads),
+                calls: StdMutex::new(Vec::new()),
+            })
+        }
+        fn call_count(&self) -> usize {
+            self.calls.lock().unwrap().len()
+        }
+    }
+
+    impl ScreenRowsSource for RowsFake {
+        fn get_screen_rows(&self, id: Uuid) -> ScreenRowsRead {
+            self.calls.lock().unwrap().push(id);
+            let mut script = self.script.lock().unwrap();
+            if script.is_empty() {
+                ScreenRowsRead::Unavailable
+            } else {
+                script.remove(0)
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct PatternFake {
+        patterns: StdMutex<HashMap<String, String>>,
+        calls: StdMutex<usize>,
+    }
+
+    impl PatternFake {
+        fn with(agent: &str, source: &str) -> Arc<Self> {
+            let fake = Self::default();
+            fake.patterns
+                .lock()
+                .unwrap()
+                .insert(agent.to_string(), source.to_string());
+            Arc::new(fake)
+        }
+        fn set(&self, agent: &str, source: Option<&str>) {
+            let mut patterns = self.patterns.lock().unwrap();
+            match source {
+                Some(source) => patterns.insert(agent.to_string(), source.to_string()),
+                None => patterns.remove(agent),
+            };
+        }
+        fn call_count(&self) -> usize {
+            *self.calls.lock().unwrap()
+        }
+    }
+
+    impl ContextPatternSource for PatternFake {
+        fn patterns(&self) -> BoxFuture<'_, HashMap<String, String>> {
+            Box::pin(async move {
+                *self.calls.lock().unwrap() += 1;
+                self.patterns.lock().unwrap().clone()
+            })
+        }
+    }
+
+    #[derive(Default)]
+    struct SinkFake {
+        emitted: StdMutex<Vec<Option<u8>>>,
+    }
+
+    impl SinkFake {
+        fn emitted(&self) -> Vec<Option<u8>> {
+            self.emitted.lock().unwrap().clone()
+        }
+    }
+
+    impl ContextEventSink for SinkFake {
+        fn emit(&self, payload: ContextUsagePayload) {
+            self.emitted.lock().unwrap().push(payload.percent);
+        }
+    }
+
+    struct Harness {
+        scraper: Arc<ContextScraper>,
+        rows: Arc<RowsFake>,
+        patterns: Arc<PatternFake>,
+        sink: Arc<SinkFake>,
+    }
+
+    fn harness(rows: Arc<RowsFake>, patterns: Arc<PatternFake>) -> Harness {
+        let sink = Arc::new(SinkFake::default());
+        let scraper = ContextScraper::new(
+            Arc::clone(&rows) as Arc<dyn ScreenRowsSource>,
+            Arc::clone(&patterns) as Arc<dyn ContextPatternSource>,
+            Arc::clone(&sink) as Arc<dyn ContextEventSink>,
+        );
+        Harness {
+            scraper,
+            rows,
+            patterns,
+            sink,
+        }
+    }
+
+    /// Criterion 5. Not "emits nothing", but "costs nothing": the rows fake counts calls,
+    /// and an unconfigured agent must never reach it - no PTY lock, no 30-row clone.
+    #[tokio::test]
+    async fn a_session_whose_agent_has_no_pattern_takes_no_lock_and_emits_nothing() {
+        let h = harness(RowsFake::scripted(vec![]), Arc::new(PatternFake::default()));
+        h.scraper
+            .register_session(Uuid::new_v4(), AGENT.to_string());
+
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+
+        assert_eq!(h.rows.call_count(), 0, "no pattern must mean no rows read");
+        assert!(h.sink.emitted().is_empty(), "and no event");
+    }
+
+    /// The empty-map guard, in the only window it covers: app start until the first agent
+    /// session. It is two lines and it is honest about its scope.
+    #[tokio::test]
+    async fn an_empty_registered_map_never_reads_patterns() {
+        let h = harness(RowsFake::scripted(vec![]), PatternFake::with(AGENT, CLAUDE));
+
+        h.scraper.tick().await;
+
+        assert_eq!(h.patterns.call_count(), 0);
+    }
+
+    /// Clearing the regex must clear the badge. An earlier design skipped unconfigured
+    /// agents entirely, which left the badge showing 42 forever for a feature the user had
+    /// just switched off.
+    #[tokio::test]
+    async fn clearing_a_pattern_emits_null_once() {
+        let h = harness(
+            RowsFake::scripted(vec![
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::Rows(vec![row(42)]),
+            ]),
+            PatternFake::with(AGENT, CLAUDE),
+        );
+        let id = Uuid::new_v4();
+        h.scraper.register_session(id, AGENT.to_string());
+
+        h.scraper.tick().await;
+        assert_eq!(h.sink.emitted(), vec![Some(42)]);
+
+        h.patterns.set(AGENT, None);
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+
+        assert_eq!(
+            h.sink.emitted(),
+            vec![Some(42), None],
+            "null once, then silence"
+        );
+        assert!(
+            h.scraper.is_registered(id),
+            "clearing a regex does not end a session"
+        );
+    }
+
+    /// The other half: typing a regex passes THROUGH invalid states, and an invalid pattern
+    /// must clear the badge rather than freeze it.
+    #[tokio::test]
+    async fn a_pattern_edited_to_something_invalid_emits_null_once() {
+        let h = harness(
+            RowsFake::scripted(vec![
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::Rows(vec![row(42)]),
+            ]),
+            PatternFake::with(AGENT, CLAUDE),
+        );
+        h.scraper
+            .register_session(Uuid::new_v4(), AGENT.to_string());
+
+        h.scraper.tick().await;
+        h.patterns.set(AGENT, Some(r"^ {2}Context (\d{1,3}%"));
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+
+        assert_eq!(h.sink.emitted(), vec![Some(42), None]);
+    }
+
+    /// The failure is sticky, so the log is too: the compile site IS the log site, and a
+    /// broken regex must not write a line every 5 seconds for the rest of the app's life.
+    #[tokio::test]
+    async fn an_uncompilable_pattern_logs_once_per_change_not_once_per_tick() {
+        let h = harness(
+            RowsFake::scripted(vec![]),
+            PatternFake::with(AGENT, r"^ {2}Context (\d{1,3}%"),
+        );
+        h.scraper
+            .register_session(Uuid::new_v4(), AGENT.to_string());
+
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+
+        assert_eq!(h.scraper.compile_count(), 1, "one compile, hence one log");
+        assert_eq!(h.rows.call_count(), 0, "and a broken pattern reads no rows");
+    }
+
+    /// The compile cache is what makes per-tick resolution affordable, and per-tick
+    /// resolution is what deletes the respawn requirement: paste a regex, see it work,
+    /// without restarting every running agent.
+    #[tokio::test]
+    async fn a_changed_pattern_is_recompiled_within_one_tick() {
+        let h = harness(
+            RowsFake::scripted(vec![
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::Rows(vec!["  Ctx 7%".to_string()]),
+            ]),
+            PatternFake::with(AGENT, CLAUDE),
+        );
+        h.scraper
+            .register_session(Uuid::new_v4(), AGENT.to_string());
+
+        h.scraper.tick().await;
+        assert_eq!(h.sink.emitted(), vec![Some(42)]);
+
+        h.patterns.set(AGENT, Some(r"^ {2}Ctx (\d{1,3})%"));
+        h.scraper.tick().await;
+
+        assert_eq!(h.scraper.compile_count(), 2);
+        assert_eq!(h.sink.emitted(), vec![Some(42), Some(7)]);
+    }
+
+    #[tokio::test]
+    async fn an_unchanged_pattern_is_not_recompiled() {
+        let h = harness(
+            RowsFake::scripted(vec![
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::Rows(vec![row(42)]),
+            ]),
+            PatternFake::with(AGENT, CLAUDE),
+        );
+        h.scraper
+            .register_session(Uuid::new_v4(), AGENT.to_string());
+
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+
+        assert_eq!(h.scraper.compile_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn session_over_emits_null_once_and_prunes() {
+        let h = harness(
+            RowsFake::scripted(vec![
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::SessionOver,
+            ]),
+            PatternFake::with(AGENT, CLAUDE),
+        );
+        let id = Uuid::new_v4();
+        h.scraper.register_session(id, AGENT.to_string());
+
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+        let reads_at_prune = h.rows.call_count();
+
+        assert_eq!(h.sink.emitted(), vec![Some(42), None]);
+        assert!(
+            !h.scraper.is_registered(id),
+            "a session that is over stops being sampled"
+        );
+
+        h.scraper.tick().await;
+        assert_eq!(
+            h.rows.call_count(),
+            reads_at_prune,
+            "and is never read again"
+        );
+        assert_eq!(
+            h.sink.emitted(),
+            vec![Some(42), None],
+            "nor emitted for again"
+        );
+    }
+
+    /// Criterion 7, and the reason `ScreenRowsRead` exists.
+    ///
+    /// A child that is alive but whose handle cannot be queried is NOT a dead session. The
+    /// design this replaced pruned on it, which is not a 5-second flicker: `registered` is
+    /// only ever written at spawn, so the entry never comes back and the badge stays N/A for
+    /// the rest of a session whose child never died. Reproduced against real Windows
+    /// processes: the same live process reads Alive through a full-rights handle and
+    /// Unqueryable through one stripped of SYNCHRONIZE.
+    #[tokio::test]
+    async fn a_live_child_that_cannot_be_queried_is_not_pruned() {
+        let h = harness(
+            RowsFake::scripted(vec![
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::Unavailable,
+                ScreenRowsRead::Rows(vec![row(42)]),
+            ]),
+            PatternFake::with(AGENT, CLAUDE),
+        );
+        let id = Uuid::new_v4();
+        h.scraper.register_session(id, AGENT.to_string());
+
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+        assert!(
+            h.scraper.is_registered(id),
+            "we could not ask is not the child is dead: the entry must survive"
+        );
+
+        h.scraper.tick().await;
+
+        assert_eq!(
+            h.sink.emitted(),
+            vec![Some(42), None, Some(42)],
+            "the reading comes back on the tick after the handle answers again"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unchanged_value_emits_once() {
+        let h = harness(
+            RowsFake::scripted(vec![
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::Rows(vec![row(42)]),
+            ]),
+            PatternFake::with(AGENT, CLAUDE),
+        );
+        h.scraper
+            .register_session(Uuid::new_v4(), AGENT.to_string());
+
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+
+        assert_eq!(h.sink.emitted(), vec![Some(42)]);
+    }
+
+    /// No monotonicity: `/clear` and `/compact` are the whole point of watching this number.
+    #[tokio::test]
+    async fn a_decrease_is_emitted() {
+        let h = harness(
+            RowsFake::scripted(vec![
+                ScreenRowsRead::Rows(vec![row(80)]),
+                ScreenRowsRead::Rows(vec![row(12)]),
+            ]),
+            PatternFake::with(AGENT, CLAUDE),
+        );
+        h.scraper
+            .register_session(Uuid::new_v4(), AGENT.to_string());
+
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+
+        assert_eq!(h.sink.emitted(), vec![Some(80), Some(12)]);
+    }
+
+    /// Two sessions of the same agent share a pattern and nothing else. Each gets its own
+    /// entry and its own first emit - which is a thing production does every time a user
+    /// launches a second Claude.
+    #[tokio::test]
+    async fn a_second_session_for_the_same_agent_gets_its_own_entry_and_first_emit() {
+        let h = harness(
+            RowsFake::scripted(vec![
+                ScreenRowsRead::Rows(vec![row(42)]),
+                ScreenRowsRead::Rows(vec![row(42)]),
+            ]),
+            PatternFake::with(AGENT, CLAUDE),
+        );
+        h.scraper
+            .register_session(Uuid::new_v4(), AGENT.to_string());
+        h.scraper
+            .register_session(Uuid::new_v4(), AGENT.to_string());
+
+        h.scraper.tick().await;
+
+        assert_eq!(
+            h.sink.emitted(),
+            vec![Some(42), Some(42)],
+            "both sessions are new to the badge, so both emit"
+        );
+        assert_eq!(h.scraper.compile_count(), 1, "one agent, one compile");
+    }
+
+    #[test]
+    fn none_serializes_as_an_explicit_null_not_an_absent_key() {
+        let json = serde_json::to_string(&ContextUsagePayload {
+            session_id: "3f2a".to_string(),
+            percent: None,
+        })
+        .expect("serializes");
+        assert_eq!(json, r#"{"sessionId":"3f2a","percent":null}"#);
+
+        let json = serde_json::to_string(&ContextUsagePayload {
+            session_id: "3f2a".to_string(),
+            percent: Some(42),
+        })
+        .expect("serializes");
+        assert_eq!(json, r#"{"sessionId":"3f2a","percent":42}"#);
+    }
 }

--- a/src-tauri/src/pty/context_scrape/mod.rs
+++ b/src-tauri/src/pty/context_scrape/mod.rs
@@ -9,3 +9,22 @@
 
 pub mod pattern;
 pub mod rows;
+
+/// What a backend can say about one session's rows.
+///
+/// THREE states, because the oracle behind it has three. A two-state channel here would
+/// make `None` mean four different things - session unknown, parser poisoned, child dead,
+/// child unqueryable - of which "stop sampling" is right for three and destroys the fourth:
+/// a live child whose handle could not be queried for one tick would be deregistered for
+/// the rest of its life. `ChildLiveness::Unqueryable` exists precisely so "we could not
+/// ask" is never confused with a definite answer, and this enum is what carries that the
+/// rest of the way.
+pub enum ScreenRowsRead {
+    /// The live grid's rows.
+    Rows(Vec<String>),
+    /// No reading this tick. Says NOTHING about whether the session is over: retry next
+    /// tick, keep the entry. (Child alive but unqueryable; parser missing or poisoned.)
+    Unavailable,
+    /// The session is over. Emit null once, then stop sampling it.
+    SessionOver,
+}

--- a/src-tauri/src/pty/context_scrape/mod.rs
+++ b/src-tauri/src/pty/context_scrape/mod.rs
@@ -1,0 +1,11 @@
+//! #1032 - a per-session, best-effort reading of a coding agent's context-window usage,
+//! taken by running a per-agent, user-configured regex over the plain de-ANSI'd rows of the
+//! `vt100` screen mirror AC already keeps for every session.
+//!
+//! **The percentage is a signal for a human. It never drives an action.** That is not a
+//! rule anyone here has to remember: the scraper holds three narrow trait objects and
+//! nothing else - no `AppHandle`, no `PtyManager` - so the capability to write to a PTY or
+//! kill a session is not reachable from this module at all.
+
+pub mod pattern;
+pub mod rows;

--- a/src-tauri/src/pty/context_scrape/pattern.rs
+++ b/src-tauri/src/pty/context_scrape/pattern.rs
@@ -1,0 +1,93 @@
+//! #1032 - compiling the user's per-agent context regex.
+//!
+//! The engine ships no anchoring rules of its own: `%`-required, column-2-anchored and
+//! glyph-required all live in the pattern, because the pattern is per-agent user
+//! configuration. What lives here is the little that must be true of ANY pattern.
+
+use regex::{Regex, RegexBuilder};
+
+/// A compiled context regex, kept with the source string it came from so the scraper can
+/// tell a changed pattern from an unchanged one without recompiling to find out.
+#[derive(Debug)]
+pub struct ContextPattern {
+    regex: Regex,
+    source: String,
+}
+
+impl ContextPattern {
+    pub fn regex(&self) -> &Regex {
+        &self.regex
+    }
+
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+}
+
+/// `regex` 1.x has no backtracking and is linear-time by construction, so a hostile
+/// pattern cannot burn CPU here. It can still ask for an enormous compiled program, so the
+/// size limit is the bound that matters: past it, compilation FAILS rather than allocating.
+const SIZE_LIMIT_BYTES: usize = 1024 * 1024;
+
+/// Compile a user-supplied pattern, or say why it cannot be one.
+///
+/// The error is for `app.log` and for #1033 if it ever wants to surface it in Settings; the
+/// engine itself treats every failure the same way - the reading is unavailable.
+pub fn compile(source: &str) -> Result<ContextPattern, String> {
+    let regex = RegexBuilder::new(source)
+        .size_limit(SIZE_LIMIT_BYTES)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    // Capture group 1 IS the reading. A pattern without one can never produce a number, so
+    // it is rejected here rather than matching happily forever and reporting nothing.
+    if regex.captures_len() < 2 {
+        return Err(format!(
+            "context regex has no capture group 1 (the percentage): {source}"
+        ));
+    }
+
+    Ok(ContextPattern {
+        regex,
+        source: source.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_pattern_with_a_capture_group_compiles_and_keeps_its_source() {
+        let source = r"^ {2}Context [░█]+ (\d{1,3})%";
+        let pattern = compile(source).expect("compiles");
+        assert_eq!(pattern.source(), source);
+        assert!(pattern.regex().is_match("  Context ░░░░░░░░░░ 0% │ Usage"));
+    }
+
+    #[test]
+    fn a_pattern_without_a_capture_group_is_rejected() {
+        let err = compile(r"^ {2}Context [░█]+ \d{1,3}%").expect_err("must be rejected");
+        assert!(
+            err.contains("capture group 1"),
+            "the error must say what is missing, since app.log is all the user gets: {err}"
+        );
+    }
+
+    #[test]
+    fn an_uncompilable_pattern_is_rejected_rather_than_panicking() {
+        assert!(compile(r"^ {2}Context (\d{1,3}%").is_err());
+    }
+
+    #[test]
+    fn a_pattern_over_the_size_limit_fails_to_compile_rather_than_allocating() {
+        // Nested bounded repeats are the cheap way to ask for an enormous program from a
+        // short pattern. Without the limit this is an allocation, not an error.
+        let hostile = format!("({})", r"(a{1000}){1000}");
+        let err = compile(&hostile).expect_err("must be rejected");
+        assert!(
+            err.to_lowercase().contains("size"),
+            "expected the size limit to be what refuses it, got: {err}"
+        );
+    }
+}

--- a/src-tauri/src/pty/context_scrape/rows.rs
+++ b/src-tauri/src/pty/context_scrape/rows.rs
@@ -1,0 +1,182 @@
+//! #1032 - the pure half of the context scrape: turn the plain rows of a session's
+//! screen mirror into a percentage, using that agent's user-configured regex.
+//!
+//! Pure by construction: no locks, no vt100, no Tauri. Everything that can go wrong here
+//! is `None`, which the scraper reports as unavailable and NEVER as `0`.
+
+use super::pattern::ContextPattern;
+
+/// The reading for one sample.
+///
+/// Scans the screen's PHYSICAL rows bottom-up and takes the first row that matches. Prose
+/// and transcript always render above the statusline, and only `⏸ manual mode on` and
+/// blanks render below it, so the lowest match is the statusline whenever the statusline
+/// is on the grid. Measured on real bytes, not inferred.
+///
+/// Capture group 1 is the percentage; `compile` has already refused a pattern that has
+/// none. A match whose group 1 is missing, unparseable, or outside `0..=100` is rejected -
+/// the row that matched still wins, and the reading is simply unavailable.
+pub fn extract(pattern: &ContextPattern, rows: &[String]) -> Option<u8> {
+    let captures = rows
+        .iter()
+        .rev()
+        .find_map(|row| pattern.regex().captures(row))?;
+    let percent: u8 = captures.get(1)?.as_str().parse().ok()?;
+    (percent <= 100).then_some(percent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pty::context_scrape::pattern::compile;
+
+    /// The two patterns the live capture measured, and what #1033's placeholder ships.
+    /// Every element of each is load-bearing, and the tests below are what say so.
+    const CLAUDE: &str = r"^ {2}Context [░█]+ (\d{1,3})%";
+    const CODEX: &str = r"^ {2}.*· Context (\d{1,3})% used";
+
+    /// The real statusline at cols=120, as far as the plan transcribes it. The plan elides
+    /// the tail with `…` in prose and the capture itself did not survive the workgroup
+    /// purge, so the tail past `16%` is left off rather than invented. Nothing after `0%`
+    /// changes an assertion here.
+    const REAL_120: &str = "  Context ░░░░░░░░░░ 0% │ Usage ██░░░░░░░░ 16%";
+
+    /// cols=20 at a TRUE 100%. claude-hud's render budget overflows and the row is
+    /// TRUNCATED right-to-left with a literal `…` (U+2026); it never wraps. The `…` here
+    /// is captured bytes, not an elision.
+    const TRUNCATED_100: &str = "  Context ████ 10…";
+
+    fn extract_with(pattern: &str, rows: &[&str]) -> Option<u8> {
+        let compiled = compile(pattern).expect("pattern compiles");
+        let owned: Vec<String> = rows.iter().map(|r| r.to_string()).collect();
+        extract(&compiled, &owned)
+    }
+
+    #[test]
+    fn the_real_120_col_row_extracts() {
+        assert_eq!(extract_with(CLAUDE, &[REAL_120]), Some(0));
+    }
+
+    #[test]
+    fn truncation_fails_closed_when_the_pattern_requires_percent() {
+        // The truth is 100. Truncation eats right-to-left, so it necessarily ate the `%`
+        // before it could eat a digit - requiring the `%` is what makes this unavailable
+        // instead of confidently wrong.
+        assert_eq!(extract_with(CLAUDE, &[TRUNCATED_100]), None);
+    }
+
+    #[test]
+    fn truncation_without_the_percent_rule_returns_a_wrong_number() {
+        // Why that rule exists, pinned so a careless pattern edit cannot drop it silently:
+        // the same row reports 10 for a session that is actually FULL.
+        assert_eq!(
+            extract_with(r"Context [░█]+ (\d+)", &[TRUNCATED_100]),
+            Some(10)
+        );
+    }
+
+    #[test]
+    fn the_lowest_matching_row_wins() {
+        // A pasted line that matches at column 2, sitting above the real statusline.
+        // Bottom-up is the only thing that separates them.
+        let rows = ["  Context ██████████ 99% (pasted)", "", REAL_120];
+        assert_eq!(extract_with(CLAUDE, &rows), Some(0));
+
+        // ...and the fixture is only worth anything if it distinguishes scan order, which
+        // is precisely what the version of this test in an earlier revision did not.
+        let compiled = compile(CLAUDE).expect("pattern compiles");
+        let top_down = rows.iter().find_map(|row| {
+            compiled
+                .regex()
+                .captures(row)
+                .and_then(|c| c.get(1)?.as_str().parse::<u8>().ok())
+        });
+        assert_eq!(
+            top_down,
+            Some(99),
+            "fixture must distinguish scan order or it pins nothing"
+        );
+    }
+
+    #[test]
+    fn input_box_prose_is_rejected_by_the_column_two_anchor() {
+        // Typed into the input box, and it beats every glyph rule: the bar is real, the `%`
+        // is real, the number is a lie. `❯ ` puts `Context` at column 16.
+        assert_eq!(
+            extract_with(CLAUDE, &["❯ The row says Context ██████████ 99% right now"]),
+            None
+        );
+    }
+
+    #[test]
+    fn a_wrapped_input_continuation_defeats_the_column_two_anchor() {
+        // The accepted residual, pinned as measured rather than left as a surprise: `❯`
+        // decorates only the FIRST visual row, so a wrapped continuation of the input box
+        // starts at exactly column 2 and the anchor cannot tell it from the statusline.
+        // Self-corrects on the next tick once the statusline is back.
+        assert_eq!(
+            extract_with(CLAUDE, &["  Context ██████████ 99% tail"]),
+            Some(99)
+        );
+    }
+
+    #[test]
+    fn the_85_percent_breakdown_still_extracts() {
+        // Content follows the percent, so a pattern anchored with `$` after `%` would read
+        // this as unavailable.
+        assert_eq!(
+            extract_with(
+                CLAUDE,
+                &["  Context █████████░ 87% (in: 12k, cache: 40k) │"]
+            ),
+            Some(87)
+        );
+    }
+
+    #[test]
+    fn all_three_bar_widths_extract() {
+        // The bar shrinks with the terminal: 10 blocks at cols=120, 6 at 80, 4 at 40. Only
+        // the 120-col row survives verbatim in the plan, so the 6- and 4-block rows are
+        // built to the same recorded shape. Bar-width-agnostic is the assertion.
+        assert_eq!(extract_with(CLAUDE, &[REAL_120]), Some(0));
+        assert_eq!(extract_with(CLAUDE, &["  Context ███░░░ 42%"]), Some(42));
+        assert_eq!(extract_with(CLAUDE, &["  Context ██░░ 42%"]), Some(42));
+    }
+
+    #[test]
+    fn zero_and_hundred_extract_despite_a_missing_glyph() {
+        // `[░█]+` must not require BOTH glyphs: the ends of the range only have one.
+        assert_eq!(extract_with(CLAUDE, &["  Context ░░░░░░░░░░ 0%"]), Some(0));
+        assert_eq!(
+            extract_with(CLAUDE, &["  Context ██████████ 100%"]),
+            Some(100)
+        );
+    }
+
+    #[test]
+    fn codex_row_extracts_context_not_weekly() {
+        // Codex is glyphless and puts a SECOND `%` on the row. ` used` is what excludes it.
+        assert_eq!(
+            extract_with(CODEX, &["  Ready · Context 0% used · weekly 83% left"]),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn an_out_of_range_match_is_rejected() {
+        // 999 is not a u8 at all, so the parse rejects it with or without a range check...
+        assert_eq!(extract_with(CLAUDE, &["  Context ██████████ 999%"]), None);
+        // ...but 200 is, and only the explicit `0..=100` rule rejects it. This is the line
+        // that goes red if that rule is deleted; the plan's own fixture is 999, which does
+        // not pin it.
+        assert_eq!(extract_with(CLAUDE, &["  Context ██████████ 200%"]), None);
+    }
+
+    #[test]
+    fn a_zero_percent_row_reports_zero_not_null() {
+        // A fresh session's `used_percentage` is null, but claude-hud computes 0/1000000
+        // and prints `0%`, byte-identical to a true 0%. Inferring null from Some(0) would
+        // erase a genuine low reading, so the engine reports what it reads.
+        assert_eq!(extract_with(CLAUDE, &["  Context ░░░░░░░░░░ 0%"]), Some(0));
+    }
+}

--- a/src-tauri/src/pty/context_scrape/rows.rs
+++ b/src-tauri/src/pty/context_scrape/rows.rs
@@ -133,14 +133,31 @@ mod tests {
         );
     }
 
+    /// Re-captured 2026-07-17 against claude.exe 2.1.212 at cols 80 and 40, with the rig
+    /// the round-1 capture used: portable-pty 0.8.1 + vt100 0.15.2,
+    /// `Parser::new(rows, cols, 0)`, rows read back with `contents_between`. The bar really
+    /// does shrink 10 -> 6 -> 4 blocks at 120 -> 80 -> 40, exactly as recorded.
+    const REAL_80: &str = "  Context ░░░░░░ 0% │ Usage ░░░░░░ 8% (resets in 3h 21m)";
+
+    /// At 40 cols claude-hud DROPS the `│ Usage ...` segment rather than wrapping it, so the
+    /// row simply ends at the percent. Nothing is ever split mid-segment.
+    const REAL_40: &str = "  Context ░░░░ 0%";
+
+    /// 120 is deliberately not re-asserted here: `the_real_120_col_row_extracts` owns it,
+    /// and a test that restates another test earns nothing.
     #[test]
-    fn all_three_bar_widths_extract() {
-        // The bar shrinks with the terminal: 10 blocks at cols=120, 6 at 80, 4 at 40. Only
-        // the 120-col row survives verbatim in the plan, so the 6- and 4-block rows are
-        // built to the same recorded shape. Bar-width-agnostic is the assertion.
-        assert_eq!(extract_with(CLAUDE, &[REAL_120]), Some(0));
-        assert_eq!(extract_with(CLAUDE, &["  Context ███░░░ 42%"]), Some(42));
-        assert_eq!(extract_with(CLAUDE, &["  Context ██░░ 42%"]), Some(42));
+    fn the_placeholder_extracts_at_80_and_40_cols() {
+        assert_eq!(extract_with(CLAUDE, &[REAL_80]), Some(0));
+        assert_eq!(extract_with(CLAUDE, &[REAL_40]), Some(0));
+    }
+
+    /// The wide rows carry a SECOND percent - `Usage ... 8%` - exactly like Codex's
+    /// `weekly 83% left`. The column-2 anchor is what keeps the reading on the context
+    /// segment: Some(0), never Some(8).
+    #[test]
+    fn the_usage_percent_on_the_same_row_is_never_read_as_context() {
+        assert_eq!(extract_with(CLAUDE, &[REAL_80]), Some(0));
+        assert_ne!(extract_with(CLAUDE, &[REAL_80]), Some(8));
     }
 
     #[test]

--- a/src-tauri/src/pty/context_scrape/rows.rs
+++ b/src-tauri/src/pty/context_scrape/rows.rs
@@ -137,6 +137,12 @@ mod tests {
     /// the round-1 capture used: portable-pty 0.8.1 + vt100 0.15.2,
     /// `Parser::new(rows, cols, 0)`, rows read back with `contents_between`. The bar really
     /// does shrink 10 -> 6 -> 4 blocks at 120 -> 80 -> 40, exactly as recorded.
+    /// Note the SECOND percent on this row (`Usage ... 8%`). What keeps the reading on
+    /// the context segment is the literal `Context [░█]+ ` before the capture group: the
+    /// pattern has no `.*`, so it can only match where the word `Context` actually is, and
+    /// `Usage ... 8%` is not preceded by it. Measured, because the obvious answer is wrong:
+    /// the column-2 anchor does NOTHING here (delete it and this row still reads 0), and it
+    /// does not save you either (`^ {2}.*(\d{1,3})%` keeps the anchor and reads 8).
     const REAL_80: &str = "  Context ░░░░░░ 0% │ Usage ░░░░░░ 8% (resets in 3h 21m)";
 
     /// At 40 cols claude-hud DROPS the `│ Usage ...` segment rather than wrapping it, so the
@@ -151,15 +157,6 @@ mod tests {
         assert_eq!(extract_with(CLAUDE, &[REAL_40]), Some(0));
     }
 
-    /// The wide rows carry a SECOND percent - `Usage ... 8%` - exactly like Codex's
-    /// `weekly 83% left`. The column-2 anchor is what keeps the reading on the context
-    /// segment: Some(0), never Some(8).
-    #[test]
-    fn the_usage_percent_on_the_same_row_is_never_read_as_context() {
-        assert_eq!(extract_with(CLAUDE, &[REAL_80]), Some(0));
-        assert_ne!(extract_with(CLAUDE, &[REAL_80]), Some(8));
-    }
-
     #[test]
     fn zero_and_hundred_extract_despite_a_missing_glyph() {
         // `[░█]+` must not require BOTH glyphs: the ends of the range only have one.
@@ -170,9 +167,17 @@ mod tests {
         );
     }
 
+    /// Codex is glyphless and puts a SECOND `%` on the row (`weekly 83% left`).
+    ///
+    /// What excludes it is the literal `\u{b7} Context ` immediately before the capture group -
+    /// `weekly 83%` is not preceded by it. NOT ` used`: measured, dropping ` used` from the
+    /// pattern still reads Some(0). ` used` is harmless, but it is not the defence, and a
+    /// pattern that leans on it instead of on the literal prefix is not protected. What
+    /// Codex's `.*` DOES buy is real exposure: `^ {2}.*(\d{1,3})% ` reads Some(3) off this
+    /// row - greedy `.*` eats the `8` and leaves `3` - so the literal prefix is the whole
+    /// defence and must stay adjacent to the capture group.
     #[test]
     fn codex_row_extracts_context_not_weekly() {
-        // Codex is glyphless and puts a SECOND `%` on the row. ` used` is what excludes it.
         assert_eq!(
             extract_with(CODEX, &["  Ready · Context 0% used · weekly 83% left"]),
             Some(0)

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
+use crate::pty::context_scrape::ScreenRowsRead;
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
 use crate::pty::output::{PtyScreenSnapshot, SessionIoFanout};
@@ -979,14 +980,62 @@ impl LocalProcessBackend {
     /// #942 - liveness of the child of a session, without disturbing it. Never blocks
     /// (zero timeout) and never reports a child it could not query as running.
     fn probe_child(&self, id: Uuid) -> ChildLiveness {
-        let mut ptys = self.ptys.lock().unwrap_or_else(|e| e.into_inner());
-        let Some(instance) = ptys.get_mut(&id) else {
-            return ChildLiveness::Gone;
-        };
-        let Some(child) = instance.child.as_mut() else {
-            return ChildLiveness::Gone;
-        };
-        probe_child_contained(child)
+        probe_child_in(&self.ptys, id)
+    }
+}
+
+/// #942 - the body of `probe_child`, free over the map so #1032's liveness gate can be
+/// driven by a test against a real ConPTY child.
+///
+/// The guard is a local and `ChildLiveness` is owned, so the `ptys` lock is released at the
+/// return. That is what makes the gate below safe by construction rather than by care: the
+/// `match` scrutinee holds no borrow of the map, so no temporary-lifetime extension can
+/// carry the guard into an arm and nest `screen_parsers` inside `ptys`.
+fn probe_child_in(ptys: &Mutex<HashMap<Uuid, PtyInstance>>, id: Uuid) -> ChildLiveness {
+    let mut ptys = ptys.lock().unwrap_or_else(|e| e.into_inner());
+    let Some(instance) = ptys.get_mut(&id) else {
+        return ChildLiveness::Gone;
+    };
+    let Some(child) = instance.child.as_mut() else {
+        return ChildLiveness::Gone;
+    };
+    probe_child_contained(child)
+}
+
+/// #1032 - a local session's screen rows, gated on its child actually being alive.
+///
+/// Why a gate at all: a coding agent's statusline SURVIVES on the frozen grid after the
+/// child dies. Verbatim, ~8s after a confirmed `code: 0`, on every exit path that matters -
+/// a killed process cannot repaint, and Claude Code never uses the alternate screen, never
+/// clears and never restores. PTY EOF never arrives either. Nothing signals the death from
+/// any direction, so the frozen grid presents a perfectly well-formed row - glyph present,
+/// `%` present, column 2, last match on the grid - that passes every defence the user's
+/// pattern has. Liveness is not a regex problem, and asking the child is the only thing
+/// that can tell a live 42% from a dead one.
+///
+/// Free over the map and the fanout, like `resize_instance` above, so the gate can be driven
+/// by a test against a real ConPTY child: `LocalProcessBackend` itself cannot be built in a
+/// unit test (its `GitWatcher` needs a Tauri `AppHandle`), and none of that has anything to
+/// do with whether a child is alive.
+fn screen_rows_if_child_alive(
+    ptys: &Mutex<HashMap<Uuid, PtyInstance>>,
+    fanout: &SessionIoFanout,
+    id: Uuid,
+) -> ScreenRowsRead {
+    match probe_child_in(ptys, id) {
+        ChildLiveness::Alive => match fanout.get_screen_rows(id) {
+            Some(rows) => ScreenRowsRead::Rows(rows),
+            // The child is alive, so the session is NOT over. A missing or poisoned parser
+            // here is a desync or a poisoned lock, never a statement about the session.
+            None => ScreenRowsRead::Unavailable,
+        },
+        ChildLiveness::Exited { .. } | ChildLiveness::Gone => ScreenRowsRead::SessionOver,
+        // "We could not ask" is NOT "the child is dead". #942 built a three-valued oracle
+        // exactly so those two never merge, and this is the arm that keeps them apart: the
+        // same running process reads Alive through a full-rights handle and Unqueryable
+        // through one stripped of SYNCHRONIZE. Reporting that as over would deregister a
+        // live session permanently, on a child that never died.
+        ChildLiveness::Unqueryable(_) => ScreenRowsRead::Unavailable,
     }
 }
 
@@ -1355,6 +1404,10 @@ impl PtyBackend for LocalProcessBackend {
 
     fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)> {
         self.fanout.get_pty_size(id)
+    }
+
+    fn get_screen_rows(&self, id: Uuid) -> ScreenRowsRead {
+        screen_rows_if_child_alive(&self.ptys, &self.fanout, id)
     }
 
     fn register_response_watcher(
@@ -1848,6 +1901,194 @@ mod startup_gate_tests {
             gate.on_resize(80, 25),
             Some((80, 25)),
             "the gate is open now: resizes go straight through"
+        );
+    }
+}
+
+#[cfg(test)]
+mod context_gate_tests {
+    use super::{
+        probe_child_in, screen_rows_if_child_alive, ChildLiveness, PtyInstance, StartupGate,
+    };
+    use crate::pty::context_scrape::ScreenRowsRead;
+    use crate::pty::idle_detector::IdleDetector;
+    use crate::pty::output::{PtyOutputTarget, SessionIoFanout};
+    use crate::session::profile::IdleTuning;
+    use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+    use std::collections::HashMap;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+    use uuid::Uuid;
+
+    /// The statusline the agent painted, and the one that stays on the grid after it dies.
+    const ROW: &str = "  Context \u{2591}\u{2591}\u{2588} 42%";
+
+    /// A real ConPTY with a REAL CHILD on the far end, plus the real fanout.
+    ///
+    /// The child is the entire point. This gate's whole job is to answer a question the grid
+    /// cannot - is the child alive? - so a fake child cannot be asked it wrongly, which means
+    /// it cannot be asked at all. `startup_gate_tests::conpty` already opens the real ConPTY
+    /// and builds the real `PtyInstance`; this fills in its `child: None`.
+    fn conpty_with_child(cols: u16, rows: u16) -> (Mutex<HashMap<Uuid, PtyInstance>>, Uuid) {
+        let pair = native_pty_system()
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty");
+
+        // A child that sits and waits, the way an agent CLI does.
+        let shell = if cfg!(windows) { "cmd.exe" } else { "sh" };
+        let child = pair
+            .slave
+            .spawn_command(CommandBuilder::new(shell))
+            .expect("spawn a real child");
+        drop(pair.slave);
+
+        let writer = pair.master.take_writer().expect("take_writer");
+        let instance = PtyInstance {
+            master: Arc::new(Mutex::new(pair.master)),
+            writer: Arc::new(Mutex::new(writer)),
+            child: Some(child),
+            job: None,
+            size: Mutex::new((cols, rows)),
+            startup_gate: Mutex::new(StartupGate::Holding(None)),
+            rendered: Arc::new(AtomicBool::new(false)),
+        };
+
+        let id = Uuid::new_v4();
+        let mut map = HashMap::new();
+        map.insert(id, instance);
+        (Mutex::new(map), id)
+    }
+
+    fn fanout() -> SessionIoFanout {
+        SessionIoFanout::new(
+            Arc::new(Mutex::new(HashMap::new())),
+            IdleDetector::new(|_| {}, |_| {}),
+            None,
+        )
+    }
+
+    fn paint(fanout: &SessionIoFanout, id: Uuid) {
+        fanout.register_session(id, IdleTuning::DEFAULT, 30, 120);
+        fanout.handle_output(
+            &PtyOutputTarget::noop(),
+            id,
+            &id.to_string(),
+            ROW.as_bytes().to_vec(),
+        );
+    }
+
+    /// Kill the child and wait until it is REALLY gone - which is NOT what
+    /// `portable_pty::Child::wait()` waits for, and finding that out cost this test a failing
+    /// run.
+    ///
+    /// `TerminateProcess` is asynchronous, and `wait()` short-circuits on `try_wait()` ->
+    /// `is_complete()` -> `GetExitCodeProcess`. The exit code is readable ~14 ms (measured
+    /// here) BEFORE the kernel signals the process object, so `wait()` returns `Ok(1)` while
+    /// `WaitForSingleObject(h, 0)` still answers WAIT_TIMEOUT. That is #942 arriving from the
+    /// other side: `is_complete` is exactly the accessor AC's oracle refuses to trust, and
+    /// the oracle asks the stronger question on purpose. Production never notices the gap -
+    /// 14 ms against a 5 s tick - but a test that kills and reads in the same breath lands
+    /// inside it every time.
+    fn kill_and_await_real_exit(ptys: &Mutex<HashMap<Uuid, PtyInstance>>, id: Uuid) {
+        {
+            let mut map = ptys.lock().unwrap();
+            let child = map
+                .get_mut(&id)
+                .expect("instance")
+                .child
+                .as_mut()
+                .expect("child");
+            child.kill().expect("kill the child");
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if !matches!(probe_child_in(ptys, id), ChildLiveness::Alive) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        panic!("the oracle answered Alive for 10s after TerminateProcess: it cannot see deaths");
+    }
+
+    /// The live case: a real child, a real grid with a real statusline on it, and the gate
+    /// hands the rows straight through.
+    #[test]
+    fn rows_are_readable_while_the_child_is_alive() {
+        let (ptys, id) = conpty_with_child(120, 30);
+        let fanout = fanout();
+        paint(&fanout, id);
+
+        match screen_rows_if_child_alive(&ptys, &fanout, id) {
+            ScreenRowsRead::Rows(rows) => assert_eq!(rows[0], ROW),
+            ScreenRowsRead::Unavailable => panic!("a live child with a live parser must read"),
+            ScreenRowsRead::SessionOver => panic!("the child is alive; the session is not over"),
+        }
+    }
+
+    /// The case the whole gate exists for, and it is RED if the probe call is deleted.
+    ///
+    /// The parser is never touched here, so the row stays on the frozen grid verbatim,
+    /// exactly as it does in production: a killed process cannot repaint, and no EOF ever
+    /// arrives to notice. Without the probe this reads a perfectly well-formed `42%` off a
+    /// dead session forever, and no rule expressible in the user pattern can tell.
+    #[test]
+    fn session_over_once_the_child_actually_exits() {
+        let (ptys, id) = conpty_with_child(120, 30);
+        let fanout = fanout();
+        paint(&fanout, id);
+
+        kill_and_await_real_exit(&ptys, id);
+
+        assert!(
+            matches!(
+                screen_rows_if_child_alive(&ptys, &fanout, id),
+                ScreenRowsRead::SessionOver
+            ),
+            "the child is gone, so the session is over - whatever the frozen grid still says"
+        );
+
+        // ...and the row really is still sitting there. This is the fact that makes the probe
+        // load-bearing rather than belt-and-braces.
+        assert_eq!(
+            fanout.get_screen_rows(id).expect("the parser is untouched")[0],
+            ROW,
+            "if this goes red the grid started self-correcting and the gate premise changed"
+        );
+    }
+
+    /// No instance at all is the other definite answer: `Gone`, so the session is over.
+    #[test]
+    fn session_over_when_there_is_no_pty_instance() {
+        let (ptys, _id) = conpty_with_child(120, 30);
+        let fanout = fanout();
+        assert!(matches!(
+            screen_rows_if_child_alive(&ptys, &fanout, Uuid::new_v4()),
+            ScreenRowsRead::SessionOver
+        ));
+    }
+
+    /// A live child whose parser is missing is a DESYNC, not a dead session, and the caller
+    /// must keep sampling it. This is the two-state collapse `ScreenRowsRead` exists to
+    /// prevent, pinned at the one seam where the real oracle is involved.
+    #[test]
+    fn a_live_child_with_no_parser_is_unavailable_not_over() {
+        let (ptys, id) = conpty_with_child(120, 30);
+        let fanout = fanout();
+        // deliberately never registered with the fanout
+
+        assert!(
+            matches!(
+                screen_rows_if_child_alive(&ptys, &fanout, id),
+                ScreenRowsRead::Unavailable
+            ),
+            "the child is alive, so nothing here may claim the session is over"
         );
     }
 }

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -7,6 +7,7 @@ use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend, SessionBackendKind};
 use crate::pty::container_backend::ContainerTransportBackend;
 use crate::pty::container_tokens::ContainerApiTokenManager;
+use crate::pty::context_scrape::ScreenRowsRead;
 use crate::pty::docker_runtime::DockerRuntime;
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
@@ -269,6 +270,15 @@ impl PtyManager {
         self.backend_for_kind(kind).get_pty_size(id)
     }
 
+    /// #1032 - forwards to the routed backend. A missing route is not "we could not read":
+    /// every route removal is preceded by parser removal, so the session really is over.
+    pub fn get_screen_rows(&self, id: Uuid) -> ScreenRowsRead {
+        let Ok(kind) = self.kind_for_session(id) else {
+            return ScreenRowsRead::SessionOver;
+        };
+        self.backend_for_kind(kind).get_screen_rows(id)
+    }
+
     pub fn register_response_watcher(
         &self,
         session_id: Uuid,
@@ -373,6 +383,10 @@ mod tests {
             Some((30, 120))
         }
 
+        fn get_screen_rows(&self, _id: Uuid) -> ScreenRowsRead {
+            ScreenRowsRead::SessionOver
+        }
+
         fn register_response_watcher(
             &self,
             session_id: Uuid,
@@ -461,6 +475,10 @@ mod tests {
 
         fn get_pty_size(&self, _id: Uuid) -> Option<(u16, u16)> {
             None
+        }
+
+        fn get_screen_rows(&self, _id: Uuid) -> ScreenRowsRead {
+            ScreenRowsRead::SessionOver
         }
 
         fn register_response_watcher(

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -5,6 +5,7 @@ pub mod container_paths;
 pub mod container_repos;
 pub mod container_runtime;
 pub mod container_tokens;
+pub mod context_scrape;
 pub mod credentials;
 pub mod docker_runtime;
 pub mod git_watcher;

--- a/src-tauri/src/pty/output.rs
+++ b/src-tauri/src/pty/output.rs
@@ -284,6 +284,22 @@ impl SessionIoFanout {
         })
     }
 
+    /// #1032 - the live grid's rows, plain text, for the context scrape.
+    ///
+    /// TWO-state on purpose. The fanout knows nothing about children, so `None` here means
+    /// "no parser for this id" and says NOTHING about whether the session is over: only a
+    /// backend holds the liveness oracle, so only a backend can make that call.
+    ///
+    /// Sync, and the rows are cloned out: the guard is a local and is released at the
+    /// return, so no caller can hold it across an await.
+    pub fn get_screen_rows(&self, id: Uuid) -> Option<Vec<String>> {
+        let parsers = self.screen_parsers.lock().ok()?;
+        let state = parsers.get(&id)?;
+        let screen = state.parser.screen();
+        let (_rows, cols) = screen.size();
+        Some(screen.rows(0, cols).collect())
+    }
+
     pub fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)> {
         let parsers = self.screen_parsers.lock().ok()?;
         let state = parsers.get(&id)?;
@@ -749,5 +765,107 @@ mod tests {
         assert!(json.contains("\"requestId\": \"r1\""));
         assert!(json.contains("\"content\": \"{\\\"ok\\\": true}\""));
         assert!(watchers.lock().unwrap().is_empty());
+    }
+
+    // ---- #1032: the rows accessor, against the real parser -------------------------
+
+    /// The whole transfer claim of the round-1 capture rests on this: the capture read its
+    /// bytes with `contents_between`, and the engine reads them with `rows`. If those two
+    /// ever disagree, every measured fact about the statusline is about a screen this
+    /// accessor does not return.
+    ///
+    /// Valid rows only: the `Equal` branch of `contents_between` ends in
+    /// `.unwrap_or_default()`, so an out-of-range row answers `""` where `rows()` simply
+    /// has no index - comparing those would pin the crate's error handling, not the claim.
+    #[test]
+    fn get_screen_rows_matches_contents_between() {
+        let fanout = fanout();
+        let id = session(&fanout);
+        feed(
+            &fanout,
+            id,
+            &[
+                "  Context \u{2591}\u{2591}\u{2588} 42% \u{2502} Usage\r\nprose above it\r\n"
+                    .as_bytes(),
+            ],
+        );
+
+        let rows = fanout
+            .get_screen_rows(id)
+            .expect("rows for a registered session");
+
+        let parsers = fanout.screen_parsers.lock().unwrap();
+        let screen = parsers.get(&id).expect("parser").parser.screen();
+        let (row_count, cols) = screen.size();
+        assert_eq!(rows.len(), row_count as usize);
+        for r in 0..row_count {
+            assert_eq!(
+                rows[r as usize],
+                screen.contents_between(r, 0, r, cols),
+                "row {r} disagrees with the accessor the capture measured"
+            );
+        }
+    }
+
+    /// The column-2 anchor is the engine's only defence against single-row input-box prose,
+    /// and it is worth exactly as much as this: that the two leading spaces of a row painted
+    /// at column 2 survive the round trip out of the grid.
+    #[test]
+    fn leading_spaces_survive_so_the_column_two_anchor_works() {
+        let fanout = fanout();
+        let id = session(&fanout);
+        feed(&fanout, id, &[b"  Context 7% and a tail"]);
+
+        let rows = fanout.get_screen_rows(id).expect("rows");
+        assert_eq!(rows[0], "  Context 7% and a tail");
+        assert!(
+            rows[0].starts_with("  Context"),
+            "the anchor rests on these two spaces: {:?}",
+            rows[0]
+        );
+    }
+
+    /// Criterion 1. The mirror is keyed by session id and so is the scraper's map; two
+    /// concurrent agents must never read each other's number.
+    #[test]
+    fn two_sessions_never_cross_rows() {
+        let fanout = fanout();
+        let a = session(&fanout);
+        let b = session(&fanout);
+
+        feed(&fanout, a, &[b"  Context 11%"]);
+        feed(&fanout, b, &[b"  Context 88%"]);
+
+        assert_eq!(
+            fanout.get_screen_rows(a).expect("rows a")[0],
+            "  Context 11%"
+        );
+        assert_eq!(
+            fanout.get_screen_rows(b).expect("rows b")[0],
+            "  Context 88%"
+        );
+    }
+
+    /// The fanout's two-state contract: absent parser is `None`, and that is all it means.
+    /// Whether the session is OVER is a question this type cannot answer and does not try to.
+    #[test]
+    fn get_screen_rows_is_none_for_an_unknown_session() {
+        let fanout = fanout();
+        assert!(fanout.get_screen_rows(Uuid::new_v4()).is_none());
+    }
+
+    /// Criterion 2. The reading comes off the mirror, which AC feeds from the PTY read loop
+    /// whether or not a terminal was ever mounted: `PtyOutputTarget::noop()`, never resized,
+    /// still reads back.
+    #[test]
+    fn rows_are_readable_for_a_session_with_no_terminal() {
+        let fanout = fanout();
+        let id = session(&fanout);
+        feed(&fanout, id, &[b"  Context 5%"]);
+
+        let rows = fanout
+            .get_screen_rows(id)
+            .expect("a never-mounted session still reads");
+        assert_eq!(rows[0], "  Context 5%");
     }
 }

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -1186,6 +1186,7 @@ mod tests {
             isolated_home: false,
             instructions_filename: None,
             config_seed: None,
+            context_regex: None,
             backend: Default::default(),
         }
     }


### PR DESCRIPTION
Closes #1032. Part of epic #1031 (Step 1 of 2 — global config).

Backend engine only: a per-agent regex runs on a timer over the vt100 screen mirror AC already keeps for every session, and emits a per-session context-usage percentage. **Rust-only** — the Settings field and the `CTX` badge are #1033, which consumes §5.5 as a normative contract and needs no decision from it.

The number is a signal for the human. **It never drives an action** — no `/clear`, `/compact`, restart, PTY write, or process destruction, at any threshold. `null` renders unavailable, never `0`.

## Plan

`plans/1032-context-scrape-vt100-mirror.md`, revision 4, certified `READY_FOR_IMPLEMENTATION` by `architect` after **3 consensus rounds**.

**Certification check — use the blob, not the worktree:**

```
git cat-file blob <rev>:plans/1032-context-scrape-vt100-mirror.md | sha256sum
→ 3f415ffe8aeb4ad298fa2ef0509c705a1bc6d54abcab20e7bbb4e47e3327cd11
```

A worktree `sha256sum` on Windows returns `61e36053ac977da35172afdb72932e5aece2c9abcca52979bd22e5d66b04f337` instead. `core.autocrlf=true` is the Git-for-Windows **install default** (`--system`), and `.gitattributes` has no `*.md` rule, so a fresh clone renders this file CRLF (761 CR bytes, one per line). **The blob is canonical; the worktree hash is a checkout artifact.** Deliberately not fixed here — adding `*.md text eol=lf` would renormalize every other `.md` in the repo.

## Review

| Step | Owner | Outcome |
|---|---|---|
| Plan (3 rounds) | `architect` | `READY_FOR_IMPLEMENTATION` at revision 4 |
| Enrich ×3 | `dev-rust` | round 3: *"Yes. I would implement revision 3 cold."* |
| Adversarial ×3 | `dev-rust-grinch` | round 3: acceptance condition met |
| Implementation review | `dev-rust-grinch` | **FAIL → fixed → PASS**, no open findings |
| Merge resolution (9.5) | `dev-rust-grinch` | **PASS**, union verified by blob hash |

**Step 9 FAIL, fixed in `b4abc56`:** the adapter compiled `context_regex.trim()` — i.e. **a string the user did not write**. On a pattern with a literal column-2 anchor (`"  Context [░█]+ (\d{1,3})%"` — the natural transcription of a row that always starts at column 2) the anchor was silently stripped, and a prose row in the input box then read `Some(99)` where the user's own pattern reads `None`. **A wrong number instead of no number**, in a design where the user's regex is the only defence there is and everything else fails closed. The stated reason for the transform was also false: `pattern.rs` already rejects `""` and `"   "` for having no capture group, so the "pattern matching everything" it guarded against cannot exist.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean (workspace)
- `cargo test --lib` **2391 passed / 0 failed** / 9 ignored (pre-existing, unrelated)
- Real-ConPTY: `startup_gate_tests` 7/0, `context_gate_tests` 4/0, `context_scrape` 29/0
- Two mechanisms **mutation-verified**, not asserted: deleting the liveness probe call reddens the gate tests; reintroducing the `Unqueryable`-prunes defect reddens **only** its own test (28 others stay green)
- Merge union proved by **blob identity** across all 25 branch files (24/25 byte-identical; only `ac_discovery.rs` moved, by exactly its 4-line stub), and the arithmetic closes: `1766 + 761 = 2527`

## Things measured that the design had assumed

The plan's §10.4 records **six retracted mechanisms**, one mistake each time: a mechanism justified by a claim nobody verified, plus a test pinning the resulting fiction. What caught every one was a probe running the mechanism against the real thing — reading the code caught none. Hence:

- **The bar-glyph defence is refuted.** Typing `Context ██████████ 99%` into the input box false-positives a glyph-anchored regex. Both Claude and Codex need real anchoring; neither is the easy case.
- **The 40-col hard-wrap hazard does not exist.** Measured at 12 widths: claude-hud pre-wraps at segment boundaries and at 40 cols drops the `│ Usage` segment; `Context <bar> <pct>` is never split. The `row_wrapped` join built to defend against it was deleted — it manufactured the wrong-number failure it was meant to prevent.
- **Truncation is the real hazard.** Overflow truncates with `…`: at cols=20 a true 100% renders `Context ████ 10…`, so a regex without a trailing `%` returns **10**. Requiring the literal `%` fails closed, because truncation eats the `%` before it finishes eating digits.
- **The context row survives a clean `/exit` and a crash**, and PTY EOF never arrives (Windows ConPTY keeps the read handle readable while anyone holds the master). A frozen grid passes every prose defence — those separate prose from statusline, none separate live from dead. Hence the liveness gate.
- **`portable_pty::Child::wait()` returns ~14 ms before the child is really gone** (`TerminateProcess` is async; `wait()` short-circuits through `GetExitCodeProcess`, which reads the code the moment termination starts). AC's own oracle is stricter than portable-pty's `wait()` — #942's argument arriving from the other side. Harness race, not a product bug; verified as a race and not a permanent disagreement before being dismissed.

## Not fixed here

Three documentation defects are committed **deliberately** in revision 4, so the history holds the exact bytes that were certified and implemented: §6.5's stale `PtyManager` row (a revision-2 leftover §6.1 orphaned), §9.1.11's `999` fixture (passes with or without the rule it names), and §4.5's claim that ` used` excludes Codex's second `%` (the literal `· Context ` adjacent to the capture does that; ` used` only defends against a *later* `· Context <digits>%`, which no captured row has). Follow-up issue for the revision-5 sweep to come.

The general liveness gap — AC does not observe a local session's natural exit, while the container backend does — is **#1040**, deliberately not blocked on.

## Scope note

`tests/` integration targets were compiled by `--all-targets` but not executed; the frontend suite was not run. The branch contains zero TypeScript and all 24 non-`ac_discovery` files are byte-identical across the merge, so the merged tree's TS is bit-for-bit main's. Non-visual change — no shipper build.
