### PR TITLE
feat(settings): show env values plaintext, mask only PASSWORD* keys (refs #1052)

### DIFF
--- a/src/shared/profile-utils.test.ts
+++ b/src/shared/profile-utils.test.ts
@@ -22,6 +22,7 @@ import {
   resolveProfileLabel,
   resolveProfilePreview,
   sessionProfileBadge,
+  shouldMaskEnvValue,
   shouldOfferRestartAfterAssign,
   stringifyArgv,
   suggestedContextRegex,
@@ -471,5 +472,25 @@ describe("profileBadgeKind (#526/#527 shared Config/Selection taxonomy)", () => 
     expect(suggestedContextRegex("opencode")).toBeNull();
     expect(suggestedContextRegex("my-agent-cli --flag")).toBeNull();
     expect(suggestedContextRegex("")).toBeNull();
+  });
+});
+
+describe("shouldMaskEnvValue (#1052 env value masking rule)", () => {
+  it("masks keys that start with PASSWORD (case-insensitive, trimmed)", () => {
+    expect(shouldMaskEnvValue("PASSWORD")).toBe(true);
+    expect(shouldMaskEnvValue("PASSWORD_TOKEN_API")).toBe(true);
+    expect(shouldMaskEnvValue("PASSWORDS")).toBe(true);
+    expect(shouldMaskEnvValue("password_token")).toBe(true);
+    expect(shouldMaskEnvValue("Password")).toBe(true);
+    expect(shouldMaskEnvValue("PaSsWoRd")).toBe(true);
+    expect(shouldMaskEnvValue("  password_x  ")).toBe(true);
+  });
+  it("leaves other keys in plaintext", () => {
+    expect(shouldMaskEnvValue("")).toBe(false);
+    expect(shouldMaskEnvValue("   ")).toBe(false);
+    expect(shouldMaskEnvValue("CODEX_HOME")).toBe(false);
+    expect(shouldMaskEnvValue("OPENAI_API_KEY")).toBe(false);
+    expect(shouldMaskEnvValue("MY_PASSWORD")).toBe(false);
+    expect(shouldMaskEnvValue("DB_PASSWORD")).toBe(false);
   });
 });

--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -327,6 +327,16 @@ export function hasEnabledEnvKey(rows: CodingAgentEnv[], key: string): boolean {
   return rows.some((row) => row.enabled && envKeyCompare(row.key) === target);
 }
 
+/**
+ * #1052 - env value display rule. A row's value is masked only when its key
+ * starts with PASSWORD, matched case-insensitively on the trimmed key. Reuses
+ * envKeyCompare (trim + uppercase) so the rule stays consistent with the rest
+ * of the env-key handling. Display-only; values are stored as plaintext.
+ */
+export function shouldMaskEnvValue(key: string): boolean {
+  return envKeyCompare(key).startsWith("PASSWORD");
+}
+
 export type EnvOrigin = "system" | "profile" | "accepted";
 
 const MANAGED_HOME_ENV_KEYS = new Set([

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -41,6 +41,7 @@ import {
   profileEnvOrigin,
   resolveProfileLabel,
   resolveProfilePreview,
+  shouldMaskEnvValue,
   sortedProfileLetters,
   suggestedContextRegex,
   validateEnvRows,
@@ -1730,7 +1731,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                   />
                   <input
                     class="settings-input settings-env-value"
-                    type="password"
+                    type={shouldMaskEnvValue(row.key) ? "password" : "text"}
                     value={row.value}
                     disabled={readOnly()}
                     onInput={(e) => updateAgentEnv(agentIndex, rowIndex(), "value", e.currentTarget.value)}
@@ -1819,12 +1820,12 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
               data-ac-role="status"
               data-ac-state="user"
             >
-              User CODEX_HOME is active for this Codex agent. Values remain masked in Settings.
+              User CODEX_HOME is active for this Codex agent.
             </div>
           </Show>
         </Show>
         <div class="settings-hint">
-          Env values are stored as plaintext local settings and are masked here by default.
+          Env values are stored as plaintext local settings and shown here in plaintext, except rows whose key starts with PASSWORD, which stay masked.
         </div>
       </div>
     );
@@ -2528,6 +2529,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                   />
                   <input
                     class="settings-input settings-env-value"
+                    type={shouldMaskEnvValue(row().key) ? "password" : "text"}
                     value={row().value}
                     onInput={(e) => updateCellEnvRow(agent.id, letter, rowIndex, "value", e.currentTarget.value)}
                     placeholder="value"


### PR DESCRIPTION
## Summary
In Settings -> Coding Agents, environment-variable **value** fields now render in **plaintext by default** and are masked (`type="password"`) **only** when the row **key** starts with `PASSWORD` (case-insensitive, trimmed). Example: `PASSWORD_TOKEN_API=123132` shows its value as dots; `OPENAI_API_KEY=sk-...` shows in plaintext. The masking is reactive to the key and applied consistently to both the agent env editor and the profile/cell env editor.

Previously the agent editor always masked values and the profile/cell editor never did; values are stored as plaintext local settings, so masking is display-only.

## Changes
- New pure helper `shouldMaskEnvValue(key)` in `src/shared/profile-utils.ts`, reusing the existing `envKeyCompare` (trim + uppercase) so the rule matches existing env-key normalization. Single source of truth; both editors call it.
- Both env value inputs in `SettingsModal.tsx` use `type={shouldMaskEnvValue(key) ? "password" : "text"}`.
- Updated the stale hint copy and removed the stale "Values remain masked" clause from the CODEX_HOME note.
- Unit tests for the helper in `src/shared/profile-utils.test.ts`.

Out of scope (unchanged): the dedicated Gemini API Key and Telegram Bot Token secret fields remain masked; no backend/IPC/persistence/type changes; no reveal toggle added.

## Review & tests
- Planned + certified by architect (LITE), implemented by dev-webpage-ui, adversarially reviewed by dev-rust-grinch: **PASS**.
- `npm run typecheck` clean; `npm test` (vitest) **1246 tests pass**, including the new `shouldMaskEnvValue` block.
- Diff: 3 files, +36/-3.

Closes #1052
