### PR TITLE
feat(settings): suggest Pi context badge pattern (refs #1054)

### DIFF
--- a/src-tauri/src/pty/context_scrape/rows.rs
+++ b/src-tauri/src/pty/context_scrape/rows.rs
@@ -34,6 +34,7 @@ mod tests {
     /// Every element of each is load-bearing, and the tests below are what say so.
     const CLAUDE: &str = r"^ {2}Context [░█]+ (\d{1,3})%";
     const CODEX: &str = r"^ {2}.*· Context (\d{1,3})% used";
+    const PI: &str = r"^(?:.*? )?(\d{1,3})\.\d%/";
 
     /// The real statusline at cols=120, as far as the plan transcribes it. The plan elides
     /// the tail with `…` in prose and the capture itself did not survive the workgroup
@@ -50,6 +51,52 @@ mod tests {
         let compiled = compile(pattern).expect("pattern compiles");
         let owned: Vec<String> = rows.iter().map(|r| r.to_string()).collect();
         extract(&compiled, &owned)
+    }
+
+    #[test]
+    fn pi_current_footers_extract_integer_used_percentage() {
+        assert_eq!(
+            extract_with(
+                PI,
+                &["$0.000 (sub) 0.0%/372k                    (openai-codex) gpt-5.6-sol • max"]
+            ),
+            Some(0)
+        );
+        assert_eq!(extract_with(PI, &["42.7%/372k"]), Some(42));
+        assert_eq!(extract_with(PI, &["100.0%/372k"]), Some(100));
+        assert_eq!(
+            extract_with(
+                PI,
+                &["$1.234 98k CH83.4% 42.7%/372k (openai-codex) gpt-5.6-sol • max"]
+            ),
+            Some(42)
+        );
+        assert_eq!(
+            extract_with(
+                PI,
+                &["$0.125 24k 42.7%/(auto) (anthropic) claude-sonnet • high"]
+            ),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn pi_unknown_and_incompatible_footers_fail_closed() {
+        for row in [
+            "?/372k",
+            "$0.000 (sub) 101.0%/372k",
+            "$0.000 (sub) 1000.0%/372k",
+            "$0.000 (sub) 42.70%/372k",
+            "$0.000 (sub) 42.7%",
+            "$0.000 98k CH83.4% (cache only)",
+            "$0.000 (sub) 42.7% of 372k",
+        ] {
+            assert_eq!(
+                extract_with(PI, &[row]),
+                None,
+                "row should fail closed: {row}"
+            );
+        }
     }
 
     #[test]

--- a/src/shared/profile-utils.test.ts
+++ b/src/shared/profile-utils.test.ts
@@ -3,6 +3,7 @@ import type { AgentConfig, CodingAgentProfilesConfig } from "./types";
 import {
   CLAUDE_CONTEXT_REGEX,
   CODEX_CONTEXT_REGEX,
+  PI_CONTEXT_REGEX,
   commandExecutableBasename,
   composeEffectiveCommand,
   defaultInstructionsFilename,
@@ -447,6 +448,24 @@ describe("profileBadgeKind (#526/#527 shared Config/Selection taxonomy)", () => 
     expect(suggestedContextRegex("codex")).toBe(CODEX_CONTEXT_REGEX);
     expect(CODEX_CONTEXT_REGEX).toContain("·"); // MIDDLE DOT, adjacent to the capture
     expect(CODEX_CONTEXT_REGEX).not.toContain("▓");
+  });
+
+  it("suggests the exact Pi slash-footer pattern for supported command shapes", () => {
+    expect(PI_CONTEXT_REGEX).toBe(String.raw`^(?:.*? )?(\d{1,3})\.\d%/`);
+    expect(suggestedContextRegex("pi")).toBe(PI_CONTEXT_REGEX);
+    expect(suggestedContextRegex("C:\\tools\\pi.exe")).toBe(PI_CONTEXT_REGEX);
+    expect(suggestedContextRegex("cmd.exe /c pi")).toBe(PI_CONTEXT_REGEX);
+  });
+
+  it("keeps Pi precedence over Claude and Codex model tokens", () => {
+    expect(suggestedContextRegex("pi --model claude-sonnet")).toBe(PI_CONTEXT_REGEX);
+    expect(suggestedContextRegex("pi --model codex-model")).toBe(PI_CONTEXT_REGEX);
+  });
+
+  it("does not treat Pi executable look-alikes as Pi", () => {
+    for (const command of ["pip", "pipx", "ping", "pixel"]) {
+      expect(suggestedContextRegex(command)).toBeNull();
+    }
   });
 
   it("resolves a wrapped or suffixed claude the same way the filename default does (a_docker_wrapped_claude_still_resolves)", () => {

--- a/src/shared/profile-utils.test.ts
+++ b/src/shared/profile-utils.test.ts
@@ -462,6 +462,13 @@ describe("profileBadgeKind (#526/#527 shared Config/Selection taxonomy)", () => 
     expect(suggestedContextRegex("pi --model codex-model")).toBe(PI_CONTEXT_REGEX);
   });
 
+  it("does not let standalone Pi argument values override the actual command", () => {
+    expect(suggestedContextRegex("claude --model pi")).toBe(CLAUDE_CONTEXT_REGEX);
+    expect(suggestedContextRegex("codex --profile pi")).toBe(CODEX_CONTEXT_REGEX);
+    expect(suggestedContextRegex("echo pi")).toBeNull();
+    expect(suggestedContextRegex("cmd.exe /c echo pi")).toBeNull();
+  });
+
   it("does not treat Pi executable look-alikes as Pi", () => {
     for (const command of ["pip", "pipx", "ping", "pixel"]) {
       expect(suggestedContextRegex(command)).toBeNull();

--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -423,9 +423,11 @@ export function defaultInstructionsFilename(command: string): string {
 
 export const CLAUDE_CONTEXT_REGEX = String.raw`^ {2}Context [░█]+ (\d{1,3})%`;
 export const CODEX_CONTEXT_REGEX = String.raw`^ {2}.*· Context (\d{1,3})% used`;
+export const PI_CONTEXT_REGEX = String.raw`^(?:.*? )?(\d{1,3})\.\d%/`;
 
 export function suggestedContextRegex(command: string): string | null {
   const stems = command.trim().split(/\s+/).filter(Boolean).map(executableTokenBasename);
+  if (stems.some((stem) => stem === "pi")) return PI_CONTEXT_REGEX;
   if (stems.some((s) => s.startsWith("claude"))) return CLAUDE_CONTEXT_REGEX;
   if (stems.some((s) => s.startsWith("codex"))) return CODEX_CONTEXT_REGEX;
   return null;

--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -426,8 +426,18 @@ export const CODEX_CONTEXT_REGEX = String.raw`^ {2}.*· Context (\d{1,3})% used`
 export const PI_CONTEXT_REGEX = String.raw`^(?:.*? )?(\d{1,3})\.\d%/`;
 
 export function suggestedContextRegex(command: string): string | null {
+  const parsed = parseArgvText(command);
+  const tokens = parsed.error
+    ? command.trim().split(/\s+/).filter(Boolean)
+    : parsed.argv;
+  const directStem = executableTokenBasename(tokens[0] ?? "");
+  const piExecutableStem =
+    directStem === "cmd" && tokens[1]?.toLowerCase() === "/c"
+      ? executableTokenBasename(tokens[2] ?? "")
+      : directStem;
+  if (piExecutableStem === "pi") return PI_CONTEXT_REGEX;
+
   const stems = command.trim().split(/\s+/).filter(Boolean).map(executableTokenBasename);
-  if (stems.some((stem) => stem === "pi")) return PI_CONTEXT_REGEX;
   if (stems.some((s) => s.startsWith("claude"))) return CLAUDE_CONTEXT_REGEX;
   if (stems.some((s) => s.startsWith("codex"))) return CODEX_CONTEXT_REGEX;
   return null;

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -8,6 +8,7 @@ import {
   AC_MATRIX_ROOT_PLACEHOLDER,
   AC_REPLICA_ROOT_PLACEHOLDER,
   AC_WORKSPACE_ROOT_PLACEHOLDER,
+  PI_CONTEXT_REGEX,
 } from "../../shared/profile-utils";
 
 vi.mock("../../shared/ipc", async () => {
@@ -234,6 +235,54 @@ describe("SettingsModal automation hooks", () => {
     expect(document.querySelector('[data-ac-testid="settings.agentRow.0.label"]')).toBeTruthy();
     expect(document.querySelector('[data-ac-testid="settings.agentPreset.codex"]')).toBeTruthy();
     expect(document.querySelector('[data-ac-testid="settings.agent.addCustom"]')).toBeTruthy();
+
+    dispose();
+  });
+
+  it("offers and saves the opt-in Pi context pattern without pre-seeding it", async () => {
+    vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
+      agents: [
+        {
+          id: "pi",
+          label: "Pi",
+          command: "pi",
+          color: "#8b5cf6",
+          envs: [],
+          isolatedHome: false,
+        },
+      ],
+    }));
+
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    const contextRegex = byTestId<HTMLInputElement>(
+      "settings.agentRow.0.contextRegex",
+    );
+    expect(contextRegex.value).toBe("");
+    expect(contextRegex.placeholder).toBe(PI_CONTEXT_REGEX);
+
+    const suggest = byTestId<HTMLButtonElement>(
+      "settings.agentRow.0.contextRegex.suggest",
+    );
+    expect(suggest.textContent?.trim()).toBe("Use suggested pattern");
+
+    suggest.click();
+    await settle();
+    expect(contextRegex.value).toBe(PI_CONTEXT_REGEX);
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.agents[0]?.contextRegex).toBe(PI_CONTEXT_REGEX);
 
     dispose();
   });


### PR DESCRIPTION
## Summary

- add the exact opt-in Pi context badge suggestion `^(?:.*? )?(\d{1,3})\.\d%/` in Coding Agent settings;
- recognize Pi only when it is the direct executable or the immediate executable in the supported `cmd[.exe] /c` wrapper;
- preserve existing Claude/Codex behavior when a model/profile argument is literally `pi`;
- cover the visible Settings suggestion flow and the real Rust context-scrape semantics, including fail-closed footer cases.

The suggestion remains disabled until the user clicks **Use suggested pattern** and saves. No preset migration, silent default, schema change, or production Rust change is included.

## Verification

- `npm run typecheck`
- focused frontend regression: 8 files, 147 tests passed
- full frontend suite: 134 files, 1,251 tests passed
- `npm run test:debt`
- `npm run build`
- focused Rust context scraper: 14/14 passed
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- full Rust suite: 2,639 passed, 14 ignored, 0 failed
- `git diff --check`

`cargo fmt --all -- --check` reproduces a pre-existing baseline/toolchain exception in 27 unrelated tracked Rust files (125 diff sections), none in this PR's `rows.rs`. The focused `rustfmt --edition 2021 --check src-tauri/src/pty/context_scrape/rows.rs` passes.

## Review

- frozen revised plan SHA-256: `05D5BFA6E70C98DE169965A532EE74E62AAD534168DC1D780AA0F38500D239D6`
- Grinch adversarial re-review: **PASS**
- branch includes current `origin/main` at PR creation

## Delivery hold

This PR is intentionally left **open and unmerged** for user inspection. Do not merge, enable auto-merge, close the PR, or delete the branch without later explicit user approval.

Closes #1054