### PR TITLE
chore(#1046): purge explanatory comments from 56 TS/TSX files

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -10,14 +10,8 @@ import "./styles/browser.css";
 
 const MIN_SIDEBAR_WIDTH = 200;
 const MAX_SIDEBAR_WIDTH = 600;
-// #840 — the web view mirrors the desktop default: sidebar on the right unless
-// the persisted `mainSidebarSide` preference says "left".
 const DEFAULT_SIDEBAR_SIDE: MainSidebarSide = "right";
 
-/**
- * Combined browser layout: sidebar + terminal with a draggable divider.
- * Used when accessing AgentsCommander via web browser instead of Tauri.
- */
 const BrowserApp: Component = () => {
   const [sidebarWidth, setSidebarWidth] = createSignal(300);
   const [sidebarSide, setSidebarSide] = createSignal<MainSidebarSide>(DEFAULT_SIDEBAR_SIDE);
@@ -33,9 +27,6 @@ const BrowserApp: Component = () => {
     Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, raw));
 
   onMount(async () => {
-    // BrowserApp owns the document theme because its children are embedded to
-    // suppress titlebars/window geometry. Dark is the CSS base, so first paint
-    // is dark with no optimistic class; correct from persisted settings below.
     const unlisten = await onThemeChanged(({ light }) => {
       applyTheme(light);
     });
@@ -49,8 +40,6 @@ const BrowserApp: Component = () => {
       const settings = await SettingsAPI.get();
       if (!disposed) {
         applyTheme(settings.themeLight);
-        // #840 — honor the shared `mainSidebarSide` preference. Default to the
-        // right for any value that isn't an explicit "left".
         setSidebarSide(settings.mainSidebarSide === "left" ? "left" : DEFAULT_SIDEBAR_SIDE);
       }
     } catch (err) {
@@ -63,11 +52,6 @@ const BrowserApp: Component = () => {
     unlistenThemeChanged?.();
   });
 
-  // #840 — flip the sidebar side and write it through to the shared
-  // `mainSidebarSide` setting (the same preference the desktop Titlebar drives),
-  // so web and desktop stay in sync. Optimistic: update the signal first for a
-  // snappy swap, then persist; on failure we keep the UI state and just log —
-  // this mirrors the desktop side-preset handler, which also does not roll back.
   const toggleSide = async () => {
     const next: MainSidebarSide = sidebarSide() === "right" ? "left" : "right";
     setSidebarSide(next);
@@ -82,9 +66,6 @@ const BrowserApp: Component = () => {
   const onMouseDown = (e: MouseEvent) => {
     e.preventDefault();
     setDragging(true);
-    // Capture the side at drag start. The divider math mirrors main/App.tsx: a
-    // left sidebar grows with clientX; a right sidebar grows as the pointer
-    // moves toward it (innerWidth - clientX).
     const side = sidebarSide();
 
     const onMouseMove = (e: MouseEvent) => {
@@ -102,7 +83,6 @@ const BrowserApp: Component = () => {
     document.addEventListener("mouseup", onMouseUp);
   };
 
-  // Touch support for mobile
   const onTouchStart = (e: TouchEvent) => {
     e.preventDefault();
     setDragging(true);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,6 @@ import { initLogLevelForWindow } from "./shared/log-level";
 const params = new URLSearchParams(window.location.search);
 const windowType = params.get("window");
 
-// Capture remote token from URL for WebSocket auth (browser mode)
 const remoteToken = params.get("remoteToken");
 if (remoteToken) {
   sessionStorage.setItem("remoteToken", remoteToken);
@@ -27,24 +26,14 @@ if (isTauri) {
   void initAutomationBridge();
 }
 
-// #612 Install the console log-level gate for THIS window (all 6 window roots
-// route through here). Ungated on purpose: the function's internal try/catch
-// falls back to a static Info level in non-Tauri/browser contexts where the
-// event bus is absent. Runs after the `console-capture` side-effect import (the
-// first import above) has installed the console monkey-patch this gate flips.
 void initLogLevelForWindow();
 
-// Browser mode (no Tauri): BrowserApp regardless of ?window param.
-// Remote web clients load ?window=main but still need the split-browser UX.
 const isLegacyDetached =
   windowType === "terminal" && params.get("detached") === "true";
 
 if (!isTauri) {
   render(() => <BrowserApp />, root);
 } else if (windowType === "detached" || isLegacyDetached) {
-  // New URL: ?window=detached&sessionId=<id>
-  // Legacy URL (pre-0.8 backend): ?window=terminal&sessionId=<id>&detached=true
-  // Kept for one version so an in-flight detach survives a mid-upgrade.
   const lockedSessionId = params.get("sessionId") || undefined;
   render(
     () => <TerminalApp lockedSessionId={lockedSessionId} detached={true} />,
@@ -55,15 +44,10 @@ if (!isTauri) {
 } else if (windowType === "resource-monitor") {
   render(() => <ResourceMonitorApp />, root);
 } else if (windowType === "screenshot-overlay") {
-  // #714 Mark the document so the overlay's transparent html/body/#root CSS
-  // (scoped to this attribute) applies here ONLY, never leaking into the other
-  // windows that share this single bundle. Set BEFORE rendering.
   document.documentElement.setAttribute("data-window", "screenshot-overlay");
   render(() => <ScreenshotOverlayApp />, root);
 } else if (windowType === "spec-board") {
   render(() => <SpecBoardApp />, root);
 } else {
-  // "main", legacy "sidebar", legacy non-detached "terminal", or no param →
-  // unified MainApp.
   render(() => <MainApp />, root);
 }

--- a/src/main/App.tsx
+++ b/src/main/App.tsx
@@ -80,8 +80,6 @@ const MainApp: Component = () => {
     divider.addEventListener("pointercancel", onUp);
   };
 
-  // Keyboard resize for a11y (plan §DW.10). ← / → adjust ±10px,
-  // Shift+← / Shift+→ ±40px, Home/End snap to clamp bounds.
   const onDividerKeyDown = (e: KeyboardEvent) => {
     const step = e.shiftKey ? 40 : 10;
     let next: number | null = null;
@@ -96,8 +94,6 @@ const MainApp: Component = () => {
     persistWidth(clamped);
   };
 
-  // Stateless detached-window count (plan §A3B.3 / G3-B1 — must NOT read
-  // sessionsStore because the store is Phase-2 and not authoritative anyway).
   async function countDetachedWindows(): Promise<number> {
     if (!isTauri) return 0;
     const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
@@ -126,9 +122,6 @@ const MainApp: Component = () => {
     }
   };
 
-  // Re-clamp splitter width when the OS resizes the window (e.g. monitor
-  // disconnect, Win+Arrow snap). Without this the saved width can exceed
-  // windowWidth - 300 and the terminal pane collapses (R2.5).
   const onWindowResize = () => {
     setSidebarWidth((w) => clampMainSidebarWidth(w, window.innerWidth));
   };
@@ -147,34 +140,19 @@ const MainApp: Component = () => {
     }
   };
 
-  // #777: start the Non-stop watchdog client ONCE for the main window. Called
-  // SYNCHRONOUSLY in MainApp's body (dev-webpage-ui #2) so its createEffect /
-  // onCleanup bind to MainApp's reactive owner and are torn down with the app.
-  // Must NOT move inside the async onMount below: after an await, createEffect /
-  // onCleanup would run outside the owner and leak the keepalive interval.
   startNonStopWatchdogClient();
 
   onMount(async () => {
-    // #289 / dark-default — dark is the base CSS, so the first frame is dark
-    // with no optimistic class; the SettingsAPI.get() block below opts into
-    // light only when the persisted preference says so. The embedded
-    // SidebarApp + TerminalApp each run their own corrective step on the same
-    // documentElement — idempotent overlap is fine.
 
-    // Main window owns zoom + geometry persistence. Embedded Sidebar+Terminal
-    // skip these initializers per DW.2.
     cleanupZoom = await initZoom("main");
     cleanupGeometry = await initWindowGeometry("main");
 
-    // Load splitter width + always-on-top from settings.
     try {
       const settings = await SettingsAPI.get();
       document.documentElement.classList.toggle("light-theme", settings.themeLight);
       const saved = settings.mainSidebarWidth ?? DEFAULT_MAIN_SIDEBAR_WIDTH;
       setSidebarWidth(clampMainSidebarWidth(saved, window.innerWidth));
       setSidebarSide(settings.mainSidebarSide === "left" ? "left" : DEFAULT_SIDEBAR_SIDE);
-      // #587 — restore the persisted central-view choice (RM attached vs
-      // terminal). setInitialView only sets the signal; it does not persist.
       centralViewStore.setInitialView(
         settings.mainResourceMonitorAttached ? "resourceMonitor" : "terminal"
       );
@@ -186,24 +164,14 @@ const MainApp: Component = () => {
       console.error("Failed to load main-window settings:", e);
     }
 
-    // Home auto-visibility contract (issue #183 + #164). Wired in a
-    // dedicated helper so the gating logic — especially the userInitiated
-    // discriminator on session_switched — is unit-testable in isolation.
     unlisteners.push(...(await wireHomeListeners()));
 
-    // #587 — central-view event contract (gated session_switched + RM attach).
-    // Extracted to a helper that mirrors wireHomeListeners so the userInitiated
-    // discriminator is unit-testable in isolation (see listeners-central-view.ts).
     unlisteners.push(...(await wireCentralViewListeners()));
 
     window.addEventListener("resize", onWindowResize);
     window.addEventListener("main-sidebar-width-change", onSidebarWidthChange);
     window.addEventListener("main-sidebar-side-change", onSidebarSideChange);
 
-    // Quit-confirmation guard (plan §A3B.3 / G.13 / G3-M1).
-    // - If 0 detached windows → let the close proceed (Tauri exits normally).
-    // - If ≥1 detached → preventDefault, open custom modal.
-    // Re-entry guard covers double-X / Alt+F4 while modal is already open.
     if (isTauri) {
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
       const win = getCurrentWindow();

--- a/src/main/components/ErrorModal.tsx
+++ b/src/main/components/ErrorModal.tsx
@@ -6,7 +6,6 @@ import { DebugAPI, onErrorLogEvent } from "../../shared/ipc";
 import { isTauri } from "../../shared/platform";
 import { errorModalStore } from "../stores/error-modal";
 
-/** Copy-to-clipboard text for one entry — header line + full message. */
 function formatEntry(e: ErrorLogEntry): string {
   return `${e.timestamp} [${e.level}] ${e.target}\n${e.message}`;
 }
@@ -21,15 +20,8 @@ const ErrorModal: Component = () => {
   let wasOpen = false;
   const unlisteners: UnlistenFn[] = [];
 
-  // H1: a memo notifies dependents only when the entry's *identity* changes.
-  // Reading errorModalStore.current directly in an effect re-fires whenever
-  // entries() changes — including when a background error is enqueued behind an
-  // already-open modal — which would steal focus and reset "Copied!". `enqueue`
-  // only appends, so an already-shown entry keeps its object reference and the
-  // memo stays quiet; it fires only on real transitions (open, advance, close).
   const currentEntry = createMemo(() => errorModalStore.current);
 
-  // --- Backend feed: listen for pings, drain on each + once on mount. -------
   const drainAndEnqueue = async () => {
     try {
       errorModalStore.enqueue(await DebugAPI.drainErrorLogs());
@@ -40,14 +32,10 @@ const ErrorModal: Component = () => {
 
   onMount(async () => {
     if (!isTauri) return; // Web remote client: the error modal is desktop-only.
-    // Subscribe BEFORE the initial drain so a ping fired mid-mount is not lost
-    // (subscribe-before-drain ordering rule). A ping racing the drain just triggers
-    // a second drain — harmless: read-and-clear returns [] when already empty.
     unlisteners.push(await onErrorLogEvent(drainAndEnqueue));
     await drainAndEnqueue();
   });
 
-  // --- Keyboard: ESC dismisses, Tab traps; modal owns the keyboard. --------
   onMount(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (!errorModalStore.open) return; // closed: let keys through untouched
@@ -59,18 +47,11 @@ const ErrorModal: Component = () => {
       }
       if (e.key === "Tab") {
         e.stopImmediatePropagation();
-        // H2: the scrollable message box is in the trap, in DOM order, so a
-        // keyboard-only user can Tab to it and scroll a long multi-line error.
         const focusables = [messageRef, copyBtnRef, dismissBtnRef].filter(
           Boolean
         ) as HTMLElement[];
         if (focusables.length < 2) return;
         const idx = focusables.indexOf(document.activeElement as HTMLElement);
-        // F1: activeElement can be outside the trap entirely — e.g. blurred to
-        // <body> after a click on the modal's non-focusable backdrop / header /
-        // padding. idx is -1 then; without this guard the forward branch's
-        // `idx === length - 1` is false, preventDefault is skipped, and native
-        // Tab escapes the modal to an element behind it.
         if (idx === -1) {
           e.preventDefault();
           (e.shiftKey ? focusables[focusables.length - 1] : focusables[0]).focus();
@@ -83,15 +64,8 @@ const ErrorModal: Component = () => {
         }
         return;
       }
-      // Any other key while open (incl. Enter): swallow propagation so xterm.js
-      // / global shortcuts do not react behind the modal. NOT preventDefault —
-      // native Enter/Space still activates the focused button, and arrow keys
-      // still scroll the focused message box (default action).
       e.stopImmediatePropagation();
     };
-    // Capture phase + stopImmediatePropagation. ErrorModal mounts before
-    // QuitConfirmModal ever does, so its capture listener is registered first
-    // and wins — while the error modal is open it fully owns the keyboard.
     document.addEventListener("keydown", onKeyDown, true);
     onCleanup(() => document.removeEventListener("keydown", onKeyDown, true));
   });
@@ -101,7 +75,6 @@ const ErrorModal: Component = () => {
     if (copyResetTimer) clearTimeout(copyResetTimer);
   });
 
-  // --- On closed->open while unfocused: flash the taskbar. Track focus owner.
   createEffect(() => {
     const open = errorModalStore.open;
     if (open === wasOpen) return;
@@ -125,9 +98,6 @@ const ErrorModal: Component = () => {
     }
   });
 
-  // --- On open / advance to next entry: focus Dismiss, reset Copy state. ----
-  // Tracks currentEntry() (the H1 memo) so it does NOT re-fire when a
-  // background error is enqueued behind an already-open modal.
   createEffect(() => {
     const cur = currentEntry();
     setCopied(false);

--- a/src/main/components/QuitConfirmModal.tsx
+++ b/src/main/components/QuitConfirmModal.tsx
@@ -2,11 +2,8 @@ import { Component, onMount, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
 
 export interface QuitConfirmModalProps {
-  /** Number of detached sessions that will be closed if the user confirms. */
   detachedCount: number;
-  /** User cancelled — clicked Cancel, pressed Enter on Cancel, or pressed ESC. */
   onCancel: () => void;
-  /** User explicitly confirmed — clicked Quit or Tab-focused Quit then pressed Enter. */
   onQuit: () => void;
 }
 
@@ -16,14 +13,10 @@ const QuitConfirmModal: Component<QuitConfirmModalProps> = (props) => {
   let previouslyFocused: HTMLElement | null = null;
 
   onMount(() => {
-    // Remember focus owner so we can restore it on close.
     previouslyFocused = document.activeElement as HTMLElement | null;
 
-    // Initial focus: Cancel (the safe button).
     cancelBtnRef?.focus();
 
-    // Keyboard routing (capture phase — see A3B.2.3): Enter on Cancel-focus = Cancel,
-    // Enter on Quit-focus = Quit, ESC = Cancel always, Tab cycles [Cancel, Quit].
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
@@ -34,8 +27,6 @@ const QuitConfirmModal: Component<QuitConfirmModalProps> = (props) => {
       if (e.key === "Enter") {
         e.preventDefault();
         e.stopPropagation();
-        // Enter triggers whichever button is focused. Default focus is Cancel,
-        // so Enter-mash = Cancel. User must Tab to Quit before Enter destroys.
         if (document.activeElement === quitBtnRef) {
           props.onQuit();
         } else {
@@ -44,15 +35,9 @@ const QuitConfirmModal: Component<QuitConfirmModalProps> = (props) => {
         return;
       }
       if (e.key === "Tab") {
-        // Focus trap: cycle between the two buttons.
         const focusables = [cancelBtnRef, quitBtnRef].filter(Boolean) as HTMLElement[];
         if (focusables.length < 2) return;
         const idx = focusables.indexOf(document.activeElement as HTMLElement);
-        // #266: activeElement can be outside the trap entirely — e.g. blurred
-        // to <body> after a click on the modal's non-focusable backdrop /
-        // header / padding. idx is -1 then; without this guard the forward
-        // branch's `idx === length - 1` is false, preventDefault is skipped,
-        // and native Tab escapes the modal to an element behind it.
         if (idx === -1) {
           e.preventDefault();
           (e.shiftKey ? focusables[focusables.length - 1] : focusables[0]).focus();
@@ -72,7 +57,6 @@ const QuitConfirmModal: Component<QuitConfirmModalProps> = (props) => {
       }
     };
 
-    // Capture phase so the modal handles keys BEFORE xterm, shortcuts.ts, etc.
     document.addEventListener("keydown", onKeyDown, true);
     onCleanup(() => {
       document.removeEventListener("keydown", onKeyDown, true);

--- a/src/main/listeners-central-view.ts
+++ b/src/main/listeners-central-view.ts
@@ -2,27 +2,6 @@ import { onResourceMonitorAttach, onSessionSwitched } from "../shared/ipc";
 import type { UnlistenFn } from "../shared/transport";
 import { centralViewStore } from "./stores/centralView";
 
-/**
- * Wires the #587 central-view event contract for the main window. Extracted
- * into a helper (mirrors `wireHomeListeners`) so the `userInitiated`
- * discriminator on `session_switched` is unit-testable in isolation.
- *
- * Listeners installed:
- * - `session_switched`: reveal the terminal (cover an embedded RM) ONLY when
- *   the backend marks the switch user-initiated (`userInitiated === true`) and
- *   it carries a real id. A non-user switch — boot restore, destroy
- *   auto-promote, detach sibling-switch, mailbox/coordinator switch — must NOT
- *   flip away from RM: `centralViewStore.showTerminal()` persists `false`, which
- *   would defeat the restored `mainResourceMonitorAttached` choice (plan §6) and
- *   yank the RM view away mid-use. This mirrors the Home listener's discriminator
- *   (`listeners-home.ts`). Explicit user clicks are additionally covered by
- *   `SessionItem.handleClick`, which calls `showTerminal()` directly (so an
- *   already-active click, which emits no `session_switched`, still covers RM).
- * - `resource_monitor_attach`: the detached RM window asks the main window to
- *   pull RM back into the central pane.
- *
- * Returns the unlisten functions so the caller can clean up on unmount.
- */
 export async function wireCentralViewListeners(): Promise<UnlistenFn[]> {
   const unlisteners: UnlistenFn[] = [];
 

--- a/src/main/listeners-home.ts
+++ b/src/main/listeners-home.ts
@@ -2,30 +2,6 @@ import { SessionAPI, onSessionDestroyed, onSessionSwitched } from "../shared/ipc
 import type { UnlistenFn } from "../shared/transport";
 import { homeStore } from "./stores/home";
 
-/**
- * Wires the Home auto-visibility contract for the main window (issue #183).
- *
- * On mount: Home is shown unconditionally — every app open lands on Home
- * regardless of any restored active session.
- *
- * Listeners installed:
- * - `session_switched`: hides Home only when the backend marks the switch
- *   as user-initiated (`userInitiated === true`). Restore, destroy
- *   auto-promote, detach sibling-switch and other automatic bookkeeping
- *   emit without that flag, so they leave Home visible. See
- *   `_plans/183-home-first-startup.md`.
- * - `session_destroyed`: shows Home when the LAST session goes away
- *   (issue #164 contract). Yields a microtask so TerminalApp's destroy
- *   handler can settle before we re-query the session list.
- *
- * The `session_created` listener was removed in #183: that event fires for
- * restored AND backend-driven creations (mailbox / web / coordinator
- * spawn), which would tear Home away from the user. User-driven create
- * sites either follow with `SessionAPI.switch(...)` or invoke
- * `homeStore.hide()` imperatively.
- *
- * Returns the unlisten functions so the caller can clean up on unmount.
- */
 export async function wireHomeListeners(): Promise<UnlistenFn[]> {
   homeStore.show();
 

--- a/src/main/stores/error-modal.ts
+++ b/src/main/stores/error-modal.ts
@@ -1,17 +1,9 @@
 import { batch, createSignal } from "solid-js";
 import type { ErrorLogEntry } from "../../shared/types";
 
-// Queue of undismissed ERROR entries. The modal renders entries[index].
-// An empty queue means the modal is closed. The queue resets to empty once
-// the user dismisses the last entry, so each error burst gets a fresh "1 of N".
 const [entries, setEntries] = createSignal<ErrorLogEntry[]>([]);
 const [index, setIndex] = createSignal(0);
 
-// Upper bound on the frontend queue (M2). drain() is read-and-clear, so the
-// frontend ACCUMULATES entries across successive drains — the Rust-side
-// ERROR_BUFFER_CAP does NOT bound this side. Without a cap, a slow error loop
-// with the user AFK would grow `entries` without limit (and `enqueue`'s
-// array copy would be O(n²) over the run). Mirrors ERROR_BUFFER_CAP.
 const FRONTEND_QUEUE_CAP = 200;
 
 export const errorModalStore = {
@@ -24,30 +16,16 @@ export const errorModalStore = {
   get total(): number {
     return entries().length;
   },
-  /** The entry currently shown, or null when the modal is closed. */
   get current(): ErrorLogEntry | null {
     const e = entries();
     const i = index();
     return e.length > 0 && i < e.length ? e[i] : null;
   },
-  /** True while the modal should be visible. */
   get open(): boolean {
     const e = entries();
     return e.length > 0 && index() < e.length;
   },
 
-  /**
-   * Append freshly-drained entries. If the modal was closed this re-opens it
-   * at the first new entry. If already open, entries are appended after the
-   * current one and the "N" in "1 of N" grows live.
-   *
-   * The queue is capped at FRONTEND_QUEUE_CAP (M2): on overflow the oldest
-   * entries are dropped and `index` is shifted down by the drop count so
-   * `current` keeps pointing at the same entry the user is viewing (clamped
-   * to 0 if that entry was itself evicted under an extreme storm). The two
-   * signal writes are `batch`ed so no effect observes a trimmed-entries /
-   * stale-index intermediate state.
-   */
   enqueue(incoming: ErrorLogEntry[]): void {
     if (incoming.length === 0) return;
     const combined = [...entries(), ...incoming];
@@ -62,10 +40,6 @@ export const errorModalStore = {
     });
   },
 
-  /**
-   * Dismiss the current entry and advance. When the last entry is dismissed
-   * the queue resets, closing the modal.
-   */
   dismissCurrent(): void {
     const next = index() + 1;
     if (next >= entries().length) {
@@ -77,7 +51,6 @@ export const errorModalStore = {
   },
 };
 
-// Test-only reset (gated to Vite MODE === "test"). Mirrors home.ts.
 export function __resetErrorModalStoreForTests(): void {
   if (import.meta.env.MODE !== "test") return;
   setEntries([]);

--- a/src/resource-monitor/App.tsx
+++ b/src/resource-monitor/App.tsx
@@ -31,11 +31,6 @@ const DEFAULT_RESOURCE_PREFERENCES = {
   resourceKeepLastSnapshot: true,
 };
 
-// #647 C: a `quarantined` group is now killable again — the Force-kill / Retry
-// affordance re-fires the durable Job Object kill (it was wrongly disabled,
-// stranding agents the AV kept alive). `terminating` stays non-killable (a kill
-// is already in flight); `terminated` is done; `failedCleanup` /
-// `unknownOwnership` are never emitted by the 4-variant backend state.
 const NON_KILLABLE_GROUP_STATES = new Set<ResourceGroupState>([
   "terminating",
   "terminated",
@@ -43,8 +38,6 @@ const NON_KILLABLE_GROUP_STATES = new Set<ResourceGroupState>([
   "unknownOwnership",
 ]);
 
-// #647 D: English guidance shown (ADDED to, never replacing, the per-PID detail)
-// when a kill is blocked by a security product stripping PROCESS_TERMINATE.
 const SECURITY_BLOCK_HINT =
   "The OS or security software is blocking process termination. Add an exclusion for AgentsCommander and the agent binaries.";
 
@@ -95,17 +88,12 @@ const overallLabel = (state: ResourceOverallState): string => {
 const processName = (process: ResourceProcessSnapshot): string =>
   process.name || process.exeName || `pid ${process.pid}`;
 
-// #516 - "wg-5-dev-team / dev-rust" identity so the user can tell which group a
-// Kill targets. Falls back to the coding-agent name when no replica identity is
-// present (non-WG / ad-hoc launches), and "-" for an unknown workgroup.
 const groupOrigin = (group: ResourceAgentGroupSnapshot): string =>
   `${group.workgroup ?? "-"} / ${group.agent ?? group.name}`;
 
 const canKillGroup = (group: ResourceAgentGroupSnapshot): boolean =>
   group.killAllowed !== false && !NON_KILLABLE_GROUP_STATES.has(group.state);
 
-// #647 C: a quarantined group is killable but its button re-fires the durable
-// kill, so it reads "Force-kill" rather than "Kill".
 const killActionLabel = (group: ResourceAgentGroupSnapshot): string =>
   group.state === "quarantined" ? "Force-kill" : "Kill";
 
@@ -119,14 +107,9 @@ const groupSeverity = (group: ResourceAgentGroupSnapshot): string => {
   return "ok";
 };
 
-// #566 - active = the agent still holds (or is releasing) live OS processes /
-// a concurrency slot: every state except `terminated` (matches the backend's
-// active_count semantics). Single source of truth for the status filter (A.1).
 const isActiveGroup = (group: ResourceAgentGroupSnapshot): boolean =>
   group.state !== "terminated";
 
-// #566 - status filter is component-local view state, not part of the IPC data
-// contract (deliberately kept out of shared/types.ts).
 type RmStatusFilter = "all" | "active" | "inactive";
 
 const STATUS_FILTERS: ReadonlyArray<{ value: RmStatusFilter; label: string }> = [
@@ -135,15 +118,9 @@ const STATUS_FILTERS: ReadonlyArray<{ value: RmStatusFilter; label: string }> = 
   { value: "inactive", label: "Inactive" },
 ];
 
-// #566 - distinct, sorted, non-empty values for a filter dimension. Derives from
-// the full snapshot set so a value stays selectable even while filtered out.
 const distinct = (values: (string | null | undefined)[]): string[] =>
   [...new Set(values.filter((v): v is string => !!v))].sort();
 
-// #566 - G3 reactivity contract: a multi-select toggle MUST replace the Set with
-// a fresh copy. Mutating in place returns the same reference, so SolidJS's
-// Object.is equality treats it as unchanged and the dependent memos silently
-// never re-run (the filters render, clicks register, nothing filters).
 const toggleFilter = (
   get: () => Set<string>,
   set: (next: Set<string>) => void,
@@ -159,16 +136,8 @@ const toggleFilter = (
 };
 
 const Titlebar: Component = () => {
-  // #587 - tracks the real OS maximize state so the button glyph (maximize vs
-  // restore) and its labels stay correct. Not all maximize paths route through
-  // handleMaximize: Tauri v2 also maximizes natively on data-tauri-drag-region
-  // double-click, and the OS does it on Win+Up / edge-snap. onResized below
-  // re-reads the truth after every such change.
   const [maximized, setMaximized] = createSignal(false);
 
-  // #587 — "Attach" pulls RM back into the main window's central pane (replaces
-  // the old window-snapping "Dock"). Emit BEFORE closing so the event is queued
-  // before this webview tears down; main's listener runs showResourceMonitor().
   const handleAttach = async () => {
     try {
       await emitResourceMonitorAttach();
@@ -192,23 +161,11 @@ const Titlebar: Component = () => {
     try {
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
       const win = getCurrentWindow();
-      // Use explicit maximize()/unmaximize() rather than toggleMaximize().
-      // The app capability set (src-tauri/capabilities/default.json) grants
-      // core:window:allow-maximize, allow-unmaximize and allow-is-maximized,
-      // but NOT allow-toggle-maximize. toggleMaximize() therefore gets rejected
-      // at the Tauri v2 ACL layer at runtime, which is why the button "did
-      // nothing" in the real build (the rejection was only logged below). The
-      // drag-region double-click still maximizes because that path uses the
-      // separate allow-internal-toggle-maximize permission, which IS in
-      // core:window:default.
       if (await win.isMaximized()) {
         await win.unmaximize();
       } else {
         await win.maximize();
       }
-      // Reflect immediately so the icon swaps without waiting for the resize
-      // event. On failure leave the glyph as-is; the onResized mirror reconciles
-      // it once the window settles.
       setMaximized(await win.isMaximized());
     } catch (err) {
       console.error("Resource monitor toggle maximize failed:", err);
@@ -225,8 +182,6 @@ const Titlebar: Component = () => {
     if (!isTauri) return;
     let unlisten: (() => void) | undefined;
     let disposed = false;
-    // Register cleanup synchronously so it binds to this component's owner; the
-    // async listener registration below fills in `unlisten` once it resolves.
     onCleanup(() => {
       disposed = true;
       unlisten?.();
@@ -337,9 +292,6 @@ const Titlebar: Component = () => {
 };
 
 interface ResourceMonitorAppProps {
-  /** True when mounted inside MainApp's central pane. Suppresses the window
-   *  titlebar and skips documentElement theme init (main owns it), and shows a
-   *  "Detach" button that pops RM out into its own window (#587). */
   embedded?: boolean;
 }
 
@@ -349,12 +301,6 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
     createSignal<ResourceAgentGroupSnapshot | null>(null);
   const [killError, setKillError] = createSignal("");
   const [killInFlight, setKillInFlight] = createSignal(false);
-  // #647: the outcome of the last kill attempt that did NOT finalize (a verified
-  // success clears it). Carries `state` to distinguish a blocked `quarantined`
-  // result (show per-PID + security hint) from an unsettled `terminating` one
-  // (a concurrent kill is still settling — show "Verifying...", offer Retry).
-  // Keyed by sessionId so the detail attaches to the right row/modal. Held in the
-  // FE because blockedBySecurity is a per-attempt flag, not on the group snapshot.
   const [killResult, setKillResult] = createSignal<{
     sessionId: string;
     state: ResourceGroupState;
@@ -373,16 +319,10 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
     setKillError("");
   };
 
-  // #647 C (Step-7 narrowing): show "Verifying..." only where a kill is genuinely
-  // in flight — a group the backend is actively terminating, or the group whose
-  // Force-kill/Retry we are awaiting right now. A group merely sitting in
-  // `quarantined` with no attempt running is NOT verifying (it needs Force-kill).
   const isVerifying = (group: ResourceAgentGroupSnapshot): boolean =>
     group.state === "terminating" ||
     (killInFlight() && killTarget()?.sessionId === group.sessionId);
 
-  // #587 — pop the embedded RM out into its own OS window, then reveal the
-  // terminal in the pane (preserves the embedded-XOR-detached invariant).
   const handleDetach = async () => {
     try {
       await WindowAPI.openResourceMonitor();
@@ -394,10 +334,6 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
 
   onMount(async () => {
     let resourcePreferences = DEFAULT_RESOURCE_PREFERENCES;
-    // #587 — embedded RM inherits the theme MainApp owns on documentElement; it
-    // must not add/remove the class itself (would fight main). Windowed RM does
-    // its own corrective read below; dark is the CSS base, so first paint is
-    // dark with no optimistic class.
     try {
       const settings = await SettingsAPI.get();
       resourcePreferences = {
@@ -425,9 +361,6 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
   const snapshot = () => resourceMonitorStore.snapshot;
   const groups = createMemo(() => snapshot()?.groups ?? []);
 
-  // #566 - filter view-state (ephemeral, not persisted). The three multi-selects
-  // are Set<string>; every toggle goes through toggleFilter (fresh-Set copy) so
-  // the dependent memos actually re-run (see the G3 contract above).
   const [statusFilter, setStatusFilter] = createSignal<RmStatusFilter>("all");
   const [projectFilter, setProjectFilter] = createSignal<Set<string>>(new Set());
   const [workgroupFilter, setWorkgroupFilter] = createSignal<Set<string>>(
@@ -435,8 +368,6 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
   );
   const [roleFilter, setRoleFilter] = createSignal<Set<string>>(new Set());
 
-  // Option lists derive from the FULL snapshot set, not the filtered one, so a
-  // value stays selectable even while it is filtered out (A.4.2).
   const projectOptions = createMemo(() =>
     distinct(groups().map((g) => g.project))
   );
@@ -445,7 +376,6 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
   );
   const roleOptions = createMemo(() => distinct(groups().map((g) => g.agent)));
 
-  // AND across dimensions, OR within a dimension; an empty Set = no constraint.
   const filteredGroups = createMemo(() => {
     const status = statusFilter();
     const projects = projectFilter();
@@ -506,18 +436,9 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
         reason: "user",
       });
       if (result.finalized) {
-        // #647 (Step 7): verified dead AND finalized by the backend — it tore the
-        // tree down and emitted session_created carrying the Exited SessionInfo
-        // (the sidebar tile flips via the addSession upsert, E5). Close + refresh.
-        // NB: success keys off `finalized`, NOT `!quarantined` — a `terminating`
-        // early-return reports `quarantined === false` yet is not a real success.
         setKillResult(null);
         setKillTarget(null);
       } else {
-        // NOT finalized — keep the modal open. The agent may still be alive
-        // (`quarantined`) or a concurrent kill is still settling (`terminating`);
-        // the durable job is preserved backend-side for a Force/Retry. `state`
-        // drives whether we show the per-PID detail (+ hint) or "Verifying...".
         setKillResult({
           sessionId: result.sessionId,
           state: result.state,
@@ -830,12 +751,6 @@ const ResourceMonitorApp: Component<ResourceMonitorAppProps> = (props) => {
                 data-ac-testid="resourceMonitor.empty"
                 data-ac-role="status"
                 data-ac-state={
-                  // #566 N1 - loading only wins when there is genuinely no data
-                  // yet (groups().length === 0). With keepLastSnapshot, every
-                  // poll's setLoading(true) would otherwise flash "loading" over
-                  // an already-populated-but-filtered view each cycle. Once rows
-                  // exist but the active filter matches none, stay on the stable
-                  // filtered-empty state; initial load (no data) still shows it.
                   resourceMonitorStore.loading && groups().length === 0
                     ? "loading"
                     : groups().length === 0

--- a/src/screenshot-overlay/App.tsx
+++ b/src/screenshot-overlay/App.tsx
@@ -11,19 +11,8 @@ import {
 import { drawOverlay } from "./render";
 import "./styles/screenshot-overlay.css";
 
-// #714 Selection must be at least this many physical px on each side to count as
-// a real drag; a smaller release is treated as a mis-click and cancels locally
-// (the backend also rejects width/height < 2). Mirrors the plan's 2px floor.
 const MIN_SELECTION_PX = 2;
 
-/**
- * #714 Per-monitor screenshot selection overlay. One instance renders in each
- * `?window=screenshot-overlay&captureId=<dashed-uuid>&monitorId=<n>` window. It
- * draws the frozen monitor image the backend captured, lets the user rubber-band
- * a rectangle with a pixel magnifier, and sends the physical crop back. The Rust
- * side owns ALL lifecycle/cleanup (confirm/cancel/WindowEvent::Destroyed); the
- * frontend cancel-on-unmount is best-effort only.
- */
 const ScreenshotOverlayApp: Component = () => {
   let canvas: HTMLCanvasElement | undefined;
 
@@ -32,9 +21,6 @@ const ScreenshotOverlayApp: Component = () => {
     const captureId = params.get("captureId") ?? "";
     const monitorId = Number(params.get("monitorId"));
 
-    // Mutable interaction state (plain locals, not signals: drawing is fully
-    // imperative and runs off pointer events + rAF, so reactivity would only add
-    // overhead).
     let overlay: ScreenshotOverlayState | null = null;
     let image: HTMLImageElement | null = null;
     let ctx: CanvasRenderingContext2D | null = null;
@@ -48,20 +34,15 @@ const ScreenshotOverlayApp: Component = () => {
     const cancelOnce = (reason: string): void => {
       if (settled) return;
       settled = true;
-      // Fire-and-forget: the backend destroys every overlay window; a stale id is
-      // a harmless no-op there.
       void ScreenshotAPI.cancel(captureId).catch((err) => {
         console.error(`[screenshot-overlay] cancel (${reason}) failed:`, err);
       });
     };
 
-    // Grab focus so the ESC keydown reaches THIS overlay even though the hotkey
-    // fired while another app was focused. Best-effort (jsdom/OS may no-op).
     const focusOverlay = (): void => {
       try {
         window.focus();
       } catch {
-        /* focus is best-effort */
       }
     };
 
@@ -73,9 +54,6 @@ const ScreenshotOverlayApp: Component = () => {
       });
     };
 
-    // Physical-px-per-CSS-px ratio, so on-screen sizes (border, magnifier) stay
-    // constant regardless of monitor DPI (the canvas backing store is physical
-    // px, displayed at the monitor's logical size).
     const physicalPerCss = (): number => {
       if (!canvas || !overlay) return 1;
       const rect = canvas.getBoundingClientRect();
@@ -85,8 +63,6 @@ const ScreenshotOverlayApp: Component = () => {
     const draw = (): void => {
       if (!ctx || !overlay || !image) return;
       const { width, height } = overlay;
-      // The drag endpoint IS the hover point while dragging (both are set from
-      // the same pointer move), so `hover` doubles as the live drag corner.
       const selection =
         dragStart && hover
           ? clampSelectionToBounds(
@@ -124,7 +100,6 @@ const ScreenshotOverlayApp: Component = () => {
       try {
         canvas?.setPointerCapture(e.pointerId);
       } catch {
-        /* pointer capture is best-effort */
       }
       scheduleDraw();
     };
@@ -135,8 +110,6 @@ const ScreenshotOverlayApp: Component = () => {
       scheduleDraw();
     };
 
-    // Focus on ENTER (not on every move) so ESC reaches the overlay the cursor is
-    // over, without an OS window call on each pointermove during a drag.
     const onPointerEnter = (): void => {
       if (!settled) focusOverlay();
     };
@@ -147,7 +120,6 @@ const ScreenshotOverlayApp: Component = () => {
       try {
         if (activePointerId !== null) canvas?.releasePointerCapture(activePointerId);
       } catch {
-        /* best-effort */
       }
       activePointerId = null;
 
@@ -158,7 +130,6 @@ const ScreenshotOverlayApp: Component = () => {
       );
 
       if (selection.width < MIN_SELECTION_PX || selection.height < MIN_SELECTION_PX) {
-        // Treat a tiny drag as a mis-click: reset and keep the overlay open.
         dragStart = null;
         scheduleDraw();
         return;
@@ -173,7 +144,6 @@ const ScreenshotOverlayApp: Component = () => {
         width: selection.width,
         height: selection.height,
       }).catch((err) => {
-        // Backend owns teardown + a failure event; just log locally.
         console.error("[screenshot-overlay] confirmSelection failed:", err);
       });
     };
@@ -191,8 +161,6 @@ const ScreenshotOverlayApp: Component = () => {
       }
     };
 
-    // Register teardown synchronously so it binds to this owner even though the
-    // async setup below resolves later.
     onCleanup(() => {
       disposed = true;
       if (rafId !== 0) cancelAnimationFrame(rafId);
@@ -204,7 +172,6 @@ const ScreenshotOverlayApp: Component = () => {
         canvas.removeEventListener("pointerenter", onPointerEnter);
         canvas.removeEventListener("pointerleave", onPointerLeave);
       }
-      // Best-effort only — Rust's WindowEvent::Destroyed is the authority.
       cancelOnce("unmount");
     });
 
@@ -213,8 +180,6 @@ const ScreenshotOverlayApp: Component = () => {
       try {
         state = await ScreenshotAPI.getOverlayState(captureId, monitorId);
       } catch (err) {
-        // Stale/starting capture: nothing to render. Rust cleans up on
-        // cancel/destroy, so just leave the (transparent) window.
         console.error("[screenshot-overlay] getOverlayState failed:", err);
         return;
       }
@@ -226,8 +191,6 @@ const ScreenshotOverlayApp: Component = () => {
       try {
         await img.decode();
       } catch {
-        // decode() can reject in non-browser test envs (or for odd encodings);
-        // fall through and draw best-effort so interaction still works.
       }
       if (disposed || !canvas) return;
       image = img;

--- a/src/screenshot-overlay/render.ts
+++ b/src/screenshot-overlay/render.ts
@@ -1,33 +1,17 @@
-// #714 Pure canvas drawing for the screenshot overlay, split out from App.tsx so
-// it can be (a) reused by the headless visual harness and (b) unit-tested with a
-// recording mock 2D context — jsdom cannot render canvas PIXELS, but it can
-// assert the exact sequence of draw operations, which is where the real risk
-// lives (un-dimming the selection, magnifier sampling with smoothing off, etc.).
-//
-// All coordinates are PHYSICAL image pixels; `physicalPerCss` converts on-screen
-// CSS sizes (border, magnifier) into backing-store px so they stay a constant
-// on-screen size across monitor DPIs.
 
 import { magnifierSourceRect, type Point, type Rect } from "./selection";
 
-// Source window (physical px) sampled into the magnifier, and the magnifier's
-// on-screen diameter/offset + selection border width in CSS px.
 export const MAGNIFIER_SOURCE_PX = 32;
 export const MAGNIFIER_DEST_CSS = 140;
 export const MAGNIFIER_OFFSET_CSS = 24;
 export const SELECTION_BORDER_CSS = 1.5;
 
 export interface OverlayRenderModel {
-  /** Physical image width/height (canvas backing-store size). */
   width: number;
   height: number;
-  /** Physical-px per CSS-px (image width / canvas CSS width). */
   physicalPerCss: number;
 }
 
-/** Draw one frame: frozen image, dark mask, the un-dimmed selection + border, and
- *  the pixel magnifier at `hover`. `selection` is expected already normalized and
- *  clamped to bounds; `hover`/`selection` may be null. */
 export function drawOverlay(
   ctx: CanvasRenderingContext2D,
   image: CanvasImageSource,
@@ -41,7 +25,6 @@ export function drawOverlay(
   ctx.clearRect(0, 0, width, height);
   ctx.drawImage(image, 0, 0, width, height);
 
-  // Dim everything, then punch the selection back to full brightness.
   ctx.fillStyle = "rgba(0, 0, 0, 0.45)";
   ctx.fillRect(0, 0, width, height);
 
@@ -78,8 +61,6 @@ function drawMagnifier(
   const offset = MAGNIFIER_OFFSET_CSS * ratio;
   const src = magnifierSourceRect(center, MAGNIFIER_SOURCE_PX, width, height);
 
-  // Default lower-right of the cursor; flip toward the interior near edges, then
-  // clamp so the whole circle stays on-canvas.
   let cx = center.x + offset + radius;
   let cy = center.y + offset + radius;
   if (cx + radius > width) cx = center.x - offset - radius;
@@ -112,10 +93,6 @@ function drawMagnifier(
   ctx.arc(cx, cy, radius, 0, Math.PI * 2);
   ctx.stroke();
 
-  // Crosshair marks the HOVERED pixel. Near a screen edge the source window is
-  // clamped so the hovered pixel is no longer at the window's center, so map
-  // `center` into the magnifier's destination space rather than assuming the
-  // dest center (else the crosshair would point at the wrong pixel at edges).
   const magX = cx - radius + ((center.x - src.x) / src.width) * dest;
   const magY = cy - radius + ((center.y - src.y) / src.height) * dest;
   ctx.strokeStyle = "rgba(255, 80, 80, 0.9)";

--- a/src/screenshot-overlay/selection.ts
+++ b/src/screenshot-overlay/selection.ts
@@ -1,7 +1,3 @@
-// #714 Pure geometry helpers for the screenshot overlay. Kept free of DOM/canvas
-// so they are unit-testable in jsdom/vitest (which cannot render canvas pixels).
-// All coordinates here are PHYSICAL image pixels unless a param is named
-// `client` (CSS/viewport pixels from a PointerEvent).
 
 export interface Point {
   x: number;
@@ -15,8 +11,6 @@ export interface Rect {
   height: number;
 }
 
-/** The subset of `DOMRect` the coordinate mapping needs. Lets tests pass a plain
- *  object instead of constructing a real bounding-client-rect. */
 export interface ClientRectLike {
   left: number;
   top: number;
@@ -28,7 +22,6 @@ function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
 
-/** Top-left origin + non-negative width/height for a drag in ANY direction. */
 export function normalizeSelection(start: Point, end: Point): Rect {
   return {
     x: Math.min(start.x, end.x),
@@ -38,11 +31,6 @@ export function normalizeSelection(start: Point, end: Point): Rect {
   };
 }
 
-/** Map a client (CSS-pixel) point onto physical image coordinates. The canvas is
- *  displayed at some CSS size (`rect`) but backed by `imageWidth × imageHeight`
- *  physical pixels, so the mapping is proportional — this is what makes the crop
- *  DPI-independent (see plan: map via bounding rect, NOT devicePixelRatio). A
- *  zero-sized rect maps to the origin instead of producing NaN. */
 export function clientToImagePoint(
   client: Point,
   rect: ClientRectLike,
@@ -57,10 +45,6 @@ export function clientToImagePoint(
   };
 }
 
-/** A square source rect of `sourceSize` physical px centered on `center`, clamped
- *  so it always stays fully inside the image (the magnifier samples from this).
- *  If the image is smaller than `sourceSize` in either axis, the square shrinks
- *  to fit. */
 export function magnifierSourceRect(
   center: Point,
   sourceSize: number,
@@ -73,9 +57,6 @@ export function magnifierSourceRect(
   return { x, y, width: size, height: size };
 }
 
-/** Clamp a normalized selection so it never extends past the image edges. Guards
- *  the far-edge rounding case (e.g. x=3839,w=2 on a 3840-wide image) that the
- *  backend bounds validator would otherwise reject as a silent no-op. */
 export function clampSelectionToBounds(
   selection: Rect,
   imageWidth: number,

--- a/src/shared/agent-presets.ts
+++ b/src/shared/agent-presets.ts
@@ -1,20 +1,5 @@
 import type { AgentConfig, CodingAgentDefinition } from "./types";
 
-/**
- * #769 — the coding-agent catalog is now backend-owned (the seeded, user-editable
- * `<config_dir>/coding-agents/agents.json`, exposed by `get_coding_agent_catalog`
- * and consumed through `codingAgentsStore`). This module keeps only:
- *
- *  - `newAgentId()` — id minter for the "+ Add" flow (unchanged), and
- *  - `FALLBACK_CODING_AGENTS` — a synchronous never-empty seed and the offline
- *    fallback the store falls back to when the IPC transport itself fails.
- *
- * `FALLBACK_CODING_AGENTS` is a second copy of the backend's embedded default
- * (`src-tauri/resources/coding-agents/agents.default.json`). The duplication is
- * intentional (it is what makes the onboarding/settings list resilient to a dead
- * backend), and a drift-guard test keeps the two copies in lockstep with the
- * backend's `embedded_default_matches_current_presets_exactly` test.
- */
 export const FALLBACK_CODING_AGENTS: CodingAgentDefinition[] = [
   {
     key: "claude",
@@ -54,7 +39,6 @@ export const FALLBACK_CODING_AGENTS: CodingAgentDefinition[] = [
     label: "Cursor CLI",
     description: "Coding Agent by Cursor",
     color: "#22d3ee",
-    // Cursor's CLI executable is `agent`, not `cursor`.
     command: "agent",
     instructionsFilename: "AGENTS.md",
     envs: [],
@@ -85,13 +69,6 @@ export const FALLBACK_CODING_AGENTS: CodingAgentDefinition[] = [
   },
 ];
 
-/**
- * Project a catalog definition onto the persisted agent seed the onboarding and
- * settings "+ Add" flows feed to `addAgent` — i.e. `Omit<AgentConfig, "id">`,
- * dropping the catalog-only `{ key, description, removable }`. `instructionsFilename`
- * and `configSeed` are carried through only when present, matching how the old
- * `AGENT_PRESET_MAP.<key>` values were shaped.
- */
 export function definitionToSeed(def: CodingAgentDefinition): Omit<AgentConfig, "id"> {
   const seed: Omit<AgentConfig, "id"> = {
     label: def.label,

--- a/src/shared/automation-bridge.ts
+++ b/src/shared/automation-bridge.ts
@@ -25,8 +25,6 @@ const SAFE_METADATA_ATTRIBUTES = [
   ["data-ac-effective-profile", "effectiveProfile"],
   ["data-ac-configured", "configured"],
   ["data-ac-env-source", "envSource"],
-  // Generic, sanitized diagnostic detail surfaced on a target (e.g. the
-  // project.loadStatus chip exposes boot/load failure info here).
   ["data-ac-detail", "detail"],
 ] as const;
 
@@ -34,20 +32,6 @@ type UiAutomationErrorCode = Extract<UiAutomationResponse, { ok: false }>["error
 
 let started = false;
 
-/** #944 - the pointer is sticky and per-WebView. Only `hover` moves it (plan R2).
- *  The CHAIN is stored, not recomputed: <For> re-mints rows (ProjectPanel :834-840,
- *  :3721-3725), so `hoveredElement` is routinely detached by the time we leave it,
- *  and a chain recomputed from a detached node stops at its detached root - which
- *  would strand `.sidebar-layout` in the pointer-inside state forever (plan C17).
- *
- *  ASSUMPTION, and the one hole `dispatchHoverEvent`'s isConnected guard cannot
- *  close: a node that is still CONNECTED has not been RE-PARENTED since we captured
- *  its chain. If it had, the old and the new ancestors would both be live, and we
- *  would fire the leave chain at the ancestors it no longer has while the ones it
- *  does have never hear a thing. Nothing detects that. It cannot happen today -
- *  Solid's <For> reorders rows within one parent and never moves a node across
- *  parents - so if you ever re-parent a live node under the pointer, this chain has
- *  to be recomputed, not filtered. */
 let hoveredElement: HTMLElement | null = null;
 let hoveredChain: HTMLElement[] = [];
 
@@ -111,10 +95,6 @@ async function executeAutomationRequestInner(
   if (expiredBeforeQuery) return expiredBeforeQuery;
 
   if (request.action === "hover") {
-    // #944 - `value` is the leave flag and nothing else. Silently treating an
-    // unrecognized value as a normal hover is a false green: the harness believes
-    // the pointer moved OFF the target while it actually moved ON to it. `backend`
-    // validates its own `value` the same way (ui_automation.rs:852-863).
     if (request.value != null && request.value !== "leave") {
       return errorResponse(
         windowLabel,
@@ -126,11 +106,6 @@ async function executeAutomationRequestInner(
       );
     }
 
-    // #944 - the leave form is TARGET-FREE and must not run the selector gauntlet:
-    // the thing you want to release is normally gone (menu torn down) or re-minted
-    // (<For>), and a cleanup step that fails when the thing it cleans up is missing
-    // is not a cleanup step. It cannot return missing_selector / target_hidden /
-    // target_obscured, by construction (plan R5).
     if (request.value === "leave") {
       const target = hoveredElement ? snapshotTarget(hoveredElement) : emptyHoverTarget();
       const hover = dispatchHoverLeave();
@@ -181,10 +156,6 @@ async function executeAutomationRequestInner(
     return successResponse(windowLabel, request, snapshotTarget(element), diagnostics);
   }
 
-  // #944 - a real pointer hovers disabled controls: a tooltip is exactly what you
-  // hover a disabled thing for. Only MUTATING actions are refused on a disabled
-  // target. (Load-bearing on `.session-context-option` having no `pointer-events:
-  // none`; see plan §8.)
   if (request.action !== "hover" && isElementDisabled(element)) {
     return errorResponse(
       windowLabel,
@@ -479,11 +450,6 @@ function snapshotText(element: HTMLElement): string {
     return "";
   }
 
-  // Defense-in-depth: an element that carries a value-bearing attribute must
-  // never surface free text, regardless of role. #516 broadened the set of
-  // text-allowed roles (status/metric/row/cell/...), so the absence of a role
-  // from the allow-list can no longer be relied on to suppress a value-like
-  // target's text — gate on the attributes explicitly instead.
   if (element.hasAttribute("data-ac-value") || element.hasAttribute("data-ac-token")) {
     return "";
   }
@@ -627,45 +593,16 @@ type HoverDiagnostics = NonNullable<UiAutomationDiagnostics["hover"]>;
 
 const HOVER_POINTER_INIT = { pointerId: 1, pointerType: "mouse", isPrimary: true } as const;
 
-/** #944 - eight events, and deliberately NOT pointermove/mousemove.
- *
- *  src/ has FOUR move listeners (an earlier version of this comment said three and
- *  called them all pointerdown-armed; two of those words were wrong):
- *
- *  - `main/App.tsx:78` (splitter) and `browser/App.tsx:101` (web-client splitter,
- *    at DOCUMENT level) attach theirs INSIDE the pointerdown / mousedown handler and
- *    remove it on release. No button, no listener.
- *  - `WorkgroupGroupRail.tsx:422` is always on (`window`), but `movePress` (:346)
- *    returns unless `reorderState()` is set, and only `startPress` - a pointerdown
- *    handler - sets it. Chromium gives a real mouse `pointerId: 1`, which is exactly
- *    what we would have hardcoded, so a synthetic move during a REAL user's group
- *    drag would cancel it or retarget it by our clientY, and their pointerup would
- *    commit that.
- *  - `screenshot-overlay/App.tsx:240` is always on and armed by NOTHING: it sets the
- *    crosshair from the event and repaints, on every move, with no button down. That
- *    window runs a bridge like any other (`main.tsx:26` inits one for every window
- *    root) and its canvas IS an automation target (`screenshotOverlay.canvas`), so a
- *    synthetic move there would drag the capture crosshair of a live overlay.
- *
- *  Nothing that consumes hover needs a move event; the flyouts are driven by
- *  enter/leave. Not dispatching one is what makes this action's inertness structural
- *  rather than lucky - the fourth listener is proof that "no consumer would notice"
- *  was never a safe bet. Plan R1. A2 pins it. */
 function dispatchHoverEnter(to: HTMLElement): HoverDiagnostics {
   const from = hoveredElement;
   const events: string[] = [];
 
   if (from === to) {
-    // A real pointer that has not moved fires nothing. `changed: false` is how a
-    // harness sees that its hover was a no-op (plan C13).
     return { from: testIdOf(from), to: testIdOf(to), changed: false, events };
   }
 
   const staleFrom = !!from && !from.isConnected;
   const toChain = hoverChain(to);
-  // Computed against the STORED chain: a detached `from` still shares body/html with
-  // `to`, so we do not re-enter ancestors we never left. null (no `from`) means the
-  // pointer arrived from outside the window: enter the whole chain, root first.
   const common = from ? firstCommonAncestor(hoveredChain, toChain) : null;
 
   if (from) {
@@ -684,7 +621,6 @@ function dispatchHoverEnter(to: HTMLElement): HoverDiagnostics {
   };
 }
 
-/** #944 - target-free (plan R5). Cannot fail, cannot be given a selector. */
 function dispatchHoverLeave(): HoverDiagnostics {
   const from = hoveredElement;
   const events: string[] = [];
@@ -693,10 +629,6 @@ function dispatchHoverLeave(): HoverDiagnostics {
   }
 
   const staleFrom = !from.isConnected;
-  // to === null: the pointer leaves the window. The chain runs all the way up
-  // (documentElement included) and relatedTarget is null. The whole STORED chain is
-  // offered: a detached row is gone (dispatchHoverEvent drops it), but
-  // `.sidebar-layout` above it is not, and it is still frozen (plan C17).
   dispatchLeaveGroup(from, null, hoveredChain, events);
 
   hoveredElement = null;
@@ -727,11 +659,6 @@ function dispatchLeaveGroup(
   }
 }
 
-/** The enter chain runs OUTERMOST-FIRST, so an ancestor's handler runs before the
- *  events for its own descendants - including `to` itself. An `onMouseEnter` that
- *  tore down its own subtree would leave the rest of this function firing into dead
- *  nodes. No handler in src/ does that today, and it is `dispatchHoverEvent`'s
- *  isConnected guard, not that fact, that makes it safe. */
 function dispatchEnterGroup(
   to: HTMLElement,
   from: HTMLElement | null,
@@ -749,20 +676,6 @@ function dispatchEnterGroup(
   }
 }
 
-/** THE invariant, and the single place it is enforced: never dispatch into a node
- *  that has left the document, and never report an event that did not land.
- *  Dispatching into a removed node is a lie the DOM would not tell (plan §8.4), and
- *  `diagnostics.events` is the harness's only evidence of what happened - a phantom
- *  entry in it is worse than a missing one.
- *
- *  A node in a chain is dead by the time we reach it in two ways:
- *  - it was already detached when the chain was captured. The routine case: <For>
- *    re-mints a row under a stationary cursor, so `from` is gone by the time we
- *    leave it, while its ancestors are still there and still owe us their leave.
- *  - a handler EARLIER in the same dispatch detached it (see dispatchEnterGroup).
- *
- *  The chains are therefore passed WHOLE and filtered here, at dispatch time. A
- *  pre-filter cannot see the second case. */
 function dispatchHoverEvent(
   target: HTMLElement,
   type: string,
@@ -777,7 +690,6 @@ function dispatchHoverEvent(
   events.push(type);
 }
 
-/** [node, ...ancestors], innermost first, up to and including documentElement. */
 function hoverChain(node: HTMLElement): HTMLElement[] {
   const chain: HTMLElement[] = [];
   let current: HTMLElement | null = node;
@@ -788,9 +700,6 @@ function hoverChain(node: HTMLElement): HTMLElement[] {
   return chain;
 }
 
-/** The first node of `fromChain` that is also on `toChain`. null = disjoint (a
- *  detached `from`, or a document-less node): the caller then leaves / enters the
- *  whole chain, which is what a pointer arriving from outside the window does. */
 function firstCommonAncestor(
   fromChain: HTMLElement[],
   toChain: HTMLElement[],
@@ -808,7 +717,6 @@ function testIdOf(element: HTMLElement | null): string | null {
   return element?.getAttribute("data-ac-testid") ?? null;
 }
 
-/** `ok: true` requires a target, and a leave with nothing hovered has none. */
 function emptyHoverTarget(): UiAutomationTarget {
   return {
     testId: "",
@@ -863,10 +771,6 @@ function createHoverEvent(
     event = new Ctor(type, eventInit);
   }
 
-  // jsdom 25 has no PointerEvent, and MouseEventInit SILENTLY DROPS pointerId /
-  // pointerType / isPrimary - so without this the suite would exercise
-  // `pointerId: undefined` while the GUI ships `1`. Same trick as
-  // WorkgroupGroupRail.test.tsx:120.
   if (isPointer && !hasPointerEvent) {
     for (const [key, value] of Object.entries(HOVER_POINTER_INIT)) {
       Object.defineProperty(event, key, { value, configurable: true });

--- a/src/shared/coordinator-badge.ts
+++ b/src/shared/coordinator-badge.ts
@@ -1,34 +1,12 @@
 import type { AppSettings } from "./types";
 
-/**
- * #882 Domain severity for the coordinator idle badge. Deliberately not a color:
- * mapping to .green / .yellow / .red lives at the render boundary.
- */
 export type CoordinatorIdleLevel = "ok" | "warn" | "stale";
 
 export interface CoordinatorBadge {
-  /** Minutes-only label, e.g. "0m", "45m", "4320m". */
   label: string;
-  /** Threshold severity. Mapped to a CSS class at the render boundary. */
   level: CoordinatorIdleLevel;
 }
 
-/**
- * #552/#580 Pure, timer-free badge derivation so it unit-tests cleanly. The
- * input timestamp is the unified team-idle anchor (#580): minutes since the team
- * was last truly active, not merely the user's last message (the param name is
- * retained — rename deferred). Minutes-only, raw integer, NO h/d rollover (spec):
- * 45m, 135m, 4320m. Severity comes from the global thresholds:
- * `minutes >= red -> "stale"`, else `>= yellow -> "warn"`, else `"ok"` (red
- * is tested first, so an inverted yellow>=red pair just collapses the warn band
- * rather than misbehaving). The threshold settings keys keep their color names
- * because they are persisted to disk and Rust config; renaming them is out of
- * scope for #882. The `Math.max(0, ...)` floor means clock skew / a
- * future-dated timestamp shows `0m`, never a negative value.
- *
- * Returns `null` when there is no usable timestamp (absent or unparseable), so
- * callers render nothing for a coordinator with no idle anchor yet.
- */
 export function coordinatorIdleBadge(
   lastUserMessageAtIso: string | undefined,
   nowMs: number,

--- a/src/shared/github-url.ts
+++ b/src/shared/github-url.ts
@@ -1,7 +1,3 @@
-/// #943 - GitHub remote parsing for the coordinator repo Browse submenu.
-/// Only github.com is supported. Any other host (self-hosted GHE, GitLab,
-/// Bitbucket, a local path remote) yields null, which the caller renders as
-/// "no Browse items".
 
 export interface GithubRepoRef {
   owner: string;
@@ -9,18 +5,11 @@ export interface GithubRepoRef {
 }
 
 const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
-/// GitHub's owner/repo charset. NOTE: `.` is in this class, so it does NOT
-/// reject `.` or `..` on its own; `isSafeSegment` does that. (Rev 1 claimed the
-/// regex was an injection guard. It was not: `git@github.com:../evil` parsed to
-/// {owner: "..", repo: "evil"}.)
 const NAME_RE = /^[A-Za-z0-9._-]+$/;
-/// scp-like remote: [user@]host:owner/repo(.git)
 const SCP_LIKE_RE = /^(?:[^@/]+@)?([^:/]+):(.+)$/;
 const URL_SCHEME_RE = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//;
 const ALLOWED_SCHEMES = new Set(["http", "https", "ssh", "git"]);
 
-/// Only the URL branch gets WHATWG path normalization; the scp-like branch does
-/// not, so `.`/`..` must be rejected explicitly on both.
 function isSafeSegment(segment: string): boolean {
   return segment.length > 0 && segment !== "." && segment !== "..";
 }
@@ -53,8 +42,6 @@ export function parseGithubRemote(remote: string | null | undefined): GithubRepo
     }
     const scheme = url.protocol.replace(":", "").toLowerCase();
     if (!ALLOWED_SCHEMES.has(scheme)) return null;
-    // URL.hostname already drops userinfo and port (and Rust already stripped
-    // userinfo before this ever crossed IPC; this is the second layer).
     return refFromHostAndPath(url.hostname, url.pathname);
   }
 
@@ -67,17 +54,6 @@ export function githubRepoUrl(ref: GithubRepoRef): string {
   return `https://github.com/${ref.owner}/${ref.repo}`;
 }
 
-/// Branch names contain `/` (`fix/909-agency-agents-roles-yaml-skip`), so the
-/// separators stay literal and each segment is percent-encoded (`#`, `?`, spaces
-/// and newlines all encode; no second URL can be smuggled in).
-///
-/// Returns null for an unusable ref. `.`/`..` segments are rejected rather than
-/// dropped: git already forbids `..` in a ref name, so rejecting is lossless for
-/// real branches, and `repo.branch` is NOT always git-sourced (it also arrives
-/// from config.json `repoBranch` via configuredReplicaRepoBadges and from the
-/// volatile branch-event layer, neither of which validates). Without this,
-/// `../../../../evil/repo` produced a URL the browser normalized into a
-/// different repository.
 export function githubBranchUrl(ref: GithubRepoRef, branch: string): string | null {
   const segments = branch.split("/").filter((segment) => segment.length > 0);
   if (segments.length === 0) return null;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -122,27 +122,12 @@ export interface CreateSessionOptions {
   agentId?: string;
   requestedProfile?: string | null;
   gitRepos?: SessionRepoInput[];
-  /**
-   * #599 R1. Forwarded to `create_session`. Omit (or pass `true`) for a
-   * genuinely fresh create — no provider auto-resume. Pass `false` only when
-   * reopening a coordinator that was destroyed by auto-close (#552/#580) or
-   * manual close (#588) so the prior Claude conversation continues.
-   */
   skipAutoResume?: boolean;
 }
 
 export interface RestartSessionOptions {
   agentId?: string;
   requestedProfile?: string | null;
-  /**
-   * Forwarded to the backend `restart_session` command. Omit (or pass `true`)
-   * for a true user-intent restart that starts a fresh conversation. Pass
-   * `false` when waking a deferred session — a session whose PTY is `Exited`
-   * either because it was deferred at startup (new-policy default, or the
-   * coord-was-asleep-at-shutdown branch of `restoreCoordinatorWakeState`) or
-   * because the user closed it during the prior run — to allow provider
-   * auto-resume (`claude --continue`, `codex resume --last`, `gemini --resume latest`).
-   */
   skipAutoResume?: boolean;
 }
 
@@ -155,14 +140,6 @@ export interface CreateRootAgentOptions {
  *  scope. Superseded by {@link ProfileAssignmentScope}. */
 export type ProfileSelectionScope = "default" | "instance";
 
-/**
- * Single stable payload for `coding_agent_profile_selection_updated`, emitted by
- * both the legacy `set_agent_default_profile`/`set_instance_profile_override`
- * commands and the new broad-scope apply (#384 §7). All fields beyond `scope`
- * are optional because broad-scope applies touch many replicas (no single
- * `agentPath`). `scope` is a plain string to tolerate both the legacy
- * default/instance emitters and the v2 replica/kind/workgroup apply.
- */
 export interface CodingAgentProfileSelectionUpdatedPayload {
   scope: ProfileAssignmentScope | ProfileSelectionScope | string;
   agentPath?: string;
@@ -175,23 +152,7 @@ export interface CodingAgentProfileSelectionUpdatedPayload {
 }
 
 export const SessionAPI = {
-  /**
-   * #973 — the ONLY create path with a terminal tile to measure, and so the only
-   * one that hands the backend a size. Every other caller (startup restore, the
-   * delivery loop, the phone mailbox, the root agent, the CLI, tests) has no view
-   * and keeps AC's historical 120x30.
-   *
-   * The size is measured, not predicted: {@link measurePtyViewport} runs the same
-   * `FitAddon.proposeDimensions()` the terminal's own post-mount fit will run,
-   * against the tile already on screen. Null when there is nothing to measure —
-   * then no size is sent, and a wrong size is worse than no size.
-   */
   create: async (opts?: CreateSessionOptions): Promise<Session> => {
-    // Browser mode is deliberately excluded. The web-mode `create_session`
-    // handler parses its args by hand and ignores cols/rows entirely: it always
-    // spawns at the 120x30 default. Recording a spawn size the PTY was never
-    // opened at would make the terminal's dedup skip the corrective resize and
-    // wedge that PTY at 120x30 forever.
     const viewport = isBrowser ? null : measurePtyViewport();
 
     const session = await transport.invoke<Session>("create_session", {
@@ -203,7 +164,6 @@ export const SessionAPI = {
       requestedProfile: opts?.requestedProfile ?? null,
       gitRepos: opts?.gitRepos ?? null,
       skipAutoResume: opts?.skipAutoResume ?? null,
-      // Both or neither: the backend builds a viewport only when both arrive.
       cols: viewport?.cols ?? null,
       rows: viewport?.rows ?? null,
     });
@@ -217,9 +177,6 @@ export const SessionAPI = {
 
   destroy: (id: string) => transport.invoke<void>("destroy_session", { id }),
 
-  /** #588 Manually close a coordinator. When the cascade setting is on and the
-   *  team has working members, the backend returns `{ closed: false, workingCount }`
-   *  so the caller can confirm; calling again with `confirmed: true` forces it. */
   closeCoordinator: (id: string, confirmed: boolean) =>
     transport.invoke<CoordinatorCloseOutcome>("close_coordinator", { id, confirmed }),
 
@@ -258,12 +215,10 @@ export const SessionAPI = {
 export const PtyAPI = {
   write: (sessionId: string, data: Uint8Array) => {
     const transport = currentTransport();
-    // Use efficient binary transport if available (WS mode)
     if (transport.writePtyBinary) {
       transport.writePtyBinary(sessionId, data);
       return Promise.resolve();
     }
-    // Fallback: JSON-encoded number array (Tauri mode)
     return transport.invoke<void>("pty_write", {
       sessionId,
       data: Array.from(data),
@@ -276,49 +231,23 @@ export const PtyAPI = {
   getScreenSnapshot: (sessionId: string) =>
     transport.invoke<PtyScreenSnapshot | null>("get_screen_snapshot", { sessionId }),
 
-  /** #1033 - last context reading for a session, or `null` when there is none.
-   *  `null` covers "no reading", "not registered", "scraper unmanaged" and "session
-   *  over" alike, and NEVER means 0. Mandatory rather than an optimisation: the
-   *  engine emits `session_context` only when the value CHANGES, so a session
-   *  already sitting at a reading when this window mounts never sends an event and
-   *  a listener alone would leave it at `CTX N/A` forever. */
   getSessionContext: (sessionId: string) =>
     transport.invoke<number | null>("get_session_context", { sessionId }),
 
-  /** Request screen snapshot replay for late-joining browser clients.
-   *  Returns PTY dimensions so the browser can mirror them. */
   subscribe: (sessionId: string) =>
     transport.invoke<{ rows: number; cols: number } | null>("subscribe_session", { sessionId }),
 
-  /** Get current PTY dimensions (rows, cols). */
   getPtySize: (sessionId: string) =>
     transport.invoke<{ rows: number; cols: number }>("get_pty_size", { sessionId }),
 };
 
 export const CodingAgentsAPI = {
-  /**
-   * #769 — the built-in coding-agent catalog. Resolves `Ok(list)` normally and
-   * on backend self-heal (missing/malformed `agents.json` → embedded default in
-   * memory, file never overwritten); a valid `Ok([])` (user removed all
-   * built-ins) is returned verbatim. Rejects only on a genuine config-dir
-   * failure, which is the sole case the store's fallback covers.
-   */
   getCatalog: () =>
     transport.invoke<CodingAgentDefinition[]>("get_coding_agent_catalog"),
 
-  /**
-   * #769 Phase 2 — lowercased command basenames that ship a non-empty default
-   * config-folder master (today `["claude","codex","opencode"]`). Backend-derived
-   * from the shipped masters; the re-seed button is gated on EXACT membership.
-   */
   listReseedableCommands: () =>
     transport.invoke<string[]>("list_reseedable_agent_commands"),
 
-  /**
-   * #769 Phase 2 — restore an agent's default config-folder master to the shipped
-   * default, backing up the prior master. Resolves `Ok(ReseedResult)`; rejects if
-   * `command` is not a reseedable built-in (gating is re-checked server-side).
-   */
   reseedDefault: (command: string) =>
     transport.invoke<ReseedResult>("reseed_coding_agent_default", { command }),
 };
@@ -345,28 +274,14 @@ export const SettingsAPI = {
     }),
   getWebServerOwnedStatus: () =>
     transport.invoke<WebServerOwnedStatus>("get_web_server_owned_status"),
-  // Narrow setters hold the SettingsState write lock through save_settings on
-  // the Rust side, eliminating the IPC-level read-modify-write race that a
-  // get+update round-trip would create against a concurrent update_settings
-  // from SettingsModal.
   setSoundsEnabled: (value: boolean) =>
     transport.invoke<void>("set_sounds_enabled", { value }),
   setThemeLight: (value: boolean) =>
     transport.invoke<void>("set_theme_light", { value }),
-  // #587 — narrow setter for the central-view toggle (RM attached vs terminal).
-  // Same write-lock pattern as the other narrow setters; avoids a get+update
-  // round-trip racing SettingsModal.
   setMainResourceMonitorAttached: (value: boolean) =>
     transport.invoke<void>("set_main_resource_monitor_attached", { value }),
-  // #965 — one narrow setter for the whole rail-collapse snapshot (explicitly
-  // collapsed project paths + the Favorites section bit). Same write-lock pattern.
-  // Called once per header click; no debounce (plan §0.2).
   setRailCollapse: (collapsedProjects: string[], favoritesCollapsed: boolean) =>
     transport.invoke<void>("set_rail_collapse", { collapsedProjects, favoritesCollapsed }),
-  // #612 — canonical command to change ONLY the log level: validates, persists
-  // logLevel, applies live + broadcasts `log_level_changed`. The SettingsModal
-  // uses the form Save path (save_settings_draft) instead; this is for
-  // programmatic / future quick-switch callers.
   setLogLevel: (level: LogLevel) =>
     transport.invoke<void>("set_log_level", { level }),
   updateCodingAgentProfiles: (profiles: CodingAgentProfilesConfig) =>
@@ -385,10 +300,6 @@ export const SettingsAPI = {
     transport.invoke<void>("set_agent_default_profile", { agentPath, profile }),
   setInstanceProfileOverride: (agentPath: string, profile: string | null) =>
     transport.invoke<void>("set_instance_profile_override", { agentPath, profile }),
-  // #384 §7 — broad-scope assignment. Preview enumerates targets + live sessions
-  // and returns a fingerprint; apply re-enumerates on the backend and rejects a
-  // stale `confirmedTargetFingerprint`. The frontend target list is display-only;
-  // the backend is authoritative for enumeration, writes, and restarts.
   previewCodingAgentProfileSelection: (
     request: PreviewCodingAgentProfileSelectionRequest,
   ) =>
@@ -421,10 +332,6 @@ export const ReposAPI = {
   search: (query: string) =>
     transport.invoke<RepoMatch[]>("search_repos", { query }),
 
-  /// #943 - `origin`'s URL for a repo path, userinfo already stripped by the
-  /// backend. `null` = no origin, not a work tree root, git missing, the 2s
-  /// backend timeout fired, or a web client (the WS dispatcher no-ops this).
-  /// The caller treats all of them the same: no Browse items.
   gitRemoteUrl: (path: string) =>
     transport.invoke<string | null>("git_remote_url", { path }),
 };
@@ -480,7 +387,6 @@ export function onSessionCommunicationChanged(
   );
 }
 
-// Voice API
 export const VoiceAPI = {
   transcribe: (audio: number[], mimeType: string) =>
     transport.invoke<string>("voice_transcribe", { audio, mimeType }),
@@ -490,11 +396,9 @@ export const VoiceAPI = {
     transport.invoke<boolean>("voice_had_typing", { sessionId }),
 };
 
-// Debug API
 export const DebugAPI = {
   saveLogs: (content: string) =>
     transport.invoke<void>("save_debug_logs", { content }),
-  /** #264 — read-and-clear the backend's buffered ERROR-level log entries. */
   drainErrorLogs: () =>
     transport.invoke<ErrorLogEntry[]>("drain_error_logs"),
 };
@@ -513,61 +417,33 @@ export function onUiAutomationRequest(
   return transport.listen<UiAutomationRequest>("ui_automation_request", callback);
 }
 
-// #264 — content-free ping fired when a new ERROR-level log entry is captured.
-// The listener responds by calling DebugAPI.drainErrorLogs().
 export function onErrorLogEvent(
   callback: () => void
 ): Promise<UnlistenFn> {
   return transport.listen<unknown>("error_log_event", () => callback());
 }
 
-// Window API
 export const WindowAPI = {
   detach: (sessionId: string) =>
     transport.invoke<string>("detach_terminal", { sessionId }),
 
-  /**
-   * Re-attach a detached session to the main window. Closes the detached
-   * window, removes the session from DetachedSessionsState, switches main
-   * to that session. Rust contract (plan §A2.2.G5): silent no-op if the
-   * session was already destroyed.
-   */
   attach: (sessionId: string) =>
     transport.invoke<void>("attach_terminal", { sessionId }),
 
-  /**
-   * Stateless authoritative list of detached session UUIDs. Used for
-   * hydrating sessionsStore.detachedIds on SidebarApp mount (G.8 race
-   * safety).
-   */
   listDetached: () =>
     transport.invoke<string[]>("list_detached_sessions"),
 
-  /**
-   * Persist a detached window's geometry to its PersistedSession so it
-   * re-spawns at the same position+size after an app restart. Per plan
-   * §A2.4.Arb1 (R.6 option a) — backend stores the value on
-   * PersistedSession.detached_geometry and auto-GCs when the session is
-   * destroyed.
-   */
   setDetachedGeometry: (sessionId: string, geometry: WindowGeometry) =>
     transport.invoke<void>("set_detached_geometry", { sessionId, geometry }),
 
   openInExplorer: (path: string) =>
     transport.invoke<void>("open_in_explorer", { path }),
 
-  /**
-   * Focus the main unified window (raising it, recreating if missing).
-   * Rust command renamed from `ensure_terminal_window` → `focus_main_window`
-   * in v0.8 (dev-rust owns that rename). Per plan §A2.4.Arb3 / R.4.
-   */
   focusMain: () => transport.invoke<void>("focus_main_window"),
 
   /** @deprecated use focusMain(); back-compat alias, drop at v0.9 */
   ensureTerminal: () => transport.invoke<void>("focus_main_window"),
 
-  // Open an http/https URL in the user's default browser. Backend rejects
-  // non-http(s) schemes (issue #164).
   openExternal: (url: string) =>
     transport.invoke<void>("open_external_url", { url }),
 
@@ -578,9 +454,6 @@ export const WindowAPI = {
     transport.invoke<void>("dock_resource_monitor_window"),
 };
 
-// #714 Screenshot capture. All global-shortcut, clipboard, and window lifecycle
-// work stays in Rust; the frontend only fetches the frozen overlay state, sends
-// the confirmed crop, cancels, and reads/reloads the hotkey registration status.
 export const ScreenshotAPI = {
   getOverlayState: (captureId: string, monitorId: number) =>
     transport.invoke<ScreenshotOverlayState>("screenshot_get_overlay_state", {
@@ -605,7 +478,6 @@ export const ResourceMonitorAPI = {
     transport.invoke<ResourceKillResult>("kill_resource_group", { request }),
 };
 
-// Brief API (issue #162)
 export const TaskAPI = {
   getTitle: (sessionId: string) =>
     transport.invoke<string | null>("task_get_title", { sessionId }),
@@ -616,13 +488,10 @@ export const TaskAPI = {
   clean: (sessionId: string) =>
     transport.invoke<TaskUpdateResult>("task_clean", { sessionId }),
 
-  // #545: path-addressed clean for a cold workgroup with no live/exited session
-  // to resolve a session id from. Returns the same TaskUpdateResult as task_clean.
   cleanAt: (workgroupRoot: string) =>
     transport.invoke<TaskUpdateResult>("task_clean_at", { workgroupRoot }),
 };
 
-// Telegram Bridge API
 export const TelegramAPI = {
   attach: (sessionId: string, botId: string) =>
     transport.invoke<BridgeInfo>("telegram_attach", { sessionId, botId }),
@@ -638,8 +507,6 @@ export const TelegramAPI = {
   sendTest: (token: string) =>
     transport.invoke<number>("telegram_send_test", { token }),
 
-  // #282 — send an existing local file to the bot's configured chat.
-  // ≤ 10 MB jpg/jpeg/png/webp ⇒ sendPhoto; otherwise sendDocument up to 50 MB.
   sendImage: (botId: string, path: string, caption?: string) =>
     transport.invoke<void>("telegram_send_image", { botId, path, caption }),
 };
@@ -686,21 +553,11 @@ export function onSessionCoordinatorChanged(
   );
 }
 
-/// #943 B2 - `repoBranches` and `repoPaths` are parallel arrays of equal length,
-/// 1:1 by construction (ac_discovery.rs maps over `agent.repo_paths` and never
-/// filters, sorts or dedupes), with an explicit `null` for an unknown branch.
-/// Consumers must still merge BY PATH, not by position: this payload is stored and
-/// re-read against a later discovery snapshot. `branch` is the unchanged
-/// single-repo shorthand (null for a multi-repo replica).
 interface DiscoveryBranchUpdate {
   replicaPath: string;
   branch: string | null;
   repoBranches: (string | null)[];
   repoPaths: string[];
-  /** #1028 - per-repo worktree-dirty, parallel to `repoPaths` exactly as
-   *  `repoBranches` is, and merged BY PATH for the same reason. `null` = the backend
-   *  has never successfully detected that path. Gate A emits for every replica,
-   *  session or not, which is what carries dirty to DORMANT coordinator rows. */
   repoDirty: (boolean | null)[];
 }
 
@@ -713,12 +570,6 @@ export function onDiscoveryBranchUpdated(
   );
 }
 
-// #552/#580 coordinator idle badge clock event. The backend emits the unified
-// team-idle anchor (#580: `max(last_user_message_at, last_activity_at)`) in the
-// `lastUserMessageAt` field — the field name is retained (rename deferred) but
-// it now means "team idle since", not just the user's last message. Mirrors
-// `ac_discovery_branch_updated` so ProjectPanel can patch the replica in place
-// without waiting for a full discovery reload.
 export function onCoordinatorClockUpdated(
   callback: (data: { replicaPath: string; lastUserMessageAt: string }) => void
 ): Promise<UnlistenFn> {
@@ -728,8 +579,6 @@ export function onCoordinatorClockUpdated(
   );
 }
 
-// #552 auto-closed pill: the auto-close task sets the marker (string timestamp)
-// when it terminates a team; reopen clears it (`autoClosedAt: null`).
 export function onCoordinatorAutoCloseChanged(
   callback: (data: { replicaPath: string; autoClosedAt: string | null }) => void
 ): Promise<UnlistenFn> {
@@ -739,8 +588,6 @@ export function onCoordinatorAutoCloseChanged(
   );
 }
 
-// #588 manually-closed pill: close_coordinator sets the marker (string
-// timestamp) when the user manually closes a coordinator; reopen clears it.
 export function onCoordinatorManualCloseChanged(
   callback: (data: { replicaPath: string; manuallyClosedAt: string | null }) => void
 ): Promise<UnlistenFn> {
@@ -786,11 +633,6 @@ export function onSessionBusy(
   return transport.listen<{ id: string }>("session_busy", callback);
 }
 
-/**
- * #1033 - a session's context-window reading changed. Emit-on-change only: pair
- * every listener with `PtyAPI.getSessionContext` to seed sessions that are already
- * sitting at a value (`App.tsx`), or they read `CTX N/A` until they next change.
- */
 export function onSessionContext(
   callback: (data: SessionContextPayload) => void
 ): Promise<UnlistenFn> {
@@ -830,7 +672,6 @@ export function onSessionEnvWarning(
   );
 }
 
-// Phone API
 export const PhoneAPI = {
   sendMessage: (from: string, to: string, body: string, team: string) =>
     transport.invoke<string>("phone_send_message", { from, to, body, team }),
@@ -841,7 +682,6 @@ export const PhoneAPI = {
     transport.invoke<void>("phone_ack_messages", { agentName, messageIds }),
 };
 
-// AC Discovery API
 export const AcDiscoveryAPI = {
   discover: () => transport.invoke<AcDiscoveryResult>("discover_ac_agents"),
 
@@ -852,7 +692,6 @@ export const AcDiscoveryAPI = {
     transport.invoke<void>("set_replica_context_files", { path, files }),
 };
 
-// Project API
 export const ProjectAPI = {
   checkPath: (path: string) =>
     transport.invoke<boolean>("check_project_path", { path }),
@@ -881,52 +720,23 @@ export const ProjectAPI = {
         currentDefaultSha256: update.currentDefaultSha256,
       }
     ),
-  /**
-   * Validate an existing AC project at `path` and register it in
-   * settings.projectPaths. Wraps the `open_project` Tauri command added in
-   * #191 — same backend logic as the CLI `open-project` verb.
-   */
   open: (path: string) =>
     transport.invoke<ProjectRegistration>("open_project", { path }),
-  /**
-   * Ensure an AC project at `path` (create `.ac/` Project AC Root if missing) and register
-   * it in settings.projectPaths. Wraps the `new_project` Tauri command added
-   * in #191 — same backend logic as the CLI `new-project` verb.
-   */
   new: (path: string) =>
     transport.invoke<ProjectRegistration>("new_project", { path }),
-  /**
-   * Remove the project registered at `path` from settings.projectPaths via the
-   * dedicated `remove_project` Tauri command (#778 Design S). Removal is
-   * disk-authoritative: the backend reconciles the list from disk before
-   * dropping `path`, so it never clobbers a CLI-registered project the way the
-   * retired whole-object settings save did. Removing a path not present is a
-   * successful no-op; the promise rejects with the backend error string on a
-   * hard failure (e.g. a G2 read abort when the settings file is locked).
-   */
   remove: (path: string) => transport.invoke<void>("remove_project", { path }),
-  /**
-   * #881 - hide the project at `path`. Rejects with a human-readable blocker
-   * message when the project still has live sessions, so callers must await it
-   * before mutating any local store.
-   */
   archive: (path: string) => transport.invoke<void>("archive_project", { path }),
-  /** #881 - restore an archived project and return its backend registration. */
   unarchive: (path: string) =>
     transport.invoke<ProjectRegistration>("unarchive_project", { path }),
-  /** #881 - archived projects decorated with on-disk existence flags. */
   listArchived: () =>
     transport.invoke<ArchivedProject[]>("list_archived_projects", {}),
 };
 
-/** #777 Non-stop watchdog: frontend pushes the full disparity snapshot; the
- *  backend owns the tolerance timer and actuation (Win32 beep + Telegram). */
 export const NonStopAPI = {
   report: (reports: NonStopReport[]) =>
     transport.invoke<void>("non_stop_report", { reports }),
 };
 
-// Project Loops API
 export const LoopAPI = {
   create: (projectPath: string, input: LoopCreateInput) =>
     transport.invoke<LoopConfigDetails>("create_loop", {
@@ -976,7 +786,6 @@ export const LoopAPI = {
     transport.invoke<LoopCronPreview>("preview_loop_cron", { expr }),
 };
 
-// Role template picker (#271)
 export const RoleTemplateAPI = {
   list: () => transport.invoke<RoleTemplateMeta[]>("list_role_templates"),
   status: () => transport.invoke<AgencyTemplatesStatus>("get_agency_templates_status"),
@@ -984,7 +793,6 @@ export const RoleTemplateAPI = {
     transport.invoke<AgencyTemplatesUpdateResult>("update_agency_templates"),
 };
 
-// Entity Creation API (agents, teams, workgroups)
 export const EntityAPI = {
   createAgentMatrix: (
     projectPath: string,
@@ -1048,7 +856,6 @@ export const EntityAPI = {
     ),
 };
 
-// Agent Creator API
 export const AgentCreatorAPI = {
   pickFolder: (defaultPath?: string) =>
     transport.invoke<string | null>("pick_folder", { defaultPath: defaultPath ?? null }),
@@ -1057,17 +864,14 @@ export const AgentCreatorAPI = {
     transport.invoke<string>("create_agent_folder", { parentPath, agentName }),
 };
 
-// Guide window
 export const GuideAPI = {
   open: () => transport.invoke<void>("open_guide_window"),
 };
 
-// Home content (issue #164)
 export const HomeAPI = {
   fetchMarkdown: () => transport.invoke<string>("fetch_home_markdown"),
 };
 
-// Theme sync across windows
 export function emitThemeChanged(light: boolean): Promise<void> {
   return transport.emit("theme_changed", { light });
 }
@@ -1078,9 +882,6 @@ export function onThemeChanged(
   return transport.listen<{ light: boolean }>("theme_changed", callback);
 }
 
-// #587 — the detached Resource Monitor window asks the main window to pull RM
-// back into the central pane. Fire-and-forget; main's listener sets the central
-// view. Mirrors the theme_changed emit/listen pair.
 export function emitResourceMonitorAttach(): Promise<void> {
   return transport.emit("resource_monitor_attach", {});
 }
@@ -1091,10 +892,6 @@ export function onResourceMonitorAttach(
   return transport.listen<unknown>("resource_monitor_attach", () => callback());
 }
 
-// Open the Settings modal (handled by sidebar ActionBar). Emitted from any
-// window — e.g. a disabled mic button asking the user to configure voice.
-// `section` targets a specific tab in SettingsModal (e.g. "integrations").
-// Omit to open on the default tab.
 export function emitOpenSettings(section?: string): Promise<void> {
   return transport.emit<{ section?: string }>(
     "open_settings",
@@ -1124,12 +921,6 @@ export function onCodingAgentProfilesUpdated(
   return transport.listen<unknown>("coding_agent_profiles_updated", () => callback());
 }
 
-/**
- * #786 — a `coding-agent` CLI mutation applied through the running GUI's
- * MailboxPoller emits this. Payload carries the op ("add"|"update"|"remove") and
- * the affected agent id (null is possible if the poller could not resolve one).
- * Mirrors the fire-and-refetch shape of onCodingAgentProfilesUpdated.
- */
 export function onCodingAgentSettingsUpdated(
   callback: (payload: { op: string; agentId: string | null }) => void
 ): Promise<UnlistenFn> {
@@ -1139,9 +930,6 @@ export function onCodingAgentSettingsUpdated(
   );
 }
 
-// #714 Screenshot capture result/failure events. Both emitted from the Rust
-// capture path; the sidebar renders them as toasts (the overlay window is
-// temporary and may be destroyed before the user reads anything).
 export function onScreenshotCaptureSaved(
   callback: (data: ScreenshotCaptureResult) => void
 ): Promise<UnlistenFn> {

--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -30,8 +30,6 @@ const EMPTY_CELL: ProfileCellConfig = {
   notes: "",
 };
 
-/** Display-only profile path placeholders. The backend is authoritative for real
- *  expansion + validation at launch (#576 / #384 F17). */
 export const AC_REPLICA_ROOT_PLACEHOLDER = "%AC_REPLICA_ROOT%";
 export const AC_WORKSPACE_ROOT_PLACEHOLDER = "%AC_WORKSPACE_ROOT%";
 export const AC_MATRIX_ROOT_PLACEHOLDER = "%AC_MATRIX_ROOT%";
@@ -57,17 +55,6 @@ export function sortedProfileLetters(profiles: CodingAgentProfilesConfig): strin
   return [...letters].sort();
 }
 
-/**
- * #548: the resolved display NAME for (agent, letter). Single source of truth for
- * label resolution, shared by the SettingsModal rails, the AgentPickerModal cards,
- * and the coordinator quick-access / session-row tooltips. Chain (resolve-on-read):
- *   1. the agent's own label,
- *   2. else the primigenio (agents[0]) agent's own label,
- *   3. else the legacy shared slot label (back-compat for pre-#548 configs),
- *   4. else "" (caller shows the bare letter).
- * `agents` MUST be in persisted order (agents[0] = primigenio); pass the raw
- * settings.agents array, never a sorted copy.
- */
 export function resolveProfileLabel(
   profiles: CodingAgentProfilesConfig,
   agents: AgentConfig[],
@@ -82,8 +69,6 @@ export function resolveProfileLabel(
   return own || inherited || legacy || "";
 }
 
-/** Presentation form for the picker cards and the tooltips:
- *  `${letter}-${NAME}` when a name resolves, else the bare letter. */
 export function profileDisplayLabel(
   profiles: CodingAgentProfilesConfig,
   agents: AgentConfig[],
@@ -119,18 +104,10 @@ export function profileCellOrDefault(
   return profiles.profilesByAgent[agentId]?.[letter] ?? EMPTY_CELL;
 }
 
-/** v2 (#384): the params string stored on a profile cell (#597: appended to the agent base command at launch). */
 export function profileCellCommandText(cell: ProfileCellConfig | null | undefined): string {
   return cell?.command ?? "";
 }
 
-/**
- * #597 - the effective launch command: the agent base command (the binary,
- * possibly with its own fixed args) followed by the profile cell command (extra
- * params). Each side is trimmed; a single space joins them when both are
- * non-empty; an empty side contributes nothing (no stray space). Mirrors the Rust
- * `compose_effective_command` so the UI preview matches what actually launches.
- */
 export function composeEffectiveCommand(base: string, cell: string): string {
   const b = base.trim();
   const c = cell.trim();
@@ -139,12 +116,10 @@ export function composeEffectiveCommand(base: string, cell: string): string {
   return `${b} ${c}`;
 }
 
-/** True when a value contains any AC path placeholder (display check). */
 export function hasAcPlaceholder(value: string): boolean {
   return AC_PLACEHOLDERS.some((token) => value.includes(token));
 }
 
-/** Display-only: the `.ac` workspace ancestor of a replica path, or null. */
 export function deriveWorkspaceRoot(replicaPath: string | null | undefined): string | null {
   if (!replicaPath) return null;
   const parts = replicaPath.replace(/\\/g, "/").replace(/\/+$/, "").split("/");
@@ -154,7 +129,6 @@ export function deriveWorkspaceRoot(replicaPath: string | null | undefined): str
   return parts.slice(0, idx + 1).join(sep);
 }
 
-/** Display-only: the matrix dir `<workspace>/_agent_<name>` for a WG replica path, or null. */
 export function deriveMatrixRoot(replicaPath: string | null | undefined): string | null {
   if (!replicaPath) return null;
   const workspace = deriveWorkspaceRoot(replicaPath);
@@ -168,12 +142,6 @@ export function deriveMatrixRoot(replicaPath: string | null | undefined): string
   return `${workspace}${sep}_agent_${name}`;
 }
 
-/**
- * Display-only preview of AC placeholder expansion against a known replica root.
- * Workspace and matrix are derived from the replica path. Returns the value
- * unchanged when no replica root is available; the backend performs the
- * authoritative expansion + absolute-path validation at launch.
- */
 export function expandAcPlaceholdersPreview(
   value: string,
   replicaRoot: string | null | undefined,
@@ -217,14 +185,8 @@ export function resolveProfilePreview(
   };
 }
 
-/** The data-driven profile-cell badge states. `invalid` (a live command parse
- *  error) is UI-local and layered on top by the caller; the rest are resolved
- *  from the persisted profile data. (#526/#527) */
 export type ProfileBadgeKind = "match" | "configured" | "fallback" | "missing" | "invalid";
 
-/** True when `letter` has an enabled cell on some coding agent OTHER than
- *  `agentId`. Distinguishes a MISSING slot (configured elsewhere, absent here)
- *  from a plain positional fallback. Excludes the agent itself. (#526/#527) */
 export function profileConfiguredElsewhere(
   profiles: CodingAgentProfilesConfig,
   agentId: string,
@@ -235,17 +197,6 @@ export function profileConfiguredElsewhere(
   );
 }
 
-/**
- * Profile-cell badge taxonomy shared 1:1 by the Config rails (SettingsModal) and
- * the Selection profile cards (AgentPickerModal), so both screens read the same
- * state for a given (agent, letter). Mirrors the B2C1a prototype:
- *   - A / baseline               → "match"      (always configured)
- *   - non-A with its own cell    → "configured" (direct match on a non-baseline slot)
- *   - non-A, absent, but the slot is configured on another agent → "missing"
- *   - non-A, absent, resolves through a lower letter             → "fallback"
- * The `invalid` state is not produced here — a live parse error is decided by the
- * caller and takes precedence.
- */
 export function profileBadgeKind(
   profiles: CodingAgentProfilesConfig,
   agentId: string,
@@ -254,8 +205,6 @@ export function profileBadgeKind(
   const cell = profiles.profilesByAgent[agentId]?.[letter];
   const configuredHere = letter === "A" || Boolean(cell?.enabled);
   if (configuredHere) {
-    // A is the baseline (MATCH); a non-A slot with its own enabled cell is a
-    // direct match on a non-baseline slot (CONFIGURED).
     return letter === "A" ? "match" : "configured";
   }
   if (profileConfiguredElsewhere(profiles, agentId, letter)) return "missing";
@@ -378,13 +327,8 @@ export function hasEnabledEnvKey(rows: CodingAgentEnv[], key: string): boolean {
   return rows.some((row) => row.enabled && envKeyCompare(row.key) === target);
 }
 
-/** Origin badge for an env value shown in the Config/Selection projections (#526/#527).
- *  - `system`   — AgentsCommander-managed home path (an AC path placeholder on a known home key)
- *  - `accepted` — a user literal absolute path kept as-is (nothing to expand)
- *  - `profile`  — a value defined by the profile cell (the common case) */
 export type EnvOrigin = "system" | "profile" | "accepted";
 
-/** Env keys AgentsCommander manages per replica (isolated home directories). */
 const MANAGED_HOME_ENV_KEYS = new Set([
   "CODEX_HOME",
   "CLAUDE_CONFIG_DIR",
@@ -394,14 +338,9 @@ const MANAGED_HOME_ENV_KEYS = new Set([
 
 function isLiteralAbsolutePath(value: string): boolean {
   const v = value.trim();
-  // Windows drive (C:\ or C:/), POSIX root, or UNC share.
   return /^[A-Za-z]:[\\/]/.test(v) || v.startsWith("/") || v.startsWith("\\\\");
 }
 
-/** Classify a profile-cell env value's origin for its badge. A managed home key
- *  using an AC path placeholder is AC-managed (`system`); a managed home key with a literal
- *  absolute path is a user-accepted override (`accepted`); everything else is a
- *  plain profile-defined value (`profile`). */
 export function profileEnvOrigin(key: string, value: string): EnvOrigin {
   if (MANAGED_HOME_ENV_KEYS.has(envKeyCompare(key))) {
     if (hasAcPlaceholder(value)) return "system";
@@ -416,11 +355,6 @@ export interface EffectiveEnvEntry {
   origin: EnvOrigin;
 }
 
-/** Merge a coding agent's enabled env rows with the selected profile cell's env
- *  into the effective env that is actually set at launch (#527 Env / EFFECTIVE).
- *  Agent rows form the base (source `system` → system badge, user → accepted);
- *  profile env overrides on key collision and carries the `profile` origin.
- *  AC path placeholders are expanded for display when a replica root is known. */
 export function effectiveEnvProjection(
   agentEnvs: CodingAgentEnv[] | undefined,
   profileEnv: Record<string, string> | undefined,
@@ -461,11 +395,6 @@ export function executableBasename(command: string): string {
   return executableTokenBasename(first);
 }
 
-/**
- * v2 (#384): basename of the executable token of a command string. Used as the
- * coding-agent subtitle in the Config Screen (binary name, not model/sandbox).
- * Identical resolution to {@link executableBasename}; named for the command-string model.
- */
 export function commandExecutableBasename(command: string): string {
   return executableBasename(command);
 }
@@ -474,28 +403,6 @@ export function isCodexAgent(agent: AgentConfig): boolean {
   return agent.id.toLowerCase() === "codex" || executableBasename(agent.command) === "codex";
 }
 
-/**
- * #529 — display-only default instructions filename derived from a coding
- * agent's launch command. Used solely as the Config Screen placeholder so a
- * blank field shows the default the backend will write at launch.
- *
- * Best-effort parity (G2) with the Rust resolver
- * (`default_instructions_filename_for_command` → `CodingAgentKind::detect`):
- * reduce EVERY whitespace token to its lowercased file-stem basename and match
- * by prefix in precedence **claude > codex > gemini**, scanning all tokens —
- * exactly what the Rust detector does. Scanning every token (not just the
- * first/last) is what gives parity on the common shapes including trailing
- * flags: `claude`, `claude --model sonnet`, `cmd.exe /c claude`, `claude-mb`,
- * an absolute-path `claude.exe`, `codex --yolo`, `opencode`, custom. The codex
- * branch returns `AGENTS.md` (same as the default) but is kept explicit so the
- * precedence is faithful — e.g. `codex ... gemini` resolves to `AGENTS.md`, not
- * `GEMINI.md`, matching Rust.
- *
- * This deliberately does NOT reproduce the full Rust shell-quote tokenizer, so
- * an exotic quoted path containing spaces may still diverge — acceptable for a
- * cosmetic placeholder, since the backend resolves the value authoritatively at
- * launch.
- */
 export function defaultInstructionsFilename(command: string): string {
   const stems = command.trim().split(/\s+/).filter(Boolean).map(executableTokenBasename);
   if (stems.some((s) => s.startsWith("claude"))) return "CLAUDE.md";
@@ -504,42 +411,9 @@ export function defaultInstructionsFilename(command: string): string {
   return "AGENTS.md";
 }
 
-/**
- * #1033 - the context patterns #1032 captured, shipped VERBATIM.
- *
- * Do not re-derive these and do not "simplify" them to typeable characters. The
- * glyph class is load-bearing: measured against regex 1.12.3, `[░█]+` rejects the
- * prose row `  Context is 42% of the budget` while a typeable `\S+` reads it as
- * `Some(42)` - a wrong number, not a miss.
- *
- * Both literals adjacent to the capture are load-bearing for the same reason: a
- * literal next to the capture is what pins where the capture lands. Strip
- * `· Context ` and ` used` from the Codex pattern and greedy `.*` slides to the
- * last `%` of `  Ready · Context 0% used · weekly 83% left`, capturing `3` out of
- * `83`.
- *
- * Capture group 1 is the percentage; both compile with `captures_len=2`, clearing
- * the backend's mandatory-capture gate (`pty/context_scrape/pattern.rs:44`).
- */
 export const CLAUDE_CONTEXT_REGEX = String.raw`^ {2}Context [░█]+ (\d{1,3})%`;
 export const CODEX_CONTEXT_REGEX = String.raw`^ {2}.*· Context (\d{1,3})% used`;
 
-/**
- * #1033 - the suggested pattern for a command, or `null` when there is no evidence
- * for one. Resolves the command exactly as {@link defaultInstructionsFilename}
- * does, so a wrapped invocation (`cmd.exe /c claude`, an absolute-path
- * `claude.exe`, `claude --model sonnet`) still resolves.
- *
- * Unlike {@link defaultInstructionsFilename}, this deliberately does NOT fall back
- * to a default for an unknown agent: it returns `null` for Gemini and everything
- * else. #1032's capture covered `claude.exe` and `codex.exe` and nothing else, and
- * the asymmetry is the point - a wrong filename costs a renamed file, while a
- * wrong pattern costs a silently wrong percentage. No suggestion means the button
- * does not render; the field still accepts anything the user types.
- *
- * The button exists because `░` (U+2591) and `█` (U+2588) are not on a keyboard:
- * without it the feature is unconfigurable for Claude.
- */
 export function suggestedContextRegex(command: string): string | null {
   const stems = command.trim().split(/\s+/).filter(Boolean).map(executableTokenBasename);
   if (stems.some((s) => s.startsWith("claude"))) return CLAUDE_CONTEXT_REGEX;
@@ -585,13 +459,6 @@ export function isAcAgentPath(path: string | null | undefined): boolean {
   return parts.includes(".ac") && /^__?agent_/.test(leaf);
 }
 
-/**
- * True only for a workgroup replica directory, i.e. a `__agent_<name>` leaf whose
- * parent is a `wg-<name>` directory under an `.ac` root. Broad-scope assignment
- * (kind/workgroup) and backend preview/apply require a real WG replica anchor;
- * origin agents (single-underscore `_agent_<name>`) and normal repos do not
- * qualify. (#384 §7)
- */
 export function isWgReplicaPath(path: string | null | undefined): boolean {
   if (!path) return false;
   const parts = path.replace(/\\/g, "/").replace(/\/+$/, "").split("/");
@@ -600,14 +467,6 @@ export function isWgReplicaPath(path: string | null | undefined): boolean {
   return parts.includes(".ac") && /^__agent_/.test(leaf) && /^wg-/.test(parent);
 }
 
-/**
- * #537: After a replica-scope Coding Agent assignment is persisted, decide whether
- * to offer an immediate "Restart now?" prompt so the change applies without a manual
- * restart. We only offer it for `replica` scope (one unambiguous live session), when
- * the picker did not already restart (the checkbox path), and when the target is a WG
- * replica with a live PTY. A `{ exited }` status (object, not string) has nothing to
- * restart, so it is skipped. kind/workgroup scope never prompts here.
- */
 export function shouldOfferRestartAfterAssign(
   selection: { scope: ProfileAssignmentScope; restartSessions: boolean },
   session: Pick<Session, "status" | "workingDirectory"> | undefined,

--- a/src/shared/role-templates.ts
+++ b/src/shared/role-templates.ts
@@ -1,6 +1,5 @@
 import type { RoleTemplateMeta } from "./types";
 
-/** Case-insensitive substring filter over name + description + category + source. */
 export function filterRoleTemplates(
   templates: RoleTemplateMeta[],
   query: string,
@@ -16,17 +15,6 @@ export function filterRoleTemplates(
   );
 }
 
-/**
- * Convert a template display name into a valid agent-folder name: lowercase,
- * whitespace/underscores → hyphens, drop chars outside [a-z0-9-], collapse
- * repeated hyphens, trim leading/trailing hyphens. Idempotent on a name that
- * is already a slug. Returns "" when the name has no slug-able characters —
- * the caller then leaves the Name field empty (same as the no-template path).
- *
- * The New Agent dialog's canCreate() rejects a Name containing a space, `/`,
- * or `\`. Template display names are free text, so a raw setName(t.name) can
- * prefill an invalid Name and silently disable Create. Always run through this.
- */
 export function slugifyTemplateName(name: string): string {
   return name
     .toLowerCase()
@@ -36,30 +24,12 @@ export function slugifyTemplateName(name: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-/**
- * Human-readable "SOURCE: …" label rendered in the picker's source badge.
- * Agency templates point at the upstream repo so users can audit them; local
- * templates state they come from the user's own templates folder.
- */
 export function sourceLabel(template: Pick<RoleTemplateMeta, "source">): string {
   return template.source === "agency"
     ? "SOURCE: https://github.com/msitarzewski/agency-agents"
     : "SOURCE: LOCAL AGENT-TEMPLATES";
 }
 
-/**
- * Decide the next {name, description} when a template is selected. A template's
- * defaults overwrite the current values UNLESS the user has manually edited the
- * field (the caller flips `nameDirty`/`descriptionDirty` in its onInput
- * handlers). Values that the previous template selection wrote stay
- * non-dirty, so a second template click freely replaces them — fixing #278
- * where the highlighted row moved but the form fields stuck on the first pick.
- *
- * The Name is slugified (display names are free text that the modal's
- * canCreate() would reject for spaces or punctuation); the Description is
- * clamped to 250 because the textarea's maxLength only limits typing, not
- * programmatic writes.
- */
 export function applyTemplatePrefill(
   template: Pick<RoleTemplateMeta, "name" | "description">,
   current: {

--- a/src/shared/session-activity.ts
+++ b/src/shared/session-activity.ts
@@ -1,21 +1,5 @@
 import type { Session, SessionStatus } from "./types";
 
-/**
- * #882 Domain classification of what a session is doing. This is NOT a CSS class:
- * sessionDotClass() is a 1:1 projection of this enum onto dot class names, and
- * it is the only place a presentation value is produced. Behavior reads this
- * enum, never the dot class.
- *
- * The precedence chain is a domain statement, not a visual one:
- *   offline > exited > pendingReview > waitingForInput > status(active|running|idle)
- *
- * DO NOT REORDER pendingReview AND waitingForInput. sessions.ts lowers the two
- * flags in separate unbatched setState calls (#886), so the store is briefly
- * observable as waitingForInput=false, pendingReview=true. Reading pendingReview
- * first means a pending session's consumers short-circuit before ever reading
- * waitingForInput, never subscribe to it, and are never woken by that first
- * write. The order is load-bearing; session-activity.test.ts pins it.
- */
 export type SessionActivity =
   | "offline"
   | "exited"
@@ -25,10 +9,8 @@ export type SessionActivity =
   | "running"
   | "idle";
 
-/** The subset of Session the classifier reads. */
 export type ActivitySession = Pick<Session, "status" | "pendingReview" | "waitingForInput">;
 
-/** Collapse the tagged Exited(code) variant onto a flat runtime state. */
 export function sessionRuntimeState(
   status: SessionStatus
 ): "active" | "running" | "idle" | "exited" {
@@ -48,14 +30,6 @@ export function sessionActivity(
   return runtime;
 }
 
-/**
- * #882 The load-bearing predicate. Working means a live session whose agent is
- * currently progressing on its own. Neither waitingForInput nor pendingReview
- * counts as working.
- *
- * pendingReview is not redundant with waitingForInput here. At rest it implies
- * it, but not mid-write; dropping it breaks the existing rail pending test.
- */
 export function isWorkingActivity(activity: SessionActivity): boolean {
   return activity === "active" || activity === "running";
 }

--- a/src/shared/sound.ts
+++ b/src/shared/sound.ts
@@ -1,26 +1,12 @@
-// Audio playback utilities. Synthesized via Web Audio API to avoid
-// bundling a binary asset and to render identically across the Tauri
-// webview and the browser-served WS transport.
 
 let cachedContext: AudioContext | null = null;
 
-// Global app-sound master switch (#158). Single source of truth that every
-// playback function in this module checks at entry. Decoupled from any
-// settings store so this module stays leaf-level (no circular imports);
-// settings code pushes the value via setSoundsEnabled on load/refresh and
-// on toolbar mute toggle. Default true matches the Rust-side default and
-// keeps users audible if the FE settings load fails.
 let soundsEnabled = true;
 
 export function setSoundsEnabled(enabled: boolean): void {
   soundsEnabled = enabled;
 }
 
-// Coalesce window for back-to-back beep calls. When several workgroups
-// transition to idle in the same effect tick, the watcher fires
-// playTeamIdleBeep() multiple times synchronously; without coalescing,
-// the oscillators stack at the same currentTime and sum to N× peak
-// gain (loud, harsh chord instead of one soft tone).
 const COALESCE_WINDOW_S = 0.03;
 let lastBeepStartedAt = Number.NEGATIVE_INFINITY;
 
@@ -35,11 +21,6 @@ function getAudioContext(): AudioContext | null {
   return cachedContext;
 }
 
-// Chromium-based webviews (incl. Tauri) start AudioContext in "suspended"
-// until a user gesture. If the very first beep fires before the user
-// has clicked or typed inside the window, ctx.resume() rejects silently.
-// Pre-arming on the first global gesture unlocks the context so later
-// beeps play even if the user has alt-tabbed away by then.
 export function primeAudio(): void {
   const unlock = () => {
     const ctx = getAudioContext();
@@ -52,16 +33,6 @@ export function primeAudio(): void {
   window.addEventListener("touchstart", unlock, { once: true });
 }
 
-/**
- * Soft two-step beep that fires when an entire team transitions from
- * busy → all-idle. Two short tones (660 Hz then 880 Hz, ~120 ms each)
- * with a quick attack/release envelope so it doesn't click. Total under
- * ~280 ms — short enough not to be annoying, distinct enough to register
- * as "team finished".
- *
- * Errors (no AudioContext, suspended context that can't be resumed) are
- * swallowed — failing to beep must never break the FE.
- */
 export async function playTeamIdleBeep(): Promise<void> {
   if (!soundsEnabled) return;
   const ctx = getAudioContext();

--- a/src/shared/terminal-viewport.ts
+++ b/src/shared/terminal-viewport.ts
@@ -1,99 +1,17 @@
 import type { PtyViewport } from "./types";
 
-/**
- * #973 — the size the PTY is opened at.
- *
- * AC opened every ConPTY at a hardcoded 120x30 and let the terminal correct it
- * a few hundred milliseconds later. dev-rust measured what that correction does
- * when it lands inside a coding agent's TUI startup: the child redraws its
- * still-empty viewport, loses the wakeup for the content that becomes ready
- * right after, and the tile stays blank. 8/10 on a bare ConPTY, no Tauri and no
- * webview.
- *
- * The fix is to open the PTY at the size the view has ALREADY fitted to, so no
- * resize has to reach a starting child at all. That only works if the size
- * handed to `create_session` is byte-exact with the size the terminal's own
- * post-mount fit produces:
- *
- *   - a redundant SAME-size resize is harmless ......... 0/10 blank
- *   - ONE ROW of drift puts the bug back at ............ 6/10 blank
- *
- * So this module does not PREDICT the fit, because a prediction that is one row
- * off is worse than no prediction at all. `TerminalView` registers a probe that
- * runs the SAME computation the post-mount fit runs — `FitAddon
- * .proposeDimensions()` — against a terminal that is already on screen in the
- * same host. Every `.terminal-instance` is `position: absolute; inset: 0` inside
- * one shared `.terminal-host`, so they all have the identical box, the same
- * `.terminal-host .xterm` padding, the same `createTerminalOptions`, and the
- * same (already resolved) font metrics. The answer is exact by construction.
- *
- * When there is nothing on screen to measure — no session is active, so
- * `TerminalView` is not even mounted — the probe returns null, the caller sends
- * no size, and the backend keeps its historical 120x30. That case is not
- * covered by this fix; it is covered by the backend's startup-resize guard.
- */
 
 type PtyViewportProbe = () => PtyViewport | null;
 
 let probe: PtyViewportProbe | null = null;
 
-/**
- * The size each session's PTY was actually OPENED at, recorded at create time
- * and consumed when the terminal for it is built.
- *
- * `TerminalView` needs this for two things: it starts xterm at that exact size
- * (so the first fit finds the size it already has and resizes nothing), and it
- * seeds the resize dedup with it (so the post-mount `syncViewport` does not send
- * the size the PTY is already open at).
- *
- * Bounded: an entry is consumed the moment the session is attached to a
- * terminal, so this holds at most the handful of sessions created but not yet
- * shown. The cap is a backstop against a caller that creates sessions it never
- * attaches.
- */
 const spawnViewports = new Map<string, PtyViewport>();
 const MAX_TRACKED_SPAWN_VIEWPORTS = 32;
 
-/**
- * The smallest viewport the backend will actually open a PTY at.
- *
- * MIRRORS `PtyViewport::PLAUSIBLE_MIN` in `src-tauri/src/pty/backend.rs`. The two
- * are not allowed to drift, and a comment cannot enforce that: `terminal-viewport
- * .test.ts` reads the Rust source and fails if this constant stops matching it.
- *
- * Below the floor the backend does not fail the spawn — it opens the PTY at
- * 120x30 and warns. So this side must never SEND a below-floor size, and above
- * all never RECORD one. See `isHonouredByBackend`.
- */
 export const BACKEND_SPAWN_FLOOR: PtyViewport = { cols: 20, rows: 5 };
 
-/** `u16` on the Rust side: a bigger number is not a viewport, it is a bug. */
 const MAX_VIEWPORT_DIMENSION = 65535;
 
-/**
- * True only when the backend will genuinely open the PTY at this size.
- *
- * This gate is load-bearing, not hygiene. Recording a size the PTY was NOT
- * opened at is the one way this fix can wedge a terminal: the dedup would treat
- * the corrective resize as a no-op and skip it, leaving the PTY at a size the
- * view never agreed to, forever. Three backend rules decide it:
- *
- *   - `create_session` builds a viewport only when BOTH cols and rows arrive.
- *   - `PtyViewport::from_fit` opens at 120x30 instead, for anything below
- *     `BACKEND_SPAWN_FLOOR`. A collapsed-but-laid-out box does NOT measure zero:
- *     xterm's fit clamps to its own MINIMUM_COLS = 2 / MINIMUM_ROWS = 1, so it
- *     hands back a perfectly well-formed 2x1 that sails through a `> 0` check
- *     and that the backend then silently declines to use. Recorded, that 2x1 is
- *     the wedge — and it is not a corner case: the probe is exact by
- *     construction, so a box that is collapsed at create time is still collapsed
- *     at attach time, the fit finds the terminal already at 2x1, and the
- *     corrective resize is deduped away before it is ever sent.
- *   - `u16` on the Rust side, so the range is checked here too.
- *
- * The worst xterm itself can hand back is NaN (`CoreTerminal.resize` rejects it,
- * `FitAddon` can propagate it), which `Number.isInteger` catches. A zero can only
- * come off the WIRE, from a web-transport client that is not xterm.
- */
 const isHonouredByBackend = (viewport: PtyViewport): boolean =>
   Number.isInteger(viewport.cols) &&
   Number.isInteger(viewport.rows) &&
@@ -102,7 +20,6 @@ const isHonouredByBackend = (viewport: PtyViewport): boolean =>
   viewport.cols <= MAX_VIEWPORT_DIMENSION &&
   viewport.rows <= MAX_VIEWPORT_DIMENSION;
 
-/** `TerminalView` publishes how it measures its own tile. Returns the unregister. */
 export const registerPtyViewportProbe = (next: PtyViewportProbe): (() => void) => {
   probe = next;
   return () => {
@@ -112,11 +29,6 @@ export const registerPtyViewportProbe = (next: PtyViewportProbe): (() => void) =
   };
 };
 
-/**
- * The size a terminal created right now would fit to, or null when there is
- * nothing on screen to measure. Never throws: a DOM read must not be able to
- * fail a session create.
- */
 export const measurePtyViewport = (): PtyViewport | null => {
   if (!probe) {
     return null;
@@ -137,7 +49,6 @@ export const measurePtyViewport = (): PtyViewport | null => {
   return measured;
 };
 
-/** Record the size the backend just opened this session's PTY at. */
 export const rememberSpawnViewport = (
   sessionId: string,
   viewport: PtyViewport
@@ -156,14 +67,6 @@ export const rememberSpawnViewport = (
   spawnViewports.set(sessionId, { cols: viewport.cols, rows: viewport.rows });
 };
 
-/**
- * The size this session's PTY was opened at, consumed on read.
- *
- * Consumed, because it is only true for the FIRST terminal built for the
- * session. A later re-attach (a detached window, a re-created tile) must fit and
- * resize normally: by then the child has long since started, the resize is safe,
- * and the tile may genuinely be a different size.
- */
 export const takeSpawnViewport = (sessionId: string): PtyViewport | null => {
   const viewport = spawnViewports.get(sessionId);
   if (!viewport) {
@@ -174,7 +77,6 @@ export const takeSpawnViewport = (sessionId: string): PtyViewport | null => {
   return viewport;
 };
 
-/** Test seam: drop the probe and every recorded spawn size. */
 export const resetPtyViewportForTests = (): void => {
   probe = null;
   spawnViewports.clear();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2,59 +2,11 @@ export interface SessionRepo {
   label: string;
   sourcePath: string;
   branch: string | null;
-  /**
-   * #1028 - worktree dirty: untracked, unstaged, or staged-but-uncommitted changes.
-   * `true` paints the badge letters red; `false` = backend says clean; `null` = never
-   * successfully detected for this path since the backend process started. A failed
-   * detection HOLDS the last known answer (git_watcher::remember_dirty), so `null`
-   * means "no first answer yet", not "flaked once". Both `false` and `null` render
-   * violet - only the badge `title` distinguishes them.
-   *
-   * REQUIRED, not `dirty?:`, deliberately. `SessionRepo` has no `Default` in Rust, so
-   * every backend construction site is compile-forced to state a value; a `?` throws
-   * that guarantee away on the TS side at `configuredReplicaRepoBadges`
-   * (components/replica-repo-badges.ts), the one production builder of this type on
-   * the cold path, where omitting the `dirty:` line would raise no tsc error and ship
-   * a permanently violet feed. `branch` above is the same shape against a Rust
-   * `Option<String>`. Cost is a `dirty: null` in test literals; that is the trade.
-   */
   dirty: boolean | null;
 }
 
-/**
- * #943 B2 - live per-repo branches, keyed by repo SOURCE PATH.
- *
- * A missing key = the live layer knows nothing about that repo (no event has
- * landed yet, or it was added to `config.json` since the last watcher tick). An
- * explicit `null` = the layer knows the repo and has no branch for it (detached
- * HEAD, not a work tree, git missing, detection timed out).
- *
- * Keyed by path and NEVER by index, even though the backend emits the branches
- * positionally: the payload is stored and re-read against a LATER discovery
- * snapshot, so a reorder/removal in `config.json` `repos` would make a positional
- * merge paint repo A's branch onto repo B for up to one 15s tick.
- */
 export type RepoBranchByPath = Record<string, string | null>;
 
-/**
- * #1028 - live per-repo worktree-dirty, keyed by repo SOURCE PATH.
- *
- * A missing key = the live layer knows nothing about that repo (no event has
- * landed yet, or it was added to `config.json` since the last watcher tick), and
- * the caller resolves it to `null`: there is no single-repo shorthand for dirty to
- * fall back to, unlike `RepoBranchByPath`. An explicit `null` = the layer knows the
- * repo and the backend has never successfully detected its dirty state. Both miss
- * and explicit-null render violet, so the two collapse on screen by design.
- *
- * `false` is a THIRD, distinct value and must survive the trip: it means "detected,
- * clean". It renders identically to `null`, so a `??`-to-`||` slip that turns it
- * into `null` is invisible on the badge and only the `title` exposes it.
- *
- * Keyed by path and NEVER by index, for the same reason as `RepoBranchByPath`: the
- * payload is stored and re-read against a LATER discovery snapshot, so a
- * reorder/removal in `config.json` `repos` would make a positional merge paint repo
- * A's dirty state onto repo B for up to one 15s tick.
- */
 export type RepoDirtyByPath = Record<string, boolean | null>;
 
 export type SessionCommunicationKind = "raiseHand";
@@ -93,7 +45,6 @@ export interface Session {
   effectiveProfile: string | null;
   profileFallbackChain: string[];
   profileFallbackApplied: boolean;
-  /** #592 - backend-computed: loaded profile cell != current config. */
   profileOutdated?: boolean;
 }
 
@@ -101,18 +52,6 @@ export type SessionStatus = "active" | "running" | "idle" | { exited: number };
 
 export type CodingAgentKind = "claude" | "codex" | "gemini";
 
-/**
- * #1033 - payload of the `session_context` event (`lib.rs:456`).
- *
- * `percent` is `number | null` and NEVER `percent?: number`. The Rust side
- * (`pty/context_scrape/mod.rs:69-78`) deliberately carries no
- * `skip_serializing_if` on it, so `None` serializes as an explicit
- * `"percent": null` rather than an absent key. Typing it optional here would
- * re-introduce *absent* as a third state beside `null` and `0`, in a feature
- * whose one hard rule is that unavailable is exactly one thing.
- *
- * `0` is a REAL reading and must survive the trip; only `null` means unavailable.
- */
 export interface SessionContextPayload {
   sessionId: string;
   percent: number | null;
@@ -174,13 +113,6 @@ export interface PtyOutputEvent {
   sequence?: number;
 }
 
-/**
- * #973 — the terminal size the view has already fitted to, handed to
- * `create_session` so the PTY is OPENED at it and no resize has to reach a
- * child that is still starting up. Mirrors the Rust `PtyViewport`
- * (`pty/backend.rs`), which the command takes as two flat optional fields:
- * both must arrive, and a zero dimension falls back to 120x30.
- */
 export interface PtyViewport {
   cols: number;
   rows: number;
@@ -194,12 +126,6 @@ export interface PtyScreenSnapshot {
   sequence: number;
 }
 
-/**
- * #598 — per-agent config-folder seed. Mirrors the Rust `ConfigSeedConfig`
- * (`#[serde(rename_all = "camelCase")]`): `enabled` (serde default true) and
- * `dest` (serde default ""). Lives on `AgentConfig` ONLY — nothing on
- * `ProfileCellConfig` / `CodingAgentProfilesConfig`.
- */
 export interface ConfigSeedConfig {
   enabled: boolean;
   dest: string;
@@ -207,7 +133,6 @@ export interface ConfigSeedConfig {
 
 export interface AgentBackendConfig {
   kind?: SessionBackendKind;
-  /** #868 - per-agent Docker image; empty/undefined requires AGENTSCOMMANDER_CONTAINER_IMAGE at launch. */
   image?: string;
 }
 
@@ -217,57 +142,13 @@ export interface AgentConfig {
   command: string;
   color: string;
   envs: CodingAgentEnv[];
-  /**
-   * v2 (#384): renamed from `isolateCodexHome`. Until adapters support other
-   * providers, only Codex consumes this flag. Serialized as `isolatedHome`.
-   */
   isolatedHome: boolean;
-  /**
-   * #529 — instructions filename written to the agent root at launch (content =
-   * AC context + Role.md). Empty/undefined falls back to the command-derived
-   * default (Claude → CLAUDE.md, Gemini → GEMINI.md, else AGENTS.md). The empty
-   * string is normalized to omitted before save, so it is never persisted.
-   */
   instructionsFilename?: string;
-  /**
-   * #598 — optional config-folder seed. When `enabled` and `dest` is non-empty,
-   * AC copies a template config folder (chosen by convention, precedence
-   * profile > matrix > coding-agent base) into the replica at spawn,
-   * overwriting it every launch. `dest` is the destination folder NAME under
-   * the replica root (e.g. ".claude"). Dropped to omitted before save when
-   * disabled or `dest` is empty (mirrors `instructionsFilename`), so an
-   * inactive seed is never persisted as a sentinel.
-   */
   configSeed?: ConfigSeedConfig;
-  /**
-   * #1033 - best-effort pattern AC runs over the rows this agent draws in its
-   * terminal, to read its context-window usage for the CTX badge. Capture group 1
-   * is the percentage.
-   *
-   * Absent means the badge is OFF for this agent. Unlike `instructionsFilename`,
-   * there is NO fallback default anywhere in the backend, so blank does not mean
-   * "use the default shown": blank means off.
-   *
-   * Stored VERBATIM and never trimmed. A pattern's leading whitespace is a
-   * load-bearing column anchor, and a trim deletes it while every normal case
-   * keeps reading correctly - so the damage is invisible. Empty/whitespace-only is
-   * dropped to omitted before save (mirroring `instructionsFilename`'s contract,
-   * NOT its trim), so it is never persisted as a sentinel.
-   *
-   * Rust `regex` grammar, NOT JS `RegExp`: the two disagree in both directions, so
-   * nothing on this side validates it. An unusable pattern reads `CTX N/A` and its
-   * reason reaches `app.log` only. Serialized as `contextRegex`; placed before
-   * `backend` to mirror the Rust field order (`config/settings.rs:79-80`).
-   */
   contextRegex?: string;
   backend?: AgentBackendConfig;
 }
 
-/**
- * `"system"` is the v2 name for AgentsCommander-managed rows. The legacy v1
- * value `"agentsCommander"` is migrated to `"system"` by the backend on load,
- * so the frontend only ever sees v2 values after `SettingsAPI.get()`.
- */
 export type CodingAgentEnvSource = "user" | "system";
 
 export interface CodingAgentEnv {
@@ -277,21 +158,9 @@ export interface CodingAgentEnv {
   enabled: boolean;
 }
 
-/**
- * #769 — a built-in coding-agent catalog entry, returned by the backend
- * `get_coding_agent_catalog` command (source of truth: the seeded, user-editable
- * `<config_dir>/coding-agents/agents.json`). Replaces the old hardcoded
- * `AGENT_PRESETS`. Maps onto `Omit<AgentConfig, "id">` plus `{ key, description,
- * removable }`; `definitionToSeed()` performs that projection for the "+ Add"
- * flow. `envs`, `isolatedHome`, and `removable` are always present (the backend
- * fills serde defaults); `instructionsFilename` / `configSeed` are omitted from
- * the JSON when unset.
- */
 export interface CodingAgentDefinition {
-  /** Stable catalog identity, `^[a-z0-9-]+$`, unique; doubles as a testid/CSS token. */
   key: string;
   label: string;
-  /** "Coding Agent by …" subtitle shown on the onboarding card. */
   description: string;
   color: string;
   command: string;
@@ -299,16 +168,9 @@ export interface CodingAgentDefinition {
   envs: CodingAgentEnv[];
   isolatedHome: boolean;
   configSeed?: ConfigSeedConfig;
-  /** Whether the user may delete this built-in (all Phase-1 built-ins are true). */
   removable: boolean;
 }
 
-/**
- * #769 Phase 2 — result of `reseed_coding_agent_default`: the config-folder
- * `dest` that was restored to the shipped default, plus the absolute path of the
- * timestamped `.bak` of the prior master (empty string when the master was absent
- * so nothing needed backing up).
- */
 export interface ReseedResult {
   dest: string;
   backupPath: string;
@@ -316,28 +178,18 @@ export interface ReseedResult {
 
 export interface CodingAgentProfilesConfig {
   schemaVersion: number;
-  /** v2 (#384): renamed from `letters`. Keyed by profile slot letter A–Z. */
   profileSlots: Record<string, ProfileSlotConfig>;
-  /** v2 (#384): renamed from `agentDefaults`. agentId → default profile letter. */
   defaultProfileByAgent: Record<string, string>;
-  /** v2 (#384): renamed from `matrix`. agentId → letter → cell. */
   profilesByAgent: Record<string, Record<string, ProfileCellConfig>>;
-  /** #548: agentId → letter → override label. Empty/absent for a cell means
-   *  inherit (primigenio label, else the legacy slot label, else the letter). */
   profileLabelsByAgent: Record<string, Record<string, string>>;
 }
 
 export interface ProfileSlotConfig {
-  /** v2 (#384): renamed from `name`. Human display label of the profile slot. */
   label: string;
 }
 
 export interface ProfileCellConfig {
   enabled: boolean;
-  /**
-   * v2 (#384): one complete invocation string per profile, replacing the v1
-   * `argv` array. An empty string falls back to `agents[].command` at launch.
-   */
   command: string;
   env: Record<string, string>;
   notes: string;
@@ -407,7 +259,6 @@ export type SessionWarningKind = (typeof SESSION_WARNING_KINDS)[number];
 
 export interface SessionWarning {
   sessionId: string;
-  /** Environment key, or a protocol sentinel such as CONTAINER_TRANSPORT_PROTOCOL. */
   key: string;
   kind: SessionWarningKind;
   message: string;
@@ -422,10 +273,6 @@ export interface WindowGeometry {
   height: number;
 }
 
-/** #714 Frozen monitor image + metadata handed to one screenshot-overlay window.
- *  Mirrors the Rust `ScreenshotOverlayState` (serde camelCase). `width`/`height`
- *  are PHYSICAL image pixels (the captured bitmap), which the overlay maps
- *  pointer coordinates onto proportionally. */
 export interface ScreenshotOverlayState {
   captureId: string;
   monitorId: number;
@@ -440,8 +287,6 @@ export interface ScreenshotOverlayState {
   targetDirectory: string;
 }
 
-/** #714 Physical, monitor-local crop rectangle sent to the backend on release.
- *  Mirrors the Rust `ScreenshotSelection`. */
 export interface ScreenshotSelection {
   captureId: string;
   monitorId: number;
@@ -451,20 +296,16 @@ export interface ScreenshotSelection {
   height: number;
 }
 
-/** #714 Success payload for `screenshot_capture_saved` + the confirm command. */
 export interface ScreenshotCaptureResult {
   path: string;
   sessionId: string;
   sessionName: string;
 }
 
-/** #714 Failure payload for the `screenshot_capture_failed` event. */
 export interface ScreenshotCaptureFailedEvent {
   message: string;
 }
 
-/** #714 Global-hotkey registration status. `error` is null when registered (or
- *  not yet attempted). Mirrors the Rust `ScreenshotHotkeyStatus`. */
 export interface ScreenshotHotkeyStatus {
   configured: string;
   registered: boolean;
@@ -473,10 +314,6 @@ export interface ScreenshotHotkeyStatus {
 
 export type MainSidebarSide = "left" | "right";
 
-/** #612 LIVE log verbosity for `agentscommander*` targets. The 5 canonical
- *  lowercase wire values shared with the Rust side (`log_level: Option<String>`)
- *  and the `log_level_changed` event payload. Defined once here and imported by
- *  `console-capture.ts` / `ipc.ts` / `SettingsModal.tsx`. */
 export type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
 
 export type WebServerOwnershipState =
@@ -540,8 +377,6 @@ export interface AppSettings {
   mainSidebarWidth: number;
   mainSidebarSide: MainSidebarSide;
   mainAlwaysOnTop: boolean;
-  // #587 — whether the Resource Monitor occupies the main central pane (vs the
-  // terminal). Restored on startup; default false (terminal).
   mainResourceMonitorAttached: boolean;
   webServerEnabled: boolean;
   webServerPort: number;
@@ -551,8 +386,6 @@ export interface AppSettings {
   apiServerBind: string;
   projectPath: string | null;
   projectPaths: string[];
-  /** #881 - projects hidden from the sidebar. Disk-authoritative: the backend
-   *  preserve-writer discards whatever this field carries on a whole-object save. */
   archivedProjectPaths: string[];
   sidebarStyle: string;
   onboardingDismissed: boolean;
@@ -561,13 +394,7 @@ export interface AppSettings {
   autoGenerateTaskTitle: boolean;
   agentTemplatesPath: string | null;
   themeLight: boolean;
-  /** #965 - rail project sections the user explicitly collapsed (header click).
-   *  NOT the ProjectPanel's collapse. Normalized project paths (see
-   *  `normalizeProjectPathForCompare`). Written only by `setRailCollapse`; a
-   *  whole-object save cannot change it (Rust restores it from live memory).
-   *  Optional so existing partial-AppSettings fixtures keep compiling. */
   railCollapsedProjects?: string[];
-  /** #965 - collapsed state of the rail's cross-project Favorites section. */
   railFavoritesCollapsed?: boolean;
   specBoardEnabled: boolean;
   resourceMonitorEnabled: boolean;
@@ -578,46 +405,20 @@ export interface AppSettings {
   agentProcessKillPrivateBytes: number;
   resourceKeepLastSnapshot: boolean;
   resourceBackoffPolling: boolean;
-  /** #552 coordinator idle-badge color thresholds, in minutes. Mirror of the
-   *  Rust `coordinator_idle_badge_*_minutes` fields (camelCase via serde).
-   *  Color helper requires yellow < red (validated at Settings save time). */
   coordinatorIdleBadgeYellowMinutes: number;
   coordinatorIdleBadgeRedMinutes: number;
-  /** #552 auto-close lifecycle clock: when enabled, a team whose sessions go
-   *  fully silent for `coordinatorAutoCloseMinutes` is terminated. */
   coordinatorAutoCloseEnabled: boolean;
   coordinatorAutoCloseMinutes: number;
-  /** #817 When true, background auto-close skips sessions with a Telegram
-   *  assignment. Default false preserves legacy behavior. */
   coordinatorAutoCloseSkipTelegramAssigned: boolean;
-  /** #588 When true, manually closing a coordinator also closes its team. */
   coordinatorCascadeCloseEnabled: boolean;
-  /** #609 Check npm on startup (<=1x/24h) and notify when a newer published
-   *  version of @mblua/agentscommander is available. Default true. */
   npmUpdateNotificationsEnabled: boolean;
-  /** #640 Global master for auto self-handoff-and-clear. ON => class default
-   *  applies (coordinator/Root on, specialists off). Per-agent overrides in
-   *  autoSelfClearByAgent. */
   autoSelfClearEnabled: boolean;
-  /** #640 Per-agent override of the class default, keyed by agent name. */
   autoSelfClearByAgent: Record<string, boolean>;
-  /** #930 When true (default), container coding-agent sessions copy the host
-   *  user's credential file for that agent into the replica config dir at spawn
-   *  and delete it on teardown. When false, the user supplies credentials
-   *  themselves (e.g. a CLAUDE_CODE_OAUTH_TOKEN env row). Mirrors the Rust
-   *  `container_credentials_from_host` field (camelCase via serde). */
   containerCredentialsFromHost: boolean;
-  /** #612 LIVE log level for agentscommander targets. null (legacy/unset) => "info". */
   logLevel: LogLevel | null;
-  /** #714 Native global hotkey for screenshot capture (e.g. "Ctrl+Q"). Optional
-   *  here only to ease partial-settings test construction; the Rust
-   *  `#[serde(default)]` always emits it, so it is present at runtime. */
   screenshotCaptureHotkey?: string;
 }
 
-/** #609 "npm update available" payload. Mirrors the Rust `UpdateInfo` struct
- *  (serde camelCase): carried by the `npm_update_available` event and returned
- *  by `get_update_status` (null when up-to-date / not yet checked / disabled). */
 export interface UpdateInfo {
   currentVersion: string;
   latestVersion: string;
@@ -671,14 +472,8 @@ export interface ResourceProcessSnapshot {
 export interface ResourceAgentGroupSnapshot {
   sessionId: string;
   name: string;
-  /** #516 - workgroup label (e.g. "wg-5-dev-team"), "Root agent" for root-agent
-   * groups, or `null` for non-WG / ad-hoc / unparseable launches. Always present. */
   workgroup: string | null;
-  /** #516 - bare agent name (e.g. "dev-rust"), or `null` when the launch cwd
-   * carries no replica identity. Always present. */
   agent: string | null;
-  /** #566 - project folder name (e.g. "AgentsCommander_ac"), or `null` for
-   * origin / ad-hoc / unparseable launches. Always present. */
   project: string | null;
   rootPid?: number | null;
   rootIdentity?: ResourceProcessIdentity | null;
@@ -721,23 +516,7 @@ export interface ResourceKillResult {
   killedPids?: number[];
   quarantined: boolean;
   message: string;
-  /**
-   * #647 D: true when the kill quarantined AND a failure carried the exact
-   * ACCESS_DENIED code (`win32 error 5`) — a security product is stripping
-   * PROCESS_TERMINATE. The per-PID detail stays in `message`; this only ADDS
-   * the AV-exclusion guidance in the UI, so a non-security failure is never
-   * hidden. Mirrors Rust `ResourceKillResult.blocked_by_security` (serde
-   * camelCase). `#[serde(default)]` backend-side, so always present on the wire.
-   */
   blockedBySecurity: boolean;
-  /**
-   * #647 (Step 7): true ONLY when `kill_resource_group` verified the tree dead,
-   * tore down the PTY/job, and flipped the tile to Exited. Success keys off THIS,
-   * NOT `!quarantined`: a `Terminating` early-return (a concurrent kill still
-   * settling) reports `quarantined === false` but is NOT a finalized success, so
-   * treating it as one would close the modal over a still-Running zombie tile.
-   * Mirrors Rust `ResourceKillResult.finalized` (`#[serde(default)]`).
-   */
   finalized: boolean;
 }
 
@@ -789,10 +568,6 @@ export interface UiAutomationDiagnostics {
   topmost?: UiAutomationTarget | null;
   expiresAtUnixMs?: number | null;
   nowUnixMs?: number;
-  /** #944 - set only on `hover`. `from`/`to` are data-ac-testid values (null when the
-   *  pointer came from / went to nothing). `events` is the dispatched type sequence,
-   *  in order: it is the assertion surface for the ordering tests and the only way a
-   *  harness can tell "the hover moved nothing" (changed: false) from a real move. */
   hover?: {
     from: string | null;
     to: string | null;
@@ -834,14 +609,12 @@ export type UiAutomationResponse =
       diagnostics?: UiAutomationDiagnostics;
     };
 
-// Team grouping for sidebar
 export interface TeamSessionGroup {
   team: Team;
   coordinator: Session | null;
   members: Session[];
 }
 
-// Team types (from discovery)
 
 export interface TeamMember {
   name: string;
@@ -857,7 +630,6 @@ export interface Team {
   visible?: boolean;
 }
 
-// Sidebar store state
 export interface SessionsState {
   sessions: Session[];
   activeId: string | null;
@@ -869,26 +641,10 @@ export interface SessionsState {
   repos: RepoMatch[];
   coordSortByActivity: boolean;
   lastActivityBySessionId: Record<string, number>;
-  /**
-   * #1033 - live per-session context-window reading, keyed by session id.
-   * Frontend-only and fed by the `session_context` event, so it is structurally
-   * out of reach of `setSessions`'s wholesale replace (unlike a field on
-   * `Session`, which the backend does not carry anyway).
-   *
-   * A missing key = no event and no snapshot has spoken for this session yet. An
-   * explicit `null` = the engine says the reading is unavailable. Both render
-   * `CTX N/A`, so the two collapse on screen by design.
-   *
-   * `0` is a THIRD, distinct value and must survive the trip: it means a real
-   * reading of zero and renders `CTX 0%`. A `??`-to-`||` slip, or a truthiness
-   * test anywhere on this value's path, turns a true `0%` into `N/A` and is
-   * invisible on screen.
-   */
   contextPercentBySessionId: Record<string, number | null>;
   hydrated: boolean;
 }
 
-// Phone communication types
 
 export interface PhoneMessage {
   id: string;
@@ -914,7 +670,6 @@ export interface AgentInfo {
   isCoordinatorOf: string[];
 }
 
-// AC discovery types
 
 export interface AcAgentMatrix {
   name: string;
@@ -938,31 +693,13 @@ export interface AcAgentReplica {
   repoPaths: string[];
   repoBranch?: string;
   isCoordinator: boolean;
-  /** #384: per-replica stable coding-agent selection (`tooling.currentCodingAgent`). */
   currentCodingAgentId?: string;
-  /** #384: per-replica profile letter (`tooling.profile`, then legacy override). */
   currentProfile?: string;
-  /** #552/#580 RFC3339 timestamp of the unified team-idle anchor, i.e. the
-   *  backend's `max(last_user_message_at, last_activity_at)` — the field now
-   *  means "team idle since" (reset when you message the coordinator, any member
-   *  is active, or the coordinator is active), NOT just the user's last message
-   *  (#580; rename to idleSinceAt deferred). `undefined` when none. Only
-   *  meaningful when `isCoordinator`. Drives the idle badge; read from the
-   *  persisted CoordinatorClocks store (survives restart + dormant). */
   lastUserMessageAt?: string;
-  /** #552 RFC3339 time this coordinator's team was auto-closed for inactivity,
-   *  or undefined. Only meaningful when `isCoordinator`. Drives the neutral
-   *  "auto-closed" pill; cleared on reopen. */
   autoClosedAt?: string;
-  /** #588 RFC3339 time this coordinator was manually closed, or undefined. Only
-   *  meaningful when `isCoordinator`. Drives the MANUALLY-CLOSED pill; cleared
-   *  on reopen. Visually identical to the auto-closed pill, different label. */
   manuallyClosedAt?: string;
 }
 
-/** #588 Result of the `close_coordinator` command. When `closed` is false the
- *  backend refused to cascade-close a coordinator whose team has working members
- *  without confirmation; `workingCount` is how many are still working. */
 export interface CoordinatorCloseOutcome {
   closed: boolean;
   workingCount: number;
@@ -982,31 +719,23 @@ export interface WorkgroupGroup {
   id: string;
   name: string;
   regex: string;
-  /** #965 - pinned into the rail's cross-project Favorites section. Absent on
-   *  legacy configs (Rust `#[serde(default)]`). */
   favorite?: boolean;
 }
 
 export interface NonStopTelegramConfig {
   enabled: boolean;
-  /** Resolves against AppSettings.telegramBots by id; null/absent => first configured bot. */
   botId?: string | null;
 }
 
 export interface NonStopSoundConfig {
   enabled: boolean;
-  /** Beep duration in seconds. Default 3. Clamped 1..=60. */
   seconds: number;
 }
 
 export interface NonStopGroupConfig {
-  /** Rail visibility AND watchdog-active. Single toggle (#777 D3/D4). Default false. */
   show: boolean;
-  /** Display name. Default "Alert me!". */
   name: string;
-  /** Membership regex, dynamic like user groups. Default "(?!)" (matches nothing). */
   regex: string;
-  /** Grace window before firing. Default 30. Clamped 1..=3600. */
   toleranceSeconds: number;
   telegram: NonStopTelegramConfig;
   sound: NonStopSoundConfig;
@@ -1016,7 +745,6 @@ export interface WorkgroupGroupsConfig {
   groups: WorkgroupGroup[];
   showAll: boolean;
   showUngrouped: boolean;
-  /** #777 built-in optional Non-stop group. Absent on legacy configs. */
   nonStop?: NonStopGroupConfig | null;
 }
 
@@ -1025,7 +753,6 @@ export interface ProjectGroupsUpdatedPayload {
   config: WorkgroupGroupsConfig;
 }
 
-/** #777 frontend -> backend watchdog signal; one entry per project with an ACTIVE Non-stop group. */
 export interface NonStopReport {
   projectPath: string;
   groupName: string;
@@ -1133,12 +860,7 @@ export interface AcDiscoveryResult {
   contextTemplateUpdates: ContextTemplateUpdate[];
 }
 
-// ---------------------------------------------------------------------------
-// Broad-scope coding-agent profile assignment (#384 §7)
-// Mirrors src-tauri/src/commands/config.rs DTOs (all camelCase via serde).
-// ---------------------------------------------------------------------------
 
-/** `"replica"` | `"kind"` | `"workgroup"` — matches Rust `ProfileAssignmentScope`. */
 export type ProfileAssignmentScope = "replica" | "kind" | "workgroup";
 
 export interface ProfileAssignmentTarget {
@@ -1148,7 +870,6 @@ export interface ProfileAssignmentTarget {
   replicaPath: string;
   identityPath: string;
   originProject: string | null;
-  /** Every live session whose working directory resolves to this replica. */
   liveSessionIds: string[];
 }
 
@@ -1157,13 +878,6 @@ export interface PreviewCodingAgentProfileSelectionRequest {
   codingAgentId: string;
   profile: string;
   scope: ProfileAssignmentScope;
-  /**
-   * #384: the preview `targetFingerprint` is hashed over `restartSessions` (plan
-   * §7, test #29), and apply re-validates that fingerprint — so the preview must
-   * carry the restart choice or the two fingerprints can never match. The §7
-   * Rust DTO listing omits this field; backend must include `restart_sessions`
-   * here for the fingerprint to be consistent. (Flagged to tech-lead/dev-rust.)
-   */
   restartSessions: boolean;
 }
 
@@ -1171,9 +885,7 @@ export interface PreviewCodingAgentProfileSelectionResult {
   scope: ProfileAssignmentScope;
   targetCount: number;
   liveSessionCount: number;
-  /** Hash of (codingAgentId, profile, restart, sorted canonical target paths). */
   targetFingerprint: string;
-  /** Backend confirmation hint; frontend broad scopes use a checkbox confirmation gate. */
   requiresExplicitConfirmation: boolean;
   targets: ProfileAssignmentTarget[];
   warnings: string[];
@@ -1185,9 +897,7 @@ export interface ApplyCodingAgentProfileSelectionRequest {
   profile: string;
   scope: ProfileAssignmentScope;
   restartSessions: boolean;
-  /** Required for `kind`/`workgroup`; `null` allowed for single-target `replica`. */
   confirmedTargetFingerprint?: string | null;
-  /** Legacy typed confirmation field; frontend sends `null` and relies on fingerprint + checkbox confirmation. */
   typedConfirmation?: string | null;
 }
 
@@ -1204,7 +914,6 @@ export interface ApplyCodingAgentProfileSelectionResult {
   restartedCount: number;
   updatedReplicaPaths: string[];
   restartedSessionIds: string[];
-  /** Sessions destroyed during restart that could not be recreated — surfaced as errors. */
   destroyedButNotRecreatedSessionIds: string[];
   targetFingerprint: string;
   warnings: string[];
@@ -1228,7 +937,6 @@ export interface AcProjectRefreshRequestedPayload {
   reason: AcProjectRefreshReason;
 }
 
-// Team wizard shared types (used by NewTeamModal and EditTeamModal)
 
 export interface TeamWizardAgentEntry {
   name: string;
@@ -1249,10 +957,6 @@ export interface TeamConfigResult {
   repos: { url: string; agents: string[] }[];
 }
 
-// ---------------------------------------------------------------------------
-// Workgroup-delete blocker report (BLOCKERS: sentinel payload)
-// Mirrors src-tauri/src/commands/wg_delete_diagnostic.rs structs.
-// ---------------------------------------------------------------------------
 
 export interface BlockerSession {
   sessionId: string;
@@ -1296,10 +1000,6 @@ export interface BlockerReport {
   externalProcesses?: BlockerProcess[];
 }
 
-// ---------------------------------------------------------------------------
-// Task mutation result
-// Mirrors src-tauri/src/commands/task.rs::TaskUpdateResult.
-// ---------------------------------------------------------------------------
 
 export interface TaskUpdateResult {
   workgroupRoot: string;
@@ -1321,27 +1021,17 @@ export type WorkgroupTaskUpdatedEvent =
       sessionIds: string[];
     };
 
-// ---------------------------------------------------------------------------
-// Project registration result (#191 — shared open/new project flow)
-// Mirrors src-tauri/src/config/projects.rs::ProjectRegistration.
-// ---------------------------------------------------------------------------
 
 export interface ProjectRegistration {
-  /** Absolute path that was added (or matched) in projectPaths. */
   path: string;
-  /** True when this call appended a new entry, false when already present. */
   registered: boolean;
-  /** True when this call created .ac/ on disk (always false for openProject). */
   created: boolean;
 }
 
-/** Mirrors src-tauri/src/config/projects.rs::ArchivedProject (#881). */
 export interface ArchivedProject {
   path: string;
   folderName: string;
-  /** The directory still exists on disk. */
   exists: boolean;
-  /** The directory still has a `.ac/` Project AC Root. */
   hasWorkspace: boolean;
 }
 
@@ -1352,45 +1042,28 @@ export type ArchiveChangeReason =
   | "open"
   | "remove";
 
-/** Mirrors src-tauri/src/commands/ac_discovery.rs::ProjectArchiveChanged (#881). */
 export interface ProjectArchiveChanged {
   path: string;
   folderName: string;
   archived: boolean;
   reason: ArchiveChangeReason;
-  /** Only for reason === "autoUnarchive". */
   sessionName?: string;
 }
 
-// ---------------------------------------------------------------------------
-// Error-log modal (#264)
-// Mirrors src-tauri/src/logging.rs::ErrorLogEntry.
-// ---------------------------------------------------------------------------
 
 export interface ErrorLogEntry {
-  /** Local timestamp string, e.g. "2026-05-21 15:56:11.123". */
   timestamp: string;
-  /** Always "ERROR" today — kept for forward-compat and copy output. */
   level: string;
-  /** Log target, e.g. "agentscommander_lib::commands::entity_creation". */
   target: string;
-  /** Full message; may contain newlines (multi-line git errors etc.). */
   message: string;
 }
 
-// ---------------------------------------------------------------------------
-// Role template picker (#271)
-// Mirrors src-tauri/src/commands/role_templates.rs::RoleTemplateMeta.
-// ---------------------------------------------------------------------------
 
 export interface RoleTemplateMeta {
-  /** Source-qualified id: "agency:<stem>" or "local:<folder>". */
   id: string;
-  /** "agency" | "local". */
   source: "agency" | "local";
   name: string;
   description: string;
-  /** Display grouping label, e.g. "Engineering" or "Local". */
   category: string;
   color?: string | null;
   emoji?: string | null;

--- a/src/shared/voice-recorder.ts
+++ b/src/shared/voice-recorder.ts
@@ -2,7 +2,6 @@ import { createSignal } from "solid-js";
 import { VoiceAPI, PtyAPI, DebugAPI, SettingsAPI } from "./ipc";
 import { getConsoleText } from "./console-capture";
 
-// Module-level reactive state (one instance per JS context / window)
 const [recordingSessionId, setRecordingSessionId] = createSignal<string | null>(null);
 const [processingSessionId, setProcessingSessionId] = createSignal<string | null>(null);
 const [micError, setMicError] = createSignal<string | null>(null);
@@ -12,7 +11,6 @@ const [autoExecuteSessionId, setAutoExecuteSessionId] = createSignal<string | nu
 const [autoExecuteCountdown, setAutoExecuteCountdown] = createSignal(0);
 const [typingWarnSessionId, setTypingWarnSessionId] = createSignal<string | null>(null);
 
-// Internal state (not reactive, not exported)
 let recorder: MediaRecorder | null = null;
 let currentStream: MediaStream | null = null;
 let audioCtx: AudioContext | null = null;
@@ -41,7 +39,6 @@ function startAudioLevelMonitor(stream: MediaStream) {
       setAudioLevel(avg);
     }, 50);
   } catch {
-    // Audio context not available
   }
 }
 
@@ -78,14 +75,11 @@ function cleanupRecording() {
 }
 
 async function start(sessionId: string) {
-  // Cancel any pending state from a previous session
   cancelAutoExecute();
   cancelTypingWarning();
 
-  // Stop any existing recording first
   if (recordingSessionId()) {
     stop();
-    // Wait a tick for onstop to fire
     await new Promise((r) => setTimeout(r, 50));
   }
 
@@ -122,8 +116,6 @@ async function start(sessionId: string) {
     rec.onstop = async () => {
       const stoppedSessionId = recordingSessionId();
 
-      // Stop tracking IMMEDIATELY — must await to guarantee the backend
-      // clears the flag before the transcription's own pty_write executes.
       if (stoppedSessionId) await VoiceAPI.markRecording(stoppedSessionId, false);
 
       stream.getTracks().forEach((t) => t.stop());
@@ -146,12 +138,10 @@ async function start(sessionId: string) {
           const encoder = new TextEncoder();
           await PtyAPI.write(stoppedSessionId, encoder.encode(text));
 
-          // Check if user typed during recording
           const hadTyping = await VoiceAPI.hadTyping(stoppedSessionId);
           if (hadTyping) {
             showTypingWarning(stoppedSessionId);
           } else {
-            // Auto-execute: send Enter after configurable delay
             try {
               const settings = await SettingsAPI.get();
               if (settings.voiceAutoExecute) {
@@ -159,7 +149,6 @@ async function start(sessionId: string) {
                 startAutoExecuteCountdown(stoppedSessionId, delay);
               }
             } catch {
-              // Settings fetch failed, skip auto-execute
             }
           }
         }
@@ -174,7 +163,6 @@ async function start(sessionId: string) {
       }
     };
 
-    // Tell backend to start tracking PTY writes for this session
     void VoiceAPI.markRecording(sessionId, true);
     rec.start();
   } catch (err: any) {
@@ -196,19 +184,16 @@ function stop() {
   }
 }
 
-/** Cancel recording — discard audio without processing */
 function cancel() {
   const sid = recordingSessionId();
   cancelAutoExecute();
   cancelTypingWarning();
   if (recorder) {
-    // Detach onstop so it doesn't trigger transcription
     recorder.onstop = null;
     if (recorder.state !== "inactive") {
       recorder.stop();
     }
   }
-  // Stop tracking before cleanup to prevent permanent leak
   if (sid) void VoiceAPI.markRecording(sid, false);
   cleanupRecording();
 }
@@ -278,7 +263,6 @@ export function formatRecordingTime(s: number): string {
 }
 
 export const voiceRecorder = {
-  // State (reactive signals)
   recordingSessionId,
   processingSessionId,
   micError,
@@ -288,7 +272,6 @@ export const voiceRecorder = {
   autoExecuteCountdown,
   typingWarnSessionId,
 
-  // Actions
   start,
   stop,
   cancel,

--- a/src/shared/window-geometry.ts
+++ b/src/shared/window-geometry.ts
@@ -23,18 +23,10 @@ async function readGeometry(): Promise<WindowGeometry> {
   };
 }
 
-/**
- * Track window move/resize and persist geometry.
- * Returns a cleanup function for onCleanup.
- *
- * Per DW.7: saveTimeout is closure-local so a main window can run this
- * alongside an independent splitter-width debouncer without racing.
- */
 export async function initWindowGeometry(
   windowType: WindowType
 ): Promise<() => void> {
   if (!isTauri) {
-    // Browser: no window geometry tracking
     return () => {};
   }
 
@@ -67,14 +59,6 @@ export async function initWindowGeometry(
   };
 }
 
-/**
- * Track a DETACHED window's move/resize and persist geometry into the
- * corresponding PersistedSession.detached_geometry field (plan
- * §A2.4.Arb1). Separate from initWindowGeometry because the key is
- * per-session, not per-window-type.
- *
- * Returns a cleanup function for onCleanup.
- */
 export async function initDetachedWindowGeometry(
   sessionId: string
 ): Promise<() => void> {

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -74,10 +74,6 @@ import "./styles/sidebar.css";
 import "../shared/styles/toast.css";
 
 interface SidebarAppProps {
-  /**
-   * True when mounted inside MainApp's unified layout. Skips window-level
-   * initializers; those are main-window concerns.
-   */
   embedded?: boolean;
   railSide?: MainSidebarSide;
 }
@@ -113,7 +109,6 @@ function consumeWarningCount(counts: Map<string, number>, warning: SessionWarnin
 }
 
 export function blockContextMenu(e: Event): void {
-  // Allow native menus where users expect text Copy/Paste.
   if (e.target instanceof Element && e.target.closest(".terminal-host, .project-filter-row")) return;
   e.preventDefault();
 }
@@ -141,11 +136,6 @@ function projectPanelForPath(
   return header?.closest<HTMLElement>(".project-panel") ?? null;
 }
 
-/**
- * #941 — align the newly selected project's header with the top of the shared
- * sidebar scrollport. The primitive semantic key deliberately suppresses raw
- * store/config emissions and same-selection re-clicks.
- */
 export function createSidebarSelectionScrollReset(
   scrollContainer: () => HTMLDivElement | undefined,
 ): void {
@@ -157,8 +147,6 @@ export function createSidebarSelectionScrollReset(
     const projectPath = workgroupGroupsStore.activeProjectPath();
     if (!projectPath) return;
 
-    // Collapse/expand and the filtered rows update in the same click. Position
-    // only after those Solid updates settle, and discard a superseded fast click.
     queueMicrotask(() => {
       if (disposed || selectionKey() !== key) return;
       const container = scrollContainer();
@@ -167,8 +155,6 @@ export function createSidebarSelectionScrollReset(
       const projectPanel = projectPanelForPath(container, projectPath);
       if (projectPanel) {
         const containerTop = container.getBoundingClientRect().top;
-        // The panel starts at its sticky header. Measure the non-sticky panel
-        // because a pinned header's rect cannot reveal its logical scroll offset.
         const projectTop = projectPanel.getBoundingClientRect().top;
         container.scrollTop = Math.max(0, container.scrollTop + projectTop - containerTop);
       }
@@ -184,10 +170,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
   const [showOnboarding, setShowOnboarding] = createSignal(false);
   const [loopToast, setLoopToast] = createSignal<LoopToast | null>(null);
   const [settingsRailSide, setSettingsRailSide] = createSignal<MainSidebarSide>("right");
-  // #695 — one-at-a-time seeded context-template update modal. `seen` is keyed
-  // by `(projectPath, filename, defaultSha256, fileSha256)` so a resolved or
-  // skipped update is not re-shown, while a genuinely new pending update (the
-  // user edited the file again, or the baked default bumped) gets a fresh key.
   const [activeContextTemplateUpdate, setActiveContextTemplateUpdate] =
     createSignal<ContextTemplateUpdate | null>(null);
   const [contextTemplateUpdateBusy, setContextTemplateUpdateBusy] = createSignal(false);
@@ -205,7 +187,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
   const railSide = () => props.railSide ?? settingsRailSide();
   let sidebarScrollableEl: HTMLDivElement | undefined;
   createSidebarSelectionScrollReset(() => sidebarScrollableEl);
-  // #592 - debounce handle for the profile-drift re-list (collapses bursts).
   let profileDriftRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   const handleMainSidebarSideChange = (event: Event) => {
     const side = (event as CustomEvent<{ side?: MainSidebarSide }>).detail?.side;
@@ -214,7 +195,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
 
   const handleRaiseTerminal = async (e: MouseEvent) => {
     if (!isTauri || props.embedded || !raiseTerminalEnabled) return;
-    // Don't steal focus from interactive elements
     const tag = (e.target as HTMLElement).tagName;
     if (tag === "SELECT" || tag === "INPUT" || tag === "TEXTAREA" || tag === "BUTTON") return;
     const now = Date.now();
@@ -236,13 +216,8 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     }, 3000);
   };
 
-  // #609 — sticky "npm update available" toaster. Per-mount dedup state so the
-  // startup event + the getUpdateStatus snapshot never double-toast a version.
   const showUpdateToast = createUpdateToaster();
 
-  // #695 — seeded context-template update flow. The exact removal key (grinch
-  // fix #5) includes the file hash so a resolved older modal never silently
-  // drops a newer pending update for the same project/file/default.
   const contextTemplateUpdateKey = (update: ContextTemplateUpdate) =>
     `${update.projectPath}\n${update.filename}\n${update.currentDefaultSha256}\n${update.currentFileSha256}`;
 
@@ -267,10 +242,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     }
   };
 
-  // Drop exactly the resolved update from the store and close the modal. The
-  // createEffect below then surfaces the next unseen pending update, one at a
-  // time. Removal and `seen` both key on the file hash, so a concurrent newer
-  // pending update survives (grinch fix #5).
   const resolveContextTemplateUpdate = (update: ContextTemplateUpdate) => {
     projectStore.removeContextTemplateUpdate(
       update.projectPath,
@@ -290,8 +261,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       await ProjectAPI.keepCustomContextTemplate(update);
       resolveContextTemplateUpdate(update);
     } catch (e) {
-      // Keep the modal open so the user can retry; the backend made no durable
-      // change, so re-showing the same notice later would be correct anyway.
       setContextTemplateUpdateError(formatContextTemplateError(e));
     } finally {
       setContextTemplateUpdateBusy(false);
@@ -306,8 +275,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     try {
       const result = await ProjectAPI.overwriteContextTemplateWithDefault(update);
       resolveContextTemplateUpdate(update);
-      // Sticky info toast — the user must be able to find the `.bak` the old
-      // file was preserved as.
       toastStore.info(
         `${update.label} overwritten with the new default. Your previous version was saved to ${result.backupPath}`,
         { durationMs: null }
@@ -319,10 +286,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     }
   };
 
-  // Surface the next pending context-template update whenever no modal is open.
-  // Short-circuiting on an active modal keeps it one-at-a-time; closing the
-  // modal re-runs this effect, which re-reads projectStore.projects and picks
-  // up any update queued while the previous one was open.
   createEffect(() => {
     if (activeContextTemplateUpdate()) return;
     const next = nextContextTemplateUpdate();
@@ -332,12 +295,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     setActiveContextTemplateUpdate(next);
   });
 
-  // #592 - pull the backend-computed drift flag and surgically patch each
-  // session. Uses setProfileOutdated (never setSessions) so the frontend-only
-  // pendingReview field is preserved. list_sessions recomputes profileOutdated
-  // from the persisted replica hash vs the current config, so this surfaces drift
-  // from ANY source: a profile event, an external settings.json edit, or
-  // pre-existing drift restored at boot.
   const refreshProfileOutdated = async () => {
     try {
       const list = await SessionAPI.list();
@@ -348,9 +305,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       console.error("Failed to refresh profile drift:", e);
     }
   };
-  // Debounce so a burst (a workgroup spawn emitting many session_created, or a
-  // broad-scope profile apply touching many replicas) collapses into a single
-  // list_sessions round-trip.
   const scheduleProfileOutdatedRefresh = () => {
     if (profileDriftRefreshTimer) clearTimeout(profileDriftRefreshTimer);
     profileDriftRefreshTimer = setTimeout(() => {
@@ -358,10 +312,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       void refreshProfileOutdated();
     }, 250);
   };
-  // Re-check drift when the window regains focus / becomes visible. The robust
-  // catch-all for a cell edited OUTSIDE the app (a hand edit to settings.json,
-  // or any path that does not emit coding_agent_profiles_updated): the badge
-  // lights up as soon as the user returns to AC.
   const handleWindowFocusDriftRefresh = () => {
     if (document.visibilityState === "hidden") return;
     scheduleProfileOutdatedRefresh();
@@ -403,14 +353,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
   };
 
   onMount(async () => {
-    // #289 / dark-default — dark is the base CSS, so first paint is dark with
-    // no optimistic class; the persisted-preference check after
-    // SettingsAPI.get() below opts into light only for users who chose it last
-    // session. Guarded with !props.embedded because MainApp owns the
-    // documentElement classList when this is mounted inside the unified layout
-    // — same pattern as zoom/geometry.
-    // #912: subscribe before the startup warning drain. The backend appends
-    // before live emit, so exact live/drained duplicates are collapsed below.
     unlisteners.push(await onSessionEnvWarning(handleLiveSessionWarning));
     void drainBufferedSessionWarnings();
 
@@ -440,11 +382,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
         void refreshProfileOutdated();
       })
     );
-    // #609 npm update notification. Subscribe BEFORE snapshotting so a startup
-    // emit fired during mount is never dropped; showUpdateToast dedups on
-    // version (subscribe-then-snapshot order). The snapshot
-    // is fire-and-forget so its IPC round-trip never delays the listener
-    // registrations that follow in this onMount.
     unlisteners.push(
       await onNpmUpdateAvailable((info) => showUpdateToast(info))
     );
@@ -455,7 +392,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       .catch((err) => {
         console.error("[update-check] getUpdateStatus failed:", err);
       });
-    // #714 screenshot capture saved/failed toasts + startup hotkey-status warning.
     unlisteners.push(...(await wireScreenshotListeners()));
     unlisteners.push(
       await onCodingAgentEnvSettingsUpdated(() => {
@@ -470,9 +406,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
         if (data.agentPath) {
           void projectStore.reloadProjectIfLoaded(data.agentPath);
         } else {
-          // Broad-scope apply (#384) touched many replicas with no single
-          // agentPath — reload every loaded project so discovery refreshes
-          // currentCodingAgentId/currentProfile everywhere.
           for (const proj of projectStore.projects) {
             void projectStore.reloadProject(proj.path);
           }
@@ -498,7 +431,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       cleanupGeometry = await initWindowGeometry("sidebar");
     }
 
-    // Apply window settings
     const appSettings = await SettingsAPI.get();
     setSettingsRailSide(appSettings.mainSidebarSide === "left" ? "left" : "right");
     if (!props.embedded) {
@@ -507,13 +439,7 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     raiseTerminalEnabled = appSettings.raiseTerminalOnClick;
     sessionsStore.setCoordSortByActivity(appSettings.coordSortByActivity ?? false);
     sessionsStore.setAlwaysShowSelectedWorkgroup(appSettings.alwaysShowSelectedWorkgroup ?? true);
-    // #965 (RC-3) — restore the rail's collapse snapshot. MUST run before
-    // projectStore.initFromSettings() populates the rail: that ordering is the only
-    // thing preventing an expand-then-collapse flash, because onMount runs AFTER the
-    // first paint. Deliberately NOT inside the `!props.embedded` guard above — the
-    // rail is live in the browser client and in the unified main window too.
     railCollapseStore.hydrateFromSettings(appSettings);
-    // Apply sidebar style from settings (remap removed themes to default)
     const style = appSettings.sidebarStyle;
     const removedThemes = ["classic", "signal-grid"];
     document.documentElement.dataset.sidebarStyle = (!style || removedThemes.includes(style)) ? "noir-minimal" : style;
@@ -525,7 +451,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       document.addEventListener("mousedown", handleRaiseTerminal);
     }
 
-    // Block the default browser context menu globally — custom menus are used instead
     document.addEventListener("contextmenu", blockContextMenu);
     window.addEventListener("main-sidebar-side-change", handleMainSidebarSideChange);
 
@@ -535,19 +460,11 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       } catch {}
     }
 
-    // Load settings into reactive store (for voice-to-text visibility etc.)
     await settingsStore.load();
 
-    // Feature #110 — start watching for team busy→all-idle transitions.
-    // Mounted after settingsStore.load() so the very first effect run
-    // already sees the user's teamIdleBeepEnabled choice; the watcher's
-    // own initialization guard separately suppresses any startup beep.
-    // primeAudio() arms the AudioContext on first user gesture so the
-    // very first beep isn't swallowed by browser autoplay policy.
     primeAudio();
     stopTeamIdleWatcher = startTeamIdleWatcher();
 
-    // First-run: show onboarding if no coding agents configured and not previously dismissed
     if (
       (!appSettings.agents || appSettings.agents.length === 0) &&
       !appSettings.onboardingDismissed
@@ -555,14 +472,12 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       setShowOnboarding(true);
     }
 
-    // Load saved project if any
     await projectStore.initFromSettings(
       appSettings.projectPaths ?? [],
       appSettings.projectPath ?? null,
       appSettings.archivedProjectPaths ?? [],
     );
 
-    // Load all repos for inactive agent display
     try {
       const allRepos = await ReposAPI.search("");
       sessionsStore.setRepos(allRepos.filter((r) => r.agents.length > 0));
@@ -574,36 +489,24 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       })
     );
 
-    // Load initial sessions
     const sessions = await SessionAPI.list();
     sessionsStore.setSessions(sessions);
 
     const activeId = await SessionAPI.getActive();
     sessionsStore.setActiveId(activeId);
 
-    // #592 - surface profile drift edited OUTSIDE the app (a hand edit to
-    // settings.json, or any path that does not emit coding_agent_profiles_updated)
-    // the moment the user returns to AC. The in-app edit events still refresh
-    // immediately; this is the robust catch-all for everything else.
     window.addEventListener("focus", handleWindowFocusDriftRefresh);
     document.addEventListener("visibilitychange", handleWindowFocusDriftRefresh);
 
-    // Listen for events
     unlisteners.push(
       await onSessionCreated((session) => {
         sessionsStore.addSession(session);
-        // New session is auto-activated if it's the first one
         if (
           sessionsStore.sessions.length === 1 &&
           !isExitedStatus(session.status)
         ) {
           sessionsStore.setActiveId(session.id);
         }
-        // #592 - session_created carries profileOutdated=false (From<&Session>
-        // cannot compute drift). A session restored at boot with pre-existing
-        // drift must re-derive it from list_sessions, which would otherwise be
-        // clobbered to false by the addSession upsert. Debounced so a workgroup
-        // spawn burst collapses into one re-list.
         scheduleProfileOutdatedRefresh();
       })
     );
@@ -611,9 +514,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
     unlisteners.push(
       await onSessionDestroyed(({ id }) => {
         sessionsStore.removeSession(id);
-        // Detached-window cleanup: if the session had a detached window,
-        // its destroy also closes that window. Clear the store flag so
-        // UI (icons, menu items) doesn't linger in detached state.
         sessionsStore.setDetached(id, false);
       })
     );
@@ -630,10 +530,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       )
     );
 
-    // Hydrate detachedIds from backend (G.8 race safety — covers detach
-    // events that fired before this component mounted, e.g. from the
-    // Phase-3 restore path or from a prior detach survived across a
-    // SidebarApp re-mount in the unified window).
     try {
       const ids = await WindowAPI.listDetached();
       ids.forEach((id) => sessionsStore.setDetached(id, true));
@@ -672,14 +568,6 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       })
     );
 
-    // #1033 - snapshot-seed every agent session no event has spoken for yet. The engine
-    // emits ONLY on change (pty/context_scrape/mod.rs), so a session already sitting at a
-    // value when this window mounted will never send one, and a listener alone leaves it
-    // reading N/A forever. Registered AFTER the listener, and hydrateSessionContext is a
-    // no-op on an existing key, so a slow invoke cannot overwrite a fresher event.
-    // Absent-key check, never a truthiness check: a hydrated `null` and a hydrated `0`
-    // are both answers. try/catch mirrors the repo-search fan-out at :564-567 so one
-    // rejected invoke cannot abort the rest of onMount.
     try {
       await Promise.all(
         sessionsStore.sessions
@@ -711,11 +599,9 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       })
     );
 
-    // Load initial bridge state
     const bridges = await TelegramAPI.listBridges();
     bridgesStore.setBridges(bridges);
 
-    // Telegram bridge events
     unlisteners.push(
       await onTelegramBridgeAttached((info) => {
         bridgesStore.addBridge(info);

--- a/src/sidebar/components/ActionBar.tsx
+++ b/src/sidebar/components/ActionBar.tsx
@@ -26,23 +26,11 @@ type ResourceBadgeState =
 const ActionBar: Component = () => {
   const [showDropdown, setShowDropdown] = createSignal(false);
   const [showSettings, setShowSettings] = createSignal(false);
-  // `equals: false` → each write notifies even if the value is the same. Lets
-  // a second disabled-mic click re-snap the modal back to Integrations if the
-  // user manually navigated away to another tab between clicks.
   const [pendingSection, setPendingSection] = createSignal<string | undefined>(undefined, { equals: false });
   const [confirmPath, setConfirmPath] = createSignal<string | null>(null);
   const [toastMsg, setToastMsg] = createSignal<string | null>(null);
   const [isPendingDialog, setIsPendingDialog] = createSignal(false);
   const [showBrowserCreateProjectNotice, setShowBrowserCreateProjectNotice] = createSignal(false);
-  // #289 — local synchronous mirror of the persisted theme. Drives the button
-  // glyph directly so rapid double-clicks each see the freshly-toggled value
-  // (a getter that reads settingsStore.current?.themeLight would see the
-  // pre-write value until fire-and-forget refresh() resolves, so clicks 2+ in
-  // a quick burst would all flip from the same stale state). createEffect
-  // syncs in when the store loads or changes externally (SettingsModal, the
-  // peer window's theme_changed event, etc.). Default false mirrors
-  // AppSettings::default (dark) for the brief window before load() resolves on
-  // mount.
   const [localThemeLight, setLocalThemeLight] = createSignal(
     settingsStore.current?.themeLight ?? false,
   );
@@ -53,7 +41,6 @@ const ActionBar: Component = () => {
   const isLight = (): boolean => localThemeLight();
   let dropdownRef: HTMLDivElement | undefined;
 
-  // Click-away to close dropdown
   const onClickAway = (e: MouseEvent) => {
     if (dropdownRef && !dropdownRef.contains(e.target as Node)) {
       setShowDropdown(false);
@@ -84,11 +71,6 @@ const ActionBar: Component = () => {
 
   onCleanup(() => window.removeEventListener("keydown", onConfirmKeyDown));
 
-  // Cross-window / same-window trigger to open the Settings modal (e.g. from a
-  // disabled mic button prompting the user to configure voice). The optional
-  // `section` argument targets a specific tab — SettingsModal picks it up via
-  // the `section` prop and its createEffect re-targets the tab if the modal is
-  // already open.
   let unlistenOpenSettings: UnlistenFn | null = null;
   let stopResourcePolling: (() => void) | null = null;
   onMount(async () => {
@@ -160,13 +142,6 @@ const ActionBar: Component = () => {
     }
   };
 
-  // #158 — global app-sound mute. Default true so old settings.json files
-  // (no `soundsEnabled` field) stay audible. setSoundsEnabled is pushed
-  // synchronously BEFORE the persist roundtrip so a beep that fires between
-  // the click and the IPC reply (e.g. team-idle-watcher transitioning during
-  // file IO) sees the new gate value — the user's intent in clicking mute is
-  // exactly to suppress imminent beeps. On persist failure we rollback the
-  // gate and toast.
   const isSoundsEnabled = (): boolean =>
     settingsStore.current?.soundsEnabled ?? true;
   const handleToggleMute = async () => {
@@ -183,11 +158,6 @@ const ActionBar: Component = () => {
     }
   };
 
-  // #289 — flip the DOM class optimistically (snappy UI), persist, and roll
-  // back both DOM and toast on failure. Mirrors handleToggleMute: the user
-  // intent in clicking is to *see* the new theme immediately, so the visual
-  // swap precedes the IPC roundtrip. emitThemeChanged keeps the other window
-  // in sync; on rollback we re-emit the previous value so it follows back.
   const applyThemeClass = (light: boolean) => {
     if (light) {
       document.documentElement.classList.add("light-theme");
@@ -242,9 +212,6 @@ const ActionBar: Component = () => {
     return `Resource Monitor: ${snapshot.activeAgentGroups}/${snapshot.maxConcurrentAgentGroups} agents, ${state}`;
   };
 
-  // #587 — the ▦ button now toggles the central-pane RM view (mirrors the 🏠
-  // Home toggle two slots away). Opening RM in a separate OS window is reachable
-  // from the embedded RM's "Detach" button.
   const handleToggleResourceMonitor = () => {
     centralViewStore.toggleResourceMonitor();
   };

--- a/src/sidebar/components/AgentPickerModal.tsx
+++ b/src/sidebar/components/AgentPickerModal.tsx
@@ -28,9 +28,6 @@ import {
   targetProfileFqn,
 } from "../../shared/profile-utils";
 
-/** Scope/replica context supplied by ProjectPanel for WG replica launches. When
- *  absent (OpenAgentModal / normal repo / RootAgentBanner) only the safe
- *  "this replica" scope is offered. (#384 Frontend §4) */
 export type AgentPickerScopeContext = {
   workgroupPath?: string;
   workgroupName?: string;
@@ -57,10 +54,6 @@ const EMPTY_DISPLAY_CELL: ProfileCellConfig = {
   notes: "",
 };
 
-// #527: per-card status pill labels for the Selection profile cards. Same
-// taxonomy/colors as the Config rails (profileBadgeKind), so a given (agent,
-// letter) reads identically on both screens. `invalid` is Config-only (live
-// command edits), so it never surfaces here.
 const SELECTION_PILL_LABEL: Record<Exclude<ProfileBadgeKind, "invalid">, string> = {
   match: "MATCH",
   configured: "CONFIGURED",
@@ -68,8 +61,6 @@ const SELECTION_PILL_LABEL: Record<Exclude<ProfileBadgeKind, "invalid">, string>
   missing: "MISSING",
 };
 
-// #551: shown on the disabled "Assign to this replica" button when the pending
-// selection still equals the replica's current Coding Agent + Profile.
 const REDUNDANT_REPLICA_ASSIGN_TOOLTIP =
   "This replica already uses this Coding Agent + Profile.";
 
@@ -77,29 +68,10 @@ const AgentPickerModal: Component<{
   sessionName: string;
   agentPath?: string | null;
   currentAgentId?: string | null;
-  // #551 FIX 2: the EXPLICIT persisted current coding agent — the replica's
-  // `currentCodingAgentId` (or a live session's `agentId`). The redundancy disable
-  // keys off THIS, never off `currentAgentId` (which may carry a soft
-  // `preferredAgentId` / `lastCodingAgent` hint used only to pre-select the picker).
-  // A never-assigned replica has no explicit current agent (undefined/null here), so
-  // its "Assign to this replica" stays enabled — the user can still pin the hinted
-  // agent as a genuine first assignment.
   explicitCurrentAgentId?: string | null;
   currentRequestedProfile?: string | null;
   scopeContext?: AgentPickerScopeContext;
-  // #551: opt-in for the replica *assign* flows. When set, the "Assign to this
-  // replica" button is disabled (with a tooltip) while the pending selection
-  // still equals the replica's current Coding Agent + Profile — re-assigning the
-  // same pair is a no-op and (since #537) pops a needless "Restart now?" prompt.
-  // The launch flow leaves this off so a replica can always be started with its
-  // configured agent.
   disableRedundantReplicaAssign?: boolean;
-  // #592: when the target session's loaded profile has DRIFTED from its current
-  // configuration (profileOutdated), re-assigning the same Coding Agent + Profile
-  // is no longer a no-op: it re-stamps the cell content and relaunches. So drift
-  // overrides the redundancy disable above and keeps "Assign to this replica"
-  // enabled: a sibling "manual reload" affordance to the outdated badge. Read
-  // from the SAME backend-computed profileOutdated the badge uses (no FE hash).
   targetProfileOutdated?: boolean;
   onSelect: (selection: AgentPickerSelection) => void | Promise<void>;
   onClose: () => void;
@@ -115,14 +87,9 @@ const AgentPickerModal: Component<{
   const [busy, setBusy] = createSignal(false);
   const [error, setError] = createSignal("");
 
-  // ── V2 scope picker state ──
   const [selectedScope, setSelectedScope] = createSignal<ProfileAssignmentScope>("replica");
   const [restartSessions, setRestartSessions] = createSignal(false);
   const [dangerArmed, setDangerArmed] = createSignal(false);
-  // #800: previews are kept per-scope so every radio button can display its
-  // true targetCount, not just the currently selected scope. The selected
-  // scope's slot is exposed via the `scopePreview` memo below so existing
-  // readers (apply, fingerprint, target review, warnings) are unchanged.
   const emptyScopePreviews: Record<ProfileAssignmentScope, PreviewCodingAgentProfileSelectionResult | null> = {
     replica: null,
     kind: null,
@@ -145,20 +112,13 @@ const AgentPickerModal: Component<{
   const scopePreviewBusy = createMemo(() => scopePreviewBusyMap()[selectedScope()]);
   const scopePreviewError = createMemo(() => scopePreviewErrorMap()[selectedScope()]);
   const [applyErrors, setApplyErrors] = createSignal<ProfileAssignmentError[]>([]);
-  // #537: transient toast so an assign failure is loud and unmissable (the
-  // persistent banner below keeps the actionable detail once the toast fades).
   const [toastMsg, setToastMsg] = createSignal<string | null>(null);
 
   let overlayRef!: HTMLDivElement;
   let profileResolveSeq = 0;
-  // #800: per-scope race guard so a slow preview for one scope can't overwrite
-  // another scope's slot. Bumped in the createEffect (all three) and in
-  // runScopePreview (the scope being fetched).
   let previewSeqByScope: Record<ProfileAssignmentScope, number> = { replica: 0, kind: 0, workgroup: 0 };
   let toastTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // #537: mirror the SidebarApp/SettingsModal toast pattern (.toast-error,
-  // auto-dismiss after 3s). Used to surface a failed Coding Agent assignment.
   const showToast = (message: string) => {
     if (toastTimer) clearTimeout(toastTimer);
     setToastMsg(message);
@@ -182,7 +142,6 @@ const AgentPickerModal: Component<{
   const profileLetters = createMemo(() =>
     settings() ? sortedProfileLetters(settings()!.codingAgentProfiles) : ["A"]
   );
-  // Prefer the explicit scope-context replica path; fall back to the legacy agentPath.
   const targetReplicaPath = createMemo(
     () => props.scopeContext?.targetReplicaPath ?? props.agentPath ?? null
   );
@@ -193,8 +152,6 @@ const AgentPickerModal: Component<{
     targetProfileFqn(targetReplicaPath(), props.sessionName)
   );
   const isWgReplica = createMemo(() => isWgReplicaPath(targetReplicaPath()));
-  // Broad scope (kind/workgroup) is only offered for a real WG replica with
-  // workgroup context. Everything else collapses to "assign to this replica".
   const showBroadScope = createMemo(
     () => Boolean(props.scopeContext?.workgroupPath) && isWgReplica()
   );
@@ -347,7 +304,6 @@ const AgentPickerModal: Component<{
     setInitialProfileShouldLaunch(Boolean(currentRequested) || Boolean(acDefault));
   });
 
-  // Backend profile resolution for the selected pair (effective letter, fallback).
   createEffect(() => {
     const current = settings();
     const agent = selectedAgent();
@@ -384,10 +340,6 @@ const AgentPickerModal: Component<{
       });
   });
 
-  // Backend scope preview — authoritative target/live-session enumeration and the
-  // fingerprint that apply re-validates. Re-runs (and clears the broad-scope
-  // confirmation checkbox, preview, fingerprint) whenever scope, coding agent, profile,
-  // restart toggle, or target replica changes (#384 Frontend §4).
   const runScopePreview = (scope: ProfileAssignmentScope, agentId: string, profile: string) => {
     const target = targetReplicaPath();
     if (!target || !isWgReplica()) return;
@@ -419,11 +371,9 @@ const AgentPickerModal: Component<{
     const scope = selectedScope();
     const agent = selectedAgent();
     const profile = selectedProfile();
-    // Track these so any change resets the confirmation gate and re-previews.
     restartSessions();
     targetReplicaPath();
 
-    // #800: invalidate all in-flight previews and reset transient artifacts.
     previewSeqByScope.replica += 1;
     previewSeqByScope.kind += 1;
     previewSeqByScope.workgroup += 1;
@@ -434,9 +384,6 @@ const AgentPickerModal: Component<{
     setScopePreviewBusyMap({ ...emptyScopeBusy });
 
     if (!agent || !isWgReplica()) return;
-    // Fetch all three broad-scope previews up front so each radio button
-    // displays its true targetCount (#800). The selected scope's slot drives
-    // apply, fingerprint, and the target review list (via `scopePreview`).
     runScopePreview("replica", agent.id, profile);
     runScopePreview("kind", agent.id, profile);
     runScopePreview("workgroup", agent.id, profile);
@@ -461,9 +408,6 @@ const AgentPickerModal: Component<{
   };
 
   const scopeCount = (scope: ProfileAssignmentScope): number => {
-    // #800: replica scope is always exactly 1 (the target itself). For kind
-    // and workgroup, read the per-scope preview slot so the count is correct
-    // even before the user selects that scope.
     if (scope === "replica") return 1;
     return scopePreviews()[scope]?.targetCount ?? 0;
   };
@@ -492,20 +436,6 @@ const AgentPickerModal: Component<{
     return `Overwrite ${count}${wg ? ` in ${wg}` : " in this workgroup"}`;
   });
 
-  // #551: the replica's *current* profile letter — the baseline for the redundant
-  // selection check. It must mirror the backend's resolve_profile fallback chain
-  // exactly (coding_agent_profiles.rs):
-  //   instance_override → explicit (requested) → origin_default → agent_default → "A"
-  // The backend ranks the persisted instance override ahead of the launch-time
-  // requested profile, so when present it — not props.currentRequestedProfile — is
-  // what the modal resolves to and applies on open. The origin_default and
-  // agent_default tiers are read from the backend resolution fields (request-
-  // independent, computed from disk/settings — same as configuredDefault()), so the
-  // baseline stays stable even after the user picks a different profile (which would
-  // otherwise let a stale session.requestedProfile wrongly enable a no-op assign).
-  // The local-settings read is only a last-resort fallback for when the backend
-  // preview is unavailable (non-AC path or a resolution error) — the same
-  // agent_default tier, read locally.
   const currentProfileLetter = createMemo(() => {
     const preview = backendPreview();
     const override = normalizeProfileLetter(preview?.instanceProfileOverride);
@@ -526,20 +456,9 @@ const AgentPickerModal: Component<{
     return "A";
   });
 
-  // #551: true while the pending selection still equals the replica's current
-  // Coding Agent + Profile (replica scope only, and only when the caller opted in
-  // via the assign flows). The untouched short-circuit covers the just-opened
-  // state robustly even if a backend default differs from the front-end default;
-  // once the user picks a profile, an explicit letter match is required.
-  // FIX 2: the agent-equality baseline is the EXPLICIT current coding agent
-  // (explicitCurrentAgentId), never the pre-select hint in currentAgentId. A
-  // never-assigned replica (no explicit current agent) is never redundant, so its
-  // assign stays enabled even though the picker opens on a preferred-agent hint.
   const isRedundantReplicaSelection = createMemo(() => {
     if (!props.disableRedundantReplicaAssign) return false;
     if (selectedScope() !== "replica") return false;
-    // #592 - drift makes a same-pair re-assign meaningful (re-stamp + relaunch
-    // with the current cell content), so it is never redundant while outdated.
     if (props.targetProfileOutdated) return false;
     const agent = selectedAgent();
     const baselineAgentId = props.explicitCurrentAgentId;
@@ -569,14 +488,10 @@ const AgentPickerModal: Component<{
     const requested = requestedProfileForSelection();
     const effective = effectivePreview().effectiveProfile;
     const target = targetReplicaPath();
-    // #537: replica scope no longer uses the pre-apply restart toggle; the post-assign
-    // "Restart now?" modal (ProjectPanel) owns the restart. Force it off so a toggle
-    // value carried over from kind/workgroup scope cannot trigger a backend restart.
     const restart = scope === "replica" ? false : restartSessions();
     try {
       let updatedCount: number | undefined;
       let restartedCount: number | undefined;
-      // Broad-scope writes are backend-owned; only call apply for a real WG replica.
       if (target && isWgReplica()) {
         const result = await SettingsAPI.applyCodingAgentProfileSelection({
           targetReplicaPath: target,
@@ -589,11 +504,7 @@ const AgentPickerModal: Component<{
           typedConfirmation: null,
         });
         if (result.errors.length > 0) {
-          // Stale fingerprint / failed targets: surface errors, keep the modal open,
-          // reset the broad confirmation and re-run preview so the user re-confirms.
           setApplyErrors(result.errors);
-          // #537: the assign no longer silently no-ops. Fire a loud toast with the
-          // backend's human-readable message so the failure cannot be missed.
           const firstError = result.errors[0];
           const extra = result.errors.length - 1;
           showToast(extra > 0 ? `${firstError.message} (+${extra} more)` : firstError.message);
@@ -616,12 +527,8 @@ const AgentPickerModal: Component<{
         restartedCount,
       });
     } catch (err: unknown) {
-      // #516 — surface the failure in the modal (keep it open) rather than
-      // letting the rejection escape as a swallowed unhandled rejection. The
-      // Resource Monitor cap gets a friendly, actionable message.
       const message = launchErrorMessage(err);
       setError(message);
-      // #537: keep unexpected apply failures as loud as the structured ones.
       showToast(message);
       if (scope !== "replica" && target && isWgReplica()) {
         setDangerArmed(false);
@@ -778,7 +685,6 @@ const AgentPickerModal: Component<{
                             fallbackApplied: false,
                           };
                     const cell = () => enabledLaunchCellFor(selectedAgent(), preview().effectiveProfile);
-                    // #527: per-card status pill — shared taxonomy with the Config rails.
                     const pillKind = (): Exclude<ProfileBadgeKind, "invalid"> => {
                       const current = settings();
                       const agent = selectedAgent();

--- a/src/sidebar/components/CodingAgentQuickConfiguration.tsx
+++ b/src/sidebar/components/CodingAgentQuickConfiguration.tsx
@@ -5,8 +5,6 @@ import { settingsStore } from "../../shared/stores/settings";
 import { newAgentId, definitionToSeed } from "../../shared/agent-presets";
 import { codingAgentsStore } from "../stores/coding-agents";
 
-// Custom Agent is not a catalog entry: it triggers the inline name/command
-// fields and is always offered last, so it stays a client-side definition.
 const CUSTOM_PRESET: CodingAgentDefinition = {
   key: "custom",
   label: "Custom Agent",
@@ -19,27 +17,11 @@ const CUSTOM_PRESET: CodingAgentDefinition = {
 };
 
 export interface CodingAgentQuickConfigurationProps {
-  /** Header title, supplied by the consumer (Welcome passes "Welcome"). */
   title: string;
-  /** Intro copy rendered above the preset cards. */
   message: string;
-  /** Closes the modal. Fired by the success state's "Get started" action. */
   onClose: () => void;
-  /**
-   * #975 — cancellation is opt-in. When omitted, no Cancel button renders and
-   * Escape stays inert, so a consumer can require an explicit choice. When
-   * supplied, Cancel renders and Escape invokes this same callback, keeping
-   * pointer and keyboard dismissal identical. The callback owns closing.
-   */
   onCancel?: () => void;
-  /**
-   * #975 — consumer-owned settings changes, folded into the single atomic
-   * update that persists the new agent. This keeps consumer-specific state
-   * (such as Welcome's onboardingDismissed) out of this component while
-   * preserving the pre-existing one-write semantics.
-   */
   onBeforeSave?: (settings: AppSettings) => AppSettings;
-  /** Overrides the dialog's accessible name. Defaults to `title`. */
   ariaLabel?: string;
 }
 
@@ -49,12 +31,8 @@ const CodingAgentQuickConfiguration: Component<CodingAgentQuickConfigurationProp
   const [done, setDone] = createSignal(false);
   const [addedLabel, setAddedLabel] = createSignal("");
 
-  // #769 — the catalog is backend-owned; the store is pre-seeded with the
-  // fallback so the card list (and the #768 no-scroll fit) renders immediately,
-  // with no wrong-length flash before the async fetch resolves.
   const allPresets = () => [...codingAgentsStore.catalog(), CUSTOM_PRESET];
 
-  // Custom agent fields
   const [customLabel, setCustomLabel] = createSignal("");
   const [customCommand, setCustomCommand] = createSignal("");
 
@@ -98,7 +76,6 @@ const CodingAgentQuickConfiguration: Component<CodingAgentQuickConfigurationProp
         ...settings,
         agents: [...settings.agents, agent],
       };
-      // #975 — the consumer decides what else rides along in this same write.
       const updated = props.onBeforeSave ? props.onBeforeSave(withAgent) : withAgent;
       await SettingsAPI.update(updated);
       settingsStore.refresh();
@@ -114,20 +91,13 @@ const CodingAgentQuickConfiguration: Component<CodingAgentQuickConfigurationProp
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Escape") {
-      // #975 — Escape resolves to whatever dismissal affordance the footer
-      // actually renders. The success state renders only "Get started", so
-      // Escape closes there and must not re-enter the consumer's cancel path:
-      // that would be a second settings write after a completed save.
       if (done()) {
         props.onClose();
         return;
       }
-      // Selecting state: Cancel renders only when the consumer supplies the
-      // callback, so without one Escape stays inert — no back-door dismissal.
       props.onCancel?.();
       return;
     }
-    // Focus trap: keep Tab cycling within the modal
     if (e.key === "Tab" && modalRef) {
       const focusable = modalRef.querySelectorAll<HTMLElement>(
         'button:not(:disabled), input:not(:disabled), [tabindex]:not([tabindex="-1"])'

--- a/src/sidebar/components/ContextBadge.tsx
+++ b/src/sidebar/components/ContextBadge.tsx
@@ -1,46 +1,15 @@
 import { Component, Show } from "solid-js";
 import { contextBadgeText } from "./session-context";
 
-/**
- * #1033 - the honesty requirement, and the only place it is user-visible.
- * Carried by BOTH states, because a reading and its absence are equally best-effort.
- */
 export const CONTEXT_BADGE_TOOLTIP =
   "Context window in use, read from what the agent draws in its terminal. " +
   "Best-effort: it can be unavailable, stale or absent. A high reading does not " +
   "mean this session must be restarted.";
 
-/**
- * #1033 - the CTX badge: how much of its context window an agent session has used,
- * scraped from what the agent draws in its own terminal.
- *
- * Shared by SessionItem, the ProjectPanel replica rows, and RootAgentBanner so the
- * badge looks and reads identically everywhere a coding-agent session can show one;
- * triplicating the ARIA markup across those three files is how the three drift. The
- * caller supplies the testid because each surface names itself.
- *
- * THE BADGE IS A SIGNAL, NEVER A CONTROL. A `<span>`, never a `<button>` - unlike
- * ProfileOutdatedBadge, which this otherwise copies. No onClick, no onKeyDown, no
- * tabindex, no cursor change, no threshold, and nothing anywhere reads this value.
- * AC has no denominator for the number (one rounded integer, unknown window size),
- * so it has no basis for a threshold and invents none.
- *
- * The two states are structurally DIFFERENT elements rather than one element with
- * nullable attributes: `role="meter"` requires `aria-valuenow`, and there is no
- * valid `aria-valuenow` for N/A, so a meter with no value would be invalid ARIA.
- *
- * No aria-live on either state, deliberately: the reading refreshes on a 5s cadence,
- * so a live region would interrupt a screen reader every 5 seconds, forever, with a
- * number that drives nothing. That is an accessibility defect, not a feature.
- */
 const ContextBadge: Component<{
   percent: number | null | undefined;
   testId?: string;
 }> = (props) => {
-  // Wrapped in an object on purpose: `<Show when={props.percent}>` would treat a
-  // REAL reading of 0% as absent and render N/A, since 0 is falsy. The wrapper is
-  // always truthy when there is a reading, and it narrows `number | null |
-  // undefined` to `number` without a cast.
   const reading = (): { value: number } | undefined => {
     const percent = props.percent;
     return percent === null || percent === undefined ? undefined : { value: percent };

--- a/src/sidebar/components/ContextTemplateUpdateModal.tsx
+++ b/src/sidebar/components/ContextTemplateUpdateModal.tsx
@@ -2,22 +2,6 @@ import { Component, Show } from "solid-js";
 import type { ContextTemplateUpdate } from "../../shared/types";
 import { automationAttrs } from "../../shared/automation-hooks";
 
-/**
- * #695 — Seeded context-template update notice. A baked context template (e.g.
- * `Context.coordinator.md`) has a newer built-in default, but the on-disk file
- * looks customized, so AC will not overwrite it silently. The user resolves it
- * explicitly: keep their version (records a durable "ignore until it changes
- * again" decision) or overwrite with the new default (which first preserves the
- * old file as a `.bak` sibling).
- *
- * Resolution is intentionally two-action only. There is NO close button, and
- * neither a backdrop click nor Escape dismisses the modal: closing without a
- * backend keep/overwrite decision would leave the state file untouched, so the
- * same notice would reappear on the next discovery (grinch fix #6 / plan §15).
- *
- * Presentational only — the caller (`SidebarApp`) owns the busy/error state and
- * drives the keep/overwrite IPC calls, mirroring `RestartPromptModal`.
- */
 const ContextTemplateUpdateModal: Component<{
   update: ContextTemplateUpdate;
   busy: boolean;
@@ -25,9 +9,6 @@ const ContextTemplateUpdateModal: Component<{
   onKeep: () => void;
   onOverwrite: () => void;
 }> = (props) => {
-  // Defensive: while this modal is up, swallow Escape so a global shortcut
-  // handler can never dismiss it or an underlying surface. The modal itself has
-  // no Escape/close wiring — only the two explicit actions resolve it.
   const swallowEscape = (e: KeyboardEvent) => {
     if (e.key === "Escape") e.stopPropagation();
   };

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -37,10 +37,6 @@ import {
   projectPanelCollapseKey,
   PROJECT_PANEL_COLLAPSE_KEY_SEP,
 } from "../stores/project-collapse";
-// #810 - PROJECT_PANEL_COLLAPSE_KEY_SEP, ProjectPanelCollapseSection, and
-// projectPanelCollapseKey moved to the project-collapse store (canonical
-// home). Re-exported here so any external importer that previously read them
-// from ProjectPanel keeps compiling.
 export {
   PROJECT_PANEL_COLLAPSE_KEY_SEP,
   projectPanelCollapseKey,
@@ -100,14 +96,9 @@ interface PendingLaunch {
   currentAgentId?: string;
   currentRequestedProfile?: string | null;
   scopeContext?: AgentPickerScopeContext;
-  /** #599 R1: reopening a coordinator destroyed by auto/manual close — resume. */
   resumeOnLaunch?: boolean;
 }
 
-/** #545: the broom has nothing to clear when the workgroup task title is
- *  empty/missing or the literal Clean sentinel. Title-only approximation of
- *  the backend's structural clean check; exact-match + case-sensitive on
- *  purpose (mirrors the backend `title: 'Clean'` sentinel). See plan G2/G4. */
 export const isTaskClean = (t?: string | null): boolean =>
   !t?.trim() || t.trim() === "Clean";
 
@@ -140,7 +131,6 @@ function sessionEffectiveStatusSearchText(session: Session): string {
   return dotClass === "exited" ? sessionStatusSearchText(session.status) : dotClass;
 }
 
-/** Build the gitRepos list for a replica. Order = replica.repoPaths order (invariant §3.1.2). */
 function buildGitRepos(replica: AcAgentReplica): SessionRepoInput[] {
   return (replica.repoPaths ?? []).map((p) => {
     return { label: repoLabelFromPath(p), sourcePath: p };
@@ -151,11 +141,6 @@ function hasValidRepoSourcePath(repo: Pick<SessionRepo, "sourcePath">): boolean 
   return typeof repo.sourcePath === "string" && repo.sourcePath.trim().length > 0;
 }
 
-/**
- * Build the AgentPicker scope context for a launching WG replica (#384 Frontend §5).
- * Broad-scope assignment is only offered when the launch resolves to a real WG
- * replica; the backend re-enumerates and is authoritative either way.
- */
 function replicaScopeContext(wg: AcWorkgroup, replica: AcAgentReplica): AgentPickerScopeContext {
   return {
     workgroupPath: wg.path,
@@ -167,9 +152,6 @@ function replicaScopeContext(wg: AcWorkgroup, replica: AcAgentReplica): AgentPic
   };
 }
 
-/** Derive scope context from a live replica session for the right-click "Coding
- *  Agent" action. Falls back to a single-path (no broad scope) context when the
- *  session is not a WG replica. */
 function deriveScopeContextFromSession(
   session: Session | undefined,
   sessionName: string,
@@ -183,7 +165,6 @@ function deriveScopeContextFromSession(
       currentProfile: session.requestedProfile,
     };
   }
-  // Workgroup dir = parent of the replica dir, preserving the original separators.
   const dirMatch = replicaPath.match(/^(.*)[\\/][^\\/]+[\\/]?$/);
   const slash = sessionName.indexOf("/");
   const wgName = slash >= 0 ? sessionName.slice(0, slash) : "";
@@ -199,9 +180,6 @@ function deriveScopeContextFromSession(
 }
 
 const CONTEXT_MENU_VIEWPORT_MARGIN = 8;
-// #977 - grace period before a pointer-leave closes the replica context menu.
-// Longer than the 180ms flyout timer: leaving the menu INTO a submenu arms both,
-// and the submenu's mouseenter must be able to cancel this one first.
 const CONTEXT_MENU_CLOSE_GRACE_MS = 250;
 
 function workgroupCollapseId(wg: AcWorkgroup, rowContext: string): string {
@@ -211,21 +189,8 @@ function workgroupCollapseId(wg: AcWorkgroup, rowContext: string): string {
   ].join(PROJECT_PANEL_COLLAPSE_KEY_SEP);
 }
 
-/**
- * #573 (grinch Step-7): upper bound for the post-assign restart await. The Tauri
- * IPC transport (`transport-tauri.ts`) has NO timeout, unlike `WsTransport.invoke`
- * (`transport-ws.ts`), which rejects after 30s with `Command timeout: <cmd>`. If
- * the backend `restart_session` neither resolves nor rejects (session-manager
- * write-lock stall, ConPTY respawn hang, dropped IPC reply), `restarting()` would
- * stay true forever and trap the modal (both buttons disabled + dismiss gated →
- * app-kill required). Racing this timeout lets the desktop modal self-heal exactly
- * as it already does on WS/remote — intentional parity, so mirror the WS value.
- * The WS 30s is a bare literal there (not exported), hence a local named const.
- */
 export const RESTART_TIMEOUT_MS = 30_000;
 
-/** #748 — resolve the repo badges' branch through the volatile live layer so a
- *  branch event updates badge text without touching row identity. */
 function configuredReplicaRepoBadgesLive(
   replica: AcAgentReplica,
   workgroup: Pick<AcWorkgroup, "repoPath">
@@ -234,11 +199,7 @@ function configuredReplicaRepoBadgesLive(
     {
       repoPaths: replica.repoPaths,
       repoBranch: effectiveRepoBranch(replica),
-      // #943 B2 - per-repo branches for cold multi-repo replicas, keyed by path.
       repoBranchByPath: effectiveRepoBranchByPath(replica),
-      // #1028 - per-repo worktree-dirty on the same cold feed. This is what turns a
-      // DORMANT coordinator row red: Gate A polls every replica whether or not a
-      // session exists.
       repoDirtyByPath: effectiveRepoDirtyByPath(replica),
     },
     workgroup
@@ -254,7 +215,6 @@ function replicaRepoMenuEntries(wg: AcWorkgroup, replica: AcAgentReplica): Sessi
   return repos.filter(hasValidRepoSourcePath);
 }
 
-/** Check if a session has a live PTY process (not exited, not offline) */
 function isSessionLive(session: Session | undefined): boolean {
   if (!session) return false;
   if (typeof session.status === "object" && "exited" in session.status) return false;
@@ -388,7 +348,6 @@ function coordinatorItemKey(item: { replica: AcAgentReplica; wg: AcWorkgroup }):
   return `${item.wg.path}\u0000${item.replica.path}`;
 }
 
-/** Get replicas in a workgroup that have active (live) sessions */
 function getActiveReplicasForWg(wg: AcWorkgroup): AcAgentReplica[] {
   return (wg.agents ?? []).filter(replica => isSessionLive(replicaSession(wg, replica)));
 }
@@ -400,30 +359,13 @@ function runningCoordinatorPeers(wg: AcWorkgroup, replica: AcAgentReplica): AcAg
 }
 
 const ProjectPanel: Component = () => {
-  // Listen for replica branch updates from the discovery watcher. TASK.md
-  // updates are wired in sidebar/App.tsx (it owns the listener for the
-  // canonical `workgroup_task_updated` event); ProjectPanel reads the
-  // resulting state through projectStore.
-  //
-  // #748 — these four events write to replicaVolatileStore, NOT projectStore.
-  // The old in-place patches rebuilt every project/workgroup reference, and the
-  // reference-keyed <For>s below then re-created the whole panel DOM per event
-  // — losing any click whose press straddled the swap. The volatile store is
-  // fine-grained (keyed by normalized replica path), so only the badge/pill
-  // reading the changed field re-runs; row identity is stable.
   let unlistenBranch: (() => void) | null = null;
   let unlistenClock: (() => void) | null = null;
   let unlistenAutoClose: (() => void) | null = null;
   let unlistenManualClose: (() => void) | null = null;
-  // #588 register this ProjectPanel as the confirm-modal host for THIS window, so
-  // the shared close helper opens the modal here (sidebar / web) but falls back to
-  // a plain destroy in a window with no host (the detached terminal webview).
   onCleanup(registerCoordinatorCloseModalHost());
   onMount(async () => {
     unlistenBranch = await onDiscoveryBranchUpdated((data) => {
-      // #943 B2 - one atomic write: the single-repo shorthand plus the per-repo
-      // branches, merged BY PATH (never by index - see the store).
-      // #1028 - per-repo dirty rides the same payload and the same atomic write.
       replicaVolatileStore.applyDiscoveryBranchUpdate(
         data.replicaPath,
         data.branch,
@@ -432,15 +374,12 @@ const ProjectPanel: Component = () => {
         data.repoDirty
       );
     });
-    // #552 coordinator idle badge + auto-closed pill. Discovery reload
-    // supersedes these overrides on any path miss (clearForPaths).
     unlistenClock = await onCoordinatorClockUpdated((data) => {
       replicaVolatileStore.setLastUserMessageAt(data.replicaPath, data.lastUserMessageAt);
     });
     unlistenAutoClose = await onCoordinatorAutoCloseChanged((data) => {
       replicaVolatileStore.setAutoClosedAt(data.replicaPath, data.autoClosedAt);
     });
-    // #588 manually-closed pill: same live layer as the auto-close marker.
     unlistenManualClose = await onCoordinatorManualCloseChanged((data) => {
       replicaVolatileStore.setManuallyClosedAt(data.replicaPath, data.manuallyClosedAt);
     });
@@ -463,20 +402,11 @@ const ProjectPanel: Component = () => {
     }));
   };
 
-  // #810 - project-level collapse lives in projectCollapseStore so the rail
-  // can drive auto-focus (collapse others, expand owner, scroll owner into
-  // view). Sub-section keys stay in the local collapsedByKey signal above.
   const isProjectPanelCollapsed = (projectPath: string) =>
     projectCollapseStore.isProjectCollapsed(projectPath);
   const toggleProjectPanelCollapsed = (projectPath: string) =>
     projectCollapseStore.toggleProjectCollapsed(projectPath);
 
-  // #537: post-assign "Restart now?" prompt. Hoisted to the stable ProjectPanel
-  // scope (NOT inside the projects <For>) so a background replica-list refresh,
-  // which replaces project object references and so re-creates each <For> row
-  // (disposing its local signals), cannot tear the modal down before the user
-  // answers. Mirrors the pendingLaunch picker below, hoisted for the same reason.
-  // The prompt closes only on Later / Restart now / overlay click.
   const [restartPrompt, setRestartPrompt] = createSignal<{
     sessionId: string;
     replicaName: string;
@@ -489,30 +419,14 @@ const ProjectPanel: Component = () => {
     teamName: string;
   } | null>(null);
   const closeEditTeamModal = () => setEditingTeamTarget(null);
-  // #573: in-flight + error state for the prompt's restart. The old code did a
-  // consume-and-clear (setRestartPrompt(null) before the async settled) with a
-  // bare `.catch(console.error)`, so a failed restart vanished silently and the
-  // user thought the new agent applied while the old one kept running. We now
-  // keep the modal open, surface the failure, and let the user retry — mirroring
-  // AgentPickerModal.apply() and Resource Monitor's confirmKill.
   const [restarting, setRestarting] = createSignal(false);
   const [restartError, setRestartError] = createSignal("");
 
-  // Restart the live session on the newly-assigned agent (same SessionAPI.restart
-  // the Restart button uses; honors currentCodingAgent, 0b03ad7). The `restarting`
-  // guard replaces the old early setRestartPrompt(null) as the double-fire guard:
-  // re-entry is refused while a restart is in flight. On success the modal closes;
-  // on failure it stays open with the error so the user can retry.
   const applyRestartPrompt = async () => {
     const prompt = restartPrompt();
     if (!prompt || restarting()) return;
     setRestarting(true);
     setRestartError("");
-    // #573 (grinch Step-7): bound the await with RESTART_TIMEOUT_MS. The Tauri IPC
-    // transport never times out, so a wedged backend would leave `restarting()`
-    // true forever and trap the modal (buttons disabled + dismiss gated). Racing a
-    // timeout guarantees `finally` runs within the bound, surfacing the error
-    // inline and re-enabling the modal — matching WsTransport.invoke's self-heal.
     let timeoutTimer: number | undefined;
     try {
       await Promise.race([
@@ -520,8 +434,6 @@ const ProjectPanel: Component = () => {
           agentId: prompt.agentId,
           requestedProfile: prompt.requestedProfile,
         }),
-        // Mirror WsTransport.invoke's reject (a bare `Command timeout: <cmd>`
-        // string) so launchErrorMessage yields identical copy on desktop and WS.
         new Promise<never>((_, reject) => {
           timeoutTimer = window.setTimeout(
             () => reject("Command timeout: restart_session"),
@@ -534,49 +446,25 @@ const ProjectPanel: Component = () => {
       console.error("Failed to restart session:", e);
       setRestartError(launchErrorMessage(e));
     } finally {
-      // Timer hygiene: cancel the pending timeout when the restart settles first,
-      // so a successful restart can't leave a dangling timer / late rejection.
       window.clearTimeout(timeoutTimer);
       setRestarting(false);
     }
   };
 
-  // Close the prompt, clearing any error. Refused while a restart is in flight so
-  // neither the Later button nor an overlay click can tear the modal down before
-  // the restart settles (the buttons are also disabled via `busy`).
   const dismissRestartPrompt = () => {
     if (restarting()) return;
     setRestartError("");
     setRestartPrompt(null);
   };
 
-  // #710: modal-open state hoisted OUT of the projects <For>. A background
-  // discovery refresh (reloadProject / branch / clock events) replaces each
-  // project object reference, so SolidJS disposes and re-creates every <For>
-  // row — and with it any signal declared inside the row callback. A modal
-  // whose open-flag lived on the row was therefore torn down mid-interaction
-  // (#710, same bug class as #537/#669). These signals live at the stable
-  // ProjectPanel scope (like pendingLaunch / restartPrompt / editingTeamTarget)
-  // and carry only STABLE identities (projectPath, loop id, session id,
-  // wg/replica path); the render blocks after the <For> re-resolve the live
-  // project/session/loop data from them, so a refresh updates the modal's data
-  // without unmounting it.
   const [newAgentTarget, setNewAgentTarget] = createSignal<{ projectPath: string } | null>(null);
   const [newTeamTarget, setNewTeamTarget] = createSignal<{ projectPath: string } | null>(null);
   const [newWorkgroupTarget, setNewWorkgroupTarget] = createSignal<{ projectPath: string } | null>(null);
   const [newLoopTarget, setNewLoopTarget] = createSignal<{ projectPath: string } | null>(null);
   const [editingLoopTarget, setEditingLoopTarget] = createSignal<{ projectPath: string; loopId: string } | null>(null);
   const [replicaCodingAgentTarget, setReplicaCodingAgentTarget] = createSignal<{ sessionId: string; sessionName: string } | null>(null);
-  // Coding Agent picker target for a gray/red (not-running) replica — #545.
-  // Carries stable paths (#710); the render block re-resolves the live wg/replica
-  // so a refresh that replaces those object refs keeps the picker open.
   const [inactiveCodingAgentTarget, setInactiveCodingAgentTarget] = createSignal<{ projectPath: string; wgPath: string; replicaPath: string } | null>(null);
 
-  // Resolve the live ProjectState for a hoisted modal from the stable path it
-  // carries. Every projectStore mutation maps over `projects` keyed by path
-  // (project.ts), so the entry stays findable across refreshes; this returns
-  // undefined only once the project is actually removed, which collapses the
-  // dependent modal (its <Show> turns falsy) — the correct "project gone" close.
   const findProjectByPath = (projectPath: string | null | undefined) => {
     if (!projectPath) return undefined;
     const normalized = normalizeProjectPathForCompare(projectPath);
@@ -585,11 +473,6 @@ const ProjectPanel: Component = () => {
     );
   };
 
-  // #710: re-resolve the live workgroup + replica for the inactive coding-agent
-  // picker from the stable identities in the target. A discovery refresh fully
-  // replaces the workgroups/agents arrays (project.ts reloadProject), so the old
-  // {wg, replica} object refs went stale and the row disposal closed the modal;
-  // matching by path re-finds them. Null (project/wg/replica gone) closes it.
   const inactiveCodingAgentResolved = createMemo(() => {
     const target = inactiveCodingAgentTarget();
     if (!target) return null;
@@ -599,9 +482,6 @@ const ProjectPanel: Component = () => {
     return proj && wg && replica ? { proj, wg, replica } : null;
   });
 
-  // #710: re-resolve the live loop for the edit-loop modal by id, so a refresh
-  // (which replaces the loops array) feeds the modal fresh data instead of
-  // disposing it. Null (loop deleted) closes the modal.
   const editingLoopResolved = createMemo(() => {
     const target = editingLoopTarget();
     if (!target) return null;
@@ -610,18 +490,6 @@ const ProjectPanel: Component = () => {
     return proj && loop ? { proj, loop } : null;
   });
 
-  // #710: top-level restart helper for the hoisted coding-agent picker's
-  // onSelect. Same bounded restart as the per-row restartReplicaSession below,
-  // minus the row-local context-menu cleanup (the menu is already gone by the
-  // time the picker resolves), so it can live at the stable ProjectPanel scope.
-  // #574 §15.1: bound the await with RESTART_TIMEOUT_MS, mirroring
-  // applyRestartPrompt. The Tauri IPC transport has no client-side timeout
-  // (transport-tauri.ts), so a wedged backend would never settle this await, the
-  // catch would never run, and NO toast would fire on desktop — the exact #574
-  // silent-failure class. WsTransport self-heals after 30s; this gives desktop
-  // the same guarantee. The bare "Command timeout: restart_session" reject
-  // string passes through launchErrorMessage verbatim, so desktop and WS get
-  // identical copy.
   const restartReplicaSessionCore = async (
     sessionId: string,
     agentId?: string,
@@ -645,8 +513,6 @@ const ProjectPanel: Component = () => {
       console.error("Failed to restart session:", e); // keep for logs
       toastStore.error(launchErrorMessage(e));
     } finally {
-      // Cancel the pending timeout when the restart settles first, so a
-      // successful restart can't leave a dangling timer / late rejection.
       window.clearTimeout(timeoutTimer);
     }
   };
@@ -655,12 +521,6 @@ const ProjectPanel: Component = () => {
     const existing = replicaSession(wg, replica);
     if (existing) {
       if (!isSessionLive(existing)) {
-        // Session exists but PTY has exited. Possible causes:
-        //  - deferred at startup by the #248 policy (non-coord, or coord that was
-        //    asleep at shutdown, or `restoreCoordinatorWakeState=false`)
-        //  - user closed it during the prior run
-        // Wake it with provider auto-resume so the prior conversation continues —
-        // this is NOT a user-intent "fresh conversation" restart.
         try {
           await SessionAPI.restart(existing.id, { skipAutoResume: false });
           if (isTauri) {
@@ -671,7 +531,6 @@ const ProjectPanel: Component = () => {
         }
         return;
       }
-      // Already instantiated and live — just switch to it
       await SessionAPI.switch(existing.id);
       if (isTauri) {
         const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
@@ -684,16 +543,6 @@ const ProjectPanel: Component = () => {
       return;
     }
 
-    // Not instantiated — create session in-place.
-    // #599 R1: a coordinator that was auto-closed (#552/#580) or manually closed
-    // (#588) is DESTROYED, so its reopen has no live/exited record and lands here
-    // instead of the restart-with-resume branch above. Both close markers are set
-    // only when AC tore down a coordinator that had been running, so their
-    // presence is the discriminator "reopen of an already-run replica" vs
-    // "genuinely fresh first launch". Carry a resume intent so the eventual
-    // create injects --continue (Claude still disk-gates it via claude_project_exists).
-    // #748: read through the volatile layer — a close event that has not been
-    // through a discovery reload yet lives only there.
     const gitRepos = buildGitRepos(replica);
     const resumeOnLaunch = !!(
       effectiveAutoClosedAt(replica) || effectiveManuallyClosedAt(replica)
@@ -773,10 +622,6 @@ const ProjectPanel: Component = () => {
       {(proj) => {
         const [showCtxMenu, setShowCtxMenu] = createSignal(false);
         const [ctxMenuPos, setCtxMenuPos] = createSignal({ x: 0, y: 0 });
-        // #710: New Agent/Team/Workgroup/Loop + Edit Loop open-state hoisted to
-        // the stable ProjectPanel scope (setNewAgentTarget/…/setEditingLoopTarget
-        // above) so a background refresh that re-creates this row can't dispose an
-        // open modal. Triggers below pass proj.path (and loop id) into them.
         const [teamCtxMenu, setTeamCtxMenu] = createSignal<{ team: AcTeam; x: number; y: number } | null>(null);
         const [deletingTeam, setDeletingTeam] = createSignal<AcTeam | null>(null);
         const [deleteError, setDeleteError] = createSignal("");
@@ -787,10 +632,6 @@ const ProjectPanel: Component = () => {
           | { kind: "inactive"; wg: AcWorkgroup; replica: AcAgentReplica; x: number; y: number }
           | null
         >(null);
-        // #710: live + inactive Coding Agent picker open-state hoisted to the
-        // stable ProjectPanel scope (replicaCodingAgentTarget /
-        // inactiveCodingAgentTarget above). The triggers below set them with
-        // stable identities (session id; project/wg/replica paths).
         const [deletingWg, setDeletingWg] = createSignal<AcWorkgroup | null>(null);
         const [wgDeleteError, setWgDeleteError] = createSignal("");
         const [wgDeleteInProgress, setWgDeleteInProgress] = createSignal(false);
@@ -812,36 +653,16 @@ const ProjectPanel: Component = () => {
         let groupFlyoutAnchorEl: HTMLElement | undefined;
         let groupFlyoutCloseTimer: number | undefined;
 
-        // #943 - repo Browse submenu.
-        //
-        // The flyout is keyed by the repo's INDEX in the open menu plus its
-        // sourcePath, and never holds a SessionRepo object: <For> is keyed by
-        // reference and the cold path (configuredReplicaRepoBadges) maps into
-        // FRESH objects on every evaluation, so a captured entry goes stale (and
-        // its <button> gets detached) whenever GitWatcher or a discovery branch
-        // event lands. The live entry is re-derived by index, identity-checked on
-        // sourcePath. Index, not label: two repos can share a label.
         const [repoFlyout, setRepoFlyout] = createSignal<{ index: number; sourcePath: string } | null>(null);
         const [repoFlyoutPos, setRepoFlyoutPos] = createSignal({ x: 0, y: 0 });
         let repoFlyoutEl: HTMLDivElement | undefined;
         let repoFlyoutAnchorEl: HTMLElement | undefined;
         let repoFlyoutCloseTimer: number | undefined;
-        // Set only while we programmatically return focus to the trigger after an
-        // Escape. Without it, `anchor.focus()` synchronously fires the trigger's
-        // onFocus, which re-opens the flyout we are trying to close.
         let suppressRepoFocusOpen = false;
 
-        // #943 - GitHub remote per repo source path, resolved once when the
-        // context menu opens. Missing key = still resolving (no arrow yet);
-        // null = resolved, no GitHub remote (no arrow, ever). `repoRemotesGen`
-        // orphans in-flight results from a menu that has already been replaced,
-        // so a stale answer cannot paint an arrow on the NEXT menu.
         const [repoRemotes, setRepoRemotes] = createSignal<Record<string, GithubRepoRef | null>>({});
         let repoRemotesGen = 0;
 
-        // Web/WS clients: `open_external_url` is a no-op stub on the host and
-        // `git_remote_url` is too (web/commands.rs), so the whole feature is
-        // desktop-only. Hide it rather than ship dead menu items.
         const browseSupported = () => isTauri;
 
         const resolveRepoRemotes = (repos: SessionRepo[]) => {
@@ -858,9 +679,6 @@ const ProjectPanel: Component = () => {
                 setRepoRemotes((prev) => ({ ...prev, [path]: parseGithubRemote(remote) }));
               })
               .catch((err) => {
-                // The command swallows every git failure into Ok(None), so a
-                // rejection here means an empty-path Err (unreachable) or a
-                // transport fault. Debug, not error: nothing is broken.
                 if (gen !== repoRemotesGen) return;
                 console.debug("[repo-browse] git_remote_url failed:", err);
                 setRepoRemotes((prev) => ({ ...prev, [path]: null }));
@@ -878,21 +696,8 @@ const ProjectPanel: Component = () => {
             { id: "main", label: "Browse Main", url: githubRepoUrl(ref) },
           ];
           const branch = repo.branch?.trim();
-          // PRODUCT RULE (user, #943), not an accident: tolerate BOTH `main` and
-          // `master`. A repo whose default branch is `master` already lands on
-          // `master` at the repo-root URL, so a second item pointing at the same
-          // page is noise. Everything else gets Browse Branch. Do NOT "fix" this
-          // back to a literal `!== "main"`.
-          //
-          // Exact match, no casefold: git refs are case-sensitive, so a branch
-          // literally named `Master` is a different, real branch and DOES get the
-          // item. "HEAD" is the detached-HEAD sentinel (both git readers map it to
-          // null; this is belt for the volatile override layer).
           if (branch && branch !== "main" && branch !== "master" && branch !== "HEAD") {
             const url = githubBranchUrl(ref, branch);
-            // null = the branch text is not a usable ref (`..`, empty). Rather
-            // than build a URL the browser would normalize into another repo, we
-            // simply do not offer the item.
             if (url) items.push({ id: "branch", label: "Browse Branch", url });
           }
           return items;
@@ -1025,9 +830,6 @@ const ProjectPanel: Component = () => {
           if (filterInputEl) focusOnMount(filterInputEl, { select: true });
         };
         const toggleFilter = () => {
-          // Magnifier acts as a toggle. Closing also drops any in-flight
-          // pattern so we never leave an active-but-hidden filter applied
-          // (the input is the only surface that reveals one is running).
           if (filterOpen()) {
             setFilterOpen(false);
             setFilterPattern("");
@@ -1086,15 +888,6 @@ const ProjectPanel: Component = () => {
           if (!regex) return true;
           return regex.test(joinSearchText(...parts));
         };
-        // Search text for the session fields visible on EVERY row that shows this
-        // session (shared by replica rows and agent SessionItems): name, agent
-        // label, and the status dot's state. Conditionally-rendered badges are
-        // contributed by the per-row callers under the gate that matches their
-        // render — repo/branch (replicaSearchText / sessionRepoSearchText) and the
-        // profile badge — so "what you match == what you see" (#515 bug 1).
-        // `shell` is dropped: it is never shown on any row. Status text comes
-        // from the same effective state as the dot, so stale live flags cannot
-        // index an exited row as waiting/pending.
         const sessionSearchText = (session: Session | undefined) => {
           if (!session) return "";
           return joinSearchText(
@@ -1103,10 +896,6 @@ const ProjectPanel: Component = () => {
             sessionEffectiveStatusSearchText(session)
           );
         };
-        // Repo/branch chips on an agent SessionItem render only for a coordinator
-        // session with repos (SessionItem gate `isCoordinator && !inactive &&
-        // gitRepos.length`). Gate the search text identically so a non-coordinator
-        // agent row is never surfaced by a branch it isn't showing (#515 bug 1).
         const sessionRepoSearchText = (session: Session | undefined) => {
           if (!session || !session.isCoordinator || session.id.startsWith("inactive-")) return "";
           return session.gitRepos.map((repo) => formatReplicaRepoBadgeLabel(repo)).join(" ");
@@ -1117,14 +906,6 @@ const ProjectPanel: Component = () => {
           if (!session.agentId) return null;
           return settingsStore.current?.agents?.find((a) => a.id === session.agentId)?.label ?? null;
         };
-        // #733/#515: single source of truth for a replica row's Coding Agent label
-        // and Profile badge, so the row render (renderReplicaItem) and the sidebar
-        // filter search text (replicaSearchText) can never diverge — a badge that is
-        // visible is always matchable. A live session wins and stays byte-identical
-        // to the pre-#733 behavior (reuses liveAgentLabel / sessionProfileBadge); a
-        // shut-down replica falls back to its persisted config (currentCodingAgentId
-        // ?? preferredAgentId — same precedence as the launch path at :616 — and
-        // currentProfile), mirroring repoBadges()' configured fallback.
         const resolveReplicaAgentLabel = (
           session: Session | undefined,
           replica: AcAgentReplica
@@ -1155,18 +936,10 @@ const ProjectPanel: Component = () => {
             taskTitle,
             stripFrontmatter(taskTitle ?? ""),
             replica.originProject ? `${replica.name}@${replica.originProject}` : replica.name,
-            // Repo/branch badges render only for coordinators (renderReplicaItem
-            // gate `isCoord() && repoBadges().length>0`). Match the same gate so a
-            // non-coordinator row is never surfaced by a badge it isn't showing
-            // (#515 bug 1).
             replica.isCoordinator
               ? repos.map((repo) => formatReplicaRepoBadgeLabel(repo)).join(" ")
               : null,
             resolveReplicaAgentLabel(session, replica),
-            // #733/#515: mirror the row badges via the shared resolvers so a dormant
-            // replica's persisted Coding Agent label + Profile letter are matchable
-            // exactly when they are visible (renderReplicaItem uses the same helpers).
-            // A live session keeps sessionProfileBadge's `X->Y` fallback text.
             resolveReplicaProfileBadge(session, replica),
             replica.isCoordinator ? "coordinator" : null,
             extraBadge,
@@ -1198,20 +971,7 @@ const ProjectPanel: Component = () => {
         const agentMatches = (agent: { name: string; path: string; preferredAgentId?: string }) => {
           const session = sessionsStore.findSessionByName(agent.name);
           const repoText = sessionRepoSearchText(session);
-          // The coding-agent badge shows the RESOLVED label (session.agentLabel,
-          // else the agentId→settings lookup). sessionSearchText only carries the
-          // raw agentLabel, so a session with a null agentLabel but a resolvable
-          // agentId would render the badge yet stay unmatchable. Include the
-          // resolved label here so the coding-agent badge is matchable wherever it
-          // renders — the headline #515 ask (filter agents by their coding agent).
-          // It is null exactly when no label resolves, i.e. when the badge is also
-          // hidden, so this never matches a badge that isn't shown.
           const codingAgentLabel = liveAgentLabel(session);
-          // On an agent SessionItem the profile badge lives inside the meta block,
-          // which renders only when an agent label resolves OR a coordinator's
-          // repos show (SessionItem outer <Show>). Mirror that gate so the filter
-          // never surfaces an agent by a profile badge it isn't showing (#515 bug
-          // 1) — unlike replica rows, which render it unconditionally.
           const metaVisible = !!codingAgentLabel || repoText !== "";
           return matchesFilterText(
             agentDisplayName(agent.name),
@@ -1256,14 +1016,6 @@ const ProjectPanel: Component = () => {
           return groupMatchesWorkgroup(wg, selected.id);
         };
         const groupVisibleWorkgroups = createMemo(() => proj.workgroups.filter(groupPredicate));
-        // Memoized so each section reads one cached pass per (filter, store)
-        // change instead of rebuilding search text + re-running regex.test on
-        // every access (these are read 3-4× per render). Dependencies are all
-        // reactive (filterPattern signal, sessionsStore, projectStore via proj),
-        // so sections still update live as the user types (#515 bug 3).
-        // NOTE: filteredCoordinatorItems is defined further down, right after the
-        // coordinatorItems memo it reads — createMemo runs eagerly, so it must
-        // follow that declaration (not lead it) to avoid a temporal dead zone.
         const filteredWorkgroups = createMemo(() => {
           const base = groupVisibleWorkgroups();
           if (!filterActive() || matchesFilterText("Workgroups")) return base;
@@ -1282,15 +1034,9 @@ const ProjectPanel: Component = () => {
           if (!wg || !groupPredicate(wg)) return false;
           return !filterActive() || matchesFilterText("Selected Workgroup") || workgroupMatches(wg, "Selected Workgroup");
         };
-        // Status line shown on each loop row — shared with the filter search
-        // text so what the regex matches always equals what the user sees.
         const loopStatusText = (loop: AcLoopSummary) =>
           loop.lastResult?.message ?? (loop.nextDueAt ? `Next: ${new Date(loop.nextDueAt).toLocaleString()}` : "No runs yet");
         const loopSearchText = (loop: AcLoopSummary) =>
-          // promptPreview is intentionally NOT matched: it renders only as the
-          // row's hover `title` (not visible text), so matching it would surface a
-          // loop with no on-screen reason — the case the comment above warned
-          // about (#515 bug 1).
           joinSearchText(
             loop.name,
             loop.workgroup,
@@ -1308,17 +1054,6 @@ const ProjectPanel: Component = () => {
         let replicaCtxMenuEl: HTMLDivElement | undefined;
         let dismissCtx: (() => void) | null = null;
 
-        // #977 - the menu closes when the pointer leaves it, after a grace period
-        // that any re-entry cancels (a quick cursor slip must not dismiss it).
-        //
-        // BOTH SUBMENUS RENDER IN THEIR OWN <Portal>, outside .session-context-menu:
-        // crossing from a submenu trigger into its flyout therefore fires the MENU's
-        // mouseleave, and a naive close would kill the menu (and the flyout with it,
-        // since the flyout Portal is a child of the menu's render block) exactly when
-        // the user reaches for it. The flyouts cancel this timer on mouseenter, so
-        // "pointer inside the menu OR inside an open submenu" reads as still-inside.
-        // Same schedule/cancel shape the flyouts already use for themselves, one
-        // level up. Click, click-outside and Escape are untouched.
         let replicaCtxMenuCloseTimer: number | undefined;
         const cancelReplicaCtxMenuClose = () => {
           if (replicaCtxMenuCloseTimer === undefined) return;
@@ -1327,11 +1062,6 @@ const ProjectPanel: Component = () => {
         };
 
         const cleanupCtx = () => {
-          // #977 - a pending pointer-leave close belongs to the menu that armed it.
-          // Every menu open handler and every dismiss path calls cleanupCtx() first,
-          // so cancelling here is what stops a stale timer from dismissing the NEXT
-          // menu (right-click a row, slide off, right-click another row inside the
-          // grace period) or from tearing that menu's dismiss listeners off with it.
           cancelReplicaCtxMenuClose();
           if (dismissCtx) {
             window.removeEventListener("click", dismissCtx);
@@ -1347,18 +1077,6 @@ const ProjectPanel: Component = () => {
           setReplicaCtxMenu(null);
           cleanupCtx();
         };
-        // A failed group action pins the Add to Group flyout open on pointer-leave
-        // (scheduleGroupFlyoutClose bails so the message stays readable). Closing the
-        // MENU would dispose that flyout and its error with it, so the close bails
-        // while the error is ON SCREEN - and the flyout is the only thing that renders
-        // one, so on screen means the flyout is open.
-        //
-        // groupFlyoutHasError() ALONE IS NOT THAT CONDITION. workgroupGroupsStore.error
-        // is a sticky PROJECT-WIDE flag: any failed groups write (another workgroup, the
-        // Edit-groups modal) or an invalid groups.toml at load sets it, and only a LATER
-        // successful save clears it. Bailing on it bare disables the pointer-leave close
-        // for every replica menu in the project, with nothing on screen to explain it,
-        // which is #977 itself reintroduced through the back door.
         const groupErrorPinned = () => groupFlyoutOpen() && groupFlyoutHasError();
         const scheduleReplicaCtxMenuClose = () => {
           cancelReplicaCtxMenuClose();
@@ -1503,14 +1221,6 @@ const ProjectPanel: Component = () => {
         const reclampRepoFlyout = () => {
           const anchor = repoFlyoutAnchorEl;
           if (!anchor?.isConnected || !repoFlyout()) return;
-          // The re-check INSIDE the deferred callback is the load-bearing one, and
-          // it is not paranoia: <For> is reference-keyed and the cold path mints
-          // fresh entry objects on every evaluation, so a GitWatcher tick or a
-          // discovery refresh re-creates the row - and detaches this anchor -
-          // between scheduling the frame and running it, while the pointer has not
-          // moved. getBoundingClientRect on a detached node is all zeros, which
-          // would fling the flyout to the top-left viewport margin. Guarding only
-          // at schedule time (as this did) never fires on that path at all.
           const clamp = () => {
             if (anchor !== repoFlyoutAnchorEl || !anchor.isConnected || !repoFlyout()) return;
             positionRepoFlyout(anchor);
@@ -1535,10 +1245,6 @@ const ProjectPanel: Component = () => {
           queueMicrotask(() => repoFlyoutEl?.querySelector("button")?.focus());
         };
 
-        /// Return focus to the trigger WITHOUT re-opening the flyout: `focus()`
-        /// fires the trigger's onFocus synchronously, and onFocus opens the
-        /// flyout. Dropping the refocus instead would strand focus on <body> and
-        /// make the menu untabbable, which is worse.
         const focusRepoTriggerQuietly = (anchor: HTMLElement | undefined) => {
           if (!anchor?.isConnected) return;
           suppressRepoFocusOpen = true;
@@ -1559,20 +1265,6 @@ const ProjectPanel: Component = () => {
           }
         };
 
-        // #943 - teardown on menu CLOSE. Covers the ~20 `setReplicaCtxMenu(null)`
-        // sites plus the window-level dismiss listener with one hook, and clears
-        // stale state so a reopened menu cannot inherit a flyout.
-        //
-        // It does NOT cover the menu -> menu switch (right-click A, then
-        // right-click B): the handlers overwrite the signal non-null -> non-null
-        // and `cleanupCtx()` has already removed the dismiss listener, so there is
-        // no null transition to observe. That case is handled in the handlers
-        // themselves (F.8), exactly as the group flyout already does it
-        // (`resetGroupMenuState()`). Both are required; neither is sufficient.
-        //
-        // Do NOT rewrite this as `createEffect(on(replicaCtxMenu, ...))`:
-        // `positionReplicaCtxMenu` rewrites the menu object on every reclamp, so
-        // an identity-keyed effect would close the flyout on churn.
         createEffect(() => {
           if (replicaCtxMenu()) return;
           closeRepoFlyout();
@@ -1587,8 +1279,6 @@ const ProjectPanel: Component = () => {
           agentId?: string,
           requestedProfile?: string | null,
         ) => {
-          // Row-local cleanup (the context menu that launched this is per-row),
-          // then defer to the hoisted core which owns the bounded restart + toast.
           setReplicaCtxMenu(null);
           cleanupCtx();
           await restartReplicaSessionCore(sessionId, agentId, requestedProfile);
@@ -1608,8 +1298,6 @@ const ProjectPanel: Component = () => {
           }
         };
 
-        // Narrow the replica context-menu union for the active vs gray/red
-        // (#545) render branches.
         const activeReplicaMenu = () => {
           const m = replicaCtxMenu();
           return m && m.kind === "active" ? m : null;
@@ -1619,11 +1307,6 @@ const ProjectPanel: Component = () => {
           return m && m.kind === "inactive" ? m : null;
         };
 
-        // Resolve any real (non-placeholder) session under this workgroup. Every
-        // replica in a workgroup shares one TASK.md and task_clean resolves it
-        // from the session cwd, so any live/exited sibling session clears the same
-        // title. This lets a never-launched (gray) replica reuse the existing
-        // session-id-based broom with no backend change (#545).
         const resolveWorkgroupSessionId = (wg: AcWorkgroup): string | null => {
           for (const peer of wg.agents) {
             const s = replicaSession(wg, peer);
@@ -1650,8 +1333,6 @@ const ProjectPanel: Component = () => {
           }
         };
 
-        // #777 F2: the built-in Non-stop slot as a flyout checkbox row. Mirrors
-        // toggleExistingGroup but targets the slot; if absent, adding materializes it.
         const nonStopChecked = (wg: AcWorkgroup) => {
           const ns = groupsConfig().nonStop;
           return !!ns && nonStopMatchesWorkgroup(ns, wg);
@@ -1847,20 +1528,7 @@ const ProjectPanel: Component = () => {
           </Show>
         );
 
-        // #943 - coordinator repo entries. Click still opens the local folder
-        // (unchanged); hover additionally opens the Browse flyout when the repo
-        // has a GitHub origin. Shared by the active and inactive menu branches.
-        //
-        // BOTH PARAMS ARE ACCESSORS, ON PURPOSE. `{helper(repoEntries(), "...")}`
-        // in JSX compiles to a tracking computation over the args, which rebuilds
-        // this entire subtree (and re-creates the <Portal>) whenever the entry
-        // list or the menu object changes identity. Passing functions gives that
-        // computation zero dependencies, so it runs once and <For> / the
-        // attribute getters do the reactive work.
         const renderRepoBrowseFlyout = (repos: () => SessionRepo[], testIdPrefix: () => string) => {
-          // The anchored entry can be re-created (cold path) or replaced
-          // (GitWatcher) while the flyout is open. Re-derive it by index every
-          // render and identity-check the sourcePath; null = it moved or vanished.
           const liveRepo = (): SessionRepo | null => {
             const fly = repoFlyout();
             if (!fly) return null;
@@ -1868,7 +1536,6 @@ const ProjectPanel: Component = () => {
             return candidate && candidate.sourcePath === fly.sourcePath ? candidate : null;
           };
 
-          // If the identity check breaks, the anchor node is gone too: close.
           createEffect(
             on(
               () => (repoFlyout() ? liveRepo() : null),
@@ -1895,9 +1562,6 @@ const ProjectPanel: Component = () => {
                       scheduleRepoFlyoutClose();
                       scheduleReplicaCtxMenuClose(); // #977 - re-armed; the menu cancels it on re-entry
                     }}
-                    // This Portal renders OUTSIDE .session-context-menu, so the
-                    // window-level dismiss listeners (bubble phase) would
-                    // otherwise see these events and kill the whole menu.
                     onClick={(e) => e.stopPropagation()}
                     onContextMenu={(e) => e.stopPropagation()}
                     onKeyDown={(e) => {
@@ -1945,8 +1609,6 @@ const ProjectPanel: Component = () => {
                         if (browseItems().length > 0) {
                           openRepoFlyout(index(), repo, e.currentTarget);
                         } else {
-                          // Moving from a browsable repo onto a non-browsable one
-                          // must not leave the previous flyout hanging.
                           closeRepoFlyout();
                         }
                       }}
@@ -1956,8 +1618,6 @@ const ProjectPanel: Component = () => {
                         if (browseItems().length > 0) openRepoFlyout(index(), repo, e.currentTarget);
                       }}
                       onKeyDown={(e) => {
-                        // Enter/Space keep the native button activation (open the
-                        // folder). Only ArrowRight enters the submenu.
                         if (e.key === "ArrowRight" && browseItems().length > 0) {
                           e.preventDefault();
                           e.stopPropagation();
@@ -2006,9 +1666,6 @@ const ProjectPanel: Component = () => {
           </>
         );
 
-        // Broom (clear task title) for a gray/red replica — reuses the
-        // active-agent TaskAPI.clean. The backend emits workgroup_task_updated,
-        // which sidebar/App.tsx applies to projectStore, refreshing the sidebar.
         const clearReplicaTaskTitle = async (wg: AcWorkgroup) => {
           setReplicaCtxMenu(null);
           cleanupCtx();
@@ -2017,9 +1674,6 @@ const ProjectPanel: Component = () => {
             if (sessionId) {
               await TaskAPI.clean(sessionId);
             } else {
-              // Cold workgroup: no live/exited session resolves the root, so
-              // address the wg-* root directly (#545). wg.path is always present
-              // (types.ts:431), even for a never-launched workgroup.
               await TaskAPI.cleanAt(wg.path);
             }
           } catch (e) {
@@ -2089,8 +1743,6 @@ const ProjectPanel: Component = () => {
 
         const hasTeams = () => proj.teams.length > 0;
         const projectAutomationId = () => automationIdPart(proj.path);
-        // #810 - the "project" section key moved to the project-collapse store.
-        // Sub-section keys below still use the local collapsedByKey signal.
         const selectedWorkgroupCollapsedKey = projectPanelCollapseKey(proj.path, "selected-workgroup");
         const workgroupsCollapsedKey = projectPanelCollapseKey(proj.path, "workgroups");
         const loopsCollapsedKey = projectPanelCollapseKey(proj.path, "loops");
@@ -2098,13 +1750,6 @@ const ProjectPanel: Component = () => {
         const teamsCollapsedKey = projectPanelCollapseKey(proj.path, "teams");
         const hasLoopTargets = () =>
           proj.workgroups.some((wg) => wg.agents.some((agent) => agent.isCoordinator));
-        // #748 — pair objects are the <For> keys of the coordinator list, so
-        // they must keep identity across memo re-runs (with coordSortByActivity
-        // on, every session busy→idle markActivity re-runs this memo; fresh
-        // pairs would dispose and re-create every coordinator row — the exact
-        // lost-click mechanism this fix removes). Reuse the cached pair while
-        // its replica+wg objects are unchanged; <For> then MOVES rows on
-        // reorder instead of re-creating them.
         const coordinatorPairCache = new Map<string, { replica: AcAgentReplica; wg: AcWorkgroup }>();
         const naturalCoordinatorItems = createMemo(() => {
           const result: { replica: AcAgentReplica; wg: AcWorkgroup }[] = [];
@@ -2166,9 +1811,6 @@ const ProjectPanel: Component = () => {
             return proj.workgroups.find(w => w.name === prev.name) ?? null;
         });
 
-        // Memoized like the other filtered collections (#515 bug 3); placed here
-        // because createMemo is eager and this reads the coordinatorItems memo
-        // defined just above.
         const filteredCoordinatorItems = createMemo(() => {
           const items = coordinatorItems();
           if (!filterActive()) return items;
@@ -2334,8 +1976,6 @@ const ProjectPanel: Component = () => {
             sessionName: session.name,
             wg,
             replica,
-            // Red/exited replicas get the full menu PLUS the broom; green/live
-            // gets the full menu with no broom (#545 rework).
             exited: !isSessionLive(session),
             x: e.clientX,
             y: e.clientY,
@@ -2355,10 +1995,6 @@ const ProjectPanel: Component = () => {
           });
         };
 
-        // Gray (never launched) replicas have no session at all, so the active
-        // menu's session-id path can't open. Show the minimal not-running menu
-        // instead: Coding Agent selector + broom. Red/exited replicas keep a real
-        // session and route to the full menu + broom instead (#545 rework).
         const handleReplicaInactiveContextMenu = (e: MouseEvent, wg: AcWorkgroup, replica: AcAgentReplica) => {
           e.preventDefault();
           e.stopPropagation();
@@ -2402,10 +2038,6 @@ const ProjectPanel: Component = () => {
           const isCoord = () => replica.isCoordinator;
           const session = () => replicaSession(wg, replica);
           const communication = createMemo(() => session()?.communication ?? null);
-          // #747: no liveness gate. A dormant restored coordinator keeps its
-          // persisted raised hand; every real-exit path clears communication
-          // and emits session_communication_changed, so exited-with-hand can
-          // only be the restored state.
           const showRaiseHand = createMemo(() =>
             isCoord() &&
             !!taskTitle &&
@@ -2418,17 +2050,6 @@ const ProjectPanel: Component = () => {
               ? s.gitRepos
               : configuredReplicaRepoBadgesLive(replica, wg);
           });
-          // #552/#580 coordinator idle badge. The value is now the unified
-          // team-idle anchor (#580): minutes since the whole team was last truly
-          // active — it pins to 0 when you message the coordinator, any member is
-          // active, or the coordinator is active. The backend carries that anchor
-          // in the EXISTING `lastUserMessageAt` field/event (rename deferred), so
-          // the FE derivation is unchanged. A createMemo (NOT an IIFE — the IIFE
-          // froze; confirmed blocker) so it subscribes to clockStore.nowMs (the
-          // live 30s tick) and settingsStore.current (threshold edits apply
-          // instantly). #748: the anchor reads through the volatile live layer
-          // (effectiveLastUserMessageAt), which the memo subscribes to — a clock
-          // event updates this badge in place instead of re-creating the row.
           const idleBadge = createMemo(() =>
             isCoord()
               ? coordinatorIdleBadge(
@@ -2438,42 +2059,12 @@ const ProjectPanel: Component = () => {
                 )
               : null
           );
-          // #552 auto-closed pill. Driven by the persisted autoClosedAt marker,
-          // read through the volatile live layer (#748). #580: MUTUALLY
-          // EXCLUSIVE with the minutes badge — when autoClosed() is true the
-          // counter is gated off (XOR below), so a closed team shows ONLY the
-          // gray AUTO-CLOSED pill; clearing the marker on reopen makes
-          // autoClosed() false and the counter returns.
-          // #589: ALSO gate on liveness. On raise the dot turns green from the
-          // sessionsStore (live session), but a discovery reload can still
-          // surface a stale marker (reloadProject supersedes the event-cleared
-          // override with a snapshot that may predate the clear), leaving the
-          // pill stuck while the dot is green. An auto-closed team is DESTROYED,
-          // so it is never live — there is no legitimate "live + auto-closed"
-          // state. Gating on `!live` hides the pill the moment the session goes
-          // live, reusing the exact signal the status dot reads, so it
-          // self-heals regardless of the stale marker; the XOR'd idle counter
-          // returns automatically. Inlined isSessionLive(session()) (===
-          // isLive() below) because createMemo runs EAGERLY and `isLive` is
-          // declared further down — calling it here would hit its temporal dead
-          // zone for a coordinator already auto-closed at mount.
           const autoClosed = createMemo(
             () => isCoord() && !!effectiveAutoClosedAt(replica) && !isSessionLive(session())
           );
-          // #588 manually-closed pill. Mirrors autoClosed, but ALSO gated on
-          // !isSessionLive(session()): a dormant coordinator has no live session
-          // so the pill shows; a reopened/raised coordinator is live so the pill
-          // hides immediately, independent of marker-clear event timing (the same
-          // stale-on-raise trap #589 fixes for AUTO-CLOSED). Use INLINE
-          // isSessionLive(session()), NOT isLive() — isLive is declared later and
-          // this memo is eager (TDZ).
           const manuallyClosed = createMemo(
             () => isCoord() && !!effectiveManuallyClosedAt(replica) && !isSessionLive(session())
           );
-          // #580 idle-badge tooltip. The auto-close clause is appended ONLY when
-          // the setting is enabled: Decision 3 keeps the badge (and its red >=60
-          // color) visible even when auto-close is OFF, where the team will NOT
-          // close — so an unconditional "auto-closes" claim would be wrong.
           const idleBadgeTitle = () =>
             "Time this team has been idle. Resets when you message the coordinator or any member is active (persists across restarts)." +
             (settingsStore.current?.coordinatorAutoCloseEnabled
@@ -2486,30 +2077,14 @@ const ProjectPanel: Component = () => {
             `replica.badges.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}`;
           const repoBadgeTestId = (label: string, index: number) =>
             `replica.repoBadge.${automationIdPart(rowContext)}.${automationIdPart(wg.name)}.${automationIdPart(replica.name)}.${index}.${automationIdPart(label)}`;
-          // #733: the Coding Agent + Profile badges fall back to the persisted
-          // replica config when there is no live session, so a shut-down replica
-          // (incl. AUTO-/MANUALLY-CLOSED coordinators — no isCoord() gate, Maria's
-          // scope decision) still shows its last agent/profile. Both the render
-          // (here) and the sidebar filter (replicaSearchText) route through the
-          // shared resolveReplica* helpers so a visible badge is always matchable
-          // (#515). The live-session branch stays byte-identical.
           const liveAgentLabel = () => resolveReplicaAgentLabel(session(), replica);
           const profileBadge = () => resolveReplicaProfileBadge(session(), replica);
-          // #1033 - the CTX badge, keyed off this replica's live session. NOT added to
-          // replicaSearchText: a 5s-volatile value is not identity, and matching it
-          // would make a filtered list rearrange itself with no user input (SS4.7).
           const ctxVisible = () =>
             contextBadgeConfigured(settingsStore.current?.agents, session()?.agentId);
           const ctxPercent = () => {
             const s = session();
             return s ? sessionsStore.contextPercentBySessionId[s.id] : undefined;
           };
-          // #548: resolver-backed tooltip naming the EFFECTIVE profile (the one
-          // actually in effect) for this session's coding agent. Plain function
-          // (NOT createMemo) — row-local and recomputes on settings reload.
-          // #733: same session-less fallback as the two helpers above — the tooltip
-          // resolves from the persisted agent id + profile letter when there is no
-          // live session (cfg-missing still short-circuits to undefined, unchanged).
           const profileBadgeTitle = () => {
             const s = session();
             const cfg = settingsStore.current?.codingAgentProfiles;
@@ -2585,9 +2160,6 @@ const ProjectPanel: Component = () => {
           const handleClose = (e: MouseEvent) => {
             e.stopPropagation();
             const s = session();
-            // #588 route through the shared helper: a coordinator close marks +
-            // (settings-gated) cascades + confirms when busy; a non-coordinator
-            // is a plain destroy inside the helper (unchanged behavior).
             if (s) void requestCoordinatorClose(s);
           };
 
@@ -2599,9 +2171,6 @@ const ProjectPanel: Component = () => {
               onClick={() => handleReplicaClick(replica, wg)}
               onContextMenu={(e) => {
                 const s = session();
-                // Any real session (green/live OR red/exited) gets the full menu;
-                // red additionally shows the broom. Only gray (no session) falls
-                // into the minimal Coding Agent + broom menu (#545 rework).
                 if (s) {
                   handleReplicaContextMenu(e, s, wg, replica);
                 } else {
@@ -2679,8 +2248,6 @@ const ProjectPanel: Component = () => {
                     <For each={repoBadges()}>
                       {(repo, index) => (
                         <span
-                          // #1028 - `=== true`, not a truthy check: `false` (clean)
-                          // and `null` (not yet detected) must both stay violet.
                           class={`ac-discovery-badge branch${repo.dirty === true ? " dirty" : ""}`}
                           title={formatReplicaRepoBadgeTitle(repo)}
                           data-ac-testid={repoBadgeTestId(repo.label, index())}
@@ -3773,10 +3340,6 @@ const ProjectPanel: Component = () => {
                   style={{ left: `${replicaCtxMenu()!.x}px`, top: `${replicaCtxMenu()!.y}px` }}
                   onClick={(e) => e.stopPropagation()}
                   onMouseEnter={cancelReplicaCtxMenuClose}
-                  // #943 - a <For> row re-created under a stationary cursor is a
-                  // detached node and can never fire its own mouseleave. This
-                  // guarantees the flyout cannot hang. The flyout's onMouseEnter
-                  // cancels the 180ms timer when crossing the 4px gap.
                   onMouseLeave={() => {
                     scheduleRepoFlyoutClose();
                     scheduleReplicaCtxMenuClose(); // #977
@@ -3784,9 +3347,6 @@ const ProjectPanel: Component = () => {
                 >
                   <Show when={activeReplicaMenu()}>
                     {(menu) => {
-                      // Broom renders in EVERY replica dot state (#545). Disabled
-                      // only when the task title has nothing to clear (empty/missing
-                      // or the literal "Clean" sentinel); enabled otherwise.
                       const broomDisabled = () => isTaskClean(menu().wg.taskTitle);
                       const broomTitle = () =>
                         broomDisabled() ? "Nothing to clear" : "Clear task title";
@@ -4108,7 +3668,6 @@ const ProjectPanel: Component = () => {
                             if (myGen !== retryGen) return;
                             console.error("delete_workgroup failed:", e);
                             const msg = typeof e === "string" ? e : e?.message ?? "Failed to delete workgroup";
-                            // BLOCKERS: sentinel — render structured blocker list, no force-delete option.
                             if (msg.startsWith("BLOCKERS:")) {
                               try {
                                 const report = JSON.parse(msg.slice("BLOCKERS:".length)) as BlockerReport;
@@ -4125,7 +3684,6 @@ const ProjectPanel: Component = () => {
                                 return;
                               }
                             }
-                            // DIRTY_REPOS: sentinel prefix — switch to force-confirm mode
                             if (!forceDelete && msg.startsWith("DIRTY_REPOS:")) {
                               setWgDeleteError(msg.slice("DIRTY_REPOS:".length));
                               setWgDirtyRepos(true);
@@ -4275,26 +3833,15 @@ const ProjectPanel: Component = () => {
           sessionName={replicaCodingAgentTarget()!.sessionName}
           agentPath={sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId)?.workingDirectory}
           currentAgentId={sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId)?.agentId}
-          // #551 FIX 2: a live session's agent IS the explicit current
-          // coding agent, so it doubles as the redundancy baseline.
           explicitCurrentAgentId={sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId)?.agentId}
           currentRequestedProfile={sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId)?.requestedProfile}
           scopeContext={deriveScopeContextFromSession(
             sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId),
             replicaCodingAgentTarget()!.sessionName,
           )}
-          // #551: re-assigning the running agent+profile is a no-op and
-          // pops a needless restart prompt — disable it with a tooltip.
           disableRedundantReplicaAssign
-          // #592: but DRIFT (loaded cell != current config) makes a same-pair
-          // re-assign meaningful (re-stamp + relaunch), so it overrides the
-          // disable. Same backend profileOutdated the badge reads.
           targetProfileOutdated={sessionsStore.sessions.find((s) => s.id === replicaCodingAgentTarget()!.sessionId)?.profileOutdated}
           onSelect={async (selection) => {
-            // The picker already persisted the selection through the backend
-            // (config write) for WG replicas. For a non-WG agent session there
-            // is no backend persist path, so apply the change by restarting with
-            // the chosen agent/profile.
             const target = replicaCodingAgentTarget();
             setReplicaCodingAgentTarget(null);
             if (!target) return;
@@ -4307,14 +3854,8 @@ const ProjectPanel: Component = () => {
               );
               return;
             }
-            // #537: WG replica was persisted but the live session still runs the
-            // old agent. Offer an immediate restart when there is a live session.
             if (shouldOfferRestartAfterAssign(selection, session)) {
               const slash = target.sessionName.lastIndexOf("/");
-              // #573: clear any error left over from a prior failed restart
-              // so a fresh prompt never opens showing a stale message. (No
-              // need to reset `restarting`: dismiss is blocked while it is
-              // true, so the picker can't reopen to reach here mid-flight.)
               setRestartError("");
               setRestartPrompt({
                 sessionId: target.sessionId,
@@ -4341,22 +3882,11 @@ const ProjectPanel: Component = () => {
             sessionName={replicaSessionName(resolved().wg, resolved().replica)}
             agentPath={resolved().replica.path}
             currentAgentId={resolved().replica.currentCodingAgentId ?? resolved().replica.preferredAgentId}
-            // #551 FIX 2: redundancy keys off the EXPLICIT currentCodingAgentId
-            // only — never the preferredAgentId hint above. A never-assigned gray
-            // replica (no currentCodingAgentId) keeps "Assign" enabled so its
-            // preferred agent can be pinned in one click.
             explicitCurrentAgentId={resolved().replica.currentCodingAgentId ?? null}
             currentRequestedProfile={resolved().replica.currentProfile ?? null}
             scopeContext={replicaScopeContext(resolved().wg, resolved().replica)}
-            // #551: pre-launch "Set Coding Agent" opens pre-selected to the
-            // replica's current pair; re-assigning it is a no-op, so disable.
             disableRedundantReplicaAssign
             onSelect={async () => {
-              // WG replica: the picker already wrote the coding-agent selection
-              // via the backend (no restart — the agent isn't running). Capture
-              // the project path BEFORE clearing the target (which collapses the
-              // resolver), then reload so the chosen agent shows and is
-              // pre-selected at first launch.
               const projectPath = resolved().proj.path;
               setInactiveCodingAgentTarget(null);
               await projectStore.reloadProject(projectPath);
@@ -4437,8 +3967,6 @@ const ProjectPanel: Component = () => {
               agentId: selection.agent.id,
               requestedProfile: selection.requestedProfile,
               gitRepos: pending.gitRepos,
-              // #599 R1: resume the prior conversation when reopening a closed
-              // coordinator; omit (default skip) for a genuinely fresh launch.
               skipAutoResume: pending.resumeOnLaunch ? false : undefined,
             });
             await SessionAPI.switch(newSession.id);

--- a/src/sidebar/components/RestartPromptModal.tsx
+++ b/src/sidebar/components/RestartPromptModal.tsx
@@ -1,22 +1,6 @@
 import { Component, Show } from "solid-js";
 import { automationAttrs } from "../../shared/automation-hooks";
 
-/**
- * #537: Post-assign confirmation. After a Coding Agent is assigned to a running WG
- * replica (replica scope), the selection is persisted but the live session keeps the
- * old agent until it restarts. This lite modal offers that restart immediately so the
- * assignment applies without a manual restart.
- *
- * Presentational only: the caller decides when to show it (a live session must exist)
- * and supplies the restart action. Mirrors the Delete-Workgroup modal shell
- * (`modal-overlay` + `agent-modal` + `new-agent-footer`).
- *
- * #573: the restart can fail (e.g. the Resource Monitor concurrency cap re-trips on
- * the relaunch). The caller drives `error`/`busy` so a rejected restart stays visible
- * — the modal keeps itself open, shows the failure, and lets the user retry, instead
- * of silently closing while the old agent still runs. Mirrors the inline-error pattern
- * in `AgentPickerModal.apply()` and Resource Monitor's `confirmKill`.
- */
 const RestartPromptModal: Component<{
   agentLabel: string;
   replicaName: string;

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -43,10 +43,6 @@ const RootAgentBanner: Component = () => {
     return !!r && sessionsStore.activeId === r.id;
   });
 
-  // Dormant root has status as `{ exited: number }` (not a string). Backend
-  // marks root exited/dormant instead of removing the record so the banner can
-  // re-wake — but PTY-dependent actions (mic, detach, telegram, close) must be
-  // hidden because there is no live PTY to receive input or attach to.
   const hasLivePty = createMemo(() => {
     const r = rootSession();
     return !!r && typeof r.status === "string";
@@ -66,9 +62,6 @@ const RootAgentBanner: Component = () => {
     const r = rootSession();
     return r ? sessionProfileBadge(r) : null;
   });
-  // #624 - mirror SessionItem's coding-agent resolver so the Root Agent row
-  // shows the same `[Coding Agent]` badge: prefer the session's own label, else
-  // resolve the configured agent's label from settings by id.
   const agentLabel = createMemo(() => {
     const r = rootSession();
     if (!r) return null;
@@ -77,8 +70,6 @@ const RootAgentBanner: Component = () => {
     return settingsStore.current?.agents?.find((a) => a.id === r.agentId)?.label ?? null;
   });
 
-  // #1033 - the CTX badge, keyed off the root session. Same shared gate as the other
-  // two surfaces; a resolver written against props.session would not compile here.
   const ctxVisible = () =>
     contextBadgeConfigured(settingsStore.current?.agents, rootSession()?.agentId);
   const ctxPercent = () => {
@@ -177,10 +168,6 @@ const RootAgentBanner: Component = () => {
       const r = rootSession();
       if (!r) {
         const session = await SessionAPI.createRootAgent();
-        // Hydrate the store: backend may reuse an existing live root and
-        // therefore NOT emit session_created (see ReuseLive in
-        // commands/session.rs). addSession upserts, so it's safe to call
-        // even when session_created later races in.
         sessionsStore.addSession(session);
         await SessionAPI.switch(session.id);
         await focusTerminal(session.id);
@@ -344,16 +331,9 @@ const RootAgentBanner: Component = () => {
     e.stopPropagation();
     const r = rootSession();
     if (!r) return;
-    // Cancel local capture before destroy: backend marks the root dormant,
-    // which hides the in-banner cancel control and leaves MediaRecorder +
-    // mic stream running. cancel() also detaches onstop so a pending
-    // transcription doesn't write to the now-dormant session.
     if (voiceRecorder.recordingSessionId() === r.id) {
       voiceRecorder.cancel();
     }
-    // Root destroy is special: backend kills PTY and marks dormant rather
-    // than removing the session record (see destroy_session_inner_with_options
-    // in commands/session.rs). The banner stays visible and can re-wake.
     SessionAPI.destroy(r.id);
   };
 
@@ -374,9 +354,6 @@ const RootAgentBanner: Component = () => {
         }
         onClick={handleClick}
         onKeyDown={(e) => {
-          // Only intercept keys aimed at the banner itself — when focus is on
-          // a child action button, that button's native handler runs and the
-          // event still bubbles here, so we must skip to avoid double-firing.
           if (e.currentTarget !== e.target) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -50,22 +50,14 @@ const SessionItem: Component<{
     return settingsStore.current?.agents?.find((a) => a.id === props.session.agentId)?.label ?? null;
   };
   const profileBadge = () => sessionProfileBadge(props.session);
-  // #1033 - settingsStore.current is a signal, so saving a pattern makes the badge
-  // appear or disappear with no reload.
   const ctxVisible = () =>
     contextBadgeConfigured(settingsStore.current?.agents, props.session.agentId);
   const ctxPercent = () => sessionsStore.contextPercentBySessionId[props.session.id];
-  // #548: unify with the ProjectPanel quick-access tooltip — resolve the name of
-  // the EFFECTIVE profile via the SAME shared resolver (no second resolver, no
-  // badge-string parsing). Plain function, matching profileBadge.
   const profileBadgeTitle = () => {
     const badge = profileBadge();
     if (!badge) return undefined;
     const cfg = settingsStore.current?.codingAgentProfiles;
     const letter = props.session.effectiveProfile || props.session.requestedProfile;
-    // Graceful degrade: before settings load there is no cfg; keep today's
-    // letter-only tooltip rather than dropping it. Once loaded, show the resolved
-    // name (same shape as the ProjectPanel quick-access tooltip).
     if (!cfg || !letter) return `Profile ${badge}`;
     return profileDisplayLabel(cfg, settingsStore.current?.agents ?? [], props.session.agentId, letter);
   };
@@ -117,8 +109,6 @@ const SessionItem: Component<{
   };
 
   const handleClick = async () => {
-    // #587 — cover an embedded RM with the terminal even when switch_session
-    // no-ops on the already-active session (which emits no session_switched).
     centralViewStore.showTerminal();
     await SessionAPI.switch(props.session.id);
     if (isTauri) {
@@ -199,9 +189,6 @@ const SessionItem: Component<{
 
   const handleClose = (e: MouseEvent) => {
     e.stopPropagation();
-    // #588 route through the shared helper: closing a coordinator from the
-    // session list marks + (settings-gated) cascades + confirms when busy. For a
-    // non-coordinator this is identical to the previous SessionAPI.destroy.
     void requestCoordinatorClose(props.session);
   };
 
@@ -282,12 +269,6 @@ const SessionItem: Component<{
 
   const isInactive = () => props.session.id.startsWith("inactive-");
 
-  /** Derive short display name from workingDirectory.
-   *  Project AC Root paths: "agent-name@origin-project" (e.g. "code-reviewer@phi_phibridge")
-   *  Other paths: "parentFolder/name" (last 2 segments)
-   *
-   *  Project AC Root parsing is delegated to extractProjectName. The innermost
-   *  .ac segment wins, matching the titlebar helpers. */
   const displayName = () => {
     const wd = props.session.workingDirectory;
     if (wd) {

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -48,10 +48,6 @@ import {
 
 type ProfileCellEnvRow = { key: string; value: string };
 
-// #576: always-visible reference for the AC path placeholders usable in a
-// profile's command and env values. The token strings are taken from the shared
-// profile-utils constants so they match the backend (placeholders.rs) byte for
-// byte; the backend stays the authority for real expansion + validation at launch.
 const AC_PLACEHOLDER_HELP = [
   "AC path placeholders (expand at launch):",
   `${AC_REPLICA_ROOT_PLACEHOLDER} — this replica's working dir`,
@@ -96,10 +92,6 @@ const API_CLIENT_EXPIRY_MS: Record<Exclude<ApiClientExpiryOption, "default">, nu
 const errorMessage = (err: unknown): string =>
   err instanceof Error ? err.message : String(err);
 
-// #526: the former "agents" + "profiles" tabs are merged into one unified
-// "Coding Agents" screen (agent list + dual comparison rails). The "profiles"
-// section name is kept as an alias so existing callers still land on the
-// unified screen. #516 adds a separate "resources" tab.
 type SettingsTab = "general" | "agents" | "resources" | "integrations";
 
 const TABS: { key: SettingsTab; label: string }[] = [
@@ -167,10 +159,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     ok: boolean;
     msg?: string;
   } | null>(null);
-  // `props.section` lets callers (e.g. disabled mic click) open on a specific
-  // tab. Invalid or absent → fall back to "general" default. The effect below
-  // also snaps to the requested section when props.section changes while the
-  // modal is already mounted (double-click on disabled mic re-targets).
   const initialTab: SettingsTab = resolveSettingsSection(props.section);
   const [activeTab, setActiveTab] = createSignal<SettingsTab>(initialTab);
   createEffect(() => {
@@ -199,9 +187,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   const [saveError, setSaveError] = createSignal("");
   const [profileCellText, setProfileCellText] = createStore<Record<string, string>>({});
   const [profileCellErrors, setProfileCellErrors] = createStore<Record<string, string>>({});
-  // Per-cell env editing draft (ordered rows). Mirrors profileCellText: keeps
-  // in-progress key/value edits stable while the underlying Record<string,string>
-  // is rebuilt on every keystroke. Keyed by `${agentId}:${letter}`.
   const [profileCellEnvRows, setProfileCellEnvRows] = createStore<Record<string, ProfileCellEnvRow[]>>({});
 
   const s = () => settings.data;
@@ -414,20 +399,10 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     }
   };
 
-  // ── #526 Config Screen: comparison pair (two rails side by side) + the agent
-  // whose inline config editor is expanded. The LEFT rail is the primary and is
-  // always filled (positional fallback to the first agent). The RIGHT rail is an
-  // explicit comparison slot: it shows exactly the agent in `rightRailId`, and is
-  // empty when that is null — so "Remove" actually clears it. Seeded once on load
-  // (onMount) rather than via an effect, so clearing it does not get re-filled.
-  // The editor is collapsed by default — the resting screen reads as the
-  // prototype (compact agent list + the two comparison rails as the protagonist).
   const [leftRailId, setLeftRailId] = createSignal<string | null>(null);
   const [rightRailId, setRightRailId] = createSignal<string | null>(null);
   const [activeAgentId, setActiveAgentId] = createSignal<string | null>(null);
 
-  // #769 Phase 2 — "Re-seed default configuration" confirm flow. `reseedTarget`
-  // holds the catalog def being re-seeded (null = modal closed).
   const [reseedTarget, setReseedTarget] = createSignal<CodingAgentDefinition | null>(null);
   const [reseeding, setReseeding] = createSignal(false);
 
@@ -443,9 +418,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   const swapRails = () => {
     const left = leftRailAgent()?.id ?? null;
     const right = rightRailAgent()?.id ?? null;
-    // #527: no-op when the right rail is empty. Swapping a null right into the
-    // left would drop the left's explicit pin to the positional fallback
-    // (agents[0]) — a surprising jump to a different agent. Keep the left pinned.
     if (right === null) return;
     setLeftRailId(right);
     setRightRailId(left);
@@ -458,15 +430,9 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     return "available";
   };
 
-  // #895 — the agent list doubles as the rail picker: clicking the first row
-  // targets the left/primary rail, clicking any later row targets the
-  // right/comparison rail.
   const railSideForIndex = (index: number): "left" | "right" =>
     index === 0 ? "left" : "right";
 
-  // What a click on that row would actually do. The head's title and
-  // `aria-disabled` are driven off this, so the row never advertises an action
-  // it will not perform.
   type RailAction = "assign" | "swap" | "none";
   const railActionFor = (agentId: string, index: number): RailAction => {
     const pill = railPillFor(agentId);
@@ -474,27 +440,16 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     return pill === "available" ? "assign" : "swap";
   };
 
-  // The two rails must never point at the same agent (`rightRailAgent()`
-  // collapses to null on a collision). So when the clicked agent already holds
-  // the *other* rail, the two exchange places instead of one stomping the other.
   const selectAgentRail = (agentId: string, index: number) => {
     const left = leftRailAgent()?.id ?? null;
     const right = rightRailAgent()?.id ?? null;
     if (railSideForIndex(index) === "left") {
       if (left === agentId) return;
-      // Row 0 already holds the comparison rail: hand the right rail the agent
-      // being displaced. A bare setLeftRailId here would leave `rightRailId`
-      // pointing at the new left agent — emptying the rail and wedging
-      // "Swap Rails", which early-returns on a null derived right.
       if (right === agentId) setRightRailId(left);
       setLeftRailId(agentId);
       return;
     }
     if (right === agentId) return;
-    // The clicked row holds the left rail. Demote it to the right and promote
-    // whatever was on the right. When the right rail is empty, `setLeftRailId(null)`
-    // hands the left back to the positional fallback (agents[0]) — never this
-    // agent, which sits at index > 0.
     if (left === agentId) setLeftRailId(right);
     setRightRailId(agentId);
   };
@@ -502,14 +457,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   const toggleAgentEditor = (agentId: string) =>
     setActiveAgentId((prev) => (prev === agentId ? null : agentId));
 
-  // Per profile-cell expand state on the Config rails. Cells can collapse to a
-  // summary row (letter + label + status badge), but start expanded by default.
-  // Keyed by `${agentId}:${letter}`.
   const [expandedCells, setExpandedCells] = createStore<Record<string, boolean | undefined>>({});
   const isCellExpanded = (agentId: string, letter: string): boolean => {
-    // Read the key directly so the store tracks it even while still unset — a
-    // hasOwnProperty short-circuit would skip the subscription and the card
-    // would never react to a later toggle. `undefined` → default expanded.
     const value = expandedCells[`${agentId}:${letter}`];
     return value === undefined ? true : value;
   };
@@ -517,8 +466,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     setExpandedCells(`${agentId}:${letter}`, !isCellExpanded(agentId, letter));
 
   onMount(async () => {
-    // #769 — populate the backend-owned coding-agent catalog for the quick-add
-    // row. Pre-seeded with the fallback, so the buttons render immediately.
     void codingAgentsStore.ensureLoaded();
     const [loaded, wsRunning, apiRunning] = await Promise.all([
       SettingsAPI.get(),
@@ -533,14 +480,11 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       setSettings("data", nextSettings);
       const loadedSeed = cloneSettings(loaded);
       setModalSeed(loadedSeed);
-      // Seed the comparison pair from the loaded agents (left primary + right
-      // comparison slot). Only when still unset, so a user's pick isn't clobbered.
       if (leftRailId() === null && loaded.agents[0]) setLeftRailId(loaded.agents[0].id);
       if (rightRailId() === null && loaded.agents[1]) setRightRailId(loaded.agents[1].id);
     }
   });
 
-  // ── Generic field updater ──
   const updateField = <K extends keyof AppSettings>(
     key: K,
     value: AppSettings[K]
@@ -550,7 +494,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     setSettings("data", key as any, value as any);
   };
 
-  // ── Agents ──
   const updateAgent = (
     index: number,
     field: keyof AgentConfig,
@@ -561,10 +504,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     setSettings("data", "agents", index, field as any, value as any);
   };
 
-  // #598 — config seed is a nested object on AgentConfig, so it cannot flow
-  // through updateAgent (scalar fields only). These setters merge the nested
-  // shape while editing; the disabled/empty case is normalized to omitted at
-  // the save choke point (settings-save.ts::normalizeAgentConfigSeed).
   const setAgentConfigSeedEnabled = (index: number, enabled: boolean) => {
     if (!settings.data) return;
     setDraftDirty(true);
@@ -653,9 +592,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
 
   type ProfileBadge = "match" | "configured" | "fallback" | "missing" | "invalid";
 
-  // #526: the data-driven taxonomy lives in profileBadgeKind() (shared 1:1 with
-  // the Selection screen so both read the same state). A live command parse error
-  // is UI-local and takes precedence here as the red "invalid" badge.
   const profileCellBadge = (agentId: string, letter: string): ProfileBadge => {
     if (profileCellErrors[profileCellKey(agentId, letter)]) return "invalid";
     return profileBadgeKind(settings.data!.codingAgentProfiles, agentId, letter);
@@ -677,10 +613,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     }));
   };
 
-  // #548: per-agent label override. Keep the WHOLE-MAP functional replacement —
-  // it creates the missing [agentId] node on an agent's first edit AND fires the
-  // top-level property signal that drives the cross-rail inherited-placeholder
-  // recompute. Do NOT "optimize" to a deep-path set (see plan §9 / §13.2).
   const updateProfileLabel = (agentId: string, letter: string, label: string) => {
     if (!settings.data) return;
     setDraftDirty(true);
@@ -704,10 +636,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     }));
   };
 
-  // #526: slot-level delete — drop the letter from profileSlots and from every
-  // coding agent's cells. produce() so the keys are actually removed; assigning a
-  // fresh object to a store path merges (keeps absent keys), which would leave the
-  // slot behind and the card would re-render as MISSING instead of vanishing.
   const removeProfileLetter = (letter: string) => {
     if (!settings.data || letter === "A") return;
     setDraftDirty(true);
@@ -724,8 +652,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
         }
       }),
     );
-    // Drop any in-progress per-cell drafts for this letter so a stale parse error
-    // can't block Save and stale env rows don't resurface.
     const suffix = `:${letter}`;
     setProfileCellText(produce((draft) => {
       for (const key of Object.keys(draft)) if (key.endsWith(suffix)) delete draft[key];
@@ -738,7 +664,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     }));
   };
 
-  // ── Profile cell command string (params appended to the agent base command, #597) ──
   const updateProfileCellCommand = (agentId: string, letter: string, text: string) => {
     const key = profileCellKey(agentId, letter);
     setDraftDirty(true);
@@ -757,7 +682,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     return profileCell(agentId, letter)?.command ?? "";
   };
 
-  // ── Profile cell env rows ──
   const cellEnvRows = (agentId: string, letter: string): ProfileCellEnvRow[] => {
     const key = profileCellKey(agentId, letter);
     if (Object.prototype.hasOwnProperty.call(profileCellEnvRows, key)) {
@@ -803,7 +727,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
   const removeCellEnvRow = (agentId: string, letter: string, rowIndex: number) =>
     setCellEnvRows(agentId, letter, cellEnvRows(agentId, letter).filter((_, i) => i !== rowIndex));
 
-  // Display-only env-row validation reusing the agent-env validator.
   const cellEnvError = (agentId: string, letter: string): string | null =>
     validateEnvRows(
       cellEnvRows(agentId, letter).map((row) => ({
@@ -829,8 +752,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           instructionsFilename: "AGENTS.md",
         };
     setSettings("data", "agents", (prev) => [...prev, agent]);
-    // A freshly added agent expands its inline editor so it is immediately
-    // editable (the resting list stays collapsed for existing agents).
     setActiveAgentId(agent.id);
   };
 
@@ -846,7 +767,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     }
   };
 
-  // ── Telegram Bots ──
   const updateBot = (
     index: number,
     field: keyof TelegramBotConfig,
@@ -894,13 +814,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     return settings.data.agents.some((a) => a.command.startsWith(command));
   };
 
-  // #769 Phase 2 — the catalog def a configured agent's command maps to IFF that
-  // command ships a re-seedable default config folder. Gating is EXACT
-  // executable-basename equality against the backend-derived reseedable set —
-  // deliberately NOT `hasAgentByCommand`'s `.startsWith` (so `pi` matches only
-  // `pi` not `pip`, and Cursor CLI `agent`/Hermes/Pi/custom get no button). The
-  // set is empty until loaded and stays empty on fetch failure, so a failure is
-  // fail-safe (no destructive button we cannot validate). Returns null → no button.
   const reseedableDefForCommand = (command: string): CodingAgentDefinition | null => {
     const basename = commandExecutableBasename(command).toLowerCase();
     if (!basename) return null;
@@ -911,7 +824,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     const def = codingAgentsStore
       .catalog()
       .find((d) => commandExecutableBasename(d.command).toLowerCase() === basename);
-    // A dest is required to name the affected folder in the confirm copy.
     return def && def.configSeed?.dest ? def : null;
   };
 
@@ -928,8 +840,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       );
       setReseedTarget(null);
     } catch (e) {
-      // Non-destructive: the server-side re-check refused or the swap failed; the
-      // prior master is intact.
       toastStore.error(`Could not re-seed ${def.label} default configuration: ${String(e)}`);
     } finally {
       setReseeding(false);
@@ -968,9 +878,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     return false;
   };
 
-  // ── Validation ──
-  // Provider resume-flag rules, shared by agent commands and profile-cell
-  // commands (#384 §2: enabled cell commands reject the same manual resume flags).
   const commandFlagError = (label: string, tokens: string[]): string | null => {
     const claudeIndex = tokens.findIndex((token) => executableTokenBasename(token) === "claude");
     if (
@@ -1002,11 +909,9 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       const flagError = commandFlagError(`Agent "${agent.label || "Unnamed"}"`, parsedCommand.argv);
       if (flagError) return flagError;
     }
-    // Live profile-cell command parse errors (red "invalid" badge) block save.
     for (const [key, error] of Object.entries(profileCellErrors)) {
       if (error) return `Profile cell ${key}: ${error}`;
     }
-    // Enabled profile-cell command + env validation (#384 §2/§3).
     const byAgent = settings.data.codingAgentProfiles.profilesByAgent;
     for (const [agentId, cells] of Object.entries(byAgent)) {
       for (const [letter, cell] of Object.entries(cells)) {
@@ -1030,9 +935,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     const data = settings.data;
     if (!data) return null;
 
-    // #565: mirror the backend (validate_resource_settings) — floor at 1, NO
-    // upper ceiling. The user sets this deliberately; the hard cap was replaced
-    // by an adjacent latency warning (see below), not a maximum.
     if (
       !Number.isInteger(data.maxConcurrentAgentProcesses) ||
       data.maxConcurrentAgentProcesses < 1
@@ -1053,11 +955,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     return null;
   };
 
-  // #552 Coordinator idle badge + auto-close thresholds. Enforced at Save (NOT
-  // inline per keystroke — the numeric inputs use the non-clamping guard so they
-  // don't fight the user mid-edit). yellow < red is required because the badge
-  // color helper tests red first, so an inverted pair makes the yellow band
-  // unreachable.
   const validateCoordinatorIdle = (): string | null => {
     const data = settings.data;
     if (!data) return null;
@@ -1101,8 +998,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     return null;
   };
 
-  // #714 Lightweight pre-check mirroring the backend MVP parser (one Ctrl/Control
-  // + one alphanumeric key). Backend stays the authority for OS registration.
   const validateScreenshotHotkey = (): string | null =>
     validateScreenshotHotkeySyntax(
       settings.data?.screenshotCaptureHotkey ?? "Ctrl+Q"
@@ -1115,7 +1010,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     validateApiServerSettings() ??
     validateScreenshotHotkey();
 
-  // ── Save ──
   const handleSave = async () => {
     if (!settings.data) return;
     const validationError = currentValidationError();
@@ -1132,18 +1026,12 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       if (wasApiServerRunning && apiServerEndpointChanged(nextSettings, seedBeforeSave)) {
         await restartApiServerAfterEndpointSave(nextSettings);
       }
-      // #158 — push soundsEnabled into sound.ts synchronously so the gate
-      // updates before the settingsStore.refresh() roundtrip below resolves.
-      // Without this, a beep emitted between this point and the next load()
-      // would see the stale gate value.
       setSoundsEnabled(nextSettings.soundsEnabled ?? true);
       if (isTauri) {
         const { getCurrentWindow } = await import("@tauri-apps/api/window");
         await getCurrentWindow().setAlwaysOnTop(nextSettings.sidebarAlwaysOnTop);
       }
-      // Refresh settings store so mic button visibility updates
       settingsStore.refresh();
-      // Refresh repos (project_paths may have changed)
       try {
         const allRepos = await ReposAPI.search("");
         sessionsStore.setRepos(allRepos.filter((r) => r.agents.length > 0));
@@ -1166,7 +1054,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     document.removeEventListener("keydown", handleKeyDown);
   });
 
-  // ── Tab renderers ──
 
   const renderGeneralTab = () => (
     <>
@@ -1943,12 +1830,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     );
   };
 
-  // Left-panel agent row: compact prototype-style header (dot, name, command
-  // basename, color swatch+hex, rail pill, delete) with the full agent config
-  // editor (#384: label/command/color/flags/env/CODEX_HOME isolation) collapsed
-  // behind the chevron. Collapsed by default — the resting screen reads as the
-  // prototype; the editor is secondary, behind the expand. #895: the head itself
-  // is the rail picker, so the editor expand lives on the chevron button.
   const renderAgentRow = (agent: AgentConfig, index: () => number) => {
     const i = () => index();
     const expanded = () => activeAgentId() === agent.id;
@@ -1986,9 +1867,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           aria-disabled={railAction() === "none"}
           onClick={() => selectAgentRail(agent.id, i())}
           onKeyDown={(e) => {
-            // The delete and chevron buttons live inside this head, and their
-            // keydown bubbles here. Only act on keys aimed at the head itself,
-            // or Enter on the trash icon would also reassign a rail.
             if (e.target !== e.currentTarget) return;
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
@@ -2024,8 +1902,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             <button
               class="settings-agent-row-delete"
               onClick={(e) => {
-                // Without this the head's click handler would also fire and
-                // assign a rail on the way out.
                 e.stopPropagation();
                 removeAgent(i());
               }}
@@ -2315,10 +2191,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     );
   };
 
-  // #769 — quick-add buttons are driven by the backend-owned catalog
-  // (`codingAgentsStore`) instead of a hand-maintained button per agent. Order,
-  // per-command `hasAgentByCommand` guards, testids, and `addAgent` are preserved
-  // verbatim; `+ Custom Agent` stays hardcoded last (it is not a catalog entry).
   const renderAgentPresets = () => (
     <div class="settings-agent-actions">
       <For each={codingAgentsStore.catalog()}>
@@ -2511,10 +2383,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     invalid: "invalid",
   };
 
-  // The cell command holds the params appended to the agent base command (#597);
-  // model/effort/sandbox are not split into separate fields (#384). The two
-  // comparison rails render the slots A..Z of two coding agents side by side;
-  // cards are addressed by rail index.
   const renderProfileCard = (agent: AgentConfig, railIndex: number, letter: string) => {
     const badge = () => profileCellBadge(agent.id, letter);
     const command = () => displayedProfileCellCommand(agent.id, letter);
@@ -2523,15 +2391,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     const expanded = () => isCellExpanded(agent.id, letter);
     const preview = () =>
       resolveProfilePreview(settings.data!.codingAgentProfiles, agent.id, letter);
-    // #538: every cell always exposes its command editor (no "Add cell" / missing
-    // box). The badge reports the real match/configured/fallback/missing state; the
-    // sub-line shows the agent base binary the cell params append to (#597), or,
-    // when no base command is set yet, the fallback/configured text, so it never
-    // contradicts a MISSING or FALLBACK badge by claiming "Configured".
     const subLine = () => {
       if (cellError()) return "Command syntax error";
-      // #597 - the binary comes from the agent base command; the cell holds only
-      // params. Show the effective binary basename, not the params text.
       const baseExe = commandExecutableBasename(agent.command);
       if (baseExe) return baseExe;
       const resolved = preview();
@@ -2674,9 +2535,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                     data-ac-role="textbox"
                   />
                   {(() => {
-                    // Accessor (not a once-computed const): <Index> keeps the row
-                    // scope alive across edits, so the origin label must re-read
-                    // row() to stay live as the user types.
                     const origin = () => profileEnvOrigin(row().key, row().value);
                     return (
                       <span
@@ -2752,9 +2610,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     );
   };
 
-  // One comparison rail = the A..Z profile slots of one coding agent. The two
-  // rails sit side by side (the comparison pair); each rail's agent is swappable
-  // via its header select or the panel-level "Swap Rails".
   const renderRail = (agent: AgentConfig | null, railIndex: number, side: "left" | "right") => {
     if (!agent) {
       return (
@@ -2844,10 +2699,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     );
   };
 
-  // #526 — the unified Coding Agents screen: compact agent list (left) + the two
-  // comparison rails (right). Replaces the former split "Coding Agents" /
-  // "Profiles" tabs. The `settings.profiles.*` test ids are kept so callers and
-  // automation that opened the old "profiles" view still resolve here.
   const renderCodingAgentsScreen = () => {
     const activeIndex = () => agentList().findIndex((a) => a.id === activeAgentId());
     const canSwap = () => agentList().length > 1;

--- a/src/sidebar/components/WorkgroupGroupRail.tsx
+++ b/src/sidebar/components/WorkgroupGroupRail.tsx
@@ -32,11 +32,7 @@ interface GroupButton {
   key: string;
   name: string;
   counter: string;
-  /** #746/#882: true when the button's workgroup set has >=1 working agent
-   *  (isSessionWorking: live + active/running, not waiting/pending). */
   working: boolean;
-  /** #763 — true when >=1 coordinator in the button's workgroup set has a
-   *  raised hand (mirrors ProjectPanel's per-row `showRaiseHand`). */
   raiseHand: boolean;
   selection: WorkgroupGroupSelection;
   workgroups: AcWorkgroup[];
@@ -46,11 +42,6 @@ interface GroupButton {
   groupIndex: number | null;
 }
 
-/** #965 — the context menu and the groups modal live at the rail root (they are
- *  shared by the project sections and the cross-project Favorites section), so a
- *  target must be stored as IDENTITY, never as a captured `ProjectState` /
- *  `WorkgroupGroup` object: `projectStore` replaces those objects on every reload,
- *  and a capture goes stale the moment discovery refreshes. */
 type RailContextTarget =
   | { kind: "project"; projectPath: string }
   | { kind: "group"; projectPath: string; groupId: string };
@@ -102,9 +93,6 @@ function tooltipFor(folderName: string, workgroups: AcWorkgroup[]): string {
     })
     .map(({ wg, replica }) => `${wgTooltipLabel(wg.name)}:(${replica.name})`);
   const body = rows.length > 0 ? rows.join("\n") : "No running agents";
-  // #965 — the rail is 68px and the project header ellipsizes, so the native
-  // multi-line `title` is the only place the full project identity can live. It
-  // is what identifies a Favorites entry's owning project without a visible label.
   return `${folderName}\n${body}`;
 }
 
@@ -121,13 +109,6 @@ function buttonContent(
   };
 }
 
-/** #965 — the rail button markup carries THREE testids, all keyed on the group id.
- *  A favorited group renders twice (Favorites + its project section), so all three
- *  would duplicate. That is a hard break, not a wart: `automation-bridge.ts` THROWS
- *  on a duplicate `data-ac-testid` rather than taking the first match, and the
- *  suites' `railButtonOrder()` / `railDots()` do document-wide PREFIX scans
- *  (`^workgroupGroups.button.` / `^workgroupGroups.dot.`) that a suffixed id would
- *  still double. Hence a DISTINCT prefix for Favorites, not a namespaced suffix. */
 type RailButtonTestIds = { button: string; raiseHand: string; dot: string };
 
 function projectRailTestIds(key: string): RailButtonTestIds {
@@ -147,9 +128,6 @@ function favoriteRailTestIds(folderName: string, groupId: string): RailButtonTes
   };
 }
 
-/** #965 — lifted out of the `buttons` memo so the cross-project Favorites section
- *  can build an identical button for a group it does not own. `reorderable` is a
- *  parameter, and Favorites MUST pass `false` (see the reorder invariants). */
 function groupButtonFor(
   project: ProjectState,
   group: WorkgroupGroup,
@@ -169,9 +147,6 @@ function groupButtonFor(
   };
 }
 
-/** #965 — was a closure inside `ProjectRailSection`; both sections need it now.
- *  Both copies of a favorited group highlight simultaneously, which is correct:
- *  it is one group. */
 function isSelected(projectPath: string, button: GroupButton): boolean {
   if (!workgroupGroupsStore.isActiveProject(projectPath)) return false;
   const current = workgroupGroupsStore.selection(projectPath);
@@ -179,18 +154,8 @@ function isSelected(projectPath: string, button: GroupButton): boolean {
   return current.kind !== "group" || button.selection.kind !== "group" || current.id === button.selection.id;
 }
 
-/** #965 — the existing group-button onClick body, parameterized by project so a
- *  Favorites click behaves identically (you clicked a group of project B, so the
- *  main panel focuses B).
- *
- *  RC-2: the two `projectCollapseStore` calls drive the **ProjectPanel** (#810
- *  auto-focus) and are unchanged. They must NEVER touch `railCollapseStore`: the
- *  rail folds only on an explicit header click. */
 function selectFromRail(project: ProjectState, selection: WorkgroupGroupSelection): void {
   workgroupGroupsStore.select(project.path, selection);
-  // Collapse every other loaded project and expand this owner on every click. Use
-  // the live project list because a fresh session has no collapse-map entries.
-  // Scrolling is owned separately by SidebarApp's primitive semantic-key effect.
   projectCollapseStore.collapseAllExceptKnown(
     project.path,
     projectStore.projects.map((p) => p.path)
@@ -198,10 +163,6 @@ function selectFromRail(project: ProjectState, selection: WorkgroupGroupSelectio
   projectCollapseStore.setProjectCollapsed(project.path, false);
 }
 
-/** #965 — the rail button markup, extracted verbatim so Favorites renders an
- *  identical button. The pointer handlers and `onRef` are OPTIONAL: Favorites
- *  passes none, so a favorite never enters a `groupButtonEls` map, never arms a
- *  drag, and never gets the `reorderable` class (and its `cursor: grab`). */
 const RailButton: Component<{
   button: GroupButton;
   testIds: RailButtonTestIds;
@@ -258,9 +219,6 @@ const RailButton: Component<{
       <span
         class="workgroup-group-rail-title"
         classList={{
-          // #775 — built-in/system groups (All, Ungrouped, …) render bold to stand
-          // out from user-created groups. Gated on the selection kind, not the
-          // display name, so a user group named "All" stays normal weight.
           "workgroup-group-rail-title-system": props.button.selection.kind !== "group",
         }}
       >
@@ -279,19 +237,12 @@ const RailButton: Component<{
   </button>
 );
 
-/** #965 — the cross-project Favorites section. Pinned OUTSIDE
- *  `.workgroup-group-rail-scroll` at the top, mirroring how #881 pinned Archive at
- *  the bottom: that is what makes it permanently visible. */
 const FavoritesRailSection: Component<{
   projects: ProjectState[];
   onOpenContextMenu: (event: MouseEvent, target: RailContextTarget) => void;
 }> = (props) => {
   const collapsed = () => railCollapseStore.isFavoritesCollapsed();
 
-  // Iterate `props.projects`, never a global list: an archived/hidden project has
-  // no rail section and must not contribute favorites. A project whose rail section
-  // is COLLAPSED still contributes, because `ensureLoaded` lives outside the
-  // collapse `<Show>` — that is what makes a collapsed project's favorites visible.
   const entries = createMemo(() =>
     props.projects.flatMap((project) =>
       workgroupGroupsStore
@@ -349,9 +300,6 @@ const ProjectRailSection: Component<{
   });
 
   const config = () => workgroupGroupsStore.config(props.project.path);
-  // #965 — the RAIL's own collapse (RC-1), never the ProjectPanel's. The only
-  // `projectCollapseStore` reference left in this file is the #810 auto-focus pair
-  // inside `selectFromRail`, which drives the ProjectPanel and is unchanged.
   const collapsed = () => railCollapseStore.isProjectCollapsed(props.project.path);
   const ungroupedWorkgroups = createMemo(() =>
     props.project.workgroups.filter(
@@ -364,11 +312,6 @@ const ProjectRailSection: Component<{
       result.push({
         key: "all",
         ...buttonContent("All", props.project.workgroups),
-        // #775 — the built-in "All" group never shows the raise-hand indicator,
-        // under any condition (even when a member workgroup's coordinator has a
-        // raised hand). Gated here on the statically-built "all" entry, not on
-        // the display name, so a user group coincidentally named "All" is
-        // unaffected. Ungrouped + dynamic groups keep their aggregation below.
         raiseHand: false,
         selection: { kind: "all" },
         workgroups: props.project.workgroups,
@@ -391,10 +334,6 @@ const ProjectRailSection: Component<{
         groupIndex: null,
       });
     }
-    // #777: the built-in Non-stop group pins directly after Ungrouped (or after
-    // All when Ungrouped is hidden, or first when both are hidden), before the
-    // user groups. Reuses buttonContent/tooltipFor so its counter + running dot
-    // render identically to every other button.
     const nonStop = config().nonStop;
     if (nonStop?.show) {
       const workgroups = props.project.workgroups.filter((wg) =>
@@ -440,9 +379,6 @@ const ProjectRailSection: Component<{
     setReorderState(null);
   };
 
-  // #965 — this section owns the reorder gesture, so it cancels the drag before
-  // delegating to the rail root (which owns the menu). preventDefault /
-  // stopPropagation live in the root's handler.
   const openContextMenu = (event: MouseEvent, target: RailContextTarget) => {
     cancelReorder(true);
     props.onOpenContextMenu(event, target);
@@ -457,37 +393,16 @@ const ProjectRailSection: Component<{
 
   const targetIndexForPointer = (clientY: number, groupId: string): number | null => {
     if (!projectEl) return null;
-    // #965 G2 — a collapsed section has no drop targets at all.
-    //
-    // UNREACHABLE today, deliberately: RC-1 makes the header's onClick the only
-    // mutator of rail collapse, and G3 cancels the drag there BEFORE the toggle, so
-    // `collapsed()` is never true while a reorder is in flight. Nor is there a
-    // partially-unmounted frame in between — Solid disposes the <Show> synchronously
-    // inside the click task. G1 below is the guard that actually fires in production.
-    //
-    // Kept as the backstop for a future mutator that folds outside the header path.
-    // Deliberately pinned by NO test: reaching it requires manufacturing a state the
-    // design forbids, and a test for that would calcify it.
     if (collapsed()) return null;
     const projectRect = projectEl.getBoundingClientRect();
     if (clientY < projectRect.top || clientY > projectRect.bottom) return null;
 
     const candidates = Array.from(groupButtonEls.entries())
       .filter(([id]) => id !== groupId)
-      // Solid does not null out `ref` callbacks on disposal, so this map retains
-      // detached elements whose getBoundingClientRect() is all zeros. Necessary,
-      // but NOT sufficient — see G1. Do not remove it.
       .map(([id, el]) => ({ id, rect: el.getBoundingClientRect() }))
       .filter(({ rect }) => rect.height > 0)
       .sort((a, b) => a.rect.top - b.rect.top);
 
-    // #965 G1 (root fix) — "no candidates" means "nothing to drop onto", NOT "drop
-    // at index 0". Falling through to `return candidates.length` (= 0) here would
-    // splice the dragged group to the front and PERSIST it: a drag in flight whose
-    // buttons unmount mid-gesture (a header click) would silently reorder the
-    // project. The only pre-existing empty case is a single-group project, where
-    // sourceIndex is 0 anyway and the reorder was already a no-op, so null is
-    // equally correct there.
     if (candidates.length === 0) return null;
 
     for (let index = 0; index < candidates.length; index++) {
@@ -513,7 +428,6 @@ const ProjectRailSection: Component<{
     try {
       event.currentTarget.setPointerCapture?.(event.pointerId);
     } catch {
-      // Window-level pointerup/pointercancel fallback still unwinds the gesture.
     }
 
     setReorderState({
@@ -579,7 +493,6 @@ const ProjectRailSection: Component<{
       try {
         await workgroupGroupsStore.reorderGroup(props.project.path, current.groupId, dropTargetIndex);
       } catch {
-        // The store already exposes the save error.
       } finally {
         setReorderState(null);
       }
@@ -659,10 +572,6 @@ const ProjectRailSection: Component<{
           title={props.project.path}
           aria-expanded={!collapsed()}
           onClick={() => {
-            // #965 G3 — cancel any in-flight drag BEFORE the toggle unmounts the
-            // buttons, so the trailing pointerup cannot resolve a drop against an
-            // empty candidate list. Same one-liner the context menu already uses.
-            // suppressClick=true is correct: the gesture was a drag, not a click.
             cancelReorder(true);
             railCollapseStore.toggleProjectCollapsed(props.project.path);
           }}
@@ -693,9 +602,6 @@ const ProjectRailSection: Component<{
               onContextMenu={(event) =>
                 openContextMenu(
                   event,
-                  // Pseudo-entries (All / Ungrouped / Alert me!) have `groupId: null`
-                  // and cannot be favorited, so they open the project menu (Edit only).
-                  // Gated on the id, never on the display name.
                   button.groupId
                     ? { kind: "group", projectPath: props.project.path, groupId: button.groupId }
                     : { kind: "project", projectPath: props.project.path }
@@ -730,9 +636,6 @@ const ProjectRailSection: Component<{
 
 const WorkgroupGroupRail: Component<WorkgroupGroupRailProps> = (props) => {
   const [showArchived, setShowArchived] = createSignal(false);
-  // #965 — the menu and the groups modal are hoisted here from ProjectRailSection:
-  // Favorites is cross-project and needs the same menu, and one <Portal> + one set
-  // of window dismiss listeners beats N of them.
   const [contextTarget, setContextTarget] = createSignal<RailContextTarget | null>(null);
   const [contextMenuPos, setContextMenuPos] = createSignal({ x: 0, y: 0 });
   const [editingProjectPath, setEditingProjectPath] = createSignal<string | null>(null);
@@ -743,8 +646,6 @@ const WorkgroupGroupRail: Component<WorkgroupGroupRailProps> = (props) => {
     workgroupGroupsStore.reconcileActiveProject(props.projects.map((project) => project.path));
   });
 
-  // Resolved LIVE from props.projects, never from a capture, so the modal header
-  // cannot go stale after a discovery refresh (and it closes if the project dies).
   const editingProject = createMemo(() => {
     const path = editingProjectPath();
     return path ? (props.projects.find((project) => project.path === path) ?? null) : null;
@@ -787,7 +688,6 @@ const WorkgroupGroupRail: Component<WorkgroupGroupRailProps> = (props) => {
       cleanupContextMenu();
     };
     dismissContextMenu = dismiss;
-    // Deferred so the opening `contextmenu` event does not dismiss its own menu.
     setTimeout(() => {
       positionContextMenu(event.clientX, event.clientY);
       window.addEventListener("click", dismiss);
@@ -801,17 +701,6 @@ const WorkgroupGroupRail: Component<WorkgroupGroupRailProps> = (props) => {
     cleanupContextMenu();
   };
 
-  // #965 — the menu/modal now outlive the section that opened them (they live at the
-  // rail root). Drop a target whose project has left `props.projects`, OR whose group
-  // has left that project's config — a cross-window delete kills the group while the
-  // project lives, and that is the commoner case. Without this the menu offers
-  // "Favorite" on a dead group and the click is a silent no-op (the throw precedes
-  // any setEntries, so no `!` indicator ever appears). Mirrors the groupButtonEls
-  // prune effect in ProjectRailSection.
-  //
-  // NOT a write barrier: a `WorkgroupGroupsModal.save()` already in flight still
-  // lands. That is harmless (the store never evicts entries, so the modal seeded from
-  // the real config and rewrites the same groups), but nobody should believe otherwise.
   createEffect(() => {
     const live = new Set(props.projects.map((project) => project.path));
     const target = contextTarget();
@@ -830,8 +719,6 @@ const WorkgroupGroupRail: Component<WorkgroupGroupRailProps> = (props) => {
 
   onCleanup(cleanupContextMenu);
 
-  // Read from the store at render, never from a capture, so the label is correct
-  // after an external update (another window favoriting the same group).
   const favoriteTargetIsFavorited = () => {
     const target = contextTarget();
     if (target?.kind !== "group") return false;
@@ -855,8 +742,6 @@ const WorkgroupGroupRail: Component<WorkgroupGroupRailProps> = (props) => {
     void workgroupGroupsStore
       .setGroupFavorite(target.projectPath, target.groupId, next)
       .catch(() => {
-        // A save failure surfaces through workgroupGroupsStore.error(path), which the
-        // project section renders as the `!` badge.
       });
   };
 

--- a/src/sidebar/components/replica-repo-badges.ts
+++ b/src/sidebar/components/replica-repo-badges.ts
@@ -20,22 +20,6 @@ export function formatReplicaRepoBadgeLabel(repo: Pick<SessionRepo, "label" | "b
   return `${repo.label}${repo.branch ? `/${repo.branch}` : ""}`;
 }
 
-/**
- * #1028 - the badge tooltip, and the ONLY surface where all three dirty states are
- * distinguishable. Colour is a binary alarm at 8px (red = uncommitted work, violet =
- * everything else), so `false` ("detected clean") and `null` ("no answer yet") are
- * byte-identical on screen; this is what tells them apart, and what makes a
- * `?? null` -> `|| null` slip in the store observable at all.
- *
- * "(status unknown)" is the NORMAL startup state, not an error: a cold row shows it
- * until the first Gate A tick (<=15s) and a live row until the first GitWatcher tick
- * (<=5s). It is the first thing a user sees on every launch, so the wording says "not
- * yet known" rather than implying a fault.
- *
- * A third badge COLOUR was rejected: this codebase renders unknown as absence, never
- * as its own colour, and a third colour would advertise a transient internal failure
- * the user can do nothing about.
- */
 export function formatReplicaRepoBadgeTitle(repo: Pick<SessionRepo, "sourcePath" | "dirty">): string {
   if (repo.dirty === true) return `${repo.sourcePath} (uncommitted changes)`;
   if (repo.dirty === false) return repo.sourcePath;
@@ -44,12 +28,7 @@ export function formatReplicaRepoBadgeTitle(repo: Pick<SessionRepo, "sourcePath"
 
 export function configuredReplicaRepoBadges(
   replica: Pick<AcAgentReplica, "repoPaths" | "repoBranch"> & {
-    /** #943 B2 - live per-repo branches. Optional: absent before the first branch
-     *  event, and absent for callers that do not read the volatile layer. */
     repoBranchByPath?: RepoBranchByPath;
-    /** #1028 - live per-repo worktree-dirty. Optional for the same two reasons: the
-     *  callers that only read `label`/`branch` (menu entries, search text) pass
-     *  nothing and every repo resolves to `dirty: null`, which they ignore. */
     repoDirtyByPath?: RepoDirtyByPath;
   },
   workgroup: Pick<AcWorkgroup, "repoPath">
@@ -60,35 +39,17 @@ export function configuredReplicaRepoBadges(
     : workgroup.repoPath
       ? [workgroup.repoPath]
       : [];
-  // Pre-B2 shorthand: discovery detects a branch only for a SINGLE-repo replica
-  // (ac_discovery.rs `repo_paths.len() == 1`), so a multi-repo replica had none.
-  // It stays as the fallback for any repo the per-repo layer has not covered: the
-  // window between project load and the first watcher tick (<=15s), the legacy
-  // workgroup.repoPath source above, or a repo added to config.json since the last
-  // tick. NOT after a reload: `clearForPaths` deliberately preserves the per-repo
-  // map, because discovery has no counterpart to re-supply it (H1).
   const singleRepoBranch = sourcePaths.length === 1 ? replica.repoBranch ?? null : null;
   const byPath = replica.repoBranchByPath;
   const dirtyByPath = replica.repoDirtyByPath;
 
   return sourcePaths
     .map((sourcePath) => {
-      // #943 B2 - keyed BY PATH, never by position. The branch payload is stored
-      // and re-read against a LATER discovery snapshot, so if config.json `repos`
-      // is reordered or an entry removed, a positional merge would paint repo A's
-      // branch onto repo B and Browse Branch would open a branch that does not
-      // belong to that repo. A path miss yields no branch instead.
-      // `undefined` = unknown path (fall back); `null` = known, no branch (mask).
       const live = byPath?.[sourcePath];
       return {
         label: repoLabelFromPath(sourcePath),
         sourcePath,
         branch: live === undefined ? singleRepoBranch : live,
-        // #1028 - there is NO single-repo shorthand for dirty (discovery never had a
-        // scalar dirty the way it had `repoBranch`), so a path miss resolves to
-        // `null` = "never detected" = violet, never to a fallback. `?? null` maps
-        // only the miss; a detected `false` passes through as `false`, which the
-        // badge title reports differently from `null`.
         dirty: dirtyByPath?.[sourcePath] ?? null,
       };
     })

--- a/src/sidebar/components/session-context.ts
+++ b/src/sidebar/components/session-context.ts
@@ -1,23 +1,5 @@
 import type { AgentConfig } from "../../shared/types";
 
-/**
- * #1033 - no regex configured for this session's agent => no badge at all. Not N/A,
- * not a chip, no visual noise. One resolver for all three surfaces, mirroring #548's
- * rule for the profile tooltip: no second resolver, or the three drift.
- *
- * Takes its inputs as arguments rather than reading a session, because the three
- * surfaces reach their session three different ways (`props.session` in SessionItem,
- * `rootSession()` in RootAgentBanner, `session()` in ProjectPanel); a gate written
- * against one of them compiles in exactly one of them.
- *
- * The `.trim()` here is a VISIBILITY test only and never touches a stored or
- * transmitted value - the stored pattern is byte-for-byte what the user typed, and
- * its leading whitespace is load-bearing. This exists so a legacy file hand-edited
- * to `"contextRegex": "   "` does not show a permanent `N/A`.
- *
- * Keys by agent id and never by `command`: two agents may share `"command": "claude"`
- * while only one configures a pattern.
- */
 export function contextBadgeConfigured(
   agents: AgentConfig[] | undefined,
   agentId: string | null | undefined,
@@ -26,19 +8,6 @@ export function contextBadgeConfigured(
   return !!agents?.find((a) => a.id === agentId)?.contextRegex?.trim();
 }
 
-/**
- * #1033 Presentation projection: a context reading -> badge text. Total.
- * Editing a value here changes pixels only; no behavior reads this string.
- *
- * Deliberately NOT injective: `null` (the engine says unavailable) and `undefined`
- * (no event and no snapshot has spoken for this session yet) both map to `CTX N/A`,
- * because unavailable is exactly one thing.
- *
- * The `=== null || === undefined` test is deliberate and must not be "simplified" to
- * a truthiness check: `0` is a REAL reading and renders `CTX 0%`. A `percent ? ... :`
- * here turns a true zero into `N/A`, keeps every other case working, and is invisible
- * on screen.
- */
 export function contextBadgeText(percent: number | null | undefined): string {
   if (percent === null || percent === undefined) return "CTX N/A";
   return `CTX ${percent}%`;

--- a/src/sidebar/components/settings-save.ts
+++ b/src/sidebar/components/settings-save.ts
@@ -1,17 +1,5 @@
 import type { AgentConfig, AppSettings } from "../../shared/types";
 
-/**
- * #529 (G3) — normalize the optional instructions filename to an honest stored
- * shape: trim a set value, and drop the field entirely when it is empty or
- * whitespace. The Config Screen input binds `value={agent.instructionsFilename
- * ?? ""}` and stores the raw string, so clearing it yields `Some("")`, which
- * Rust's `skip_serializing_if = "Option::is_none"` does NOT omit — it would
- * persist `"instructionsFilename": ""`, contradicting the "never persist a
- * sentinel" rule. Normalizing here, at the single save choke point, keeps the
- * per-keystroke `updateAgent` setter untouched and guarantees `""` never
- * reaches the backend. The backend stays tolerant either way (it trims an
- * empty value back to the command-derived default at launch).
- */
 function normalizeAgentInstructionsFilename(agent: AgentConfig): AgentConfig {
   const trimmed = agent.instructionsFilename?.trim();
   if (trimmed) return { ...agent, instructionsFilename: trimmed };
@@ -19,18 +7,6 @@ function normalizeAgentInstructionsFilename(agent: AgentConfig): AgentConfig {
   return rest;
 }
 
-/**
- * #598 — normalize the optional config-folder seed to an honest stored shape.
- * The Coding Agents tab keeps `configSeed` as a live object while editing (so
- * the dest input and the enable toggle stay bound), but the backend uses
- * `#[serde(skip_serializing_if = "Option::is_none")]`: an inactive seed
- * (disabled, or an empty/whitespace `dest`) must serialize as omitted, not as
- * `{enabled:false}` or `{dest:""}`. Drop it unless it is genuinely active and
- * trim the kept `dest`, mirroring normalizeAgentInstructionsFilename. The
- * backend independently re-validates an active dest at save (rejecting
- * separators, `..`, `:`, etc.) and fails soft at launch, so this only governs
- * the persisted shape, never the validation.
- */
 function normalizeAgentConfigSeed(agent: AgentConfig): AgentConfig {
   const dest = agent.configSeed?.dest?.trim();
   if (agent.configSeed?.enabled && dest) {
@@ -40,31 +16,12 @@ function normalizeAgentConfigSeed(agent: AgentConfig): AgentConfig {
   return rest;
 }
 
-/**
- * #1033 - normalize the optional context regex. Mirrors
- * normalizeAgentInstructionsFilename's CONTRACT (drop the key rather than persist
- * an empty-string sentinel, since Rust's skip_serializing_if = "Option::is_none"
- * does not omit Some("")) but deliberately NOT its trim.
- *
- * A regex's leading whitespace is load-bearing: a user who writes the column-2
- * anchor as two literal spaces instead of `^ {2}` has it silently deleted by a
- * trim, and the pattern then matches agent prose anywhere on the row. Measured
- * against regex 1.12.3: trimming turns the typed-in-the-input-box false positive
- * from None into Some(99) while the real statusline keeps reading correctly, so
- * the damage is invisible in every normal case. Whitespace-only is still dropped
- * (it cannot compile: no capture group), so the sentinel rule is unaffected.
- */
 function normalizeAgentContextRegex(agent: AgentConfig): AgentConfig {
   if (agent.contextRegex && agent.contextRegex.trim()) return agent; // kept BYTE-FOR-BYTE
   const { contextRegex: _drop, ...rest } = agent;
   return rest;
 }
 
-/**
- * #868 - normalize the optional runtime backend. The editor preserves a hidden
- * image in the live draft while toggling Container <-> Local, but Local must
- * persist exactly like the historical default: no `backend` object at all.
- */
 function normalizeAgentBackend(agent: AgentConfig): AgentConfig {
   const kind = agent.backend?.kind ?? "localProcess";
   if (kind === "localProcess") {

--- a/src/sidebar/components/workgroup-session.ts
+++ b/src/sidebar/components/workgroup-session.ts
@@ -24,10 +24,6 @@ export function findReplicaSession(wg: AcWorkgroup, replica: AcAgentReplica): Se
   );
 }
 
-/**
- * #882 Domain predicate over session state. Replaces the pre-#882 dot-class
- * predicate. Same answer for every at-rest store state.
- */
 export function isReplicaWorking(wg: AcWorkgroup, replica: AcAgentReplica): boolean {
   return isSessionWorking(findReplicaSession(wg, replica));
 }
@@ -36,14 +32,6 @@ export function workgroupIsWorking(wg: AcWorkgroup): boolean {
   return wg.agents.some((replica) => isReplicaWorking(wg, replica));
 }
 
-/**
- * #777/#882 parity primitive. The rail counter and the non-stop watchdog both
- * partition their workgroup list with this one function, in one traversal,
- * preserving input order. Do not reimplement either side with filter().
- *
- * Must be called inside a reactive scope. It reads sessionsStore through
- * findReplicaSession; caching its result at module scope silently kills tracking.
- */
 export function splitWorkgroupsByWorking(
   workgroups: readonly AcWorkgroup[]
 ): { working: AcWorkgroup[]; notWorking: AcWorkgroup[] } {
@@ -55,17 +43,6 @@ export function splitWorkgroupsByWorking(
   return { working, notWorking };
 }
 
-/**
- * #763 — true when this replica is a coordinator currently showing a raised
- * hand. Mirrors ProjectPanel's per-row `showRaiseHand` predicate exactly so the
- * group-tab badge lights iff a coordinator row shows the hand:
- *  - no liveness gate — #747 keeps a restored/dormant coordinator's persisted
- *    hand visible (every real-exit path clears communication), so the tab must
- *    light for those too;
- *  - the `wg.taskTitle` gate matches the coordinator quick-list row, which only
- *    renders the hand inside its task line (`renderReplicaItem(..., wg.taskTitle,
- *    "quick")`).
- */
 export function replicaHasRaisedHand(wg: AcWorkgroup, replica: AcAgentReplica): boolean {
   if (!replica.isCoordinator) return false;
   if (!wg.taskTitle) return false;
@@ -73,7 +50,6 @@ export function replicaHasRaisedHand(wg: AcWorkgroup, replica: AcAgentReplica): 
   return communication?.kind === "raiseHand" && communication?.visible === true;
 }
 
-/** #763 — true when any coordinator in the workgroup has a raised hand. */
 export function workgroupHasRaisedHand(wg: AcWorkgroup): boolean {
   return wg.agents.some((replica) => replicaHasRaisedHand(wg, replica));
 }

--- a/src/sidebar/stores/coding-agents.ts
+++ b/src/sidebar/stores/coding-agents.ts
@@ -3,34 +3,14 @@ import type { CodingAgentDefinition } from "../../shared/types";
 import { CodingAgentsAPI } from "../../shared/ipc";
 import { FALLBACK_CODING_AGENTS } from "../../shared/agent-presets";
 
-/**
- * #769 — the coding-agent catalog consumed by OnboardingModal and SettingsModal.
- * Mirrors `workgroupGroupsStore.ensureLoaded`: the signal is seeded SYNCHRONOUSLY
- * with `FALLBACK_CODING_AGENTS`, so the onboarding/settings agent list is never
- * blank for even one frame (the "never-empty" guarantee comes from the initial
- * value, not a loading branch). `ensureLoaded()` fetches once (in-flight dedup +
- * `loaded` guard); on transport failure it KEEPS the fallback, logs, and marks
- * loaded — it never throws to the component.
- *
- * A valid `Ok([])` from the backend (the user removed every built-in) is honored
- * verbatim — the fallback is NOT resurrected on a successful empty response, only
- * on reject/pending. Onboarding stays actionable because the modal appends its
- * own "Custom Agent" entry client-side.
- */
 const [catalog, setCatalog] = createSignal<CodingAgentDefinition[]>(FALLBACK_CODING_AGENTS);
-// #769 Phase 2 — command basenames that ship a re-seedable default config master.
-// Init EMPTY and stay empty on any fetch failure: the re-seed button is a
-// destructive action, so we never offer it for a set we could not validate (no
-// hardcoded fallback here, unlike the catalog).
 const [reseedableCommands, setReseedableCommands] = createSignal<string[]>([]);
 const [loaded, setLoaded] = createSignal(false);
 let inFlight: Promise<void> | null = null;
 
 export const codingAgentsStore = {
-  /** Reactive catalog. Starts as `FALLBACK_CODING_AGENTS`; replaced once loaded. */
   catalog,
   loaded,
-  /** Reactive re-seedable command-basename set. Empty until loaded, empty on failure. */
   reseedableCommands,
 
   async ensureLoaded(): Promise<void> {
@@ -39,27 +19,20 @@ export const codingAgentsStore = {
 
     inFlight = (async () => {
       try {
-        // Independent failure domains: a catalog failure keeps the fallback list,
-        // a reseedable failure leaves the set empty (no buttons). Neither blocks
-        // the other. `allSettled` never rejects; the outer try also contains any
-        // synchronous throw so ensureLoaded can never reject into its caller.
         const [catalogRes, reseedableRes] = await Promise.allSettled([
           Promise.resolve().then(() => CodingAgentsAPI.getCatalog()),
           Promise.resolve().then(() => CodingAgentsAPI.listReseedableCommands()),
         ]);
 
         if (catalogRes.status === "fulfilled") {
-          // Honor a valid empty list verbatim (do not fall back to the seed).
           setCatalog(catalogRes.value);
         } else {
-          // Keep the synchronously-seeded fallback so the list is never blank.
           console.error("Failed to load coding-agent catalog; using fallback:", catalogRes.reason);
         }
 
         if (reseedableRes.status === "fulfilled") {
           setReseedableCommands(reseedableRes.value);
         } else {
-          // Leave the set empty → no re-seed buttons (failure-safe).
           console.error("Failed to load reseedable commands; hiding re-seed buttons:", reseedableRes.reason);
         }
       } catch (error) {
@@ -73,7 +46,6 @@ export const codingAgentsStore = {
     return inFlight;
   },
 
-  /** Test-only: restore the pristine pre-fetch state. */
   resetForTests(): void {
     setCatalog(FALLBACK_CODING_AGENTS);
     setReseedableCommands([]);

--- a/src/sidebar/stores/coordinator-close.ts
+++ b/src/sidebar/stores/coordinator-close.ts
@@ -13,16 +13,8 @@ const [pendingCoordinatorClose, setPendingCoordinatorClose] =
   createSignal<PendingCoordinatorClose | null>(null);
 export { pendingCoordinatorClose, setPendingCoordinatorClose };
 
-// #588 confirm-modal host presence (ref-counted). ProjectPanel — the ONLY
-// renderer of the pendingCoordinatorClose modal — registers itself on mount so
-// the by-id helper knows whether a confirmation modal can actually be shown in
-// THIS window. In a detached terminal webview no host registers (separate JS
-// context, no ProjectPanel), so a busy-coordinator keyboard close falls back to
-// a plain destroy instead of setting a signal nothing renders (a silent no-op).
 let modalHostRefs = 0;
 
-/** #588 Register the confirm-modal host (ProjectPanel) for the current window.
- *  Returns a disposer to call on cleanup. */
 export function registerCoordinatorCloseModalHost(): () => void {
   modalHostRefs += 1;
   return () => {
@@ -30,25 +22,16 @@ export function registerCoordinatorCloseModalHost(): () => void {
   };
 }
 
-/** #588 True iff a confirm-modal host is mounted in this window. */
 function coordinatorCloseModalHostAvailable(): boolean {
   return modalHostRefs > 0;
 }
 
-/** Test-only: reset the modal-host ref-count so each test starts from a known
- *  state regardless of order (mirrors the `__*ForTests` hooks elsewhere). */
 export function __resetCoordinatorCloseModalHostForTests(): void {
   modalHostRefs = 0;
 }
 
-/** #588 by-id entry point: the single implementation. Resolves the live session
- *  ONLY to give the modal a friendly name; the backend self-routes a
- *  non-coordinator id to a plain destroy, so id-only callers (the keyboard
- *  shortcut) need no `Session`. On needs-confirmation it opens the modal (host
- *  lives in ProjectPanel). */
 export async function requestCoordinatorCloseById(id: string): Promise<void> {
   const s = sessionsStore.sessions.find((x) => x.id === id);
-  // Known non-coordinator -> identical net effect to destroy_session.
   if (s && !s.isCoordinator) {
     await SessionAPI.destroy(id);
     return;
@@ -63,11 +46,6 @@ export async function requestCoordinatorCloseById(id: string): Promise<void> {
           workingCount: outcome.workingCount,
         });
       } else {
-        // #588 No confirm-modal host in this window (e.g. the detached terminal
-        // webview's keyboard shortcut): fall back to closing JUST the coordinator
-        // (plain destroy, no cascade) so the user is never left with a silent
-        // no-op. The backend refused to cascade busy members without confirmation;
-        // destroying only the coordinator restores the pre-#588 behavior here.
         await SessionAPI.destroy(id);
       }
     }
@@ -76,9 +54,6 @@ export async function requestCoordinatorCloseById(id: string): Promise<void> {
   }
 }
 
-/** #588 entry point for callers that already hold the `Session` (ProjectPanel
- *  "X", SessionItem). Non-coordinator -> plain destroy (unchanged behavior);
- *  coordinator -> delegate to the by-id helper (one implementation). */
 export async function requestCoordinatorClose(session: Session): Promise<void> {
   if (!session.isCoordinator) {
     await SessionAPI.destroy(session.id);
@@ -87,9 +62,6 @@ export async function requestCoordinatorClose(session: Session): Promise<void> {
   await requestCoordinatorCloseById(session.id);
 }
 
-/** Confirm the pending cascade close (called from the modal). Consume-and-clear:
- *  the modal closes before the confirmed call awaits. Accepted (grinch F6, §7):
- *  a failed close leaves the team visibly running, so there is no false success. */
 export async function confirmPendingCoordinatorClose(): Promise<void> {
   const pending = pendingCoordinatorClose();
   if (!pending) return;

--- a/src/sidebar/stores/project-collapse.ts
+++ b/src/sidebar/stores/project-collapse.ts
@@ -1,12 +1,6 @@
 import { createSignal } from "solid-js";
 import { normalizeProjectPathForCompare } from "./project-refresh";
 
-// #810/#941 - Project-level (NOT sub-section) collapse state is hoisted into a
-// shared store so WorkgroupGroupRail can collapse others and expand the owner.
-// Sub-section collapse (workgroups/loops/agents/teams/workgroup/team) STAYS in
-// ProjectPanel's local collapsedByKey signal. This store only owns the "project"
-// section key. Session-only, no persistence
-// (consistent with Role.md: no localStorage for UI state).
 export const PROJECT_PANEL_COLLAPSE_KEY_SEP = "\u0000";
 
 export type ProjectPanelCollapseSection =
@@ -31,8 +25,6 @@ export function projectPanelCollapseKey(
   ].join(PROJECT_PANEL_COLLAPSE_KEY_SEP);
 }
 
-// Only the "project" section lives here. Keyed by the SAME composite string
-// ProjectPanel used locally (projectPath-normalized + "project" + "").
 const [collapsedProjects, setCollapsedProjects] = createSignal<Record<string, boolean>>({});
 
 function projectKey(projectPath: string): string {
@@ -51,13 +43,6 @@ export const projectCollapseStore = {
     const key = projectKey(projectPath);
     setCollapsedProjects((prev) => ({ ...prev, [key]: !(prev[key] ?? false) }));
   },
-  // #810 - one-shot: collapse every KNOWN project except the owner. "Known"
-  // means any project path that has an entry in the map (i.e. has been
-  // toggled or auto-focused before). The rail does NOT use this overload -
-  // it uses collapseAllExceptKnown with the live projectStore.projects list,
-  // because on a fresh session the map is {} and this method would no-op
-  // (grinch F2). This method is kept for the unit test to assert the
-  // known-set semantics and as a future-proof API.
   collapseAllProjectsExcept(projectPath: string): void {
     const ownerKey = projectKey(projectPath);
     setCollapsedProjects((prev) => {
@@ -68,11 +53,6 @@ export const projectCollapseStore = {
       return next;
     });
   },
-  // Overload for collapsing an explicit list of project paths. Used by the
-  // rail onClick (grinch F2): feeds the live projectStore.projects so
-  // "collapse others" works on a fresh session where the map is empty. The
-  // owner is deliberately left untouched so the caller composes the two
-  // intents (this + setProjectCollapsed(owner, false)).
   collapseAllExceptKnown(ownerPath: string, allPaths: string[]): void {
     const ownerKey = projectKey(ownerPath);
     setCollapsedProjects((prev) => {

--- a/src/sidebar/stores/project-merge.ts
+++ b/src/sidebar/stores/project-merge.ts
@@ -2,27 +2,7 @@ import type { AcDiscoveryResult, AcWorkgroup } from "../../shared/types";
 import type { ProjectState } from "./project";
 import { normalizeProjectPathForCompare } from "./project-refresh";
 
-/**
- * #748 — identity-preserving merge of a fresh discovery snapshot over the
- * loaded project state. ProjectPanel keys everything with reference-keyed
- * <For>s, so an object that changes reference is disposed and re-created in
- * the DOM — and a click whose press straddles that swap is lost (no `click`
- * for a detached mousedown target).
- *
- * DOM guarantee is PROJECT-granular: a fully identical snapshot returns the
- * existing project object itself (the store skips the write — zero DOM work),
- * and other projects always keep their reference. When something inside a
- * project DID change, that project's reference changes and its whole <For>
- * row re-renders; the nested entity references this merge still preserves do
- * not keep DOM alive in that case (the row's nested <For>s are fresh
- * instances) — they keep downstream memos/derivations cheap and make the
- * store contents diff-friendly. Finer-than-project DOM stability would need
- * the createStore+reconcile refactor that is explicitly out of scope here.
- */
 
-/** Structural equality for JSON-shaped discovery data (no functions/Dates).
- *  A key holding `undefined` and a missing key compare as equal, matching
- *  how the optional fields behave everywhere they are read. */
 export function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a === null || b === null || typeof a !== "object" || typeof b !== "object") return false;
@@ -48,12 +28,6 @@ export function deepEqual(a: unknown, b: unknown): boolean {
   return true;
 }
 
-/**
- * Keyed identity-preserving array merge: each incoming item keeps the existing
- * object reference when the entity (matched by key) is unchanged; only changed
- * or new entities take the incoming object. Returns the EXISTING array
- * reference when nothing changed at any position.
- */
 function mergeKeyedArray<T>(
   existing: readonly T[],
   incoming: readonly T[],
@@ -70,12 +44,9 @@ function mergeKeyedArray<T>(
     if (result !== existing[index]) changed = true;
     return result;
   });
-  // The only cast in this module: `existing` is only ever the caller's own
-  // mutable array, accepted as readonly for variance.
   return changed ? merged : (existing as T[]);
 }
 
-/** Preserve per-agent references inside a workgroup that changed elsewhere. */
 function mergeWorkgroup(oldWg: AcWorkgroup, newWg: AcWorkgroup): AcWorkgroup {
   if (deepEqual(oldWg, newWg)) return oldWg;
   const agents = mergeKeyedArray(oldWg.agents, newWg.agents, (agent) =>
@@ -84,8 +55,6 @@ function mergeWorkgroup(oldWg: AcWorkgroup, newWg: AcWorkgroup): AcWorkgroup {
   return { ...newWg, agents };
 }
 
-/** Merge a discovery result into the loaded project, preserving identity of
- *  every unchanged entity. Returns `existing` itself when nothing changed. */
 export function mergeDiscoveryResult(
   existing: ProjectState,
   result: AcDiscoveryResult

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -23,15 +23,10 @@ export interface ProjectState {
   agents: AcAgentMatrix[];
   teams: AcTeam[];
   loops: AcLoopSummary[];
-  /** #695 — pending seeded context-template updates surfaced by discovery. Each
-   *  entry is a customized template whose baked default has a newer version; the
-   *  sidebar resolves it through an explicit keep/overwrite modal. */
   contextTemplateUpdates: ContextTemplateUpdate[];
 }
 
 const [projects, setProjects] = createSignal<ProjectState[]>([]);
-// #881: archived projects leave `projects`, but their persisted sessions must
-// stay suppressed from the generic session list until an unarchive/open event.
 const [archivedPaths, setArchivedPaths] = createSignal<string[]>([]);
 const [loading, setLoading] = createSignal(false);
 const [lastLoadError, setLastLoadError] = createSignal<string | null>(null);
@@ -49,8 +44,6 @@ function normalizePath(p: string): string {
   return normalizeProjectPathForCompare(p);
 }
 
-/** Replica paths of every workgroup agent in a project/discovery shape — the
- *  set of paths whose live volatile overrides a fresh snapshot supersedes. */
 function workgroupReplicaPaths(source: { workgroups: AcWorkgroup[] }): string[] {
   return source.workgroups.flatMap((wg) => wg.agents.map((agent) => agent.path));
 }
@@ -85,14 +78,6 @@ async function discoverAndAppendIfCurrent(path: string, key: string): Promise<vo
   appendDiscoveredProject(path, result);
 }
 
-/** Append a freshly discovered project unless an equivalent path is already
- *  loaded (Round-1 G2 dedup: re-check against the BACKEND-absolutised regPath,
- *  which may differ from the caller's input in case/slashes/`..` — closes the
- *  double-render race when two concurrent calls pass differently-shaped
- *  strings that resolve to the same registered entry). The volatile overrides
- *  this snapshot supersedes are cleared ONLY when the append actually applied:
- *  a dedup-discarded snapshot must not wipe live event overrides that are
- *  newer than the state the store kept (#748). */
 function appendDiscoveredProject(regPath: string, result: AcDiscoveryResult) {
   const folderName = regPath.replace(/\\/g, "/").split("/").pop() ?? "unknown";
   const normalizedReg = normalizePath(regPath);
@@ -120,7 +105,6 @@ function appendDiscoveredProject(regPath: string, result: AcDiscoveryResult) {
   });
 }
 
-/** Stringify whatever a rejected Tauri command throws (usually the Err string). */
 function formatLoadError(e: unknown): string {
   if (typeof e === "string") return e;
   if (e instanceof Error) return e.message;
@@ -132,12 +116,10 @@ function formatLoadError(e: unknown): string {
 }
 
 export const projectStore = {
-  /** All loaded projects */
   get projects() {
     return projects();
   },
 
-  /** Legacy single-project accessor (first project or null) */
   get current() {
     return projects()[0] ?? null;
   },
@@ -150,22 +132,14 @@ export const projectStore = {
     return loading();
   },
 
-  /** Last error from a failed loadProject(). Surfaced as a sidebar status chip
-   *  (deferred Round-1 G11) and, critically, to the UI-automation surface so a
-   *  swallowed backend open_project/discover_project failure is observable
-   *  without devtools (#384 empty-tree triage). */
   get lastLoadError() {
     return lastLoadError();
   },
 
-  /** Whether initFromSettings() ran, and how many paths it received. Lets the
-   *  empty-tree diagnostic distinguish "onMount never reached initFromSettings"
-   *  (attempted=false) from "ran but projectPaths was empty" (pathCount=0). */
   get initState() {
     return initState();
   },
 
-  /** Register a project path in settings (via shared backend) and load its discovery data. */
   async loadProject(path: string) {
     const normalized = normalizePath(path);
     if (projects().some((p) => normalizePath(p.path) === normalized)) return;
@@ -176,10 +150,6 @@ export const projectStore = {
       loadingCount++;
       setLoading(true);
       try {
-        // #191 — backend owns the validation + dedup + persist atomically.
-        // Throws if `.ac/` is missing; caller (createAndLoad / pickAndCheck)
-        // is responsible for creating it first via projectStore.createAndLoad
-        // when that case is expected.
         const reg = await ProjectAPI.open(path);
         const normalizedReg = normalizePath(reg.path);
         await runSerializedArchiveChange(normalizedReg, () =>
@@ -187,11 +157,6 @@ export const projectStore = {
         );
         setLastLoadError(null);
       } catch (e) {
-        // Round-1 G11: surface the failure instead of only logging it. The
-        // sidebar status chip + UI-automation `project.loadStatus` target now
-        // expose this so a swallowed open_project/discover_project error is
-        // diagnosable without devtools (previously it silently dropped a
-        // project whose Project AC Root was deleted between sessions).
         console.error("Failed to load project:", e);
         setLastLoadError(formatLoadError(e));
       } finally {
@@ -204,46 +169,33 @@ export const projectStore = {
     return promise;
   },
 
-  /** Initialize from saved settings (call on mount) */
   async initFromSettings(
     projectPaths: string[],
     legacyPath: string | null,
     archivedProjectPaths: string[] = []
   ) {
-    // #881 (FE-F11) - union, not wholesale replace. `onProjectArchiveChanged`
-    // is registered before this boot-time call runs against an already-read
-    // settings snapshot; a concurrent archive from another window/CLI that
-    // `applyArchiveChange` committed into `archivedPaths` during that gap must
-    // survive, or the stale snapshot silently reverts it (and loadProject then
-    // re-registers the path on disk). Merge instead of clobbering.
     setArchivedPaths((prev) => {
       const keys = new Set(prev.map(normalizePath));
       return [...prev, ...archivedProjectPaths.filter((p) => !keys.has(normalizePath(p)))];
     });
-    // Merge legacy single path into the array (deduplicated)
     const paths = [...projectPaths];
     if (legacyPath && !paths.some((p) => normalizePath(p) === normalizePath(legacyPath))) {
       paths.push(legacyPath);
     }
-    // Record that boot-time load ran and with how many paths, so an empty tree
-    // can be triaged (onMount never got here vs. ran with zero paths).
     setInitState({ attempted: true, pathCount: paths.length });
     for (const path of paths) {
       await projectStore.loadProject(path);
     }
   },
 
-  /** Create `.ac/` Project AC Root in path if missing and register/load it. */
   async createAndLoad(path: string) {
     const reg = await ProjectAPI.new(path);
-    // After ensuring Project AC Root exists and persistence is set, run discovery for UI.
     const normalized = normalizePath(reg.path);
     await runSerializedArchiveChange(normalized, () =>
       discoverAndAppendIfCurrent(reg.path, normalized)
     );
   },
 
-  /** Full open flow: pick folder, check Project AC Root, auto-load if found */
   async pickAndCheck(): Promise<{ picked: string | null; hasWorkspace: boolean }> {
     const picked = await AgentCreatorAPI.pickFolder();
     if (!picked) return { picked: null, hasWorkspace: false };
@@ -255,22 +207,7 @@ export const projectStore = {
     return { picked, hasWorkspace };
   },
 
-  // #748 — the former updateReplicaBranch / updateCoordinatorClock /
-  // updateCoordinatorAutoClosed / updateCoordinatorManuallyClosed patchers
-  // lived here and rebuilt EVERY project/workgroup object reference per event,
-  // which made ProjectPanel's reference-keyed <For>s dispose and re-create the
-  // whole clickable sidebar DOM (losing any click in flight). Those live
-  // fields are now written to replicaVolatileStore (stores/replica-volatile.ts)
-  // and read through its effective* accessors, so events never touch project
-  // identity.
 
-  /** Update a workgroup's TASK.md fields from the discovery watcher. Clones
-   *  ONLY the project + workgroup on the matched path (#748 — unrelated rows
-   *  must keep their object identity); no match or no change leaves the store
-   *  value untouched. `taskTitle` is normalized null→undefined: the task event
-   *  serializes an explicit null while the discovery snapshot OMITS the field
-   *  (`skip_serializing_if` on task_title), so storing null would make the
-   *  next reload's deepEqual see a phantom change and re-create the row. */
   updateWorkgroupTask(
     workgroupPath: string,
     task: string | null,
@@ -296,9 +233,6 @@ export const projectStore = {
     });
   },
 
-  /** Apply a Loop summary returned by a mutation/event without waiting for
-   *  discovery. Identity-preserving (#748): an already-identical summary (a
-   *  duplicate event) leaves the store value untouched. */
   upsertLoop(projectPath: string, loop: AcLoopSummary) {
     const normalized = normalizePath(projectPath);
     setProjects((prev) => {
@@ -318,8 +252,6 @@ export const projectStore = {
     });
   },
 
-  /** Remove a Loop summary returned by a delete event without waiting for
-   *  discovery. Identity-preserving (#748): an unknown loop id is a no-op. */
   removeLoop(projectPath: string, loopId: string) {
     const normalized = normalizePath(projectPath);
     setProjects((prev) => {
@@ -334,7 +266,6 @@ export const projectStore = {
     });
   },
 
-  /** Re-discover a single project and update its data in place */
   async reloadProject(path: string) {
     const normalized = normalizePath(path);
     const existing = inFlightReloads.get(normalized);
@@ -350,18 +281,8 @@ export const projectStore = {
           try {
             const result = await ProjectAPI.discover(path);
             if (queuedReloads.has(normalized)) {
-              // A mutation/event may have already applied fresher summary data while this
-              // discovery was awaiting. Let the queued discovery provide the next full state.
               continue;
             }
-            // #748 — identity-preserving merge: entities the snapshot did not
-            // change keep their object references (an identical snapshot is a
-            // complete no-op). The volatile overrides for the replicas this
-            // snapshot covers are superseded in the same batch — discovery
-            // wins on reload, events re-patch after, exactly as the old
-            // wholesale replace behaved — but ONLY when the project is
-            // actually loaded: clearing for a snapshot the map cannot apply
-            // would wipe live overrides while installing nothing.
             const loaded = projects().some((p) => normalizePath(p.path) === normalized);
             batch(() => {
               setProjects((prev) => {
@@ -391,7 +312,6 @@ export const projectStore = {
     return promise;
   },
 
-  /** Re-discover a project only when it is already loaded in the sidebar. */
   async reloadProjectIfLoaded(path: string): Promise<boolean> {
     const loadedPath = findLoadedProjectPathForRefresh(projects(), path);
     if (!loadedPath) return false;
@@ -399,28 +319,19 @@ export const projectStore = {
     return true;
   },
 
-  /** Remove a project from the list by path */
   async removeProject(path: string) {
     const normalized = normalizePath(path);
     const removed = projects().find((p) => normalizePath(p.path) === normalized);
     batch(() => {
       setProjects((prev) => prev.filter((p) => normalizePath(p.path) !== normalized));
       setArchivedPaths((prev) => prev.filter((p) => normalizePath(p) !== normalized));
-      // #748 — drop the removed project's live overrides so a later re-add
-      // starts from its fresh discovery snapshot, not a stale live layer.
       if (removed) {
         replicaVolatileStore.clearForPaths(workgroupReplicaPaths(removed));
       }
     });
-    // #778 — persist the removal through the dedicated disk-authoritative
-    // command. A whole-object settings save no longer removes anything under
-    // Design S (it preserves the on-disk project_paths so it can't clobber
-    // CLI-registered projects), so removal must go through remove_project.
     await ProjectAPI.remove(path);
   },
 
-  /** #881 - hide a project. The backend call runs first and its rejection
-   *  propagates so a blocked archive leaves the project visible. */
   async archiveProject(path: string) {
     const normalized = normalizePath(path);
     await runSerializedArchiveChange(normalized, async () => {
@@ -438,7 +349,6 @@ export const projectStore = {
     });
   },
 
-  /** #881 - restore an archived project and load its discovery data. */
   async unarchiveProject(path: string) {
     const key = normalizePath(path);
     await runSerializedArchiveChange(key, async () => {
@@ -450,8 +360,6 @@ export const projectStore = {
     });
   },
 
-  /** #881 - reconcile cross-window/browser archive events. Idempotent because
-   *  initiating windows receive their own backend event echoes. */
   async applyArchiveChange(event: ProjectArchiveChanged) {
     const key = normalizePath(event.path);
     await runSerializedArchiveChange(key, async () => {
@@ -487,11 +395,6 @@ export const projectStore = {
     });
   },
 
-  /** #695 — drop exactly one resolved pending context-template update. The key
-   *  is `(projectPath, filename, currentDefaultSha256, currentFileSha256)`: the
-   *  file hash is part of the key (grinch fix #5) so resolving a stale modal
-   *  cannot silently remove a newer pending update queued for the same
-   *  project/file/default after the user edited the template again. */
   removeContextTemplateUpdate(
     projectPath: string,
     filename: string,
@@ -509,7 +412,6 @@ export const projectStore = {
             update.currentDefaultSha256 !== defaultSha256 ||
             update.currentFileSha256 !== fileSha256
         );
-        // #748 — nothing matched the exact key: keep the project identity.
         if (contextTemplateUpdates.length === project.contextTemplateUpdates.length) {
           return project;
         }

--- a/src/sidebar/stores/rail-collapse.ts
+++ b/src/sidebar/stores/rail-collapse.ts
@@ -3,24 +3,7 @@ import { normalizeProjectPathForCompare } from "./project-refresh";
 import { SettingsAPI } from "../../shared/ipc";
 import type { AppSettings } from "../../shared/types";
 
-// #965 - collapse state for the WorkgroupGroupRail's category headers.
-//
-// DELIBERATELY SEPARATE from `project-collapse.ts` (the ProjectPanel's card
-// collapse). The user's ruling: the rail folds ONLY on an explicit header click.
-// The #810 auto-focus (`collapseAllExceptKnown`, fired on every rail group click)
-// keeps driving the ProjectPanel exactly as before and must have ZERO effect here.
-// That is why this is its own module with its own signals and only two mutators,
-// both bound to a header click. Do not add a `collapseAllExcept*` here, and do not
-// import this store from `project-collapse.ts`. (Plan RC-1 / RC-2.)
-//
-// Persisted (unlike the ProjectPanel store) via the `set_rail_collapse` narrow
-// setter, written straight through on each toggle - no debounce, no dedupe: a
-// header click is a human-rate event, and a trailing debounce would lose the last
-// toggle if the user quits inside the window.
 
-// Keyed by the normalized project path directly. No composite section key: this
-// map holds exactly one notion. The persisted `railCollapsedProjects` is this key
-// set verbatim, so restore is exact and idempotent.
 const [collapsedProjects, setCollapsedProjects] = createSignal<Record<string, boolean>>({});
 const [favoritesCollapsed, setFavoritesCollapsed] = createSignal(false);
 
@@ -40,10 +23,6 @@ function snapshot(): { collapsedProjects: string[]; favoritesCollapsed: boolean 
 
 function persist(): void {
   const next = snapshot();
-  // Fire-and-forget: this is cosmetic UI state, and a settings-write failure must
-  // never surface as a broken rail. But it is NOT silent: the backend save is
-  // read+serialize+tmp+rename, so a transiently unreadable settings.json aborts it
-  // (plan §0.5). Warn so that class is debuggable instead of invisible.
   void SettingsAPI.setRailCollapse(next.collapsedProjects, next.favoritesCollapsed).catch((err) => {
     console.warn("[rail-collapse] failed to persist rail collapse:", err);
   });
@@ -57,8 +36,6 @@ export const railCollapseStore = {
     return favoritesCollapsed();
   },
 
-  // The ONLY two mutators. Both are an explicit header click. See RC-1 before
-  // adding a third.
   toggleProjectCollapsed(projectPath: string): void {
     const k = key(projectPath);
     setCollapsedProjects((prev) => ({ ...prev, [k]: !(prev[k] ?? false) }));
@@ -69,13 +46,6 @@ export const railCollapseStore = {
     persist();
   },
 
-  // #965 - single hydration point (RC-3). Sets the signals directly, never through
-  // the toggles, so it never writes back.
-  //
-  // DO NOT wrap this in a createEffect over `settingsStore.current`. That store
-  // re-fetches on `coding_agent_settings_updated` (`shared/stores/settings.ts:28-32`),
-  // and a reactive hydrate would clobber the user's in-session rail collapse with
-  // the on-disk snapshot, mid-session. One-shot call only.
   hydrateFromSettings(settings: AppSettings | null): void {
     const next: Record<string, boolean> = {};
     for (const path of settings?.railCollapsedProjects ?? []) next[key(path)] = true;

--- a/src/sidebar/stores/replica-volatile.ts
+++ b/src/sidebar/stores/replica-volatile.ts
@@ -3,32 +3,9 @@ import { createStore } from "solid-js/store";
 import type { AcAgentReplica, RepoBranchByPath, RepoDirtyByPath } from "../../shared/types";
 import { normalizeProjectPathForCompare } from "./project-refresh";
 
-/**
- * #748 — live event-driven layer for the volatile per-replica fields that used
- * to be patched INTO projectStore's replica objects (repoBranch,
- * lastUserMessageAt, autoClosedAt, manuallyClosedAt). Patching them in place
- * replaced every project/workgroup object reference, and ProjectPanel's
- * reference-keyed <For> then disposed and re-created the entire clickable
- * sidebar DOM on every event — a click whose press straddled that swap never
- * produced a `click` (detached mousedown target → no common inclusive
- * ancestor; Chromium fires nothing, w3c/uievents#141). Keeping the volatile
- * fields in a separate fine-grained store keyed by NORMALIZED replica path
- * (events carry the session working_directory, which can differ in slash/case
- * from the discovery path on Windows) leaves row identity stable: an event
- * re-runs only the badge/pill memo that reads it.
- *
- * Entry-field semantics: `undefined` = no live override (fall back to the
- * discovery snapshot on the replica object); `null` = an event explicitly
- * cleared the value (masks a stale discovery marker until the next snapshot).
- */
 export interface ReplicaVolatileEntry {
   repoBranch?: string | null;
-  /** #943 B2 - per-repo branches keyed by repo source path. See RepoBranchByPath
-   *  (shared/types.ts) for the missing-key vs explicit-null semantics. */
   repoBranchByPath?: RepoBranchByPath;
-  /** #1028 - per-repo worktree-dirty keyed by repo source path. Same missing-key vs
-   *  explicit-null semantics as `repoBranchByPath` above; see RepoDirtyByPath
-   *  (shared/types.ts). Like that map, this one is PRESERVED by `clearForPaths`. */
   repoDirtyByPath?: RepoDirtyByPath;
   lastUserMessageAt?: string;
   autoClosedAt?: string | null;
@@ -46,24 +23,9 @@ function setField<K extends keyof ReplicaVolatileEntry>(
   field: K,
   value: ReplicaVolatileEntry[K]
 ) {
-  // Merge-function form so a first write creates the entry ({...undefined} = {}).
   setEntries(volatileKey(path), (prev) => ({ ...prev, [field]: value }));
 }
 
-/**
- * #943 B2 - build a path -> value map from the event's parallel arrays.
- * #1028 - generalised over the value type: `T = string` gives RepoBranchByPath,
- * `T = boolean` gives RepoDirtyByPath.
- *
- * A length mismatch could only come from a build that broke the backend's 1:1
- * invariant. Pairing them anyway would attach a value to the wrong repo, so the
- * map is dropped instead and every repo falls back to "unknown": visible, inert,
- * and self-healing on the next tick. No branch beats a wrong branch, and an
- * unknown-dirty (violet) beats a red badge on the wrong repo.
- *
- * The guard is applied PER CALL, not once for both arrays: a malformed `repoDirty`
- * must not be able to drop the branch map with it.
- */
 function zipByPath<T>(
   repoPaths: string[] | undefined,
   values: (T | null)[] | undefined
@@ -73,12 +35,6 @@ function zipByPath<T>(
   if (paths.length !== vals.length) return {};
   const map: Record<string, T | null> = {};
   for (let i = 0; i < paths.length; i += 1) {
-    // `?? null`, NEVER `|| null`. With T = string this looks like dead syntax an
-    // implementer would "simplify". With T = boolean it is load-bearing and the
-    // difference is INVISIBLE on the badge: `false ?? null` is `false` (detected
-    // clean, correct), but `false || null` is `null` ("never detected"), and both
-    // render violet. Only the badge title exposes the slip, which is why
-    // `repoDirty: [false]` has its own test.
     map[paths[i]] = vals[i] ?? null;
   }
   return map;
@@ -89,18 +45,6 @@ export const replicaVolatileStore = {
     setField(replicaPath, "repoBranch", branch);
   },
 
-  /**
-   * #943 B2 - apply one `ac_discovery_branch_updated` event.
-   *
-   * Atomic on purpose: the single-repo shorthand and the path-keyed per-repo map
-   * always land together, so no reader can observe a half-updated pair (for a
-   * single-repo replica that would paint the previous branch for a frame).
-   *
-   * Repo paths are used as keys verbatim - the backend sends the same strings
-   * discovery already put on `AcAgentReplica.repoPaths` - unlike the REPLICA path,
-   * which is normalized because branch/clock events carry the session
-   * working_directory and can differ in slash/case (#552).
-   */
   applyDiscoveryBranchUpdate(
     replicaPath: string,
     branch: string | null,
@@ -111,9 +55,6 @@ export const replicaVolatileStore = {
     batch(() => {
       setField(replicaPath, "repoBranch", branch);
       setField(replicaPath, "repoBranchByPath", zipByPath<string>(repoPaths, repoBranches));
-      // #1028 - inside the SAME batch: dirty and branch come from one payload and
-      // must land together, or a reader observes a row whose branch has ticked and
-      // whose colour has not.
       setField(replicaPath, "repoDirtyByPath", zipByPath<boolean>(repoPaths, repoDirty));
     });
   },
@@ -130,54 +71,11 @@ export const replicaVolatileStore = {
     setField(replicaPath, "manuallyClosedAt", manuallyClosedAt);
   },
 
-  /**
-   * Drop the live overrides for replica paths a fresh discovery snapshot now
-   * covers — but only the fields that snapshot actually re-supplies.
-   *
-   * `repoBranch`, `lastUserMessageAt`, `autoClosedAt` and `manuallyClosedAt` each
-   * have a counterpart on `AcAgentReplica` (ac_discovery.rs reads the branch and
-   * the persisted CoordinatorClocks), so on load/reload the snapshot is the newer
-   * truth and a pre-reload override must not mask it — the "discovery wins on
-   * reload, events re-patch after" contract the old in-place patches had.
-   *
-   * `repoBranchByPath` (#943 B2) and `repoDirtyByPath` (#1028) are deliberately
-   * PRESERVED, because neither has a counterpart: we did not widen
-   * `AcAgentReplica`, so wiping either installs nothing. The backend would never
-   * re-send it either: the discovery branch watcher only emits when the payload
-   * CHANGES (`ac_discovery.rs` Gate A), and an unchanged repo set with unchanged
-   * branches and unchanged dirty is an identical payload. So a wiped map would be
-   * gone until something changed on disk or the app restarted, and reloads are
-   * routine (every loop tick, every CLI-driven refresh, every entity creation).
-   * "Discovery wins on reload" is meaningless for a field discovery never sends.
-   *
-   * What each map falls back to when wiped is NOT the same, and the dirty half is
-   * the worse one:
-   *   - `repoBranchByPath` degrades to the single-repo `repoBranch` shorthand —
-   *     `null` for a multi-repo replica — which is how Browse Branch died on the
-   *     first reload and stayed dead, "not for 15s, forever" (H1, a HIGH bug).
-   *   - `repoDirtyByPath` has NO shorthand to degrade to (discovery never sent a
-   *     scalar dirty), so every repo silently reverts to `null` = violet = "clean,
-   *     as far as you can see" — a false CLEAN on a passively-read surface, which is
-   *     the one direction #1028 is built never to assert.
-   *
-   * Preserving them is safe precisely BECAUSE they are keyed by path: a repo
-   * dropped from config.json simply never matches again, a repo added since the last
-   * tick has no entry until the watcher emits one, and a real change re-emits.
-   *
-   * Use `clearAll` when the replicas themselves are gone.
-   */
   clearForPaths(replicaPaths: Iterable<string>) {
     batch(() => {
       for (const path of replicaPaths) {
         const key = volatileKey(path);
         if (entries[key] === undefined) continue;
-        // Delete the entry, then restore ONLY the two by-path maps. Returning a smaller
-        // object instead would not clear anything: a Solid store setter MERGES a
-        // wrappable value into the existing node (mergeStoreNode), so the snapshot-
-        // backed fields would survive the reload and mask discovery forever - a
-        // worse bug than the one this method is fixing. The function form is used
-        // to read `prev` RAW (untracked); both writes sit inside the batch above,
-        // so readers only ever observe the final state.
         let preservedBranch: RepoBranchByPath | undefined;
         let preservedDirty: RepoDirtyByPath | undefined;
         setEntries(key, (prev) => {
@@ -185,15 +83,6 @@ export const replicaVolatileStore = {
           preservedDirty = prev?.repoDirtyByPath;
           return undefined; // deleting the key notifies its readers
         });
-        // `||`, not `&&`. Today the two are always written together (the only
-        // writer is applyDiscoveryBranchUpdate, whose batch sets both, and a
-        // length-mismatch stores `{}` rather than leaving the field undefined), so
-        // `&&` would behave identically and no test can tell them apart. It is `||`
-        // because it is the condition that stays CORRECT if that ever stops holding:
-        // with `&&`, a single one-sided entry silently drops the map that IS there,
-        // and the symptom would be a badge quietly losing its red on reload - the
-        // exact failure this preserve exists to prevent, re-entering by the back
-        // door. The cost of the safe operator here is zero.
         if (preservedBranch !== undefined || preservedDirty !== undefined) {
           setEntries(key, { repoBranchByPath: preservedBranch, repoDirtyByPath: preservedDirty });
         }
@@ -201,16 +90,8 @@ export const replicaVolatileStore = {
     });
   },
 
-  /**
-   * Full wipe, both by-path maps included (`repoBranchByPath` #943 B2 and
-   * `repoDirtyByPath` #1028). For when the replicas themselves go away
-   * (`projectStore.clear`) and for test isolation — unlike `clearForPaths`, there is
-   * no surviving replica whose per-repo branches or dirty state would be worth
-   * keeping, so the argument for preserving them there does not apply here.
-   */
   clearAll() {
     batch(() => {
-      // Stored keys are already normalized, so volatileKey is a no-op on them.
       for (const key of Object.keys(entries)) {
         setEntries(key, undefined); // deleting the key notifies its readers
       }
@@ -221,25 +102,17 @@ export const replicaVolatileStore = {
 type ReplicaVolatileBase = Pick<AcAgentReplica, "path"> &
   Partial<Pick<AcAgentReplica, "repoBranch" | "lastUserMessageAt" | "autoClosedAt" | "manuallyClosedAt">>;
 
-/** Live branch when an event patched it (null = branch gone), else the discovery snapshot. */
 export function effectiveRepoBranch(replica: ReplicaVolatileBase): string | undefined {
   const override = entries[volatileKey(replica.path)]?.repoBranch;
   return override === undefined ? replica.repoBranch : override ?? undefined;
 }
 
-/** #943 B2 - live per-repo branches for this replica, keyed by repo source path.
- *  `undefined` when no branch event has landed yet, in which case the caller keeps
- *  the pre-B2 single-repo `repoBranch` fallback. */
 export function effectiveRepoBranchByPath(
   replica: ReplicaVolatileBase
 ): RepoBranchByPath | undefined {
   return entries[volatileKey(replica.path)]?.repoBranchByPath;
 }
 
-/** #1028 - live per-repo worktree-dirty for this replica, keyed by repo source path.
- *  `undefined` until the first discovery branch event lands, which the caller maps to
- *  `dirty: null` (violet, "status unknown"): the normal state for the first <=15s
- *  after launch, not an error. There is no single-repo shorthand to fall back to. */
 export function effectiveRepoDirtyByPath(
   replica: ReplicaVolatileBase
 ): RepoDirtyByPath | undefined {

--- a/src/sidebar/stores/sessions-helpers.ts
+++ b/src/sidebar/stores/sessions-helpers.ts
@@ -1,29 +1,9 @@
 import type { Session, SessionStatus } from "../../shared/types";
 
-/**
- * True when `status` is one of the runtime string states ("active" | "running"
- * | "idle"). False when it is an Exited({ exited: N }) object.
- *
- * Used by sessionsStore.setActiveId to skip Exited sessions when promoting
- * the selected session to "active": a dormant root must keep its
- * { exited: N } status so RootAgentBanner's wake path
- * (typeof status !== "string") still fires and chooses
- * restart(..., { skipAutoResume: false }) — i.e. wake-with-provider-resume.
- */
 export function isRuntimeStringStatus(status: SessionStatus): boolean {
   return typeof status === "string";
 }
 
-/**
- * Upsert `incoming` into `prev` by id. If the id is already present, merge
- * `incoming`'s fields onto the existing entry (incoming wins). Otherwise
- * append.
- *
- * Used by sessionsStore.addSession so the RootAgentBanner can hydrate the
- * store with the Session returned from createRootAgent/restart even when the
- * backend reuses an existing live root and therefore does NOT emit a fresh
- * session_created event (see src-tauri/src/commands/session.rs ReuseLive).
- */
 export function upsertSessionList(prev: Session[], incoming: Session): Session[] {
   const idx = prev.findIndex((s) => s.id === incoming.id);
   if (idx === -1) return [...prev, incoming];
@@ -32,11 +12,6 @@ export function upsertSessionList(prev: Session[], incoming: Session): Session[]
   return next;
 }
 
-/**
- * Keep the previous visible order while allowing removals and appending new
- * items. Used to prevent activity-driven coordinator sorting from moving rows
- * under the pointer during Sidebar interaction.
- */
 export function preserveVisibleOrder<T>(
   next: T[],
   previous: T[] | undefined,
@@ -65,11 +40,6 @@ export function preserveVisibleOrder<T>(
   return ordered;
 }
 
-/**
- * Reconcile a frozen visible key order with a freshly recomputed key set:
- * existing keys keep their frozen positions, disappeared keys are removed, and
- * newly visible keys append in the recomputed order.
- */
 export function reconcileVisibleOrderKeys(nextKeys: string[], frozenKeys: string[] | undefined): string[] {
   if (!frozenKeys || frozenKeys.length === 0) return nextKeys;
 

--- a/src/sidebar/stores/sessions.ts
+++ b/src/sidebar/stores/sessions.ts
@@ -55,7 +55,6 @@ const allTeamPathsMemo = createMemo(() => {
   return paths;
 });
 
-/** Build a placeholder Session for an inactive repo */
 function makeInactiveEntry(name: string, path: string): Session {
   return {
     id: `inactive-${normalizePath(path)}`,
@@ -84,7 +83,6 @@ function makeInactiveEntry(name: string, path: string): Session {
   };
 }
 
-/** Names and paths owned by WG replicas and matrix agents — used to hide them from Agent Sessions */
 const wgReplicaMemo = createMemo(() => {
   const names = new Set<string>();
   const paths = new Set<string>();
@@ -104,7 +102,6 @@ const wgReplicaMemo = createMemo(() => {
 });
 
 const filteredSessionsMemo = createMemo(() => {
-  // Root agent renders exclusively in RootAgentBanner; never list it as a generic session.
   const nonRootSessions = state.sessions.filter((s) => !s.isRootAgent);
 
   const activeSessions = (() => {
@@ -128,14 +125,10 @@ const filteredSessionsMemo = createMemo(() => {
     });
   })();
 
-  // Hide sessions owned by WG replicas — they display in ProjectPanel instead
   const wg = wgReplicaMemo();
   const visibleSessions = wg.names.size > 0
     ? activeSessions.filter((s) => !wg.names.has(s.name))
     : activeSessions;
-  // #881: hide every session under an archived project. This relies on the
-  // backend invariant that activation inside an archived project unarchives it
-  // before a live PTY can remain hidden.
   const archived = projectStore.archivedPaths;
   const notArchived = (s: Session) =>
     !s.workingDirectory || !isUnderAnyPath(s.workingDirectory, archived);
@@ -148,7 +141,6 @@ const filteredSessionsMemo = createMemo(() => {
   };
   if (!state.showInactive) return [...projectVisibleSessions].sort((a, b) => sortKey(a).localeCompare(sortKey(b), "en", { sensitivity: "base", numeric: true }));
 
-  // Add inactive repos/members that don't have active sessions
   const activePathSet = new Set(
     state.sessions
       .filter((s) => s.workingDirectory)
@@ -166,12 +158,10 @@ const filteredSessionsMemo = createMemo(() => {
   };
 
   if (!state.teamFilter) {
-    // "All" — show inactive from all discovered repos
     for (const repo of state.repos) {
       addInactive(repo.name, repo.path);
     }
   } else if (state.teamFilter === NO_TEAM) {
-    // "No team" — show inactive repos NOT in any team
     const teamPaths = allTeamPathsMemo();
     for (const repo of state.repos) {
       if (!teamPaths.has(normalizePath(repo.path))) {
@@ -179,7 +169,6 @@ const filteredSessionsMemo = createMemo(() => {
       }
     }
   } else {
-    // Specific team — show inactive team members only
     const team = state.teams.find((t) => t.id === state.teamFilter);
     if (team) {
       for (const m of team.members) {
@@ -188,7 +177,6 @@ const filteredSessionsMemo = createMemo(() => {
     }
   }
 
-  // Also filter inactive entries whose paths belong to WG replicas
   const filteredInactive = wg.paths.size > 0
     ? inactiveEntries.filter((e) => !wg.paths.has(normalizePath(e.workingDirectory)))
     : inactiveEntries;
@@ -202,18 +190,6 @@ const filteredSessionsMemo = createMemo(() => {
 
 const [collapsedTeams, setCollapsedTeams] = createSignal<Record<string, boolean>>({});
 
-/**
- * Detached-session UUID set. A session id is here iff a detached terminal
- * window for it currently exists. Hydrated by SidebarApp.onMount via
- * WindowAPI.listDetached (G.8 race safety) and maintained through
- * terminal_detached / terminal_attached / session_destroyed events.
- *
- * NOTE: this store is NOT the authoritative source of truth for "is the
- * detached window open?" — the Tauri window list is. Read the Tauri
- * window list directly when correctness matters (e.g. quit-confirmation
- * count per G3-B1). This signal exists only to drive sidebar UI
- * (icon/title toggles, context-menu items).
- */
 const [detachedIds, setDetachedIds] = createSignal<Set<string>>(new Set());
 
 const groupedSessionsMemo = createMemo((): { groups: TeamSessionGroup[]; ungrouped: Session[] } => {
@@ -226,18 +202,15 @@ const groupedSessionsMemo = createMemo((): { groups: TeamSessionGroup[]; ungroup
   const assignedPaths = new Set<string>();
 
   for (const team of teams) {
-    // Skip hidden teams — their sessions will appear as ungrouped
     if (team.visible === false) continue;
     const memberPaths = new Set(team.members.map((m) => normalizePath(m.path)));
 
-    // Find sessions belonging to this team
     const teamSessions = sessions.filter((s) =>
       s.workingDirectory && memberPaths.has(normalizePath(s.workingDirectory))
     );
 
     if (teamSessions.length === 0 && !state.showInactive) continue;
 
-    // Identify coordinator session
     let coordinator: Session | null = null;
     const members: Session[] = [];
 
@@ -252,7 +225,6 @@ const groupedSessionsMemo = createMemo((): { groups: TeamSessionGroup[]; ungroup
       assignedPaths.add(np);
     }
 
-    // When showInactive, add inactive placeholders for missing team members
     if (state.showInactive) {
       const activePathSet = new Set(teamSessions.map((s) => normalizePath(s.workingDirectory)));
       for (const m of team.members) {
@@ -272,7 +244,6 @@ const groupedSessionsMemo = createMemo((): { groups: TeamSessionGroup[]; ungroup
     groups.push({ team, coordinator, members });
   }
 
-  // Sessions not in any team
   const ungrouped = sessions.filter((s) => {
     if (!s.workingDirectory) return true;
     return !assignedPaths.has(normalizePath(s.workingDirectory));
@@ -332,10 +303,6 @@ export const sessionsStore = {
     const prev = state.activeId;
     console.debug(`[idle-fe] setActiveId: ${id?.slice(0,8)} (prev: ${prev?.slice(0,8)})`);
     setState("activeId", id);
-    // Promote selected session to "active" only when its status is a runtime
-    // string. Exited({ exited: N }) is preserved so dormant roots keep the
-    // status the banner reads (typeof status !== "string") to choose
-    // restart(..., { skipAutoResume: false }).
     setState(
       "sessions",
       (s) => s.id === id && isRuntimeStringStatus(s.status),
@@ -361,7 +328,6 @@ export const sessionsStore = {
     const isActive = id === state.activeId;
     console.debug(`[idle-fe] setSessionWaiting: ${id.slice(0,8)} waiting=${waiting} wasAlreadyWaiting=${wasAlreadyWaiting} isActive=${isActive} pendingReview=${session?.pendingReview}`);
     setState("sessions", (s) => s.id === id, "waitingForInput", waiting);
-    // Only set pendingReview on a real busy→idle transition, not re-detection
     if (waiting && !wasAlreadyWaiting && !isActive) {
       console.debug(`[idle-fe] >>> SETTING pendingReview=true for ${id.slice(0,8)}`);
       setState("sessions", (s) => s.id === id, "pendingReview", true);
@@ -383,9 +349,6 @@ export const sessionsStore = {
     setState("sessions", (s) => s.id === sessionId, "isCoordinator", value);
   },
 
-  // #592 - surgical per-session drift flag update. Mirrors setIsCoordinator;
-  // never use setSessions for this (a wholesale replace would reset the
-  // frontend-only pendingReview field).
   setProfileOutdated(id: string, outdated: boolean) {
     setState("sessions", (s) => s.id === id, "profileOutdated", outdated);
   },
@@ -511,47 +474,18 @@ export const sessionsStore = {
     setState("lastActivityBySessionId", (prev) => ({ ...prev, [sessionId]: performance.now() }));
   },
 
-  /**
-   * #1033 - a `session_context` event landed. `null` is stored as `null`, never
-   * dropped: it is the engine's explicit "unavailable", and it must overwrite a
-   * stale reading. Touches no part of `state.sessions`, so `setSessions`'s
-   * wholesale replace cannot reach it and #592's setSessions warning does not
-   * apply.
-   */
   setSessionContext(sessionId: string, percent: number | null) {
     setState("contextPercentBySessionId", (prev) => ({ ...prev, [sessionId]: percent }));
   },
 
-  /**
-   * #1033 - snapshot-seed a session no event has spoken for. A no-op when the key
-   * already exists, which is what lets App.tsx register the listener FIRST and
-   * hydrate afterwards without a slow invoke clobbering a fresher event.
-   *
-   * The guard is key PRESENCE, never truthiness: a stored `0` is a real reading
-   * and a stored `null` is a real answer, and both must count as spoken for. A
-   * `!prev[sessionId]` here would let a stale snapshot overwrite a true `0%`.
-   */
   hydrateSessionContext(sessionId: string, percent: number | null) {
     setState("contextPercentBySessionId", (prev) =>
       sessionId in prev ? prev : { ...prev, [sessionId]: percent },
     );
   },
 
-  /**
-   * #1033 - the reading map is event-fed and outlives a render, so it leaks between
-   * tests in the same file exactly as #943 B2's volatile layer did: order-dependent
-   * and silently wrong rather than red. Not a production path; setSessions cannot
-   * clear this map by design.
-   */
   resetContextReadingsForTests() {
     batch(() => {
-      // Deletes each key rather than setState(path, {}). Measured: Solid MERGES an
-      // object into the value at a path, whether passed directly or returned from
-      // an updater, so both `{}` forms are a silent no-op here. Mirrors
-      // replicaVolatileStore.clearAll, which clears its keyed map the same way.
-      //
-      // The key must be DELETED and not set to null: a present null is a real
-      // answer, and hydrateSessionContext would then no-op on it.
       for (const id of Object.keys(state.contextPercentBySessionId)) {
         setState("contextPercentBySessionId", id, undefined as unknown as null);
       }
@@ -562,17 +496,14 @@ export const sessionsStore = {
     setCollapsedTeams((prev) => ({ ...prev, [teamId]: !prev[teamId] }));
   },
 
-  /** Find a session whose name exactly matches the given string */
   findSessionByName(name: string): Session | undefined {
     return state.sessions.find((s) => s.name === name);
   },
 
-  /** True iff a detached window currently exists for this session id. */
   isDetached(id: string): boolean {
     return detachedIds().has(id);
   },
 
-  /** Toggle detached state. Creates a new Set reference so subscribers re-run. */
   setDetached(id: string, detached: boolean) {
     const current = detachedIds();
     if (detached === current.has(id)) return; // no-op

--- a/src/sidebar/stores/team-idle-watcher.ts
+++ b/src/sidebar/stores/team-idle-watcher.ts
@@ -1,41 +1,3 @@
-// Per-workgroup busy→all-idle transition detector for Feature #110.
-//
-// **Spec deviation:** issue #110 calls for per-*team* aggregation, but
-// `sessionsStore.state.teams` is currently dead code — `setTeams()` is
-// defined but never called from anywhere in the repo. We aggregate by
-// workgroup instead, sourcing from `projectStore.projects[].workgroups[]`
-// (the live data path that ProjectPanel/TeamFilter actually use).
-// **If teams become live (someone wires up `setTeams`), revisit this
-// aggregation** — the right unit may be the team-config rather than the
-// workgroup instance.
-//
-// **Why per-session previous-busy tracking** (instead of a busy *set*
-// diff): "session destroyed", "session exited", and "session renamed"
-// all collapse to "session left the aggregation" under a set-diff
-// model, which would fire spurious beeps on user kills, exit-0
-// processes, and rename events. Tracking each session's busy flag from
-// the previous tick lets us require a *genuine* busy→idle flip on a
-// still-alive bound session before we consider beeping.
-//
-// **Why a stable sessionId→wgPath binding**: sessions match replicas
-// by name `${wg.name}/${replica.name}` at creation, but can be renamed
-// later. Resolving the binding on every effect run by name means a
-// busy session whose name changes drops out of its workgroup's
-// aggregation, which is exactly the bug above. We bind once on first
-// observation and never unbind, so rename-while-busy is harmless.
-//
-// **Why createRoot**: the watcher is started from inside an async
-// onMount in SidebarApp; by the time we reach `await
-// settingsStore.load()` the synchronous reactive owner is gone.
-// createRoot gives the effect its own owner and an explicit dispose
-// we can call from onCleanup.
-//
-// **Focused-WG suppression (#254)**: while the user is looking at a
-// workgroup (the active session belongs to it AND the AC window holds
-// OS focus), that workgroup's beep is gated off — they can already
-// see the state change, the beep is redundant. When focus moves away
-// (tab switch or alt-tab), the just-left workgroup keeps suppressing
-// for GRACE_MS to absorb the user's typical short detour back.
 
 import { createEffect, createRoot, createSignal } from "solid-js";
 import type { Session } from "../../shared/types";
@@ -46,22 +8,8 @@ import { projectStore } from "./project";
 
 export const GRACE_MS = 4000;
 
-// OS-level focus state for the AC sidebar window. Driven by
-// Tauri's onFocusChanged event; treated as true on mount so the
-// initial tick (before the listener has reported anything) treats
-// the visible WG as focused. Exposed as a signal so the watcher's
-// createEffect re-runs on focus flips even when no session has
-// changed — without this, alt-tab→idle transitions inside the
-// grace window would miss the grace setter.
 const [osFocused, setOsFocused] = createSignal(true);
 
-/**
- * Pure decision helper: should we suppress the beep for `wgPath`
- * given the current focus state and grace map?
- *
- * Suppressed when the workgroup is currently focused, OR a grace
- * entry exists for it and `now` is still inside the window.
- */
 export function shouldSuppressBeep(
   wgPath: string,
   focusedWg: string | null,
@@ -73,14 +21,6 @@ export function shouldSuppressBeep(
   return until !== undefined && now < until;
 }
 
-/**
- * Pure transition helper: on a focus change, arm a grace window
- * for the workgroup being left behind (if any) and return the new
- * "previous focused WG" to persist for the next tick.
- *
- * Mutates `graceUntil` in place — callers own the map. Returns the
- * value the caller should assign to its `previousFocusedWg`.
- */
 export function updateGraceOnFocusChange(
   previousFocusedWg: string | null,
   focusedWg: string | null,
@@ -98,22 +38,16 @@ async function startOsFocusListener(): Promise<() => void> {
   try {
     const { getCurrentWindow } = await import("@tauri-apps/api/window");
     const win = getCurrentWindow();
-    // Best-effort initial sync: if the window is already
-    // unfocused at mount, reflect that before any tick runs.
     try {
       const focused = await win.isFocused();
       setOsFocused(focused);
     } catch {
-      // Non-fatal — keep the default-true seed.
     }
     const unlisten = await win.onFocusChanged(({ payload: focused }) => {
       setOsFocused(focused);
     });
     return unlisten;
   } catch {
-    // Browser/WS transport or import failure — assume always-focused
-    // so the legacy behavior (per-WG suppression keyed only on
-    // activeId) still applies; we just can't react to OS alt-tab.
     return () => {};
   }
 }
@@ -127,48 +61,18 @@ function isBusy(session: Session): boolean {
   return !session.waitingForInput;
 }
 
-/**
- * Start the watcher. Returns a dispose function; call from SidebarApp's
- * onCleanup.
- *
- * Behavior on first effect run: snapshot only, no beep (the "no beep
- * at startup" rule). Subsequent runs fire `playTeamIdleBeep()` for any
- * workgroup that meets ALL of:
- *   - At least one session bound to the workgroup, alive last tick,
- *     was busy then and is alive + idle now (genuine transition).
- *   - All currently-bound, currently-alive sessions in the workgroup
- *     are idle.
- *   - The user setting `teamIdleBeepEnabled` is true.
- */
 export function startTeamIdleWatcher(): () => void {
   return createRoot((dispose) => {
-    // sessionId -> wg.path. Populated on first observation of each
-    // session and never overwritten — protects against rename.
     const sessionToWg = new Map<string, string>();
 
-    // wg.path -> Map<sessionId, wasBusy>. The inner map records each
-    // bound, alive session's isBusy from the previous tick. Sessions
-    // that were not alive last tick (destroyed/exited) won't appear.
     const previousByWg = new Map<string, Map<string, boolean>>();
 
-    // wg.path -> epoch ms at which the grace period for that WG
-    // ends. Populated whenever effective focus moves off a WG; the
-    // entry suppresses beeps for that WG until Date.now() >= value.
     const graceUntil = new Map<string, number>();
 
-    // The effective focused WG from the previous effect tick. Used
-    // to detect focus *transitions* so we can arm the grace window
-    // for the WG being left behind.
     let previousFocusedWg: string | null = null;
 
     let initialized = false;
 
-    // Spawn the OS focus listener; capture the unlisten so we can
-    // detach it in dispose. The signal stays at its default until
-    // the async listener resolves. `disposed` guards the race where
-    // the watcher is torn down before the dynamic import resolves —
-    // without it the listener would be registered into an orphan
-    // variable and leak forever.
     let disposed = false;
     let unlistenOsFocus: (() => void) | null = null;
     void startOsFocusListener().then((unlisten) => {
@@ -176,7 +80,6 @@ export function startTeamIdleWatcher(): () => void {
         try {
           unlisten();
         } catch {
-          // ignore — best-effort detach
         }
         return;
       }
@@ -190,8 +93,6 @@ export function startTeamIdleWatcher(): () => void {
       const activeId = sessionsStore.activeId;
       const hasOsFocus = osFocused();
 
-      // 1. Augment bindings (never unbind). Iterate workgroups and
-      //    bind any newly-discovered replica-session pairs by name.
       for (const project of projects) {
         for (const wg of project.workgroups) {
           for (const replica of wg.agents) {
@@ -205,10 +106,6 @@ export function startTeamIdleWatcher(): () => void {
         }
       }
 
-      // 2. Build current per-wg busy state from the alive bound
-      //    sessions only. Destroyed sessions (not in `sessions`) and
-      //    exited sessions are excluded — they don't contribute to
-      //    aggregation per spec.
       const sessionsById = new Map<string, Session>();
       for (const s of sessions) sessionsById.set(s.id, s);
 
@@ -225,22 +122,9 @@ export function startTeamIdleWatcher(): () => void {
         inner.set(sessionId, isBusy(session));
       }
 
-      // 3. Resolve the effective focused workgroup for this tick.
-      //    A WG is "focused" only when AC has OS focus AND the
-      //    active session is bound to that WG. Losing either
-      //    condition (alt-tab, tab switch) collapses focusedWg to
-      //    null and arms a grace window for the WG being left.
       const focusedWg =
         hasOsFocus && activeId ? sessionToWg.get(activeId) ?? null : null;
 
-      // 4. First run is snapshot-only — see header comment.
-      //    Crucially, we skip the focus-transition bookkeeping on
-      //    the snapshot tick: the OS-focus listener resolves
-      //    asynchronously, so the initial tick may run with the
-      //    default-true `osFocused` seed even when AC was launched
-      //    in the background. Seeding `previousFocusedWg` here
-      //    would then arm a phantom grace window on the first real
-      //    tick once `osFocused` resolves to false.
       if (!initialized) {
         initialized = true;
         for (const [wgPath, perSession] of currentByWg) {
@@ -257,15 +141,12 @@ export function startTeamIdleWatcher(): () => void {
         GRACE_MS,
       );
 
-      // 5. Detect genuine busy→idle transitions per workgroup.
       if (enabled) {
         const now = Date.now();
         for (const [wgPath, currentBusy] of currentByWg) {
           const previousBusy = previousByWg.get(wgPath);
           if (!previousBusy) continue;
 
-          // Genuine transition: a session that was busy last tick is
-          // still alive (still in current map) and is now idle.
           let hadTransition = false;
           for (const [sessionId, wasBusy] of previousBusy) {
             if (!wasBusy) continue;
@@ -277,7 +158,6 @@ export function startTeamIdleWatcher(): () => void {
           }
           if (!hadTransition) continue;
 
-          // All currently-alive bound sessions are idle?
           let allIdle = currentBusy.size > 0;
           if (allIdle) {
             for (const isBusyNow of currentBusy.values()) {
@@ -294,17 +174,11 @@ export function startTeamIdleWatcher(): () => void {
           void playTeamIdleBeep();
         }
 
-        // Drop expired grace entries so the map stays bounded by
-        // the count of currently-tracked WGs (already finite, but
-        // tidier).
         for (const [wgPath, until] of graceUntil) {
           if (now >= until) graceUntil.delete(wgPath);
         }
       }
 
-      // 6. Persist current state for the next tick. Workgroups that
-      //    no longer have any alive bound sessions drop out, so a
-      //    later resurrection starts from a clean snapshot.
       previousByWg.clear();
       for (const [wgPath, perSession] of currentByWg) {
         previousByWg.set(wgPath, new Map(perSession));
@@ -317,7 +191,6 @@ export function startTeamIdleWatcher(): () => void {
         try {
           unlistenOsFocus();
         } catch {
-          // ignore — best-effort detach
         }
         unlistenOsFocus = null;
       }

--- a/src/sidebar/stores/workgroup-groups.ts
+++ b/src/sidebar/stores/workgroup-groups.ts
@@ -16,8 +16,6 @@ export type WorkgroupGroupSelection =
   | { kind: "nonstop" }
   | { kind: "group"; id: string };
 
-// #777 Non-stop group defaults + clamp bounds (mirror the Rust side in
-// project_settings.rs so both ends agree).
 export const DEFAULT_NON_STOP_NAME = "Alert me!";
 const LEGACY_NON_STOP_NAME = "Non-stop";
 export const MATCH_NONE_REGEX = "(?!)";
@@ -69,7 +67,6 @@ export function defaultGroupsConfig(): WorkgroupGroupsConfig {
   };
 }
 
-/** #777 default Non-stop slot (D3): hidden, matches nothing, 30s tolerance, 3s beep. */
 export function defaultNonStop(): NonStopGroupConfig {
   return {
     show: false,
@@ -89,10 +86,6 @@ function clampInt(value: number, min: number, max: number, fallback: number): nu
   return n;
 }
 
-/** #777 C6: repair a persisted/hand-edited `nonStop` so a bad value degrades
- *  gracefully instead of entering the fatal validate-and-reset path (which would
- *  wipe every user group). Clamps numerics, truncates the name, and resets an
- *  invalid/oversize regex to match-none. Never throws. `null`/`undefined` stay absent. */
 export function normalizeNonStop(
   nonStop: NonStopGroupConfig | null | undefined
 ): NonStopGroupConfig | null | undefined {
@@ -195,7 +188,6 @@ function normalizeSelection(
   if (selection.kind === "ungrouped" && !config.showUngrouped) {
     return config.showAll ? { kind: "all" } : { kind: "ungrouped" };
   }
-  // #777: selecting Non-stop while it is hidden/absent falls back like All/Ungrouped.
   if (selection.kind === "nonstop" && !config.nonStop?.show) {
     return config.showAll ? { kind: "all" } : { kind: "ungrouped" };
   }
@@ -312,9 +304,6 @@ export function compileGroupRegex(group: WorkgroupGroup): RegExp | null {
   }
 }
 
-/** #777 Non-stop membership matcher. Mirrors the rail's `groupMatches` exactly
- *  (reuses `compileGroupRegex`), so the rail, the predicate, and the watchdog
- *  client resolve membership identically. Oversize/invalid regex -> false (no throw). */
 export function nonStopMatchesWorkgroup(config: NonStopGroupConfig, wg: AcWorkgroup): boolean {
   const id = groupMatchId(wg);
   if (charLength(id) > MAX_GROUP_MATCH_ID_LENGTH) return false;
@@ -366,9 +355,6 @@ export function validateGroupsConfig(
     }
   });
 
-  // #777 C6: soft regex-syntax check for Non-stop, ONLY under validateRegexSyntax
-  // (the save/modal path). Load uses validateRegexSyntax:false, so a bad nonStop
-  // never trips the fatal reset-to-defaults path; normalizeNonStop repairs it there.
   if (config.nonStop && options.validateRegexSyntax) {
     if (charLength(config.nonStop.regex) > MAX_GROUP_REGEX_LENGTH) {
       errors.push(`Alert me!: regex cannot exceed ${MAX_GROUP_REGEX_LENGTH} characters.`);
@@ -402,8 +388,6 @@ function setConfig(
 ) {
   const key = keyFor(projectPath);
   const current = ensureEntry(projectPath);
-  // #777 C6: clamp/repair nonStop on every store write (covers load + post-save),
-  // so a bad persisted value degrades gracefully instead of wiping the config.
   const nextConfig = cloneConfig({ ...config, nonStop: normalizeNonStop(config.nonStop) });
   setEntries(key, {
     ...current,
@@ -571,11 +555,6 @@ export const workgroupGroupsStore = {
     await this.save(projectPath, { ...config, groups });
   },
 
-  // #965 - pin/unpin a group into the rail's cross-project Favorites section. The
-  // flag lives on the group record, so it survives rename (`id` is stable), travels
-  // with reorder, and dies with the group. `save()` re-seeds the store from the
-  // SAVED config, so the flag is authoritative from the backend on the same tick
-  // and the toggle cannot visually revert.
   async setGroupFavorite(projectPath: string, groupId: string, favorite: boolean): Promise<void> {
     const config = this.config(projectPath);
     const group = config.groups.find((candidate) => candidate.id === groupId);
@@ -661,8 +640,6 @@ export const workgroupGroupsStore = {
     });
   },
 
-  // #777 C5: membership helpers for the built-in Non-stop slot. Mirror
-  // addWorkgroupToGroup/removeWorkgroupFromGroup but target `config.nonStop.regex`.
   async addWorkgroupToNonStop(projectPath: string, wgName: string): Promise<void> {
     if (charLength(wgName) > MAX_GROUP_MATCH_ID_LENGTH) {
       const message = `Workgroup id cannot exceed ${MAX_GROUP_MATCH_ID_LENGTH} characters.`;
@@ -673,7 +650,6 @@ export const workgroupGroupsStore = {
     const config = this.config(projectPath);
     const current = config.nonStop;
     if (!current) {
-      // Materialize the slot (shown) with an exact-match regex for this workgroup.
       await this.save(projectPath, {
         ...config,
         nonStop: { ...defaultNonStop(), show: true, regex: exactGroupRegexForWorkgroup(wgName) },

--- a/src/sidebar/watchdog/non-stop-watchdog-client.ts
+++ b/src/sidebar/watchdog/non-stop-watchdog-client.ts
@@ -5,28 +5,12 @@ import { workgroupGroupsStore, nonStopDisplayName, nonStopMatchesWorkgroup } fro
 import { splitWorkgroupsByWorking } from "../components/workgroup-session";
 import { projectStore } from "../stores/project";
 
-// #777 Non-stop watchdog client (hybrid design, D1). The frontend owns ONLY the
-// disparity detection. #882: the working/not-working partition comes from
-// splitWorkgroupsByWorking(), the same single function the rail counter calls,
-// which derives from session state and not from the dot's CSS class. So parity
-// with the rail counter is by construction and cannot drift, and a visual tweak
-// to the status dot can no longer change when this fires. The backend owns the
-// tolerance timer and actuation. Detection is reactive (a Solid effect that
-// re-runs on any session/config/project change), which is immune to Chromium's
-// hidden-window timer throttling; the keepalive setInterval is only a
-// non-critical backstop.
 
 const KEEPALIVE_MS = 10_000;
 
-/** Compute the current watchdog snapshot from the live stores. Exported for unit
- *  testing the disparity/parity detection directly (the createEffect + keepalive
- *  wiring in startNonStopWatchdogClient is audited by review, mirroring the
- *  team-idle-watcher convention). */
 export function buildSnapshot(): NonStopReport[] {
   const reports: NonStopReport[] = [];
   for (const project of projectStore.projects) {
-    // (dev-webpage-ui #3) Load the groups config ourselves; do not depend on the
-    // rail's mount order. Idempotent + dedupes in-flight (workgroup-groups.ts).
     void workgroupGroupsStore.ensureLoaded(project.path);
     const ns = workgroupGroupsStore.config(project.path).nonStop;
     if (!ns || !ns.show) continue;
@@ -61,16 +45,9 @@ export function startNonStopWatchdogClient(): void {
     const json = JSON.stringify(snapshot);
     if (json === lastJson) return; // dedupe unchanged snapshots
     lastJson = json;
-    // Fire-and-forget: a failed report must never throw (the keepalive retries,
-    // and the backend times from its own clock once armed).
     void NonStopAPI.report(snapshot).catch(() => {});
   };
-  // Reactive: recomputes whenever session state, groups config, or the project
-  // list changes. This is the throttle-immune onset/clear detector (event-driven,
-  // not a polled timer) and fires the first report on mount.
   createEffect(push);
-  // Light keepalive backstop: refreshes config + confirms liveness. Non-critical
-  // for timing (the backend times from its own clock once armed).
   const timer = setInterval(() => {
     lastJson = ""; // force a resend even if unchanged
     push();

--- a/src/terminal/App.tsx
+++ b/src/terminal/App.tsx
@@ -30,11 +30,6 @@ import "./styles/terminal.css";
 interface TerminalAppProps {
   lockedSessionId?: string;
   detached?: boolean;
-  /**
-   * True when mounted inside MainApp's unified layout. Skips titlebar
-   * render, window-level initializers, and redundant theme listener
-   * (DW.2 + DW.5 + Arb-4).
-   */
   embedded?: boolean;
 }
 
@@ -44,31 +39,22 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
   let cleanupZoom: (() => void) | null = null;
   let cleanupGeometry: (() => void) | null = null;
 
-  // Home is rendered as an overlay covering the TASK/LAST PROMPT panels and
-  // the terminal content area beneath them, while those panels stay mounted
-  // (#164 follow-up). Keeping WorkgroupTask/LastPrompt mounted preserves the height
-  // of `.terminal-content-area`, so TerminalView's ResizeObserver does not
-  // fire on Home toggle and the PTY does not receive a SIGWINCH. Detached
-  // and locked windows never render Home — they keep the normal layout.
   const isHomeShown = createMemo(
     () => !!(props.embedded && !props.detached && !props.lockedSessionId && homeStore.visible)
   );
 
   const loadActiveSession = async () => {
     if (props.lockedSessionId) {
-      // Detached mode: lock to specific session
       const sessions = await SessionAPI.list();
       const session = sessions.find((s) => s.id === props.lockedSessionId);
       if (session) {
         terminalStore.setActiveSession(session.id, session.name, session.shell, session.effectiveShellArgs, session.workingDirectory, session.workgroupTask ?? null, session.isRootAgent);
       } else {
-        // Session no longer exists, close this window
         terminalStore.setActiveSession(null, "", "", null, "", null, false);
       }
       return;
     }
 
-    // Normal mode: follow active session
     const activeId = await SessionAPI.getActive();
     if (activeId) {
       const sessions = await SessionAPI.list();
@@ -82,22 +68,11 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
   };
 
   onMount(async () => {
-    // #289 / dark-default — dark is the base CSS, so first paint is dark with
-    // no optimistic class; the settingsStore.load() corrective step below opts
-    // into light only for users who persisted that preference. Guarded with
-    // !props.embedded because MainApp owns the documentElement classList when
-    // this is mounted inside the unified layout — same pattern as
-    // zoom/geometry/onThemeChanged below.
     shortcutHandler = registerShortcuts();
 
-    // Register destroy listener FIRST to catch any destroy event fired
-    // during the async awaits below (A2.3.G7 mount-race window).
     unlisteners.push(
       await onSessionDestroyed(async ({ id }) => {
         if (props.lockedSessionId && id === props.lockedSessionId) {
-          // Our locked session was destroyed, close this detached window.
-          // R.2 discipline: destroy() not close() so onCloseRequested is
-          // not fired (avoids looping into attach_terminal on a dead session).
           if (isTauri) {
             const { getCurrentWindow } = await import("@tauri-apps/api/window");
             getCurrentWindow().destroy();
@@ -110,11 +85,6 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
       })
     );
 
-    // Detached-window X → re-attach to main, not destroy (plan §A2.2.G4 / G.13).
-    // Register as early as possible in onMount so the race window from first
-    // paint to handler-registered is minimized. If attach fails (session
-    // destroyed mid-flight, backend command error, etc.), fall back to
-    // destroying the window so the user isn't stuck.
     if (isTauri && props.detached && props.lockedSessionId) {
       const sessionId = props.lockedSessionId;
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
@@ -131,28 +101,21 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
       unlisteners.push(unlistenCloseRequested);
     }
 
-    // Window-level initializers — skipped when embedded (main owns these).
     if (!props.embedded) {
-      // Detached windows use "detached" (mapped to terminalZoom in zoomKeyMap).
       cleanupZoom = await initZoom(props.detached ? "detached" : "terminal");
       if (props.detached && props.lockedSessionId) {
-        // Per-session geometry persistence (plan §A2.4.Arb1).
         cleanupGeometry = await initDetachedWindowGeometry(props.lockedSessionId);
       } else {
         cleanupGeometry = await initWindowGeometry("terminal");
       }
     }
     await settingsStore.load();
-    // #289 / dark-default — apply persisted theme. Awaited above (vs.
-    // fire-and-forget) so themeLight is known before the corrective toggle
-    // runs. Embedded children skip per the convention above.
     if (!props.embedded) {
       document.documentElement.classList.toggle("light-theme", !!settingsStore.current?.themeLight);
     }
     await loadActiveSession();
 
     if (!props.lockedSessionId) {
-      // Normal mode: respond to session switches
       unlisteners.push(
         await onSessionSwitched(async ({ id }) => {
           if (!id) {
@@ -201,7 +164,6 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
     );
 
 
-    // Issue #162 & #163 merged: cross-window brief refresh and polling updates.
     const normalizePathForCompare = (p: string): string => {
       let s = p;
       if (s.startsWith("\\\\?\\")) s = s.slice(4);
@@ -210,14 +172,12 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
     };
     unlisteners.push(
       await onWorkgroupTaskUpdated((data) => {
-        // #163: Poller (ac_discovery.rs) provides sessionIds
         if (data.source === "poll") {
           const targetId = props.lockedSessionId ?? terminalStore.activeSessionId;
           if (!targetId) return;
           if (!data.sessionIds.includes(targetId)) return;
           terminalStore.setActiveWorkgroupTask(data.task);
         }
-        // #162: Manual edits (brief.rs) provide workgroupRoot
         else if (data.source === "manual") {
           const wgRoot = data.workgroupRoot;
           const cwd = terminalStore.activeWorkingDirectory;
@@ -231,8 +191,6 @@ const TerminalApp: Component<TerminalAppProps> = (props) => {
       })
     );
 
-    // Theme sync: follow sidebar theme toggle (redundant in embedded mode —
-    // sidebar's toggle already flips the shared documentElement classList).
     if (!props.embedded) {
       unlisteners.push(
         await onThemeChanged(({ light }) => {

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -31,86 +31,34 @@ interface SessionTerminal {
   fitAddon: FitAddon;
   inputBuffer: string;
   snapshotReplayRequested: boolean;
-  /**
-   * A `get_screen_snapshot` round-trip is in flight AND the screen can still be
-   * rebuilt from it. Never gates rendering (#955) — it only says whether the
-   * retained live events are still complete enough to reconcile against.
-   */
   snapshotReplayPending: boolean;
   snapshotResizeSuppressed: boolean;
   snapshotSettleTimer: ReturnType<typeof setTimeout> | null;
   hasRenderedOutput: boolean;
   replayStatus: HTMLDivElement;
-  /** Live events already written to xterm, retained only to rebuild (#955). */
   pendingSnapshotEvents: PtyOutputEvent[];
   pendingSnapshotBytes: number;
   lastAppliedSequence: number | null;
-  /**
-   * #973. The size the PTY was OPENED at, when this is the first terminal built
-   * for a session the view sized itself. Null for a re-attach, and for every
-   * session created with no tile to measure.
-   */
   spawnViewport: PtyViewport | null;
-  /**
-   * #973. The size the PTY is at, as far as this view knows: the size it was
-   * opened at, then whatever resize we last sent. Null means "unknown", and the
-   * next resize is always sent.
-   */
   lastSentViewport: PtyViewport | null;
-  /** #973. One drift warning per terminal, not one per resize. */
   spawnDriftReported: boolean;
-  /**
-   * #973. The pending re-send of a resize the PTY never got, and how many times
-   * we have tried. Rolling the dedup back on failure is not enough on its own:
-   * after the dedup, the failed call is usually the ONLY one of its burst, so
-   * there is no subsequent resize for the rollback to un-suppress.
-   */
   resizeRetryTimer: ReturnType<typeof setTimeout> | null;
   resizeRetryAttempts: number;
 }
 
 interface TerminalViewProps {
-  /**
-   * If set, this TerminalView is inside a detached window locked to one
-   * session. Disables the main-window pre-warm listener (plan §A2.3.G6).
-   */
   lockedSessionId?: string;
 }
 
 const SNAPSHOT_UNAVAILABLE_MESSAGE =
   "Terminal buffer unavailable. Resize the window to request a repaint.";
 
-// #955: `get_screen_snapshot` is an IPC round-trip, and it used to gate every
-// byte a new terminal rendered. On a saturated webview main thread it was
-// measured taking seconds — and, in the capture on the issue, never settling at
-// all: the agent painted continuously into a permanently black tile.
-//
-// The gate is gone. Live bytes render on arrival, and the snapshot reconciles
-// afterwards. These two bounds are what remains of the round-trip:
-//
-// 1. A settle deadline, purely diagnostic. It gates nothing; it sizes the
-//    round-trip in the log and lets a terminal that has still shown *nothing*
-//    say so instead of sitting black.
 const SNAPSHOT_SETTLE_WARN_MS = 500;
-// 2. A retention budget. Live events are held (in addition to being rendered)
-//    so the screen can be rebuilt into the snapshot's frame of reference when
-//    the snapshot loses the race. Past this many bytes the live stream has
-//    repainted the screen many times over, the snapshot is worthless, and
-//    holding more would leak if the round-trip never settles.
 const SNAPSHOT_RECONCILE_LIMIT_BYTES = 2 * 1024 * 1024;
 
-// #973. A `pty_resize` that fails leaves the PTY at a size the terminal is not —
-// the exact bug class this issue exists to close, arrived at from the other end.
-// So a failed resize is re-sent, with a linear back-off, and bounded: a resize
-// that can never succeed (the session is gone, the backend is gone) must not
-// retry forever. Exhausting the budget is reported at error level, because a PTY
-// stranded at the wrong size must not look like a PTY that was resized.
 const PTY_RESIZE_RETRY_DELAY_MS = 120;
 const PTY_RESIZE_MAX_RETRIES = 3;
 
-// WebGL context budget: ~16 per document. Canvas fallback activates silently
-// when the budget is exhausted (e.g. after ~16 concurrent sessions in main).
-// See plan §DW.9.
 const TerminalView: Component<TerminalViewProps> = (props) => {
   let hostRef!: HTMLDivElement;
   let activeSessionId: string | null = null;
@@ -121,14 +69,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
 
   const terminals = new Map<string, SessionTerminal>();
 
-  /**
-   * #973 diagnostic. The PTY was opened at the size the view had already fitted
-   * to, so a later fit that disagrees means the two measurements drifted apart —
-   * a scrollbar, a font metric settling late, an extra layout pass, a DPI quirk.
-   * The resize still goes out (correctness first), but it lands inside the
-   * child's startup, which is the whole bug. This is the line that says it
-   * happened, on a real box, instead of us assuming it never does.
-   */
   const reportSpawnSizeDrift = (
     sessionId: string,
     entry: SessionTerminal,
@@ -157,15 +97,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     }
   };
 
-  /**
-   * #973 — re-send a resize the PTY never got.
-   *
-   * It re-sends the size the terminal IS when the timer fires, not the size that
-   * failed. The view may have moved on in the meantime, and what has to be true at
-   * the end is that the PTY is where the terminal is now. That also makes the retry
-   * self-cancelling: if a later resize already landed on that size, `sendPtyResize`
-   * dedups this one away and nothing is sent.
-   */
   const scheduleResizeRetry = (sessionId: string, entry: SessionTerminal) => {
     if (entry.resizeRetryTimer !== null) {
       return;
@@ -185,8 +116,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     entry.resizeRetryTimer = setTimeout(() => {
       entry.resizeRetryTimer = null;
 
-      // Disposed, or replaced by a re-attach: that terminal's size is not this
-      // terminal's business any more.
       if (terminals.get(sessionId) !== entry) {
         return;
       }
@@ -195,17 +124,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     }, PTY_RESIZE_RETRY_DELAY_MS * attempt);
   };
 
-  /**
-   * #973 — the ONE place a resize reaches the PTY, and it only does so when the
-   * size actually moved.
-   *
-   * A single attach used to fire 5-20 `pty_resize` calls: `syncViewport` sent one
-   * unconditionally, from a double `requestAnimationFrame` AND a `ResizeObserver`,
-   * and xterm's own `onResize` sent another. dev-rust measured that a redundant
-   * SAME-size burst is harmless (0/10 blank) while one row of real drift is not
-   * (6/10) — so both halves matter: send nothing when nothing changed, and when
-   * something did change, say it exactly once.
-   */
   const sendPtyResize = (
     sessionId: string,
     entry: SessionTerminal,
@@ -224,20 +142,14 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
 
     void PtyAPI.resize(sessionId, cols, rows)
       .then(() => {
-        // The channel works. Whatever budget an earlier failure burned is returned.
         entry.resizeRetryAttempts = 0;
       })
       .catch((err: unknown) => {
-        // A FAILED resize must not poison the cache: if it did, the retry below
-        // would be deduped away as a no-op and the PTY would sit at the wrong size
-        // forever. (dev-rust hit exactly this trap in the backend's own dedup.)
         if (entry.lastSentViewport === sent) {
           entry.lastSentViewport = previous;
         }
         console.warn(`[terminal] pty_resize ${sessionId} failed:`, err);
 
-        // ...and un-suppressing a resize nobody is going to send again is not a
-        // retry. Send it again.
         scheduleResizeRetry(sessionId, entry);
       });
   };
@@ -254,24 +166,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     }
   };
 
-  /**
-   * #973 — the size a terminal created RIGHT NOW would fit to, handed to
-   * `create_session` so the PTY is opened at it and nothing has to resize a child
-   * that is still starting up.
-   *
-   * This is not a prediction. `proposeDimensions()` is the exact computation the
-   * new terminal's own post-mount `fit()` will run, and it is run here against a
-   * tile that is already on screen in the same `.terminal-host`: every
-   * `.terminal-instance` is `position: absolute; inset: 0`, so a new one gets the
-   * identical box; `createTerminalOptions` is the same for all of them; and the
-   * font metrics are already resolved, because this terminal has been rendering
-   * with them. Same inputs, same computation, same answer.
-   *
-   * Null whenever any of that stops being true — nothing is active, the tile is
-   * `display: none` (a pre-warmed or backgrounded session measures a 0 box), or
-   * xterm itself reports it has not been laid out yet. The caller then sends no
-   * size, which is strictly better than sending a wrong one.
-   */
   const measureFittedViewport = (): PtyViewport | null => {
     if (!activeSessionId) {
       return null;
@@ -390,11 +284,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     entry.pendingSnapshotBytes = 0;
   };
 
-  /**
-   * Retain a live event that has ALREADY been written to xterm, so the screen
-   * can be rebuilt from the snapshot's frame of reference once it lands. This
-   * buffer never withholds output (#955) — it exists only to reconcile.
-   */
   const retainForSnapshotReconcile = (
     entry: SessionTerminal,
     event: PtyOutputEvent
@@ -407,13 +296,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     }
   };
 
-  /**
-   * #955: live PTY bytes are written the instant they arrive. They are NEVER
-   * gated on the snapshot round-trip — that gate was the defect: every newly
-   * created terminal stayed black for as long as `get_screen_snapshot` took to
-   * settle, which on a saturated IPC channel was forever, while the agent
-   * painted underneath and the bytes piled up in an array.
-   */
   const writeLivePtyOutput = (entry: SessionTerminal, event: PtyOutputEvent) => {
     const sequence = eventSequence(event);
 
@@ -452,16 +334,10 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
   };
 
   interface SnapshotSettle {
-    /** The retained live events were still complete: a rebuild is safe. */
     reconcilable: boolean;
     retainedEvents: PtyOutputEvent[];
   }
 
-  /**
-   * Conclude the snapshot round-trip, whatever its outcome. Returns the live
-   * events retained while it was in flight, or null if the terminal was
-   * replaced/disposed underneath it.
-   */
   const concludeSnapshotFetch = (
     sessionId: string,
     entry: SessionTerminal
@@ -500,15 +376,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     console.debug(line);
   };
 
-  /**
-   * Live output already painted this terminal, so the snapshot lost the race.
-   * A snapshot is a FULL-SCREEN repaint (`vt100::Screen::contents_formatted`),
-   * so writing it on top of live bytes would duplicate them. Rebuild instead:
-   * reset, lay down the snapshot (everything up to its sequence), then replay
-   * the live events that came after it. The sequence dedup drops the ones the
-   * snapshot already contains, so the result is exactly what the un-raced path
-   * renders — no duplicated and no missing output.
-   */
   const rebuildFromSnapshot = (
     entry: SessionTerminal,
     snapshot: PtyScreenSnapshot,
@@ -516,8 +383,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
   ) => {
     entry.terminal.reset();
     entry.hasRenderedOutput = false;
-    // Rewind, do not raise: the retained events after the snapshot's sequence
-    // must replay, and markAppliedSequence() only ever moves the watermark up.
     entry.lastAppliedSequence = snapshot.sequence;
 
     writeTerminalBytes(entry, new Uint8Array(snapshot.data));
@@ -533,8 +398,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     const { reconcilable, retainedEvents } = settle;
 
     if (!snapshot || snapshot.data.length === 0) {
-      // Nothing to seed with. Whatever live output has arrived stands, and the
-      // dedup makes this flush a no-op for anything already on screen.
       flushPendingEvents(entry, retainedEvents);
       if (!entry.hasRenderedOutput) {
         setReplayStatus(entry, SNAPSHOT_UNAVAILABLE_MESSAGE);
@@ -543,9 +406,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     }
 
     if (entry.hasRenderedOutput && !reconcilable) {
-      // The retention budget was spent, so the live events after the snapshot's
-      // sequence are no longer held and a rebuild would drop them. The live
-      // stream has long since repainted the screen: keep it, drop the snapshot.
       console.warn(
         `[terminal] snapshot ${sessionId} discarded: live output outran the reconcile budget`
       );
@@ -563,8 +423,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     if (entry.hasRenderedOutput) {
       rebuildFromSnapshot(entry, snapshot, retainedEvents);
     } else {
-      // The snapshot won the race into a clean terminal: seed it and let the
-      // retained events (if any) land on top. This is the re-attach path.
       writeTerminalBytes(entry, new Uint8Array(snapshot.data));
       markAppliedSequence(entry, snapshot.sequence);
       flushPendingEvents(entry, retainedEvents);
@@ -585,8 +443,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     entry.pendingSnapshotEvents = [];
     entry.pendingSnapshotBytes = 0;
 
-    // #955 diagnostic: size the round-trip. The gate is gone, but a slow settle
-    // still points straight at a saturated IPC channel / webview main thread.
     const requestedAt = performance.now();
 
     clearSnapshotSettleTimer(entry);
@@ -600,8 +456,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         `[terminal] snapshot ${sessionId} still pending after ${SNAPSHOT_SETTLE_WARN_MS}ms, pendingEvents=${entry.pendingSnapshotEvents.length}`
       );
 
-      // Live output keeps rendering regardless — that is the fix. Only a
-      // terminal that has shown nothing at all has anything to report.
       if (!entry.hasRenderedOutput) {
         setReplayStatus(entry, SNAPSHOT_UNAVAILABLE_MESSAGE);
       }
@@ -648,10 +502,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     container.hidden = true;
     hostRef.appendChild(container);
 
-    // #973. The PTY was opened at the size this view fitted to, so start xterm AT
-    // that size. Without this it would start at xterm's 80x24 default and the very
-    // first fit would resize it — firing, through `onResize`, exactly the resize
-    // into the child's startup that opening at the right size exists to avoid.
     const spawnViewport = takeSpawnViewport(sessionId);
     const terminal = new Terminal({
       ...createTerminalOptions(isTauri),
@@ -677,7 +527,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       });
       terminal.loadAddon(webglAddon);
     } catch {
-      // Canvas renderer fallback is automatic.
     }
 
     const entry: SessionTerminal = {
@@ -695,30 +544,18 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       pendingSnapshotBytes: 0,
       lastAppliedSequence: null,
       spawnViewport,
-      // The PTY is already at the size it was opened at. That is the baseline the
-      // post-mount fit is deduped against, and the reason it sends nothing at all.
       lastSentViewport: spawnViewport,
       spawnDriftReported: false,
       resizeRetryTimer: null,
       resizeRetryAttempts: 0,
     };
 
-    // Per-terminal keyboard shortcuts. Match keys via event.key (layout-aware,
-    // matches the convention in shared/shortcuts.ts) so Dvorak/Colemak/AZERTY
-    // users press the key labeled C/V in their layout, not the QWERTY position.
     terminal.attachCustomKeyEventHandler((event) => {
-      // IME composition: hand the keystroke back to xterm so its internal
-      // _compositionHelper can finish the multi-keystroke sequence. Some CJK
-      // IMEs chord Ctrl+Shift during composition; intercepting would corrupt
-      // the IME state.
       if (event.isComposing) return true;
 
       const isCtrlShift = event.ctrlKey && event.shiftKey;
       const key = event.key.toLowerCase();
 
-      // Ctrl+Shift+C → copy xterm selection to system clipboard. With no
-      // selection, return true so the event falls through (in dev, WebView2
-      // opens DevTools; in production, nothing happens).
       if (isCtrlShift && key === "c") {
         if (event.type === "keydown") {
           if (!terminal.hasSelection()) return true;
@@ -729,13 +566,9 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
             .catch((err) => console.warn("[copy] write failed:", err?.name ?? "Error"));
           return false;
         }
-        // keyup mirror: re-check selection (stateless; selection persists post-copy).
         return terminal.hasSelection() ? false : true;
       }
 
-      // Ctrl+Shift+V → paste system clipboard via terminal.paste() so the
-      // payload is wrapped in bracketed-paste markers. clipboard.readText()
-      // is async; re-check session and dispose state inside .then.
       if (isCtrlShift && key === "v") {
         if (event.type === "keydown") {
           event.preventDefault();
@@ -746,10 +579,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
               if (!text) return;
               if (activeSessionId !== sessionId) return; // session switched during await
               if (terminal.element?.isConnected !== true) return; // terminal not in DOM (pre-open or post-dispose detached)
-              // Strip both 7-bit ESC[200~/201~ and 8-bit C1 \x9b 200~/201~
-              // forms — defense-in-depth against future shells that activate
-              // 8-bit recognition. xterm@6.0.0 does NOT sanitize internally
-              // (CVE-2019-11848 redux). See plan #104 §1.1.D / §6.8.
               const sanitized = text.replace(/\x9b20[01]~|\x1b\[20[01]~/g, "");
               terminal.paste(sanitized);
             })
@@ -759,7 +588,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
         return false;
       }
 
-      // Shift+Enter → send LF (soft newline) instead of CR (submit)
       if (event.key === "Enter" && event.shiftKey) {
         if (event.type === "keydown" && activeSessionId === sessionId) {
           const encoder = new TextEncoder();
@@ -813,10 +641,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
     next.terminal.focus();
 
     if (isBrowser) {
-      // Browser mode: fit xterm to container and resize PTY to match.
-      // The program receives SIGWINCH and redraws at the new size.
-      // We skip the snapshot replay because it was rendered for the
-      // native terminal's dimensions and would look garbled here.
       requestAnimationFrame(() => {
         if (sessionId !== activeSessionId) return;
         syncViewport(sessionId);
@@ -853,11 +677,6 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
       disposeSessionTerminal(id);
     });
 
-    // Plan §A2.3.G6 pre-warm: in main-window mode, subscribe to
-    // terminal_detached events and pre-create hidden xterm entries so
-    // pty_output for detached sessions accumulates in main's cache. On
-    // re-attach, showSessionTerminal promotes the pre-warmed entry to
-    // visible with full scrollback intact. Skip in detached windows.
     if (!props.lockedSessionId) {
       unlistenTerminalDetached = await onTerminalDetached(({ sessionId }) => {
         if (!terminals.has(sessionId)) {

--- a/src/terminal/components/prompt-input-capture.ts
+++ b/src/terminal/components/prompt-input-capture.ts
@@ -19,20 +19,11 @@ function findPasteEnd(data: string, fromIndex: number) {
     : { index: end8, marker: PASTE_END_8BIT };
 }
 
-// 8-bit C1 OSC introducer. OSC (7-bit `ESC ]`) is handled apart from the other
-// string controls because it alone accepts BEL as a terminator (see below).
 const OSC_INTRO_8BIT = "\x9d";
 
-// The remaining ECMA-48 "string" controls, which terminate ONLY at ST: DCS, SOS,
-// PM, APC. 7-bit finals after ESC: P (DCS), X (SOS), ^ (PM), _ (APC).
 const STRING_SEQ_INTRO_7BIT = new Set(["P", "X", "^", "_"]);
-// 8-bit C1 equivalents: \x90 (DCS), \x98 (SOS), \x9e (PM), \x9f (APC).
 const STRING_SEQ_INTRO_8BIT = new Set(["\x90", "\x98", "\x9e", "\x9f"]);
 
-// Bytes that begin a control sequence we must skip rather than capture as prompt
-// text: ESC (every 7-bit sequence), 8-bit CSI (\x9b, also the bracketed-paste
-// prefix handled before this check), and the 8-bit string introducers (OSC + the
-// ST-only family).
 function isControlIntroducer(char: string): boolean {
   return (
     char === "\x1b" ||
@@ -42,7 +33,6 @@ function isControlIntroducer(char: string): boolean {
   );
 }
 
-// CSI: consume up to and including the final byte (0x40–0x7e).
 function skipCsi(data: string, bodyStart: number): number {
   for (let i = bodyStart; i < data.length; i += 1) {
     const code = data.charCodeAt(i);
@@ -53,11 +43,6 @@ function skipCsi(data: string, bodyStart: number): number {
   return data.length;
 }
 
-// OSC/DCS/SOS/PM/APC: consume the whole "string" sequence up to its terminator.
-// All end at ST (`ESC \` or 8-bit \x9c); OSC additionally accepts BEL (\x07) —
-// the xterm convention OpenCode uses for its OSC-4 colour-palette reply (#533).
-// For DCS/SOS/PM/APC, `belTerminates` is false, so a stray BEL inside the payload
-// is consumed rather than mistaken for a terminator.
 function skipStringSequence(
   data: string,
   bodyStart: number,
@@ -89,8 +74,6 @@ function skipControlSequence(data: string, index: number): number {
     if (next !== undefined && STRING_SEQ_INTRO_7BIT.has(next)) {
       return skipStringSequence(data, index + 2, false); // DCS/SOS/PM/APC: ST only
     }
-    // Lone trailing ESC or a short escape this helper does not model — drop just
-    // the ESC, preserving prior behaviour for those cases.
     return index + 1;
   }
 


### PR DESCRIPTION
Closes #1046.

## What

Purge explanatory comments from **56 TS/TSX files under `src/`** — pure whole-line comment deletions, **−3,538 comment lines**, zero code change.

## How

A lexer-grade stripper (TypeScript Compiler API, no emitter) removed only line-isolated comment ranges. The stripper is a throwaway (not committed). Three oracles gate the change:
- **Leaf-token identity** (parser-grade): before/after token streams byte-identical on all 56 → no string/regex/template/type/identifier byte changed.
- **Line-subsequence**: every output line ∈ original, in order → pure deletion.
- **numstat**: deletions-only.

## Scope / safety

- Exactly the 56 planned paths. **Zero Rust, zero CSS, zero test files.** No `@vitest-environment`, shebang, `vite-env.d.ts`, `HomeView.tsx`, or seed-config file touched.
- Load-bearing comments preserved by a hardened denylist: `ipc.ts` keeps its exactly-2 `@deprecated`; `@jsx`/`@license`/`@preserve`/`prettier-ignore`/`///<reference>` all guarded.
- `github-url.ts` security rationale (documenting a real fixed URL-parsing vuln) preserved verbatim below so the project keeps the knowledge even though the source prose is stripped.

## Verification

- `npm run build` ✓, `tsc --noEmit` ✓ (types intact after full JSDoc removal), `vitest` 1129/1129 ✓.
- `cargo test` byte-identical pre/post @ `1482049` (0 Rust changed by construction; only the pre-existing `rustdoc.exe` doctest infra failures).
- **Dev (dev-webpage-ui)** implemented from a cold start against the frozen plan (Plan-SHA256 `2891CAB5…1FB21`); **Grinch (dev-rust-grinch)** independently re-verified with its own blob-vs-disk oracle: 56/56 pass all checks, **PASS, non-visual**.

### One benign diff artifact
`src/sidebar/stores/project.ts` renders `+1/−99` under git's default **myers** algorithm — a surviving blank line between two removed comment blocks rendered as delete+add. Under `histogram`/`patience` it is `0/−98`; the added line is empty; the subsequence + token oracles prove no content was added. Not an AC4 violation.

---

### Preserved security rationale from `src/shared/github-url.ts`

The stripped `///` prose recorded that a prior revision falsely claimed the parsing regex was an injection guard (`git@github.com:../evil` parsed to `{owner:"..", repo:"evil"}`), and that `.`/`..` must be rejected on **both** parse branches because `repo.branch` is not always git-sourced (it arrives unvalidated from `config.json` `repoBranch` and the volatile branch-event layer); without that, `../../../../evil/repo` normalized into a different repository. The guards themselves are unchanged code.
