### PR TITLE
feat(#1033): the CTX badge and its Settings pattern field

### DIFF
--- a/plans/1033-context-badge-sidebar.md
+++ b/plans/1033-context-badge-sidebar.md
@@ -1,0 +1,741 @@
+# Plan Contract: #1033 - the context regex field and the CTX badge (frontend)
+
+**Status: READY_FOR_IMPLEMENTATION**
+**Issue:** #1033, child of epic #1031
+**Branch:** `feature/1033-context-badge-sidebar`, cut from `main` = `d1b4a52dc590bc7428e9969220942a496802d9bc`
+**Revision:** 1, authored and certified in one pass (lite path). Classification re-checked against the stated bar in §10.2 and it holds.
+
+> **#1032 landed and is invisible.** It emits `session_context` and nobody listens. Every byte of this issue is TypeScript, CSS and one placeholder helper. `dev-webpage-ui` implements it and owns every file under `src/`.
+>
+> **Three of the "copy this" instructions are traps: followed faithfully, each ships a defect.** None is visible by reading the code, and each is refuted below by a probe rather than an argument.
+>
+> 1. **Copy the #529 normalizer** (`settings-save.ts:15-20`): its `.trim()` deletes a pattern's leading whitespace, which is the column-2 anchor. The badge **fails open** and every normal case keeps working (§2.6).
+> 2. **Copy the #529 placeholder and hint**: there, blank means "use the default shown". Here, **blank means the feature is off**, and there is no fallback pattern anywhere in the backend (§2.7).
+> 3. **"Mirror the #882 path exactly"**: #882's value rides on `Session` from the backend. This one does not, and the engine emits **only on change**, so a listener alone leaves a reloaded sidebar reading `CTX N/A` **forever** (§2.3, §4.4). This is the one I would have shipped.
+>
+> A fourth is not a trap but a gap: the pattern #1032 tells me to ship verbatim is **correct** and **cannot be typed on a keyboard** (§2.8).
+
+---
+
+## 1. Issue and objective
+
+Give the user the reading #1032 already produces:
+
+1. A per-agent **context regex** field in Settings, Coding Agents, so the scrape can be configured at all.
+2. A **`CTX N%`** badge on the sidebar's coding-agent sessions, so the reading is visible.
+
+**The percentage is a signal for a human. It never drives an action.** No click target, no threshold, no PTY write, ever.
+
+---
+
+## 2. Evidence and current-state gap
+
+Everything below was verified by me against `d1b4a52`. Where I ran a probe, the probe is named and its output is quoted.
+
+### 2.1 The backend contract is frozen, shipped, and verified by hash
+
+```
+git cat-file blob main:plans/1032-context-scrape-vt100-mirror.md | sha256sum
+→ 3f415ffe8aeb4ad298fa2ef0509c705a1bc6d54abcab20e7bbb4e47e3327cd11
+```
+
+Matches the tech-lead's certification hash. `plans/1032…md` §5.5 is normative for this plan and I make no contract decisions.
+
+Verified on `main`, in the source, not quoted from the issue:
+
+| Piece | Location at `d1b4a52` |
+|---|---|
+| `AgentConfig.context_regex: Option<String>`, `#[serde(default, skip_serializing_if = "Option::is_none")]` | `config/settings.rs:79-80` |
+| `ContextUsagePayload { session_id, percent: Option<u8> }`, **no `skip_serializing_if` on `percent`** (comment `:73-76` says why) | `pty/context_scrape/mod.rs:69-78` |
+| Event `session_context`, emitted through `ScraperSink` | `lib.rs:456` |
+| Command `get_session_context(app, session_id) -> Result<Option<u8>, String>` | `commands/pty.rs:457-463` |
+| Command registered | `lib.rs:2174` |
+| `last_reading` = `entry.last_emitted`, *"`None` covers both 'no reading' and 'not registered', which are the same thing to the badge"* | `mod.rs:195-203` |
+| `SAMPLE_INTERVAL` = **5s** | `mod.rs:26` |
+| Pattern compile: Rust `regex` 1.12.3, 1 MiB size limit, **capture group 1 mandatory** (`captures_len() < 2` rejects) | `pty/context_scrape/pattern.rs:36-54` |
+
+**The frontend surface is empty.** `git grep -nE "session_context|sessionContext|contextRegex|getSessionContext|onSessionContext|context_regex" -- src/` returns **exit 1, zero lines**. All of it is mine.
+
+#### 2.1.1 An instrument warning for whoever works this branch next
+
+**Plain `grep -r` in this environment is wrapped and lies by omission.** It summarises (`121 matches in 16 files`), truncates, and dropped the line I was looking for; `grep -rnF 'emit("session_context"' src-tauri/src/` returned **nothing** while `git grep -nF` returned `lib.rs:456`. Same worktree, same second. Every enumeration in this plan was taken with `git grep` or a direct read. Do not verify anything here with bare `grep`.
+
+### 2.2 The issue's coordinates are stale, and #1028 is why (re-anchored)
+
+I re-anchored every coordinate. The drift is real, but **its cause is not what the dispatch says, and the difference matters for whoever re-reads #1031 next.**
+
+The dispatch says #1031's family "cites `4acadfe` in its Provenance but the refs were recycled from a memo at `f123b03`, 130 commits stale". For **this** issue's most load-bearing coordinate that is **not** what happened. Measured, by reading `types.ts` out of each commit:
+
+| SHA | `export interface Session` | `agentId` |
+|---|---|---|
+| `f123b03` (the memo) | `:17` | `:31` |
+| **`4acadfe`** (the SHA #1031 claims) | `:32` | **`:46`** |
+| `57b1f13` (#1028) | `:70` | **`:84`** |
+| `d1b4a52` (this branch) | `:70` | `:84` |
+
+**The issue's `types.ts:46-53` was exactly right at the `4acadfe` it cites.** It was not recycled from `f123b03`, where the same field sits at `:31`. **#1028 invalidated it afterwards**, adding 38 lines above `Session` (`RepoDirtyByPath`, `:40-58`, among them).
+
+So the failure mode here is an issue that aged, not an issue that lied, and the remedy is the same either way: re-anchor against `d1b4a52`, which is what the table below does. I am recording the correction because "the refs are recycled and 130 commits stale" invites the next reader to distrust every #1031 coordinate on principle, and at least this one was accurate when written.
+
+| The issue / epic says | Actually at `d1b4a52` | Note |
+|---|---|---|
+| `types.ts:46-53` (`Session.agentId`/`agentLabel`) | **`types.ts:84-85`**, `Session` spans **`:70-98`** | drifted 38 lines |
+| `SettingsModal.tsx:2190-2202` (#529 input) | **holds exactly**, hint at `:2203-2206` | |
+| `SettingsModal.tsx:433` `agentList()`, `:560` `setSettings`, `:651` profiles | **all hold** | |
+| `settings-save.ts:16-21` (normalizer) | fn is **`:15-20`**; applied in the chain at **`:95-98`** | off by one |
+| `session-status.ts:12-15` / `:16-31` | **holds exactly** | |
+| `ipc.ts:762-773` (`onSessionIdle`/`Busy`) | **`:767-777`** | |
+| `App.tsx:654-665` (listeners) | **holds exactly** | |
+| `sessions.ts:357-370` (`setSessionWaiting`) | **holds exactly** | |
+| `SessionItem.tsx:369-389` (badge slot), `:45-49` (resolver) | **both hold exactly** | |
+| `SettingsModal.tsx` / `settings-save.ts` paths | **`src/sidebar/components/…`**, not `src/components/…` | the issue omits the dir |
+
+The three render sites, re-anchored: **`SessionItem.tsx:373`** (`agent-badge`) and **`:383`** (`profile-badge`); **`RootAgentBanner.tsx:407`**; **`ProjectPanel.tsx:2686`**.
+
+### 2.3 **TRAP 3 (header).** The event is emit-on-change, so a listener alone is **not** sufficient
+
+This is the single most important fact in this plan and it is not in the issue.
+
+`mod.rs:190` registers a session with `last_emitted: None`, and #1032's §4.1.1 gate emits only `if reading != last_emitted`. **A session already sitting at 42% emits nothing more until it changes.** A sidebar that starts listening after that point hears silence and renders `CTX N/A` **indefinitely**, while the terminal plainly shows 42%.
+
+`App.tsx`'s `onMount` awaits settings (`:537`), a repo search (`:565`) and the session list (`:576`) before it reaches the listener block at `:654`. The scraper starts in `setup` at `lib.rs:696` and ticks every 5s regardless.
+
+**So `get_session_context` is mandatory, not an optimisation.** #1032 shipped it for exactly this and said so (`mod.rs:195-196`: *"for the snapshot command"*). The ordering rule is §4.4.
+
+### 2.4 `setSessions` is a wholesale replace, and it has exactly one production caller
+
+`sessions.ts:318-320` is a bare `setState("sessions", sessions)`. No field preservation. `setProfileOutdated`'s comment (`:385-387`) warns about precisely this: *"never use setSessions for this (a wholesale replace would reset the frontend-only pendingReview field)"*.
+
+Production callers of `setSessions`: **`App.tsx:577` only** (once, at mount). Everything else is a test or `ui-harness.tsx:240`. So the wipe is real but it happens **before** the `:654` listener block, which is why the #882 path never noticed it. §4.2 sidesteps it entirely rather than relying on that ordering.
+
+### 2.5 The store already has the exact shape this needs
+
+`SessionsState.lastActivityBySessionId: Record<string, number>` (`types.ts:833`), initialised `{}` (`sessions.ts:26`), getter `:439-441`, setter `markActivity` `:506-508` (`setState("lastActivityBySessionId", (prev) => ({ ...prev, [sessionId]: performance.now() }))`), read in `ProjectPanel.tsx:2125`.
+
+A **session-id-keyed, frontend-only, event-fed map on `SessionsState`, structurally immune to `setSessions`.** That is this feature, exactly. §4.2 copies it.
+
+The miss-versus-null question it raises is also already answered in this codebase: `RepoDirtyByPath` (`types.ts:40-58`, #1028) documents a missing key and an explicit `null` collapsing to one rendering **by design**. §4.2 copies that discipline and its comment style.
+
+### 2.6 **TRAP 1 (header).** Copying the #529 normalizer fails the badge OPEN. Measured
+
+`normalizeAgentInstructionsFilename` (`settings-save.ts:15-20`) does `agent.instructionsFilename?.trim()` and **persists the trimmed value**. For a filename that is correct. For a regex it is destructive: **leading whitespace is load-bearing in a pattern.** A user who writes the column-2 anchor as two literal spaces rather than `^ {2}` has that anchor silently deleted at save.
+
+Probe (`rxp`, real `regex` 1.12.3, real 1 MiB limit):
+
+```
+stored  = "  Context [░█]+ (\\d{1,3})%"
+trimmed = "Context [░█]+ (\\d{1,3})%"     <-- what a copied #529 normalizer persists
+
+  real statusline (truth=0)     stored -> Some(0)    trimmed -> Some(0)
+  ATTACK: typed in input box    stored -> None       trimmed -> Some(99)
+```
+
+The normal case keeps working, so nothing looks broken. The typed-in-box attack of #1032's §2.11.3 goes from **rejected to accepted**. This is the failure mode the epic calls unshippable, introduced by faithfully following the instruction to copy the template.
+
+**Decided: the `contextRegex` normalizer drops empty-or-whitespace and stores every kept value BYTE-FOR-BYTE, untrimmed.** A deliberate, stated divergence from `instructionsFilename`, `configSeed.dest` and `backend.image`, all three of which trim. The "no sentinel" half of the contract is unaffected.
+
+### 2.7 **TRAP 2 (header).** The #529 placeholder and hint semantics invert here
+
+The template pairs `placeholder={defaultInstructionsFilename(agent.command)}` (`:2198`) with the hint *"Leave blank to use the default shown"* (`:2203-2206`). That is true there: the backend really does fall back to the derived default.
+
+**Here, blank means the feature is OFF.** `mod.rs`'s table: never configured, forever, emits nothing. There is no fallback pattern anywhere in the backend. A hint saying "leave blank to use the default shown" would be a plain lie, and it is the sentence the implementer is most likely to copy along with the markup.
+
+**Decided: keep a placeholder (it is the only in-product example of the shape), and write the hint fresh.** §5.4 fixes the copy verbatim.
+
+### 2.8 **GAP (not a trap: the instruction is right).** The pattern this plan ships cannot be typed, and weakening it is measurably worse
+
+§4.5 of #1032 records the Claude pattern as `^ {2}Context [░█]+ (\d{1,3})%`. `░` is U+2591 and `█` is U+2588. **Neither is on a keyboard.** With the field as the only affordance, the feature is unconfigurable for Claude, which is the agent the user asked for.
+
+The obvious escape is a typeable character class. Measured, same rig:
+
+| Row | `[░█]+` (#1032 §4.5, verbatim) | `\S+` (typeable) |
+|---|---|---|
+| `  Context ░░░░░░░░░░ 0% │ Usage █░░░░░░░░░ 8% (resets in 3h 22m)` | `Some(0)` | `Some(0)` |
+| `  Context ░░░░ 0%` (cols=40) | `Some(0)` | `Some(0)` |
+| `  Context ████ 10…` (truncated at 100) | `None` | `None` |
+| `❯ The row says Context ██████████ 99% right now` | `None` | `None` |
+| `  Context left until auto-compact: 15%` (stock Claude) | `None` | `None` |
+| **`  Context is 42% of the budget`** (prose at column 2) | **`None`** | **`Some(42)`** |
+
+**The glyph class is load-bearing and the dispatch is right to ship the pattern verbatim.** It rejects a word-shaped bar; `\S+` accepts one. So the typeability problem must be solved with an affordance, not by relaxing the pattern.
+
+**Decided: a "Use suggested pattern" button** (§5.4), filling the field from a command-keyed helper. ~8 LOC on the `settings-add-btn` precedent (`SettingsModal.tsx:1890-1897`).
+
+### 2.9 Client-side regex validation is wrong in **both** directions. Measured
+
+`handleSave` has a validation gate (`currentValidationError()`, `SettingsModal.tsx:1120`), so "validate the regex before saving" is the natural next thought. It cannot be done in JavaScript. `RegExp` and Rust's `regex` are different grammars, and I measured both sides rather than asserting it:
+
+| Pattern | JS `new RegExp` | Rust `regex` 1.12.3 |
+|---|---|---|
+| `^ {2}Context [░█]+ (\d{1,3})%` | accepts | accepts, `captures_len=2` |
+| `^ {2}.*· Context (\d{1,3})% used` | accepts | accepts, `captures_len=2` |
+| `(?P<pct>\d{1,3})` | **SyntaxError** | **accepts** |
+| `(?=.*Context)(\d+)` | accepts | **rejects** (parse error) |
+| `(a)\1` | accepts | **rejects** (parse error) |
+
+A JS gate would **block** valid patterns and **pass** invalid ones. Either behaviour is worse than none.
+
+**Decided: #1033 ships no regex validation.** An unusable pattern renders `CTX N/A` and its reason reaches `app.log` only, exactly as #1032 §5.5 froze (*"I pasted a regex and nothing happened"*). Surfacing real compile errors needs a backend command; that is a separate issue and this plan does not block it (§10.3).
+
+Both shipped patterns compile with `captures_len=2`, so they clear `pattern.rs:44`'s mandatory-capture gate. Verified, not assumed.
+
+### 2.10 #1043 is right about the Codex pattern's stated reason, and the real reason is sharper
+
+#1032 §4.5 says ` used` is what excludes the row's second percentage (`weekly 83% left`). Measured against `  Ready · Context 0% used · weekly 83% left`:
+
+| Pattern | Result |
+|---|---|
+| `^ {2}.*· Context (\d{1,3})% used` (shipped) | `Some(0)` |
+| `^ {2}.*· Context (\d{1,3})%` (` used` removed) | `Some(0)` |
+| `^ {2}.*(\d{1,3})% used` (`· Context ` removed) | `Some(0)` |
+| **`^ {2}.*(\d{1,3})%` (both removed)** | **`Some(3)`** |
+
+On the real row **either literal alone pins the capture**; ` used` is not what excludes `weekly 83%`. Strip both and greedy `.*` slides to the last `%` and captures **`3`** out of `83`: a wrong number, not a miss. And on a reordered row (`Context 0% left · weekly 83% used`) the shipped pattern returns `None` while dropping ` used` returns the correct `Some(0)`, so ` used` is the more brittle of the two.
+
+**The transferable rule, and the reason this plan does not let anyone invent a pattern: a literal adjacent to the capture is what pins where the capture lands.** The patterns ship verbatim; §5.4's copy states this reason and not #1032 §4.5's.
+
+### 2.11 The a11y requirements do not survive contact with the surface
+
+- **`prefers-reduced-motion` occurs in zero CSS files** (`git grep -n "prefers-reduced-motion" -- "*.css"` is empty). "Honour reduced motion" presumes an animation. §4.6 ships none, which satisfies it by construction rather than by a media query for an animation that does not exist.
+- **`role="meter"` requires `aria-valuenow`.** There is no valid `aria-valuenow` for `N/A`. A meter with no value is invalid ARIA, so the unavailable state **must not be a meter** (§4.5). The only `aria-value*` precedent in the repo is `main/App.tsx:250-265` (`role="separator"` plus the `data-ac-testid`/`data-ac-role`/`data-ac-state` trio), and §5.3 follows its shape.
+- **A live region here would be an accessibility defect, not a feature.** The value refreshes on a 5s cadence (`mod.rs:26`); an `aria-live` badge would interrupt a screen reader roughly every 5 seconds, forever, with a number that drives nothing. §4.6 ships no live region. The issue's "live regions only on significant transitions" is honoured by there being no significant transition to announce (§4.6 ships no thresholds).
+
+### 2.12 The gap
+
+Nothing in `src/` knows the feature exists.
+
+---
+
+## 3. Scope
+
+### In
+
+1. `contextRegex?: string` on the TS `AgentConfig`, plus its input, suggest button, hint and save-time normalizer.
+2. `suggestedContextRegex(command)` and the two pattern constants.
+3. The IPC surface: `SessionContextPayload`, `onSessionContext`, `PtyAPI.getSessionContext`.
+4. `contextPercentBySessionId` on `SessionsState`, its setter, its hydrate-if-absent seeder, and its getter.
+5. The `App.tsx` listener plus the mount-time hydration (§4.4).
+6. `session-context.ts` (pure projection) and `ContextBadge.tsx` (shared markup), wired into the three sites.
+7. One CSS block.
+
+### Out
+
+- **Any backend change.** The contract is frozen (§2.1). If this plan seems to need one, stop and report; it does not.
+- **Regex validation and compile-error surfacing** (§2.9, §10.3).
+- **Threshold styling and any threshold at all** (§4.6).
+- **The terminal window's `StatusBar.tsx`.** Separate Tauri window, own store, second listener path. Not free. Decide separately.
+- **Cross-project / `.ac/project-settings.json`:** #1034.
+- Notifications, toasts, gauges, history graphs, hiding/filtering configs.
+
+---
+
+## 4. The decided solution
+
+### 4.1 Shape
+
+```
+lib.rs:456  emit "session_context" {sessionId, percent: number|null}
+  → onSessionContext(cb)                     src/shared/ipc.ts   [new, beside onSessionIdle]
+  → listener in onMount, pushed to unlisteners   src/sidebar/App.tsx
+  → sessionsStore.setSessionContext(id, percent)
+  → state.contextPercentBySessionId[id]
+  → contextBadgeText(percent)                session-context.ts  [pure projection]
+  → <ContextBadge percent testId />          ContextBadge.tsx    [shared markup]
+  → SessionItem · ProjectPanel · RootAgentBanner
+
+commands/pty.rs:457  get_session_context
+  → PtyAPI.getSessionContext(id)             src/shared/ipc.ts   [new, beside getScreenSnapshot]
+  → mount-time hydrate, AFTER the listener, never clobbering it  (§4.4)
+```
+
+### 4.2 State lives in a session-keyed map, not on `Session`
+
+**Decided: `contextPercentBySessionId: Record<string, number | null>` on `SessionsState`.** Exact precedent §2.5.
+
+Rejected: a field on `Session`. `Session` mirrors a Rust struct field-for-field, and #1032 deliberately did **not** put `percent` there. A TS-only field on it would make the interface lie about the wire, and it would sit in the blast radius of `setSessions`'s wholesale replace (§2.4). The map has neither problem and is already the house style for this exact case.
+
+**Two absent-ish states, one rendering, stated the way `RepoDirtyByPath` states it:**
+
+| Store state | Means | Renders |
+|---|---|---|
+| key missing | no event yet, and no snapshot yet | `CTX N/A` |
+| `null` | the engine says unavailable | `CTX N/A` |
+| `0` | **a real reading of zero** | `CTX 0%` |
+
+`0` is a third, distinct value and must survive the trip. **A `??`-to-`||` slip turns a true `0%` into `N/A` and is invisible on screen.** §9 pins it.
+
+**This does not reintroduce the third state #1032 §5.5 forbids.** That rule governs the **payload type**, which is `percent: number | null` and never `percent?: number` (§5.1). At the store layer, missing and `null` collapse to one rendering, so "unavailable is exactly one thing" holds where the user can see it.
+
+### 4.3 The badge is a shared component, not three copies
+
+`ProfileOutdatedBadge.tsx` is the precedent and it is exact, down to the problem: *"Shared by SessionItem, the ProjectPanel replica rows, and RootAgentBanner so the badge looks and behaves identically everywhere a coding-agent session can drift"*, with a `testId?: string` prop because each surface names itself. `ContextBadge.tsx` copies that shape. Triplicating the ARIA markup across three files is how the three drift.
+
+The projection stays in its own pure module (`session-context.ts`), mirroring `session-status.ts`, so §9 can assert totality without rendering anything.
+
+### 4.4 Hydration: listener first, then hydrate, never clobber
+
+§2.3 makes hydration mandatory. The order is not free:
+
+- **Hydrate then listen** loses any event landing in the gap. An event only fires on change, so "lost" means wrong until the *next* change, which may be never.
+- **Listen then hydrate, unconditionally** lets a slow `await` resolve with a stale snapshot **after** a fresher event already landed, and overwrite it.
+
+**Decided: register the listener first; then hydrate only sessions whose key is absent.**
+
+```ts
+unlisteners.push(
+  await onSessionContext(({ sessionId, percent }) => {
+    sessionsStore.setSessionContext(sessionId, percent);
+  })
+);
+
+// #1033 - snapshot-seed every agent session no event has spoken for yet. The engine
+// emits ONLY on change (pty/context_scrape/mod.rs), so a session already sitting at a
+// value when this window mounted will never send one, and a listener alone leaves it
+// reading N/A forever. Registered AFTER the listener, and hydrateSessionContext is a
+// no-op on an existing key, so a slow invoke cannot overwrite a fresher event.
+// Absent-key check, never a truthiness check: a hydrated `null` and a hydrated `0`
+// are both answers. try/catch mirrors the repo-search fan-out at :564-567 so one
+// rejected invoke cannot abort the rest of onMount.
+try {
+  await Promise.all(
+    sessionsStore.sessions
+      .filter((s) => s.agentId)
+      .map(async (s) => {
+        sessionsStore.hydrateSessionContext(s.id, await PtyAPI.getSessionContext(s.id));
+      })
+  );
+} catch {}
+```
+
+`hydrateSessionContext` is a no-op when the key exists. It is the only thing standing between the user and a permanent `N/A` on a window reload.
+
+**`Promise.all`, not a sequential `for`/`await`:** the fan-out is one map lookup per session behind an IPC hop (`commands/pty.rs:457-463`), and it sits at the tail of an `onMount` that has already awaited settings, a repo search and the session list. Serialising it buys nothing and delays the first paint of every badge by the sum of the round-trips. **The `try` wraps the whole `Promise.all`,** so one rejected invoke costs the batch its unsettled hydrations, not `onMount`; every session it misses still shows `CTX N/A` and self-corrects on its next change. That is the same trade `:564-567` already makes for repos.
+
+**Placement: inside the existing `onMount`, after the `:654-665` listener block.** Sessions are already loaded at `:577`. Sessions with `agentId === null` (plain shells) are never registered by the backend and are skipped here, so the fan-out is bounded by agent sessions.
+
+### 4.5 Markup: the meter only exists when there is a value
+
+`role="meter"` requires `aria-valuenow` (§2.11), so the two states are structurally different elements, not one element with a nullable attribute:
+
+| State | Element |
+|---|---|
+| `percent` is a number | `<span class="ctx-badge" role="meter" aria-valuenow={p} aria-valuemin={0} aria-valuemax={100} aria-valuetext={`Context ${p}% used`} aria-label="Context window used">` |
+| `null` or missing | `<span class="ctx-badge unavailable">` with **no** `role`, **no** `aria-value*` |
+
+Both carry the same `title` (§5.5's tooltip constant), the same `data-ac-testid`, `data-ac-role="status"`, and `data-ac-state` of `"reading"` or `"unavailable"`.
+
+### 4.6 No thresholds, no colour semantics, no animation, no live region
+
+**Decided: the badge is inert text.**
+
+The issue permits threshold styling under constraints; it does not require it. I am shipping none, and the reason is not minimalism:
+
+- **AC has no basis for a number.** The epic states the reading is *"one rounded integer, unknown denominator"*, with `context_window_size` unavailable to a scrape. Any threshold I pick is invented, and §10.4 of #1032 is a six-entry record of what inventing costs here.
+- It makes "do not depend on colour alone" true by construction (there is no colour).
+- It makes "honour reduced motion" true by construction (there is no motion, and no CSS file in the repo has ever needed the query).
+- It makes "live regions only on significant transitions" true by construction (no transition is significant, and a 5s live region is an active defect, §2.11).
+
+If the user wants a reminder level later, it is a clean follow-up: one class, one CSS block, and a threshold **the user chooses**, labelled an AgentsCommander reminder level.
+
+### 4.7 The ProjectPanel search-text invariant gets a stated exception
+
+`ProjectPanel.tsx:1118-1125` (#733/#515) documents a real invariant: *"a badge that is visible is always matchable"* by the sidebar filter, so the row render and `replicaSearchText` (`:1142`) cannot diverge. Repo badges honour it (`sessionRepoSearchText`, `:1108-1111`).
+
+**Decided: `CTX` is NOT added to `replicaSearchText`, and this is an exception, not an oversight.** Every other badge in that row is stable identity (agent label, profile letter, repo/branch). This one changes every 5 seconds. Making it matchable would make a filtered list **add and drop rows on its own**, with no user input, as numbers tick. The invariant protects discoverability of identity; a volatile gauge is not identity.
+
+---
+
+## 5. Affected surfaces
+
+### 5.1 `src/shared/types.ts`
+
+| Where | Change |
+|---|---|
+| `AgentConfig`, after `backend?` at **`:225`** | `contextRegex?: string;` plus a doc comment: best-effort recognition pattern, **absent means the badge is off** (no fallback default, unlike `instructionsFilename`), stored verbatim and never trimmed (§2.6), Rust-`regex` grammar and not JS (§2.9). Mirrors Rust field order (`settings.rs:79-80`, before `backend`) |
+| new, beside the `Session` types | `export interface SessionContextPayload { sessionId: string; percent: number \| null }`. **`percent: number \| null`, never `percent?: number`** (§5.5 of #1032, load-bearing; `mod.rs:73-76` is the reason) |
+| `SessionsState`, after `lastActivityBySessionId` at **`:833`** | `contextPercentBySessionId: Record<string, number \| null>;` plus the §4.2 miss/null/`0` comment in `RepoDirtyByPath`'s style (`:40-58`) |
+
+### 5.2 `src/shared/ipc.ts`
+
+| Where | Change |
+|---|---|
+| `PtyAPI`, after `getScreenSnapshot` at **`:275-276`** | `getSessionContext: (sessionId: string) => transport.invoke<number \| null>("get_session_context", { sessionId }),` |
+| after `onSessionBusy` at **`:773-777`** | `export function onSessionContext(callback: (data: SessionContextPayload) => void): Promise<UnlistenFn> { return transport.listen<SessionContextPayload>("session_context", callback); }` |
+
+### 5.3 New files
+
+| File | Contents |
+|---|---|
+| `src/sidebar/components/session-context.ts` | **Two exports.** (1) `contextBadgeConfigured(agents, agentId): boolean`, the one visibility gate for all three surfaces (§5.8). (2) `contextBadgeText(percent: number \| null \| undefined): string` → `` `CTX ${percent}%` `` or `"CTX N/A"`. **Pure. Total.** Doc comment mirroring `session-status.ts:12-15`: editing a value here changes pixels only; no behavior reads it. State plainly that it is deliberately **not** injective (`null` and `undefined` both map to `CTX N/A`, because unavailable is exactly one thing), and that the `percent === null \|\| percent === undefined` test is deliberate: `0` is a real reading (§4.2) |
+| `src/sidebar/components/ContextBadge.tsx` | `Component<{ percent: number \| null \| undefined; testId?: string }>`, default export, §4.5's two elements. Docstring modelled on `ProfileOutdatedBadge.tsx`: cite #1033, name the three sharing surfaces, and say the badge is a signal and never a control (no `onClick`, no `<button>`, ever) |
+
+### 5.4 `src/sidebar/components/SettingsModal.tsx` and its helpers
+
+| Where | Change |
+|---|---|
+| `src/shared/profile-utils.ts`, after `defaultInstructionsFilename` at **`:499-505`** | Two exported constants and `suggestedContextRegex(command: string): string \| null`, reusing `executableTokenBasename` (`:452`) exactly as `defaultInstructionsFilename` does. **Returns `null` for anything that is not Claude or Codex** (see below) |
+| `SettingsModal.tsx:33` | add `suggestedContextRegex` to the existing `profile-utils` import |
+| `SettingsModal.tsx`, after the hint at **`:2206`** | the field, the suggest button, the hint (copy below) |
+| `settings-save.ts`, beside the other normalizers (**`:15-60`**) | `normalizeAgentContextRegex`, **which does not trim** (§2.6) |
+| `settings-save.ts:98` | add `.map(normalizeAgentContextRegex)` to the chain |
+
+**The two constants, verbatim from #1032 §4.5 (do not edit, do not re-derive):**
+
+```ts
+export const CLAUDE_CONTEXT_REGEX = String.raw`^ {2}Context [░█]+ (\d{1,3})%`;
+export const CODEX_CONTEXT_REGEX = String.raw`^ {2}.*· Context (\d{1,3})% used`;
+```
+
+**`suggestedContextRegex` returns `null` for Gemini and everything else, and that is a deliberate divergence** from `defaultInstructionsFilename`, which falls back to `"AGENTS.md"`. A filename fallback that is wrong costs a renamed file. A *pattern* fallback that is wrong costs a silently wrong percentage. #1032's capture covered `claude.exe` 2.1.212 and `codex.exe` 0.144.4 and nothing else; there is no evidence for a Gemini row, so no guess ships. No suggestion means the button does not render; the field still accepts anything the user types.
+
+**The normalizer, and the one line that matters:**
+
+```ts
+/**
+ * #1033 - normalize the optional context regex. Mirrors
+ * normalizeAgentInstructionsFilename's CONTRACT (drop the key rather than persist
+ * an empty-string sentinel, since Rust's skip_serializing_if = "Option::is_none"
+ * does not omit Some("")) but deliberately NOT its trim.
+ *
+ * A regex's leading whitespace is load-bearing: a user who writes the column-2
+ * anchor as two literal spaces instead of `^ {2}` has it silently deleted by a
+ * trim, and the pattern then matches agent prose anywhere on the row. Measured
+ * against regex 1.12.3: trimming turns the typed-in-the-input-box false positive
+ * from None into Some(99) while the real statusline keeps reading correctly, so
+ * the damage is invisible in every normal case. Whitespace-only is still dropped
+ * (it cannot compile: no capture group), so the sentinel rule is unaffected.
+ */
+function normalizeAgentContextRegex(agent: AgentConfig): AgentConfig {
+  if (agent.contextRegex && agent.contextRegex.trim()) return agent; // kept BYTE-FOR-BYTE
+  const { contextRegex: _drop, ...rest } = agent;
+  return rest;
+}
+```
+
+**The markup**, on the `:2190-2202` template plus the `settings-add-btn` precedent (`:1890-1897`):
+
+```tsx
+<label class="settings-field">
+  <span class="settings-label">Context badge pattern</span>
+  <input
+    class="settings-input"
+    value={agent.contextRegex ?? ""}
+    onInput={(e) => updateAgent(i(), "contextRegex", e.currentTarget.value)}
+    placeholder={suggestedContextRegex(agent.command) ?? ""}
+    data-ac-testid={`settings.agentRow.${i()}.contextRegex`}
+    data-ac-role="textbox"
+    spellcheck={false}
+  />
+</label>
+<Show when={suggestedContextRegex(agent.command)}>
+  {(suggested) => (
+    <button
+      class="settings-add-btn"
+      onClick={() => updateAgent(i(), "contextRegex", suggested())}
+      data-ac-testid={`settings.agentRow.${i()}.contextRegex.suggest`}
+      data-ac-role="button"
+    >
+      Use suggested pattern
+    </button>
+  )}
+</Show>
+<div class="settings-hint">
+  Best-effort pattern AC runs over what this agent draws in its terminal, to show
+  a CTX badge on its sessions. Capture group 1 is the percentage. The reading can
+  be unavailable, stale or absent, and a high one does not mean the session needs
+  restarting. <strong>Leave blank for no badge.</strong>
+</div>
+```
+
+**Copy rules the implementer may not quietly "improve":**
+
+- **No "leave blank to use the default shown".** Blank is off (§2.7).
+- **The button exists because the suggested pattern contains `░` and `█`, which cannot be typed** (§2.8). Do not delete it as decoration, and do not "simplify" the pattern to typeable characters: `\S+` reads `  Context is 42% of the budget` as `Some(42)`, measured.
+- **No threshold, no limit, no Anthropic wording** anywhere in this copy.
+- `updateAgent`'s signature is `(index, field: keyof AgentConfig, value)` (`:553-557`); the new field widens `keyof AgentConfig` automatically. Keying by **row index** here is correct and is not the thing #1031 warns about: the warning is against keying by `command`, and `"command": "claude"` matching two agents is exactly why `suggestedContextRegex(agent.command)` is fine (a many-to-one **default** lookup, explicitly legitimate) while the stored value stays per-row.
+
+### 5.5 The badge tooltip, shared by both states
+
+```
+Context window in use, read from what the agent draws in its terminal.
+Best-effort: it can be unavailable, stale or absent. A high reading does not
+mean this session must be restarted.
+```
+
+Lives as one exported constant in `ContextBadge.tsx`. It is the accessible tooltip the issue requires and it is the only place the honesty requirement is user-visible, so it is not optional.
+
+### 5.6 `src/sidebar/stores/sessions.ts`
+
+| Where | Change |
+|---|---|
+| `:26`, after `lastActivityBySessionId: {}` | `contextPercentBySessionId: {},` |
+| beside the `:439-441` getter | `get contextPercentBySessionId() { return state.contextPercentBySessionId; }` |
+| beside `markActivity` (`:506-508`) | `setSessionContext(sessionId, percent)` and `hydrateSessionContext(sessionId, percent)` (§4.4; the latter returns early when the key exists) |
+
+Neither setter touches `state.sessions`, so `setProfileOutdated`'s #592 warning (`:385-387`) does not apply and `setSessions` cannot reach them.
+
+### 5.7 `src/sidebar/App.tsx`
+
+| Where | Change |
+|---|---|
+| `:22-23` import block | add `onSessionContext` |
+| after the `:654-665` listener block | §4.4's listener and hydration loop, `unlisteners.push(...)` exactly as its neighbours do |
+
+### 5.8 The three render sites
+
+| File:line at `d1b4a52` | Change |
+|---|---|
+| `SessionItem.tsx`, after `profile-badge` at **`:389`** | `<Show when={ctxVisible()}><ContextBadge percent={ctxPercent()} testId={`session.${props.session.id}.contextBadge`} /></Show>`. Resolvers go beside `sessionAgentLabel` (`:45-49`), which already reads `settingsStore.current?.agents?.find(a => a.id === props.session.agentId)` (`:48`), so `settingsStore` needs no new import (`:10`) |
+| `RootAgentBanner.tsx`, after `profile-badge` at **`:416`** | same, keyed off `rootSession()` (`:35-37`); `agentLabel()` (`:70-76`) already has the identical lookup |
+| `ProjectPanel.tsx`, after `profile-badge` at **`:2687`** | same, keyed off `session()` (`:2401`). **Do not touch `replicaSearchText`** (§4.7) |
+
+**The visibility gate is ONE shared resolver, not three copies.** It lives in `session-context.ts` (§5.3) and takes its inputs as arguments, exactly as `profileDisplayLabel(cfg, agents, agentId, letter)` does, because the three surfaces reach their session three different ways: `props.session` in `SessionItem`, `rootSession()` in `RootAgentBanner`, `session()` in `ProjectPanel`. A gate written against `props.session` compiles in exactly one of them.
+
+```ts
+// #1033 - no regex configured for this session's agent => no badge at all. Not N/A,
+// not a chip, no visual noise. One resolver for all three surfaces, mirroring #548's
+// rule for the profile tooltip: no second resolver, or the three drift.
+export function contextBadgeConfigured(
+  agents: AgentConfig[] | undefined,
+  agentId: string | null | undefined
+): boolean {
+  if (!agentId) return false;
+  return !!agents?.find((a) => a.id === agentId)?.contextRegex?.trim();
+}
+```
+
+Callers, one line each. `settingsStore.current` is a signal, so a save (which calls `settingsStore.refresh()`, `SettingsModal.tsx:1144`) makes the badge appear or disappear with no reload:
+
+```ts
+// SessionItem.tsx, beside sessionAgentLabel (:45-49)
+const ctxVisible = () => contextBadgeConfigured(settingsStore.current?.agents, props.session.agentId);
+const ctxPercent = () => sessionsStore.contextPercentBySessionId[props.session.id];
+
+// RootAgentBanner.tsx, beside agentLabel (:70-76)
+const ctxVisible = () => contextBadgeConfigured(settingsStore.current?.agents, rootSession()?.agentId);
+const ctxPercent = () => { const r = rootSession(); return r ? sessionsStore.contextPercentBySessionId[r.id] : undefined; };
+
+// ProjectPanel.tsx, beside liveAgentLabel/profileBadge (:2494-2495)
+const ctxVisible = () => contextBadgeConfigured(settingsStore.current?.agents, session()?.agentId);
+const ctxPercent = () => { const s = session(); return s ? sessionsStore.contextPercentBySessionId[s.id] : undefined; };
+```
+
+**The `.trim()` here is a visibility test only and never touches a stored or transmitted value** (§2.6 forbids that). It exists so a legacy file hand-edited to `"contextRegex": "   "` does not show a permanent `N/A`.
+
+**A missing key reads `undefined`, and that is why `ContextBadge` accepts `number | null | undefined`** rather than `number | null`: `contextPercentBySessionId[id]` on an unhydrated session is `undefined`, not `null`, and §5.3's projection collapses both to `CTX N/A` (§4.2).
+
+All three sit inside their surface's existing meta row, so the badge inherits its gates: it is hidden during voice recording (`SessionItem.tsx:367`, `RootAgentBanner.tsx:396`), exactly like `agent-badge` and `profile-badge` are today. That is a pre-existing cosmetic quirk of the row and this plan does not change it.
+
+### 5.9 `src/sidebar/styles/sidebar.css`
+
+One block after `.profile-badge` (**`:745-759`**), copying its shape (`inline-flex`, `min-width`, `padding: 0 5px`, `border-radius: 3px`, `font-size: 9px`, `line-height: 1`, `white-space: nowrap`) with `.ctx-badge` on the neutral `var(--sidebar-border)` / `var(--sidebar-fg-dim)` pair `.agent-badge` (`:729-738`) already uses, and `.ctx-badge.unavailable` at reduced opacity. **No `@keyframes`, no `transition`, no colour that encodes a value** (§4.6). `.session-item-meta` is already `flex-wrap: wrap; gap: 6px` (`:676-683`), so it needs no change.
+
+---
+
+## 6. Required behavior, edge cases, failure behavior
+
+### 6.1 Required
+
+- **`CTX N/A` when there is no reading. Never `0` for unknown.** `0` renders `CTX 0%` because it is a real reading (§4.2, and §6.3 of #1032 pins why the engine cannot tell a true `0%` from claude-hud's null fallback).
+- **The badge is a signal, never a control.** `<span>`, never `<button>`. No `onClick`, no `onKeyDown`, no `tabindex`, no cursor change. Nothing reads the projection.
+- **No regex configured, no badge at all.**
+- **Accept decreases.** No monotonicity, no smoothing, no "Compacting" inferred from a fall or an absence.
+- **The stored pattern is byte-for-byte what the user typed** (§2.6).
+
+### 6.2 Edge cases
+
+| Case | Behavior | Why |
+|---|---|---|
+| No regex configured | **No badge** | §5.8's gate |
+| Regex configured, no event yet | `CTX N/A` | key missing (§4.2) |
+| Engine says unavailable | `CTX N/A` | explicit `null` |
+| Real reading of `0` | **`CTX 0%`** | `0` is a value, not an absence (§4.2) |
+| Reading drops 80 → 12 (post-compact) | `CTX 12%` | decreases accepted |
+| Sidebar window reloads while a session sits at 42% | **`CTX 42%`** | hydration (§4.4); **without it, `N/A` forever** (§2.3) |
+| Snapshot resolves after a fresher event | Event wins | `hydrateSessionContext` no-ops on an existing key (§4.4) |
+| Regex cleared and saved | Badge disappears | engine emits `null` once **and** the gate goes false; both agree |
+| Regex invalid or has no capture group | `CTX N/A`, reason in `app.log` only | §2.9, frozen by §5.5 |
+| Pattern with literal leading spaces | Works | the normalizer does not trim (§2.6) |
+| Two concurrent sessions | Independent | map keyed by session id |
+| Plain shell (`agentId === null`) | No badge, not hydrated | never registered by the backend |
+| Inactive placeholder rows (`id` starts `inactive-`) | No badge | `makeInactiveEntry` (`sessions.ts:57-60`) has no `agentId` |
+| Session ends | Its key is stale but the row is gone | no cleanup needed; bounded by sessions per window lifetime, same as `lastActivityBySessionId` |
+| Voice recording on the row | Whole meta row hides, badge with it | pre-existing (`SessionItem.tsx:367`) |
+| Screen reader | Reads text plus `aria-valuetext`; **never interrupts** | no live region (§2.11) |
+
+### 6.3 Failure behavior
+
+Every failure renders `CTX N/A` and nothing else. A rejected pattern, a dead engine, an unmanaged scraper (`commands/pty.rs:459-461` returns `Ok(None)`), a failed `getSessionContext` (wrap it so a rejected promise cannot break the rest of `onMount`, exactly as `App.tsx:564-567` and `SettingsModal.tsx:1146-1149` already `try {} catch {}` their fan-outs), a session the engine never registered: all indistinguishable, all `N/A`, all harmless.
+
+---
+
+## 7. Compatibility and security impact
+
+### Compatibility
+
+- **No backend change. No IPC breaking change.** The event and command already ship.
+- **Existing settings files load unchanged** and gain no key: `contextRegex` is optional in TS, `#[serde(default, skip_serializing_if)]` in Rust, and the normalizer drops it when unset.
+- **`SettingsModal.automation.test.ts` cannot break on the new row.** Verified: the file selects **only** by `data-ac-testid` and contains no `querySelectorAll`, no `toHaveLength`, no `.length ===`, and no positional or `nth` selector. A new testid is invisible to it. Run it anyway (§8).
+- **`Session` is untouched**, so nothing that consumes `SessionAPI.list()` moves.
+
+### Security
+
+- **The regex is user-supplied and is only ever a regex**, compiled by the already-shipped backend under a 1 MiB limit with no backtracking (`pattern.rs:27-30`). #1033 neither compiles nor executes it.
+- **No agent output reaches the frontend through this path.** The payload is one `u8` or `null`. #1032 deliberately keeps captured text out of `app.log`; this plan keeps it out of the DOM by never receiving any.
+- **The reading is never persisted.** It lives in a store map for the window's lifetime.
+- **`aria-valuetext` and the badge text interpolate a `number`,** never a string from the agent, so there is no injection surface in the tooltip or the meter.
+
+---
+
+## 8. Implementation order
+
+1. **`types.ts`**: `contextRegex`, `SessionContextPayload`, `contextPercentBySessionId`. Inert.
+2. **`ipc.ts`**: `getSessionContext`, `onSessionContext`. Inert.
+3. **`profile-utils.ts`**: the two constants and `suggestedContextRegex`, plus §9.1. **Gate: the constants must be byte-identical to §5.4. Diff them against this plan, do not retype them.**
+4. **`session-context.ts`**: `contextBadgeText`, plus §9.2.
+5. **`settings-save.ts`**: `normalizeAgentContextRegex` and the chain entry, plus §9.3. **Gate: §9.3's untrimmed test must be red if `.trim()` is added to the kept value.**
+6. **`SettingsModal.tsx`**: the field, the button, the hint. **Gate: `SettingsModal.automation.test.ts` green.**
+7. **`sessions.ts`**: the state key, getter, and the two setters, plus §9.4.
+8. **`ContextBadge.tsx`** + **`sidebar.css`**, plus §9.5.
+9. **`App.tsx`** + the three sites, plus §9.6.
+
+Steps 1 to 5 are invisible. The field becomes usable at 6. The badge first appears at 9.
+
+---
+
+## 9. Tests and objective acceptance criteria
+
+**Fixture discipline, inherited and non-negotiable.** Row fixtures are **copied from #1032's capture** (§2.11 of that plan), never hand-written. **No fixture may contain `▓`** (U+2593): it never occurs in the real output, and the issue's own probe fixtures used it and tested fiction. The real glyphs are `░` (U+2591) and `█` (U+2588).
+
+### 9.1 `profile-utils.test.ts`
+
+| Test | Asserts |
+|---|---|
+| `the_claude_suggestion_is_the_captured_pattern` | `suggestedContextRegex("claude")` is byte-identical to `CLAUDE_CONTEXT_REGEX`, and the string **contains `░` and `█` and no `▓`** |
+| `the_codex_suggestion_is_the_captured_pattern` | same for `codex` |
+| `a_docker_wrapped_claude_still_resolves` | a `command` whose basename resolves through `executableTokenBasename` still returns the Claude pattern, mirroring `defaultInstructionsFilename`'s own cases |
+| **`an_unknown_agent_gets_no_suggestion`** | `suggestedContextRegex("gemini")` and `("nonsense")` are **`null`**, not `AGENTS.md`-style fallbacks. **Pins §5.4's deliberate divergence**: a wrong pattern is a wrong number, not a renamed file |
+
+### 9.2 `session-context.test.ts`, pure
+
+| Test | Asserts |
+|---|---|
+| `a_reading_renders_as_a_percentage` | `contextBadgeText(42)` → `"CTX 42%"` |
+| **`zero_is_a_reading_not_an_absence`** | `contextBadgeText(0)` → **`"CTX 0%"`**. The highest-value test in this file: it is the only thing that stays red if anyone writes `percent ? … : "CTX N/A"` |
+| `null_and_undefined_both_render_unavailable` | both → `"CTX N/A"`. Pins that unavailable is exactly one thing |
+| `the_projection_is_total` | every value in `[0, 1, 50, 99, 100, null, undefined]` returns a non-empty string and never throws |
+
+And the visibility gate, in the same file because it is the same module (§5.8):
+
+| Test | Asserts |
+|---|---|
+| `a_configured_agent_is_visible` | `contextBadgeConfigured([{id:"a", contextRegex:"x", …}], "a")` → `true` |
+| `an_agent_with_no_regex_is_not_visible` | same agent without `contextRegex` → `false` |
+| **`a_whitespace_only_regex_is_not_visible`** | `contextRegex: "   "` → `false`. The hand-edited-file case (§5.8); without it that agent shows a permanent `N/A` |
+| `a_null_agentId_is_not_visible` | `contextBadgeConfigured(agents, null)` → `false`. Plain shells |
+| `an_unknown_agentId_is_not_visible` | an id absent from `agents` → `false`, no throw |
+| **`the_gate_keys_by_id_and_not_by_command`** | two agents sharing `command: "claude"`, only one with a `contextRegex` → `true` for that id, **`false` for the other**. Pins #1031's hard rule at the only place #1033 could break it |
+
+### 9.3 `settings-save.test.ts`
+
+| Test | Asserts |
+|---|---|
+| `a_set_pattern_round_trips` | a normal pattern survives the merge unchanged |
+| **`a_pattern_with_literal_leading_spaces_is_not_trimmed`** | `"  Context [░█]+ (\d{1,3})%"` persists **byte-for-byte**, leading spaces intact. **Red the moment anyone copies #529's `.trim()`.** The single most important test in this plan (§2.6) |
+| `an_empty_pattern_is_dropped_not_persisted_as_a_sentinel` | `contextRegex: ""` → the key is **absent** from the merged agent |
+| `a_whitespace_only_pattern_is_dropped` | `"   "` → key absent |
+| `an_agent_without_the_field_is_unchanged` | no key in, no key out; nothing gains a sentinel |
+
+### 9.4 `sessions` store
+
+| Test | Asserts |
+|---|---|
+| `an_event_sets_a_sessions_reading` | `setSessionContext(id, 42)` → map holds `42` |
+| `two_sessions_never_cross` | two ids, two values, independent |
+| `a_null_is_stored_as_null_not_dropped` | `setSessionContext(id, null)` → the key exists and holds `null` |
+| **`hydrate_never_clobbers_a_value_an_event_already_set`** | `setSessionContext(id, 43)` then `hydrateSessionContext(id, 42)` → still **`43`** (§4.4) |
+| `hydrate_seeds_a_session_no_event_has_spoken_for` | `hydrateSessionContext(id, 42)` on an empty map → `42` |
+| **`hydrate_treats_a_stored_zero_as_spoken_for`** | `setSessionContext(id, 0)` then `hydrateSessionContext(id, 42)` → still **`0`**. Red if the guard is a truthiness check instead of a key-presence check |
+| `setSessions_cannot_wipe_a_reading` | set a reading, call `setSessions([...])`, reading survives (§2.4/§4.2) |
+
+### 9.5 `ContextBadge.test.tsx`
+
+| Test | Asserts |
+|---|---|
+| `a_reading_is_a_meter_with_a_value` | `role="meter"`, `aria-valuenow="42"`, `aria-valuemin="0"`, `aria-valuemax="100"`, `aria-valuetext` present, text `CTX 42%` |
+| **`the_unavailable_state_is_not_a_meter`** | `percent={null}` → **no `role`**, **no `aria-valuenow`**. Pins §2.11: a meter without a value is invalid ARIA |
+| **`the_badge_is_not_a_control`** | rendered element is not a `<button>`, has **no** `onclick`, no `tabindex`, no `href`. Pins #1031's one hard rule at the DOM |
+| `both_states_carry_the_tooltip` | `title` is the §5.5 constant in both states |
+| `no_live_region` | **no `aria-live`** on either state (§2.11) |
+
+### 9.6 Wiring
+
+| Test | Asserts |
+|---|---|
+| `no_regex_configured_renders_no_badge` | agent session, agent has no `contextRegex` → **the testid is absent entirely**. Not `N/A`, not an empty chip |
+| `a_configured_agent_with_no_reading_renders_N_A` | regex set, no event → `CTX N/A` |
+| `an_event_paints_the_badge` | regex set, emit `{sessionId, percent: 42}` → `CTX 42%` |
+| **`an_event_with_percent_null_paints_N_A`** | `{sessionId, percent: null}` → `CTX N/A`, **not** `CTX 0%` |
+| `the_badge_appears_when_a_regex_is_saved` | agents updated in `settingsStore` → badge appears with no reload (`SettingsModal.tsx:1144`) |
+| `two_concurrent_sessions_show_independent_values` | two rows, two values, no bleed |
+
+### 9.7 Acceptance criteria, objective
+
+1. Regex round-trips: set, save, reload shows it; cleared, the key is **absent** from the persisted JSON.
+2. A settings file with no `contextRegex` loads unchanged and saves with no sentinel.
+3. A pattern with leading spaces is stored with its leading spaces.
+4. No regex, no badge, no `N/A`, no chip.
+5. A session with a reading shows `CTX N%`; one without shows `CTX N/A`; a true `0` shows `CTX 0%`.
+6. Neither state is clickable and neither triggers anything.
+7. Two concurrent sessions are independent.
+8. **A sidebar reload against a live session at 42% shows `CTX 42%`, not `N/A`** (§2.3; the criterion the issue does not have and the feature is broken without).
+9. Clicking **Use suggested pattern** on a Claude row fills the field with a pattern containing `░`/`█` that the user could not have typed.
+10. `SettingsModal.automation.test.ts` green. `npm test` and `npx tsc --noEmit` green.
+
+**Verification note (`npm test`).** Get a baseline count on `main` **before** blaming this branch for any red. The Rust suite here has a known flake population; treat the TS suite with the same suspicion and compare k/n on both sides.
+
+---
+
+## 10. Verdict
+
+### Status: READY_FOR_IMPLEMENTATION
+
+Authored and certified in one pass, as dispatched. Every coordinate re-anchored against `d1b4a52` by me. Every claim about the pattern grammar, the trim and the glyphs came from a probe against `regex` 1.12.3; the two findings that reading caught (§10.1 items 2 and 6) are marked as such, because which instrument found which is the useful part of the record.
+
+### 10.1 What checking changed, and which instrument caught which
+
+| # | The instruction or assumption | What checking it said | Caught by |
+|---|---|---|---|
+| 1 | "copy the #529 normalizer" (`settings-save.ts:15-20`) | **Trap.** Its trim turns the typed-in-box false positive from `None` into `Some(99)` while the real statusline still reads correctly. Fails **open**, invisibly (§2.6) | probe |
+| 2 | "placeholder = derived default", hint "leave blank to use the default shown" | **Trap.** Blank is **off** here; there is no fallback pattern in the backend. The copy inverts (§2.7) | reading `mod.rs` |
+| 3 | "#1032 §4.5 records both patterns verbatim, use them" | **Right, and now I know why.** `[░█]` rejects `  Context is 42% of the budget`; `\S+` reads it as `Some(42)`. But the pattern **cannot be typed**, so it needs the suggest button or the feature is unconfigurable for Claude (§2.8) | probe |
+| 4 | (unstated) validate the regex before saving | **Impossible in JS.** Wrong in both directions, measured on both sides (§2.9) | probe, both sides |
+| 5 | #1043: "#1032 §4.5's reason for the Codex pattern is wrong" | **Confirmed, and sharper.** Either literal alone pins the capture; strip both and greedy `.*` captures `3` out of `83` (§2.10) | probe |
+| 6 | "mirror the #882 path exactly" | **Insufficient.** #882's value rides on `Session` from the backend; this one does not, so a listener alone leaves a reloaded sidebar at `N/A` forever (§2.3, §4.4) | **reading the frozen backend** |
+
+**Item 6 is the one I would have shipped, and the instrument column is the point: a probe did not catch it. Reading did.**
+
+That is not a rebuttal of #1032's §10.4 (*"reading the crate carefully caught none of the six"*), it is the other half of the same lesson. #1032's six were **mechanisms built on unverified claims about an external thing** (a crate, a TUI, a PTY), and only running the real thing could refute them. Item 6 is the opposite kind: a claim about **our own frozen contract's emission semantics**, sitting in plain text in `mod.rs:190` and in #1032's own §4.1.1 table (*"Unchanged → no emit"*). No probe was needed and none would have been aimed there, because the thing that hid it was not complexity. It was the word **frozen**.
+
+"The backend contract is frozen and shipped, mirror it" is an invitation to read the *types* and skip the *behaviour*. The types are perfect: `percent: number | null` says everything about what a payload means and nothing about **when one arrives**. I mirrored #882 correctly, against a contract I had verified by hash, and would have shipped a badge that reads `N/A` forever on a window reload.
+
+**The transferable rule, and it is the one I would defend without evidence: a frozen contract still has to be read for when it speaks, not just what it says.** Match the instrument to the claim. External thing, unverified claim: probe it. Our own contract, and an assumption you did not notice you made: read it, and read the parts the summary told you not to worry about.
+
+### 10.2 Lite holds, and here is the bar it was checked against
+
+- **Both halves have an exact named precedent.** Field: #529 (`SettingsModal.tsx:2190-2202`) plus its normalizer's contract. Badge: #882 (`session_idle` → `ipc.ts` → `App.tsx` → store → projection → CSS), `ProfileOutdatedBadge.tsx` for the shared component, `lastActivityBySessionId` for the state, `RepoDirtyByPath` for the miss/null discipline, `sessionProfileBadge` for a resolver across the same three sites.
+- **No new abstraction, dependency, schema or protocol.** No dependency. The contract is frozen and shipped. The store key copies a store key that exists.
+- **The backend contract is frozen and shipped**, verified by blob hash.
+
+**It is lite, and it is not a copy job.** Six instructions or assumptions needed checking; three were traps that ship a defect if followed (§10.1 items 1, 2 and 6), one was a correct instruction with an unusable consequence (item 3), one was an idea that had to be killed (item 4), and one was a peer's correction that held (item 5). I am flagging the gap between "lite" and "mechanical" rather than letting `READY_FOR_IMPLEMENTATION` imply the second.
+
+### 10.3 What I deliberately did not build
+
+- **No thresholds.** AC has no denominator and therefore no basis for a number (§4.6). A follow-up with a **user-chosen** level, labelled an AgentsCommander reminder level, is clean.
+- **No regex validation** (§2.9). If the user finds "I pasted a pattern and nothing happened" as bad as #1032 §5.5 predicts, the fix is a backend `validate_context_regex` command returning `pattern.rs:36`'s existing `Result<_, String>`, which is a Rust issue and not this one.
+- **No terminal-window badge.** Second window, second store, second listener path.
+- **`CTX` is not in `replicaSearchText`** (§4.7), a stated exception to #733/#515 because a 5s-volatile value would make a filtered list rearrange itself with no user input.
+
+### 10.4 The one thing I want the implementer to carry
+
+**`0` is a reading and `N/A` is not a `0`.** Three separate places can destroy that with a single idiomatic character: `percent ? …` in the projection, `||` instead of `??` at a call site, and a truthiness guard in `hydrateSessionContext`. All three keep every normal case working and are invisible on screen, which is exactly the shape of the trim defect in §2.6. §9.2, §9.4 and §9.6 exist to be red when any of them happens; do not "simplify" them green.

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -10,6 +10,7 @@ import type {
   Session,
   SessionCommunication,
   SessionRepo,
+  SessionContextPayload,
   SessionEnvWarningPayload,
   SessionWarning,
   PtyOutputEvent,
@@ -274,6 +275,15 @@ export const PtyAPI = {
 
   getScreenSnapshot: (sessionId: string) =>
     transport.invoke<PtyScreenSnapshot | null>("get_screen_snapshot", { sessionId }),
+
+  /** #1033 - last context reading for a session, or `null` when there is none.
+   *  `null` covers "no reading", "not registered", "scraper unmanaged" and "session
+   *  over" alike, and NEVER means 0. Mandatory rather than an optimisation: the
+   *  engine emits `session_context` only when the value CHANGES, so a session
+   *  already sitting at a reading when this window mounts never sends an event and
+   *  a listener alone would leave it at `CTX N/A` forever. */
+  getSessionContext: (sessionId: string) =>
+    transport.invoke<number | null>("get_session_context", { sessionId }),
 
   /** Request screen snapshot replay for late-joining browser clients.
    *  Returns PTY dimensions so the browser can mirror them. */
@@ -774,6 +784,17 @@ export function onSessionBusy(
   callback: (data: { id: string }) => void
 ): Promise<UnlistenFn> {
   return transport.listen<{ id: string }>("session_busy", callback);
+}
+
+/**
+ * #1033 - a session's context-window reading changed. Emit-on-change only: pair
+ * every listener with `PtyAPI.getSessionContext` to seed sessions that are already
+ * sitting at a value (`App.tsx`), or they read `CTX N/A` until they next change.
+ */
+export function onSessionContext(
+  callback: (data: SessionContextPayload) => void
+): Promise<UnlistenFn> {
+  return transport.listen<SessionContextPayload>("session_context", callback);
 }
 
 export function onTelegramBridgeAttached(

--- a/src/shared/profile-utils.test.ts
+++ b/src/shared/profile-utils.test.ts
@@ -428,10 +428,13 @@ describe("profileBadgeKind (#526/#527 shared Config/Selection taxonomy)", () => 
 
   // #1033 - the suggested context pattern (plan SS9.1).
   //
-  // The glyphs are asserted as \u escapes on purpose: a literal in this file could be
-  // mangled by an encoding round-trip and still LOOK right, while an escape pins the
-  // code point itself. U+2593 must never appear anywhere - it does not occur in the
-  // real output, and the issue's own probe fixtures used it and tested fiction.
+  // The glyphs below are literals, not code-point escapes. What proves they are the
+  // right code points is not this file: both constants are byte-identical to the
+  // plan's SS5.4 and were injected from it rather than retyped, so the bytes are
+  // verified at their source. These assertions pin the weaker, still-useful thing -
+  // that the shipped pattern carries a bar glyph and a middle dot at all, and that
+  // U+2593 never appears: it does not occur in the real output, and the issue's own
+  // probe fixtures used it and tested fiction.
   it("suggests the captured Claude pattern verbatim (the_claude_suggestion_is_the_captured_pattern)", () => {
     expect(suggestedContextRegex("claude")).toBe(CLAUDE_CONTEXT_REGEX);
     expect(CLAUDE_CONTEXT_REGEX).toContain("░"); // LIGHT SHADE

--- a/src/shared/profile-utils.test.ts
+++ b/src/shared/profile-utils.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { AgentConfig, CodingAgentProfilesConfig } from "./types";
 import {
+  CLAUDE_CONTEXT_REGEX,
+  CODEX_CONTEXT_REGEX,
   commandExecutableBasename,
   composeEffectiveCommand,
   defaultInstructionsFilename,
@@ -22,6 +24,7 @@ import {
   sessionProfileBadge,
   shouldOfferRestartAfterAssign,
   stringifyArgv,
+  suggestedContextRegex,
   validateEnvRows,
 } from "./profile-utils";
 
@@ -421,5 +424,49 @@ describe("profileBadgeKind (#526/#527 shared Config/Selection taxonomy)", () => 
     };
     // A disabled cell is not a live config → B resolves back to A.
     expect(profileBadgeKind(config, "codex", "B")).toBe("fallback");
+  });
+
+  // #1033 - the suggested context pattern (plan SS9.1).
+  //
+  // The glyphs are asserted as \u escapes on purpose: a literal in this file could be
+  // mangled by an encoding round-trip and still LOOK right, while an escape pins the
+  // code point itself. U+2593 must never appear anywhere - it does not occur in the
+  // real output, and the issue's own probe fixtures used it and tested fiction.
+  it("suggests the captured Claude pattern verbatim (the_claude_suggestion_is_the_captured_pattern)", () => {
+    expect(suggestedContextRegex("claude")).toBe(CLAUDE_CONTEXT_REGEX);
+    expect(CLAUDE_CONTEXT_REGEX).toContain("░"); // LIGHT SHADE
+    expect(CLAUDE_CONTEXT_REGEX).toContain("█"); // FULL BLOCK
+    expect(CLAUDE_CONTEXT_REGEX).not.toContain("▓"); // never real output
+  });
+
+  it("suggests the captured Codex pattern verbatim (the_codex_suggestion_is_the_captured_pattern)", () => {
+    expect(suggestedContextRegex("codex")).toBe(CODEX_CONTEXT_REGEX);
+    expect(CODEX_CONTEXT_REGEX).toContain("·"); // MIDDLE DOT, adjacent to the capture
+    expect(CODEX_CONTEXT_REGEX).not.toContain("▓");
+  });
+
+  it("resolves a wrapped or suffixed claude the same way the filename default does (a_docker_wrapped_claude_still_resolves)", () => {
+    // The same shapes defaultInstructionsFilename pins, since both reuse
+    // executableTokenBasename over every token.
+    expect(suggestedContextRegex("claude --model sonnet")).toBe(CLAUDE_CONTEXT_REGEX);
+    expect(suggestedContextRegex("cmd.exe /c claude")).toBe(CLAUDE_CONTEXT_REGEX);
+    expect(suggestedContextRegex("cmd.exe /c claude --continue")).toBe(CLAUDE_CONTEXT_REGEX);
+    expect(suggestedContextRegex("claude-mb")).toBe(CLAUDE_CONTEXT_REGEX);
+    expect(suggestedContextRegex("C:\\tools\\claude.exe")).toBe(CLAUDE_CONTEXT_REGEX);
+    expect(suggestedContextRegex("codex --sandbox workspace-write")).toBe(CODEX_CONTEXT_REGEX);
+    // claude > codex precedence, mirroring the Rust detector.
+    expect(suggestedContextRegex("codex --base gemini")).toBe(CODEX_CONTEXT_REGEX);
+  });
+
+  it("suggests nothing for an agent no capture covered (an_unknown_agent_gets_no_suggestion)", () => {
+    // Deliberately NOT defaultInstructionsFilename's "AGENTS.md"-style fallback: a
+    // wrong filename costs a renamed file, a wrong pattern costs a silently wrong
+    // percentage. No evidence, no guess.
+    expect(suggestedContextRegex("gemini")).toBeNull();
+    expect(suggestedContextRegex("gemini --yolo")).toBeNull();
+    expect(suggestedContextRegex("nonsense")).toBeNull();
+    expect(suggestedContextRegex("opencode")).toBeNull();
+    expect(suggestedContextRegex("my-agent-cli --flag")).toBeNull();
+    expect(suggestedContextRegex("")).toBeNull();
   });
 });

--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -504,6 +504,49 @@ export function defaultInstructionsFilename(command: string): string {
   return "AGENTS.md";
 }
 
+/**
+ * #1033 - the context patterns #1032 captured, shipped VERBATIM.
+ *
+ * Do not re-derive these and do not "simplify" them to typeable characters. The
+ * glyph class is load-bearing: measured against regex 1.12.3, `[░█]+` rejects the
+ * prose row `  Context is 42% of the budget` while a typeable `\S+` reads it as
+ * `Some(42)` - a wrong number, not a miss.
+ *
+ * Both literals adjacent to the capture are load-bearing for the same reason: a
+ * literal next to the capture is what pins where the capture lands. Strip
+ * `· Context ` and ` used` from the Codex pattern and greedy `.*` slides to the
+ * last `%` of `  Ready · Context 0% used · weekly 83% left`, capturing `3` out of
+ * `83`.
+ *
+ * Capture group 1 is the percentage; both compile with `captures_len=2`, clearing
+ * the backend's mandatory-capture gate (`pty/context_scrape/pattern.rs:44`).
+ */
+export const CLAUDE_CONTEXT_REGEX = String.raw`^ {2}Context [░█]+ (\d{1,3})%`;
+export const CODEX_CONTEXT_REGEX = String.raw`^ {2}.*· Context (\d{1,3})% used`;
+
+/**
+ * #1033 - the suggested pattern for a command, or `null` when there is no evidence
+ * for one. Resolves the command exactly as {@link defaultInstructionsFilename}
+ * does, so a wrapped invocation (`cmd.exe /c claude`, an absolute-path
+ * `claude.exe`, `claude --model sonnet`) still resolves.
+ *
+ * Unlike {@link defaultInstructionsFilename}, this deliberately does NOT fall back
+ * to a default for an unknown agent: it returns `null` for Gemini and everything
+ * else. #1032's capture covered `claude.exe` and `codex.exe` and nothing else, and
+ * the asymmetry is the point - a wrong filename costs a renamed file, while a
+ * wrong pattern costs a silently wrong percentage. No suggestion means the button
+ * does not render; the field still accepts anything the user types.
+ *
+ * The button exists because `░` (U+2591) and `█` (U+2588) are not on a keyboard:
+ * without it the feature is unconfigurable for Claude.
+ */
+export function suggestedContextRegex(command: string): string | null {
+  const stems = command.trim().split(/\s+/).filter(Boolean).map(executableTokenBasename);
+  if (stems.some((s) => s.startsWith("claude"))) return CLAUDE_CONTEXT_REGEX;
+  if (stems.some((s) => s.startsWith("codex"))) return CODEX_CONTEXT_REGEX;
+  return null;
+}
+
 export function agentNameFromPathOrSession(
   path: string | null | undefined,
   sessionName: string,

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -237,6 +237,9 @@ export function resetUiStoresForTests(): void {
   // lands a branch event leaks its repoBranch/repoBranchByPath into the next test
   // in the same file (order-dependent, and silently wrong rather than red).
   replicaVolatileStore.clearAll();
+  // #1033 - same hazard, same reason: the context reading map is event-fed and is
+  // deliberately out of setSessions' reach, so it survives into the next test.
+  sessionsStore.resetContextReadingsForTests();
   sessionsStore.setSessions([]);
   sessionsStore.setActiveId(null);
   sessionsStore.setTeams([]);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -101,6 +101,23 @@ export type SessionStatus = "active" | "running" | "idle" | { exited: number };
 
 export type CodingAgentKind = "claude" | "codex" | "gemini";
 
+/**
+ * #1033 - payload of the `session_context` event (`lib.rs:456`).
+ *
+ * `percent` is `number | null` and NEVER `percent?: number`. The Rust side
+ * (`pty/context_scrape/mod.rs:69-78`) deliberately carries no
+ * `skip_serializing_if` on it, so `None` serializes as an explicit
+ * `"percent": null` rather than an absent key. Typing it optional here would
+ * re-introduce *absent* as a third state beside `null` and `0`, in a feature
+ * whose one hard rule is that unavailable is exactly one thing.
+ *
+ * `0` is a REAL reading and must survive the trip; only `null` means unavailable.
+ */
+export interface SessionContextPayload {
+  sessionId: string;
+  percent: number | null;
+}
+
 export interface SessionGroup {
   id: string;
   name: string;
@@ -222,6 +239,27 @@ export interface AgentConfig {
    * inactive seed is never persisted as a sentinel.
    */
   configSeed?: ConfigSeedConfig;
+  /**
+   * #1033 - best-effort pattern AC runs over the rows this agent draws in its
+   * terminal, to read its context-window usage for the CTX badge. Capture group 1
+   * is the percentage.
+   *
+   * Absent means the badge is OFF for this agent. Unlike `instructionsFilename`,
+   * there is NO fallback default anywhere in the backend, so blank does not mean
+   * "use the default shown": blank means off.
+   *
+   * Stored VERBATIM and never trimmed. A pattern's leading whitespace is a
+   * load-bearing column anchor, and a trim deletes it while every normal case
+   * keeps reading correctly - so the damage is invisible. Empty/whitespace-only is
+   * dropped to omitted before save (mirroring `instructionsFilename`'s contract,
+   * NOT its trim), so it is never persisted as a sentinel.
+   *
+   * Rust `regex` grammar, NOT JS `RegExp`: the two disagree in both directions, so
+   * nothing on this side validates it. An unusable pattern reads `CTX N/A` and its
+   * reason reaches `app.log` only. Serialized as `contextRegex`; placed before
+   * `backend` to mirror the Rust field order (`config/settings.rs:79-80`).
+   */
+  contextRegex?: string;
   backend?: AgentBackendConfig;
 }
 
@@ -831,6 +869,22 @@ export interface SessionsState {
   repos: RepoMatch[];
   coordSortByActivity: boolean;
   lastActivityBySessionId: Record<string, number>;
+  /**
+   * #1033 - live per-session context-window reading, keyed by session id.
+   * Frontend-only and fed by the `session_context` event, so it is structurally
+   * out of reach of `setSessions`'s wholesale replace (unlike a field on
+   * `Session`, which the backend does not carry anyway).
+   *
+   * A missing key = no event and no snapshot has spoken for this session yet. An
+   * explicit `null` = the engine says the reading is unavailable. Both render
+   * `CTX N/A`, so the two collapse on screen by design.
+   *
+   * `0` is a THIRD, distinct value and must survive the trip: it means a real
+   * reading of zero and renders `CTX 0%`. A `??`-to-`||` slip, or a truthiness
+   * test anywhere on this value's path, turns a true `0%` into `N/A` and is
+   * invisible on screen.
+   */
+  contextPercentBySessionId: Record<string, number | null>;
   hydrated: boolean;
 }
 

--- a/src/sidebar/App.context-badge.workflow.test.tsx
+++ b/src/sidebar/App.context-badge.workflow.test.tsx
@@ -1,0 +1,359 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SidebarApp from "./App";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../shared/testing/ui-harness";
+import { sessionsStore } from "./stores/sessions";
+import type { AgentConfig, Session } from "../shared/types";
+
+// #1033 - the wiring, end to end, through the REAL App listener and the REAL
+// mount-time hydration: backend event / snapshot -> ipc -> store -> projection -> DOM.
+//
+// This mounts SidebarApp rather than re-declaring the listener inside the test,
+// because the listener and its ordering ARE the thing under test. #1032's engine
+// emits ONLY on change, so a listener alone leaves a reloaded sidebar reading N/A
+// forever against a session that is plainly sitting at 42%.
+
+const projectPath = "C:\\Project";
+const wgName = "wg-2-dev-team";
+const replicaName = "dev-webpage-ui";
+const otherReplicaName = "dev-rust";
+const workgroupPath = `${projectPath}\\.ac\\${wgName}`;
+const replicaPath = `${workgroupPath}\\__agent_${replicaName}`;
+const otherReplicaPath = `${workgroupPath}\\__agent_${otherReplicaName}`;
+const sessionId = "coord-session";
+const otherSessionId = "member-session";
+
+const CLAUDE_PATTERN = String.raw`^ {2}Context [░█]+ (\d{1,3})%`;
+
+/**
+ * The replica row renders once per row context: `quick` is the coordinator
+ * quick-access panel (coordinators only), `workgroups` is the workgroup tree
+ * (every replica). Both render the same badge from the same shared resolver.
+ */
+function badgeSelector(replica: string, rowContext: "quick" | "workgroups" = "quick"): string {
+  return `[data-ac-testid="replica.contextBadge.${rowContext}.${wgName}.${replica}"]`;
+}
+
+function agentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    id: "claude",
+    label: "Claude Code",
+    command: "claude",
+    color: "#d97757",
+    envs: [],
+    isolatedHome: false,
+    ...overrides,
+  };
+}
+
+function agentSession(overrides: Partial<Session> = {}): Session {
+  return session({
+    id: sessionId,
+    name: `${wgName}/${replicaName}`,
+    workingDirectory: replicaPath,
+    status: "running",
+    isCoordinator: true,
+    agentId: "claude",
+    agentLabel: "Claude Code",
+    ...overrides,
+  });
+}
+
+function setupTransport(
+  fake: FakeTransport,
+  opts: { agents: AgentConfig[]; sessions: Session[]; replicas?: string[] },
+): void {
+  const replicas = opts.replicas ?? [replicaName];
+  fake.resolve(
+    "get_settings",
+    baseSettings({ projectPaths: [projectPath], projectPath, agents: opts.agents }),
+  );
+  fake.resolve("get_update_status", null);
+  fake.resolve("open_project", { path: projectPath, registered: true, created: false });
+  fake.resolve(
+    "discover_project",
+    discovery({
+      workgroups: [
+        {
+          name: wgName,
+          path: workgroupPath,
+          task: null,
+          taskTitle: "Ctx badge",
+          agents: replicas.map((name) => ({
+            name,
+            path: `${workgroupPath}\\__agent_${name}`,
+            repoPaths: [],
+            isCoordinator: name === replicaName,
+          })),
+        },
+      ],
+    }),
+  );
+  fake.resolve("get_project_groups", { groups: [], showAll: true, showUngrouped: true });
+  fake.resolve("search_repos", []);
+  fake.resolve("list_sessions", opts.sessions);
+  fake.resolve("get_active_session", null);
+  fake.resolve("list_detached_sessions", []);
+  fake.resolve("telegram_list_bridges", []);
+  // Default: the engine has no reading for anyone.
+  fake.resolve("get_session_context", null);
+}
+
+async function mounted(fake: FakeTransport) {
+  const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+  await waitFor(() => {
+    expect(sessionsStore.sessions.find((s) => s.id === sessionId)).toBeTruthy();
+    expect(rendered.root.querySelector(`[data-ac-testid="replica.row.quick.${wgName}.${replicaName}"]`)).not.toBeNull();
+  });
+  return rendered;
+}
+
+describe("SidebarApp CTX badge workflow (#1033)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  // The criterion the issue does not have and the feature is broken without.
+  // NO event is emitted here: the session is ALREADY at 42%, which is exactly when
+  // the emit-on-change engine stays silent forever. Only the snapshot can paint it.
+  it("shows a session already sitting at a value after a reload (a_reloaded_sidebar_hydrates_a_session_already_at_a_value)", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, {
+      agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })],
+      sessions: [agentSession()],
+    });
+    fake.onInvoke("get_session_context", (args) => (args.sessionId === sessionId ? 42 : null));
+
+    const rendered = await mounted(fake);
+    try {
+      await waitFor(() => {
+        expect(rendered.root.querySelector(badgeSelector(replicaName))?.textContent).toBe("CTX 42%");
+      });
+      // ...and it really was the snapshot: no session_context event was ever sent.
+      expect(fake.callsFor("get_session_context").length).toBeGreaterThan(0);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("paints the badge from a backend event, and accepts a decrease (an_event_paints_the_badge)", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, {
+      agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })],
+      sessions: [agentSession()],
+    });
+
+    const rendered = await mounted(fake);
+    try {
+      await waitFor(() => {
+        expect(rendered.root.querySelector(badgeSelector(replicaName))?.textContent).toBe("CTX N/A");
+      });
+
+      fake.emitFromBackend("session_context", { sessionId, percent: 42 });
+      await waitFor(() => {
+        expect(rendered.root.querySelector(badgeSelector(replicaName))?.textContent).toBe("CTX 42%");
+      });
+
+      // Decreases are accepted as-is: no monotonicity, no smoothing, and nothing
+      // infers "Compacting" from a fall.
+      fake.emitFromBackend("session_context", { sessionId, percent: 12 });
+      await waitFor(() => {
+        expect(rendered.root.querySelector(badgeSelector(replicaName))?.textContent).toBe("CTX 12%");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("paints a real zero as a reading, never as unknown (an_event_with_percent_zero_paints_zero)", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, {
+      agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })],
+      sessions: [agentSession()],
+    });
+
+    const rendered = await mounted(fake);
+    try {
+      fake.emitFromBackend("session_context", { sessionId, percent: 0 });
+
+      await waitFor(() => {
+        const badge = rendered.root.querySelector(badgeSelector(replicaName));
+        expect(badge?.textContent).toBe("CTX 0%");
+        expect(badge?.getAttribute("role")).toBe("meter");
+        expect(badge?.getAttribute("aria-valuenow")).toBe("0");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("paints an explicit null as N/A and never as 0% (an_event_with_percent_null_paints_N_A)", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, {
+      agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })],
+      sessions: [agentSession()],
+    });
+
+    const rendered = await mounted(fake);
+    try {
+      fake.emitFromBackend("session_context", { sessionId, percent: 42 });
+      await waitFor(() => {
+        expect(rendered.root.querySelector(badgeSelector(replicaName))?.textContent).toBe("CTX 42%");
+      });
+
+      // The engine lost the reading (cleared pattern, suppressed statusline, ...).
+      fake.emitFromBackend("session_context", { sessionId, percent: null });
+
+      await waitFor(() => {
+        const badge = rendered.root.querySelector(badgeSelector(replicaName));
+        expect(badge?.textContent).toBe("CTX N/A");
+        expect(badge?.hasAttribute("role")).toBe(false);
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("renders no badge at all for an agent with no pattern (no_regex_configured_renders_no_badge)", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, { agents: [agentConfig()], sessions: [agentSession()] });
+
+    const rendered = await mounted(fake);
+    try {
+      // Not N/A, not an empty chip: absent entirely.
+      expect(rendered.root.querySelector(badgeSelector(replicaName))).toBeNull();
+      expect(rendered.root.querySelector(".ctx-badge")).toBeNull();
+      expect(rendered.root.textContent).not.toContain("CTX");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("makes the badge appear as soon as a pattern is saved, with no reload (the_badge_appears_when_a_regex_is_saved)", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, { agents: [agentConfig()], sessions: [agentSession()] });
+
+    const rendered = await mounted(fake);
+    try {
+      expect(rendered.root.querySelector(badgeSelector(replicaName))).toBeNull();
+
+      // What SettingsModal's save does: re-resolve settings into the signal.
+      fake.resolve(
+        "get_settings",
+        baseSettings({
+          projectPaths: [projectPath],
+          projectPath,
+          agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })],
+        }),
+      );
+      const { settingsStore } = await import("../shared/stores/settings");
+      await settingsStore.load();
+
+      await waitFor(() => {
+        expect(rendered.root.querySelector(badgeSelector(replicaName))?.textContent).toBe("CTX N/A");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("keeps two concurrent sessions independent (two_concurrent_sessions_show_independent_values)", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, {
+      agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })],
+      replicas: [replicaName, otherReplicaName],
+      sessions: [
+        agentSession(),
+        agentSession({
+          id: otherSessionId,
+          name: `${wgName}/${otherReplicaName}`,
+          workingDirectory: otherReplicaPath,
+          isCoordinator: false,
+        }),
+      ],
+    });
+
+    const rendered = await mounted(fake);
+    try {
+      fake.emitFromBackend("session_context", { sessionId, percent: 42 });
+      fake.emitFromBackend("session_context", { sessionId: otherSessionId, percent: 7 });
+
+      // Read both from the workgroup tree: the quick panel holds coordinators only.
+      await waitFor(() => {
+        expect(
+          rendered.root.querySelector(badgeSelector(replicaName, "workgroups"))?.textContent,
+        ).toBe("CTX 42%");
+        expect(
+          rendered.root.querySelector(badgeSelector(otherReplicaName, "workgroups"))?.textContent,
+        ).toBe("CTX 7%");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("never asks the engine about a plain shell (a_plain_shell_is_not_hydrated)", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, {
+      agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })],
+      sessions: [agentSession(), session({ id: "plain-shell", name: "pwsh", agentId: null })],
+    });
+
+    const rendered = await mounted(fake);
+    try {
+      await waitFor(() => {
+        expect(fake.callsFor("get_session_context").length).toBeGreaterThan(0);
+      });
+      const asked = fake.callsFor("get_session_context").map((c) => c.args.sessionId);
+      expect(asked).toContain(sessionId);
+      // Plain shells are never registered by the backend, so the fan-out skips them.
+      expect(asked).not.toContain("plain-shell");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // A rejected snapshot must cost its own badge and nothing else: the session still
+  // shows N/A and self-corrects on its next change, and onMount is not aborted.
+  it("survives a rejected snapshot (a_failed_snapshot_is_harmless)", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, {
+      agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })],
+      sessions: [agentSession()],
+    });
+    fake.reject("get_session_context", "scraper is gone");
+
+    const rendered = await mounted(fake);
+    try {
+      await waitFor(() => {
+        expect(rendered.root.querySelector(badgeSelector(replicaName))?.textContent).toBe("CTX N/A");
+      });
+
+      fake.emitFromBackend("session_context", { sessionId, percent: 42 });
+      await waitFor(() => {
+        expect(rendered.root.querySelector(badgeSelector(replicaName))?.textContent).toBe("CTX 42%");
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -8,6 +8,7 @@ import type {
   SessionWarning,
 } from "../shared/types";
 import {
+  PtyAPI,
   SessionAPI,
   SettingsAPI,
   TelegramAPI,
@@ -21,6 +22,7 @@ import {
   onSessionCommunicationChanged,
   onSessionIdle,
   onSessionBusy,
+  onSessionContext,
   onSessionGitRepos,
   onSessionCoordinatorChanged,
   onTelegramBridgeAttached,
@@ -663,6 +665,30 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
         sessionsStore.setSessionWaiting(id, false);
       })
     );
+
+    unlisteners.push(
+      await onSessionContext(({ sessionId, percent }) => {
+        sessionsStore.setSessionContext(sessionId, percent);
+      })
+    );
+
+    // #1033 - snapshot-seed every agent session no event has spoken for yet. The engine
+    // emits ONLY on change (pty/context_scrape/mod.rs), so a session already sitting at a
+    // value when this window mounted will never send one, and a listener alone leaves it
+    // reading N/A forever. Registered AFTER the listener, and hydrateSessionContext is a
+    // no-op on an existing key, so a slow invoke cannot overwrite a fresher event.
+    // Absent-key check, never a truthiness check: a hydrated `null` and a hydrated `0`
+    // are both answers. try/catch mirrors the repo-search fan-out at :564-567 so one
+    // rejected invoke cannot abort the rest of onMount.
+    try {
+      await Promise.all(
+        sessionsStore.sessions
+          .filter((s) => s.agentId)
+          .map(async (s) => {
+            sessionsStore.hydrateSessionContext(s.id, await PtyAPI.getSessionContext(s.id));
+          })
+      );
+    } catch {}
 
     unlisteners.push(
       await onSessionGitRepos(({ sessionId, repos }) => {

--- a/src/sidebar/components/ContextBadge.test.tsx
+++ b/src/sidebar/components/ContextBadge.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { render } from "solid-js/web";
+import ContextBadge, { CONTEXT_BADGE_TOOLTIP } from "./ContextBadge";
+
+const TESTID = "session.s1.contextBadge";
+
+function target<T extends HTMLElement = HTMLElement>(testId: string): T {
+  const element = document.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  if (!element) throw new Error(`Missing test target: ${testId}`);
+  return element;
+}
+
+function renderBadge(percent: number | null | undefined) {
+  const root = document.createElement("div");
+  document.body.append(root);
+  const dispose = render(() => <ContextBadge percent={percent} testId={TESTID} />, root);
+  return { dispose };
+}
+
+describe("ContextBadge (#1033)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders a reading as a meter carrying its value (a_reading_is_a_meter_with_a_value)", () => {
+    renderBadge(42);
+
+    const badge = target(TESTID);
+    expect(badge.getAttribute("role")).toBe("meter");
+    expect(badge.getAttribute("aria-valuenow")).toBe("42");
+    expect(badge.getAttribute("aria-valuemin")).toBe("0");
+    expect(badge.getAttribute("aria-valuemax")).toBe("100");
+    expect(badge.getAttribute("aria-valuetext")).toBe("Context 42% used");
+    expect(badge.textContent).toBe("CTX 42%");
+    expect(badge.getAttribute("data-ac-state")).toBe("reading");
+  });
+
+  // A real 0 is a reading: it must be a meter like any other, not the N/A state.
+  // Red if anyone writes `<Show when={props.percent}>`, since 0 is falsy.
+  it("treats a real zero as a reading, not an absence (zero_is_a_meter_not_unavailable)", () => {
+    renderBadge(0);
+
+    const badge = target(TESTID);
+    expect(badge.getAttribute("role")).toBe("meter");
+    expect(badge.getAttribute("aria-valuenow")).toBe("0");
+    expect(badge.textContent).toBe("CTX 0%");
+    expect(badge.getAttribute("data-ac-state")).toBe("reading");
+  });
+
+  // Pins the ARIA rule: a meter REQUIRES aria-valuenow, and there is no valid
+  // aria-valuenow for N/A, so the unavailable state must not be a meter at all.
+  it("is not a meter when there is no reading (the_unavailable_state_is_not_a_meter)", () => {
+    renderBadge(null);
+
+    const badge = target(TESTID);
+    expect(badge.hasAttribute("role")).toBe(false);
+    expect(badge.hasAttribute("aria-valuenow")).toBe(false);
+    expect(badge.hasAttribute("aria-valuemin")).toBe(false);
+    expect(badge.hasAttribute("aria-valuemax")).toBe(false);
+    expect(badge.hasAttribute("aria-valuetext")).toBe(false);
+    expect(badge.textContent).toBe("CTX N/A");
+    expect(badge.getAttribute("data-ac-state")).toBe("unavailable");
+  });
+
+  it("renders a missing key exactly like an explicit null (undefined_is_the_same_one_unavailable_state)", () => {
+    renderBadge(undefined);
+
+    const badge = target(TESTID);
+    expect(badge.hasAttribute("role")).toBe(false);
+    expect(badge.textContent).toBe("CTX N/A");
+    expect(badge.getAttribute("data-ac-state")).toBe("unavailable");
+  });
+
+  // #1031's one hard rule, pinned at the DOM: the badge is a signal, never a control.
+  it("is not a control in either state (the_badge_is_not_a_control)", () => {
+    for (const percent of [42, null]) {
+      document.body.innerHTML = "";
+      renderBadge(percent);
+
+      const badge = target(TESTID);
+      expect(badge.tagName).toBe("SPAN");
+      expect(badge.tagName).not.toBe("BUTTON");
+      expect(badge.hasAttribute("onclick")).toBe(false);
+      expect(badge.hasAttribute("tabindex")).toBe(false);
+      expect(badge.hasAttribute("href")).toBe(false);
+      expect(badge.closest("button")).toBeNull();
+      expect(badge.closest("a")).toBeNull();
+    }
+  });
+
+  it("carries the honesty tooltip in both states (both_states_carry_the_tooltip)", () => {
+    for (const percent of [42, null]) {
+      document.body.innerHTML = "";
+      renderBadge(percent);
+
+      expect(target(TESTID).getAttribute("title")).toBe(CONTEXT_BADGE_TOOLTIP);
+    }
+    // The requirement the tooltip exists to satisfy, not just that a string is set.
+    expect(CONTEXT_BADGE_TOOLTIP).toContain("Best-effort");
+    expect(CONTEXT_BADGE_TOOLTIP).toContain("unavailable, stale or absent");
+    expect(CONTEXT_BADGE_TOOLTIP).toContain("does not");
+  });
+
+  // A 5s-cadence live region would interrupt a screen reader every 5 seconds,
+  // forever, with a number that drives nothing.
+  it("announces nothing on its own (no_live_region)", () => {
+    for (const percent of [42, null]) {
+      document.body.innerHTML = "";
+      renderBadge(percent);
+
+      const badge = target(TESTID);
+      expect(badge.hasAttribute("aria-live")).toBe(false);
+      expect(badge.hasAttribute("aria-atomic")).toBe(false);
+      expect(badge.getAttribute("data-ac-role")).toBe("status");
+    }
+  });
+});

--- a/src/sidebar/components/ContextBadge.tsx
+++ b/src/sidebar/components/ContextBadge.tsx
@@ -1,0 +1,85 @@
+import { Component, Show } from "solid-js";
+import { contextBadgeText } from "./session-context";
+
+/**
+ * #1033 - the honesty requirement, and the only place it is user-visible.
+ * Carried by BOTH states, because a reading and its absence are equally best-effort.
+ */
+export const CONTEXT_BADGE_TOOLTIP =
+  "Context window in use, read from what the agent draws in its terminal. " +
+  "Best-effort: it can be unavailable, stale or absent. A high reading does not " +
+  "mean this session must be restarted.";
+
+/**
+ * #1033 - the CTX badge: how much of its context window an agent session has used,
+ * scraped from what the agent draws in its own terminal.
+ *
+ * Shared by SessionItem, the ProjectPanel replica rows, and RootAgentBanner so the
+ * badge looks and reads identically everywhere a coding-agent session can show one;
+ * triplicating the ARIA markup across those three files is how the three drift. The
+ * caller supplies the testid because each surface names itself.
+ *
+ * THE BADGE IS A SIGNAL, NEVER A CONTROL. A `<span>`, never a `<button>` - unlike
+ * ProfileOutdatedBadge, which this otherwise copies. No onClick, no onKeyDown, no
+ * tabindex, no cursor change, no threshold, and nothing anywhere reads this value.
+ * AC has no denominator for the number (one rounded integer, unknown window size),
+ * so it has no basis for a threshold and invents none.
+ *
+ * The two states are structurally DIFFERENT elements rather than one element with
+ * nullable attributes: `role="meter"` requires `aria-valuenow`, and there is no
+ * valid `aria-valuenow` for N/A, so a meter with no value would be invalid ARIA.
+ *
+ * No aria-live on either state, deliberately: the reading refreshes on a 5s cadence,
+ * so a live region would interrupt a screen reader every 5 seconds, forever, with a
+ * number that drives nothing. That is an accessibility defect, not a feature.
+ */
+const ContextBadge: Component<{
+  percent: number | null | undefined;
+  testId?: string;
+}> = (props) => {
+  // Wrapped in an object on purpose: `<Show when={props.percent}>` would treat a
+  // REAL reading of 0% as absent and render N/A, since 0 is falsy. The wrapper is
+  // always truthy when there is a reading, and it narrows `number | null |
+  // undefined` to `number` without a cast.
+  const reading = (): { value: number } | undefined => {
+    const percent = props.percent;
+    return percent === null || percent === undefined ? undefined : { value: percent };
+  };
+
+  return (
+    <Show
+      when={reading()}
+      fallback={
+        <span
+          class="ctx-badge unavailable"
+          title={CONTEXT_BADGE_TOOLTIP}
+          data-ac-testid={props.testId}
+          data-ac-role="status"
+          data-ac-state="unavailable"
+        >
+          {contextBadgeText(props.percent)}
+        </span>
+      }
+    >
+      {(value) => (
+        <span
+          class="ctx-badge"
+          role="meter"
+          aria-label="Context window used"
+          aria-valuenow={value().value}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuetext={`Context ${value().value}% used`}
+          title={CONTEXT_BADGE_TOOLTIP}
+          data-ac-testid={props.testId}
+          data-ac-role="status"
+          data-ac-state="reading"
+        >
+          {contextBadgeText(value().value)}
+        </span>
+      )}
+    </Show>
+  );
+};
+
+export default ContextBadge;

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -57,6 +57,8 @@ import { coordinatorIdleBadge } from "../../shared/coordinator-badge";
 import { COORD_IDLE_CLASS } from "./coordinator-badge-class";
 import SessionItem from "./SessionItem";
 import ProfileOutdatedBadge from "./ProfileOutdatedBadge";
+import ContextBadge from "./ContextBadge";
+import { contextBadgeConfigured } from "./session-context";
 import NewEntityAgentModal from "./NewEntityAgentModal";
 import NewTeamModal from "./NewTeamModal";
 import NewWorkgroupModal from "./NewWorkgroupModal";
@@ -2493,6 +2495,15 @@ const ProjectPanel: Component = () => {
           // (#515). The live-session branch stays byte-identical.
           const liveAgentLabel = () => resolveReplicaAgentLabel(session(), replica);
           const profileBadge = () => resolveReplicaProfileBadge(session(), replica);
+          // #1033 - the CTX badge, keyed off this replica's live session. NOT added to
+          // replicaSearchText: a 5s-volatile value is not identity, and matching it
+          // would make a filtered list rearrange itself with no user input (SS4.7).
+          const ctxVisible = () =>
+            contextBadgeConfigured(settingsStore.current?.agents, session()?.agentId);
+          const ctxPercent = () => {
+            const s = session();
+            return s ? sessionsStore.contextPercentBySessionId[s.id] : undefined;
+          };
           // #548: resolver-backed tooltip naming the EFFECTIVE profile (the one
           // actually in effect) for this session's coding agent. Plain function
           // (NOT createMemo) — row-local and recomputes on settings reload.
@@ -2684,6 +2695,12 @@ const ProjectPanel: Component = () => {
                   </Show>
                   <Show when={profileBadge()}>
                     {(badge) => <span class="profile-badge" title={profileBadgeTitle()}>{badge()}</span>}
+                  </Show>
+                  <Show when={ctxVisible()}>
+                    <ContextBadge
+                      percent={ctxPercent()}
+                      testId={`replica.contextBadge.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}`}
+                    />
                   </Show>
                   {/* #592 - drift indicator for a WG replica session. Mirrors the
                       SessionItem badge: the backend marks profileOutdated in

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -12,6 +12,8 @@ import {
 import { sessionsStore } from "../stores/sessions";
 import { bridgesStore } from "../stores/bridges";
 import { settingsStore } from "../../shared/stores/settings";
+import ContextBadge from "./ContextBadge";
+import { contextBadgeConfigured } from "./session-context";
 import { voiceRecorder, formatRecordingTime } from "../../shared/voice-recorder";
 import type { Session, TelegramBotConfig } from "../../shared/types";
 import { sessionProfileBadge } from "../../shared/profile-utils";
@@ -74,6 +76,15 @@ const RootAgentBanner: Component = () => {
     if (!r.agentId) return null;
     return settingsStore.current?.agents?.find((a) => a.id === r.agentId)?.label ?? null;
   });
+
+  // #1033 - the CTX badge, keyed off the root session. Same shared gate as the other
+  // two surfaces; a resolver written against props.session would not compile here.
+  const ctxVisible = () =>
+    contextBadgeConfigured(settingsStore.current?.agents, rootSession()?.agentId);
+  const ctxPercent = () => {
+    const r = rootSession();
+    return r ? sessionsStore.contextPercentBySessionId[r.id] : undefined;
+  };
 
   const bridge = () => {
     const r = rootSession();
@@ -413,6 +424,12 @@ const RootAgentBanner: Component = () => {
               </Show>
               <Show when={profileBadge()}>
                 {(badge) => <span class="profile-badge root-profile-badge">{badge()}</span>}
+              </Show>
+              <Show when={ctxVisible()}>
+                <ContextBadge
+                  percent={ctxPercent()}
+                  testId="rootAgent.contextBadge"
+                />
               </Show>
               {/* #592 - drift reload for the Root Agent (loaded profile cell no
                   longer matches its current config). Reuses the restart path, which

--- a/src/sidebar/components/SessionItem.context-badge.test.tsx
+++ b/src/sidebar/components/SessionItem.context-badge.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SessionItem from "./SessionItem";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { settingsStore } from "../../shared/stores/settings";
+import { sessionsStore } from "../stores/sessions";
+import type { AgentConfig, AppSettings, Session } from "../../shared/types";
+
+// #1033 - the CTX badge on the sidebar's own session rows. The listener, the
+// hydration and the projection are covered against the real App in
+// App.context-badge.workflow.test.tsx; this pins THIS surface's gate and wiring,
+// which is the half that cannot be shared and is therefore the half that drifts.
+
+const sessionId = "s1";
+const CLAUDE_PATTERN = String.raw`^ {2}Context [░█]+ (\d{1,3})%`;
+
+function agentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    id: "claude",
+    label: "Claude Code",
+    command: "claude",
+    color: "#d97757",
+    envs: [],
+    isolatedHome: false,
+    ...overrides,
+  };
+}
+
+function badge(root: ParentNode): HTMLElement | null {
+  return root.querySelector<HTMLElement>(`[data-ac-testid="session.${sessionId}.contextBadge"]`);
+}
+
+async function renderRow(settings: AppSettings, sessionProps: Partial<Session> = {}) {
+  const fake = new FakeTransport();
+  fake.resolve("get_settings", settings);
+  const rendered = renderWithFakeTransport(
+    () => (
+      <SessionItem
+        session={session({ id: sessionId, agentId: "claude", agentLabel: "Claude Code", ...sessionProps })}
+        isActive={false}
+      />
+    ),
+    fake,
+  );
+  await settingsStore.load();
+  return rendered;
+}
+
+describe("SessionItem CTX badge (#1033)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  it("renders no badge at all when the agent has no pattern", async () => {
+    const rendered = await renderRow(baseSettings({ agents: [agentConfig()] }));
+    try {
+      // Not N/A, not an empty chip: absent entirely.
+      expect(badge(rendered.root)).toBeNull();
+      expect(rendered.root.textContent).not.toContain("CTX");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("renders N/A when a pattern is set but no reading has arrived", async () => {
+    const rendered = await renderRow(
+      baseSettings({ agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })] }),
+    );
+    try {
+      await waitFor(() => expect(badge(rendered.root)?.textContent).toBe("CTX N/A"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("paints the reading the store holds, including a real zero", async () => {
+    sessionsStore.setSessionContext(sessionId, 0);
+    const rendered = await renderRow(
+      baseSettings({ agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })] }),
+    );
+    try {
+      await waitFor(() => {
+        expect(badge(rendered.root)?.textContent).toBe("CTX 0%");
+        expect(badge(rendered.root)?.getAttribute("role")).toBe("meter");
+      });
+
+      sessionsStore.setSessionContext(sessionId, 42);
+      await waitFor(() => expect(badge(rendered.root)?.textContent).toBe("CTX 42%"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("appears with no reload as soon as a pattern is saved", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", baseSettings({ agents: [agentConfig()] }));
+    const rendered = renderWithFakeTransport(
+      () => (
+        <SessionItem
+          session={session({ id: sessionId, agentId: "claude", agentLabel: "Claude Code" })}
+          isActive={false}
+        />
+      ),
+      fake,
+    );
+    try {
+      await settingsStore.load();
+      expect(badge(rendered.root)).toBeNull();
+
+      // What SettingsModal's save does: re-resolve settings into the signal.
+      fake.resolve(
+        "get_settings",
+        baseSettings({ agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })] }),
+      );
+      await settingsStore.load();
+
+      await waitFor(() => expect(badge(rendered.root)?.textContent).toBe("CTX N/A"));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // Pins the gate at the only place #1033 could break #1031's key-by-id rule: two
+  // agents share a command, only one configures a pattern.
+  it("keys the gate by agent id and never by command", async () => {
+    const rendered = await renderRow(
+      baseSettings({
+        agents: [
+          agentConfig({ id: "claude", contextRegex: CLAUDE_PATTERN }),
+          agentConfig({ id: "claude-2", label: "Claude Two" }),
+        ],
+      }),
+      { agentId: "claude-2", agentLabel: "Claude Two" },
+    );
+    try {
+      expect(badge(rendered.root)).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows no badge for a plain shell", async () => {
+    const rendered = await renderRow(
+      baseSettings({ agents: [agentConfig({ contextRegex: CLAUDE_PATTERN })] }),
+      { agentId: null, agentLabel: null },
+    );
+    try {
+      expect(badge(rendered.root)).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -13,6 +13,8 @@ import { voiceRecorder, formatRecordingTime } from "../../shared/voice-recorder"
 import OpenAgentModal from "./OpenAgentModal";
 import AgentPickerModal from "./AgentPickerModal";
 import ProfileOutdatedBadge from "./ProfileOutdatedBadge";
+import ContextBadge from "./ContextBadge";
+import { contextBadgeConfigured } from "./session-context";
 import { TelegramIcon } from "./TelegramIcon";
 import { profileDisplayLabel, sessionProfileBadge } from "../../shared/profile-utils";
 import { sessionDotClass } from "./session-status";
@@ -48,6 +50,11 @@ const SessionItem: Component<{
     return settingsStore.current?.agents?.find((a) => a.id === props.session.agentId)?.label ?? null;
   };
   const profileBadge = () => sessionProfileBadge(props.session);
+  // #1033 - settingsStore.current is a signal, so saving a pattern makes the badge
+  // appear or disappear with no reload.
+  const ctxVisible = () =>
+    contextBadgeConfigured(settingsStore.current?.agents, props.session.agentId);
+  const ctxPercent = () => sessionsStore.contextPercentBySessionId[props.session.id];
   // #548: unify with the ProjectPanel quick-access tooltip — resolve the name of
   // the EFFECTIVE profile via the SAME shared resolver (no second resolver, no
   // badge-string parsing). Plain function, matching profileBadge.
@@ -386,6 +393,12 @@ const SessionItem: Component<{
                     {badge()}
                   </span>
                 )}
+              </Show>
+              <Show when={ctxVisible()}>
+                <ContextBadge
+                  percent={ctxPercent()}
+                  testId={`session.${props.session.id}.contextBadge`}
+                />
               </Show>
               <Show when={props.session.profileOutdated}>
                 <ProfileOutdatedBadge onReload={() => void restartSession()} />

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -42,6 +42,7 @@ import {
   resolveProfileLabel,
   resolveProfilePreview,
   sortedProfileLetters,
+  suggestedContextRegex,
   validateEnvRows,
 } from "../../shared/profile-utils";
 
@@ -2203,6 +2204,36 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             <div class="settings-hint">
               Filename AC writes into the agent root at launch (its AC context +
               Role.md). Leave blank to use the default shown.
+            </div>
+            <label class="settings-field">
+              <span class="settings-label">Context badge pattern</span>
+              <input
+                class="settings-input"
+                value={agent.contextRegex ?? ""}
+                onInput={(e) => updateAgent(i(), "contextRegex", e.currentTarget.value)}
+                placeholder={suggestedContextRegex(agent.command) ?? ""}
+                data-ac-testid={`settings.agentRow.${i()}.contextRegex`}
+                data-ac-role="textbox"
+                spellcheck={false}
+              />
+            </label>
+            <Show when={suggestedContextRegex(agent.command)}>
+              {(suggested) => (
+                <button
+                  class="settings-add-btn"
+                  onClick={() => updateAgent(i(), "contextRegex", suggested())}
+                  data-ac-testid={`settings.agentRow.${i()}.contextRegex.suggest`}
+                  data-ac-role="button"
+                >
+                  Use suggested pattern
+                </button>
+              )}
+            </Show>
+            <div class="settings-hint">
+              Best-effort pattern AC runs over what this agent draws in its terminal, to show
+              a CTX badge on its sessions. Capture group 1 is the percentage. The reading can
+              be unavailable, stale or absent, and a high one does not mean the session needs
+              restarting. <strong>Leave blank for no badge.</strong>
             </div>
             <label class="settings-checkbox-field">
               <input

--- a/src/sidebar/components/session-context.test.ts
+++ b/src/sidebar/components/session-context.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { AgentConfig } from "../../shared/types";
+import { contextBadgeConfigured, contextBadgeText } from "./session-context";
+
+function agent(over: Partial<AgentConfig> & { id: string }): AgentConfig {
+  return {
+    label: "Claude",
+    command: "claude",
+    color: "#d97757",
+    envs: [],
+    isolatedHome: false,
+    ...over,
+  };
+}
+
+describe("contextBadgeText", () => {
+  it("renders a reading as a percentage (a_reading_renders_as_a_percentage)", () => {
+    expect(contextBadgeText(42)).toBe("CTX 42%");
+    expect(contextBadgeText(100)).toBe("CTX 100%");
+  });
+
+  // The highest-value test in this file: it is the only thing that stays red if
+  // anyone writes `percent ? ... : "CTX N/A"`. A true 0% is a reading, and turning
+  // it into N/A keeps every other case working and is invisible on screen.
+  it("renders a real reading of zero as CTX 0%, never N/A (zero_is_a_reading_not_an_absence)", () => {
+    expect(contextBadgeText(0)).toBe("CTX 0%");
+  });
+
+  it("renders both null and undefined as one unavailable state (null_and_undefined_both_render_unavailable)", () => {
+    // Pins that unavailable is exactly one thing: an explicit null from the engine
+    // and a key no event has spoken for are indistinguishable to the user.
+    expect(contextBadgeText(null)).toBe("CTX N/A");
+    expect(contextBadgeText(undefined)).toBe("CTX N/A");
+  });
+
+  it("is total (the_projection_is_total)", () => {
+    for (const value of [0, 1, 50, 99, 100, null, undefined]) {
+      expect(() => contextBadgeText(value)).not.toThrow();
+      expect(contextBadgeText(value).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("contextBadgeConfigured", () => {
+  it("shows the badge for an agent with a pattern (a_configured_agent_is_visible)", () => {
+    expect(contextBadgeConfigured([agent({ id: "a", contextRegex: "x" })], "a")).toBe(true);
+  });
+
+  it("hides the badge for an agent with no pattern (an_agent_with_no_regex_is_not_visible)", () => {
+    expect(contextBadgeConfigured([agent({ id: "a" })], "a")).toBe(false);
+  });
+
+  // The hand-edited-file case: without this, such an agent shows a permanent N/A.
+  // This trim is a visibility test only; it never reaches a stored value.
+  it("hides the badge for a whitespace-only pattern (a_whitespace_only_regex_is_not_visible)", () => {
+    expect(contextBadgeConfigured([agent({ id: "a", contextRegex: "   " })], "a")).toBe(false);
+  });
+
+  it("hides the badge for a plain shell (a_null_agentId_is_not_visible)", () => {
+    const agents = [agent({ id: "a", contextRegex: "x" })];
+    expect(contextBadgeConfigured(agents, null)).toBe(false);
+    expect(contextBadgeConfigured(agents, undefined)).toBe(false);
+  });
+
+  it("hides the badge for an unknown agent id without throwing (an_unknown_agentId_is_not_visible)", () => {
+    expect(contextBadgeConfigured([agent({ id: "a", contextRegex: "x" })], "ghost")).toBe(false);
+    expect(contextBadgeConfigured(undefined, "a")).toBe(false);
+    expect(contextBadgeConfigured([], "a")).toBe(false);
+  });
+
+  // Pins #1031's hard rule at the only place #1033 could break it: two agents may
+  // share a command while only one configures a pattern, so the gate must key by id.
+  it("keys by agent id and never by command (the_gate_keys_by_id_and_not_by_command)", () => {
+    const agents = [
+      agent({ id: "claude-a", command: "claude", contextRegex: "x" }),
+      agent({ id: "claude-b", command: "claude" }),
+    ];
+    expect(contextBadgeConfigured(agents, "claude-a")).toBe(true);
+    expect(contextBadgeConfigured(agents, "claude-b")).toBe(false);
+  });
+});

--- a/src/sidebar/components/session-context.ts
+++ b/src/sidebar/components/session-context.ts
@@ -1,0 +1,45 @@
+import type { AgentConfig } from "../../shared/types";
+
+/**
+ * #1033 - no regex configured for this session's agent => no badge at all. Not N/A,
+ * not a chip, no visual noise. One resolver for all three surfaces, mirroring #548's
+ * rule for the profile tooltip: no second resolver, or the three drift.
+ *
+ * Takes its inputs as arguments rather than reading a session, because the three
+ * surfaces reach their session three different ways (`props.session` in SessionItem,
+ * `rootSession()` in RootAgentBanner, `session()` in ProjectPanel); a gate written
+ * against one of them compiles in exactly one of them.
+ *
+ * The `.trim()` here is a VISIBILITY test only and never touches a stored or
+ * transmitted value - the stored pattern is byte-for-byte what the user typed, and
+ * its leading whitespace is load-bearing. This exists so a legacy file hand-edited
+ * to `"contextRegex": "   "` does not show a permanent `N/A`.
+ *
+ * Keys by agent id and never by `command`: two agents may share `"command": "claude"`
+ * while only one configures a pattern.
+ */
+export function contextBadgeConfigured(
+  agents: AgentConfig[] | undefined,
+  agentId: string | null | undefined,
+): boolean {
+  if (!agentId) return false;
+  return !!agents?.find((a) => a.id === agentId)?.contextRegex?.trim();
+}
+
+/**
+ * #1033 Presentation projection: a context reading -> badge text. Total.
+ * Editing a value here changes pixels only; no behavior reads this string.
+ *
+ * Deliberately NOT injective: `null` (the engine says unavailable) and `undefined`
+ * (no event and no snapshot has spoken for this session yet) both map to `CTX N/A`,
+ * because unavailable is exactly one thing.
+ *
+ * The `=== null || === undefined` test is deliberate and must not be "simplified" to
+ * a truthiness check: `0` is a REAL reading and renders `CTX 0%`. A `percent ? ... :`
+ * here turns a true zero into `N/A`, keeps every other case working, and is invisible
+ * on screen.
+ */
+export function contextBadgeText(percent: number | null | undefined): string {
+  if (percent === null || percent === undefined) return "CTX N/A";
+  return `CTX ${percent}%`;
+}

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -378,4 +378,59 @@ describe("mergeSettingsForSavePreservingProjects api-server seed rebasing", () =
     expect(merged.apiServerPort).toBe(9000);
     expect(merged.apiServerBind).toBe("0.0.0.0");
   });
+
+  // #1033 - the context regex normalizer (plan SS9.3).
+  //
+  // The single most important test in this plan. The other three normalizers in this
+  // file all trim; this one must not. Leading whitespace is a regex's column anchor,
+  // and measured against regex 1.12.3 a trim turns the typed-in-the-input-box false
+  // positive from None into Some(99) while the real statusline keeps reading fine -
+  // so the damage is invisible in every normal case.
+  it("keeps a pattern's literal leading spaces byte-for-byte (a_pattern_with_literal_leading_spaces_is_not_trimmed)", () => {
+    const stored = String.raw`  Context [░█]+ (\d{1,3})%`;
+    const draft = settings({ agents: [agent({ id: "claude", contextRegex: stored })] });
+
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect(merged.agents[0]?.contextRegex).toBe(stored);
+    expect(merged.agents[0]?.contextRegex?.startsWith("  ")).toBe(true);
+  });
+
+  it("round-trips a normal pattern unchanged (a_set_pattern_round_trips)", () => {
+    const stored = String.raw`^ {2}Context [░█]+ (\d{1,3})%`;
+    const draft = settings({ agents: [agent({ id: "claude", contextRegex: stored })] });
+
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect(merged.agents[0]?.contextRegex).toBe(stored);
+  });
+
+  it("drops an empty pattern rather than persisting a sentinel (an_empty_pattern_is_dropped_not_persisted_as_a_sentinel)", () => {
+    // Rust's skip_serializing_if = "Option::is_none" does NOT omit Some(""), so an
+    // empty string here would persist as `"contextRegex": ""`.
+    const draft = settings({ agents: [agent({ id: "empty", contextRegex: "" })] });
+
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect("contextRegex" in (merged.agents[0] as object)).toBe(false);
+  });
+
+  it("drops a whitespace-only pattern (a_whitespace_only_pattern_is_dropped)", () => {
+    // It cannot compile anyway (no capture group), so the sentinel rule is unaffected
+    // and this does not weaken the no-trim guarantee above.
+    const draft = settings({ agents: [agent({ id: "spaces", contextRegex: "   " })] });
+
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect("contextRegex" in (merged.agents[0] as object)).toBe(false);
+  });
+
+  it("leaves an agent without the field unchanged (an_agent_without_the_field_is_unchanged)", () => {
+    const draft = settings({ agents: [agent({ id: "absent" })] });
+
+    const merged = mergeSettingsForSavePreservingProjects(draft, settings());
+
+    expect("contextRegex" in (merged.agents[0] as object)).toBe(false);
+    expect(merged.agents[0]?.id).toBe("absent");
+  });
 });

--- a/src/sidebar/components/settings-save.ts
+++ b/src/sidebar/components/settings-save.ts
@@ -41,6 +41,26 @@ function normalizeAgentConfigSeed(agent: AgentConfig): AgentConfig {
 }
 
 /**
+ * #1033 - normalize the optional context regex. Mirrors
+ * normalizeAgentInstructionsFilename's CONTRACT (drop the key rather than persist
+ * an empty-string sentinel, since Rust's skip_serializing_if = "Option::is_none"
+ * does not omit Some("")) but deliberately NOT its trim.
+ *
+ * A regex's leading whitespace is load-bearing: a user who writes the column-2
+ * anchor as two literal spaces instead of `^ {2}` has it silently deleted by a
+ * trim, and the pattern then matches agent prose anywhere on the row. Measured
+ * against regex 1.12.3: trimming turns the typed-in-the-input-box false positive
+ * from None into Some(99) while the real statusline keeps reading correctly, so
+ * the damage is invisible in every normal case. Whitespace-only is still dropped
+ * (it cannot compile: no capture group), so the sentinel rule is unaffected.
+ */
+function normalizeAgentContextRegex(agent: AgentConfig): AgentConfig {
+  if (agent.contextRegex && agent.contextRegex.trim()) return agent; // kept BYTE-FOR-BYTE
+  const { contextRegex: _drop, ...rest } = agent;
+  return rest;
+}
+
+/**
  * #868 - normalize the optional runtime backend. The editor preserves a hidden
  * image in the live draft while toggling Container <-> Local, but Local must
  * persist exactly like the historical default: no `backend` object at all.
@@ -95,6 +115,7 @@ export function mergeSettingsForSavePreservingProjects(
     agents: draft.agents
       .map(normalizeAgentInstructionsFilename)
       .map(normalizeAgentConfigSeed)
+      .map(normalizeAgentContextRegex)
       .map(normalizeAgentBackend),
     projectPaths: fresh.projectPaths ?? [],
     projectPath: fresh.projectPath ?? null,

--- a/src/sidebar/stores/sessions.test.ts
+++ b/src/sidebar/stores/sessions.test.ts
@@ -107,3 +107,79 @@ describe("sessionsStore.setCommunication (#676)", () => {
     ]);
   });
 });
+
+describe("sessionsStore context readings (#1033)", () => {
+  beforeEach(() => {
+    sessionsStore.setSessions([]);
+  });
+  afterEach(() => {
+    sessionsStore.setSessions([]);
+  });
+
+  it("stores a reading an event carried (an_event_sets_a_sessions_reading)", () => {
+    sessionsStore.setSessionContext("ctx-a", 42);
+
+    expect(sessionsStore.contextPercentBySessionId["ctx-a"]).toBe(42);
+  });
+
+  it("keeps two sessions independent (two_sessions_never_cross)", () => {
+    sessionsStore.setSessionContext("ctx-b1", 42);
+    sessionsStore.setSessionContext("ctx-b2", 7);
+
+    expect(sessionsStore.contextPercentBySessionId["ctx-b1"]).toBe(42);
+    expect(sessionsStore.contextPercentBySessionId["ctx-b2"]).toBe(7);
+  });
+
+  it("stores an explicit null rather than dropping the key (a_null_is_stored_as_null_not_dropped)", () => {
+    // null is the engine's answer, not an absence: it must overwrite a stale reading.
+    sessionsStore.setSessionContext("ctx-c", 42);
+    sessionsStore.setSessionContext("ctx-c", null);
+
+    expect("ctx-c" in sessionsStore.contextPercentBySessionId).toBe(true);
+    expect(sessionsStore.contextPercentBySessionId["ctx-c"]).toBeNull();
+  });
+
+  it("seeds a session no event has spoken for (hydrate_seeds_a_session_no_event_has_spoken_for)", () => {
+    sessionsStore.hydrateSessionContext("ctx-d", 42);
+
+    expect(sessionsStore.contextPercentBySessionId["ctx-d"]).toBe(42);
+  });
+
+  // The ordering rule: App.tsx registers the listener BEFORE hydrating, so a slow
+  // invoke must never overwrite a fresher event that already landed.
+  it("never clobbers a value an event already set (hydrate_never_clobbers_a_value_an_event_already_set)", () => {
+    sessionsStore.setSessionContext("ctx-e", 43);
+
+    sessionsStore.hydrateSessionContext("ctx-e", 42);
+
+    expect(sessionsStore.contextPercentBySessionId["ctx-e"]).toBe(43);
+  });
+
+  // Red if the guard is a truthiness check instead of a key-presence check.
+  it("treats a stored zero as spoken for (hydrate_treats_a_stored_zero_as_spoken_for)", () => {
+    sessionsStore.setSessionContext("ctx-f", 0);
+
+    sessionsStore.hydrateSessionContext("ctx-f", 42);
+
+    expect(sessionsStore.contextPercentBySessionId["ctx-f"]).toBe(0);
+  });
+
+  // A stored null is an answer too, so hydration must not "fill it in".
+  it("treats a stored null as spoken for (hydrate_treats_a_stored_null_as_spoken_for)", () => {
+    sessionsStore.setSessionContext("ctx-g", null);
+
+    sessionsStore.hydrateSessionContext("ctx-g", 42);
+
+    expect(sessionsStore.contextPercentBySessionId["ctx-g"]).toBeNull();
+  });
+
+  // The map lives outside state.sessions on purpose: setSessions is a wholesale
+  // replace with no field preservation, and a reading on Session would be wiped.
+  it("survives setSessions's wholesale replace (setSessions_cannot_wipe_a_reading)", () => {
+    sessionsStore.setSessionContext("ctx-h", 42);
+
+    sessionsStore.setSessions([session({ id: "ctx-h" })]);
+
+    expect(sessionsStore.contextPercentBySessionId["ctx-h"]).toBe(42);
+  });
+});

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -1,4 +1,4 @@
-import { createMemo, createSignal } from "solid-js";
+import { batch, createMemo, createSignal } from "solid-js";
 import { createStore } from "solid-js/store";
 import { NO_TEAM } from "../../shared/constants";
 import type { RepoMatch, Session, SessionCommunication, SessionRepo, SessionsState, Team, TeamSessionGroup } from "../../shared/types";
@@ -24,6 +24,7 @@ const [state, setState] = createStore<SessionsState>({
   repos: [],
   coordSortByActivity: false,
   lastActivityBySessionId: {},
+  contextPercentBySessionId: {},
   hydrated: false,
 });
 
@@ -439,6 +440,9 @@ export const sessionsStore = {
   get lastActivityBySessionId() {
     return state.lastActivityBySessionId;
   },
+  get contextPercentBySessionId() {
+    return state.contextPercentBySessionId;
+  },
   get hydrated() {
     return state.hydrated;
   },
@@ -505,6 +509,53 @@ export const sessionsStore = {
 
   markActivity(sessionId: string) {
     setState("lastActivityBySessionId", (prev) => ({ ...prev, [sessionId]: performance.now() }));
+  },
+
+  /**
+   * #1033 - a `session_context` event landed. `null` is stored as `null`, never
+   * dropped: it is the engine's explicit "unavailable", and it must overwrite a
+   * stale reading. Touches no part of `state.sessions`, so `setSessions`'s
+   * wholesale replace cannot reach it and #592's setSessions warning does not
+   * apply.
+   */
+  setSessionContext(sessionId: string, percent: number | null) {
+    setState("contextPercentBySessionId", (prev) => ({ ...prev, [sessionId]: percent }));
+  },
+
+  /**
+   * #1033 - snapshot-seed a session no event has spoken for. A no-op when the key
+   * already exists, which is what lets App.tsx register the listener FIRST and
+   * hydrate afterwards without a slow invoke clobbering a fresher event.
+   *
+   * The guard is key PRESENCE, never truthiness: a stored `0` is a real reading
+   * and a stored `null` is a real answer, and both must count as spoken for. A
+   * `!prev[sessionId]` here would let a stale snapshot overwrite a true `0%`.
+   */
+  hydrateSessionContext(sessionId: string, percent: number | null) {
+    setState("contextPercentBySessionId", (prev) =>
+      sessionId in prev ? prev : { ...prev, [sessionId]: percent },
+    );
+  },
+
+  /**
+   * #1033 - the reading map is event-fed and outlives a render, so it leaks between
+   * tests in the same file exactly as #943 B2's volatile layer did: order-dependent
+   * and silently wrong rather than red. Not a production path; setSessions cannot
+   * clear this map by design.
+   */
+  resetContextReadingsForTests() {
+    batch(() => {
+      // Deletes each key rather than setState(path, {}). Measured: Solid MERGES an
+      // object into the value at a path, whether passed directly or returned from
+      // an updater, so both `{}` forms are a silent no-op here. Mirrors
+      // replicaVolatileStore.clearAll, which clears its keyed map the same way.
+      //
+      // The key must be DELETED and not set to null: a present null is a real
+      // answer, and hydrateSessionContext would then no-op on it.
+      for (const id of Object.keys(state.contextPercentBySessionId)) {
+        setState("contextPercentBySessionId", id, undefined as unknown as null);
+      }
+    });
   },
 
   toggleTeamCollapsed(teamId: string) {

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -758,6 +758,28 @@ html, body, #root {
   white-space: nowrap;
 }
 
+/* #1033 - context-window reading. A signal, never a control: no cursor, no hover
+   affordance, no colour that encodes a value, no threshold, no animation. */
+.ctx-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 3px;
+  background: var(--sidebar-border);
+  color: var(--sidebar-fg-dim);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  line-height: 1;
+  white-space: nowrap;
+}
+.ctx-badge.unavailable {
+  opacity: 0.4;
+}
+
 /* #592 - drift indicator: amber, clickable (Reload). */
 .profile-outdated-badge {
   display: inline-flex;


### PR DESCRIPTION
Closes #1033. Part of epic #1031 (Step 1 of 2 — global config). **This is the visible half.** #1032 landed the engine and renders nothing; everything a user can see is here.

## What ships

A `CTX 42%` chip beside the agent label on coding-agent sessions, in all three sidebar surfaces, plus the field that configures it in Settings → Coding Agents. **No pattern configured → no badge at all** (not `N/A`, no chip, no noise). Frontend-only: `git diff --name-only d1b4a52..2726bab -- src-tauri/ Cargo.toml Cargo.lock` is **empty**.

```html
<span class="ctx-badge" role="meter" aria-label="Context window used"
      aria-valuemin="0" aria-valuemax="100" aria-valuenow="42"
      aria-valuetext="Context 42% used" data-ac-state="reading" title="…">CTX 42%</span>
```

**The reading never drives an action.** No thresholds at all — AC has no denominator (one rounded integer, unknown source), so any threshold would be invented. That also makes "not colour alone", "honour reduced motion" and "no live region" true by construction rather than by care.

## Plan

`plans/1033-context-badge-sidebar.md`, revision 1, certified `READY_FOR_IMPLEMENTATION` by `architect` in one lite pass.

**Certification check — use the blob, not the worktree:**

```
git cat-file blob <rev>:plans/1033-context-badge-sidebar.md | sha256sum
→ 5b4a2784c99db3a72fc0ee32c2d6e8c2375485b0b49dff6a9c31363abcf70671
```

`core.autocrlf=true` is the Git-for-Windows install default and `.gitattributes` has no `*.md` rule, so a fresh clone renders the file CRLF and a worktree `sha256sum` will not match. Blob is canonical. Same as #1032; see #1043.

## Lite, but not a copy job — three of the "copy this precedent" instructions were traps

Architect's §10 flags the gap rather than letting `READY_FOR_IMPLEMENTATION` imply "mechanical". Each trap ships a defect if followed faithfully:

1. **#529's normalizer trims and persists the trimmed value.** Copying it fails the badge **open**: leading whitespace is load-bearing in a regex, so stripping a column-2 anchor flips the typed-in-input-box attack from rejected to `Some(99)`. **This is the same defect class that failed #1032's Step 9 review**, arriving by a different route. The normalizer here drops empty/whitespace but stores kept values byte-for-byte — a stated divergence from `instructionsFilename`, `configSeed.dest` and `backend.image`, which all trim.
2. **#529's placeholder semantics invert.** There blank means "use the default shown" and the backend falls back; here blank means the feature is **off** and no fallback pattern exists anywhere. The hint reads "Leave blank for no badge."
3. **"Mirror the #882 path exactly" is insufficient.** The engine emits **only on change**, and unlike #882 the value does not ride on `Session`. A session already at 42% emits nothing more, so a sidebar that starts listening later renders **`CTX N/A` forever** while the terminal shows 42%. **`get_session_context` hydration is mandatory, not an optimisation** — listener first, then hydrate-if-absent.

**And the pattern cannot be typed.** `░` is U+2591, `█` is U+2588. With a text field as the only affordance the feature is unconfigurable for Claude — the agent this was asked for. Hence the **"Use suggested pattern"** button, whose helper returns `null` for Gemini and anything unknown rather than guessing: a wrong filename costs a renamed file, a wrong pattern costs a silently wrong percentage.

## Verification

`npx tsc --noEmit` green · `npm test` **129 files / 1129 tests / 0 failures** (+49 new) · `SettingsModal.automation.test.ts` 40/40.

**No test was taken as evidence without a mutation.** Each defect was written, observed red, restored:

| Defect written | Result |
|---|---|
| `percent ? … : "CTX N/A"` in the projection | red: `expected 'CTX N/A' to be 'CTX 0%'` |
| #529's trim copied faithfully | red — **and only that one**, which is the trap's invisibility exactly |
| truthiness guard in `hydrateSessionContext` | 2 red |
| `<Show when={props.percent}>` | red — a **fourth** way to destroy `0` the plan did not list (`0` is falsy in JSX too) |
| hydration block removed from `App.tsx` | red: `expected 'CTX N/A' to be 'CTX 42%'` — proves the badge is painted by the snapshot with **no event ever emitted** |

Merge union proved on both sides: 22/22 branch files blob-identical across the merge, the 4 files the merge added are set-equal to #1030's 4, and the four files bearing #1032's frozen contract are blob-identical across `d1b4a52`/`c668362`/`2726bab`. The `session_context.rs` name collision is a **pun** — that file is seeded-template machinery (`Context.AgentsCommander.md`), proved at the source by `git grep` returning exit 1, not by its name.

## Instruments that lied, recorded because they will lie again

- **`\` collapses to `\` above the shell, in the tool-call layer** — quoting a heredoc does not help. One edit was literally `replace("░", "░")`: a no-op that passed every guard, because the patcher asserted the anchor *matched* and never that the text *changed*.
- **`.ts`/`.tsx` are CRLF in the worktree and LF in the blob** (no `.gitattributes` rule, system-wide `core.autocrlf`). A mutation anchored on `\n` silently did not apply and reported `21 passed` — indistinguishable from "the test is a fiction".
- **Piped `git log --oneline` truncates**: 6 reported where the truth is 9. Every count in this PR is from a file or a subprocess.

The rule both reviewers converged on: **RED is self-proving (it cannot go red without landing, given a deterministically green baseline carrying the expected assertion); GREEN proves nothing** — it means either "landed and uncovered" or "never landed". Both green probes in this branch were re-run with an explicit landing proof before being trusted.

## Follow-ups, non-blocking

- **The RootAgentBanner badge is unpinned** — there is no test file for that surface at all. Verified with a landing proof: making the badge never render there leaves the suite 1129/1129 green. The code is correct against §5.8; the exposure is future drift. A follow-up test.
- **#1043** — three false statements in #1032's landed plan. §5.1 of this plan also contradicts itself harmlessly (says insert after `backend?` while its rationale says before; the rationale was followed and matches Rust's field order). Plan committed unedited and flagged in the commit.
- **#1034** (project-scoped config) and **#1040** (the general liveness gap) remain out of scope.
