### PR TITLE
feat: add team context usage alerts (#1056)

### DIFF
--- a/src-tauri/src/cli/team.rs
+++ b/src-tauri/src/cli/team.rs
@@ -9,7 +9,8 @@ use crate::commands::entity_creation::{
     agent_ref_bare_name, create_new_team_config_on_disk, create_or_update_replica_on_disk,
     normalize_team_config_for_project, parse_team_from_workgroup_name, read_team_config,
     remove_replica_dir, resolve_agent_ref, sanitize_name, validate_existing_name,
-    write_team_config, ReplicaDiskCreateArgs, RepoAssignment,
+    write_team_config_guarded, ReplicaDiskCreateArgs, RepoAssignment, TeamConfigMutationGuard,
+    TeamConfigResult,
 };
 
 #[derive(Args)]
@@ -101,6 +102,7 @@ struct TeamListItem {
     agents: Vec<String>,
     coordinator: String,
     repos: Vec<RepoAssignment>,
+    context_alert_percentages: Vec<u8>,
 }
 
 #[derive(Debug, Serialize)]
@@ -111,6 +113,7 @@ struct TeamCreateResult {
     agents: Vec<String>,
     coordinator: String,
     repos: Vec<RepoAssignment>,
+    context_alert_percentages: Vec<u8>,
 }
 
 #[derive(Debug, Serialize)]
@@ -171,6 +174,7 @@ fn create(args: TeamCreateArgs) -> Result<(), String> {
         agents: config.agents,
         coordinator: config.coordinator,
         repos: config.repos,
+        context_alert_percentages: config.context_alert_percentages,
     })
 }
 
@@ -188,6 +192,7 @@ fn list(args: TeamListArgs) -> Result<(), String> {
             agents: config.agents,
             coordinator: config.coordinator,
             repos: config.repos,
+            context_alert_percentages: config.context_alert_percentages,
         });
     } else if let Ok(entries) = std::fs::read_dir(&workspace_dir) {
         for entry in entries.flatten() {
@@ -206,6 +211,7 @@ fn list(args: TeamListArgs) -> Result<(), String> {
                     agents: config.agents,
                     coordinator: config.coordinator,
                     repos: config.repos,
+                    context_alert_percentages: config.context_alert_percentages,
                 });
             }
         }
@@ -214,29 +220,58 @@ fn list(args: TeamListArgs) -> Result<(), String> {
     print_json(&items)
 }
 
+fn add_member_to_team_config(
+    mut config: TeamConfigResult,
+    agent_ref: &str,
+    make_coordinator: bool,
+) -> Result<(TeamConfigResult, bool), String> {
+    let was_present = config.agents.iter().any(|agent| agent == agent_ref);
+    push_unique(&mut config.agents, agent_ref.to_string());
+    if make_coordinator {
+        config.coordinator = agent_ref.to_string();
+    }
+    if !config.coordinator.is_empty() && !config.agents.contains(&config.coordinator) {
+        return Err("Coordinator must be one of the selected agents".to_string());
+    }
+    Ok((config, !was_present))
+}
+
+fn remove_member_from_team_config(
+    mut config: TeamConfigResult,
+    agent_ref: &str,
+) -> Result<(TeamConfigResult, bool), String> {
+    if config.coordinator == agent_ref {
+        return Err(
+            "Cannot remove the current coordinator without choosing a replacement".to_string(),
+        );
+    }
+    let before = config.agents.len();
+    config.agents.retain(|agent| agent != agent_ref);
+    for repo in &mut config.repos {
+        repo.agents.retain(|agent| agent != agent_ref);
+    }
+    let removed = config.agents.len() != before;
+    Ok((config, removed))
+}
+
 fn add_member(args: TeamAddMemberArgs) -> Result<(), String> {
     validate_existing_name(&args.workgroup, "Workgroup")?;
     let project_path = resolve_cli_project(&args.project)?;
     let workspace_dir = resolve_cli_workspace(&project_path)?;
+    let guard = TeamConfigMutationGuard::acquire(&workspace_dir)?;
     let wg_dir = workspace_dir.join(&args.workgroup);
     if !wg_dir.is_dir() {
         return Err(format!("Workgroup '{}' not found", args.workgroup));
     }
     let team = parse_team_from_workgroup_name(&args.workgroup)?;
-    let mut config = normalize_team_config_for_project(
+    let config = normalize_team_config_for_project(
         &workspace_dir,
         &read_team_config(&workspace_dir, &team)?,
     )?;
     let agent_ref = resolve_agent_ref(&workspace_dir, &args.agent)?;
-    let was_present = config.agents.contains(&agent_ref);
-    push_unique(&mut config.agents, agent_ref.clone());
-    if args.coordinator {
-        config.coordinator = agent_ref.clone();
-    }
-    if !config.coordinator.is_empty() && !config.agents.contains(&config.coordinator) {
-        return Err("Coordinator must be one of the selected agents".to_string());
-    }
-    write_team_config(&workspace_dir, &team, &config)?;
+    let (config, added) = add_member_to_team_config(config, &agent_ref, args.coordinator)?;
+    write_team_config_guarded(&workspace_dir, &team, &config, &guard)?;
+    drop(guard);
 
     let replica_dir = create_or_update_replica_on_disk(ReplicaDiskCreateArgs {
         workspace_dir: workspace_dir.clone(),
@@ -259,7 +294,7 @@ fn add_member(args: TeamAddMemberArgs) -> Result<(), String> {
         agent: agent_ref_bare_name(&agent_ref),
         replica_path: replica_dir.to_string_lossy().to_string(),
         coordinator: agent_ref_bare_name(&config.coordinator),
-        added: !was_present,
+        added,
         clone_errors,
     })
 }
@@ -268,30 +303,24 @@ fn remove_member(args: TeamRemoveMemberArgs) -> Result<(), String> {
     validate_existing_name(&args.workgroup, "Workgroup")?;
     let project_path = resolve_cli_project(&args.project)?;
     let workspace_dir = resolve_cli_workspace(&project_path)?;
+    let guard = TeamConfigMutationGuard::acquire(&workspace_dir)?;
     let wg_dir = workspace_dir.join(&args.workgroup);
     if !wg_dir.is_dir() {
         return Err(format!("Workgroup '{}' not found", args.workgroup));
     }
     let team = parse_team_from_workgroup_name(&args.workgroup)?;
-    let mut config = normalize_team_config_for_project(
+    let config = normalize_team_config_for_project(
         &workspace_dir,
         &read_team_config(&workspace_dir, &team)?,
     )?;
     let agent_ref = resolve_agent_ref(&workspace_dir, &args.agent)?;
-    if config.coordinator == agent_ref {
-        return Err(
-            "Cannot remove the current coordinator without choosing a replacement".to_string(),
-        );
-    }
     let agent_name = agent_ref_bare_name(&agent_ref);
     let replica_dir = wg_dir.join(format!("__agent_{}", agent_name));
     crate::cli::session_safety::ensure_no_live_sessions_under(&replica_dir)?;
-    let before = config.agents.len();
-    config.agents.retain(|agent| agent != &agent_ref);
-    for repo in &mut config.repos {
-        repo.agents.retain(|agent| agent != &agent_ref);
-    }
-    write_team_config(&workspace_dir, &team, &config)?;
+    let (config, removed) = remove_member_from_team_config(config, &agent_ref)?;
+    write_team_config_guarded(&workspace_dir, &team, &config, &guard)?;
+    drop(guard);
+
     remove_replica_dir(&replica_dir)?;
     write_refresh(
         &project_path,
@@ -304,7 +333,7 @@ fn remove_member(args: TeamRemoveMemberArgs) -> Result<(), String> {
         workgroup: args.workgroup,
         agent: agent_name,
         replica_path: replica_dir.to_string_lossy().to_string(),
-        removed: config.agents.len() != before,
+        removed,
     })
 }
 
@@ -313,4 +342,69 @@ fn print_json<T: Serialize>(value: &T) -> Result<(), String> {
         .map_err(|e| format!("Failed to serialize JSON output: {}", e))?;
     crate::cli_println!("{}", json);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with_alerts() -> TeamConfigResult {
+        TeamConfigResult {
+            agents: vec!["_agent_alpha".to_string()],
+            coordinator: "_agent_alpha".to_string(),
+            repos: vec![RepoAssignment {
+                url: "https://example.test/repo.git".to_string(),
+                agents: vec!["_agent_alpha".to_string()],
+            }],
+            context_alert_percentages: vec![50, 75, 90],
+        }
+    }
+
+    #[test]
+    fn roster_helpers_preserve_complete_alert_vector() {
+        let original_alerts = config_with_alerts().context_alert_percentages;
+        let (added, did_add) =
+            add_member_to_team_config(config_with_alerts(), "_agent_beta", false)
+                .expect("add member");
+        assert!(did_add);
+        assert_eq!(added.context_alert_percentages, original_alerts);
+        assert_eq!(added.repos[0].agents, vec!["_agent_alpha"]);
+
+        let (removed, did_remove) =
+            remove_member_from_team_config(added, "_agent_beta").expect("remove member");
+        assert!(did_remove);
+        assert_eq!(removed.context_alert_percentages, vec![50, 75, 90]);
+        assert_eq!(removed.agents, vec!["_agent_alpha"]);
+    }
+
+    #[test]
+    fn cli_team_list_and_create_results_include_camel_case_alerts() {
+        let list = TeamListItem {
+            team: "dev-team".to_string(),
+            workgroup: None,
+            agents: Vec::new(),
+            coordinator: String::new(),
+            repos: Vec::new(),
+            context_alert_percentages: vec![50, 75],
+        };
+        let create = TeamCreateResult {
+            team: "dev-team".to_string(),
+            path: "_team_dev-team".to_string(),
+            agents: Vec::new(),
+            coordinator: String::new(),
+            repos: Vec::new(),
+            context_alert_percentages: Vec::new(),
+        };
+
+        let list_json = serde_json::to_value(list).expect("list JSON");
+        let create_json = serde_json::to_value(create).expect("create JSON");
+        assert_eq!(
+            list_json["contextAlertPercentages"],
+            serde_json::json!([50, 75])
+        );
+        assert_eq!(
+            create_json["contextAlertPercentages"],
+            serde_json::json!([])
+        );
+    }
 }

--- a/src-tauri/src/cli/workgroup.rs
+++ b/src-tauri/src/cli/workgroup.rs
@@ -8,8 +8,8 @@ use crate::cli::create_agent_matrix::{write_project_refresh_request, ProjectRefr
 use crate::commands::entity_creation::{
     check_workgroup_repos_dirty, clone_missing_repos_for_workgroup, create_workgroup_on_disk,
     list_workgroup_dirs, read_team_config, resolve_agent_ref, sanitize_name,
-    validate_delete_root_not_link_or_reparse, validate_existing_name,
-    RepoAssignment, TeamConfigResult, WgDeleteOutcome, WorkgroupDiskCreateArgs,
+    validate_delete_root_not_link_or_reparse, validate_existing_name, RepoAssignment,
+    TeamConfigResult, WgDeleteOutcome, WorkgroupDiskCreateArgs,
 };
 use crate::config::projects::resolve_project_reference;
 use crate::config::workspace::existing_workspace_dir;
@@ -276,7 +276,11 @@ fn remove(args: WorkgroupRemoveArgs) -> Result<(), String> {
             &args.workgroup,
         ) {
             Ok(n) if n > 0 => {
-                log::info!("[workgroup-remove] dropped {} clock key(s) for {}", n, args.workgroup)
+                log::info!(
+                    "[workgroup-remove] dropped {} clock key(s) for {}",
+                    n,
+                    args.workgroup
+                )
             }
             Ok(_) => {}
             Err(e) => log::warn!("[workgroup-remove] clock cleanup failed: {}", e),
@@ -346,6 +350,7 @@ pub(crate) fn build_new_team_config(
         agents: roster,
         coordinator,
         repos: repo_config,
+        context_alert_percentages: Vec::new(),
     })
 }
 
@@ -520,5 +525,62 @@ mod tests {
                 .expect("deleted outcome should refresh"),
             RemoveRefreshDecision::EmitWorkgroupRemoved
         );
+    }
+
+    #[test]
+    fn cli_team_builder_defaults_context_alerts_to_disabled() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().join(".ac");
+        std::fs::create_dir_all(workspace.join("_agent_coordinator")).expect("coordinator matrix");
+        std::fs::create_dir_all(workspace.join("_agent_member")).expect("member matrix");
+
+        let config = build_new_team_config(
+            &workspace,
+            "coordinator",
+            &["member".to_string()],
+            &[],
+            &[],
+            &[],
+        )
+        .expect("build config");
+        assert!(config.context_alert_percentages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn legacy_workgroup_provisioning_never_upserts_concurrent_team_winner() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("Project");
+        let workspace = project.join(".ac");
+        std::fs::create_dir_all(workspace.join("_agent_coordinator")).expect("coordinator matrix");
+        let winner = TeamConfigResult {
+            agents: vec!["_agent_coordinator".to_string()],
+            coordinator: "_agent_coordinator".to_string(),
+            repos: Vec::new(),
+            context_alert_percentages: vec![75],
+        };
+        crate::commands::entity_creation::create_new_team_config_on_disk(
+            &workspace, "dev-team", &winner,
+        )
+        .expect("concurrent winner");
+
+        let err = create_workgroup_on_disk(WorkgroupDiskCreateArgs {
+            project_path: project,
+            team_name: "dev-team".to_string(),
+            task_title: "Race test".to_string(),
+            coordinator: Some("_agent_coordinator".to_string()),
+            agents: vec!["_agent_coordinator".to_string()],
+            repos: Vec::new(),
+        })
+        .await
+        .expect_err("legacy loser must not upsert");
+
+        assert!(err.contains("Team 'dev-team' already exists"), "{err}");
+        assert_eq!(
+            read_team_config(&workspace, "dev-team")
+                .expect("winner config")
+                .context_alert_percentages,
+            vec![75]
+        );
+        assert!(list_workgroup_dirs(&workspace).is_empty());
     }
 }

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -3408,15 +3408,31 @@ fn target_keys_for_delete(path: &Path) -> Vec<String> {
     }
 }
 
+const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+
+fn metadata_parts_are_link_or_reparse(is_symlink: bool, file_attributes: u32) -> bool {
+    is_symlink || file_attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
 pub(crate) fn metadata_is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
-    metadata.file_type().is_symlink() || delete_root_has_windows_reparse_point(metadata)
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::fs::MetadataExt;
+        metadata_parts_are_link_or_reparse(
+            metadata.file_type().is_symlink(),
+            metadata.file_attributes(),
+        )
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        metadata_parts_are_link_or_reparse(metadata.file_type().is_symlink(), 0)
+    }
 }
 
 #[cfg(target_os = "windows")]
 fn delete_root_has_windows_reparse_point(metadata: &std::fs::Metadata) -> bool {
     use std::os::windows::fs::MetadataExt;
-    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
-    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    metadata_parts_are_link_or_reparse(false, metadata.file_attributes())
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -4316,6 +4332,13 @@ mod tests {
             validate_delete_root_not_link_or_reparse(&link).unwrap_err(),
             "delete_root_is_symlink"
         );
+    }
+
+    #[test]
+    fn synthetic_windows_reparse_attribute_is_always_classified_for_rejection() {
+        assert!(!metadata_parts_are_link_or_reparse(false, 0));
+        assert!(metadata_parts_are_link_or_reparse(false, 0x0000_0400));
+        assert!(metadata_parts_are_link_or_reparse(false, 0x0000_0410));
     }
 
     #[cfg(windows)]

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -1,8 +1,10 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::fs::{File, OpenOptions, TryLockError};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, Emitter, Manager, State};
 
@@ -54,6 +56,8 @@ pub struct TeamConfigResult {
     pub coordinator: String,
     #[serde(default)]
     pub repos: Vec<RepoAssignment>,
+    #[serde(default)]
+    pub context_alert_percentages: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -564,29 +568,381 @@ fn selected_workspace_dir(project: &Path) -> Result<PathBuf, String> {
         .ok_or_else(|| format!(".ac directory not found in {}", project.display()))
 }
 
+const TEAM_CONFIG_MUTATION_LOCK_NAME: &str = ".team-config-write.lock";
+const TEAM_CONFIG_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const TEAM_CONFIG_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy)]
+struct TeamConfigLockTiming {
+    poll_interval: Duration,
+    timeout: Duration,
+}
+
+impl TeamConfigLockTiming {
+    const PRODUCTION: Self = Self {
+        poll_interval: TEAM_CONFIG_LOCK_POLL_INTERVAL,
+        timeout: TEAM_CONFIG_LOCK_TIMEOUT,
+    };
+}
+
+#[derive(Debug)]
+pub(crate) struct TeamConfigMutationGuard {
+    _file: File,
+    canonical_workspace: PathBuf,
+    lock_path: PathBuf,
+}
+
+impl TeamConfigMutationGuard {
+    pub(crate) fn acquire(workspace_dir: &Path) -> Result<Self, String> {
+        Self::acquire_with_timing(workspace_dir, TeamConfigLockTiming::PRODUCTION)
+    }
+
+    fn acquire_with_timing(
+        workspace_dir: &Path,
+        timing: TeamConfigLockTiming,
+    ) -> Result<Self, String> {
+        let requested_lock_path = workspace_dir.join(TEAM_CONFIG_MUTATION_LOCK_NAME);
+        let canonical_workspace = std::fs::canonicalize(workspace_dir)
+            .map(|path| crate::path_utils::normalize_windows_verbatim_path_buf(&path))
+            .map_err(|e| {
+                format!(
+                    "Failed to resolve workspace for team config lock '{}': {}",
+                    requested_lock_path.display(),
+                    e
+                )
+            })?;
+        if !canonical_workspace.is_dir() {
+            return Err(format!(
+                "Failed to open team config lock '{}': workspace is not a directory",
+                requested_lock_path.display()
+            ));
+        }
+        let lock_path = canonical_workspace.join(TEAM_CONFIG_MUTATION_LOCK_NAME);
+
+        let open_existing = || -> Result<File, String> {
+            validate_team_config_lock_sentinel(&lock_path, &canonical_workspace)?;
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+                .map_err(|open_error| {
+                    format!(
+                        "Failed to open existing team config lock '{}': {}",
+                        lock_path.display(),
+                        open_error
+                    )
+                })
+        };
+        let file = match std::fs::symlink_metadata(&lock_path) {
+            Ok(_) => open_existing()?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                match OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create_new(true)
+                    .open(&lock_path)
+                {
+                    Ok(file) => file,
+                    Err(create_error)
+                        if create_error.kind() == std::io::ErrorKind::AlreadyExists =>
+                    {
+                        open_existing()?
+                    }
+                    Err(create_error) => {
+                        return Err(format!(
+                            "Failed to create team config lock '{}': {}",
+                            lock_path.display(),
+                            create_error
+                        ));
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(format!(
+                    "Failed to inspect team config lock '{}': {}",
+                    lock_path.display(),
+                    e
+                ));
+            }
+        };
+        validate_team_config_lock_sentinel(&lock_path, &canonical_workspace)?;
+        if !file
+            .metadata()
+            .map_err(|e| {
+                format!(
+                    "Failed to inspect opened team config lock '{}': {}",
+                    lock_path.display(),
+                    e
+                )
+            })?
+            .is_file()
+        {
+            return Err(format!(
+                "Team config lock '{}' must be a regular file",
+                lock_path.display()
+            ));
+        }
+
+        let started = Instant::now();
+        loop {
+            match file.try_lock() {
+                Ok(()) => break,
+                Err(TryLockError::WouldBlock) if started.elapsed() >= timing.timeout => {
+                    return Err(format!(
+                        "Timed out after {} ms waiting for team config lock '{}'",
+                        timing.timeout.as_millis(),
+                        lock_path.display()
+                    ));
+                }
+                Err(TryLockError::WouldBlock) => {
+                    let remaining = timing.timeout.saturating_sub(started.elapsed());
+                    let delay = timing.poll_interval.min(remaining);
+                    if delay.is_zero() {
+                        std::thread::yield_now();
+                    } else {
+                        std::thread::sleep(delay);
+                    }
+                }
+                Err(TryLockError::Error(e)) => {
+                    return Err(format!(
+                        "Failed to acquire team config lock '{}': {}",
+                        lock_path.display(),
+                        e
+                    ));
+                }
+            }
+        }
+
+        Ok(Self {
+            _file: file,
+            canonical_workspace,
+            lock_path,
+        })
+    }
+
+    fn require_workspace(&self, workspace_dir: &Path) -> Result<(), String> {
+        let canonical = std::fs::canonicalize(workspace_dir)
+            .map(|path| crate::path_utils::normalize_windows_verbatim_path_buf(&path))
+            .map_err(|e| {
+                format!(
+                    "Failed to verify workspace for team config lock '{}': {}",
+                    self.lock_path.display(),
+                    e
+                )
+            })?;
+        if canonical != self.canonical_workspace {
+            return Err(format!(
+                "Team config lock '{}' belongs to workspace '{}', not '{}'",
+                self.lock_path.display(),
+                self.canonical_workspace.display(),
+                canonical.display()
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_team_config_lock_sentinel(
+    lock_path: &Path,
+    canonical_workspace: &Path,
+) -> Result<(), String> {
+    let metadata = std::fs::symlink_metadata(lock_path).map_err(|e| {
+        format!(
+            "Failed to inspect team config lock '{}': {}",
+            lock_path.display(),
+            e
+        )
+    })?;
+    if metadata_is_link_or_reparse(&metadata) || !metadata.is_file() {
+        return Err(format!(
+            "Team config lock '{}' must be a regular non-link file",
+            lock_path.display()
+        ));
+    }
+    let canonical_lock = std::fs::canonicalize(lock_path)
+        .map(|path| crate::path_utils::normalize_windows_verbatim_path_buf(&path))
+        .map_err(|e| {
+            format!(
+                "Failed to resolve team config lock '{}': {}",
+                lock_path.display(),
+                e
+            )
+        })?;
+    let canonical_parent = canonical_lock.parent().ok_or_else(|| {
+        format!(
+            "Team config lock '{}' has no canonical parent",
+            lock_path.display()
+        )
+    })?;
+    if canonical_parent != canonical_workspace {
+        return Err(format!(
+            "Team config lock '{}' escapes canonical workspace '{}'",
+            lock_path.display(),
+            canonical_workspace.display()
+        ));
+    }
+    Ok(())
+}
+
+async fn acquire_team_config_mutation_guard_async(
+    workspace_dir: &Path,
+) -> Result<TeamConfigMutationGuard, String> {
+    let workspace = workspace_dir.to_path_buf();
+    let workspace_label = workspace.display().to_string();
+    tokio::task::spawn_blocking(move || TeamConfigMutationGuard::acquire(&workspace))
+        .await
+        .map_err(|e| {
+            format!(
+                "Failed to acquire team config lock for workspace '{}': blocking task failed: {}",
+                workspace_label, e
+            )
+        })?
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum TeamConfigReadError {
+    #[error("Team config not found at '{path}': {source}")]
+    NotFound {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Team config at '{path}' is unreadable: {source}")]
+    Unreadable {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Team config at '{path}' is malformed: {source}")]
+    Malformed {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("Team config at '{path}' is invalid: {cause}")]
+    Invalid { path: PathBuf, cause: String },
+}
+
+impl TeamConfigReadError {
+    // Consumed by the Phase 2 runtime; Phase 1 pins the stable classification contract.
+    #[allow(dead_code)]
+    pub(crate) fn class(&self) -> &'static str {
+        match self {
+            Self::NotFound { .. } => "not_found",
+            Self::Unreadable { .. } => "unreadable",
+            Self::Malformed { .. } => "malformed",
+            Self::Invalid { .. } => "invalid",
+        }
+    }
+}
+
+pub(crate) fn read_team_config_classified(
+    workspace_dir: &Path,
+    team_name: &str,
+) -> Result<TeamConfigResult, TeamConfigReadError> {
+    let config_path = workspace_dir
+        .join(format!("_team_{}", team_name))
+        .join("config.json");
+    validate_existing_name(team_name, "Team").map_err(|cause| TeamConfigReadError::Invalid {
+        path: config_path.clone(),
+        cause,
+    })?;
+    let content = std::fs::read(&config_path).map_err(|source| {
+        if source.kind() == std::io::ErrorKind::NotFound {
+            TeamConfigReadError::NotFound {
+                path: config_path.clone(),
+                source,
+            }
+        } else {
+            TeamConfigReadError::Unreadable {
+                path: config_path.clone(),
+                source,
+            }
+        }
+    })?;
+    let config: TeamConfigResult =
+        serde_json::from_slice(&content).map_err(|source| TeamConfigReadError::Malformed {
+            path: config_path.clone(),
+            source,
+        })?;
+    normalize_team_config_for_project(workspace_dir, &config).map_err(|cause| {
+        TeamConfigReadError::Invalid {
+            path: config_path,
+            cause,
+        }
+    })
+}
+
 pub(crate) fn read_team_config(
     workspace_dir: &Path,
     team_name: &str,
 ) -> Result<TeamConfigResult, String> {
-    validate_existing_name(team_name, "Team")?;
-    let team_dir = workspace_dir.join(format!("_team_{}", team_name));
-    let config_path = team_dir.join("config.json");
-    if !config_path.exists() {
-        return Err(format!("Team '{}' config not found", team_name));
-    }
-    let content = std::fs::read_to_string(&config_path)
-        .map_err(|e| format!("Failed to read config.json: {}", e))?;
-    let config: TeamConfigResult = serde_json::from_str(&content)
-        .map_err(|e| format!("Failed to parse config.json: {}", e))?;
-    normalize_team_config_for_project(workspace_dir, &config)
+    read_team_config_classified(workspace_dir, team_name).map_err(|e| e.to_string())
 }
 
+fn normalized_team_config_bytes(
+    workspace_dir: &Path,
+    config: &TeamConfigResult,
+) -> Result<Vec<u8>, String> {
+    let normalized = normalize_team_config_for_project(workspace_dir, config)?;
+    serde_json::to_vec_pretty(&normalized)
+        .map_err(|e| format!("Failed to serialize config.json: {}", e))
+}
+
+// Standalone synchronous wrapper for non-compound callers and focused writer tests.
+#[allow(dead_code)]
 pub(crate) fn write_team_config(
     workspace_dir: &Path,
     team_name: &str,
     config: &TeamConfigResult,
 ) -> Result<PathBuf, String> {
+    let guard = TeamConfigMutationGuard::acquire(workspace_dir)?;
+    write_team_config_guarded(workspace_dir, team_name, config, &guard)
+}
+
+pub(crate) fn write_team_config_guarded(
+    workspace_dir: &Path,
+    team_name: &str,
+    config: &TeamConfigResult,
+    guard: &TeamConfigMutationGuard,
+) -> Result<PathBuf, String> {
+    write_team_config_guarded_with_publisher(
+        workspace_dir,
+        team_name,
+        config,
+        guard,
+        crate::config::local_config_io::write_file_atomic,
+    )
+}
+
+fn write_existing_team_config_guarded(
+    workspace_dir: &Path,
+    team_name: &str,
+    config: &TeamConfigResult,
+    guard: &TeamConfigMutationGuard,
+) -> Result<PathBuf, String> {
+    guard.require_workspace(workspace_dir)?;
     validate_existing_name(team_name, "Team")?;
+    let team_dir = workspace_dir.join(format!("_team_{}", team_name));
+    if !team_dir.exists() {
+        return Err(format!("Team '{}' not found", team_name));
+    }
+    write_team_config_guarded(workspace_dir, team_name, config, guard)
+}
+
+fn write_team_config_guarded_with_publisher<P>(
+    workspace_dir: &Path,
+    team_name: &str,
+    config: &TeamConfigResult,
+    guard: &TeamConfigMutationGuard,
+    publish: P,
+) -> Result<PathBuf, String>
+where
+    P: FnOnce(&Path, &[u8]) -> Result<(), String>,
+{
+    guard.require_workspace(workspace_dir)?;
+    validate_existing_name(team_name, "Team")?;
+    let config_bytes = normalized_team_config_bytes(workspace_dir, config)?;
     let team_dir = workspace_dir.join(format!("_team_{}", team_name));
     std::fs::create_dir_all(&team_dir)
         .map_err(|e| format!("Failed to create team directory: {}", e))?;
@@ -597,11 +953,8 @@ pub(crate) fn write_team_config(
         std::fs::write(&conventions, "")
             .map_err(|e| format!("Failed to write conventions.md: {}", e))?;
     }
-    let config = normalize_team_config_for_project(workspace_dir, config)?;
-    let config_str = serde_json::to_string_pretty(&config)
-        .map_err(|e| format!("Failed to serialize config.json: {}", e))?;
-    std::fs::write(team_dir.join("config.json"), config_str)
-        .map_err(|e| format!("Failed to write config.json: {}", e))?;
+    publish(&team_dir.join("config.json"), &config_bytes)
+        .map_err(|e| format!("Failed to publish config.json: {}", e))?;
     Ok(team_dir)
 }
 
@@ -610,7 +963,19 @@ pub(crate) fn create_new_team_config_on_disk(
     team_name: &str,
     config: &TeamConfigResult,
 ) -> Result<PathBuf, String> {
+    let guard = TeamConfigMutationGuard::acquire(workspace_dir)?;
+    create_new_team_config_on_disk_guarded(workspace_dir, team_name, config, &guard)
+}
+
+pub(crate) fn create_new_team_config_on_disk_guarded(
+    workspace_dir: &Path,
+    team_name: &str,
+    config: &TeamConfigResult,
+    guard: &TeamConfigMutationGuard,
+) -> Result<PathBuf, String> {
+    guard.require_workspace(workspace_dir)?;
     validate_existing_name(team_name, "Team")?;
+    let config_bytes = normalized_team_config_bytes(workspace_dir, config)?;
     let team_dir = workspace_dir.join(format!("_team_{}", team_name));
     std::fs::create_dir(&team_dir).map_err(|e| match e.kind() {
         std::io::ErrorKind::AlreadyExists => format!("Team '{}' already exists", team_name),
@@ -620,12 +985,48 @@ pub(crate) fn create_new_team_config_on_disk(
         .map_err(|e| format!("Failed to create memory directory: {}", e))?;
     std::fs::write(team_dir.join("conventions.md"), "")
         .map_err(|e| format!("Failed to write conventions.md: {}", e))?;
-    let config = normalize_team_config_for_project(workspace_dir, config)?;
-    let config_str = serde_json::to_string_pretty(&config)
-        .map_err(|e| format!("Failed to serialize config.json: {}", e))?;
-    std::fs::write(team_dir.join("config.json"), config_str)
-        .map_err(|e| format!("Failed to write config.json: {}", e))?;
+    crate::config::local_config_io::write_file_atomic(&team_dir.join("config.json"), &config_bytes)
+        .map_err(|e| format!("Failed to publish config.json: {}", e))?;
     Ok(team_dir)
+}
+
+pub(crate) fn normalize_context_alert_percentages(values: &[u8]) -> Result<Vec<u8>, String> {
+    if values.len() > 3 {
+        return Err("contextAlertPercentages must contain at most 3 values".to_string());
+    }
+    if values.iter().any(|value| !(1..=100).contains(value)) {
+        return Err(
+            "contextAlertPercentages values must be integer percentages from 1 through 100"
+                .to_string(),
+        );
+    }
+    let mut normalized = values.to_vec();
+    normalized.sort_unstable();
+    if normalized.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err("contextAlertPercentages values must be distinct".to_string());
+    }
+    Ok(normalized)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContextAlertWriteMode {
+    Create,
+    Update,
+}
+
+fn resolve_context_alert_argument(
+    mode: ContextAlertWriteMode,
+    supplied: Option<Vec<u8>>,
+    current: Option<&[u8]>,
+) -> Result<Vec<u8>, String> {
+    match supplied {
+        Some(values) => normalize_context_alert_percentages(&values),
+        None if mode == ContextAlertWriteMode::Create => Ok(Vec::new()),
+        None => current.map(|values| values.to_vec()).ok_or_else(|| {
+            "Current team config is required when contextAlertPercentages is omitted on update"
+                .to_string()
+        }),
+    }
 }
 
 pub(crate) fn normalize_team_config_for_project(
@@ -648,10 +1049,13 @@ pub(crate) fn normalize_team_config_for_project(
             agents: normalize_team_agent_refs(workspace_dir, &repo.agents)?,
         });
     }
+    let context_alert_percentages =
+        normalize_context_alert_percentages(&config.context_alert_percentages)?;
     Ok(TeamConfigResult {
         agents,
         coordinator,
         repos,
+        context_alert_percentages,
     })
 }
 
@@ -775,9 +1179,12 @@ pub(crate) async fn create_workgroup_on_disk(
                 agents: args.agents.clone(),
                 coordinator,
                 repos: args.repos.clone(),
+                context_alert_percentages: Vec::new(),
             };
             let config = normalize_team_config_for_project(&base, &config)?;
-            write_team_config(&base, &safe_team, &config)?;
+            let guard = acquire_team_config_mutation_guard_async(&base).await?;
+            create_new_team_config_on_disk_guarded(&base, &safe_team, &config, &guard)?;
+            drop(guard);
             config
         } else {
             read_team_config(&base, &safe_team)?
@@ -965,7 +1372,8 @@ pub async fn delete_agent_matrix(
     agent_path: String,
 ) -> Result<(), String> {
     let base = selected_workspace_dir(Path::new(&project_path))?;
-    let plan = collect_agent_delete_plan(&base, Path::new(&agent_path))?;
+    let guard = acquire_team_config_mutation_guard_async(&base).await?;
+    let plan = collect_agent_delete_plan_guarded(&base, Path::new(&agent_path), &guard)?;
     preflight_agent_delete(&plan, session_mgr.inner()).await?;
 
     let metadata = prepare_agent_delete_metadata(&plan, settings.inner()).await?;
@@ -978,19 +1386,23 @@ pub async fn delete_agent_matrix(
     )
     .await
     {
+        drop(guard);
         let rollback = rollback_staged_agent_delete_targets(&staged);
         return Err(format_agent_delete_post_stage_live_failure(
             live_err, rollback,
         ));
     }
 
-    let persist = persist_agent_delete_metadata(&metadata, settings.inner()).await;
+    let persist = persist_agent_delete_metadata(&metadata, settings.inner(), &guard).await;
     if let Err(e) = persist {
-        let restore = restore_agent_delete_metadata_snapshots(&metadata, settings.inner()).await;
+        let restore =
+            restore_agent_delete_metadata_snapshots(&metadata, settings.inner(), &guard).await;
+        drop(guard);
         let rollback = rollback_staged_agent_delete_targets(&staged);
         return Err(format_agent_delete_metadata_failure(e, restore, rollback));
     }
 
+    drop(guard);
     remove_staged_agent_delete_targets(&staged)?;
 
     log::info!(
@@ -1032,6 +1444,7 @@ struct AgentTeamMutation {
 
 #[derive(Debug, Clone)]
 struct PreparedAgentDeleteMetadata {
+    workspace_dir: PathBuf,
     team_mutations: Vec<AgentTeamMutation>,
     agent_name: String,
     settings_changed: Arc<AtomicBool>,
@@ -1039,6 +1452,7 @@ struct PreparedAgentDeleteMetadata {
 
 #[derive(Debug, Clone)]
 struct AgentDeletePlan {
+    workspace_dir: PathBuf,
     agent_name: String,
     agent_ref: String,
     origin_dir: PathBuf,
@@ -1076,7 +1490,18 @@ fn resolve_agent_delete_identity(
     Ok((agent_name.to_string(), agent_ref, origin_dir))
 }
 
+#[cfg(test)]
 fn collect_agent_delete_plan(base: &Path, agent_path: &Path) -> Result<AgentDeletePlan, String> {
+    let guard = TeamConfigMutationGuard::acquire(base)?;
+    collect_agent_delete_plan_guarded(base, agent_path, &guard)
+}
+
+fn collect_agent_delete_plan_guarded(
+    base: &Path,
+    agent_path: &Path,
+    guard: &TeamConfigMutationGuard,
+) -> Result<AgentDeletePlan, String> {
+    guard.require_workspace(base)?;
     let (agent_name, agent_ref, origin_dir) = resolve_agent_delete_identity(base, agent_path)?;
     let team_mutations = collect_agent_team_mutations_raw(base, &agent_name, &agent_ref)?;
 
@@ -1112,6 +1537,7 @@ fn collect_agent_delete_plan(base: &Path, agent_path: &Path) -> Result<AgentDele
     }
 
     Ok(AgentDeletePlan {
+        workspace_dir: base.to_path_buf(),
         agent_name,
         agent_ref,
         origin_dir,
@@ -1159,12 +1585,16 @@ fn collect_agent_team_mutations_raw(
             .unwrap_or("_team_unknown");
         let team_name = dir_name.strip_prefix("_team_").unwrap_or(dir_name);
         let config_path = team_dir.join("config.json");
-        if !config_path.exists() {
-            continue;
-        }
-
-        let before_json = std::fs::read(&config_path)
-            .map_err(|e| format!("Cannot read team '{}' config.json: {}", team_name, e))?;
+        let before_json = match std::fs::read(&config_path) {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                return Err(format!(
+                    "Cannot read team '{}' config.json: {}",
+                    team_name, e
+                ));
+            }
+        };
         let mut value: serde_json::Value = match serde_json::from_slice(&before_json) {
             Ok(value) => value,
             Err(e) => {
@@ -1229,6 +1659,18 @@ fn collect_agent_team_mutations_raw(
         }
 
         if changed {
+            let object = value.as_object_mut().ok_or_else(|| {
+                format!(
+                    "Cannot delete agent '{}': team '{}' config.json must be an object",
+                    agent_name, team_name
+                )
+            })?;
+            normalize_raw_context_alert_percentages(object).map_err(|e| {
+                format!(
+                    "Cannot delete agent '{}': team '{}' has invalid contextAlertPercentages: {}",
+                    agent_name, team_name, e
+                )
+            })?;
             let mut after_json = serde_json::to_vec_pretty(&value)
                 .map_err(|e| format!("Cannot serialize team '{}' config.json: {}", team_name, e))?;
             after_json.push(b'\n');
@@ -1251,6 +1693,27 @@ fn collect_agent_team_mutations_raw(
     }
 
     Ok(mutations)
+}
+
+fn normalize_raw_context_alert_percentages(
+    object: &mut serde_json::Map<String, serde_json::Value>,
+) -> Result<(), String> {
+    let values = match object.get("contextAlertPercentages") {
+        Some(value) => serde_json::from_value::<Vec<u8>>(value.clone()).map_err(|e| {
+            format!(
+                "expected an array of integer percentages representable as u8: {}",
+                e
+            )
+        })?,
+        None => Vec::new(),
+    };
+    let normalized = normalize_context_alert_percentages(&values)?;
+    object.insert(
+        "contextAlertPercentages".to_string(),
+        serde_json::to_value(normalized)
+            .map_err(|e| format!("failed to serialize canonical percentages: {}", e))?,
+    );
+    Ok(())
 }
 
 fn agent_ref_matches_target(raw_ref: &str, agent_name: &str) -> bool {
@@ -1339,7 +1802,8 @@ async fn ensure_no_live_sessions_under_target_keys(
     agent_name: &str,
     session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
 ) -> Result<(), String> {
-    let sessions = { session_mgr.read().await.list_sessions().await };
+    let manager = { session_mgr.read().await.clone() };
+    let sessions = manager.list_sessions().await;
     let blockers: Vec<_> = sessions
         .into_iter()
         .filter(|session| !matches!(session.status, SessionStatus::Exited(_)))
@@ -1386,6 +1850,7 @@ async fn prepare_agent_delete_metadata(
             .contains_key(&plan.agent_name);
 
     Ok(PreparedAgentDeleteMetadata {
+        workspace_dir: plan.workspace_dir.clone(),
         team_mutations: plan.team_mutations.clone(),
         agent_name: plan.agent_name.clone(),
         settings_changed: Arc::new(AtomicBool::new(settings_changed)),
@@ -1395,10 +1860,12 @@ async fn prepare_agent_delete_metadata(
 async fn persist_agent_delete_metadata(
     metadata: &PreparedAgentDeleteMetadata,
     settings: &SettingsState,
+    team_guard: &TeamConfigMutationGuard,
 ) -> Result<(), String> {
     persist_agent_delete_metadata_with_saver(
         metadata,
         settings,
+        team_guard,
         crate::config::settings::save_settings,
     )
     .await
@@ -1407,6 +1874,7 @@ async fn persist_agent_delete_metadata(
 async fn persist_agent_delete_metadata_with_saver<S>(
     metadata: &PreparedAgentDeleteMetadata,
     settings: &SettingsState,
+    team_guard: &TeamConfigMutationGuard,
     save_settings_fn: S,
 ) -> Result<(), String>
 where
@@ -1415,7 +1883,10 @@ where
     persist_agent_delete_metadata_with_writers(
         metadata,
         settings,
-        write_team_config_json_atomic,
+        team_guard,
+        |config_path, json| {
+            write_team_config_json_atomic(&metadata.workspace_dir, team_guard, config_path, json)
+        },
         save_settings_fn,
     )
     .await
@@ -1424,6 +1895,7 @@ where
 async fn persist_agent_delete_metadata_with_writers<T, S>(
     metadata: &PreparedAgentDeleteMetadata,
     settings: &SettingsState,
+    team_guard: &TeamConfigMutationGuard,
     mut write_team_config_fn: T,
     save_settings_fn: S,
 ) -> Result<(), String>
@@ -1431,11 +1903,12 @@ where
     T: FnMut(&Path, &[u8]) -> Result<(), String>,
     S: Fn(&AppSettings) -> Result<AppSettings, String>,
 {
+    team_guard.require_workspace(&metadata.workspace_dir)?;
     metadata.settings_changed.store(false, Ordering::SeqCst);
 
     for mutation in &metadata.team_mutations {
         if let Err(e) = write_team_config_fn(&mutation.config_path, &mutation.after_json) {
-            let restore = restore_team_config_snapshots(metadata);
+            let restore = restore_team_config_snapshots(metadata, team_guard);
             return Err(format!(
                 "Failed to write team '{}' config during agent delete: {}{}",
                 mutation.team_name,
@@ -1491,7 +1964,7 @@ where
     };
 
     if let Err(e) = settings_result {
-        let restore = restore_team_config_snapshots(metadata);
+        let restore = restore_team_config_snapshots(metadata, team_guard);
         return Err(format!("{}{}", e, format_restore_suffix(restore)));
     }
 
@@ -1520,15 +1993,24 @@ fn restore_removed_settings(
 async fn restore_agent_delete_metadata_snapshots(
     metadata: &PreparedAgentDeleteMetadata,
     _settings: &SettingsState,
+    team_guard: &TeamConfigMutationGuard,
 ) -> Result<(), String> {
-    restore_team_config_snapshots(metadata)
+    restore_team_config_snapshots(metadata, team_guard)
 }
 
-fn restore_team_config_snapshots(metadata: &PreparedAgentDeleteMetadata) -> Result<(), String> {
+fn restore_team_config_snapshots(
+    metadata: &PreparedAgentDeleteMetadata,
+    team_guard: &TeamConfigMutationGuard,
+) -> Result<(), String> {
+    team_guard.require_workspace(&metadata.workspace_dir)?;
     let mut errors = Vec::new();
     for mutation in &metadata.team_mutations {
-        if let Err(e) = write_team_config_json_atomic(&mutation.config_path, &mutation.before_json)
-        {
+        if let Err(e) = write_team_config_json_atomic(
+            &metadata.workspace_dir,
+            team_guard,
+            &mutation.config_path,
+            &mutation.before_json,
+        ) {
             errors.push(format!("{}: {}", mutation.config_path.display(), e));
         }
     }
@@ -1550,7 +2032,13 @@ fn format_restore_suffix(restore: Result<(), String>) -> String {
     }
 }
 
-fn write_team_config_json_atomic(config_path: &Path, json: &[u8]) -> Result<(), String> {
+fn write_team_config_json_atomic(
+    workspace_dir: &Path,
+    team_guard: &TeamConfigMutationGuard,
+    config_path: &Path,
+    json: &[u8],
+) -> Result<(), String> {
+    team_guard.require_workspace(workspace_dir)?;
     crate::config::local_config_io::write_file_atomic(config_path, json)
 }
 
@@ -1657,6 +2145,8 @@ pub async fn list_all_agents(project_paths: Vec<String>) -> Result<Vec<AgentInfo
 }
 
 /// Create a team directory inside {project_path}/.ac/_team_{name}/
+// Tauri command parameters plus injected state exceed Clippy's argument threshold.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn create_team(
     app: AppHandle,
@@ -1666,9 +2156,15 @@ pub async fn create_team(
     agents: Vec<String>,
     coordinator: String,
     repos: Vec<RepoAssignment>,
+    context_alert_percentages: Option<Vec<u8>>,
 ) -> Result<CreatedEntityResult, String> {
     let safe_name = sanitize_name(&name)?;
     let base = selected_workspace_dir(Path::new(&project_path))?;
+    let context_alert_percentages = resolve_context_alert_argument(
+        ContextAlertWriteMode::Create,
+        context_alert_percentages,
+        None,
+    )?;
 
     let config = normalize_team_config_for_project(
         &base,
@@ -1676,9 +2172,12 @@ pub async fn create_team(
             agents,
             coordinator,
             repos,
+            context_alert_percentages,
         },
     )?;
-    let team_dir = create_new_team_config_on_disk(&base, &safe_name, &config)?;
+    let guard = acquire_team_config_mutation_guard_async(&base).await?;
+    let team_dir = create_new_team_config_on_disk_guarded(&base, &safe_name, &config, &guard)?;
+    drop(guard);
 
     let result_path = crate::path_utils::path_to_string_without_windows_verbatim_prefix(&team_dir);
     log::info!("[entity_creation] Created team: {}", result_path);
@@ -1835,13 +2334,15 @@ pub async fn delete_team(
 ) -> Result<(), String> {
     validate_existing_name(&team_name, "Team")?;
     let base = selected_workspace_dir(Path::new(&project_path))?;
+    let guard = acquire_team_config_mutation_guard_async(&base).await?;
 
     let team_dir = base.join(format!("_team_{}", team_name));
     if !team_dir.exists() {
         return Err(format!("Team '{}' not found", team_name));
     }
 
-    // Collect associated workgroup dirs (wg-N-{team_name}/)
+    // Collect associated workgroup dirs (wg-N-{team_name}/) while the team
+    // mutation guard keeps this snapshot linear with compatible config writers.
     let wg_suffix = format!("-{}", team_name);
     let mut wg_dirs: Vec<PathBuf> = Vec::new();
     if let Ok(entries) = std::fs::read_dir(&base) {
@@ -1860,7 +2361,7 @@ pub async fn delete_team(
         }
     }
 
-    // Check workgroup repos for dirty git state before deleting
+    // Check workgroup repos for dirty git state before deleting.
     let dirty_repos = check_workgroup_repos_dirty(&wg_dirs);
     if !dirty_repos.is_empty() {
         let list = dirty_repos
@@ -1874,9 +2375,11 @@ pub async fn delete_team(
         ));
     }
 
-    // Delete team dir first — bail before touching workgroups if this fails
+    // Delete the team first, then release the config guard before the
+    // best-effort workgroup and clock cascade.
     std::fs::remove_dir_all(&team_dir)
         .map_err(|e| format!("Failed to delete team directory: {}", e))?;
+    drop(guard);
     log::info!("[entity_creation] Deleted team: {}", team_name);
 
     // (#621) Count clock keys removed across the cascade; persist once after the loop.
@@ -2068,24 +2571,45 @@ pub async fn update_team(
     agents: Vec<String>,
     coordinator: String,
     repos: Vec<RepoAssignment>,
+    context_alert_percentages: Option<Vec<u8>>,
 ) -> Result<(), String> {
     validate_existing_name(&team_name, "Team")?;
     let base = selected_workspace_dir(Path::new(&project_path))?;
+    let supplied_context_alert_percentages = context_alert_percentages
+        .map(|values| normalize_context_alert_percentages(&values))
+        .transpose()?;
+    let guard = acquire_team_config_mutation_guard_async(&base).await?;
 
     let team_dir = base.join(format!("_team_{}", team_name));
     if !team_dir.exists() {
         return Err(format!("Team '{}' not found", team_name));
     }
 
+    let context_alert_percentages = match supplied_context_alert_percentages {
+        Some(values) => {
+            resolve_context_alert_argument(ContextAlertWriteMode::Update, Some(values), None)?
+        }
+        None => {
+            let current =
+                read_team_config_classified(&base, &team_name).map_err(|e| e.to_string())?;
+            resolve_context_alert_argument(
+                ContextAlertWriteMode::Update,
+                None,
+                Some(&current.context_alert_percentages),
+            )?
+        }
+    };
     let config = normalize_team_config_for_project(
         &base,
         &TeamConfigResult {
             agents,
             coordinator,
             repos,
+            context_alert_percentages,
         },
     )?;
-    write_team_config(&base, &team_name, &config)?;
+    write_existing_team_config_guarded(&base, &team_name, &config, &guard)?;
+    drop(guard);
 
     log::info!("[entity_creation] Updated team: {}", team_name);
 
@@ -2815,7 +3339,7 @@ pub(crate) fn validate_delete_root_not_link_or_reparse(path: &Path) -> Result<()
     if delete_root_has_windows_reparse_point(&metadata) {
         return Err("delete_root_is_reparse_point".to_string());
     }
-    if metadata.file_type().is_symlink() {
+    if metadata_is_link_or_reparse(&metadata) {
         return Err("delete_root_is_symlink".to_string());
     }
     if !metadata.is_dir() {
@@ -2829,7 +3353,8 @@ async fn ensure_no_live_sessions_under_manager(
     session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
 ) -> Result<(), String> {
     let root_key = path_key_for_delete(root);
-    let sessions = { session_mgr.read().await.list_sessions().await };
+    let manager = { session_mgr.read().await.clone() };
+    let sessions = manager.list_sessions().await;
     let blockers: Vec<_> = sessions
         .into_iter()
         .filter(|session| !matches!(session.status, SessionStatus::Exited(_)))
@@ -2881,6 +3406,10 @@ fn target_keys_for_delete(path: &Path) -> Vec<String> {
     } else {
         vec![canonical_key, raw_key]
     }
+}
+
+pub(crate) fn metadata_is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
+    metadata.file_type().is_symlink() || delete_root_has_windows_reparse_point(metadata)
 }
 
 #[cfg(target_os = "windows")]
@@ -3410,6 +3939,7 @@ mod tests {
                 url: "https://example.test/repo.git".to_string(),
                 agents: vec!["architect".to_string(), "_agent_dev-rust".to_string()],
             }],
+            context_alert_percentages: vec![90, 50, 75],
         };
 
         let normalized =
@@ -3429,6 +3959,7 @@ mod tests {
                 "_agent_dev-rust".to_string()
             ]
         );
+        assert_eq!(normalized.context_alert_percentages, vec![50, 75, 90]);
 
         write_team_config(&workspace_dir, "dev-team", &config).expect("write config");
         let written =
@@ -3454,6 +3985,7 @@ mod tests {
                 .to_string()],
             coordinator: "_agent_architect".to_string(),
             repos: Vec::new(),
+            context_alert_percentages: Vec::new(),
         };
         let err = normalize_team_config_for_project(&workspace_dir, &absolute_config)
             .expect_err("absolute path refs must be rejected");
@@ -3467,6 +3999,7 @@ mod tests {
             agents: vec![r"C:\Users\maria\project\.ac\_agent_architect".to_string()],
             coordinator: "_agent_architect".to_string(),
             repos: Vec::new(),
+            context_alert_percentages: Vec::new(),
         };
         let err = normalize_team_config_for_project(&workspace_dir, &windows_config)
             .expect_err("windows path refs must be rejected");
@@ -3902,6 +4435,560 @@ mod tests {
         Arc::new(tokio::sync::RwLock::new(SessionManager::new()))
     }
 
+    fn empty_team_config(context_alert_percentages: Vec<u8>) -> TeamConfigResult {
+        TeamConfigResult {
+            agents: Vec::new(),
+            coordinator: String::new(),
+            repos: Vec::new(),
+            context_alert_percentages,
+        }
+    }
+
+    #[test]
+    fn team_config_serde_defaults_only_a_missing_alert_field() {
+        let legacy: TeamConfigResult = serde_json::from_value(serde_json::json!({
+            "agents": [],
+            "coordinator": "",
+            "repos": []
+        }))
+        .expect("legacy config");
+        assert!(legacy.context_alert_percentages.is_empty());
+
+        for invalid in [
+            serde_json::Value::Null,
+            serde_json::json!("50"),
+            serde_json::json!({}),
+            serde_json::json!([50.5]),
+            serde_json::json!([-1]),
+            serde_json::json!([256]),
+        ] {
+            let mut root = serde_json::json!({
+                "agents": [],
+                "coordinator": "",
+                "repos": []
+            });
+            root["contextAlertPercentages"] = invalid;
+            assert!(
+                serde_json::from_value::<TeamConfigResult>(root).is_err(),
+                "present unrepresentable alert data must fail"
+            );
+        }
+    }
+
+    #[test]
+    fn team_config_serializes_exact_camel_case_alert_key() {
+        let empty = serde_json::to_value(empty_team_config(Vec::new())).expect("serialize empty");
+        assert_eq!(empty["contextAlertPercentages"], serde_json::json!([]));
+        assert!(empty.get("context_alert_percentages").is_none());
+
+        let populated =
+            serde_json::to_value(empty_team_config(vec![50, 75, 90])).expect("serialize populated");
+        assert_eq!(
+            populated["contextAlertPercentages"],
+            serde_json::json!([50, 75, 90])
+        );
+        let round_trip: TeamConfigResult =
+            serde_json::from_value(populated).expect("deserialize populated");
+        assert_eq!(round_trip.context_alert_percentages, vec![50, 75, 90]);
+    }
+
+    #[test]
+    fn context_alert_normalizer_accepts_boundaries_and_sorts() {
+        for (input, expected) in [
+            (vec![], vec![]),
+            (vec![1], vec![1]),
+            (vec![100], vec![100]),
+            (vec![50, 75], vec![50, 75]),
+            (vec![50, 75, 90], vec![50, 75, 90]),
+            (vec![90, 50, 75], vec![50, 75, 90]),
+        ] {
+            assert_eq!(
+                normalize_context_alert_percentages(&input).expect("valid percentages"),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn context_alert_normalizer_rejects_product_invalid_values() {
+        for invalid in [
+            vec![0],
+            vec![101],
+            vec![1, 2, 3, 4],
+            vec![50, 50],
+            vec![75, 50, 75],
+        ] {
+            assert!(
+                normalize_context_alert_percentages(&invalid).is_err(),
+                "invalid percentages were accepted: {:?}",
+                invalid
+            );
+        }
+    }
+
+    #[test]
+    fn context_alert_argument_resolution_pins_create_update_compatibility() {
+        assert_eq!(
+            resolve_context_alert_argument(ContextAlertWriteMode::Create, None, None)
+                .expect("legacy create"),
+            Vec::<u8>::new()
+        );
+        assert_eq!(
+            resolve_context_alert_argument(
+                ContextAlertWriteMode::Create,
+                Some(vec![90, 50, 75]),
+                None,
+            )
+            .expect("explicit create"),
+            vec![50, 75, 90]
+        );
+        assert_eq!(
+            resolve_context_alert_argument(ContextAlertWriteMode::Update, None, Some(&[50, 75]),)
+                .expect("legacy update"),
+            vec![50, 75]
+        );
+        assert_eq!(
+            resolve_context_alert_argument(
+                ContextAlertWriteMode::Update,
+                Some(Vec::new()),
+                Some(&[50, 75]),
+            )
+            .expect("explicit clear"),
+            Vec::<u8>::new()
+        );
+        assert!(resolve_context_alert_argument(
+            ContextAlertWriteMode::Update,
+            Some(vec![0]),
+            Some(&[50]),
+        )
+        .is_err());
+        assert!(resolve_context_alert_argument(ContextAlertWriteMode::Update, None, None).is_err());
+    }
+
+    #[test]
+    fn classified_team_config_reader_reports_stable_error_classes() {
+        let tmp = create_test_workspace();
+        let base = test_base(&tmp);
+
+        let missing = read_team_config_classified(&base, "missing").expect_err("missing");
+        assert_eq!(missing.class(), "not_found");
+        assert!(missing.to_string().contains("_team_missing"));
+
+        let unreadable_dir = base.join("_team_unreadable");
+        std::fs::create_dir_all(unreadable_dir.join("config.json")).expect("config directory");
+        let unreadable = read_team_config_classified(&base, "unreadable").expect_err("unreadable");
+        assert_eq!(unreadable.class(), "unreadable");
+        assert!(unreadable.to_string().contains("config.json"));
+
+        let partial_dir = base.join("_team_partial");
+        std::fs::create_dir_all(&partial_dir).expect("partial team");
+        std::fs::write(partial_dir.join("config.json"), b"{\"agents\": [").expect("partial config");
+        let malformed = read_team_config_classified(&base, "partial").expect_err("malformed");
+        assert_eq!(malformed.class(), "malformed");
+        assert!(malformed.to_string().contains("_team_partial"));
+
+        let typed_dir = base.join("_team_wrong-type");
+        std::fs::create_dir_all(&typed_dir).expect("typed team");
+        std::fs::write(
+            typed_dir.join("config.json"),
+            br#"{"agents":[],"coordinator":"","repos":[],"contextAlertPercentages":"50"}"#,
+        )
+        .expect("typed config");
+        let malformed = read_team_config_classified(&base, "wrong-type").expect_err("wrong type");
+        assert_eq!(malformed.class(), "malformed");
+
+        let invalid_dir = base.join("_team_invalid");
+        std::fs::create_dir_all(&invalid_dir).expect("invalid team");
+        std::fs::write(
+            invalid_dir.join("config.json"),
+            br#"{"agents":[],"coordinator":"","repos":[],"contextAlertPercentages":[0]}"#,
+        )
+        .expect("invalid config");
+        let invalid = read_team_config_classified(&base, "invalid").expect_err("invalid product");
+        assert_eq!(invalid.class(), "invalid");
+        assert!(invalid.to_string().contains("1 through 100"));
+
+        let invalid_name =
+            read_team_config_classified(&base, "../escape").expect_err("invalid team name");
+        assert_eq!(invalid_name.class(), "invalid");
+    }
+
+    #[test]
+    fn team_config_writer_round_trips_legacy_and_canonical_alerts() {
+        let tmp = create_test_workspace();
+        let base = test_base(&tmp);
+        let legacy_dir = base.join("_team_legacy");
+        std::fs::create_dir_all(&legacy_dir).expect("legacy team");
+        std::fs::write(
+            legacy_dir.join("config.json"),
+            br#"{"agents":[],"coordinator":"","repos":[]}"#,
+        )
+        .expect("legacy config");
+        assert!(read_team_config(&base, "legacy")
+            .expect("read legacy")
+            .context_alert_percentages
+            .is_empty());
+
+        write_team_config(&base, "legacy", &empty_team_config(vec![90, 50, 75]))
+            .expect("canonical write");
+        let read_back = read_team_config(&base, "legacy").expect("read canonical");
+        assert_eq!(read_back.context_alert_percentages, vec![50, 75, 90]);
+        let json: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(legacy_dir.join("config.json")).expect("read bytes"),
+        )
+        .expect("parse bytes");
+        assert_eq!(
+            json["contextAlertPercentages"],
+            serde_json::json!([50, 75, 90])
+        );
+    }
+
+    #[test]
+    fn invalid_new_team_alerts_have_no_team_directory_side_effects() {
+        let tmp = create_test_workspace();
+        let base = test_base(&tmp);
+        let team_dir = base.join("_team_invalid-create");
+
+        let err =
+            create_new_team_config_on_disk(&base, "invalid-create", &empty_team_config(vec![0]))
+                .expect_err("invalid create");
+        assert!(err.contains("1 through 100"));
+        assert!(!team_dir.exists());
+        assert!(!team_dir.join("memory").exists());
+        assert!(!team_dir.join("conventions.md").exists());
+        assert!(base.join(TEAM_CONFIG_MUTATION_LOCK_NAME).is_file());
+
+        TeamConfigMutationGuard::acquire_with_timing(
+            &base,
+            TeamConfigLockTiming {
+                poll_interval: Duration::ZERO,
+                timeout: Duration::ZERO,
+            },
+        )
+        .expect("invalid create released lock");
+    }
+
+    #[test]
+    fn existing_team_publish_failure_keeps_prior_bytes_and_artifacts() {
+        let tmp = create_test_workspace();
+        let base = test_base(&tmp);
+        let team_dir =
+            create_new_team_config_on_disk(&base, "publish-failure", &empty_team_config(vec![50]))
+                .expect("create team");
+        let config_path = team_dir.join("config.json");
+        let before = std::fs::read(&config_path).expect("prior bytes");
+        let marker = team_dir.join("memory").join("marker");
+        std::fs::write(&marker, b"keep").expect("marker");
+        let guard = TeamConfigMutationGuard::acquire(&base).expect("guard");
+        let invalid_publisher_called = AtomicBool::new(false);
+        let invalid_err = write_team_config_guarded_with_publisher(
+            &base,
+            "publish-failure",
+            &empty_team_config(vec![0]),
+            &guard,
+            |_, _| {
+                invalid_publisher_called.store(true, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .expect_err("invalid config");
+        assert!(invalid_err.contains("1 through 100"));
+        assert!(!invalid_publisher_called.load(Ordering::SeqCst));
+        assert_eq!(std::fs::read(&config_path).expect("invalid bytes"), before);
+
+        let publisher_called = AtomicBool::new(false);
+        let err = write_team_config_guarded_with_publisher(
+            &base,
+            "publish-failure",
+            &empty_team_config(vec![75]),
+            &guard,
+            |_, _| {
+                publisher_called.store(true, Ordering::SeqCst);
+                Err("forced publish failure".to_string())
+            },
+        )
+        .expect_err("publish failure");
+
+        assert!(err.contains("forced publish failure"));
+        assert!(publisher_called.load(Ordering::SeqCst));
+        assert_eq!(std::fs::read(&config_path).expect("current bytes"), before);
+        assert_eq!(std::fs::read(&marker).expect("marker bytes"), b"keep");
+        assert!(team_dir.join("conventions.md").is_file());
+    }
+
+    #[test]
+    fn explicit_alert_value_repairs_product_invalid_existing_config() {
+        let tmp = create_test_workspace();
+        let base = test_base(&tmp);
+        let team_dir = base.join("_team_repair");
+        std::fs::create_dir_all(&team_dir).expect("team");
+        std::fs::write(
+            team_dir.join("config.json"),
+            br#"{"agents":[],"coordinator":"","repos":[],"contextAlertPercentages":[0]}"#,
+        )
+        .expect("invalid old config");
+        assert_eq!(
+            read_team_config_classified(&base, "repair")
+                .expect_err("old config invalid")
+                .class(),
+            "invalid"
+        );
+
+        let guard = TeamConfigMutationGuard::acquire(&base).expect("guard");
+        write_existing_team_config_guarded(&base, "repair", &empty_team_config(vec![75]), &guard)
+            .expect("repair write");
+        drop(guard);
+        assert_eq!(
+            read_team_config(&base, "repair")
+                .expect("repaired config")
+                .context_alert_percentages,
+            vec![75]
+        );
+    }
+
+    #[test]
+    fn team_config_guard_serializes_threads_and_releases_on_drop() {
+        let tmp = create_test_workspace();
+        let base = test_base(&tmp);
+        let first = TeamConfigMutationGuard::acquire(&base).expect("first guard");
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let thread_barrier = Arc::clone(&barrier);
+        let thread_base = base.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let waiter = std::thread::spawn(move || {
+            thread_barrier.wait();
+            let acquired = TeamConfigMutationGuard::acquire_with_timing(
+                &thread_base,
+                TeamConfigLockTiming {
+                    poll_interval: Duration::from_millis(10),
+                    timeout: Duration::from_secs(2),
+                },
+            )
+            .is_ok();
+            tx.send(acquired).expect("send result");
+        });
+
+        barrier.wait();
+        assert!(
+            rx.recv_timeout(Duration::from_millis(150)).is_err(),
+            "second writer acquired a held OS lock"
+        );
+        drop(first);
+        assert!(
+            rx.recv_timeout(Duration::from_secs(2))
+                .expect("waiter result"),
+            "second writer did not acquire after release"
+        );
+        waiter.join().expect("waiter join");
+    }
+
+    #[test]
+    fn team_config_guard_rejects_wrong_workspace_and_bad_sentinel() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root_a = tmp.path().join("a");
+        let root_b = tmp.path().join("b");
+        std::fs::create_dir_all(&root_a).expect("root a");
+        std::fs::create_dir_all(&root_b).expect("root b");
+        let guard = TeamConfigMutationGuard::acquire(&root_a).expect("guard a");
+        let err = write_team_config_guarded(
+            &root_b,
+            "wrong-root",
+            &empty_team_config(Vec::new()),
+            &guard,
+        )
+        .expect_err("wrong root");
+        assert!(err.contains("belongs to workspace"));
+        assert!(!root_b.join("_team_wrong-root").exists());
+        drop(guard);
+
+        let bad_root = tmp.path().join("bad");
+        std::fs::create_dir_all(bad_root.join(TEAM_CONFIG_MUTATION_LOCK_NAME))
+            .expect("directory sentinel");
+        let err = TeamConfigMutationGuard::acquire(&bad_root).expect_err("directory sentinel");
+        assert!(err.contains(TEAM_CONFIG_MUTATION_LOCK_NAME));
+        assert!(err.contains("regular non-link file"));
+    }
+
+    #[test]
+    fn held_team_config_lock_times_out_without_writing_and_is_reacquirable() {
+        let tmp = create_test_workspace();
+        let base = test_base(&tmp);
+        let team_dir =
+            create_new_team_config_on_disk(&base, "timeout", &empty_team_config(vec![50]))
+                .expect("create team");
+        let config_path = team_dir.join("config.json");
+        let before = std::fs::read(&config_path).expect("before");
+        let held = TeamConfigMutationGuard::acquire(&base).expect("held guard");
+        let err = TeamConfigMutationGuard::acquire_with_timing(
+            &base,
+            TeamConfigLockTiming {
+                poll_interval: Duration::ZERO,
+                timeout: Duration::ZERO,
+            },
+        )
+        .expect_err("held lock timeout");
+        assert!(err.contains("Timed out"));
+        assert!(err.contains(TEAM_CONFIG_MUTATION_LOCK_NAME));
+        assert_eq!(std::fs::read(&config_path).expect("after"), before);
+        drop(held);
+
+        TeamConfigMutationGuard::acquire_with_timing(
+            &base,
+            TeamConfigLockTiming {
+                poll_interval: Duration::ZERO,
+                timeout: Duration::ZERO,
+            },
+        )
+        .expect("reacquire after timeout holder drops");
+    }
+
+    #[test]
+    fn delete_and_update_linearize_without_recreating_deleted_team() {
+        let tmp = create_test_workspace();
+        let base = test_base(&tmp);
+        create_new_team_config_on_disk(&base, "race", &empty_team_config(vec![50]))
+            .expect("create team");
+
+        let update_guard = TeamConfigMutationGuard::acquire(&base).expect("update guard");
+        write_existing_team_config_guarded(
+            &base,
+            "race",
+            &empty_team_config(vec![75]),
+            &update_guard,
+        )
+        .expect("update first");
+        drop(update_guard);
+        let delete_guard = TeamConfigMutationGuard::acquire(&base).expect("delete guard");
+        std::fs::remove_dir_all(base.join("_team_race")).expect("delete after update");
+        drop(delete_guard);
+        assert!(!base.join("_team_race").exists());
+
+        create_new_team_config_on_disk(&base, "race", &empty_team_config(vec![50]))
+            .expect("recreate for reverse order");
+        let delete_guard = TeamConfigMutationGuard::acquire(&base).expect("delete guard");
+        std::fs::remove_dir_all(base.join("_team_race")).expect("delete first");
+        drop(delete_guard);
+        let update_guard = TeamConfigMutationGuard::acquire(&base).expect("update guard");
+        let err = write_existing_team_config_guarded(
+            &base,
+            "race",
+            &empty_team_config(vec![90]),
+            &update_guard,
+        )
+        .expect_err("update must not recreate");
+        assert!(err.contains("not found"));
+        assert!(!base.join("_team_race").exists());
+    }
+
+    #[test]
+    fn guarded_update_none_and_membership_preserve_alerts_in_both_orders() {
+        fn add_member(base: &Path) {
+            let guard = TeamConfigMutationGuard::acquire(base).expect("membership guard");
+            let mut current = read_team_config(base, "linear").expect("membership read");
+            if !current.agents.contains(&"_agent_beta".to_string()) {
+                current.agents.push("_agent_beta".to_string());
+            }
+            write_existing_team_config_guarded(base, "linear", &current, &guard)
+                .expect("membership write");
+        }
+
+        fn legacy_update(base: &Path) {
+            let guard = TeamConfigMutationGuard::acquire(base).expect("update guard");
+            let mut current =
+                read_team_config_classified(base, "linear").expect("classified current config");
+            current.context_alert_percentages = resolve_context_alert_argument(
+                ContextAlertWriteMode::Update,
+                None,
+                Some(&current.context_alert_percentages),
+            )
+            .expect("preserve omitted alert argument");
+            write_existing_team_config_guarded(base, "linear", &current, &guard)
+                .expect("legacy update write");
+        }
+
+        let tmp = create_test_workspace();
+        let base = test_base(&tmp);
+        create_test_agent(&base, "alpha", "Alpha");
+        create_test_agent(&base, "beta", "Beta");
+        let initial = TeamConfigResult {
+            agents: vec!["_agent_alpha".to_string()],
+            coordinator: "_agent_alpha".to_string(),
+            repos: Vec::new(),
+            context_alert_percentages: vec![90, 50],
+        };
+        create_new_team_config_on_disk(&base, "linear", &initial).expect("create team");
+
+        legacy_update(&base);
+        add_member(&base);
+        let update_then_member = read_team_config(&base, "linear").expect("final config");
+        assert_eq!(update_then_member.context_alert_percentages, vec![50, 90]);
+        assert!(update_then_member
+            .agents
+            .contains(&"_agent_beta".to_string()));
+
+        let guard = TeamConfigMutationGuard::acquire(&base).expect("reset guard");
+        write_existing_team_config_guarded(&base, "linear", &initial, &guard)
+            .expect("reset config");
+        drop(guard);
+        add_member(&base);
+        legacy_update(&base);
+        let member_then_update = read_team_config(&base, "linear").expect("reverse final config");
+        assert_eq!(member_then_update.context_alert_percentages, vec![50, 90]);
+        assert!(member_then_update
+            .agents
+            .contains(&"_agent_beta".to_string()));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn team_config_guard_rejects_reparse_sentinel_escape() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let outside = tmp.path().join("outside");
+        let sentinel = workspace.join(TEAM_CONFIG_MUTATION_LOCK_NAME);
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        std::fs::create_dir_all(&outside).expect("outside");
+        let output = std::process::Command::new("cmd")
+            .args([
+                "/C",
+                "mklink",
+                "/J",
+                sentinel.to_str().expect("sentinel path"),
+                outside.to_str().expect("outside path"),
+            ])
+            .output()
+            .expect("run mklink");
+        if !output.status.success() {
+            println!(
+                "skipping team guard reparse sentinel check: stdout: {} stderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        let err = TeamConfigMutationGuard::acquire(&workspace).expect_err("reparse escape");
+        assert!(err.contains("regular non-link file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn team_config_guard_rejects_symlink_sentinel_escape() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = tmp.path().join("workspace");
+        let outside = tmp.path().join("outside.lock");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        std::fs::write(&outside, b"").expect("outside lock");
+        symlink(&outside, workspace.join(TEAM_CONFIG_MUTATION_LOCK_NAME))
+            .expect("symlink sentinel");
+
+        let err = TeamConfigMutationGuard::acquire(&workspace).expect_err("symlink escape");
+        assert!(err.contains("regular non-link file"));
+        assert_eq!(std::fs::read(&outside).expect("outside bytes"), b"");
+    }
+
     async fn add_live_session(
         manager: &Arc<tokio::sync::RwLock<SessionManager>>,
         working_dir: &Path,
@@ -3928,7 +5015,8 @@ mod tests {
         settings: &SettingsState,
         manager: &Arc<tokio::sync::RwLock<SessionManager>>,
     ) -> Result<PreparedAgentDeleteMetadata, String> {
-        let plan = collect_agent_delete_plan(base, agent_path)?;
+        let guard = TeamConfigMutationGuard::acquire(base)?;
+        let plan = collect_agent_delete_plan_guarded(base, agent_path, &guard)?;
         preflight_agent_delete(&plan, manager).await?;
         let metadata = prepare_agent_delete_metadata(&plan, settings).await?;
         let staged = stage_agent_delete_targets(&plan, manager).await?;
@@ -3937,22 +5025,27 @@ mod tests {
             ensure_no_live_sessions_under_target_keys(&plan.target_keys, &plan.agent_name, manager)
                 .await
         {
+            drop(guard);
             let rollback = rollback_staged_agent_delete_targets(&staged);
             return Err(format_agent_delete_post_stage_live_failure(
                 live_err, rollback,
             ));
         }
 
-        if let Err(e) = persist_agent_delete_metadata_with_saver(&metadata, settings, |candidate| {
-            Ok(candidate.clone())
-        })
-        .await
+        if let Err(e) =
+            persist_agent_delete_metadata_with_saver(&metadata, settings, &guard, |candidate| {
+                Ok(candidate.clone())
+            })
+            .await
         {
-            let restore = restore_agent_delete_metadata_snapshots(&metadata, settings).await;
+            let restore =
+                restore_agent_delete_metadata_snapshots(&metadata, settings, &guard).await;
+            drop(guard);
             let rollback = rollback_staged_agent_delete_targets(&staged);
             return Err(format_agent_delete_metadata_failure(e, restore, rollback));
         }
 
+        drop(guard);
         remove_staged_agent_delete_targets(&staged)?;
         Ok(metadata)
     }
@@ -4064,6 +5157,114 @@ mod tests {
             serde_json::json!(["_agent_architect"])
         );
         assert_eq!(config["repos"][1]["agents"], serde_json::json!([]));
+        assert_eq!(
+            config["contextAlertPercentages"],
+            serde_json::json!([]),
+            "a relevant legacy raw write must insert the disabled canonical key"
+        );
+    }
+
+    #[test]
+    fn raw_agent_delete_preserves_unknown_keys_and_sorts_populated_alerts() {
+        let tmp = create_test_workspace();
+        let base = test_base(&tmp);
+        let agent_dir = create_test_agent(&base, "dev-rust", "Dev Rust");
+        let (config_path, _) = write_team_value(
+            &base,
+            "dev-team",
+            serde_json::json!({
+                "agents": ["_agent_dev-rust", "_agent_architect"],
+                "coordinator": "_agent_architect",
+                "repos": [{ "url": "u", "agents": ["_agent_dev-rust"] }],
+                "contextAlertPercentages": [90, 50, 75],
+                "futureUnknown": { "nested": [1, 2, 3] }
+            }),
+        );
+        let guard = TeamConfigMutationGuard::acquire(&base).expect("guard");
+        let plan =
+            collect_agent_delete_plan_guarded(&base, &agent_dir, &guard).expect("raw delete plan");
+        assert_eq!(plan.team_mutations.len(), 1);
+        write_team_config_json_atomic(
+            &base,
+            &guard,
+            &config_path,
+            &plan.team_mutations[0].after_json,
+        )
+        .expect("apply raw mutation");
+        drop(guard);
+
+        let current: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&config_path).expect("current bytes"))
+                .expect("parse current");
+        assert_eq!(current["agents"], serde_json::json!(["_agent_architect"]));
+        assert_eq!(current["repos"][0]["agents"], serde_json::json!([]));
+        assert_eq!(
+            current["contextAlertPercentages"],
+            serde_json::json!([50, 75, 90])
+        );
+        assert_eq!(
+            current["futureUnknown"],
+            serde_json::json!({ "nested": [1, 2, 3] })
+        );
+    }
+
+    #[test]
+    fn raw_agent_delete_rejects_each_malformed_relevant_alert_shape_without_writes() {
+        let invalid_values = [
+            serde_json::json!("50"),
+            serde_json::json!([50.5]),
+            serde_json::json!([0]),
+            serde_json::json!([101]),
+            serde_json::json!([1, 2, 3, 4]),
+            serde_json::json!([50, 50]),
+            serde_json::json!([-1]),
+            serde_json::json!([256]),
+        ];
+
+        for (index, invalid) in invalid_values.into_iter().enumerate() {
+            let tmp = create_test_workspace();
+            let base = test_base(&tmp);
+            let agent_dir = create_test_agent(&base, "dev-rust", "Dev Rust");
+            let (config_path, before) = write_team_value(
+                &base,
+                &format!("invalid-{}", index),
+                serde_json::json!({
+                    "agents": ["_agent_dev-rust"],
+                    "coordinator": "_agent_architect",
+                    "repos": [],
+                    "contextAlertPercentages": invalid,
+                    "keep": true
+                }),
+            );
+
+            let err = collect_agent_delete_plan(&base, &agent_dir)
+                .expect_err("malformed relevant alert data must block");
+            assert!(err.contains("invalid contextAlertPercentages"), "{err}");
+            assert!(agent_dir.is_dir());
+            assert_eq!(std::fs::read(&config_path).expect("config bytes"), before);
+        }
+    }
+
+    #[test]
+    fn raw_agent_delete_leaves_unrelated_invalid_alert_config_untouched() {
+        let tmp = create_test_workspace();
+        let base = test_base(&tmp);
+        let agent_dir = create_test_agent(&base, "dev-rust", "Dev Rust");
+        let (config_path, before) = write_team_value(
+            &base,
+            "unrelated",
+            serde_json::json!({
+                "agents": ["_agent_architect"],
+                "coordinator": "_agent_architect",
+                "repos": [],
+                "contextAlertPercentages": [0],
+                "keep": "verbatim"
+            }),
+        );
+
+        let plan = collect_agent_delete_plan(&base, &agent_dir).expect("unrelated plan");
+        assert!(plan.team_mutations.is_empty());
+        assert_eq!(std::fs::read(&config_path).expect("config bytes"), before);
     }
 
     #[test]
@@ -4126,9 +5327,16 @@ mod tests {
         )
         .0;
 
-        let plan = collect_agent_delete_plan(&base, &agent_dir).expect("collect plan");
-        write_team_config_json_atomic(&config_path, &plan.team_mutations[0].after_json)
-            .expect("write mutation");
+        let guard = TeamConfigMutationGuard::acquire(&base).expect("team guard");
+        let plan =
+            collect_agent_delete_plan_guarded(&base, &agent_dir, &guard).expect("collect plan");
+        write_team_config_json_atomic(
+            &base,
+            &guard,
+            &config_path,
+            &plan.team_mutations[0].after_json,
+        )
+        .expect("write mutation");
 
         let config: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&config_path).expect("read config"))
@@ -4319,6 +5527,7 @@ mod tests {
         std::fs::create_dir_all(&first).expect("first");
         std::fs::create_dir_all(&second).expect("second");
         let plan = AgentDeletePlan {
+            workspace_dir: tmp.path().to_path_buf(),
             agent_name: "dev-rust".to_string(),
             agent_ref: "_agent_dev-rust".to_string(),
             origin_dir: first.clone(),
@@ -4368,6 +5577,7 @@ mod tests {
         std::fs::create_dir_all(&first).expect("first");
         std::fs::create_dir_all(&second).expect("second");
         let plan = AgentDeletePlan {
+            workspace_dir: tmp.path().to_path_buf(),
             agent_name: "dev-rust".to_string(),
             agent_ref: "_agent_dev-rust".to_string(),
             origin_dir: first.clone(),
@@ -4438,7 +5648,9 @@ mod tests {
         );
         let settings = settings_state(AppSettings::default());
         let manager = test_manager();
-        let plan = collect_agent_delete_plan(&base, &agent_dir).expect("collect plan");
+        let guard = TeamConfigMutationGuard::acquire(&base).expect("team guard");
+        let plan =
+            collect_agent_delete_plan_guarded(&base, &agent_dir, &guard).expect("collect plan");
         let metadata = prepare_agent_delete_metadata(&plan, &settings)
             .await
             .expect("metadata");
@@ -4450,19 +5662,21 @@ mod tests {
         let persist_err = persist_agent_delete_metadata_with_writers(
             &metadata,
             &settings,
+            &guard,
             |path, bytes| {
                 let count = writes.fetch_add(1, TestOrdering::SeqCst);
                 if count == 1 {
                     Err("forced team write failure".to_string())
                 } else {
-                    write_team_config_json_atomic(path, bytes)
+                    write_team_config_json_atomic(&base, &guard, path, bytes)
                 }
             },
             |candidate| Ok(candidate.clone()),
         )
         .await
         .expect_err("team write failure");
-        let restore = restore_agent_delete_metadata_snapshots(&metadata, &settings).await;
+        let restore = restore_agent_delete_metadata_snapshots(&metadata, &settings, &guard).await;
+        drop(guard);
         let rollback = rollback_staged_agent_delete_targets(&staged);
         let msg = format_agent_delete_metadata_failure(persist_err, restore, rollback);
 
@@ -4496,7 +5710,9 @@ mod tests {
             .insert("dev-rust".to_string(), "A".to_string());
         let settings = settings_state(settings);
         let manager = test_manager();
-        let plan = collect_agent_delete_plan(&base, &agent_dir).expect("collect plan");
+        let guard = TeamConfigMutationGuard::acquire(&base).expect("team guard");
+        let plan =
+            collect_agent_delete_plan_guarded(&base, &agent_dir, &guard).expect("collect plan");
         let metadata = prepare_agent_delete_metadata(&plan, &settings)
             .await
             .expect("metadata");
@@ -4504,12 +5720,14 @@ mod tests {
             .await
             .expect("stage");
 
-        let persist_err = persist_agent_delete_metadata_with_saver(&metadata, &settings, |_| {
-            Err("forced settings save failure".to_string())
-        })
-        .await
-        .expect_err("settings save failure");
-        let restore = restore_agent_delete_metadata_snapshots(&metadata, &settings).await;
+        let persist_err =
+            persist_agent_delete_metadata_with_saver(&metadata, &settings, &guard, |_| {
+                Err("forced settings save failure".to_string())
+            })
+            .await
+            .expect_err("settings save failure");
+        let restore = restore_agent_delete_metadata_snapshots(&metadata, &settings, &guard).await;
+        drop(guard);
         let rollback = rollback_staged_agent_delete_targets(&staged);
         let msg = format_agent_delete_metadata_failure(persist_err, restore, rollback);
 

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -74,8 +74,8 @@ pub struct AgentConfig {
     ///
     /// The engine ships no anchoring rules of its own; every rule that makes a
     /// pattern trustworthy lives in the pattern, because only the user knows what
-    /// their agent renders. The reading is a signal for a human and never drives an
-    /// action.
+    /// their agent renders. A reading may enqueue an informational notice to the exact
+    /// workgroup coordinator, but it never drives remedial or destructive session action.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_regex: Option<String>,
     /// Backend used for future non-local session transports. Omitted/default

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,15 +21,15 @@ pub mod web;
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use commands::ac_discovery::DiscoveryBranchWatcher;
 use config::sessions_persistence;
 use config::settings::SettingsState;
 use pty::context_scrape::{
-    ContextEventSink, ContextPatternSource, ContextScraper, ContextUsagePayload, ScreenRowsRead,
-    ScreenRowsSource,
+    ContextEventSink, ContextPatternSource, ContextSample, ContextSampleSink, ContextScraper,
+    ContextSessionLiveness, ContextUsagePayload, ScreenRowsRead, ScreenRowsSource,
 };
 use pty::git_watcher::GitWatcher;
 use pty::idle_detector::IdleDetector;
@@ -520,12 +520,10 @@ pub(crate) fn should_auto_create_root_agent_on_first_restore(
     commands::session::resolve_root_agent_command(settings, None, last_coding_agent).is_ok()
 }
 
-// ---- #1032: the three adapters ----------------------------------------------------
+// ---- #1032/#1056: the four narrow scrape adapters ---------------------------------
 //
-// This is the boundary. Everything above it holds an `AppHandle` and a `PtyManager` and
-// can do anything to a session; the `ContextScraper` below it holds these three trait
-// objects and can do exactly three things. The narrowing is the feature's one hard rule
-// ("the value never drives an action") made structural instead of remembered.
+// This is the capability boundary. A sample may enqueue an informational coordinator
+// notice, but the scraper itself cannot route, inject, wake, or remediate a session.
 
 /// Rows, via the routed backend. The three states come from the backend, which is the only
 /// thing that holds a liveness oracle.
@@ -549,9 +547,24 @@ impl ScreenRowsSource for ScraperRows {
                         "[context] PtyManager lock is poisoned; context readings are unavailable"
                     );
                 }
-                // NOT SessionOver: a poisoned lock says nothing about whether the session
-                // is alive, and guessing would deregister live sessions.
                 ScreenRowsRead::Unavailable
+            }
+        }
+    }
+
+    fn get_session_liveness(&self, id: uuid::Uuid) -> ContextSessionLiveness {
+        match self.pty_mgr.lock() {
+            Ok(mgr) => mgr.context_session_liveness(id),
+            Err(_) => {
+                if !self
+                    .poison_logged
+                    .swap(true, std::sync::atomic::Ordering::Relaxed)
+                {
+                    log::warn!(
+                        "[context] PtyManager lock is poisoned; context liveness is unavailable"
+                    );
+                }
+                ContextSessionLiveness::Unavailable
             }
         }
     }
@@ -600,6 +613,56 @@ struct ScraperSink {
 impl ContextEventSink for ScraperSink {
     fn emit(&self, payload: ContextUsagePayload) {
         let _ = self.app_handle.emit("session_context", payload);
+    }
+}
+
+/// Nonblocking, bounded bridge from the scraper thread to the alert actor. It deliberately
+/// carries no app, PTY, session, filesystem, or delivery capability.
+struct ScraperSamples {
+    sender: tokio::sync::mpsc::Sender<ContextSample>,
+    closed_logged: AtomicBool,
+    saturated: AtomicBool,
+    dropped: AtomicU64,
+}
+
+impl ContextSampleSink for ScraperSamples {
+    fn observe(&self, sample: ContextSample) {
+        match self.sender.try_send(sample) {
+            Ok(()) => {
+                let recovery_capacity =
+                    crate::session::context_alerts::CONTEXT_SAMPLE_QUEUE_CAPACITY / 4;
+                if self.saturated.load(Ordering::Relaxed)
+                    && self.sender.capacity() >= recovery_capacity
+                    && self
+                        .saturated
+                        .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
+                        .is_ok()
+                {
+                    let dropped = self.dropped.swap(0, Ordering::Relaxed);
+                    log::info!(
+                        "[context-alert] sample queue recovered remainingCapacity={} dropped={}",
+                        self.sender.capacity(),
+                        dropped
+                    );
+                }
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                let dropped = self.dropped.fetch_add(1, Ordering::Relaxed) + 1;
+                if !self.saturated.swap(true, Ordering::Relaxed) {
+                    log::warn!(
+                        "[context-alert] sample queue saturated; advisory samples are being dropped (dropped={})",
+                        dropped
+                    );
+                }
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                if !self.closed_logged.swap(true, Ordering::Relaxed) {
+                    log::warn!(
+                        "[context-alert] sample queue is closed; advisory samples are being dropped"
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -926,6 +989,15 @@ pub fn run(
                 .0
                 .store(true, std::sync::atomic::Ordering::SeqCst);
 
+            // #1056 context-alert actor. Start it before the scraper so the bounded sender
+            // exists before the first sample; manage it for final joined shutdown.
+            let context_alert_monitor =
+                crate::session::context_alerts::ContextAlertMonitor::start(
+                    app.handle().clone(),
+                    shutdown_for_setup.token().child_token(),
+                );
+            app.manage(Arc::clone(&context_alert_monitor));
+
             // #1032 context scrape. Must be after `.manage(settings)` above, since the
             // pattern adapter reads settings back out of managed state. Mirrors GitWatcher.
             let context_scraper = ContextScraper::new(
@@ -938,6 +1010,12 @@ pub fn run(
                 }),
                 Arc::new(ScraperSink {
                     app_handle: app.handle().clone(),
+                }),
+                Arc::new(ScraperSamples {
+                    sender: context_alert_monitor.sender(),
+                    closed_logged: AtomicBool::new(false),
+                    saturated: AtomicBool::new(false),
+                    dropped: AtomicU64::new(0),
                 }),
             );
             context_scraper.start(shutdown_for_setup.clone());
@@ -2357,6 +2435,16 @@ pub fn run(
                     log::info!("[shutdown] Triggering background task shutdown (async, not awaited)...");
                     shutdown_for_exit.trigger();
 
+                    // #1056 joins the alert delivery slot and actor before selection or PTY
+                    // teardown, so no notice task is intentionally detached.
+                    if let Some(monitor) = app_handle.try_state::<
+                        Arc<crate::session::context_alerts::ContextAlertMonitor>,
+                    >() {
+                        if let Err(error) = tauri::async_runtime::block_on(monitor.close_and_join()) {
+                            log::warn!("[shutdown] context alert monitor join failed: {}", error);
+                        }
+                    }
+
                     let selection_shutdown = tauri::async_runtime::block_on(
                         selection_coordinator_for_exit.close_and_join(),
                     );
@@ -2530,13 +2618,15 @@ mod tests {
         restore_session_should_become_active, restore_session_should_wake,
         should_auto_create_root_agent_on_first_restore, should_wake_on_restore,
         should_wake_root_agent_on_restore, skip_auto_resume_for_restore, ApiServerHandle,
-        ApiServerTask, ContextPatternSource, PersistedActiveFlagNormalization,
-        RestoreObserverStartBarrier, ScraperPatterns, SettingsState, WebServerHandle,
+        ApiServerTask, ContextPatternSource, ContextSample, ContextSampleSink,
+        PersistedActiveFlagNormalization, RestoreObserverStartBarrier, ScraperPatterns,
+        ScraperSamples, SettingsState, WebServerHandle,
     };
     use crate::config::sessions_persistence::PersistedSession;
     use crate::config::settings::{AgentConfig, AppSettings};
     use crate::session::session::SessionStatus;
     use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::time::Duration;
     use tokio_util::sync::CancellationToken;
 
@@ -2573,6 +2663,48 @@ mod tests {
             settings: std::sync::Arc::new(tokio::sync::RwLock::new(settings)) as SettingsState,
         };
         futures::executor::block_on(source.patterns())
+    }
+
+    #[tokio::test]
+    async fn sample_adapter_is_nonblocking_and_recovers_only_after_quarter_capacity() {
+        let capacity = crate::session::context_alerts::CONTEXT_SAMPLE_QUEUE_CAPACITY;
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(capacity);
+        let adapter = ScraperSamples {
+            sender,
+            closed_logged: AtomicBool::new(false),
+            saturated: AtomicBool::new(false),
+            dropped: AtomicU64::new(0),
+        };
+        let sample = || ContextSample::Unavailable {
+            session_id: uuid::Uuid::nil(),
+        };
+
+        for _ in 0..capacity {
+            adapter.observe(sample());
+        }
+        adapter.observe(sample());
+        assert!(adapter.saturated.load(Ordering::Relaxed));
+        assert_eq!(adapter.dropped.load(Ordering::Relaxed), 1);
+
+        receiver.recv().await.expect("one queued sample");
+        adapter.observe(sample());
+        assert!(
+            adapter.saturated.load(Ordering::Relaxed),
+            "a one-slot drain must not end the saturation episode"
+        );
+
+        for _ in 0..257 {
+            receiver.recv().await.expect("queued sample to drain");
+        }
+        adapter.observe(sample());
+        assert!(!adapter.saturated.load(Ordering::Relaxed));
+        assert_eq!(adapter.dropped.load(Ordering::Relaxed), 0);
+        assert!(adapter.sender.capacity() >= capacity / 4);
+
+        drop(receiver);
+        adapter.observe(sample());
+        adapter.observe(sample());
+        assert!(adapter.closed_logged.load(Ordering::Relaxed));
     }
 
     /// #1032 - the adapter must hand `compile` the string the user wrote, byte for byte.

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -8446,6 +8446,8 @@ mod tests {
             fixture.sender_cwd.clone(),
         )
         .unwrap();
+        // Spawn must use the target's canonical path, not a caller's possible 8.3 spelling.
+        let expected_spawn_cwd = target.replica_dir().to_string_lossy().into_owned();
         let notice = InternalSystemNotice::for_context_alert(
             "dev-rust".to_string(),
             "wg-1-dev-team".to_string(),
@@ -8471,7 +8473,7 @@ mod tests {
         assert_eq!(hooks.spawn_calls.lock().unwrap().len(), 1);
         let spawn = hooks.spawn_calls.lock().unwrap()[0].clone();
         assert_eq!(spawn.to, CANONICAL_WAKE_FROM);
-        assert_eq!(spawn.cwd, fixture.sender_cwd.to_string_lossy());
+        assert_eq!(spawn.cwd, expected_spawn_cwd);
         assert_ne!(hooks.inject_calls.lock().unwrap()[0], wrong_id);
         assert_eq!(hooks.destroy_calls.lock().unwrap().len(), 0);
     }

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -18,10 +18,11 @@ use crate::phone::types::OutboxMessage;
 use crate::pty::backend::SessionBackendKind;
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
+use crate::session::session::{Session, SessionCommunicationKind, SessionInfo, SessionStatus};
 #[cfg(test)]
 use crate::session::session::{SessionCommunication, SessionRepo};
-use crate::session::session::{SessionCommunicationKind, SessionInfo, SessionStatus};
 use crate::{AppOutbox, MasterToken};
+use tokio_util::sync::CancellationToken;
 
 fn sender_name_for_session_cwd_with_root_flag(
     working_directory: &str,
@@ -64,6 +65,263 @@ pub(crate) fn retain_unarchived_session_dirs(
 pub(crate) enum WakeDeliveryOrigin {
     FilesystemPoller,
     DbQueue,
+}
+
+/// Canonical routing capability for an AgentsCommander-generated notice. The FQN and
+/// replica path are validated and retained together so no internal caller can later route
+/// by spelling alone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InternalSystemTarget {
+    fqn: String,
+    replica_dir: PathBuf,
+}
+
+impl InternalSystemTarget {
+    pub(crate) fn for_context_alert(fqn: String, replica_dir: PathBuf) -> Result<Self, String> {
+        let metadata = std::fs::symlink_metadata(&replica_dir).map_err(|e| {
+            format!(
+                "Internal system target replica '{}' is not readable: {}",
+                replica_dir.display(),
+                e
+            )
+        })?;
+        if !metadata.is_dir()
+            || crate::commands::entity_creation::metadata_is_link_or_reparse(&metadata)
+        {
+            return Err(format!(
+                "Internal system target replica '{}' must be a real non-link directory",
+                replica_dir.display()
+            ));
+        }
+        let canonical = std::fs::canonicalize(&replica_dir)
+            .map(|path| crate::path_utils::normalize_windows_verbatim_path_buf(&path))
+            .map_err(|e| {
+                format!(
+                    "Internal system target replica '{}' cannot be canonicalized: {}",
+                    replica_dir.display(),
+                    e
+                )
+            })?;
+        let layout = crate::config::workspace::wg_replica_layout_from_agent_dir(&canonical)?
+            .ok_or_else(|| {
+                format!(
+                    "Internal system target replica '{}' is not a canonical workgroup replica",
+                    canonical.display()
+                )
+            })?;
+        crate::commands::entity_creation::parse_team_from_workgroup_name(&layout.wg_name)?;
+        crate::commands::entity_creation::validate_existing_name(&layout.agent_name, "Agent")?;
+        let project = layout
+            .project_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| {
+                !name.is_empty()
+                    && !name.contains(':')
+                    && !name.chars().any(|ch| ch == '\0' || ch.is_ascii_control())
+            })
+            .ok_or_else(|| {
+                format!(
+                    "Internal system target project '{}' has an invalid FQN component",
+                    layout.project_dir.display()
+                )
+            })?
+            .to_string();
+        let expected = format!("{}:{}/{}", project, layout.wg_name, layout.agent_name);
+        if fqn != expected {
+            return Err(format!(
+                "Internal system target FQN '{}' does not match canonical replica '{}' (expected '{}')",
+                fqn,
+                canonical.display(),
+                expected
+            ));
+        }
+        Ok(Self {
+            fqn,
+            replica_dir: canonical,
+        })
+    }
+
+    pub(crate) fn fqn(&self) -> &str {
+        &self.fqn
+    }
+
+    pub(crate) fn replica_dir(&self) -> &Path {
+        &self.replica_dir
+    }
+}
+
+/// Validated fixed facts rendered by the private system formatter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InternalSystemNotice {
+    member: String,
+    workgroup: String,
+    observed: u8,
+    thresholds: Vec<u8>,
+}
+
+impl InternalSystemNotice {
+    pub(crate) fn for_context_alert(
+        member: String,
+        workgroup: String,
+        observed: u8,
+        thresholds: Vec<u8>,
+    ) -> Result<Self, String> {
+        crate::commands::entity_creation::validate_existing_name(&member, "Agent")?;
+        crate::commands::entity_creation::parse_team_from_workgroup_name(&workgroup)?;
+        if observed > 100 {
+            return Err("Context alert observation must be from 0 through 100".to_string());
+        }
+        if thresholds.is_empty() || thresholds.len() > 3 {
+            return Err("Context alert notice must contain 1 through 3 thresholds".to_string());
+        }
+        if thresholds
+            .iter()
+            .any(|threshold| !(1..=100).contains(threshold) || *threshold > observed)
+            || thresholds.windows(2).any(|pair| pair[0] >= pair[1])
+        {
+            return Err(
+                "Context alert notice thresholds must be strictly ascending, distinct, from 1 through 100, and no greater than the observation"
+                    .to_string(),
+            );
+        }
+        Ok(Self {
+            member,
+            workgroup,
+            observed,
+            thresholds,
+        })
+    }
+
+    pub(crate) fn thresholds(&self) -> &[u8] {
+        &self.thresholds
+    }
+
+    fn line(&self) -> String {
+        let thresholds = self
+            .thresholds
+            .iter()
+            .map(|threshold| format!("{}%", threshold))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "[AgentsCommander context alert] Member '{}' in workgroup '{}' was observed at {}% context use, reaching configured threshold(s): {}. No automatic action was taken; the coordinator decides whether follow-up is needed.",
+            self.member, self.workgroup, self.observed, thresholds
+        )
+    }
+}
+
+pub(crate) type InternalNoticeGuard = Arc<dyn Fn() -> Result<(), String> + Send + Sync>;
+
+enum WakeDelivery<'a> {
+    Peer {
+        message: &'a OutboxMessage,
+        origin: WakeDeliveryOrigin,
+    },
+    InternalSystem {
+        target: InternalSystemTarget,
+        notice: InternalSystemNotice,
+        cancellation: CancellationToken,
+        guard: InternalNoticeGuard,
+    },
+}
+
+enum WakeContent<'a> {
+    Peer {
+        from: &'a str,
+        body: &'a str,
+        origin: WakeDeliveryOrigin,
+    },
+    InternalSystem(&'a InternalSystemNotice),
+}
+
+fn format_wake_content(content: WakeContent<'_>) -> String {
+    match content {
+        WakeContent::Peer { from, body, origin } => {
+            let _ = origin;
+            crate::phone::messaging::format_pty_wrap(from, body)
+        }
+        WakeContent::InternalSystem(notice) => format!("\n{}\n\r", notice.line()),
+    }
+}
+
+fn internal_system_envelope(target: &InternalSystemTarget) -> OutboxMessage {
+    OutboxMessage {
+        id: Uuid::new_v4().to_string(),
+        token: None,
+        from: "AgentsCommander".to_string(),
+        to: target.fqn.clone(),
+        body: String::new(),
+        mode: "wake".to_string(),
+        get_output: false,
+        request_id: None,
+        sender_agent: None,
+        preferred_agent: "auto".to_string(),
+        priority: "normal".to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        command: None,
+        action: None,
+        target: None,
+        force: None,
+        timeout_secs: None,
+        switch_coding_agent: None,
+        switch_profile: None,
+        dry_run: None,
+        quiet_period_ms: None,
+    }
+}
+
+fn canonical_cwd_owned_by_replica(cwd: &str, replica_dir: &Path) -> Result<bool, String> {
+    let lexical = Path::new(cwd);
+    let Some(lexical_replica) = lexical.ancestors().find(|ancestor| {
+        ancestor
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("__agent_"))
+    }) else {
+        return Ok(false);
+    };
+    let Some(lexical_workgroup) = lexical_replica.parent() else {
+        return Ok(false);
+    };
+    let Some(lexical_workspace) = lexical_workgroup.parent() else {
+        return Ok(false);
+    };
+    for (path, label) in [
+        (lexical_replica, "replica"),
+        (lexical_workgroup, "workgroup"),
+        (lexical_workspace, "Project AC Root"),
+    ] {
+        let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+            format!(
+                "Failed to inspect recipient {} '{}': {}",
+                label,
+                path.display(),
+                error
+            )
+        })?;
+        if !metadata.is_dir()
+            || crate::commands::entity_creation::metadata_is_link_or_reparse(&metadata)
+        {
+            return Ok(false);
+        }
+    }
+    let canonical_replica = std::fs::canonicalize(lexical_replica)
+        .map(|path| crate::path_utils::normalize_windows_verbatim_path_buf(&path))
+        .map_err(|error| {
+            format!(
+                "Failed to canonicalize recipient replica '{}': {}",
+                lexical_replica.display(),
+                error
+            )
+        })?;
+    if canonical_replica != replica_dir {
+        return Ok(false);
+    }
+    let canonical = std::fs::canonicalize(cwd)
+        .map(|path| crate::path_utils::normalize_windows_verbatim_path_buf(&path))
+        .map_err(|e| format!("Failed to canonicalize recipient CWD '{}': {}", cwd, e))?;
+    Ok(canonical == replica_dir || canonical.starts_with(replica_dir))
 }
 
 fn container_body_override_for_delivery(
@@ -1651,7 +1909,11 @@ struct MailboxTestHooks {
     /// - so the AC3 hooked test exercises the real conversion, not a copy.
     consumption_results: Arc<Mutex<VecDeque<ConsumptionVerdict>>>,
     inject_calls: Arc<Mutex<Vec<Uuid>>>,
+    internal_payloads: Arc<Mutex<Vec<String>>>,
+    internal_bookkeeping: Arc<Mutex<Vec<InternalSystemBookkeeping>>>,
+    internal_live_settle_gate: Arc<Mutex<Option<tokio::sync::oneshot::Receiver<()>>>>,
     destroy_calls: Arc<Mutex<Vec<Uuid>>>,
+    destroy_results: Arc<Mutex<VecDeque<Result<(), String>>>>,
     spawn_calls: Arc<Mutex<Vec<MailboxSpawnCall>>>,
     attach_calls: MailboxAttachCalls,
     events: Arc<Mutex<Vec<MailboxTestEvent>>>,
@@ -1661,6 +1923,19 @@ struct MailboxTestHooks {
     /// wake that respawns a coordinator target yields a coordinator record;
     /// tests exercising the raised-hand carry set this to mirror that.
     spawn_is_coordinator: Arc<Mutex<bool>>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InternalSystemBookkeeping {
+    session_id: Uuid,
+    post_boundary: bool,
+    silence_touch: bool,
+    set_last_prompt: bool,
+    peer_event: bool,
+    response_watcher: bool,
+    consumption_verdict: bool,
+    mailbox_archive: bool,
 }
 
 #[cfg(test)]
@@ -2490,6 +2765,46 @@ impl MailboxPoller {
         msg: &OutboxMessage,
         origin: WakeDeliveryOrigin,
     ) -> Result<(), String> {
+        self.deliver_wake_engine(
+            app,
+            WakeDelivery::Peer {
+                message: msg,
+                origin,
+            },
+        )
+        .await
+    }
+
+    /// Single private entry for every wake delivery kind. The variant is selected only by
+    /// code: serialized peer messages can enter only `Peer`, while the validated target,
+    /// notice, cancellation, and guard capability are required for `InternalSystem`.
+    async fn deliver_wake_engine<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        delivery: WakeDelivery<'_>,
+    ) -> Result<(), String> {
+        match delivery {
+            WakeDelivery::Peer { message, origin } => {
+                self.deliver_peer_wake(app, message, origin).await
+            }
+            WakeDelivery::InternalSystem {
+                target,
+                notice,
+                cancellation,
+                guard,
+            } => {
+                self.deliver_internal_system_wake(app, target, notice, cancellation, guard)
+                    .await
+            }
+        }
+    }
+
+    async fn deliver_peer_wake<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        msg: &OutboxMessage,
+        origin: WakeDeliveryOrigin,
+    ) -> Result<(), String> {
         // (#885 J2) A purge is destroying this agent's record right now. A wake
         // delivered into that window falls through to spawn-persistent below and
         // would cold-spawn the agent we are purging, silently breaking the verb's
@@ -2867,6 +3182,602 @@ impl MailboxPoller {
             .await
     }
 
+    /// Deliver a validated AgentsCommander-generated notice through the existing wake,
+    /// resume, background-spawn, settle, and canonical injection plumbing. No serialized
+    /// message field can select this path.
+    pub(crate) async fn deliver_internal_system_notice<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        target: InternalSystemTarget,
+        notice: InternalSystemNotice,
+        cancellation: CancellationToken,
+        guard: InternalNoticeGuard,
+    ) -> Result<(), String> {
+        self.deliver_wake_engine(
+            app,
+            WakeDelivery::InternalSystem {
+                target,
+                notice,
+                cancellation,
+                guard,
+            },
+        )
+        .await
+    }
+
+    async fn deliver_internal_system_wake<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        target: InternalSystemTarget,
+        notice: InternalSystemNotice,
+        cancellation: CancellationToken,
+        guard: InternalNoticeGuard,
+    ) -> Result<(), String> {
+        if cancellation.is_cancelled() {
+            return Err("Context alert delivery was canceled".to_string());
+        }
+        if let Some(purge) = app.try_state::<Arc<crate::session::purge_guard::PurgeGuard>>() {
+            if purge.blocks_agent(target.fqn()) {
+                return Err(format!(
+                    "purge-wg in progress for '{}'; context alert deferred",
+                    target.fqn()
+                ));
+            }
+        }
+        Self::run_internal_guard(Arc::clone(&guard)).await?;
+
+        let envelope = internal_system_envelope(&target);
+        let mut exited: Option<SessionInfo> = None;
+        for (candidate, has_pty) in self.find_internal_system_candidates(app, &target).await? {
+            match candidate.status {
+                SessionStatus::Exited(_) => {
+                    if exited.is_none() {
+                        exited = Some(candidate);
+                    }
+                }
+                _ if has_pty => {
+                    tokio::select! {
+                        biased;
+                        _ = cancellation.cancelled() => {
+                            return Err("Context alert delivery was canceled during live settle".to_string());
+                        }
+                        _ = self.settle_internal_live_before_inject(app, Uuid::parse_str(&candidate.id)
+                            .map_err(|e| format!("Invalid coordinator session id '{}': {}", candidate.id, e))?) => {}
+                    }
+                    if cancellation.is_cancelled() {
+                        return Err(
+                            "Context alert delivery was canceled before live injection".to_string()
+                        );
+                    }
+                    let session_id = Uuid::parse_str(&candidate.id)
+                        .map_err(|e| format!("Invalid coordinator session id: {}", e))?;
+                    match self
+                        .inject_internal_system_notice(
+                            app,
+                            session_id,
+                            &target,
+                            &notice,
+                            Arc::clone(&guard),
+                        )
+                        .await
+                    {
+                        Ok(()) => return Ok(()),
+                        Err(error) if err_is_pty_session_missing(&error) => {
+                            log::warn!(
+                                "[context-alert] coordinator session {} vanished before injection: {}",
+                                session_id,
+                                error
+                            );
+                        }
+                        Err(error) => return Err(error),
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut spawn_with_resume = false;
+        let mut carried_bot: Option<String> = None;
+        let mut carried_communication = None;
+        if let Some(exited_candidate) = exited {
+            if cancellation.is_cancelled() {
+                return Err(
+                    "Context alert delivery was canceled before exited-session actuation"
+                        .to_string(),
+                );
+            }
+            let exited_id = Uuid::parse_str(&exited_candidate.id)
+                .map_err(|e| format!("Invalid exited coordinator session id: {}", e))?;
+            self.recheck_internal_exited_candidate(app, exited_id, &target)
+                .await?;
+            Self::run_internal_guard(Arc::clone(&guard)).await?;
+            self.recheck_internal_exited_record(
+                app,
+                exited_id,
+                &target,
+                &exited_candidate.working_directory,
+            )
+            .await?;
+            carried_bot = exited_candidate.telegram_bot_id.clone();
+            carried_communication = exited_candidate.communication.clone();
+            self.destroy_exited_wake_session(app, exited_id)
+                .await
+                .map_err(|error| {
+                    format!(
+                        "Failed to destroy stale coordinator session {}: {}",
+                        exited_id, error
+                    )
+                })?;
+            spawn_with_resume = true;
+        }
+
+        // Final pre-spawn authorization followed by a fresh exact-path enumeration. A
+        // supported recipient that appeared wins; this attempt returns stale rather than
+        // creating a duplicate.
+        Self::run_internal_guard(Arc::clone(&guard)).await?;
+        if !self
+            .find_internal_system_candidates(app, &target)
+            .await?
+            .is_empty()
+        {
+            return Err(format!(
+                "Coordinator recipient '{}' changed immediately before background spawn",
+                target.fqn()
+            ));
+        }
+
+        let resolved_command = self
+            .resolve_internal_agent_command(app, &target)
+            .await?
+            .ok_or_else(|| {
+                format!(
+                    "No supported coding-agent command is configured for '{}'",
+                    target.fqn()
+                )
+            })?;
+        let agent_id = resolved_command.agent_id.as_deref().ok_or_else(|| {
+            format!(
+                "Resolved command for '{}' has no trusted coding-agent id",
+                target.fqn()
+            )
+        })?;
+        let cwd = target.replica_dir().to_string_lossy().to_string();
+        let settings_snapshot = {
+            let settings = app.state::<SettingsState>();
+            let snapshot = settings.read().await.clone();
+            snapshot
+        };
+        let spawn_agent_id = agent_id.to_string();
+        let spawn_cwd = cwd.clone();
+        let resolved_spawn = tokio::task::spawn_blocking(move || {
+            crate::commands::session::build_configured_agent_spawn_for_cwd(
+                &settings_snapshot,
+                &spawn_agent_id,
+                &spawn_cwd,
+                None,
+            )
+        })
+        .await
+        .map_err(|error| format!("Internal profile resolution task failed: {}", error))??
+        .ok_or_else(|| {
+            format!(
+                "Configured coding-agent '{}' could not produce a trusted spawn for '{}'",
+                agent_id,
+                target.fqn()
+            )
+        })?;
+        if resolved_spawn.trusted_agent_id.trim().is_empty()
+            || resolved_spawn.trusted_agent_id != agent_id
+        {
+            return Err(format!(
+                "Resolved spawn for '{}' lost its trusted coding-agent identity",
+                target.fqn()
+            ));
+        }
+        if !crate::pty::inject::needs_explicit_enter(&resolved_spawn.shell) {
+            return Err(format!(
+                "Resolved spawn shell '{}' for '{}' is not a supported coding-agent CLI",
+                resolved_spawn.shell,
+                target.fqn()
+            ));
+        }
+
+        // Repeat the guard and exact-path absence check immediately before actuation. Command
+        // and profile resolution above can perform filesystem work and must not widen this race.
+        Self::run_internal_guard(Arc::clone(&guard)).await?;
+        if !self
+            .find_internal_system_candidates(app, &target)
+            .await?
+            .is_empty()
+        {
+            return Err(format!(
+                "Coordinator recipient '{}' changed immediately before background spawn",
+                target.fqn()
+            ));
+        }
+
+        if cancellation.is_cancelled() {
+            return Err("Context alert delivery was canceled before background spawn".to_string());
+        }
+        let (_, local) = crate::config::teams::split_project_prefix(target.fqn());
+        let info = self
+            .spawn_wake_session(
+                app,
+                &envelope,
+                &resolved_command,
+                cwd,
+                local.to_string(),
+                spawn_with_resume,
+                resolved_spawn.shell.clone(),
+                resolved_spawn.shell_args.clone(),
+                Some(resolved_spawn.trusted_agent_label.clone()),
+                Some(resolved_spawn),
+            )
+            .await
+            .map_err(|error| {
+                format!(
+                    "Failed to spawn supported coordinator session for '{}': {}",
+                    target.fqn(),
+                    error
+                )
+            })?;
+        let session_id = Uuid::parse_str(&info.id)
+            .map_err(|e| format!("Invalid spawned coordinator session id: {}", e))?;
+
+        if carried_bot.is_some() {
+            self.attach_persisted_telegram_for_wake(app, session_id, carried_bot.as_deref())
+                .await;
+        }
+        if let Some(communication) = carried_communication {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let manager = session_mgr.read().await.clone();
+            let restored = manager
+                .restore_communication(session_id, communication.clone())
+                .await;
+            if restored {
+                crate::session::selection::publish_session_communication(
+                    app,
+                    session_id,
+                    Some(&communication),
+                );
+            }
+        }
+
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => {
+                return Err("Context alert delivery was canceled during spawned-session settle".to_string());
+            }
+            result = self.wait_for_spawned_wake_idle(app, session_id) => result?,
+        }
+        if cancellation.is_cancelled() {
+            return Err(
+                "Context alert delivery was canceled before spawned-session injection".to_string(),
+            );
+        }
+        self.inject_internal_system_notice(app, session_id, &target, &notice, guard)
+            .await
+    }
+
+    async fn settle_internal_live_before_inject<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_id: Uuid,
+    ) {
+        #[cfg(test)]
+        if let Some(hooks) = &self.test_hooks {
+            let gate = hooks.internal_live_settle_gate.lock().unwrap().take();
+            if let Some(gate) = gate {
+                let _ = gate.await;
+                return;
+            }
+        }
+        self.settle_live_before_inject(app, session_id).await;
+    }
+
+    async fn run_internal_guard(guard: InternalNoticeGuard) -> Result<(), String> {
+        tokio::task::spawn_blocking(move || guard())
+            .await
+            .map_err(|error| format!("Internal notice guard task failed: {}", error))?
+    }
+
+    async fn resolve_internal_agent_command<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        target: &InternalSystemTarget,
+    ) -> Result<Option<ResolvedWakeAgentCommand>, String> {
+        let agents = {
+            let settings = app.state::<SettingsState>();
+            let agents = settings.read().await.agents.clone();
+            agents
+        };
+        let replica_dir = target.replica_dir().to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            let current = crate::config::coding_agent_profiles::read_replica_current_coding_agent(
+                &replica_dir,
+            );
+            let config_path = replica_dir
+                .join(crate::config::agent_local_dir_name())
+                .join("config.json");
+            let last = std::fs::read_to_string(&config_path)
+                .ok()
+                .and_then(|content| serde_json::from_str::<AgentLocalConfig>(&content).ok())
+                .and_then(|config| config.tooling.last_coding_agent);
+            resolve_wake_agent_command_from_sources(
+                &agents,
+                "auto",
+                current.as_deref(),
+                last.as_deref(),
+                Some(&config_path),
+                None,
+            )
+        })
+        .await
+        .map_err(|error| format!("Internal command lookup task failed: {}", error))?
+    }
+
+    async fn find_internal_system_candidates<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        target: &InternalSystemTarget,
+    ) -> Result<Vec<(SessionInfo, bool)>, String> {
+        let sessions = {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let manager = session_mgr.read().await.clone();
+            manager.list_sessions().await
+        };
+        let target_fqn = target.fqn().to_string();
+        let replica_dir = target.replica_dir().to_path_buf();
+        let structural: Vec<SessionInfo> = sessions
+            .into_iter()
+            .filter(|session| {
+                !session.is_root_agent
+                    && session.agent_id.is_some()
+                    && crate::pty::inject::needs_explicit_enter(&session.shell)
+                    && crate::config::teams::agent_fqn_from_path(&session.working_directory)
+                        == target_fqn
+            })
+            .collect();
+        let mut owned = tokio::task::spawn_blocking(move || {
+            structural
+                .into_iter()
+                .filter(|session| {
+                    canonical_cwd_owned_by_replica(&session.working_directory, &replica_dir)
+                        .unwrap_or(false)
+                })
+                .collect::<Vec<_>>()
+        })
+        .await
+        .map_err(|error| format!("Coordinator candidate path task failed: {}", error))?;
+        owned.sort_by_key(|session| {
+            let temporary = session
+                .name
+                .starts_with(crate::session::session::TEMP_SESSION_PREFIX);
+            let status = match session.status {
+                SessionStatus::Active | SessionStatus::Running => 0u8,
+                SessionStatus::Idle => 1,
+                SessionStatus::Exited(_) => 2,
+            };
+            (temporary, status)
+        });
+
+        let mut result = Vec::with_capacity(owned.len());
+        for session in owned {
+            let id = Uuid::parse_str(&session.id)
+                .map_err(|e| format!("Invalid coordinator session id '{}': {}", session.id, e))?;
+            let has_pty = self.has_pty_session_for_wake(app, id).await;
+            if matches!(session.status, SessionStatus::Exited(_)) || has_pty {
+                result.push((session, has_pty));
+            }
+        }
+        Ok(result)
+    }
+
+    async fn recheck_internal_exited_candidate<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_id: Uuid,
+        target: &InternalSystemTarget,
+    ) -> Result<(), String> {
+        let session = {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let manager = session_mgr.read().await.clone();
+            manager.get_session(session_id).await
+        }
+        .ok_or_else(|| format!("Exited coordinator session {} disappeared", session_id))?;
+        if !matches!(session.status, SessionStatus::Exited(_))
+            || session.is_root_agent
+            || session.agent_id.is_none()
+            || !crate::pty::inject::needs_explicit_enter(&session.shell)
+        {
+            return Err(format!(
+                "Coordinator session {} changed before exited-session destruction",
+                session_id
+            ));
+        }
+        let cwd = session.working_directory;
+        let replica = target.replica_dir().to_path_buf();
+        let owned =
+            tokio::task::spawn_blocking(move || canonical_cwd_owned_by_replica(&cwd, &replica))
+                .await
+                .map_err(|error| format!("Exited coordinator path task failed: {}", error))??;
+        if !owned {
+            return Err(format!(
+                "Coordinator session {} no longer belongs to target replica",
+                session_id
+            ));
+        }
+        Ok(())
+    }
+
+    async fn recheck_internal_exited_record<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_id: Uuid,
+        target: &InternalSystemTarget,
+        expected_cwd: &str,
+    ) -> Result<(), String> {
+        let session = {
+            let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let manager = session_mgr.read().await.clone();
+            manager.get_session(session_id).await
+        }
+        .ok_or_else(|| format!("Exited coordinator session {} disappeared", session_id))?;
+        if !matches!(session.status, SessionStatus::Exited(_))
+            || session.is_root_agent
+            || session.agent_id.is_none()
+            || !crate::pty::inject::needs_explicit_enter(&session.shell)
+            || session.working_directory != expected_cwd
+            || crate::config::teams::agent_fqn_from_path(&session.working_directory) != target.fqn()
+        {
+            return Err(format!(
+                "Coordinator session {} restarted or changed immediately before destruction",
+                session_id
+            ));
+        }
+        let cwd = session.working_directory;
+        let replica = target.replica_dir().to_path_buf();
+        let owned =
+            tokio::task::spawn_blocking(move || canonical_cwd_owned_by_replica(&cwd, &replica))
+                .await
+                .map_err(|error| {
+                    format!(
+                        "Final exited coordinator path task failed for {}: {}",
+                        session_id, error
+                    )
+                })??;
+        if !owned {
+            return Err(format!(
+                "Coordinator session {} escaped the canonical target before destruction",
+                session_id
+            ));
+        }
+        Ok(())
+    }
+
+    async fn inject_internal_system_notice<R: tauri::Runtime>(
+        &self,
+        app: &tauri::AppHandle<R>,
+        session_id: Uuid,
+        target: &InternalSystemTarget,
+        notice: &InternalSystemNotice,
+        guard: InternalNoticeGuard,
+    ) -> Result<(), String> {
+        let payload = format_wake_content(WakeContent::InternalSystem(notice));
+
+        #[cfg(test)]
+        if let Some(hooks) = &self.test_hooks {
+            let session = {
+                let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+                let manager = session_mgr.read().await.clone();
+                manager.get_session(session_id).await
+            }
+            .ok_or_else(|| format!("Session {} missing before test injection", session_id))?;
+            if session.is_root_agent
+                || matches!(session.status, SessionStatus::Exited(_))
+                || session.agent_id.is_none()
+                || !crate::pty::inject::needs_explicit_enter(&session.shell)
+                || !canonical_cwd_owned_by_replica(
+                    &session.working_directory,
+                    target.replica_dir(),
+                )?
+            {
+                return Err(format!(
+                    "Session {} failed supported-agent final validation",
+                    session_id
+                ));
+            }
+            guard()?;
+            hooks.inject_calls.lock().unwrap().push(session_id);
+            hooks
+                .internal_payloads
+                .lock()
+                .unwrap()
+                .push(payload.clone());
+            hooks
+                .events
+                .lock()
+                .unwrap()
+                .push(MailboxTestEvent::Inject(session_id));
+            hooks
+                .inject_results
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(Ok(()))?;
+            hooks
+                .internal_bookkeeping
+                .lock()
+                .unwrap()
+                .push(InternalSystemBookkeeping {
+                    session_id,
+                    post_boundary: true,
+                    silence_touch: true,
+                    set_last_prompt: false,
+                    peer_event: false,
+                    response_watcher: false,
+                    consumption_verdict: false,
+                    mailbox_archive: false,
+                });
+            return Ok(());
+        } else {
+            crate::pty::inject::inject_text_into_supported_agent_session_with_pre_write_check(
+                app,
+                session_id,
+                &payload,
+                |session: &Session| {
+                    if !canonical_cwd_owned_by_replica(
+                        &session.working_directory,
+                        target.replica_dir(),
+                    )? {
+                        return Err(format!(
+                            "Coordinator session {} escaped canonical target replica",
+                            session_id
+                        ));
+                    }
+                    guard()
+                },
+            )
+            .await?;
+        }
+
+        #[cfg(not(test))]
+        crate::pty::inject::inject_text_into_supported_agent_session_with_pre_write_check(
+            app,
+            session_id,
+            &payload,
+            |session: &Session| {
+                if !canonical_cwd_owned_by_replica(
+                    &session.working_directory,
+                    target.replica_dir(),
+                )? {
+                    return Err(format!(
+                        "Coordinator session {} escaped canonical target replica",
+                        session_id
+                    ));
+                }
+                guard()
+            },
+        )
+        .await?;
+
+        crate::commands::pty::note_post_boundary_content_to_session(app, session_id).await;
+        if let Some(idle) = app.try_state::<Arc<crate::pty::idle_detector::IdleDetector>>() {
+            idle.touch_silence(session_id);
+        }
+        let (project, _) = crate::config::teams::split_project_prefix(target.fqn());
+        log::info!(
+            "[context-alert] delivered coordinatorSession={} project={} workgroup={} member={} observed={} thresholds={:?}",
+            session_id,
+            project.unwrap_or(""),
+            notice.workgroup,
+            notice.member,
+            notice.observed,
+            notice.thresholds
+        );
+        Ok(())
+    }
+
     async fn has_pty_session_for_wake<R: tauri::Runtime>(
         &self,
         app: &tauri::AppHandle<R>,
@@ -2965,6 +3876,9 @@ impl MailboxPoller {
             {
                 let mut events = hooks.events.lock().unwrap();
                 events.push(MailboxTestEvent::Destroy(session_id));
+            }
+            if let Some(result) = hooks.destroy_results.lock().unwrap().pop_front() {
+                result?;
             }
             let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
             let mgr = session_mgr.read().await;
@@ -3507,7 +4421,11 @@ impl MailboxPoller {
             (true, Some(rid)) => {
                 crate::phone::messaging::format_pty_wrap_with_markers(&msg.from, body, rid)
             }
-            _ => crate::phone::messaging::format_pty_wrap(&msg.from, body),
+            _ => format_wake_content(WakeContent::Peer {
+                from: &msg.from,
+                body,
+                origin,
+            }),
         };
 
         // Register response watcher only for non-interactive sessions
@@ -6489,6 +7407,130 @@ mod tests {
     use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
     use crate::pty::manager::PtyManager;
 
+    fn internal_target_fixture() -> (tempfile::TempDir, InternalSystemTarget) {
+        let temp = tempfile::tempdir().unwrap();
+        let replica = temp
+            .path()
+            .join("project-a")
+            .join(".ac")
+            .join("wg-2-dev-team")
+            .join("__agent_coordinator");
+        std::fs::create_dir_all(&replica).unwrap();
+        let target = InternalSystemTarget::for_context_alert(
+            "project-a:wg-2-dev-team/coordinator".to_string(),
+            replica,
+        )
+        .unwrap();
+        (temp, target)
+    }
+
+    #[test]
+    fn internal_target_binds_exact_fqn_to_canonical_replica() {
+        let (temp, target) = internal_target_fixture();
+        assert_eq!(target.fqn(), "project-a:wg-2-dev-team/coordinator");
+        assert!(target.replica_dir().is_absolute());
+
+        let replica = temp
+            .path()
+            .join("project-a")
+            .join(".ac")
+            .join("wg-2-dev-team")
+            .join("__agent_coordinator");
+        let error = InternalSystemTarget::for_context_alert(
+            "project-a:wg-3-dev-team/coordinator".to_string(),
+            replica,
+        )
+        .unwrap_err();
+        assert!(error.contains("does not match canonical replica"));
+        assert!(InternalSystemTarget::for_context_alert(
+            "project-a:wg-2-dev-team/coordinator".to_string(),
+            temp.path().join("missing-replica"),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn internal_notice_validates_and_formats_exact_trusted_line() {
+        let notice = InternalSystemNotice::for_context_alert(
+            "dev-rust".to_string(),
+            "wg-2-dev-team".to_string(),
+            91,
+            vec![50, 75, 90],
+        )
+        .unwrap();
+        assert_eq!(
+            format_wake_content(WakeContent::InternalSystem(&notice)),
+            "\n[AgentsCommander context alert] Member 'dev-rust' in workgroup 'wg-2-dev-team' was observed at 91% context use, reaching configured threshold(s): 50%, 75%, 90%. No automatic action was taken; the coordinator decides whether follow-up is needed.\n\r"
+        );
+        for (member, workgroup, observed, thresholds) in [
+            ("../escape", "wg-2-dev-team", 91, vec![50]),
+            ("dev-rust", "wg-0-dev-team", 91, vec![50]),
+            ("dev-rust", "wg-2-dev-team", 101, vec![50]),
+            ("dev-rust", "wg-2-dev-team", 91, vec![]),
+            ("dev-rust", "wg-2-dev-team", 91, vec![25, 50, 75, 90]),
+            ("dev-rust", "wg-2-dev-team", 91, vec![75, 50]),
+            ("dev-rust", "wg-2-dev-team", 91, vec![50, 50]),
+            ("dev-rust", "wg-2-dev-team", 91, vec![0]),
+            ("dev-rust", "wg-2-dev-team", 91, vec![101]),
+            ("dev-rust", "wg-2-dev-team", 50, vec![75]),
+        ] {
+            assert!(
+                InternalSystemNotice::for_context_alert(
+                    member.to_string(),
+                    workgroup.to_string(),
+                    observed,
+                    thresholds,
+                )
+                .is_err(),
+                "invalid notice case must be rejected: member={member} workgroup={workgroup} observed={observed}"
+            );
+        }
+    }
+
+    #[test]
+    fn private_internal_envelope_has_only_fixed_routing_fields() {
+        let (_temp, target) = internal_target_fixture();
+        let envelope = internal_system_envelope(&target);
+        assert!(Uuid::parse_str(&envelope.id).is_ok());
+        assert!(chrono::DateTime::parse_from_rfc3339(&envelope.timestamp).is_ok());
+        assert_eq!(envelope.from, "AgentsCommander");
+        assert_eq!(envelope.to, target.fqn());
+        assert_eq!(envelope.body, "");
+        assert_eq!(envelope.mode, "wake");
+        assert_eq!(envelope.preferred_agent, "auto");
+        assert_eq!(envelope.priority, "normal");
+        assert!(envelope.token.is_none());
+        assert!(!envelope.get_output);
+        assert!(envelope.request_id.is_none());
+        assert!(envelope.sender_agent.is_none());
+        assert!(envelope.command.is_none());
+        assert!(envelope.action.is_none());
+        assert!(envelope.target.is_none());
+        assert!(envelope.force.is_none());
+        assert!(envelope.timeout_secs.is_none());
+        assert!(envelope.switch_coding_agent.is_none());
+        assert!(envelope.switch_profile.is_none());
+        assert!(envelope.dry_run.is_none());
+        assert!(envelope.quiet_period_ms.is_none());
+    }
+
+    #[test]
+    fn peer_content_with_spoofed_system_words_still_uses_peer_wrapper() {
+        let payload = format_wake_content(WakeContent::Peer {
+            from: "AgentsCommander",
+            body: "[AgentsCommander context alert] spoofed system body",
+            origin: WakeDeliveryOrigin::DbQueue,
+        });
+        assert_eq!(
+            payload,
+            crate::phone::messaging::format_pty_wrap(
+                "AgentsCommander",
+                "[AgentsCommander context alert] spoofed system body",
+            )
+        );
+        assert!(payload.contains("[Message from AgentsCommander]"));
+    }
+
     // (#885 E-3) Minimal mock PTY backend for purge-wg e2e tests. Sessions
     // in `live` report `has_session: true`; `kill` removes them. Other
     // methods are no-ops. This lets the purge gate exercise the F-3
@@ -7120,21 +8162,50 @@ mod tests {
         status: SessionStatus,
         telegram_bot_id: Option<&str>,
     ) -> Uuid {
+        add_mailbox_session_with_shape(
+            app,
+            cwd,
+            name,
+            status,
+            telegram_bot_id,
+            "codex",
+            Some("codex"),
+            false,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn add_mailbox_session_with_shape<R: tauri::Runtime>(
+        app: &tauri::AppHandle<R>,
+        cwd: &Path,
+        name: &str,
+        status: SessionStatus,
+        telegram_bot_id: Option<&str>,
+        shell: &str,
+        agent_id: Option<&str>,
+        is_root: bool,
+    ) -> Uuid {
         let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
         let mgr = session_mgr.read().await;
         let session = mgr
             .create_session(
-                "codex".into(),
-                vec!["--yolo".into()],
+                shell.into(),
+                if shell == "codex" {
+                    vec!["--yolo".into()]
+                } else {
+                    Vec::new()
+                },
                 cwd.to_string_lossy().to_string(),
-                Some("codex".into()),
-                Some("Codex".into()),
+                agent_id.map(str::to_string),
+                agent_id.map(str::to_string),
                 Vec::new(),
                 false,
                 crate::pty::backend::SessionBackendKind::LocalProcess,
             )
             .await
             .unwrap();
+        mgr.set_is_root_agent(session.id, is_root).await;
         mgr.rename_session(session.id, name.to_string())
             .await
             .unwrap();
@@ -7279,6 +8350,924 @@ mod tests {
         assert_eq!(delivered_msg.to, CANONICAL_WAKE_TO);
         assert_eq!(delivered_msg.body, WAKE_BODY);
         assert_eq!(delivered_msg.mode, "wake");
+    }
+
+    #[tokio::test]
+    async fn internal_live_delivery_uses_exact_payload_guard_and_system_bookkeeping() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let coordinator_id = add_mailbox_session(
+            &app,
+            &fixture.sender_cwd,
+            "wg-1-dev-team/tech-lead",
+            SessionStatus::Running,
+            None,
+        )
+        .await;
+        let target = InternalSystemTarget::for_context_alert(
+            CANONICAL_WAKE_FROM.to_string(),
+            fixture.sender_cwd.clone(),
+        )
+        .unwrap();
+        let notice = InternalSystemNotice::for_context_alert(
+            "dev-rust".to_string(),
+            "wg-1-dev-team".to_string(),
+            80,
+            vec![50, 75],
+        )
+        .unwrap();
+        let calls = Arc::new(AtomicU32::new(0));
+        let guard_calls = Arc::clone(&calls);
+        let guard: InternalNoticeGuard = Arc::new(move || {
+            guard_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        });
+        let hooks = MailboxTestHooks::default();
+        hooks
+            .pty_presence
+            .lock()
+            .unwrap()
+            .insert(coordinator_id, true);
+        let poller = MailboxPoller::new_with_test_hooks(hooks.clone());
+
+        poller
+            .deliver_internal_system_notice(&app, target, notice, CancellationToken::new(), guard)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            hooks.inject_calls.lock().unwrap().as_slice(),
+            &[coordinator_id]
+        );
+        assert_eq!(
+            hooks.internal_payloads.lock().unwrap().as_slice(),
+            &["\n[AgentsCommander context alert] Member 'dev-rust' in workgroup 'wg-1-dev-team' was observed at 80% context use, reaching configured threshold(s): 50%, 75%. No automatic action was taken; the coordinator decides whether follow-up is needed.\n\r".to_string()]
+        );
+        assert_eq!(
+            hooks.internal_bookkeeping.lock().unwrap().as_slice(),
+            &[InternalSystemBookkeeping {
+                session_id: coordinator_id,
+                post_boundary: true,
+                silence_touch: true,
+                set_last_prompt: false,
+                peer_event: false,
+                response_watcher: false,
+                consumption_verdict: false,
+                mailbox_archive: false,
+            }]
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_no_spawn_or_destroy_events(&hooks);
+    }
+
+    #[tokio::test]
+    async fn internal_same_fqn_at_another_root_is_not_injected_and_exact_target_spawns() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let wrong_replica = fixture
+            ._temp
+            .path()
+            .join("other-root")
+            .join("proj-a")
+            .join(".ac")
+            .join("wg-1-dev-team")
+            .join("__agent_tech-lead");
+        std::fs::create_dir_all(&wrong_replica).unwrap();
+        let wrong_id = add_mailbox_session(
+            &app,
+            &wrong_replica,
+            "wrong-root",
+            SessionStatus::Running,
+            None,
+        )
+        .await;
+        let target = InternalSystemTarget::for_context_alert(
+            CANONICAL_WAKE_FROM.to_string(),
+            fixture.sender_cwd.clone(),
+        )
+        .unwrap();
+        let notice = InternalSystemNotice::for_context_alert(
+            "dev-rust".to_string(),
+            "wg-1-dev-team".to_string(),
+            50,
+            vec![50],
+        )
+        .unwrap();
+        let hooks = MailboxTestHooks::default();
+        hooks.pty_presence.lock().unwrap().insert(wrong_id, true);
+        let poller = MailboxPoller::new_with_test_hooks(hooks.clone());
+
+        poller
+            .deliver_internal_system_notice(
+                &app,
+                target,
+                notice,
+                CancellationToken::new(),
+                Arc::new(|| Ok(())),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(hooks.spawn_calls.lock().unwrap().len(), 1);
+        let spawn = hooks.spawn_calls.lock().unwrap()[0].clone();
+        assert_eq!(spawn.to, CANONICAL_WAKE_FROM);
+        assert_eq!(spawn.cwd, fixture.sender_cwd.to_string_lossy());
+        assert_ne!(hooks.inject_calls.lock().unwrap()[0], wrong_id);
+        assert_eq!(hooks.destroy_calls.lock().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn internal_exited_recipient_is_destroyed_then_resumed_without_selection_spawn() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let exited_id = add_mailbox_session(
+            &app,
+            &fixture.sender_cwd,
+            "exited-coordinator",
+            SessionStatus::Exited(0),
+            None,
+        )
+        .await;
+        let target = InternalSystemTarget::for_context_alert(
+            CANONICAL_WAKE_FROM.to_string(),
+            fixture.sender_cwd.clone(),
+        )
+        .unwrap();
+        let notice = InternalSystemNotice::for_context_alert(
+            "dev-rust".to_string(),
+            "wg-1-dev-team".to_string(),
+            50,
+            vec![50],
+        )
+        .unwrap();
+        let hooks = MailboxTestHooks::default();
+        let poller = MailboxPoller::new_with_test_hooks(hooks.clone());
+
+        poller
+            .deliver_internal_system_notice(
+                &app,
+                target,
+                notice,
+                CancellationToken::new(),
+                Arc::new(|| Ok(())),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(hooks.destroy_calls.lock().unwrap().as_slice(), &[exited_id]);
+        assert_eq!(hooks.spawn_calls.lock().unwrap().len(), 1);
+        assert!(!hooks.spawn_calls.lock().unwrap()[0].skip_auto_resume);
+        let events = hooks.events.lock().unwrap();
+        assert!(matches!(events[0], MailboxTestEvent::Destroy(id) if id == exited_id));
+        assert!(matches!(events[1], MailboxTestEvent::Spawn(_)));
+        assert!(matches!(events[2], MailboxTestEvent::Inject(_)));
+    }
+
+    #[tokio::test]
+    async fn internal_precanceled_attempt_performs_no_wake_actuation() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let target = InternalSystemTarget::for_context_alert(
+            CANONICAL_WAKE_FROM.to_string(),
+            fixture.sender_cwd.clone(),
+        )
+        .unwrap();
+        let notice = InternalSystemNotice::for_context_alert(
+            "dev-rust".to_string(),
+            "wg-1-dev-team".to_string(),
+            50,
+            vec![50],
+        )
+        .unwrap();
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let hooks = MailboxTestHooks::default();
+        let poller = MailboxPoller::new_with_test_hooks(hooks.clone());
+
+        assert!(
+            poller
+                .deliver_internal_system_notice(
+                    &app,
+                    target,
+                    notice,
+                    cancellation,
+                    Arc::new(|| Ok(())),
+                )
+                .await
+                .is_err()
+        );
+        assert!(hooks.events.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn internal_unsupported_root_agentless_plain_shell_and_escaped_records_are_untouched() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let root_id = add_mailbox_session_with_shape(
+            &app,
+            &fixture.sender_cwd,
+            "root",
+            SessionStatus::Running,
+            None,
+            "codex",
+            Some("codex"),
+            true,
+        )
+        .await;
+        let agentless_id = add_mailbox_session_with_shape(
+            &app,
+            &fixture.sender_cwd,
+            "agentless",
+            SessionStatus::Running,
+            None,
+            "codex",
+            None,
+            false,
+        )
+        .await;
+        let shell_id = add_mailbox_session_with_shape(
+            &app,
+            &fixture.sender_cwd,
+            "plain-shell",
+            SessionStatus::Running,
+            None,
+            "pwsh",
+            Some("codex"),
+            false,
+        )
+        .await;
+        let escape_subdir = fixture.sender_cwd.join("subdir");
+        std::fs::create_dir_all(&escape_subdir).unwrap();
+        let escaped_cwd = escape_subdir.join("..").join("..").join("__agent_dev-rust");
+        let escaped_id = add_mailbox_session_with_shape(
+            &app,
+            &escaped_cwd,
+            "escaped",
+            SessionStatus::Running,
+            None,
+            "codex",
+            Some("codex"),
+            false,
+        )
+        .await;
+        let hooks = MailboxTestHooks::default();
+        for id in [root_id, agentless_id, shell_id, escaped_id] {
+            hooks.pty_presence.lock().unwrap().insert(id, true);
+        }
+        let poller = MailboxPoller::new_with_test_hooks(hooks.clone());
+        let target = InternalSystemTarget::for_context_alert(
+            CANONICAL_WAKE_FROM.to_string(),
+            fixture.sender_cwd.clone(),
+        )
+        .unwrap();
+        let notice = InternalSystemNotice::for_context_alert(
+            "dev-rust".to_string(),
+            "wg-1-dev-team".to_string(),
+            50,
+            vec![50],
+        )
+        .unwrap();
+
+        poller
+            .deliver_internal_system_notice(
+                &app,
+                target,
+                notice,
+                CancellationToken::new(),
+                Arc::new(|| Ok(())),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(hooks.spawn_calls.lock().unwrap().len(), 1);
+        let injected = hooks.inject_calls.lock().unwrap()[0];
+        assert!(![root_id, agentless_id, shell_id, escaped_id].contains(&injected));
+        assert!(hooks.destroy_calls.lock().unwrap().is_empty());
+        let manager = app
+            .state::<Arc<tokio::sync::RwLock<SessionManager>>>()
+            .read()
+            .await
+            .clone();
+        for id in [root_id, agentless_id, shell_id, escaped_id] {
+            assert!(manager.get_session(id).await.is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn internal_missing_command_and_unsupported_resolved_shell_never_spawn() {
+        let missing = make_mailbox_fixture();
+        let missing_app = app_handle(&missing.app);
+        missing_app
+            .state::<SettingsState>()
+            .write()
+            .await
+            .agents
+            .clear();
+        let missing_hooks = MailboxTestHooks::default();
+        let missing_poller = MailboxPoller::new_with_test_hooks(missing_hooks.clone());
+        let missing_target = InternalSystemTarget::for_context_alert(
+            CANONICAL_WAKE_FROM.to_string(),
+            missing.sender_cwd.clone(),
+        )
+        .unwrap();
+        let notice = InternalSystemNotice::for_context_alert(
+            "dev-rust".to_string(),
+            "wg-1-dev-team".to_string(),
+            50,
+            vec![50],
+        )
+        .unwrap();
+        let error = missing_poller
+            .deliver_internal_system_notice(
+                &missing_app,
+                missing_target,
+                notice.clone(),
+                CancellationToken::new(),
+                Arc::new(|| Ok(())),
+            )
+            .await
+            .unwrap_err();
+        assert!(error.contains("No supported coding-agent command"));
+        assert!(missing_hooks.spawn_calls.lock().unwrap().is_empty());
+
+        let unsupported = make_mailbox_fixture();
+        let unsupported_app = app_handle(&unsupported.app);
+        unsupported_app
+            .state::<SettingsState>()
+            .write()
+            .await
+            .agents = vec![wake_agent("codex", "Codex", "pwsh")];
+        std::fs::write(
+            unsupported.sender_cwd.join("config.json"),
+            r#"{"identity":"../../_agent_tech-lead","tooling":{"currentCodingAgent":"codex"}}"#,
+        )
+        .unwrap();
+        let unsupported_hooks = MailboxTestHooks::default();
+        let unsupported_poller = MailboxPoller::new_with_test_hooks(unsupported_hooks.clone());
+        let unsupported_target = InternalSystemTarget::for_context_alert(
+            CANONICAL_WAKE_FROM.to_string(),
+            unsupported.sender_cwd.clone(),
+        )
+        .unwrap();
+        let error = unsupported_poller
+            .deliver_internal_system_notice(
+                &unsupported_app,
+                unsupported_target,
+                notice,
+                CancellationToken::new(),
+                Arc::new(|| Ok(())),
+            )
+            .await
+            .unwrap_err();
+        assert!(error.contains("not a supported coding-agent CLI"));
+        assert!(unsupported_hooks.spawn_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn internal_repeatable_guard_blocks_live_destroy_and_spawn_boundaries() {
+        let live = make_mailbox_fixture();
+        let live_app = app_handle(&live.app);
+        let live_id = add_mailbox_session(
+            &live_app,
+            &live.sender_cwd,
+            "live",
+            SessionStatus::Running,
+            None,
+        )
+        .await;
+        let live_hooks = MailboxTestHooks::default();
+        live_hooks
+            .pty_presence
+            .lock()
+            .unwrap()
+            .insert(live_id, true);
+        let live_calls = Arc::new(AtomicU32::new(0));
+        let live_guard_calls = Arc::clone(&live_calls);
+        let live_error = MailboxPoller::new_with_test_hooks(live_hooks.clone())
+            .deliver_internal_system_notice(
+                &live_app,
+                InternalSystemTarget::for_context_alert(
+                    CANONICAL_WAKE_FROM.to_string(),
+                    live.sender_cwd.clone(),
+                )
+                .unwrap(),
+                InternalSystemNotice::for_context_alert(
+                    "dev-rust".to_string(),
+                    "wg-1-dev-team".to_string(),
+                    50,
+                    vec![50],
+                )
+                .unwrap(),
+                CancellationToken::new(),
+                Arc::new(move || {
+                    if live_guard_calls.fetch_add(1, Ordering::SeqCst) >= 1 {
+                        Err("stale before write".to_string())
+                    } else {
+                        Ok(())
+                    }
+                }),
+            )
+            .await
+            .unwrap_err();
+        assert!(live_error.contains("stale before write"));
+        assert!(live_hooks.inject_calls.lock().unwrap().is_empty());
+
+        let exited = make_mailbox_fixture();
+        let exited_app = app_handle(&exited.app);
+        let exited_id = add_mailbox_session(
+            &exited_app,
+            &exited.sender_cwd,
+            "exited",
+            SessionStatus::Exited(0),
+            None,
+        )
+        .await;
+        let exited_hooks = MailboxTestHooks::default();
+        let exited_calls = Arc::new(AtomicU32::new(0));
+        let exited_guard_calls = Arc::clone(&exited_calls);
+        let exited_error = MailboxPoller::new_with_test_hooks(exited_hooks.clone())
+            .deliver_internal_system_notice(
+                &exited_app,
+                InternalSystemTarget::for_context_alert(
+                    CANONICAL_WAKE_FROM.to_string(),
+                    exited.sender_cwd.clone(),
+                )
+                .unwrap(),
+                InternalSystemNotice::for_context_alert(
+                    "dev-rust".to_string(),
+                    "wg-1-dev-team".to_string(),
+                    50,
+                    vec![50],
+                )
+                .unwrap(),
+                CancellationToken::new(),
+                Arc::new(move || {
+                    if exited_guard_calls.fetch_add(1, Ordering::SeqCst) >= 1 {
+                        Err("stale before destroy".to_string())
+                    } else {
+                        Ok(())
+                    }
+                }),
+            )
+            .await
+            .unwrap_err();
+        assert!(exited_error.contains("stale before destroy"));
+        assert!(exited_hooks.destroy_calls.lock().unwrap().is_empty());
+        assert!(exited_hooks.spawn_calls.lock().unwrap().is_empty());
+        assert!(exited_app
+            .state::<Arc<tokio::sync::RwLock<SessionManager>>>()
+            .read()
+            .await
+            .get_session(exited_id)
+            .await
+            .is_some());
+
+        let absent = make_mailbox_fixture();
+        let absent_app = app_handle(&absent.app);
+        let absent_hooks = MailboxTestHooks::default();
+        let absent_calls = Arc::new(AtomicU32::new(0));
+        let absent_guard_calls = Arc::clone(&absent_calls);
+        let absent_error = MailboxPoller::new_with_test_hooks(absent_hooks.clone())
+            .deliver_internal_system_notice(
+                &absent_app,
+                InternalSystemTarget::for_context_alert(
+                    CANONICAL_WAKE_FROM.to_string(),
+                    absent.sender_cwd.clone(),
+                )
+                .unwrap(),
+                InternalSystemNotice::for_context_alert(
+                    "dev-rust".to_string(),
+                    "wg-1-dev-team".to_string(),
+                    50,
+                    vec![50],
+                )
+                .unwrap(),
+                CancellationToken::new(),
+                Arc::new(move || {
+                    if absent_guard_calls.fetch_add(1, Ordering::SeqCst) >= 1 {
+                        Err("stale before spawn".to_string())
+                    } else {
+                        Ok(())
+                    }
+                }),
+            )
+            .await
+            .unwrap_err();
+        assert!(absent_error.contains("stale before spawn"));
+        assert!(absent_hooks.spawn_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn internal_destroy_failure_is_retryable_and_never_falls_through_to_spawn() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let exited_id = add_mailbox_session(
+            &app,
+            &fixture.sender_cwd,
+            "exited",
+            SessionStatus::Exited(0),
+            None,
+        )
+        .await;
+        let hooks = MailboxTestHooks::default();
+        hooks
+            .destroy_results
+            .lock()
+            .unwrap()
+            .push_back(Err("scripted destruction failure".to_string()));
+        let error = MailboxPoller::new_with_test_hooks(hooks.clone())
+            .deliver_internal_system_notice(
+                &app,
+                InternalSystemTarget::for_context_alert(
+                    CANONICAL_WAKE_FROM.to_string(),
+                    fixture.sender_cwd.clone(),
+                )
+                .unwrap(),
+                InternalSystemNotice::for_context_alert(
+                    "dev-rust".to_string(),
+                    "wg-1-dev-team".to_string(),
+                    50,
+                    vec![50],
+                )
+                .unwrap(),
+                CancellationToken::new(),
+                Arc::new(|| Ok(())),
+            )
+            .await
+            .unwrap_err();
+        assert!(error.contains("scripted destruction failure"));
+        assert_eq!(hooks.destroy_calls.lock().unwrap().as_slice(), &[exited_id]);
+        assert!(hooks.spawn_calls.lock().unwrap().is_empty());
+        assert!(hooks.inject_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn internal_candidate_appearing_at_pre_spawn_recheck_prevents_spawn() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let hooks = MailboxTestHooks::default();
+        let (start_sender, start_receiver) = tokio::sync::oneshot::channel();
+        let (done_sender, done_receiver) = std::sync::mpsc::channel();
+        let start_sender = Arc::new(Mutex::new(Some(start_sender)));
+        let done_receiver = Arc::new(Mutex::new(done_receiver));
+        let appeared = Arc::new(Mutex::new(None));
+        let task_app = app.clone();
+        let task_cwd = fixture.sender_cwd.clone();
+        let task_hooks = hooks.clone();
+        let task_appeared = Arc::clone(&appeared);
+        let appearance = tokio::spawn(async move {
+            let _ = start_receiver.await;
+            let id = add_mailbox_session(
+                &task_app,
+                &task_cwd,
+                "appeared",
+                SessionStatus::Running,
+                None,
+            )
+            .await;
+            task_hooks.pty_presence.lock().unwrap().insert(id, true);
+            *task_appeared.lock().unwrap() = Some(id);
+            done_sender.send(()).unwrap();
+        });
+        let guard_calls = Arc::new(AtomicU32::new(0));
+        let guard_counter = Arc::clone(&guard_calls);
+        let guard_start = Arc::clone(&start_sender);
+        let guard_done = Arc::clone(&done_receiver);
+        let guard: InternalNoticeGuard = Arc::new(move || {
+            if guard_counter.fetch_add(1, Ordering::SeqCst) == 1 {
+                guard_start
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .unwrap()
+                    .send(())
+                    .unwrap();
+                guard_done
+                    .lock()
+                    .unwrap()
+                    .recv_timeout(Duration::from_secs(1))
+                    .map_err(|error| format!("appearance task did not finish: {error}"))?;
+            }
+            Ok(())
+        });
+        let error = MailboxPoller::new_with_test_hooks(hooks.clone())
+            .deliver_internal_system_notice(
+                &app,
+                InternalSystemTarget::for_context_alert(
+                    CANONICAL_WAKE_FROM.to_string(),
+                    fixture.sender_cwd.clone(),
+                )
+                .unwrap(),
+                InternalSystemNotice::for_context_alert(
+                    "dev-rust".to_string(),
+                    "wg-1-dev-team".to_string(),
+                    50,
+                    vec![50],
+                )
+                .unwrap(),
+                CancellationToken::new(),
+                guard,
+            )
+            .await
+            .unwrap_err();
+        appearance.await.unwrap();
+        assert!(error.contains("changed immediately before background spawn"));
+        assert!(appeared.lock().unwrap().is_some());
+        assert!(hooks.spawn_calls.lock().unwrap().is_empty());
+        assert!(hooks.inject_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn internal_exited_candidate_disappearing_during_guard_cannot_spawn_duplicate() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let exited_id = add_mailbox_session(
+            &app,
+            &fixture.sender_cwd,
+            "exited",
+            SessionStatus::Exited(0),
+            None,
+        )
+        .await;
+        let hooks = MailboxTestHooks::default();
+        let (start_sender, start_receiver) = tokio::sync::oneshot::channel();
+        let (done_sender, done_receiver) = std::sync::mpsc::channel();
+        let start_sender = Arc::new(Mutex::new(Some(start_sender)));
+        let done_receiver = Arc::new(Mutex::new(done_receiver));
+        let task_app = app.clone();
+        let task_cwd = fixture.sender_cwd.clone();
+        let task_hooks = hooks.clone();
+        let replacement = tokio::spawn(async move {
+            let _ = start_receiver.await;
+            let manager = task_app
+                .state::<Arc<tokio::sync::RwLock<SessionManager>>>()
+                .read()
+                .await
+                .clone();
+            manager.destroy_session(exited_id).await.unwrap();
+            let replacement_id = add_mailbox_session(
+                &task_app,
+                &task_cwd,
+                "replacement",
+                SessionStatus::Running,
+                None,
+            )
+            .await;
+            task_hooks
+                .pty_presence
+                .lock()
+                .unwrap()
+                .insert(replacement_id, true);
+            done_sender.send(()).unwrap();
+        });
+        let guard_calls = Arc::new(AtomicU32::new(0));
+        let guard_counter = Arc::clone(&guard_calls);
+        let guard_start = Arc::clone(&start_sender);
+        let guard_done = Arc::clone(&done_receiver);
+        let guard: InternalNoticeGuard = Arc::new(move || {
+            if guard_counter.fetch_add(1, Ordering::SeqCst) == 1 {
+                guard_start
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .unwrap()
+                    .send(())
+                    .unwrap();
+                guard_done
+                    .lock()
+                    .unwrap()
+                    .recv_timeout(Duration::from_secs(1))
+                    .map_err(|error| format!("replacement task did not finish: {error}"))?;
+            }
+            Ok(())
+        });
+        let error = MailboxPoller::new_with_test_hooks(hooks.clone())
+            .deliver_internal_system_notice(
+                &app,
+                InternalSystemTarget::for_context_alert(
+                    CANONICAL_WAKE_FROM.to_string(),
+                    fixture.sender_cwd.clone(),
+                )
+                .unwrap(),
+                InternalSystemNotice::for_context_alert(
+                    "dev-rust".to_string(),
+                    "wg-1-dev-team".to_string(),
+                    50,
+                    vec![50],
+                )
+                .unwrap(),
+                CancellationToken::new(),
+                guard,
+            )
+            .await
+            .unwrap_err();
+        replacement.await.unwrap();
+        assert!(error.contains("disappeared"));
+        assert!(hooks.destroy_calls.lock().unwrap().is_empty());
+        assert!(hooks.spawn_calls.lock().unwrap().is_empty());
+        assert!(hooks.inject_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn internal_cancellation_during_live_settle_returns_without_injection() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let live_id = add_mailbox_session(
+            &app,
+            &fixture.sender_cwd,
+            "live",
+            SessionStatus::Running,
+            None,
+        )
+        .await;
+        let hooks = MailboxTestHooks::default();
+        hooks.pty_presence.lock().unwrap().insert(live_id, true);
+        let (settle_release, settle_gate) = tokio::sync::oneshot::channel();
+        *hooks.internal_live_settle_gate.lock().unwrap() = Some(settle_gate);
+        let cancellation = CancellationToken::new();
+        let cancel_when_settling = cancellation.clone();
+        let settle_hooks = hooks.clone();
+        let canceller = tokio::spawn(async move {
+            for _ in 0..2_000 {
+                if settle_hooks
+                    .internal_live_settle_gate
+                    .lock()
+                    .unwrap()
+                    .is_none()
+                {
+                    cancel_when_settling.cancel();
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+            panic!("internal settle gate was not entered");
+        });
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            MailboxPoller::new_with_test_hooks(hooks.clone()).deliver_internal_system_notice(
+                &app,
+                InternalSystemTarget::for_context_alert(
+                    CANONICAL_WAKE_FROM.to_string(),
+                    fixture.sender_cwd.clone(),
+                )
+                .unwrap(),
+                InternalSystemNotice::for_context_alert(
+                    "dev-rust".to_string(),
+                    "wg-1-dev-team".to_string(),
+                    50,
+                    vec![50],
+                )
+                .unwrap(),
+                cancellation,
+                Arc::new(|| Ok(())),
+            ),
+        )
+        .await
+        .expect("cancellation must not wait for the settle cap");
+        canceller.await.unwrap();
+        drop(settle_release);
+        assert!(result.unwrap_err().contains("canceled during live settle"));
+        assert!(hooks.inject_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn internal_injection_failure_returns_without_system_bookkeeping_or_spawn() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let live_id = add_mailbox_session(
+            &app,
+            &fixture.sender_cwd,
+            "live",
+            SessionStatus::Running,
+            None,
+        )
+        .await;
+        let hooks = MailboxTestHooks::default();
+        hooks.pty_presence.lock().unwrap().insert(live_id, true);
+        hooks
+            .inject_results
+            .lock()
+            .unwrap()
+            .push_back(Err("scripted text write failure".to_string()));
+        let error = MailboxPoller::new_with_test_hooks(hooks.clone())
+            .deliver_internal_system_notice(
+                &app,
+                InternalSystemTarget::for_context_alert(
+                    CANONICAL_WAKE_FROM.to_string(),
+                    fixture.sender_cwd.clone(),
+                )
+                .unwrap(),
+                InternalSystemNotice::for_context_alert(
+                    "dev-rust".to_string(),
+                    "wg-1-dev-team".to_string(),
+                    50,
+                    vec![50],
+                )
+                .unwrap(),
+                CancellationToken::new(),
+                Arc::new(|| Ok(())),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(error.contains("scripted text write failure"));
+        assert_eq!(hooks.inject_calls.lock().unwrap().as_slice(), &[live_id]);
+        assert!(hooks.internal_bookkeeping.lock().unwrap().is_empty());
+        assert!(hooks.spawn_calls.lock().unwrap().is_empty());
+        assert!(hooks.destroy_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn internal_exited_resume_carries_telegram_and_raised_hand() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let exited_id = add_mailbox_session(
+            &app,
+            &fixture.sender_cwd,
+            "exited",
+            SessionStatus::Running,
+            Some("bot-1"),
+        )
+        .await;
+        let communication = SessionCommunication {
+            kind: SessionCommunicationKind::RaiseHand,
+            visible: true,
+            updated_at: "2026-07-19T00:00:00Z".to_string(),
+        };
+        let manager = app
+            .state::<Arc<tokio::sync::RwLock<SessionManager>>>()
+            .read()
+            .await
+            .clone();
+        manager.set_is_coordinator(exited_id, true).await;
+        manager.mark_exited(exited_id, 0).await;
+        assert!(
+            manager
+                .restore_communication(exited_id, communication.clone())
+                .await
+        );
+        let hooks = MailboxTestHooks::default();
+        *hooks.spawn_is_coordinator.lock().unwrap() = true;
+        MailboxPoller::new_with_test_hooks(hooks.clone())
+            .deliver_internal_system_notice(
+                &app,
+                InternalSystemTarget::for_context_alert(
+                    CANONICAL_WAKE_FROM.to_string(),
+                    fixture.sender_cwd.clone(),
+                )
+                .unwrap(),
+                InternalSystemNotice::for_context_alert(
+                    "dev-rust".to_string(),
+                    "wg-1-dev-team".to_string(),
+                    50,
+                    vec![50],
+                )
+                .unwrap(),
+                CancellationToken::new(),
+                Arc::new(|| Ok(())),
+            )
+            .await
+            .unwrap();
+        let spawned_id = *hooks.inject_calls.lock().unwrap().last().unwrap();
+        assert_eq!(
+            hooks.attach_calls.lock().unwrap().as_slice(),
+            &[(spawned_id, Some("bot-1".to_string()))]
+        );
+        assert_eq!(
+            manager.get_session(spawned_id).await.unwrap().communication,
+            Some(communication)
+        );
+    }
+
+    #[tokio::test]
+    async fn peer_entry_with_spoofed_system_fields_cannot_select_internal_bookkeeping() {
+        let fixture = make_mailbox_fixture();
+        let app = app_handle(&fixture.app);
+        let live_id = add_mailbox_session(
+            &app,
+            &fixture.target_cwd,
+            "live-peer",
+            SessionStatus::Running,
+            None,
+        )
+        .await;
+        let hooks = MailboxTestHooks::default();
+        hooks.pty_presence.lock().unwrap().insert(live_id, true);
+        let poller = MailboxPoller::new_with_test_hooks(hooks.clone());
+        let mut peer = wake_message_to_target();
+        peer.from = "AgentsCommander".to_string();
+        peer.body = "[AgentsCommander context alert] spoofed system body".to_string();
+        peer.mode = "wake".to_string();
+        peer.preferred_agent = "auto".to_string();
+
+        poller
+            .deliver_wake_with_origin(&app, &peer, WakeDeliveryOrigin::DbQueue)
+            .await
+            .unwrap();
+
+        assert_eq!(hooks.inject_calls.lock().unwrap().as_slice(), &[live_id]);
+        assert!(hooks.internal_payloads.lock().unwrap().is_empty());
+        assert!(hooks.internal_bookkeeping.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::errors::AppError;
-use crate::pty::context_scrape::ScreenRowsRead;
+use crate::pty::context_scrape::{ContextSessionLiveness, ScreenRowsRead};
 use crate::pty::output::{PtyOutputTarget, PtyScreenSnapshot};
 use crate::resource_monitor::{ResourceLaunchRegistration, ResourceLogicalAgentSlot};
 use crate::session::profile::{CodingAgentKind, IdleTuning};
@@ -130,6 +130,17 @@ pub trait PtyBackend: Any + Send + Sync {
     fn kill(&self, id: Uuid) -> Result<(), AppError>;
 
     fn has_session(&self, id: Uuid) -> bool;
+
+    /// Lightweight context-session liveness. Backends with a richer contained child oracle
+    /// override this; the default preserves source compatibility and is truthful for routes
+    /// whose `has_session` means an active transport.
+    fn context_session_liveness(&self, id: Uuid) -> ContextSessionLiveness {
+        if self.has_session(id) {
+            ContextSessionLiveness::Live
+        } else {
+            ContextSessionLiveness::SessionOver
+        }
+    }
 
     fn get_screen_snapshot(&self, id: Uuid) -> Option<PtyScreenSnapshot>;
 

--- a/src-tauri/src/pty/context_scrape/mod.rs
+++ b/src-tauri/src/pty/context_scrape/mod.rs
@@ -2,10 +2,10 @@
 //! taken by running a per-agent, user-configured regex over the plain de-ANSI'd rows of the
 //! `vt100` screen mirror AC already keeps for every session.
 //!
-//! **The percentage is a signal for a human. It never drives an action.** That is not a
-//! rule anyone here has to remember: the scraper holds three narrow trait objects and
-//! nothing else - no `AppHandle`, no `PtyManager` - so the capability to write to a PTY or
-//! kill a session is not reachable from this module at all.
+//! **The percentage is a signal for a human.** A sample may be offered to the bounded
+//! context-alert monitor so it can enqueue an informational coordinator notice, but this
+//! scraper cannot route, inject, or remediate the sampled session. That boundary is
+//! structural: it holds four narrow trait objects and no `AppHandle` or `PtyManager`.
 
 pub mod pattern;
 pub mod rows;
@@ -24,6 +24,15 @@ use pattern::ContextPattern;
 /// configured session per tick - against the ~1.9-2.4 us a single keystroke already holds
 /// the same `ptys` lock for.
 pub const SAMPLE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Lightweight liveness used when no usable regex exists. It deliberately does not expose
+/// or clone the terminal parser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextSessionLiveness {
+    Live,
+    Unavailable,
+    SessionOver,
+}
 
 /// What a backend can say about one session's rows.
 ///
@@ -44,9 +53,13 @@ pub enum ScreenRowsRead {
     SessionOver,
 }
 
-/// The rows of one session's screen. Three states in, three states out.
+/// The rows and lightweight liveness of one session.
 pub trait ScreenRowsSource: Send + Sync {
     fn get_screen_rows(&self, id: Uuid) -> ScreenRowsRead;
+
+    fn get_session_liveness(&self, _id: Uuid) -> ContextSessionLiveness {
+        ContextSessionLiveness::Unavailable
+    }
 }
 
 /// Every agent's configured pattern STRING, resolved fresh each tick.
@@ -58,9 +71,21 @@ pub trait ContextPatternSource: Send + Sync {
     fn patterns(&self) -> BoxFuture<'_, HashMap<String, String>>;
 }
 
-/// Where a reading goes. The ONLY thing this module can do to the outside world.
+/// Where a badge reading goes. Its equality gate remains independent of internal samples.
 pub trait ContextEventSink: Send + Sync {
     fn emit(&self, payload: ContextUsagePayload);
+}
+
+/// Every scrape outcome offered to the bounded internal monitor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContextSample {
+    Reading { session_id: Uuid, percent: u8 },
+    Unavailable { session_id: Uuid },
+    SessionOver { session_id: Uuid },
+}
+
+pub trait ContextSampleSink: Send + Sync {
+    fn observe(&self, sample: ContextSample);
 }
 
 /// The IPC contract, normative for #1033.
@@ -118,20 +143,20 @@ impl Cached {
     }
 }
 
-/// Samples every registered session on a timer and emits a reading when it changes.
+/// Samples every registered session on a timer.
 ///
-/// Holds three trait objects and NOTHING else. No `AppHandle`: an `AppHandle` reaches
-/// `PtyManager` through managed state, and from there `kill`, `write` and session
-/// destruction - so "this never drives an action" would be a promise instead of a fact.
-/// None of the three traits is downcastable back to its implementation (no `Any`
-/// supertrait, no `as_any`), so the total capability of this type is: read rows, read
-/// patterns, emit a payload.
+/// No trait is downcastable to its implementation. The total capability of this type is:
+/// read rows or lightweight liveness, read patterns, emit a badge payload, and synchronously
+/// offer one small sample. It cannot route, inject, wake, or destroy anything.
 pub struct ContextScraper {
     rows: Arc<dyn ScreenRowsSource>,
     patterns: Arc<dyn ContextPatternSource>,
     sink: Arc<dyn ContextEventSink>,
+    samples: Arc<dyn ContextSampleSink>,
     registered: Mutex<HashMap<Uuid, Registered>>,
     compiled: Mutex<HashMap<String, Cached>>,
+    /// Rotates the sorted producer order so partial saturation cannot starve a fixed tail.
+    sample_cursor: AtomicUsize,
     /// Test-visible: the number of `pattern::compile` calls. The compile site is also the
     /// log site, so this is what "logged once per change, not once per tick" is measured by.
     compiles: AtomicUsize,
@@ -142,13 +167,16 @@ impl ContextScraper {
         rows: Arc<dyn ScreenRowsSource>,
         patterns: Arc<dyn ContextPatternSource>,
         sink: Arc<dyn ContextEventSink>,
+        samples: Arc<dyn ContextSampleSink>,
     ) -> Arc<Self> {
         Arc::new(Self {
             rows,
             patterns,
             sink,
+            samples,
             registered: Mutex::new(HashMap::new()),
             compiled: Mutex::new(HashMap::new()),
+            sample_cursor: AtomicUsize::new(0),
             compiles: AtomicUsize::new(0),
         })
     }
@@ -192,6 +220,22 @@ impl ContextScraper {
         );
     }
 
+    /// Stop sampling a session. Producer-side end pruning and monitor maintenance both use
+    /// this idempotent operation.
+    pub(crate) fn unregister_session(&self, id: Uuid) {
+        self.registered
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&id);
+    }
+
+    pub(crate) fn is_session_registered(&self, id: Uuid) -> bool {
+        self.registered
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(&id)
+    }
+
     /// The last reading emitted for a session, for the snapshot command. `None` covers both
     /// "no reading" and "not registered", which are the same thing to the badge.
     pub fn last_reading(&self, id: Uuid) -> Option<u8> {
@@ -231,12 +275,8 @@ impl ContextScraper {
         pattern
     }
 
-    async fn tick(&self) {
+    pub(crate) async fn tick(&self) {
         // Before `patterns()`, so an app with no agent session running reads nothing at all.
-        // Honest bound: this window is app start until the first agent session, and no
-        // longer - entries for unconfigured agents are never pruned, because reaching them
-        // would cost either a PTY probe or a discarded 30-row clone per session per tick,
-        // purely to reclaim ~100 bytes for a feature that is switched off.
         if self
             .registered
             .lock()
@@ -248,35 +288,63 @@ impl ContextScraper {
 
         let patterns = self.patterns.patterns().await;
 
-        // Snapshot first: the loop must not mutate `registered` while iterating it.
-        let ids: Vec<(Uuid, String)> = {
+        // Snapshot first: the loop must not mutate `registered` while iterating it. Sorting
+        // makes the rotation deterministic and rotating prevents a fixed saturation tail.
+        let mut ids: Vec<(Uuid, String)> = {
             let registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
             registered
                 .iter()
                 .map(|(id, entry)| (*id, entry.agent_id.clone()))
                 .collect()
         };
+        ids.sort_unstable_by_key(|(id, _)| *id);
+        if !ids.is_empty() {
+            let start = self.sample_cursor.fetch_add(1, Ordering::Relaxed) % ids.len();
+            ids.rotate_left(start);
+        }
 
         let mut over: Vec<Uuid> = Vec::new();
 
         for (id, agent_id) in ids {
-            let (reading, session_over): (Option<u8>, bool) = match patterns.get(&agent_id) {
-                // Not configured: no lock, no rows, no compile.
-                None => (None, false),
-                Some(source) => match self.resolve(&agent_id, source) {
-                    // Does not compile: no lock, no rows either.
-                    None => (None, false),
-                    Some(pattern) => match self.rows.get_screen_rows(id) {
-                        ScreenRowsRead::Rows(rows) => (rows::extract(&pattern, &rows), false),
-                        ScreenRowsRead::Unavailable => (None, false),
-                        ScreenRowsRead::SessionOver => (None, true),
+            let usable_pattern = patterns
+                .get(&agent_id)
+                .filter(|source| !source.trim().is_empty())
+                .and_then(|source| self.resolve(&agent_id, source));
+
+            let (reading, sample, session_over) = match usable_pattern {
+                None => match self.rows.get_session_liveness(id) {
+                    ContextSessionLiveness::Live | ContextSessionLiveness::Unavailable => {
+                        (None, ContextSample::Unavailable { session_id: id }, false)
+                    }
+                    ContextSessionLiveness::SessionOver => {
+                        (None, ContextSample::SessionOver { session_id: id }, true)
+                    }
+                },
+                Some(pattern) => match self.rows.get_screen_rows(id) {
+                    ScreenRowsRead::Rows(rows) => match rows::extract(&pattern, &rows) {
+                        Some(percent) => (
+                            Some(percent),
+                            ContextSample::Reading {
+                                session_id: id,
+                                percent,
+                            },
+                            false,
+                        ),
+                        None => (None, ContextSample::Unavailable { session_id: id }, false),
                     },
+                    ScreenRowsRead::Unavailable => {
+                        (None, ContextSample::Unavailable { session_id: id }, false)
+                    }
+                    ScreenRowsRead::SessionOver => {
+                        (None, ContextSample::SessionOver { session_id: id }, true)
+                    }
                 },
             };
 
-            // ONE gate, for every state there is. Clearing a pattern, an invalid pattern, a
-            // suppressed statusline, a dead session and a real decrease all arrive here, and
-            // all of them emit exactly when the value changed.
+            // Every scrape outcome is offered before the badge equality gate. The production
+            // sink is nonblocking and fail-soft, so a drop cannot suppress this gate or pruning.
+            self.samples.observe(sample);
+
             let changed = {
                 let mut registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
                 match registered.get_mut(&id) {
@@ -299,7 +367,7 @@ impl ContextScraper {
             }
         }
 
-        // After the loop, never during it.
+        // After the loop, never during it. This pruning is independent of sample delivery.
         if !over.is_empty() {
             let mut registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
             registered.retain(|id, _| !over.contains(id));
@@ -313,10 +381,7 @@ impl ContextScraper {
 
     #[cfg(test)]
     fn is_registered(&self, id: Uuid) -> bool {
-        self.registered
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .contains_key(&id)
+        self.is_session_registered(id)
     }
 }
 
@@ -340,6 +405,8 @@ mod tests {
     struct RowsFake {
         script: StdMutex<Vec<ScreenRowsRead>>,
         calls: StdMutex<Vec<Uuid>>,
+        liveness_script: StdMutex<Vec<ContextSessionLiveness>>,
+        liveness_calls: StdMutex<Vec<Uuid>>,
     }
 
     impl RowsFake {
@@ -347,10 +414,23 @@ mod tests {
             Arc::new(Self {
                 script: StdMutex::new(reads),
                 calls: StdMutex::new(Vec::new()),
+                liveness_script: StdMutex::new(Vec::new()),
+                liveness_calls: StdMutex::new(Vec::new()),
+            })
+        }
+        fn with_liveness(reads: Vec<ContextSessionLiveness>) -> Arc<Self> {
+            Arc::new(Self {
+                script: StdMutex::new(Vec::new()),
+                calls: StdMutex::new(Vec::new()),
+                liveness_script: StdMutex::new(reads),
+                liveness_calls: StdMutex::new(Vec::new()),
             })
         }
         fn call_count(&self) -> usize {
             self.calls.lock().unwrap().len()
+        }
+        fn liveness_call_count(&self) -> usize {
+            self.liveness_calls.lock().unwrap().len()
         }
     }
 
@@ -360,6 +440,16 @@ mod tests {
             let mut script = self.script.lock().unwrap();
             if script.is_empty() {
                 ScreenRowsRead::Unavailable
+            } else {
+                script.remove(0)
+            }
+        }
+
+        fn get_session_liveness(&self, id: Uuid) -> ContextSessionLiveness {
+            self.liveness_calls.lock().unwrap().push(id);
+            let mut script = self.liveness_script.lock().unwrap();
+            if script.is_empty() {
+                ContextSessionLiveness::Unavailable
             } else {
                 script.remove(0)
             }
@@ -419,25 +509,46 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct SamplesFake {
+        observed: StdMutex<Vec<ContextSample>>,
+    }
+
+    impl SamplesFake {
+        fn observed(&self) -> Vec<ContextSample> {
+            self.observed.lock().unwrap().clone()
+        }
+    }
+
+    impl ContextSampleSink for SamplesFake {
+        fn observe(&self, sample: ContextSample) {
+            self.observed.lock().unwrap().push(sample);
+        }
+    }
+
     struct Harness {
         scraper: Arc<ContextScraper>,
         rows: Arc<RowsFake>,
         patterns: Arc<PatternFake>,
         sink: Arc<SinkFake>,
+        samples: Arc<SamplesFake>,
     }
 
     fn harness(rows: Arc<RowsFake>, patterns: Arc<PatternFake>) -> Harness {
         let sink = Arc::new(SinkFake::default());
+        let samples = Arc::new(SamplesFake::default());
         let scraper = ContextScraper::new(
             Arc::clone(&rows) as Arc<dyn ScreenRowsSource>,
             Arc::clone(&patterns) as Arc<dyn ContextPatternSource>,
             Arc::clone(&sink) as Arc<dyn ContextEventSink>,
+            Arc::clone(&samples) as Arc<dyn ContextSampleSink>,
         );
         Harness {
             scraper,
             rows,
             patterns,
             sink,
+            samples,
         }
     }
 
@@ -454,6 +565,71 @@ mod tests {
 
         assert_eq!(h.rows.call_count(), 0, "no pattern must mean no rows read");
         assert!(h.sink.emitted().is_empty(), "and no event");
+        assert_eq!(h.samples.observed().len(), 2, "one sample per tick");
+    }
+
+    #[tokio::test]
+    async fn missing_pattern_uses_only_lightweight_liveness_and_prunes_on_end() {
+        let rows = RowsFake::with_liveness(vec![
+            ContextSessionLiveness::Live,
+            ContextSessionLiveness::SessionOver,
+        ]);
+        let h = harness(Arc::clone(&rows), Arc::new(PatternFake::default()));
+        let id = Uuid::new_v4();
+        h.scraper.register_session(id, AGENT.to_string());
+
+        h.scraper.tick().await;
+        assert!(h.scraper.is_registered(id));
+        h.scraper.tick().await;
+
+        assert_eq!(rows.call_count(), 0, "no screen rows may be cloned");
+        assert_eq!(rows.liveness_call_count(), 2);
+        assert_eq!(
+            h.samples.observed(),
+            vec![
+                ContextSample::Unavailable { session_id: id },
+                ContextSample::SessionOver { session_id: id },
+            ]
+        );
+        assert!(!h.scraper.is_registered(id));
+    }
+
+    #[tokio::test]
+    async fn blank_and_invalid_patterns_use_liveness_without_reading_rows() {
+        for (source, liveness) in [
+            ("   ", ContextSessionLiveness::Live),
+            (r"(unclosed", ContextSessionLiveness::Unavailable),
+        ] {
+            let rows = RowsFake::with_liveness(vec![liveness]);
+            let h = harness(Arc::clone(&rows), PatternFake::with(AGENT, source));
+            let id = Uuid::new_v4();
+            h.scraper.register_session(id, AGENT.to_string());
+
+            h.scraper.tick().await;
+
+            assert_eq!(rows.call_count(), 0, "source={source:?}");
+            assert_eq!(rows.liveness_call_count(), 1, "source={source:?}");
+            assert_eq!(
+                h.samples.observed(),
+                vec![ContextSample::Unavailable { session_id: id }]
+            );
+            assert!(h.scraper.is_registered(id));
+        }
+    }
+
+    #[tokio::test]
+    async fn unregister_is_idempotent_and_prevents_future_probes() {
+        let rows = RowsFake::with_liveness(vec![ContextSessionLiveness::Live]);
+        let h = harness(Arc::clone(&rows), Arc::new(PatternFake::default()));
+        let id = Uuid::new_v4();
+        h.scraper.register_session(id, AGENT.to_string());
+
+        h.scraper.unregister_session(id);
+        h.scraper.unregister_session(id);
+        h.scraper.tick().await;
+
+        assert!(!h.scraper.is_session_registered(id));
+        assert_eq!(rows.liveness_call_count(), 0);
     }
 
     /// The empty-map guard, in the only window it covers: app start until the first agent
@@ -658,6 +834,20 @@ mod tests {
             vec![Some(42), None, Some(42)],
             "the reading comes back on the tick after the handle answers again"
         );
+        assert_eq!(
+            h.samples.observed(),
+            vec![
+                ContextSample::Reading {
+                    session_id: id,
+                    percent: 42,
+                },
+                ContextSample::Unavailable { session_id: id },
+                ContextSample::Reading {
+                    session_id: id,
+                    percent: 42,
+                },
+            ]
+        );
     }
 
     #[tokio::test]
@@ -678,6 +868,24 @@ mod tests {
         h.scraper.tick().await;
 
         assert_eq!(h.sink.emitted(), vec![Some(42)]);
+        assert_eq!(
+            h.samples.observed(),
+            vec![
+                ContextSample::Reading {
+                    session_id: h
+                        .scraper
+                        .registered
+                        .lock()
+                        .unwrap()
+                        .keys()
+                        .next()
+                        .copied()
+                        .unwrap(),
+                    percent: 42,
+                };
+                3
+            ]
+        );
     }
 
     /// No monotonicity: `/clear` and `/compact` are the whole point of watching this number.
@@ -724,6 +932,43 @@ mod tests {
             "both sessions are new to the badge, so both emit"
         );
         assert_eq!(h.scraper.compile_count(), 1, "one agent, one compile");
+    }
+
+    #[tokio::test]
+    async fn sorted_sample_order_rotates_one_position_each_tick() {
+        let ids = [Uuid::from_u128(1), Uuid::from_u128(2), Uuid::from_u128(3)];
+        let h = harness(
+            RowsFake::scripted(vec![
+                ScreenRowsRead::Rows(vec![row(10)]),
+                ScreenRowsRead::Rows(vec![row(20)]),
+                ScreenRowsRead::Rows(vec![row(30)]),
+                ScreenRowsRead::Rows(vec![row(40)]),
+                ScreenRowsRead::Rows(vec![row(50)]),
+                ScreenRowsRead::Rows(vec![row(60)]),
+            ]),
+            PatternFake::with(AGENT, CLAUDE),
+        );
+        for id in ids {
+            h.scraper.register_session(id, AGENT.to_string());
+        }
+
+        h.scraper.tick().await;
+        h.scraper.tick().await;
+
+        let observed_ids: Vec<Uuid> = h
+            .samples
+            .observed()
+            .into_iter()
+            .map(|sample| match sample {
+                ContextSample::Reading { session_id, .. }
+                | ContextSample::Unavailable { session_id }
+                | ContextSample::SessionOver { session_id } => session_id,
+            })
+            .collect();
+        assert_eq!(
+            observed_ids,
+            vec![ids[0], ids[1], ids[2], ids[1], ids[2], ids[0]]
+        );
     }
 
     #[test]

--- a/src-tauri/src/pty/inject.rs
+++ b/src-tauri/src/pty/inject.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 use crate::pty::manager::PtyManager;
 use crate::session::manager::SessionManager;
+use crate::session::session::{Session, SessionStatus};
 
 /// Returns true when the given shell command requires a separate Enter keystroke
 /// to submit pasted input. Coding agents (Claude, Codex, Gemini, Cursor agent)
@@ -55,15 +56,78 @@ where
     R: tauri::Runtime,
     F: FnOnce() -> Result<(), String>,
 {
-    // Resolve shell without holding any lock across an await point
-    let shell = {
-        let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
-        let mgr = session_mgr.read().await;
-        let result = mgr.get_shell(session_id).await;
-        drop(mgr);
-        result
-    };
+    inject_text_into_session_impl(app, session_id, text, move |_| pre_write_check()).await
+}
 
+/// Canonical injector for trusted internal notices. Unlike the peer-compatible variant,
+/// this rejects a missing, root, exited, agentless, or plain-shell recipient immediately
+/// before the text write and gives the caller that resolved session snapshot for its final
+/// canonical-path and authorization check.
+fn validate_supported_agent_session(session: &Session, session_id: Uuid) -> Result<(), String> {
+    if session.is_root_agent {
+        return Err(format!(
+            "Session {} is a root session, not a supported coordinator agent",
+            session_id
+        ));
+    }
+    if matches!(session.status, SessionStatus::Exited(_)) {
+        return Err(format!("Session {} exited before injection", session_id));
+    }
+    if session.agent_id.is_none() {
+        return Err(format!(
+            "Session {} has no configured coding-agent identity",
+            session_id
+        ));
+    }
+    if !needs_explicit_enter(&session.shell) {
+        return Err(format!(
+            "Session {} shell '{}' is not a supported coding-agent CLI",
+            session_id, session.shell
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) async fn inject_text_into_supported_agent_session_with_pre_write_check<R, F>(
+    app: &tauri::AppHandle<R>,
+    session_id: Uuid,
+    text: &str,
+    pre_write_check: F,
+) -> Result<(), String>
+where
+    R: tauri::Runtime,
+    F: FnOnce(&Session) -> Result<(), String>,
+{
+    inject_text_into_session_impl(app, session_id, text, move |session| {
+        let session = session.ok_or_else(|| {
+            format!(
+                "Session {} is missing before supported-agent injection",
+                session_id
+            )
+        })?;
+        validate_supported_agent_session(session, session_id)?;
+        pre_write_check(session)
+    })
+    .await
+}
+
+async fn inject_text_into_session_impl<R, F>(
+    app: &tauri::AppHandle<R>,
+    session_id: Uuid,
+    text: &str,
+    pre_write_check: F,
+) -> Result<(), String>
+where
+    R: tauri::Runtime,
+    F: FnOnce(Option<&Session>) -> Result<(), String>,
+{
+    // Resolve one public snapshot without retaining a manager guard across an await.
+    let session = {
+        let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+        let manager = session_mgr.read().await.clone();
+        manager.get_session(session_id).await
+    };
+    let shell = session.as_ref().map(|session| session.shell.clone());
     let send_enter = shell.as_deref().map(needs_explicit_enter).unwrap_or(false);
     log::info!(
         "[inject] session={} shell={:?} send_enter={}",
@@ -72,9 +136,10 @@ where
         send_enter
     );
 
-    pre_write_check()?;
+    // Deliberately synchronous and immediately adjacent to the PTY-owner lock. Callers of
+    // the supported variant perform their final filesystem/config guard here.
+    pre_write_check(session.as_ref())?;
 
-    // Write the text block
     {
         let pty_mgr = app.state::<Arc<Mutex<PtyManager>>>();
         pty_mgr
@@ -92,11 +157,7 @@ where
         );
     }
 
-    // Agent CLIs (Claude, Codex, Gemini, Cursor agent): send Enter twice with
-    // staggered delays.
-    // Sometimes a single \r doesn't register (race with paste-detection mode).
-    // The second \r is a safety net. If the first worked, the agent is already
-    // processing and an extra Enter on empty input is harmless.
+    // Keep the established text/write/double-Enter algorithm shared by both variants.
     if send_enter {
         tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
         log::info!("[inject] sending Enter (1/2) for session {}", session_id);
@@ -133,7 +194,70 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::needs_explicit_enter;
+    use super::{needs_explicit_enter, validate_supported_agent_session};
+    use crate::pty::backend::SessionBackendKind;
+    use crate::session::session::{Session, SessionStatus};
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn supported_session() -> Session {
+        Session {
+            id: Uuid::new_v4(),
+            name: "coordinator".to_string(),
+            shell: "codex".to_string(),
+            shell_args: Vec::new(),
+            backend_kind: SessionBackendKind::LocalProcess,
+            effective_shell_args: None,
+            created_at: Utc::now(),
+            working_directory: "C:/replica".to_string(),
+            status: SessionStatus::Running,
+            waiting_for_input: false,
+            communication: None,
+            pending_review: false,
+            last_prompt: None,
+            agent_id: Some("codex-profile".to_string()),
+            agent_label: Some("Codex".to_string()),
+            git_repos: Vec::new(),
+            is_coordinator: true,
+            is_root_agent: false,
+            git_repos_gen: 0,
+            token: Uuid::new_v4(),
+            agent_kind: None,
+            requested_profile: None,
+            effective_profile: None,
+            profile_fallback_chain: Vec::new(),
+            profile_fallback_applied: false,
+            effective_codex_home: None,
+            resolved_claude_projects_dir: None,
+            profile_content_hash: None,
+            telegram_bot_id: None,
+            was_detached: false,
+            detached_geometry: None,
+            start_fresh_on_restore: false,
+        }
+    }
+
+    #[test]
+    fn supported_agent_final_snapshot_rejects_unsafe_recipient_records() {
+        let valid = supported_session();
+        assert!(validate_supported_agent_session(&valid, valid.id).is_ok());
+
+        let mut root = supported_session();
+        root.is_root_agent = true;
+        assert!(validate_supported_agent_session(&root, root.id).is_err());
+
+        let mut exited = supported_session();
+        exited.status = SessionStatus::Exited(0);
+        assert!(validate_supported_agent_session(&exited, exited.id).is_err());
+
+        let mut agentless = supported_session();
+        agentless.agent_id = None;
+        assert!(validate_supported_agent_session(&agentless, agentless.id).is_err());
+
+        let mut shell = supported_session();
+        shell.shell = "pwsh".to_string();
+        assert!(validate_supported_agent_session(&shell, shell.id).is_err());
+    }
 
     #[test]
     fn agent_clis_require_explicit_enter() {

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
-use crate::pty::context_scrape::ScreenRowsRead;
+use crate::pty::context_scrape::{ContextSessionLiveness, ScreenRowsRead};
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
 use crate::pty::output::{PtyScreenSnapshot, SessionIoFanout};
@@ -1017,6 +1017,44 @@ fn probe_child_in(ptys: &Mutex<HashMap<Uuid, PtyInstance>>, id: Uuid) -> ChildLi
 /// by a test against a real ConPTY child: `LocalProcessBackend` itself cannot be built in a
 /// unit test (its `GitWatcher` needs a Tauri `AppHandle`), and none of that has anything to
 /// do with whether a child is alive.
+pub(crate) fn context_liveness_from_child_liveness(
+    liveness: &ChildLiveness,
+) -> ContextSessionLiveness {
+    match liveness {
+        ChildLiveness::Alive => ContextSessionLiveness::Live,
+        ChildLiveness::Unqueryable(_) => ContextSessionLiveness::Unavailable,
+        ChildLiveness::Exited { .. } | ChildLiveness::Gone => ContextSessionLiveness::SessionOver,
+    }
+}
+
+#[cfg(test)]
+mod context_liveness_tests {
+    use super::{context_liveness_from_child_liveness, ChildLiveness, ContextSessionLiveness};
+
+    #[test]
+    fn maps_every_contained_child_liveness_state() {
+        assert_eq!(
+            context_liveness_from_child_liveness(&ChildLiveness::Alive),
+            ContextSessionLiveness::Live
+        );
+        assert_eq!(
+            context_liveness_from_child_liveness(&ChildLiveness::Unqueryable("denied".into())),
+            ContextSessionLiveness::Unavailable
+        );
+        assert_eq!(
+            context_liveness_from_child_liveness(&ChildLiveness::Exited {
+                code: 0,
+                success: true,
+            }),
+            ContextSessionLiveness::SessionOver
+        );
+        assert_eq!(
+            context_liveness_from_child_liveness(&ChildLiveness::Gone),
+            ContextSessionLiveness::SessionOver
+        );
+    }
+}
+
 fn screen_rows_if_child_alive(
     ptys: &Mutex<HashMap<Uuid, PtyInstance>>,
     fanout: &SessionIoFanout,
@@ -1214,6 +1252,10 @@ impl PtyBackend for LocalProcessBackend {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .contains_key(&id)
+    }
+
+    fn context_session_liveness(&self, id: Uuid) -> ContextSessionLiveness {
+        context_liveness_from_child_liveness(&probe_child_in(&self.ptys, id))
     }
 
     fn resize(&self, id: Uuid, cols: u16, rows: u16) -> Result<(), AppError> {

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -7,7 +7,7 @@ use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend, SessionBackendKind};
 use crate::pty::container_backend::ContainerTransportBackend;
 use crate::pty::container_tokens::ContainerApiTokenManager;
-use crate::pty::context_scrape::ScreenRowsRead;
+use crate::pty::context_scrape::{ContextSessionLiveness, ScreenRowsRead};
 use crate::pty::docker_runtime::DockerRuntime;
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
@@ -267,6 +267,13 @@ impl PtyManager {
             return false;
         };
         self.backend_for_kind(kind).has_session(id)
+    }
+
+    pub fn context_session_liveness(&self, id: Uuid) -> ContextSessionLiveness {
+        let Ok(kind) = self.kind_for_session(id) else {
+            return ContextSessionLiveness::SessionOver;
+        };
+        self.backend_for_kind(kind).context_session_liveness(id)
     }
 
     pub fn resize(&self, id: Uuid, cols: u16, rows: u16) -> Result<(), AppError> {
@@ -623,6 +630,25 @@ mod tests {
 
         assert!(matches!(err, AppError::SessionNotFound(_)));
         assert!(backend.calls().is_empty());
+    }
+
+    #[test]
+    fn context_liveness_uses_backend_default_and_missing_route_is_over() {
+        let live_id = Uuid::new_v4();
+        let missing_id = Uuid::new_v4();
+        let backend = Arc::new(RecordingBackend::default());
+        backend.set_live(live_id);
+        let manager = PtyManager::new_for_test(backend);
+        manager.record_route(live_id, SessionBackendKind::LocalProcess);
+
+        assert_eq!(
+            manager.context_session_liveness(live_id),
+            ContextSessionLiveness::Live
+        );
+        assert_eq!(
+            manager.context_session_liveness(missing_id),
+            ContextSessionLiveness::SessionOver
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/context_alerts.rs
+++ b/src-tauri/src/session/context_alerts.rs
@@ -197,6 +197,12 @@ struct ErrorMarker {
     message: String,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct ResolutionRecovery {
+    policy: bool,
+    runtime: bool,
+}
+
 struct SessionAlertState {
     fingerprint: Option<MemberIdentityFingerprint>,
     policy: Vec<u8>,
@@ -526,7 +532,7 @@ fn apply_numeric_resolution(
     percent: u8,
     resolution: MemberPolicyResolution,
     now: Instant,
-) {
+) -> ResolutionRecovery {
     match resolution {
         MemberPolicyResolution::Eligible(resolved) => {
             if resolved.fingerprint.session_id != session_id {
@@ -535,7 +541,7 @@ fn apply_numeric_resolution(
                     session_id,
                     resolved.fingerprint.session_id
                 );
-                return;
+                return ResolutionRecovery::default();
             }
             let changed_identity = state
                 .sessions
@@ -550,8 +556,7 @@ fn apply_numeric_resolution(
                 .entry(session_id)
                 .or_insert_with(SessionAlertState::empty);
             session.fingerprint = Some(resolved.fingerprint.clone());
-            clear_runtime_error(session, session_id);
-            let was_paused = clear_policy_error(session, session_id);
+            let recovery = clear_resolution_errors(session, session_id);
             reconcile_policy(
                 state,
                 in_flight,
@@ -560,13 +565,20 @@ fn apply_numeric_resolution(
                 &resolved.thresholds,
                 now,
             );
-            if was_paused {
+            if recovery.policy {
                 make_session_batches_due_now(state, session_id, now);
             }
             evaluate_numeric_sample(state, session_id, percent, now);
+            recovery
         }
-        MemberPolicyResolution::Disabled(_) | MemberPolicyResolution::PermanentIneligible(_) => {
+        MemberPolicyResolution::Disabled(fingerprint) => {
+            let recovery = clear_resolution_errors_for_identity(state, session_id, &fingerprint);
             state.remove_session(session_id, in_flight);
+            recovery
+        }
+        MemberPolicyResolution::PermanentIneligible(_) => {
+            state.remove_session(session_id, in_flight);
+            ResolutionRecovery::default()
         }
         MemberPolicyResolution::Paused {
             fingerprint,
@@ -587,6 +599,7 @@ fn apply_numeric_resolution(
                 .or_insert_with(SessionAlertState::empty);
             session.fingerprint = Some(fingerprint);
             set_policy_error(session, session_id, class, message);
+            ResolutionRecovery::default()
         }
         MemberPolicyResolution::RetryableFailure(message) => {
             let session = state
@@ -594,6 +607,7 @@ fn apply_numeric_resolution(
                 .entry(session_id)
                 .or_insert_with(SessionAlertState::empty);
             set_runtime_error(session, session_id, message);
+            ResolutionRecovery::default()
         }
     }
 }
@@ -643,13 +657,48 @@ fn set_runtime_error(session: &mut SessionAlertState, session_id: Uuid, message:
     }
 }
 
-fn clear_runtime_error(session: &mut SessionAlertState, session_id: Uuid) {
+fn clear_runtime_error(session: &mut SessionAlertState, session_id: Uuid) -> bool {
     if session.runtime_error.take().is_some() {
         log::info!(
             "[context-alert] resolution recovered session={}",
             session_id
         );
+        true
+    } else {
+        false
     }
+}
+
+fn clear_resolution_errors(
+    session: &mut SessionAlertState,
+    session_id: Uuid,
+) -> ResolutionRecovery {
+    ResolutionRecovery {
+        runtime: clear_runtime_error(session, session_id),
+        policy: clear_policy_error(session, session_id),
+    }
+}
+
+fn clear_resolution_errors_for_identity(
+    state: &mut ActorState,
+    session_id: Uuid,
+    fingerprint: &MemberIdentityFingerprint,
+) -> ResolutionRecovery {
+    let same_identity = fingerprint.session_id == session_id
+        && state.sessions.get(&session_id).is_some_and(|session| {
+            session
+                .fingerprint
+                .as_ref()
+                .is_none_or(|current| current == fingerprint)
+        });
+    if !same_identity {
+        return ResolutionRecovery::default();
+    }
+    state
+        .sessions
+        .get_mut(&session_id)
+        .map(|session| clear_resolution_errors(session, session_id))
+        .unwrap_or_default()
 }
 
 fn reconcile_policy(
@@ -841,19 +890,19 @@ async fn dispatch_due_batch(
     in_flight: &mut Option<InFlightSlot>,
     completion_tx: &mpsc::Sender<DeliveryCompletion>,
     shutdown: &CancellationToken,
-) {
+) -> ResolutionRecovery {
     if in_flight.is_some() {
-        return;
+        return ResolutionRecovery::default();
     }
     let now = clock.now();
     let Some((due_at, generation)) = state.earliest_due() else {
-        return;
+        return ResolutionRecovery::default();
     };
     if due_at > now {
-        return;
+        return ResolutionRecovery::default();
     }
     let Some(batch) = state.batches.get(&generation).cloned() else {
-        return;
+        return ResolutionRecovery::default();
     };
     let snapshot = AttemptSnapshot {
         generation,
@@ -866,7 +915,7 @@ async fn dispatch_due_batch(
     let attempt_cancellation = shutdown.child_token();
     let preparation = tokio::select! {
         biased;
-        _ = shutdown.cancelled() => return,
+        _ = shutdown.cancelled() => return ResolutionRecovery::default(),
         preparation = runtime.prepare_attempt(snapshot, attempt_cancellation.clone()) => preparation,
     };
 
@@ -880,7 +929,7 @@ async fn dispatch_due_batch(
                 == Some(&attempt.snapshot.fingerprint);
             if !fingerprint_matches {
                 state.remove_session(session_id, None);
-                return;
+                return ResolutionRecovery::default();
             }
             reconcile_policy(
                 state,
@@ -895,15 +944,16 @@ async fn dispatch_due_batch(
                     && current.fingerprint == attempt.snapshot.fingerprint
             });
             if !still_matches {
-                return;
+                return ResolutionRecovery::default();
             }
             if let Some(current) = state.batches.get_mut(&generation) {
                 current.in_flight = true;
             }
-            if let Some(session) = state.sessions.get_mut(&session_id) {
-                clear_policy_error(session, session_id);
-                clear_runtime_error(session, session_id);
-            }
+            let recovery = state
+                .sessions
+                .get_mut(&session_id)
+                .map(|session| clear_resolution_errors(session, session_id))
+                .unwrap_or_default();
             let runtime = Arc::clone(runtime);
             let tx = completion_tx.clone();
             let join = tauri::async_runtime::spawn(async move {
@@ -922,6 +972,7 @@ async fn dispatch_due_batch(
                 cancellation: attempt_cancellation,
                 join,
             });
+            recovery
         }
         AttemptPreparation::Cancel {
             reason,
@@ -934,17 +985,30 @@ async fn dispatch_due_batch(
             );
             match current_policy {
                 Some(policy) if policy.fingerprint == batch.fingerprint => {
-                    reconcile_policy(
+                    let recovery = clear_resolution_errors_for_identity(
                         state,
-                        None,
                         batch.session_id,
                         &policy.fingerprint,
-                        &policy.thresholds,
-                        now,
                     );
-                    state.remove_batch(generation);
+                    if policy.thresholds.is_empty() {
+                        state.remove_session(batch.session_id, None);
+                    } else {
+                        reconcile_policy(
+                            state,
+                            None,
+                            batch.session_id,
+                            &policy.fingerprint,
+                            &policy.thresholds,
+                            now,
+                        );
+                        state.remove_batch(generation);
+                    }
+                    recovery
                 }
-                _ => state.remove_session(batch.session_id, None),
+                _ => {
+                    state.remove_session(batch.session_id, None);
+                    ResolutionRecovery::default()
+                }
             }
         }
         AttemptPreparation::Paused {
@@ -959,15 +1023,17 @@ async fn dispatch_due_batch(
                 == Some(&fingerprint);
             if !same_identity {
                 state.remove_session(batch.session_id, None);
-                return;
+                return ResolutionRecovery::default();
             }
             if let Some(session) = state.sessions.get_mut(&batch.session_id) {
                 set_policy_error(session, batch.session_id, class, message.clone());
             }
             fail_batch(state, generation, now, &message);
+            ResolutionRecovery::default()
         }
         AttemptPreparation::RetryableFailure(message) => {
             fail_batch(state, generation, now, &message);
+            ResolutionRecovery::default()
         }
     }
 }
@@ -1202,10 +1268,13 @@ impl ProductionContextAlertRuntime {
         let resolution = self.resolve_member_policy_inner(snapshot.session_id).await;
         let policy = match resolution {
             MemberPolicyResolution::Eligible(policy) => policy,
-            MemberPolicyResolution::Disabled(_) => {
+            MemberPolicyResolution::Disabled(fingerprint) => {
                 return AttemptPreparation::Cancel {
                     reason: "context alert policy is disabled".to_string(),
-                    current_policy: None,
+                    current_policy: Some(ResolvedPolicy {
+                        fingerprint,
+                        thresholds: Vec::new(),
+                    }),
                 }
             }
             MemberPolicyResolution::PermanentIneligible(reason) => {
@@ -2346,6 +2415,127 @@ mod tests {
         assert!(!state.sessions.contains_key(&id));
         assert!(state.batches.is_empty());
         slot.join.await.unwrap();
+    }
+
+    #[test]
+    fn disabled_numeric_resolution_logs_policy_recovery_once_before_removing_state() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+
+        let first = apply_numeric_resolution(
+            &mut state,
+            None,
+            id,
+            80,
+            MemberPolicyResolution::Paused {
+                fingerprint: fingerprint(id),
+                class: "malformed",
+                message: "partial JSON".to_string(),
+            },
+            now,
+        );
+        assert_eq!(first, ResolutionRecovery::default());
+        assert!(state.sessions[&id].policy_error.is_some());
+
+        let recovered = apply_numeric_resolution(
+            &mut state,
+            None,
+            id,
+            80,
+            MemberPolicyResolution::Disabled(fingerprint(id)),
+            now,
+        );
+        assert_eq!(
+            recovered,
+            ResolutionRecovery {
+                policy: true,
+                runtime: false,
+            },
+            "the true policy transition is the single info recovery log"
+        );
+        assert!(!state.sessions.contains_key(&id));
+
+        let repeated = apply_numeric_resolution(
+            &mut state,
+            None,
+            id,
+            80,
+            MemberPolicyResolution::Disabled(fingerprint(id)),
+            now,
+        );
+        assert_eq!(
+            repeated,
+            ResolutionRecovery::default(),
+            "a later disabled sample has no stale marker to log again"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_retry_cancellation_logs_policy_recovery_once_and_drops_state() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 80, eligible(id, &[50]), now);
+        apply_numeric_resolution(
+            &mut state,
+            None,
+            id,
+            80,
+            MemberPolicyResolution::Paused {
+                fingerprint: fingerprint(id),
+                class: "unreadable",
+                message: "config read failed".to_string(),
+            },
+            now,
+        );
+        assert!(state.sessions[&id].policy_error.is_some());
+        assert_eq!(state.batches.len(), 1);
+
+        let runtime = ScriptedRuntime::new();
+        runtime.set_policy(id, &[]);
+        let runtime_trait: Arc<dyn ContextAlertRuntime> = runtime.clone();
+        let clock: Arc<dyn AlertClock> = ManualClock::new(now);
+        let (completion_tx, _completion_rx) = mpsc::channel(1);
+        let shutdown = CancellationToken::new();
+        let mut in_flight = None;
+
+        let recovered = dispatch_due_batch(
+            &runtime_trait,
+            &clock,
+            &mut state,
+            &mut in_flight,
+            &completion_tx,
+            &shutdown,
+        )
+        .await;
+        assert_eq!(
+            recovered,
+            ResolutionRecovery {
+                policy: true,
+                runtime: false,
+            },
+            "disabled retry preparation clears and logs the policy marker once"
+        );
+        assert!(!state.sessions.contains_key(&id));
+        assert!(state.batches.is_empty());
+        assert_eq!(runtime.prepare_calls.lock().unwrap().len(), 1);
+
+        let repeated = dispatch_due_batch(
+            &runtime_trait,
+            &clock,
+            &mut state,
+            &mut in_flight,
+            &completion_tx,
+            &shutdown,
+        )
+        .await;
+        assert_eq!(repeated, ResolutionRecovery::default());
+        assert_eq!(
+            runtime.prepare_calls.lock().unwrap().len(),
+            1,
+            "removed disabled state cannot emit a duplicate recovery log"
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/context_alerts.rs
+++ b/src-tauri/src/session/context_alerts.rs
@@ -1,0 +1,3430 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use futures::future::BoxFuture;
+use tauri::Manager;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::commands::entity_creation::{
+    metadata_is_link_or_reparse, parse_team_from_workgroup_name, read_team_config_classified,
+    TeamConfigReadError,
+};
+use crate::phone::mailbox::{
+    InternalNoticeGuard, InternalSystemNotice, InternalSystemTarget, MailboxPoller,
+};
+use crate::pty::context_scrape::{ContextSample, ContextScraper};
+use crate::session::manager::SessionManager;
+use crate::session::session::{Session, SessionStatus};
+
+pub(crate) const CONTEXT_SAMPLE_QUEUE_CAPACITY: usize = 1024;
+pub(crate) const CONTEXT_ALERT_MAINTENANCE_INTERVAL: Duration = Duration::from_secs(30);
+
+const FIRST_RETRY_DELAY: Duration = Duration::from_secs(5);
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MemberIdentityFingerprint {
+    session_id: Uuid,
+    agent_id: String,
+    working_directory: String,
+    project_dir: PathBuf,
+    workspace_dir: PathBuf,
+    workgroup_dir: PathBuf,
+    replica_dir: PathBuf,
+    matrix_dir: PathBuf,
+    project: String,
+    team: String,
+    workgroup: String,
+    member: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedPolicy {
+    fingerprint: MemberIdentityFingerprint,
+    thresholds: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MemberPolicyResolution {
+    Eligible(ResolvedPolicy),
+    Disabled(MemberIdentityFingerprint),
+    PermanentIneligible(String),
+    Paused {
+        fingerprint: MemberIdentityFingerprint,
+        class: &'static str,
+        message: String,
+    },
+    RetryableFailure(String),
+}
+
+#[derive(Debug, Clone)]
+struct AttemptSnapshot {
+    generation: u64,
+    session_id: Uuid,
+    fingerprint: MemberIdentityFingerprint,
+    observed: u8,
+    thresholds: Vec<u8>,
+    failure_count: u32,
+}
+
+struct ReadyAttempt {
+    snapshot: AttemptSnapshot,
+    current_policy: Vec<u8>,
+    target: InternalSystemTarget,
+    notice: InternalSystemNotice,
+    guard: InternalNoticeGuard,
+    cancellation: CancellationToken,
+}
+
+impl ReadyAttempt {
+    fn thresholds(&self) -> &[u8] {
+        self.notice.thresholds()
+    }
+}
+
+enum AttemptPreparation {
+    Ready(ReadyAttempt),
+    Cancel {
+        reason: String,
+        current_policy: Option<ResolvedPolicy>,
+    },
+    Paused {
+        fingerprint: MemberIdentityFingerprint,
+        class: &'static str,
+        message: String,
+    },
+    RetryableFailure(String),
+}
+
+trait ContextAlertRuntime: Send + Sync {
+    fn resolve_member_policy(&self, session_id: Uuid)
+        -> BoxFuture<'static, MemberPolicyResolution>;
+    fn check_session_live(&self, session_id: Uuid) -> BoxFuture<'static, bool>;
+    fn retire_sample_registration(&self, session_id: Uuid) -> BoxFuture<'static, ()>;
+    fn prepare_attempt(
+        &self,
+        snapshot: AttemptSnapshot,
+        cancellation: CancellationToken,
+    ) -> BoxFuture<'static, AttemptPreparation>;
+    fn deliver_attempt(&self, attempt: ReadyAttempt) -> BoxFuture<'static, Result<(), String>>;
+}
+
+trait AlertClock: Send + Sync {
+    fn now(&self) -> Instant;
+    fn sleep_until(&self, deadline: Instant) -> BoxFuture<'static, ()>;
+}
+
+#[derive(Default)]
+struct ProductionAlertClock;
+
+impl AlertClock for ProductionAlertClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+
+    fn sleep_until(&self, deadline: Instant) -> BoxFuture<'static, ()> {
+        Box::pin(tokio::time::sleep_until(tokio::time::Instant::from_std(
+            deadline,
+        )))
+    }
+}
+
+pub(crate) struct ContextAlertMonitor {
+    sender: mpsc::Sender<ContextSample>,
+    cancellation: CancellationToken,
+    join: Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
+}
+
+impl ContextAlertMonitor {
+    pub(crate) fn start(app: tauri::AppHandle, cancellation: CancellationToken) -> Arc<Self> {
+        Self::start_with_runtime(
+            Arc::new(ProductionContextAlertRuntime { app }),
+            Arc::new(ProductionAlertClock),
+            cancellation,
+        )
+    }
+
+    fn start_with_runtime(
+        runtime: Arc<dyn ContextAlertRuntime>,
+        clock: Arc<dyn AlertClock>,
+        cancellation: CancellationToken,
+    ) -> Arc<Self> {
+        let (sender, receiver) = mpsc::channel(CONTEXT_SAMPLE_QUEUE_CAPACITY);
+        let actor_cancellation = cancellation.clone();
+        let join = tauri::async_runtime::spawn(async move {
+            run_context_alert_actor(runtime, clock, receiver, actor_cancellation).await;
+        });
+        Arc::new(Self {
+            sender,
+            cancellation,
+            join: Mutex::new(Some(join)),
+        })
+    }
+
+    pub(crate) fn sender(&self) -> mpsc::Sender<ContextSample> {
+        self.sender.clone()
+    }
+
+    pub(crate) async fn close_and_join(&self) -> Result<(), String> {
+        self.cancellation.cancel();
+        let handle = self
+            .join
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take();
+        let Some(handle) = handle else {
+            return Ok(());
+        };
+        handle
+            .await
+            .map_err(|error| format!("Context alert actor join failed: {}", error))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LatchState {
+    Armed,
+    Latched,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ErrorMarker {
+    class: String,
+    message: String,
+}
+
+struct SessionAlertState {
+    fingerprint: Option<MemberIdentityFingerprint>,
+    policy: Vec<u8>,
+    last_valid_percent: Option<u8>,
+    latches: BTreeMap<u8, LatchState>,
+    outstanding: BTreeMap<u8, u64>,
+    policy_error: Option<ErrorMarker>,
+    runtime_error: Option<ErrorMarker>,
+}
+
+impl SessionAlertState {
+    fn empty() -> Self {
+        Self {
+            fingerprint: None,
+            policy: Vec::new(),
+            last_valid_percent: None,
+            latches: BTreeMap::new(),
+            outstanding: BTreeMap::new(),
+            policy_error: None,
+            runtime_error: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AlertBatch {
+    generation: u64,
+    session_id: Uuid,
+    fingerprint: MemberIdentityFingerprint,
+    observed: u8,
+    thresholds: Vec<u8>,
+    failure_count: u32,
+    due_at: Instant,
+    in_flight: bool,
+}
+
+struct ActorState {
+    sessions: HashMap<Uuid, SessionAlertState>,
+    batches: BTreeMap<u64, AlertBatch>,
+    next_generation: Option<u64>,
+    generation_exhaustion_logged: bool,
+}
+
+impl ActorState {
+    fn new() -> Self {
+        Self {
+            sessions: HashMap::new(),
+            batches: BTreeMap::new(),
+            next_generation: Some(1),
+            generation_exhaustion_logged: false,
+        }
+    }
+
+    fn allocate_generation(&mut self) -> Option<u64> {
+        let generation = self.next_generation?;
+        self.next_generation = generation.checked_add(1);
+        Some(generation)
+    }
+
+    fn remove_batch(&mut self, generation: u64) -> Option<AlertBatch> {
+        let batch = self.batches.remove(&generation)?;
+        if let Some(session) = self.sessions.get_mut(&batch.session_id) {
+            for threshold in &batch.thresholds {
+                if session.outstanding.get(threshold) == Some(&generation) {
+                    session.outstanding.remove(threshold);
+                }
+            }
+        }
+        Some(batch)
+    }
+
+    fn remove_session(&mut self, session_id: Uuid, in_flight: Option<&InFlightSlot>) {
+        if let Some(slot) = in_flight {
+            if self
+                .batches
+                .get(&slot.generation)
+                .is_some_and(|batch| batch.session_id == session_id)
+            {
+                slot.cancellation.cancel();
+            }
+        }
+        self.sessions.remove(&session_id);
+        self.batches
+            .retain(|_, batch| batch.session_id != session_id);
+    }
+
+    fn earliest_due(&self) -> Option<(Instant, u64)> {
+        self.batches
+            .values()
+            .filter(|batch| !batch.in_flight)
+            .map(|batch| (batch.due_at, batch.generation))
+            .min()
+    }
+}
+
+struct InFlightSlot {
+    generation: u64,
+    cancellation: CancellationToken,
+    join: tauri::async_runtime::JoinHandle<()>,
+}
+
+struct DeliveryCompletion {
+    generation: u64,
+    result: Result<(), String>,
+}
+
+fn retry_delay(failure_count: u32) -> Duration {
+    if failure_count == 0 {
+        return Duration::ZERO;
+    }
+    let shift = failure_count.saturating_sub(1).min(4);
+    FIRST_RETRY_DELAY
+        .checked_mul(1u32 << shift)
+        .unwrap_or(MAX_RETRY_DELAY)
+        .min(MAX_RETRY_DELAY)
+}
+
+fn optional_sleep(clock: Arc<dyn AlertClock>, deadline: Option<Instant>) -> BoxFuture<'static, ()> {
+    match deadline {
+        Some(deadline) => clock.sleep_until(deadline),
+        None => Box::pin(futures::future::pending()),
+    }
+}
+
+fn next_actor_deadline(
+    state: &ActorState,
+    in_flight: Option<&InFlightSlot>,
+    maintenance_deadline: Instant,
+) -> Instant {
+    if in_flight.is_some() {
+        return maintenance_deadline;
+    }
+    state
+        .earliest_due()
+        .map(|(deadline, _)| deadline.min(maintenance_deadline))
+        .unwrap_or(maintenance_deadline)
+}
+
+async fn run_context_alert_actor(
+    runtime: Arc<dyn ContextAlertRuntime>,
+    clock: Arc<dyn AlertClock>,
+    mut samples: mpsc::Receiver<ContextSample>,
+    shutdown: CancellationToken,
+) {
+    let mut state = ActorState::new();
+    let mut samples_open = true;
+    let mut maintenance_deadline = clock.now() + CONTEXT_ALERT_MAINTENANCE_INTERVAL;
+    let (completion_tx, mut completion_rx) = mpsc::channel::<DeliveryCompletion>(1);
+    let mut in_flight: Option<InFlightSlot> = None;
+
+    loop {
+        let deadline = next_actor_deadline(&state, in_flight.as_ref(), maintenance_deadline);
+        let sleep = optional_sleep(Arc::clone(&clock), Some(deadline));
+        tokio::pin!(sleep);
+
+        tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => {
+                if let Some(slot) = in_flight.take() {
+                    slot.cancellation.cancel();
+                    if let Err(error) = slot.join.await {
+                        log::warn!("[context-alert] delivery wrapper join failed during shutdown: {}", error);
+                    } else if let Ok(completion) = completion_rx.try_recv() {
+                        if let Err(error) = completion.result {
+                            log::warn!(
+                                "[context-alert] delivery generation={} ended with error during shutdown: {}",
+                                completion.generation,
+                                error
+                            );
+                        }
+                    }
+                }
+                state.sessions.clear();
+                state.batches.clear();
+                break;
+            }
+            completion = completion_rx.recv(), if in_flight.is_some() => {
+                if let Some(completion) = completion {
+                    handle_delivery_completion(
+                        &mut state,
+                        &mut in_flight,
+                        completion,
+                        clock.now(),
+                    ).await;
+                    if clock.now() >= maintenance_deadline {
+                        run_maintenance(
+                            &runtime,
+                            &mut state,
+                            in_flight.as_ref(),
+                            &shutdown,
+                        ).await;
+                        maintenance_deadline = clock.now() + CONTEXT_ALERT_MAINTENANCE_INTERVAL;
+                    }
+                    dispatch_due_batch(
+                        &runtime,
+                        &clock,
+                        &mut state,
+                        &mut in_flight,
+                        &completion_tx,
+                        &shutdown,
+                    ).await;
+                }
+            }
+            _ = &mut sleep => {
+                if clock.now() >= maintenance_deadline {
+                    run_maintenance(
+                        &runtime,
+                        &mut state,
+                        in_flight.as_ref(),
+                        &shutdown,
+                    ).await;
+                    maintenance_deadline = clock.now() + CONTEXT_ALERT_MAINTENANCE_INTERVAL;
+                }
+                if in_flight.is_none() {
+                    dispatch_due_batch(
+                        &runtime,
+                        &clock,
+                        &mut state,
+                        &mut in_flight,
+                        &completion_tx,
+                        &shutdown,
+                    ).await;
+                }
+            }
+            sample = samples.recv(), if samples_open => {
+                match sample {
+                    Some(sample) => {
+                        process_sample(
+                            &runtime,
+                            &clock,
+                            &mut state,
+                            in_flight.as_ref(),
+                            sample,
+                            &shutdown,
+                        ).await;
+                        if clock.now() >= maintenance_deadline {
+                            run_maintenance(
+                                &runtime,
+                                &mut state,
+                                in_flight.as_ref(),
+                                &shutdown,
+                            ).await;
+                            maintenance_deadline = clock.now() + CONTEXT_ALERT_MAINTENANCE_INTERVAL;
+                        }
+                        if in_flight.is_none() {
+                            dispatch_due_batch(
+                                &runtime,
+                                &clock,
+                                &mut state,
+                                &mut in_flight,
+                                &completion_tx,
+                                &shutdown,
+                            ).await;
+                        }
+                    }
+                    None => {
+                        samples_open = false;
+                        log::warn!("[context-alert] sample channel closed; maintenance and pending retries remain active");
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn process_sample(
+    runtime: &Arc<dyn ContextAlertRuntime>,
+    clock: &Arc<dyn AlertClock>,
+    state: &mut ActorState,
+    in_flight: Option<&InFlightSlot>,
+    sample: ContextSample,
+    shutdown: &CancellationToken,
+) {
+    match sample {
+        ContextSample::SessionOver { session_id } => {
+            state.remove_session(session_id, in_flight);
+        }
+        ContextSample::Unavailable { session_id } => {
+            let live = tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => return,
+                live = runtime.check_session_live(session_id) => live,
+            };
+            if !live {
+                state.remove_session(session_id, in_flight);
+                let retire = runtime.retire_sample_registration(session_id);
+                tokio::select! {
+                    biased;
+                    _ = shutdown.cancelled() => {},
+                    _ = retire => {},
+                }
+            }
+        }
+        ContextSample::Reading {
+            session_id,
+            percent,
+        } => {
+            if percent > 100 {
+                log::error!(
+                    "[context-alert] impossible producer reading session={} percent={}",
+                    session_id,
+                    percent
+                );
+                return;
+            }
+            let resolution = tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => return,
+                resolution = runtime.resolve_member_policy(session_id) => resolution,
+            };
+            apply_numeric_resolution(
+                state,
+                in_flight,
+                session_id,
+                percent,
+                resolution,
+                clock.now(),
+            );
+        }
+    }
+}
+
+fn apply_numeric_resolution(
+    state: &mut ActorState,
+    in_flight: Option<&InFlightSlot>,
+    session_id: Uuid,
+    percent: u8,
+    resolution: MemberPolicyResolution,
+    now: Instant,
+) {
+    match resolution {
+        MemberPolicyResolution::Eligible(resolved) => {
+            if resolved.fingerprint.session_id != session_id {
+                log::error!(
+                    "[context-alert] runtime returned mismatched session identity expected={} actual={}",
+                    session_id,
+                    resolved.fingerprint.session_id
+                );
+                return;
+            }
+            let changed_identity = state
+                .sessions
+                .get(&session_id)
+                .and_then(|session| session.fingerprint.as_ref())
+                .is_some_and(|fingerprint| fingerprint != &resolved.fingerprint);
+            if changed_identity {
+                state.remove_session(session_id, in_flight);
+            }
+            let session = state
+                .sessions
+                .entry(session_id)
+                .or_insert_with(SessionAlertState::empty);
+            session.fingerprint = Some(resolved.fingerprint.clone());
+            clear_runtime_error(session, session_id);
+            let was_paused = clear_policy_error(session, session_id);
+            reconcile_policy(
+                state,
+                in_flight,
+                session_id,
+                &resolved.fingerprint,
+                &resolved.thresholds,
+                now,
+            );
+            if was_paused {
+                make_session_batches_due_now(state, session_id, now);
+            }
+            evaluate_numeric_sample(state, session_id, percent, now);
+        }
+        MemberPolicyResolution::Disabled(_) | MemberPolicyResolution::PermanentIneligible(_) => {
+            state.remove_session(session_id, in_flight);
+        }
+        MemberPolicyResolution::Paused {
+            fingerprint,
+            class,
+            message,
+        } => {
+            let changed_identity = state
+                .sessions
+                .get(&session_id)
+                .and_then(|session| session.fingerprint.as_ref())
+                .is_some_and(|current| current != &fingerprint);
+            if changed_identity {
+                state.remove_session(session_id, in_flight);
+            }
+            let session = state
+                .sessions
+                .entry(session_id)
+                .or_insert_with(SessionAlertState::empty);
+            session.fingerprint = Some(fingerprint);
+            set_policy_error(session, session_id, class, message);
+        }
+        MemberPolicyResolution::RetryableFailure(message) => {
+            let session = state
+                .sessions
+                .entry(session_id)
+                .or_insert_with(SessionAlertState::empty);
+            set_runtime_error(session, session_id, message);
+        }
+    }
+}
+
+fn set_policy_error(
+    session: &mut SessionAlertState,
+    session_id: Uuid,
+    class: &'static str,
+    message: String,
+) {
+    let next = ErrorMarker {
+        class: class.to_string(),
+        message,
+    };
+    if session.policy_error.as_ref() != Some(&next) {
+        log::warn!(
+            "[context-alert] policy paused session={} class={} error={}",
+            session_id,
+            next.class,
+            next.message
+        );
+        session.policy_error = Some(next);
+    }
+}
+
+fn clear_policy_error(session: &mut SessionAlertState, session_id: Uuid) -> bool {
+    if session.policy_error.take().is_some() {
+        log::info!("[context-alert] policy recovered session={}", session_id);
+        true
+    } else {
+        false
+    }
+}
+
+fn set_runtime_error(session: &mut SessionAlertState, session_id: Uuid, message: String) {
+    let next = ErrorMarker {
+        class: "runtime".to_string(),
+        message,
+    };
+    if session.runtime_error.as_ref() != Some(&next) {
+        log::warn!(
+            "[context-alert] resolution failed session={} error={}",
+            session_id,
+            next.message
+        );
+        session.runtime_error = Some(next);
+    }
+}
+
+fn clear_runtime_error(session: &mut SessionAlertState, session_id: Uuid) {
+    if session.runtime_error.take().is_some() {
+        log::info!(
+            "[context-alert] resolution recovered session={}",
+            session_id
+        );
+    }
+}
+
+fn reconcile_policy(
+    state: &mut ActorState,
+    in_flight: Option<&InFlightSlot>,
+    session_id: Uuid,
+    fingerprint: &MemberIdentityFingerprint,
+    new_policy: &[u8],
+    now: Instant,
+) {
+    let old_policy = state
+        .sessions
+        .get(&session_id)
+        .map(|session| session.policy.clone())
+        .unwrap_or_default();
+    let removed: HashSet<u8> = old_policy
+        .iter()
+        .copied()
+        .filter(|threshold| !new_policy.contains(threshold))
+        .collect();
+
+    if !removed.is_empty() {
+        let affected: Vec<u64> = state
+            .batches
+            .values()
+            .filter(|batch| {
+                batch.session_id == session_id
+                    && batch
+                        .thresholds
+                        .iter()
+                        .any(|threshold| removed.contains(threshold))
+            })
+            .map(|batch| batch.generation)
+            .collect();
+        let mut replacements = Vec::new();
+        for generation in affected {
+            let Some(mut batch) = state.batches.remove(&generation) else {
+                continue;
+            };
+            let old_thresholds = batch.thresholds.clone();
+            batch
+                .thresholds
+                .retain(|threshold| !removed.contains(threshold));
+            if in_flight.is_some_and(|slot| slot.generation == generation) {
+                if let Some(slot) = in_flight {
+                    slot.cancellation.cancel();
+                }
+                if !batch.thresholds.is_empty() {
+                    replacements.push((
+                        batch.observed,
+                        batch.thresholds.clone(),
+                        batch.failure_count,
+                    ));
+                }
+            } else if !batch.thresholds.is_empty() {
+                state.batches.insert(generation, batch);
+            }
+            if let Some(session) = state.sessions.get_mut(&session_id) {
+                for threshold in old_thresholds {
+                    if session.outstanding.get(&threshold) == Some(&generation) {
+                        session.outstanding.remove(&threshold);
+                    }
+                }
+                if let Some(current) = state.batches.get(&generation) {
+                    for threshold in &current.thresholds {
+                        session.outstanding.insert(*threshold, generation);
+                    }
+                }
+            }
+        }
+        for (observed, thresholds, failure_count) in replacements {
+            create_batch(
+                state,
+                session_id,
+                fingerprint.clone(),
+                observed,
+                thresholds,
+                failure_count,
+                now,
+            );
+        }
+    }
+
+    let session = state
+        .sessions
+        .entry(session_id)
+        .or_insert_with(SessionAlertState::empty);
+    session.policy = new_policy.to_vec();
+    session
+        .latches
+        .retain(|threshold, _| new_policy.contains(threshold));
+    session
+        .outstanding
+        .retain(|threshold, _| new_policy.contains(threshold));
+    for threshold in new_policy {
+        session
+            .latches
+            .entry(*threshold)
+            .or_insert(LatchState::Armed);
+    }
+}
+
+fn evaluate_numeric_sample(state: &mut ActorState, session_id: Uuid, percent: u8, now: Instant) {
+    let Some(session) = state.sessions.get_mut(&session_id) else {
+        return;
+    };
+    let Some(fingerprint) = session.fingerprint.clone() else {
+        return;
+    };
+    let mut newly_crossed = Vec::new();
+    for threshold in session.policy.clone() {
+        let latch = session
+            .latches
+            .entry(threshold)
+            .or_insert(LatchState::Armed);
+        if percent < threshold {
+            *latch = LatchState::Armed;
+        } else if *latch == LatchState::Armed {
+            *latch = LatchState::Latched;
+            if !session.outstanding.contains_key(&threshold) {
+                newly_crossed.push(threshold);
+            }
+        }
+    }
+    session.last_valid_percent = Some(percent);
+    if newly_crossed.is_empty() {
+        return;
+    }
+    newly_crossed.sort_unstable();
+    create_batch(
+        state,
+        session_id,
+        fingerprint,
+        percent,
+        newly_crossed,
+        0,
+        now,
+    );
+}
+
+fn create_batch(
+    state: &mut ActorState,
+    session_id: Uuid,
+    fingerprint: MemberIdentityFingerprint,
+    observed: u8,
+    thresholds: Vec<u8>,
+    failure_count: u32,
+    due_at: Instant,
+) {
+    let Some(generation) = state.allocate_generation() else {
+        if !state.generation_exhaustion_logged {
+            log::error!("[context-alert] batch generation exhausted; new crossings remain latched");
+            state.generation_exhaustion_logged = true;
+        }
+        return;
+    };
+    if let Some(session) = state.sessions.get_mut(&session_id) {
+        for threshold in &thresholds {
+            session.outstanding.insert(*threshold, generation);
+        }
+    }
+    state.batches.insert(
+        generation,
+        AlertBatch {
+            generation,
+            session_id,
+            fingerprint,
+            observed,
+            thresholds,
+            failure_count,
+            due_at,
+            in_flight: false,
+        },
+    );
+}
+
+fn make_session_batches_due_now(state: &mut ActorState, session_id: Uuid, now: Instant) {
+    for batch in state.batches.values_mut() {
+        if batch.session_id == session_id && !batch.in_flight {
+            batch.due_at = now;
+        }
+    }
+}
+
+async fn dispatch_due_batch(
+    runtime: &Arc<dyn ContextAlertRuntime>,
+    clock: &Arc<dyn AlertClock>,
+    state: &mut ActorState,
+    in_flight: &mut Option<InFlightSlot>,
+    completion_tx: &mpsc::Sender<DeliveryCompletion>,
+    shutdown: &CancellationToken,
+) {
+    if in_flight.is_some() {
+        return;
+    }
+    let now = clock.now();
+    let Some((due_at, generation)) = state.earliest_due() else {
+        return;
+    };
+    if due_at > now {
+        return;
+    }
+    let Some(batch) = state.batches.get(&generation).cloned() else {
+        return;
+    };
+    let snapshot = AttemptSnapshot {
+        generation,
+        session_id: batch.session_id,
+        fingerprint: batch.fingerprint.clone(),
+        observed: batch.observed,
+        thresholds: batch.thresholds,
+        failure_count: batch.failure_count,
+    };
+    let attempt_cancellation = shutdown.child_token();
+    let preparation = tokio::select! {
+        biased;
+        _ = shutdown.cancelled() => return,
+        preparation = runtime.prepare_attempt(snapshot, attempt_cancellation.clone()) => preparation,
+    };
+
+    match preparation {
+        AttemptPreparation::Ready(attempt) => {
+            let session_id = attempt.snapshot.session_id;
+            let fingerprint_matches = state
+                .sessions
+                .get(&session_id)
+                .and_then(|session| session.fingerprint.as_ref())
+                == Some(&attempt.snapshot.fingerprint);
+            if !fingerprint_matches {
+                state.remove_session(session_id, None);
+                return;
+            }
+            reconcile_policy(
+                state,
+                None,
+                session_id,
+                &attempt.snapshot.fingerprint,
+                &attempt.current_policy,
+                now,
+            );
+            let still_matches = state.batches.get(&generation).is_some_and(|current| {
+                current.thresholds == attempt.thresholds()
+                    && current.fingerprint == attempt.snapshot.fingerprint
+            });
+            if !still_matches {
+                return;
+            }
+            if let Some(current) = state.batches.get_mut(&generation) {
+                current.in_flight = true;
+            }
+            if let Some(session) = state.sessions.get_mut(&session_id) {
+                clear_policy_error(session, session_id);
+                clear_runtime_error(session, session_id);
+            }
+            let runtime = Arc::clone(runtime);
+            let tx = completion_tx.clone();
+            let join = tauri::async_runtime::spawn(async move {
+                let delivery =
+                    tauri::async_runtime::spawn(
+                        async move { runtime.deliver_attempt(attempt).await },
+                    );
+                let result = match delivery.await {
+                    Ok(result) => result,
+                    Err(error) => Err(format!("Context alert delivery task failed: {}", error)),
+                };
+                let _ = tx.send(DeliveryCompletion { generation, result }).await;
+            });
+            *in_flight = Some(InFlightSlot {
+                generation,
+                cancellation: attempt_cancellation,
+                join,
+            });
+        }
+        AttemptPreparation::Cancel {
+            reason,
+            current_policy,
+        } => {
+            log::debug!(
+                "[context-alert] canceled pending generation={} reason={}",
+                generation,
+                reason
+            );
+            match current_policy {
+                Some(policy) if policy.fingerprint == batch.fingerprint => {
+                    reconcile_policy(
+                        state,
+                        None,
+                        batch.session_id,
+                        &policy.fingerprint,
+                        &policy.thresholds,
+                        now,
+                    );
+                    state.remove_batch(generation);
+                }
+                _ => state.remove_session(batch.session_id, None),
+            }
+        }
+        AttemptPreparation::Paused {
+            fingerprint,
+            class,
+            message,
+        } => {
+            let same_identity = state
+                .sessions
+                .get(&batch.session_id)
+                .and_then(|session| session.fingerprint.as_ref())
+                == Some(&fingerprint);
+            if !same_identity {
+                state.remove_session(batch.session_id, None);
+                return;
+            }
+            if let Some(session) = state.sessions.get_mut(&batch.session_id) {
+                set_policy_error(session, batch.session_id, class, message.clone());
+            }
+            fail_batch(state, generation, now, &message);
+        }
+        AttemptPreparation::RetryableFailure(message) => {
+            fail_batch(state, generation, now, &message);
+        }
+    }
+}
+
+fn fail_batch(state: &mut ActorState, generation: u64, now: Instant, message: &str) {
+    let Some(batch) = state.batches.get_mut(&generation) else {
+        return;
+    };
+    batch.in_flight = false;
+    batch.failure_count = batch.failure_count.saturating_add(1);
+    batch.due_at = now + retry_delay(batch.failure_count);
+    log::warn!(
+        "[context-alert] generation={} attempt={} failed; retryInMs={} error={}",
+        generation,
+        batch.failure_count,
+        retry_delay(batch.failure_count).as_millis(),
+        message
+    );
+}
+
+async fn handle_delivery_completion(
+    state: &mut ActorState,
+    in_flight: &mut Option<InFlightSlot>,
+    completion: DeliveryCompletion,
+    now: Instant,
+) {
+    let Some(slot) = in_flight.take() else {
+        log::debug!(
+            "[context-alert] ignored completion generation={} without a global slot",
+            completion.generation
+        );
+        return;
+    };
+    let slot_generation = slot.generation;
+    if let Err(error) = slot.join.await {
+        log::warn!(
+            "[context-alert] delivery wrapper generation={} join failed: {}",
+            slot_generation,
+            error
+        );
+    }
+    if slot_generation != completion.generation {
+        log::debug!(
+            "[context-alert] ignored mismatched completion slot={} result={}",
+            slot_generation,
+            completion.generation
+        );
+        return;
+    }
+    let matching = state
+        .batches
+        .get(&completion.generation)
+        .is_some_and(|batch| batch.in_flight);
+    if !matching {
+        log::debug!(
+            "[context-alert] ignored stale completion generation={}",
+            completion.generation
+        );
+        return;
+    }
+    match completion.result {
+        Ok(()) => {
+            state.remove_batch(completion.generation);
+        }
+        Err(message) => fail_batch(state, completion.generation, now, &message),
+    }
+}
+
+async fn run_maintenance(
+    runtime: &Arc<dyn ContextAlertRuntime>,
+    state: &mut ActorState,
+    in_flight: Option<&InFlightSlot>,
+    shutdown: &CancellationToken,
+) {
+    let ids: Vec<Uuid> = state.sessions.keys().copied().collect();
+    for session_id in ids {
+        let live = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => return,
+            live = runtime.check_session_live(session_id) => live,
+        };
+        if !live {
+            state.remove_session(session_id, in_flight);
+            let retire = runtime.retire_sample_registration(session_id);
+            tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => return,
+                _ = retire => {},
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ProductionContextAlertRuntime {
+    app: tauri::AppHandle,
+}
+
+impl ContextAlertRuntime for ProductionContextAlertRuntime {
+    fn resolve_member_policy(
+        &self,
+        session_id: Uuid,
+    ) -> BoxFuture<'static, MemberPolicyResolution> {
+        let runtime = self.clone();
+        Box::pin(async move { runtime.resolve_member_policy_inner(session_id).await })
+    }
+
+    fn check_session_live(&self, session_id: Uuid) -> BoxFuture<'static, bool> {
+        let runtime = self.clone();
+        Box::pin(async move { runtime.session_and_registration_live(session_id).await })
+    }
+
+    fn retire_sample_registration(&self, session_id: Uuid) -> BoxFuture<'static, ()> {
+        let app = self.app.clone();
+        Box::pin(async move {
+            if let Some(scraper) = app.try_state::<Arc<ContextScraper>>() {
+                scraper.unregister_session(session_id);
+            }
+        })
+    }
+
+    fn prepare_attempt(
+        &self,
+        snapshot: AttemptSnapshot,
+        cancellation: CancellationToken,
+    ) -> BoxFuture<'static, AttemptPreparation> {
+        let runtime = self.clone();
+        Box::pin(async move { runtime.prepare_attempt_inner(snapshot, cancellation).await })
+    }
+
+    fn deliver_attempt(&self, attempt: ReadyAttempt) -> BoxFuture<'static, Result<(), String>> {
+        let app = self.app.clone();
+        Box::pin(async move {
+            MailboxPoller::new()
+                .deliver_internal_system_notice(
+                    &app,
+                    attempt.target,
+                    attempt.notice,
+                    attempt.cancellation,
+                    attempt.guard,
+                )
+                .await
+        })
+    }
+}
+
+impl ProductionContextAlertRuntime {
+    async fn public_session(&self, session_id: Uuid) -> Option<Session> {
+        let state = self
+            .app
+            .try_state::<Arc<tokio::sync::RwLock<SessionManager>>>()?;
+        let manager = state.read().await.clone();
+        manager.get_session(session_id).await
+    }
+
+    fn registered(&self, session_id: Uuid) -> bool {
+        self.app
+            .try_state::<Arc<ContextScraper>>()
+            .is_some_and(|scraper| scraper.is_session_registered(session_id))
+    }
+
+    async fn session_and_registration_live(&self, session_id: Uuid) -> bool {
+        self.public_session(session_id)
+            .await
+            .is_some_and(|session| !matches!(session.status, SessionStatus::Exited(_)))
+            && self.registered(session_id)
+    }
+
+    async fn resolve_member_policy_inner(&self, session_id: Uuid) -> MemberPolicyResolution {
+        let Some(session) = self.public_session(session_id).await else {
+            return MemberPolicyResolution::PermanentIneligible(
+                "sampled session is no longer present".to_string(),
+            );
+        };
+        if session.is_root_agent
+            || matches!(session.status, SessionStatus::Exited(_))
+            || session.agent_id.is_none()
+            || !self.registered(session_id)
+        {
+            return MemberPolicyResolution::PermanentIneligible(
+                "sampled session is no longer an eligible registered member".to_string(),
+            );
+        }
+        let agent_id = session.agent_id.clone().unwrap_or_default();
+        let working_directory = session.working_directory.clone();
+        let blocking_session = session.clone();
+        let blocking =
+            tokio::task::spawn_blocking(move || resolve_member_policy_blocking(&blocking_session))
+                .await;
+        let resolution = match blocking {
+            Ok(resolution) => resolution,
+            Err(error) => {
+                return MemberPolicyResolution::RetryableFailure(format!(
+                    "Member policy blocking task failed for session {}: {}",
+                    session_id, error
+                ));
+            }
+        };
+
+        if matches!(
+            resolution,
+            MemberPolicyResolution::Eligible(_)
+                | MemberPolicyResolution::Disabled(_)
+                | MemberPolicyResolution::Paused { .. }
+        ) {
+            let current = self.public_session(session_id).await;
+            if !session_matches_policy_snapshot(
+                current.as_ref(),
+                session_id,
+                &agent_id,
+                &working_directory,
+                self.registered(session_id),
+            ) {
+                return MemberPolicyResolution::PermanentIneligible(
+                    "sampled session identity changed during policy resolution".to_string(),
+                );
+            }
+        }
+        resolution
+    }
+
+    async fn prepare_attempt_inner(
+        &self,
+        snapshot: AttemptSnapshot,
+        cancellation: CancellationToken,
+    ) -> AttemptPreparation {
+        log::debug!(
+            "[context-alert] preparing generation={} priorFailures={}",
+            snapshot.generation,
+            snapshot.failure_count
+        );
+        let resolution = self.resolve_member_policy_inner(snapshot.session_id).await;
+        let policy = match resolution {
+            MemberPolicyResolution::Eligible(policy) => policy,
+            MemberPolicyResolution::Disabled(_) => {
+                return AttemptPreparation::Cancel {
+                    reason: "context alert policy is disabled".to_string(),
+                    current_policy: None,
+                }
+            }
+            MemberPolicyResolution::PermanentIneligible(reason) => {
+                return AttemptPreparation::Cancel {
+                    reason,
+                    current_policy: None,
+                }
+            }
+            MemberPolicyResolution::Paused {
+                fingerprint,
+                class,
+                message,
+            } => {
+                return AttemptPreparation::Paused {
+                    fingerprint,
+                    class,
+                    message,
+                }
+            }
+            MemberPolicyResolution::RetryableFailure(message) => {
+                return AttemptPreparation::RetryableFailure(message)
+            }
+        };
+        if policy.fingerprint != snapshot.fingerprint {
+            return AttemptPreparation::Cancel {
+                reason: "sampled member identity changed before delivery".to_string(),
+                current_policy: None,
+            };
+        }
+        let thresholds: Vec<u8> = snapshot
+            .thresholds
+            .iter()
+            .copied()
+            .filter(|threshold| policy.thresholds.contains(threshold))
+            .collect();
+        if thresholds.is_empty() {
+            return AttemptPreparation::Cancel {
+                reason: "all pending context alert thresholds were removed".to_string(),
+                current_policy: Some(policy),
+            };
+        }
+        let fingerprint = snapshot.fingerprint.clone();
+        let observed = snapshot.observed;
+        let route = tokio::task::spawn_blocking(move || {
+            prepare_internal_route_blocking(&fingerprint, observed, &thresholds)
+        })
+        .await;
+        let (target, notice) = match route {
+            Ok(Ok(route)) => route,
+            Ok(Err(error)) => return AttemptPreparation::RetryableFailure(error),
+            Err(error) => {
+                return AttemptPreparation::RetryableFailure(format!(
+                    "Coordinator route blocking task failed: {}",
+                    error
+                ))
+            }
+        };
+        let guard_app = self.app.clone();
+        let guard_fingerprint = snapshot.fingerprint.clone();
+        let guard_target = target.clone();
+        let guard_thresholds = notice.thresholds().to_vec();
+        let guard_cancellation = cancellation.clone();
+        let guard: InternalNoticeGuard = Arc::new(move || {
+            validate_attempt_guard(
+                &guard_app,
+                &guard_fingerprint,
+                &guard_target,
+                &guard_thresholds,
+                &guard_cancellation,
+            )
+        });
+        AttemptPreparation::Ready(ReadyAttempt {
+            snapshot,
+            current_policy: policy.thresholds,
+            target,
+            notice,
+            guard,
+            cancellation,
+        })
+    }
+}
+
+fn session_matches_policy_snapshot(
+    current: Option<&Session>,
+    session_id: Uuid,
+    agent_id: &str,
+    working_directory: &str,
+    registered: bool,
+) -> bool {
+    current.is_some_and(|current| {
+        current.id == session_id
+            && current.agent_id.as_deref() == Some(agent_id)
+            && current.working_directory == working_directory
+            && !current.is_root_agent
+            && !matches!(current.status, SessionStatus::Exited(_))
+            && registered
+    })
+}
+
+fn canonical_real_directory(path: &Path, label: &str) -> Result<PathBuf, String> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| format!("{} '{}' is not readable: {}", label, path.display(), error))?;
+    if !metadata.is_dir() || metadata_is_link_or_reparse(&metadata) {
+        return Err(format!(
+            "{} '{}' must be a real non-link directory",
+            label,
+            path.display()
+        ));
+    }
+    std::fs::canonicalize(path)
+        .map(|canonical| crate::path_utils::normalize_windows_verbatim_path_buf(&canonical))
+        .map_err(|error| {
+            format!(
+                "{} '{}' cannot be canonicalized: {}",
+                label,
+                path.display(),
+                error
+            )
+        })
+}
+
+fn resolve_member_policy_blocking(session: &Session) -> MemberPolicyResolution {
+    let lexical_cwd = Path::new(&session.working_directory);
+    let Some(lexical_replica) = lexical_cwd.ancestors().find(|ancestor| {
+        ancestor
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("__agent_"))
+    }) else {
+        return MemberPolicyResolution::PermanentIneligible(
+            "sampled CWD is not inside a lexical workgroup member replica".to_string(),
+        );
+    };
+    let Some(lexical_workgroup) = lexical_replica.parent() else {
+        return MemberPolicyResolution::PermanentIneligible(
+            "sampled lexical replica has no workgroup parent".to_string(),
+        );
+    };
+    let Some(lexical_workspace) = lexical_workgroup.parent() else {
+        return MemberPolicyResolution::PermanentIneligible(
+            "sampled lexical workgroup has no Project AC Root parent".to_string(),
+        );
+    };
+    for (path, label) in [
+        (lexical_replica, "replica"),
+        (lexical_workgroup, "workgroup"),
+        (lexical_workspace, "Project AC Root"),
+    ] {
+        let metadata = match std::fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                return MemberPolicyResolution::PermanentIneligible(format!(
+                    "sampled lexical {} '{}' is not readable: {}",
+                    label,
+                    path.display(),
+                    error
+                ))
+            }
+        };
+        if !metadata.is_dir() || metadata_is_link_or_reparse(&metadata) {
+            return MemberPolicyResolution::PermanentIneligible(format!(
+                "sampled lexical {} '{}' must be a real non-link directory",
+                label,
+                path.display()
+            ));
+        }
+    }
+    let canonical_lexical_replica = match std::fs::canonicalize(lexical_replica)
+        .map(|path| crate::path_utils::normalize_windows_verbatim_path_buf(&path))
+    {
+        Ok(path) => path,
+        Err(error) => {
+            return MemberPolicyResolution::PermanentIneligible(format!(
+                "sampled lexical replica '{}' cannot be canonicalized: {}",
+                lexical_replica.display(),
+                error
+            ))
+        }
+    };
+
+    let canonical_cwd = match std::fs::canonicalize(&session.working_directory)
+        .map(|path| crate::path_utils::normalize_windows_verbatim_path_buf(&path))
+    {
+        Ok(path) => path,
+        Err(error) => {
+            return MemberPolicyResolution::PermanentIneligible(format!(
+                "sampled CWD '{}' cannot be canonicalized: {}",
+                session.working_directory, error
+            ))
+        }
+    };
+    let Some(replica_candidate) = canonical_cwd.ancestors().find(|ancestor| {
+        ancestor
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("__agent_"))
+    }) else {
+        return MemberPolicyResolution::PermanentIneligible(
+            "sampled CWD is not inside a workgroup member replica".to_string(),
+        );
+    };
+    let replica_dir = match canonical_real_directory(replica_candidate, "Member replica") {
+        Ok(path) => path,
+        Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
+    };
+    if canonical_lexical_replica != replica_dir {
+        return MemberPolicyResolution::PermanentIneligible(
+            "sampled CWD reaches a different replica through a link or path escape".to_string(),
+        );
+    }
+    if canonical_cwd != replica_dir && !canonical_cwd.starts_with(&replica_dir) {
+        return MemberPolicyResolution::PermanentIneligible(
+            "sampled CWD escapes its member replica".to_string(),
+        );
+    }
+    let layout = match crate::config::workspace::wg_replica_layout_from_agent_dir(&replica_dir) {
+        Ok(Some(layout)) => layout,
+        Ok(None) => {
+            return MemberPolicyResolution::PermanentIneligible(
+                "sampled replica does not have the canonical workgroup layout".to_string(),
+            )
+        }
+        Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
+    };
+    let workgroup_dir = match canonical_real_directory(&layout.wg_dir, "Workgroup") {
+        Ok(path) => path,
+        Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
+    };
+    let workspace_dir = match canonical_real_directory(&layout.workspace_dir, "Project AC Root") {
+        Ok(path) => path,
+        Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
+    };
+    let team = match parse_team_from_workgroup_name(&layout.wg_name) {
+        Ok(team) => team,
+        Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
+    };
+    let (_, identity) =
+        match crate::config::replica_identity::read_wg_replica_config_read_only(&replica_dir) {
+            Ok(result) => result,
+            Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
+        };
+    let identity_workspace =
+        match canonical_real_directory(&identity.workspace_dir, "Identity workspace") {
+            Ok(path) => path,
+            Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
+        };
+    let matrix_dir = match canonical_real_directory(&identity.matrix_dir, "Agent Matrix") {
+        Ok(path) => path,
+        Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
+    };
+    if identity.agent_name != layout.agent_name || identity_workspace != workspace_dir {
+        return MemberPolicyResolution::PermanentIneligible(
+            "sampled replica identity does not match its canonical layout".to_string(),
+        );
+    }
+    let project_dir = match canonical_real_directory(&layout.project_dir, "Project") {
+        Ok(path) => path,
+        Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
+    };
+    let project = match validated_project_fqn_component(
+        project_dir.file_name().and_then(|name| name.to_str()),
+    ) {
+        Ok(project) => project,
+        Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
+    };
+    let agent_id = match session.agent_id.clone() {
+        Some(agent_id) if !agent_id.is_empty() => agent_id,
+        _ => {
+            return MemberPolicyResolution::PermanentIneligible(
+                "sampled session has no coding-agent id".to_string(),
+            )
+        }
+    };
+    let fingerprint = MemberIdentityFingerprint {
+        session_id: session.id,
+        agent_id,
+        working_directory: session.working_directory.clone(),
+        project_dir,
+        workspace_dir: workspace_dir.clone(),
+        workgroup_dir,
+        replica_dir,
+        matrix_dir,
+        project,
+        team: team.clone(),
+        workgroup: layout.wg_name,
+        member: layout.agent_name,
+    };
+
+    match read_team_config_classified(&workspace_dir, &team) {
+        Ok(config) => {
+            let member_ref = format!("_agent_{}", fingerprint.member);
+            if !config.agents.contains(&member_ref) {
+                return MemberPolicyResolution::PermanentIneligible(
+                    "sampled member is no longer in the canonical team roster".to_string(),
+                );
+            }
+            if config.context_alert_percentages.is_empty() {
+                MemberPolicyResolution::Disabled(fingerprint)
+            } else {
+                MemberPolicyResolution::Eligible(ResolvedPolicy {
+                    fingerprint,
+                    thresholds: config.context_alert_percentages,
+                })
+            }
+        }
+        Err(error @ TeamConfigReadError::NotFound { .. }) => {
+            MemberPolicyResolution::PermanentIneligible(error.to_string())
+        }
+        Err(error) => MemberPolicyResolution::Paused {
+            fingerprint,
+            class: error.class(),
+            message: error.to_string(),
+        },
+    }
+}
+
+fn validated_project_fqn_component(component: Option<&str>) -> Result<String, String> {
+    match component {
+        Some(project)
+            if !project.is_empty()
+                && !project.contains(':')
+                && !project
+                    .chars()
+                    .any(|character| character == '\0' || character.is_ascii_control()) =>
+        {
+            Ok(project.to_string())
+        }
+        _ => Err("project directory has an invalid qualified-name component".to_string()),
+    }
+}
+
+fn prepare_internal_route_blocking(
+    fingerprint: &MemberIdentityFingerprint,
+    observed: u8,
+    thresholds: &[u8],
+) -> Result<(InternalSystemTarget, InternalSystemNotice), String> {
+    let config = read_team_config_classified(&fingerprint.workspace_dir, &fingerprint.team)
+        .map_err(|error| error.to_string())?;
+    let coordinator =
+        crate::config::replica_identity::agent_bare_name_from_ref(&config.coordinator)?;
+    let expected = fingerprint
+        .workgroup_dir
+        .join(format!("__agent_{}", coordinator));
+    let canonical_expected = canonical_real_directory(&expected, "Coordinator replica")?;
+    if canonical_expected.parent() != Some(fingerprint.workgroup_dir.as_path())
+        || canonical_expected
+            .file_name()
+            .and_then(|name| name.to_str())
+            != Some(format!("__agent_{}", coordinator).as_str())
+    {
+        return Err("Coordinator replica escapes the sampled workgroup".to_string());
+    }
+    let resolved = crate::config::teams::resolve_wg_coordinator_replica(
+        &fingerprint.workspace_dir,
+        &fingerprint.workgroup_dir,
+    )
+    .ok_or_else(|| "Current coordinator replica is unavailable".to_string())?;
+    let canonical_resolved =
+        canonical_real_directory(&resolved.replica_dir, "Resolved coordinator replica")?;
+    if resolved.project != fingerprint.project
+        || resolved.team != fingerprint.team
+        || resolved.wg_name != fingerprint.workgroup
+        || resolved.agent_name != coordinator
+        || canonical_resolved != canonical_expected
+    {
+        return Err(
+            "Resolved coordinator identity does not match the exact sampled workgroup".to_string(),
+        );
+    }
+    let fqn = format!(
+        "{}:{}/{}",
+        resolved.project, resolved.wg_name, resolved.agent_name
+    );
+    let target = InternalSystemTarget::for_context_alert(fqn, canonical_resolved)?;
+    let notice = InternalSystemNotice::for_context_alert(
+        fingerprint.member.clone(),
+        fingerprint.workgroup.clone(),
+        observed,
+        thresholds.to_vec(),
+    )?;
+    Ok((target, notice))
+}
+
+fn validate_attempt_guard<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    fingerprint: &MemberIdentityFingerprint,
+    target: &InternalSystemTarget,
+    thresholds: &[u8],
+    cancellation: &CancellationToken,
+) -> Result<(), String> {
+    if cancellation.is_cancelled() {
+        return Err("Context alert attempt was canceled".to_string());
+    }
+    if app
+        .try_state::<Arc<crate::session::purge_guard::PurgeGuard>>()
+        .is_some_and(|guard| guard.blocks_agent(target.fqn()))
+    {
+        return Err(format!("purge-wg blocks '{}'", target.fqn()));
+    }
+    let scraper = app
+        .try_state::<Arc<ContextScraper>>()
+        .ok_or_else(|| "Context scraper is unavailable".to_string())?;
+    if !scraper.is_session_registered(fingerprint.session_id) {
+        return Err("Sampled session is no longer registered".to_string());
+    }
+    let replica = canonical_real_directory(&fingerprint.replica_dir, "Member replica")?;
+    let workgroup = canonical_real_directory(&fingerprint.workgroup_dir, "Workgroup")?;
+    let workspace = canonical_real_directory(&fingerprint.workspace_dir, "Project AC Root")?;
+    let project = canonical_real_directory(&fingerprint.project_dir, "Project")?;
+    if replica != fingerprint.replica_dir
+        || workgroup != fingerprint.workgroup_dir
+        || workspace != fingerprint.workspace_dir
+        || project != fingerprint.project_dir
+        || replica.parent() != Some(workgroup.as_path())
+        || workgroup.parent() != Some(workspace.as_path())
+        || workspace.parent() != Some(project.as_path())
+        || replica.file_name().and_then(|name| name.to_str())
+            != Some(format!("__agent_{}", fingerprint.member).as_str())
+        || parse_team_from_workgroup_name(&fingerprint.workgroup)? != fingerprint.team
+    {
+        return Err("Sampled canonical identity paths changed".to_string());
+    }
+    let (_, identity) =
+        crate::config::replica_identity::read_wg_replica_config_read_only(&replica)?;
+    let identity_workspace =
+        canonical_real_directory(&identity.workspace_dir, "Identity workspace")?;
+    let identity_matrix = canonical_real_directory(&identity.matrix_dir, "Agent Matrix")?;
+    if identity.agent_name != fingerprint.member
+        || identity_workspace != fingerprint.workspace_dir
+        || identity_matrix != fingerprint.matrix_dir
+    {
+        return Err("Sampled member identity changed".to_string());
+    }
+    let config = read_team_config_classified(&workspace, &fingerprint.team)
+        .map_err(|error| error.to_string())?;
+    if !config
+        .agents
+        .contains(&format!("_agent_{}", fingerprint.member))
+        || thresholds
+            .iter()
+            .any(|threshold| !config.context_alert_percentages.contains(threshold))
+    {
+        return Err("Sampled member roster or context alert policy changed".to_string());
+    }
+    let (fresh_target, _) = prepare_internal_route_blocking(fingerprint, 100, thresholds)?;
+    if fresh_target != *target {
+        return Err("Coordinator target changed before notice delivery".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    struct GuardRows;
+
+    impl crate::pty::context_scrape::ScreenRowsSource for GuardRows {
+        fn get_screen_rows(&self, _id: Uuid) -> crate::pty::context_scrape::ScreenRowsRead {
+            crate::pty::context_scrape::ScreenRowsRead::Unavailable
+        }
+    }
+
+    struct GuardPatterns;
+
+    impl crate::pty::context_scrape::ContextPatternSource for GuardPatterns {
+        fn patterns(&self) -> BoxFuture<'_, HashMap<String, String>> {
+            Box::pin(async { HashMap::new() })
+        }
+    }
+
+    struct GuardEvents;
+
+    impl crate::pty::context_scrape::ContextEventSink for GuardEvents {
+        fn emit(&self, _payload: crate::pty::context_scrape::ContextUsagePayload) {}
+    }
+
+    struct GuardSamples;
+
+    impl crate::pty::context_scrape::ContextSampleSink for GuardSamples {
+        fn observe(&self, _sample: ContextSample) {}
+    }
+
+    struct ManualClock {
+        now: Mutex<Instant>,
+        waiters: Mutex<Vec<(Instant, tokio::sync::oneshot::Sender<()>)>>,
+    }
+
+    impl ManualClock {
+        fn new(now: Instant) -> Arc<Self> {
+            Arc::new(Self {
+                now: Mutex::new(now),
+                waiters: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn advance(&self, duration: Duration) {
+            let now = {
+                let mut now = self.now.lock().unwrap();
+                *now += duration;
+                *now
+            };
+            let mut waiters = self.waiters.lock().unwrap();
+            let mut pending = Vec::new();
+            for (deadline, sender) in waiters.drain(..) {
+                if deadline <= now {
+                    let _ = sender.send(());
+                } else {
+                    pending.push((deadline, sender));
+                }
+            }
+            *waiters = pending;
+        }
+
+        fn has_live_waiter_within(&self, duration: Duration) -> bool {
+            let latest = *self.now.lock().unwrap() + duration;
+            self.waiters
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(deadline, sender)| !sender.is_closed() && *deadline <= latest)
+        }
+    }
+
+    impl AlertClock for ManualClock {
+        fn now(&self) -> Instant {
+            *self.now.lock().unwrap()
+        }
+
+        fn sleep_until(&self, deadline: Instant) -> BoxFuture<'static, ()> {
+            let now = *self.now.lock().unwrap();
+            if deadline <= now {
+                return Box::pin(async {});
+            }
+            let (sender, receiver) = tokio::sync::oneshot::channel();
+            self.waiters.lock().unwrap().push((deadline, sender));
+            Box::pin(async move {
+                let _ = receiver.await;
+            })
+        }
+    }
+
+    struct ScriptedRuntime {
+        _temp: tempfile::TempDir,
+        target: InternalSystemTarget,
+        policies: Mutex<HashMap<Uuid, ResolvedPolicy>>,
+        live: AtomicBool,
+        live_checks: AtomicUsize,
+        resolve_calls: AtomicUsize,
+        prepare_calls: Mutex<Vec<AttemptSnapshot>>,
+        deliveries: Mutex<Vec<AttemptSnapshot>>,
+        delivery_results: Mutex<VecDeque<Result<(), String>>>,
+        blocked_delivery: Mutex<Option<tokio::sync::oneshot::Receiver<Result<(), String>>>>,
+        blocked_resolution: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+        panic_next_delivery: AtomicBool,
+        retired: Mutex<Vec<Uuid>>,
+    }
+
+    impl ScriptedRuntime {
+        fn new() -> Arc<Self> {
+            let temp = tempfile::tempdir().unwrap();
+            let replica = temp
+                .path()
+                .join("project")
+                .join(".ac")
+                .join("wg-1-team")
+                .join("__agent_coordinator");
+            std::fs::create_dir_all(&replica).unwrap();
+            let target = InternalSystemTarget::for_context_alert(
+                "project:wg-1-team/coordinator".to_string(),
+                replica,
+            )
+            .unwrap();
+            Arc::new(Self {
+                _temp: temp,
+                target,
+                policies: Mutex::new(HashMap::new()),
+                live: AtomicBool::new(true),
+                live_checks: AtomicUsize::new(0),
+                resolve_calls: AtomicUsize::new(0),
+                prepare_calls: Mutex::new(Vec::new()),
+                deliveries: Mutex::new(Vec::new()),
+                delivery_results: Mutex::new(VecDeque::new()),
+                blocked_delivery: Mutex::new(None),
+                blocked_resolution: Mutex::new(None),
+                panic_next_delivery: AtomicBool::new(false),
+                retired: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn set_policy(&self, id: Uuid, thresholds: &[u8]) {
+            self.policies.lock().unwrap().insert(
+                id,
+                ResolvedPolicy {
+                    fingerprint: fingerprint(id),
+                    thresholds: thresholds.to_vec(),
+                },
+            );
+        }
+
+        fn delivery_count(&self) -> usize {
+            self.deliveries.lock().unwrap().len()
+        }
+
+        fn block_next_delivery(&self) -> tokio::sync::oneshot::Sender<Result<(), String>> {
+            let (sender, receiver) = tokio::sync::oneshot::channel();
+            *self.blocked_delivery.lock().unwrap() = Some(receiver);
+            sender
+        }
+
+        fn block_next_resolution(&self) -> tokio::sync::oneshot::Sender<()> {
+            let (sender, receiver) = tokio::sync::oneshot::channel();
+            *self.blocked_resolution.lock().unwrap() = Some(receiver);
+            sender
+        }
+    }
+
+    impl ContextAlertRuntime for ScriptedRuntime {
+        fn resolve_member_policy(
+            &self,
+            session_id: Uuid,
+        ) -> BoxFuture<'static, MemberPolicyResolution> {
+            self.resolve_calls.fetch_add(1, Ordering::SeqCst);
+            let resolution = self
+                .policies
+                .lock()
+                .unwrap()
+                .get(&session_id)
+                .cloned()
+                .map(MemberPolicyResolution::Eligible)
+                .unwrap_or_else(|| {
+                    MemberPolicyResolution::PermanentIneligible("missing policy".to_string())
+                });
+            let blocked = self.blocked_resolution.lock().unwrap().take();
+            Box::pin(async move {
+                if let Some(blocked) = blocked {
+                    let _ = blocked.await;
+                }
+                resolution
+            })
+        }
+
+        fn check_session_live(&self, _session_id: Uuid) -> BoxFuture<'static, bool> {
+            self.live_checks.fetch_add(1, Ordering::SeqCst);
+            let live = self.live.load(Ordering::SeqCst);
+            Box::pin(async move { live })
+        }
+
+        fn retire_sample_registration(&self, session_id: Uuid) -> BoxFuture<'static, ()> {
+            self.retired.lock().unwrap().push(session_id);
+            Box::pin(async {})
+        }
+
+        fn prepare_attempt(
+            &self,
+            snapshot: AttemptSnapshot,
+            cancellation: CancellationToken,
+        ) -> BoxFuture<'static, AttemptPreparation> {
+            self.prepare_calls.lock().unwrap().push(snapshot.clone());
+            let policy = self
+                .policies
+                .lock()
+                .unwrap()
+                .get(&snapshot.session_id)
+                .cloned();
+            let target = self.target.clone();
+            Box::pin(async move {
+                let Some(policy) = policy else {
+                    return AttemptPreparation::Cancel {
+                        reason: "missing policy".to_string(),
+                        current_policy: None,
+                    };
+                };
+                let thresholds: Vec<u8> = snapshot
+                    .thresholds
+                    .iter()
+                    .copied()
+                    .filter(|threshold| policy.thresholds.contains(threshold))
+                    .collect();
+                if thresholds.is_empty() {
+                    return AttemptPreparation::Cancel {
+                        reason: "removed".to_string(),
+                        current_policy: Some(policy),
+                    };
+                }
+                let notice = InternalSystemNotice::for_context_alert(
+                    snapshot.fingerprint.member.clone(),
+                    snapshot.fingerprint.workgroup.clone(),
+                    snapshot.observed,
+                    thresholds,
+                )
+                .unwrap();
+                AttemptPreparation::Ready(ReadyAttempt {
+                    snapshot,
+                    current_policy: policy.thresholds,
+                    target,
+                    notice,
+                    guard: Arc::new(|| Ok(())),
+                    cancellation,
+                })
+            })
+        }
+
+        fn deliver_attempt(&self, attempt: ReadyAttempt) -> BoxFuture<'static, Result<(), String>> {
+            self.deliveries
+                .lock()
+                .unwrap()
+                .push(attempt.snapshot.clone());
+            if self.panic_next_delivery.swap(false, Ordering::SeqCst) {
+                return Box::pin(async move {
+                    panic!("scripted delivery panic");
+                });
+            }
+            if let Some(receiver) = self.blocked_delivery.lock().unwrap().take() {
+                return Box::pin(async move {
+                    receiver
+                        .await
+                        .unwrap_or_else(|_| Err("blocked delivery sender dropped".to_string()))
+                });
+            }
+            let result = self
+                .delivery_results
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(Ok(()));
+            Box::pin(async move { result })
+        }
+    }
+
+    async fn yield_until(mut predicate: impl FnMut() -> bool) {
+        for _ in 0..2_000 {
+            if predicate() {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            predicate(),
+            "condition did not become true after bounded yields"
+        );
+    }
+
+    struct IdentityFixture {
+        _temp: tempfile::TempDir,
+        session: Session,
+        team_config: PathBuf,
+        workspace: PathBuf,
+        workgroup: PathBuf,
+        replica: PathBuf,
+        member_matrix: PathBuf,
+    }
+
+    async fn identity_fixture() -> IdentityFixture {
+        identity_fixture_named("project-a", "wg-2-dev-team").await
+    }
+
+    async fn identity_fixture_named(project: &str, workgroup_name: &str) -> IdentityFixture {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join(project).join(".ac");
+        let workgroup = workspace.join(workgroup_name);
+        let replica = workgroup.join("__agent_member");
+        let coordinator_replica = workgroup.join("__agent_coordinator");
+        let nested = replica.join("repo-one").join("src");
+        let member_matrix = workspace.join("_agent_member");
+        let coordinator_matrix = workspace.join("_agent_coordinator");
+        let team = parse_team_from_workgroup_name(workgroup_name).unwrap();
+        let team_dir = workspace.join(format!("_team_{}", team));
+        for path in [
+            &nested,
+            &coordinator_replica,
+            &member_matrix,
+            &coordinator_matrix,
+            &team_dir,
+        ] {
+            std::fs::create_dir_all(path).unwrap();
+        }
+        std::fs::write(
+            replica.join("config.json"),
+            r#"{"identity":"../../_agent_member","context":[],"repos":[]}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            coordinator_replica.join("config.json"),
+            r#"{"identity":"../../_agent_coordinator","context":[],"repos":[]}"#,
+        )
+        .unwrap();
+        let team_config = team_dir.join("config.json");
+        std::fs::write(
+            &team_config,
+            r#"{"agents":["_agent_member","_agent_coordinator"],"coordinator":"_agent_coordinator","repos":[],"contextAlertPercentages":[50,75]}"#,
+        )
+        .unwrap();
+        let manager = SessionManager::new();
+        let session = manager
+            .create_session(
+                "claude".to_string(),
+                Vec::new(),
+                nested.to_string_lossy().to_string(),
+                Some("claude-profile".to_string()),
+                Some("Claude".to_string()),
+                Vec::new(),
+                false,
+                crate::pty::backend::SessionBackendKind::LocalProcess,
+            )
+            .await
+            .unwrap();
+        IdentityFixture {
+            _temp: temp,
+            session,
+            team_config,
+            workspace,
+            workgroup,
+            replica,
+            member_matrix,
+        }
+    }
+
+    fn fingerprint(id: Uuid) -> MemberIdentityFingerprint {
+        MemberIdentityFingerprint {
+            session_id: id,
+            agent_id: "claude".to_string(),
+            working_directory: "cwd".to_string(),
+            project_dir: PathBuf::from("project"),
+            workspace_dir: PathBuf::from("workspace"),
+            workgroup_dir: PathBuf::from("workgroup"),
+            replica_dir: PathBuf::from("replica"),
+            matrix_dir: PathBuf::from("matrix"),
+            project: "project".to_string(),
+            team: "team".to_string(),
+            workgroup: "wg-1-team".to_string(),
+            member: "member".to_string(),
+        }
+    }
+
+    fn eligible(id: Uuid, thresholds: &[u8]) -> MemberPolicyResolution {
+        MemberPolicyResolution::Eligible(ResolvedPolicy {
+            fingerprint: fingerprint(id),
+            thresholds: thresholds.to_vec(),
+        })
+    }
+
+    #[test]
+    fn first_high_coalesces_sorted_thresholds_and_unchanged_high_deduplicates() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 80, eligible(id, &[50, 75, 90]), now);
+        assert_eq!(state.batches.len(), 1);
+        let batch = state.batches.values().next().unwrap();
+        assert_eq!(batch.observed, 80);
+        assert_eq!(batch.thresholds, vec![50, 75]);
+
+        apply_numeric_resolution(&mut state, None, id, 80, eligible(id, &[50, 75, 90]), now);
+        assert_eq!(state.batches.len(), 1);
+    }
+
+    #[test]
+    fn first_below_exact_equality_and_successive_crossings_are_deterministic() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 49, eligible(id, &[50, 75]), now);
+        assert!(state.batches.is_empty());
+
+        apply_numeric_resolution(&mut state, None, id, 50, eligible(id, &[50, 75]), now);
+        apply_numeric_resolution(&mut state, None, id, 75, eligible(id, &[50, 75]), now);
+        let batches: Vec<&AlertBatch> = state.batches.values().collect();
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].thresholds, vec![50]);
+        assert_eq!(batches[0].observed, 50);
+        assert_eq!(batches[1].thresholds, vec![75]);
+        assert_eq!(batches[1].observed, 75);
+        assert!(batches[0].generation < batches[1].generation);
+    }
+
+    #[test]
+    fn policy_removal_prunes_pending_and_readd_starts_armed() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 80, eligible(id, &[50, 75]), now);
+        apply_numeric_resolution(&mut state, None, id, 80, eligible(id, &[75, 90]), now);
+        assert_eq!(state.batches.values().next().unwrap().thresholds, vec![75]);
+        assert_eq!(state.sessions[&id].latches[&90], LatchState::Armed);
+
+        apply_numeric_resolution(&mut state, None, id, 80, eligible(id, &[90]), now);
+        assert!(state.batches.is_empty());
+        apply_numeric_resolution(&mut state, None, id, 95, eligible(id, &[90]), now);
+        assert_eq!(state.batches.values().next().unwrap().thresholds, vec![90]);
+    }
+
+    #[test]
+    fn successful_notice_keeps_current_latch_and_allows_a_later_rearm() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 60, eligible(id, &[50]), now);
+        let generation = *state.batches.keys().next().unwrap();
+        state.remove_batch(generation);
+
+        apply_numeric_resolution(&mut state, None, id, 40, eligible(id, &[50]), now);
+        apply_numeric_resolution(&mut state, None, id, 55, eligible(id, &[50]), now);
+        assert_eq!(state.batches.len(), 1);
+        assert_ne!(*state.batches.keys().next().unwrap(), generation);
+    }
+
+    #[test]
+    fn partial_rearm_and_outstanding_dedup_are_threshold_scoped() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 92, eligible(id, &[50, 75, 90]), now);
+        apply_numeric_resolution(&mut state, None, id, 80, eligible(id, &[50, 75, 90]), now);
+        let session = state.sessions.get(&id).unwrap();
+        assert_eq!(session.latches[&50], LatchState::Latched);
+        assert_eq!(session.latches[&75], LatchState::Latched);
+        assert_eq!(session.latches[&90], LatchState::Armed);
+
+        apply_numeric_resolution(&mut state, None, id, 92, eligible(id, &[50, 75, 90]), now);
+        assert_eq!(
+            state.batches.len(),
+            1,
+            "90 remains outstanding in first batch"
+        );
+    }
+
+    #[test]
+    fn retry_schedule_caps_at_sixty_seconds_on_the_same_logical_batch() {
+        let expected = [5, 10, 20, 40, 60, 60];
+        for (failure_count, seconds) in expected.into_iter().enumerate() {
+            assert_eq!(
+                retry_delay((failure_count + 1) as u32),
+                Duration::from_secs(seconds)
+            );
+        }
+        assert_eq!(retry_delay(99), Duration::from_secs(60));
+
+        let id = Uuid::new_v4();
+        let mut now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 60, eligible(id, &[50]), now);
+        let generation = *state.batches.keys().next().unwrap();
+        for seconds in expected {
+            fail_batch(&mut state, generation, now, "scripted failure");
+            now += Duration::from_secs(seconds);
+            assert_eq!(state.batches[&generation].due_at, now);
+        }
+        assert_eq!(state.batches[&generation].failure_count, 6);
+        assert_eq!(state.sessions[&id].outstanding[&50], generation);
+    }
+
+    #[test]
+    fn partial_rearm_at_eighty_sixty_and_zero_is_exact() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        let policy = [50, 75, 90];
+
+        apply_numeric_resolution(&mut state, None, id, 92, eligible(id, &policy), now);
+        let first = *state.batches.keys().next().unwrap();
+        state.remove_batch(first);
+
+        apply_numeric_resolution(&mut state, None, id, 80, eligible(id, &policy), now);
+        assert_eq!(state.sessions[&id].latches[&50], LatchState::Latched);
+        assert_eq!(state.sessions[&id].latches[&75], LatchState::Latched);
+        assert_eq!(state.sessions[&id].latches[&90], LatchState::Armed);
+        apply_numeric_resolution(&mut state, None, id, 92, eligible(id, &policy), now);
+        assert_eq!(state.batches.values().next().unwrap().thresholds, vec![90]);
+        let second = *state.batches.keys().next().unwrap();
+        state.remove_batch(second);
+
+        apply_numeric_resolution(&mut state, None, id, 60, eligible(id, &policy), now);
+        assert_eq!(state.sessions[&id].latches[&50], LatchState::Latched);
+        assert_eq!(state.sessions[&id].latches[&75], LatchState::Armed);
+        assert_eq!(state.sessions[&id].latches[&90], LatchState::Armed);
+        apply_numeric_resolution(&mut state, None, id, 92, eligible(id, &policy), now);
+        assert_eq!(
+            state.batches.values().next().unwrap().thresholds,
+            vec![75, 90]
+        );
+        let third = *state.batches.keys().next().unwrap();
+        state.remove_batch(third);
+
+        apply_numeric_resolution(&mut state, None, id, 0, eligible(id, &policy), now);
+        assert!(state.sessions[&id]
+            .latches
+            .values()
+            .all(|latch| *latch == LatchState::Armed));
+        apply_numeric_resolution(&mut state, None, id, 92, eligible(id, &policy), now);
+        assert_eq!(
+            state.batches.values().next().unwrap().thresholds,
+            vec![50, 75, 90]
+        );
+    }
+
+    #[test]
+    fn decrease_while_pending_rearms_without_replacing_historical_batch() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 60, eligible(id, &[50]), now);
+        let generation = *state.batches.keys().next().unwrap();
+
+        apply_numeric_resolution(&mut state, None, id, 40, eligible(id, &[50]), now);
+        assert_eq!(state.sessions[&id].latches[&50], LatchState::Armed);
+        assert_eq!(state.batches[&generation].observed, 60);
+        apply_numeric_resolution(&mut state, None, id, 55, eligible(id, &[50]), now);
+
+        assert_eq!(state.sessions[&id].latches[&50], LatchState::Latched);
+        assert_eq!(state.batches.len(), 1);
+        assert_eq!(state.sessions[&id].outstanding[&50], generation);
+    }
+
+    #[tokio::test]
+    async fn in_flight_policy_pruning_cancels_and_replaces_only_survivors() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 90, eligible(id, &[50, 75]), now);
+        let original = *state.batches.keys().next().unwrap();
+        state.batches.get_mut(&original).unwrap().failure_count = 3;
+        state.batches.get_mut(&original).unwrap().in_flight = true;
+        let cancellation = CancellationToken::new();
+        let slot = InFlightSlot {
+            generation: original,
+            cancellation: cancellation.clone(),
+            join: tauri::async_runtime::spawn(async {}),
+        };
+
+        reconcile_policy(&mut state, Some(&slot), id, &fingerprint(id), &[75], now);
+
+        assert!(cancellation.is_cancelled());
+        assert!(!state.batches.contains_key(&original));
+        let replacement = state.batches.values().next().unwrap();
+        assert_ne!(replacement.generation, original);
+        assert_eq!(replacement.thresholds, vec![75]);
+        assert_eq!(replacement.observed, 90);
+        assert_eq!(replacement.failure_count, 3);
+        assert_eq!(replacement.due_at, now);
+        assert_eq!(state.sessions[&id].outstanding[&75], replacement.generation);
+        slot.join.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn exhausted_generation_fails_closed_for_in_flight_replacement() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 90, eligible(id, &[50, 75]), now);
+        let generation = *state.batches.keys().next().unwrap();
+        state.batches.get_mut(&generation).unwrap().in_flight = true;
+        state.next_generation = None;
+        let cancellation = CancellationToken::new();
+        let slot = InFlightSlot {
+            generation,
+            cancellation: cancellation.clone(),
+            join: tauri::async_runtime::spawn(async {}),
+        };
+
+        reconcile_policy(&mut state, Some(&slot), id, &fingerprint(id), &[75], now);
+
+        assert!(cancellation.is_cancelled());
+        assert!(state.batches.is_empty());
+        assert!(state.sessions[&id].outstanding.is_empty());
+        slot.join.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stale_matching_completion_clears_slot_without_mutating_replacement() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 90, eligible(id, &[50, 75]), now);
+        let original = *state.batches.keys().next().unwrap();
+        state.batches.get_mut(&original).unwrap().in_flight = true;
+        let cancellation = CancellationToken::new();
+        let mut in_flight = Some(InFlightSlot {
+            generation: original,
+            cancellation: cancellation.clone(),
+            join: tauri::async_runtime::spawn(async {}),
+        });
+        reconcile_policy(
+            &mut state,
+            in_flight.as_ref(),
+            id,
+            &fingerprint(id),
+            &[75],
+            now,
+        );
+        let replacement = *state.batches.keys().next().unwrap();
+        assert_ne!(replacement, original);
+
+        handle_delivery_completion(
+            &mut state,
+            &mut in_flight,
+            DeliveryCompletion {
+                generation: original,
+                result: Ok(()),
+            },
+            now,
+        )
+        .await;
+
+        assert!(in_flight.is_none());
+        assert!(cancellation.is_cancelled());
+        assert!(state.batches.contains_key(&replacement));
+        assert_eq!(state.batches[&replacement].thresholds, vec![75]);
+    }
+
+    #[tokio::test]
+    async fn explicit_policy_disable_cancels_in_flight_and_removes_all_state() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 60, eligible(id, &[50]), now);
+        let generation = *state.batches.keys().next().unwrap();
+        state.batches.get_mut(&generation).unwrap().in_flight = true;
+        let cancellation = CancellationToken::new();
+        let slot = InFlightSlot {
+            generation,
+            cancellation: cancellation.clone(),
+            join: tauri::async_runtime::spawn(async {}),
+        };
+
+        apply_numeric_resolution(
+            &mut state,
+            Some(&slot),
+            id,
+            60,
+            MemberPolicyResolution::Disabled(fingerprint(id)),
+            now,
+        );
+
+        assert!(cancellation.is_cancelled());
+        assert!(!state.sessions.contains_key(&id));
+        assert!(state.batches.is_empty());
+        slot.join.await.unwrap();
+    }
+
+    #[test]
+    fn retry_preparation_policy_addition_arms_but_does_not_evaluate_cached_usage() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 80, eligible(id, &[90]), now);
+        assert!(state.batches.is_empty());
+        assert_eq!(state.sessions[&id].last_valid_percent, Some(80));
+
+        reconcile_policy(&mut state, None, id, &fingerprint(id), &[50, 90], now);
+        assert!(state.batches.is_empty());
+        assert_eq!(state.sessions[&id].latches[&50], LatchState::Armed);
+
+        apply_numeric_resolution(&mut state, None, id, 80, eligible(id, &[50, 90]), now);
+        assert_eq!(state.batches.values().next().unwrap().thresholds, vec![50]);
+    }
+
+    #[test]
+    fn policy_pause_and_runtime_error_transitions_preserve_only_matching_identity() {
+        let id = Uuid::new_v4();
+        let first_error_id = Uuid::new_v4();
+        let first_pause_id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 60, eligible(id, &[50]), now);
+        let generation = *state.batches.keys().next().unwrap();
+
+        let paused = MemberPolicyResolution::Paused {
+            fingerprint: fingerprint(id),
+            class: "malformed",
+            message: "partial JSON".to_string(),
+        };
+        apply_numeric_resolution(&mut state, None, id, 70, paused.clone(), now);
+        let marker = state.sessions[&id].policy_error.clone();
+        apply_numeric_resolution(&mut state, None, id, 70, paused, now);
+        assert_eq!(state.sessions[&id].policy_error, marker);
+        assert!(state.batches.contains_key(&generation));
+        assert_eq!(state.sessions[&id].last_valid_percent, Some(60));
+
+        apply_numeric_resolution(&mut state, None, id, 70, eligible(id, &[50]), now);
+        assert!(state.sessions[&id].policy_error.is_none());
+        assert_eq!(state.batches.len(), 1, "repair must not duplicate a latch");
+
+        apply_numeric_resolution(
+            &mut state,
+            None,
+            first_pause_id,
+            90,
+            MemberPolicyResolution::Paused {
+                fingerprint: fingerprint(first_pause_id),
+                class: "malformed",
+                message: "first partial read".to_string(),
+            },
+            now,
+        );
+        assert!(state.sessions[&first_pause_id].last_valid_percent.is_none());
+        assert!(state
+            .batches
+            .values()
+            .all(|batch| batch.session_id != first_pause_id));
+        apply_numeric_resolution(
+            &mut state,
+            None,
+            first_pause_id,
+            90,
+            eligible(first_pause_id, &[50]),
+            now,
+        );
+        assert!(state
+            .batches
+            .values()
+            .any(|batch| batch.session_id == first_pause_id));
+
+        apply_numeric_resolution(
+            &mut state,
+            None,
+            first_error_id,
+            90,
+            MemberPolicyResolution::RetryableFailure("blocking join failed".to_string()),
+            now,
+        );
+        assert!(state.sessions[&first_error_id].fingerprint.is_none());
+        assert!(state.sessions[&first_error_id].last_valid_percent.is_none());
+        assert!(state
+            .batches
+            .values()
+            .all(|batch| batch.session_id != first_error_id));
+        apply_numeric_resolution(
+            &mut state,
+            None,
+            first_error_id,
+            90,
+            eligible(first_error_id, &[50]),
+            now,
+        );
+        assert!(state.sessions[&first_error_id].runtime_error.is_none());
+        assert!(state
+            .batches
+            .values()
+            .any(|batch| batch.session_id == first_error_id));
+
+        let mut changed = fingerprint(id);
+        changed.member = "replacement".to_string();
+        apply_numeric_resolution(
+            &mut state,
+            None,
+            id,
+            70,
+            MemberPolicyResolution::Paused {
+                fingerprint: changed.clone(),
+                class: "invalid",
+                message: "changed identity".to_string(),
+            },
+            now,
+        );
+        assert_eq!(state.sessions[&id].fingerprint.as_ref(), Some(&changed));
+        assert!(state.batches.values().all(|batch| batch.session_id != id));
+        assert!(state.sessions[&id].last_valid_percent.is_none());
+    }
+
+    #[test]
+    fn earliest_deadline_and_generation_tie_break_prevent_failed_batch_starvation() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 60, eligible(id, &[50, 75]), now);
+        apply_numeric_resolution(&mut state, None, id, 80, eligible(id, &[50, 75]), now);
+        let generations: Vec<u64> = state.batches.keys().copied().collect();
+        assert_eq!(state.earliest_due(), Some((now, generations[0])));
+
+        fail_batch(&mut state, generations[0], now, "permanent first failure");
+        assert_eq!(state.earliest_due(), Some((now, generations[1])));
+        assert_eq!(state.batches[&generations[0]].failure_count, 1);
+        assert_eq!(state.batches[&generations[1]].failure_count, 0);
+    }
+
+    #[test]
+    fn exhausted_new_crossing_never_wraps_or_corrupts_existing_batch() {
+        let existing_id = Uuid::new_v4();
+        let exhausted_id = Uuid::new_v4();
+        let now = Instant::now();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(
+            &mut state,
+            None,
+            existing_id,
+            60,
+            eligible(existing_id, &[50]),
+            now,
+        );
+        let existing_generation = *state.batches.keys().next().unwrap();
+        state.next_generation = None;
+        apply_numeric_resolution(
+            &mut state,
+            None,
+            exhausted_id,
+            60,
+            eligible(exhausted_id, &[50]),
+            now,
+        );
+
+        assert_eq!(state.batches.len(), 1);
+        assert!(state.batches.contains_key(&existing_generation));
+        assert_eq!(
+            state.sessions[&exhausted_id].latches[&50],
+            LatchState::Latched
+        );
+        assert!(state.sessions[&exhausted_id].outstanding.is_empty());
+    }
+
+    #[tokio::test]
+    async fn blocking_identity_resolution_classifies_valid_malformed_and_missing_policy() {
+        let fixture = identity_fixture().await;
+        let policy = match resolve_member_policy_blocking(&fixture.session) {
+            MemberPolicyResolution::Eligible(policy) => policy,
+            other => panic!("expected eligible resolution, got {other:?}"),
+        };
+        assert_eq!(policy.thresholds, vec![50, 75]);
+        assert_eq!(policy.fingerprint.project, "project-a");
+        assert_eq!(policy.fingerprint.workgroup, "wg-2-dev-team");
+        assert_eq!(policy.fingerprint.member, "member");
+        assert!(policy.fingerprint.replica_dir.is_absolute());
+
+        let (target, notice) =
+            prepare_internal_route_blocking(&policy.fingerprint, 80, &[50, 75]).unwrap();
+        assert_eq!(target.fqn(), "project-a:wg-2-dev-team/coordinator");
+        assert_eq!(notice.thresholds(), &[50, 75]);
+
+        std::fs::write(&fixture.team_config, b"{partial").unwrap();
+        match resolve_member_policy_blocking(&fixture.session) {
+            MemberPolicyResolution::Paused { class, .. } => assert_eq!(class, "malformed"),
+            other => panic!("expected paused malformed resolution, got {other:?}"),
+        }
+
+        std::fs::remove_file(&fixture.team_config).unwrap();
+        assert!(matches!(
+            resolve_member_policy_blocking(&fixture.session),
+            MemberPolicyResolution::PermanentIneligible(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn production_attempt_guard_rechecks_cancellation_purge_registration_policy_and_route() {
+        let fixture = identity_fixture().await;
+        let policy = match resolve_member_policy_blocking(&fixture.session) {
+            MemberPolicyResolution::Eligible(policy) => policy,
+            other => panic!("expected eligible resolution, got {other:?}"),
+        };
+        let (target, _) =
+            prepare_internal_route_blocking(&policy.fingerprint, 80, &[50, 75]).unwrap();
+        let scraper = ContextScraper::new(
+            Arc::new(GuardRows),
+            Arc::new(GuardPatterns),
+            Arc::new(GuardEvents),
+            Arc::new(GuardSamples),
+        );
+        scraper.register_session(fixture.session.id, "claude".to_string());
+        let purge = Arc::new(crate::session::purge_guard::PurgeGuard::default());
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&scraper))
+            .manage(Arc::clone(&purge))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let app_handle = app.handle().clone();
+        let cancellation = CancellationToken::new();
+
+        validate_attempt_guard(
+            &app_handle,
+            &policy.fingerprint,
+            &target,
+            &[50, 75],
+            &cancellation,
+        )
+        .unwrap();
+
+        let canceled = CancellationToken::new();
+        canceled.cancel();
+        assert!(validate_attempt_guard(
+            &app_handle,
+            &policy.fingerprint,
+            &target,
+            &[50, 75],
+            &canceled,
+        )
+        .unwrap_err()
+        .contains("canceled"));
+
+        let purge_lease = purge
+            .acquire(HashSet::new(), HashSet::from([target.fqn().to_string()]))
+            .await;
+        assert!(validate_attempt_guard(
+            &app_handle,
+            &policy.fingerprint,
+            &target,
+            &[50, 75],
+            &cancellation,
+        )
+        .unwrap_err()
+        .contains("purge-wg"));
+        drop(purge_lease);
+
+        std::fs::write(
+            &fixture.team_config,
+            r#"{"agents":["_agent_member","_agent_coordinator"],"coordinator":"_agent_coordinator","repos":[],"contextAlertPercentages":[75]}"#,
+        )
+        .unwrap();
+        assert!(validate_attempt_guard(
+            &app_handle,
+            &policy.fingerprint,
+            &target,
+            &[50, 75],
+            &cancellation,
+        )
+        .unwrap_err()
+        .contains("policy changed"));
+
+        std::fs::write(
+            &fixture.team_config,
+            r#"{"agents":["_agent_member","_agent_coordinator"],"coordinator":"_agent_member","repos":[],"contextAlertPercentages":[50,75]}"#,
+        )
+        .unwrap();
+        assert!(validate_attempt_guard(
+            &app_handle,
+            &policy.fingerprint,
+            &target,
+            &[50, 75],
+            &cancellation,
+        )
+        .unwrap_err()
+        .contains("Coordinator target changed"));
+
+        std::fs::write(
+            &fixture.team_config,
+            r#"{"agents":["_agent_coordinator"],"coordinator":"_agent_coordinator","repos":[],"contextAlertPercentages":[50,75]}"#,
+        )
+        .unwrap();
+        assert!(validate_attempt_guard(
+            &app_handle,
+            &policy.fingerprint,
+            &target,
+            &[50, 75],
+            &cancellation,
+        )
+        .unwrap_err()
+        .contains("roster"));
+
+        scraper.unregister_session(fixture.session.id);
+        assert!(validate_attempt_guard(
+            &app_handle,
+            &policy.fingerprint,
+            &target,
+            &[50, 75],
+            &cancellation,
+        )
+        .unwrap_err()
+        .contains("no longer registered"));
+    }
+
+    #[tokio::test]
+    async fn identity_resolution_rejects_invalid_roster_matrix_and_cwd_shapes() {
+        let roster = identity_fixture().await;
+        std::fs::write(
+            &roster.team_config,
+            r#"{"agents":["_agent_coordinator"],"coordinator":"_agent_coordinator","repos":[],"contextAlertPercentages":[50]}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            resolve_member_policy_blocking(&roster.session),
+            MemberPolicyResolution::PermanentIneligible(_)
+        ));
+
+        let missing_matrix = identity_fixture().await;
+        std::fs::remove_dir_all(&missing_matrix.member_matrix).unwrap();
+        assert!(matches!(
+            resolve_member_policy_blocking(&missing_matrix.session),
+            MemberPolicyResolution::PermanentIneligible(_)
+        ));
+
+        let ad_hoc = identity_fixture().await;
+        let mut ad_hoc_session = ad_hoc.session.clone();
+        ad_hoc_session.working_directory = ad_hoc.workspace.to_string_lossy().to_string();
+        assert!(matches!(
+            resolve_member_policy_blocking(&ad_hoc_session),
+            MemberPolicyResolution::PermanentIneligible(_)
+        ));
+
+        let origin = identity_fixture().await;
+        let mut origin_session = origin.session.clone();
+        origin_session.working_directory = origin.member_matrix.to_string_lossy().to_string();
+        assert!(matches!(
+            resolve_member_policy_blocking(&origin_session),
+            MemberPolicyResolution::PermanentIneligible(_)
+        ));
+
+        let lookalike = identity_fixture().await;
+        let nested_lookalike = lookalike
+            .replica
+            .join("repo-one")
+            .join("__agent_impostor")
+            .join("src");
+        std::fs::create_dir_all(&nested_lookalike).unwrap();
+        let mut lookalike_session = lookalike.session.clone();
+        lookalike_session.working_directory = nested_lookalike.to_string_lossy().to_string();
+        assert!(matches!(
+            resolve_member_policy_blocking(&lookalike_session),
+            MemberPolicyResolution::PermanentIneligible(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn identity_resolution_distinguishes_unreadable_malformed_invalid_and_missing_config() {
+        let unreadable = identity_fixture().await;
+        std::fs::remove_file(&unreadable.team_config).unwrap();
+        std::fs::create_dir(&unreadable.team_config).unwrap();
+        match resolve_member_policy_blocking(&unreadable.session) {
+            MemberPolicyResolution::Paused { class, .. } => assert_eq!(class, "unreadable"),
+            other => panic!("expected unreadable pause, got {other:?}"),
+        }
+
+        let malformed = identity_fixture().await;
+        std::fs::write(&malformed.team_config, b"{partial").unwrap();
+        match resolve_member_policy_blocking(&malformed.session) {
+            MemberPolicyResolution::Paused { class, .. } => assert_eq!(class, "malformed"),
+            other => panic!("expected malformed pause, got {other:?}"),
+        }
+
+        let invalid = identity_fixture().await;
+        std::fs::write(
+            &invalid.team_config,
+            r#"{"agents":["_agent_member","_agent_coordinator"],"coordinator":"_agent_coordinator","repos":[],"contextAlertPercentages":[0]}"#,
+        )
+        .unwrap();
+        match resolve_member_policy_blocking(&invalid.session) {
+            MemberPolicyResolution::Paused { class, .. } => assert_eq!(class, "invalid"),
+            other => panic!("expected invalid pause, got {other:?}"),
+        }
+
+        let missing = identity_fixture().await;
+        std::fs::remove_file(&missing.team_config).unwrap();
+        assert!(matches!(
+            resolve_member_policy_blocking(&missing.session),
+            MemberPolicyResolution::PermanentIneligible(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn exact_workgroups_and_same_spelled_filesystem_roots_never_share_target_capability() {
+        let first_workgroup = identity_fixture_named("same-project", "wg-1-dev-team").await;
+        let second_workgroup = identity_fixture_named("same-project", "wg-2-dev-team").await;
+        let first_policy = match resolve_member_policy_blocking(&first_workgroup.session) {
+            MemberPolicyResolution::Eligible(policy) => policy,
+            other => panic!("expected first policy, got {other:?}"),
+        };
+        let second_policy = match resolve_member_policy_blocking(&second_workgroup.session) {
+            MemberPolicyResolution::Eligible(policy) => policy,
+            other => panic!("expected second policy, got {other:?}"),
+        };
+        let (first_target, _) =
+            prepare_internal_route_blocking(&first_policy.fingerprint, 80, &[50]).unwrap();
+        let (second_target, _) =
+            prepare_internal_route_blocking(&second_policy.fingerprint, 80, &[50]).unwrap();
+        assert_eq!(first_target.fqn(), "same-project:wg-1-dev-team/coordinator");
+        assert_eq!(
+            second_target.fqn(),
+            "same-project:wg-2-dev-team/coordinator"
+        );
+        assert_ne!(first_target, second_target);
+
+        let other_project = identity_fixture_named("other-project", "wg-1-dev-team").await;
+        let other_policy = match resolve_member_policy_blocking(&other_project.session) {
+            MemberPolicyResolution::Eligible(policy) => policy,
+            other => panic!("expected other-project policy, got {other:?}"),
+        };
+        let (other_target, _) =
+            prepare_internal_route_blocking(&other_policy.fingerprint, 80, &[50]).unwrap();
+        assert_eq!(
+            other_target.fqn(),
+            "other-project:wg-1-dev-team/coordinator"
+        );
+        assert_ne!(first_target, other_target);
+
+        let same_spelling_a = identity_fixture_named("same-project", "wg-3-dev-team").await;
+        let same_spelling_b = identity_fixture_named("same-project", "wg-3-dev-team").await;
+        let policy_a = match resolve_member_policy_blocking(&same_spelling_a.session) {
+            MemberPolicyResolution::Eligible(policy) => policy,
+            other => panic!("expected same-spelling policy A, got {other:?}"),
+        };
+        let policy_b = match resolve_member_policy_blocking(&same_spelling_b.session) {
+            MemberPolicyResolution::Eligible(policy) => policy,
+            other => panic!("expected same-spelling policy B, got {other:?}"),
+        };
+        let (target_a, _) =
+            prepare_internal_route_blocking(&policy_a.fingerprint, 80, &[50]).unwrap();
+        let (target_b, _) =
+            prepare_internal_route_blocking(&policy_b.fingerprint, 80, &[50]).unwrap();
+        assert_eq!(target_a.fqn(), target_b.fqn());
+        assert_ne!(target_a.replica_dir(), target_b.replica_dir());
+        assert_ne!(target_a, target_b);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn coordinator_route_rejects_symlink_before_repair_capable_resolver() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = identity_fixture().await;
+        let policy = match resolve_member_policy_blocking(&fixture.session) {
+            MemberPolicyResolution::Eligible(policy) => policy,
+            other => panic!("expected eligible policy, got {other:?}"),
+        };
+        let expected = fixture.workgroup.join("__agent_coordinator");
+        let real = fixture.workgroup.join("coordinator-real");
+        std::fs::rename(&expected, &real).unwrap();
+        symlink(&real, &expected).unwrap();
+
+        let error = prepare_internal_route_blocking(&policy.fingerprint, 80, &[50]).unwrap_err();
+        assert!(error.contains("real non-link directory"));
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn coordinator_route_rejects_reparse_before_repair_capable_resolver() {
+        let fixture = identity_fixture().await;
+        let policy = match resolve_member_policy_blocking(&fixture.session) {
+            MemberPolicyResolution::Eligible(policy) => policy,
+            other => panic!("expected eligible policy, got {other:?}"),
+        };
+        let expected = fixture.workgroup.join("__agent_coordinator");
+        let real = fixture.workgroup.join("coordinator-real");
+        std::fs::rename(&expected, &real).unwrap();
+        let output = std::process::Command::new("cmd")
+            .args([
+                "/C",
+                "mklink",
+                "/J",
+                expected.to_str().unwrap(),
+                real.to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        if !output.status.success() {
+            println!(
+                "skipping coordinator reparse check: stdout: {} stderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        let error = prepare_internal_route_blocking(&policy.fingerprint, 80, &[50]).unwrap_err();
+        assert!(error.contains("real non-link directory"));
+        let _ = std::fs::remove_dir(&expected);
+    }
+
+    #[tokio::test]
+    async fn post_filesystem_snapshot_recheck_rejects_end_removal_and_identity_changes() {
+        let fixture = identity_fixture().await;
+        let original = fixture.session.clone();
+        let agent = original.agent_id.as_deref().unwrap();
+        assert!(session_matches_policy_snapshot(
+            Some(&original),
+            original.id,
+            agent,
+            &original.working_directory,
+            true,
+        ));
+
+        let mut normal_transition = original.clone();
+        normal_transition.status = SessionStatus::Idle;
+        assert!(session_matches_policy_snapshot(
+            Some(&normal_transition),
+            original.id,
+            agent,
+            &original.working_directory,
+            true,
+        ));
+
+        let mut active_transition = original.clone();
+        active_transition.status = SessionStatus::Active;
+        assert!(session_matches_policy_snapshot(
+            Some(&active_transition),
+            original.id,
+            agent,
+            &original.working_directory,
+            true,
+        ));
+
+        let mut exited = original.clone();
+        exited.status = SessionStatus::Exited(0);
+        assert!(!session_matches_policy_snapshot(
+            Some(&exited),
+            original.id,
+            agent,
+            &original.working_directory,
+            true,
+        ));
+        let mut root = original.clone();
+        root.is_root_agent = true;
+        assert!(!session_matches_policy_snapshot(
+            Some(&root),
+            original.id,
+            agent,
+            &original.working_directory,
+            true,
+        ));
+        let mut agentless = original.clone();
+        agentless.agent_id = None;
+        assert!(!session_matches_policy_snapshot(
+            Some(&agentless),
+            original.id,
+            agent,
+            &original.working_directory,
+            true,
+        ));
+        assert!(!session_matches_policy_snapshot(
+            None,
+            original.id,
+            agent,
+            &original.working_directory,
+            true,
+        ));
+        assert!(!session_matches_policy_snapshot(
+            Some(&original),
+            original.id,
+            agent,
+            &original.working_directory,
+            false,
+        ));
+
+        let mut changed_agent = original.clone();
+        changed_agent.agent_id = Some("other-agent".to_string());
+        assert!(!session_matches_policy_snapshot(
+            Some(&changed_agent),
+            original.id,
+            agent,
+            &original.working_directory,
+            true,
+        ));
+        let mut changed_cwd = original.clone();
+        changed_cwd.working_directory = fixture.workgroup.to_string_lossy().to_string();
+        assert!(!session_matches_policy_snapshot(
+            Some(&changed_cwd),
+            original.id,
+            agent,
+            &original.working_directory,
+            true,
+        ));
+    }
+
+    #[test]
+    fn project_fqn_component_rejects_empty_colon_control_and_missing_utf8_name() {
+        assert_eq!(
+            validated_project_fqn_component(Some("project-a")).unwrap(),
+            "project-a"
+        );
+        for invalid in [None, Some(""), Some("project:a"), Some("project\nname")] {
+            assert!(validated_project_fqn_component(invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn generation_exhaustion_never_wraps() {
+        let mut state = ActorState::new();
+        state.next_generation = Some(u64::MAX);
+        assert_eq!(state.allocate_generation(), Some(u64::MAX));
+        assert_eq!(state.allocate_generation(), None);
+    }
+
+    #[tokio::test]
+    async fn actor_uses_manual_retry_clock_and_monitor_shutdown_is_idempotent() {
+        let id = Uuid::new_v4();
+        let runtime = ScriptedRuntime::new();
+        runtime.set_policy(id, &[50]);
+        runtime
+            .delivery_results
+            .lock()
+            .unwrap()
+            .extend([Err("first failure".to_string()), Ok(())]);
+        let clock = ManualClock::new(Instant::now());
+        let shutdown = CancellationToken::new();
+        let monitor = ContextAlertMonitor::start_with_runtime(
+            Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>,
+            Arc::clone(&clock) as Arc<dyn AlertClock>,
+            shutdown,
+        );
+
+        monitor
+            .sender()
+            .send(ContextSample::Reading {
+                session_id: id,
+                percent: 60,
+            })
+            .await
+            .unwrap();
+        yield_until(|| runtime.delivery_count() == 1).await;
+        yield_until(|| clock.has_live_waiter_within(Duration::from_secs(5))).await;
+
+        clock.advance(Duration::from_secs(4));
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(runtime.delivery_count(), 1);
+
+        clock.advance(Duration::from_secs(1));
+        yield_until(|| runtime.delivery_count() == 2).await;
+        {
+            let deliveries = runtime.deliveries.lock().unwrap();
+            assert_eq!(deliveries[0].generation, deliveries[1].generation);
+            assert_eq!(deliveries[0].thresholds, vec![50]);
+        }
+
+        monitor.close_and_join().await.unwrap();
+        monitor.close_and_join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn shutdown_cancels_but_joins_the_single_in_flight_delivery() {
+        let id = Uuid::new_v4();
+        let runtime = ScriptedRuntime::new();
+        runtime.set_policy(id, &[50]);
+        let release = runtime.block_next_delivery();
+        let monitor = ContextAlertMonitor::start_with_runtime(
+            Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>,
+            ManualClock::new(Instant::now()) as Arc<dyn AlertClock>,
+            CancellationToken::new(),
+        );
+        monitor
+            .sender()
+            .send(ContextSample::Reading {
+                session_id: id,
+                percent: 60,
+            })
+            .await
+            .unwrap();
+        yield_until(|| runtime.delivery_count() == 1).await;
+
+        let closing_monitor = Arc::clone(&monitor);
+        let close = tokio::spawn(async move { closing_monitor.close_and_join().await });
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !close.is_finished(),
+            "shutdown must join, not detach, delivery"
+        );
+        release.send(Ok(())).unwrap();
+        close.await.unwrap().unwrap();
+        monitor.close_and_join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unavailable_preserves_latches_and_impossible_reading_is_rejected() {
+        let id = Uuid::new_v4();
+        let now = Instant::now();
+        let runtime = ScriptedRuntime::new();
+        runtime.set_policy(id, &[50]);
+        let runtime_dyn = Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>;
+        let clock = ManualClock::new(now);
+        let clock_dyn = Arc::clone(&clock) as Arc<dyn AlertClock>;
+        let shutdown = CancellationToken::new();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, id, 60, eligible(id, &[50]), now);
+        let generation = *state.batches.keys().next().unwrap();
+
+        process_sample(
+            &runtime_dyn,
+            &clock_dyn,
+            &mut state,
+            None,
+            ContextSample::Unavailable { session_id: id },
+            &shutdown,
+        )
+        .await;
+        apply_numeric_resolution(&mut state, None, id, 60, eligible(id, &[50]), now);
+        assert_eq!(state.batches.len(), 1);
+        assert!(state.batches.contains_key(&generation));
+        assert_eq!(state.sessions[&id].last_valid_percent, Some(60));
+
+        let resolves_before = runtime.resolve_calls.load(Ordering::SeqCst);
+        process_sample(
+            &runtime_dyn,
+            &clock_dyn,
+            &mut state,
+            None,
+            ContextSample::Reading {
+                session_id: id,
+                percent: 101,
+            },
+            &shutdown,
+        )
+        .await;
+        assert_eq!(
+            runtime.resolve_calls.load(Ordering::SeqCst),
+            resolves_before
+        );
+        assert!(state.batches.contains_key(&generation));
+
+        runtime.live.store(false, Ordering::SeqCst);
+        process_sample(
+            &runtime_dyn,
+            &clock_dyn,
+            &mut state,
+            None,
+            ContextSample::Unavailable { session_id: id },
+            &shutdown,
+        )
+        .await;
+        assert!(!state.sessions.contains_key(&id));
+        assert!(runtime.retired.lock().unwrap().contains(&id));
+    }
+
+    #[tokio::test]
+    async fn definite_end_has_no_tombstone_and_new_uuid_starts_fresh() {
+        let old_id = Uuid::new_v4();
+        let new_id = Uuid::new_v4();
+        let now = Instant::now();
+        let runtime = ScriptedRuntime::new();
+        let runtime_dyn = Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>;
+        let clock = ManualClock::new(now) as Arc<dyn AlertClock>;
+        let shutdown = CancellationToken::new();
+        let mut state = ActorState::new();
+        apply_numeric_resolution(&mut state, None, old_id, 60, eligible(old_id, &[50]), now);
+
+        process_sample(
+            &runtime_dyn,
+            &clock,
+            &mut state,
+            None,
+            ContextSample::SessionOver { session_id: old_id },
+            &shutdown,
+        )
+        .await;
+        assert!(!state.sessions.contains_key(&old_id));
+        assert!(state.batches.is_empty());
+
+        apply_numeric_resolution(
+            &mut state,
+            None,
+            old_id,
+            60,
+            MemberPolicyResolution::PermanentIneligible("stale queued UUID".to_string()),
+            now,
+        );
+        assert!(!state.sessions.contains_key(&old_id));
+        apply_numeric_resolution(&mut state, None, new_id, 60, eligible(new_id, &[50]), now);
+        assert_eq!(state.batches.values().next().unwrap().session_id, new_id);
+    }
+
+    #[tokio::test]
+    async fn one_global_delivery_slot_keeps_samples_and_maintenance_live() {
+        let id = Uuid::new_v4();
+        let runtime = ScriptedRuntime::new();
+        runtime.set_policy(id, &[50, 75]);
+        let release = runtime.block_next_delivery();
+        let clock = ManualClock::new(Instant::now());
+        let monitor = ContextAlertMonitor::start_with_runtime(
+            Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>,
+            Arc::clone(&clock) as Arc<dyn AlertClock>,
+            CancellationToken::new(),
+        );
+
+        monitor
+            .sender()
+            .send(ContextSample::Reading {
+                session_id: id,
+                percent: 60,
+            })
+            .await
+            .unwrap();
+        yield_until(|| runtime.delivery_count() == 1).await;
+        monitor
+            .sender()
+            .send(ContextSample::Reading {
+                session_id: id,
+                percent: 80,
+            })
+            .await
+            .unwrap();
+        yield_until(|| runtime.resolve_calls.load(Ordering::SeqCst) >= 2).await;
+        assert_eq!(
+            runtime.delivery_count(),
+            1,
+            "the second due batch must wait"
+        );
+
+        yield_until(|| clock.has_live_waiter_within(CONTEXT_ALERT_MAINTENANCE_INTERVAL)).await;
+        clock.advance(CONTEXT_ALERT_MAINTENANCE_INTERVAL);
+        yield_until(|| runtime.live_checks.load(Ordering::SeqCst) >= 1).await;
+        assert_eq!(runtime.delivery_count(), 1);
+
+        release.send(Ok(())).unwrap();
+        yield_until(|| runtime.delivery_count() == 2).await;
+        {
+            let deliveries = runtime.deliveries.lock().unwrap();
+            assert_eq!(deliveries[0].thresholds, vec![50]);
+            assert_eq!(deliveries[1].thresholds, vec![75]);
+            assert!(deliveries[0].generation < deliveries[1].generation);
+        }
+        monitor.close_and_join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn large_clock_jump_coalesces_missed_maintenance_intervals() {
+        let id = Uuid::new_v4();
+        let runtime = ScriptedRuntime::new();
+        runtime.set_policy(id, &[50]);
+        let clock = ManualClock::new(Instant::now());
+        let monitor = ContextAlertMonitor::start_with_runtime(
+            Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>,
+            Arc::clone(&clock) as Arc<dyn AlertClock>,
+            CancellationToken::new(),
+        );
+        monitor
+            .sender()
+            .send(ContextSample::Reading {
+                session_id: id,
+                percent: 40,
+            })
+            .await
+            .unwrap();
+        yield_until(|| runtime.resolve_calls.load(Ordering::SeqCst) == 1).await;
+        yield_until(|| clock.has_live_waiter_within(CONTEXT_ALERT_MAINTENANCE_INTERVAL)).await;
+
+        clock.advance(CONTEXT_ALERT_MAINTENANCE_INTERVAL * 10);
+        yield_until(|| runtime.live_checks.load(Ordering::SeqCst) == 1).await;
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(runtime.live_checks.load(Ordering::SeqCst), 1);
+        assert!(clock.has_live_waiter_within(CONTEXT_ALERT_MAINTENANCE_INTERVAL));
+        monitor.close_and_join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn delivery_task_panic_is_one_retryable_failure_for_same_generation() {
+        let id = Uuid::new_v4();
+        let runtime = ScriptedRuntime::new();
+        runtime.set_policy(id, &[50]);
+        runtime.panic_next_delivery.store(true, Ordering::SeqCst);
+        let clock = ManualClock::new(Instant::now());
+        let monitor = ContextAlertMonitor::start_with_runtime(
+            Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>,
+            Arc::clone(&clock) as Arc<dyn AlertClock>,
+            CancellationToken::new(),
+        );
+        monitor
+            .sender()
+            .send(ContextSample::Reading {
+                session_id: id,
+                percent: 60,
+            })
+            .await
+            .unwrap();
+        yield_until(|| runtime.delivery_count() == 1).await;
+        yield_until(|| clock.has_live_waiter_within(Duration::from_secs(5))).await;
+        clock.advance(Duration::from_secs(5));
+        yield_until(|| runtime.delivery_count() == 2).await;
+        {
+            let deliveries = runtime.deliveries.lock().unwrap();
+            assert_eq!(deliveries[0].generation, deliveries[1].generation);
+        }
+        monitor.close_and_join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn closed_sample_receiver_keeps_due_retry_and_biased_deadline_live() {
+        let id = Uuid::new_v4();
+        let runtime = ScriptedRuntime::new();
+        runtime.set_policy(id, &[50]);
+        runtime
+            .delivery_results
+            .lock()
+            .unwrap()
+            .extend([Err("retry".to_string()), Ok(())]);
+        let clock = ManualClock::new(Instant::now());
+        let shutdown = CancellationToken::new();
+        let (sender, receiver) = mpsc::channel(2_048);
+        let actor = tauri::async_runtime::spawn(run_context_alert_actor(
+            Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>,
+            Arc::clone(&clock) as Arc<dyn AlertClock>,
+            receiver,
+            shutdown.clone(),
+        ));
+        sender
+            .send(ContextSample::Reading {
+                session_id: id,
+                percent: 60,
+            })
+            .await
+            .unwrap();
+        yield_until(|| runtime.delivery_count() == 1).await;
+        yield_until(|| clock.has_live_waiter_within(Duration::from_secs(5))).await;
+        for _ in 0..1_000 {
+            sender
+                .try_send(ContextSample::Unavailable { session_id: id })
+                .unwrap();
+        }
+        drop(sender);
+        clock.advance(Duration::from_secs(5));
+        yield_until(|| runtime.delivery_count() == 2).await;
+        assert!(
+            runtime.live_checks.load(Ordering::SeqCst) < 1_000,
+            "the biased due deadline must run before draining a ready sample backlog"
+        );
+
+        shutdown.cancel();
+        actor.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn shutdown_interrupts_blocked_resolution_without_detaching_actor() {
+        let id = Uuid::new_v4();
+        let runtime = ScriptedRuntime::new();
+        runtime.set_policy(id, &[50]);
+        let blocked = runtime.block_next_resolution();
+        let monitor = ContextAlertMonitor::start_with_runtime(
+            Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>,
+            ManualClock::new(Instant::now()) as Arc<dyn AlertClock>,
+            CancellationToken::new(),
+        );
+        monitor
+            .sender()
+            .send(ContextSample::Reading {
+                session_id: id,
+                percent: 60,
+            })
+            .await
+            .unwrap();
+        yield_until(|| runtime.resolve_calls.load(Ordering::SeqCst) == 1).await;
+
+        tokio::time::timeout(Duration::from_secs(1), monitor.close_and_join())
+            .await
+            .expect("shutdown must cancel a blocked resolution")
+            .unwrap();
+        drop(blocked);
+        assert_eq!(runtime.delivery_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn new_monitor_instance_models_restart_and_first_high_alerts_again() {
+        let id = Uuid::new_v4();
+        let runtime = ScriptedRuntime::new();
+        runtime.set_policy(id, &[50]);
+        for expected in 1..=2 {
+            let monitor = ContextAlertMonitor::start_with_runtime(
+                Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>,
+                ManualClock::new(Instant::now()) as Arc<dyn AlertClock>,
+                CancellationToken::new(),
+            );
+            monitor
+                .sender()
+                .send(ContextSample::Reading {
+                    session_id: id,
+                    percent: 60,
+                })
+                .await
+                .unwrap();
+            yield_until(|| runtime.delivery_count() == expected).await;
+            monitor.close_and_join().await.unwrap();
+        }
+        assert_ne!(
+            runtime.deliveries.lock().unwrap()[0].generation,
+            0,
+            "each process-local actor begins at a checked nonzero generation"
+        );
+        assert_eq!(runtime.deliveries.lock().unwrap()[0].generation, 1);
+        assert_eq!(runtime.deliveries.lock().unwrap()[1].generation, 1);
+    }
+
+    #[tokio::test]
+    async fn maintenance_retires_state_when_a_dropped_end_is_witnessed_as_not_live() {
+        let id = Uuid::new_v4();
+        let runtime = ScriptedRuntime::new();
+        runtime.set_policy(id, &[50]);
+        let clock = ManualClock::new(Instant::now());
+        let monitor = ContextAlertMonitor::start_with_runtime(
+            Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>,
+            Arc::clone(&clock) as Arc<dyn AlertClock>,
+            CancellationToken::new(),
+        );
+
+        monitor
+            .sender()
+            .send(ContextSample::Reading {
+                session_id: id,
+                percent: 40,
+            })
+            .await
+            .unwrap();
+        yield_until(|| runtime.resolve_calls.load(Ordering::SeqCst) == 1).await;
+        yield_until(|| clock.has_live_waiter_within(CONTEXT_ALERT_MAINTENANCE_INTERVAL)).await;
+        runtime.live.store(false, Ordering::SeqCst);
+        clock.advance(CONTEXT_ALERT_MAINTENANCE_INTERVAL);
+        yield_until(|| runtime.retired.lock().unwrap().contains(&id)).await;
+
+        monitor.close_and_join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unavailable_retires_even_when_actor_has_no_alert_state() {
+        let id = Uuid::new_v4();
+        let runtime = ScriptedRuntime::new();
+        runtime.live.store(false, Ordering::SeqCst);
+        let clock = ManualClock::new(Instant::now());
+        let monitor = ContextAlertMonitor::start_with_runtime(
+            Arc::clone(&runtime) as Arc<dyn ContextAlertRuntime>,
+            clock as Arc<dyn AlertClock>,
+            CancellationToken::new(),
+        );
+
+        monitor
+            .sender()
+            .send(ContextSample::Unavailable { session_id: id })
+            .await
+            .unwrap();
+        yield_until(|| runtime.retired.lock().unwrap().contains(&id)).await;
+
+        monitor.close_and_join().await.unwrap();
+    }
+}

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,4 +1,5 @@
 pub mod auto_close;
+pub mod context_alerts;
 pub mod manager;
 // Inner module shares the parent name; renaming would churn every import.
 pub mod profile;

--- a/src-tauri/tests/cli_workgroup_team.rs
+++ b/src-tauri/tests/cli_workgroup_team.rs
@@ -458,6 +458,10 @@ fn workgroup_add_creates_task_messaging_replicas_and_lists() {
         created_team["agents"],
         serde_json::json!(["_agent_architect", "_agent_dev-rust"])
     );
+    assert_eq!(
+        created_team["contextAlertPercentages"],
+        serde_json::json!([])
+    );
 
     let team_config_path = project
         .join(".ac")
@@ -503,6 +507,10 @@ fn workgroup_add_creates_task_messaging_replicas_and_lists() {
         serde_json::json!(["_agent_architect", "_agent_dev-rust"])
     );
     assert_eq!(team_config["coordinator"], "_agent_architect");
+    assert_eq!(
+        team_config["contextAlertPercentages"],
+        serde_json::json!([])
+    );
 
     let list = run_json(&bin, &["workgroup", "list", "--project", "ProjectAlpha"]);
     assert_eq!(list.as_array().expect("array").len(), 1);
@@ -1224,7 +1232,8 @@ fn workgroup_add_existing_invalid_team_config_errors_without_rewrite() {
             "dev-rust",
         ],
     );
-    assert!(stderr.contains("Failed to parse config.json"));
+    assert!(stderr.contains("Team config at"));
+    assert!(stderr.contains("is malformed"));
     assert_eq!(std::fs::read(&config_path).expect("after"), original);
 }
 

--- a/src/shared/ipc.transport.test.ts
+++ b/src/shared/ipc.transport.test.ts
@@ -99,4 +99,247 @@ describe("shared ipc transport seam", () => {
       expect(ipc.isSelectionCoordinatorBusyError(error)).toBe(false);
     }
   });
+
+  it("sends exact create and update team objects, including explicit empty arrays", async () => {
+    const ipc = await import("./ipc");
+    const fake = new FakeTransport();
+    fake.resolve("create_team", undefined);
+    fake.resolve("update_team", undefined);
+    const restore = ipc.__setTransportForTests(fake);
+    try {
+      await ipc.EntityAPI.createTeam(
+        "C:\\Project",
+        "dev-team",
+        ["_agent_one"],
+        "_agent_one",
+        [{ url: "https://example.test/repo.git", agents: ["_agent_one"] }],
+        [],
+      );
+      await ipc.EntityAPI.createTeam(
+        "C:\\Project",
+        "ops-team",
+        ["_agent_two"],
+        "_agent_two",
+        [],
+        [50, 75, 90],
+      );
+      await ipc.EntityAPI.updateTeam(
+        "C:\\Project",
+        "dev-team",
+        ["_agent_one"],
+        "_agent_one",
+        [],
+        [25],
+      );
+      await ipc.EntityAPI.updateTeam(
+        "C:\\Project",
+        "dev-team",
+        ["_agent_one"],
+        "_agent_one",
+        [],
+        [],
+      );
+    } finally {
+      restore();
+    }
+
+    expect(fake.callsFor("create_team")).toEqual([
+      {
+        cmd: "create_team",
+        args: {
+          projectPath: "C:\\Project",
+          name: "dev-team",
+          agents: ["_agent_one"],
+          coordinator: "_agent_one",
+          repos: [{ url: "https://example.test/repo.git", agents: ["_agent_one"] }],
+          contextAlertPercentages: [],
+        },
+      },
+      {
+        cmd: "create_team",
+        args: {
+          projectPath: "C:\\Project",
+          name: "ops-team",
+          agents: ["_agent_two"],
+          coordinator: "_agent_two",
+          repos: [],
+          contextAlertPercentages: [50, 75, 90],
+        },
+      },
+    ]);
+    expect(fake.callsFor("update_team")).toEqual([
+      {
+        cmd: "update_team",
+        args: {
+          projectPath: "C:\\Project",
+          teamName: "dev-team",
+          agents: ["_agent_one"],
+          coordinator: "_agent_one",
+          repos: [],
+          contextAlertPercentages: [25],
+        },
+      },
+      {
+        cmd: "update_team",
+        args: {
+          projectPath: "C:\\Project",
+          teamName: "dev-team",
+          agents: ["_agent_one"],
+          coordinator: "_agent_one",
+          repos: [],
+          contextAlertPercentages: [],
+        },
+      },
+    ]);
+  });
+
+  it("adapts only missing or undefined alert fields to fresh empty arrays", async () => {
+    const ipc = await import("./ipc");
+    const fake = new FakeTransport();
+    const legacy = { agents: ["_agent_one"], coordinator: "_agent_one", repos: [] };
+    fake.resolve("get_team_config", legacy);
+    const restore = ipc.__setTransportForTests(fake);
+    try {
+      const first = await ipc.EntityAPI.getTeamConfig("C:\\Project", "dev-team");
+      const second = await ipc.EntityAPI.getTeamConfig("C:\\Project", "dev-team");
+      expect(first.contextAlertPercentages).toEqual([]);
+      expect(first.contextAlertPercentages).not.toBe(second.contextAlertPercentages);
+      expect(Object.prototype.hasOwnProperty.call(legacy, "contextAlertPercentages")).toBe(false);
+
+      const explicitUndefined = {
+        ...legacy,
+        contextAlertPercentages: undefined,
+      };
+      fake.resolve("get_team_config", explicitUndefined);
+      const decoded = await ipc.EntityAPI.getTeamConfig("C:\\Project", "dev-team");
+      expect(decoded.contextAlertPercentages).toEqual([]);
+      expect(explicitUndefined.contextAlertPercentages).toBeUndefined();
+    } finally {
+      restore();
+    }
+
+    expect(fake.callsFor("get_team_config")[0]?.args).toEqual({
+      projectPath: "C:\\Project",
+      teamName: "dev-team",
+    });
+  });
+
+  it("preserves product-invalid numeric rows in order and deep-clones valid transport data", async () => {
+    const ipc = await import("./ipc");
+    const fake = new FakeTransport();
+    const raw = {
+      agents: ["_agent_one"],
+      coordinator: "_agent_one",
+      repos: [{ url: "https://example.test/repo.git", agents: ["_agent_one"] }],
+      contextAlertPercentages: [101, 50.5, 50.5, 25],
+    };
+    fake.resolve("get_team_config", raw);
+    const restore = ipc.__setTransportForTests(fake);
+    try {
+      const decoded = await ipc.EntityAPI.getTeamConfig("C:\\Project", "dev-team");
+      expect(decoded).toEqual(raw);
+      expect(decoded).not.toBe(raw);
+      expect(decoded.agents).not.toBe(raw.agents);
+      expect(decoded.repos).not.toBe(raw.repos);
+      expect(decoded.repos[0]).not.toBe(raw.repos[0]);
+      expect(decoded.repos[0]?.agents).not.toBe(raw.repos[0]?.agents);
+      expect(decoded.contextAlertPercentages).not.toBe(raw.contextAlertPercentages);
+
+      decoded.agents.push("_agent_two");
+      decoded.repos[0]?.agents.push("_agent_two");
+      decoded.contextAlertPercentages.reverse();
+      expect(raw.agents).toEqual(["_agent_one"]);
+      expect(raw.repos[0]?.agents).toEqual(["_agent_one"]);
+      expect(raw.contextAlertPercentages).toEqual([101, 50.5, 50.5, 25]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("rejects present unrepresentable alert data with the exact decoder error", async () => {
+    const ipc = await import("./ipc");
+    const fake = new FakeTransport();
+    const restore = ipc.__setTransportForTests(fake);
+    const message =
+      "Invalid get_team_config response: contextAlertPercentages must be an array of finite numbers";
+    try {
+      for (const contextAlertPercentages of [
+        null,
+        {},
+        "50",
+        [50, "75"],
+        [Number.NaN],
+        [Number.POSITIVE_INFINITY],
+      ]) {
+        fake.resolve("get_team_config", {
+          agents: [],
+          coordinator: "_agent_one",
+          repos: [],
+          contextAlertPercentages,
+        });
+        await expect(
+          ipc.EntityAPI.getTeamConfig("C:\\Project", "dev-team"),
+        ).rejects.toThrow(message);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it("rejects malformed roots and legacy fields with their exact boundary errors", async () => {
+    const ipc = await import("./ipc");
+    const fake = new FakeTransport();
+    const restore = ipc.__setTransportForTests(fake);
+    const cases: { response: unknown; message: string }[] = [
+      {
+        response: null,
+        message: "Invalid get_team_config response: expected an object",
+      },
+      {
+        response: [],
+        message: "Invalid get_team_config response: expected an object",
+      },
+      {
+        response: { agents: [1], coordinator: "_agent_one", repos: [] },
+        message: "Invalid get_team_config response: agents must be an array of strings",
+      },
+      {
+        response: { agents: [], coordinator: null, repos: [] },
+        message: "Invalid get_team_config response: coordinator must be a string",
+      },
+      {
+        response: { agents: [], coordinator: "_agent_one", repos: {} },
+        message:
+          "Invalid get_team_config response: repos must be an array of { url: string; agents: string[] }",
+      },
+      {
+        response: {
+          agents: [],
+          coordinator: "_agent_one",
+          repos: [{ url: 7, agents: [] }],
+        },
+        message:
+          "Invalid get_team_config response: repos must be an array of { url: string; agents: string[] }",
+      },
+      {
+        response: {
+          agents: [],
+          coordinator: "_agent_one",
+          repos: [{ url: "https://example.test/repo.git", agents: [7] }],
+        },
+        message:
+          "Invalid get_team_config response: repos must be an array of { url: string; agents: string[] }",
+      },
+    ];
+    try {
+      for (const testCase of cases) {
+        fake.resolve("get_team_config", testCase.response);
+        await expect(
+          ipc.EntityAPI.getTeamConfig("C:\\Project", "dev-team"),
+        ).rejects.toThrow(testCase.message);
+      }
+    } finally {
+      restore();
+    }
+  });
 });

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -820,6 +820,76 @@ export const RoleTemplateAPI = {
     transport.invoke<AgencyTemplatesUpdateResult>("update_agency_templates"),
 };
 
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function normalizeTeamConfigResult(value: unknown): TeamConfigResult {
+  if (!isUnknownRecord(value)) {
+    throw new Error("Invalid get_team_config response: expected an object");
+  }
+
+  const agents = value.agents;
+  if (!isStringArray(agents)) {
+    throw new Error(
+      "Invalid get_team_config response: agents must be an array of strings",
+    );
+  }
+
+  const coordinator = value.coordinator;
+  if (typeof coordinator !== "string") {
+    throw new Error("Invalid get_team_config response: coordinator must be a string");
+  }
+
+  const rawRepos = value.repos;
+  if (!Array.isArray(rawRepos)) {
+    throw new Error(
+      "Invalid get_team_config response: repos must be an array of { url: string; agents: string[] }",
+    );
+  }
+  const repos: { url: string; agents: string[] }[] = [];
+  for (const rawRepo of rawRepos) {
+    if (
+      !isUnknownRecord(rawRepo)
+      || typeof rawRepo.url !== "string"
+      || !isStringArray(rawRepo.agents)
+    ) {
+      throw new Error(
+        "Invalid get_team_config response: repos must be an array of { url: string; agents: string[] }",
+      );
+    }
+    repos.push({ url: rawRepo.url, agents: [...rawRepo.agents] });
+  }
+
+  const rawContextAlertPercentages = value.contextAlertPercentages;
+  let contextAlertPercentages: number[];
+  if (rawContextAlertPercentages === undefined) {
+    contextAlertPercentages = [];
+  } else if (
+    Array.isArray(rawContextAlertPercentages)
+    && rawContextAlertPercentages.every(
+      (percentage) => typeof percentage === "number" && Number.isFinite(percentage),
+    )
+  ) {
+    contextAlertPercentages = [...rawContextAlertPercentages];
+  } else {
+    throw new Error(
+      "Invalid get_team_config response: contextAlertPercentages must be an array of finite numbers",
+    );
+  }
+
+  return {
+    agents: [...agents],
+    coordinator,
+    repos,
+    contextAlertPercentages,
+  };
+}
+
 export const EntityAPI = {
   createAgentMatrix: (
     projectPath: string,
@@ -848,9 +918,17 @@ export const EntityAPI = {
     name: string,
     agents: string[],
     coordinator: string,
-    repos: { url: string; agents: string[] }[]
+    repos: { url: string; agents: string[] }[],
+    contextAlertPercentages: number[],
   ) =>
-    transport.invoke<void>("create_team", { projectPath, name, agents, coordinator, repos }),
+    transport.invoke<void>("create_team", {
+      projectPath,
+      name,
+      agents,
+      coordinator,
+      repos,
+      contextAlertPercentages,
+    }),
 
   deleteTeam: (projectPath: string, teamName: string) =>
     transport.invoke<void>("delete_team", { projectPath, teamName }),
@@ -860,12 +938,21 @@ export const EntityAPI = {
     teamName: string,
     agents: string[],
     coordinator: string,
-    repos: { url: string; agents: string[] }[]
+    repos: { url: string; agents: string[] }[],
+    contextAlertPercentages: number[],
   ) =>
-    transport.invoke<void>("update_team", { projectPath, teamName, agents, coordinator, repos }),
+    transport.invoke<void>("update_team", {
+      projectPath,
+      teamName,
+      agents,
+      coordinator,
+      repos,
+      contextAlertPercentages,
+    }),
 
   getTeamConfig: (projectPath: string, teamName: string) =>
-    transport.invoke<TeamConfigResult>("get_team_config", { projectPath, teamName }),
+    transport.invoke<unknown>("get_team_config", { projectPath, teamName })
+      .then(normalizeTeamConfigResult),
 
   createWorkgroup: (projectPath: string, teamName: string, taskTitle?: string) =>
     transport.invoke<void>("create_workgroup", {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1030,6 +1030,7 @@ export interface TeamConfigResult {
   agents: string[];
   coordinator: string;
   repos: { url: string; agents: string[] }[];
+  contextAlertPercentages: number[];
 }
 
 

--- a/src/sidebar/components/EditTeamModal.context-alerts.test.tsx
+++ b/src/sidebar/components/EditTeamModal.context-alerts.test.tsx
@@ -1,0 +1,352 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import EditTeamModal from "./EditTeamModal";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  discovery,
+  input,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+
+const projectPath = "C:\\Project";
+const teamName = "dev-team";
+const agentPath = `${projectPath}\\.ac\\_agent_dev-webpage-ui`;
+const repoUrl = "https://github.com/acme/repo.git";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  reject: (reason: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let rejectPromise!: (reason: unknown) => void;
+  const promise = new Promise<T>((_resolve, reject) => {
+    rejectPromise = reject;
+  });
+  return { promise, reject: rejectPromise };
+}
+
+function teamConfig(contextAlertPercentages?: unknown): Record<string, unknown> {
+  const config: Record<string, unknown> = {
+    agents: ["_agent_dev-webpage-ui"],
+    coordinator: "_agent_dev-webpage-ui",
+    repos: [],
+  };
+  if (arguments.length > 0) config.contextAlertPercentages = contextAlertPercentages;
+  return config;
+}
+
+function setupTransport(fake: FakeTransport, config: unknown): void {
+  fake.resolve("list_all_agents", [
+    { name: "dev-webpage-ui", path: agentPath, projectName: "Project" },
+  ]);
+  fake.resolve("get_team_config", config);
+  fake.resolve("update_team", undefined);
+  fake.resolve("discover_project", discovery());
+}
+
+function button(label: string): HTMLButtonElement {
+  const found = Array.from(document.body.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!(found instanceof HTMLButtonElement)) throw new Error(`Button not found: ${label}`);
+  return found;
+}
+
+function field(selector: string): HTMLInputElement {
+  const found = document.body.querySelector(selector);
+  if (!(found instanceof HTMLInputElement)) throw new Error(`Input not found: ${selector}`);
+  return found;
+}
+
+function thresholdInputs(): HTMLInputElement[] {
+  return Array.from(document.body.querySelectorAll<HTMLInputElement>(
+    ".team-context-alert-input",
+  ));
+}
+
+async function advanceToStepThree(): Promise<void> {
+  await waitFor(() => expect(button("Next")).toBeTruthy());
+  click(button("Next"));
+  await waitFor(() => expect(button("Next").disabled).toBe(false));
+  click(button("Next"));
+  await waitFor(() => expect(button("Add threshold")).toBeTruthy());
+}
+
+describe("EditTeamModal context alerts", () => {
+  let restoreDom: (() => void) | null = null;
+  let rendered: ReturnType<typeof renderWithFakeTransport> | null = null;
+
+  beforeEach(() => {
+    restoreDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    rendered?.cleanup();
+    rendered = null;
+    restoreDom?.();
+    restoreDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("hydrates legacy empty and valid unordered policies through EntityAPI without reloading", async () => {
+    const legacyFake = new FakeTransport();
+    setupTransport(legacyFake, teamConfig());
+    rendered = renderWithFakeTransport(
+      () => <EditTeamModal projectPath={projectPath} teamName={teamName} onClose={() => undefined} />,
+      legacyFake,
+    );
+    await advanceToStepThree();
+    expect(thresholdInputs()).toHaveLength(0);
+    expect(document.body.textContent).toContain("No context alerts configured.");
+    expect(legacyFake.callsFor("get_team_config")).toHaveLength(1);
+
+    rendered.cleanup();
+    rendered = null;
+    document.body.replaceChildren();
+    resetUiStoresForTests();
+
+    const populatedFake = new FakeTransport();
+    setupTransport(populatedFake, teamConfig([90, 50, 75]));
+    rendered = renderWithFakeTransport(
+      () => <EditTeamModal projectPath={projectPath} teamName={teamName} onClose={() => undefined} />,
+      populatedFake,
+    );
+    await advanceToStepThree();
+    expect(thresholdInputs().map((element) => element.value)).toEqual(["50", "75", "90"]);
+    expect(populatedFake.callsFor("get_team_config")).toHaveLength(1);
+    expect(populatedFake.callsFor("update_team")).toHaveLength(0);
+  });
+
+  it("preserves an unchanged populated policy during a repository edit and sends complete state", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, teamConfig([90, 50, 75]));
+    const onClose = vi.fn();
+    rendered = renderWithFakeTransport(
+      () => <EditTeamModal projectPath={projectPath} teamName={teamName} onClose={onClose} />,
+      fake,
+    );
+    await advanceToStepThree();
+    const repositoryInput = field('input[placeholder="https://github.com/org/repo.git"]');
+    input(repositoryInput, repoUrl);
+    click(button("Add Repo"));
+    click(button("Save"));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+
+    expect(fake.callsFor("update_team")).toEqual([
+      {
+        cmd: "update_team",
+        args: {
+          projectPath,
+          teamName,
+          agents: ["_agent_dev-webpage-ui"],
+          coordinator: "_agent_dev-webpage-ui",
+          repos: [{ url: repoUrl, agents: ["_agent_dev-webpage-ui"] }],
+          contextAlertPercentages: [50, 75, 90],
+        },
+      },
+    ]);
+    expect(fake.callsFor("discover_project")).toHaveLength(1);
+  });
+
+  it("clears the final row with an explicit empty update array", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake, teamConfig([50]));
+    const onClose = vi.fn();
+    rendered = renderWithFakeTransport(
+      () => <EditTeamModal projectPath={projectPath} teamName={teamName} onClose={onClose} />,
+      fake,
+    );
+    await advanceToStepThree();
+    click(button("Remove"));
+    expect(thresholdInputs()).toHaveLength(0);
+    click(button("Save"));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(fake.lastCall("update_team")?.args.contextAlertPercentages).toEqual([]);
+  });
+
+  it("preserves every product-invalid numeric row until the user corrects it", async () => {
+    const cases: {
+      values: number[];
+      expectedRaw: string[];
+      correct: () => void;
+    }[] = [
+      {
+        values: [80, 80],
+        expectedRaw: ["80", "80"],
+        correct: () => input(thresholdInputs()[1]!, "90"),
+      },
+      {
+        values: [50.5],
+        expectedRaw: ["50.5"],
+        correct: () => input(thresholdInputs()[0]!, "50"),
+      },
+      {
+        values: [101],
+        expectedRaw: ["101"],
+        correct: () => input(thresholdInputs()[0]!, "100"),
+      },
+      {
+        values: [10, 20, 30, 40],
+        expectedRaw: ["10", "20", "30", "40"],
+        correct: () => {
+          const removeFourth = document.body.querySelector('[aria-label="Remove threshold 4"]');
+          if (!(removeFourth instanceof HTMLButtonElement)) throw new Error("Fourth remove missing");
+          click(removeFourth);
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const fake = new FakeTransport();
+      setupTransport(fake, teamConfig(testCase.values));
+      rendered = renderWithFakeTransport(
+        () => <EditTeamModal projectPath={projectPath} teamName={teamName} onClose={() => undefined} />,
+        fake,
+      );
+      await advanceToStepThree();
+      expect(thresholdInputs().map((element) => element.value)).toEqual(testCase.expectedRaw);
+      expect(button("Save").disabled).toBe(true);
+      click(button("Save"));
+      expect(fake.callsFor("update_team")).toHaveLength(0);
+
+      testCase.correct();
+      expect(button("Save").disabled).toBe(false);
+
+      rendered.cleanup();
+      rendered = null;
+      document.body.replaceChildren();
+      resetUiStoresForTests();
+    }
+  });
+
+  it("shows only the load-error state and Cancel for rejected or unrepresentable config", async () => {
+    const cases: { configure: (fake: FakeTransport) => void; message: string }[] = [
+      {
+        configure: (fake) => {
+          setupTransport(fake, teamConfig([]));
+          fake.reject("get_team_config", "load rejected");
+        },
+        message: "load rejected",
+      },
+      {
+        configure: (fake) => setupTransport(fake, teamConfig(null)),
+        message:
+          "Invalid get_team_config response: contextAlertPercentages must be an array of finite numbers",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const fake = new FakeTransport();
+      testCase.configure(fake);
+      rendered = renderWithFakeTransport(
+        () => <EditTeamModal projectPath={projectPath} teamName={teamName} onClose={() => undefined} />,
+        fake,
+      );
+      await waitFor(() => expect(
+        document.body.querySelector('[role="alert"][aria-label="Team configuration load error"]')
+          ?.textContent,
+      ).toContain(testCase.message));
+      expect(Array.from(document.body.querySelectorAll(".new-agent-footer button")).map(
+        (candidate) => candidate.textContent?.trim(),
+      )).toEqual(["Cancel"]);
+      expect(document.body.textContent).not.toContain("Add threshold");
+      expect(document.body.textContent).not.toContain("Save");
+      expect(fake.callsFor("update_team")).toHaveLength(0);
+
+      rendered.cleanup();
+      rendered = null;
+      document.body.replaceChildren();
+      resetUiStoresForTests();
+    }
+  });
+
+  it("keeps save errors and all drafts separate from later editor changes", async () => {
+    const fake = new FakeTransport();
+    const config = teamConfig([80]);
+    config.repos = [{ url: repoUrl, agents: ["_agent_dev-webpage-ui"] }];
+    setupTransport(fake, config);
+    fake.reject("update_team", "save rejected");
+    const onClose = vi.fn();
+    rendered = renderWithFakeTransport(
+      () => <EditTeamModal projectPath={projectPath} teamName={teamName} onClose={onClose} />,
+      fake,
+    );
+    await advanceToStepThree();
+    const thresholdInput = thresholdInputs()[0];
+    if (!thresholdInput) throw new Error("Threshold input missing");
+    click(button("Save"));
+    await waitFor(() => expect(
+      document.body.querySelector('[role="alert"][aria-label="Team save error"]')?.textContent,
+    ).toContain("save rejected"));
+    expect(document.body.textContent).toContain("repo");
+    expect(fake.callsFor("discover_project")).toHaveLength(0);
+    expect(onClose).not.toHaveBeenCalled();
+
+    input(thresholdInput, "81");
+    expect(document.body.querySelector('[role="alert"][aria-label="Team save error"]')?.textContent)
+      .toContain("save rejected");
+    expect(thresholdInput.value).toBe("81");
+  });
+
+  it("locks all step-three interactions around one immutable deferred save", async () => {
+    const fake = new FakeTransport();
+    const config = teamConfig([80]);
+    config.repos = [{ url: repoUrl, agents: ["_agent_dev-webpage-ui"] }];
+    setupTransport(fake, config);
+    const pending = deferred<void>();
+    fake.onInvoke("update_team", () => pending.promise);
+    const onClose = vi.fn();
+    rendered = renderWithFakeTransport(
+      () => <EditTeamModal projectPath={projectPath} teamName={teamName} onClose={onClose} />,
+      fake,
+    );
+    await advanceToStepThree();
+    const thresholdInput = thresholdInputs()[0];
+    if (!thresholdInput) throw new Error("Threshold input missing");
+    const repositoryInput = field('input[placeholder="https://github.com/org/repo.git"]');
+    const saveButton = button("Save");
+
+    click(saveButton);
+    await waitFor(() => expect(
+      document.body.querySelector(".entity-wizard-modal")?.getAttribute("aria-busy"),
+    ).toBe("true"));
+    const captured = JSON.stringify(fake.lastCall("update_team")?.args);
+    expect(fake.callsFor("update_team")).toHaveLength(1);
+    expect(thresholdInput.disabled).toBe(true);
+    expect(repositoryInput.disabled).toBe(true);
+    expect(button("Add threshold").disabled).toBe(true);
+    expect(button("Add Repo").disabled).toBe(true);
+    expect(button("Back").disabled).toBe(true);
+    expect(saveButton.disabled).toBe(true);
+    expect(Array.from(document.body.querySelectorAll<HTMLInputElement>(
+      '.wizard-repo-card input[type="checkbox"]',
+    )).every((element) => element.disabled)).toBe(true);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    click(saveButton);
+    input(thresholdInput, "90");
+    expect(fake.callsFor("update_team")).toHaveLength(1);
+    expect(JSON.stringify(fake.lastCall("update_team")?.args)).toBe(captured);
+    expect(onClose).not.toHaveBeenCalled();
+
+    pending.reject(new Error("deferred save rejection"));
+    await waitFor(() => expect(
+      document.body.querySelector('[role="alert"][aria-label="Team save error"]')?.textContent,
+    ).toContain("deferred save rejection"));
+    expect(document.body.querySelector(".entity-wizard-modal")?.getAttribute("aria-busy"))
+      .toBe("false");
+    expect(thresholdInput.disabled).toBe(false);
+    expect(thresholdInput.value).toBe("80");
+    expect(fake.callsFor("discover_project")).toHaveLength(0);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/sidebar/components/EditTeamModal.tsx
+++ b/src/sidebar/components/EditTeamModal.tsx
@@ -1,8 +1,25 @@
-import { Component, createSignal, createMemo, For, Show, onMount, onCleanup } from "solid-js";
-import { EntityAPI } from "../../shared/ipc";
+import { createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import type { Component } from "solid-js";
 import { AC_WORKSPACE_DIR } from "../../shared/constants";
+import { EntityAPI } from "../../shared/ipc";
+import type {
+  TeamWizardAgentEntry,
+  TeamWizardRepoEntry,
+  TeamWizardStep,
+} from "../../shared/types";
 import { projectStore } from "../stores/project";
-import type { TeamWizardAgentEntry, TeamWizardRepoEntry, TeamWizardStep } from "../../shared/types";
+import { TeamContextAlertsEditor } from "./TeamContextAlertsEditor";
+import type { ContextAlertThresholdDraft } from "./team-context-alerts";
+import {
+  hydrateContextAlertThresholdDrafts,
+  validateContextAlertThresholdDrafts,
+} from "./team-context-alerts";
+
+function normalizeCaughtError(error: unknown, fallback: string): string {
+  if (typeof error === "string") return error;
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
 
 const EditTeamModal: Component<{
   projectPath: string;
@@ -15,130 +32,142 @@ const EditTeamModal: Component<{
   const [coordinator, setCoordinator] = createSignal<string>("");
   const [repos, setRepos] = createSignal<TeamWizardRepoEntry[]>([]);
   const [repoInput, setRepoInput] = createSignal("");
-  const [error, setError] = createSignal("");
+  const [contextAlertDrafts, setContextAlertDrafts] =
+    createSignal<ContextAlertThresholdDraft[]>([]);
+  const [loadError, setLoadError] = createSignal("");
+  const [repoError, setRepoError] = createSignal("");
+  const [saveError, setSaveError] = createSignal("");
   const [saving, setSaving] = createSignal(false);
   const [loading, setLoading] = createSignal(true);
-
+  const [configLoaded, setConfigLoaded] = createSignal(false);
   const [agentFilter, setAgentFilter] = createSignal("");
 
+  const contextAlertValidation = createMemo(() =>
+    validateContextAlertThresholdDrafts(contextAlertDrafts()),
+  );
+
   const currentProjectName = createMemo(() => {
-    const p = props.projectPath.replace(/[\\/]+$/, "");
-    const idx = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
-    return idx >= 0 ? p.slice(idx + 1) : p;
+    const path = props.projectPath.replace(/[\\/]+$/, "");
+    const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+    return separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
   });
 
   const agentsByProject = createMemo(() => {
     const filter = agentFilter().toLowerCase();
     const filtered = filter
-      ? allAgents().filter((a) => a.name.toLowerCase().includes(filter))
+      ? allAgents().filter((agent) => agent.name.toLowerCase().includes(filter))
       : allAgents();
 
-    const map = new Map<string, TeamWizardAgentEntry[]>();
-    for (const a of filtered) {
-      const list = map.get(a.projectName) ?? [];
-      list.push(a);
-      map.set(a.projectName, list);
+    const grouped = new Map<string, TeamWizardAgentEntry[]>();
+    for (const agent of filtered) {
+      const entries = grouped.get(agent.projectName) ?? [];
+      entries.push(agent);
+      grouped.set(agent.projectName, entries);
     }
 
-    const cur = currentProjectName();
-    const entries = Array.from(map.entries());
-    entries.sort((a, b) => {
-      if (a[0] === cur) return -1;
-      if (b[0] === cur) return 1;
-      return a[0].localeCompare(b[0]);
+    const current = currentProjectName();
+    const entries = Array.from(grouped.entries());
+    entries.sort((left, right) => {
+      if (left[0] === current) return -1;
+      if (right[0] === current) return 1;
+      return left[0].localeCompare(right[0]);
     });
     return new Map(entries);
   });
 
   const selectedAgentList = createMemo(() =>
-    allAgents().filter((a) => selectedAgents().has(a.path))
+    allAgents().filter((agent) => selectedAgents().has(agent.path)),
   );
 
-  const portableAgentRef = (path: string) => {
+  const portableAgentRef = (path: string): string => {
     const last = path.replace(/\\/g, "/").split("/").filter(Boolean).pop() ?? path;
     return last.startsWith("_agent_") ? last : `_agent_${last}`;
   };
 
-  const canNext2 = createMemo(() =>
-    selectedAgents().size > 0 && coordinator() !== ""
+  const canNext2 = createMemo(() => selectedAgents().size > 0 && coordinator() !== "");
+
+  const canSave = createMemo(() =>
+    configLoaded()
+    && !saving()
+    && canNext2()
+    && contextAlertValidation().valid,
   );
 
   onMount(async () => {
     try {
-      // Load all agents and current team config in parallel
-      const paths = projectStore.projects.map((p) => p.path);
+      const paths = projectStore.projects.map((project) => project.path);
       const [agentList, teamConfig] = await Promise.all([
         EntityAPI.listAllAgents(paths),
         EntityAPI.getTeamConfig(props.projectPath, props.teamName),
       ]);
 
-      const entries: TeamWizardAgentEntry[] = agentList.map((a) => ({
-        name: a.name,
-        path: a.path,
-        projectName: a.projectName,
+      const entries: TeamWizardAgentEntry[] = agentList.map((agent) => ({
+        name: agent.name,
+        path: agent.path,
+        projectName: agent.projectName,
       }));
+      const discoveredRefs = new Set(entries.map((entry) => portableAgentRef(entry.path)));
 
-      const discoveredRefs = new Set(entries.map((e) => portableAgentRef(e.path)));
-
-      // Synthesize entries for portable refs not found in discovered agents.
       for (const configPath of teamConfig.agents) {
         const agentRef = portableAgentRef(configPath);
         if (!discoveredRefs.has(agentRef)) {
-          const agentName = agentRef.replace(/^_agent_/, "");
           const fallbackPath =
             `${props.projectPath.replace(/[\\/]+$/, "")}/${AC_WORKSPACE_DIR}/${agentRef}`;
           entries.push({
-            name: agentName,
+            name: agentRef.replace(/^_agent_/, ""),
             path: fallbackPath,
             projectName: currentProjectName(),
           });
         }
       }
 
-      setAllAgents(entries);
-      const entryPathByRef = new Map(entries.map((e) => [portableAgentRef(e.path), e.path]));
-      const configPathForUi = (agentRef: string) =>
+      const entryPathByRef = new Map(
+        entries.map((entry) => [portableAgentRef(entry.path), entry.path]),
+      );
+      const configPathForUi = (agentRef: string): string =>
         entryPathByRef.get(portableAgentRef(agentRef)) ?? agentRef;
-
-      // Pre-select agents matching config paths
       const configAgentRefs = new Set(teamConfig.agents.map(portableAgentRef));
-      const matched = new Set<string>();
+      const nextSelectedAgents = new Set<string>();
       for (const entry of entries) {
         if (configAgentRefs.has(portableAgentRef(entry.path))) {
-          matched.add(entry.path);
+          nextSelectedAgents.add(entry.path);
         }
       }
-      setSelectedAgents(matched);
 
-      // Pre-select coordinator
+      let nextCoordinator = "";
       if (teamConfig.coordinator) {
-        const coordRef = portableAgentRef(teamConfig.coordinator);
-        const coordEntry = entries.find((e) => portableAgentRef(e.path) === coordRef);
-        if (coordEntry) {
-          setCoordinator(coordEntry.path);
-        }
+        const coordinatorRef = portableAgentRef(teamConfig.coordinator);
+        const coordinatorEntry = entries.find(
+          (entry) => portableAgentRef(entry.path) === coordinatorRef,
+        );
+        if (coordinatorEntry) nextCoordinator = coordinatorEntry.path;
       }
 
-      // Pre-populate repos
-      if (teamConfig.repos && teamConfig.repos.length > 0) {
-        setRepos(
-          teamConfig.repos.map((r) => ({
-            url: r.url,
-            agents: new Set(r.agents.map(configPathForUi)),
-          }))
-        );
-      }
-    } catch (e) {
-      console.error("Failed to load team config:", e);
-      setError("Failed to load team configuration");
+      const nextRepos = teamConfig.repos.map((repo) => ({
+        url: repo.url,
+        agents: new Set(repo.agents.map(configPathForUi)),
+      }));
+      const nextContextAlertDrafts = hydrateContextAlertThresholdDrafts(
+        teamConfig.contextAlertPercentages,
+      );
+
+      setAllAgents(entries);
+      setSelectedAgents(nextSelectedAgents);
+      setCoordinator(nextCoordinator);
+      setRepos(nextRepos);
+      setContextAlertDrafts(nextContextAlertDrafts);
+      setConfigLoaded(true);
+    } catch (error: unknown) {
+      console.error("Failed to load team config:", error);
+      setLoadError(normalizeCaughtError(error, "Failed to load team configuration"));
     } finally {
       setLoading(false);
     }
   });
 
   const toggleAgent = (path: string) => {
-    setSelectedAgents((prev) => {
-      const next = new Set(prev);
+    setSelectedAgents((previous) => {
+      const next = new Set(previous);
       if (next.has(path)) {
         next.delete(path);
         if (coordinator() === path) setCoordinator("");
@@ -150,85 +179,115 @@ const EditTeamModal: Component<{
   };
 
   const addRepo = () => {
+    if (saving()) return;
     const url = repoInput().trim();
     if (!url) return;
-    if (repos().some((r) => r.url === url)) {
-      setError("Repo already added");
+    if (repos().some((repo) => repo.url === url)) {
+      setRepoError("Repo already added");
       return;
     }
-    setRepos((prev) => [...prev, { url, agents: new Set(selectedAgentList().map((a) => a.path)) }]);
+    setRepos((previous) => [
+      ...previous,
+      { url, agents: new Set(selectedAgentList().map((agent) => agent.path)) },
+    ]);
     setRepoInput("");
-    setError("");
+    setRepoError("");
   };
 
   const removeRepo = (url: string) => {
-    setRepos((prev) => prev.filter((r) => r.url !== url));
+    if (saving()) return;
+    setRepos((previous) => previous.filter((repo) => repo.url !== url));
   };
 
   const toggleRepoAgent = (repoUrl: string, agentPath: string) => {
-    setRepos((prev) =>
-      prev.map((r) => {
-        if (r.url !== repoUrl) return r;
-        const next = new Set(r.agents);
-        if (next.has(agentPath)) next.delete(agentPath);
-        else next.add(agentPath);
-        return { ...r, agents: next };
-      })
+    if (saving()) return;
+    setRepos((previous) =>
+      previous.map((repo) => {
+        if (repo.url !== repoUrl) return repo;
+        const nextAgents = new Set(repo.agents);
+        if (nextAgents.has(agentPath)) nextAgents.delete(agentPath);
+        else nextAgents.add(agentPath);
+        return { ...repo, agents: nextAgents };
+      }),
     );
   };
 
   const toggleRepoAll = (repoUrl: string) => {
-    setRepos((prev) =>
-      prev.map((r) => {
-        if (r.url !== repoUrl) return r;
-        const allSelected = selectedAgentList().every((a) => r.agents.has(a.path));
-        const next = allSelected ? new Set<string>() : new Set(selectedAgentList().map((a) => a.path));
-        return { ...r, agents: next };
-      })
+    if (saving()) return;
+    setRepos((previous) =>
+      previous.map((repo) => {
+        if (repo.url !== repoUrl) return repo;
+        const allSelected = selectedAgentList().every((agent) => repo.agents.has(agent.path));
+        const nextAgents = allSelected
+          ? new Set<string>()
+          : new Set(selectedAgentList().map((agent) => agent.path));
+        return { ...repo, agents: nextAgents };
+      }),
     );
   };
 
-  const repoDisplayName = (url: string) => {
+  const repoDisplayName = (url: string): string => {
     const match = url.match(/\/([^/]+?)(?:\.git)?$/);
     return match ? match[1] : url;
   };
 
   const handleSave = async () => {
-    if (saving()) return;
+    const validation = contextAlertValidation();
+    if (
+      saving()
+      || !configLoaded()
+      || !canNext2()
+      || !validation.valid
+    ) {
+      return;
+    }
+
+    const request = {
+      projectPath: props.projectPath,
+      teamName: props.teamName,
+      agents: Array.from(selectedAgents()).map(portableAgentRef),
+      coordinator: portableAgentRef(coordinator()),
+      repos: repos().map((repo) => ({
+        url: repo.url,
+        agents: Array.from(repo.agents).map(portableAgentRef),
+      })),
+      contextAlertPercentages: [...validation.canonicalPercentages],
+    };
+
     setSaving(true);
-    setError("");
+    setSaveError("");
     try {
-      const repoData = repos().map((r) => ({
-        url: r.url,
-        agents: Array.from(r.agents).map(portableAgentRef),
-      }));
       await EntityAPI.updateTeam(
-        props.projectPath,
-        props.teamName,
-        Array.from(selectedAgents()).map(portableAgentRef),
-        portableAgentRef(coordinator()),
-        repoData
+        request.projectPath,
+        request.teamName,
+        request.agents,
+        request.coordinator,
+        request.repos,
+        request.contextAlertPercentages,
       );
-      await projectStore.reloadProject(props.projectPath);
+      await projectStore.reloadProject(request.projectPath);
       props.onClose();
-    } catch (e: any) {
-      console.error("update_team failed:", e);
-      setError(typeof e === "string" ? e : e.message || "Failed to update team");
+    } catch (error: unknown) {
+      console.error("update_team failed:", error);
+      setSaveError(normalizeCaughtError(error, "Failed to update team"));
     } finally {
       setSaving(false);
     }
   };
 
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") props.onClose();
+  const handleDocumentKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape" && !saving()) props.onClose();
   };
 
-  document.addEventListener("keydown", handleKeyDown);
-  onCleanup(() => document.removeEventListener("keydown", handleKeyDown));
+  document.addEventListener("keydown", handleDocumentKeyDown);
+  onCleanup(() => document.removeEventListener("keydown", handleDocumentKeyDown));
 
   return (
     <div class="modal-overlay">
-      <div class="agent-modal entity-wizard-modal">
+      <div
+        class="agent-modal entity-wizard-modal"
+        aria-busy={saving() ? "true" : "false"}
+      >
         <div class="agent-modal-header">
           <span class="agent-modal-title">Edit Team: {props.teamName}</span>
           <span class="wizard-step-indicator">Step {step()} of 3</span>
@@ -240,17 +299,28 @@ const EditTeamModal: Component<{
           </div>
         </Show>
 
-        <Show when={!loading()}>
-          {/* Step 1: Info (read-only name) */}
+        <Show when={!loading() && !configLoaded()}>
+          <div class="wizard-body">
+            <div
+              id="edit-team-load-error"
+              class="new-agent-error"
+              role="alert"
+              aria-label="Team configuration load error"
+            >
+              {loadError()}
+            </div>
+          </div>
+          <div class="new-agent-footer">
+            <button class="new-agent-cancel-btn" onClick={() => props.onClose()}>Cancel</button>
+          </div>
+        </Show>
+
+        <Show when={!loading() && configLoaded()}>
           <Show when={step() === 1}>
             <div class="new-agent-form">
               <div class="new-agent-field">
                 <label class="new-agent-label">Team name</label>
-                <input
-                  class="agent-search-input"
-                  value={props.teamName}
-                  disabled
-                />
+                <input class="agent-search-input" value={props.teamName} disabled />
               </div>
               <div class="new-agent-field">
                 <label class="new-agent-label" style={{ opacity: 0.6 }}>
@@ -260,16 +330,10 @@ const EditTeamModal: Component<{
             </div>
             <div class="new-agent-footer">
               <button class="new-agent-cancel-btn" onClick={() => props.onClose()}>Cancel</button>
-              <button
-                class="new-agent-create-btn"
-                onClick={() => setStep(2)}
-              >
-                Next
-              </button>
+              <button class="new-agent-create-btn" onClick={() => setStep(2)}>Next</button>
             </div>
           </Show>
 
-          {/* Step 2: Agent selection */}
           <Show when={step() === 2}>
             <div class="wizard-body">
               <Show when={allAgents().length === 0}>
@@ -284,7 +348,7 @@ const EditTeamModal: Component<{
                   <input
                     class="wizard-search-input"
                     value={agentFilter()}
-                    onInput={(e) => setAgentFilter(e.currentTarget.value)}
+                    onInput={(event) => setAgentFilter(event.currentTarget.value)}
                     placeholder="Filter agents..."
                   />
                 </div>
@@ -295,7 +359,7 @@ const EditTeamModal: Component<{
                       <For each={agents}>
                         {(agent) => {
                           const isSelected = () => selectedAgents().has(agent.path);
-                          const isCoord = () => coordinator() === agent.path;
+                          const isCoordinator = () => coordinator() === agent.path;
                           return (
                             <div class="wizard-agent-row">
                               <label class="wizard-checkbox-label">
@@ -311,7 +375,7 @@ const EditTeamModal: Component<{
                                   <input
                                     type="radio"
                                     name="coordinator"
-                                    checked={isCoord()}
+                                    checked={isCoordinator()}
                                     onChange={() => setCoordinator(agent.path)}
                                   />
                                   <span class="wizard-coord-text">Coord</span>
@@ -324,9 +388,6 @@ const EditTeamModal: Component<{
                     </div>
                   )}
                 </For>
-              </Show>
-              <Show when={error()}>
-                <div class="new-agent-error">{error()}</div>
               </Show>
             </div>
             <div class="new-agent-footer">
@@ -341,75 +402,146 @@ const EditTeamModal: Component<{
             </div>
           </Show>
 
-          {/* Step 3: Repo assignment */}
           <Show when={step() === 3}>
             <div class="wizard-body">
-              <div class="wizard-repo-input-row">
-                <input
-                  class="agent-search-input"
-                  value={repoInput()}
-                  onInput={(e) => { setRepoInput(e.currentTarget.value); setError(""); }}
-                  placeholder="https://github.com/org/repo.git"
-                  onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addRepo(); } }}
-                />
-                <button class="new-agent-browse-btn" onClick={addRepo}>Add Repo</button>
-              </div>
+              <TeamContextAlertsEditor
+                idPrefix="edit-team-context-alerts"
+                drafts={contextAlertDrafts()}
+                validation={contextAlertValidation()}
+                disabled={saving()}
+                onChange={(next) => {
+                  if (saving()) return;
+                  setContextAlertDrafts(next);
+                }}
+              />
 
-              <Show when={repos().length > 0}>
-                <div class="wizard-repo-list">
-                  <For each={repos()}>
-                    {(repo) => {
-                      const allChecked = () => selectedAgentList().every((a) => repo.agents.has(a.path));
-                      return (
-                        <div class="wizard-repo-card">
-                          <div class="wizard-repo-header">
-                            <span class="wizard-repo-name">{repoDisplayName(repo.url)}</span>
-                            <button class="wizard-repo-remove" onClick={() => removeRepo(repo.url)} title="Remove repo">
-                              &#x2715;
-                            </button>
-                          </div>
-                          <div class="wizard-repo-agents">
-                            <label class="wizard-checkbox-label wizard-all-label">
-                              <input
-                                type="checkbox"
-                                checked={allChecked()}
-                                onChange={() => toggleRepoAll(repo.url)}
-                              />
-                              <span>All agents</span>
-                            </label>
-                            <For each={selectedAgentList()}>
-                              {(agent) => (
-                                <label class="wizard-checkbox-label">
-                                  <input
-                                    type="checkbox"
-                                    checked={repo.agents.has(agent.path)}
-                                    onChange={() => toggleRepoAgent(repo.url, agent.path)}
-                                  />
-                                  <span>{agent.name}</span>
-                                </label>
-                              )}
-                            </For>
-                          </div>
-                        </div>
-                      );
+              <section class="team-settings-section" aria-labelledby="edit-team-repositories-heading">
+                <h3 id="edit-team-repositories-heading" class="team-settings-heading">
+                  Repositories (optional)
+                </h3>
+                <div class="wizard-repo-input-row">
+                  <input
+                    class="agent-search-input"
+                    value={repoInput()}
+                    disabled={saving()}
+                    onInput={(event) => {
+                      if (saving()) {
+                        event.currentTarget.value = repoInput();
+                        return;
+                      }
+                      setRepoInput(event.currentTarget.value);
+                      setRepoError("");
                     }}
-                  </For>
+                    placeholder="https://github.com/org/repo.git"
+                    onKeyDown={(event) => {
+                      if (saving()) return;
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        addRepo();
+                      }
+                    }}
+                  />
+                  <button
+                    class="new-agent-browse-btn"
+                    type="button"
+                    disabled={saving()}
+                    onClick={addRepo}
+                  >
+                    Add Repo
+                  </button>
                 </div>
-              </Show>
 
-              <Show when={repos().length === 0}>
-                <div class="wizard-empty">No repos assigned. Add repo URLs above.</div>
-              </Show>
+                <Show when={repos().length > 0}>
+                  <div class="wizard-repo-list">
+                    <For each={repos()}>
+                      {(repo) => {
+                        const allChecked = () =>
+                          selectedAgentList().every((agent) => repo.agents.has(agent.path));
+                        return (
+                          <div class="wizard-repo-card">
+                            <div class="wizard-repo-header">
+                              <span class="wizard-repo-name">{repoDisplayName(repo.url)}</span>
+                              <button
+                                class="wizard-repo-remove"
+                                type="button"
+                                disabled={saving()}
+                                onClick={() => removeRepo(repo.url)}
+                                title="Remove repo"
+                              >
+                                &#x2715;
+                              </button>
+                            </div>
+                            <div class="wizard-repo-agents">
+                              <label class="wizard-checkbox-label wizard-all-label">
+                                <input
+                                  type="checkbox"
+                                  checked={allChecked()}
+                                  disabled={saving()}
+                                  onChange={() => toggleRepoAll(repo.url)}
+                                />
+                                <span>All agents</span>
+                              </label>
+                              <For each={selectedAgentList()}>
+                                {(agent) => (
+                                  <label class="wizard-checkbox-label">
+                                    <input
+                                      type="checkbox"
+                                      checked={repo.agents.has(agent.path)}
+                                      disabled={saving()}
+                                      onChange={() => toggleRepoAgent(repo.url, agent.path)}
+                                    />
+                                    <span>{agent.name}</span>
+                                  </label>
+                                )}
+                              </For>
+                            </div>
+                          </div>
+                        );
+                      }}
+                    </For>
+                  </div>
+                </Show>
 
-              <Show when={error()}>
-                <div class="new-agent-error">{error()}</div>
+                <Show when={repos().length === 0}>
+                  <div class="wizard-empty">No repos assigned. Add repo URLs above.</div>
+                </Show>
+
+                <Show when={repoError()}>
+                  <div
+                    id="edit-team-repository-error"
+                    class="new-agent-error"
+                    role="alert"
+                    aria-label="Repository error"
+                  >
+                    {repoError()}
+                  </div>
+                </Show>
+              </section>
+
+              <Show when={saveError()}>
+                <div
+                  id="edit-team-save-error"
+                  class="new-agent-error"
+                  role="alert"
+                  aria-label="Team save error"
+                >
+                  {saveError()}
+                </div>
               </Show>
             </div>
             <div class="new-agent-footer">
-              <button class="new-agent-cancel-btn" onClick={() => setStep(2)}>Back</button>
+              <button
+                class="new-agent-cancel-btn"
+                disabled={saving()}
+                onClick={() => {
+                  if (!saving()) setStep(2);
+                }}
+              >
+                Back
+              </button>
               <button
                 class="new-agent-create-btn"
-                disabled={saving()}
+                disabled={!canSave()}
                 onClick={handleSave}
               >
                 {saving() ? "Saving..." : "Save"}

--- a/src/sidebar/components/NewTeamModal.context-alerts.test.tsx
+++ b/src/sidebar/components/NewTeamModal.context-alerts.test.tsx
@@ -1,0 +1,309 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import NewTeamModal from "./NewTeamModal";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  click,
+  discovery,
+  input,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+
+const projectPath = "C:\\Project";
+const agentPath = `${projectPath}\\.ac\\_agent_dev-webpage-ui`;
+const repoUrl = "https://github.com/acme/repo.git";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise!: (value: T) => void;
+  let rejectPromise!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+function setupTransport(fake: FakeTransport): void {
+  fake.resolve("list_all_agents", [
+    { name: "dev-webpage-ui", path: agentPath, projectName: "Project" },
+  ]);
+  fake.resolve("create_team", undefined);
+  fake.resolve("discover_project", discovery());
+}
+
+function button(label: string): HTMLButtonElement {
+  const found = Array.from(document.body.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!(found instanceof HTMLButtonElement)) throw new Error(`Button not found: ${label}`);
+  return found;
+}
+
+function field(selector: string): HTMLInputElement {
+  const found = document.body.querySelector(selector);
+  if (!(found instanceof HTMLInputElement)) throw new Error(`Input not found: ${selector}`);
+  return found;
+}
+
+async function advanceToStepThree(): Promise<void> {
+  await waitFor(() => expect(field('input[placeholder="dream-team"]')).toBeTruthy());
+  input(field('input[placeholder="dream-team"]'), "dev-team");
+  click(button("Next"));
+
+  await waitFor(() => expect(document.body.querySelector('input[type="checkbox"]')).toBeTruthy());
+  const agentCheckbox = document.body.querySelector('input[type="checkbox"]');
+  if (!(agentCheckbox instanceof HTMLInputElement)) throw new Error("Agent checkbox missing");
+  click(agentCheckbox);
+  await waitFor(() => expect(document.body.querySelector('input[type="radio"]')).toBeTruthy());
+  const coordinatorRadio = document.body.querySelector('input[type="radio"]');
+  if (!(coordinatorRadio instanceof HTMLInputElement)) throw new Error("Coordinator radio missing");
+  click(coordinatorRadio);
+  await waitFor(() => expect(button("Next").disabled).toBe(false));
+  click(button("Next"));
+  await waitFor(() => expect(button("Add threshold")).toBeTruthy());
+}
+
+function addThreshold(raw: string): HTMLInputElement {
+  click(button("Add threshold"));
+  const allInputs = Array.from(
+    document.body.querySelectorAll<HTMLInputElement>(".team-context-alert-input"),
+  );
+  const thresholdInput = allInputs[allInputs.length - 1];
+  if (!thresholdInput) throw new Error("Threshold input missing");
+  input(thresholdInput, raw);
+  return thresholdInput;
+}
+
+describe("NewTeamModal context alerts", () => {
+  let restoreDom: (() => void) | null = null;
+  let rendered: ReturnType<typeof renderWithFakeTransport> | null = null;
+
+  beforeEach(() => {
+    restoreDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    rendered?.cleanup();
+    rendered = null;
+    restoreDom?.();
+    restoreDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("submits the default empty policy, reloads, and closes in order", async () => {
+    const fake = new FakeTransport();
+    const order: string[] = [];
+    setupTransport(fake);
+    fake.onInvoke("create_team", () => {
+      order.push("create");
+    });
+    fake.onInvoke("discover_project", () => {
+      order.push("reload");
+      return discovery();
+    });
+    const onClose = vi.fn(() => order.push("close"));
+    rendered = renderWithFakeTransport(
+      () => <NewTeamModal projectPath={projectPath} onClose={onClose} />,
+      fake,
+    );
+
+    await advanceToStepThree();
+    click(button("Create"));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+
+    expect(fake.callsFor("create_team")).toEqual([
+      {
+        cmd: "create_team",
+        args: {
+          projectPath,
+          name: "dev-team",
+          agents: ["_agent_dev-webpage-ui"],
+          coordinator: "_agent_dev-webpage-ui",
+          repos: [],
+          contextAlertPercentages: [],
+        },
+      },
+    ]);
+    expect(order).toEqual(["create", "reload", "close"]);
+  });
+
+  it("submits one, two, and three rows canonically without reordering visible drafts", async () => {
+    const thresholdCases = [
+      { raw: ["50"], expected: [50] },
+      { raw: ["75", "25"], expected: [25, 75] },
+      { raw: ["90", "50", "75"], expected: [50, 75, 90] },
+    ];
+
+    for (const thresholdCase of thresholdCases) {
+      const fake = new FakeTransport();
+      setupTransport(fake);
+      const onClose = vi.fn();
+      rendered = renderWithFakeTransport(
+        () => <NewTeamModal projectPath={projectPath} onClose={onClose} />,
+        fake,
+      );
+      await advanceToStepThree();
+      for (const raw of thresholdCase.raw) addThreshold(raw);
+      expect(Array.from(document.body.querySelectorAll<HTMLInputElement>(
+        ".team-context-alert-input",
+      )).map((element) => element.value)).toEqual(thresholdCase.raw);
+
+      click(button("Create"));
+      await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+      expect(fake.lastCall("create_team")?.args.contextAlertPercentages).toEqual(
+        thresholdCase.expected,
+      );
+
+      rendered.cleanup();
+      rendered = null;
+      document.body.replaceChildren();
+      resetUiStoresForTests();
+    }
+  });
+
+  it("blocks blank and duplicate drafts, then enables Create after correction", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    rendered = renderWithFakeTransport(
+      () => <NewTeamModal projectPath={projectPath} onClose={() => undefined} />,
+      fake,
+    );
+    await advanceToStepThree();
+
+    click(button("Add threshold"));
+    const first = field(".team-context-alert-input");
+    expect(button("Create").disabled).toBe(true);
+    click(button("Create"));
+    expect(fake.callsFor("create_team")).toHaveLength(0);
+
+    input(first, "80");
+    const second = addThreshold("080");
+    expect(first.getAttribute("aria-invalid")).toBe("true");
+    expect(second.getAttribute("aria-invalid")).toBe("true");
+    expect(button("Create").disabled).toBe(true);
+    click(button("Create"));
+    expect(fake.callsFor("create_team")).toHaveLength(0);
+    expect(fake.callsFor("discover_project")).toHaveLength(0);
+
+    input(second, "90");
+    expect(button("Create").disabled).toBe(false);
+  });
+
+  it("keeps raw threshold text through Back and Next", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    rendered = renderWithFakeTransport(
+      () => <NewTeamModal projectPath={projectPath} onClose={() => undefined} />,
+      fake,
+    );
+    await advanceToStepThree();
+    addThreshold("080");
+
+    click(button("Back"));
+    await waitFor(() => expect(button("Next")).toBeTruthy());
+    click(button("Next"));
+    await waitFor(() => expect(field(".team-context-alert-input").value).toBe("080"));
+    expect(fake.callsFor("create_team")).toHaveLength(0);
+  });
+
+  it("keeps creation, repository, member, and raw state after rejection without conflating errors", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    fake.reject("create_team", "create rejected");
+    const onClose = vi.fn();
+    rendered = renderWithFakeTransport(
+      () => <NewTeamModal projectPath={projectPath} onClose={onClose} />,
+      fake,
+    );
+    await advanceToStepThree();
+    const thresholdInput = addThreshold("80");
+    const repositoryInput = field('input[placeholder="https://github.com/org/repo.git"]');
+    input(repositoryInput, repoUrl);
+    click(button("Add Repo"));
+    input(repositoryInput, repoUrl);
+    click(button("Add Repo"));
+    expect(document.body.querySelector('[role="alert"][aria-label="Repository error"]'))
+      .toBeTruthy();
+
+    click(button("Create"));
+    await waitFor(() => expect(
+      document.body.querySelector('[role="alert"][aria-label="Team creation error"]')?.textContent,
+    ).toContain("create rejected"));
+    expect(document.body.textContent).toContain("repo");
+    expect(thresholdInput.value).toBe("80");
+    expect(fake.lastCall("create_team")?.args.agents).toEqual(["_agent_dev-webpage-ui"]);
+    expect(fake.callsFor("discover_project")).toHaveLength(0);
+    expect(onClose).not.toHaveBeenCalled();
+
+    input(thresholdInput, "81");
+    expect(document.body.querySelector('[role="alert"][aria-label="Team creation error"]')?.textContent)
+      .toContain("create rejected");
+    expect(document.body.querySelector('[role="alert"][aria-label="Repository error"]'))
+      .toBeTruthy();
+  });
+
+  it("locks all step-three interactions around one immutable deferred request", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    const pending = deferred<void>();
+    fake.onInvoke("create_team", () => pending.promise);
+    const onClose = vi.fn();
+    rendered = renderWithFakeTransport(
+      () => <NewTeamModal projectPath={projectPath} onClose={onClose} />,
+      fake,
+    );
+    await advanceToStepThree();
+    const thresholdInput = addThreshold("80");
+    const repositoryInput = field('input[placeholder="https://github.com/org/repo.git"]');
+    input(repositoryInput, repoUrl);
+    click(button("Add Repo"));
+    const createButton = button("Create");
+
+    click(createButton);
+    await waitFor(() => expect(
+      document.body.querySelector(".entity-wizard-modal")?.getAttribute("aria-busy"),
+    ).toBe("true"));
+    const captured = JSON.stringify(fake.lastCall("create_team")?.args);
+    expect(fake.callsFor("create_team")).toHaveLength(1);
+    expect(thresholdInput.disabled).toBe(true);
+    expect(repositoryInput.disabled).toBe(true);
+    expect(button("Add threshold").disabled).toBe(true);
+    expect(button("Add Repo").disabled).toBe(true);
+    expect(button("Back").disabled).toBe(true);
+    expect(createButton.disabled).toBe(true);
+    expect(Array.from(document.body.querySelectorAll<HTMLInputElement>(
+      '.wizard-repo-card input[type="checkbox"]',
+    )).every((element) => element.disabled)).toBe(true);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    click(createButton);
+    input(thresholdInput, "90");
+    expect(fake.callsFor("create_team")).toHaveLength(1);
+    expect(JSON.stringify(fake.lastCall("create_team")?.args)).toBe(captured);
+    expect(onClose).not.toHaveBeenCalled();
+
+    pending.reject(new Error("deferred rejection"));
+    await waitFor(() => expect(
+      document.body.querySelector('[role="alert"][aria-label="Team creation error"]')?.textContent,
+    ).toContain("deferred rejection"));
+    expect(document.body.querySelector(".entity-wizard-modal")?.getAttribute("aria-busy"))
+      .toBe("false");
+    expect(thresholdInput.disabled).toBe(false);
+    expect(thresholdInput.value).toBe("80");
+    expect(fake.callsFor("discover_project")).toHaveLength(0);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/sidebar/components/NewTeamModal.tsx
+++ b/src/sidebar/components/NewTeamModal.tsx
@@ -1,6 +1,10 @@
-import { Component, createSignal, createMemo, For, Show, onMount, onCleanup } from "solid-js";
+import { createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import type { Component } from "solid-js";
 import { EntityAPI } from "../../shared/ipc";
 import { projectStore } from "../stores/project";
+import { TeamContextAlertsEditor } from "./TeamContextAlertsEditor";
+import type { ContextAlertThresholdDraft } from "./team-context-alerts";
+import { validateContextAlertThresholdDrafts } from "./team-context-alerts";
 
 interface AgentEntry {
   name: string;
@@ -15,6 +19,12 @@ interface RepoEntry {
 
 type Step = 1 | 2 | 3;
 
+function normalizeCaughtError(error: unknown, fallback: string): string {
+  if (typeof error === "string") return error;
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
 const NewTeamModal: Component<{
   projectPath: string;
   onClose: () => void;
@@ -26,84 +36,90 @@ const NewTeamModal: Component<{
   const [coordinator, setCoordinator] = createSignal<string>("");
   const [repos, setRepos] = createSignal<RepoEntry[]>([]);
   const [repoInput, setRepoInput] = createSignal("");
-  const [error, setError] = createSignal("");
+  const [contextAlertDrafts, setContextAlertDrafts] =
+    createSignal<ContextAlertThresholdDraft[]>([]);
+  const [repoError, setRepoError] = createSignal("");
+  const [createError, setCreateError] = createSignal("");
   const [creating, setCreating] = createSignal(false);
   const [loadingAgents, setLoadingAgents] = createSignal(false);
+  const [agentFilter, setAgentFilter] = createSignal("");
   let nameRef!: HTMLInputElement;
 
-  const [agentFilter, setAgentFilter] = createSignal("");
+  const contextAlertValidation = createMemo(() =>
+    validateContextAlertThresholdDrafts(contextAlertDrafts()),
+  );
 
-  // Derive current project's folder name from props.projectPath
   const currentProjectName = createMemo(() => {
-    const p = props.projectPath.replace(/[\\/]+$/, "");
-    const idx = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
-    return idx >= 0 ? p.slice(idx + 1) : p;
+    const path = props.projectPath.replace(/[\\/]+$/, "");
+    const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+    return separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
   });
 
-  // Group agents by project, current project first, with search filter
   const agentsByProject = createMemo(() => {
     const filter = agentFilter().toLowerCase();
     const filtered = filter
-      ? allAgents().filter((a) => a.name.toLowerCase().includes(filter))
+      ? allAgents().filter((agent) => agent.name.toLowerCase().includes(filter))
       : allAgents();
 
-    const map = new Map<string, AgentEntry[]>();
-    for (const a of filtered) {
-      const list = map.get(a.projectName) ?? [];
-      list.push(a);
-      map.set(a.projectName, list);
+    const grouped = new Map<string, AgentEntry[]>();
+    for (const agent of filtered) {
+      const entries = grouped.get(agent.projectName) ?? [];
+      entries.push(agent);
+      grouped.set(agent.projectName, entries);
     }
 
-    // Sort: current project first, rest alphabetical
-    const cur = currentProjectName();
-    const entries = Array.from(map.entries());
-    entries.sort((a, b) => {
-      if (a[0] === cur) return -1;
-      if (b[0] === cur) return 1;
-      return a[0].localeCompare(b[0]);
+    const current = currentProjectName();
+    const entries = Array.from(grouped.entries());
+    entries.sort((left, right) => {
+      if (left[0] === current) return -1;
+      if (right[0] === current) return 1;
+      return left[0].localeCompare(right[0]);
     });
     return new Map(entries);
   });
 
   const selectedAgentList = createMemo(() =>
-    allAgents().filter((a) => selectedAgents().has(a.path))
+    allAgents().filter((agent) => selectedAgents().has(agent.path)),
   );
 
-  const portableAgentRef = (path: string) => {
+  const portableAgentRef = (path: string): string => {
     const last = path.replace(/\\/g, "/").split("/").filter(Boolean).pop() ?? path;
     return last.startsWith("_agent_") ? last : `_agent_${last}`;
   };
 
   const canNext1 = createMemo(() => {
-    const n = teamName().trim();
-    return n.length > 0 && !n.includes("/") && !n.includes("\\") && !n.includes(" ");
+    const name = teamName().trim();
+    return name.length > 0 && !name.includes("/") && !name.includes("\\") && !name.includes(" ");
   });
 
-  const canNext2 = createMemo(() =>
-    selectedAgents().size > 0 && coordinator() !== ""
+  const canNext2 = createMemo(() => selectedAgents().size > 0 && coordinator() !== "");
+
+  const canCreate = createMemo(() =>
+    !creating() && canNext1() && canNext2() && contextAlertValidation().valid,
   );
 
   onMount(async () => {
     setLoadingAgents(true);
     try {
-      const paths = projectStore.projects.map((p) => p.path);
+      const paths = projectStore.projects.map((project) => project.path);
       const result = await EntityAPI.listAllAgents(paths);
-      const entries: AgentEntry[] = result.map((a) => ({
-        name: a.name,
-        path: a.path,
-        projectName: a.projectName,
-      }));
-      setAllAgents(entries);
-    } catch (e) {
-      console.error("list_all_agents failed:", e);
+      setAllAgents(
+        result.map((agent) => ({
+          name: agent.name,
+          path: agent.path,
+          projectName: agent.projectName,
+        })),
+      );
+    } catch (error: unknown) {
+      console.error("list_all_agents failed:", error);
     } finally {
       setLoadingAgents(false);
     }
   });
 
   const toggleAgent = (path: string) => {
-    setSelectedAgents((prev) => {
-      const next = new Set(prev);
+    setSelectedAgents((previous) => {
+      const next = new Set(previous);
       if (next.has(path)) {
         next.delete(path);
         if (coordinator() === path) setCoordinator("");
@@ -115,84 +131,111 @@ const NewTeamModal: Component<{
   };
 
   const addRepo = () => {
+    if (creating()) return;
     const url = repoInput().trim();
     if (!url) return;
-    if (repos().some((r) => r.url === url)) {
-      setError("Repo already added");
+    if (repos().some((repo) => repo.url === url)) {
+      setRepoError("Repo already added");
       return;
     }
-    setRepos((prev) => [...prev, { url, agents: new Set(selectedAgentList().map((a) => a.path)) }]);
+    setRepos((previous) => [
+      ...previous,
+      { url, agents: new Set(selectedAgentList().map((agent) => agent.path)) },
+    ]);
     setRepoInput("");
-    setError("");
+    setRepoError("");
   };
 
   const removeRepo = (url: string) => {
-    setRepos((prev) => prev.filter((r) => r.url !== url));
+    if (creating()) return;
+    setRepos((previous) => previous.filter((repo) => repo.url !== url));
   };
 
   const toggleRepoAgent = (repoUrl: string, agentPath: string) => {
-    setRepos((prev) =>
-      prev.map((r) => {
-        if (r.url !== repoUrl) return r;
-        const next = new Set(r.agents);
-        if (next.has(agentPath)) next.delete(agentPath);
-        else next.add(agentPath);
-        return { ...r, agents: next };
-      })
+    if (creating()) return;
+    setRepos((previous) =>
+      previous.map((repo) => {
+        if (repo.url !== repoUrl) return repo;
+        const nextAgents = new Set(repo.agents);
+        if (nextAgents.has(agentPath)) nextAgents.delete(agentPath);
+        else nextAgents.add(agentPath);
+        return { ...repo, agents: nextAgents };
+      }),
     );
   };
 
   const toggleRepoAll = (repoUrl: string) => {
-    setRepos((prev) =>
-      prev.map((r) => {
-        if (r.url !== repoUrl) return r;
-        const allSelected = selectedAgentList().every((a) => r.agents.has(a.path));
-        const next = allSelected ? new Set<string>() : new Set(selectedAgentList().map((a) => a.path));
-        return { ...r, agents: next };
-      })
+    if (creating()) return;
+    setRepos((previous) =>
+      previous.map((repo) => {
+        if (repo.url !== repoUrl) return repo;
+        const allSelected = selectedAgentList().every((agent) => repo.agents.has(agent.path));
+        const nextAgents = allSelected
+          ? new Set<string>()
+          : new Set(selectedAgentList().map((agent) => agent.path));
+        return { ...repo, agents: nextAgents };
+      }),
     );
   };
 
-  const repoDisplayName = (url: string) => {
+  const repoDisplayName = (url: string): string => {
     const match = url.match(/\/([^/]+?)(?:\.git)?$/);
     return match ? match[1] : url;
   };
 
   const handleCreate = async () => {
-    if (creating()) return;
+    const validation = contextAlertValidation();
+    if (
+      creating()
+      || !canNext1()
+      || !canNext2()
+      || !validation.valid
+    ) {
+      return;
+    }
+
+    const request = {
+      projectPath: props.projectPath,
+      name: teamName().trim(),
+      agents: Array.from(selectedAgents()).map(portableAgentRef),
+      coordinator: portableAgentRef(coordinator()),
+      repos: repos().map((repo) => ({
+        url: repo.url,
+        agents: Array.from(repo.agents).map(portableAgentRef),
+      })),
+      contextAlertPercentages: [...validation.canonicalPercentages],
+    };
+
     setCreating(true);
-    setError("");
+    setCreateError("");
     try {
-      const repoData = repos().map((r) => ({
-        url: r.url,
-        agents: Array.from(r.agents).map(portableAgentRef),
-      }));
       await EntityAPI.createTeam(
-        props.projectPath,
-        teamName().trim(),
-        Array.from(selectedAgents()).map(portableAgentRef),
-        portableAgentRef(coordinator()),
-        repoData
+        request.projectPath,
+        request.name,
+        request.agents,
+        request.coordinator,
+        request.repos,
+        request.contextAlertPercentages,
       );
-      await projectStore.reloadProject(props.projectPath);
+      await projectStore.reloadProject(request.projectPath);
       props.onClose();
-    } catch (e: any) {
-      console.error("create_team failed:", e);
-      setError(typeof e === "string" ? e : e.message || "Failed to create team");
+    } catch (error: unknown) {
+      console.error("create_team failed:", error);
+      setCreateError(normalizeCaughtError(error, "Failed to create team"));
     } finally {
       setCreating(false);
     }
   };
 
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey && step() === 1) {
-      e.preventDefault();
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter" && !event.shiftKey && step() === 1) {
+      event.preventDefault();
       if (canNext1()) setStep(2);
     }
   };
 
-  const handleDocumentKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") props.onClose();
+  const handleDocumentKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape" && !creating()) props.onClose();
   };
 
   document.addEventListener("keydown", handleDocumentKeyDown);
@@ -200,13 +243,15 @@ const NewTeamModal: Component<{
 
   return (
     <div class="modal-overlay" onKeyDown={handleKeyDown}>
-      <div class="agent-modal entity-wizard-modal">
+      <div
+        class="agent-modal entity-wizard-modal"
+        aria-busy={creating() ? "true" : "false"}
+      >
         <div class="agent-modal-header">
           <span class="agent-modal-title">New Team</span>
           <span class="wizard-step-indicator">Step {step()} of 3</span>
         </div>
 
-        {/* Step 1: Name */}
         <Show when={step() === 1}>
           <div class="new-agent-form">
             <div class="new-agent-field">
@@ -215,14 +260,11 @@ const NewTeamModal: Component<{
                 ref={nameRef!}
                 class="agent-search-input"
                 value={teamName()}
-                onInput={(e) => { setTeamName(e.currentTarget.value); setError(""); }}
+                onInput={(event) => setTeamName(event.currentTarget.value)}
                 placeholder="dream-team"
                 autofocus
               />
             </div>
-            <Show when={error()}>
-              <div class="new-agent-error">{error()}</div>
-            </Show>
           </div>
           <div class="new-agent-footer">
             <button class="new-agent-cancel-btn" onClick={() => props.onClose()}>Cancel</button>
@@ -236,7 +278,6 @@ const NewTeamModal: Component<{
           </div>
         </Show>
 
-        {/* Step 2: Agent selection */}
         <Show when={step() === 2}>
           <div class="wizard-body">
             <Show when={loadingAgents()}>
@@ -254,7 +295,7 @@ const NewTeamModal: Component<{
                 <input
                   class="wizard-search-input"
                   value={agentFilter()}
-                  onInput={(e) => setAgentFilter(e.currentTarget.value)}
+                  onInput={(event) => setAgentFilter(event.currentTarget.value)}
                   placeholder="Filter agents..."
                 />
               </div>
@@ -265,7 +306,7 @@ const NewTeamModal: Component<{
                     <For each={agents}>
                       {(agent) => {
                         const isSelected = () => selectedAgents().has(agent.path);
-                        const isCoord = () => coordinator() === agent.path;
+                        const isCoordinator = () => coordinator() === agent.path;
                         return (
                           <div class="wizard-agent-row">
                             <label class="wizard-checkbox-label">
@@ -281,7 +322,7 @@ const NewTeamModal: Component<{
                                 <input
                                   type="radio"
                                   name="coordinator"
-                                  checked={isCoord()}
+                                  checked={isCoordinator()}
                                   onChange={() => setCoordinator(agent.path)}
                                 />
                                 <span class="wizard-coord-text">Coord</span>
@@ -294,9 +335,6 @@ const NewTeamModal: Component<{
                   </div>
                 )}
               </For>
-            </Show>
-            <Show when={error()}>
-              <div class="new-agent-error">{error()}</div>
             </Show>
           </div>
           <div class="new-agent-footer">
@@ -311,75 +349,146 @@ const NewTeamModal: Component<{
           </div>
         </Show>
 
-        {/* Step 3: Repo assignment */}
         <Show when={step() === 3}>
           <div class="wizard-body">
-            <div class="wizard-repo-input-row">
-              <input
-                class="agent-search-input"
-                value={repoInput()}
-                onInput={(e) => { setRepoInput(e.currentTarget.value); setError(""); }}
-                placeholder="https://github.com/org/repo.git"
-                onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); addRepo(); } }}
-              />
-              <button class="new-agent-browse-btn" onClick={addRepo}>Add Repo</button>
-            </div>
+            <TeamContextAlertsEditor
+              idPrefix="new-team-context-alerts"
+              drafts={contextAlertDrafts()}
+              validation={contextAlertValidation()}
+              disabled={creating()}
+              onChange={(next) => {
+                if (creating()) return;
+                setContextAlertDrafts(next);
+              }}
+            />
 
-            <Show when={repos().length > 0}>
-              <div class="wizard-repo-list">
-                <For each={repos()}>
-                  {(repo) => {
-                    const allChecked = () => selectedAgentList().every((a) => repo.agents.has(a.path));
-                    return (
-                      <div class="wizard-repo-card">
-                        <div class="wizard-repo-header">
-                          <span class="wizard-repo-name">{repoDisplayName(repo.url)}</span>
-                          <button class="wizard-repo-remove" onClick={() => removeRepo(repo.url)} title="Remove repo">
-                            &#x2715;
-                          </button>
-                        </div>
-                        <div class="wizard-repo-agents">
-                          <label class="wizard-checkbox-label wizard-all-label">
-                            <input
-                              type="checkbox"
-                              checked={allChecked()}
-                              onChange={() => toggleRepoAll(repo.url)}
-                            />
-                            <span>All agents</span>
-                          </label>
-                          <For each={selectedAgentList()}>
-                            {(agent) => (
-                              <label class="wizard-checkbox-label">
-                                <input
-                                  type="checkbox"
-                                  checked={repo.agents.has(agent.path)}
-                                  onChange={() => toggleRepoAgent(repo.url, agent.path)}
-                                />
-                                <span>{agent.name}</span>
-                              </label>
-                            )}
-                          </For>
-                        </div>
-                      </div>
-                    );
+            <section class="team-settings-section" aria-labelledby="new-team-repositories-heading">
+              <h3 id="new-team-repositories-heading" class="team-settings-heading">
+                Repositories (optional)
+              </h3>
+              <div class="wizard-repo-input-row">
+                <input
+                  class="agent-search-input"
+                  value={repoInput()}
+                  disabled={creating()}
+                  onInput={(event) => {
+                    if (creating()) {
+                      event.currentTarget.value = repoInput();
+                      return;
+                    }
+                    setRepoInput(event.currentTarget.value);
+                    setRepoError("");
                   }}
-                </For>
+                  placeholder="https://github.com/org/repo.git"
+                  onKeyDown={(event) => {
+                    if (creating()) return;
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      addRepo();
+                    }
+                  }}
+                />
+                <button
+                  class="new-agent-browse-btn"
+                  type="button"
+                  disabled={creating()}
+                  onClick={addRepo}
+                >
+                  Add Repo
+                </button>
               </div>
-            </Show>
 
-            <Show when={repos().length === 0}>
-              <div class="wizard-empty">No repos added yet. Add repo URLs above.</div>
-            </Show>
+              <Show when={repos().length > 0}>
+                <div class="wizard-repo-list">
+                  <For each={repos()}>
+                    {(repo) => {
+                      const allChecked = () =>
+                        selectedAgentList().every((agent) => repo.agents.has(agent.path));
+                      return (
+                        <div class="wizard-repo-card">
+                          <div class="wizard-repo-header">
+                            <span class="wizard-repo-name">{repoDisplayName(repo.url)}</span>
+                            <button
+                              class="wizard-repo-remove"
+                              type="button"
+                              disabled={creating()}
+                              onClick={() => removeRepo(repo.url)}
+                              title="Remove repo"
+                            >
+                              &#x2715;
+                            </button>
+                          </div>
+                          <div class="wizard-repo-agents">
+                            <label class="wizard-checkbox-label wizard-all-label">
+                              <input
+                                type="checkbox"
+                                checked={allChecked()}
+                                disabled={creating()}
+                                onChange={() => toggleRepoAll(repo.url)}
+                              />
+                              <span>All agents</span>
+                            </label>
+                            <For each={selectedAgentList()}>
+                              {(agent) => (
+                                <label class="wizard-checkbox-label">
+                                  <input
+                                    type="checkbox"
+                                    checked={repo.agents.has(agent.path)}
+                                    disabled={creating()}
+                                    onChange={() => toggleRepoAgent(repo.url, agent.path)}
+                                  />
+                                  <span>{agent.name}</span>
+                                </label>
+                              )}
+                            </For>
+                          </div>
+                        </div>
+                      );
+                    }}
+                  </For>
+                </div>
+              </Show>
 
-            <Show when={error()}>
-              <div class="new-agent-error">{error()}</div>
+              <Show when={repos().length === 0}>
+                <div class="wizard-empty">No repos added yet. Add repo URLs above.</div>
+              </Show>
+
+              <Show when={repoError()}>
+                <div
+                  id="new-team-repository-error"
+                  class="new-agent-error"
+                  role="alert"
+                  aria-label="Repository error"
+                >
+                  {repoError()}
+                </div>
+              </Show>
+            </section>
+
+            <Show when={createError()}>
+              <div
+                id="new-team-create-error"
+                class="new-agent-error"
+                role="alert"
+                aria-label="Team creation error"
+              >
+                {createError()}
+              </div>
             </Show>
           </div>
           <div class="new-agent-footer">
-            <button class="new-agent-cancel-btn" onClick={() => setStep(2)}>Back</button>
+            <button
+              class="new-agent-cancel-btn"
+              disabled={creating()}
+              onClick={() => {
+                if (!creating()) setStep(2);
+              }}
+            >
+              Back
+            </button>
             <button
               class="new-agent-create-btn"
-              disabled={creating()}
+              disabled={!canCreate()}
               onClick={handleCreate}
             >
               {creating() ? "Creating..." : "Create"}

--- a/src/sidebar/components/ProjectPanel.edit-team-modal.test.tsx
+++ b/src/sidebar/components/ProjectPanel.edit-team-modal.test.tsx
@@ -94,7 +94,7 @@ describe("ProjectPanel edit-team modal (#669)", () => {
     document.body.replaceChildren();
   });
 
-  it("keeps the edit team modal and unsaved repo edits open across project refreshes", async () => {
+  it("keeps the edit team modal, raw threshold node, and unsaved repo open across refreshes", async () => {
     const fake = new FakeTransport();
     setupTransport(fake);
 
@@ -113,6 +113,13 @@ describe("ProjectPanel edit-team modal (#669)", () => {
     click(findButtonByText("Next"));
 
     await waitFor(() => expect(repoInput()).toBeTruthy());
+    click(findButtonByText("Add threshold"));
+    const thresholdInput = document.body.querySelector<HTMLInputElement>(
+      ".team-context-alert-input",
+    );
+    if (!thresholdInput) throw new Error("Threshold input not found");
+    input(thresholdInput, "080");
+
     input(repoInput(), unsavedRepoUrl);
     click(findButtonByText("Add Repo"));
     await waitFor(() => expect(modalText()).toContain("unsaved-repo"));
@@ -124,5 +131,9 @@ describe("ProjectPanel edit-team modal (#669)", () => {
 
     expect(modalText()).toContain(`Edit Team: ${teamName}`);
     expect(modalText()).toContain("unsaved-repo");
+    expect(document.body.querySelector(".team-context-alert-input")).toBe(thresholdInput);
+    expect(thresholdInput.value).toBe("080");
+    expect(fake.callsFor("get_team_config")).toHaveLength(1);
+    expect(fake.callsFor("update_team")).toHaveLength(0);
   });
 });

--- a/src/sidebar/components/TeamContextAlertsEditor.test.tsx
+++ b/src/sidebar/components/TeamContextAlertsEditor.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+import { createSignal } from "solid-js";
+import { render } from "solid-js/web";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  click,
+  input,
+  installBrowserDomStubs,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { TeamContextAlertsEditor } from "./TeamContextAlertsEditor";
+import type { ContextAlertThresholdDraft } from "./team-context-alerts";
+import { validateContextAlertThresholdDrafts } from "./team-context-alerts";
+
+function draft(id: number, raw: string): ContextAlertThresholdDraft {
+  return { id, raw };
+}
+
+function button(root: ParentNode, label: string): HTMLButtonElement {
+  const found = Array.from(root.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!(found instanceof HTMLButtonElement)) throw new Error(`Button not found: ${label}`);
+  return found;
+}
+
+function removeButton(root: ParentNode, number: number): HTMLButtonElement {
+  const found = root.querySelector(`[aria-label="Remove threshold ${number}"]`);
+  if (!(found instanceof HTMLButtonElement)) throw new Error(`Remove button not found: ${number}`);
+  return found;
+}
+
+function inputs(root: ParentNode): HTMLInputElement[] {
+  return Array.from(root.querySelectorAll<HTMLInputElement>(".team-context-alert-input"));
+}
+
+function mountEditor(initial: ContextAlertThresholdDraft[], initiallyDisabled = false) {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  const [drafts, setDrafts] = createSignal(initial);
+  const [disabled, setDisabled] = createSignal(initiallyDisabled);
+  const dispose = render(
+    () => (
+      <TeamContextAlertsEditor
+        idPrefix="test-context-alerts"
+        drafts={drafts()}
+        validation={validateContextAlertThresholdDrafts(drafts())}
+        disabled={disabled()}
+        onChange={setDrafts}
+      />
+    ),
+    root,
+  );
+  return {
+    root,
+    drafts,
+    setDrafts,
+    setDisabled,
+    cleanup: () => {
+      dispose();
+      root.remove();
+    },
+  };
+}
+
+describe("TeamContextAlertsEditor", () => {
+  let restoreDom: (() => void) | null = null;
+  let cleanupEditor: (() => void) | null = null;
+
+  beforeEach(() => {
+    restoreDom = installBrowserDomStubs();
+  });
+
+  afterEach(() => {
+    cleanupEditor?.();
+    cleanupEditor = null;
+    restoreDom?.();
+    restoreDom = null;
+    document.body.replaceChildren();
+  });
+
+  it("renders the labelled empty state, count, scope, signal caveat, and no-action copy", () => {
+    const mounted = mountEditor([]);
+    cleanupEditor = mounted.cleanup;
+
+    const section = mounted.root.querySelector("section");
+    expect(section?.getAttribute("aria-labelledby")).toBe("test-context-alerts-heading");
+    expect(mounted.root.textContent).toContain("Context usage alerts (optional)");
+    expect(mounted.root.textContent).toContain("No context alerts configured.");
+    expect(mounted.root.textContent).toContain("0 of 3 thresholds");
+    expect(mounted.root.textContent).toContain("Applies to every workgroup of this team.");
+    expect(mounted.root.textContent).toContain("best-effort");
+    expect(mounted.root.textContent).toContain("contextRegex");
+    expect(mounted.root.textContent).toContain("No automatic action is taken");
+    expect(button(mounted.root, "Add threshold").getAttribute("aria-describedby")).toBe(
+      "test-context-alerts-count",
+    );
+  });
+
+  it("adds a blank focused row while preserving its input node through raw updates", async () => {
+    const mounted = mountEditor([]);
+    cleanupEditor = mounted.cleanup;
+
+    click(button(mounted.root, "Add threshold"));
+    await waitFor(() => expect(inputs(mounted.root)).toHaveLength(1));
+    const thresholdInput = inputs(mounted.root)[0];
+    if (!thresholdInput) throw new Error("Threshold input missing");
+    await waitFor(() => expect(document.activeElement).toBe(thresholdInput));
+
+    expect(mounted.drafts()).toEqual([{ id: 1, raw: "" }]);
+    expect(thresholdInput.getAttribute("aria-invalid")).toBe("true");
+    expect(mounted.root.querySelector('[role="alert"][aria-label="Context alert threshold errors"]'))
+      .toBeTruthy();
+
+    for (const raw of ["+", "+50", "050"] as const) {
+      input(thresholdInput, raw);
+      expect(mounted.drafts()[0]?.raw).toBe(raw);
+      expect(inputs(mounted.root)[0]).toBe(thresholdInput);
+      expect(document.activeElement).toBe(thresholdInput);
+    }
+    expect(thresholdInput.getAttribute("aria-invalid")).toBeNull();
+  });
+
+  it("enforces the cap without hiding malformed over-cardinality rows", () => {
+    const capped = mountEditor([draft(1, "10"), draft(2, "20"), draft(3, "30")]);
+    cleanupEditor = capped.cleanup;
+    expect(button(capped.root, "Add threshold").disabled).toBe(true);
+    expect(capped.root.textContent).toContain("3 of 3 thresholds");
+
+    capped.setDrafts([
+      draft(1, "10"),
+      draft(2, "20"),
+      draft(3, "30"),
+      draft(4, "40"),
+    ]);
+    expect(inputs(capped.root)).toHaveLength(4);
+    expect(capped.root.textContent).toContain("4 of 3 thresholds");
+    expect(button(capped.root, "Add threshold").disabled).toBe(true);
+    expect(Array.from(capped.root.querySelectorAll<HTMLButtonElement>("[aria-label^='Remove threshold']")))
+      .toHaveLength(4);
+    expect(Array.from(capped.root.querySelectorAll<HTMLButtonElement>("[aria-label^='Remove threshold']"))
+      .every((candidate) => !candidate.disabled)).toBe(true);
+  });
+
+  it("preserves surviving keyed nodes and focuses next, previous, then Add after removals", async () => {
+    const mounted = mountEditor([draft(1, "10"), draft(2, "20"), draft(3, "30")]);
+    cleanupEditor = mounted.cleanup;
+    const [first, second, third] = inputs(mounted.root);
+    if (!first || !second || !third) throw new Error("Expected three inputs");
+
+    click(removeButton(mounted.root, 2));
+    await waitFor(() => expect(document.activeElement).toBe(third));
+    expect(inputs(mounted.root)).toEqual([first, third]);
+
+    click(removeButton(mounted.root, 2));
+    await waitFor(() => expect(document.activeElement).toBe(first));
+    expect(inputs(mounted.root)).toEqual([first]);
+
+    click(removeButton(mounted.root, 1));
+    await waitFor(() => expect(document.activeElement).toBe(button(mounted.root, "Add threshold")));
+    expect(inputs(mounted.root)).toEqual([]);
+  });
+
+  it("uses stable accessible text inputs and exposes exact raw spellings to the validator", () => {
+    const mounted = mountEditor([draft(9, "50")]);
+    cleanupEditor = mounted.cleanup;
+    const thresholdInput = inputs(mounted.root)[0];
+    if (!thresholdInput) throw new Error("Threshold input missing");
+
+    expect(thresholdInput.id).toBe("test-context-alerts-threshold-9");
+    expect(thresholdInput.labels?.[0]?.textContent?.trim()).toBe("Threshold 1 percentage");
+    expect(thresholdInput.type).toBe("text");
+    expect(thresholdInput.getAttribute("inputmode")).toBe("numeric");
+    expect(thresholdInput.autocomplete).toBe("off");
+    for (const forbiddenAttribute of ["pattern", "min", "max", "step"]) {
+      expect(thresholdInput.hasAttribute(forbiddenAttribute)).toBe(false);
+    }
+    expect(thresholdInput.getAttribute("aria-describedby")).toBe("test-context-alerts-help");
+    expect(mounted.root.querySelector(".team-context-alert-suffix")?.getAttribute("aria-hidden"))
+      .toBe("true");
+
+    for (const raw of ["+50", "-50", "5e1", "text", "50.5"] as const) {
+      input(thresholdInput, raw);
+      expect(mounted.drafts()[0]?.raw).toBe(raw);
+      expect(thresholdInput.getAttribute("aria-invalid")).toBe("true");
+      const describedIds = thresholdInput.getAttribute("aria-describedby")?.split(/\s+/) ?? [];
+      expect(describedIds).toContain("test-context-alerts-help");
+      expect(describedIds).toContain("test-context-alerts-threshold-9-error");
+      expect(mounted.root.querySelector("#test-context-alerts-threshold-9-error")).toBeTruthy();
+    }
+
+    input(thresholdInput, "050");
+    expect(mounted.drafts()[0]?.raw).toBe("050");
+    expect(thresholdInput.getAttribute("aria-invalid")).toBeNull();
+    expect(thresholdInput.getAttribute("aria-describedby")).toBe("test-context-alerts-help");
+    expect(mounted.root.querySelector("#test-context-alerts-threshold-9-error")).toBeNull();
+  });
+
+  it("disables every editor control without changing controlled raw drafts", () => {
+    const mounted = mountEditor([draft(1, "50")], true);
+    cleanupEditor = mounted.cleanup;
+    const thresholdInput = inputs(mounted.root)[0];
+    if (!thresholdInput) throw new Error("Threshold input missing");
+
+    expect(thresholdInput.disabled).toBe(true);
+    expect(button(mounted.root, "Add threshold").disabled).toBe(true);
+    expect(removeButton(mounted.root, 1).disabled).toBe(true);
+    input(thresholdInput, "75");
+    expect(mounted.drafts()).toEqual([draft(1, "50")]);
+
+    mounted.setDisabled(false);
+    expect(thresholdInput.disabled).toBe(false);
+    expect(removeButton(mounted.root, 1).disabled).toBe(false);
+  });
+});

--- a/src/sidebar/components/TeamContextAlertsEditor.tsx
+++ b/src/sidebar/components/TeamContextAlertsEditor.tsx
@@ -1,0 +1,184 @@
+import { createEffect, createMemo, For, onCleanup, Show } from "solid-js";
+import type { Component } from "solid-js";
+import { focusOnMount } from "../../shared/focus-on-mount";
+import type {
+  ContextAlertThresholdDraft,
+  ContextAlertThresholdValidation,
+} from "./team-context-alerts";
+import { MAX_CONTEXT_ALERT_THRESHOLDS } from "./team-context-alerts";
+
+interface TeamContextAlertsEditorProps {
+  idPrefix: string;
+  drafts: readonly ContextAlertThresholdDraft[];
+  validation: ContextAlertThresholdValidation;
+  disabled: boolean;
+  onChange: (next: ContextAlertThresholdDraft[]) => void;
+}
+
+export const TeamContextAlertsEditor: Component<TeamContextAlertsEditorProps> = (props) => {
+  const inputElements = new Map<number, HTMLInputElement>();
+  let addButton: HTMLButtonElement | undefined;
+  let focusAfterAddId: number | null = null;
+
+  const draftIds = createMemo(() => props.drafts.map((draft) => draft.id));
+  const headingId = () => `${props.idPrefix}-heading`;
+  const helpId = () => `${props.idPrefix}-help`;
+  const countId = () => `${props.idPrefix}-count`;
+  const aggregateErrorId = () => `${props.idPrefix}-errors`;
+  const inputId = (draftId: number) => `${props.idPrefix}-threshold-${draftId}`;
+  const rowErrorId = (draftId: number) => `${inputId(draftId)}-error`;
+  const draftById = (draftId: number) =>
+    props.drafts.find((draft) => draft.id === draftId);
+  const validationById = (draftId: number) =>
+    props.validation.rows.find((row) => row.draftId === draftId);
+
+  createEffect(() => {
+    const editorDisabled = props.disabled;
+    for (const draft of props.drafts) {
+      const input = inputElements.get(draft.id);
+      if (input && (editorDisabled || input.value !== draft.raw)) input.value = draft.raw;
+    }
+  });
+
+  const addThreshold = () => {
+    if (props.disabled || props.drafts.length >= MAX_CONTEXT_ALERT_THRESHOLDS) return;
+    const id = Math.max(0, ...props.drafts.map(({ id: draftId }) => draftId)) + 1;
+    focusAfterAddId = id;
+    props.onChange([...props.drafts, { id, raw: "" }]);
+  };
+
+  const updateThreshold = (draftId: number, raw: string) => {
+    if (props.disabled) return;
+    props.onChange(
+      props.drafts.map((draft) =>
+        draft.id === draftId ? { ...draft, raw } : draft,
+      ),
+    );
+  };
+
+  const removeThreshold = (draftId: number) => {
+    if (props.disabled) return;
+    const currentIndex = props.drafts.findIndex((draft) => draft.id === draftId);
+    if (currentIndex < 0) return;
+
+    const next = props.drafts.filter((draft) => draft.id !== draftId);
+    const focusDraft = next[currentIndex] ?? next[currentIndex - 1];
+    props.onChange(next);
+
+    const focusTarget = focusDraft ? inputElements.get(focusDraft.id) : addButton;
+    if (focusTarget) focusOnMount(focusTarget);
+  };
+
+  return (
+    <section class="team-settings-section" aria-labelledby={headingId()}>
+      <h3 id={headingId()} class="team-settings-heading">
+        Context usage alerts (optional)
+      </h3>
+      <p id={helpId()} class="team-context-alert-help">
+        Applies to every workgroup of this team. When a member reaches or crosses a configured
+        percentage, AgentsCommander sends that workgroup&apos;s coordinator an informational notice
+        naming the member and observed usage. Readings are best-effort and depend on a working
+        contextRegex (Context badge pattern) for the coding agent selected for the session. No
+        automatic action is taken: no session is cleared, closed, restarted, handed off,
+        reassigned, or otherwise changed.
+      </p>
+
+      <div class="team-context-alert-toolbar">
+        <button
+          ref={addButton}
+          class="new-agent-browse-btn"
+          type="button"
+          disabled={props.disabled || props.drafts.length >= MAX_CONTEXT_ALERT_THRESHOLDS}
+          aria-describedby={countId()}
+          onClick={addThreshold}
+        >
+          Add threshold
+        </button>
+        <span id={countId()} class="team-context-alert-count" aria-live="polite">
+          {props.drafts.length} of {MAX_CONTEXT_ALERT_THRESHOLDS} thresholds
+        </span>
+      </div>
+
+      <Show when={props.drafts.length === 0}>
+        <div class="wizard-empty team-context-alert-empty">No context alerts configured.</div>
+      </Show>
+
+      <div class="team-context-alert-rows">
+        <For each={draftIds()}>
+          {(draftId, index) => {
+            onCleanup(() => inputElements.delete(draftId));
+            const rowValidation = () => validationById(draftId);
+            const hasError = () => (rowValidation()?.errorCodes.length ?? 0) > 0;
+            const describedBy = () =>
+              hasError() ? `${helpId()} ${rowErrorId(draftId)}` : helpId();
+
+            return (
+              <div class="team-context-alert-row">
+                <div class="team-context-alert-field">
+                  <label class="new-agent-label" for={inputId(draftId)}>
+                    Threshold {index() + 1} percentage
+                  </label>
+                  <div class="team-context-alert-input-wrap">
+                    <input
+                      ref={(element) => {
+                        inputElements.set(draftId, element);
+                        if (focusAfterAddId === draftId) {
+                          focusAfterAddId = null;
+                          focusOnMount(element);
+                        }
+                      }}
+                      id={inputId(draftId)}
+                      class="agent-search-input team-context-alert-input"
+                      type="text"
+                      inputmode="numeric"
+                      autocomplete="off"
+                      value={draftById(draftId)?.raw ?? ""}
+                      disabled={props.disabled}
+                      aria-describedby={describedBy()}
+                      aria-invalid={hasError() ? "true" : undefined}
+                      onInput={(event) => {
+                        if (props.disabled) {
+                          event.currentTarget.value = draftById(draftId)?.raw ?? "";
+                          return;
+                        }
+                        updateThreshold(draftId, event.currentTarget.value);
+                      }}
+                    />
+                    <span class="team-context-alert-suffix" aria-hidden="true">%</span>
+                  </div>
+                  <Show when={hasError()}>
+                    <div id={rowErrorId(draftId)} class="team-context-alert-row-error">
+                      {rowValidation()?.messages.join(" ")}
+                    </div>
+                  </Show>
+                </div>
+                <button
+                  class="new-agent-cancel-btn team-context-alert-remove"
+                  type="button"
+                  disabled={props.disabled}
+                  aria-label={`Remove threshold ${index() + 1}`}
+                  onClick={() => removeThreshold(draftId)}
+                >
+                  Remove
+                </button>
+              </div>
+            );
+          }}
+        </For>
+      </div>
+
+      <Show when={props.validation.summaryMessages.length > 0}>
+        <div
+          id={aggregateErrorId()}
+          class="new-agent-error team-context-alert-errors"
+          role="alert"
+          aria-label="Context alert threshold errors"
+        >
+          <For each={props.validation.summaryMessages}>
+            {(message) => <div>{message}</div>}
+          </For>
+        </div>
+      </Show>
+    </section>
+  );
+};

--- a/src/sidebar/components/team-context-alerts.test.ts
+++ b/src/sidebar/components/team-context-alerts.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  hydrateContextAlertThresholdDrafts,
+  validateContextAlertThresholdDrafts,
+} from "./team-context-alerts";
+import type { ContextAlertThresholdDraft } from "./team-context-alerts";
+
+function drafts(...rawValues: string[]): ContextAlertThresholdDraft[] {
+  return rawValues.map((raw, index) => ({ id: index + 1, raw }));
+}
+
+describe("team context alert draft validation", () => {
+  it("canonicalizes empty, boundary, leading-zero, and unordered drafts without mutation", () => {
+    const cases: { input: ContextAlertThresholdDraft[]; expected: number[] }[] = [
+      { input: [], expected: [] },
+      { input: drafts("1"), expected: [1] },
+      { input: drafts("100"), expected: [100] },
+      { input: drafts("001"), expected: [1] },
+      { input: drafts("90", "50", "75"), expected: [50, 75, 90] },
+    ];
+
+    for (const testCase of cases) {
+      const before = testCase.input.map((draft) => ({ ...draft }));
+      const result = validateContextAlertThresholdDrafts(testCase.input);
+      expect(result.valid).toBe(true);
+      if (!result.valid) throw new Error("Expected valid draft result");
+      expect(result.canonicalPercentages).toEqual(testCase.expected);
+      expect(result.canonicalPercentages).not.toBe(testCase.expected);
+      expect(result.rows).toHaveLength(testCase.input.length);
+      expect(result.summaryMessages).toEqual([]);
+      expect(testCase.input).toEqual(before);
+    }
+  });
+
+  it("accepts surrounding whitespace without rewriting the raw value", () => {
+    const input = drafts(" \t50\n ");
+    const result = validateContextAlertThresholdDrafts(input);
+    expect(result.valid).toBe(true);
+    if (!result.valid) throw new Error("Expected valid whitespace result");
+    expect(result.canonicalPercentages).toEqual([50]);
+    expect(input[0]?.raw).toBe(" \t50\n ");
+  });
+
+  it("returns fixed lexical and range annotations for invalid spellings", () => {
+    const longDigits = "9".repeat(400);
+    const cases: { raw: string; code: string; message: string }[] = [
+      { raw: "", code: "blank", message: "Enter a threshold percentage." },
+      { raw: "   ", code: "blank", message: "Enter a threshold percentage." },
+      {
+        raw: "text",
+        code: "wholeNumber",
+        message: "Enter a whole-number percentage using digits only.",
+      },
+      {
+        raw: "+50",
+        code: "wholeNumber",
+        message: "Enter a whole-number percentage using digits only.",
+      },
+      {
+        raw: "-50",
+        code: "wholeNumber",
+        message: "Enter a whole-number percentage using digits only.",
+      },
+      {
+        raw: "5e1",
+        code: "wholeNumber",
+        message: "Enter a whole-number percentage using digits only.",
+      },
+      {
+        raw: "50.0",
+        code: "wholeNumber",
+        message: "Enter a whole-number percentage using digits only.",
+      },
+      {
+        raw: "50.5",
+        code: "wholeNumber",
+        message: "Enter a whole-number percentage using digits only.",
+      },
+      {
+        raw: "0",
+        code: "range",
+        message: "Threshold must be between 1% and 100%.",
+      },
+      {
+        raw: "101",
+        code: "range",
+        message: "Threshold must be between 1% and 100%.",
+      },
+      {
+        raw: longDigits,
+        code: "range",
+        message: "Threshold must be between 1% and 100%.",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const result = validateContextAlertThresholdDrafts(drafts(testCase.raw));
+      expect(result.valid).toBe(false);
+      expect(result.canonicalPercentages).toBeNull();
+      expect(result.rows[0]?.errorCodes).toEqual([testCase.code]);
+      expect(result.rows[0]?.messages).toEqual([testCase.message]);
+      expect(result.summaryMessages).toEqual([`Threshold 1: ${testCase.message}`]);
+    }
+  });
+
+  it("marks every numerically equivalent duplicate while leaving unrelated rows clean", () => {
+    for (const input of [drafts("80", "080", "50"), drafts("80", "080", "00080")]) {
+      const result = validateContextAlertThresholdDrafts(input);
+      expect(result.valid).toBe(false);
+      expect(result.canonicalPercentages).toBeNull();
+      expect(result.rows[0]?.errorCodes).toContain("duplicate");
+      expect(result.rows[1]?.errorCodes).toContain("duplicate");
+      if (input.length === 3 && input[2]?.raw === "50") {
+        expect(result.rows[2]?.errorCodes).toEqual([]);
+      } else {
+        expect(result.rows[2]?.errorCodes).toContain("duplicate");
+      }
+      expect(result.summaryMessages.every((message) => message.includes("already configured"))).toBe(true);
+    }
+  });
+
+  it("preserves every over-cap row and emits the cap summary once before row errors", () => {
+    for (const count of [4, 5]) {
+      const input = drafts("10", "20", "30", "40", "50").slice(0, count);
+      const result = validateContextAlertThresholdDrafts(input);
+      expect(result.valid).toBe(false);
+      expect(result.canonicalPercentages).toBeNull();
+      expect(result.rows).toHaveLength(count);
+      expect(result.rows.slice(0, 3).every((row) => !row.errorCodes.includes("cardinality"))).toBe(true);
+      expect(result.rows.slice(3).every((row) => row.errorCodes[0] === "cardinality")).toBe(true);
+      expect(result.rows.slice(3).every(
+        (row) => row.messages[0] === "Remove a threshold so no more than 3 remain.",
+      )).toBe(true);
+      expect(result.summaryMessages[0]).toBe(
+        "A team can have at most 3 context alert thresholds.",
+      );
+      expect(result.summaryMessages.filter(
+        (message) => message === "A team can have at most 3 context alert thresholds.",
+      )).toHaveLength(1);
+    }
+  });
+
+  it("hydrates valid arrays canonically but preserves every invalid numeric row", () => {
+    expect(hydrateContextAlertThresholdDrafts([])).toEqual([]);
+    expect(hydrateContextAlertThresholdDrafts([90, 50, 75])).toEqual([
+      { id: 1, raw: "50" },
+      { id: 2, raw: "75" },
+      { id: 3, raw: "90" },
+    ]);
+
+    for (const values of [
+      [80, 80],
+      [50.5, 75],
+      [101, 25],
+      [10, 20, 30, 40],
+    ]) {
+      expect(hydrateContextAlertThresholdDrafts(values)).toEqual(
+        values.map((value, index) => ({ id: index + 1, raw: String(value) })),
+      );
+    }
+  });
+});

--- a/src/sidebar/components/team-context-alerts.ts
+++ b/src/sidebar/components/team-context-alerts.ts
@@ -1,0 +1,146 @@
+export const CONTEXT_ALERT_PERCENTAGE_MIN = 1;
+export const CONTEXT_ALERT_PERCENTAGE_MAX = 100;
+export const MAX_CONTEXT_ALERT_THRESHOLDS = 3;
+
+export interface ContextAlertThresholdDraft {
+  id: number;
+  raw: string;
+}
+
+export type ContextAlertThresholdErrorCode =
+  | "blank"
+  | "wholeNumber"
+  | "range"
+  | "duplicate"
+  | "cardinality";
+
+export interface ContextAlertThresholdRowValidation {
+  draftId: number;
+  errorCodes: ContextAlertThresholdErrorCode[];
+  messages: string[];
+}
+
+export type ContextAlertThresholdValidation =
+  | {
+      valid: true;
+      canonicalPercentages: number[];
+      rows: ContextAlertThresholdRowValidation[];
+      summaryMessages: string[];
+    }
+  | {
+      valid: false;
+      canonicalPercentages: null;
+      rows: ContextAlertThresholdRowValidation[];
+      summaryMessages: string[];
+    };
+
+const CARDINALITY_SUMMARY = "A team can have at most 3 context alert thresholds.";
+const CARDINALITY_ROW_MESSAGE = "Remove a threshold so no more than 3 remain.";
+const BLANK_MESSAGE = "Enter a threshold percentage.";
+const WHOLE_NUMBER_MESSAGE = "Enter a whole-number percentage using digits only.";
+const RANGE_MESSAGE = "Threshold must be between 1% and 100%.";
+const DUPLICATE_MESSAGE =
+  "Thresholds must be distinct; this percentage is already configured.";
+
+interface ParsedDraft {
+  value: number | null;
+  lexicalCode: "blank" | "wholeNumber" | "range" | null;
+  lexicalMessage: string | null;
+}
+
+function parseDraft(raw: string): ParsedDraft {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { value: null, lexicalCode: "blank", lexicalMessage: BLANK_MESSAGE };
+  }
+  if (!/^[0-9]+$/.test(trimmed)) {
+    return {
+      value: null,
+      lexicalCode: "wholeNumber",
+      lexicalMessage: WHOLE_NUMBER_MESSAGE,
+    };
+  }
+
+  const value = Number(trimmed);
+  if (value < CONTEXT_ALERT_PERCENTAGE_MIN || value > CONTEXT_ALERT_PERCENTAGE_MAX) {
+    return { value: null, lexicalCode: "range", lexicalMessage: RANGE_MESSAGE };
+  }
+  return { value, lexicalCode: null, lexicalMessage: null };
+}
+
+export function validateContextAlertThresholdDrafts(
+  drafts: readonly ContextAlertThresholdDraft[],
+): ContextAlertThresholdValidation {
+  const parsedDrafts = drafts.map((draft) => parseDraft(draft.raw));
+  const valueCounts = new Map<number, number>();
+  for (const parsed of parsedDrafts) {
+    if (parsed.value !== null) {
+      valueCounts.set(parsed.value, (valueCounts.get(parsed.value) ?? 0) + 1);
+    }
+  }
+
+  const rows = drafts.map<ContextAlertThresholdRowValidation>((draft, index) => {
+    const errorCodes: ContextAlertThresholdErrorCode[] = [];
+    const messages: string[] = [];
+    const parsed = parsedDrafts[index];
+
+    if (index >= MAX_CONTEXT_ALERT_THRESHOLDS) {
+      errorCodes.push("cardinality");
+      messages.push(CARDINALITY_ROW_MESSAGE);
+    }
+    if (parsed.lexicalCode !== null && parsed.lexicalMessage !== null) {
+      errorCodes.push(parsed.lexicalCode);
+      messages.push(parsed.lexicalMessage);
+    }
+    if (parsed.value !== null && (valueCounts.get(parsed.value) ?? 0) > 1) {
+      errorCodes.push("duplicate");
+      messages.push(DUPLICATE_MESSAGE);
+    }
+
+    return { draftId: draft.id, errorCodes, messages };
+  });
+
+  const summaryMessages: string[] = [];
+  if (drafts.length > MAX_CONTEXT_ALERT_THRESHOLDS) {
+    summaryMessages.push(CARDINALITY_SUMMARY);
+  }
+  for (const [index, row] of rows.entries()) {
+    for (const message of row.messages) {
+      summaryMessages.push(`Threshold ${index + 1}: ${message}`);
+    }
+  }
+
+  if (rows.some((row) => row.errorCodes.length > 0)) {
+    return {
+      valid: false,
+      canonicalPercentages: null,
+      rows,
+      summaryMessages,
+    };
+  }
+
+  const canonicalPercentages = parsedDrafts
+    .map((parsed) => parsed.value)
+    .filter((value): value is number => value !== null)
+    .sort((left, right) => left - right);
+
+  return {
+    valid: true,
+    canonicalPercentages,
+    rows,
+    summaryMessages,
+  };
+}
+
+export function hydrateContextAlertThresholdDrafts(
+  values: readonly number[],
+): ContextAlertThresholdDraft[] {
+  const hydrated = values.map((value, index) => ({ id: index + 1, raw: String(value) }));
+  const validation = validateContextAlertThresholdDrafts(hydrated);
+  if (!validation.valid) return hydrated;
+
+  return validation.canonicalPercentages.map((value, index) => ({
+    id: index + 1,
+    raw: String(value),
+  }));
+}

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -7462,8 +7462,19 @@ html.light-theme[data-sidebar-style="neon-circuit"] .coord-quick-access {
 
 .entity-wizard-modal {
   max-height: 80vh;
+  min-width: 0;
   display: flex;
   flex-direction: column;
+}
+
+.entity-wizard-modal > .agent-modal-header,
+.entity-wizard-modal > .new-agent-footer {
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.entity-wizard-modal > .new-agent-footer {
+  flex-wrap: wrap;
 }
 
 .wizard-step-indicator {
@@ -7475,6 +7486,9 @@ html.light-theme[data-sidebar-style="neon-circuit"] .coord-quick-access {
 
 .wizard-body {
   flex: 1;
+  min-height: 0;
+  min-width: 0;
+  overflow-x: hidden;
   overflow-y: auto;
   padding: var(--spacing-md);
   display: flex;
@@ -7605,7 +7619,12 @@ html.light-theme[data-sidebar-style="neon-circuit"] .coord-quick-access {
 
 .wizard-repo-input-row {
   display: flex;
+  min-width: 0;
   gap: var(--spacing-xs);
+}
+
+.wizard-repo-input-row .agent-search-input {
+  min-width: 0;
 }
 
 .wizard-repo-list {
@@ -7665,6 +7684,133 @@ html.light-theme[data-sidebar-style="neon-circuit"] .coord-quick-access {
   font-weight: 600;
   font-size: 11px;
   opacity: 0.8;
+}
+
+.team-settings-section {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: var(--spacing-sm);
+}
+
+.team-settings-heading {
+  margin: 0;
+  color: var(--sidebar-fg);
+  font-size: var(--font-size-sm);
+  overflow-wrap: anywhere;
+}
+
+.team-context-alert-help {
+  margin: 0;
+  color: var(--sidebar-fg-dim);
+  font-size: var(--font-size-sm);
+  overflow-wrap: anywhere;
+}
+
+.team-context-alert-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+  gap: var(--spacing-sm);
+}
+
+.team-context-alert-count {
+  color: var(--sidebar-fg-dim);
+  font-size: var(--font-size-sm);
+  overflow-wrap: anywhere;
+}
+
+.team-context-alert-rows {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: var(--spacing-sm);
+}
+
+.team-context-alert-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  min-width: 0;
+  gap: var(--spacing-sm);
+}
+
+.team-context-alert-field {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: var(--spacing-xs);
+}
+
+.team-context-alert-input-wrap {
+  position: relative;
+  min-width: 0;
+}
+
+.team-context-alert-input {
+  min-width: 0;
+  padding-inline-end: calc(var(--spacing-lg) + var(--spacing-md));
+}
+
+.team-context-alert-input[aria-invalid="true"] {
+  border-color: var(--status-exited);
+}
+
+.team-context-alert-input[aria-invalid="true"]:focus {
+  outline-color: var(--sidebar-accent);
+  outline-style: solid;
+}
+
+.team-context-alert-suffix {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: var(--spacing-md);
+  display: flex;
+  align-items: center;
+  color: var(--sidebar-fg-dim);
+  pointer-events: none;
+}
+
+.team-context-alert-remove {
+  align-self: start;
+  white-space: normal;
+}
+
+.team-context-alert-row-error {
+  color: var(--status-exited);
+  font-size: var(--font-size-sm);
+  overflow-wrap: anywhere;
+}
+
+.team-context-alert-errors {
+  color: var(--status-exited);
+  overflow-wrap: anywhere;
+}
+
+.team-context-alert-empty {
+  padding: var(--spacing-sm) 0;
+  text-align: start;
+}
+
+@media (max-width: 440px) {
+  .team-context-alert-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .team-context-alert-remove {
+    justify-self: start;
+  }
+
+  .team-context-alert-toolbar,
+  .wizard-repo-input-row {
+    flex-wrap: wrap;
+  }
+
+  .wizard-repo-input-row .agent-search-input,
+  .wizard-repo-input-row .new-agent-browse-btn {
+    flex: 1 1 100%;
+  }
 }
 
 /* ===== Context Menu Extras ===== */


### PR DESCRIPTION
## Summary

- add zero-to-three normalized context alert thresholds to Create Team and Edit Team, with compatible persistence/CLI/IPC behavior
- sample every registered session independently of the sidebar badge equality gate and evaluate team policy in a bounded, fair runtime monitor
- deliver fixed informational notices only to the exact canonical workgroup coordinator, with retries, re-arm/dedup semantics, secure wake/resume/spawn handling, and no automatic remediation
- preserve peer-message behavior and add deterministic identity, routing, liveness, queue, retry, shutdown, reparse, accessibility, validation, and persistence coverage

## Verification

- Grinch full-range review: PASS after two LOW findings were corrected
- Grinch current-main merge review: PASS
- Rust workspace check and clippy with warnings denied: PASS
- full non-doctest Rust workspace suite: 2,573 library tests passed, 9 ignored; all bin/integration targets passed
- frontend typecheck: PASS
- frontend suite: 138 files / 1,281 tests passed
- native WebView2 manual verification: dark/light, narrow/normal/wide, keyboard, validation, persistence, legacy/corrupt config — PASS
- isolated native two-workgroup runtime verification: 16/16 assertions PASS, including exact coordinator routing, coalescing, dedup, re-arm, policy refresh, retry, resume/spawn, selection preservation, and no remediation
- certified implementation plan digest remained unchanged

## Notes

- `cargo fmt --all -- --check` retains unrelated pre-existing formatting drift; every changed Rust surface passed targeted rustfmt checks.
- The standard doctest command retains the known Windows rustdoc/toolchain limitation after runnable targets pass; the explicit non-doctest workspace gate is green.
- A pre-existing out-of-range selection admission-release race observed during review is tracked separately in #1066 and was not folded into this feature.
- Post-merge wg-9 standalone build/deploy will be performed from landed `main`.

Closes #1056
